### PR TITLE
feat: support alter twcs compaction options

### DIFF
--- a/src/store-api/src/mito_engine_options.rs
+++ b/src/store-api/src/mito_engine_options.rs
@@ -23,20 +23,40 @@ pub const APPEND_MODE_KEY: &str = "append_mode";
 pub const MERGE_MODE_KEY: &str = "merge_mode";
 /// Option key for TTL(time-to-live)
 pub const TTL_KEY: &str = "ttl";
+/// Option key for compaction type.
+pub const COMPACTION_TYPE: &str = "compaction.type";
+/// TWCS compaction strategy.
+pub const COMPACTION_TYPE_TWCS: &str = "twcs";
+/// Option key for twcs max active window runs.
+pub const TWCS_MAX_ACTIVE_WINDOW_RUNS: &str = "compaction.twcs.max_active_window_runs";
+/// Option key for twcs max active window files.
+pub const TWCS_MAX_ACTIVE_WINDOW_FILES: &str = "compaction.twcs.max_active_window_files";
+/// Option key for twcs max inactive window runs.
+pub const TWCS_MAX_INACTIVE_WINDOW_RUNS: &str = "compaction.twcs.max_inactive_window_runs";
+/// Option key for twcs max inactive window files.
+pub const TWCS_MAX_INACTIVE_WINDOW_FILES: &str = "compaction.twcs.max_inactive_window_files";
+/// Option key for twcs max output file size.
+pub const TWCS_MAX_OUTPUT_FILE_SIZE: &str = "compaction.twcs.max_output_file_size";
+/// Option key for twcs time window.
+pub const TWCS_TIME_WINDOW: &str = "compaction.twcs.time_window";
+/// Option key for twcs remote compaction.
+pub const REMOTE_COMPACTION: &str = "compaction.twcs.remote_compaction";
+/// Option key for twcs fallback to local.
+pub const TWCS_FALLBACK_TO_LOCAL: &str = "compaction.twcs.fallback_to_local";
 
 /// Returns true if the `key` is a valid option key for the mito engine.
 pub fn is_mito_engine_option_key(key: &str) -> bool {
     [
         "ttl",
-        "compaction.type",
-        "compaction.twcs.max_active_window_runs",
-        "compaction.twcs.max_active_window_files",
-        "compaction.twcs.max_inactive_window_runs",
-        "compaction.twcs.max_inactive_window_files",
-        "compaction.twcs.max_output_file_size",
-        "compaction.twcs.time_window",
-        "compaction.twcs.remote_compaction",
-        "compaction.twcs.fallback_to_local",
+        COMPACTION_TYPE,
+        TWCS_MAX_ACTIVE_WINDOW_RUNS,
+        TWCS_MAX_ACTIVE_WINDOW_FILES,
+        TWCS_MAX_INACTIVE_WINDOW_RUNS,
+        TWCS_MAX_INACTIVE_WINDOW_FILES,
+        TWCS_MAX_OUTPUT_FILE_SIZE,
+        TWCS_TIME_WINDOW,
+        REMOTE_COMPACTION,
+        TWCS_FALLBACK_TO_LOCAL,
         "storage",
         "index.inverted_index.ignore_column_ids",
         "index.inverted_index.segment_row_count",

--- a/src/table/src/metadata.rs
+++ b/src/table/src/metadata.rs
@@ -24,6 +24,7 @@ use datatypes::schema::{ColumnSchema, RawSchema, Schema, SchemaBuilder, SchemaRe
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use snafu::{ensure, OptionExt, ResultExt};
+use store_api::mito_engine_options::{COMPACTION_TYPE, COMPACTION_TYPE_TWCS};
 use store_api::region_request::ChangeOption;
 use store_api::storage::{ColumnDescriptor, ColumnDescriptorBuilder, ColumnId, RegionId};
 
@@ -217,6 +218,21 @@ impl TableMeta {
                         new_options.ttl = None;
                     } else {
                         new_options.ttl = Some(*new_ttl);
+                    }
+                }
+                ChangeOption::Twsc(key, value) => {
+                    if !value.is_empty() {
+                        new_options
+                            .extra_options
+                            .insert(key.to_string(), value.to_string());
+                        // Ensure node restart correctly.
+                        new_options.extra_options.insert(
+                            COMPACTION_TYPE.to_string(),
+                            COMPACTION_TYPE_TWCS.to_string(),
+                        );
+                    } else {
+                        // Invalidate the previous change option if an empty value has been set.
+                        new_options.extra_options.remove(key.as_str());
                     }
                 }
             }

--- a/tests/cases/standalone/common/alter/alter_table_options.result
+++ b/tests/cases/standalone/common/alter/alter_table_options.result
@@ -137,6 +137,108 @@ SELECT i FROM ato;
 | 2 |
 +---+
 
+ALTER TABLE ato SET 'compaction.twcs.time_window'='2h';
+
+Affected Rows: 0
+
+ALTER TABLE ato SET 'compaction.twcs.max_output_file_size'='500MB';
+
+Affected Rows: 0
+
+ALTER TABLE ato SET 'compaction.twcs.max_inactive_window_files'='2';
+
+Affected Rows: 0
+
+ALTER TABLE ato SET 'compaction.twcs.max_active_window_files'='2';
+
+Affected Rows: 0
+
+ALTER TABLE ato SET 'compaction.twcs.max_active_window_runs'='6';
+
+Affected Rows: 0
+
+ALTER TABLE ato SET 'compaction.twcs.max_inactive_window_runs'='6';
+
+Affected Rows: 0
+
+SHOW CREATE TABLE ato;
+
++-------+----------------------------------------------------+
+| Table | Create Table                                       |
++-------+----------------------------------------------------+
+| ato   | CREATE TABLE IF NOT EXISTS "ato" (                 |
+|       |   "i" INT NULL,                                    |
+|       |   "j" TIMESTAMP(3) NOT NULL,                       |
+|       |   TIME INDEX ("j"),                                |
+|       |   PRIMARY KEY ("i")                                |
+|       | )                                                  |
+|       |                                                    |
+|       | ENGINE=mito                                        |
+|       | WITH(                                              |
+|       |   compaction.twcs.max_active_window_files = '2',   |
+|       |   compaction.twcs.max_active_window_runs = '6',    |
+|       |   compaction.twcs.max_inactive_window_files = '2', |
+|       |   compaction.twcs.max_inactive_window_runs = '6',  |
+|       |   compaction.twcs.max_output_file_size = '500MB',  |
+|       |   compaction.twcs.time_window = '2h',              |
+|       |   compaction.type = 'twcs',                        |
+|       |   ttl = '1s'                                       |
+|       | )                                                  |
++-------+----------------------------------------------------+
+
+ALTER TABLE ato SET 'compaction.twcs.time_window'='';
+
+Affected Rows: 0
+
+SHOW CREATE TABLE ato;
+
++-------+----------------------------------------------------+
+| Table | Create Table                                       |
++-------+----------------------------------------------------+
+| ato   | CREATE TABLE IF NOT EXISTS "ato" (                 |
+|       |   "i" INT NULL,                                    |
+|       |   "j" TIMESTAMP(3) NOT NULL,                       |
+|       |   TIME INDEX ("j"),                                |
+|       |   PRIMARY KEY ("i")                                |
+|       | )                                                  |
+|       |                                                    |
+|       | ENGINE=mito                                        |
+|       | WITH(                                              |
+|       |   compaction.twcs.max_active_window_files = '2',   |
+|       |   compaction.twcs.max_active_window_runs = '6',    |
+|       |   compaction.twcs.max_inactive_window_files = '2', |
+|       |   compaction.twcs.max_inactive_window_runs = '6',  |
+|       |   compaction.twcs.max_output_file_size = '500MB',  |
+|       |   compaction.type = 'twcs',                        |
+|       |   ttl = '1s'                                       |
+|       | )                                                  |
++-------+----------------------------------------------------+
+
+-- SQLNESS ARG restart=true
+SHOW CREATE TABLE ato;
+
++-------+----------------------------------------------------+
+| Table | Create Table                                       |
++-------+----------------------------------------------------+
+| ato   | CREATE TABLE IF NOT EXISTS "ato" (                 |
+|       |   "i" INT NULL,                                    |
+|       |   "j" TIMESTAMP(3) NOT NULL,                       |
+|       |   TIME INDEX ("j"),                                |
+|       |   PRIMARY KEY ("i")                                |
+|       | )                                                  |
+|       |                                                    |
+|       | ENGINE=mito                                        |
+|       | WITH(                                              |
+|       |   compaction.twcs.max_active_window_files = '2',   |
+|       |   compaction.twcs.max_active_window_runs = '6',    |
+|       |   compaction.twcs.max_inactive_window_files = '2', |
+|       |   compaction.twcs.max_inactive_window_runs = '6',  |
+|       |   compaction.twcs.max_output_file_size = '500MB',  |
+|       |   compaction.type = 'twcs',                        |
+|       |   ttl = '1s'                                       |
+|       | )                                                  |
++-------+----------------------------------------------------+
+
 DROP TABLE ato;
 
 Affected Rows: 0

--- a/tests/cases/standalone/common/alter/alter_table_options.sql
+++ b/tests/cases/standalone/common/alter/alter_table_options.sql
@@ -28,4 +28,25 @@ SHOW CREATE TABLE ato;
 
 SELECT i FROM ato;
 
+ALTER TABLE ato SET 'compaction.twcs.time_window'='2h';
+
+ALTER TABLE ato SET 'compaction.twcs.max_output_file_size'='500MB';
+
+ALTER TABLE ato SET 'compaction.twcs.max_inactive_window_files'='2';
+
+ALTER TABLE ato SET 'compaction.twcs.max_active_window_files'='2';
+
+ALTER TABLE ato SET 'compaction.twcs.max_active_window_runs'='6';
+
+ALTER TABLE ato SET 'compaction.twcs.max_inactive_window_runs'='6';
+
+SHOW CREATE TABLE ato;
+
+ALTER TABLE ato SET 'compaction.twcs.time_window'='';
+
+SHOW CREATE TABLE ato;
+
+-- SQLNESS ARG restart=true
+SHOW CREATE TABLE ato;
+
 DROP TABLE ato;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/4905
## What's changed and what's your intention?
support alter twcs compaction options on sql level
- The approach here is to expand ChangeOption enum with twcs compaction options.
- The key and value type is validated at store-api end.
- If value is missing (empty string) it will be set with default value.


Changes will be reflected on show create table statements.
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
