### PR TITLE
refactor(mito): tidy memtable stats

### DIFF
--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -42,6 +42,7 @@ use crate::sst::file::FileTimeRange;
 pub mod bulk;
 pub mod key_values;
 pub mod partition_tree;
+mod stats;
 pub mod time_partition;
 pub mod time_series;
 pub(crate) mod version;

--- a/src/mito2/src/memtable/partition_tree.rs
+++ b/src/mito2/src/memtable/partition_tree.rs
@@ -18,7 +18,6 @@ pub(crate) mod data;
 mod dedup;
 mod dict;
 mod merger;
-mod metrics;
 mod partition;
 mod shard;
 mod shard_builder;
@@ -38,8 +37,8 @@ use table::predicate::Predicate;
 use crate::error::{Result, UnsupportedOperationSnafu};
 use crate::flush::WriteBufferManagerRef;
 use crate::memtable::key_values::KeyValue;
-use crate::memtable::partition_tree::metrics::WriteMetrics;
 use crate::memtable::partition_tree::tree::PartitionTree;
+use crate::memtable::stats::WriteMetrics;
 use crate::memtable::{
     AllocTracker, BoxedBatchIterator, BulkPart, IterBuilder, KeyValues, Memtable, MemtableBuilder,
     MemtableId, MemtableRange, MemtableRangeContext, MemtableRef, MemtableStats,

--- a/src/mito2/src/memtable/partition_tree/dict.rs
+++ b/src/mito2/src/memtable/partition_tree/dict.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 
 use datatypes::arrow::array::{Array, ArrayBuilder, BinaryArray, BinaryBuilder};
 
-use crate::memtable::partition_tree::metrics::WriteMetrics;
 use crate::memtable::partition_tree::PkIndex;
+use crate::memtable::stats::WriteMetrics;
 use crate::metrics::MEMTABLE_DICT_BYTES;
 
 /// Maximum keys in a [DictBlock].

--- a/src/mito2/src/memtable/partition_tree/partition.rs
+++ b/src/mito2/src/memtable/partition_tree/partition.rs
@@ -30,12 +30,12 @@ use crate::error::Result;
 use crate::memtable::key_values::KeyValue;
 use crate::memtable::partition_tree::data::{DataBatch, DataParts, DATA_INIT_CAP};
 use crate::memtable::partition_tree::dedup::DedupReader;
-use crate::memtable::partition_tree::metrics::WriteMetrics;
 use crate::memtable::partition_tree::shard::{
     BoxedDataBatchSource, Shard, ShardMerger, ShardNode, ShardSource,
 };
 use crate::memtable::partition_tree::shard_builder::ShardBuilder;
 use crate::memtable::partition_tree::{PartitionTreeConfig, PkId};
+use crate::memtable::stats::WriteMetrics;
 use crate::metrics::PARTITION_TREE_READ_STAGE_ELAPSED;
 use crate::read::{Batch, BatchBuilder};
 use crate::row_converter::{McmpRowCodec, RowCodec};

--- a/src/mito2/src/memtable/partition_tree/shard.rs
+++ b/src/mito2/src/memtable/partition_tree/shard.rs
@@ -428,8 +428,8 @@ mod tests {
     use super::*;
     use crate::memtable::partition_tree::data::timestamp_array_to_i64_slice;
     use crate::memtable::partition_tree::dict::KeyDictBuilder;
-    use crate::memtable::partition_tree::metrics::WriteMetrics;
     use crate::memtable::partition_tree::PkIndex;
+    use crate::memtable::stats::WriteMetrics;
     use crate::memtable::KeyValues;
     use crate::test_util::memtable_util::{
         build_key_values_with_ts_seq_values, encode_keys, metadata_for_test,

--- a/src/mito2/src/memtable/partition_tree/shard_builder.rs
+++ b/src/mito2/src/memtable/partition_tree/shard_builder.rs
@@ -26,10 +26,10 @@ use crate::memtable::partition_tree::data::{
     DataBatch, DataBuffer, DataBufferReader, DataBufferReaderBuilder, DataParts, DATA_INIT_CAP,
 };
 use crate::memtable::partition_tree::dict::{DictBuilderReader, KeyDictBuilder};
-use crate::memtable::partition_tree::metrics::WriteMetrics;
 use crate::memtable::partition_tree::partition::PrimaryKeyFilter;
 use crate::memtable::partition_tree::shard::Shard;
 use crate::memtable::partition_tree::{PartitionTreeConfig, PkId, PkIndex, ShardId};
+use crate::memtable::stats::WriteMetrics;
 use crate::metrics::PARTITION_TREE_READ_STAGE_ELAPSED;
 
 /// Builder to write keys and data to a shard that the key dictionary
@@ -318,7 +318,6 @@ mod tests {
 
     use super::*;
     use crate::memtable::partition_tree::data::timestamp_array_to_i64_slice;
-    use crate::memtable::partition_tree::metrics::WriteMetrics;
     use crate::memtable::KeyValues;
     use crate::test_util::memtable_util::{
         build_key_values_with_ts_seq_values, encode_key_by_kv, metadata_for_test,

--- a/src/mito2/src/memtable/partition_tree/tree.rs
+++ b/src/mito2/src/memtable/partition_tree/tree.rs
@@ -33,11 +33,11 @@ use table::predicate::Predicate;
 use crate::error::{PrimaryKeyLengthMismatchSnafu, Result, SerializeFieldSnafu};
 use crate::flush::WriteBufferManagerRef;
 use crate::memtable::key_values::KeyValue;
-use crate::memtable::partition_tree::metrics::WriteMetrics;
 use crate::memtable::partition_tree::partition::{
     Partition, PartitionKey, PartitionReader, PartitionRef, ReadPartitionContext,
 };
 use crate::memtable::partition_tree::PartitionTreeConfig;
+use crate::memtable::stats::WriteMetrics;
 use crate::memtable::{BoxedBatchIterator, KeyValues};
 use crate::metrics::{PARTITION_TREE_READ_STAGE_ELAPSED, READ_ROWS_TOTAL, READ_STAGE_ELAPSED};
 use crate::read::dedup::LastNonNullIter;

--- a/src/mito2/src/memtable/stats.rs
+++ b/src/mito2/src/memtable/stats.rs
@@ -14,16 +14,16 @@
 
 //! Internal metrics of the memtable.
 
-/// Metrics of writing the partition tree.
-pub struct WriteMetrics {
+/// Metrics of writing memtables.
+pub(crate) struct WriteMetrics {
     /// Size allocated by keys.
-    pub key_bytes: usize,
+    pub(crate) key_bytes: usize,
     /// Size allocated by values.
-    pub value_bytes: usize,
+    pub(crate) value_bytes: usize,
     /// Minimum timestamp.
-    pub min_ts: i64,
+    pub(crate) min_ts: i64,
     /// Maximum timestamp
-    pub max_ts: i64,
+    pub(crate) max_ts: i64,
 }
 
 impl Default for WriteMetrics {

--- a/src/mito2/src/memtable/stats.rs
+++ b/src/mito2/src/memtable/stats.rs
@@ -14,6 +14,8 @@
 
 //! Internal metrics of the memtable.
 
+use std::sync::atomic::{AtomicI64, Ordering};
+
 /// Metrics of writing memtables.
 pub(crate) struct WriteMetrics {
     /// Size allocated by keys.
@@ -24,6 +26,51 @@ pub(crate) struct WriteMetrics {
     pub(crate) min_ts: i64,
     /// Maximum timestamp
     pub(crate) max_ts: i64,
+}
+
+impl WriteMetrics {
+    /// Update the min/max timestamp range according to current write metric.
+    pub(crate) fn update_timestamp_range(&self, prev_max_ts: &AtomicI64, prev_min_ts: &AtomicI64) {
+        loop {
+            let current_min = prev_min_ts.load(Ordering::Relaxed);
+            if self.min_ts >= current_min {
+                break;
+            }
+
+            let Err(updated) = prev_min_ts.compare_exchange(
+                current_min,
+                self.min_ts,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) else {
+                break;
+            };
+
+            if updated == self.min_ts {
+                break;
+            }
+        }
+
+        loop {
+            let current_max = prev_max_ts.load(Ordering::Relaxed);
+            if self.max_ts <= current_max {
+                break;
+            }
+
+            let Err(updated) = prev_max_ts.compare_exchange(
+                current_max,
+                self.max_ts,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) else {
+                break;
+            };
+
+            if updated == self.max_ts {
+                break;
+            }
+        }
+    }
 }
 
 impl Default for WriteMetrics {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Extract the logic to track memtable write metrics and update memtable timestamp ranges into a common mod for reuse.


## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
