### PR TITLE
feat: set max log files to 720 by default, info log only

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -161,6 +161,7 @@
 | `logging.otlp_endpoint` | String | `http://localhost:4317` | The OTLP tracing endpoint. |
 | `logging.append_stdout` | Bool | `true` | Whether to append logs to stdout. |
 | `logging.log_format` | String | `text` | The log format. Can be `text`/`json`. |
+| `logging.max_log_files` | Integer | `720` | The maximum amount of log files. |
 | `logging.tracing_sample_ratio` | -- | -- | The percentage of tracing will be sampled and exported.<br/>Valid range `[0, 1]`, 1 means all traces are sampled, 0 means all traces are not sampled, the default value is 1.<br/>ratio > 1 are treated as 1. Fractions < 0 are treated as 0 |
 | `logging.tracing_sample_ratio.default_ratio` | Float | `1.0` | -- |
 | `logging.slow_query` | -- | -- | The slow query log options. |
@@ -251,6 +252,7 @@
 | `logging.otlp_endpoint` | String | `http://localhost:4317` | The OTLP tracing endpoint. |
 | `logging.append_stdout` | Bool | `true` | Whether to append logs to stdout. |
 | `logging.log_format` | String | `text` | The log format. Can be `text`/`json`. |
+| `logging.max_log_files` | Integer | `720` | The maximum amount of log files. |
 | `logging.tracing_sample_ratio` | -- | -- | The percentage of tracing will be sampled and exported.<br/>Valid range `[0, 1]`, 1 means all traces are sampled, 0 means all traces are not sampled, the default value is 1.<br/>ratio > 1 are treated as 1. Fractions < 0 are treated as 0 |
 | `logging.tracing_sample_ratio.default_ratio` | Float | `1.0` | -- |
 | `logging.slow_query` | -- | -- | The slow query log options. |
@@ -320,6 +322,7 @@
 | `logging.otlp_endpoint` | String | `http://localhost:4317` | The OTLP tracing endpoint. |
 | `logging.append_stdout` | Bool | `true` | Whether to append logs to stdout. |
 | `logging.log_format` | String | `text` | The log format. Can be `text`/`json`. |
+| `logging.max_log_files` | Integer | `720` | The maximum amount of log files. |
 | `logging.tracing_sample_ratio` | -- | -- | The percentage of tracing will be sampled and exported.<br/>Valid range `[0, 1]`, 1 means all traces are sampled, 0 means all traces are not sampled, the default value is 1.<br/>ratio > 1 are treated as 1. Fractions < 0 are treated as 0 |
 | `logging.tracing_sample_ratio.default_ratio` | Float | `1.0` | -- |
 | `logging.slow_query` | -- | -- | The slow query log options. |
@@ -476,6 +479,7 @@
 | `logging.otlp_endpoint` | String | `http://localhost:4317` | The OTLP tracing endpoint. |
 | `logging.append_stdout` | Bool | `true` | Whether to append logs to stdout. |
 | `logging.log_format` | String | `text` | The log format. Can be `text`/`json`. |
+| `logging.max_log_files` | Integer | `720` | The maximum amount of log files. |
 | `logging.tracing_sample_ratio` | -- | -- | The percentage of tracing will be sampled and exported.<br/>Valid range `[0, 1]`, 1 means all traces are sampled, 0 means all traces are not sampled, the default value is 1.<br/>ratio > 1 are treated as 1. Fractions < 0 are treated as 0 |
 | `logging.tracing_sample_ratio.default_ratio` | Float | `1.0` | -- |
 | `logging.slow_query` | -- | -- | The slow query log options. |
@@ -526,6 +530,7 @@
 | `logging.otlp_endpoint` | String | `http://localhost:4317` | The OTLP tracing endpoint. |
 | `logging.append_stdout` | Bool | `true` | Whether to append logs to stdout. |
 | `logging.log_format` | String | `text` | The log format. Can be `text`/`json`. |
