### PR TITLE
chore: bump version to 0.9.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "api"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "common-base",
  "common-decimal",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "auth"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "api",
  "async-trait",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "catalog",
  "common-error",
@@ -1393,7 +1393,7 @@ dependencies = [
  "common-meta",
  "moka",
  "snafu 0.8.5",
- "substrait 0.9.4",
+ "substrait 0.9.5",
 ]
 
 [[package]]
@@ -1420,7 +1420,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "api",
  "arrow",
@@ -1759,7 +1759,7 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "client"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "api",
  "arc-swap",
@@ -1789,7 +1789,7 @@ dependencies = [
  "serde_json",
  "snafu 0.8.5",
  "substrait 0.37.3",
- "substrait 0.9.4",
+ "substrait 0.9.5",
  "tokio",
  "tokio-stream",
  "tonic 0.11.0",
@@ -1819,7 +1819,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "auth",
@@ -1876,7 +1876,7 @@ dependencies = [
  "similar-asserts",
  "snafu 0.8.5",
  "store-api",
- "substrait 0.9.4",
+ "substrait 0.9.5",
  "table",
  "temp-env",
  "tempfile",
@@ -1922,7 +1922,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "common-base"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anymap2",
  "async-trait",
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "chrono",
  "common-error",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "common-config"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "common-base",
  "common-error",
@@ -1974,7 +1974,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2011,7 +2011,7 @@ dependencies = [
 
 [[package]]
 name = "common-decimal"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "bigdecimal 0.4.5",
  "common-error",
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "snafu 0.8.5",
  "strum 0.25.0",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "common-frontend"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "api",
  "async-trait",
@@ -2048,7 +2048,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "api",
  "arc-swap",
@@ -2088,7 +2088,7 @@ dependencies = [
 
 [[package]]
 name = "common-greptimedb-telemetry"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "common-runtime",
@@ -2105,7 +2105,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "api",
  "arrow-flight",
@@ -2131,7 +2131,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "api",
  "common-base",
@@ -2149,7 +2149,7 @@ dependencies = [
 
 [[package]]
 name = "common-macro"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "arc-swap",
  "common-query",
@@ -2163,7 +2163,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2176,7 +2176,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anymap2",
  "api",
@@ -2233,11 +2233,11 @@ dependencies = [
 
 [[package]]
 name = "common-plugins"
-version = "0.9.4"
+version = "0.9.5"
 
 [[package]]
 name = "common-pprof"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2249,7 +2249,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -2284,7 +2284,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "api",
  "async-trait",
@@ -2310,7 +2310,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "arc-swap",
  "common-error",
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "common-error",
@@ -2351,7 +2351,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "atty",
  "backtrace",
@@ -2379,7 +2379,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "client",
  "common-query",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "arrow",
  "chrono",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "common-version"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "build-data",
  "const_format",
@@ -2418,7 +2418,7 @@ dependencies = [
 
 [[package]]
 name = "common-wal"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "common-base",
  "common-error",
@@ -3227,7 +3227,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "api",
  "arrow-flight",
@@ -3277,7 +3277,7 @@ dependencies = [
  "session",
  "snafu 0.8.5",
  "store-api",
- "substrait 0.9.4",
+ "substrait 0.9.5",
  "table",
  "tokio",
  "toml 0.8.19",
@@ -3286,7 +3286,7 @@ dependencies = [
 
 [[package]]
 name = "datatypes"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3892,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "file-engine"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "api",
  "async-trait",
@@ -4003,7 +4003,7 @@ dependencies = [
 
 [[package]]
 name = "flow"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "api",
  "arrow",
@@ -4060,7 +4060,7 @@ dependencies = [
  "snafu 0.8.5",
  "store-api",
  "strum 0.25.0",
- "substrait 0.9.4",
+ "substrait 0.9.5",
  "table",
  "tokio",
  "tonic 0.11.0",
@@ -4122,7 +4122,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frontend"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "api",
  "arc-swap",
@@ -5170,7 +5170,7 @@ dependencies = [
 
 [[package]]
 name = "index"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -6001,7 +6001,7 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "log-store"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6321,7 +6321,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "api",
  "async-trait",
@@ -6347,7 +6347,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "api",
  "async-trait",
@@ -6425,7 +6425,7 @@ dependencies = [
 
 [[package]]
 name = "metric-engine"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "api",
  "aquamarine",
@@ -6528,7 +6528,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "api",
  "aquamarine",
@@ -7264,7 +7264,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7555,7 +7555,7 @@ dependencies = [
 
 [[package]]
 name = "operator"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "api",
  "async-trait",
@@ -7600,7 +7600,7 @@ dependencies = [
  "sql",
  "sqlparser 0.45.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=54a267ac89c09b11c0c88934690530807185d3e7)",
  "store-api",
- "substrait 0.9.4",
+ "substrait 0.9.5",
  "table",
  "tokio",
  "tokio-util",
@@ -7850,7 +7850,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "api",
  "async-trait",
@@ -8151,7 +8151,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeline"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -8313,7 +8313,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "auth",
  "common-base",
@@ -8587,7 +8587,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -8823,7 +8823,7 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-compression 0.4.13",
  "async-trait",
@@ -8945,7 +8945,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -9012,7 +9012,7 @@ dependencies = [
  "stats-cli",
  "store-api",
  "streaming-stats",
- "substrait 0.9.4",
+ "substrait 0.9.5",
  "table",
  "tokio",
  "tokio-stream",
@@ -10446,7 +10446,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "script"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "api",
  "arc-swap",
@@ -10740,7 +10740,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "ahash 0.8.11",
  "aide",
@@ -10851,7 +10851,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "api",
  "arc-swap",
@@ -11172,7 +11172,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "api",
  "chrono",
@@ -11233,7 +11233,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "clap 4.5.19",
@@ -11453,7 +11453,7 @@ dependencies = [
 
 [[package]]
 name = "store-api"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "api",
  "aquamarine",
@@ -11622,7 +11622,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -11821,7 +11821,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "api",
  "async-trait",
@@ -12087,7 +12087,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "tests-fuzz"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "arbitrary",
  "async-trait",
@@ -12129,7 +12129,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "api",
  "arrow-flight",
@@ -12191,7 +12191,7 @@ dependencies = [
  "sql",
  "sqlx",
  "store-api",
- "substrait 0.9.4",
+ "substrait 0.9.5",
  "table",
  "tempfile",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.9.4"
+version = "0.9.5"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

bump version to 0.9.5

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
