### PR TITLE
chore: graceful exit on bind fail

### DIFF
--- a/src/common/greptimedb-telemetry/src/lib.rs
+++ b/src/common/greptimedb-telemetry/src/lib.rs
@@ -325,7 +325,7 @@ mod tests {
             });
             let addr = ([127, 0, 0, 1], port).into();
 
-            let server = Server::bind(&addr).serve(make_svc);
+            let server = Server::try_bind(&addr).unwrap().serve(make_svc);
             let graceful = server.with_graceful_shutdown(async {
                 rx.await.ok();
             });

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -36,6 +36,15 @@ use crate::http::error_result::status_code_to_http_status;
 #[snafu(visibility(pub))]
 #[stack_trace_debug]
 pub enum Error {
+    #[snafu(display("Failed to bind address: {}", addr))]
+    AddressBind {
+        addr: SocketAddr,
+        #[snafu(source)]
+        error: hyper::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Arrow error"))]
     Arrow {
         #[snafu(source)]
@@ -565,9 +574,9 @@ impl ErrorExt for Error {
             | Arrow { .. }
             | FileWatch { .. } => StatusCode::Internal,
 
-            AlreadyStarted { .. } | InvalidPromRemoteReadQueryResult { .. } => {
-                StatusCode::IllegalState
-            }
+            AddressBind { .. }
+            | AlreadyStarted { .. }
+            | InvalidPromRemoteReadQueryResult { .. } => StatusCode::IllegalState,
 
             UnsupportedDataType { .. } => StatusCode::Unsupported,
 

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -53,7 +53,7 @@ use tower_http::trace::TraceLayer;
 use self::authorize::AuthState;
 use self::table_result::TableResponse;
 use crate::configurator::ConfiguratorRef;
-use crate::error::{AlreadyStartedSnafu, Error, HyperSnafu, Result, ToJsonSnafu};
+use crate::error::{AddressBindSnafu, AlreadyStartedSnafu, Error, HyperSnafu, Result, ToJsonSnafu};
 use crate::http::arrow_result::ArrowResponse;
 use crate::http::csv_result::CsvResponse;
 use crate::http::error_result::ErrorResponse;
@@ -933,7 +933,8 @@ impl Server for HttpServer {
                 app = configurator.config_http(app);
             }
             let app = self.build(app);
-            let server = axum::Server::bind(&listening)
+            let server = axum::Server::try_bind(&listening)
+                .with_context(|_| AddressBindSnafu { addr: listening })?
                 .tcp_nodelay(true)
                 // Enable TCP keepalive to close the dangling established connections.
                 // It's configured to let the keepalive probes first send after the connection sits


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

exit greacefully instead of panic when failed to bind to http 4000
previously this bind fail will print confusing and alarming long panic msg and not very friendly

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
