### PR TITLE
test: adds sqlness test for TTL

### DIFF
--- a/tests/cases/standalone/common/ttl/alter_table_ttl.result
+++ b/tests/cases/standalone/common/ttl/alter_table_ttl.result
@@ -1,0 +1,108 @@
+CREATE TABLE test_ttl(ts TIMESTAMP TIME INDEX, val INT, PRIMARY KEY(val)) WITH (ttl = '1 day');
+
+Affected Rows: 0
+
+INSERT INTO test_ttl VALUES
+       (now(), 1),
+       (now(), 2),
+       (now(), 3);
+
+Affected Rows: 3
+
+SELECT val from test_ttl;
+
++-----+
+| val |
++-----+
+| 1   |
+| 2   |
+| 3   |
++-----+
+
+-- SQLNESS SLEEP 2s
+ADMIN flush_table('test_ttl');
+
++-------------------------------+
+| ADMIN flush_table('test_ttl') |
++-------------------------------+
+| 0                             |
++-------------------------------+
+
+ADMIN compact_table('test_ttl');
+
++---------------------------------+
+| ADMIN compact_table('test_ttl') |
++---------------------------------+
+| 0                               |
++---------------------------------+
+
+SELECT val from test_ttl;
+
++-----+
+| val |
++-----+
+| 1   |
+| 2   |
+| 3   |
++-----+
+
+ALTER TABLE test_ttl SET ttl = '1 second';
+
+Affected Rows: 0
+
+-- SQLNESS SLEEP 2s
+ADMIN compact_table('test_ttl');
+
++---------------------------------+
+| ADMIN compact_table('test_ttl') |
++---------------------------------+
+| 0                               |
++---------------------------------+
+
+SELECT val from test_ttl;
+
+++
+++
+
+ALTER TABLE test_ttl SET ttl = '1 minute';
+
+Affected Rows: 0
+
+INSERT INTO test_ttl VALUES
+       (now(), 1),
+       (now(), 2),
+       (now(), 3);
+
+Affected Rows: 3
+
+-- SQLNESS SLEEP 2s
+ADMIN flush_table('test_ttl');
+
++-------------------------------+
+| ADMIN flush_table('test_ttl') |
++-------------------------------+
+| 0                             |
++-------------------------------+
+
+ADMIN compact_table('test_ttl');
+
++---------------------------------+
+| ADMIN compact_table('test_ttl') |
++---------------------------------+
+| 0                               |
++---------------------------------+
+
+SELECT val from test_ttl;
+
++-----+
+| val |
++-----+
+| 1   |
+| 2   |
+| 3   |
++-----+
+
+DROP TABLE test_ttl;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/ttl/alter_table_ttl.sql
+++ b/tests/cases/standalone/common/ttl/alter_table_ttl.sql
@@ -1,0 +1,40 @@
+CREATE TABLE test_ttl(ts TIMESTAMP TIME INDEX, val INT, PRIMARY KEY(val)) WITH (ttl = '1 day');
+
+INSERT INTO test_ttl VALUES
+       (now(), 1),
+       (now(), 2),
+       (now(), 3);
+
+SELECT val from test_ttl;
+
+-- SQLNESS SLEEP 2s
+ADMIN flush_table('test_ttl');
+
+ADMIN compact_table('test_ttl');
+
+SELECT val from test_ttl;
+
+ALTER TABLE test_ttl SET ttl = '1 second';
+
+-- SQLNESS SLEEP 2s
+ADMIN compact_table('test_ttl');
+
+SELECT val from test_ttl;
+
+ALTER TABLE test_ttl SET ttl = '1 minute';
+
+INSERT INTO test_ttl VALUES
+       (now(), 1),
+       (now(), 2),
+       (now(), 3);
+
+-- SQLNESS SLEEP 2s
+ADMIN flush_table('test_ttl');
+
+ADMIN compact_table('test_ttl');
+
+
+SELECT val from test_ttl;
+
+
+DROP TABLE test_ttl;

