### PR TITLE
fix: set transaction variables not working in mysql protocol

### DIFF
--- a/src/servers/src/mysql/federated.rs
+++ b/src/servers/src/mysql/federated.rs
@@ -60,6 +60,8 @@ static OTHER_NOT_SUPPORTED_STMT: Lazy<RegexSet> = Lazy::new(|| {
         "(?i)^(SET FOREIGN_KEY_CHECKS(.*))",
         "(?i)^(SET AUTOCOMMIT(.*))",
         "(?i)^(SET SQL_LOG_BIN(.*))",
+        "(?i)^(SET SESSION TRANSACTION(.*))",
+        "(?i)^(SET TRANSACTION(.*))",
         "(?i)^(SET sql_mode(.*))",
         "(?i)^(SET SQL_SELECT_LIMIT(.*))",
         "(?i)^(SET @@(.*))",


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The  MySQL driver may send some statements such as `set session transaction read only` etc.

https://github.com/mysql/mysql-connector-j/blob/cf2917ea44ae2e43a4514a33771035aa99de73bf/src/main/user-impl/java/com/mysql/cj/jdbc/ConnectionImpl.java#L2442

After we support the `set` statement, these special statements can't work with the JDBC driver.  In this PR, we just ignore them and add a test for it.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
