### PR TITLE
fix: pass series row selector to file range reader

### DIFF
--- a/src/mito2/src/read/scan_util.rs
+++ b/src/mito2/src/read/scan_util.rs
@@ -170,7 +170,7 @@ pub(crate) fn scan_file_ranges(
 
         for range in ranges {
             let build_reader_start = Instant::now();
-            let reader = range.reader(None).await?;
+            let reader = range.reader(stream_ctx.input.series_row_selector).await?;
             let build_cost = build_reader_start.elapsed();
             part_metrics.inc_build_reader_cost(build_cost);
             let compat_batch = range.compat_batch();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/5052

## What's changed and what's your intention?

Passes row selector hint to the file range.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
