### PR TITLE
refactor: consolidate `DatanodeClientOptions`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1840,6 +1840,7 @@ dependencies = [
  "common-grpc",
  "common-macro",
  "common-meta",
+ "common-options",
  "common-procedure",
  "common-query",
  "common-recordbatch",
@@ -2237,6 +2238,15 @@ dependencies = [
  "tonic 0.11.0",
  "typetag",
  "uuid",
+]
+
+[[package]]
+name = "common-options"
+version = "0.9.5"
+dependencies = [
+ "common-grpc",
+ "humantime-serde",
+ "serde",
 ]
 
 [[package]]
@@ -4173,6 +4183,7 @@ dependencies = [
  "common-grpc",
  "common-macro",
  "common-meta",
+ "common-options",
  "common-procedure",
  "common-query",
  "common-recordbatch",
@@ -6485,6 +6496,7 @@ dependencies = [
  "common-grpc",
  "common-macro",
  "common-meta",
+ "common-options",
  "common-procedure",
  "common-procedure-test",
  "common-runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,23 +2,25 @@
 members = [
     "src/api",
     "src/auth",
-    "src/catalog",
     "src/cache",
+    "src/catalog",
     "src/client",
     "src/cmd",
     "src/common/base",
     "src/common/catalog",
     "src/common/config",
     "src/common/datasource",
+    "src/common/decimal",
     "src/common/error",
     "src/common/frontend",
     "src/common/function",
-    "src/common/macro",
     "src/common/greptimedb-telemetry",
     "src/common/grpc",
     "src/common/grpc-expr",
+    "src/common/macro",
     "src/common/mem-prof",
     "src/common/meta",
+    "src/common/options",
     "src/common/plugins",
     "src/common/pprof",
     "src/common/procedure",
@@ -30,7 +32,6 @@ members = [
     "src/common/telemetry",
     "src/common/test-util",
     "src/common/time",
-    "src/common/decimal",
     "src/common/version",
     "src/common/wal",
     "src/datanode",
@@ -38,6 +39,7 @@ members = [
     "src/file-engine",
     "src/flow",
     "src/frontend",
+    "src/index",
     "src/log-store",
     "src/meta-client",
     "src/meta-srv",
@@ -57,7 +59,6 @@ members = [
     "src/sql",
     "src/store-api",
     "src/table",
-    "src/index",
     "tests-fuzz",
     "tests-integration",
     "tests/runner",
@@ -214,6 +215,7 @@ common-grpc-expr = { path = "src/common/grpc-expr" }
 common-macro = { path = "src/common/macro" }
 common-mem-prof = { path = "src/common/mem-prof" }
 common-meta = { path = "src/common/meta" }
+common-options = { path = "src/common/options" }
 common-plugins = { path = "src/common/plugins" }
 common-pprof = { path = "src/common/pprof" }
 common-procedure = { path = "src/common/procedure" }

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -33,6 +33,7 @@ common-error.workspace = true
 common-grpc.workspace = true
 common-macro.workspace = true
 common-meta.workspace = true
+common-options.workspace = true
 common-procedure.workspace = true
 common-query.workspace = true
 common-recordbatch.workspace = true

--- a/src/cmd/tests/load_config_test.rs
+++ b/src/cmd/tests/load_config_test.rs
@@ -20,13 +20,13 @@ use common_config::Configurable;
 use common_grpc::channel_manager::{
     DEFAULT_MAX_GRPC_RECV_MESSAGE_SIZE, DEFAULT_MAX_GRPC_SEND_MESSAGE_SIZE,
 };
+use common_options::datanode::{ClientOptions, DatanodeClientOptions};
 use common_telemetry::logging::{LoggingOptions, SlowQueryOptions, DEFAULT_OTLP_ENDPOINT};
 use common_wal::config::raft_engine::RaftEngineConfig;
 use common_wal::config::DatanodeWalConfig;
 use datanode::config::{DatanodeOptions, RegionEngineConfig, StorageConfig};
 use file_engine::config::EngineConfig;
 use frontend::frontend::FrontendOptions;
-use frontend::service_config::datanode::DatanodeClientOptions;
 use meta_client::MetaClientOptions;
 use meta_srv::metasrv::MetasrvOptions;
 use meta_srv::selector::SelectorType;
@@ -126,10 +126,11 @@ fn test_load_frontend_example_config() {
                 tracing_sample_ratio: Some(Default::default()),
                 ..Default::default()
             },
-            datanode: frontend::service_config::DatanodeOptions {
-                client: DatanodeClientOptions {
+            datanode: DatanodeClientOptions {
+                client: ClientOptions {
                     connect_timeout: Duration::from_secs(10),
                     tcp_nodelay: true,
+                    ..Default::default()
                 },
             },
             export_metrics: ExportMetricsOption {
@@ -166,8 +167,8 @@ fn test_load_metasrv_example_config() {
                 },
                 ..Default::default()
             },
-            datanode: meta_srv::metasrv::DatanodeOptions {
-                client: meta_srv::metasrv::DatanodeClientOptions {
+            datanode: DatanodeClientOptions {
+                client: ClientOptions {
                     timeout: Duration::from_secs(10),
                     connect_timeout: Duration::from_secs(10),
                     tcp_nodelay: true,

--- a/src/common/options/Cargo.toml
+++ b/src/common/options/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "common-options"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+common-grpc.workspace = true
+humantime-serde.workspace = true
+serde.workspace = true
+
+[lints]
+workspace = true

--- a/src/common/options/src/datanode.rs
+++ b/src/common/options/src/datanode.rs
@@ -18,20 +18,23 @@ use common_grpc::channel_manager;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub struct DatanodeOptions {
-    pub client: DatanodeClientOptions,
+pub struct DatanodeClientOptions {
+    pub client: ClientOptions,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct DatanodeClientOptions {
+pub struct ClientOptions {
+    #[serde(with = "humantime_serde")]
+    pub timeout: Duration,
     #[serde(with = "humantime_serde")]
     pub connect_timeout: Duration,
     pub tcp_nodelay: bool,
 }
 
-impl Default for DatanodeClientOptions {
+impl Default for ClientOptions {
     fn default() -> Self {
         Self {
+            timeout: Duration::from_secs(channel_manager::DEFAULT_GRPC_REQUEST_TIMEOUT_SECS),
             connect_timeout: Duration::from_secs(
                 channel_manager::DEFAULT_GRPC_CONNECT_TIMEOUT_SECS,
             ),

--- a/src/common/options/src/lib.rs
+++ b/src/common/options/src/lib.rs
@@ -12,16 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod influxdb;
-pub mod mysql;
-pub mod opentsdb;
-pub mod otlp;
-pub mod postgres;
-pub mod prom_store;
-
-pub use influxdb::InfluxdbOptions;
-pub use mysql::MysqlOptions;
-pub use opentsdb::OpentsdbOptions;
-pub use otlp::OtlpOptions;
-pub use postgres::PostgresOptions;
-pub use prom_store::PromStoreOptions;
+pub mod datanode;

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -30,6 +30,7 @@ common-function.workspace = true
 common-grpc.workspace = true
 common-macro.workspace = true
 common-meta.workspace = true
+common-options.workspace = true
 common-procedure.workspace = true
 common-query.workspace = true
 common-recordbatch.workspace = true

--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use common_config::config::Configurable;
+use common_options::datanode::DatanodeClientOptions;
 use common_telemetry::logging::{LoggingOptions, TracingOptions};
 use meta_client::MetaClientOptions;
 use serde::{Deserialize, Serialize};
@@ -22,8 +23,7 @@ use servers::heartbeat_options::HeartbeatOptions;
 use servers::http::HttpOptions;
 
 use crate::service_config::{
-    DatanodeOptions, InfluxdbOptions, MysqlOptions, OpentsdbOptions, OtlpOptions, PostgresOptions,
-    PromStoreOptions,
+    InfluxdbOptions, MysqlOptions, OpentsdbOptions, OtlpOptions, PostgresOptions, PromStoreOptions,
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -42,7 +42,7 @@ pub struct FrontendOptions {
     pub otlp: OtlpOptions,
     pub meta_client: Option<MetaClientOptions>,
     pub logging: LoggingOptions,
-    pub datanode: DatanodeOptions,
+    pub datanode: DatanodeClientOptions,
     pub user_provider: Option<String>,
     pub export_metrics: ExportMetricsOption,
     pub tracing: TracingOptions,
@@ -64,7 +64,7 @@ impl Default for FrontendOptions {
             otlp: OtlpOptions::default(),
             meta_client: None,
             logging: LoggingOptions::default(),
-            datanode: DatanodeOptions::default(),
+            datanode: DatanodeClientOptions::default(),
             user_provider: None,
             export_metrics: ExportMetricsOption::default(),
             tracing: TracingOptions::default(),

--- a/src/meta-srv/Cargo.toml
+++ b/src/meta-srv/Cargo.toml
@@ -24,6 +24,7 @@ common-greptimedb-telemetry.workspace = true
 common-grpc.workspace = true
 common-macro.workspace = true
 common-meta.workspace = true
+common-options.workspace = true
 common-procedure.workspace = true
 common-runtime.workspace = true
 common-telemetry.workspace = true


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
Fixes #4932

## What's changed and what's your intention?

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Unify the datanode options in frontend and metasrv
- Move the `DatanodeClientOptions` into `common/options` crate.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
