### PR TITLE
feat: Alter inverted index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4449,7 +4449,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=43ddd8dea69f4df0fe2e8b5cdc0044d2cfa35908#43ddd8dea69f4df0fe2e8b5cdc0044d2cfa35908"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=9c56862fdcf713ad485932a62702b8afbd5a22dd#9c56862fdcf713ad485932a62702b8afbd5a22dd"
 dependencies = [
  "prost 0.12.6",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ etcd-client = "0.13"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "43ddd8dea69f4df0fe2e8b5cdc0044d2cfa35908" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "9c56862fdcf713ad485932a62702b8afbd5a22dd" }
 hex = "0.4"
 http = "0.2"
 humantime = "2.1"

--- a/src/api/src/v1/column_def.rs
+++ b/src/api/src/v1/column_def.rs
@@ -181,14 +181,14 @@ mod tests {
         let options = options_from_column_schema(&schema);
         assert!(options.is_none());
 
-        let schema = ColumnSchema::new("test", ConcreteDataType::string_datatype(), true)
+        let mut schema = ColumnSchema::new("test", ConcreteDataType::string_datatype(), true)
             .with_fulltext_options(FulltextOptions {
                 enable: true,
                 analyzer: FulltextAnalyzer::English,
                 case_sensitive: false,
             })
-            .unwrap()
-            .set_inverted_index(true);
+            .unwrap();
+        schema.with_inverted_index(true);
         let options = options_from_column_schema(&schema).unwrap();
         assert_eq!(
             options.options.get(FULLTEXT_GRPC_KEY).unwrap(),

--- a/src/common/grpc-expr/src/error.rs
+++ b/src/common/grpc-expr/src/error.rs
@@ -139,6 +139,12 @@ pub enum Error {
         #[snafu(source)]
         error: prost::DecodeError,
     },
+
+    #[snafu(display("Missing alter index options"))]
+    MissingAlterIndexOption {
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -164,7 +170,8 @@ impl ErrorExt for Error {
             }
             Error::InvalidSetTableOptionRequest { .. }
             | Error::InvalidUnsetTableOptionRequest { .. }
-            | Error::InvalidSetFulltextOptionRequest { .. } => StatusCode::InvalidArguments,
+            | Error::InvalidSetFulltextOptionRequest { .. }
+            | Error::MissingAlterIndexOption { .. } => StatusCode::InvalidArguments,
         }
     }
 

--- a/src/common/meta/src/ddl/alter_table/region_request.rs
+++ b/src/common/meta/src/ddl/alter_table/region_request.rs
@@ -133,10 +133,8 @@ fn create_proto_alter_kind(
         Kind::RenameTable(_) => Ok(None),
         Kind::SetTableOptions(v) => Ok(Some(alter_request::Kind::SetTableOptions(v.clone()))),
         Kind::UnsetTableOptions(v) => Ok(Some(alter_request::Kind::UnsetTableOptions(v.clone()))),
-        Kind::SetColumnFulltext(v) => Ok(Some(alter_request::Kind::SetColumnFulltext(v.clone()))),
-        Kind::UnsetColumnFulltext(v) => {
-            Ok(Some(alter_request::Kind::UnsetColumnFulltext(v.clone())))
-        }
+        Kind::SetIndex(v) => Ok(Some(alter_request::Kind::SetIndex(v.clone()))),
+        Kind::UnsetIndex(v) => Ok(Some(alter_request::Kind::UnsetIndex(v.clone()))),
     }
 }
 

--- a/src/common/meta/src/ddl/alter_table/update_metadata.rs
+++ b/src/common/meta/src/ddl/alter_table/update_metadata.rs
@@ -60,8 +60,8 @@ impl AlterTableProcedure {
             | AlterKind::ModifyColumnTypes { .. }
             | AlterKind::SetTableOptions { .. }
             | AlterKind::UnsetTableOptions { .. }
-            | AlterKind::SetColumnFulltext { .. }
-            | AlterKind::UnsetColumnFulltext { .. } => {}
+            | AlterKind::SetIndex { .. }
+            | AlterKind::UnsetIndex { .. } => {}
         }
 
         Ok(new_info)

--- a/src/datatypes/src/schema/column_schema.rs
+++ b/src/datatypes/src/schema/column_schema.rs
@@ -158,11 +158,22 @@ impl ColumnSchema {
         self
     }
 
