### PR TITLE
feat: refine region state checks and handle stalled requests

### DIFF
--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -550,6 +550,26 @@ impl RegionMap {
         Ok(region)
     }
 
+    /// Gets region by region id.
+    ///
+    /// Calls the callback if the region does not exist.
+    pub(crate) fn get_region_or<F: OnFailure>(
+        &self,
+        region_id: RegionId,
+        cb: &mut F,
+    ) -> Option<MitoRegionRef> {
+        match self
+            .get_region(region_id)
+            .context(RegionNotFoundSnafu { region_id })
+        {
+            Ok(region) => Some(region),
+            Err(e) => {
+                cb.on_failure(e);
+                None
+            }
+        }
+    }
+
     /// Gets writable region by region id.
     ///
     /// Calls the callback if the region does not exist or is readonly.

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -1029,6 +1029,15 @@ impl WorkerListener {
             listener.on_compaction_scheduled(_region_id);
         }
     }
+
+    pub(crate) async fn on_notify_region_change_result_begin(&self, _region_id: RegionId) {
+        #[cfg(any(test, feature = "test"))]
+        if let Some(listener) = &self.listener {
+            listener
+                .on_notify_region_change_result_begin(_region_id)
+                .await;
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -589,18 +589,17 @@ impl StalledRequests {
     /// Appends stalled requests.
     pub(crate) fn append(&mut self, requests: &mut Vec<SenderWriteRequest>) {
         for req in requests.drain(..) {
-            self.estimated_size += self.push(req);
+            self.push(req);
         }
     }
 
     /// Pushes a stalled request to the buffer.
-    pub(crate) fn push(&mut self, req: SenderWriteRequest) -> usize {
+    pub(crate) fn push(&mut self, req: SenderWriteRequest) {
         let (size, requests) = self.requests.entry(req.request.region_id).or_default();
         let req_size = req.request.estimated_size();
-
         *size += req_size;
+        self.estimated_size += req_size;
         requests.push(req);
-        req_size
     }
 
     /// Removes stalled requests of specific region.

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -580,6 +580,9 @@ type RequestBuffer = Vec<WorkerRequest>;
 #[derive(Default)]
 pub(crate) struct StalledRequests {
     /// Stalled requests.
+    ///
+    /// Key: RegionId
+    /// Value: (estimated size, stalled requests)
     pub(crate) requests: HashMap<RegionId, (usize, Vec<SenderWriteRequest>)>,
     /// Estimated size of all stalled requests.
     pub(crate) estimated_size: usize,

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 
 use common_telemetry::{debug, info};
 use snafu::ResultExt;
-use store_api::logstore::LogStore;
 use store_api::metadata::{RegionMetadata, RegionMetadataBuilder, RegionMetadataRef};
 use store_api::region_request::{AlterKind, ChangeOption, RegionAlterRequest};
 use store_api::storage::RegionId;
@@ -33,7 +32,7 @@ use crate::region::MitoRegionRef;
 use crate::request::{DdlRequest, OptionOutputTx, SenderDdlRequest};
 use crate::worker::RegionWorkerLoop;
 
-impl<S: LogStore> RegionWorkerLoop<S> {
+impl<S> RegionWorkerLoop<S> {
     pub(crate) async fn handle_alter_request(
         &mut self,
         region_id: RegionId,

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 
 use common_telemetry::{debug, info};
 use snafu::ResultExt;
+use store_api::logstore::LogStore;
 use store_api::metadata::{RegionMetadata, RegionMetadataBuilder, RegionMetadataRef};
 use store_api::region_request::{AlterKind, ChangeOption, RegionAlterRequest};
 use store_api::storage::RegionId;
@@ -32,7 +33,7 @@ use crate::region::MitoRegionRef;
 use crate::request::{DdlRequest, OptionOutputTx, SenderDdlRequest};
 use crate::worker::RegionWorkerLoop;
 
-impl<S> RegionWorkerLoop<S> {
+impl<S: LogStore> RegionWorkerLoop<S> {
     pub(crate) async fn handle_alter_request(
         &mut self,
         region_id: RegionId,

--- a/src/mito2/src/worker/handle_manifest.rs
+++ b/src/mito2/src/worker/handle_manifest.rs
@@ -234,7 +234,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             sender.send(Err(e));
             return;
         }
-
+        let listener = self.listener.clone();
         let request_sender = self.sender.clone();
         // Now the region is in altering state.
         common_runtime::spawn_global(async move {
@@ -255,6 +255,9 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                     new_meta,
                 }),
             };
+            listener
+                .on_notify_region_change_result_begin(region.region_id)
+                .await;
 
             if let Err(res) = request_sender.send(notify).await {
                 warn!(

--- a/src/mito2/src/worker/handle_write.rs
+++ b/src/mito2/src/worker/handle_write.rs
@@ -124,7 +124,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         let stalled = std::mem::take(&mut self.stalled_requests);
         self.stalled_count.sub(stalled.requests.len() as i64);
         // We already stalled these requests, don't stall them again.
-        for (_, requests) in stalled.requests {
+        for (_, (_, requests)) in stalled.requests {
             self.handle_write_requests(requests, false).await;
         }
     }
@@ -133,7 +133,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
     pub(crate) fn reject_stalled_requests(&mut self) {
         let stalled = std::mem::take(&mut self.stalled_requests);
         self.stalled_count.sub(stalled.requests.len() as i64);
-        for (_, requests) in stalled.requests {
+        for (_, (_, requests)) in stalled.requests {
             reject_write_requests(requests);
         }
     }

--- a/src/mito2/src/worker/handle_write.rs
+++ b/src/mito2/src/worker/handle_write.rs
@@ -23,8 +23,9 @@ use store_api::logstore::LogStore;
 use store_api::metadata::RegionMetadata;
 use store_api::storage::RegionId;
 
-use crate::error::{InvalidRequestSnafu, RejectWriteSnafu, Result};
+use crate::error::{InvalidRequestSnafu, RegionLeaderStateSnafu, RejectWriteSnafu, Result};
 use crate::metrics::{WRITE_REJECT_TOTAL, WRITE_ROWS_TOTAL, WRITE_STAGE_ELAPSED};
+use crate::region::{RegionLeaderState, RegionRoleState};
 use crate::region_write_ctx::RegionWriteCtx;
 use crate::request::{SenderWriteRequest, WriteRequest};
 use crate::worker::RegionWorkerLoop;
@@ -47,9 +48,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             // The memory pressure is still too high, reject write requests.
             reject_write_requests(write_requests);
             // Also reject all stalled requests.
-            let stalled = std::mem::take(&mut self.stalled_requests);
-            self.stalled_count.sub(stalled.requests.len() as i64);
-            reject_write_requests(stalled.requests);
+            self.reject_stalled_requests();
             return;
         }
 
@@ -124,7 +123,32 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         let stalled = std::mem::take(&mut self.stalled_requests);
         self.stalled_count.sub(stalled.requests.len() as i64);
         // We already stalled these requests, don't stall them again.
-        self.handle_write_requests(stalled.requests, false).await;
+        for (_, requests) in stalled.requests {
+            self.handle_write_requests(requests, false).await;
+        }
+    }
+
+    /// Rejects all stalled requests.
+    pub(crate) fn reject_stalled_requests(&mut self) {
+        let stalled = std::mem::take(&mut self.stalled_requests);
+        self.stalled_count.sub(stalled.requests.len() as i64);
+        for (_, requests) in stalled.requests {
+            reject_write_requests(requests);
+        }
+    }
+
+    /// Rejects a specific region's stalled requests.
+    pub(crate) fn reject_region_stalled_requests(&mut self, region_id: &RegionId) {
+        let requests = self.stalled_requests.remove(region_id);
+        self.stalled_count.sub(requests.len() as i64);
+        reject_write_requests(requests);
+    }
+
+    /// Handles a specific region's stalled requests.
+    pub(crate) async fn handle_region_stalled_requests(&mut self, region_id: &RegionId) {
+        let requests = self.stalled_requests.remove(region_id);
+        self.stalled_count.sub(requests.len() as i64);
+        self.handle_write_requests(requests, true).await;
     }
 }
 
@@ -152,19 +176,39 @@ impl<S> RegionWorkerLoop<S> {
             if let hash_map::Entry::Vacant(e) = region_ctxs.entry(region_id) {
                 let Some(region) = self
                     .regions
-                    .writable_region_or(region_id, &mut sender_req.sender)
+                    .get_region_or(region_id, &mut sender_req.sender)
                 else {
-                    // No such region or the region is read only.
+                    // No such region.
                     continue;
                 };
+                match region.state() {
+                    RegionRoleState::Leader(RegionLeaderState::Writable) => {
+                        let region_ctx = RegionWriteCtx::new(
+                            region.region_id,
+                            &region.version_control,
+                            region.provider.clone(),
+                        );
 
-                let region_ctx = RegionWriteCtx::new(
-                    region.region_id,
-                    &region.version_control,
-                    region.provider.clone(),
-                );
-
-                e.insert(region_ctx);
+                        e.insert(region_ctx);
+                    }
+                    RegionRoleState::Leader(RegionLeaderState::Altering) => {
+                        self.stalled_count.add(1);
+                        self.stalled_requests.push(sender_req);
+                        continue;
+                    }
+                    state => {
+                        // The region is not writable.
+                        sender_req.sender.send(
+                            RegionLeaderStateSnafu {
+                                region_id,
+                                state,
+                                expect: RegionLeaderState::Writable,
+                            }
+                            .fail(),
+                        );
+                        continue;
+                    }
+                }
             }
 
             // Safety: Now we ensure the region exists.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

refine region state checks and handle stalled requests

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `NotifyRegionChangeResultListener` for enhanced region change notifications.
	- Added asynchronous test for handling concurrent alter requests.
	- New methods for improved error handling in region management, including `get_region_or` and `writable_region_or`.
	- Enhanced management of stalled requests with new methods for rejection and handling.

- **Bug Fixes**
	- Improved error handling and state management in region edit and change requests.

- **Documentation**
	- Updated method signatures to reflect new constraints and functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->