### PR TITLE
ci: use 4xlarge for nightly build

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -12,7 +12,7 @@ on:
       linux_amd64_runner:
         type: choice
         description: The runner uses to build linux-amd64 artifacts
-        default: ec2-c6i.2xlarge-amd64
+        default: ec2-c6i.4xlarge-amd64
         options:
           - ubuntu-20.04
           - ubuntu-20.04-8-cores
@@ -27,7 +27,7 @@ on:
       linux_arm64_runner:
         type: choice
         description: The runner uses to build linux-arm64 artifacts
-        default: ec2-c6g.2xlarge-arm64
+        default: ec2-c6g.4xlarge-arm64
         options:
           - ec2-c6g.xlarge-arm64 # 4C8G
           - ec2-c6g.2xlarge-arm64 # 8C16G


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/5150

## What's changed and what's your intention?
The nightly build action sometimes fails due to oom.

https://github.com/GreptimeTeam/greptimedb/actions/runs/12287191091/job/34288925005
```
   Compiling path-slash v0.2.1
   Compiling sqlness v0.6.1
   Compiling log-query v0.12.0 (/greptimedb/src/log-query)
   Compiling tests-fuzz v0.12.0 (/greptimedb/tests-fuzz)
   Compiling sqlness-runner v0.12.0 (/greptimedb/tests/runner)
make: *** [Makefile:206: run-it-in-container] Killed
```

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
