### PR TITLE
feat: also shutdown gracefully on sigterm on unix

### DIFF
--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -95,8 +95,8 @@ pub trait App: Send {
 
         if self.wait_signal() {
             if let Err(e) = start_wait_for_close_signal().await {
-                error!(e; "Failed to listen for ctrl-c signal");
-                // It's unusual to fail to listen for ctrl-c signal, maybe there's something unexpected in
+                error!(e; "Failed to listen for close signal");
+                // It's unusual to fail to listen for close signal, maybe there's something unexpected in
                 // the underlying system. So we stop the app instead of running nonetheless to let people
                 // investigate the issue.
             }

--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -45,7 +45,7 @@ lazy_static::lazy_static! {
 
 /// wait for the close signal, for unix platform it's SIGINT or SIGTERM
 #[cfg(unix)]
-async fn start_wait_for_close_signal() -> std::result::Result<(), Box<dyn std::error::Error>> {
+async fn start_wait_for_close_signal() -> std::io::Result<()> {
     use tokio::signal::unix::{signal, SignalKind};
     let mut sigint = signal(SignalKind::interrupt())?;
     let mut sigterm = signal(SignalKind::terminate())?;
@@ -64,7 +64,7 @@ async fn start_wait_for_close_signal() -> std::result::Result<(), Box<dyn std::e
 
 /// wait for the close signal, for non-unix platform it's ctrl-c
 #[cfg(not(unix))]
-async fn start_wait_for_close_signal() -> std::result::Result<(), Box<dyn std::error::Error>> {
+async fn start_wait_for_close_signal() -> std::io::Result<()> {
     tokio::signal::ctrl_c().await
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

as title, windows remain the same with only ctrl c can close

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
