### PR TITLE
feat: simple limit impl in PartSort

### DIFF
--- a/src/query/src/optimizer/windowed_sort.rs
+++ b/src/query/src/optimizer/windowed_sort.rs
@@ -98,6 +98,7 @@ impl WindowedSortPhysicalRule {
                     } else {
                         Arc::new(PartSortExec::new(
                             first_sort_expr.clone(),
+                            sort_exec.fetch(),
                             scanner_info.partition_ranges.clone(),
                             sort_exec.input().clone(),
                         ))

--- a/src/query/src/optimizer/windowed_sort.rs
+++ b/src/query/src/optimizer/windowed_sort.rs
@@ -150,7 +150,7 @@ fn fetch_partition_range(input: Arc<dyn ExecutionPlan>) -> DataFusionResult<Opti
 
         if let Some(region_scan_exec) = plan.as_any().downcast_ref::<RegionScanExec>() {
             partition_ranges = Some(region_scan_exec.get_uncollapsed_partition_ranges());
-            time_index = region_scan_exec.time_index();
+            time_index = Some(region_scan_exec.time_index());
             tag_columns = Some(region_scan_exec.tag_columns());
 
             // set distinguish_partition_ranges to true, this is an incorrect workaround

--- a/src/query/src/part_sort.rs
+++ b/src/query/src/part_sort.rs
@@ -110,7 +110,16 @@ impl PartSortExec {
 
 impl DisplayAs for PartSortExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "PartSortExec {}", self.expression)
+        write!(
+            f,
+            "PartSortExec: expr={} num_ranges={}",
+            self.expression,
+            self.partition_ranges.len(),
+        )?;
+        if let Some(limit) = self.limit {
+            write!(f, " limit={}", limit)?;
+        }
+        Ok(())
     }
 }
 

--- a/src/query/src/part_sort.rs
+++ b/src/query/src/part_sort.rs
@@ -302,19 +302,12 @@ impl PartSortStream {
                 )
             })?;
 