--- a/tests/cases/standalone/common/ttl/basic.result
+++ b/tests/cases/standalone/common/ttl/basic.result
@@ -1,0 +1,43 @@
+CREATE TABLE test_ttl(ts TIMESTAMP TIME INDEX, val INT) WITH (ttl = '1 second');
+
+Affected Rows: 0
+
+INSERT INTO test_ttl VALUES
+       (now(), 1);
+
+Affected Rows: 1
+
+SELECT val from test_ttl;
+
++-----+
+| val |
++-----+
+| 1   |
++-----+
+
+-- SQLNESS SLEEP 2s
+ADMIN flush_table('test_ttl');
+
++-------------------------------+
+| ADMIN flush_table('test_ttl') |
++-------------------------------+
+| 0                             |
++-------------------------------+
+
+ADMIN compact_table('test_ttl');
+
++---------------------------------+
+| ADMIN compact_table('test_ttl') |
++---------------------------------+
+| 0                               |
++---------------------------------+
+
+SELECT val from test_ttl;
+
+++
+++
+
+DROP TABLE test_ttl;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/ttl/basic.sql
+++ b/tests/cases/standalone/common/ttl/basic.sql
@@ -1,0 +1,15 @@
+CREATE TABLE test_ttl(ts TIMESTAMP TIME INDEX, val INT) WITH (ttl = '1 second');
+
+INSERT INTO test_ttl VALUES
+       (now(), 1);
+
+SELECT val from test_ttl;
+
+-- SQLNESS SLEEP 2s
+ADMIN flush_table('test_ttl');
+
+ADMIN compact_table('test_ttl');
+
+SELECT val from test_ttl;
+
+DROP TABLE test_ttl;

--- a/tests/cases/standalone/common/ttl/database_ttl.result
+++ b/tests/cases/standalone/common/ttl/database_ttl.result
@@ -1,0 +1,96 @@
+CREATE DATABASE test_ttl_db WITH (ttl = '1 second');
+
+Affected Rows: 1
+
+USE test_ttl_db;
+
+Affected Rows: 0
+
+-- It will use the database TTL setting --
+CREATE TABLE test_ttl(ts TIMESTAMP TIME INDEX, val INT);
+
+Affected Rows: 0
+
+INSERT INTO test_ttl VALUES
+       (now(), 1);
+
+Affected Rows: 1
+
+SELECT val from test_ttl;
+
++-----+
+| val |
++-----+
+| 1   |
++-----+
+
+-- SQLNESS SLEEP 2s
+ADMIN flush_table('test_ttl');
+
++-------------------------------+
+| ADMIN flush_table('test_ttl') |
++-------------------------------+
+| 0                             |
++-------------------------------+
+
+ADMIN compact_table('test_ttl');
+
++---------------------------------+
+| ADMIN compact_table('test_ttl') |
++---------------------------------+
+| 0                               |
++---------------------------------+
+
+-- Must be expired --
+SELECT val from test_ttl;
+
+++
+++
+
+ALTER DATABASE test_ttl_db SET ttl = '1 day';
+
+Affected Rows: 0
+
+INSERT INTO test_ttl VALUES
+       (now(), 1);
+
+Affected Rows: 1
+
+-- SQLNESS SLEEP 2s
+ADMIN flush_table('test_ttl');
+
++-------------------------------+
+| ADMIN flush_table('test_ttl') |
++-------------------------------+
+| 0                             |
++-------------------------------+
+
+ADMIN compact_table('test_ttl');
+
++---------------------------------+
+| ADMIN compact_table('test_ttl') |
++---------------------------------+
+| 0                               |
++---------------------------------+
+
+-- Must not be expired --
+SELECT val from test_ttl;
+
++-----+
+| val |
++-----+
+| 1   |
++-----+
+
+DROP TABLE test_ttl;
+
+Affected Rows: 0
+
+USE public;
+
+Affected Rows: 0
+
+DROP DATABASE test_ttl_db;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/ttl/database_ttl.sql
+++ b/tests/cases/standalone/common/ttl/database_ttl.sql
@@ -1,0 +1,39 @@
+CREATE DATABASE test_ttl_db WITH (ttl = '1 second');
+
+USE test_ttl_db;
+
+-- It will use the database TTL setting --
+CREATE TABLE test_ttl(ts TIMESTAMP TIME INDEX, val INT);
+
+INSERT INTO test_ttl VALUES
+       (now(), 1);
+
+SELECT val from test_ttl;
+
+-- SQLNESS SLEEP 2s
+ADMIN flush_table('test_ttl');
+
+ADMIN compact_table('test_ttl');
+
+-- Must be expired --
+SELECT val from test_ttl;
+
+ALTER DATABASE test_ttl_db SET ttl = '1 day';
+
+INSERT INTO test_ttl VALUES
+       (now(), 1);
+
+-- SQLNESS SLEEP 2s
+ADMIN flush_table('test_ttl');
+
+ADMIN compact_table('test_ttl');
+
+-- Must not be expired --
+SELECT val from test_ttl;
+
+DROP TABLE test_ttl;
+
+
+USE public;
+
+DROP DATABASE test_ttl_db;

