### PR TITLE
fix: flush metric metadata region

### DIFF
--- a/src/metric-engine/src/engine/catchup.rs
+++ b/src/metric-engine/src/engine/catchup.rs
@@ -47,9 +47,10 @@ impl MetricEngineInner {
             .await
             .context(MitoCatchupOperationSnafu)?;
 
+        let data_region_id = utils::to_data_region_id(region_id);
         self.mito
             .handle_request(
-                region_id,
+                data_region_id,
                 RegionRequest::Catchup(RegionCatchupRequest {
                     set_writable: req.set_writable,
                     entry_id: req.entry_id,

--- a/src/metric-engine/src/engine/flush.rs
+++ b/src/metric-engine/src/engine/flush.rs
@@ -10,7 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License.'
+// limitations under the License.
 
 use snafu::ResultExt;
 use store_api::region_engine::RegionEngine;
@@ -42,8 +42,9 @@ impl MetricEngineInner {
             .context(MitoFlushOperationSnafu)
             .map(|response| response.affected_rows)?;
 
+        let data_region_id = utils::to_data_region_id(region_id);
         self.mito
-            .handle_request(region_id, RegionRequest::Flush(req.clone()))
+            .handle_request(data_region_id, RegionRequest::Flush(req.clone()))
             .await
             .context(MitoFlushOperationSnafu)
             .map(|response| response.affected_rows)

--- a/src/metric-engine/src/engine/flush.rs
+++ b/src/metric-engine/src/engine/flush.rs
@@ -1,0 +1,51 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.'
+
+use snafu::ResultExt;
+use store_api::region_engine::RegionEngine;
+use store_api::region_request::{AffectedRows, RegionFlushRequest, RegionRequest};
+use store_api::storage::RegionId;
+
+use crate::engine::MetricEngineInner;
+use crate::error::{MitoFlushOperationSnafu, Result, UnsupportedRegionRequestSnafu};
+use crate::utils;
+
+impl MetricEngineInner {
+    pub async fn flush_region(
+        &self,
+        region_id: RegionId,
+        req: RegionFlushRequest,
+    ) -> Result<AffectedRows> {
+        if !self.is_physical_region(region_id) {
+            return UnsupportedRegionRequestSnafu {
+                request: RegionRequest::Flush(req),
+            }
+            .fail();
+        }
+
+        let metadata_region_id = utils::to_metadata_region_id(region_id);
+        // Flushes the metadata region as well
+        self.mito
+            .handle_request(metadata_region_id, RegionRequest::Flush(req.clone()))
+            .await
+            .context(MitoFlushOperationSnafu)
+            .map(|response| response.affected_rows)?;
+
+        self.mito
+            .handle_request(region_id, RegionRequest::Flush(req.clone()))
+            .await
+            .context(MitoFlushOperationSnafu)
+            .map(|response| response.affected_rows)
+    }
+}

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -639,7 +639,7 @@ impl From<v1::ChangeColumnType> for ChangeColumnType {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct RegionFlushRequest {
     pub row_group_size: Option<usize>,
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Flush metric metadata region as well

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
