### PR TITLE
fix(metric-engine): set ttl also on opening metadata regions

### DIFF
--- a/src/metric-engine/src/engine/create.rs
+++ b/src/metric-engine/src/engine/create.rs
@@ -32,7 +32,7 @@ use store_api::metric_engine_consts::{
     METADATA_SCHEMA_TIMESTAMP_COLUMN_INDEX, METADATA_SCHEMA_TIMESTAMP_COLUMN_NAME,
     METADATA_SCHEMA_VALUE_COLUMN_INDEX, METADATA_SCHEMA_VALUE_COLUMN_NAME,
 };
-use store_api::mito_engine_options::TTL_KEY;
+use store_api::mito_engine_options::{APPEND_MODE_KEY, TTL_KEY};
 use store_api::region_engine::RegionEngine;
 use store_api::region_request::{AffectedRows, RegionCreateRequest, RegionRequest};
 use store_api::storage::consts::ReservedColumnId;
@@ -456,7 +456,7 @@ impl MetricEngineInner {
         // concat region dir
         let metadata_region_dir = join_dir(&request.region_dir, METADATA_REGION_SUBDIR);
 
-        let options = region_options_for_metadata_region();
+        let options = region_options_for_metadata_region(request.options.clone());
         RegionCreateRequest {
             engine: MITO_ENGINE_NAME.to_string(),
             column_metadatas: vec![
@@ -536,10 +536,12 @@ impl MetricEngineInner {
 }
 
 /// Creates the region options for metadata region in metric engine.
-pub(crate) fn region_options_for_metadata_region() -> HashMap<String, String> {
-    [(TTL_KEY.to_string(), "10000 years".to_string())]
-        .into_iter()
-        .collect()
+pub(crate) fn region_options_for_metadata_region(
+    mut original: HashMap<String, String>,
+) -> HashMap<String, String> {
+    original.remove(APPEND_MODE_KEY);
+    original.insert(TTL_KEY.to_string(), "10000 years".to_string());
+    original
 }
 
 #[cfg(test)]

--- a/src/metric-engine/src/engine/create.rs
+++ b/src/metric-engine/src/engine/create.rs
@@ -32,7 +32,7 @@ use store_api::metric_engine_consts::{
     METADATA_SCHEMA_TIMESTAMP_COLUMN_INDEX, METADATA_SCHEMA_TIMESTAMP_COLUMN_NAME,
     METADATA_SCHEMA_VALUE_COLUMN_INDEX, METADATA_SCHEMA_VALUE_COLUMN_NAME,
 };
-use store_api::mito_engine_options::{APPEND_MODE_KEY, TTL_KEY};
+use store_api::mito_engine_options::TTL_KEY;
 use store_api::region_engine::RegionEngine;
 use store_api::region_request::{AffectedRows, RegionCreateRequest, RegionRequest};
 use store_api::storage::consts::ReservedColumnId;
@@ -456,10 +456,9 @@ impl MetricEngineInner {
         // concat region dir
         let metadata_region_dir = join_dir(&request.region_dir, METADATA_REGION_SUBDIR);
 
-        // remove TTL and APPEND_MODE option
-        let mut options = request.options.clone();
-        options.insert(TTL_KEY.to_string(), "10000 years".to_string());
-        options.remove(APPEND_MODE_KEY);
+        let options = [(TTL_KEY.to_string(), "10000 years".to_string())]
+            .into_iter()
+            .collect();
 
         RegionCreateRequest {
             engine: MITO_ENGINE_NAME.to_string(),

--- a/src/metric-engine/src/engine/create.rs
+++ b/src/metric-engine/src/engine/create.rs
@@ -456,10 +456,7 @@ impl MetricEngineInner {
         // concat region dir
         let metadata_region_dir = join_dir(&request.region_dir, METADATA_REGION_SUBDIR);
 
-        let options = [(TTL_KEY.to_string(), "10000 years".to_string())]
-            .into_iter()
-            .collect();
-
+        let options = region_options_for_metadata_region();
         RegionCreateRequest {
             engine: MITO_ENGINE_NAME.to_string(),
             column_metadatas: vec![
@@ -536,6 +533,13 @@ impl MetricEngineInner {
         };
         [metric_name_col, tsid_col]
     }
+}
+
+/// Creates the region options for metadata region in metric engine.
+pub(crate) fn region_options_for_metadata_region() -> HashMap<String, String> {
+    [(TTL_KEY.to_string(), "10000 years".to_string())]
+        .into_iter()
+        .collect()
 }
 
 #[cfg(test)]

--- a/src/metric-engine/src/engine/open.rs
+++ b/src/metric-engine/src/engine/open.rs
@@ -69,7 +69,7 @@ impl MetricEngineInner {
         let metadata_region_dir = join_dir(&request.region_dir, METADATA_REGION_SUBDIR);
         let data_region_dir = join_dir(&request.region_dir, DATA_REGION_SUBDIR);
 
-        let metadata_region_options = region_options_for_metadata_region();
+        let metadata_region_options = region_options_for_metadata_region(request.options.clone());
         let open_metadata_region_request = RegionOpenRequest {
             region_dir: metadata_region_dir,
             options: metadata_region_options,

--- a/src/metric-engine/src/engine/open.rs
+++ b/src/metric-engine/src/engine/open.rs
@@ -19,6 +19,7 @@ use mito2::engine::MITO_ENGINE_NAME;
 use object_store::util::join_dir;
 use snafu::ResultExt;
 use store_api::metric_engine_consts::{DATA_REGION_SUBDIR, METADATA_REGION_SUBDIR};
+use store_api::mito_engine_options::TTL_KEY;
 use store_api::region_engine::RegionEngine;
 use store_api::region_request::{AffectedRows, RegionOpenRequest, RegionRequest};
 use store_api::storage::RegionId;
@@ -68,9 +69,12 @@ impl MetricEngineInner {
         let metadata_region_dir = join_dir(&request.region_dir, METADATA_REGION_SUBDIR);
         let data_region_dir = join_dir(&request.region_dir, DATA_REGION_SUBDIR);
 
+        let metadata_region_options = [(TTL_KEY.to_string(), "10000 years".to_string())]
+            .into_iter()
+            .collect();
         let open_metadata_region_request = RegionOpenRequest {
             region_dir: metadata_region_dir,
-            options: request.options.clone(),
+            options: metadata_region_options,
             engine: MITO_ENGINE_NAME.to_string(),
             skip_wal_replay: request.skip_wal_replay,
         };

--- a/src/metric-engine/src/engine/open.rs
+++ b/src/metric-engine/src/engine/open.rs
@@ -19,12 +19,12 @@ use mito2::engine::MITO_ENGINE_NAME;
 use object_store::util::join_dir;
 use snafu::ResultExt;
 use store_api::metric_engine_consts::{DATA_REGION_SUBDIR, METADATA_REGION_SUBDIR};
-use store_api::mito_engine_options::TTL_KEY;
 use store_api::region_engine::RegionEngine;
 use store_api::region_request::{AffectedRows, RegionOpenRequest, RegionRequest};
 use store_api::storage::RegionId;
 
 use super::MetricEngineInner;
+use crate::engine::create::region_options_for_metadata_region;
 use crate::engine::options::set_data_region_options;
 use crate::error::{OpenMitoRegionSnafu, Result};
 use crate::metrics::{LOGICAL_REGION_COUNT, PHYSICAL_REGION_COUNT};
@@ -69,9 +69,7 @@ impl MetricEngineInner {
         let metadata_region_dir = join_dir(&request.region_dir, METADATA_REGION_SUBDIR);
         let data_region_dir = join_dir(&request.region_dir, DATA_REGION_SUBDIR);
 
-        let metadata_region_options = [(TTL_KEY.to_string(), "10000 years".to_string())]
-            .into_iter()
-            .collect();
+        let metadata_region_options = region_options_for_metadata_region();
         let open_metadata_region_request = RegionOpenRequest {
             region_dir: metadata_region_dir,
             options: metadata_region_options,

--- a/typos.toml
+++ b/typos.toml
@@ -11,5 +11,6 @@ extend-exclude = [
     "tests-fuzz/src/data/lorem_words",
     "*.sql",
     "*.result",
-    "src/pipeline/benches/data.log"
+    "src/pipeline/benches/data.log",
+    "cyborg/pnpm-lock.yaml"
 ]


### PR DESCRIPTION

I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#5044

## What's changed and what's your intention?

The region options for metadata region in metric engines should stay independent from database options, no matter during opening or creating regions.


## Checklist

- [x] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