--- a/tests/cases/standalone/common/ttl/database_ttl_with_metric_engine.result
+++ b/tests/cases/standalone/common/ttl/database_ttl_with_metric_engine.result
@@ -1,0 +1,123 @@
+CREATE DATABASE test_ttl_db WITH (ttl = '1 second');
+
+Affected Rows: 1
+
+USE test_ttl_db;
+
+Affected Rows: 0
+
+CREATE TABLE phy (ts timestamp time index, val double) engine=metric with ("physical_metric_table" = "");
+
+Affected Rows: 0
+
+-- It will use the database TTL setting --
+CREATE TABLE test_ttl (ts timestamp time index, val double, host string primary key) engine = metric with ("on_physical_table" = "phy");
+
+Affected Rows: 0
+
+INSERT INTO test_ttl(ts, val, host) VALUES
+       (now(), 1, 'host1'),
+       (now(), 2, 'host2'),
+       (now(), 3, 'host3');
+
+Affected Rows: 3
+
+SELECT val, host FROM test_ttl;
+
++-----+-------+
+| val | host  |
++-----+-------+
+| 2.0 | host2 |
+| 3.0 | host3 |
+| 1.0 | host1 |
++-----+-------+
+
+-- SQLNESS SLEEP 2s
+ADMIN flush_table('phy');
+
++--------------------------+
+| ADMIN flush_table('phy') |
++--------------------------+
+| 0                        |
++--------------------------+
+
+ADMIN compact_table('phy');
+
++----------------------------+
+| ADMIN compact_table('phy') |
++----------------------------+
+| 0                          |
++----------------------------+
+
+--- should be expired --
+SELECT val, host FROM test_ttl;
+
+++
+++
+
+ALTER DATABASE test_ttl_db SET ttl = '1 day';
+
+Affected Rows: 0
+
+INSERT INTO test_ttl(ts, val, host) VALUES
+       (now(), 1, 'host1'),
+       (now(), 2, 'host2'),
+       (now(), 3, 'host3');
+
+Affected Rows: 3
+
+ADMIN flush_table('phy');
+
++--------------------------+
+| ADMIN flush_table('phy') |
++--------------------------+
+| 0                        |
++--------------------------+
+
+ADMIN compact_table('phy');
+
++----------------------------+
+| ADMIN compact_table('phy') |
++----------------------------+
+| 0                          |
++----------------------------+
+
+--- should not be expired --
+SELECT val, host FROM test_ttl;
+
++-----+-------+
+| val | host  |
++-----+-------+
+| 2.0 | host2 |
+| 3.0 | host3 |
+| 1.0 | host1 |
++-----+-------+
+
+-- restart the db, ensure everything is ok
+-- SQLNESS ARG restart=true
+SELECT val, host FROM test_ttl;
+
++-----+-------+
+| val | host  |
++-----+-------+
+| 2.0 | host2 |
+| 3.0 | host3 |
+| 1.0 | host1 |
++-----+-------+
+
+DROP TABLE test_ttl;
+
+Affected Rows: 0
+
+DROP TABLE phy;
+
+Affected Rows: 0
+
+USE public;
+
+Affected Rows: 0
+
+DROP DATABASE test_ttl_db;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/ttl/database_ttl_with_metric_engine.sql
+++ b/tests/cases/standalone/common/ttl/database_ttl_with_metric_engine.sql
@@ -1,0 +1,50 @@
+CREATE DATABASE test_ttl_db WITH (ttl = '1 second');
+
+USE test_ttl_db;
+
+CREATE TABLE phy (ts timestamp time index, val double) engine=metric with ("physical_metric_table" = "");
+
+-- It will use the database TTL setting --
+CREATE TABLE test_ttl (ts timestamp time index, val double, host string primary key) engine = metric with ("on_physical_table" = "phy");
+
+
+INSERT INTO test_ttl(ts, val, host) VALUES
+       (now(), 1, 'host1'),
+       (now(), 2, 'host2'),
+       (now(), 3, 'host3');
+
+SELECT val, host FROM test_ttl;
+
+-- SQLNESS SLEEP 2s
+ADMIN flush_table('phy');
+
+ADMIN compact_table('phy');
+
+--- should be expired --
+SELECT val, host FROM test_ttl;
+
+ALTER DATABASE test_ttl_db SET ttl = '1 day';
+
+INSERT INTO test_ttl(ts, val, host) VALUES
+       (now(), 1, 'host1'),
+       (now(), 2, 'host2'),
+       (now(), 3, 'host3');
+
+ADMIN flush_table('phy');
+
+ADMIN compact_table('phy');
+
+--- should not be expired --
+SELECT val, host FROM test_ttl;
+
+-- restart the db, ensure everything is ok
+-- SQLNESS ARG restart=true
+SELECT val, host FROM test_ttl;
+
+DROP TABLE test_ttl;
+
+DROP TABLE phy;
+
+USE public;
+
+DROP DATABASE test_ttl_db;

