### PR TITLE
chore: remove unused dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,26 +223,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "approx_eq"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3f9eb837c6a783fbf002e3e5cc7925a3aa6893d6d42f9169517528983777590"
-
-[[package]]
-name = "aquamarine"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1da02abba9f9063d786eab1509833ebb2fac0f966862ca59439c76b9c566760"
-dependencies = [
- "include_dir",
- "itertools 0.10.5",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4068,15 +4048,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "format_num"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14ac05eb8d2eb4ed1eeff847911deae077b0b53332465de9d6a26b0ea9961bc8"
-dependencies = [
- "regex",
-]
-
-[[package]]
 name = "fragile"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5194,25 +5165,6 @@ name = "if_chain"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
-
-[[package]]
-name = "include_dir"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
-dependencies = [
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
-dependencies = [
- "proc-macro2",
- "quote",
-]
 
 [[package]]
 name = "index"
@@ -6486,7 +6438,6 @@ name = "metric-engine"
 version = "0.12.0"
 dependencies = [
  "api",
- "aquamarine",
  "async-trait",
  "base64 0.21.7",
  "common-base",
@@ -6580,7 +6531,6 @@ name = "mito2"
 version = "0.12.0"
 dependencies = [
  "api",
- "aquamarine",
  "async-channel 1.9.0",
  "async-stream",
  "async-trait",
@@ -6594,7 +6544,6 @@ dependencies = [
  "common-function",
  "common-macro",
  "common-meta",
- "common-procedure-test",
  "common-query",
  "common-recordbatch",
  "common-runtime",
@@ -8171,7 +8120,6 @@ dependencies = [
  "query",
  "rayon",
  "regex",
- "ron",
  "serde",
  "serde_json",
  "session",
@@ -8583,10 +8531,7 @@ dependencies = [
  "greptime-proto",
  "lazy_static",
  "prometheus",
- "promql-parser",
  "prost 0.12.6",
- "query",
- "session",
  "snafu 0.8.5",
  "tokio",
 ]
@@ -8934,7 +8879,6 @@ version = "0.12.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
- "approx_eq",
  "arc-swap",
  "arrow",
  "arrow-schema",
@@ -8966,7 +8910,6 @@ dependencies = [
  "datafusion-sql",
  "datatypes",
  "fastrand",
- "format_num",
  "futures",
  "futures-util",
  "greptime-proto",
@@ -8994,9 +8937,7 @@ dependencies = [
  "sql",
  "sqlparser 0.45.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=54a267ac89c09b11c0c88934690530807185d3e7)",
  "statrs",
- "stats-cli",
  "store-api",
- "streaming-stats",
  "substrait 0.12.0",
  "table",
  "tokio",
@@ -10487,7 +10428,6 @@ dependencies = [
  "datatypes",
  "futures",
  "lazy_static",
- "log-store",
  "once_cell",
  "operator",
  "paste",
@@ -10510,7 +10450,6 @@ dependencies = [
  "sql",
  "table",
  "tokio",
- "tokio-test",
 ]
 
 [[package]]
@@ -10852,7 +10791,6 @@ dependencies = [
  "tokio-postgres-rustls",
  "tokio-rustls 0.26.0",
  "tokio-stream",
- "tokio-test",
  "tokio-util",
  "tonic 0.11.0",
  "tonic-reflection",
@@ -11487,21 +11425,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "stats-cli"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8786c4fc8a91bc4fcd90aed33413f79e4dc9811f24ba14d1d59adf57cf1c871"
-dependencies = [
- "clap 2.34.0",
- "num-traits",
-]
-
-[[package]]
 name = "store-api"
 version = "0.12.0"
 dependencies = [
  "api",
- "aquamarine",
  "async-stream",
  "async-trait",
  "common-base",
@@ -11536,15 +11463,6 @@ name = "str_stack"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
-
-[[package]]
-name = "streaming-stats"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d670ce4e348a2081843569e0f79b21c99c91bb9028b3b3ecb0f050306de547"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "strfmt"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1310,7 +1310,6 @@ dependencies = [
  "common-meta",
  "moka",
  "snafu 0.8.5",
- "substrait 0.12.0",
 ]
 
 [[package]]
@@ -1349,7 +1348,6 @@ dependencies = [
  "catalog",
  "chrono",
  "common-catalog",
- "common-config",
  "common-error",
  "common-macro",
  "common-meta",
@@ -1358,7 +1356,6 @@ dependencies = [
  "common-recordbatch",
  "common-runtime",
  "common-telemetry",
- "common-test-util",
  "common-time",
  "common-version",
  "dashmap",
@@ -1369,7 +1366,6 @@ dependencies = [
  "humantime",
  "itertools 0.10.5",
  "lazy_static",
- "log-store",
  "meta-client",
  "moka",
  "object-store",
@@ -1693,7 +1689,6 @@ dependencies = [
  "common-grpc",
  "common-macro",
  "common-meta",
- "common-options",
  "common-procedure",
  "common-query",
  "common-recordbatch",
@@ -1722,7 +1717,6 @@ dependencies = [
  "store-api",
  "substrait 0.12.0",
  "table",
- "temp-env",
  "tempfile",
  "tokio",
  "tracing-appender",
@@ -1746,8 +1740,6 @@ dependencies = [
  "common-query",
  "common-recordbatch",
  "common-telemetry",
- "datanode",
- "derive-new 0.5.9",
  "enum_dispatch",
  "futures-util",
  "lazy_static",
@@ -1928,13 +1920,6 @@ dependencies = [
 [[package]]
 name = "common-catalog"
 version = "0.12.0"
-dependencies = [
- "chrono",
- "common-error",
- "common-macro",
- "snafu 0.8.5",
- "tokio",
-]
 
 [[package]]
 name = "common-config"
@@ -1978,7 +1963,6 @@ dependencies = [
  "datafusion",
  "datatypes",
  "derive_builder 0.12.0",
- "dotenv",
  "futures",
  "lazy_static",
  "object-store",
@@ -2022,15 +2006,10 @@ dependencies = [
 name = "common-frontend"
 version = "0.12.0"
 dependencies = [
- "api",
  "async-trait",
- "common-base",
  "common-error",
  "common-macro",
- "common-query",
- "session",
  "snafu 0.8.5",
- "sql",
 ]
 
 [[package]]
@@ -2064,7 +2043,6 @@ dependencies = [
  "num-traits",
  "once_cell",
  "paste",
- "ron",
  "s2",
  "serde",
  "serde_json",
@@ -2353,8 +2331,6 @@ dependencies = [
  "snafu 0.8.5",
  "tempfile",
  "tokio",
- "tokio-metrics",
- "tokio-metrics-collector",
  "tokio-test",
  "tokio-util",
 ]
@@ -2832,16 +2808,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "ctor"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
-dependencies = [
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -3388,17 +3354,6 @@ dependencies = [
 
 [[package]]
 name = "derive-new"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive-new"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
@@ -3919,7 +3874,6 @@ dependencies = [
  "common-error",
  "common-macro",
  "common-procedure",
- "common-procedure-test",
  "common-query",
  "common-recordbatch",
  "common-telemetry",
@@ -4067,7 +4021,6 @@ dependencies = [
  "itertools 0.10.5",
  "lazy_static",
  "meta-client",
- "minstant",
  "nom",
  "num-traits",
  "operator",
@@ -4145,7 +4098,6 @@ dependencies = [
  "common-config",
  "common-datasource",
  "common-error",
- "common-frontend",
  "common-function",
  "common-grpc",
  "common-macro",
@@ -4167,7 +4119,6 @@ dependencies = [
  "lazy_static",
  "log-store",
  "meta-client",
- "meta-srv",
  "opentelemetry-proto 0.5.0",
  "operator",
  "partition",
@@ -6601,16 +6552,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minstant"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb9b5c752f145ac5046bccc3c4f62892e3c950c1d1eab80c5949cd68a2078db"
-dependencies = [
- "ctor",
- "web-time 1.1.0",
-]
-
-[[package]]
 name = "mio"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8090,7 +8031,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
- "derive-new 0.7.0",
+ "derive-new",
  "futures",
  "hex",
  "lazy-regex",
@@ -12563,30 +12504,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-metrics"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eace09241d62c98b7eeb1107d4c5c64ca3bd7da92e8c218c153ab3a78f9be112"
-dependencies = [
- "futures-util",
- "pin-project-lite",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
-name = "tokio-metrics-collector"
-version = "0.2.1"
-source = "git+https://github.com/MichaelScofield/tokio-metrics-collector.git?rev=89d692d5753d28564a7aac73c6ac5aba22243ba0#89d692d5753d28564a7aac73c6ac5aba22243ba0"
-dependencies = [
- "lazy_static",
- "parking_lot 0.12.3",
- "prometheus",
- "tokio",
- "tokio-metrics",
-]
-
-[[package]]
 name = "tokio-postgres"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13012,7 +12929,7 @@ dependencies = [
  "tracing-core",
  "tracing-log 0.2.0",
  "tracing-subscriber",
- "web-time 0.2.4",
+ "web-time",
 ]
 
 [[package]]
@@ -13778,16 +13695,6 @@ name = "web-time"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/src/cache/Cargo.toml
+++ b/src/cache/Cargo.toml
@@ -11,4 +11,3 @@ common-macro.workspace = true
 common-meta.workspace = true
 moka.workspace = true
 snafu.workspace = true
-substrait.workspace = true

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -18,7 +18,6 @@ async-stream.workspace = true
 async-trait = "0.1"
 bytes.workspace = true
 common-catalog.workspace = true
-common-config.workspace = true
 common-error.workspace = true
 common-macro.workspace = true
 common-meta.workspace = true
@@ -58,7 +57,5 @@ catalog = { workspace = true, features = ["testing"] }
 chrono.workspace = true
 common-meta = { workspace = true, features = ["testing"] }
 common-query = { workspace = true, features = ["testing"] }
-common-test-util.workspace = true
-log-store.workspace = true
 object-store.workspace = true
 tokio.workspace = true

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -23,7 +23,6 @@ common-error.workspace = true
 common-grpc.workspace = true
 common-macro.workspace = true
 common-meta.workspace = true
-common-options.workspace = true
 common-procedure.workspace = true
 common-query.workspace = true
 common-recordbatch.workspace = true
@@ -61,5 +60,4 @@ client = { workspace = true, features = ["testing"] }
 common-test-util.workspace = true
 common-version.workspace = true
 serde.workspace = true
-temp-env = "0.3"
 tempfile.workspace = true

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -42,8 +42,6 @@ tonic.workspace = true
 
 [dev-dependencies]
 common-grpc-expr.workspace = true
-datanode.workspace = true
-derive-new = "0.5"
 tracing = "0.1"
 
 [dev-dependencies.substrait_proto]

--- a/src/common/catalog/Cargo.toml
+++ b/src/common/catalog/Cargo.toml
@@ -8,10 +8,5 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-common-error.workspace = true
-common-macro.workspace = true
-snafu.workspace = true
 
 [dev-dependencies]
-chrono.workspace = true
-tokio.workspace = true

--- a/src/common/datasource/Cargo.toml
+++ b/src/common/datasource/Cargo.toml
@@ -48,5 +48,4 @@ url = "2.3"
 [dev-dependencies]
 common-telemetry.workspace = true
 common-test-util.workspace = true
-dotenv.workspace = true
 uuid.workspace = true

--- a/src/common/frontend/Cargo.toml
+++ b/src/common/frontend/Cargo.toml
@@ -5,12 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-api.workspace = true
 async-trait.workspace = true
-common-base.workspace = true
 common-error.workspace = true
 common-macro.workspace = true
-common-query.workspace = true
-session.workspace = true
 snafu.workspace = true
-sql.workspace = true

--- a/src/common/function/Cargo.toml
+++ b/src/common/function/Cargo.toml
@@ -51,6 +51,5 @@ wkt = { version = "0.11", optional = true }
 
 [dev-dependencies]
 approx = "0.5"
-ron = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 tokio.workspace = true

--- a/src/common/runtime/Cargo.toml
+++ b/src/common/runtime/Cargo.toml
@@ -35,8 +35,6 @@ serde_json.workspace = true
 snafu.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
-tokio-metrics = "0.3"
-tokio-metrics-collector = { git = "https://github.com/MichaelScofield/tokio-metrics-collector.git", rev = "89d692d5753d28564a7aac73c6ac5aba22243ba0" }
 tokio-util.workspace = true
 
 [dev-dependencies]

--- a/src/file-engine/Cargo.toml
+++ b/src/file-engine/Cargo.toml
@@ -38,5 +38,4 @@ tokio.workspace = true
 
 [dev-dependencies]
 api.workspace = true
-common-procedure-test.workspace = true
 common-test-util.workspace = true

--- a/src/flow/Cargo.toml
+++ b/src/flow/Cargo.toml
@@ -47,7 +47,6 @@ hydroflow = { git = "https://github.com/GreptimeTeam/hydroflow.git", branch = "m
 itertools.workspace = true
 lazy_static.workspace = true
 meta-client.workspace = true
-minstant = "0.1.7"
 nom = "7.1.3"
 num-traits = "0.2"
 operator.workspace = true

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -25,7 +25,6 @@ common-catalog.workspace = true
 common-config.workspace = true
 common-datasource.workspace = true
 common-error.workspace = true
-common-frontend.workspace = true
 common-function.workspace = true
 common-grpc.workspace = true
 common-macro.workspace = true
@@ -71,7 +70,6 @@ common-test-util.workspace = true
 datanode.workspace = true
 datatypes.workspace = true
 futures = "0.3"
-meta-srv = { workspace = true, features = ["mock"] }
 serde_json.workspace = true
 strfmt = "0.2"
 tower.workspace = true

--- a/src/metric-engine/Cargo.toml
+++ b/src/metric-engine/Cargo.toml
@@ -9,7 +9,6 @@ workspace = true
 
 [dependencies]
 api.workspace = true
-aquamarine.workspace = true
 async-trait.workspace = true
 base64.workspace = true
 common-base.workspace = true

--- a/src/mito2/Cargo.toml
+++ b/src/mito2/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 
 [dependencies]
 api.workspace = true
-aquamarine.workspace = true
 async-channel = "1.9"
 async-stream.workspace = true
 async-trait = "0.1"
@@ -77,7 +76,6 @@ uuid.workspace = true
 [dev-dependencies]
 common-function.workspace = true
 common-meta = { workspace = true, features = ["testing"] }
-common-procedure-test.workspace = true
 common-test-util.workspace = true
 criterion = "0.4"
 dotenv.workspace = true

--- a/src/pipeline/Cargo.toml
+++ b/src/pipeline/Cargo.toml
@@ -63,7 +63,6 @@ yaml-rust = "0.4"
 catalog = { workspace = true, features = ["testing"] }
 criterion = { version = "0.4", features = ["html_reports"] }
 rayon = "1.0"
-ron = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 session = { workspace = true, features = ["testing"] }
 

--- a/src/promql/Cargo.toml
+++ b/src/promql/Cargo.toml
@@ -22,11 +22,8 @@ futures = "0.3"
 greptime-proto.workspace = true
 lazy_static.workspace = true
 prometheus.workspace = true
-promql-parser.workspace = true
 prost.workspace = true
 snafu.workspace = true
 
 [dev-dependencies]
-query.workspace = true
-session = { workspace = true, features = ["testing"] }
 tokio.workspace = true

--- a/src/query/Cargo.toml
+++ b/src/query/Cargo.toml
@@ -67,13 +67,11 @@ tokio.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
-approx_eq = "0.1"
 arrow.workspace = true
 catalog = { workspace = true, features = ["testing"] }
 common-macro.workspace = true
 common-query = { workspace = true, features = ["testing"] }
 fastrand = "2.0"
-format_num = "0.1"
 num = "0.4"
 num-traits = "0.2"
 paste = "1.0"
@@ -83,8 +81,6 @@ serde.workspace = true
 serde_json.workspace = true
 session = { workspace = true, features = ["testing"] }
 statrs = "0.16"
-stats-cli = "3.0"
 store-api.workspace = true
-streaming-stats = "0.2"
 table = { workspace = true, features = ["testing"] }
 tokio-stream.workspace = true

--- a/src/script/Cargo.toml
+++ b/src/script/Cargo.toml
@@ -80,13 +80,11 @@ tokio.workspace = true
 catalog = { workspace = true, features = ["testing"] }
 common-test-util.workspace = true
 criterion = { version = "0.4", features = ["html_reports", "async_tokio"] }
-log-store.workspace = true
 operator.workspace = true
 rayon = "1.0"
 ron = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 session = { workspace = true, features = ["testing"] }
-tokio-test = "0.4"
 
 [[bench]]
 name = "py_benchmark"

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -134,7 +134,6 @@ table.workspace = true
 tempfile = "3.0.0"
 tokio-postgres = "0.7"
 tokio-postgres-rustls = "0.12"
-tokio-test = "0.4"
 
 [target.'cfg(unix)'.dev-dependencies]
 pprof = { version = "0.13", features = ["criterion", "flamegraph"] }

--- a/src/store-api/Cargo.toml
+++ b/src/store-api/Cargo.toml
@@ -9,7 +9,6 @@ workspace = true
 
 [dependencies]
 api.workspace = true
-aquamarine.workspace = true
 async-trait.workspace = true
 common-base.workspace = true
 common-error.workspace = true


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Remove unused dependencies using `cargo udeps --workspace --all-targets --all-features`.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