-        let mut indices = sort_to_indices(&sort_column, opt, None).map_err(|e| {
+        let indices = sort_to_indices(&sort_column, opt, self.limit).map_err(|e| {
             DataFusionError::ArrowError(
                 e,
                 Some(format!("Fail to sort to indices at {}", location!())),
             )
         })?;
-
-        // apply limit if specified
-        if let Some(limit) = self.limit
-            && limit < indices.len()
-        {
-            indices = indices.slice(0, limit);
-        }
 
         self.check_in_range(
             &sort_column,

--- a/src/query/src/window_sort.rs
+++ b/src/query/src/window_sort.rs
@@ -169,7 +169,16 @@ impl WindowedSortExec {
 
 impl DisplayAs for WindowedSortExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "WindowedSortExec")
+        write!(
+            f,
+            "WindowedSortExec: expr={} num_ranges={}",
+            self.expression,
+            self.ranges.len()
+        )?;
+        if let Some(fetch) = self.fetch {
+            write!(f, " fetch={}", fetch)?;
+        }
+        Ok(())
     }
 }
 

--- a/src/table/src/table/scan.rs
+++ b/src/table/src/table/scan.rs
@@ -146,13 +146,15 @@ impl RegionScanExec {
         let _ = scanner.prepare(partition_ranges, distinguish_partition_range);
     }
 
-    pub fn time_index(&self) -> Option<String> {
+    pub fn time_index(&self) -> String {
         self.scanner
             .lock()
             .unwrap()
-            .schema()
-            .timestamp_column()
-            .map(|x| x.name.clone())
+            .metadata()
+            .time_index_column()
+            .column_schema
+            .name
+            .clone()
     }
 
     pub fn tag_columns(&self) -> Vec<String> {

--- a/tests/cases/standalone/common/order/windowed_sort.result
+++ b/tests/cases/standalone/common/order/windowed_sort.result
@@ -69,7 +69,7 @@ EXPLAIN ANALYZE SELECT * FROM test ORDER BY t LIMIT 5;
 |_|_|_|
 | 1_| 0_|_GlobalLimitExec: skip=0, fetch=5 REDACTED
 |_|_|_SortPreservingMergeExec: [t@1 ASC NULLS LAST] REDACTED
-|_|_|_WindowedSortExec REDACTED
+|_|_|_WindowedSortExec: expr=t@1 ASC NULLS LAST num_ranges=2 fetch=5 REDACTED
 |_|_|_SeqScan: region=REDACTED, partition_count=2 (1 memtable ranges, 1 file 1 ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 5_|
@@ -101,8 +101,8 @@ EXPLAIN ANALYZE SELECT * FROM test ORDER BY t DESC LIMIT 5;
 |_|_|_|
 | 1_| 0_|_GlobalLimitExec: skip=0, fetch=5 REDACTED
 |_|_|_SortPreservingMergeExec: [t@1 DESC] REDACTED
-|_|_|_WindowedSortExec REDACTED
-|_|_|_PartSortExec t@1 DESC REDACTED
+|_|_|_WindowedSortExec: expr=t@1 DESC num_ranges=2 fetch=5 REDACTED
+|_|_|_PartSortExec: expr=t@1 DESC num_ranges=2 limit=5 REDACTED
 |_|_|_SeqScan: region=REDACTED, partition_count=2 (1 memtable ranges, 1 file 1 ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 5_|
@@ -183,8 +183,8 @@ EXPLAIN ANALYZE SELECT * FROM test_pk ORDER BY t LIMIT 5;
 |_|_|_|
 | 1_| 0_|_GlobalLimitExec: skip=0, fetch=5 REDACTED
 |_|_|_SortPreservingMergeExec: [t@2 ASC NULLS LAST] REDACTED
-|_|_|_WindowedSortExec REDACTED
-|_|_|_PartSortExec t@2 ASC NULLS LAST REDACTED
+|_|_|_WindowedSortExec: expr=t@2 ASC NULLS LAST num_ranges=2 fetch=5 REDACTED
+|_|_|_PartSortExec: expr=t@2 ASC NULLS LAST num_ranges=2 limit=5 REDACTED
 |_|_|_SeqScan: region=REDACTED, partition_count=2 (1 memtable ranges, 1 file 1 ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 5_|
@@ -216,8 +216,8 @@ EXPLAIN ANALYZE SELECT * FROM test_pk ORDER BY t DESC LIMIT 5;
 |_|_|_|
 | 1_| 0_|_GlobalLimitExec: skip=0, fetch=5 REDACTED
 |_|_|_SortPreservingMergeExec: [t@2 DESC] REDACTED
-|_|_|_WindowedSortExec REDACTED
-|_|_|_PartSortExec t@2 DESC REDACTED
+|_|_|_WindowedSortExec: expr=t@2 DESC num_ranges=2 fetch=5 REDACTED
+|_|_|_PartSortExec: expr=t@2 DESC num_ranges=2 limit=5 REDACTED
 |_|_|_SeqScan: region=REDACTED, partition_count=2 (1 memtable ranges, 1 file 1 ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 5_|


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


This patch
- implement a simple limit to `PartSort`
- fixes a old semantic bug

This simple limit mechanism can bring an obvious improvement even though it's not the optimal impl

Before:
```sql
+-------+------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| stage | node | plan                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+-------+------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|     0 |    0 |  MergeScanExec: peers=[7967164334080(1855, 0), ] metrics=[output_rows: 1, greptime_exec_read_cost: 0, first_consume_time: 4422746177, finish_time: 4423509695, ready_time: 2067118, ]
                                                                                                                                                                                                                                                                                                                                                                                                 |
|     1 |    0 |  GlobalLimitExec: skip=0, fetch=1 metrics=[output_rows: 1, elapsed_compute: 19264562, ]
  SortPreservingMergeExec: [ts@20 DESC] metrics=[output_rows: 32, elapsed_compute: 343122, ]
    WindowedSortExec metrics=[output_rows: 84, elapsed_compute: 2184785, ]
      PartSortExec ts@20 DESC metrics=[output_rows: 20896000, elapsed_compute: 32, ]
        UnorderedScan: region=7967164334080(1855, 0), partition_count=1000 (1 memtable ranges, 6 file 999 ranges) metrics=[output_rows: 20896000, mem_used: 8192401024, elapsed_poll: 10590199207, elapsed_await: 17958644936, ]
 |
|  NULL | NULL | Total rows: 1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+-------+------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
3 rows in set (4.435 sec)
```

After:
```sql
+-------+------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| stage | node | plan                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+-------+------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|     0 |    0 |  MergeScanExec: peers=[7967164334080(1855, 0), ] metrics=[output_rows: 1, greptime_exec_read_cost: 0, first_consume_time: 2913701812, finish_time: 2914868211, ready_time: 1752908, ]
                                                                                                                                                                                                                                                                                                                                                                                   |
|     1 |    0 |  GlobalLimitExec: skip=0, fetch=1 metrics=[output_rows: 1, elapsed_compute: 1176240, ]
  SortPreservingMergeExec: [ts@20 DESC] metrics=[output_rows: 32, elapsed_compute: 88515, ]
    WindowedSortExec metrics=[output_rows: 32, elapsed_compute: 32, ]
      PartSortExec ts@20 DESC metrics=[output_rows: 138, elapsed_compute: 32, ]
        UnorderedScan: region=7967164334080(1855, 0), partition_count=1000 (1 memtable ranges, 6 file 999 ranges) metrics=[output_rows: 15732800, mem_used: 6000557824, elapsed_await: 5066264562, elapsed_poll: 3775656192, ]
 |
|  NULL | NULL | Total rows: 1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+-------+------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
3 rows in set (2.919 sec)
```

## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
