### PR TITLE
fix: loki write row len error

### DIFF
--- a/src/servers/src/http/event.rs
+++ b/src/servers/src/http/event.rs
@@ -514,8 +514,8 @@ pub async fn loki_ingest(
             let line = entry.line;
 
             // create and init row
-            let mut row = Vec::with_capacity(schemas.capacity());
-            for _ in 0..row.capacity() {
+            let mut row = Vec::with_capacity(schemas.len());
+            for _ in 0..schemas.len() {
                 row.push(GreptimeValue { value_data: None });
             }
             // insert ts and line

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -1816,11 +1816,17 @@ pub async fn test_loki_logs(store_type: StorageType) {
     // init loki request
     let req: PushRequest = PushRequest {
         streams: vec![StreamAdapter {
-            labels: "{service=\"test\",source=\"integration\"}".to_string(),
-            entries: vec![EntryAdapter {
-                timestamp: Some(Timestamp::from_str("2024-11-07T10:53:50").unwrap()),
-                line: "this is a log message".to_string(),
-            }],
+            labels: r#"{service="test",source="integration","wadaxi"="do anything"}"#.to_string(),
+            entries: vec![
+                EntryAdapter {
+                    timestamp: Some(Timestamp::from_str("2024-11-07T10:53:50").unwrap()),
+                    line: "this is a log message".to_string(),
+                },
+                EntryAdapter {
+                    timestamp: Some(Timestamp::from_str("2024-11-07T10:53:50").unwrap()),
+                    line: "this is a log message".to_string(),
+                },
+            ],
             hash: rand::random(),
         }],
     };
@@ -1848,7 +1854,7 @@ pub async fn test_loki_logs(store_type: StorageType) {
     assert_eq!(StatusCode::OK, res.status());
 
     // test schema
-    let expected = "[[\"loki_table_name\",\"CREATE TABLE IF NOT EXISTS \\\"loki_table_name\\\" (\\n  \\\"greptime_timestamp\\\" TIMESTAMP(9) NOT NULL,\\n  \\\"line\\\" STRING NULL,\\n  \\\"service\\\" STRING NULL,\\n  \\\"source\\\" STRING NULL,\\n  TIME INDEX (\\\"greptime_timestamp\\\"),\\n  PRIMARY KEY (\\\"service\\\", \\\"source\\\")\\n)\\n\\nENGINE=mito\\nWITH(\\n  append_mode = 'true'\\n)\"]]";
+    let expected = "[[\"loki_table_name\",\"CREATE TABLE IF NOT EXISTS \\\"loki_table_name\\\" (\\n  \\\"greptime_timestamp\\\" TIMESTAMP(9) NOT NULL,\\n  \\\"line\\\" STRING NULL,\\n  \\\"service\\\" STRING NULL,\\n  \\\"source\\\" STRING NULL,\\n  \\\"wadaxi\\\" STRING NULL,\\n  TIME INDEX (\\\"greptime_timestamp\\\"),\\n  PRIMARY KEY (\\\"service\\\", \\\"source\\\", \\\"wadaxi\\\")\\n)\\n\\nENGINE=mito\\nWITH(\\n  append_mode = 'true'\\n)\"]]";
     validate_data(
         "loki_schema",
         &client,
@@ -1858,7 +1864,7 @@ pub async fn test_loki_logs(store_type: StorageType) {
     .await;
 
     // test content
-    let expected = r#"[[1730976830000000000,"this is a log message","test","integration"]]"#;
+    let expected = r#"[[1730976830000000000,"this is a log message","test","integration","do anything"],[1730976830000000000,"this is a log message","test","integration","do anything"]]"#;
     validate_data(
         "loki_content",
         &client,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

* fix loki write row len error
* The previous test passed as is because there was only one record in a request. Either the schema doesn't trigger recapacity, or it doesn't reuse the schema.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
