### PR TITLE
refactor: produce BatchBuilder from a Batch to modify it again

### DIFF
--- a/src/mito2/src/read.rs
+++ b/src/mito2/src/read.rs
@@ -861,6 +861,18 @@ impl BatchBuilder {
     }
 }
 
+impl From<Batch> for BatchBuilder {
+    fn from(batch: Batch) -> Self {
+        Self {
+            primary_key: batch.primary_key,
+            timestamps: Some(batch.timestamps),
+            sequences: Some(batch.sequences),
+            op_types: Some(batch.op_types),
+            fields: batch.fields,
+        }
+    }
+}
+
 /// Async [Batch] reader and iterator wrapper.
 ///
 /// This is the data source for SST writers or internal readers.

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -24,7 +24,7 @@ use crate::sst::index::IndexOutput;
 use crate::sst::DEFAULT_WRITE_BUFFER_SIZE;
 
 pub(crate) mod file_range;
-pub(crate) mod format;
+pub mod format;
 pub(crate) mod helper;
 pub(crate) mod metadata;
 mod page_reader;


### PR DESCRIPTION
chore: pub some mods

I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

For outside projects to reuse greptimedb codes:

1. make Batch modifiable by converting it back to its BatchBuilder
2. pub ReadFormat to convert arrow RecordBatch to mito2 Batch

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
