### PR TITLE
feat: get row group time range from cached metadata

### DIFF
--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -80,14 +80,15 @@ impl CacheManager {
         CacheManagerBuilder::default()
     }
 
-    /// Gets cached [ParquetMetaData].
+    /// Gets cached [ParquetMetaData] from in-memory cache first.
+    /// If not found, tries to get it from write cache and fill the in-memory cache.
     pub async fn get_parquet_meta_data(
         &self,
         region_id: RegionId,
         file_id: FileId,
     ) -> Option<Arc<ParquetMetaData>> {
         // Try to get metadata from sst meta cache
-        let metadata = self.get_parquet_meta_data_mem(region_id, file_id);
+        let metadata = self.get_parquet_meta_data_from_mem_cache(region_id, file_id);
         if metadata.is_some() {
             return metadata;
         }
@@ -106,8 +107,9 @@ impl CacheManager {
         None
     }
 
-    /// Gets cached [ParquetMetaData] from memory cache.
-    pub fn get_parquet_meta_data_mem(
+    /// Gets cached [ParquetMetaData] from in-memory cache.
+    /// This method does not perform I/O.
+    pub fn get_parquet_meta_data_from_mem_cache(
         &self,
         region_id: RegionId,
         file_id: FileId,

--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -87,11 +87,7 @@ impl CacheManager {
         file_id: FileId,
     ) -> Option<Arc<ParquetMetaData>> {
         // Try to get metadata from sst meta cache
-        let metadata = self.sst_meta_cache.as_ref().and_then(|sst_meta_cache| {
-            let value = sst_meta_cache.get(&SstMetaKey(region_id, file_id));
-            update_hit_miss(value, SST_META_TYPE)
-        });
-
+        let metadata = self.get_parquet_meta_data_mem(region_id, file_id);
         if metadata.is_some() {
             return metadata;
         }
@@ -108,6 +104,19 @@ impl CacheManager {
         };
 
         None
+    }
+
+    /// Gets cached [ParquetMetaData] from memory cache.
+    pub fn get_parquet_meta_data_mem(
+        &self,
+        region_id: RegionId,
+        file_id: FileId,
+    ) -> Option<Arc<ParquetMetaData>> {
+        // Try to get metadata from sst meta cache
+        self.sst_meta_cache.as_ref().and_then(|sst_meta_cache| {
+            let value = sst_meta_cache.get(&SstMetaKey(region_id, file_id));
+            update_hit_miss(value, SST_META_TYPE)
+        })
     }
 
     /// Puts [ParquetMetaData] into the cache.

--- a/src/mito2/src/read/range.rs
+++ b/src/mito2/src/read/range.rs
@@ -543,7 +543,7 @@ mod tests {
         assert!(!range.can_split_preserve_order());
         let mut output = Vec::new();
         range.maybe_split(&mut output);
-        assert!(output.is_empty());
+        assert_eq!(1, output.len());
     }
 
     #[test]

--- a/src/mito2/src/read/range.rs
+++ b/src/mito2/src/read/range.rs
@@ -179,8 +179,9 @@ impl RangeMeta {
         for (i, file) in files.iter().enumerate() {
             let file_index = num_memtables + i;
             // Get parquet meta from the cache.
-            let parquet_meta =
-                cache.and_then(|c| c.get_parquet_meta_data_mem(file.region_id(), file.file_id()));
+            let parquet_meta = cache.and_then(|c| {
+                c.get_parquet_meta_data_from_mem_cache(file.region_id(), file.file_id())
+            });
             if let Some(parquet_meta) = parquet_meta {
                 // Scans each row group.
                 for row_group_index in 0..file.meta_ref().num_row_groups {

--- a/src/mito2/src/sst/file.rs
+++ b/src/mito2/src/sst/file.rs
@@ -111,7 +111,8 @@ pub struct FileMeta {
     pub region_id: RegionId,
     /// Compared to normal file names, FileId ignore the extension
     pub file_id: FileId,
-    /// Timestamp range of file.
+    /// Timestamp range of file. The timestamps have the same time unit as the
+    /// data in the SST.
     pub time_range: FileTimeRange,
     /// SST level of the file.
     pub level: Level,

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -62,7 +62,8 @@ impl Default for WriteOptions {
 
 /// Parquet SST info returned by the writer.
 pub struct SstInfo {
-    /// Time range of the SST.
+    /// Time range of the SST. The timestamps have the same time unit as the
+    /// data in the SST.
     pub time_range: FileTimeRange,
     /// File size in bytes.
     pub file_size: u64,

--- a/src/mito2/src/sst/parquet/format.rs
+++ b/src/mito2/src/sst/parquet/format.rs
@@ -31,13 +31,14 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 
 use api::v1::SemanticType;
+use common_time::Timestamp;
 use datafusion_common::ScalarValue;
 use datatypes::arrow::array::{ArrayRef, BinaryArray, DictionaryArray, UInt32Array, UInt64Array};
 use datatypes::arrow::datatypes::{SchemaRef, UInt32Type};
 use datatypes::arrow::record_batch::RecordBatch;
 use datatypes::prelude::DataType;
 use datatypes::vectors::{Helper, Vector};
-use parquet::file::metadata::RowGroupMetaData;
+use parquet::file::metadata::{ParquetMetaData, RowGroupMetaData};
 use parquet::file::statistics::Statistics;
 use snafu::{ensure, OptionExt, ResultExt};
 use store_api::metadata::{ColumnMetadata, RegionMetadataRef};
@@ -48,6 +49,7 @@ use crate::error::{
 };
 use crate::read::{Batch, BatchBuilder, BatchColumn};
 use crate::row_converter::{McmpRowCodec, RowCodec, SortField};
+use crate::sst::file::{FileMeta, FileTimeRange};
 use crate::sst::to_sst_arrow_schema;
 
 /// Arrow array type for the primary key dictionary.
@@ -556,6 +558,49 @@ fn new_primary_key_array(primary_key: &[u8], num_rows: usize) -> ArrayRef {
 
     // Safety: The key index is valid.
     Arc::new(DictionaryArray::new(keys, values))
+}
+
+/// Gets the min/max time index of the row group from the parquet meta.
+pub(crate) fn parquet_row_group_time_range(
+    file_meta: &FileMeta,
+    parquet_meta: &ParquetMetaData,
+    row_group_idx: usize,
+) -> Option<FileTimeRange> {
+    let row_group_meta = parquet_meta.row_group(row_group_idx);
+    let num_columns = parquet_meta.file_metadata().schema_descr().num_columns();
+    assert!(
+        num_columns >= FIXED_POS_COLUMN_NUM,
+        "file only has {} columns",
+        num_columns
+    );
+    let time_index_pos = num_columns - FIXED_POS_COLUMN_NUM;
+
+    let stats = row_group_meta.column(time_index_pos).statistics()?;
+    if stats.has_min_max_set() {
+        // The physical type for the timestamp should be i64.
+        let (min, max) = match stats {
+            Statistics::Int64(value_stats) => (*value_stats.min(), *value_stats.max()),
+            Statistics::Int32(_)
+            | Statistics::Boolean(_)
+            | Statistics::Int96(_)
+            | Statistics::Float(_)
+            | Statistics::Double(_)
+            | Statistics::ByteArray(_)
+            | Statistics::FixedLenByteArray(_) => return None,
+        };
+
+        debug_assert!(
+            min >= file_meta.time_range.0.value() && min <= file_meta.time_range.1.value()
+        );
+        debug_assert!(
+            max >= file_meta.time_range.0.value() && max <= file_meta.time_range.1.value()
+        );
+        let unit = file_meta.time_range.0.unit();
+
+        Some((Timestamp::new(min, unit), Timestamp::new(max, unit)))
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/src/mito2/src/sst/parquet/format.rs
+++ b/src/mito2/src/sst/parquet/format.rs
@@ -561,6 +561,7 @@ fn new_primary_key_array(primary_key: &[u8], num_rows: usize) -> ArrayRef {
 }
 
 /// Gets the min/max time index of the row group from the parquet meta.
+/// It assumes the parquet is created by the mito engine.
 pub(crate) fn parquet_row_group_time_range(
     file_meta: &FileMeta,
     parquet_meta: &ParquetMetaData,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/4828

## What's changed and what's your intention?

This PR tries to get the correct time ranges for each row group from the cached if it is available.

Before this PR (Without cache):
```
explain analyze select * from test_mem order by timestamp limit 1;

|     0 |    0 |  MergeScanExec: peers=[4402341478400(1025, 0), ] metrics=[output_rows: 1, greptime_exec_read_cost: 0, ready_time: 49619816, first_consume_time: 4880361674, finish_time: 4880541784, ]
                                                                                                                                                                                                                                                                                                                                                                                                                             |
|     1 |    0 |  GlobalLimitExec: skip=0, fetch=1 metrics=[output_rows: 1, elapsed_compute: 18032975, ]
  SortPreservingMergeExec: [timestamp@9 ASC NULLS LAST] metrics=[output_rows: 16, elapsed_compute: 52859, ]
    WindowedSortExec metrics=[output_rows: 16, elapsed_compute: 16, ]
      PartSortExec timestamp@9 ASC NULLS LAST metrics=[output_rows: 59871400, elapsed_compute: 16, ]
        UnorderedScan: region=4402341478400(1025, 0), partition_count=6273 (0 memtable ranges, 14 file 6273 ranges) metrics=[output_rows: 59871400, mem_used: 15721819437, elapsed_poll: 39427675196, elapsed_await: 40790185280, ]
 |
|  NULL | NULL | Total rows: 1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
3 rows in set (4.90 sec)
```

After this PR:
The first select loads the cache
```
select * from test_mem order by timestamp limit 1;
1 row in set (4.84 sec)
```
The second select uses the cached metadata:
```
|     0 |    0 |  MergeScanExec: peers=[4402341478400(1025, 0), ] metrics=[output_rows: 1, greptime_exec_read_cost: 0, first_consume_time: 518512288, ready_time: 43054274, finish_time: 518704818, ]
                                                                                                                                                                                                                                                                                                                                                                                                                          |
|     1 |    0 |  GlobalLimitExec: skip=0, fetch=1 metrics=[output_rows: 1, elapsed_compute: 20933988, ]
  SortPreservingMergeExec: [timestamp@9 ASC NULLS LAST] metrics=[output_rows: 16, elapsed_compute: 45327, ]
    WindowedSortExec metrics=[output_rows: 16, elapsed_compute: 16, ]
      PartSortExec timestamp@9 ASC NULLS LAST metrics=[output_rows: 4915200, elapsed_compute: 16, ]
        UnorderedScan: region=4402341478400(1025, 0), partition_count=6273 (0 memtable ranges, 14 file 6273 ranges) metrics=[output_rows: 4915200, mem_used: 1290689016, elapsed_await: 3418148406, elapsed_poll: 3247222754, ]
 |
|  NULL | NULL | Total rows: 1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
3 rows in set (0.54 sec)
```

The performance improvement depends on the data distribution.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
