### PR TITLE
chore: rename change to modify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4595,7 +4595,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=e1070ad3e7ad3d89f8dd1e20756b0c0cc26f3365#e1070ad3e7ad3d89f8dd1e20756b0c0cc26f3365"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=be5f5f21e0b4eafe93de6db3ae870c1c982fef9f#be5f5f21e0b4eafe93de6db3ae870c1c982fef9f"
 dependencies = [
  "prost 0.12.6",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4595,7 +4595,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=be5f5f21e0b4eafe93de6db3ae870c1c982fef9f#be5f5f21e0b4eafe93de6db3ae870c1c982fef9f"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=fb4e2146b1ea8816148304f1f258e7a73736a905#fb4e2146b1ea8816148304f1f258e7a73736a905"
 dependencies = [
  "prost 0.12.6",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ etcd-client = "0.13"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "e1070ad3e7ad3d89f8dd1e20756b0c0cc26f3365" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "be5f5f21e0b4eafe93de6db3ae870c1c982fef9f" }
 hex = "0.4"
 humantime = "2.1"
 humantime-serde = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ etcd-client = "0.13"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "be5f5f21e0b4eafe93de6db3ae870c1c982fef9f" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "fb4e2146b1ea8816148304f1f258e7a73736a905" }
 hex = "0.4"
 humantime = "2.1"
 humantime-serde = "1.1"

--- a/src/common/grpc-expr/src/alter.rs
+++ b/src/common/grpc-expr/src/alter.rs
@@ -17,15 +17,15 @@ use api::v1::add_column_location::LocationType;
 use api::v1::alter_expr::Kind;
 use api::v1::column_def::as_fulltext_option;
 use api::v1::{
-    column_def, AddColumnLocation as Location, AlterExpr, Analyzer, ChangeColumnTypes,
-    CreateTableExpr, DropColumns, RenameTable, SemanticType,
+    column_def, AddColumnLocation as Location, AlterExpr, Analyzer, CreateTableExpr, DropColumns,
+    ModifyColumnTypes, RenameTable, SemanticType,
 };
 use common_query::AddColumnLocation;
 use datatypes::schema::{ColumnSchema, FulltextOptions, RawSchema};
 use snafu::{ensure, OptionExt, ResultExt};
 use store_api::region_request::ChangeOption;
 use table::metadata::TableId;
-use table::requests::{AddColumnRequest, AlterKind, AlterTableRequest, ChangeColumnTypeRequest};
+use table::requests::{AddColumnRequest, AlterKind, AlterTableRequest, ModifyColumnTypeRequest};
 
 use crate::error::{
     InvalidChangeFulltextOptionRequestSnafu, InvalidChangeTableOptionRequestSnafu,
@@ -68,25 +68,25 @@ pub fn alter_expr_to_request(table_id: TableId, expr: AlterExpr) -> Result<Alter
                 columns: add_column_requests,
             }
         }
