### PR TITLE
fix: the region_stats API will return an error in instance test

### DIFF
--- a/tests-integration/src/cluster.rs
+++ b/tests-integration/src/cluster.rs
@@ -346,6 +346,7 @@ impl GreptimeDbClusterBuilder {
     ) -> Arc<FeInstance> {
         let mut meta_client = MetaClientBuilder::frontend_default_options(1000)
             .channel_manager(metasrv.channel_manager)
+            .enable_access_cluster_info()
             .build();
         meta_client.start(&[&metasrv.server_addr]).await.unwrap();
         let meta_client = Arc::new(meta_client);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Fixes #4935

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
