### PR TITLE
feat: introduce default customizers

### DIFF
--- a/src/cmd/src/metasrv.rs
+++ b/src/cmd/src/metasrv.rs
@@ -49,8 +49,8 @@ impl Instance {
         }
     }
 
-    pub fn mut_inner(&mut self) -> &mut MetasrvInstance {
-        &mut self.instance
+    pub fn get_inner(&self) -> &MetasrvInstance {
+        &self.instance
     }
 }
 
@@ -90,6 +90,14 @@ impl Command {
     pub fn load_options(&self, global_options: &GlobalOptions) -> Result<MetasrvOptions> {
         self.subcmd.load_options(global_options)
     }
+
+    pub fn config_file(&self) -> &Option<String> {
+        self.subcmd.config_file()
+    }
+
+    pub fn env_prefix(&self) -> &String {
+        self.subcmd.env_prefix()
+    }
 }
 
 #[derive(Parser)]
@@ -107,6 +115,18 @@ impl SubCommand {
     fn load_options(&self, global_options: &GlobalOptions) -> Result<MetasrvOptions> {
         match self {
             SubCommand::Start(cmd) => cmd.load_options(global_options),
+        }
+    }
+
+    fn config_file(&self) -> &Option<String> {
+        match self {
+            SubCommand::Start(cmd) => &cmd.config_file,
+        }
+    }
+
+    fn env_prefix(&self) -> &String {
+        match self {
+            SubCommand::Start(cmd) => &cmd.env_prefix,
         }
     }
 }

--- a/src/common/base/src/plugins.rs
+++ b/src/common/base/src/plugins.rs
@@ -38,6 +38,18 @@ impl Plugins {
         self.read().get::<T>().cloned()
     }
 
+    pub fn get_or_insert<T, F>(&self, f: F) -> T
+    where
+        T: 'static + Send + Sync + Clone,
+        F: FnOnce() -> T,
+    {
+        let mut binding = self.write();
+        if !binding.contains::<T>() {
+            binding.insert(f());
+        }
+        binding.get::<T>().cloned().unwrap()
+    }
+
     pub fn map_mut<T: 'static + Send + Sync, F, R>(&self, mapper: F) -> R
     where
         F: FnOnce(Option<&mut T>) -> R,

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -149,8 +149,8 @@ impl MetasrvInstance {
         self.plugins.clone()
     }
 
-    pub fn mut_inner(&mut self) -> &mut Metasrv {
-        &mut self.metasrv
+    pub fn get_inner(&self) -> &Metasrv {
+        &self.metasrv
     }
 }
 

--- a/src/meta-srv/src/handler.rs
+++ b/src/meta-srv/src/handler.rs
@@ -14,7 +14,7 @@
 
 use std::collections::{BTreeMap, HashSet};
 use std::ops::Range;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use api::v1::meta::mailbox_message::Payload;
@@ -210,7 +210,7 @@ impl Pushers {
 }
 
 #[derive(Clone)]
-struct NameCachedHandler {
+pub struct NameCachedHandler {
     name: &'static str,
     handler: Arc<dyn HeartbeatHandler>,
 }
@@ -547,15 +547,27 @@ impl HeartbeatHandlerGroupBuilder {
         })
     }
 
