### PR TITLE
fix: dbg assert may fail

### DIFF
--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -189,8 +189,6 @@ impl MysqlInstanceShim {
             dummy_params(param_num)?
         };
 
-        debug_assert_eq!(params.len(), param_num - 1);
-
         let columns = schema
             .as_ref()
             .map(|schema| {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The dbg_assert may fail for:

1. It asserts that the number of params in the sql text is the same as the number of params in the datafusion plan
2. but datafusion may optimize sql like `SELECT ? + 1 FROM 1 = 0` to an empty plan, so they may mismatch.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
