### PR TITLE
feat: show create postgresql foreign table

### DIFF
--- a/src/datatypes/src/data_type.rs
+++ b/src/datatypes/src/data_type.rs
@@ -370,6 +370,51 @@ impl ConcreteDataType {
             _ => None,
         }
     }
+
+    /// Return the datatype name in postgres type system
+    pub fn postgres_datatype_name(&self) -> &'static str {
+        match self {
+            &ConcreteDataType::Null(_) => "UNKNOWN",
+            &ConcreteDataType::Boolean(_) => "BOOL",
+            &ConcreteDataType::Int8(_) | &ConcreteDataType::UInt8(_) => "CHAR",
+            &ConcreteDataType::Int16(_) | &ConcreteDataType::UInt16(_) => "INT2",
+            &ConcreteDataType::Int32(_) | &ConcreteDataType::UInt32(_) => "INT4",
+            &ConcreteDataType::Int64(_) | &ConcreteDataType::UInt64(_) => "INT8",
+            &ConcreteDataType::Float32(_) => "FLOAT4",
+            &ConcreteDataType::Float64(_) => "FLOAT8",
+            &ConcreteDataType::Binary(_) | &ConcreteDataType::Vector(_) => "BYTEA",
+            &ConcreteDataType::String(_) => "VARCHAR",
+            &ConcreteDataType::Date(_) => "DATE",
+            &ConcreteDataType::DateTime(_) | &ConcreteDataType::Timestamp(_) => "TIMESTAMP",
+            &ConcreteDataType::Time(_) => "TIME",
+            &ConcreteDataType::Interval(_) => "INTERVAL",
+            &ConcreteDataType::Decimal128(_) => "NUMERIC",
+            &ConcreteDataType::Json(_) => "JSON",
+            ConcreteDataType::List(list) => match list.item_type() {
+                &ConcreteDataType::Null(_) => "UNKNOWN",
+                &ConcreteDataType::Boolean(_) => "_BOOL",
+                &ConcreteDataType::Int8(_) | &ConcreteDataType::UInt8(_) => "_CHAR",
+                &ConcreteDataType::Int16(_) | &ConcreteDataType::UInt16(_) => "_INT2",
+                &ConcreteDataType::Int32(_) | &ConcreteDataType::UInt32(_) => "_INT4",
+                &ConcreteDataType::Int64(_) | &ConcreteDataType::UInt64(_) => "_INT8",
+                &ConcreteDataType::Float32(_) => "_FLOAT4",
+                &ConcreteDataType::Float64(_) => "_FLOAT8",
+                &ConcreteDataType::Binary(_) => "_BYTEA",
+                &ConcreteDataType::String(_) => "_VARCHAR",
+                &ConcreteDataType::Date(_) => "_DATE",
+                &ConcreteDataType::DateTime(_) | &ConcreteDataType::Timestamp(_) => "_TIMESTAMP",
+                &ConcreteDataType::Time(_) => "_TIME",
+                &ConcreteDataType::Interval(_) => "_INTERVAL",
+                &ConcreteDataType::Decimal128(_) => "_NUMERIC",
+                &ConcreteDataType::Json(_) => "_JSON",
+                &ConcreteDataType::Duration(_)
+                | &ConcreteDataType::Dictionary(_)
+                | &ConcreteDataType::Vector(_)
+                | &ConcreteDataType::List(_) => "UNKNOWN",
+            },
+            &ConcreteDataType::Duration(_) | &ConcreteDataType::Dictionary(_) => "UNKNOWN",
+        }
+    }
 }
 
 impl From<&ConcreteDataType> for ConcreteDataType {

--- a/src/operator/src/statement/show.rs
+++ b/src/operator/src/statement/show.rs
@@ -160,18 +160,7 @@ impl StatementExecutor {
             .fail();
         }
 
-        let schema_options = self
-            .table_metadata_manager
-            .schema_manager()
-            .get(SchemaNameKey {
-                catalog: &table_name.catalog_name,
-                schema: &table_name.schema_name,
-            })
-            .await
-            .context(TableMetadataManagerSnafu)?
-            .map(|v| v.into_inner());
-
-        query::sql::show_create_table(table, schema_options, None, query_ctx)
+        query::sql::show_create_foreign_table_for_pg(table, query_ctx)
             .context(ExecuteStatementSnafu)
     }
 

