### PR TITLE
docs: Introducing GreptimeDB Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,6 @@
 <a href="https://github.com/greptimeTeam/greptimedb/blob/main/LICENSE">
 <img src="https://img.shields.io/github/license/greptimeTeam/greptimedb" alt="License"/>
 </a>
-<a href="https://gurubase.io/g/greptimedb">
-<img src="https://img.shields.io/badge/Gurubase-Ask%20GreptimeDB%20Guru-006BFF" alt="Gurubase"/>
-</a>
 
 <br/>
 
@@ -48,6 +45,9 @@
 </a>
 <a href="https://www.linkedin.com/company/greptime/">
 <img src="https://img.shields.io/badge/linkedin-connect_with_us-0a66c2.svg?style=for-the-badge" alt="LinkedIn"/>
+</a>
+<a href="https://gurubase.io/g/greptimedb">
+<img src="https://img.shields.io/badge/Gurubase-Ask%20GreptimeDB%20Guru-006BFF?style=for-the-badge" alt="Gurubase"/>
 </a>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@
 <a href="https://github.com/greptimeTeam/greptimedb/blob/main/LICENSE">
 <img src="https://img.shields.io/github/license/greptimeTeam/greptimedb" alt="License"/>
 </a>
+<a href="https://gurubase.io/g/greptimedb">
+<img src="https://img.shields.io/badge/Gurubase-Ask%20GreptimeDB%20Guru-006BFF" alt="Gurubase"/>
+</a>
 
 <br/>
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [GreptimeDB Guru](https://gurubase.io/g/greptimedb) to Gurubase. GreptimeDB Guru uses the data from this repo and data from the [docs](https://docs.greptime.com/) to answer questions by leveraging the LLM.

In this PR, I showcased the "GreptimeDB Guru", which highlights that GreptimeDB now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable GreptimeDB Guru in Gurubase, just let me know that's totally fine.
