### PR TITLE
chore: bump main branch version to 0.12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ env:
   # The scheduled version is '${{ env.NEXT_RELEASE_VERSION }}-nightly-YYYYMMDD', like v0.2.0-nigthly-20230313;
   NIGHTLY_RELEASE_PREFIX: nightly
   # Note: The NEXT_RELEASE_VERSION should be modified manually by every formal release.
-  NEXT_RELEASE_VERSION: v0.11.0
+  NEXT_RELEASE_VERSION: v0.12.0
 
 # Permission reference: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
 permissions:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,7 +188,7 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "api"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "common-base",
  "common-decimal",
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "auth"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "api",
  "async-trait",
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "catalog",
  "common-error",
@@ -1348,7 +1348,7 @@ dependencies = [
  "common-meta",
  "moka",
  "snafu 0.8.5",
- "substrait 0.11.0",
+ "substrait 0.12.0",
 ]
 
 [[package]]
@@ -1375,7 +1375,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "api",
  "arrow",
@@ -1714,7 +1714,7 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "auth",
@@ -1758,7 +1758,7 @@ dependencies = [
  "session",
  "snafu 0.8.5",
  "store-api",
- "substrait 0.11.0",
+ "substrait 0.12.0",
  "table",
  "temp-env",
  "tempfile",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -1797,7 +1797,7 @@ dependencies = [
  "rand",
  "serde_json",
  "snafu 0.8.5",
- "substrait 0.11.0",
+ "substrait 0.12.0",
  "substrait 0.37.3",
  "tokio",
  "tokio-stream",
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "auth",
@@ -1898,7 +1898,7 @@ dependencies = [
  "similar-asserts",
  "snafu 0.8.5",
  "store-api",
- "substrait 0.11.0",
+ "substrait 0.12.0",
  "table",
  "temp-env",
  "tempfile",
@@ -1944,7 +1944,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "common-base"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anymap2",
  "async-trait",
@@ -1965,7 +1965,7 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "common-error",
@@ -1976,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "common-config"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "common-base",
  "common-error",
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2036,7 +2036,7 @@ dependencies = [
 
 [[package]]
 name = "common-decimal"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bigdecimal 0.4.5",
  "common-error",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "snafu 0.8.5",
  "strum 0.25.0",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "common-frontend"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "api",
  "async-trait",
@@ -2073,7 +2073,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "api",
  "approx 0.5.1",
@@ -2118,7 +2118,7 @@ dependencies = [
 
 [[package]]
 name = "common-greptimedb-telemetry"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "common-runtime",
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "api",
  "common-base",
@@ -2180,7 +2180,7 @@ dependencies = [
 
 [[package]]
 name = "common-macro"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "arc-swap",
  "common-query",
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2207,7 +2207,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anymap2",
  "api",
@@ -2264,7 +2264,7 @@ dependencies = [
 
 [[package]]
 name = "common-options"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "common-grpc",
  "humantime-serde",
@@ -2273,11 +2273,11 @@ dependencies = [
 
 [[package]]
 name = "common-plugins"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "common-pprof"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2289,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "api",
  "async-trait",
@@ -2350,7 +2350,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "arc-swap",
  "common-error",
@@ -2369,7 +2369,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "clap 4.5.19",
@@ -2399,7 +2399,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "atty",
  "backtrace",
@@ -2427,7 +2427,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "client",
  "common-query",
@@ -2439,7 +2439,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "arrow",
  "chrono",
@@ -2457,7 +2457,7 @@ dependencies = [
 
 [[package]]
 name = "common-version"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "build-data",
  "const_format",
@@ -2467,7 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "common-wal"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "common-base",
  "common-error",
@@ -3276,7 +3276,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -3327,7 +3327,7 @@ dependencies = [
  "session",
  "snafu 0.8.5",
  "store-api",
- "substrait 0.11.0",
+ "substrait 0.12.0",
  "table",
  "tokio",
  "toml 0.8.19",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "datatypes"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3954,7 +3954,7 @@ dependencies = [
 
 [[package]]
 name = "file-engine"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "api",
  "async-trait",
@@ -4071,7 +4071,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "flow"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "api",
  "arrow",
@@ -4128,7 +4128,7 @@ dependencies = [
  "snafu 0.8.5",
  "store-api",
  "strum 0.25.0",
- "substrait 0.11.0",
+ "substrait 0.12.0",
  "table",
  "tokio",
  "tonic 0.11.0",
@@ -4175,7 +4175,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frontend"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "index"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -6150,7 +6150,7 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "log-query"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "common-error",
@@ -6161,7 +6161,7 @@ dependencies = [
 
 [[package]]
 name = "log-store"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6482,7 +6482,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "api",
  "async-trait",
@@ -6509,7 +6509,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "api",
  "async-trait",
@@ -6588,7 +6588,7 @@ dependencies = [
 
 [[package]]
 name = "metric-engine"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -6692,7 +6692,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -7404,7 +7404,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7657,7 +7657,7 @@ dependencies = [
 
 [[package]]
 name = "operator"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -7705,7 +7705,7 @@ dependencies = [
  "sql",
  "sqlparser 0.45.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=54a267ac89c09b11c0c88934690530807185d3e7)",
  "store-api",
- "substrait 0.11.0",
+ "substrait 0.12.0",
  "table",
  "tokio",
  "tokio-util",
@@ -7955,7 +7955,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "api",
  "async-trait",
@@ -8241,7 +8241,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeline"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -8404,7 +8404,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "auth",
  "clap 4.5.19",
@@ -8681,7 +8681,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -8919,7 +8919,7 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-compression 0.4.13",
  "async-trait",
@@ -9043,7 +9043,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -9110,7 +9110,7 @@ dependencies = [
  "stats-cli",
  "store-api",
  "streaming-stats",
- "substrait 0.11.0",
+ "substrait 0.12.0",
  "table",
  "tokio",
  "tokio-stream",
@@ -10572,7 +10572,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "script"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -10866,7 +10866,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -10979,7 +10979,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -11327,7 +11327,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "api",
  "chrono",
@@ -11390,7 +11390,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "clap 4.5.19",
@@ -11610,7 +11610,7 @@ dependencies = [
 
 [[package]]
 name = "store-api"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -11781,7 +11781,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -11980,7 +11980,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "api",
  "async-trait",
@@ -12246,7 +12246,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "tests-fuzz"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "arbitrary",
  "async-trait",
@@ -12288,7 +12288,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -12352,7 +12352,7 @@ dependencies = [
  "sql",
  "sqlx",
  "store-api",
- "substrait 0.11.0",
+ "substrait 0.12.0",
  "table",
  "tempfile",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
closes https://github.com/GreptimeTeam/greptimedb/issues/5104

## What's changed and what's your intention?

Bump the main branch version to 0.12

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