--- a/tests/cases/standalone/common/ttl/metric_engine_ttl.result
+++ b/tests/cases/standalone/common/ttl/metric_engine_ttl.result
@@ -1,0 +1,94 @@
+CREATE TABLE phy (ts timestamp time index, val double) engine=metric with ("physical_metric_table" = "", ttl = '1 second');
+
+Affected Rows: 0
+
+CREATE TABLE test_ttl (ts timestamp time index, val double, host string primary key) engine = metric with ("on_physical_table" = "phy");
+
+Affected Rows: 0
+
+INSERT INTO test_ttl(ts, val, host) VALUES
+       (now(), 1, 'host1'),
+       (now(), 2, 'host2'),
+       (now(), 3, 'host3');
+
+Affected Rows: 3
+
+SELECT val, host FROM test_ttl;
+
++-----+-------+
+| val | host  |
++-----+-------+
+| 2.0 | host2 |
+| 3.0 | host3 |
+| 1.0 | host1 |
++-----+-------+
+
+-- SQLNESS SLEEP 2s
+ADMIN flush_table('phy');
+
++--------------------------+
+| ADMIN flush_table('phy') |
++--------------------------+
+| 0                        |
++--------------------------+
+
+ADMIN compact_table('phy');
+
++----------------------------+
+| ADMIN compact_table('phy') |
++----------------------------+
+| 0                          |
++----------------------------+
+
+--- should be expired --
+SELECT val, host FROM test_ttl;
+
+++
+++
+
+ALTER TABLE phy SET ttl = '1 minute';
+
+Affected Rows: 0
+
+INSERT INTO test_ttl(ts, val, host) VALUES
+       (now(), 1, 'host1'),
+       (now(), 2, 'host2'),
+       (now(), 3, 'host3');
+
+Affected Rows: 3
+
+ADMIN flush_table('phy');
+
++--------------------------+
+| ADMIN flush_table('phy') |
++--------------------------+
+| 0                        |
++--------------------------+
+
+ADMIN compact_table('phy');
+
++----------------------------+
+| ADMIN compact_table('phy') |
++----------------------------+
+| 0                          |
++----------------------------+
+
+--- should not be expired --
+SELECT val, host FROM test_ttl;
+
++-----+-------+
+| val | host  |
++-----+-------+
+| 2.0 | host2 |
+| 3.0 | host3 |
+| 1.0 | host1 |
++-----+-------+
+
+DROP TABLE test_ttl;
+
+Affected Rows: 0
+
+DROP TABLE phy;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/ttl/metric_engine_ttl.result
+++ b/tests/cases/standalone/common/ttl/metric_engine_ttl.result
@@ -46,7 +46,7 @@ SELECT val, host FROM test_ttl;
 ++
 ++
 
