### PR TITLE
feat: cache logical region's metadata

### DIFF
--- a/src/metric-engine/src/engine/alter.rs
+++ b/src/metric-engine/src/engine/alter.rs
@@ -84,6 +84,12 @@ impl MetricEngineInner {
             return Ok(physical_region_id);
         };
 
+        // lock metadata region for this logical region id
+        let _write_guard = self
+            .metadata_region
+            .write_lock_logical_region(logical_region_id)
+            .await;
+
         let metadata_region_id = to_metadata_region_id(physical_region_id);
         let mut columns_to_add = vec![];
         for col in &columns {

--- a/src/metric-engine/src/engine/alter.rs
+++ b/src/metric-engine/src/engine/alter.rs
@@ -64,15 +64,19 @@ impl MetricEngineInner {
     /// Return the physical region id behind this logical region
     async fn alter_logical_region(
         &self,
-        region_id: RegionId,
+        logical_region_id: RegionId,
         request: RegionAlterRequest,
     ) -> Result<RegionId> {
         let physical_region_id = {
             let state = &self.state.read().unwrap();
-            state.get_physical_region_id(region_id).with_context(|| {
-                error!("Trying to alter an nonexistent region {region_id}");
-                LogicalRegionNotFoundSnafu { region_id }
-            })?
+            state
+                .get_physical_region_id(logical_region_id)
+                .with_context(|| {
+                    error!("Trying to alter an nonexistent region {logical_region_id}");
+                    LogicalRegionNotFoundSnafu {
+                        region_id: logical_region_id,
+                    }
+                })?
         };
 
         // only handle adding column
@@ -87,7 +91,7 @@ impl MetricEngineInner {
                 .metadata_region
                 .column_semantic_type(
                     metadata_region_id,
-                    region_id,
+                    logical_region_id,
                     &col.column_metadata.column_schema.name,
                 )
                 .await?
@@ -102,7 +106,7 @@ impl MetricEngineInner {
         self.add_columns_to_physical_data_region(
             data_region_id,
             metadata_region_id,
-            region_id,
+            logical_region_id,
             columns_to_add,
         )
         .await?;
@@ -110,9 +114,15 @@ impl MetricEngineInner {
         // register columns to logical region
         for col in columns {
             self.metadata_region
-                .add_column(metadata_region_id, region_id, &col.column_metadata)
+                .add_column(metadata_region_id, logical_region_id, &col.column_metadata)
                 .await?;
         }
+
+        // invalid logical column cache
+        self.state
+            .write()
+            .unwrap()
+            .invalid_logical_column_cache(logical_region_id);
 
         Ok(physical_region_id)
     }

--- a/src/metric-engine/src/engine/read.rs
+++ b/src/metric-engine/src/engine/read.rs
@@ -169,11 +169,11 @@ impl MetricEngineInner {
     ) -> Result<Vec<usize>> {
         // project on logical columns
         let all_logical_columns = self
-            .load_logical_columns(physical_region_id, logical_region_id)
+            .load_logical_column_names(physical_region_id, logical_region_id)
             .await?;
         let projected_logical_names = origin_projection
             .iter()
-            .map(|i| all_logical_columns[*i].column_schema.name.clone())
+            .map(|i| all_logical_columns[*i].clone())
             .collect::<Vec<_>>();
 
         // generate physical projection
@@ -200,10 +200,8 @@ impl MetricEngineInner {
         logical_region_id: RegionId,
     ) -> Result<Vec<usize>> {
         let logical_columns = self
-            .load_logical_columns(physical_region_id, logical_region_id)
-            .await?
-            .into_iter()
-            .map(|col| col.column_schema.name);
+            .load_logical_column_names(physical_region_id, logical_region_id)
+            .await?;
         let mut projection = Vec::with_capacity(logical_columns.len());
         let data_region_id = utils::to_data_region_id(physical_region_id);
         let physical_metadata = self

--- a/src/metric-engine/src/engine/region_metadata.rs
+++ b/src/metric-engine/src/engine/region_metadata.rs
@@ -23,13 +23,25 @@ use crate::error::Result;
 impl MetricEngineInner {
     /// Load column metadata of a logical region.
     ///
-    /// The return value is ordered on [ColumnId].
+    /// The return value is ordered on column name.
     pub async fn load_logical_columns(
         &self,
         physical_region_id: RegionId,
         logical_region_id: RegionId,
     ) -> Result<Vec<ColumnMetadata>> {
-        // load logical and physical columns, and intersect them to get logical column metadata
+        // First try to load from state cache
+        if let Some(columns) = self
+            .state
+            .read()
+            .unwrap()
+            .logical_columns()
+            .get(&logical_region_id)
+        {
+            return Ok(columns.clone());
+        }
+
+        // Else load from metadata region and update the cache.
+        // Load logical and physical columns, and intersect them to get logical column metadata.
         let mut logical_column_metadata = self
             .metadata_region
             .logical_columns(physical_region_id, logical_region_id)
@@ -37,11 +49,48 @@ impl MetricEngineInner {
             .into_iter()
             .map(|(_, column_metadata)| column_metadata)
             .collect::<Vec<_>>();
-
-        // sort columns on column id to ensure the order
+        // Sort columns on column name to ensure the order
         logical_column_metadata
             .sort_unstable_by(|c1, c2| c1.column_schema.name.cmp(&c2.column_schema.name));
+        // Update cache
+        self.state
+            .write()
+            .unwrap()
+            .add_logical_columns(logical_region_id, logical_column_metadata.clone());
 
         Ok(logical_column_metadata)
+    }
+
+    /// Load logical column names of a logical region.
+    ///
+    /// The return value is ordered on column name alphabetically.
+    pub async fn load_logical_column_names(
+        &self,
+        physical_region_id: RegionId,
+        logical_region_id: RegionId,
+    ) -> Result<Vec<String>> {
+        // First try to load from state cache
+        if let Some(columns) = self
+            .state
+            .read()
+            .unwrap()
+            .logical_columns()
+            .get(&logical_region_id)
+        {
+            return Ok(columns
+                .iter()
+                .map(|c| c.column_schema.name.clone())
+                .collect());
+        }
+
+        // Else load from metadata region
+        let columns = self
+            .load_logical_columns(physical_region_id, logical_region_id)
+            .await?
+            .into_iter()
+            .map(|c| c.column_schema.name)
+            .collect::<Vec<_>>();
+
+        Ok(columns)
     }
 }

--- a/src/metric-engine/src/engine/region_metadata.rs
+++ b/src/metric-engine/src/engine/region_metadata.rs
@@ -41,6 +41,10 @@ impl MetricEngineInner {
         }
 
         // Else load from metadata region and update the cache.
+        let _read_guard = self
+            .metadata_region
+            .read_lock_logical_region(logical_region_id)
+            .await;
         // Load logical and physical columns, and intersect them to get logical column metadata.
         let mut logical_column_metadata = self
             .metadata_region

--- a/src/metric-engine/src/metadata_region.rs
+++ b/src/metric-engine/src/metadata_region.rs
@@ -58,7 +58,7 @@ const COLUMN_PREFIX: &str = "__column_";
 /// itself.
 pub struct MetadataRegion {
     mito: MitoEngine,
-    /// Logical lock for operations that need to be serialized. Like update & read region columnns.
+    /// Logical lock for operations that need to be serialized. Like update & read region columns.
     ///
     /// Region entry will be registered on creating and opening logical region, and deregistered on
     /// removing logical region.

--- a/src/metric-engine/src/metadata_region.rs
+++ b/src/metric-engine/src/metadata_region.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use api::v1::value::ValueData;
 use api::v1::{ColumnDataType, ColumnSchema, Row, Rows, SemanticType, Value};
@@ -21,7 +22,7 @@ use base64::Engine;
 use common_recordbatch::util::collect;
 use datafusion::prelude::{col, lit};
 use mito2::engine::MitoEngine;
-use snafu::ResultExt;
+use snafu::{OptionExt, ResultExt};
 use store_api::metadata::ColumnMetadata;
 use store_api::metric_engine_consts::{
     METADATA_SCHEMA_KEY_COLUMN_INDEX, METADATA_SCHEMA_KEY_COLUMN_NAME,
@@ -31,11 +32,12 @@ use store_api::metric_engine_consts::{
 use store_api::region_engine::RegionEngine;
 use store_api::region_request::{RegionDeleteRequest, RegionPutRequest};
 use store_api::storage::{RegionId, ScanRequest};
+use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock};
 
 use crate::error::{
     CollectRecordBatchStreamSnafu, DecodeColumnValueSnafu, DeserializeColumnMetadataSnafu,
-    MitoReadOperationSnafu, MitoWriteOperationSnafu, ParseRegionIdSnafu, RegionAlreadyExistsSnafu,
-    Result,
+    LogicalRegionNotFoundSnafu, MitoReadOperationSnafu, MitoWriteOperationSnafu,
+    ParseRegionIdSnafu, RegionAlreadyExistsSnafu, Result,
 };
 use crate::utils;
 
@@ -56,11 +58,19 @@ const COLUMN_PREFIX: &str = "__column_";
 /// itself.
 pub struct MetadataRegion {
     mito: MitoEngine,
+    /// Logical lock for operations that need to be serialized. Like update & read region columnns.
+    ///
+    /// Region entry will be registered on creating and opening logical region, and deregistered on
+    /// removing logical region.
+    logical_region_lock: RwLock<HashMap<RegionId, Arc<RwLock<()>>>>,
 }
 
 impl MetadataRegion {
     pub fn new(mito: MitoEngine) -> Self {
-        Self { mito }
+        Self {
+            mito,
+            logical_region_lock: RwLock::new(HashMap::new()),
+        }
     }
 
     /// Add a new table key to metadata.
@@ -85,8 +95,19 @@ impl MetadataRegion {
             }
             .fail()
         } else {
+            self.logical_region_lock
+                .write()
+                .await
+                .insert(logical_region_id, Arc::new(RwLock::new(())));
             Ok(())
         }
+    }
+
+    pub async fn open_logical_region(&self, logical_region_id: RegionId) {
+        self.logical_region_lock
+            .write()
+            .await
+            .insert(logical_region_id, Arc::new(RwLock::new(())));
     }
 
     /// Add a new column key to metadata.
@@ -109,6 +130,40 @@ impl MetadataRegion {
             Self::serialize_column_metadata(column_metadata),
         )
         .await
+    }
+
+    /// Retrieve a read lock guard of given logical region id.
+    pub async fn read_lock_logical_region(
+        &self,
+        logical_region_id: RegionId,
+    ) -> Result<OwnedRwLockReadGuard<()>> {
+        let lock = self
+            .logical_region_lock
+            .read()
+            .await
+            .get(&logical_region_id)
+            .context(LogicalRegionNotFoundSnafu {
+                region_id: logical_region_id,
+            })?
+            .clone();
+        Ok(RwLock::read_owned(lock).await)
+    }
+
+    /// Retrieve a write lock guard of given logical region id.
+    pub async fn write_lock_logical_region(
+        &self,
+        logical_region_id: RegionId,
+    ) -> Result<OwnedRwLockWriteGuard<()>> {
+        let lock = self
+            .logical_region_lock
+            .read()
+            .await
+            .get(&logical_region_id)
+            .context(LogicalRegionNotFoundSnafu {
+                region_id: logical_region_id,
+            })?
+            .clone();
+        Ok(RwLock::write_owned(lock).await)
     }
 
     /// Remove a registered logical region from metadata.
@@ -135,6 +190,11 @@ impl MetadataRegion {
         // remove region key and column keys
         column_keys.push(region_key);
         self.delete(region_id, &column_keys).await?;
+
+        self.logical_region_lock
+            .write()
+            .await
+            .remove(&logical_region_id);
 
         Ok(())
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


Cache logical region's metadata to accelerate query.

Given some metrics are likely never to be used, this cache is loaded lazily.


## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
