### PR TITLE
feat: implement parse_query api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8613,9 +8613,9 @@ dependencies = [
 
 [[package]]
 name = "promql-parser"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330afb34377fc1094de2f7a3d9f7578ebffa35bfef4f2099d935dc66317fe4f9"
+checksum = "7fe99e6f80a79abccf1e8fb48dd63473a36057e600cc6ea36147c8318698ae6f"
 dependencies = [
  "cfgrammar",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8614,8 +8614,7 @@ dependencies = [
 [[package]]
 name = "promql-parser"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1ad4a4cfa84ec4aa5831c82e57af0a3faf3f0af83bee13fa1390b2d0a32dc9"
+source = "git+https://github.com/GreptimeTeam/promql-parser.git?branch=feature/serialize-ast#a85d78c57cb4d7ada7113fe0b814508b6465eb26"
 dependencies = [
  "cfgrammar",
  "chrono",
@@ -8623,6 +8622,8 @@ dependencies = [
  "lrlex",
  "lrpar",
  "regex",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8613,8 +8613,9 @@ dependencies = [
 
 [[package]]
 name = "promql-parser"
-version = "0.4.1"
-source = "git+https://github.com/GreptimeTeam/promql-parser.git?branch=feature/serialize-ast#a85d78c57cb4d7ada7113fe0b814508b6465eb26"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330afb34377fc1094de2f7a3d9f7578ebffa35bfef4f2099d935dc66317fe4f9"
 dependencies = [
  "cfgrammar",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,7 @@ parquet = { version = "51.0.0", default-features = false, features = ["arrow", "
 paste = "1.0"
 pin-project = "1.0"
 prometheus = { version = "0.13.3", features = ["process"] }
-promql-parser = { version = "0.4.2", features = ["ser"] }
+promql-parser = { version = "0.4.3", features = ["ser"] }
 prost = "0.12"
 raft-engine = { version = "0.4.1", default-features = false }
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,7 @@ parquet = { version = "51.0.0", default-features = false, features = ["arrow", "
 paste = "1.0"
 pin-project = "1.0"
 prometheus = { version = "0.13.3", features = ["process"] }
-promql-parser = { git = "https://github.com/GreptimeTeam/promql-parser.git", branch = "feature/serialize-ast", features = ["ser"] }
+promql-parser = { version = "0.4.2", features = ["ser"] }
 prost = "0.12"
 raft-engine = { version = "0.4.1", default-features = false }
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,7 @@ parquet = { version = "51.0.0", default-features = false, features = ["arrow", "
 paste = "1.0"
 pin-project = "1.0"
 prometheus = { version = "0.13.3", features = ["process"] }
-promql-parser = { version = "0.4.1" }
+promql-parser = { git = "https://github.com/GreptimeTeam/promql-parser.git", branch = "feature/serialize-ast", features = ["ser"] }
 prost = "0.12"
 raft-engine = { version = "0.4.1", default-features = false }
 rand = "0.8"

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -819,7 +819,7 @@ impl HttpServer {
             .route("/query_range", routing::post(range_query).get(range_query))
             .route("/labels", routing::post(labels_query).get(labels_query))
             .route("/series", routing::post(series_query).get(series_query))
-            .route("/parse_query", routing::get(parse_query))
+            .route("/parse_query", routing::post(parse_query).get(parse_query))
             .route(
                 "/label/:label_name/values",
                 routing::get(label_values_query),

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -62,8 +62,8 @@ use crate::http::influxdb::{influxdb_health, influxdb_ping, influxdb_write_v1, i
 use crate::http::influxdb_result_v1::InfluxdbV1Response;
 use crate::http::json_result::JsonResponse;
 use crate::http::prometheus::{
-    build_info_query, format_query, instant_query, label_values_query, labels_query, range_query,
-    series_query,
+    build_info_query, format_query, instant_query, label_values_query, labels_query, parse_query,
+    range_query, series_query,
 };
 use crate::interceptor::LogIngestInterceptorRef;
 use crate::metrics::http_metrics_layer;
@@ -819,6 +819,7 @@ impl HttpServer {
             .route("/query_range", routing::post(range_query).get(range_query))
             .route("/labels", routing::post(labels_query).get(labels_query))
             .route("/series", routing::post(series_query).get(series_query))
+            .route("/parse_query", routing::get(parse_query))
             .route(
                 "/label/:label_name/values",
                 routing::get(label_values_query),

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -101,6 +101,9 @@ pub enum PrometheusResponse {
     LabelValues(Vec<String>),
     FormatQuery(String),
     BuildInfo(OwnedBuildInfo),
+    #[schemars(skip)]
+    #[serde(skip_deserializing)]
+    ParseResult(promql_parser::parser::Expr),
 }
 
 impl Default for PrometheusResponse {
@@ -1013,4 +1016,44 @@ pub async fn series_query(
     let mut resp = PrometheusJsonResponse::success(PrometheusResponse::Series(series));
     resp.resp_metrics = merge_map;
     resp
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, JsonSchema)]
+pub struct ParseQuery {
+    query: Option<String>,
+    db: Option<String>,
+}
+
+#[axum_macros::debug_handler]
+#[tracing::instrument(
+    skip_all,
+    fields(protocol = "prometheus", request_type = "parse_query")
+)]
+pub async fn parse_query(
+    State(_handler): State<PrometheusHandlerRef>,
+    Query(params): Query<ParseQuery>,
+    Extension(mut query_ctx): Extension<QueryContext>,
+    Form(form_params): Form<ParseQuery>,
+) -> PrometheusJsonResponse {
+    if let Some(db) = &params.db {
+        let (catalog, schema) = parse_catalog_and_schema_from_db_string(db);
+        try_update_catalog_schema(&mut query_ctx, &catalog, &schema);
+    }
+    let query_ctx = Arc::new(query_ctx);
+
+    if let Some(query) = params.query.or(form_params.query) {
+        let _timer = crate::metrics::METRIC_HTTP_PROMETHEUS_PROMQL_ELAPSED
+            .with_label_values(&[query_ctx.get_db_string().as_str(), "series_query"])
+            .start_timer();
+
+        match promql_parser::parser::parse(&query) {
+            Ok(ast) => PrometheusJsonResponse::success(PrometheusResponse::ParseResult(ast)),
+            Err(err) => {
+                let msg = err.to_string();
+                PrometheusJsonResponse::error(StatusCode::InvalidArguments, msg)
+            }
+        }
+    } else {
+        PrometheusJsonResponse::error(StatusCode::InvalidArguments, "query is required")
+    }
 }

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -671,7 +671,7 @@ pub async fn test_prom_http_api(store_type: StorageType) {
     //  the json output directly.
     // the correctness should be covered by parser. In this test we only check
     //  response format.
-    let expected = "{\"status\":\"success\",\"data\":{\"type\":\"vectorSelector\",\"name\":\"http_requests\",\"matchers\":[],\"offset\":0}}";
+    let expected = "{\"status\":\"success\",\"data\":{\"type\":\"vectorSelector\",\"name\":\"http_requests\",\"matchers\":[],\"offset\":0,\"startOrEnd\":null,\"timestamp\":null}}";
     assert_eq!(expected, data);
 
     let res = client

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -660,6 +660,29 @@ pub async fn test_prom_http_api(store_type: StorageType) {
     let body = serde_json::from_str::<PrometheusJsonResponse>(&res.text().await).unwrap();
     assert_eq!(body.status, "success");
 
+    // parse_query
+    let res = client
+        .get("/v1/prometheus/api/v1/parse_query?query=http_requests")
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+    let data = res.text().await;
+    // we don't have deserialization for ast so we keep test simple and compare
+    //  the json output directly.
+    // the correctness should be covered by parser. In this test we only check
+    //  response format.
+    let expected = "{\"status\":\"success\",\"data\":{\"type\":\"vectorSelector\",\"name\":\"http_requests\",\"matchers\":[],\"offset\":0}}";
+    assert_eq!(expected, data);
+
+    let res = client
+        .get("/v1/prometheus/api/v1/parse_query?query=not http_requests")
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    let data = res.text().await;
+    let expected = "{\"status\":\"error\",\"data\":{\"resultType\":\"\",\"result\":[]},\"error\":\"invalid promql query\",\"errorType\":\"InvalidArguments\"}";
+    assert_eq!(expected, data);
+
     guard.remove_all().await;
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Fixes #4839 

## What's changed and what's your intention?

This patch adds a new Prometheus 3.0 API for visualizing PromQL AST, like in this type of UI: https://github.com/perses/perses/pull/2344

Please merge https://github.com/GreptimeTeam/promql-parser/pull/94 first.

## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