+    fn add_handler_after_inner(&mut self, target: &str, handler: NameCachedHandler) -> Result<()> {
+        if let Some(pos) = self.handlers.iter().position(|x| x.name == target) {
+            self.handlers.insert(pos + 1, handler);
+            return Ok(());
+        }
+
+        error::HandlerNotFoundSnafu { name: target }.fail()
+    }
+
     /// Adds the handler after the specified handler.
     pub fn add_handler_after(
         &mut self,
         target: &'static str,
         handler: impl HeartbeatHandler + 'static,
     ) -> Result<()> {
+        self.add_handler_after_inner(target, NameCachedHandler::new(handler))
+    }
+
+    fn add_handler_before_inner(&mut self, target: &str, handler: NameCachedHandler) -> Result<()> {
         if let Some(pos) = self.handlers.iter().position(|x| x.name == target) {
-            self.handlers
-                .insert(pos + 1, NameCachedHandler::new(handler));
+            self.handlers.insert(pos, handler);
             return Ok(());
         }
 
@@ -568,8 +580,12 @@ impl HeartbeatHandlerGroupBuilder {
         target: &'static str,
         handler: impl HeartbeatHandler + 'static,
     ) -> Result<()> {
+        self.add_handler_before_inner(target, NameCachedHandler::new(handler))
+    }
+
+    fn replace_handler_inner(&mut self, target: &str, handler: NameCachedHandler) -> Result<()> {
         if let Some(pos) = self.handlers.iter().position(|x| x.name == target) {
-            self.handlers.insert(pos, NameCachedHandler::new(handler));
+            self.handlers[pos] = handler;
             return Ok(());
         }
 
@@ -582,25 +598,115 @@ impl HeartbeatHandlerGroupBuilder {
         target: &'static str,
         handler: impl HeartbeatHandler + 'static,
     ) -> Result<()> {
-        if let Some(pos) = self.handlers.iter().position(|x| x.name == target) {
-            self.handlers[pos] = NameCachedHandler::new(handler);
-            return Ok(());
-        }
+        self.replace_handler_inner(target, NameCachedHandler::new(handler))
+    }
 
-        error::HandlerNotFoundSnafu { name: target }.fail()
+    fn add_handler_last_inner(&mut self, handler: NameCachedHandler) {
+        self.handlers.push(handler);
     }
 
     fn add_handler_last(&mut self, handler: impl HeartbeatHandler + 'static) {
-        self.handlers.push(NameCachedHandler::new(handler));
+        self.add_handler_last_inner(NameCachedHandler::new(handler));
     }
 }
 
 pub type HeartbeatHandlerGroupBuilderCustomizerRef =
     Arc<dyn HeartbeatHandlerGroupBuilderCustomizer>;
 
+pub enum CustomizeHeartbeatGroup {
+    AddHandlerAfter {
+        target: String,
+        handler: NameCachedHandler,
+    },
+    AddHandlerBefore {
+        target: String,
+        handler: NameCachedHandler,
+    },
+    ReplaceHandler {
+        target: String,
+        handler: NameCachedHandler,
+    },
+    AddHandlerLast {
+        handler: NameCachedHandler,
+    },
+}
+
+impl CustomizeHeartbeatGroup {
+    pub fn new_add_handler_after(
+        target: &'static str,
+        handler: impl HeartbeatHandler + 'static,
+    ) -> Self {
+        Self::AddHandlerAfter {
+            target: target.to_string(),
+            handler: NameCachedHandler::new(handler),
+        }
+    }
+
+    pub fn new_add_handler_before(
+        target: &'static str,
+        handler: impl HeartbeatHandler + 'static,
+    ) -> Self {
+        Self::AddHandlerBefore {
+            target: target.to_string(),
+            handler: NameCachedHandler::new(handler),
+        }
+    }
+
+    pub fn new_replace_handler(
+        target: &'static str,
+        handler: impl HeartbeatHandler + 'static,
+    ) -> Self {
+        Self::ReplaceHandler {
+            target: target.to_string(),
+            handler: NameCachedHandler::new(handler),
+        }
+    }
+
+    pub fn new_add_handler_last(handler: impl HeartbeatHandler + 'static) -> Self {
+        Self::AddHandlerLast {
+            handler: NameCachedHandler::new(handler),
+        }
+    }
+}
+
 /// The customizer of the [`HeartbeatHandlerGroupBuilder`].
 pub trait HeartbeatHandlerGroupBuilderCustomizer: Send + Sync {
     fn customize(&self, builder: &mut HeartbeatHandlerGroupBuilder) -> Result<()>;
+
+    fn add_action(&self, action: CustomizeHeartbeatGroup);
+}
+
+#[derive(Default)]
+pub struct DefaultHeartbeatHandlerGroupBuilderCustomizer {
+    action: Mutex<Vec<CustomizeHeartbeatGroup>>,
+}
+
+impl HeartbeatHandlerGroupBuilderCustomizer for DefaultHeartbeatHandlerGroupBuilderCustomizer {
+    fn customize(&self, builder: &mut HeartbeatHandlerGroupBuilder) -> Result<()> {
+        info!("Customizing the heartbeat handler group builder");
+        let mut actions = self.action.lock().unwrap();
+        for action in actions.drain(..) {
+            match action {
+                CustomizeHeartbeatGroup::AddHandlerAfter { target, handler } => {
+                    builder.add_handler_after_inner(&target, handler)?;
+                }
+                CustomizeHeartbeatGroup::AddHandlerBefore { target, handler } => {
+                    builder.add_handler_before_inner(&target, handler)?;
+                }
+                CustomizeHeartbeatGroup::ReplaceHandler { target, handler } => {
+                    builder.replace_handler_inner(&target, handler)?;
+                }
+                CustomizeHeartbeatGroup::AddHandlerLast { handler } => {
+                    builder.add_handler_last_inner(handler);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn add_action(&self, action: CustomizeHeartbeatGroup) {
+        self.action.lock().unwrap().push(action);
+    }
 }
 
 #[cfg(test)]

--- a/src/meta-srv/src/handler/filter_inactive_region_stats.rs
+++ b/src/meta-srv/src/handler/filter_inactive_region_stats.rs
@@ -20,6 +20,8 @@ use crate::error::Result;
 use crate::handler::{HandleControl, HeartbeatAccumulator, HeartbeatHandler};
 use crate::metasrv::Context;
 
+pub const NAME: &str = "FilterInactiveRegionStatsHandler";
+
 pub struct FilterInactiveRegionStatsHandler;
 
 #[async_trait]


### PR DESCRIPTION

I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

1. Introduce `DefaultHeartbeatHandlerGroupBuilderCustomizer` and `DefaultLeadershipChangeNotifierCustomizer`
2. Expose `env_prefix` and `config_file`

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
