### PR TITLE
feat(mito): Support background task priority

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2394,6 +2394,7 @@ dependencies = [
  "futures-util",
  "humantime-serde",
  "num_cpus",
+ "rate_limit",
  "rskafka",
  "rustls 0.23.13",
  "rustls-native-certs 0.7.3",
@@ -9146,6 +9147,12 @@ dependencies = [
  "num-traits",
  "rand",
 ]
+
+[[package]]
+name = "rate_limit"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22b369104f6b45d4a91867e59b5a9c9fec8bc1d36ba7a3ac7eb60876ae6c1fca"
 
 [[package]]
 name = "raw-cpuid"

--- a/src/common/wal/Cargo.toml
+++ b/src/common/wal/Cargo.toml
@@ -26,6 +26,7 @@ serde.workspace = true
 serde_with.workspace = true
 snafu.workspace = true
 tokio.workspace = true
+rate_limit = "0.1.1"
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/src/mito2/src/compaction.rs
+++ b/src/mito2/src/compaction.rs
@@ -63,7 +63,7 @@ use crate::request::{OptionOutputTx, OutputTx, WorkerRequest};
 use crate::schedule::remote_job_scheduler::{
     CompactionJob, DefaultNotifier, RemoteJob, RemoteJobSchedulerRef,
 };
-use crate::schedule::scheduler::{Job, SchedulerRef};
+use crate::schedule::scheduler::{Job, Priority, SchedulerRef};
 use crate::sst::file::{FileHandle, FileId, FileMeta, Level};
 use crate::sst::version::LevelMeta;
 use crate::worker::WorkerListener;
@@ -362,12 +362,13 @@ impl CompactionScheduler {
 
         // Submit the compaction task.
         self.scheduler
-            .schedule(Job {
-                r#type: "compaction",
-                task: Box::pin(async move {
+            .schedule(Job::new(
+                "compaction",
+                Priority::Low(Some(Duration::from_secs(60))),
+                Box::pin(async move {
                     local_compaction_task.run().await;
                 }),
-            })
+            ))
             .map_err(|e| {
                 error!(e; "Failed to submit compaction request for region {}", region_id);
                 // If failed to submit the job, we need to remove the region from the scheduler.

--- a/src/mito2/src/engine/compaction_test.rs
+++ b/src/mito2/src/engine/compaction_test.rs
@@ -29,6 +29,7 @@ use tokio::sync::Notify;
 use crate::config::MitoConfig;
 use crate::engine::listener::CompactionListener;
 use crate::engine::MitoEngine;
+use crate::schedule::scheduler::Job;
 use crate::test_util::{
     build_rows_for_key, column_metadata_to_column_schema, put_rows, CreateRequestBuilder, TestEnv,
 };
@@ -315,9 +316,9 @@ async fn test_readonly_during_compaction() {
     let job_notify = notify.clone();
     engine
         .purge_scheduler()
-        .schedule(Box::pin(async move {
+        .schedule(Job::new_test(Box::pin(async move {
             job_notify.notify_one();
-        }))
+        })))
         .unwrap();
     notify.notified().await;
 

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -870,6 +870,13 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+
+    #[snafu(display("Fail to send to async channel, err_msg: {}", err_msg))]
+    SendToChannel {
+        err_msg: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -1002,6 +1009,7 @@ impl ErrorExt for Error {
             | ApplyFulltextIndex { source, .. } => source.status_code(),
             DecodeStats { .. } | StatsNotPresent { .. } => StatusCode::Internal,
             RegionBusy { .. } => StatusCode::RegionBusy,
+            SendToChannel { .. } => StatusCode::Internal,
         }
     }
 

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -260,9 +260,12 @@ impl RegionFlushTask {
         // wal entry id, sequence and immutable memtables.
         let version_data = version_control.current();
 
-        Box::pin(async move {
-            self.do_flush(version_data).await;
-        })
+        Job::new(
+            "flush",
+            Box::pin(async move {
+                self.do_flush(version_data).await;
+            }),
+        )
     }
 
     /// Runs the flush task.

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -41,7 +41,7 @@ use crate::request::{
     BackgroundNotify, FlushFailed, FlushFinished, OptionOutputTx, OutputTx, SenderDdlRequest,
     SenderWriteRequest, WorkerRequest,
 };
-use crate::schedule::scheduler::{Job, SchedulerRef};
+use crate::schedule::scheduler::{Job, Priority, SchedulerRef};
 use crate::sst::file::{FileId, FileMeta, IndexType};
 use crate::sst::parquet::WriteOptions;
 use crate::worker::WorkerListener;
@@ -262,6 +262,7 @@ impl RegionFlushTask {
 
         Job::new(
             "flush",
+            Priority::High,
             Box::pin(async move {
                 self.do_flush(version_data).await;
             }),

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -50,6 +50,15 @@ lazy_static! {
         )
         .unwrap();
 
+    /// Elapsed time of tasks in scheduler.
+    pub static ref SCHEDULER_TASK_ELAPSED: HistogramVec = register_histogram_vec!(
+            "greptime_mito_handle_scheduler_task_elapsed",
+            "mito handle scheduler task elapsed",
+            &[TYPE_LABEL],
+            vec![0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 2.5, 5.0, 10.0, 60.0, 300.0]
+        )
+        .unwrap();
+
     // ------ Flush related metrics
     /// Counter of scheduled flush requests.
     /// Note that the flush scheduler may merge some flush requests.

--- a/src/mito2/src/schedule.rs
+++ b/src/mito2/src/schedule.rs
@@ -12,5 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[allow(dead_code)]
+mod priority;
 pub mod remote_job_scheduler;
 pub mod scheduler;

--- a/src/mito2/src/schedule/priority.rs
+++ b/src/mito2/src/schedule/priority.rs
@@ -1,0 +1,323 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ops::Add;
+use std::pin::Pin;
+use std::time::{Duration, Instant};
+
+use async_stream::stream;
+use futures::Stream;
+use tokio::select;
+use tokio::time::Sleep;
+
+use crate::error;
+
+pub fn bounded<T>(size: usize) -> (Sender<T>, Receiver<T>) {
+    let (tx_low, rx_low) = async_channel::bounded(size);
+    let (tx_high, rx_high) = async_channel::bounded(size);
+    (Sender { tx_low, tx_high }, Receiver { rx_low, rx_high })
+}
+
+pub fn unbounded<T>() -> (Sender<T>, Receiver<T>) {
+    let (tx_low, rx_low) = async_channel::unbounded();
+    let (tx_high, rx_high) = async_channel::unbounded();
+    (Sender { tx_low, tx_high }, Receiver { rx_low, rx_high })
+}
+
+#[derive(Clone)]
+pub struct Sender<T> {
+    tx_low: async_channel::Sender<(Instant, T)>,
+    tx_high: async_channel::Sender<T>,
+}
+
+impl<T> Sender<T> {
+    pub async fn send_high(&self, item: T) -> error::Result<()> {
+        self.tx_high.send(item).await.map_err(|e| {
+            error::SendToChannelSnafu {
+                err_msg: format!("{:?}", e),
+            }
+            .build()
+        })
+    }
+
+    pub async fn send_low(&self, item: T, deadline: Option<Duration>) -> error::Result<()> {
+        self.tx_low
+            .send((
+                Instant::now().add(deadline.unwrap_or(Duration::from_secs(0))),
+                item,
+            ))
+            .await
+            .map_err(|e| {
+                error::SendToChannelSnafu {
+                    err_msg: format!("{:?}", e),
+                }
+                .build()
+            })
+    }
+}
+
+#[derive(Clone)]
+pub struct Receiver<T> {
+    rx_low: async_channel::Receiver<(Instant, T)>,
+    rx_high: async_channel::Receiver<T>,
+}
+
+impl<T> Receiver<T>
+where
+    T: Send + 'static,
+{
+    pub fn into_stream(self) -> Pin<Box<dyn Stream<Item = T> + Send>> {
+        let s = stream!({
+            let mut timer: Option<Pin<Box<Sleep>>> = None;
+            let mut pending: Option<T> = None;
+            loop {
+                select! {
+                    biased;
+                    Some(_) = maybe_timeout(&mut timer) => {
+                        if let Some(timed) = std::mem::take(&mut pending){
+                            yield timed
+                        }
+                    }
+
+                    Ok(high) = self.rx_high.recv() => {
+                        // also check if low channel has pending.
+                        if pending.is_none() && let Ok((deadline, low_item)) = self.rx_low.try_recv() {
+                            let now = Instant::now();
+                            if deadline > now {
+                                let tta = deadline - now;
+                                timer = Some(Box::pin(tokio::time::sleep(tta)));
+                            }
+                            pending = Some(low_item);
+                        }
+                        yield high;
+                    }
+
+                    Ok((_, low)) = self.rx_low.recv() => {
+                        if let Some(timed) = std::mem::take(&mut pending){
+                            timer = None;
+                            yield timed;
+                        }
+                        yield low
+                    }
+
+                    else => {
+                        if self.rx_high.is_closed() && self.rx_low.is_closed() {
+                            return;
+                        }
+                    }
+                }
+            }
+        });
+        Box::pin(s)
+    }
+}
+
+async fn maybe_timeout(f: &mut Option<Pin<Box<Sleep>>>) -> Option<()> {
+    match f {
+        None => None,
+        Some(sleeper) => {
+            sleeper.await;
+            *f = None;
+            Some(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use futures::StreamExt;
+    use tokio::time::timeout;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_high() {
+        let (tx, rx) = unbounded();
+        tx.send_high(1).await.unwrap();
+        tx.send_high(2).await.unwrap();
+        tx.send_high(3).await.unwrap();
+
+        drop(tx);
+        let s = rx.into_stream();
+        assert_eq!(vec![1, 2, 3], s.collect::<Vec<_>>().await);
+    }
+
+    #[tokio::test]
+    async fn test_low() {
+        let (tx, rx) = unbounded();
+        tx.send_low(1, None).await.unwrap();
+        tx.send_low(2, None).await.unwrap();
+        tx.send_low(3, None).await.unwrap();
+
+        drop(tx);
+        let s = rx.into_stream();
+        assert_eq!(vec![1, 2, 3], s.collect::<Vec<_>>().await);
+    }
+
+    #[tokio::test]
+    async fn test_high_and_low() {
+        let (tx, rx) = unbounded();
+        tx.send_low(1, None).await.unwrap();
+        tx.send_low(2, None).await.unwrap();
+        tx.send_low(3, None).await.unwrap();
+
+        tx.send_high(4).await.unwrap();
+        tx.send_high(5).await.unwrap();
+        tx.send_high(6).await.unwrap();
+        drop(tx);
+        let s = rx.into_stream();
+        assert_eq!(
+            vec![4, 5, 6, 1, 2, 3],
+            timeout(Duration::from_secs(5), s.collect::<Vec<_>>())
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_high_and_low_with_deadline() {
+        let (tx, rx) = unbounded();
+
+        for i in 0..10 {
+            tx.send_high(i).await.unwrap();
+        }
+
+        tx.send_low(11, Some(Duration::from_millis(10)))
+            .await
+            .unwrap();
+
+        let mut s = rx.into_stream();
+        let mut res = vec![];
+        drop(tx);
+        while let Some(v) = s.next().await {
+            res.push(v);
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_empty() {
+        let (tx, rx) = unbounded();
+        tx.send_low(1, None).await.unwrap();
+        drop(tx);
+        assert_eq!(vec![1], rx.into_stream().collect::<Vec<_>>().await);
+    }
+
+    #[derive(Clone)]
+    struct Item {
+        high: bool,
+        submitted: Instant,
+    }
+
+    impl Item {
+        fn new(high_priority: bool) -> Self {
+            Item {
+                high: high_priority,
+                submitted: Instant::now(),
+            }
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_high_workload() {
+        let (tx, rx) = unbounded();
+
+        const HIGH_COUNT: u32 = 100000;
+        const LOW_COUNT: u32 = 100;
+        const LOW_DEADLINE_US: u64 = 5000;
+
+        let sender = tx.clone();
+        tokio::spawn(async move {
+            for _ in 0..HIGH_COUNT {
+                sender.send_high(Item::new(true)).await.unwrap();
+                tokio::task::yield_now().await;
+            }
+        });
+
+        let sender = tx.clone();
+        tokio::spawn(async move {
+            for _ in 0..LOW_COUNT {
+                sender
+                    .send_low(
+                        Item::new(false),
+                        Some(Duration::from_micros(LOW_DEADLINE_US)),
+                    )
+                    .await
+                    .unwrap();
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        });
+
+        let mut rx = rx.into_stream();
+        let mut low_count = 0;
+        let mut high_count = 0;
+        drop(tx);
+        let mut low_delay = Duration::from_secs(0);
+        while let Some(v) = rx.next().await {
+            if !v.high {
+                low_count += 1;
+                low_delay += Instant::now() - v.submitted;
+            } else {
+                high_count += 1;
+            }
+            if low_count >= LOW_COUNT && high_count >= HIGH_COUNT {
+                break;
+            }
+        }
+
+        assert_eq!(HIGH_COUNT, high_count);
+        assert_eq!(LOW_COUNT, low_count);
+        let avg_delay_micros = low_delay.as_micros() / LOW_COUNT as u128;
+        assert!(avg_delay_micros < LOW_DEADLINE_US as u128);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_random_send() {
+        let low_send = Arc::new(AtomicUsize::new(0));
+        let high_send = Arc::new(AtomicUsize::new(0));
+
+        let (tx, rx) = unbounded();
+
+        let low_send_clone = low_send.clone();
+        let high_send_clone = high_send.clone();
+        tokio::spawn(async move {
+            for _ in 0..10000 {
+                let p: bool = rand::random();
+                if p {
+                    tx.send_high(Item::new(true)).await.unwrap();
+                    high_send_clone.fetch_add(1, Ordering::Relaxed);
+                } else {
+                    tx.send_low(Item::new(false), None).await.unwrap();
+                    low_send_clone.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        });
+        let mut high_recv = 0;
+        let mut low_recv = 0;
+        let mut s = rx.into_stream();
+        while let Some(v) = s.next().await {
+            if v.high {
+                high_recv += 1;
+            } else {
+                low_recv += 1;
+            }
+        }
+        assert_eq!(low_send.load(Ordering::Relaxed), low_recv);
+        assert_eq!(high_send.load(Ordering::Relaxed), high_recv);
+    }
+}

--- a/src/mito2/src/schedule/scheduler.rs
+++ b/src/mito2/src/schedule/scheduler.rs
@@ -99,7 +99,7 @@ impl LocalScheduler {
                         }
                         req_opt = receiver.recv() =>{
                             if let Ok(job) = req_opt {
-                                let _timer = SCHEDULER_TASK_ELAPSED.with_label_values(&[job.r#type]);
+                                let _timer = SCHEDULER_TASK_ELAPSED.with_label_values(&[job.r#type]).start_timer();
                                 job.task.await;
                             }
                         }
@@ -109,6 +109,9 @@ impl LocalScheduler {
                 if state_clone.load(Ordering::Relaxed) == STATE_AWAIT_TERMINATION {
                     // recv_async waits until all sender's been dropped.
                     while let Ok(job) = receiver.recv().await {
+                        let _timer = SCHEDULER_TASK_ELAPSED
+                            .with_label_values(&[job.r#type])
+                            .start_timer();
                         job.task.await;
                     }
                     state_clone.store(STATE_STOP, Ordering::Relaxed);

--- a/src/mito2/src/sst/file_purger.rs
+++ b/src/mito2/src/sst/file_purger.rs
@@ -20,7 +20,7 @@ use common_telemetry::{error, info};
 use crate::access_layer::AccessLayerRef;
 use crate::cache::file_cache::{FileType, IndexKey};
 use crate::cache::CacheManagerRef;
-use crate::schedule::scheduler::SchedulerRef;
+use crate::schedule::scheduler::{Job, SchedulerRef};
 use crate::sst::file::FileMeta;
 
 /// Request to remove a file.
@@ -79,39 +79,44 @@ impl FilePurger for LocalFilePurger {
         }
 
         let cache_manager = self.cache_manager.clone();
-        if let Err(e) = self.scheduler.schedule(Box::pin(async move {
-            if let Err(e) = sst_layer.delete_sst(&file_meta).await {
-                error!(e; "Failed to delete SST file, file_id: {}, region: {}",
+        let job = Job::new(
+            "purge",
+            Box::pin(async move {
+                if let Err(e) = sst_layer.delete_sst(&file_meta).await {
+                    error!(e; "Failed to delete SST file, file_id: {}, region: {}",
                     file_meta.file_id, file_meta.region_id);
-            } else {
-                info!(
-                    "Successfully deleted SST file, file_id: {}, region: {}",
-                    file_meta.file_id, file_meta.region_id
-                );
-            }
+                } else {
+                    info!(
+                        "Successfully deleted SST file, file_id: {}, region: {}",
+                        file_meta.file_id, file_meta.region_id
+                    );
+                }
 
-            if let Some(write_cache) = cache_manager.as_ref().and_then(|cache| cache.write_cache())
-            {
-                // Removes the inverted index from the cache.
-                if file_meta.inverted_index_available() {
+                if let Some(write_cache) =
+                    cache_manager.as_ref().and_then(|cache| cache.write_cache())
+                {
+                    // Removes the inverted index from the cache.
+                    if file_meta.inverted_index_available() {
+                        write_cache
+                            .remove(IndexKey::new(
+                                file_meta.region_id,
+                                file_meta.file_id,
+                                FileType::Puffin,
+                            ))
+                            .await;
+                    }
+                    // Remove the SST file from the cache.
                     write_cache
                         .remove(IndexKey::new(
                             file_meta.region_id,
                             file_meta.file_id,
-                            FileType::Puffin,
+                            FileType::Parquet,
                         ))
                         .await;
                 }
-                // Remove the SST file from the cache.
-                write_cache
-                    .remove(IndexKey::new(
-                        file_meta.region_id,
-                        file_meta.file_id,
-                        FileType::Parquet,
-                    ))
-                    .await;
-            }
-        })) {
+            }),
+        );
+        if let Err(e) = self.scheduler.schedule(job) {
             error!(e; "Failed to schedule the file purge request");
         }
     }

--- a/src/mito2/src/sst/file_purger.rs
+++ b/src/mito2/src/sst/file_purger.rs
@@ -20,7 +20,7 @@ use common_telemetry::{error, info};
 use crate::access_layer::AccessLayerRef;
 use crate::cache::file_cache::{FileType, IndexKey};
 use crate::cache::CacheManagerRef;
-use crate::schedule::scheduler::{Job, SchedulerRef};
+use crate::schedule::scheduler::{Job, Priority, SchedulerRef};
 use crate::sst::file::FileMeta;
 
 /// Request to remove a file.
@@ -81,6 +81,7 @@ impl FilePurger for LocalFilePurger {
         let cache_manager = self.cache_manager.clone();
         let job = Job::new(
             "purge",
+            Priority::Low(None),
             Box::pin(async move {
                 if let Err(e) = sst_layer.delete_sst(&file_meta).await {
                     error!(e; "Failed to delete SST file, file_id: {}, region: {}",


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
This PR adds priorities to background tasks like flush/compaction/file purge.

In current local scheduler implementation, the scheduler spawns some corountines to poll background tasks from a FIFO and wait until the job finishes then poll the next one. In intense insert workloads, the flush jobs would be blocked by compaction jobs if we don't assign a priority to background jobs.

This PR introduces an asynchronous priority channel with two levels: High and Low. It includes an optional deadline for low-priority jobs. The channel first attempts to poll jobs from the high-priority queue, switching to the low-priority queue only if the high-priority queue is empty. If a job at the head of the low-priority queue reaches its deadline, it will be polled immediately. Although jobs in low-priority channel have deadline, all jobs enqueued still follow the FIFO convention.


## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
