### PR TITLE
fix: prepare param mismatch

### DIFF
--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -204,7 +204,7 @@ impl MysqlInstanceShim {
             .unwrap_or_default();
 
         // DataFusion may optimize the plan so that some parameters are not used.
-        if params.len() != param_num {
+        if params.len() != param_num - 1 {
             self.save_plan(
                 SqlPlan {
                     query: query.to_string(),

--- a/tests/cases/standalone/common/prepare/mysql_prepare.result
+++ b/tests/cases/standalone/common/prepare/mysql_prepare.result
@@ -25,7 +25,7 @@ EXECUTE stmt USING 'a';
 Failed to parse query result, err: MySqlError { ERROR 1815 (HY000): (EngineExecuteQuery): Cast error: Cannot cast string 'a' to value of Int32 type }
 
 -- SQLNESS PROTOCOL MYSQL
-DEALLOCATE PREPARE stmt;
+DEALLOCATE stmt;
 
 affected_rows: 0
 
@@ -45,7 +45,7 @@ EXECUTE stmt USING 'a';
 affected_rows: 0
 
 -- SQLNESS PROTOCOL MYSQL
-DEALLOCATE PREPARE stmt;
+DEALLOCATE stmt;
 
 affected_rows: 0
 
@@ -64,4 +64,9 @@ EXECUTE stmt USING 1, 'hello';
 +----------+---------------+
 | 1        | hello         |
 +----------+---------------+
+
+-- SQLNESS PROTOCOL MYSQL
+DEALLOCATE stmt;
+
+affected_rows: 0
 

--- a/tests/cases/standalone/common/prepare/mysql_prepare.result
+++ b/tests/cases/standalone/common/prepare/mysql_prepare.result
@@ -1,0 +1,67 @@
+-- invalid prepare, from
+-- https://github.com/duckdb/duckdb/blob/00a605270719941ca0412ad5d0a14b1bdfbf9eb5/test/sql/prepared/invalid_prepare.test
+-- SQLNESS PROTOCOL MYSQL
+SELECT ?;
+
+Failed to execute query, err: MySqlError { ERROR 1815 (HY000): (PlanQuery): Failed to plan SQL: Error during planning: Placeholder type could not be resolved. Make sure that the placeholder is bound to a concrete type, e.g. by providing parameter values. }
+
+-- SQLNESS PROTOCOL MYSQL
+PREPARE stmt FROM 'SELECT ?::int;';
+
+affected_rows: 0
+
+-- SQLNESS PROTOCOL MYSQL
+EXECUTE stmt USING 1;
+
++----------+
+| Int64(1) |
++----------+
+| 1        |
++----------+
+
+-- SQLNESS PROTOCOL MYSQL
+EXECUTE stmt USING 'a';
+
+Failed to parse query result, err: MySqlError { ERROR 1815 (HY000): (EngineExecuteQuery): Cast error: Cannot cast string 'a' to value of Int32 type }
+
+-- SQLNESS PROTOCOL MYSQL
+DEALLOCATE PREPARE stmt;
+
+affected_rows: 0
+
+-- SQLNESS PROTOCOL MYSQL
+PREPARE stmt FROM 'SELECT ?::int WHERE 1=0;';
+
+affected_rows: 0
+
+-- SQLNESS PROTOCOL MYSQL
+EXECUTE stmt USING 1;
+
+affected_rows: 0
+
+-- SQLNESS PROTOCOL MYSQL
+EXECUTE stmt USING 'a';
+
+affected_rows: 0
+
+-- SQLNESS PROTOCOL MYSQL
+DEALLOCATE PREPARE stmt;
+
+affected_rows: 0
+
+-- parameter variants, from:
+-- https://github.com/duckdb/duckdb/blob/2360dd00f193b5d0850f9379d0c3794eb2084f36/test/sql/prepared/parameter_variants.test
+-- SQLNESS PROTOCOL MYSQL
+PREPARE stmt FROM 'SELECT CAST(? AS INTEGER), CAST(? AS STRING);';
+
+affected_rows: 0
+
+-- SQLNESS PROTOCOL MYSQL
+EXECUTE stmt USING 1, 'hello';
+
++----------+---------------+
+| Int64(1) | Utf8("hello") |
++----------+---------------+
+| 1        | hello         |
++----------+---------------+
+

--- a/tests/cases/standalone/common/prepare/mysql_prepare.sql
+++ b/tests/cases/standalone/common/prepare/mysql_prepare.sql
@@ -13,7 +13,7 @@ EXECUTE stmt USING 1;
 EXECUTE stmt USING 'a';
 
 -- SQLNESS PROTOCOL MYSQL
-DEALLOCATE PREPARE stmt;
+DEALLOCATE stmt;
 
 -- SQLNESS PROTOCOL MYSQL
 PREPARE stmt FROM 'SELECT ?::int WHERE 1=0;';
@@ -25,7 +25,7 @@ EXECUTE stmt USING 1;
 EXECUTE stmt USING 'a';
 
 -- SQLNESS PROTOCOL MYSQL
-DEALLOCATE PREPARE stmt;
+DEALLOCATE stmt;
 
 -- parameter variants, from:
 -- https://github.com/duckdb/duckdb/blob/2360dd00f193b5d0850f9379d0c3794eb2084f36/test/sql/prepared/parameter_variants.test
@@ -34,3 +34,6 @@ PREPARE stmt FROM 'SELECT CAST(? AS INTEGER), CAST(? AS STRING);';
 
 -- SQLNESS PROTOCOL MYSQL
 EXECUTE stmt USING 1, 'hello';
+
+-- SQLNESS PROTOCOL MYSQL
+DEALLOCATE stmt;

--- a/tests/cases/standalone/common/prepare/mysql_prepare.sql
+++ b/tests/cases/standalone/common/prepare/mysql_prepare.sql
@@ -1,0 +1,36 @@
+-- invalid prepare, from
+-- https://github.com/duckdb/duckdb/blob/00a605270719941ca0412ad5d0a14b1bdfbf9eb5/test/sql/prepared/invalid_prepare.test
+-- SQLNESS PROTOCOL MYSQL
+SELECT ?;
+
+-- SQLNESS PROTOCOL MYSQL
+PREPARE stmt FROM 'SELECT ?::int;';
+
+-- SQLNESS PROTOCOL MYSQL
+EXECUTE stmt USING 1;
+
+-- SQLNESS PROTOCOL MYSQL
+EXECUTE stmt USING 'a';
+
+-- SQLNESS PROTOCOL MYSQL
+DEALLOCATE PREPARE stmt;
+
+-- SQLNESS PROTOCOL MYSQL
+PREPARE stmt FROM 'SELECT ?::int WHERE 1=0;';
+
+-- SQLNESS PROTOCOL MYSQL
+EXECUTE stmt USING 1;
+
+-- SQLNESS PROTOCOL MYSQL
+EXECUTE stmt USING 'a';
+
+-- SQLNESS PROTOCOL MYSQL
+DEALLOCATE PREPARE stmt;
+
+-- parameter variants, from:
+-- https://github.com/duckdb/duckdb/blob/2360dd00f193b5d0850f9379d0c3794eb2084f36/test/sql/prepared/parameter_variants.test
+-- SQLNESS PROTOCOL MYSQL
+PREPARE stmt FROM 'SELECT CAST(? AS INTEGER), CAST(? AS STRING);';
+
+-- SQLNESS PROTOCOL MYSQL
+EXECUTE stmt USING 1, 'hello';


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

#4970 

## What's changed and what's your intention?

Datafusion may convert the prepared sql to an optimized plan without initial params, so that we can't confirm if the param is needed when executing the prepared plan.

This patch introduces a workaroud that just drop the optimized plan if the param number mismatches and use the initial sql. It may affect the performance of the sql, but previously these sqls even cannot execute.

e.g.
```SQL
PREPARE stmt FROM 'SELECT ? + 1 WHERE 1 = 0';
EXECUTE stmt USING 1;
```

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
