### PR TITLE
test: subquery test migrated from duckdb

### DIFF
--- a/tests/cases/standalone/common/subquery/table.result
+++ b/tests/cases/standalone/common/subquery/table.result
@@ -1,0 +1,164 @@
+-- From https://github.com/duckdb/duckdb/tree/main/test/sql/subquery/table
+-- aliasing
+CREATE TABLE a(ts TIMESTAMP TIME INDEX, i INTEGER);
+
+Affected Rows: 0
+
+insert into a values (1, 42);
+
+Affected Rows: 1
+
+select * from (select i as j from a group by j) where j = 42;
+
++----+
+| j  |
++----+
+| 42 |
++----+
+
+select * from (select i as j from a group by i) where j = 42;
+
++----+
+| j  |
++----+
+| 42 |
++----+
+
+DROP TABLE a;
+
+Affected Rows: 0
+
+-- nested table subquery
+CREATE TABLE test (ts TIMESTAMP TIME INDEX, i INTEGER, j INTEGER);
+
+Affected Rows: 0
+
+INSERT INTO test VALUES (0, 3, 4), (1, 4, 5), (2, 5, 6);
+
+Affected Rows: 3
+
+SELECT * FROM (SELECT i, j FROM (SELECT j AS i, i AS j FROM (SELECT j AS i, i AS j FROM test) AS a) AS a) AS a, (SELECT i+1 AS r,j FROM test) AS b, test WHERE a.i=b.r AND test.j=a.i ORDER BY 1;
+
++---+---+---+---+-------------------------+---+---+
+| i | j | r | j | ts                      | i | j |
++---+---+---+---+-------------------------+---+---+
+| 4 | 5 | 4 | 4 | 1970-01-01T00:00:00     | 3 | 4 |
+| 5 | 6 | 5 | 5 | 1970-01-01T00:00:00.001 | 4 | 5 |
++---+---+---+---+-------------------------+---+---+
+
+SELECT i FROM (SELECT i + 1 AS i FROM (SELECT i + 1 AS i FROM (SELECT i + 1 AS i FROM test)));
+
++---+
+| i |
++---+
+| 6 |
+| 7 |
+| 8 |
++---+
+
+DROP TABLE test;
+
+Affected Rows: 0
+
+-- subquery union
+SELECT * FROM (SELECT 42) UNION ALL SELECT * FROM (SELECT 43);
+
++-----------+
+| Int64(42) |
++-----------+
+| 42        |
+| 43        |
++-----------+
+
+-- table subquery
+CREATE TABLE test (ts TIMESTAMP TIME INDEX, i INTEGER, j INTEGER);
+
+Affected Rows: 0
+
+INSERT INTO test VALUES (0, 3, 4), (1, 4, 5), (2, 5, 6);
+
+Affected Rows: 3
+
+SELECT * FROM (SELECT i, j AS d FROM test ORDER BY i) AS b;
+
++---+---+
+| i | d |
++---+---+
+| 3 | 4 |
+| 4 | 5 |
+| 5 | 6 |
++---+---+
+
+SELECT b.d FROM (SELECT i * 2 + j AS d FROM test) AS b;
+
++----+
+| d  |
++----+
+| 10 |
+| 13 |
+| 16 |
++----+
+
+SELECT a.i,a.j,b.r,b.j FROM (SELECT i, j FROM test) AS a INNER JOIN (SELECT i+1 AS r,j FROM test) AS b ON a.i=b.r ORDER BY 1;
+
++---+---+---+---+
+| i | j | r | j |
++---+---+---+---+
+| 4 | 5 | 4 | 4 |
+| 5 | 6 | 5 | 5 |
++---+---+---+---+
+
+SELECT * FROM (SELECT i, j FROM test) AS a, (SELECT i+1 AS r,j FROM test) AS b, test WHERE a.i=b.r AND test.j=a.i ORDER BY 1;
+
++---+---+---+---+-------------------------+---+---+
+| i | j | r | j | ts                      | i | j |
++---+---+---+---+-------------------------+---+---+
+| 4 | 5 | 4 | 4 | 1970-01-01T00:00:00     | 3 | 4 |
+| 5 | 6 | 5 | 5 | 1970-01-01T00:00:00.001 | 4 | 5 |
++---+---+---+---+-------------------------+---+---+
+
+DROP TABLE test;
+
+Affected Rows: 0
+
+-- test unamed subquery
+SELECT * FROM (SELECT 42);
+
++-----------+
+| Int64(42) |
++-----------+
+| 42        |
++-----------+
+
+SELECT * FROM (SELECT 42), (SELECT 43);
+
++-----------+-----------+
+| Int64(42) | Int64(43) |
++-----------+-----------+
+| 42        | 43        |
++-----------+-----------+
+
+SELECT * FROM (VALUES (42, 43));
+
++---------+---------+
+| column1 | column2 |
++---------+---------+
+| 42      | 43      |
++---------+---------+
+
+SELECT * FROM (SELECT 42), (SELECT 43), (SELECT 44), (SELECT 45);
+
++-----------+-----------+-----------+-----------+
+| Int64(42) | Int64(43) | Int64(44) | Int64(45) |
++-----------+-----------+-----------+-----------+
+| 42        | 43        | 44        | 45        |
++-----------+-----------+-----------+-----------+
+
+SELECT * FROM (SELECT * FROM (SELECT 42), (SELECT 43)) JOIN (SELECT 44) ON (true) JOIN (SELECT 45) ON (true);
+
++-----------+-----------+-----------+-----------+
+| Int64(42) | Int64(43) | Int64(44) | Int64(45) |
++-----------+-----------+-----------+-----------+
+| 42        | 43        | 44        | 45        |
++-----------+-----------+-----------+-----------+
+

