### PR TITLE
feat: support alter twcs compression options

### DIFF
--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -27,6 +27,8 @@ use crate::error::{
 };
 use crate::flush::FlushReason;
 use crate::manifest::action::RegionChange;
+use crate::region::options::CompactionOptions::Twcs;
+use crate::region::options::TwcsOptions;
 use crate::region::version::VersionRef;
 use crate::region::MitoRegionRef;
 use crate::request::{DdlRequest, OptionOutputTx, SenderDdlRequest};
@@ -166,6 +168,67 @@ impl<S> RegionWorkerLoop<S> {
                     } else {
                         current_options.ttl = Some(new_ttl);
                     }
+                }
+                ChangeOption::TwscMaxActiveWindowRuns(runs) => {
+                    let Twcs(options) = &mut current_options.compaction;
+                    let runs = runs.unwrap_or(TwcsOptions::default().max_active_window_runs);
+                    info!(
+                        "Update region compaction.twcs.max_active_window_runs: {}, previous: {} new: {}",
+                        region.region_id, options.max_active_window_runs, runs
+                    );
+                    options.max_active_window_runs = runs;
+                }
+                ChangeOption::TwscMaxActiveWindowFiles(files) => {
+                    let Twcs(options) = &mut current_options.compaction;
+                    let files = files.unwrap_or(TwcsOptions::default().max_active_window_files);
+                    info!(
+                        "Update region compaction.twcs.max_active_window_files: {}, previous: {} new: {}",
+                        region.region_id, options.max_active_window_files, files
+                    );
+                    options.max_active_window_files = files;
+                }
+                ChangeOption::TwscMaxInactiveWindowRuns(runs) => {
+                    let Twcs(options) = &mut current_options.compaction;
+                    let runs = runs.unwrap_or(TwcsOptions::default().max_inactive_window_runs);
+                    info!(
+                        "Update region compaction.twcs.max_inactive_window_runs: {}, previous: {} new: {}",
+                        region.region_id, options.max_inactive_window_runs, runs
+                    );
+                    options.max_inactive_window_runs = runs;
+                }
+                ChangeOption::TwscMaxInactiveWindowFiles(files) => {
+                    let Twcs(options) = &mut current_options.compaction;
+                    let files = files.unwrap_or(TwcsOptions::default().max_inactive_window_files);
+                    info!(
+                        "Update region compaction.twcs.max_inactive_window_files: {}, previous: {} new: {}",
+                        region.region_id, options.max_inactive_window_files, files
+                    );
+                    options.max_inactive_window_files = files;
+                }
+                ChangeOption::TwscMaxOutputFileSize(size) => {
+                    let Twcs(options) = &mut current_options.compaction;
+                    info!(
+                        "Update region compaction.twcs.max_output_file_size: {}, previous: {:?} new: {:?}",
+                        region.region_id, options.max_output_file_size, size
+                    );
+                    options.max_output_file_size = size;
+                }
+                ChangeOption::TwscTimeWindow(window) => {
+                    let Twcs(options) = &mut current_options.compaction;
+                    info!(
+                        "Update region compaction.twcs.time_window: {}, previous: {:?} new: {:?}",
+                        region.region_id, options.time_window, window
+                    );
+                    options.time_window = window;
+                }
+                ChangeOption::TwscFallbackToLocal(allow) => {
+                    let Twcs(options) = &mut current_options.compaction;
+                    let allow = allow.unwrap_or(TwcsOptions::default().fallback_to_local);
+                    info!(
+                        "Update region compaction.twcs.fallback_to_local: {}, previous: {:?} new: {:?}",
+                        region.region_id, options.remote_compaction, allow
+                    );
+                    options.fallback_to_local = allow;
                 }
             }
         }

--- a/src/store-api/src/mito_engine_options.rs
+++ b/src/store-api/src/mito_engine_options.rs
@@ -23,20 +23,34 @@ pub const APPEND_MODE_KEY: &str = "append_mode";
 pub const MERGE_MODE_KEY: &str = "merge_mode";
 /// Option key for TTL(time-to-live)
 pub const TTL_KEY: &str = "ttl";