-ALTER TABLE phy SET ttl = '1 minute';
+ALTER TABLE phy SET ttl = '1 day';
 
 Affected Rows: 0
 
@@ -74,6 +74,18 @@ ADMIN compact_table('phy');
 +----------------------------+
 
 --- should not be expired --
+SELECT val, host FROM test_ttl;
+
++-----+-------+
+| val | host  |
++-----+-------+
+| 2.0 | host2 |
+| 3.0 | host3 |
+| 1.0 | host1 |
++-----+-------+
+
+-- restar the cluster, ensure everything is ok
+-- SQLNESS ARG restart=true
 SELECT val, host FROM test_ttl;
 
 +-----+-------+

--- a/tests/cases/standalone/common/ttl/metric_engine_ttl.result
+++ b/tests/cases/standalone/common/ttl/metric_engine_ttl.result
@@ -84,7 +84,7 @@ SELECT val, host FROM test_ttl;
 | 1.0 | host1 |
 +-----+-------+
 
--- restar the cluster, ensure everything is ok
+-- restart the db, ensure everything is ok
 -- SQLNESS ARG restart=true
 SELECT val, host FROM test_ttl;
 

--- a/tests/cases/standalone/common/ttl/metric_engine_ttl.sql
+++ b/tests/cases/standalone/common/ttl/metric_engine_ttl.sql
@@ -1,0 +1,37 @@
+CREATE TABLE phy (ts timestamp time index, val double) engine=metric with ("physical_metric_table" = "", ttl = '1 second');
+
+CREATE TABLE test_ttl (ts timestamp time index, val double, host string primary key) engine = metric with ("on_physical_table" = "phy");
+
+INSERT INTO test_ttl(ts, val, host) VALUES
+       (now(), 1, 'host1'),
+       (now(), 2, 'host2'),
+       (now(), 3, 'host3');
+
+SELECT val, host FROM test_ttl;
+
+-- SQLNESS SLEEP 2s
+ADMIN flush_table('phy');
+
+ADMIN compact_table('phy');
+
+--- should be expired --
+SELECT val, host FROM test_ttl;
+
+ALTER TABLE phy SET ttl = '1 minute';
+
+INSERT INTO test_ttl(ts, val, host) VALUES
+       (now(), 1, 'host1'),
+       (now(), 2, 'host2'),
+       (now(), 3, 'host3');
+
+ADMIN flush_table('phy');
+
+ADMIN compact_table('phy');
+
+--- should not be expired --
+SELECT val, host FROM test_ttl;
+
+
+DROP TABLE test_ttl;
+
+DROP TABLE phy;

--- a/tests/cases/standalone/common/ttl/metric_engine_ttl.sql
+++ b/tests/cases/standalone/common/ttl/metric_engine_ttl.sql
@@ -17,7 +17,7 @@ ADMIN compact_table('phy');
 --- should be expired --
 SELECT val, host FROM test_ttl;
 
-ALTER TABLE phy SET ttl = '1 minute';
+ALTER TABLE phy SET ttl = '1 day';
 
 INSERT INTO test_ttl(ts, val, host) VALUES
        (now(), 1, 'host1'),
@@ -31,6 +31,9 @@ ADMIN compact_table('phy');
 --- should not be expired --
 SELECT val, host FROM test_ttl;
 
+-- restar the cluster, ensure everything is ok
+-- SQLNESS ARG restart=true
+SELECT val, host FROM test_ttl;
 
 DROP TABLE test_ttl;
 

--- a/tests/cases/standalone/common/ttl/metric_engine_ttl.sql
+++ b/tests/cases/standalone/common/ttl/metric_engine_ttl.sql
@@ -31,7 +31,7 @@ ADMIN compact_table('phy');
 --- should not be expired --
 SELECT val, host FROM test_ttl;
 
--- restar the cluster, ensure everything is ok
+-- restart the db, ensure everything is ok
 -- SQLNESS ARG restart=true
 SELECT val, host FROM test_ttl;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Close #5045 

## What's changed and what's your intention?

Adds sqlness tests for TTL behavior including normal table, metric engine table, and database TTL.



## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
