### PR TITLE
feat: hints all in one

### DIFF
--- a/src/servers/src/hint_headers.rs
+++ b/src/servers/src/hint_headers.rs
@@ -35,6 +35,8 @@ pub(crate) fn extract_hints<T: ToHeaderMap>(headers: &T) -> Vec<(String, String)
                 hints.push((key.trim().to_string(), value.trim().to_string()));
             }
         });
+        // If hints are provided in the `x-greptime-hints` header, ignore the rest of the headers
+        return hints;
     }
     for key in HINT_KEYS.iter() {
         if let Some(value) = headers.get(key) {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Another hint format: `x-greptime-hints: auto_create_table=true, ttl=7d`.

Currently, the following two formats are supported:
1. x-greptime-hint-xxx: value
2. x-greptime-hints: xxx=yyy, aaa=bbb

This PR implements the second format and we may remove support for the first one in the future as it may lead too many keys.

This PR is a continuation of #5128.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