+/// Option key for twcs max active window runs.
+pub const TWCS_MAX_ACTIVE_WINDOW_RUNS: &str = "compaction.twcs.max_active_window_runs";
+/// Option key for twcs max active window files.
+pub const TWCS_MAX_ACTIVE_WINDOW_FILES: &str = "compaction.twcs.max_active_window_files";
+/// Option key for twcs max inactive window runs.
+pub const TWCS_MAX_INACTIVE_WINDOW_RUNS: &str = "compaction.twcs.max_inactive_window_runs";
+/// Option key for twcs max inactive window files.
+pub const TWCS_MAX_INACTIVE_WINDOW_FILES: &str = "compaction.twcs.max_inactive_window_files";
+/// Option key for twcs max output file size.
+pub const TWCS_MAX_OUTPUT_FILE_SIZE: &str = "compaction.twcs.max_output_file_size";
+/// Option key for twcs time window.
+pub const TWCS_TIME_WINDOW: &str = "compaction.twcs.time_window";
+/// Option key for twcs fallback to local.
+pub const TWCS_FALLBACK_TO_LOCAL: &str = "compaction.twcs.fallback_to_local";
 
 /// Returns true if the `key` is a valid option key for the mito engine.
 pub fn is_mito_engine_option_key(key: &str) -> bool {
     [
         "ttl",
         "compaction.type",
-        "compaction.twcs.max_active_window_runs",
-        "compaction.twcs.max_active_window_files",
-        "compaction.twcs.max_inactive_window_runs",
-        "compaction.twcs.max_inactive_window_files",
-        "compaction.twcs.max_output_file_size",
-        "compaction.twcs.time_window",
+        TWCS_MAX_ACTIVE_WINDOW_RUNS,
+        TWCS_MAX_ACTIVE_WINDOW_FILES,
+        TWCS_MAX_INACTIVE_WINDOW_RUNS,
+        TWCS_MAX_INACTIVE_WINDOW_FILES,
+        TWCS_MAX_OUTPUT_FILE_SIZE,
+        TWCS_TIME_WINDOW,
         "compaction.twcs.remote_compaction",
-        "compaction.twcs.fallback_to_local",
+        TWCS_FALLBACK_TO_LOCAL,
         "storage",
         "index.inverted_index.ignore_column_ids",
         "index.inverted_index.segment_row_count",

--- a/src/table/src/metadata.rs
+++ b/src/table/src/metadata.rs
@@ -219,6 +219,17 @@ impl TableMeta {
                         new_options.ttl = Some(*new_ttl);
                     }
                 }
+                _ => {
+                    let change_option = request.to_change_table_option();
+                    if !change_option.value.is_empty() {
+                        new_options
+                            .extra_options
+                            .insert(change_option.key, change_option.value);
+                    } else {
+                        // Invalidate the previous change option if an empty value has been set.
+                        new_options.extra_options.remove(&change_option.key);
+                    }
+                }
             }
         }
         let mut builder = self.new_meta_builder();

--- a/tests/cases/standalone/common/alter/alter_table_options.result
+++ b/tests/cases/standalone/common/alter/alter_table_options.result
@@ -137,6 +137,87 @@ SELECT i FROM ato;
 | 2 |
 +---+
 
