### PR TITLE
chore: remove struct size assertion

### DIFF
--- a/src/mito2/src/cache/cache_size.rs
+++ b/src/mito2/src/cache/cache_size.rs
@@ -127,16 +127,3 @@ fn parquet_offset_index_heap_size(offset_index: &ParquetOffsetIndex) -> usize {
         })
         .sum()
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::cache::test_util::parquet_meta;
-
-    #[test]
-    fn test_parquet_meta_size() {
-        let metadata = parquet_meta();
-
-        assert_eq!(956, parquet_meta_size(&metadata));
-    }
-}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Follow up of discussion in https://github.com/GreptimeTeam/greptimedb/pull/4857#discussion_r1815835989

Remove the test on struct size as it's subjective to rustc implemetations, and should only be used in interviews to politely reject a candidate.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
