### PR TITLE
refactor: Avoid wrapping Option for CacheManagerRef

### DIFF
--- a/src/mito2/src/cache/write_cache.rs
+++ b/src/mito2/src/cache/write_cache.rs
@@ -501,7 +501,7 @@ mod tests {
 
         // Read metadata from write cache
         let builder = ParquetReaderBuilder::new(data_home, handle.clone(), mock_store.clone())
-            .cache(Some(cache_manager.clone()));
+            .cache(cache_manager.clone());
         let reader = builder.build().await.unwrap();
 
         // Check parquet metadata

--- a/src/mito2/src/compaction.rs
+++ b/src/mito2/src/compaction.rs
@@ -562,7 +562,7 @@ pub struct SerializedCompactionOutput {
 struct CompactionSstReaderBuilder<'a> {
     metadata: RegionMetadataRef,
     sst_layer: AccessLayerRef,
-    cache: Option<CacheManagerRef>,
+    cache: CacheManagerRef,
     inputs: &'a [FileHandle],
     append_mode: bool,
     filter_deleted: bool,

--- a/src/mito2/src/compaction/compactor.rs
+++ b/src/mito2/src/compaction/compactor.rs
@@ -295,7 +295,7 @@ impl Compactor for DefaultCompactor {
                 let reader = CompactionSstReaderBuilder {
                     metadata: region_metadata.clone(),
                     sst_layer: sst_layer.clone(),
-                    cache: Some(cache_manager.clone()),
+                    cache: cache_manager.clone(),
                     inputs: &output.inputs,
                     append_mode,
                     filter_deleted: output.filter_deleted,

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -438,16 +438,12 @@ impl EngineInner {
             channel_size: self.config.parallel_scan_channel_size,
         };
 
-        let scan_region = ScanRegion::new(
-            version,
-            region.access_layer.clone(),
-            request,
-            Some(cache_manager),
-        )
-        .with_parallelism(scan_parallelism)
-        .with_ignore_inverted_index(self.config.inverted_index.apply_on_query.disabled())
-        .with_ignore_fulltext_index(self.config.fulltext_index.apply_on_query.disabled())
-        .with_start_time(query_start);
+        let scan_region =
+            ScanRegion::new(version, region.access_layer.clone(), request, cache_manager)
+                .with_parallelism(scan_parallelism)
+                .with_ignore_inverted_index(self.config.inverted_index.apply_on_query.disabled())
+                .with_ignore_fulltext_index(self.config.fulltext_index.apply_on_query.disabled())
+                .with_start_time(query_start);
 
         Ok(scan_region)
     }

--- a/src/mito2/src/read/last_row.rs
+++ b/src/mito2/src/read/last_row.rs
@@ -85,7 +85,7 @@ impl RowGroupLastRowCachedReader {
     pub(crate) fn new(
         file_id: FileId,
         row_group_idx: usize,
-        cache_manager: Option<CacheManagerRef>,
+        cache_manager: CacheManagerRef,
         row_group_reader: RowGroupReader,
     ) -> Self {
         let key = SelectorResultKey {
@@ -94,9 +94,6 @@ impl RowGroupLastRowCachedReader {
             selector: TimeSeriesRowSelector::LastRow,
         };
 
-        let Some(cache_manager) = cache_manager else {
-            return Self::new_miss(key, row_group_reader, None);
-        };
         if let Some(value) = cache_manager.get_selector_result(&key) {
             let schema_matches = value.projection
                 == row_group_reader

--- a/src/mito2/src/read/range.rs
+++ b/src/mito2/src/read/range.rs
@@ -90,7 +90,7 @@ impl RangeMeta {
         Self::push_unordered_file_ranges(
             input.memtables.len(),
             &input.files,
-            input.cache_manager.as_deref(),
+            &input.cache_manager,
             &mut ranges,
         );
 
@@ -172,16 +172,15 @@ impl RangeMeta {
     fn push_unordered_file_ranges(
         num_memtables: usize,
         files: &[FileHandle],
-        cache: Option<&CacheManager>,
+        cache: &CacheManager,
         ranges: &mut Vec<RangeMeta>,
     ) {
         // For append mode, we can parallelize reading row groups.
         for (i, file) in files.iter().enumerate() {
             let file_index = num_memtables + i;
             // Get parquet meta from the cache.
-            let parquet_meta = cache.and_then(|c| {
-                c.get_parquet_meta_data_from_mem_cache(file.region_id(), file.file_id())
-            });
+            let parquet_meta =
+                cache.get_parquet_meta_data_from_mem_cache(file.region_id(), file.file_id());
             if let Some(parquet_meta) = parquet_meta {
                 // Scans each row group.
                 for row_group_index in 0..file.meta_ref().num_row_groups {

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -229,7 +229,7 @@ impl SeqScan {
                         .await
                         .map_err(BoxedError::new)
                         .context(ExternalSnafu)?;
-                let cache = stream_ctx.input.cache_manager.as_deref();
+                let cache = &stream_ctx.input.cache_manager;
                 let mut metrics = ScannerMetrics::default();
                 let mut fetch_start = Instant::now();
                 #[cfg(debug_assertions)]

--- a/src/mito2/src/read/unordered_scan.rs
+++ b/src/mito2/src/read/unordered_scan.rs
@@ -135,7 +135,7 @@ impl UnorderedScan {
         let stream = try_stream! {
             part_metrics.on_first_poll();
 
-            let cache = stream_ctx.input.cache_manager.as_deref();
+            let cache = &stream_ctx.input.cache_manager;
             // Scans each part.
             for part_range in part_ranges {
                 let mut metrics = ScannerMetrics::default();

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -195,11 +195,11 @@ mod tests {
             .unwrap();
 
         // Enable page cache.
-        let cache = Some(Arc::new(
+        let cache = Arc::new(
             CacheManager::builder()
                 .page_cache_size(64 * 1024 * 1024)
                 .build(),
-        ));
+        );
         let builder = ParquetReaderBuilder::new(FILE_DIR.to_string(), handle.clone(), object_store)
             .cache(cache.clone());
         for _ in 0..3 {
@@ -219,15 +219,15 @@ mod tests {
 
         // Doesn't have compressed page cached.
         let page_key = PageKey::new_compressed(metadata.region_id, handle.file_id(), 0, 0);
-        assert!(cache.as_ref().unwrap().get_pages(&page_key).is_none());
+        assert!(cache.get_pages(&page_key).is_none());
 
         // Cache 4 row groups.
         for i in 0..4 {
             let page_key = PageKey::new_uncompressed(metadata.region_id, handle.file_id(), i, 0);
-            assert!(cache.as_ref().unwrap().get_pages(&page_key).is_some());
+            assert!(cache.get_pages(&page_key).is_some());
         }
         let page_key = PageKey::new_uncompressed(metadata.region_id, handle.file_id(), 5, 0);
-        assert!(cache.as_ref().unwrap().get_pages(&page_key).is_none());
+        assert!(cache.get_pages(&page_key).is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

#4968

## What's changed and what's your intention?

__!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- replace all usage of `Option<CacheManagerRef>` with `CacheMangerRef`.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
