### PR TITLE
fix: pprof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8396,8 +8396,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 [[package]]
 name = "pprof"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5c97c51bd34c7e742402e216abdeb44d415fbe6ae41d56b114723e953711cb"
+source = "git+https://github.com/GreptimeTeam/pprof-rs?rev=1bd1e21#1bd1e210d8626da3d1e5aff976e6feee994f576d"
 dependencies = [
  "backtrace",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -261,6 +261,8 @@ tokio-rustls = { git = "https://github.com/GreptimeTeam/tokio-rustls" }
 # This is commented, since we are not using aws-lc-sys, if we need to use it, we need to uncomment this line or use a release after this commit, or it wouldn't compile with gcc < 8.1
 # see https://github.com/aws/aws-lc-rs/pull/526
 # aws-lc-sys = { git ="https://github.com/aws/aws-lc-rs", rev = "556558441e3494af4b156ae95ebc07ebc2fd38aa" }
+# Apply a fix for pprof for unaligned pointer access
+pprof = { git = "https://github.com/GreptimeTeam/pprof-rs", rev = "1bd1e21" }
 
 [workspace.dependencies.meter-macros]
 git = "https://github.com/GreptimeTeam/greptime-meter.git"

--- a/src/servers/src/http/pprof.rs
+++ b/src/servers/src/http/pprof.rs
@@ -75,6 +75,8 @@ pub mod handler {
 
         info!("finish pprof");
 
+        info!("Dump data success, size: {}", body.len());
+
         Ok((StatusCode::OK, body))
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

previous due to lack of maintaince pprof crate is not usable in certain platform. 

Fork and applied a fix which check for null pointer and update ahash crate which now fix pprof for my machine.

The fork is here: https://github.com/GreptimeTeam/pprof-rs

Before this fix, my machine panic on trying to pprof, now it can get a flamegraph(The db is basically idle when doing the pprof): 
![pprof](https://github.com/user-attachments/assets/5b9bf4a9-0592-4272-9de9-aaa4e8761e49)


- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
