### PR TITLE
fix: correct `set_region_role_state_gracefully` behaviors

### DIFF
--- a/.github/actions/setup-greptimedb-cluster/action.yml
+++ b/.github/actions/setup-greptimedb-cluster/action.yml
@@ -58,8 +58,8 @@ runs:
         --set image.tag=${{ inputs.image-tag }} \
         --set base.podTemplate.main.resources.requests.cpu=50m \
         --set base.podTemplate.main.resources.requests.memory=256Mi \
-        --set base.podTemplate.main.resources.limits.cpu=4000m \
-        --set base.podTemplate.main.resources.limits.memory=4Gi \
+        --set base.podTemplate.main.resources.limits.cpu=2000m \
+        --set base.podTemplate.main.resources.limits.memory=2Gi \
         --set frontend.replicas=${{ inputs.frontend-replicas }} \
         --set datanode.replicas=${{ inputs.datanode-replicas }} \
         --set meta.replicas=${{ inputs.meta-replicas }} \

--- a/.github/actions/setup-greptimedb-cluster/action.yml
+++ b/.github/actions/setup-greptimedb-cluster/action.yml
@@ -58,8 +58,8 @@ runs:
         --set image.tag=${{ inputs.image-tag }} \
         --set base.podTemplate.main.resources.requests.cpu=50m \
         --set base.podTemplate.main.resources.requests.memory=256Mi \
-        --set base.podTemplate.main.resources.limits.cpu=2000m \
-        --set base.podTemplate.main.resources.limits.memory=2Gi \
+        --set base.podTemplate.main.resources.limits.cpu=4000m \
+        --set base.podTemplate.main.resources.limits.memory=4Gi \
         --set frontend.replicas=${{ inputs.frontend-replicas }} \
         --set datanode.replicas=${{ inputs.datanode-replicas }} \
         --set meta.replicas=${{ inputs.meta-replicas }} \

--- a/.github/actions/setup-kafka-cluster/action.yml
+++ b/.github/actions/setup-kafka-cluster/action.yml
@@ -18,8 +18,8 @@ runs:
         --set controller.replicaCount=${{ inputs.controller-replicas }} \
         --set controller.resources.requests.cpu=50m \
         --set controller.resources.requests.memory=128Mi \
-        --set controller.resources.limits.cpu=4000m \
-        --set controller.resources.limits.memory=4Gi \
+        --set controller.resources.limits.cpu=2000m \
+        --set controller.resources.limits.memory=2Gi \
         --set listeners.controller.protocol=PLAINTEXT \
         --set listeners.client.protocol=PLAINTEXT \
         --create-namespace \

--- a/.github/actions/setup-kafka-cluster/action.yml
+++ b/.github/actions/setup-kafka-cluster/action.yml
@@ -18,6 +18,8 @@ runs:
         --set controller.replicaCount=${{ inputs.controller-replicas }} \
         --set controller.resources.requests.cpu=50m \
         --set controller.resources.requests.memory=128Mi \
+        --set controller.resources.limits.cpu=4000m \
+        --set controller.resources.limits.memory=4Gi \
         --set listeners.controller.protocol=PLAINTEXT \
         --set listeners.client.protocol=PLAINTEXT \
         --create-namespace \

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -323,8 +323,6 @@ jobs:
         uses: ./.github/actions/setup-kafka-cluster
       - name: Setup Etcd cluser
         uses: ./.github/actions/setup-etcd-cluster
-      - name: Setup Postgres cluser
-        uses: ./.github/actions/setup-postgres-cluster
       # Prepares for fuzz tests
       - uses: arduino/setup-protoc@v3
         with:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -472,8 +472,6 @@ jobs:
         uses: ./.github/actions/setup-kafka-cluster
       - name: Setup Etcd cluser
         uses: ./.github/actions/setup-etcd-cluster
-      - name: Setup Postgres cluser
-        uses: ./.github/actions/setup-postgres-cluster
       # Prepares for fuzz tests
       - uses: arduino/setup-protoc@v3
         with:

--- a/src/metric-engine/src/engine.rs
+++ b/src/metric-engine/src/engine.rs
@@ -210,7 +210,6 @@ impl RegionEngine for MetricEngine {
         for x in [
             utils::to_metadata_region_id(region_id),
             utils::to_data_region_id(region_id),
-            region_id,
         ] {
             if let Err(e) = self.inner.mito.set_region_role(x, role)
                 && e.status_code() != StatusCode::RegionNotFound
@@ -226,6 +225,13 @@ impl RegionEngine for MetricEngine {
         region_id: RegionId,
         region_role_state: SettableRegionRoleState,
     ) -> std::result::Result<SetRegionRoleStateResponse, BoxedError> {
+        self.inner
+            .mito
+            .set_region_role_state_gracefully(
+                utils::to_metadata_region_id(region_id),
+                region_role_state,
+            )
+            .await?;
         self.inner
             .mito
             .set_region_role_state_gracefully(region_id, region_role_state)

--- a/src/metric-engine/src/engine/catchup.rs
+++ b/src/metric-engine/src/engine/catchup.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use common_telemetry::debug;
 use snafu::ResultExt;
 use store_api::region_engine::RegionEngine;
 use store_api::region_request::{AffectedRows, RegionCatchupRequest, RegionRequest};
@@ -35,6 +36,7 @@ impl MetricEngineInner {
         }
         let metadata_region_id = utils::to_metadata_region_id(region_id);
         // TODO(weny): improve the catchup, we can read the wal entries only once.
+        debug!("Catchup metadata region {metadata_region_id}");
         self.mito
             .handle_request(
                 metadata_region_id,
@@ -48,6 +50,7 @@ impl MetricEngineInner {
             .context(MitoCatchupOperationSnafu)?;
 
         let data_region_id = utils::to_data_region_id(region_id);
+        debug!("Catchup data region {data_region_id}");
         self.mito
             .handle_request(
                 data_region_id,

--- a/src/mito2/src/worker/handle_catchup.rs
+++ b/src/mito2/src/worker/handle_catchup.rs
@@ -16,8 +16,8 @@
 
 use std::sync::Arc;
 
-use common_telemetry::info;
 use common_telemetry::tracing::warn;
+use common_telemetry::{debug, info};
 use snafu::ensure;
 use store_api::logstore::LogStore;
 use store_api::region_engine::RegionRole;
@@ -40,6 +40,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         };
 
         if region.is_writable() {
+            debug!("Region {region_id} is writable, skip catchup");
             return Ok(0);
         }
         // Note: Currently, We protect the split brain by ensuring the mutable table is empty.

--- a/tests-fuzz/src/utils.rs
+++ b/tests-fuzz/src/utils.rs
@@ -142,7 +142,7 @@ macro_rules! make_get_from_env_helper {
 
 make_get_from_env_helper!(GT_FUZZ_INPUT_MAX_ALTER_ACTIONS, 256);
 make_get_from_env_helper!(GT_FUZZ_INPUT_MAX_INSERT_ACTIONS, 8);
-make_get_from_env_helper!(GT_FUZZ_INPUT_MAX_ROWS, 2048);
+make_get_from_env_helper!(GT_FUZZ_INPUT_MAX_ROWS, 512);
 make_get_from_env_helper!(GT_FUZZ_INPUT_MAX_TABLES, 64);
 make_get_from_env_helper!(GT_FUZZ_INPUT_MAX_COLUMNS, 32);
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


This PR fixes the behavior of `set_region_role_state_gracefully`, ensuring it correctly sets the region role state for the metadata region. Additionally, it updates the testing setup and adjusts resource limits.


## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
