### PR TITLE
chore: bump version of main branch to v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "api"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "common-base",
  "common-decimal",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "auth"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "api",
  "async-trait",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "catalog",
  "common-error",
@@ -1387,7 +1387,7 @@ dependencies = [
  "common-meta",
  "moka",
  "snafu 0.8.5",
- "substrait 0.10.1",
+ "substrait 0.11.0",
 ]
 
 [[package]]
@@ -1414,7 +1414,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "api",
  "arrow",
@@ -1753,7 +1753,7 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "client"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -1782,7 +1782,7 @@ dependencies = [
  "rand",
  "serde_json",
  "snafu 0.8.5",
- "substrait 0.10.1",
+ "substrait 0.11.0",
  "substrait 0.37.3",
  "tokio",
  "tokio-stream",
@@ -1823,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "auth",
@@ -1882,7 +1882,7 @@ dependencies = [
  "similar-asserts",
  "snafu 0.8.5",
  "store-api",
- "substrait 0.10.1",
+ "substrait 0.11.0",
  "table",
  "temp-env",
  "tempfile",
@@ -1928,7 +1928,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "common-base"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anymap2",
  "async-trait",
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "chrono",
  "common-error",
@@ -1960,7 +1960,7 @@ dependencies = [
 
 [[package]]
 name = "common-config"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "common-base",
  "common-error",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "common-decimal"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "bigdecimal 0.4.5",
  "common-error",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "snafu 0.8.5",
  "strum 0.25.0",
@@ -2042,7 +2042,7 @@ dependencies = [
 
 [[package]]
 name = "common-frontend"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "api",
  "async-trait",
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "api",
  "approx 0.5.1",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "common-greptimedb-telemetry"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "common-runtime",
@@ -2119,7 +2119,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "api",
  "common-base",
@@ -2164,7 +2164,7 @@ dependencies = [
 
 [[package]]
 name = "common-macro"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "arc-swap",
  "common-query",
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anymap2",
  "api",
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "common-options"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "common-grpc",
  "humantime-serde",
@@ -2257,11 +2257,11 @@ dependencies = [
 
 [[package]]
 name = "common-plugins"
-version = "0.10.1"
+version = "0.11.0"
 
 [[package]]
 name = "common-pprof"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2273,7 +2273,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2300,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -2308,7 +2308,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "api",
  "async-trait",
@@ -2334,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "arc-swap",
  "common-error",
@@ -2353,7 +2353,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "clap 4.5.19",
@@ -2383,7 +2383,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "atty",
  "backtrace",
@@ -2411,7 +2411,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "client",
  "common-query",
@@ -2423,7 +2423,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "arrow",
  "chrono",
@@ -2439,7 +2439,7 @@ dependencies = [
 
 [[package]]
 name = "common-version"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "build-data",
  "const_format",
@@ -2450,7 +2450,7 @@ dependencies = [
 
 [[package]]
 name = "common-wal"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "common-base",
  "common-error",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -3309,7 +3309,7 @@ dependencies = [
  "session",
  "snafu 0.8.5",
  "store-api",
- "substrait 0.10.1",
+ "substrait 0.11.0",
  "table",
  "tokio",
  "toml 0.8.19",
@@ -3318,7 +3318,7 @@ dependencies = [
 
 [[package]]
 name = "datatypes"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3936,7 +3936,7 @@ dependencies = [
 
 [[package]]
 name = "file-engine"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "api",
  "async-trait",
@@ -4053,7 +4053,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "flow"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "api",
  "arrow",
@@ -4110,7 +4110,7 @@ dependencies = [
  "snafu 0.8.5",
  "store-api",
  "strum 0.25.0",
- "substrait 0.10.1",
+ "substrait 0.11.0",
  "table",
  "tokio",
  "tonic 0.11.0",
@@ -4172,7 +4172,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frontend"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -5312,7 +5312,7 @@ dependencies = [
 
 [[package]]
 name = "index"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -6156,7 +6156,7 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "log-store"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6486,7 +6486,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "api",
  "async-trait",
@@ -6513,7 +6513,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "api",
  "async-trait",
@@ -6592,7 +6592,7 @@ dependencies = [
 
 [[package]]
 name = "metric-engine"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -7459,7 +7459,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7750,7 +7750,7 @@ dependencies = [
 
 [[package]]
 name = "operator"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "api",
  "async-stream",
@@ -7797,7 +7797,7 @@ dependencies = [
  "sql",
  "sqlparser 0.45.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=54a267ac89c09b11c0c88934690530807185d3e7)",
  "store-api",
- "substrait 0.10.1",
+ "substrait 0.11.0",
  "table",
  "tokio",
  "tokio-util",
@@ -8047,7 +8047,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "api",
  "async-trait",
@@ -8348,7 +8348,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeline"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -8511,7 +8511,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "auth",
  "common-base",
@@ -8785,7 +8785,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -9023,7 +9023,7 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-compression 0.4.13",
  "async-trait",
@@ -9147,7 +9147,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -9214,7 +9214,7 @@ dependencies = [
  "stats-cli",
  "store-api",
  "streaming-stats",
- "substrait 0.10.1",
+ "substrait 0.11.0",
  "table",
  "tokio",
  "tokio-stream",
@@ -10677,7 +10677,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "script"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -10971,7 +10971,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "ahash 0.8.11",
  "aide",
@@ -11086,7 +11086,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -11432,7 +11432,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "api",
  "chrono",
@@ -11495,7 +11495,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "clap 4.5.19",
@@ -11715,7 +11715,7 @@ dependencies = [
 
 [[package]]
 name = "store-api"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -11886,7 +11886,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -12085,7 +12085,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "api",
  "async-trait",
@@ -12351,7 +12351,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "tests-fuzz"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "arbitrary",
  "async-trait",
@@ -12393,7 +12393,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -12457,7 +12457,7 @@ dependencies = [
  "sql",
  "sqlx",
  "store-api",
- "substrait 0.10.1",
+ "substrait 0.11.0",
  "table",
  "tempfile",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
N/A

## What's changed and what's your intention?

Now greptimedb maintains the `release/vX.Y` branch, and the `main` branch should be the next minor version.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
