### PR TITLE
fix: error in admin function is not formatted properly

### DIFF
--- a/src/operator/src/statement/admin.rs
+++ b/src/operator/src/statement/admin.rs
@@ -59,7 +59,7 @@ impl StatementExecutor {
             .map(|arg| {
                 let FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(value))) = arg else {
                     return error::BuildAdminFunctionArgsSnafu {
-                        msg: "unsupported function arg {arg}",
+                        msg: format!("unsupported function arg {arg}"),
                     }
                     .fail();
                 };
@@ -200,7 +200,7 @@ fn values_to_vectors_by_valid_types(
             }
 
             error::BuildAdminFunctionArgsSnafu {
-                msg: "failed to cast {value}",
+                msg: format!("failed to cast {value}"),
             }
             .fail()
         })


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Prior to this change, the error is something like
```
MySQL [(none)]> admin flush_table(phy);
ERROR 1210 (HY000): (InvalidArguments): Failed to build admin function args: unsupported function arg {arg}
```

which doesn't format `arg` in error message.

## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
