### PR TITLE
fix: column already exists

### DIFF
--- a/src/metric-engine/src/engine/region_metadata.rs
+++ b/src/metric-engine/src/engine/region_metadata.rs
@@ -57,7 +57,7 @@ impl MetricEngineInner {
             .collect::<Vec<_>>();
 
         // Update cache
-        let mutable_state = self.state.write().unwrap();
+        let mut mutable_state = self.state.write().unwrap();
         // Merge with existing cached columnd.
         let existing_columns = mutable_state
             .logical_columns()
@@ -75,10 +75,7 @@ impl MetricEngineInner {
             .collect::<Vec<_>>();
         // Sort columns on column name to ensure the order
         dedup_columns.sort_unstable_by(|c1, c2| c1.column_schema.name.cmp(&c2.column_schema.name));
-        self.state
-            .write()
-            .unwrap()
-            .set_logical_columns(logical_region_id, dedup_columns.clone());
+        mutable_state.set_logical_columns(logical_region_id, dedup_columns.clone());
 
         Ok(dedup_columns)
     }

--- a/src/metric-engine/src/engine/region_metadata.rs
+++ b/src/metric-engine/src/engine/region_metadata.rs
@@ -58,7 +58,7 @@ impl MetricEngineInner {
 
         // Update cache
         let mut mutable_state = self.state.write().unwrap();
-        // Merge with existing cached columnd.
+        // Merge with existing cached columns.
         let existing_columns = mutable_state
             .logical_columns()
             .get(&logical_region_id)

--- a/src/metric-engine/src/engine/region_metadata.rs
+++ b/src/metric-engine/src/engine/region_metadata.rs
@@ -14,6 +14,8 @@
 
 //! Implementation of retrieving logical region's region metadata.
 
+use std::collections::HashMap;
+
 use store_api::metadata::ColumnMetadata;
 use store_api::storage::RegionId;
 
@@ -46,23 +48,39 @@ impl MetricEngineInner {
             .read_lock_logical_region(logical_region_id)
             .await;
         // Load logical and physical columns, and intersect them to get logical column metadata.
-        let mut logical_column_metadata = self
+        let logical_column_metadata = self
             .metadata_region
             .logical_columns(physical_region_id, logical_region_id)
             .await?
             .into_iter()
             .map(|(_, column_metadata)| column_metadata)
             .collect::<Vec<_>>();
-        // Sort columns on column name to ensure the order
-        logical_column_metadata
-            .sort_unstable_by(|c1, c2| c1.column_schema.name.cmp(&c2.column_schema.name));
+
         // Update cache
+        let mutable_state = self.state.write().unwrap();
+        // Merge with existing cached columnd.
+        let existing_columns = mutable_state
+            .logical_columns()
+            .get(&logical_region_id)
+            .cloned()
+            .unwrap_or_default()
+            .into_iter();
+        let mut dedup_columns = logical_column_metadata
+            .into_iter()
+            .chain(existing_columns)
+            .map(|c| (c.column_id, c))
+            .collect::<HashMap<_, _>>()
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        // Sort columns on column name to ensure the order
+        dedup_columns.sort_unstable_by(|c1, c2| c1.column_schema.name.cmp(&c2.column_schema.name));
         self.state
             .write()
             .unwrap()
-            .add_logical_columns(logical_region_id, logical_column_metadata.clone());
+            .set_logical_columns(logical_region_id, dedup_columns.clone());
 
-        Ok(logical_column_metadata)
+        Ok(dedup_columns)
     }
 
     /// Load logical column names of a logical region.

--- a/src/metric-engine/src/engine/state.rs
+++ b/src/metric-engine/src/engine/state.rs
@@ -85,19 +85,13 @@ impl MetricEngineState {
             .insert(logical_region_id, physical_region_id);
     }
 
-    /// Add and reorder logical columns.
-    ///
-    /// Caller should make sure:
-    /// 1. there is no duplicate columns
-    /// 2. the column order is the same with the order in the metadata, which is
-    ///    alphabetically ordered on column name.
-    pub fn add_logical_columns(
+    /// Replace the logical columns of the logical region with given columns.
+    pub fn set_logical_columns(
         &mut self,
         logical_region_id: RegionId,
-        new_columns: impl IntoIterator<Item = ColumnMetadata>,
+        columns: Vec<ColumnMetadata>,
     ) {
-        let columns = self.logical_columns.entry(logical_region_id).or_default();
-        columns.extend(new_columns);
+        self.logical_columns.insert(logical_region_id, columns);
     }
 
     pub fn get_physical_region_id(&self, logical_region_id: RegionId) -> Option<RegionId> {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

![image](https://github.com/user-attachments/assets/744ddb73-9d7a-4cc9-9f8c-9d38def4d7f5)

This is caused by a concurrent update bug to the metadata cache.

## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
