### PR TITLE
chore: bump promql-parser to v0.4.1 and use `to_string()` for EvalStmt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8612,11 +8612,12 @@ dependencies = [
 
 [[package]]
 name = "promql-parser"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "007a331efb31f6ddb644590ef22359c9469784931162aad92599e34bcfa66583"
+checksum = "0c1ad4a4cfa84ec4aa5831c82e57af0a3faf3f0af83bee13fa1390b2d0a32dc9"
 dependencies = [
  "cfgrammar",
+ "chrono",
  "lazy_static",
  "lrlex",
  "lrpar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,7 @@ parquet = { version = "51.0.0", default-features = false, features = ["arrow", "
 paste = "1.0"
 pin-project = "1.0"
 prometheus = { version = "0.13.3", features = ["process"] }
-promql-parser = { version = "0.4" }
+promql-parser = { version = "0.4.1" }
 prost = "0.12"
 raft-engine = { version = "0.4.1", default-features = false }
 rand = "0.8"

--- a/src/query/src/stats.rs
+++ b/src/query/src/stats.rs
@@ -70,8 +70,7 @@ impl SlowQueryTimer {
                 slow!(
                     cost = elapsed.as_millis() as u64,
                     threshold = threshold.as_millis() as u64,
-                    // TODO(zyy17): It's better to implement Display for EvalStmt for pretty print.
-                    promql = format!("{:?}", stmt)
+                    promql = stmt.to_string()
                 );
             }
         }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

__!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
