### PR TITLE
fix: prevent metadata region from inheriting database ttl

### DIFF
--- a/src/metric-engine/src/engine/create.rs
+++ b/src/metric-engine/src/engine/create.rs
@@ -458,7 +458,7 @@ impl MetricEngineInner {
 
         // remove TTL and APPEND_MODE option
         let mut options = request.options.clone();
-        options.remove(TTL_KEY);
+        options.insert(TTL_KEY.to_string(), "10000 years".to_string());
         options.remove(APPEND_MODE_KEY);
 
         RegionCreateRequest {
@@ -724,6 +724,9 @@ mod test {
             metadata_region_request.region_dir,
             "/test_dir/metadata/".to_string()
         );
-        assert!(!metadata_region_request.options.contains_key("ttl"));
+        assert_eq!(
+            metadata_region_request.options.get("ttl").unwrap(),
+            "10000 years"
+        );
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


A quick bad fix for 0.10.1.

Metadata region has a constant 0 as time index column's value. When inheriting TTL from database it will remove all metadata. 

## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
