### PR TITLE
feat: defer `HeartbeatHandlerGroup` construction  and enhance `LeadershipChangeNotifier`

### DIFF
--- a/src/cmd/src/metasrv.rs
+++ b/src/cmd/src/metasrv.rs
@@ -48,6 +48,10 @@ impl Instance {
             _guard: guard,
         }
     }
+
+    pub fn mut_inner(&mut self) -> &mut MetasrvInstance {
+        &mut self.instance
+    }
 }
 
 #[async_trait]

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -653,7 +653,7 @@ impl StartCommand {
     }
 }
 
-struct StandaloneInformationExtension {
+pub struct StandaloneInformationExtension {
     region_server: RegionServer,
     procedure_manager: ProcedureManagerRef,
     start_time_ms: u64,

--- a/src/common/meta/src/leadership_notifier.rs
+++ b/src/common/meta/src/leadership_notifier.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use common_telemetry::error;
+use common_telemetry::{error, info};
 
 use crate::error::Result;
 
@@ -47,6 +47,7 @@ pub struct LeadershipChangeNotifier {
 
 impl LeadershipChangeNotifierCustomizer for LeadershipChangeNotifier {
     fn customize(&self, notifier: &mut LeadershipChangeNotifier) {
+        info!("Customizing leadership change notifier");
         notifier.listeners.extend(self.listeners.clone());
     }
 }

--- a/src/common/meta/src/leadership_notifier.rs
+++ b/src/common/meta/src/leadership_notifier.rs
@@ -45,6 +45,12 @@ pub struct LeadershipChangeNotifier {
     listeners: Vec<Arc<dyn LeadershipChangeListener>>,
 }
 
+impl LeadershipChangeNotifierCustomizer for LeadershipChangeNotifier {
+    fn customize(&self, notifier: &mut LeadershipChangeNotifier) {
+        notifier.listeners.extend(self.listeners.clone());
+    }
+}
+
 impl LeadershipChangeNotifier {
     /// Adds a listener to the notifier.
     pub fn add_listener(&mut self, listener: Arc<dyn LeadershipChangeListener>) {

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -98,7 +98,7 @@ impl MetasrvInstance {
     }
 
     pub async fn start(&mut self) -> Result<()> {
-        self.metasrv.build_heartbeat_handler()?;
+        self.metasrv.build_heartbeat_handler_group()?;
         self.metasrv.try_start().await?;
 
         if let Some(t) = self.export_metrics_task.as_ref() {

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -98,6 +98,7 @@ impl MetasrvInstance {
     }
 
     pub async fn start(&mut self) -> Result<()> {
+        self.metasrv.build_heartbeat_handler()?;
         self.metasrv.try_start().await?;
 
         if let Some(t) = self.export_metrics_task.as_ref() {

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -98,7 +98,6 @@ impl MetasrvInstance {
     }
 
     pub async fn start(&mut self) -> Result<()> {
-        self.metasrv.build_heartbeat_handler_group()?;
         self.metasrv.try_start().await?;
 
         if let Some(t) = self.export_metrics_task.as_ref() {

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -148,6 +148,10 @@ impl MetasrvInstance {
     pub fn plugins(&self) -> Plugins {
         self.plugins.clone()
     }
+
+    pub fn mut_inner(&mut self) -> &mut Metasrv {
+        &mut self.metasrv
+    }
 }
 
 pub async fn bootstrap_metasrv_with_router(

--- a/src/meta-srv/src/handler.rs
+++ b/src/meta-srv/src/handler.rs
@@ -531,19 +531,19 @@ impl HeartbeatHandlerGroupBuilder {
     /// Builds the group of heartbeat handlers.
     ///
     /// Applies the customizer if it exists.
-    pub fn build(&mut self) -> Result<HeartbeatHandlerGroup> {
+    pub fn build(mut self) -> Result<HeartbeatHandlerGroup> {
         if let Some(customizer) = self
             .plugins
             .as_ref()
             .and_then(|plugins| plugins.get::<HeartbeatHandlerGroupBuilderCustomizerRef>())
         {
             debug!("Customizing the heartbeat handler group builder");
-            customizer.customize(self)?;
+            customizer.customize(&mut self)?;
         }
 
         Ok(HeartbeatHandlerGroup {
-            handlers: self.handlers.clone(),
-            pushers: self.pushers.clone(),
+            handlers: self.handlers,
+            pushers: self.pushers,
         })
     }
 

--- a/src/meta-srv/src/handler.rs
+++ b/src/meta-srv/src/handler.rs
@@ -209,15 +209,16 @@ impl Pushers {
     }
 }
 
+#[derive(Clone)]
 struct NameCachedHandler {
     name: &'static str,
-    handler: Box<dyn HeartbeatHandler>,
+    handler: Arc<dyn HeartbeatHandler>,
 }
 
 impl NameCachedHandler {
     fn new(handler: impl HeartbeatHandler + 'static) -> Self {
         let name = handler.name();
-        let handler = Box::new(handler);
+        let handler = Arc::new(handler);
         Self { name, handler }
     }
 }
@@ -225,7 +226,7 @@ impl NameCachedHandler {
 pub type HeartbeatHandlerGroupRef = Arc<HeartbeatHandlerGroup>;
 
 /// The group of heartbeat handlers.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct HeartbeatHandlerGroup {
     handlers: Vec<NameCachedHandler>,
     pushers: Pushers,
@@ -457,6 +458,18 @@ pub struct HeartbeatHandlerGroupBuilder {
 
     /// The group of heartbeat handlers.
     handlers: Vec<NameCachedHandler>,
+}
+
+impl From<&HeartbeatHandlerGroup> for HeartbeatHandlerGroupBuilder {
+    fn from(value: &HeartbeatHandlerGroup) -> Self {
+        HeartbeatHandlerGroupBuilder {
+            region_failure_handler: None,
+            region_lease_handler: None,
+            plugins: None,
+            pushers: value.pushers.clone(),
+            handlers: value.handlers.clone(),
+        }
+    }
 }
 
 impl HeartbeatHandlerGroupBuilder {

--- a/src/meta-srv/src/handler.rs
+++ b/src/meta-srv/src/handler.rs
@@ -443,6 +443,7 @@ impl Mailbox for HeartbeatMailbox {
 }
 
 /// The builder to build the group of heartbeat handlers.
+#[derive(Clone)]
 pub struct HeartbeatHandlerGroupBuilder {
     /// The handler to handle region failure.
     region_failure_handler: Option<RegionFailureHandler>,
@@ -458,18 +459,6 @@ pub struct HeartbeatHandlerGroupBuilder {
 
     /// The group of heartbeat handlers.
     handlers: Vec<NameCachedHandler>,
-}
-
-impl From<&HeartbeatHandlerGroup> for HeartbeatHandlerGroupBuilder {
-    fn from(value: &HeartbeatHandlerGroup) -> Self {
-        HeartbeatHandlerGroupBuilder {
-            region_failure_handler: None,
-            region_lease_handler: None,
-            plugins: None,
-            pushers: value.pushers.clone(),
-            handlers: value.handlers.clone(),
-        }
-    }
 }
 
 impl HeartbeatHandlerGroupBuilder {

--- a/src/meta-srv/src/handler.rs
+++ b/src/meta-srv/src/handler.rs
@@ -531,19 +531,19 @@ impl HeartbeatHandlerGroupBuilder {
     /// Builds the group of heartbeat handlers.
     ///
     /// Applies the customizer if it exists.
-    pub fn build(mut self) -> Result<HeartbeatHandlerGroup> {
+    pub fn build(&mut self) -> Result<HeartbeatHandlerGroup> {
         if let Some(customizer) = self
             .plugins
             .as_ref()
             .and_then(|plugins| plugins.get::<HeartbeatHandlerGroupBuilderCustomizerRef>())
         {
             debug!("Customizing the heartbeat handler group builder");
-            customizer.customize(&mut self)?;
+            customizer.customize(self)?;
         }
 
         Ok(HeartbeatHandlerGroup {
-            handlers: self.handlers.into_iter().collect(),
-            pushers: self.pushers,
+            handlers: self.handlers.clone(),
+            pushers: self.pushers.clone(),
         })
     }
 

--- a/src/meta-srv/src/handler/failure_handler.rs
+++ b/src/meta-srv/src/handler/failure_handler.rs
@@ -21,6 +21,7 @@ use crate::handler::{HandleControl, HeartbeatAccumulator, HeartbeatHandler};
 use crate::metasrv::Context;
 use crate::region::supervisor::{DatanodeHeartbeat, HeartbeatAcceptor, RegionSupervisor};
 
+#[derive(Clone)]
 pub struct RegionFailureHandler {
     heartbeat_acceptor: HeartbeatAcceptor,
 }

--- a/src/meta-srv/src/handler/region_lease_handler.rs
+++ b/src/meta-srv/src/handler/region_lease_handler.rs
@@ -26,6 +26,7 @@ use crate::metasrv::Context;
 use crate::region::lease_keeper::{RegionLeaseKeeperRef, RenewRegionLeasesResponse};
 use crate::region::RegionLeaseKeeper;
 
+#[derive(Clone)]
 pub struct RegionLeaseHandler {
     region_lease_seconds: u64,
     region_lease_keeper: RegionLeaseKeeperRef,

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -372,7 +372,7 @@ pub struct Metasrv {
 
 impl Metasrv {
     pub fn build_heartbeat_handler(&mut self) -> Result<()> {
-        self.handler_group = Some(Arc::new(self.handler_group_builder.clone().build()?));
+        self.handler_group = Some(Arc::new(self.handler_group_builder.build()?));
 
         Ok(())
     }

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -55,7 +55,9 @@ use crate::error::{
     StopProcedureManagerSnafu,
 };
 use crate::failure_detector::PhiAccrualFailureDetectorOptions;
-use crate::handler::HeartbeatHandlerGroupRef;
+use crate::handler::{
+    HeartbeatHandlerGroup, HeartbeatHandlerGroupBuilder, HeartbeatHandlerGroupRef,
+};
 use crate::lease::lookup_datanode_peer;
 use crate::procedure::region_migration::manager::RegionMigrationManagerRef;
 use crate::procedure::ProcedureManagerListenerAdapter;
@@ -560,6 +562,15 @@ impl Metasrv {
 
     pub fn handler_group(&self) -> &HeartbeatHandlerGroupRef {
         &self.handler_group
+    }
+
+    pub fn modify_handler_group<F>(&mut self, f: F) -> Result<()>
+    where
+        F: FnOnce(HeartbeatHandlerGroupBuilder) -> Result<HeartbeatHandlerGroup>,
+    {
+        let builder = HeartbeatHandlerGroupBuilder::from(self.handler_group.as_ref());
+        self.handler_group = Arc::new(f(builder)?);
+        Ok(())
     }
 
     pub fn election(&self) -> Option<&ElectionRef> {

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -371,12 +371,6 @@ pub struct Metasrv {
 }
 
 impl Metasrv {
-    pub fn build_heartbeat_handler(&mut self) -> Result<()> {
-        self.handler_group = Some(Arc::new(self.handler_group_builder.build()?));
-
-        Ok(())
-    }
-
     pub async fn try_start(&self) -> Result<()> {
         if self
             .started
@@ -571,6 +565,12 @@ impl Metasrv {
 
     pub fn handler_group_builder(&mut self) -> &mut HeartbeatHandlerGroupBuilder {
         &mut self.handler_group_builder
+    }
+
+    pub fn build_heartbeat_handler_group(&mut self) -> Result<()> {
+        self.handler_group = Some(Arc::new(self.handler_group_builder.build()?));
+
+        Ok(())
     }
 
     pub fn election(&self) -> Option<&ElectionRef> {

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -372,7 +372,7 @@ impl MetasrvBuilder {
             // TODO(jeremy): We do not allow configuring the flow selector.
             flow_selector: Arc::new(RoundRobinSelector::new(SelectTarget::Flownode)),
             handler_group: None,
-            handler_group_builder,
+            handler_group_builder: Some(handler_group_builder),
             election,
             procedure_manager,
             mailbox,

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -48,9 +48,7 @@ use crate::flow_meta_alloc::FlowPeerAllocator;
 use crate::greptimedb_telemetry::get_greptimedb_telemetry_task;
 use crate::handler::failure_handler::RegionFailureHandler;
 use crate::handler::region_lease_handler::RegionLeaseHandler;
-use crate::handler::{
-    HeartbeatHandlerGroup, HeartbeatHandlerGroupBuilder, HeartbeatMailbox, Pushers,
-};
+use crate::handler::{HeartbeatHandlerGroupBuilder, HeartbeatMailbox, Pushers};
 use crate::lease::MetaPeerLookupService;
 use crate::metasrv::{
     ElectionRef, Metasrv, MetasrvInfo, MetasrvOptions, SelectorContext, SelectorRef, TABLE_ID_SEQ,
@@ -74,7 +72,7 @@ pub struct MetasrvBuilder {
     kv_backend: Option<KvBackendRef>,
     in_memory: Option<ResettableKvBackendRef>,
     selector: Option<SelectorRef>,
-    handler_group: Option<HeartbeatHandlerGroup>,
+    handler_group_builder: Option<HeartbeatHandlerGroupBuilder>,
     election: Option<ElectionRef>,
     meta_peer_client: Option<MetaPeerClientRef>,
     node_manager: Option<NodeManagerRef>,
@@ -88,7 +86,7 @@ impl MetasrvBuilder {
             kv_backend: None,
             in_memory: None,
             selector: None,
-            handler_group: None,
+            handler_group_builder: None,
             meta_peer_client: None,
             election: None,
             options: None,
@@ -118,8 +116,11 @@ impl MetasrvBuilder {
         self
     }
 
-    pub fn heartbeat_handler(mut self, handler_group: HeartbeatHandlerGroup) -> Self {
-        self.handler_group = Some(handler_group);
+    pub fn heartbeat_handler(
+        mut self,
+        handler_group_builder: HeartbeatHandlerGroupBuilder,
+    ) -> Self {
+        self.handler_group_builder = Some(handler_group_builder);
         self
     }
 
@@ -161,7 +162,7 @@ impl MetasrvBuilder {
             kv_backend,
             in_memory,
             selector,
-            handler_group,
+            handler_group_builder,
             node_manager,
             plugins,
             table_metadata_allocator,
@@ -338,8 +339,8 @@ impl MetasrvBuilder {
             .context(error::InitDdlManagerSnafu)?,
         );
 
-        let handler_group = match handler_group {
-            Some(handler_group) => handler_group,
+        let handler_group_builder = match handler_group_builder {
+            Some(handler_group_builder) => handler_group_builder,
             None => {
                 let region_lease_handler = RegionLeaseHandler::new(
                     distributed_time_constants::REGION_LEASE_SECS,
@@ -352,7 +353,6 @@ impl MetasrvBuilder {
                     .with_region_failure_handler(region_failover_handler)
                     .with_region_lease_handler(Some(region_lease_handler))
                     .add_default_handlers()
-                    .build()?
             }
         };
 
@@ -371,7 +371,8 @@ impl MetasrvBuilder {
             selector,
             // TODO(jeremy): We do not allow configuring the flow selector.
             flow_selector: Arc::new(RoundRobinSelector::new(SelectTarget::Flownode)),
-            handler_group: Arc::new(handler_group),
+            handler_group: None,
+            handler_group_builder,
             election,
             procedure_manager,
             mailbox,

--- a/src/meta-srv/src/mocks.rs
+++ b/src/meta-srv/src/mocks.rs
@@ -75,7 +75,7 @@ pub async fn mock(
     };
 
     let mut metasrv = builder.build().await.unwrap();
-    metasrv.build_heartbeat_handler().unwrap();
+    metasrv.build_heartbeat_handler_group().unwrap();
     metasrv.try_start().await.unwrap();
 
     let (client, server) = tokio::io::duplex(1024);

--- a/src/meta-srv/src/mocks.rs
+++ b/src/meta-srv/src/mocks.rs
@@ -74,7 +74,8 @@ pub async fn mock(
         None => builder,
     };
 
-    let metasrv = builder.build().await.unwrap();
+    let mut metasrv = builder.build().await.unwrap();
+    metasrv.build_heartbeat_handler().unwrap();
     metasrv.try_start().await.unwrap();
 
     let (client, server) = tokio::io::duplex(1024);

--- a/src/meta-srv/src/mocks.rs
+++ b/src/meta-srv/src/mocks.rs
@@ -75,7 +75,6 @@ pub async fn mock(
     };
 
     let mut metasrv = builder.build().await.unwrap();
-    metasrv.build_heartbeat_handler_group().unwrap();
     metasrv.try_start().await.unwrap();
 
     let (client, server) = tokio::io::duplex(1024);

--- a/src/meta-srv/src/region/supervisor.rs
+++ b/src/meta-srv/src/region/supervisor.rs
@@ -258,6 +258,7 @@ impl RegionFailureDetectorController for RegionFailureDetectorControl {
 }
 
 /// [`HeartbeatAcceptor`] forwards heartbeats to [`RegionSupervisor`].
+#[derive(Clone)]
 pub(crate) struct HeartbeatAcceptor {
     sender: Sender<Event>,
 }

--- a/src/meta-srv/src/service/heartbeat.rs
+++ b/src/meta-srv/src/service/heartbeat.rs
@@ -23,6 +23,7 @@ use api::v1::meta::{
 use common_telemetry::{debug, error, info, warn};
 use futures::StreamExt;
 use once_cell::sync::OnceCell;
+use snafu::OptionExt;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
 use tokio_stream::wrappers::ReceiverStream;
@@ -45,7 +46,13 @@ impl heartbeat_server::Heartbeat for Metasrv {
     ) -> GrpcResult<Self::HeartbeatStream> {
         let mut in_stream = req.into_inner();
         let (tx, rx) = mpsc::channel(128);
-        let handler_group = self.handler_group().clone();
+        let handler_group = self
+            .handler_group()
+            .clone()
+            .context(error::UnexpectedSnafu {
+                violated: "expected heartbeat handler",
+            })?;
+
         let ctx = self.new_ctx();
         let _handle = common_runtime::spawn_global(async move {
             let mut pusher_key = None;

--- a/src/meta-srv/src/service/heartbeat.rs
+++ b/src/meta-srv/src/service/heartbeat.rs
@@ -50,7 +50,7 @@ impl heartbeat_server::Heartbeat for Metasrv {
             .handler_group()
             .clone()
             .context(error::UnexpectedSnafu {
-                violated: "expected heartbeat handler",
+                violated: "expected heartbeat handlers",
             })?;
 
         let ctx = self.new_ctx();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

- Added `mut_inner` method to `Instance` and `MetasrvInstance` for mutable access to inner structs.
- Changed `NameCachedHandler` to use `Arc` instead of `Box` for `HeartbeatHandler`.
- Extended `LeadershipChangeNotifier` with a customizer trait to allow listener extensions.
- Made `StandaloneInformationExtension` public for external use.
- Defer  `HeartbeatHandlerGroup` construction.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
