### PR TITLE
perf: take a new batch to reduce last row cache usage

### DIFF
--- a/src/mito2/src/read/last_row.rs
+++ b/src/mito2/src/read/last_row.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use datatypes::vectors::UInt32Vector;
-use snafu::ResultExt;
 use store_api::storage::TimeSeriesRowSelector;
 
 use crate::cache::{


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
This PR takes a new batch to avoid referencing the old last-row batch. This can reduce the memory usage of the selector result cache.

In TSBS, this reduces cache usage from over 1GB to 8.3MB.


## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
