### PR TITLE
fix: case sensitive for __field__ matcher

### DIFF
--- a/src/query/src/promql/planner.rs
+++ b/src/query/src/promql/planner.rs
@@ -805,10 +805,11 @@ impl PromPlanner {
 
             let exprs = result_set
                 .into_iter()
-                .map(|col| DfExpr::Column(col.into()))
+                .map(|col| DfExpr::Column(Column::new_unqualified(col)))
                 .chain(self.create_tag_column_exprs()?)
                 .chain(Some(self.create_time_index_column_expr()?))
                 .collect::<Vec<_>>();
+
             // reuse this variable for simplicity
             table_scan = LogicalPlanBuilder::from(table_scan)
                 .project(exprs)

--- a/tests/cases/standalone/common/tql/basic.result
+++ b/tests/cases/standalone/common/tql/basic.result
@@ -123,3 +123,30 @@ DROP TABLE test;
 
 Affected Rows: 0
 
+CREATE TABLE test (`Field_I` DOUBLE, `Ts_J` TIMESTAMP TIME INDEX, `Tag_K` STRING PRIMARY KEY);
+
+Affected Rows: 0
+
+INSERT INTO test VALUES (1, 1, "a"), (1, 1, "b"), (2, 2, "a");
+
+Affected Rows: 3
+
+TQL EVAL (0, 10, '5s') test{__field__="Field_I"};
+
++---------+-------+---------------------+
+| Field_I | Tag_K | Ts_J                |
++---------+-------+---------------------+
+| 2.0     | a     | 1970-01-01T00:00:05 |
+| 2.0     | a     | 1970-01-01T00:00:10 |
+| 1.0     | b     | 1970-01-01T00:00:05 |
+| 1.0     | b     | 1970-01-01T00:00:10 |
++---------+-------+---------------------+
+
+TQL EVAL (0, 10, '5s') test{__field__="field_i"};
+
+Error: 1004(InvalidArguments), Cannot find column field_i
+
+drop table test;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/tql/basic.sql
+++ b/tests/cases/standalone/common/tql/basic.sql
@@ -32,3 +32,13 @@ TQL EVAL ('1970-01-01T00:00:00'::timestamp, '1970-01-01T00:00:00'::timestamp + '
 TQL EVAL (now() - now(), now() -  (now() - '10 seconds'::interval), '1s')  test{k="a"};
 
 DROP TABLE test;
+
+CREATE TABLE test (`Field_I` DOUBLE, `Ts_J` TIMESTAMP TIME INDEX, `Tag_K` STRING PRIMARY KEY);
+
+INSERT INTO test VALUES (1, 1, "a"), (1, 1, "b"), (2, 2, "a");
+
+TQL EVAL (0, 10, '5s') test{__field__="Field_I"};
+
+TQL EVAL (0, 10, '5s') test{__field__="field_i"};
+
+drop table test;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Closes https://github.com/GreptimeTeam/greptimedb/issues/4786#top

## What's changed and what's your intention?


Make `__field__` in promql case sensitive

## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
