### PR TITLE
feat: recover file cache index asynchronously

### DIFF
--- a/src/datanode/src/store.rs
+++ b/src/datanode/src/store.rs
@@ -25,7 +25,7 @@ use std::time::Duration;
 use std::{env, path};
 
 use common_base::readable_size::ReadableSize;
-use common_telemetry::{error, info, warn};
+use common_telemetry::{info, warn};
 use object_store::layers::{LruCacheLayer, RetryInterceptor, RetryLayer};
 use object_store::services::Fs;
 use object_store::util::{join_dir, normalize_dir, with_instrument_layers};
@@ -154,13 +154,7 @@ async fn build_cache_layer(
 
         let cache_layer = LruCacheLayer::new(Arc::new(cache_store), cache_capacity.0 as usize)
             .context(error::InitBackendSnafu)?;
-        let moved_cache_layer = cache_layer.clone();
-        tokio::spawn(async move {
-            if let Err(err) = moved_cache_layer.recover_cache().await {
-                error!(err; "Failed to recover file cache.")
-            }
-        });
-
+        cache_layer.recover_cache(false).await;
         info!(
             "Enabled local object storage cache, path: {}, capacity: {}.",
             path, cache_capacity

--- a/src/mito2/src/cache/write_cache.rs
+++ b/src/mito2/src/cache/write_cache.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use common_base::readable_size::ReadableSize;
-use common_telemetry::{debug, error, info};
+use common_telemetry::{debug, info};
 use futures::AsyncWriteExt;
 use object_store::manager::ObjectStoreManagerRef;
 use object_store::ObjectStore;
@@ -68,12 +68,7 @@ impl WriteCache {
         intermediate_manager: IntermediateManager,
     ) -> Result<Self> {
         let file_cache = Arc::new(FileCache::new(local_store, cache_capacity, ttl));
-        let moved_file_cache = file_cache.clone();
-        tokio::spawn(async move {
-            if let Err(err) = moved_file_cache.recover().await {
-                error!(err; "Failed to recover file cache.")
-            }
-        });
+        file_cache.recover(false).await;
 
         Ok(Self {
             file_cache,

--- a/src/object-store/Cargo.toml
+++ b/src/object-store/Cargo.toml
@@ -27,6 +27,7 @@ opendal = { version = "0.49", features = [
     "services-s3",
 ] }
 prometheus.workspace = true
+tokio.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]

--- a/src/object-store/tests/object_store_test.rs
+++ b/src/object-store/tests/object_store_test.rs
@@ -233,7 +233,9 @@ async fn test_file_backend_with_lru_cache() -> Result<()> {
             .atomic_write_dir(&cache_dir.path().to_string_lossy());
         let file_cache = Arc::new(builder.build().unwrap());
 
-        LruCacheLayer::new(file_cache, 32).await.unwrap()
+        let cache_layer = LruCacheLayer::new(file_cache, 32).unwrap();
+        cache_layer.recover_cache().await.unwrap();
+        cache_layer
     };
 
     let store = OperatorBuilder::new(store)
@@ -308,7 +310,8 @@ async fn test_object_store_cache_policy() -> Result<()> {
     let cache_store = file_cache.clone();
 
     // create operator for cache dir to verify cache file
-    let cache_layer = LruCacheLayer::new(cache_store.clone(), 38).await.unwrap();
+    let cache_layer = LruCacheLayer::new(cache_store.clone(), 38).unwrap();
+    cache_layer.recover_cache().await.unwrap();
     let store = store.layer(cache_layer.clone());
 
     // create several object handler.
@@ -436,7 +439,8 @@ async fn test_object_store_cache_policy() -> Result<()> {
 
     drop(cache_layer);
     // Test recover
-    let cache_layer = LruCacheLayer::new(cache_store, 38).await.unwrap();
+    let cache_layer = LruCacheLayer::new(cache_store, 38).unwrap();
+    cache_layer.recover_cache().await.unwrap();
 
     // The p2 `NotFound` cache will not be recovered
     assert_eq!(cache_layer.read_cache_stat().await, (3, 34));

--- a/src/object-store/tests/object_store_test.rs
+++ b/src/object-store/tests/object_store_test.rs
@@ -234,7 +234,7 @@ async fn test_file_backend_with_lru_cache() -> Result<()> {
         let file_cache = Arc::new(builder.build().unwrap());
 
         let cache_layer = LruCacheLayer::new(file_cache, 32).unwrap();
-        cache_layer.recover_cache().await.unwrap();
+        cache_layer.recover_cache(true).await;
         cache_layer
     };
 
@@ -311,7 +311,7 @@ async fn test_object_store_cache_policy() -> Result<()> {
 
     // create operator for cache dir to verify cache file
     let cache_layer = LruCacheLayer::new(cache_store.clone(), 38).unwrap();
-    cache_layer.recover_cache().await.unwrap();
+    cache_layer.recover_cache(true).await;
     let store = store.layer(cache_layer.clone());
 
     // create several object handler.
@@ -440,7 +440,7 @@ async fn test_object_store_cache_policy() -> Result<()> {
     drop(cache_layer);
     // Test recover
     let cache_layer = LruCacheLayer::new(cache_store, 38).unwrap();
-    cache_layer.recover_cache().await.unwrap();
+    cache_layer.recover_cache(true).await;
 
     // The p2 `NotFound` cache will not be recovered
     assert_eq!(cache_layer.read_cache_stat().await, (3, 34));


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Recovering the cache index synchronously for a large number of files (potentially in the hundreds of thousands) can be highly time-consuming (e.g., ~10 seconds). This PR addresses the issue by making the cache index recovery process asynchronous, significantly reducing the startup time of the datanode.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
