### PR TITLE
chore: update greptime-proto to `86ed051`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4531,7 +4531,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=9faf45e8bd83cba106ddfb09bba85784bf9ade2a#9faf45e8bd83cba106ddfb09bba85784bf9ade2a"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=86ed051dfde8735277b2ba8e01c7ea46848ef00f#86ed051dfde8735277b2ba8e01c7ea46848ef00f"
 dependencies = [
  "prost 0.12.6",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ etcd-client = { version = "0.13" }
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "9faf45e8bd83cba106ddfb09bba85784bf9ade2a" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "86ed051dfde8735277b2ba8e01c7ea46848ef00f" }
 humantime = "2.1"
 humantime-serde = "1.1"
 itertools = "0.10"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

update greptime-proto to `86ed051`

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