+| `logging.max_log_files` | Integer | `720` | The maximum amount of log files. |
 | `logging.tracing_sample_ratio` | -- | -- | The percentage of tracing will be sampled and exported.<br/>Valid range `[0, 1]`, 1 means all traces are sampled, 0 means all traces are not sampled, the default value is 1.<br/>ratio > 1 are treated as 1. Fractions < 0 are treated as 0 |
 | `logging.tracing_sample_ratio.default_ratio` | Float | `1.0` | -- |
 | `logging.slow_query` | -- | -- | The slow query log options. |

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -580,6 +580,9 @@ append_stdout = true
 ## The log format. Can be `text`/`json`.
 log_format = "text"
 
+## The maximum amount of log files.
+max_log_files = 720
+
 ## The percentage of tracing will be sampled and exported.
 ## Valid range `[0, 1]`, 1 means all traces are sampled, 0 means all traces are not sampled, the default value is 1.
 ## ratio > 1 are treated as 1. Fractions < 0 are treated as 0

--- a/config/flownode.example.toml
+++ b/config/flownode.example.toml
@@ -78,6 +78,9 @@ append_stdout = true
 ## The log format. Can be `text`/`json`.
 log_format = "text"
 
+## The maximum amount of log files.
+max_log_files = 720
+
 ## The percentage of tracing will be sampled and exported.
 ## Valid range `[0, 1]`, 1 means all traces are sampled, 0 means all traces are not sampled, the default value is 1.
 ## ratio > 1 are treated as 1. Fractions < 0 are treated as 0

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -185,6 +185,9 @@ append_stdout = true
 ## The log format. Can be `text`/`json`.
 log_format = "text"
 
+## The maximum amount of log files.
+max_log_files = 720
+
 ## The percentage of tracing will be sampled and exported.
 ## Valid range `[0, 1]`, 1 means all traces are sampled, 0 means all traces are not sampled, the default value is 1.
 ## ratio > 1 are treated as 1. Fractions < 0 are treated as 0

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -172,6 +172,9 @@ append_stdout = true
 ## The log format. Can be `text`/`json`.
 log_format = "text"
 
+## The maximum amount of log files.
+max_log_files = 720
+
 ## The percentage of tracing will be sampled and exported.
 ## Valid range `[0, 1]`, 1 means all traces are sampled, 0 means all traces are not sampled, the default value is 1.
 ## ratio > 1 are treated as 1. Fractions < 0 are treated as 0

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -624,6 +624,9 @@ append_stdout = true
 ## The log format. Can be `text`/`json`.
 log_format = "text"
 
+## The maximum amount of log files.
+max_log_files = 720
+
 ## The percentage of tracing will be sampled and exported.
 ## Valid range `[0, 1]`, 1 means all traces are sampled, 0 means all traces are not sampled, the default value is 1.
 ## ratio > 1 are treated as 1. Fractions < 0 are treated as 0

