### PR TITLE
chore: make nix compilation environment config more robust

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -729,6 +729,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04-8-cores
     timeout-minutes: 60
+    needs: [coverage, fmt, clippy, check]
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v27

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -725,6 +725,17 @@ jobs:
           fail_ci_if_error: false
           verbose: true
 
+  cleanbuild:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-20.04-8-cores
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - run: nix-shell --pure --run "cargo build"
+
   # compat:
   #   name: Compatibility Test
   #   needs: build

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -725,18 +725,6 @@ jobs:
           fail_ci_if_error: false
           verbose: true
 
-  cleanbuild:
-    if: github.event.pull_request.draft == false
-    runs-on: ubuntu-20.04-8-cores
-    timeout-minutes: 60
-    needs: [coverage, fmt, clippy, check]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v27
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - run: nix-shell --pure --run "cargo build"
-
   # compat:
   #   name: Compatibility Test
   #   needs: build

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -114,6 +114,17 @@ jobs:
           GT_S3_REGION: ${{ vars.AWS_CI_TEST_BUCKET_REGION }}
           UNITTEST_LOG_DIR: "__unittest_logs"
 
+  cleanbuild-linux-nix:
+    runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 60
+    needs: [coverage, fmt, clippy, check]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - run: nix-shell --pure --run "cargo build"
+
   check-status:
     name: Check status
     needs: [sqlness-test, sqlness-windows, test-on-windows]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "nightly-2024-10-19"
+components = ["rust-analyzer"]

--- a/shell.nix
+++ b/shell.nix
@@ -6,6 +6,7 @@ in
 
 pkgs.mkShell rec {
   nativeBuildInputs = with pkgs; [
+    pkg-config
     git
     clang
     gcc

--- a/shell.nix
+++ b/shell.nix
@@ -4,19 +4,23 @@ let
   pkgs = import nixpkgs { config = {}; overlays = []; };
 in
 
-pkgs.mkShellNoCC {
-  packages = with pkgs; [
+pkgs.mkShell rec {
+  nativeBuildInputs = with pkgs; [
     git
     clang
     gcc
-    mold
-    libgit2
     protobuf
+    mold
     (fenix.fromToolchainFile {
       dir = ./.;
     })
-    fenix.rust-analyzer
     cargo-nextest
+    taplo
   ];
 
+  buildInputs = with pkgs; [
+    libgit2
+  ];
+
+  LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath buildInputs;
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

- ensure libgit2 used from nix environment
- use pkg-config to prevent missing library libssl
- use rust-analyzer from current nightly

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
