### PR TITLE
feat: yields empty batch after reading a range

### DIFF
--- a/src/catalog/src/system_schema/memory_table.rs
+++ b/src/catalog/src/system_schema/memory_table.rs
@@ -74,7 +74,7 @@ impl MemoryTableBuilder {
     /// Construct the `information_schema.{table_name}` virtual table
     pub async fn memory_records(&mut self) -> Result<RecordBatch> {
         if self.columns.is_empty() {
-            RecordBatch::new_empty(self.schema.clone()).context(CreateRecordBatchSnafu)
+            Ok(RecordBatch::new_empty(self.schema.clone()))
         } else {
             RecordBatch::new(self.schema.clone(), std::mem::take(&mut self.columns))
                 .context(CreateRecordBatchSnafu)

--- a/src/common/recordbatch/src/recordbatch.rs
+++ b/src/common/recordbatch/src/recordbatch.rs
@@ -58,13 +58,13 @@ impl RecordBatch {
     }
 
     /// Create an empty [`RecordBatch`] from `schema`.
-    pub fn new_empty(schema: SchemaRef) -> Result<RecordBatch> {
+    pub fn new_empty(schema: SchemaRef) -> RecordBatch {
         let df_record_batch = DfRecordBatch::new_empty(schema.arrow_schema().clone());
-        Ok(RecordBatch {
+        RecordBatch {
             schema,
             columns: vec![],
             df_record_batch,
-        })
+        }
     }
 
     pub fn try_project(&self, indices: &[usize]) -> Result<Self> {

--- a/src/common/recordbatch/src/recordbatch.rs
+++ b/src/common/recordbatch/src/recordbatch.rs
@@ -17,6 +17,7 @@ use std::slice;
 use std::sync::Arc;
 
 use datafusion::arrow::util::pretty::pretty_format_batches;
+use datatypes::prelude::DataType;
 use datatypes::schema::SchemaRef;
 use datatypes::value::Value;
 use datatypes::vectors::{Helper, VectorRef};
@@ -60,9 +61,14 @@ impl RecordBatch {
     /// Create an empty [`RecordBatch`] from `schema`.
     pub fn new_empty(schema: SchemaRef) -> RecordBatch {
         let df_record_batch = DfRecordBatch::new_empty(schema.arrow_schema().clone());
+        let columns = schema
+            .column_schemas()
+            .iter()
+            .map(|col| col.data_type.create_mutable_vector(0).to_vector())
+            .collect();
         RecordBatch {
             schema,
-            columns: vec![],
+            columns,
             df_record_batch,
         }
     }

--- a/src/mito2/src/read.rs
+++ b/src/mito2/src/read.rs
@@ -516,9 +516,8 @@ impl Batch {
 
     /// Returns true if the given batch is behind the current batch.
     #[cfg(debug_assertions)]
-    pub(crate) fn is_behind(&self, other: &Batch) -> bool {
+    pub(crate) fn check_next_batch(&self, other: &Batch) -> bool {
         // Checks the primary key and then the timestamp.
-
         use std::cmp::Ordering;
         self.primary_key()
             .cmp(other.primary_key())
@@ -549,7 +548,7 @@ impl BatchChecker {
         let is_behind = self
             .last_batch
             .as_ref()
-            .map(|last| batch.is_behind(last))
+            .map(|last| last.check_next_batch(batch))
             .unwrap_or(true);
         self.last_batch = Some(batch.clone());
         is_behind
@@ -563,22 +562,22 @@ impl BatchChecker {
         if let Some(last) = &self.last_batch {
             write!(
                 message,
-                "last_pk: {:?}, last_ts: {:?}, last_seq: {:?}",
+                "last_pk: {:?}, last_ts: {:?}, last_seq: {:?}, ",
                 last.primary_key(),
                 last.last_timestamp(),
                 last.last_sequence()
             )
             .unwrap();
-        } else {
-            write!(
-                message,
-                "batch_pk: {:?}, batch_ts: {:?}, batch_seq: {:?}",
-                batch.primary_key(),
-                batch.timestamps(),
-                batch.sequences()
-            )
-            .unwrap();
         }
+        write!(
+            message,
+            "batch_pk: {:?}, batch_ts: {:?}, batch_seq: {:?}",
+            batch.primary_key(),
+            batch.timestamps(),
+            batch.sequences()
+        )
+        .unwrap();
+
         message
     }
 

--- a/src/mito2/src/read.rs
+++ b/src/mito2/src/read.rs
@@ -491,6 +491,117 @@ impl Batch {
         // Safety: sequences is not null so it actually returns Some.
         self.sequences.get_data(index).unwrap()
     }
+
+    /// Checks the batch is monotonic by timestamps.
+    #[cfg(debug_assertions)]
+    pub(crate) fn check_monotonic(&self) -> bool {
+        if self.timestamps_native().is_none() {
+            return true;
+        }
+
+        let timestamps = self.timestamps_native().unwrap();
+        let sequences = self.sequences.as_arrow().values();
+        timestamps.windows(2).enumerate().all(|(i, window)| {
+            let current = window[0];
+            let next = window[1];
+            let current_sequence = sequences[i];
+            let next_sequence = sequences[i + 1];
+            if current == next {
+                current_sequence >= next_sequence
+            } else {
+                current < next
+            }
+        })
+    }
+
+    /// Returns true if the given batch is behind the current batch.
+    #[cfg(debug_assertions)]
+    pub(crate) fn is_behind(&self, other: &Batch) -> bool {
+        // Checks the primary key and then the timestamp.
+
+        use std::cmp::Ordering;
+        self.primary_key()
+            .cmp(other.primary_key())
+            .then_with(|| self.last_timestamp().cmp(&other.first_timestamp()))
+            .then_with(|| other.first_sequence().cmp(&self.last_sequence()))
+            <= Ordering::Equal
+    }
+}
+
+/// A struct to check the batch is monotonic.
+#[cfg(debug_assertions)]
+#[derive(Default)]
+pub(crate) struct BatchChecker {
+    last_batch: Option<Batch>,
+}
+
+#[cfg(debug_assertions)]
+impl BatchChecker {
+    /// Returns true if the given batch is monotonic and behind
+    /// the last batch.
+    pub(crate) fn check_monotonic(&mut self, batch: &Batch) -> bool {
+        if !batch.check_monotonic() {
+            return false;
+        }
+
+        // Checks the batch is behind the last batch.
+        // Then Updates the last batch.
+        let is_behind = self
+            .last_batch
+            .as_ref()
+            .map(|last| batch.is_behind(last))
+            .unwrap_or(true);
+        self.last_batch = Some(batch.clone());
+        is_behind
+    }
+
+    /// Formats current batch and last batch for debug.
+    pub(crate) fn format_batch(&self, batch: &Batch) -> String {
+        use std::fmt::Write;
+
+        let mut message = String::new();
+        if let Some(last) = &self.last_batch {
+            write!(
+                message,
+                "last_pk: {:?}, last_ts: {:?}, last_seq: {:?}",
+                last.primary_key(),
+                last.last_timestamp(),
+                last.last_sequence()
+            )
+            .unwrap();
+        } else {
+            write!(
+                message,
+                "batch_pk: {:?}, batch_ts: {:?}, batch_seq: {:?}",
+                batch.primary_key(),
+                batch.timestamps(),
+                batch.sequences()
+            )
+            .unwrap();
+        }
+        message
+    }
+
+    /// Checks batches from the part range are monotonic. Otherwise, panics.
+    pub(crate) fn ensure_part_range_batch(
+        &mut self,
+        scanner: &str,
+        region_id: store_api::storage::RegionId,
+        partition: usize,
+        part_range: store_api::region_engine::PartitionRange,
+        batch: &Batch,
+    ) {
+        if !self.check_monotonic(batch) {
+            panic!(
+                "{}: batch is not sorted, region_id: {}, partition: {}, part_range: {:?}, {}",
+                scanner,
+                region_id,
+                partition,
+                part_range,
+                self.format_batch(batch),
+            );
+        }
+    }
 }
 
 /// Len of timestamp in arrow row format.

--- a/src/mito2/src/read/projection.rs
+++ b/src/mito2/src/read/projection.rs
@@ -160,6 +160,11 @@ impl ProjectionMapper {
         self.output_schema.clone()
     }
 
+    /// Returns an empty [RecordBatch].
+    pub(crate) fn empty_record_batch(&self) -> RecordBatch {
+        RecordBatch::new_empty(self.output_schema.clone())
+    }
+
     /// Converts a [Batch] to a [RecordBatch].
     ///
     /// The batch must match the `projection` using to build the mapper.

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -203,6 +203,7 @@ impl SeqScan {
         let semaphore = self.semaphore.clone();
         let partition_ranges = self.properties.partitions[partition].clone();
         let compaction = self.compaction;
+        let distinguish_range = self.properties.distinguish_partition_range();
         let part_metrics = PartitionMetrics::new(
             self.stream_ctx.input.mapper.metadata().region_id,
             partition,
@@ -268,7 +269,7 @@ impl SeqScan {
 
                 // Yields an empty part to indicate this range is terminated.
                 // The query engine can use this to optimize some queries.
-                if !compaction {
+                if distinguish_range {
                     let yield_start = Instant::now();
                     yield stream_ctx.input.mapper.empty_record_batch();
                     metrics.yield_cost += yield_start.elapsed();

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -268,9 +268,11 @@ impl SeqScan {
 
                 // Yields an empty part to indicate this range is terminated.
                 // The query engine can use this to optimize some queries.
-                let yield_start = Instant::now();
-                yield stream_ctx.input.mapper.empty_record_batch();
-                metrics.yield_cost += yield_start.elapsed();
+                if !compaction {
+                    let yield_start = Instant::now();
+                    yield stream_ctx.input.mapper.empty_record_batch();
+                    metrics.yield_cost += yield_start.elapsed();
+                }
 
                 metrics.scan_cost += fetch_start.elapsed();
                 part_metrics.merge_metrics(&metrics);

--- a/src/mito2/src/read/unordered_scan.rs
+++ b/src/mito2/src/read/unordered_scan.rs
@@ -150,6 +150,10 @@ impl UnorderedScan {
                     metrics.num_batches += 1;
                     metrics.num_rows += batch.num_rows();
 
+                    if batch.is_empty() {
+                        continue;
+                    }
+
                     let convert_start = Instant::now();
                     let record_batch = stream_ctx.input.mapper.convert(&batch, cache)?;
                     metrics.convert_cost += convert_start.elapsed();
@@ -159,6 +163,12 @@ impl UnorderedScan {
 
                     fetch_start = Instant::now();
                 }
+
+                // Yields an empty part to indicate this range is terminated.
+                // The query engine can use this to optimize some queries.
+                let yield_start = Instant::now();
+                yield stream_ctx.input.mapper.empty_record_batch();
+                metrics.yield_cost += yield_start.elapsed();
 
                 metrics.scan_cost += fetch_start.elapsed();
                 part_metrics.merge_metrics(&metrics);

--- a/src/store-api/src/region_engine.rs
+++ b/src/store-api/src/region_engine.rs
@@ -203,6 +203,9 @@ pub struct ScannerProperties {
     /// Total rows that **may** return by scanner. This field is only read iff
     /// [ScannerProperties::append_mode] is true.
     total_rows: usize,
+
+    /// Whether to yield an empty batch to distinguish partition ranges.
+    distinguish_partition_range: bool,
 }
 
 impl ScannerProperties {
@@ -224,12 +227,19 @@ impl ScannerProperties {
         self
     }
 
+    /// Sets distinguish partition range for scanner.
+    pub fn with_distinguish_partition_range(mut self, distinguish_partition_range: bool) -> Self {
+        self.distinguish_partition_range = distinguish_partition_range;
+        self
+    }
+
     /// Creates a new [`ScannerProperties`] with the given partitioning.
     pub fn new(partitions: Vec<Vec<PartitionRange>>, append_mode: bool, total_rows: usize) -> Self {
         Self {
             partitions,
             append_mode,
             total_rows,
+            distinguish_partition_range: false,
         }
     }
 
@@ -243,6 +253,10 @@ impl ScannerProperties {
 
     pub fn total_rows(&self) -> usize {
         self.total_rows
+    }
+
+    pub fn distinguish_partition_range(&self) -> bool {
+        self.distinguish_partition_range
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
This PR adds an empty batch to the end of the stream for each `PartitionRange`.

It also adds a `BatchChecker` to validate batches in the scanner.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
