### PR TITLE
feat: use cache kv manager for SchemaMetadataManager

### DIFF
--- a/src/catalog/src/kvbackend.rs
+++ b/src/catalog/src/kvbackend.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use client::{CachedMetaKvBackend, CachedMetaKvBackendBuilder, MetaKvBackend};
+pub use client::{CachedKvBackend, CachedKvBackendBuilder, MetaKvBackend};
 
 mod client;
 mod manager;

--- a/src/catalog/src/kvbackend/client.rs
+++ b/src/catalog/src/kvbackend/client.rs
@@ -122,7 +122,7 @@ impl TxnService for CachedKvBackend {
     type Error = Error;
 
     async fn txn(&self, txn: Txn) -> std::result::Result<TxnResponse, Self::Error> {
-        //todo(hl): txn of CachedKvBackend simply pass through to inner backend without invalidating caches.
+        // TODO(hl): txn of CachedKvBackend simply pass through to inner backend without invalidating caches.
         self.kv_backend.txn(txn).await
     }
 

--- a/src/cmd/src/flownode.rs
+++ b/src/cmd/src/flownode.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use cache::{build_fundamental_cache_registry, with_default_composite_cache_registry};
-use catalog::kvbackend::{CachedMetaKvBackendBuilder, KvBackendCatalogManager, MetaKvBackend};
+use catalog::kvbackend::{CachedKvBackendBuilder, KvBackendCatalogManager, MetaKvBackend};
 use clap::Parser;
 use client::client_manager::NodeClients;
 use common_base::Plugins;
@@ -246,11 +246,12 @@ impl StartCommand {
         let cache_tti = meta_config.metadata_cache_tti;
 
         // TODO(discord9): add helper function to ease the creation of cache registry&such
-        let cached_meta_backend = CachedMetaKvBackendBuilder::new(meta_client.clone())
-            .cache_max_capacity(cache_max_capacity)
-            .cache_ttl(cache_ttl)
-            .cache_tti(cache_tti)
-            .build();
+        let cached_meta_backend =
+            CachedKvBackendBuilder::new(Arc::new(MetaKvBackend::new(meta_client.clone())))
+                .cache_max_capacity(cache_max_capacity)
+                .cache_ttl(cache_ttl)
+                .cache_tti(cache_tti)
+                .build();
         let cached_meta_backend = Arc::new(cached_meta_backend);
 
         // Builds cache registry

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use cache::{build_fundamental_cache_registry, with_default_composite_cache_registry};
-use catalog::kvbackend::{CachedMetaKvBackendBuilder, KvBackendCatalogManager, MetaKvBackend};
+use catalog::kvbackend::{CachedKvBackendBuilder, KvBackendCatalogManager, MetaKvBackend};
 use clap::Parser;
 use client::client_manager::NodeClients;
 use common_base::Plugins;
@@ -293,11 +293,12 @@ impl StartCommand {
         .context(MetaClientInitSnafu)?;
 
         // TODO(discord9): add helper function to ease the creation of cache registry&such
-        let cached_meta_backend = CachedMetaKvBackendBuilder::new(meta_client.clone())
-            .cache_max_capacity(cache_max_capacity)
-            .cache_ttl(cache_ttl)
-            .cache_tti(cache_tti)
-            .build();
+        let cached_meta_backend =
+            CachedKvBackendBuilder::new(Arc::new(MetaKvBackend::new(meta_client.clone())))
+                .cache_max_capacity(cache_max_capacity)
+                .cache_ttl(cache_ttl)
+                .cache_tti(cache_tti)
+                .build();
         let cached_meta_backend = Arc::new(cached_meta_backend);
 
         // Builds cache registry

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -18,6 +18,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
+use catalog::kvbackend::CachedKvBackendBuilder;
 use catalog::memory::MemoryCatalogManager;
 use common_base::Plugins;
 use common_error::ext::BoxedError;
@@ -208,7 +209,10 @@ impl DatanodeBuilder {
             (Box::new(NoopRegionServerEventListener) as _, None)
         };
 
-        let schema_metadata_manager = Arc::new(SchemaMetadataManager::new(kv_backend.clone()));
+        let cached_kv_backend =
+            Arc::new(CachedKvBackendBuilder::new(kv_backend.clone()).build()) as KvBackendRef;
+
+        let schema_metadata_manager = Arc::new(SchemaMetadataManager::new(cached_kv_backend));
         let region_server = self
             .new_region_server(schema_metadata_manager, region_event_listener)
             .await?;

--- a/src/datanode/src/heartbeat.rs
+++ b/src/datanode/src/heartbeat.rs
@@ -30,7 +30,7 @@ use common_meta::heartbeat::handler::{
 };
 use common_meta::heartbeat::mailbox::{HeartbeatMailbox, MailboxRef};
 use common_meta::heartbeat::utils::outgoing_message_to_mailbox_message;
-use common_meta::instruction::Instruction;
+use common_meta::instruction::{CacheIdent, Instruction};
 use common_telemetry::{debug, error, info, trace, warn};
 use meta_client::client::{HeartbeatSender, MetaClient};
 use meta_client::MetaClientRef;
@@ -393,8 +393,14 @@ impl HeartbeatResponseHandler for InvalidateSchemaCacheHandler {
             "InvalidateSchemaCacheHandler: invalidating caches: {:?}",
             caches
         );
+
+        let schema_caches = caches
+            .into_iter()
+            .filter(|i| matches!(i, CacheIdent::SchemaName(_)))
+            .collect::<Vec<_>>();
+
         self.cached_kv_backend
-            .invalidate(&Context::default(), &caches)
+            .invalidate(&Context::default(), &schema_caches)
             .await?;
         Ok(HandleControl::Done)
     }

--- a/src/datanode/src/heartbeat.rs
+++ b/src/datanode/src/heartbeat.rs
@@ -18,19 +18,15 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use api::v1::meta::{HeartbeatRequest, NodeInfo, Peer, RegionRole, RegionStat};
-use async_trait::async_trait;
 use catalog::kvbackend::CachedKvBackend;
-use common_meta::cache_invalidator::{CacheInvalidator, Context};
 use common_meta::datanode::REGION_STATISTIC_KEY;
 use common_meta::distributed_time_constants::META_KEEP_ALIVE_INTERVAL_SECS;
 use common_meta::heartbeat::handler::parse_mailbox_message::ParseMailboxMessageHandler;
 use common_meta::heartbeat::handler::{
-    HandleControl, HandlerGroupExecutor, HeartbeatResponseHandler, HeartbeatResponseHandlerContext,
-    HeartbeatResponseHandlerExecutorRef,
+    HandlerGroupExecutor, HeartbeatResponseHandlerContext, HeartbeatResponseHandlerExecutorRef,
 };
 use common_meta::heartbeat::mailbox::{HeartbeatMailbox, MailboxRef};
 use common_meta::heartbeat::utils::outgoing_message_to_mailbox_message;
-use common_meta::instruction::{CacheIdent, Instruction};
 use common_telemetry::{debug, error, info, trace, warn};
 use meta_client::client::{HeartbeatSender, MetaClient};
 use meta_client::MetaClientRef;
@@ -44,6 +40,7 @@ use crate::alive_keeper::RegionAliveKeeper;
 use crate::config::DatanodeOptions;
 use crate::error::{self, MetaClientInitSnafu, Result};
 use crate::event_listener::RegionServerEventReceiver;
+use crate::heartbeat::handler::cache_invalidator::InvalidateSchemaCacheHandler;
 use crate::metrics::{self, HEARTBEAT_RECV_COUNT, HEARTBEAT_SENT_COUNT};
 use crate::region_server::RegionServer;
 
@@ -364,142 +361,5 @@ impl HeartbeatTask {
         }
 
         Ok(())
-    }
-}
-
-#[derive(Clone)]
-pub struct InvalidateSchemaCacheHandler {
-    cached_kv_backend: Arc<CachedKvBackend>,
-}
-
-#[async_trait]
-impl HeartbeatResponseHandler for InvalidateSchemaCacheHandler {
-    fn is_acceptable(&self, ctx: &HeartbeatResponseHandlerContext) -> bool {
-        matches!(
-            ctx.incoming_message.as_ref(),
-            Some((_, Instruction::InvalidateCaches(_)))
-        )
-    }
-
-    async fn handle(
-        &self,
-        ctx: &mut HeartbeatResponseHandlerContext,
-    ) -> common_meta::error::Result<HandleControl> {
-        let Some((_, Instruction::InvalidateCaches(caches))) = ctx.incoming_message.take() else {
-            unreachable!("InvalidateSchemaCacheHandler: should be guarded by 'is_acceptable'")
-        };
-
-        debug!(
-            "InvalidateSchemaCacheHandler: invalidating caches: {:?}",
-            caches
-        );
-
-        let schema_caches = caches
-            .into_iter()
-            .filter(|i| matches!(i, CacheIdent::SchemaName(_)))
-            .collect::<Vec<_>>();
-
-        self.cached_kv_backend
-            .invalidate(&Context::default(), &schema_caches)
-            .await?;
-        Ok(HandleControl::Done)
-    }
-}
-
-impl InvalidateSchemaCacheHandler {
-    pub fn new(cached_kv_backend: Arc<CachedKvBackend>) -> Self {
-        Self { cached_kv_backend }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::sync::Arc;
-    use std::time::Duration;
-
-    use api::v1::meta::HeartbeatResponse;
-    use catalog::kvbackend::CachedKvBackendBuilder;
-    use common_meta::heartbeat::handler::{
-        HandlerGroupExecutor, HeartbeatResponseHandlerContext, HeartbeatResponseHandlerExecutor,
-    };
-    use common_meta::heartbeat::mailbox::{HeartbeatMailbox, MessageMeta};
-    use common_meta::instruction::{CacheIdent, Instruction};
-    use common_meta::key::schema_name::{SchemaName, SchemaNameKey, SchemaNameValue};
-    use common_meta::key::{MetadataKey, SchemaMetadataManager};
-    use common_meta::kv_backend::memory::MemoryKvBackend;
-    use common_meta::kv_backend::KvBackend;
-    use common_meta::rpc::store::PutRequest;
-
-    use crate::heartbeat::InvalidateSchemaCacheHandler;
-
-    #[tokio::test]
-    async fn test_invalidate_schema_cache_handler() {
-        let inner_kv = Arc::new(MemoryKvBackend::default());
-        let cached_kv = Arc::new(CachedKvBackendBuilder::new(inner_kv.clone()).build());
-        let schema_metadata_manager = SchemaMetadataManager::new(cached_kv.clone());
-
-        let schema_name = "test_schema";
-        let catalog_name = "test_catalog";
-        schema_metadata_manager
-            .register_region_table_info(
-                1,
-                "test_table",
-                schema_name,
-                catalog_name,
-                Some(SchemaNameValue {
-                    ttl: Some(Duration::from_secs(1)),
-                }),
-            )
-            .await;
-
-        schema_metadata_manager
-            .get_schema_options_by_table_id(1)
-            .await
-            .unwrap();
-
-        let schema_key = SchemaNameKey::new(catalog_name, schema_name).to_bytes();
-        let new_schema_value = SchemaNameValue {
-            ttl: Some(Duration::from_secs(3)),
-        }
-        .try_as_raw_value()
-        .unwrap();
-        inner_kv
-            .put(PutRequest {
-                key: schema_key.clone(),
-                value: new_schema_value,
-                prev_kv: false,
-            })
-            .await
-            .unwrap();
-
-        let executor = Arc::new(HandlerGroupExecutor::new(vec![Arc::new(
-            InvalidateSchemaCacheHandler::new(cached_kv),
-        )]));
-
-        let (tx, _) = tokio::sync::mpsc::channel(8);
-        let mailbox = Arc::new(HeartbeatMailbox::new(tx));
-
-        // removes a valid key
-        let response = HeartbeatResponse::default();
-        let mut ctx: HeartbeatResponseHandlerContext =
-            HeartbeatResponseHandlerContext::new(mailbox, response);
-        ctx.incoming_message = Some((
-            MessageMeta::new_test(1, "hi", "foo", "bar"),
-            Instruction::InvalidateCaches(vec![CacheIdent::SchemaName(SchemaName {
-                catalog_name: catalog_name.to_string(),
-                schema_name: schema_name.to_string(),
-            })]),
-        ));
-        executor.handle(ctx).await.unwrap();
-
-        assert_eq!(
-            Some(Duration::from_secs(3)),
-            SchemaNameValue::try_from_raw_value(
-                &inner_kv.get(&schema_key).await.unwrap().unwrap().value
-            )
-            .unwrap()
-            .unwrap()
-            .ttl
-        );
     }
 }

--- a/src/datanode/src/heartbeat/handler.rs
+++ b/src/datanode/src/heartbeat/handler.rs
@@ -24,6 +24,7 @@ use futures::future::BoxFuture;
 use snafu::OptionExt;
 use store_api::storage::RegionId;
 
+pub(crate) mod cache_invalidator;
 mod close_region;
 mod downgrade_region;
 mod open_region;

--- a/src/datanode/src/heartbeat/handler.rs
+++ b/src/datanode/src/heartbeat/handler.rs
@@ -286,7 +286,7 @@ mod tests {
 
             let mut ctx = heartbeat_env.create_handler_ctx((meta, instruction));
             let control = heartbeat_handler.handle(&mut ctx).await.unwrap();
-            assert_matches!(control, HandleControl::Done);
+            assert_matches!(control, HandleControl::Continue);
 
             let (_, reply) = heartbeat_env.receiver.recv().await.unwrap();
 
@@ -341,7 +341,7 @@ mod tests {
 
             let mut ctx = heartbeat_env.create_handler_ctx((meta, instruction));
             let control = heartbeat_handler.handle(&mut ctx).await.unwrap();
-            assert_matches!(control, HandleControl::Done);
+            assert_matches!(control, HandleControl::Continue);
 
             let (_, reply) = heartbeat_env.receiver.recv().await.unwrap();
 
@@ -374,7 +374,7 @@ mod tests {
 
         let mut ctx = heartbeat_env.create_handler_ctx((meta, instruction));
         let control = heartbeat_handler.handle(&mut ctx).await.unwrap();
-        assert_matches!(control, HandleControl::Done);
+        assert_matches!(control, HandleControl::Continue);
 
         let (_, reply) = heartbeat_env.receiver.recv().await.unwrap();
 
@@ -421,7 +421,7 @@ mod tests {
 
             let mut ctx = heartbeat_env.create_handler_ctx((meta, instruction));
             let control = heartbeat_handler.handle(&mut ctx).await.unwrap();
-            assert_matches!(control, HandleControl::Done);
+            assert_matches!(control, HandleControl::Continue);
 
             let (_, reply) = heartbeat_env.receiver.recv().await.unwrap();
 
@@ -443,7 +443,7 @@ mod tests {
         });
         let mut ctx = heartbeat_env.create_handler_ctx((meta, instruction));
         let control = heartbeat_handler.handle(&mut ctx).await.unwrap();
-        assert_matches!(control, HandleControl::Done);
+        assert_matches!(control, HandleControl::Continue);
 
         let (_, reply) = heartbeat_env.receiver.recv().await.unwrap();
 

--- a/src/datanode/src/heartbeat/handler.rs
+++ b/src/datanode/src/heartbeat/handler.rs
@@ -134,7 +134,7 @@ impl HeartbeatResponseHandler for RegionHeartbeatResponseHandler {
             }
         });
 
-        Ok(HandleControl::Done)
+        Ok(HandleControl::Continue)
     }
 }
 

