### PR TITLE
fix: correct `is_exceeded_size_limit` behavior for in-memory store

### DIFF
--- a/src/common/meta/src/error.rs
+++ b/src/common/meta/src/error.rs
@@ -425,8 +425,8 @@ pub enum Error {
         source: BoxedError,
     },
 
-    #[snafu(display("Meta client exceeded size limit"))]
-    MetaClientExceededSizeLimit {
+    #[snafu(display("The response exceeded size limit"))]
+    ResponseExceededSizeLimit {
         #[snafu(implicit)]
         location: Location,
         source: BoxedError,
@@ -770,7 +770,7 @@ impl ErrorExt for Error {
             | StopProcedureManager { source, .. } => source.status_code(),
             RegisterProcedureLoader { source, .. } => source.status_code(),
             External { source, .. } => source.status_code(),
-            MetaClientExceededSizeLimit { source, .. } => source.status_code(),
+            ResponseExceededSizeLimit { source, .. } => source.status_code(),
             OperateDatanode { source, .. } => source.status_code(),
             Table { source, .. } => source.status_code(),
             RetryLater { source, .. } => source.status_code(),
@@ -818,7 +818,7 @@ impl Error {
                 error: etcd_client::Error::GRpcStatus(status),
                 ..
             } => status.code() == tonic::Code::OutOfRange,
-            Error::MetaClientExceededSizeLimit { .. } => true,
+            Error::ResponseExceededSizeLimit { .. } => true,
             _ => false,
         }
     }

--- a/src/common/meta/src/error.rs
+++ b/src/common/meta/src/error.rs
@@ -425,6 +425,13 @@ pub enum Error {
         source: BoxedError,
     },
 
+    #[snafu(display("Meta client exceeded size limit"))]
+    MetaClientExceededSizeLimit {
+        #[snafu(implicit)]
+        location: Location,
+        source: BoxedError,
+    },
+
     #[snafu(display("Invalid heartbeat response"))]
     InvalidHeartbeatResponse {
         #[snafu(implicit)]
@@ -763,6 +770,7 @@ impl ErrorExt for Error {
             | StopProcedureManager { source, .. } => source.status_code(),
             RegisterProcedureLoader { source, .. } => source.status_code(),
             External { source, .. } => source.status_code(),
+            MetaClientExceededSizeLimit { source, .. } => source.status_code(),
             OperateDatanode { source, .. } => source.status_code(),
             Table { source, .. } => source.status_code(),
             RetryLater { source, .. } => source.status_code(),
@@ -805,13 +813,13 @@ impl Error {
 
     /// Returns true if the response exceeds the size limit.
     pub fn is_exceeded_size_limit(&self) -> bool {
-        if let Error::EtcdFailed {
-            error: etcd_client::Error::GRpcStatus(status),
-            ..
-        } = self
-        {
-            return status.code() == tonic::Code::OutOfRange;
+        match self {
+            Error::EtcdFailed {
+                error: etcd_client::Error::GRpcStatus(status),
+                ..
+            } => status.code() == tonic::Code::OutOfRange,
+            Error::MetaClientExceededSizeLimit { .. } => true,
+            _ => false,
         }
-        false
     }
 }

--- a/src/meta-client/src/client/cluster.rs
+++ b/src/meta-client/src/client/cluster.rs
@@ -22,7 +22,7 @@ use api::v1::meta::{MetasrvNodeInfo, MetasrvPeersRequest, ResponseHeader, Role};
 use common_error::ext::BoxedError;
 use common_grpc::channel_manager::ChannelManager;
 use common_meta::error::{
-    Error as MetaError, ExternalSnafu, MetaClientExceededSizeLimitSnafu, Result as MetaResult,
+    Error as MetaError, ExternalSnafu, ResponseExceededSizeLimitSnafu, Result as MetaResult,
 };
 use common_meta::kv_backend::{KvBackend, TxnService};
 use common_meta::rpc::store::{
@@ -109,7 +109,7 @@ impl KvBackend for Client {
         match resp {
             Ok(resp) => Ok(resp),
             Err(err) if err.is_exceeded_size_limit() => {
-                Err(BoxedError::new(err)).context(MetaClientExceededSizeLimitSnafu)
+                Err(BoxedError::new(err)).context(ResponseExceededSizeLimitSnafu)
             }
             Err(err) => Err(BoxedError::new(err)).context(ExternalSnafu),
         }

--- a/src/meta-client/src/mocks.rs
+++ b/src/meta-client/src/mocks.rs
@@ -12,31 +12,57 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use common_grpc::channel_manager::ChannelManager;
+use common_meta::kv_backend::{KvBackendRef, ResettableKvBackendRef};
 use meta_srv::mocks as server_mock;
 use meta_srv::mocks::MockInfo;
 
 use crate::client::{MetaClient, MetaClientBuilder};
 
-pub async fn mock_client_with_memstore() -> MetaClient {
-    let mock_info = server_mock::mock_with_memstore().await;
-    mock_client_by(mock_info).await
+pub struct MockMetaContext {
+    pub kv_backend: KvBackendRef,
+    pub in_memory: Option<ResettableKvBackendRef>,
 }
 
-#[allow(dead_code)]
-pub async fn mock_client_with_etcdstore(addr: &str) -> MetaClient {
-    let mock_info = server_mock::mock_with_etcdstore(addr).await;
-    mock_client_by(mock_info).await
-}
-
-pub async fn mock_client_by(mock_info: MockInfo) -> MetaClient {
+pub async fn mock_client_with_memstore() -> (MetaClient, MockMetaContext) {
     let MockInfo {
         server_addr,
         channel_manager,
+        kv_backend,
+        in_memory,
         ..
-    } = mock_info;
+    } = server_mock::mock_with_memstore().await;
+    (
+        mock_client_by(server_addr, channel_manager).await,
+        MockMetaContext {
+            kv_backend,
+            in_memory,
+        },
+    )
+}
 
+#[allow(dead_code)]
+pub async fn mock_client_with_etcdstore(addr: &str) -> (MetaClient, MockMetaContext) {
+    let MockInfo {
+        server_addr,
+        channel_manager,
+        kv_backend,
+        in_memory,
+        ..
+    } = server_mock::mock_with_etcdstore(addr).await;
+    (
+        mock_client_by(server_addr, channel_manager).await,
+        MockMetaContext {
+            kv_backend,
+            in_memory,
+        },
+    )
+}
+
+pub async fn mock_client_by(server_addr: String, channel_manager: ChannelManager) -> MetaClient {
     let id = (1000u64, 2000u64);
     let mut meta_client = MetaClientBuilder::datanode_default_options(id.0, id.1)
+        .enable_access_cluster_info()
         .channel_manager(channel_manager)
         .build();
     meta_client.start(&[&server_addr]).await.unwrap();

--- a/src/meta-srv/src/mocks.rs
+++ b/src/meta-srv/src/mocks.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use api::v1::meta::cluster_server::ClusterServer;
 use api::v1::meta::heartbeat_server::HeartbeatServer;
 use api::v1::meta::procedure_service_server::ProcedureServiceServer;
 use api::v1::meta::store_server::StoreServer;
@@ -23,7 +24,7 @@ use common_grpc::channel_manager::{ChannelConfig, ChannelManager};
 use common_meta::key::TableMetadataManager;
 use common_meta::kv_backend::etcd::EtcdStore;
 use common_meta::kv_backend::memory::MemoryKvBackend;
-use common_meta::kv_backend::KvBackendRef;
+use common_meta::kv_backend::{KvBackendRef, ResettableKvBackendRef};
 use tonic::codec::CompressionEncoding;
 use tower::service_fn;
 
@@ -36,21 +37,24 @@ pub struct MockInfo {
     pub server_addr: String,
     pub channel_manager: ChannelManager,
     pub metasrv: Arc<Metasrv>,
+    pub kv_backend: KvBackendRef,
+    pub in_memory: Option<ResettableKvBackendRef>,
 }
 
 pub async fn mock_with_memstore() -> MockInfo {
     let kv_backend = Arc::new(MemoryKvBackend::new());
-    mock(Default::default(), kv_backend, None, None).await
+    let in_memory = Arc::new(MemoryKvBackend::new());
+    mock(Default::default(), kv_backend, None, None, Some(in_memory)).await
 }
 
 pub async fn mock_with_etcdstore(addr: &str) -> MockInfo {
     let kv_backend = EtcdStore::with_endpoints([addr], 128).await.unwrap();
-    mock(Default::default(), kv_backend, None, None).await
+    mock(Default::default(), kv_backend, None, None, None).await
 }
 
 pub async fn mock_with_memstore_and_selector(selector: SelectorRef) -> MockInfo {
     let kv_backend = Arc::new(MemoryKvBackend::new());
-    mock(Default::default(), kv_backend, Some(selector), None).await
+    mock(Default::default(), kv_backend, Some(selector), None, None).await
 }
 
 pub async fn mock(
@@ -58,13 +62,16 @@ pub async fn mock(
     kv_backend: KvBackendRef,
     selector: Option<SelectorRef>,
     datanode_clients: Option<Arc<NodeClients>>,
+    in_memory: Option<ResettableKvBackendRef>,
 ) -> MockInfo {
     let server_addr = opts.server_addr.clone();
     let table_metadata_manager = Arc::new(TableMetadataManager::new(kv_backend.clone()));
 
     table_metadata_manager.init().await.unwrap();
 
-    let builder = MetasrvBuilder::new().options(opts).kv_backend(kv_backend);
+    let builder = MetasrvBuilder::new()
+        .options(opts)
+        .kv_backend(kv_backend.clone());
 
     let builder = match selector {
         Some(s) => builder.selector(s),
@@ -73,6 +80,11 @@ pub async fn mock(
 
     let builder = match datanode_clients {
         Some(clients) => builder.node_manager(clients),
+        None => builder,
+    };
+
+    let builder = match &in_memory {
+        Some(in_memory) => builder.in_memory(in_memory.clone()),
         None => builder,
     };
 
@@ -89,6 +101,7 @@ pub async fn mock(
         let router = add_compressed_service!(router, StoreServer::from_arc(service.clone()));
         let router =
             add_compressed_service!(router, ProcedureServiceServer::from_arc(service.clone()));
+        let router = add_compressed_service!(router, ClusterServer::from_arc(service.clone()));
         router
             .serve_with_incoming(futures::stream::iter(vec![Ok::<_, std::io::Error>(server)]))
             .await
@@ -126,5 +139,7 @@ pub async fn mock(
         server_addr,
         channel_manager,
         metasrv,
+        kv_backend,
+        in_memory,
     }
 }

--- a/tests-integration/src/cluster.rs
+++ b/tests-integration/src/cluster.rs
@@ -190,6 +190,7 @@ impl GreptimeDbClusterBuilder {
             self.kv_backend.clone(),
             self.meta_selector.clone(),
             Some(datanode_clients.clone()),
+            None,
         )
         .await;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR fixes the behavior of `PaginationStream`, ensuring it automatically adjusts the next request's `page_size` when the range response size from the in-memory store exceeds the size limit.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