-        Kind::ChangeColumnTypes(ChangeColumnTypes {
-            change_column_types,
+        Kind::ModifyColumnTypes(ModifyColumnTypes {
+            modify_column_types,
         }) => {
-            let change_column_type_requests = change_column_types
+            let modify_column_type_requests = modify_column_types
                 .into_iter()
                 .map(|cct| {
                     let target_type =
                         ColumnDataTypeWrapper::new(cct.target_type(), cct.target_type_extension)
                             .into();
 
-                    Ok(ChangeColumnTypeRequest {
+                    Ok(ModifyColumnTypeRequest {
                         column_name: cct.column_name,
                         target_type,
                     })
                 })
                 .collect::<Result<Vec<_>>>()?;
 
-            AlterKind::ChangeColumnTypes {
-                columns: change_column_type_requests,
+            AlterKind::ModifyColumnTypes {
+                columns: modify_column_type_requests,
             }
         }
         Kind::DropColumns(DropColumns { drop_columns }) => AlterKind::DropColumns {
@@ -183,7 +183,7 @@ fn parse_location(location: Option<Location>) -> Result<Option<AddColumnLocation
 #[cfg(test)]
 mod tests {
     use api::v1::{
-        AddColumn, AddColumns, ChangeColumnType, ColumnDataType, ColumnDef, DropColumn,
+        AddColumn, AddColumns, ColumnDataType, ColumnDef, DropColumn, ModifyColumnType,
         SemanticType,
     };
     use datatypes::prelude::ConcreteDataType;
@@ -309,14 +309,14 @@ mod tests {
     }
 
     #[test]
-    fn test_change_column_type_expr() {
+    fn test_modify_column_type_expr() {
         let expr = AlterExpr {
             catalog_name: "test_catalog".to_string(),
             schema_name: "test_schema".to_string(),
             table_name: "monitor".to_string(),
 
-            kind: Some(Kind::ChangeColumnTypes(ChangeColumnTypes {
-                change_column_types: vec![ChangeColumnType {
+            kind: Some(Kind::ModifyColumnTypes(ModifyColumnTypes {
+                modify_column_types: vec![ModifyColumnType {
                     column_name: "mem_usage".to_string(),
                     target_type: ColumnDataType::String as i32,
                     target_type_extension: None,
@@ -329,16 +329,16 @@ mod tests {
         assert_eq!(alter_request.schema_name, "test_schema");
         assert_eq!("monitor".to_string(), alter_request.table_name);
 
-        let mut change_column_types = match alter_request.alter_kind {
-            AlterKind::ChangeColumnTypes { columns } => columns,
+        let mut modify_column_types = match alter_request.alter_kind {
+            AlterKind::ModifyColumnTypes { columns } => columns,
             _ => unreachable!(),
         };
 
-        let change_column_type = change_column_types.pop().unwrap();
-        assert_eq!("mem_usage", change_column_type.column_name);
+        let modify_column_type = modify_column_types.pop().unwrap();
+        assert_eq!("mem_usage", modify_column_type.column_name);
         assert_eq!(
             ConcreteDataType::string_datatype(),
-            change_column_type.target_type
+            modify_column_type.target_type
         );
     }
 

--- a/src/common/meta/src/ddl/alter_table/region_request.rs
+++ b/src/common/meta/src/ddl/alter_table/region_request.rs
@@ -91,7 +91,7 @@ fn create_proto_alter_kind(
                 add_columns,
             })))
         }
-        Kind::ChangeColumnTypes(x) => Ok(Some(alter_request::Kind::ChangeColumnTypes(x.clone()))),
+        Kind::ModifyColumnTypes(x) => Ok(Some(alter_request::Kind::ModifyColumnTypes(x.clone()))),
         Kind::DropColumns(x) => {
             let drop_columns = x
                 .drop_columns
@@ -123,8 +123,8 @@ mod tests {
     use api::v1::region::region_request::Body;
     use api::v1::region::RegionColumnDef;
     use api::v1::{
-        region, AddColumn, AddColumnLocation, AddColumns, AlterExpr, ChangeColumnType,
-        ChangeColumnTypes, ColumnDataType, ColumnDef as PbColumnDef, SemanticType,
+        region, AddColumn, AddColumnLocation, AddColumns, AlterExpr, ColumnDataType,
+        ColumnDef as PbColumnDef, ModifyColumnType, ModifyColumnTypes, SemanticType,
     };
     use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
     use store_api::storage::{RegionId, TableId};
@@ -284,8 +284,8 @@ mod tests {
                 catalog_name: DEFAULT_CATALOG_NAME.to_string(),
                 schema_name: DEFAULT_SCHEMA_NAME.to_string(),
                 table_name,
-                kind: Some(Kind::ChangeColumnTypes(ChangeColumnTypes {
-                    change_column_types: vec![ChangeColumnType {
+                kind: Some(Kind::ModifyColumnTypes(ModifyColumnTypes {
+                    modify_column_types: vec![ModifyColumnType {
                         column_name: "cpu".to_string(),
                         target_type: ColumnDataType::String as i32,
                         target_type_extension: None,
@@ -306,9 +306,9 @@ mod tests {
         assert_eq!(alter_region_request.schema_version, 1);
         assert_eq!(
             alter_region_request.kind,
-            Some(region::alter_request::Kind::ChangeColumnTypes(
-                ChangeColumnTypes {
-                    change_column_types: vec![ChangeColumnType {
+            Some(region::alter_request::Kind::ModifyColumnTypes(
+                ModifyColumnTypes {
+                    modify_column_types: vec![ModifyColumnType {
                         column_name: "cpu".to_string(),
                         target_type: ColumnDataType::String as i32,
                         target_type_extension: None,

--- a/src/common/meta/src/ddl/alter_table/update_metadata.rs
+++ b/src/common/meta/src/ddl/alter_table/update_metadata.rs
@@ -52,7 +52,7 @@ impl AlterTableProcedure {
                 new_info.name = new_table_name.to_string();
             }
             AlterKind::DropColumns { .. }
-            | AlterKind::ChangeColumnTypes { .. }
+            | AlterKind::ModifyColumnTypes { .. }
             | AlterKind::ChangeTableOptions { .. }
             | AlterKind::ChangeColumnFulltext { .. } => {}
         }

--- a/src/sql/src/parsers/alter_parser.rs
+++ b/src/sql/src/parsers/alter_parser.rs
@@ -170,7 +170,7 @@ impl ParserContext<'_> {
                     self.parse_alter_column_fulltext(column_name)
                 } else {
                     let data_type = self.parser.parse_data_type().context(error::SyntaxSnafu)?;
-                    Ok(AlterTableOperation::ChangeColumnType {
+                    Ok(AlterTableOperation::ModifyColumnType {
                         column_name,
                         target_type: data_type,
                     })
@@ -399,7 +399,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_alter_change_column_type() {
+    fn test_parse_alter_modify_column_type() {
         let sql_1 = "ALTER TABLE my_metric_1 MODIFY COLUMN a STRING";
         let result_1 = ParserContext::create_with_dialect(
             sql_1,
@@ -427,10 +427,10 @@ mod tests {
                 let alter_operation = alter_table.alter_operation();
                 assert_matches!(
                     alter_operation,
-                    AlterTableOperation::ChangeColumnType { .. }
+                    AlterTableOperation::ModifyColumnType { .. }
                 );
                 match alter_operation {
-                    AlterTableOperation::ChangeColumnType {
+                    AlterTableOperation::ModifyColumnType {
                         column_name,
                         target_type,
                     } => {
@@ -461,10 +461,10 @@ mod tests {
                 let alter_operation = alter_table.alter_operation();
                 assert_matches!(
                     alter_operation,
-                    AlterTableOperation::ChangeColumnType { .. }
+                    AlterTableOperation::ModifyColumnType { .. }
                 );
                 match alter_operation {
-                    AlterTableOperation::ChangeColumnType {
+                    AlterTableOperation::ModifyColumnType {
                         column_name,
                         target_type,
                     } => {
@@ -492,10 +492,10 @@ mod tests {
                 let alter_operation = alter_table.alter_operation();
                 assert_matches!(
                     alter_operation,
-                    AlterTableOperation::ChangeColumnType { .. }
+                    AlterTableOperation::ModifyColumnType { .. }
                 );
                 match alter_operation {
-                    AlterTableOperation::ChangeColumnType {
+                    AlterTableOperation::ModifyColumnType {
                         column_name,
                         target_type,
                     } => {

--- a/src/sql/src/statements/alter.rs
+++ b/src/sql/src/statements/alter.rs
@@ -66,7 +66,7 @@ pub enum AlterTableOperation {
         location: Option<AddColumnLocation>,
     },
     /// `MODIFY <column_name> [target_type]`
-    ChangeColumnType {
+    ModifyColumnType {
         column_name: Ident,
         target_type: DataType,
     },
@@ -101,7 +101,7 @@ impl Display for AlterTableOperation {
             AlterTableOperation::RenameTable { new_table_name } => {
                 write!(f, r#"RENAME {new_table_name}"#)
             }
-            AlterTableOperation::ChangeColumnType {
+            AlterTableOperation::ModifyColumnType {
                 column_name,
                 target_type,
             } => {

--- a/src/sql/src/statements/transform/type_alias.rs
+++ b/src/sql/src/statements/transform/type_alias.rs
@@ -53,7 +53,7 @@ impl TransformRule for TypeAliasTransformRule {
                     .for_each(|column| replace_type_alias(column.mut_data_type()));
             }
             Statement::Alter(alter_table) => {
-                if let AlterTableOperation::ChangeColumnType { target_type, .. } =
+                if let AlterTableOperation::ModifyColumnType { target_type, .. } =
                     alter_table.alter_operation_mut()
                 {
                     replace_type_alias(target_type)

--- a/src/store-api/src/metadata.rs
+++ b/src/store-api/src/metadata.rs
@@ -33,7 +33,7 @@ use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize};
 use snafu::{ensure, Location, OptionExt, ResultExt, Snafu};
 
-use crate::region_request::{AddColumn, AddColumnLocation, AlterKind, ChangeColumnType};
+use crate::region_request::{AddColumn, AddColumnLocation, AlterKind, ModifyColumnType};
 use crate::storage::consts::is_internal_column;
 use crate::storage::{ColumnId, RegionId};
 
@@ -552,7 +552,7 @@ impl RegionMetadataBuilder {
         match kind {
             AlterKind::AddColumns { columns } => self.add_columns(columns)?,
             AlterKind::DropColumns { names } => self.drop_columns(&names),
-            AlterKind::ChangeColumnTypes { columns } => self.change_column_types(columns),
+            AlterKind::ModifyColumnTypes { columns } => self.modify_column_types(columns),
             AlterKind::ChangeColumnFulltext {
                 column_name,
                 options,
@@ -642,11 +642,11 @@ impl RegionMetadataBuilder {
     }
 
     /// Changes columns type to the metadata if exist.
-    fn change_column_types(&mut self, columns: Vec<ChangeColumnType>) {
+    fn modify_column_types(&mut self, columns: Vec<ModifyColumnType>) {
         let mut change_type_map: HashMap<_, _> = columns
             .into_iter()
             .map(
-                |ChangeColumnType {
+                |ModifyColumnType {
                      column_name,
                      target_type,
                  }| (column_name, target_type),
@@ -1265,8 +1265,8 @@ mod test {
 
         let mut builder = RegionMetadataBuilder::from_existing(metadata);
         builder
-            .alter(AlterKind::ChangeColumnTypes {
-                columns: vec![ChangeColumnType {
+            .alter(AlterKind::ModifyColumnTypes {
+                columns: vec![ModifyColumnType {
                     column_name: "b".to_string(),
                     target_type: ConcreteDataType::string_datatype(),
                 }],

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -194,7 +194,7 @@ pub struct AddColumnRequest {
 
 /// Change column datatype request
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ChangeColumnTypeRequest {
+pub struct ModifyColumnTypeRequest {
     pub column_name: String,
     pub target_type: ConcreteDataType,
 }
@@ -207,8 +207,8 @@ pub enum AlterKind {
     DropColumns {
         names: Vec<String>,
     },
-    ChangeColumnTypes {
-        columns: Vec<ChangeColumnTypeRequest>,
+    ModifyColumnTypes {
+        columns: Vec<ModifyColumnTypeRequest>,
     },
     RenameTable {
         new_table_name: String,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

proto: https://github.com/GreptimeTeam/greptime-proto/pull/200

## What's changed and what's your intention?

Just a rename.

Rename `ChangeColumnType` to `ModifyColumnType` to match it with SQL syntax.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