--- a/tests/cases/standalone/common/subquery/table.result
+++ b/tests/cases/standalone/common/subquery/table.result
@@ -1,4 +1,3 @@
--- From https://github.com/duckdb/duckdb/tree/main/test/sql/subquery/table
 -- aliasing
 CREATE TABLE a(ts TIMESTAMP TIME INDEX, i INTEGER);
 

--- a/tests/cases/standalone/common/subquery/table.result
+++ b/tests/cases/standalone/common/subquery/table.result
@@ -1,4 +1,5 @@
--- aliasing
+-- aliasing, from:
+-- https://github.com/duckdb/duckdb/blob/9196dd9b0a163e6c8aada26218803d04be30c562/test/sql/subquery/table/test_aliasing.test
 CREATE TABLE a(ts TIMESTAMP TIME INDEX, i INTEGER);
 
 Affected Rows: 0
@@ -7,7 +8,7 @@ insert into a values (1, 42);
 
 Affected Rows: 1
 
-select * from (select i as j from a group by j) where j = 42;
+SELECT * FROM (SELECT i AS j FROM a GROUP BY j) WHERE j = 42;
 
 +----+
 | j  |
@@ -15,7 +16,7 @@ select * from (select i as j from a group by j) where j = 42;
 | 42 |
 +----+
 
-select * from (select i as j from a group by i) where j = 42;
+SELECT * FROM (SELECT i AS j FROM a GROUP BY i) WHERE j = 42;
 
 +----+
 | j  |
@@ -27,7 +28,8 @@ DROP TABLE a;
 
 Affected Rows: 0
 
--- nested table subquery
+-- nested table subquery, from:
+-- https://github.com/duckdb/duckdb/blob/2e4e2913266ddc46c7281d1b992228cb0095954b/test/sql/subquery/table/test_nested_table_subquery.test_slow
 CREATE TABLE test (ts TIMESTAMP TIME INDEX, i INTEGER, j INTEGER);
 
 Affected Rows: 0
@@ -59,7 +61,8 @@ DROP TABLE test;
 
 Affected Rows: 0
 
--- subquery union
+-- subquery union, from:
+-- https://github.com/duckdb/duckdb/blob/9196dd9b0a163e6c8aada26218803d04be30c562/test/sql/subquery/table/test_subquery_union.test
 SELECT * FROM (SELECT 42) UNION ALL SELECT * FROM (SELECT 43);
 
 +-----------+
@@ -69,7 +72,8 @@ SELECT * FROM (SELECT 42) UNION ALL SELECT * FROM (SELECT 43);
 | 43        |
 +-----------+
 
--- table subquery
+-- table subquery, from:
+-- https://github.com/duckdb/duckdb/blob/8704c7d0807d6ce1e2ebcdf6398e1b6cc050e507/test/sql/subquery/table/test_table_subquery.test
 CREATE TABLE test (ts TIMESTAMP TIME INDEX, i INTEGER, j INTEGER);
 
 Affected Rows: 0
