### PR TITLE
fix: auto created table ttl check

### DIFF
--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -576,6 +576,9 @@ impl Inserter {
 
                     for table in tables {
                         let table_info = table.table_info();
+                        if table_info.is_ttl_instant_table() {
+                            instant_table_ids.insert(table_info.table_id());
+                        }
                         table_name_to_ids.insert(table_info.name.clone(), table_info.table_id());
                     }
                 }
@@ -596,6 +599,9 @@ impl Inserter {
                         .create_physical_table(create_table, ctx, statement_executor)
                         .await?;
                     let table_info = table.table_info();
+                    if table_info.is_ttl_instant_table() {
+                        instant_table_ids.insert(table_info.table_id());
+                    }
                     table_name_to_ids.insert(table_info.name.clone(), table_info.table_id());
                 }
                 for alter_expr in alter_tables.into_iter() {

--- a/tests-integration/tests/grpc.rs
+++ b/tests-integration/tests/grpc.rs
@@ -444,6 +444,40 @@ async fn insert_with_hints_and_assert(db: &Database) {
 +-------+-------------------------------------+\
 ";
     assert_eq!(pretty, expected);
+
+    // testing data with ttl=instant and auto_create_table = true can be handled correctly
+    let (expected_host_col, expected_cpu_col, expected_mem_col, expected_ts_col) = expect_data();
+
+    let request = InsertRequest {
+        table_name: "demo1".to_string(),
+        columns: vec![
+            expected_host_col.clone(),
+            expected_cpu_col.clone(),
+            expected_mem_col.clone(),
+            expected_ts_col.clone(),
+        ],
+        row_count: 4,
+    };
+    let result = db
+        .insert_with_hints(
+            InsertRequests {
+                inserts: vec![request],
+            },
+            &[("auto_create_table", "true"), ("ttl", "instant")],
+        )
+        .await;
+    assert_eq!(result.unwrap(), 0);
+
+    // check table is empty
+    let output = db.sql("SELECT * FROM demo1").await.unwrap();
+
+    let record_batches = match output.data {
+        OutputData::RecordBatches(record_batches) => record_batches,
+        OutputData::Stream(stream) => RecordBatches::try_collect(stream).await.unwrap(),
+        OutputData::AffectedRows(_) => unreachable!(),
+    };
+
+    assert!(record_batches.iter().all(|r| r.num_rows() == 0));
 }
 
 async fn insert_and_assert(db: &Database) {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

auto created table also needed to check for ttl==instant

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- previous auto created table is not check for ttl==instant which will cause the first batch to create the table to be in the table even if ttl==instant
- fix is to also check for them so ttl=instant table wouldn't have any data anyway 

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
