### PR TITLE
fix: inverted index constraint to be case-insensitive

### DIFF
--- a/src/sql/src/parsers/create_parser.rs
+++ b/src/sql/src/parsers/create_parser.rs
@@ -792,7 +792,7 @@ impl<'a> ParserContext<'a> {
             TokenWithLocation {
                 token: Token::Word(w),
                 ..
-            } if w.value == INVERTED => {
+            } if w.value.eq_ignore_ascii_case(INVERTED) => {
                 self.parser
                     .expect_keyword(Keyword::INDEX)
                     .context(error::UnexpectedSnafu {
@@ -1867,7 +1867,7 @@ ENGINE=mito";
                              cpu float64 default 0,
                              memory float64,
                              TIME INDEX (ts),
-                             INVERTED INDEX()
+                             inverted index()
                              ) engine=mito;
          ";
         let result =


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

A mistake...

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
