### PR TITLE
chore(cli): set default timeout for cli commands

### DIFF
--- a/src/cmd/src/cli/database.rs
+++ b/src/cmd/src/cli/database.rs
@@ -73,12 +73,11 @@ impl DatabaseClient {
         if let Some(ref auth) = self.auth_header {
             request = request.header("Authorization", auth);
         }
-        if !self.timeout.is_zero() {
-            request = request.header(
-                GREPTIME_DB_HEADER_TIMEOUT,
-                format_duration(self.timeout).to_string(),
-            );
-        }
+
+        request = request.header(
+            GREPTIME_DB_HEADER_TIMEOUT,
+            format_duration(self.timeout).to_string(),
+        );
 
         let response = request.send().await.with_context(|_| HttpQuerySqlSnafu {
             reason: format!("bad url: {}", url),

--- a/src/cmd/src/cli/database.rs
+++ b/src/cmd/src/cli/database.rs
@@ -30,7 +30,7 @@ pub(crate) struct DatabaseClient {
     addr: String,
     catalog: String,
     auth_header: Option<String>,
-    timeout: Option<Duration>,
+    timeout: Duration,
 }
 
 impl DatabaseClient {
@@ -38,7 +38,7 @@ impl DatabaseClient {
         addr: String,
         catalog: String,
         auth_basic: Option<String>,
-        timeout: Option<Duration>,
+        timeout: Duration,
     ) -> Self {
         let auth_header = if let Some(basic) = auth_basic {
             let encoded = general_purpose::STANDARD.encode(basic);
@@ -73,10 +73,10 @@ impl DatabaseClient {
         if let Some(ref auth) = self.auth_header {
             request = request.header("Authorization", auth);
         }
-        if let Some(ref timeout) = self.timeout {
+        if !self.timeout.is_zero() {
             request = request.header(
                 GREPTIME_DB_HEADER_TIMEOUT,
-                format_duration(*timeout).to_string(),
+                format_duration(self.timeout).to_string(),
             );
         }
 

--- a/src/cmd/src/cli/export.rs
+++ b/src/cmd/src/cli/export.rs
@@ -86,7 +86,7 @@ pub struct ExportCommand {
     auth_basic: Option<String>,
 
     /// The timeout of invoking the database.
-    #[clap(long, value_parser = humantime::parse_duration)]
+    #[clap(long, value_parser = humantime::parse_duration, default_value = "180s")]
     timeout: Option<Duration>,
 }
 

--- a/src/cmd/src/cli/export.rs
+++ b/src/cmd/src/cli/export.rs
@@ -86,8 +86,11 @@ pub struct ExportCommand {
     auth_basic: Option<String>,
 
     /// The timeout of invoking the database.
+    ///
+    /// It is used to override the server-side timeout setting.
+    /// Sets `0s` to follow server-side default timeout.
     #[clap(long, value_parser = humantime::parse_duration, default_value = "180s")]
-    timeout: Option<Duration>,
+    timeout: Duration,
 }
 
 impl ExportCommand {

--- a/src/cmd/src/cli/export.rs
+++ b/src/cmd/src/cli/export.rs
@@ -90,7 +90,7 @@ pub struct ExportCommand {
     /// It is used to override the server-side timeout setting.
     /// Sets `0s` to disable server-side default timeout.
     #[clap(long, value_parser = humantime::parse_duration)]
-    timeout: Duration,
+    timeout: Option<Duration>,
 }
 
 impl ExportCommand {
@@ -101,7 +101,8 @@ impl ExportCommand {
             self.addr.clone(),
             catalog.clone(),
             self.auth_basic.clone(),
-            self.timeout,
+            // Treats `None` as `0s` to disable server-side default timeout.
+            self.timeout.unwrap_or_default(),
         );
 
         Ok(Instance::new(

--- a/src/cmd/src/cli/export.rs
+++ b/src/cmd/src/cli/export.rs
@@ -88,7 +88,7 @@ pub struct ExportCommand {
     /// The timeout of invoking the database.
     ///
     /// It is used to override the server-side timeout setting.
-    /// Sets `0s` to disable server-side default timeout.
+    /// The default behavior will disable server-side default timeout(i.e. `0s`).
     #[clap(long, value_parser = humantime::parse_duration)]
     timeout: Option<Duration>,
 }

--- a/src/cmd/src/cli/export.rs
+++ b/src/cmd/src/cli/export.rs
@@ -88,7 +88,7 @@ pub struct ExportCommand {
     /// The timeout of invoking the database.
     ///
     /// It is used to override the server-side timeout setting.
-    /// Sets `0s` to follow server-side default timeout.
+    /// Sets `0s` to disable server-side default timeout.
     #[clap(long, value_parser = humantime::parse_duration)]
     timeout: Duration,
 }

--- a/src/cmd/src/cli/export.rs
+++ b/src/cmd/src/cli/export.rs
@@ -89,7 +89,7 @@ pub struct ExportCommand {
     ///
     /// It is used to override the server-side timeout setting.
     /// Sets `0s` to follow server-side default timeout.
-    #[clap(long, value_parser = humantime::parse_duration, default_value = "180s")]
+    #[clap(long, value_parser = humantime::parse_duration)]
     timeout: Duration,
 }
 

--- a/src/cmd/src/cli/import.rs
+++ b/src/cmd/src/cli/import.rs
@@ -74,7 +74,7 @@ pub struct ImportCommand {
     ///
     /// It is used to override the server-side timeout setting.
     /// Sets `0s` to follow server-side default timeout.
-    #[clap(long, value_parser = humantime::parse_duration, default_value = "180s")]
+    #[clap(long, value_parser = humantime::parse_duration)]
     timeout: Duration,
 }
 

--- a/src/cmd/src/cli/import.rs
+++ b/src/cmd/src/cli/import.rs
@@ -75,7 +75,7 @@ pub struct ImportCommand {
     /// It is used to override the server-side timeout setting.
     /// Sets `0s` to disable server-side default timeout.
     #[clap(long, value_parser = humantime::parse_duration)]
-    timeout: Duration,
+    timeout: Option<Duration>,
 }
 
 impl ImportCommand {
@@ -85,7 +85,8 @@ impl ImportCommand {
             self.addr.clone(),
             catalog.clone(),
             self.auth_basic.clone(),
-            self.timeout,
+            // Treats `None` as `0s` to disable server-side default timeout.
+            self.timeout.unwrap_or_default(),
         );
 
         Ok(Instance::new(

--- a/src/cmd/src/cli/import.rs
+++ b/src/cmd/src/cli/import.rs
@@ -71,8 +71,11 @@ pub struct ImportCommand {
     auth_basic: Option<String>,
 
     /// The timeout of invoking the database.
-    #[clap(long, value_parser = humantime::parse_duration)]
-    timeout: Option<Duration>,
+    ///
+    /// It is used to override the server-side timeout setting.
+    /// Sets `0s` to follow server-side default timeout.
+    #[clap(long, value_parser = humantime::parse_duration, default_value = "180s")]
+    timeout: Duration,
 }
 
 impl ImportCommand {

--- a/src/cmd/src/cli/import.rs
+++ b/src/cmd/src/cli/import.rs
@@ -73,7 +73,7 @@ pub struct ImportCommand {
     /// The timeout of invoking the database.
     ///
     /// It is used to override the server-side timeout setting.
-    /// Sets `0s` to disable server-side default timeout.
+    /// The default behavior will disable server-side default timeout(i.e. `0s`).
     #[clap(long, value_parser = humantime::parse_duration)]
     timeout: Option<Duration>,
 }

--- a/src/cmd/src/cli/import.rs
+++ b/src/cmd/src/cli/import.rs
@@ -73,7 +73,7 @@ pub struct ImportCommand {
     /// The timeout of invoking the database.
     ///
     /// It is used to override the server-side timeout setting.
-    /// Sets `0s` to follow server-side default timeout.
+    /// Sets `0s` to disable server-side default timeout.
     #[clap(long, value_parser = humantime::parse_duration)]
     timeout: Duration,
 }

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -1119,6 +1119,29 @@ mod test {
         assert_eq!(res.status(), StatusCode::REQUEST_TIMEOUT);
         let elapsed = now.elapsed();
         assert!(elapsed > Duration::from_millis(15));
+
+        tokio::time::timeout(
+            Duration::from_millis(15),
+            client
+                .get("/test/timeout")
+                .header(GREPTIME_DB_HEADER_TIMEOUT, "0s")
+                .send(),
+        )
+        .await
+        .unwrap_err();
+
+        tokio::time::timeout(
+            Duration::from_millis(15),
+            client
+                .get("/test/timeout")
+                .header(
+                    GREPTIME_DB_HEADER_TIMEOUT,
+                    humantime::format_duration(Duration::default()).to_string(),
+                )
+                .send(),
+        )
+        .await
+        .unwrap_err();
     }
 
     #[tokio::test]

--- a/src/servers/src/http/test_helpers.rs
+++ b/src/servers/src/http/test_helpers.rs
@@ -194,6 +194,7 @@ impl RequestBuilder {
 /// This is convenient for tests where panics are what you want. For access to
 /// non-panicking versions or the complete `Response` API use `into_inner()` or
 /// `as_ref()`.
+#[derive(Debug)]
 pub struct TestResponse {
     response: reqwest::Response,
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Update the timeout option from `Option<Duration>` to `Duration` . And users can explicitly set the timeout to `0s` to disable server-side timeout configuration.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