--- a/src/query/src/sql.rs
+++ b/src/query/src/sql.rs
@@ -45,6 +45,7 @@ use datafusion_expr::{case, col, lit, Expr};
 use datatypes::prelude::*;
 use datatypes::schema::{ColumnDefaultConstraint, ColumnSchema, RawSchema, Schema};
 use datatypes::vectors::StringVector;
+use itertools::Itertools;
 use object_store::ObjectStore;
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -61,6 +62,7 @@ use sql::statements::show::{
 use sql::statements::statement::Statement;
 use sql::statements::OptionMap;
 use sqlparser::ast::ObjectName;
+use store_api::metric_engine_consts::{is_metric_engine, is_metric_engine_internal_column};
 use table::requests::{FILE_TABLE_LOCATION_KEY, FILE_TABLE_PATTERN_KEY};
 use table::TableRef;
 
@@ -736,6 +738,52 @@ pub fn show_create_table(
         p
     });
     let sql = format!("{}", stmt);
+    let columns = vec![
+        Arc::new(StringVector::from(vec![table_name.clone()])) as _,
+        Arc::new(StringVector::from(vec![sql])) as _,
+    ];
+    let records = RecordBatches::try_from_columns(SHOW_CREATE_TABLE_OUTPUT_SCHEMA.clone(), columns)
+        .context(error::CreateRecordBatchSnafu)?;
+
+    Ok(Output::new_with_record_batches(records))
+}
+
+pub fn show_create_foreign_table_for_pg(
+    table: TableRef,
+    _query_ctx: QueryContextRef,
+) -> Result<Output> {
+    let table_info = table.table_info();
+
+    let table_meta = &table_info.meta;
+    let table_name = &table_info.name;
+    let schema = &table_info.meta.schema;
+    let is_metric_engine = is_metric_engine(&table_meta.engine);
+
+    let columns = schema
+        .column_schemas()
+        .iter()
+        .filter_map(|c| {
+            if is_metric_engine && is_metric_engine_internal_column(&c.name) {
+                None
+            } else {
+                Some(format!(
+                    "\"{}\" {}",
+                    c.name,
+                    c.data_type.postgres_datatype_name()
+                ))
+            }
+        })
+        .join(",\n  ");
+
+    let sql = format!(
+        r#"CREATE FOREIGN TABLE ft_{} (
+  {}
+)
+SERVER greptimedb
+OPTIONS (table_name '{}')"#,
+        table_name, columns, table_name
+    );
+
     let columns = vec![
         Arc::new(StringVector::from(vec![table_name.clone()])) as _,
         Arc::new(StringVector::from(vec![sql])) as _,

--- a/src/sql/src/statements/show.rs
+++ b/src/sql/src/statements/show.rs
@@ -178,12 +178,26 @@ impl Display for ShowCreateDatabase {
 #[derive(Debug, Clone, PartialEq, Eq, Visit, VisitMut)]
 pub struct ShowCreateTable {
     pub table_name: ObjectName,
+    pub variant: ShowCreateTableVariant,
+}
+
+/// Variant of a show create table
+#[derive(Default, Debug, Clone, PartialEq, Eq, Visit, VisitMut)]
+pub enum ShowCreateTableVariant {
+    #[default]
+    Original,
+    PostgresForeignTable,
 }
 
 impl Display for ShowCreateTable {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let table_name = &self.table_name;
-        write!(f, r#"SHOW CREATE TABLE {table_name}"#)
+        write!(f, r#"SHOW CREATE TABLE {table_name}"#)?;
+        if let ShowCreateTableVariant::PostgresForeignTable = self.variant {
+            write!(f, " FOR POSTGRES_FOREIGN_TABLE")?;
+        }
+
+        Ok(())
     }
 }
 
@@ -343,15 +357,45 @@ mod tests {
             Statement::ShowCreateTable(show) => {
                 let table_name = show.table_name.to_string();
                 assert_eq!(table_name, "test");
+                assert_eq!(show.variant, ShowCreateTableVariant::Original);
+            }
+            _ => {
+                unreachable!();
+            }
+        }
+
+        let sql = "SHOW CREATE TABLE test FOR POSTGRES_FOREIGN_TABLE";
+        let stmts: Vec<Statement> =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
+        assert_eq!(1, stmts.len());
+        assert_matches!(&stmts[0], Statement::ShowCreateTable { .. });
+        match &stmts[0] {
+            Statement::ShowCreateTable(show) => {
+                let table_name = show.table_name.to_string();
+                assert_eq!(table_name, "test");
+                assert_eq!(show.variant, ShowCreateTableVariant::PostgresForeignTable);
             }
             _ => {
                 unreachable!();
             }
         }
     }
+
     #[test]
     pub fn test_show_create_missing_table_name() {
         let sql = "SHOW CREATE TABLE";
+        assert!(ParserContext::create_with_dialect(
+            sql,
+            &GreptimeDbDialect {},
+            ParseOptions::default()
+        )
+        .is_err());
+    }
+
+    #[test]
+    pub fn test_show_create_unknown_for() {
+        let sql = "SHOW CREATE TABLE t FOR UNKNOWN";
         assert!(ParserContext::create_with_dialect(
             sql,
             &GreptimeDbDialect {},

--- a/tests/cases/standalone/common/show/show_create.result
+++ b/tests/cases/standalone/common/show/show_create.result
@@ -46,6 +46,22 @@ SHOW CREATE TABLE system_metrics;
 |                | )                                                         |
 +----------------+-----------------------------------------------------------+
 
+SHOW CREATE TABLE system_metrics FOR POSTGRES_FOREIGN_TABLE;
+
++----------------+------------------------------------------+
+| Table          | Create Table                             |
++----------------+------------------------------------------+
+| system_metrics | CREATE FOREIGN TABLE ft_system_metrics ( |
+|                |   "id" INT4,                             |
+|                |   "host" VARCHAR,                        |
+|                |   "cpu" FLOAT8,                          |
+|                |   "disk" FLOAT4,                         |
+|                |   "ts" TIMESTAMP                         |
+|                | )                                        |
+|                | SERVER greptimedb                        |
+|                | OPTIONS (table_name 'system_metrics')    |
++----------------+------------------------------------------+
+
 DROP TABLE system_metrics;
 
 Affected Rows: 0
@@ -140,6 +156,20 @@ show create table t1;
 |       |   on_physical_table = 'phy'       |
 |       | )                                 |
 +-------+-----------------------------------+
+
+SHOW CREATE TABLE t1 FOR POSTGRES_FOREIGN_TABLE;
+
++-------+------------------------------+
+| Table | Create Table                 |
++-------+------------------------------+
+| t1    | CREATE FOREIGN TABLE ft_t1 ( |
+|       |   "host" VARCHAR,            |
+|       |   "ts" TIMESTAMP,            |
+|       |   "val" FLOAT8               |
+|       | )                            |
+|       | SERVER greptimedb            |
+|       | OPTIONS (table_name 't1')    |
++-------+------------------------------+
 
 drop table t1;
 

--- a/tests/cases/standalone/common/show/show_create.sql
+++ b/tests/cases/standalone/common/show/show_create.sql
@@ -20,6 +20,8 @@ WITH(
 
 SHOW CREATE TABLE system_metrics;
 
+SHOW CREATE TABLE system_metrics FOR POSTGRES_FOREIGN_TABLE;
+
 DROP TABLE system_metrics;
 
 create table table_without_partition (
@@ -56,6 +58,8 @@ CREATE TABLE t1 (ts timestamp time index, val double, host string primary key) e
 show create table phy;
 
 show create table t1;
+
+SHOW CREATE TABLE t1 FOR POSTGRES_FOREIGN_TABLE;
 
 drop table t1;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Fixes #5109 

## What's changed and what's your intention?

This patch adds a new sql statement `SHOW CREATE TABLE <table> FOR postgres_foreign_table` that returns sql statement for creating postgres foreign table for fdw.

## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
