### PR TITLE
fix: find latest window

### DIFF
--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -410,7 +410,11 @@ mod tests {
         assert_eq!(
             Some((i64::MAX / 3600000 + 1) * 3600),
             find_latest_window_in_seconds(
-                [new_file_handle(FileId::random(), i64::MIN, i64::MAX, 0),].iter(),
+                [
+                    new_file_handle(FileId::random(), i64::MIN, i64::MAX, 0),
+                    new_file_handle(FileId::random(), 0, 1000, 0)
+                ]
+                .iter(),
                 3600
             )
         );

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -353,10 +353,10 @@ fn find_latest_window_in_seconds<'a>(
     let mut latest_timestamp = None;
     for f in files {
         let (_, end) = f.time_range();
-        if let Some(latest) = latest_timestamp
-            && end > latest
-        {
-            latest_timestamp = Some(end);
+        if let Some(latest) = latest_timestamp {
+            if end > latest {
+                latest_timestamp = Some(end);
+            }
         } else {
             latest_timestamp = Some(end);
         }
@@ -405,6 +405,14 @@ mod tests {
                 10000,
             )
             .unwrap()
+        );
+
+        assert_eq!(
+            Some((i64::MAX / 3600000 + 1) * 3600),
+            find_latest_window_in_seconds(
+                [new_file_handle(FileId::random(), i64::MIN, i64::MAX, 0),].iter(),
+                3600
+            )
         );
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

fix issue in finding latest time window.

## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
