### PR TITLE
refactor: replace info logs with debug logs in region server

### DIFF
--- a/src/metric-engine/src/engine.rs
+++ b/src/metric-engine/src/engine.rs
@@ -338,7 +338,7 @@ mod test {
             .await
             .unwrap();
 
-        // close nonexistent region
+        // close nonexistent region won't report error
         let nonexistent_region_id = RegionId::new(12313, 12);
         engine
             .handle_request(
@@ -346,7 +346,7 @@ mod test {
                 RegionRequest::Close(RegionCloseRequest {}),
             )
             .await
-            .unwrap_err();
+            .unwrap();
 
         // open nonexistent region won't report error
         let invalid_open_request = RegionOpenRequest {

--- a/src/metric-engine/src/engine/close.rs
+++ b/src/metric-engine/src/engine/close.rs
@@ -14,13 +14,14 @@
 
 //! Close a metric region
 
+use common_telemetry::debug;
 use snafu::ResultExt;
 use store_api::region_engine::RegionEngine;
 use store_api::region_request::{AffectedRows, RegionCloseRequest, RegionRequest};
 use store_api::storage::RegionId;
 
 use super::MetricEngineInner;
-use crate::error::{CloseMitoRegionSnafu, LogicalRegionNotFoundSnafu, Result};
+use crate::error::{CloseMitoRegionSnafu, Result};
 use crate::metrics::PHYSICAL_REGION_COUNT;
 use crate::utils;
 
@@ -54,7 +55,8 @@ impl MetricEngineInner {
         {
             Ok(0)
         } else {
-            Err(LogicalRegionNotFoundSnafu { region_id }.build())
+            debug!("Closing a non-existent logical region {}", region_id);
+            Ok(0)
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Tidy some logs in the region server

 | before  | after   |
 | :-------: | :-------: |
 | <img width="711" alt="image" src="https://github.com/user-attachments/assets/1e1d9e85-681b-4ba8-9163-64a99958d0ad">   | Downgraded to debug log   |
 | <img width="989" alt="image" src="https://github.com/user-attachments/assets/83e3cbe6-74db-4e0a-ae6e-fe5436095329">   | Downgraded to debug log. With a new info log to display region counter. <img width="282" alt="image" src="https://github.com/user-attachments/assets/d9e180f7-b25b-439f-a2e2-1263dd7dea4a">   |
 |  <img width="951" alt="image" src="https://github.com/user-attachments/assets/ab762e50-d128-45d7-a8f9-7622b4f53b71"> | Downgraded to debug log  |


## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