--- a/src/datanode/src/heartbeat/handler/cache_invalidator.rs
+++ b/src/datanode/src/heartbeat/handler/cache_invalidator.rs
@@ -61,7 +61,7 @@ impl HeartbeatResponseHandler for InvalidateSchemaCacheHandler {
             };
             let key: SchemaNameKey = (&schema_name).into();
             let key_bytes = key.to_bytes();
-            // invalidate and refill cache
+            // invalidate cache
             self.cached_kv_backend.invalidate_key(&key_bytes).await;
         }
 

--- a/src/datanode/src/heartbeat/handler/cache_invalidator.rs
+++ b/src/datanode/src/heartbeat/handler/cache_invalidator.rs
@@ -1,0 +1,163 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Schema cache invalidator handler
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use catalog::kvbackend::CachedKvBackend;
+use common_meta::cache_invalidator::{CacheInvalidator, Context};
+use common_meta::heartbeat::handler::{
+    HandleControl, HeartbeatResponseHandler, HeartbeatResponseHandlerContext,
+};
+use common_meta::instruction::{CacheIdent, Instruction};
+use common_telemetry::debug;
+
+#[derive(Clone)]
+pub(crate) struct InvalidateSchemaCacheHandler {
+    cached_kv_backend: Arc<CachedKvBackend>,
+}
+
+#[async_trait]
+impl HeartbeatResponseHandler for InvalidateSchemaCacheHandler {
+    fn is_acceptable(&self, ctx: &HeartbeatResponseHandlerContext) -> bool {
+        matches!(
+            ctx.incoming_message.as_ref(),
+            Some((_, Instruction::InvalidateCaches(_)))
+        )
+    }
+
+    async fn handle(
+        &self,
+        ctx: &mut HeartbeatResponseHandlerContext,
+    ) -> common_meta::error::Result<HandleControl> {
+        let Some((_, Instruction::InvalidateCaches(caches))) = ctx.incoming_message.take() else {
+            unreachable!("InvalidateSchemaCacheHandler: should be guarded by 'is_acceptable'")
+        };
+
+        debug!(
+            "InvalidateSchemaCacheHandler: invalidating caches: {:?}",
+            caches
+        );
+
+        let schema_caches = caches
+            .into_iter()
+            .filter(|i| matches!(i, CacheIdent::SchemaName(_)))
+            .collect::<Vec<_>>();
+
+        self.cached_kv_backend
+            .invalidate(&Context::default(), &schema_caches)
+            .await?;
+        Ok(HandleControl::Done)
+    }
+}
+
+impl InvalidateSchemaCacheHandler {
+    pub fn new(cached_kv_backend: Arc<CachedKvBackend>) -> Self {
+        Self { cached_kv_backend }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use api::v1::meta::HeartbeatResponse;
+    use catalog::kvbackend::CachedKvBackendBuilder;
+    use common_meta::heartbeat::handler::{
+        HandlerGroupExecutor, HeartbeatResponseHandlerContext, HeartbeatResponseHandlerExecutor,
+    };
+    use common_meta::heartbeat::mailbox::{HeartbeatMailbox, MessageMeta};
+    use common_meta::instruction::{CacheIdent, Instruction};
+    use common_meta::key::schema_name::{SchemaName, SchemaNameKey, SchemaNameValue};
+    use common_meta::key::{MetadataKey, SchemaMetadataManager};
+    use common_meta::kv_backend::memory::MemoryKvBackend;
+    use common_meta::kv_backend::KvBackend;
+    use common_meta::rpc::store::PutRequest;
+
+    use crate::heartbeat::handler::cache_invalidator::InvalidateSchemaCacheHandler;
+
+    #[tokio::test]
+    async fn test_invalidate_schema_cache_handler() {
+        let inner_kv = Arc::new(MemoryKvBackend::default());
+        let cached_kv = Arc::new(CachedKvBackendBuilder::new(inner_kv.clone()).build());
+        let schema_metadata_manager = SchemaMetadataManager::new(cached_kv.clone());
+
+        let schema_name = "test_schema";
+        let catalog_name = "test_catalog";
+        schema_metadata_manager
+            .register_region_table_info(
+                1,
+                "test_table",
+                schema_name,
+                catalog_name,
+                Some(SchemaNameValue {
+                    ttl: Some(Duration::from_secs(1)),
+                }),
+            )
+            .await;
+
+        schema_metadata_manager
+            .get_schema_options_by_table_id(1)
+            .await
+            .unwrap();
+
+        let schema_key = SchemaNameKey::new(catalog_name, schema_name).to_bytes();
+        let new_schema_value = SchemaNameValue {
+            ttl: Some(Duration::from_secs(3)),
+        }
+        .try_as_raw_value()
+        .unwrap();
+        inner_kv
+            .put(PutRequest {
+                key: schema_key.clone(),
+                value: new_schema_value,
+                prev_kv: false,
+            })
+            .await
+            .unwrap();
+
+        let executor = Arc::new(HandlerGroupExecutor::new(vec![Arc::new(
+            InvalidateSchemaCacheHandler::new(cached_kv),
+        )]));
+
+        let (tx, _) = tokio::sync::mpsc::channel(8);
+        let mailbox = Arc::new(HeartbeatMailbox::new(tx));
+
+        // removes a valid key
+        let response = HeartbeatResponse::default();
+        let mut ctx: HeartbeatResponseHandlerContext =
+            HeartbeatResponseHandlerContext::new(mailbox, response);
+        ctx.incoming_message = Some((
+            MessageMeta::new_test(1, "hi", "foo", "bar"),
+            Instruction::InvalidateCaches(vec![CacheIdent::SchemaName(SchemaName {
+                catalog_name: catalog_name.to_string(),
+                schema_name: schema_name.to_string(),
+            })]),
+        ));
+        executor.handle(ctx).await.unwrap();
+
+        assert_eq!(
+            Some(Duration::from_secs(3)),
+            SchemaNameValue::try_from_raw_value(
+                &inner_kv.get(&schema_key).await.unwrap().unwrap().value
+            )
+            .unwrap()
+            .unwrap()
+            .ttl
+        );
+    }
+}

--- a/src/datanode/src/heartbeat/handler/cache_invalidator.rs
+++ b/src/datanode/src/heartbeat/handler/cache_invalidator.rs
@@ -63,7 +63,6 @@ impl HeartbeatResponseHandler for InvalidateSchemaCacheHandler {
             let key_bytes = key.to_bytes();
             // invalidate and refill cache
             self.cached_kv_backend.invalidate_key(&key_bytes).await;
-            let _ = self.cached_kv_backend.get(&key_bytes).await?;
         }
 
         Ok(HandleControl::Done)

--- a/src/datanode/src/heartbeat/handler/cache_invalidator.rs
+++ b/src/datanode/src/heartbeat/handler/cache_invalidator.rs
@@ -25,7 +25,6 @@ use common_meta::heartbeat::handler::{
 use common_meta::instruction::{CacheIdent, Instruction};
 use common_meta::key::schema_name::SchemaNameKey;
 use common_meta::key::MetadataKey;
-use common_meta::kv_backend::KvBackend;
 use common_telemetry::debug;
 
 #[derive(Clone)]

--- a/src/meta-srv/src/cache_invalidator.rs
+++ b/src/meta-srv/src/cache_invalidator.rs
@@ -44,7 +44,7 @@ impl MetasrvCacheInvalidator {
             .clone()
             .unwrap_or_else(|| DEFAULT_SUBJECT.to_string());
 
-        let msg = &MailboxMessage::json_message(
+        let mut msg = MailboxMessage::json_message(
             subject,
             &format!("Metasrv@{}", self.info.server_addr),
             "Frontend broadcast",
@@ -54,22 +54,21 @@ impl MetasrvCacheInvalidator {
         .with_context(|_| meta_error::SerdeJsonSnafu)?;
 
         self.mailbox
-            .broadcast(&BroadcastChannel::Frontend, msg)
+            .broadcast(&BroadcastChannel::Frontend, &msg)
             .await
             .map_err(BoxedError::new)
             .context(meta_error::ExternalSnafu)?;
 
-        let msg = &MailboxMessage::json_message(
-            subject,
-            &format!("Metasrv@{}", self.info.server_addr),
-            "Flownode broadcast",
-            common_time::util::current_time_millis(),
-            &instruction,
-        )
-        .with_context(|_| meta_error::SerdeJsonSnafu)?;
-
+        msg.to = "Datanode broadcast".to_string();
         self.mailbox
-            .broadcast(&BroadcastChannel::Flownode, msg)
+            .broadcast(&BroadcastChannel::Datanode, &msg)
+            .await
+            .map_err(BoxedError::new)
+            .context(meta_error::ExternalSnafu)?;
+
+        msg.to = "Flownode broadcast".to_string();
+        self.mailbox
+            .broadcast(&BroadcastChannel::Flownode, &msg)
             .await
             .map_err(BoxedError::new)
             .context(meta_error::ExternalSnafu)

--- a/tests-integration/src/cluster.rs
+++ b/tests-integration/src/cluster.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 use api::v1::region::region_server::RegionServer;
 use arrow_flight::flight_service_server::FlightServiceServer;
 use cache::{build_fundamental_cache_registry, with_default_composite_cache_registry};
-use catalog::kvbackend::{CachedMetaKvBackendBuilder, KvBackendCatalogManager, MetaKvBackend};
+use catalog::kvbackend::{CachedKvBackendBuilder, KvBackendCatalogManager, MetaKvBackend};
 use client::client_manager::NodeClients;
 use client::Client;
 use cmd::DistributedInformationExtension;
@@ -351,8 +351,9 @@ impl GreptimeDbClusterBuilder {
         meta_client.start(&[&metasrv.server_addr]).await.unwrap();
         let meta_client = Arc::new(meta_client);
 
-        let cached_meta_backend =
-            Arc::new(CachedMetaKvBackendBuilder::new(meta_client.clone()).build());
+        let cached_meta_backend = Arc::new(
+            CachedKvBackendBuilder::new(Arc::new(MetaKvBackend::new(meta_client.clone()))).build(),
+        );
 
         let layered_cache_builder = LayeredCacheRegistryBuilder::default().add_cache_registry(
             CacheRegistryBuilder::default()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Add cache layer for SchemaMetadataManager

## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
