### PR TITLE
chore: add `/ready` api for health checking

### DIFF
--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -638,10 +638,15 @@ impl HttpServer {
             router.clone()
         };
 
-        router = router.route(
-            "/health",
-            routing::get(handler::health).post(handler::health),
-        );
+        router = router
+            .route(
+                "/health",
+                routing::get(handler::health).post(handler::health),
+            )
+            .route(
+                "/ready",
+                routing::get(handler::health).post(handler::health),
+            );
 
         router = router.route("/status", routing::get(handler::status));
 

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -757,21 +757,26 @@ pub async fn test_health_api(store_type: StorageType) {
     let (app, _guard) = setup_test_http_app_with_frontend(store_type, "health_api").await;
     let client = TestClient::new(app);
 
-    // we can call health api with both `GET` and `POST` method.
-    let res_post = client.post("/health").send().await;
-    assert_eq!(res_post.status(), StatusCode::OK);
-    let res_get = client.get("/health").send().await;
-    assert_eq!(res_get.status(), StatusCode::OK);
+    async fn health_api(client: &TestClient, endpoint: &str) {
+        // we can call health api with both `GET` and `POST` method.
+        let res_post = client.post(endpoint).send().await;
+        assert_eq!(res_post.status(), StatusCode::OK);
+        let res_get = client.get(endpoint).send().await;
+        assert_eq!(res_get.status(), StatusCode::OK);
 
-    // both `GET` and `POST` method return same result
-    let body_text = res_post.text().await;
-    assert_eq!(body_text, res_get.text().await);
+        // both `GET` and `POST` method return same result
+        let body_text = res_post.text().await;
+        assert_eq!(body_text, res_get.text().await);
 
-    // currently health api simply returns an empty json `{}`, which can be deserialized to an empty `HealthResponse`
-    assert_eq!(body_text, "{}");
+        // currently health api simply returns an empty json `{}`, which can be deserialized to an empty `HealthResponse`
+        assert_eq!(body_text, "{}");
 
-    let body = serde_json::from_str::<HealthResponse>(&body_text).unwrap();
-    assert_eq!(body, HealthResponse {});
+        let body = serde_json::from_str::<HealthResponse>(&body_text).unwrap();
+        assert_eq!(body, HealthResponse {});
+    }
+
+    health_api(&client, "/health").await;
+    health_api(&client, "/ready").await;
 }
 
 pub async fn test_status_api(store_type: StorageType) {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Add `/ready` HTTP endpoint for health checking. See https://grafana.com/docs/loki/latest/reference/loki-http-api/#readiness-probe.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
