### PR TITLE
fix: obsolete wal entires while opening a migrated region

### DIFF
--- a/src/datanode/src/heartbeat/handler/downgrade_region.rs
+++ b/src/datanode/src/heartbeat/handler/downgrade_region.rs
@@ -74,7 +74,10 @@ impl HandlerContext {
 
             // Ignores flush request
             if !writable {
-                warn!("Region: {region_id} is not writable, flush_timeout: {:?}", flush_timeout);
+                warn!(
+                    "Region: {region_id} is not writable, flush_timeout: {:?}",
+                    flush_timeout
+                );
                 return self.downgrade_to_follower_gracefully(region_id).await;
             }
 

--- a/src/datanode/src/heartbeat/handler/downgrade_region.rs
+++ b/src/datanode/src/heartbeat/handler/downgrade_region.rs
@@ -74,6 +74,7 @@ impl HandlerContext {
 
             // Ignores flush request
             if !writable {
+                warn!("Region: {region_id} is not writable, flush_timeout: {:?}", flush_timeout);
                 return self.downgrade_to_follower_gracefully(region_id).await;
             }
 

--- a/src/meta-srv/src/procedure/region_migration/downgrade_leader_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/downgrade_leader_region.rs
@@ -165,6 +165,7 @@ impl DowngradeLeaderRegion {
         match receiver.await? {
             Ok(msg) => {
                 let reply = HeartbeatMailbox::json_reply(&msg)?;
+                info!("Downgrade region reply: {:?}", reply);
                 let InstructionReply::DowngradeRegion(DowngradeRegionReply {
                     last_entry_id,
                     exists,

--- a/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
@@ -21,6 +21,7 @@ use common_meta::instruction::{Instruction, InstructionReply, OpenRegion, Simple
 use common_meta::key::datanode_table::RegionInfo;
 use common_meta::RegionIdent;
 use common_procedure::Status;
+use common_telemetry::info;
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt};
 
@@ -144,6 +145,7 @@ impl OpenCandidateRegion {
         match receiver.await? {
             Ok(msg) => {
                 let reply = HeartbeatMailbox::json_reply(&msg)?;
+                info!("Received open region reply: {:?}", reply);
                 let InstructionReply::OpenRegion(SimpleReply { result, error }) = reply else {
                     return error::UnexpectedInstructionReplySnafu {
                         mailbox_message: msg.to_string(),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Delete obsolete wal entries while opening a migrated region

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
