### PR TITLE
fix: run `install.sh` error

### DIFF
--- a/.github/scripts/check-install-script.sh
+++ b/.github/scripts/check-install-script.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+# Get the latest version of github.com/GreptimeTeam/greptimedb
+VERSION=$(curl -s https://api.github.com/repos/GreptimeTeam/greptimedb/releases/latest | jq -r '.tag_name')
+
+echo "Downloading the latest version: $VERSION"
+
+# Download the install script
+curl -fsSL https://raw.githubusercontent.com/greptimeteam/greptimedb/main/scripts/install.sh | sh -s $VERSION
+
+# Execute the `greptime` command
+./greptime --version

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -22,6 +22,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Check install.sh
+        run: ./.github/scripts/check-install-script.sh
+
       - name: Run sqlness test
         uses: ./.github/actions/sqlness-test
         with:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -ue
 
@@ -15,7 +15,7 @@ GITHUB_ORG=GreptimeTeam
 GITHUB_REPO=greptimedb
 BIN=greptime
 
-function get_os_type() {
+get_os_type() {
   os_type="$(uname -s)"
 
   case "$os_type" in
@@ -31,7 +31,7 @@ function get_os_type() {
   esac
 }
 
-function get_arch_type() {
+get_arch_type() {
   arch_type="$(uname -m)"
 
   case "$arch_type" in
@@ -53,7 +53,7 @@ function get_arch_type() {
   esac
 }
 
-function download_artifact() {
+download_artifact() {
   if [ -n "${OS_TYPE}" ] && [ -n "${ARCH_TYPE}" ]; then
     # Use the latest stable released version.
     # GitHub API reference: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-the-latest-release.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

When running the `install.sh` on Linux, it has the following errors:

```
curl -fsSL \
  https://raw.githubusercontent.com/greptimeteam/greptimedb/main/scripts/install.sh  | sh -s v0.9.5
sh: 18: Syntax error: "(" unexpected
```

1. Use `#!/bin/sh` as shebang for better compatibility;
2. Remove `function` keyword for using `sh`(https://www.shellcheck.net/wiki/SC2112);
3. Check the `install.sh` in nightly CI;

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