-    pub fn set_inverted_index(mut self, value: bool) -> Self {
-        let _ = self
-            .metadata
-            .insert(INVERTED_INDEX_KEY.to_string(), value.to_string());
-        self
+    pub fn with_inverted_index(&mut self, value: bool) {
+        match value {
+            true => {
+                self.metadata
+                    .insert(INVERTED_INDEX_KEY.to_string(), value.to_string());
+            }
+            false => {
+                self.metadata.remove(INVERTED_INDEX_KEY);
+            }
+        }
+    }
+
+    // Put a placeholder to invalidate schemas.all(!has_inverted_index_key).
+    pub fn insert_inverted_index_placeholder(&mut self) {
+        self.metadata
+            .insert(INVERTED_INDEX_KEY.to_string(), "".to_string());
     }
 
     pub fn is_inverted_indexed(&self) -> bool {

--- a/src/mito2/src/engine/alter_test.rs
+++ b/src/mito2/src/engine/alter_test.rs
@@ -26,8 +26,8 @@ use datatypes::schema::{ColumnSchema, FulltextAnalyzer, FulltextOptions};
 use store_api::metadata::ColumnMetadata;
 use store_api::region_engine::{RegionEngine, RegionRole};
 use store_api::region_request::{
-    AddColumn, AddColumnLocation, AlterKind, RegionAlterRequest, RegionOpenRequest, RegionRequest,
-    SetRegionOption,
+    AddColumn, AddColumnLocation, AlterKind, ApiSetIndexOptions, RegionAlterRequest,
+    RegionOpenRequest, RegionRequest, SetRegionOption,
 };
 use store_api::storage::{RegionId, ScanRequest};
 
@@ -69,15 +69,28 @@ fn add_tag1() -> RegionAlterRequest {
     }
 }
 
+fn alter_column_inverted_index() -> RegionAlterRequest {
+    RegionAlterRequest {
+        schema_version: 0,
+        kind: AlterKind::SetIndex {
+            options: ApiSetIndexOptions::Inverted {
+                column_name: "tag_0".to_string(),
+            },
+        },
+    }
+}
+
 fn alter_column_fulltext_options() -> RegionAlterRequest {
     RegionAlterRequest {
         schema_version: 0,
-        kind: AlterKind::SetColumnFulltext {
-            column_name: "tag_0".to_string(),
-            options: FulltextOptions {
-                enable: true,
-                analyzer: FulltextAnalyzer::English,
-                case_sensitive: false,
+        kind: AlterKind::SetIndex {
+            options: ApiSetIndexOptions::Fulltext {
+                column_name: "tag_0".to_string(),
+                options: FulltextOptions {
+                    enable: true,
+                    analyzer: FulltextAnalyzer::English,
+                    case_sensitive: false,
+                },
             },
         },
     }
@@ -576,6 +589,116 @@ async fn test_alter_column_fulltext_options() {
         .await
         .unwrap();
     check_fulltext_options(&engine, &expect_fulltext_options);
+    check_region_version(&engine, region_id, 1, 3, 1, 3);
+}
+
+#[tokio::test]
+async fn test_alter_column_set_inverted_index() {
+    common_telemetry::init_default_ut_logging();
+
+    let mut env = TestEnv::new();
+    let listener = Arc::new(AlterFlushListener::default());
+    let engine = env
+        .create_engine_with(MitoConfig::default(), None, Some(listener.clone()))
+        .await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new().build();
+
+    env.get_schema_metadata_manager()
+        .register_region_table_info(
+            region_id.table_id(),
+            "test_table",
+            "test_catalog",
+            "test_schema",
+            None,
+            env.get_kv_backend(),
+        )
+        .await;
+
+    let column_schemas = rows_schema(&request);
+    let region_dir = request.region_dir.clone();
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    let rows = Rows {
+        schema: column_schemas,
+        rows: build_rows(0, 3),
+    };
+    put_rows(&engine, region_id, rows).await;
+
+    // Spawns a task to flush the engine.
+    let engine_cloned = engine.clone();
+    let flush_job = tokio::spawn(async move {
+        flush_region(&engine_cloned, region_id, None).await;
+    });
+    // Waits for flush begin.
+    listener.wait_flush_begin().await;
+
+    // Consumes the notify permit in the listener.
+    listener.wait_request_begin().await;
+
+    // Submits an alter request to the region. The region should add the request
+    // to the pending ddl request list.
+    let request = alter_column_inverted_index();
+    let engine_cloned = engine.clone();
+    let alter_job = tokio::spawn(async move {
+        engine_cloned
+            .handle_request(region_id, RegionRequest::Alter(request))
+            .await
+            .unwrap();
+    });
+    // Waits until the worker handles the alter request.
+    listener.wait_request_begin().await;
+
+    // Spawns two task to flush the engine. The flush scheduler should put them to the
+    // pending task list.
+    let engine_cloned = engine.clone();
+    let pending_flush_job = tokio::spawn(async move {
+        flush_region(&engine_cloned, region_id, None).await;
+    });
+    // Waits until the worker handles the flush request.
+    listener.wait_request_begin().await;
+
+    // Wake up flush.
+    listener.wake_flush();
+    // Wait for the flush job.
+    flush_job.await.unwrap();
+    // Wait for pending flush job.
+    pending_flush_job.await.unwrap();
+    // Wait for the write job.
+    alter_job.await.unwrap();
+
+    let check_inverted_index_set = |engine: &MitoEngine| {
+        assert!(engine
+            .get_region(region_id)
+            .unwrap()
+            .metadata()
+            .column_by_name("tag_0")
+            .unwrap()
+            .column_schema
+            .is_inverted_indexed())
+    };
+    check_inverted_index_set(&engine);
+    check_region_version(&engine, region_id, 1, 3, 1, 3);
+
+    // Reopen region.
+    let engine = env.reopen_engine(engine, MitoConfig::default()).await;
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Open(RegionOpenRequest {
+                engine: String::new(),
+                region_dir,
+                options: HashMap::default(),
+                skip_wal_replay: false,
+            }),
+        )
+        .await
+        .unwrap();
+    check_inverted_index_set(&engine);
     check_region_version(&engine, region_id, 1, 3, 1, 3);
 }
 

--- a/src/query/src/sql/show_create_table.rs
+++ b/src/query/src/sql/show_create_table.rs
@@ -248,6 +248,8 @@ mod tests {
 
     #[test]
     fn test_show_create_table_sql() {
+        let mut host_schema = ColumnSchema::new("host", ConcreteDataType::string_datatype(), true);
+        host_schema.with_inverted_index(true);
         let schema = vec![
             ColumnSchema::new("id", ConcreteDataType::uint32_datatype(), true)
                 .with_skipping_options(SkippingIndexOptions {
@@ -255,8 +257,7 @@ mod tests {
                     ..Default::default()
                 })
                 .unwrap(),
-            ColumnSchema::new("host", ConcreteDataType::string_datatype(), true)
-                .set_inverted_index(true),
+            host_schema,
             ColumnSchema::new("cpu", ConcreteDataType::float64_datatype(), true),
             ColumnSchema::new("disk", ConcreteDataType::float32_datatype(), true),
             ColumnSchema::new("msg", ConcreteDataType::string_datatype(), true)

--- a/src/sql/src/statements.rs
+++ b/src/sql/src/statements.rs
@@ -494,10 +494,10 @@ pub fn column_to_schema(
     if let Some(inverted_index_cols) = invereted_index_cols {
         if inverted_index_cols.is_empty() {
             if primary_keys.contains(&column.name().value) {
-                column_schema = column_schema.set_inverted_index(false);
+                column_schema.insert_inverted_index_placeholder();
             }
         } else if inverted_index_cols.contains(&column.name().value) {
-            column_schema = column_schema.set_inverted_index(true);
+            column_schema.with_inverted_index(true);
         }
     }
 

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -216,13 +216,29 @@ pub enum AlterKind {
     UnsetTableOptions {
         keys: Vec<UnsetRegionOption>,
     },
-    SetColumnFulltext {
+    SetIndex {
+        options: SetIndexOptions,
+    },
+    UnsetIndex {
+        options: UnsetIndexOptions,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum SetIndexOptions {
+    Fulltext {
         column_name: String,
         options: FulltextOptions,
     },
-    UnsetColumnFulltext {
+    Inverted {
         column_name: String,
     },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum UnsetIndexOptions {
+    Fulltext { column_name: String },
+    Inverted { column_name: String },
 }
 
 #[derive(Debug)]

--- a/tests/cases/standalone/common/alter/change_col_inverted_index.result
+++ b/tests/cases/standalone/common/alter/change_col_inverted_index.result
@@ -1,0 +1,183 @@
+CREATE TABLE fox (
+    ts TIMESTAMP TIME INDEX,
+    fox STRING,
+);
+
+Affected Rows: 0
+
+INSERT INTO fox VALUES
+    (1, 'The quick brown fox jumps over the lazy dog'),
+    (2, 'The             fox jumps over the lazy dog'),
+    (3, 'The quick brown     jumps over the lazy dog'),
+    (4, 'The quick brown fox       over the lazy dog'),
+    (5, 'The quick brown fox jumps      the lazy dog'),
+    (6, 'The quick brown fox jumps over          dog'),
+    (7, 'The quick brown fox jumps over the      dog');
+
+Affected Rows: 7
+
+ALTER TABLE fox MODIFY COLUMN fox SET INVERTED INDEX;
+
+Affected Rows: 0
+
+SELECT fox FROM fox WHERE MATCHES(fox, '"fox jumps"') ORDER BY ts;
+
++---------------------------------------------+
+| fox                                         |
++---------------------------------------------+
+| The quick brown fox jumps over the lazy dog |
+| The             fox jumps over the lazy dog |
+| The quick brown fox jumps      the lazy dog |
+| The quick brown fox jumps over          dog |
+| The quick brown fox jumps over the      dog |
++---------------------------------------------+
+
+SHOW CREATE TABLE fox;
+
++-------+------------------------------------+
+| Table | Create Table                       |
++-------+------------------------------------+
+| fox   | CREATE TABLE IF NOT EXISTS "fox" ( |
+|       |   "ts" TIMESTAMP(3) NOT NULL,      |
+|       |   "fox" STRING NULL,               |
+|       |   TIME INDEX ("ts"),               |
+|       |   INVERTED INDEX ("fox")           |
+|       | )                                  |
+|       |                                    |
+|       | ENGINE=mito                        |
+|       |                                    |
++-------+------------------------------------+
+
+-- SQLNESS ARG restart=true
+SHOW CREATE TABLE fox;
+
++-------+------------------------------------+
+| Table | Create Table                       |
++-------+------------------------------------+
+| fox   | CREATE TABLE IF NOT EXISTS "fox" ( |
+|       |   "ts" TIMESTAMP(3) NOT NULL,      |
+|       |   "fox" STRING NULL,               |
+|       |   TIME INDEX ("ts"),               |
+|       |   INVERTED INDEX ("fox")           |
+|       | )                                  |
+|       |                                    |
+|       | ENGINE=mito                        |
+|       |                                    |
++-------+------------------------------------+
+
+SHOW INDEX FROM fox;
+
++-------+------------+----------------+--------------+-------------+-----------+-------------+----------+--------+------+----------------------------+---------+---------------+---------+------------+
+| Table | Non_unique | Key_name       | Seq_in_index | Column_name | Collation | Cardinality | Sub_part | Packed | Null | Index_type                 | Comment | Index_comment | Visible | Expression |
++-------+------------+----------------+--------------+-------------+-----------+-------------+----------+--------+------+----------------------------+---------+---------------+---------+------------+
+| fox   | 1          | INVERTED INDEX | 2            | fox         | A         |             |          |        | YES  | greptime-inverted-index-v1 |         |               | YES     |            |
+| fox   | 1          | TIME INDEX     | 1            | ts          | A         |             |          |        | NO   |                            |         |               | YES     |            |
++-------+------------+----------------+--------------+-------------+-----------+-------------+----------+--------+------+----------------------------+---------+---------------+---------+------------+
+
+ALTER TABLE fox MODIFY COLUMN fox UNSET INVERTED INDEX;
+
+Affected Rows: 0
+
+SHOW CREATE TABLE fox;
+
++-------+------------------------------------+
+| Table | Create Table                       |
++-------+------------------------------------+
+| fox   | CREATE TABLE IF NOT EXISTS "fox" ( |
+|       |   "ts" TIMESTAMP(3) NOT NULL,      |
+|       |   "fox" STRING NULL,               |
+|       |   TIME INDEX ("ts")                |
+|       | )                                  |
+|       |                                    |
+|       | ENGINE=mito                        |
+|       |                                    |
++-------+------------------------------------+
+
+-- SQLNESS ARG restart=true
+SHOW CREATE TABLE fox;
+
++-------+------------------------------------+
+| Table | Create Table                       |
++-------+------------------------------------+
+| fox   | CREATE TABLE IF NOT EXISTS "fox" ( |
+|       |   "ts" TIMESTAMP(3) NOT NULL,      |
+|       |   "fox" STRING NULL,               |
+|       |   TIME INDEX ("ts")                |
+|       | )                                  |
+|       |                                    |
+|       | ENGINE=mito                        |
+|       |                                    |
++-------+------------------------------------+
+
+SHOW INDEX FROM fox;
+
++-------+------------+------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+---------+------------+
+| Table | Non_unique | Key_name   | Seq_in_index | Column_name | Collation | Cardinality | Sub_part | Packed | Null | Index_type | Comment | Index_comment | Visible | Expression |
++-------+------------+------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+---------+------------+
+| fox   | 1          | TIME INDEX | 1            | ts          | A         |             |          |        | NO   |            |         |               | YES     |            |
++-------+------------+------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+---------+------------+
+
+DROP TABLE fox;
+
+Affected Rows: 0
+
+CREATE TABLE test_pk (ts TIMESTAMP TIME INDEX, foo STRING, bar INT, PRIMARY KEY (foo, bar));
+
+Affected Rows: 0
+
+SHOW INDEX FROM test_pk;
+
++---------+------------+-------------------------+--------------+-------------+-----------+-------------+----------+--------+------+-----------------------------------------------------+---------+---------------+---------+------------+
+| Table   | Non_unique | Key_name                | Seq_in_index | Column_name | Collation | Cardinality | Sub_part | Packed | Null | Index_type                                          | Comment | Index_comment | Visible | Expression |
++---------+------------+-------------------------+--------------+-------------+-----------+-------------+----------+--------+------+-----------------------------------------------------+---------+---------------+---------+------------+
+| test_pk | 1          | PRIMARY, INVERTED INDEX | 3            | bar         | A         |             |          |        | YES  | greptime-primary-key-v1, greptime-inverted-index-v1 |         |               | YES     |            |
+| test_pk | 1          | PRIMARY, INVERTED INDEX | 2            | foo         | A         |             |          |        | YES  | greptime-primary-key-v1, greptime-inverted-index-v1 |         |               | YES     |            |
+| test_pk | 1          | TIME INDEX              | 1            | ts          | A         |             |          |        | NO   |                                                     |         |               | YES     |            |
++---------+------------+-------------------------+--------------+-------------+-----------+-------------+----------+--------+------+-----------------------------------------------------+---------+---------------+---------+------------+
+
+ALTER TABLE test_pk MODIFY COLUMN foo UNSET INVERTED INDEX;
+
+Affected Rows: 0
+
+SHOW INDEX FROM test_pk;
+
++---------+------------+-------------------------+--------------+-------------+-----------+-------------+----------+--------+------+-----------------------------------------------------+---------+---------------+---------+------------+
+| Table   | Non_unique | Key_name                | Seq_in_index | Column_name | Collation | Cardinality | Sub_part | Packed | Null | Index_type                                          | Comment | Index_comment | Visible | Expression |
++---------+------------+-------------------------+--------------+-------------+-----------+-------------+----------+--------+------+-----------------------------------------------------+---------+---------------+---------+------------+
+| test_pk | 1          | PRIMARY, INVERTED INDEX | 3            | bar         | A         |             |          |        | YES  | greptime-primary-key-v1, greptime-inverted-index-v1 |         |               | YES     |            |
+| test_pk | 1          | PRIMARY                 | 2            | foo         | A         |             |          |        | YES  | greptime-primary-key-v1                             |         |               | YES     |            |
+| test_pk | 1          | TIME INDEX              | 1            | ts          | A         |             |          |        | NO   |                                                     |         |               | YES     |            |
++---------+------------+-------------------------+--------------+-------------+-----------+-------------+----------+--------+------+-----------------------------------------------------+---------+---------------+---------+------------+
+
+ALTER TABLE test_pk MODIFY COLUMN bar UNSET INVERTED INDEX;
+
+Affected Rows: 0
+
+SHOW INDEX FROM test_pk;
+
++---------+------------+------------+--------------+-------------+-----------+-------------+----------+--------+------+-------------------------+---------+---------------+---------+------------+
+| Table   | Non_unique | Key_name   | Seq_in_index | Column_name | Collation | Cardinality | Sub_part | Packed | Null | Index_type              | Comment | Index_comment | Visible | Expression |
++---------+------------+------------+--------------+-------------+-----------+-------------+----------+--------+------+-------------------------+---------+---------------+---------+------------+
+| test_pk | 1          | PRIMARY    | 3            | bar         | A         |             |          |        | YES  | greptime-primary-key-v1 |         |               | YES     |            |
+| test_pk | 1          | PRIMARY    | 2            | foo         | A         |             |          |        | YES  | greptime-primary-key-v1 |         |               | YES     |            |
+| test_pk | 1          | TIME INDEX | 1            | ts          | A         |             |          |        | NO   |                         |         |               | YES     |            |
++---------+------------+------------+--------------+-------------+-----------+-------------+----------+--------+------+-------------------------+---------+---------------+---------+------------+
+
+ALTER TABLE test_pk MODIFY COLUMN foo SET INVERTED INDEX;
+
+Affected Rows: 0
+
+SHOW INDEX FROM test_pk;
+
++---------+------------+-------------------------+--------------+-------------+-----------+-------------+----------+--------+------+-----------------------------------------------------+---------+---------------+---------+------------+
+| Table   | Non_unique | Key_name                | Seq_in_index | Column_name | Collation | Cardinality | Sub_part | Packed | Null | Index_type                                          | Comment | Index_comment | Visible | Expression |
++---------+------------+-------------------------+--------------+-------------+-----------+-------------+----------+--------+------+-----------------------------------------------------+---------+---------------+---------+------------+
+| test_pk | 1          | PRIMARY                 | 3            | bar         | A         |             |          |        | YES  | greptime-primary-key-v1                             |         |               | YES     |            |
+| test_pk | 1          | PRIMARY, INVERTED INDEX | 2            | foo         | A         |             |          |        | YES  | greptime-primary-key-v1, greptime-inverted-index-v1 |         |               | YES     |            |
+| test_pk | 1          | TIME INDEX              | 1            | ts          | A         |             |          |        | NO   |                                                     |         |               | YES     |            |
++---------+------------+-------------------------+--------------+-------------+-----------+-------------+----------+--------+------+-----------------------------------------------------+---------+---------------+---------+------------+
+
+DROP TABLE test_pk;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/alter/change_col_inverted_index.sql
+++ b/tests/cases/standalone/common/alter/change_col_inverted_index.sql
@@ -1,0 +1,54 @@
+CREATE TABLE fox (
+    ts TIMESTAMP TIME INDEX,
+    fox STRING,
+);
+
+INSERT INTO fox VALUES
+    (1, 'The quick brown fox jumps over the lazy dog'),
+    (2, 'The             fox jumps over the lazy dog'),
+    (3, 'The quick brown     jumps over the lazy dog'),
+    (4, 'The quick brown fox       over the lazy dog'),
+    (5, 'The quick brown fox jumps      the lazy dog'),
+    (6, 'The quick brown fox jumps over          dog'),
+    (7, 'The quick brown fox jumps over the      dog');
+
+
+ALTER TABLE fox MODIFY COLUMN fox SET INVERTED INDEX;
+
+SELECT fox FROM fox WHERE MATCHES(fox, '"fox jumps"') ORDER BY ts;
+
+SHOW CREATE TABLE fox;
+
+-- SQLNESS ARG restart=true
+SHOW CREATE TABLE fox;
+
+SHOW INDEX FROM fox;
+
+ALTER TABLE fox MODIFY COLUMN fox UNSET INVERTED INDEX;
+
+SHOW CREATE TABLE fox;
+
+-- SQLNESS ARG restart=true
+SHOW CREATE TABLE fox;
+
+SHOW INDEX FROM fox;
+
+DROP TABLE fox;
+
+CREATE TABLE test_pk (ts TIMESTAMP TIME INDEX, foo STRING, bar INT, PRIMARY KEY (foo, bar));
+
+SHOW INDEX FROM test_pk;
+
+ALTER TABLE test_pk MODIFY COLUMN foo UNSET INVERTED INDEX;
+
+SHOW INDEX FROM test_pk;
+
+ALTER TABLE test_pk MODIFY COLUMN bar UNSET INVERTED INDEX;
+
+SHOW INDEX FROM test_pk;
+
+ALTER TABLE test_pk MODIFY COLUMN foo SET INVERTED INDEX;
+
+SHOW INDEX FROM test_pk;
+
+DROP TABLE test_pk;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

__!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
This pr enables `alter table x modify column set/ unset inverted index syntax`.
1. modify index proto has been refactored.
2. parse support the new syntax with refactoring.
3. metadata update with alter inverted index.

- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
