### PR TITLE
refactor: use UNSET instead of enable

### DIFF
--- a/src/sql/src/statements/alter.rs
+++ b/src/sql/src/statements/alter.rs
@@ -76,7 +76,7 @@ pub enum AlterTableOperation {
     DropColumn { name: Ident },
     /// `RENAME <new_table_name>`
     RenameTable { new_table_name: String },
-    /// `MODIFY COLUMN <column_name> SET FULLTEXT [WITH <options>]`
+    /// `MODIFY COLUMN <column_name> [SET | UNSET] FULLTEXT [WITH <options>]`
     ChangeColumnFulltext {
         column_name: Ident,
         options: FulltextOptions,

--- a/tests/cases/standalone/common/alter/change_col_fulltext_options.result
+++ b/tests/cases/standalone/common/alter/change_col_fulltext_options.result
@@ -94,7 +94,7 @@ SHOW CREATE TABLE test;
 |       | )                                                                                     |
 +-------+---------------------------------------------------------------------------------------+
 
-ALTER TABLE test MODIFY COLUMN message SET FULLTEXT WITH(enable = 'false');
+ALTER TABLE test MODIFY COLUMN message UNSET FULLTEXT;
 
 Affected Rows: 0
 
@@ -140,7 +140,7 @@ ALTER TABLE test MODIFY COLUMN message SET FULLTEXT WITH(analyzer = 'Chinese', c
 
 Error: 1004(InvalidArguments), Invalid column option, column name: message, error: FULLTEXT index options already enabled
 
-ALTER TABLE test MODIFY COLUMN message SET FULLTEXT WITH(enable = 'false');
+ALTER TABLE test MODIFY COLUMN message UNSET FULLTEXT;
 
 Affected Rows: 0
 

--- a/tests/cases/standalone/common/alter/change_col_fulltext_options.sql
+++ b/tests/cases/standalone/common/alter/change_col_fulltext_options.sql
@@ -29,7 +29,7 @@ SELECT * FROM test WHERE MATCHES(message, 'hello');
 -- SQLNESS ARG restart=true
 SHOW CREATE TABLE test;
 
-ALTER TABLE test MODIFY COLUMN message SET FULLTEXT WITH(enable = 'false');
+ALTER TABLE test MODIFY COLUMN message UNSET FULLTEXT;
 
 SHOW CREATE TABLE test;
 
@@ -39,7 +39,7 @@ SHOW CREATE TABLE test;
 
 ALTER TABLE test MODIFY COLUMN message SET FULLTEXT WITH(analyzer = 'Chinese', case_sensitive = 'false');
 
-ALTER TABLE test MODIFY COLUMN message SET FULLTEXT WITH(enable = 'false');
+ALTER TABLE test MODIFY COLUMN message UNSET FULLTEXT;
 
 SHOW CREATE TABLE test;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

#4952 

## What's changed and what's your intention?

Previously introduced alter fulltext use 
```sql
ALTER TABLE monitor COLUMN <column_name> SET FULLTEXT WITH(enable='false');
```
to disable the fulltext index.

This patch change it to 
```sql
ALTER TABLE monitor COLUMN <column_name> UNSET FULLTEXT;
```
for simplicity and better compatibility with fulltext index settings in `CREATE` stmt.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
