### PR TITLE
chore:  Reduce FETCH_OPTION_TIMEOUT from 10 to 3 seconds in config.rs

### DIFF
--- a/src/mito2/src/config.rs
+++ b/src/mito2/src/config.rs
@@ -46,7 +46,7 @@ const PAGE_CACHE_SIZE_FACTOR: u64 = 8;
 const INDEX_CREATE_MEM_THRESHOLD_FACTOR: u64 = 16;
 
 /// Fetch option timeout
-pub(crate) const FETCH_OPTION_TIMEOUT: Duration = Duration::from_secs(10);
+pub(crate) const FETCH_OPTION_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// Configuration for [MitoEngine](crate::engine::MitoEngine).
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Reduce timeout for fetching database options from 10 sec to 3 sec to avoid potention impact on ingestion rate.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