@@ -116,26 +120,43 @@ SELECT * FROM (SELECT i, j FROM test) AS a, (SELECT i+1 AS r,j FROM test) AS b, 
 | 5 | 6 | 5 | 5 | 1970-01-01T00:00:00.001 | 4 | 5 |
 +---+---+---+---+-------------------------+---+---+
 
+SELECT sum(x) FROM (SELECT i AS x FROM test GROUP BY i) sq;
+
++-----------+
+| SUM(sq.x) |
++-----------+
+| 12        |
++-----------+
+
+SELECT sum(x) FROM (SELECT i+1 AS x FROM test GROUP BY x) sq;
+
++-----------+
+| SUM(sq.x) |
++-----------+
+| 15        |
++-----------+
+
 DROP TABLE test;
 
 Affected Rows: 0
 
--- test unamed subquery
-SELECT * FROM (SELECT 42);
+-- test unamed subquery, from:
+-- https://github.com/duckdb/duckdb/blob/00a605270719941ca0412ad5d0a14b1bdfbf9eb5/test/sql/subquery/table/test_unnamed_subquery.test
+SELECT a FROM (SELECT 42 a);
 
-+-----------+
-| Int64(42) |
-+-----------+
-| 42        |
-+-----------+
++----+
+| a  |
++----+
+| 42 |
++----+
 
-SELECT * FROM (SELECT 42), (SELECT 43);
+SELECT * FROM (SELECT 42 a), (SELECT 43 b);
 
-+-----------+-----------+
-| Int64(42) | Int64(43) |
-+-----------+-----------+
-| 42        | 43        |
-+-----------+-----------+
++----+----+
+| a  | b  |
++----+----+
+| 42 | 43 |
++----+----+
 
 SELECT * FROM (VALUES (42, 43));
 
@@ -145,19 +166,19 @@ SELECT * FROM (VALUES (42, 43));
 | 42      | 43      |
 +---------+---------+
 
-SELECT * FROM (SELECT 42), (SELECT 43), (SELECT 44), (SELECT 45);
+SELECT * FROM (SELECT 42 a), (SELECT 43 b), (SELECT 44 c), (SELECT 45 d);
 
-+-----------+-----------+-----------+-----------+
-| Int64(42) | Int64(43) | Int64(44) | Int64(45) |
-+-----------+-----------+-----------+-----------+
-| 42        | 43        | 44        | 45        |
-+-----------+-----------+-----------+-----------+
++----+----+----+----+
+| a  | b  | c  | d  |
++----+----+----+----+
+| 42 | 43 | 44 | 45 |
++----+----+----+----+
 
-SELECT * FROM (SELECT * FROM (SELECT 42), (SELECT 43)) JOIN (SELECT 44) ON (true) JOIN (SELECT 45) ON (true);
+SELECT * FROM (SELECT * FROM (SELECT 42 a), (SELECT 43 b)) JOIN (SELECT 44 c) ON (true) JOIN (SELECT 45 d) ON (true);
 
-+-----------+-----------+-----------+-----------+
-| Int64(42) | Int64(43) | Int64(44) | Int64(45) |
-+-----------+-----------+-----------+-----------+
-| 42        | 43        | 44        | 45        |
-+-----------+-----------+-----------+-----------+
++----+----+----+----+
+| a  | b  | c  | d  |
++----+----+----+----+
+| 42 | 43 | 44 | 45 |
++----+----+----+----+
 

--- a/tests/cases/standalone/common/subquery/table.sql
+++ b/tests/cases/standalone/common/subquery/table.sql
@@ -1,15 +1,17 @@
--- aliasing
+-- aliasing, from:
+-- https://github.com/duckdb/duckdb/blob/9196dd9b0a163e6c8aada26218803d04be30c562/test/sql/subquery/table/test_aliasing.test
 CREATE TABLE a(ts TIMESTAMP TIME INDEX, i INTEGER);
 
 insert into a values (1, 42);
 
-select * from (select i as j from a group by j) where j = 42;
+SELECT * FROM (SELECT i AS j FROM a GROUP BY j) WHERE j = 42;
 