+ALTER TABLE ato SET 'compaction.twcs.time_window'='2h';
+
+Affected Rows: 0
+
+ALTER TABLE ato SET 'compaction.twcs.max_output_file_size'='500MB';
+
+Affected Rows: 0
+
+ALTER TABLE ato SET 'compaction.twcs.max_inactive_window_files'='2';
+
+Affected Rows: 0
+
+ALTER TABLE ato SET 'compaction.twcs.max_active_window_files'='2';
+
+Affected Rows: 0
+
+ALTER TABLE ato SET 'compaction.twcs.max_active_window_runs'='6';
+
+Affected Rows: 0
+
+ALTER TABLE ato SET 'compaction.twcs.max_inactive_window_runs'='6';
+
+Affected Rows: 0
+
+ALTER TABLE ato SET 'compaction.twcs.fallback_to_local'='false';
+
+Affected Rows: 0
+
+SHOW CREATE TABLE ato;
+
++-------+------------------------------------------------------+
+| Table | Create Table                                         |
++-------+------------------------------------------------------+
+| ato   | CREATE TABLE IF NOT EXISTS "ato" (                   |
+|       |   "i" INT NULL,                                      |
+|       |   "j" TIMESTAMP(3) NOT NULL,                         |
+|       |   TIME INDEX ("j"),                                  |
+|       |   PRIMARY KEY ("i")                                  |
+|       | )                                                    |
+|       |                                                      |
+|       | ENGINE=mito                                          |
+|       | WITH(                                                |
+|       |   compaction.twcs.fallback_to_local = 'false',       |
+|       |   compaction.twcs.max_active_window_files = '2',     |
+|       |   compaction.twcs.max_active_window_runs = '6',      |
+|       |   compaction.twcs.max_inactive_window_files = '2',   |
+|       |   compaction.twcs.max_inactive_window_runs = '6',    |
+|       |   compaction.twcs.max_output_file_size = '500.0MiB', |
+|       |   compaction.twcs.time_window = '2h',                |
+|       |   ttl = '1s'                                         |
+|       | )                                                    |
++-------+------------------------------------------------------+
+
+ALTER TABLE ato SET 'compaction.twcs.time_window'='';
+
+Affected Rows: 0
+
+SHOW CREATE TABLE ato;
+
++-------+------------------------------------------------------+
+| Table | Create Table                                         |
++-------+------------------------------------------------------+
+| ato   | CREATE TABLE IF NOT EXISTS "ato" (                   |
+|       |   "i" INT NULL,                                      |
+|       |   "j" TIMESTAMP(3) NOT NULL,                         |
+|       |   TIME INDEX ("j"),                                  |
+|       |   PRIMARY KEY ("i")                                  |
+|       | )                                                    |
+|       |                                                      |
+|       | ENGINE=mito                                          |
+|       | WITH(                                                |
+|       |   compaction.twcs.fallback_to_local = 'false',       |
+|       |   compaction.twcs.max_active_window_files = '2',     |
+|       |   compaction.twcs.max_active_window_runs = '6',      |
+|       |   compaction.twcs.max_inactive_window_files = '2',   |
+|       |   compaction.twcs.max_inactive_window_runs = '6',    |
+|       |   compaction.twcs.max_output_file_size = '500.0MiB', |
+|       |   ttl = '1s'                                         |
+|       | )                                                    |
++-------+------------------------------------------------------+
+
 DROP TABLE ato;
 
 Affected Rows: 0

--- a/tests/cases/standalone/common/alter/alter_table_options.sql
+++ b/tests/cases/standalone/common/alter/alter_table_options.sql
@@ -28,4 +28,24 @@ SHOW CREATE TABLE ato;
 
 SELECT i FROM ato;
 
+ALTER TABLE ato SET 'compaction.twcs.time_window'='2h';
+
+ALTER TABLE ato SET 'compaction.twcs.max_output_file_size'='500MB';
+
+ALTER TABLE ato SET 'compaction.twcs.max_inactive_window_files'='2';
+
+ALTER TABLE ato SET 'compaction.twcs.max_active_window_files'='2';
+
+ALTER TABLE ato SET 'compaction.twcs.max_active_window_runs'='6';
+
+ALTER TABLE ato SET 'compaction.twcs.max_inactive_window_runs'='6';
+
+ALTER TABLE ato SET 'compaction.twcs.fallback_to_local'='false';
+
+SHOW CREATE TABLE ato;
+
+ALTER TABLE ato SET 'compaction.twcs.time_window'='';
+
+SHOW CREATE TABLE ato;
+
 DROP TABLE ato;


### PR DESCRIPTION
## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/4905

## What's changed and what's your intention?
support alter twcs compaction options on sql level

__!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:
expand alter table set options to include  twcs compaction options.

- Summarize your change (**mandatory**)
The approach here is to expand ChangeOption enum with twcs compaction options. 
The key and value type is validated at store-api end. 
If value is missing (empty string) it will be set with default value.
Changes will be reflected on show create table statements.

- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
