### PR TITLE
fix: show create table doesn't quote option keys which contains dot

### DIFF
--- a/src/query/src/sql/show_create_table.rs
+++ b/src/query/src/sql/show_create_table.rs
@@ -260,7 +260,7 @@ mod tests {
         let regions = vec![0, 1, 2];
 
         let mut options = table::requests::TableOptions {
-            ttl: Some(Duration::from_secs(30)),
+            ttl: Some(Duration::from_secs(30).into()),
             ..Default::default()
         };
 

--- a/src/sql/src/statements/option_map.rs
+++ b/src/sql/src/statements/option_map.rs
@@ -79,10 +79,18 @@ impl OptionMap {
     pub fn kv_pairs(&self) -> Vec<String> {
         let mut result = Vec::with_capacity(self.options.len() + self.secrets.len());
         for (k, v) in self.options.iter() {
-            result.push(format!("{k} = '{}'", v.escape_default()));
+            if k.contains(".") {
+                result.push(format!("'{k}' = '{}'", v.escape_default()));
+            } else {
+                result.push(format!("{k} = '{}'", v.escape_default()));
+            }
         }
         for (k, _) in self.secrets.iter() {
-            result.push(format!("{k} = '******'"));
+            if k.contains(".") {
+                result.push(format!("'{k}' = '******'"));
+            } else {
+                result.push(format!("{k} = '******'"));
+            }
         }
         result
     }

--- a/tests/cases/standalone/common/alter/alter_table_options.result
+++ b/tests/cases/standalone/common/alter/alter_table_options.result
@@ -173,28 +173,28 @@ Affected Rows: 0
 
 SHOW CREATE TABLE ato;
 
-+-------+----------------------------------------------------+
-| Table | Create Table                                       |
-+-------+----------------------------------------------------+
-| ato   | CREATE TABLE IF NOT EXISTS "ato" (                 |
-|       |   "i" INT NULL,                                    |
-|       |   "j" TIMESTAMP(3) NOT NULL,                       |
-|       |   TIME INDEX ("j"),                                |
-|       |   PRIMARY KEY ("i")                                |
-|       | )                                                  |
-|       |                                                    |
-|       | ENGINE=mito                                        |
-|       | WITH(                                              |
-|       |   compaction.twcs.max_active_window_files = '2',   |
-|       |   compaction.twcs.max_active_window_runs = '6',    |
-|       |   compaction.twcs.max_inactive_window_files = '2', |
-|       |   compaction.twcs.max_inactive_window_runs = '6',  |
-|       |   compaction.twcs.max_output_file_size = '500MB',  |
-|       |   compaction.twcs.time_window = '2h',              |
-|       |   compaction.type = 'twcs',                        |
-|       |   ttl = '1s'                                       |
-|       | )                                                  |
-+-------+----------------------------------------------------+
++-------+------------------------------------------------------+
+| Table | Create Table                                         |
++-------+------------------------------------------------------+
+| ato   | CREATE TABLE IF NOT EXISTS "ato" (                   |
+|       |   "i" INT NULL,                                      |
+|       |   "j" TIMESTAMP(3) NOT NULL,                         |
+|       |   TIME INDEX ("j"),                                  |
+|       |   PRIMARY KEY ("i")                                  |
+|       | )                                                    |
+|       |                                                      |
+|       | ENGINE=mito                                          |
+|       | WITH(                                                |
+|       |   'compaction.twcs.max_active_window_files' = '2',   |
+|       |   'compaction.twcs.max_active_window_runs' = '6',    |
+|       |   'compaction.twcs.max_inactive_window_files' = '2', |
+|       |   'compaction.twcs.max_inactive_window_runs' = '6',  |
+|       |   'compaction.twcs.max_output_file_size' = '500MB',  |
+|       |   'compaction.twcs.time_window' = '2h',              |
+|       |   'compaction.type' = 'twcs',                        |
+|       |   ttl = '1s'                                         |
+|       | )                                                    |
++-------+------------------------------------------------------+
 
 ALTER TABLE ato UNSET 'compaction.twcs.time_window';
 
@@ -206,27 +206,27 @@ Error: 1004(InvalidArguments), Invalid unset table option request: Invalid set r
 
 SHOW CREATE TABLE ato;
 
-+-------+----------------------------------------------------+
-| Table | Create Table                                       |
-+-------+----------------------------------------------------+
-| ato   | CREATE TABLE IF NOT EXISTS "ato" (                 |
-|       |   "i" INT NULL,                                    |
-|       |   "j" TIMESTAMP(3) NOT NULL,                       |
-|       |   TIME INDEX ("j"),                                |
-|       |   PRIMARY KEY ("i")                                |
-|       | )                                                  |
-|       |                                                    |
-|       | ENGINE=mito                                        |
-|       | WITH(                                              |
-|       |   compaction.twcs.max_active_window_files = '2',   |
-|       |   compaction.twcs.max_active_window_runs = '6',    |
-|       |   compaction.twcs.max_inactive_window_files = '2', |
-|       |   compaction.twcs.max_inactive_window_runs = '6',  |
-|       |   compaction.twcs.max_output_file_size = '500MB',  |
-|       |   compaction.type = 'twcs',                        |
-|       |   ttl = '1s'                                       |
-|       | )                                                  |
-+-------+----------------------------------------------------+
++-------+------------------------------------------------------+
+| Table | Create Table                                         |
++-------+------------------------------------------------------+
+| ato   | CREATE TABLE IF NOT EXISTS "ato" (                   |
+|       |   "i" INT NULL,                                      |
+|       |   "j" TIMESTAMP(3) NOT NULL,                         |
+|       |   TIME INDEX ("j"),                                  |
+|       |   PRIMARY KEY ("i")                                  |
+|       | )                                                    |
+|       |                                                      |
+|       | ENGINE=mito                                          |
+|       | WITH(                                                |
+|       |   'compaction.twcs.max_active_window_files' = '2',   |
+|       |   'compaction.twcs.max_active_window_runs' = '6',    |
+|       |   'compaction.twcs.max_inactive_window_files' = '2', |
+|       |   'compaction.twcs.max_inactive_window_runs' = '6',  |
+|       |   'compaction.twcs.max_output_file_size' = '500MB',  |
+|       |   'compaction.type' = 'twcs',                        |
+|       |   ttl = '1s'                                         |
+|       | )                                                    |
++-------+------------------------------------------------------+
 
 ALTER TABLE ato SET 'compaction.twcs.max_inactive_window_runs'='';
 
@@ -234,50 +234,50 @@ Affected Rows: 0
 
 SHOW CREATE TABLE ato;
 
-+-------+----------------------------------------------------+
-| Table | Create Table                                       |
-+-------+----------------------------------------------------+
-| ato   | CREATE TABLE IF NOT EXISTS "ato" (                 |
-|       |   "i" INT NULL,                                    |
-|       |   "j" TIMESTAMP(3) NOT NULL,                       |
-|       |   TIME INDEX ("j"),                                |
-|       |   PRIMARY KEY ("i")                                |
-|       | )                                                  |
-|       |                                                    |
-|       | ENGINE=mito                                        |
-|       | WITH(                                              |
-|       |   compaction.twcs.max_active_window_files = '2',   |
-|       |   compaction.twcs.max_active_window_runs = '6',    |
-|       |   compaction.twcs.max_inactive_window_files = '2', |
-|       |   compaction.twcs.max_output_file_size = '500MB',  |
-|       |   compaction.type = 'twcs',                        |
-|       |   ttl = '1s'                                       |
-|       | )                                                  |
-+-------+----------------------------------------------------+
++-------+------------------------------------------------------+
+| Table | Create Table                                         |
++-------+------------------------------------------------------+
+| ato   | CREATE TABLE IF NOT EXISTS "ato" (                   |
+|       |   "i" INT NULL,                                      |
+|       |   "j" TIMESTAMP(3) NOT NULL,                         |
+|       |   TIME INDEX ("j"),                                  |
+|       |   PRIMARY KEY ("i")                                  |
+|       | )                                                    |
+|       |                                                      |
+|       | ENGINE=mito                                          |
+|       | WITH(                                                |
+|       |   'compaction.twcs.max_active_window_files' = '2',   |
+|       |   'compaction.twcs.max_active_window_runs' = '6',    |
+|       |   'compaction.twcs.max_inactive_window_files' = '2', |
+|       |   'compaction.twcs.max_output_file_size' = '500MB',  |
+|       |   'compaction.type' = 'twcs',                        |
+|       |   ttl = '1s'                                         |
+|       | )                                                    |
++-------+------------------------------------------------------+
 
 -- SQLNESS ARG restart=true
 SHOW CREATE TABLE ato;
 
-+-------+----------------------------------------------------+
-| Table | Create Table                                       |
-+-------+----------------------------------------------------+
-| ato   | CREATE TABLE IF NOT EXISTS "ato" (                 |
-|       |   "i" INT NULL,                                    |
-|       |   "j" TIMESTAMP(3) NOT NULL,                       |
-|       |   TIME INDEX ("j"),                                |
-|       |   PRIMARY KEY ("i")                                |
-|       | )                                                  |
-|       |                                                    |
-|       | ENGINE=mito                                        |
-|       | WITH(                                              |
-|       |   compaction.twcs.max_active_window_files = '2',   |
-|       |   compaction.twcs.max_active_window_runs = '6',    |
-|       |   compaction.twcs.max_inactive_window_files = '2', |
-|       |   compaction.twcs.max_output_file_size = '500MB',  |
-|       |   compaction.type = 'twcs',                        |
-|       |   ttl = '1s'                                       |
-|       | )                                                  |
-+-------+----------------------------------------------------+
++-------+------------------------------------------------------+
+| Table | Create Table                                         |
++-------+------------------------------------------------------+
+| ato   | CREATE TABLE IF NOT EXISTS "ato" (                   |
+|       |   "i" INT NULL,                                      |
+|       |   "j" TIMESTAMP(3) NOT NULL,                         |
+|       |   TIME INDEX ("j"),                                  |
+|       |   PRIMARY KEY ("i")                                  |
+|       | )                                                    |
+|       |                                                      |
+|       | ENGINE=mito                                          |
+|       | WITH(                                                |
+|       |   'compaction.twcs.max_active_window_files' = '2',   |
+|       |   'compaction.twcs.max_active_window_runs' = '6',    |
+|       |   'compaction.twcs.max_inactive_window_files' = '2', |
+|       |   'compaction.twcs.max_output_file_size' = '500MB',  |
+|       |   'compaction.type' = 'twcs',                        |
+|       |   ttl = '1s'                                         |
+|       | )                                                    |
++-------+------------------------------------------------------+
 
 DROP TABLE ato;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Table options such as `compaction.twcs.time_window` and `compaction.type` must be enclosed in quotes when executing `show create table`; otherwise, the result cannot be used as an SQL statement.


## Checklist

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
