### PR TITLE
fix(sqlness): enforce order in union tests

### DIFF
--- a/tests/cases/standalone/common/subquery/table.result
+++ b/tests/cases/standalone/common/subquery/table.result
@@ -63,7 +63,7 @@ Affected Rows: 0
 
 -- subquery union, from:
 -- https://github.com/duckdb/duckdb/blob/9196dd9b0a163e6c8aada26218803d04be30c562/test/sql/subquery/table/test_subquery_union.test
-SELECT * FROM (SELECT 42) UNION ALL SELECT * FROM (SELECT 43);
+SELECT * FROM (SELECT 42) UNION ALL SELECT * FROM (SELECT 43) ORDER BY 1;
 
 +-----------+
 | Int64(42) |

--- a/tests/cases/standalone/common/subquery/table.sql
+++ b/tests/cases/standalone/common/subquery/table.sql
@@ -24,7 +24,7 @@ DROP TABLE test;
 
 -- subquery union, from:
 -- https://github.com/duckdb/duckdb/blob/9196dd9b0a163e6c8aada26218803d04be30c562/test/sql/subquery/table/test_subquery_union.test
-SELECT * FROM (SELECT 42) UNION ALL SELECT * FROM (SELECT 43);
+SELECT * FROM (SELECT 42) UNION ALL SELECT * FROM (SELECT 43) ORDER BY 1;
 
 -- table subquery, from:
 -- https://github.com/duckdb/duckdb/blob/8704c7d0807d6ce1e2ebcdf6398e1b6cc050e507/test/sql/subquery/table/test_table_subquery.test


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The order of UNION statements is not guaranteed.

```sql
mysql> SELECT * FROM (SELECT 42) UNION ALL SELECT * FROM (SELECT 43);
+-----------+
| Int64(42) |
+-----------+
|        42 |
|        43 |
+-----------+
2 rows in set (0.00 sec)

mysql> SELECT * FROM (SELECT 42) UNION ALL SELECT * FROM (SELECT 43);
+-----------+
| Int64(42) |
+-----------+
|        43 |
|        42 |
+-----------+
2 rows in set (0.00 sec)

```

Updated the SQL and result files for subquery union tests to include an ORDER BY clause, ensuring consistent result ordering. This change aligns with the test case from the DuckDB repository.


## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
