### PR TITLE
feat: do not remove time filters in ScanRegion

### DIFF
--- a/scripts/check-snafu.py
+++ b/scripts/check-snafu.py
@@ -58,8 +58,10 @@ def main():
         if not check_snafu_in_files(branch_name, other_rust_files)
     ]
 
-    for name in unused_snafu:
-        print(name)
+    if unused_snafu:
+        print("Unused error variants:")
+        for name in unused_snafu:
+            print(name)
 
     if unused_snafu:
         raise SystemExit(1)

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -756,13 +756,6 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Failed to build time range filters for value: {:?}", timestamp))]
-    BuildTimeRangeFilter {
-        timestamp: Timestamp,
-        #[snafu(implicit)]
-        location: Location,
-    },
-
     #[snafu(display("Failed to open region"))]
     OpenRegion {
         #[snafu(implicit)]
@@ -1023,7 +1016,6 @@ impl ErrorExt for Error {
             ChecksumMismatch { .. } => StatusCode::Unexpected,
             RegionStopped { .. } => StatusCode::RegionNotReady,
             TimeRangePredicateOverflow { .. } => StatusCode::InvalidArguments,
-            BuildTimeRangeFilter { .. } => StatusCode::Unexpected,
             UnsupportedOperation { .. } => StatusCode::Unsupported,
             RemoteCompaction { .. } => StatusCode::Unexpected,
 

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -346,8 +346,8 @@ impl ScanRegion {
         Ok(input)
     }
 
-    /// Build time range predicate from filters, also remove time filters from request.
-    fn build_time_range_predicate(&mut self) -> TimestampRange {
+    /// Build time range predicate from filters.
+    fn build_time_range_predicate(&self) -> TimestampRange {
         let time_index = self.version.metadata.time_index_column();
         let unit = time_index
             .column_schema
@@ -355,11 +355,7 @@ impl ScanRegion {
             .as_timestamp()
             .expect("Time index must have timestamp-compatible type")
             .unit();
-        build_time_range_predicate(
-            &time_index.column_schema.name,
-            unit,
-            &mut self.request.filters,
-        )
+        build_time_range_predicate(&time_index.column_schema.name, unit, &self.request.filters)
     }
 
     /// Remove field filters if the merge mode is [MergeMode::LastNonNull].

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -681,7 +681,6 @@ impl ScanInput {
             .access_layer
             .read_sst(file.clone())
             .predicate(self.predicate.clone())
-            .time_range(self.time_range)
             .projection(Some(self.mapper.column_ids().to_vec()))
             .cache(self.cache_manager.clone())
             .inverted_index_applier(self.inverted_index_applier.clone())

--- a/src/query/src/tests/time_range_filter_test.rs
+++ b/src/query/src/tests/time_range_filter_test.rs
@@ -115,9 +115,9 @@ struct TimeRangeTester {
 impl TimeRangeTester {
     async fn check(&self, sql: &str, expect: TimestampRange) {
         let _ = exec_selection(self.engine.clone(), sql).await;
-        let mut filters = self.take_filters();
+        let filters = self.take_filters();
 
-        let range = build_time_range_predicate("ts", TimeUnit::Millisecond, &mut filters);
+        let range = build_time_range_predicate("ts", TimeUnit::Millisecond, &filters);
         assert_eq!(expect, range);
     }
 

--- a/src/table/src/predicate.rs
+++ b/src/table/src/predicate.rs
@@ -135,21 +135,17 @@ impl Predicate {
 // since it requires query engine to convert sql to filters.
 /// `build_time_range_predicate` extracts time range from logical exprs to facilitate fast
 /// time range pruning.
-pub fn build_time_range_predicate<'a>(
-    ts_col_name: &'a str,
+pub fn build_time_range_predicate(
+    ts_col_name: &str,
     ts_col_unit: TimeUnit,
-    filters: &'a mut Vec<Expr>,
+    filters: &[Expr],
 ) -> TimestampRange {
     let mut res = TimestampRange::min_to_max();
-    let mut filters_remain = vec![];
-    for expr in std::mem::take(filters) {
-        if let Some(range) = extract_time_range_from_expr(ts_col_name, ts_col_unit, &expr) {
+    for expr in filters {
+        if let Some(range) = extract_time_range_from_expr(ts_col_name, ts_col_unit, expr) {
             res = res.and(&range);
-        } else {
-            filters_remain.push(expr);
         }
     }
-    *filters = filters_remain;
     res
 }
 
@@ -392,7 +388,7 @@ mod tests {
     fn check_build_predicate(expr: Expr, expect: TimestampRange) {
         assert_eq!(
             expect,
-            build_time_range_predicate("ts", TimeUnit::Millisecond, &mut vec![expr])
+            build_time_range_predicate("ts", TimeUnit::Millisecond, &[expr])
         );
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Don't remove time filters when building time ranges in `ScanRegion`. Then the parquet reader can use the time filters to prune row groups. This PR also removes the time range from the parquet reader.

Now the scanner only uses the time range to find files to scan.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
