### PR TITLE
feat!: remove GET method in `/debug` path

### DIFF
--- a/docs/how-to/how-to-profile-cpu.md
+++ b/docs/how-to/how-to-profile-cpu.md
@@ -3,7 +3,7 @@
 ## HTTP API
 Sample at 99 Hertz, for 5 seconds, output report in [protobuf format](https://github.com/google/pprof/blob/master/proto/profile.proto).
 ```bash
-curl -s '0:4000/debug/prof/cpu' > /tmp/pprof.out
+curl -X POST -s '0:4000/debug/prof/cpu' > /tmp/pprof.out
 ```
 
 Then you can use `pprof` command with the protobuf file.
@@ -13,10 +13,10 @@ go tool pprof -top /tmp/pprof.out
 
 Sample at 99 Hertz, for 60 seconds, output report in flamegraph format.
 ```bash
-curl -s '0:4000/debug/prof/cpu?seconds=60&output=flamegraph' > /tmp/pprof.svg
+curl -X POST -s '0:4000/debug/prof/cpu?seconds=60&output=flamegraph' > /tmp/pprof.svg
 ```
 
 Sample at 49 Hertz, for 10 seconds, output report in text format.
 ```bash
-curl -s '0:4000/debug/prof/cpu?seconds=10&frequency=49&output=text' > /tmp/pprof.txt
+curl -X POST -s '0:4000/debug/prof/cpu?seconds=10&frequency=49&output=text' > /tmp/pprof.txt
 ```

--- a/docs/how-to/how-to-profile-memory.md
+++ b/docs/how-to/how-to-profile-memory.md
@@ -29,7 +29,7 @@ MALLOC_CONF=prof:true,lg_prof_interval:28 ./target/debug/greptime standalone sta
 Dump memory profiling data through HTTP API:
 
 ```bash
-curl localhost:4000/debug/prof/mem > greptime.hprof
+curl -X POST localhost:4000/debug/prof/mem > greptime.hprof
 ```
 
 You can periodically dump profiling data and compare them to find the delta memory usage.

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -705,22 +705,12 @@ impl HttpServer {
                 "/debug",
                 Router::new()
                     // handler for changing log level dynamically
-                    .route(
-                        "/log_level",
-                        routing::get(dyn_log::dyn_log_handler).post(dyn_log::dyn_log_handler),
-                    )
+                    .route("/log_level", routing::post(dyn_log::dyn_log_handler))
                     .nest(
                         "/prof",
                         Router::new()
-                            .route(
-                                "/cpu",
-                                routing::get(pprof::pprof_handler).post(pprof::pprof_handler),
-                            )
-                            .route(
-                                "/mem",
-                                routing::get(mem_prof::mem_prof_handler)
-                                    .post(mem_prof::mem_prof_handler),
-                            ),
+                            .route("/cpu", routing::post(pprof::pprof_handler))
+                            .route("/mem", routing::post(mem_prof::mem_prof_handler)),
                     ),
             )
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


Remove GET methods for `/debug/log_level`, `/debug/cpu` and `/debug/mem` according to https://github.com/GreptimeTeam/docs/pull/1345#discussion_r1869416449

## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
