### PR TITLE
feat: update partition duration of memtable using compaction window

### DIFF
--- a/src/mito2/src/engine/compaction_test.rs
+++ b/src/mito2/src/engine/compaction_test.rs
@@ -439,7 +439,7 @@ async fn test_compaction_update_time_window() {
 
     // Puts window 7200.
     let rows = Rows {
-        schema: column_schemas.to_vec(),
+        schema: column_schemas.clone(),
         rows: build_rows_for_key("a", 3600, 4000, 0),
     };
     put_rows(&engine, region_id, rows).await;
@@ -451,7 +451,7 @@ async fn test_compaction_update_time_window() {
 
     // Puts window 3600.
     let rows = Rows {
-        schema: column_schemas.to_vec(),
+        schema: column_schemas.clone(),
         rows: build_rows_for_key("a", 2400, 3600, 0),
     };
     put_rows(&engine, region_id, rows).await;

--- a/src/mito2/src/engine/compaction_test.rs
+++ b/src/mito2/src/engine/compaction_test.rs
@@ -374,3 +374,90 @@ async fn test_readonly_during_compaction() {
     let vec = collect_stream_ts(stream).await;
     assert_eq!((0..20).map(|v| v * 1000).collect::<Vec<_>>(), vec);
 }
+
+#[tokio::test]
+async fn test_compaction_update_time_window() {
+    common_telemetry::init_default_ut_logging();
+    let mut env = TestEnv::new();
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+
+    env.get_schema_metadata_manager()
+        .register_region_table_info(
+            region_id.table_id(),
+            "test_table",
+            "test_catalog",
+            "test_schema",
+            None,
+        )
+        .await;
+
+    let request = CreateRequestBuilder::new()
+        .insert_option("compaction.type", "twcs")
+        .insert_option("compaction.twcs.max_active_window_runs", "2")
+        .insert_option("compaction.twcs.max_active_window_files", "2")
+        .insert_option("compaction.twcs.max_inactive_window_runs", "2")
+        .insert_option("compaction.twcs.max_inactive_window_files", "2")
+        .build();
+
+    let column_schemas = request
+        .column_metadatas
+        .iter()
+        .map(column_metadata_to_column_schema)
+        .collect::<Vec<_>>();
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+    // Flush 3 SSTs for compaction.
+    put_and_flush(&engine, region_id, &column_schemas, 0..1200).await; // window 3600
+    put_and_flush(&engine, region_id, &column_schemas, 1200..2400).await; // window 3600
+    put_and_flush(&engine, region_id, &column_schemas, 2400..3600).await; // window 3600
+
+    let result = engine
+        .handle_request(
+            region_id,
+            RegionRequest::Compact(RegionCompactRequest::default()),
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.affected_rows, 0);
+
+    let scanner = engine.scanner(region_id, ScanRequest::default()).unwrap();
+    assert_eq!(0, scanner.num_memtables());
+    // We keep at most two files.
+    assert_eq!(
+        2,
+        scanner.num_files(),
+        "unexpected files: {:?}",
+        scanner.file_ids()
+    );
+
+    // Flush a new SST and the time window is applied.
+    put_and_flush(&engine, region_id, &column_schemas, 0..1200).await; // window 3600
+
+    // Puts window 7200.
+    let rows = Rows {
+        schema: column_schemas.to_vec(),
+        rows: build_rows_for_key("a", 3600, 4000, 0),
+    };
+    put_rows(&engine, region_id, rows).await;
+    let scanner = engine.scanner(region_id, ScanRequest::default()).unwrap();
+    assert_eq!(1, scanner.num_memtables());
+    let stream = scanner.scan().await.unwrap();
+    let vec = collect_stream_ts(stream).await;
+    assert_eq!((0..4000).map(|v| v * 1000).collect::<Vec<_>>(), vec);
+
+    // Puts window 3600.
+    let rows = Rows {
+        schema: column_schemas.to_vec(),
+        rows: build_rows_for_key("a", 2400, 3600, 0),
+    };
+    put_rows(&engine, region_id, rows).await;
+    let scanner = engine.scanner(region_id, ScanRequest::default()).unwrap();
+    assert_eq!(2, scanner.num_memtables());
+    let stream = scanner.scan().await.unwrap();
+    let vec = collect_stream_ts(stream).await;
+    assert_eq!((0..4000).map(|v| v * 1000).collect::<Vec<_>>(), vec);
+}

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -70,7 +70,7 @@ impl Default for MemtableConfig {
 pub struct MemtableStats {
     /// The estimated bytes allocated by this memtable from heap.
     estimated_bytes: usize,
-    /// The time range that this memtable contains. It is None if
+    /// The inclusive time range that this memtable contains. It is None if
     /// and only if the memtable is empty.
     time_range: Option<(Timestamp, Timestamp)>,
     /// Total rows in memtable

--- a/src/mito2/src/memtable/time_partition.rs
+++ b/src/mito2/src/memtable/time_partition.rs
@@ -541,7 +541,7 @@ mod tests {
         assert_eq!(0, partitions.num_partitions());
 
         let kvs = memtable_util::build_key_values(
-            &metadata,
+            metadata,
             "hello".to_string(),
             0,
             &[2000, 0],
@@ -553,7 +553,7 @@ mod tests {
         assert!(!partitions.is_empty());
 
         let kvs = memtable_util::build_key_values(
-            &metadata,
+            metadata,
             "hello".to_string(),
             0,
             &[3000, 7000, 4000, 5000],

--- a/src/mito2/src/memtable/version.rs
+++ b/src/mito2/src/memtable/version.rs
@@ -15,6 +15,7 @@
 //! Memtable version.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use smallvec::SmallVec;
 use store_api::metadata::RegionMetadataRef;
@@ -65,27 +66,41 @@ impl MemtableVersion {
     /// Returns a new [MemtableVersion] which switches the old mutable memtable to immutable
     /// memtable.
     ///
+    /// It will switch to use the `time_window` provided.
+    ///
     /// Returns `None` if the mutable memtable is empty.
     pub(crate) fn freeze_mutable(
         &self,
         metadata: &RegionMetadataRef,
+        time_window: Option<Duration>,
     ) -> Result<Option<MemtableVersion>> {
         if self.mutable.is_empty() {
-            // No need to freeze the mutable memtable.
-            return Ok(None);
+            // No need to freeze the mutable memtable, but we need to check the time window.
+            if self.mutable.part_duration() == time_window {
+                // If the time window is the same, we don't need to update it.
+                return Ok(None);
+            }
+
+            // Update the time window.
+            let mutable = self.mutable.new_with_part_duration(time_window);
+            return Ok(Some(MemtableVersion {
+                mutable: Arc::new(mutable),
+                immutables: self.immutables.clone(),
+            }));
         }
 
         // Marks the mutable memtable as immutable so it can free the memory usage from our
         // soft limit.
         self.mutable.freeze()?;
         // Fork the memtable.
-        let mutable = Arc::new(self.mutable.fork(metadata));
+        let mutable = Arc::new(self.mutable.fork(metadata, time_window));
 
-        // Pushes the mutable memtable to immutable list.
         let mut immutables =
             SmallVec::with_capacity(self.immutables.len() + self.mutable.num_partitions());
-        self.mutable.list_memtables_to_small_vec(&mut immutables);
         immutables.extend(self.immutables.iter().cloned());
+        // Pushes the mutable memtable to immutable list.
+        self.mutable.list_memtables_to_small_vec(&mut immutables);
+
         Ok(Some(MemtableVersion {
             mutable,
             immutables,

--- a/src/mito2/src/region/version.rs
+++ b/src/mito2/src/region/version.rs
@@ -80,8 +80,12 @@ impl VersionControl {
     /// Freezes the mutable memtable if it is not empty.
     pub(crate) fn freeze_mutable(&self) -> Result<()> {
         let version = self.current().version;
+        let time_window = version.compaction_time_window;
 
-        let Some(new_memtables) = version.memtables.freeze_mutable(&version.metadata)? else {
+        let Some(new_memtables) = version
+            .memtables
+            .freeze_mutable(&version.metadata, time_window)?
+        else {
             return Ok(());
         };
 

--- a/src/mito2/src/test_util/memtable_util.rs
+++ b/src/mito2/src/test_util/memtable_util.rs
@@ -14,7 +14,6 @@
 
 //! Memtable test utilities.
 
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use api::helper::ColumnDataTypeWrapper;
@@ -34,8 +33,8 @@ use crate::error::Result;
 use crate::memtable::key_values::KeyValue;
 use crate::memtable::partition_tree::data::{timestamp_array_to_i64_slice, DataBatch, DataBuffer};
 use crate::memtable::{
-    BoxedBatchIterator, BulkPart, KeyValues, Memtable, MemtableBuilder, MemtableId, MemtableRange,
-    MemtableRanges, MemtableRef, MemtableStats,
+    BoxedBatchIterator, BulkPart, KeyValues, Memtable, MemtableBuilder, MemtableId, MemtableRanges,
+    MemtableRef, MemtableStats,
 };
 use crate::row_converter::{McmpRowCodec, RowCodec, SortField};
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
fixes https://github.com/GreptimeTeam/greptimedb/issues/5098

## What's changed and what's your intention?

This PR tries to create a new mutable memtable with the latest compaction time window. It sets the `part_duration` of the `TimePartitions` when a region freezes its memtables.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
