### PR TITLE
chore: ignore zed project directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ venv/
 # Fuzz tests 
 tests-fuzz/artifacts/
 tests-fuzz/corpus/
+
+# Zed project directory
+.zed/
+


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
Adds Zed project settings directory to .gitignore.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