-select * from (select i as j from a group by i) where j = 42;
+SELECT * FROM (SELECT i AS j FROM a GROUP BY i) WHERE j = 42;
 
 DROP TABLE a;
 
--- nested table subquery
+-- nested table subquery, from:
+-- https://github.com/duckdb/duckdb/blob/2e4e2913266ddc46c7281d1b992228cb0095954b/test/sql/subquery/table/test_nested_table_subquery.test_slow
 CREATE TABLE test (ts TIMESTAMP TIME INDEX, i INTEGER, j INTEGER);
 
 INSERT INTO test VALUES (0, 3, 4), (1, 4, 5), (2, 5, 6);
@@ -20,10 +22,12 @@ SELECT i FROM (SELECT i + 1 AS i FROM (SELECT i + 1 AS i FROM (SELECT i + 1 AS i
 
 DROP TABLE test;
 
--- subquery union
+-- subquery union, from:
+-- https://github.com/duckdb/duckdb/blob/9196dd9b0a163e6c8aada26218803d04be30c562/test/sql/subquery/table/test_subquery_union.test
 SELECT * FROM (SELECT 42) UNION ALL SELECT * FROM (SELECT 43);
 
--- table subquery
+-- table subquery, from:
+-- https://github.com/duckdb/duckdb/blob/8704c7d0807d6ce1e2ebcdf6398e1b6cc050e507/test/sql/subquery/table/test_table_subquery.test
 CREATE TABLE test (ts TIMESTAMP TIME INDEX, i INTEGER, j INTEGER);
 
 INSERT INTO test VALUES (0, 3, 4), (1, 4, 5), (2, 5, 6);
@@ -36,15 +40,25 @@ SELECT a.i,a.j,b.r,b.j FROM (SELECT i, j FROM test) AS a INNER JOIN (SELECT i+1 
 
 SELECT * FROM (SELECT i, j FROM test) AS a, (SELECT i+1 AS r,j FROM test) AS b, test WHERE a.i=b.r AND test.j=a.i ORDER BY 1;
 
+SELECT sum(x) FROM (SELECT i AS x FROM test GROUP BY i) sq;
+
+SELECT sum(x) FROM (SELECT i+1 AS x FROM test GROUP BY x) sq;
+
 DROP TABLE test;
 
--- test unamed subquery
-SELECT * FROM (SELECT 42);
+-- test unamed subquery, from:
+-- https://github.com/duckdb/duckdb/blob/00a605270719941ca0412ad5d0a14b1bdfbf9eb5/test/sql/subquery/table/test_unnamed_subquery.test
+SELECT a FROM (SELECT 42 a);
 
-SELECT * FROM (SELECT 42), (SELECT 43);
+SELECT * FROM (SELECT 42 a), (SELECT 43 b);
 
 SELECT * FROM (VALUES (42, 43));
 
-SELECT * FROM (SELECT 42), (SELECT 43), (SELECT 44), (SELECT 45);
+SELECT * FROM (SELECT 42 a), (SELECT 43 b), (SELECT 44 c), (SELECT 45 d);
 
-SELECT * FROM (SELECT * FROM (SELECT 42), (SELECT 43)) JOIN (SELECT 44) ON (true) JOIN (SELECT 45) ON (true);
+SELECT * FROM (SELECT * FROM (SELECT 42 a), (SELECT 43 b)) JOIN (SELECT 44 c) ON (true) JOIN (SELECT 45 d) ON (true);
+
+-- skipped, unsupported feature: unnamed_subquery, see also:
+-- https://github.com/GreptimeTeam/greptimedb/issues/5012
+-- SELECT * FROM (SELECT unnamed_subquery.a FROM (SELECT 42 a)), (SELECT unnamed_subquery.b FROM (SELECT 43 b));
+-- SELECT unnamed_subquery.a, unnamed_subquery2.b FROM (SELECT 42 a), (SELECT 43 b);

--- a/tests/cases/standalone/common/subquery/table.sql
+++ b/tests/cases/standalone/common/subquery/table.sql
@@ -1,5 +1,3 @@
--- From https://github.com/duckdb/duckdb/tree/main/test/sql/subquery/table
-
 -- aliasing
 CREATE TABLE a(ts TIMESTAMP TIME INDEX, i INTEGER);
 

--- a/tests/cases/standalone/common/subquery/table.sql
+++ b/tests/cases/standalone/common/subquery/table.sql
@@ -1,0 +1,52 @@
+-- From https://github.com/duckdb/duckdb/tree/main/test/sql/subquery/table
+
+-- aliasing
+CREATE TABLE a(ts TIMESTAMP TIME INDEX, i INTEGER);
+
+insert into a values (1, 42);
+
+select * from (select i as j from a group by j) where j = 42;
+
+select * from (select i as j from a group by i) where j = 42;
+
+DROP TABLE a;
+
+-- nested table subquery
+CREATE TABLE test (ts TIMESTAMP TIME INDEX, i INTEGER, j INTEGER);
+
+INSERT INTO test VALUES (0, 3, 4), (1, 4, 5), (2, 5, 6);
+
+SELECT * FROM (SELECT i, j FROM (SELECT j AS i, i AS j FROM (SELECT j AS i, i AS j FROM test) AS a) AS a) AS a, (SELECT i+1 AS r,j FROM test) AS b, test WHERE a.i=b.r AND test.j=a.i ORDER BY 1;
+
+SELECT i FROM (SELECT i + 1 AS i FROM (SELECT i + 1 AS i FROM (SELECT i + 1 AS i FROM test)));
+
+DROP TABLE test;
+
+-- subquery union
+SELECT * FROM (SELECT 42) UNION ALL SELECT * FROM (SELECT 43);
+
+-- table subquery
+CREATE TABLE test (ts TIMESTAMP TIME INDEX, i INTEGER, j INTEGER);
+
+INSERT INTO test VALUES (0, 3, 4), (1, 4, 5), (2, 5, 6);
+
+SELECT * FROM (SELECT i, j AS d FROM test ORDER BY i) AS b;
+
+SELECT b.d FROM (SELECT i * 2 + j AS d FROM test) AS b;
+
+SELECT a.i,a.j,b.r,b.j FROM (SELECT i, j FROM test) AS a INNER JOIN (SELECT i+1 AS r,j FROM test) AS b ON a.i=b.r ORDER BY 1;
+
+SELECT * FROM (SELECT i, j FROM test) AS a, (SELECT i+1 AS r,j FROM test) AS b, test WHERE a.i=b.r AND test.j=a.i ORDER BY 1;
+
+DROP TABLE test;
+
+-- test unamed subquery
+SELECT * FROM (SELECT 42);
+
+SELECT * FROM (SELECT 42), (SELECT 43);
+
+SELECT * FROM (VALUES (42, 43));
+
+SELECT * FROM (SELECT 42), (SELECT 43), (SELECT 44), (SELECT 45);
+
+SELECT * FROM (SELECT * FROM (SELECT 42), (SELECT 43)) JOIN (SELECT 44) ON (true) JOIN (SELECT 45) ON (true);

--- a/tests/cases/standalone/common/subquery/test_neumann.result
+++ b/tests/cases/standalone/common/subquery/test_neumann.result
@@ -39,3 +39,16 @@ SELECT s.n, e.course, e.grade FROM students s, exams e WHERE s.id=e.sid AND e.gr
 | Dirk | Graphics         | 7     |
 | Mark | Database Systems | 10    |
 +------+------------------+-------+
+
+SELECT n, major FROM students s WHERE EXISTS(SELECT * FROM exams e WHERE e.sid=s.id AND grade=10) OR s.n='Dirk' ORDER BY n;
+
+Error: 3001(EngineExecuteQuery), DataFusion error: This feature is not implemented: Physical plan does not support logical expression Exists(Exists { subquery: <subquery>, negated: false })
+
+DROP TABLE students;
+
+Affected Rows: 0
+
+DROP TABLE exams;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/subquery/test_neumann.result
+++ b/tests/cases/standalone/common/subquery/test_neumann.result
@@ -1,3 +1,5 @@
+-- from:
+-- https://github.com/duckdb/duckdb/blob/74687ec572e9e6ccf34f9b15daa62998b34a3e13/test/sql/subquery/test_neumann.test
 CREATE TABLE students(ts TIMESTAMP TIME INDEX, id INTEGER, n VARCHAR, major VARCHAR, y INTEGER);
 
 Affected Rows: 0
@@ -40,10 +42,12 @@ SELECT s.n, e.course, e.grade FROM students s, exams e WHERE s.id=e.sid AND e.gr
 | Mark | Database Systems | 10    |
 +------+------------------+-------+
 
-SELECT n, major FROM students s WHERE EXISTS(SELECT * FROM exams e WHERE e.sid=s.id AND grade=10) OR s.n='Dirk' ORDER BY n;
-
-Error: 3001(EngineExecuteQuery), DataFusion error: This feature is not implemented: Physical plan does not support logical expression Exists(Exists { subquery: <subquery>, negated: false })
-
+-- skipped, unsupported feature: correlated column in predicate, see also:
+-- https://github.com/GreptimeTeam/greptimedb/issues/5012
+-- SELECT s.n, e.course, e.grade FROM students s, exams e WHERE s.id=e.sid AND (s.major = 'CS' OR s.major = 'Games Eng') AND e.grade <= (SELECT AVG(e2.grade) - 1 FROM exams e2 WHERE s.id=e2.sid OR (e2.curriculum=s.major AND s.y>=e2.y)) ORDER BY n, course;
+-- skipped, unsupported feature: exists, see also:
+-- https://github.com/GreptimeTeam/greptimedb/issues/5012
+-- SELECT n, major FROM students s WHERE EXISTS(SELECT * FROM exams e WHERE e.sid=s.id AND grade=10) OR s.n='Dirk' ORDER BY n;
 DROP TABLE students;
 
 Affected Rows: 0

--- a/tests/cases/standalone/common/subquery/test_neumann.result
+++ b/tests/cases/standalone/common/subquery/test_neumann.result
@@ -1,0 +1,41 @@
+CREATE TABLE students(ts TIMESTAMP TIME INDEX, id INTEGER, n VARCHAR, major VARCHAR, y INTEGER);
+
+Affected Rows: 0
+
+CREATE TABLE exams(ts TIMESTAMP TIME INDEX, sid INTEGER, course VARCHAR, curriculum VARCHAR, grade INTEGER, y INTEGER);
+
+Affected Rows: 0
+
+INSERT INTO students VALUES (1, 1, 'Mark', 'CS', 2017);
+
+Affected Rows: 1
+
+INSERT INTO students VALUES (2, 2, 'Dirk', 'CS', 2017);
+
+Affected Rows: 1
+
+INSERT INTO exams VALUES (1, 1, 'Database Systems', 'CS', 10, 2015);
+
+Affected Rows: 1
+
+INSERT INTO exams VALUES (2, 1, 'Graphics', 'CS', 9, 2016);
+
+Affected Rows: 1
+
+INSERT INTO exams VALUES (3, 2, 'Database Systems', 'CS', 7, 2015);
+
+Affected Rows: 1
+
+INSERT INTO exams VALUES (4, 2, 'Graphics', 'CS', 7, 2016);
+
+Affected Rows: 1
+
+SELECT s.n, e.course, e.grade FROM students s, exams e WHERE s.id=e.sid AND e.grade=(SELECT MAX(e2.grade) FROM exams e2 WHERE s.id=e2.sid) ORDER BY n, course;
+
++------+------------------+-------+
+| n    | course           | grade |
++------+------------------+-------+
+| Dirk | Database Systems | 7     |
+| Dirk | Graphics         | 7     |
+| Mark | Database Systems | 10    |
++------+------------------+-------+

--- a/tests/cases/standalone/common/subquery/test_neumann.sql
+++ b/tests/cases/standalone/common/subquery/test_neumann.sql
@@ -19,3 +19,5 @@ SELECT s.n, e.course, e.grade FROM students s, exams e WHERE s.id=e.sid AND e.gr
 SELECT n, major FROM students s WHERE EXISTS(SELECT * FROM exams e WHERE e.sid=s.id AND grade=10) OR s.n='Dirk' ORDER BY n;
 
 DROP TABLE students;
+
+DROP TABLE exams;

--- a/tests/cases/standalone/common/subquery/test_neumann.sql
+++ b/tests/cases/standalone/common/subquery/test_neumann.sql
@@ -1,3 +1,5 @@
+-- from:
+-- https://github.com/duckdb/duckdb/blob/74687ec572e9e6ccf34f9b15daa62998b34a3e13/test/sql/subquery/test_neumann.test
 CREATE TABLE students(ts TIMESTAMP TIME INDEX, id INTEGER, n VARCHAR, major VARCHAR, y INTEGER);
 
 CREATE TABLE exams(ts TIMESTAMP TIME INDEX, sid INTEGER, course VARCHAR, curriculum VARCHAR, grade INTEGER, y INTEGER);
@@ -16,7 +18,13 @@ INSERT INTO exams VALUES (4, 2, 'Graphics', 'CS', 7, 2016);
 
 SELECT s.n, e.course, e.grade FROM students s, exams e WHERE s.id=e.sid AND e.grade=(SELECT MAX(e2.grade) FROM exams e2 WHERE s.id=e2.sid) ORDER BY n, course;
 
-SELECT n, major FROM students s WHERE EXISTS(SELECT * FROM exams e WHERE e.sid=s.id AND grade=10) OR s.n='Dirk' ORDER BY n;
+-- skipped, unsupported feature: correlated column in predicate, see also:
+-- https://github.com/GreptimeTeam/greptimedb/issues/5012
+-- SELECT s.n, e.course, e.grade FROM students s, exams e WHERE s.id=e.sid AND (s.major = 'CS' OR s.major = 'Games Eng') AND e.grade <= (SELECT AVG(e2.grade) - 1 FROM exams e2 WHERE s.id=e2.sid OR (e2.curriculum=s.major AND s.y>=e2.y)) ORDER BY n, course;
+
+-- skipped, unsupported feature: exists, see also:
+-- https://github.com/GreptimeTeam/greptimedb/issues/5012
+-- SELECT n, major FROM students s WHERE EXISTS(SELECT * FROM exams e WHERE e.sid=s.id AND grade=10) OR s.n='Dirk' ORDER BY n;
 
 DROP TABLE students;
 

--- a/tests/cases/standalone/common/subquery/test_neumann.sql
+++ b/tests/cases/standalone/common/subquery/test_neumann.sql
@@ -1,0 +1,21 @@
+CREATE TABLE students(ts TIMESTAMP TIME INDEX, id INTEGER, n VARCHAR, major VARCHAR, y INTEGER);
+
+CREATE TABLE exams(ts TIMESTAMP TIME INDEX, sid INTEGER, course VARCHAR, curriculum VARCHAR, grade INTEGER, y INTEGER);
+
+INSERT INTO students VALUES (1, 1, 'Mark', 'CS', 2017);
+
+INSERT INTO students VALUES (2, 2, 'Dirk', 'CS', 2017);
+
+INSERT INTO exams VALUES (1, 1, 'Database Systems', 'CS', 10, 2015);
+
+INSERT INTO exams VALUES (2, 1, 'Graphics', 'CS', 9, 2016);
+
+INSERT INTO exams VALUES (3, 2, 'Database Systems', 'CS', 7, 2015);
+
+INSERT INTO exams VALUES (4, 2, 'Graphics', 'CS', 7, 2016);
+
+SELECT s.n, e.course, e.grade FROM students s, exams e WHERE s.id=e.sid AND e.grade=(SELECT MAX(e2.grade) FROM exams e2 WHERE s.id=e2.sid) ORDER BY n, course;
+
+SELECT n, major FROM students s WHERE EXISTS(SELECT * FROM exams e WHERE e.sid=s.id AND grade=10) OR s.n='Dirk' ORDER BY n;
+
+DROP TABLE students;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

#1168 

## What's changed and what's your intention?

As titile.

Only a few parts are migrated. Mostly because other parts are not available for greptimedb for these reasons:

1. Datafusion does not support: scalar subquery, exists, pivot ...
2. Different internal pre-defined tables, functions and types:
   - **Tables**: orders, lineitem ...
   - **Functions**: generate_series, gen_random_uuid ...
   - **Types**: array/list type
3. Different grammar: duckdb uses query context differently,
   - e.g.`SELECT (SELECT max((SELECT subq_0.c0 AS c1))) FROM (SELECT NULL AS c0) AS subq_0;`
   - Seems the correct form for greptimedb is `SELECT (SELECT max((SELECT subq_0.c0 AS c1 FROM (SELECT NULL AS c0) AS subq_0)));`
   - (Query above is still not available since datafusion does not support Scalar subqueries yet)

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
