### PR TITLE
fix: validate matcher op for __name__ in promql

### DIFF
--- a/src/query/src/promql/planner.rs
+++ b/src/query/src/promql/planner.rs
@@ -689,6 +689,13 @@ impl PromPlanner {
             let mut matches = label_matchers.find_matchers(METRIC_NAME);
             ensure!(!matches.is_empty(), NoMetricMatcherSnafu);
             ensure!(matches.len() == 1, MultipleMetricMatchersSnafu);
+            ensure!(
+                matches[0].op == MatchOp::Equal,
+                UnsupportedMatcherOpSnafu {
+                    matcher_op: matches[0].op.to_string(),
+                    matcher: METRIC_NAME
+                }
+            );
             metric_name = matches.pop().map(|m| m.value);
         }
 

--- a/tests/cases/standalone/common/tql/basic.result
+++ b/tests/cases/standalone/common/tql/basic.result
@@ -66,6 +66,10 @@ TQL EVAL (0, 10, '5s') {__name__!="test"};
 
 Error: 2000(InvalidSyntax), vector selector must contain at least one non-empty matcher
 
+TQL EVAL (0, 10, '5s') {__name__=~"test"};
+
+Error: 1004(InvalidArguments), Matcher operator =~ is not supported for __name__
+
 -- the point at 1ms will be shadowed by the point at 2ms
 TQL EVAL (0, 10, '5s') test{k="a"};
 

--- a/tests/cases/standalone/common/tql/basic.sql
+++ b/tests/cases/standalone/common/tql/basic.sql
@@ -22,6 +22,8 @@ TQL EVAL (0, 10, '5s') {__name__="test", __field__="i"};
 -- NOT SUPPORTED: `__name__` matcher without equal condition
 TQL EVAL (0, 10, '5s') {__name__!="test"};
 
+TQL EVAL (0, 10, '5s') {__name__=~"test"};
+
 -- the point at 1ms will be shadowed by the point at 2ms
 TQL EVAL (0, 10, '5s') test{k="a"};
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Closes https://github.com/GreptimeTeam/greptimedb/issues/5182

## What's changed and what's your intention?

We only allow precise equal on `__name__` matcher in PromQL.

This behavior is stated in our doc but I forget to add validation  https://docs.greptime.com/user-guide/query-data/promql#selector


## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
