### PR TITLE
perf: avoid holding memtable during compaction

### DIFF
--- a/src/mito2/src/compaction.rs
+++ b/src/mito2/src/compaction.rs
@@ -59,7 +59,7 @@ use crate::read::scan_region::ScanInput;
 use crate::read::seq_scan::SeqScan;
 use crate::read::BoxedBatchReader;
 use crate::region::options::MergeMode;
-use crate::region::version::{VersionControlRef};
+use crate::region::version::VersionControlRef;
 use crate::region::ManifestContextRef;
 use crate::request::{OptionOutputTx, OutputTx, WorkerRequest};
 use crate::schedule::remote_job_scheduler::{

--- a/src/mito2/src/compaction.rs
+++ b/src/mito2/src/compaction.rs
@@ -44,7 +44,7 @@ use tokio::sync::mpsc::{self, Sender};
 
 use crate::access_layer::AccessLayerRef;
 use crate::cache::CacheManagerRef;
-use crate::compaction::compactor::{CompactionRegion, DefaultCompactor};
+use crate::compaction::compactor::{CompactionRegion, CompactionVersion, DefaultCompactor};
 use crate::compaction::picker::{new_picker, CompactionTask};
 use crate::compaction::task::CompactionTaskImpl;
 use crate::config::MitoConfig;
@@ -59,7 +59,7 @@ use crate::read::scan_region::ScanInput;
 use crate::read::seq_scan::SeqScan;
 use crate::read::BoxedBatchReader;
 use crate::region::options::MergeMode;
-use crate::region::version::{VersionControlRef, VersionRef};
+use crate::region::version::{VersionControlRef};
 use crate::region::ManifestContextRef;
 use crate::request::{OptionOutputTx, OutputTx, WorkerRequest};
 use crate::schedule::remote_job_scheduler::{
@@ -73,7 +73,7 @@ use crate::worker::WorkerListener;
 /// Region compaction request.
 pub struct CompactionRequest {
     pub(crate) engine_config: Arc<MitoConfig>,
-    pub(crate) current_version: VersionRef,
+    pub(crate) current_version: CompactionVersion,
     pub(crate) access_layer: AccessLayerRef,
     /// Sender to send notification to the region worker.
     pub(crate) request_sender: mpsc::Sender<WorkerRequest>,
@@ -519,7 +519,7 @@ impl CompactionStatus {
         listener: WorkerListener,
         schema_metadata_manager: SchemaMetadataManagerRef,
     ) -> CompactionRequest {
-        let current_version = self.version_control.current().version;
+        let current_version = CompactionVersion::from(self.version_control.current().version);
         let start_time = Instant::now();
         let mut req = CompactionRequest {
             engine_config,

--- a/src/mito2/src/compaction/window.rs
+++ b/src/mito2/src/compaction/window.rs
@@ -251,7 +251,7 @@ mod tests {
                 memtable: None,
                 merge_mode: None,
             },
-            compaction_time_window:None,
+            compaction_time_window: None,
         }
     }
 

--- a/src/mito2/src/compaction/window.rs
+++ b/src/mito2/src/compaction/window.rs
@@ -23,10 +23,9 @@ use common_time::Timestamp;
 use store_api::storage::RegionId;
 
 use crate::compaction::buckets::infer_time_bucket;
-use crate::compaction::compactor::CompactionRegion;
+use crate::compaction::compactor::{CompactionRegion, CompactionVersion};
 use crate::compaction::picker::{Picker, PickerOutput};
 use crate::compaction::{get_expired_ssts, CompactionOutput};
-use crate::region::version::VersionRef;
 use crate::sst::file::{FileHandle, FileId};
 
 /// Compaction picker that splits the time range of all involved files to windows, and merges
@@ -48,7 +47,11 @@ impl WindowedCompactionPicker {
     // use persisted window. If persist window is not present, we check the time window
     // provided while creating table. If all of those are absent, we infer the window
     // from files in level0.
-    fn calculate_time_window(&self, region_id: RegionId, current_version: &VersionRef) -> i64 {
+    fn calculate_time_window(
+        &self,
+        region_id: RegionId,
+        current_version: &CompactionVersion,
+    ) -> i64 {
         self.compaction_time_window_seconds
             .or(current_version
                 .compaction_time_window
@@ -67,7 +70,7 @@ impl WindowedCompactionPicker {
     fn pick_inner(
         &self,
         region_id: RegionId,
-        current_version: &VersionRef,
+        current_version: &CompactionVersion,
         current_time: Timestamp,
     ) -> (Vec<CompactionOutput>, Vec<FileHandle>, i64) {
         let time_window = self.calculate_time_window(region_id, current_version);
@@ -205,28 +208,19 @@ mod tests {
     use common_time::Timestamp;
     use store_api::storage::RegionId;
 
+    use crate::compaction::compactor::CompactionVersion;
     use crate::compaction::window::{file_time_bucket_span, WindowedCompactionPicker};
-    use crate::memtable::partition_tree::{PartitionTreeConfig, PartitionTreeMemtableBuilder};
-    use crate::memtable::time_partition::TimePartitions;
-    use crate::memtable::version::MemtableVersion;
     use crate::region::options::RegionOptions;
-    use crate::region::version::{Version, VersionRef};
     use crate::sst::file::{FileId, FileMeta, Level};
     use crate::sst::version::SstVersion;
     use crate::test_util::memtable_util::metadata_for_test;
     use crate::test_util::NoopFilePurger;
 
-    fn build_version(files: &[(FileId, i64, i64, Level)], ttl: Option<Duration>) -> VersionRef {
+    fn build_version(
+        files: &[(FileId, i64, i64, Level)],
+        ttl: Option<Duration>,
+    ) -> CompactionVersion {
         let metadata = metadata_for_test();
-        let memtables = Arc::new(MemtableVersion::new(Arc::new(TimePartitions::new(
-            metadata.clone(),
-            Arc::new(PartitionTreeMemtableBuilder::new(
-                PartitionTreeConfig::default(),
-                None,
-            )),
-            0,
-            None,
-        ))));
         let file_purger_ref = Arc::new(NoopFilePurger);
 
         let mut ssts = SstVersion::new();
@@ -244,14 +238,9 @@ mod tests {
             }),
         );
 
-        Arc::new(Version {
+        CompactionVersion {
             metadata,
-            memtables,
             ssts: Arc::new(ssts),
-            flushed_entry_id: 0,
-            flushed_sequence: 0,
-            truncated_entry_id: None,
-            compaction_time_window: None,
             options: RegionOptions {
                 ttl: ttl.map(|t| t.into()),
                 compaction: Default::default(),
@@ -262,7 +251,8 @@ mod tests {
                 memtable: None,
                 merge_mode: None,
             },
-        })
+            compaction_time_window:None,
+        }
     }
 
     #[test]

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -148,7 +148,7 @@ impl WriteBufferManager for WriteBufferManagerImpl {
                 mutable_memtable_memory_usage);
                 return true;
             } else {
-                debug!(
+                common_telemetry::trace!(
                     "Engine won't flush, memory_usage: {}, global_write_buffer_size: {}, \
                  mutable_usage: {}.",
                     memory_usage, self.global_write_buffer_size, mutable_memtable_memory_usage,

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -138,17 +138,22 @@ impl WriteBufferManager for WriteBufferManagerImpl {
         // If the memory exceeds the buffer size, we trigger more aggressive
         // flush. But if already more than half memory is being flushed,
         // triggering more flush may not help. We will hold it instead.
-        if memory_usage >= self.global_write_buffer_size
-            && mutable_memtable_memory_usage >= self.global_write_buffer_size / 2
-        {
-            debug!(
+        if memory_usage >= self.global_write_buffer_size {
+            if mutable_memtable_memory_usage >= self.global_write_buffer_size / 2 {
+                debug!(
                 "Engine should flush (over total limit), memory_usage: {}, global_write_buffer_size: {}, \
                  mutable_usage: {}.",
                 memory_usage,
                 self.global_write_buffer_size,
-                mutable_memtable_memory_usage,
-            );
-            return true;
+                mutable_memtable_memory_usage);
+                return true;
+            } else {
+                debug!(
+                    "Engine won't flush, memory_usage: {}, global_write_buffer_size: {}, \
+                 mutable_usage: {}.",
+                    memory_usage, self.global_write_buffer_size, mutable_memtable_memory_usage,
+                );
+            }
         }
 
         false

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use common_telemetry::{debug, error, info};
+use common_telemetry::{debug, error, info, trace};
 use smallvec::SmallVec;
 use snafu::ResultExt;
 use store_api::storage::RegionId;
@@ -148,11 +148,11 @@ impl WriteBufferManager for WriteBufferManagerImpl {
                 mutable_memtable_memory_usage);
                 return true;
             } else {
-                common_telemetry::trace!(
-                    "Engine won't flush, memory_usage: {}, global_write_buffer_size: {}, \
-                 mutable_usage: {}.",
-                    memory_usage, self.global_write_buffer_size, mutable_memtable_memory_usage,
-                );
+                trace!(
+                    "Engine won't flush, memory_usage: {}, global_write_buffer_size: {}, mutable_usage: {}.",
+                    memory_usage,
+                    self.global_write_buffer_size,
+                    mutable_memtable_memory_usage);
             }
         }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
Refactor compaction from holding whole version to holding only the necessary components including ssts, options, metadata and time window.

 • Introduced CompactionVersion struct to encapsulate region version details for compaction, removing dependency on VersionRef.
 • Updated CompactionRequest and CompactionRegion to use CompactionVersion.
 • Modified open_compaction_region to construct CompactionVersion without memtables.
 • Adjusted WindowedCompactionPicker to work with CompactionVersion.
 • Enhanced flush logic in WriteBufferManager to improve memory usage checks and logging.


This PR can smooth log ingestion and reduce write stalls and memory usage.
Before
<img width="637" alt="image" src="https://github.com/user-attachments/assets/61515448-d6f5-4429-8c2f-72046810945e" />

After
![image](https://github.com/user-attachments/assets/0f31726b-7b31-4c46-aa29-2c88c3b1fbba)


## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