--- a/src/common/telemetry/src/logging.rs
+++ b/src/common/telemetry/src/logging.rs
@@ -216,7 +216,10 @@ pub fn init_global_logging(
                 .filename_prefix("greptimedb")
                 .max_log_files(opts.max_log_files)
                 .build(&opts.dir)
-                .expect("initializing rolling file appender failed");
+                .expect(&format!(
+                    "initializing rolling file appender at {} failed",
+                    &opts.dir
+                ));
             let (writer, guard) = tracing_appender::non_blocking(rolling_appender);
             guards.push(guard);
 
@@ -237,8 +240,16 @@ pub fn init_global_logging(
 
         // Configure the error file logging layer with rolling policy.
         let err_file_logging_layer = if !opts.dir.is_empty() {
-            let rolling_appender =
-                RollingFileAppender::new(Rotation::HOURLY, &opts.dir, "greptimedb-err");
+            let rolling_appender = RollingFileAppender::builder()
+                .rotation(Rotation::HOURLY)
+                .filename_prefix("greptimedb-err")
+                // Simply set maximum to constant 30 here
+                .max_log_files(30)
+                .build(&opts.dir)
+                .expect(&format!(
+                    "initializing rolling file appender at {} failed",
+                    &opts.dir
+                ));
             let (writer, guard) = tracing_appender::non_blocking(rolling_appender);
             guards.push(guard);
 
@@ -265,8 +276,15 @@ pub fn init_global_logging(
         };
 
         let slow_query_logging_layer = if !opts.dir.is_empty() && opts.slow_query.enable {
-            let rolling_appender =
-                RollingFileAppender::new(Rotation::HOURLY, &opts.dir, "greptimedb-slow-queries");
+            let rolling_appender = RollingFileAppender::builder()
+                .rotation(Rotation::HOURLY)
+                .filename_prefix("greptimedb-slow-queries")
+                .max_log_files(opts.max_log_files)
+                .build(&opts.dir)
+                .expect(&format!(
+                    "initializing rolling file appender at {} failed",
+                    &opts.dir
+                ));
             let (writer, guard) = tracing_appender::non_blocking(rolling_appender);
             guards.push(guard);
 

--- a/src/common/telemetry/src/logging.rs
+++ b/src/common/telemetry/src/logging.rs
@@ -54,6 +54,9 @@ pub struct LoggingOptions {
     /// The log format that can be one of "json" or "text". Default is "text".
     pub log_format: LogFormat,
 
+    /// The maximum number of log files set by default.
+    pub max_log_files: usize,
+
     /// Whether to append logs to stdout. Default is true.
     pub append_stdout: bool,
 
@@ -68,9 +71,6 @@ pub struct LoggingOptions {
 
     /// The logging options of slow query.
     pub slow_query: SlowQueryOptions,
-
-    /// The maximum number of log files set by default.
-    pub max_log_files: usize,
 }
 
 /// The options of slow query.
@@ -216,8 +216,11 @@ pub fn init_global_logging(
                 .filename_prefix("greptimedb")
                 .max_log_files(opts.max_log_files)
                 .build(&opts.dir)
-                .unwrap_or_else(|_| {
-                    panic!("initializing rolling file appender at {} failed", &opts.dir)
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "initializing rolling file appender at {} failed: {}",
+                        &opts.dir, e
+                    )
                 });
             let (writer, guard) = tracing_appender::non_blocking(rolling_appender);
             guards.push(guard);
@@ -242,11 +245,13 @@ pub fn init_global_logging(
             let rolling_appender = RollingFileAppender::builder()
                 .rotation(Rotation::HOURLY)
                 .filename_prefix("greptimedb-err")
-                // Simply set maximum to constant 30 here
-                .max_log_files(30)
+                .max_log_files(opts.max_log_files)
                 .build(&opts.dir)
-                .unwrap_or_else(|_| {
-                    panic!("initializing rolling file appender at {} failed", &opts.dir)
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "initializing rolling file appender at {} failed: {}",
+                        &opts.dir, e
+                    )
                 });
             let (writer, guard) = tracing_appender::non_blocking(rolling_appender);
             guards.push(guard);
@@ -279,8 +284,11 @@ pub fn init_global_logging(
                 .filename_prefix("greptimedb-slow-queries")
                 .max_log_files(opts.max_log_files)
                 .build(&opts.dir)
-                .unwrap_or_else(|_| {
-                    panic!("initializing rolling file appender at {} failed", &opts.dir)
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "initializing rolling file appender at {} failed: {}",
+                        &opts.dir, e
+                    )
                 });
             let (writer, guard) = tracing_appender::non_blocking(rolling_appender);
             guards.push(guard);

--- a/src/common/telemetry/src/logging.rs
+++ b/src/common/telemetry/src/logging.rs
@@ -216,10 +216,9 @@ pub fn init_global_logging(
                 .filename_prefix("greptimedb")
                 .max_log_files(opts.max_log_files)
                 .build(&opts.dir)
-                .expect(&format!(
-                    "initializing rolling file appender at {} failed",
-                    &opts.dir
-                ));
+                .unwrap_or_else(|_| {
+                    panic!("initializing rolling file appender at {} failed", &opts.dir)
+                });
             let (writer, guard) = tracing_appender::non_blocking(rolling_appender);
             guards.push(guard);
 
@@ -246,10 +245,9 @@ pub fn init_global_logging(
                 // Simply set maximum to constant 30 here
                 .max_log_files(30)
                 .build(&opts.dir)
-                .expect(&format!(
-                    "initializing rolling file appender at {} failed",
-                    &opts.dir
-                ));
+                .unwrap_or_else(|_| {
+                    panic!("initializing rolling file appender at {} failed", &opts.dir)
+                });
             let (writer, guard) = tracing_appender::non_blocking(rolling_appender);
             guards.push(guard);
 
@@ -281,10 +279,9 @@ pub fn init_global_logging(
                 .filename_prefix("greptimedb-slow-queries")
                 .max_log_files(opts.max_log_files)
                 .build(&opts.dir)
-                .expect(&format!(
-                    "initializing rolling file appender at {} failed",
-                    &opts.dir
-                ));
+                .unwrap_or_else(|_| {
+                    panic!("initializing rolling file appender at {} failed", &opts.dir)
+                });
             let (writer, guard) = tracing_appender::non_blocking(rolling_appender);
             guards.push(guard);
 

--- a/src/log-store/src/kafka/client_manager.rs
+++ b/src/log-store/src/kafka/client_manager.rs
@@ -132,7 +132,7 @@ impl ClientManager {
     }
 
     async fn try_create_client(&self, provider: &Arc<KafkaProvider>) -> Result<Client> {
-        // Sets to Retry to retry connecting if the kafka cluter replies with an UnknownTopic error.
+        // Sets to Retry to retry connecting if the kafka cluster replies with an UnknownTopic error.
         // That's because the topic is believed to exist as the metasrv is expected to create required topics upon start.
         // The reconnecting won't stop until succeed or a different error returns.
         let client = self
@@ -182,7 +182,7 @@ mod tests {
 
     use super::*;
 
-    /// Creates `num_topiocs` number of topics each will be decorated by the given decorator.
+    /// Creates `num_topics` number of topics each will be decorated by the given decorator.
     pub async fn create_topics<F>(
         num_topics: usize,
         decorator: F,

--- a/src/script/src/python/rspython/builtins/test.rs
+++ b/src/script/src/python/rspython/builtins/test.rs
@@ -145,7 +145,7 @@ enum PyValue {
 }
 
 impl PyValue {
-    /// compare if results is just as expect, not using PartialEq because it is not transtive .e.g. [1,2,3] == len(3) == [4,5,6]
+    /// compare if results is just as expect, not using PartialEq because it is not transitive .e.g. [1,2,3] == len(3) == [4,5,6]
     fn just_as_expect(&self, other: &Self) -> bool {
         match (self, other) {
             (PyValue::FloatVec(a), PyValue::FloatVec(b)) => a

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -835,6 +835,7 @@ retry_delay = "500ms"
 [logging]
 append_stdout = true
 enable_otlp_tracing = false
+max_log_files = 720
 
 [logging.slow_query]
 enable = false

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -833,9 +833,9 @@ max_retry_times = 3
 retry_delay = "500ms"
 
 [logging]
+max_log_files = 720
 append_stdout = true
 enable_otlp_tracing = false
-max_log_files = 720
 
 [logging.slow_query]
 enable = false


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
Closes #4777.

## What's changed and what's your intention?

Exposed `max_log_files` in `LoggingOptions`, set it to 720 by default, and build `info_log` with this restriction.

## Checklist

Not sure how to test this. It passed CI tho.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
