### PR TITLE
feat: init PgElection with candidate registration

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -697,7 +697,7 @@ jobs:
         working-directory: tests-integration/fixtures/postgres
         run: docker compose -f docker-compose-standalone.yml up -d --wait
       - name: Run nextest cases
-        run: cargo llvm-cov nextest --features all --workspace --lcov --output-path lcov.info -F pyo3_backend -F dashboard
+        run: cargo llvm-cov nextest --features all-features --workspace --lcov --output-path lcov.info -F pyo3_backend -F dashboard
         env:
           CARGO_BUILD_RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
           RUST_BACKTRACE: 1

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -697,7 +697,7 @@ jobs:
         working-directory: tests-integration/fixtures/postgres
         run: docker compose -f docker-compose-standalone.yml up -d --wait
       - name: Run nextest cases
-        run: cargo llvm-cov nextest --workspace --lcov --output-path lcov.info -F pyo3_backend -F dashboard
+        run: cargo llvm-cov nextest --features all --workspace --lcov --output-path lcov.info -F pyo3_backend -F dashboard
         env:
           CARGO_BUILD_RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
           RUST_BACKTRACE: 1

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -697,7 +697,7 @@ jobs:
         working-directory: tests-integration/fixtures/postgres
         run: docker compose -f docker-compose-standalone.yml up -d --wait
       - name: Run nextest cases
-        run: cargo llvm-cov nextest --features all-features --workspace --lcov --output-path lcov.info -F pyo3_backend -F dashboard
+        run: cargo llvm-cov nextest --workspace --lcov --output-path lcov.info -F pyo3_backend -F dashboard -F pg_kvbackend
         env:
           CARGO_BUILD_RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
           RUST_BACKTRACE: 1

--- a/src/common/meta/src/kv_backend/postgres.rs
+++ b/src/common/meta/src/kv_backend/postgres.rs
@@ -45,9 +45,9 @@ const METADKV_CREATION: &str =
 
 const FULL_TABLE_SCAN: &str = "SELECT k, v FROM greptime_metakv $1 ORDER BY K";
 
-const POINT_GET: &str = "SELECT k, v FROM greptime_metakv WHERE k = $1";
+pub const POINT_GET: &str = "SELECT k, v FROM greptime_metakv WHERE k = $1";
 
-const PREFIX_SCAN: &str = "SELECT k, v FROM greptime_metakv WHERE k LIKE $1 ORDER BY K";
+pub const PREFIX_SCAN: &str = "SELECT k, v FROM greptime_metakv WHERE k LIKE $1 ORDER BY K";
 
 const RANGE_SCAN_LEFT_BOUNDED: &str = "SELECT k, v FROM greptime_metakv WHERE k >= $1 ORDER BY K";
 
@@ -56,7 +56,7 @@ const RANGE_SCAN_FULL_RANGE: &str =
 
 const FULL_TABLE_DELETE: &str = "DELETE FROM greptime_metakv RETURNING k,v";
 
-const POINT_DELETE: &str = "DELETE FROM greptime_metakv WHERE K = $1 RETURNING k,v;";
+pub const POINT_DELETE: &str = "DELETE FROM greptime_metakv WHERE K = $1 RETURNING k,v;";
 
 const PREFIX_DELETE: &str = "DELETE FROM greptime_metakv WHERE k LIKE $1 RETURNING k,v;";
 
@@ -65,7 +65,7 @@ const RANGE_DELETE_LEFT_BOUNDED: &str = "DELETE FROM greptime_metakv WHERE k >= 
 const RANGE_DELETE_FULL_RANGE: &str =
     "DELETE FROM greptime_metakv WHERE k >= $1 AND K < $2 RETURNING k,v;";
 
-const CAS: &str = r#"
+pub const CAS: &str = r#"
 WITH prev AS (
     SELECT k,v FROM greptime_metakv WHERE k = $1 AND v = $2
 ), update AS (
@@ -79,7 +79,7 @@ WHERE
 SELECT k, v FROM prev;
 "#;
 
-const PUT_IF_NOT_EXISTS: &str = r#"    
+pub const PUT_IF_NOT_EXISTS: &str = r#"    
 WITH prev AS (
     select k,v from greptime_metakv where k = $1
 ), insert AS (

--- a/src/common/meta/src/kv_backend/postgres.rs
+++ b/src/common/meta/src/kv_backend/postgres.rs
@@ -45,9 +45,9 @@ const METADKV_CREATION: &str =
 
 const FULL_TABLE_SCAN: &str = "SELECT k, v FROM greptime_metakv $1 ORDER BY K";
 
-pub const POINT_GET: &str = "SELECT k, v FROM greptime_metakv WHERE k = $1";
+const POINT_GET: &str = "SELECT k, v FROM greptime_metakv WHERE k = $1";
 
-pub const PREFIX_SCAN: &str = "SELECT k, v FROM greptime_metakv WHERE k LIKE $1 ORDER BY K";
+const PREFIX_SCAN: &str = "SELECT k, v FROM greptime_metakv WHERE k LIKE $1 ORDER BY K";
 
 const RANGE_SCAN_LEFT_BOUNDED: &str = "SELECT k, v FROM greptime_metakv WHERE k >= $1 ORDER BY K";
 
@@ -56,7 +56,7 @@ const RANGE_SCAN_FULL_RANGE: &str =
 
 const FULL_TABLE_DELETE: &str = "DELETE FROM greptime_metakv RETURNING k,v";
 
-pub const POINT_DELETE: &str = "DELETE FROM greptime_metakv WHERE K = $1 RETURNING k,v;";
+const POINT_DELETE: &str = "DELETE FROM greptime_metakv WHERE K = $1 RETURNING k,v;";
 
 const PREFIX_DELETE: &str = "DELETE FROM greptime_metakv WHERE k LIKE $1 RETURNING k,v;";
 

--- a/src/common/meta/src/kv_backend/postgres.rs
+++ b/src/common/meta/src/kv_backend/postgres.rs
@@ -65,7 +65,7 @@ const RANGE_DELETE_LEFT_BOUNDED: &str = "DELETE FROM greptime_metakv WHERE k >= 
 const RANGE_DELETE_FULL_RANGE: &str =
     "DELETE FROM greptime_metakv WHERE k >= $1 AND K < $2 RETURNING k,v;";
 
-pub const CAS: &str = r#"
+const CAS: &str = r#"
 WITH prev AS (
     SELECT k,v FROM greptime_metakv WHERE k = $1 AND v = $2
 ), update AS (
@@ -79,7 +79,7 @@ WHERE
 SELECT k, v FROM prev;
 "#;
 
-pub const PUT_IF_NOT_EXISTS: &str = r#"    
+const PUT_IF_NOT_EXISTS: &str = r#"    
 WITH prev AS (
     select k,v from greptime_metakv where k = $1
 ), insert AS (

--- a/src/meta-srv/Cargo.toml
+++ b/src/meta-srv/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [dependencies]
 api.workspace = true
 async-trait = "0.1"
+chrono.workspace = true
 clap.workspace = true
 client.workspace = true
 common-base.workspace = true
@@ -55,7 +56,7 @@ snafu.workspace = true
 store-api.workspace = true
 table.workspace = true
 tokio.workspace = true
-tokio-postgres = { workspace = true, optional = true }
+tokio-postgres = { workspace = true, optional = true, features = ["with-chrono-0_4"] }
 tokio-stream = { workspace = true, features = ["net"] }
 toml.workspace = true
 tonic.workspace = true

--- a/src/meta-srv/Cargo.toml
+++ b/src/meta-srv/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 
 [features]
 mock = []
-pg_kvbackend = ["dep:tokio-postgres"]
+pg_kvbackend = ["dep:tokio-postgres", "common-meta/pg_kvbackend"]
 
 [lints]
 workspace = true

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -45,13 +45,7 @@ use tonic::codec::CompressionEncoding;
 use tonic::transport::server::{Router, TcpIncoming};
 
 use crate::election::etcd::EtcdElection;
-#[cfg(feature = "pg_kvbackend")]
-use crate::election::postgres::PgElection;
-#[cfg(feature = "pg_kvbackend")]
-use crate::election::CANDIDATE_LEASE_SECS;
-#[cfg(feature = "pg_kvbackend")]
-use crate::error::InvalidArgumentsSnafu;
-use crate::error::{InitExportMetricsTaskSnafu, TomlFormatSnafu};
+use crate::error::{InitExportMetricsTaskSnafu, InvalidArgumentsSnafu, TomlFormatSnafu};
 use crate::metasrv::builder::MetasrvBuilder;
 use crate::metasrv::{BackendImpl, Metasrv, MetasrvOptions, SelectorRef};
 use crate::selector::lease_based::LeaseBasedSelector;
@@ -231,15 +225,7 @@ pub async fn metasrv_builder(
             let kv_backend = PgStore::with_pg_client(pg_client)
                 .await
                 .context(error::KvBackendSnafu)?;
-            let election_client = create_postgres_client(opts).await?;
-            let election = PgElection::with_pg_client(
-                opts.server_addr.clone(),
-                election_client,
-                opts.store_key_prefix.clone(),
-                CANDIDATE_LEASE_SECS,
-            )
-            .await?;
-            (kv_backend, Some(election))
+            (kv_backend, None)
         }
     };
 

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -46,6 +46,8 @@ use tonic::transport::server::{Router, TcpIncoming};
 
 use crate::election::etcd::EtcdElection;
 #[cfg(feature = "pg_kvbackend")]
+use crate::election::postgres::PgElection;
+#[cfg(feature = "pg_kvbackend")]
 use crate::error::InvalidArgumentsSnafu;
 use crate::error::{InitExportMetricsTaskSnafu, TomlFormatSnafu};
 use crate::metasrv::builder::MetasrvBuilder;
@@ -224,9 +226,17 @@ pub async fn metasrv_builder(
         #[cfg(feature = "pg_kvbackend")]
         (None, BackendImpl::PostgresStore) => {
             let pg_client = create_postgres_client(opts).await?;
-            let kv_backend = PgStore::with_pg_client(pg_client).await.unwrap();
-            // TODO(jeremy, weny): implement election for postgres
-            (kv_backend, None)
+            let kv_backend = PgStore::with_pg_client(pg_client)
+                .await
+                .context(error::KvBackendSnafu)?;
+            let election_client = create_postgres_client(opts).await?;
+            let election = PgElection::with_pg_client(
+                opts.server_addr.clone(),
+                election_client,
+                opts.store_key_prefix.clone(),
+            )
+            .await?;
+            (kv_backend, Some(election))
         }
     };
 

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -45,7 +45,9 @@ use tonic::codec::CompressionEncoding;
 use tonic::transport::server::{Router, TcpIncoming};
 
 use crate::election::etcd::EtcdElection;
-use crate::error::{InitExportMetricsTaskSnafu, InvalidArgumentsSnafu, TomlFormatSnafu};
+#[cfg(feature = "pg_kvbackend")]
+use crate::error::InvalidArgumentsSnafu;
+use crate::error::{InitExportMetricsTaskSnafu, TomlFormatSnafu};
 use crate::metasrv::builder::MetasrvBuilder;
 use crate::metasrv::{BackendImpl, Metasrv, MetasrvOptions, SelectorRef};
 use crate::selector::lease_based::LeaseBasedSelector;

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -48,6 +48,8 @@ use crate::election::etcd::EtcdElection;
 #[cfg(feature = "pg_kvbackend")]
 use crate::election::postgres::PgElection;
 #[cfg(feature = "pg_kvbackend")]
+use crate::election::CANDIDATE_LEASE_SECS;
+#[cfg(feature = "pg_kvbackend")]
 use crate::error::InvalidArgumentsSnafu;
 use crate::error::{InitExportMetricsTaskSnafu, TomlFormatSnafu};
 use crate::metasrv::builder::MetasrvBuilder;
@@ -57,8 +59,6 @@ use crate::selector::load_based::LoadBasedSelector;
 use crate::selector::round_robin::RoundRobinSelector;
 use crate::selector::SelectorType;
 use crate::service::admin;
-#[cfg(feature = "pg_kvbackend")]
-use crate::election::CANDIDATE_LEASE_SECS;
 use crate::{error, Result};
 
 pub struct MetasrvInstance {

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -57,6 +57,8 @@ use crate::selector::load_based::LoadBasedSelector;
 use crate::selector::round_robin::RoundRobinSelector;
 use crate::selector::SelectorType;
 use crate::service::admin;
+#[cfg(feature = "pg_kvbackend")]
+use crate::election::CANDIDATE_LEASE_SECS;
 use crate::{error, Result};
 
 pub struct MetasrvInstance {
@@ -234,6 +236,7 @@ pub async fn metasrv_builder(
                 opts.server_addr.clone(),
                 election_client,
                 opts.store_key_prefix.clone(),
+                CANDIDATE_LEASE_SECS,
             )
             .await?;
             (kv_backend, Some(election))

--- a/src/meta-srv/src/election.rs
+++ b/src/meta-srv/src/election.rs
@@ -38,7 +38,7 @@ pub enum LeaderChangeMessage {
 }
 
 /// LeaderKey is a key that represents the leader of metasrv.
-/// The structure is correponding to [etcd_client::LeaderKey].
+/// The structure is corresponding to [etcd_client::LeaderKey].
 pub trait LeaderKey: Send + Sync + Debug {
     /// The name in byte. name is the election identifier that corresponds to the leadership key.
     fn name(&self) -> &[u8];

--- a/src/meta-srv/src/election.rs
+++ b/src/meta-srv/src/election.rs
@@ -48,7 +48,7 @@ pub trait LeaderKey: Send + Sync + Debug {
     fn key(&self) -> &[u8];
 
     /// The creation revision of the key.
-    fn rev_id(&self) -> i64;
+    fn revision(&self) -> i64;
 
     /// The lease ID of the election leader.
     fn lease_id(&self) -> i64;
@@ -69,7 +69,7 @@ impl fmt::Display for LeaderChangeMessage {
         write!(f, "LeaderKey {{ ")?;
         write!(f, "name: {}", String::from_utf8_lossy(leader_key.name()))?;
         write!(f, ", key: {}", String::from_utf8_lossy(leader_key.key()))?;
-        write!(f, ", rev: {}", leader_key.rev_id())?;
+        write!(f, ", rev: {}", leader_key.revision())?;
         write!(f, ", lease: {}", leader_key.lease_id())?;
         write!(f, " }})")
     }

--- a/src/meta-srv/src/election.rs
+++ b/src/meta-srv/src/election.rs
@@ -27,19 +27,30 @@ use crate::metasrv::MetasrvNodeInfo;
 pub const ELECTION_KEY: &str = "__metasrv_election";
 pub const CANDIDATES_ROOT: &str = "__metasrv_election_candidates/";
 
-const CANDIDATE_LEASE_SECS: u64 = 600;
+pub(crate) const CANDIDATE_LEASE_SECS: u64 = 600;
 const KEEP_ALIVE_INTERVAL_SECS: u64 = CANDIDATE_LEASE_SECS / 2;
 
+/// Messages sent when the leader changes.
 #[derive(Debug, Clone)]
 pub enum LeaderChangeMessage {
     Elected(Arc<dyn LeaderKey>),
     StepDown(Arc<dyn LeaderKey>),
 }
 
+/// LeaderKey is a key that represents the leader of metasrv.
+/// The structure is correponding to [etcd_client::LeaderKey].
 pub trait LeaderKey: Send + Sync + Debug {
+    /// The name in byte. name is the election identifier that corresponds to the leadership key.
     fn name(&self) -> &[u8];
+
+    /// The key in byte. key is an opaque key representing the ownership of the election. If the key
+    /// is deleted, then leadership is lost.
     fn key(&self) -> &[u8];
+
+    /// The creation revision of the key.
     fn rev(&self) -> i64;
+
+    /// The lease ID of the election leader.
     fn lease(&self) -> i64;
 }
 

--- a/src/meta-srv/src/election.rs
+++ b/src/meta-srv/src/election.rs
@@ -48,10 +48,10 @@ pub trait LeaderKey: Send + Sync + Debug {
     fn key(&self) -> &[u8];
 
     /// The creation revision of the key.
-    fn rev(&self) -> i64;
+    fn rev_id(&self) -> i64;
 
     /// The lease ID of the election leader.
-    fn lease(&self) -> i64;
+    fn lease_id(&self) -> i64;
 }
 
 impl fmt::Display for LeaderChangeMessage {
@@ -69,8 +69,8 @@ impl fmt::Display for LeaderChangeMessage {
         write!(f, "LeaderKey {{ ")?;
         write!(f, "name: {}", String::from_utf8_lossy(leader_key.name()))?;
         write!(f, ", key: {}", String::from_utf8_lossy(leader_key.key()))?;
-        write!(f, ", rev: {}", leader_key.rev())?;
-        write!(f, ", lease: {}", leader_key.lease())?;
+        write!(f, ", rev: {}", leader_key.rev_id())?;
+        write!(f, ", lease: {}", leader_key.lease_id())?;
         write!(f, " }})")
     }
 }

--- a/src/meta-srv/src/election.rs
+++ b/src/meta-srv/src/election.rs
@@ -87,7 +87,7 @@ pub trait Election: Send + Sync {
     /// initialization operations can be performed.
     ///
     /// note: a new leader will only return true on the first call.
-    fn in_infancy(&self) -> bool;
+    fn in_leader_infancy(&self) -> bool;
 
     /// Registers a candidate for the election.
     async fn register_candidate(&self, node_info: &MetasrvNodeInfo) -> Result<()>;

--- a/src/meta-srv/src/election/etcd.rs
+++ b/src/meta-srv/src/election/etcd.rs
@@ -149,7 +149,7 @@ impl Election for EtcdElection {
         self.is_leader.load(Ordering::Relaxed)
     }
 
-    fn in_infancy(&self) -> bool {
+    fn in_leader_infancy(&self) -> bool {
         self.infancy
             .compare_exchange(true, false, Ordering::Relaxed, Ordering::Relaxed)
             .is_ok()

--- a/src/meta-srv/src/election/etcd.rs
+++ b/src/meta-srv/src/election/etcd.rs
@@ -344,7 +344,7 @@ impl EtcdElection {
 
                 if let Err(e) = self
                     .leader_watcher
-                    .send(LeaderChangeMessage::Elected(Arc::new(leader.clone())))
+                    .send(LeaderChangeMessage::Elected(Arc::new(leader)))
                 {
                     error!(e; "Failed to send leader change message");
                 }

--- a/src/meta-srv/src/election/etcd.rs
+++ b/src/meta-srv/src/election/etcd.rs
@@ -44,7 +44,7 @@ impl LeaderKey for EtcdLeaderKey {
         self.key()
     }
 
-    fn rev_id(&self) -> i64 {
+    fn revision(&self) -> i64 {
         self.rev()
     }
 

--- a/src/meta-srv/src/election/postgres.rs
+++ b/src/meta-srv/src/election/postgres.rs
@@ -28,7 +28,7 @@ use crate::error::{
 };
 use crate::metasrv::{ElectionRef, LeaderValue, MetasrvNodeInfo};
 
-// Seperator between value and expire time.
+// Separator between value and expire time.
 const LEASE_SEP: &str = r#"||__metadata_lease_sep||"#;
 
 // SQL to put a value with expire time. Parameters: key, value, lease_prefix, expire_time

--- a/src/meta-srv/src/election/postgres.rs
+++ b/src/meta-srv/src/election/postgres.rs
@@ -444,7 +444,7 @@ mod tests {
             let handle = tokio::spawn(candidate(leader_value.clone()));
             handles.push(handle);
         }
-        // Wait for candidates registrating themselves.
+        // Wait for candidates to registrate themselves.
         tokio::time::sleep(Duration::from_secs(3)).await;
 
         let endpoint = env::var("GT_POSTGRES_ENDPOINTS").unwrap_or_default();

--- a/src/meta-srv/src/election/postgres.rs
+++ b/src/meta-srv/src/election/postgres.rs
@@ -308,9 +308,7 @@ mod tests {
             .await
             .context(PostgresExecutionSnafu)?;
         tokio::spawn(async move {
-            if let Err(e) = connection.await {
-                eprintln!("connection error: {}", e);
-            }
+            connection.await.context(PostgresExecutionSnafu).unwrap();
         });
         Ok(client)
     }

--- a/src/meta-srv/src/election/postgres.rs
+++ b/src/meta-srv/src/election/postgres.rs
@@ -230,6 +230,7 @@ impl PgElection {
         if res.is_empty() {
             Ok(None)
         } else {
+            // Safety: Checked if res is empty above.
             let current_time_str = res[0].get(1);
             let current_time = match Timestamp::from_str(current_time_str, None) {
                 Ok(ts) => ts,
@@ -238,7 +239,7 @@ impl PgElection {
                 }
                 .fail()?,
             };
-
+            // Safety: Checked if res is empty above.
             let value_and_expire_time = res[0].get(0);
             let (value, expire_time) = parse_value_and_expire_time(value_and_expire_time)?;
 

--- a/src/meta-srv/src/election/postgres.rs
+++ b/src/meta-srv/src/election/postgres.rs
@@ -88,7 +88,7 @@ pub struct PgElection {
     leader_value: String,
     client: Client,
     is_leader: AtomicBool,
-    infancy: AtomicBool,
+    leader_infancy: AtomicBool,
     leader_watcher: broadcast::Sender<LeaderChangeMessage>,
     store_key_prefix: String,
     candidate_lease_ttl_secs: u64,
@@ -106,7 +106,7 @@ impl PgElection {
             leader_value,
             client,
             is_leader: AtomicBool::new(false),
-            infancy: AtomicBool::new(true),
+            leader_infancy: AtomicBool::new(false),
             leader_watcher: tx,
             store_key_prefix,
             candidate_lease_ttl_secs,
@@ -138,8 +138,8 @@ impl Election for PgElection {
         self.is_leader.load(Ordering::Relaxed)
     }
 
-    fn in_infancy(&self) -> bool {
-        self.infancy
+    fn in_leader_infancy(&self) -> bool {
+        self.leader_infancy
             .compare_exchange(true, false, Ordering::Relaxed, Ordering::Relaxed)
             .is_ok()
     }
@@ -383,7 +383,7 @@ mod tests {
             leader_value: "test_leader".to_string(),
             client,
             is_leader: AtomicBool::new(false),
-            infancy: AtomicBool::new(true),
+            leader_infancy: AtomicBool::new(true),
             leader_watcher: tx,
             store_key_prefix: "test_prefix".to_string(),
             candidate_lease_ttl_secs: 10,
@@ -452,7 +452,7 @@ mod tests {
             leader_value,
             client,
             is_leader: AtomicBool::new(false),
-            infancy: AtomicBool::new(true),
+            leader_infancy: AtomicBool::new(true),
             leader_watcher: tx,
             store_key_prefix: "test_prefix".to_string(),
             candidate_lease_ttl_secs,
@@ -488,7 +488,7 @@ mod tests {
             leader_value,
             client,
             is_leader: AtomicBool::new(false),
-            infancy: AtomicBool::new(true),
+            leader_infancy: AtomicBool::new(true),
             leader_watcher: tx,
             store_key_prefix: "test_prefix".to_string(),
             candidate_lease_ttl_secs,

--- a/src/meta-srv/src/election/postgres.rs
+++ b/src/meta-srv/src/election/postgres.rs
@@ -317,7 +317,7 @@ mod tests {
 
     #[tokio::test]
     async fn temp_test() {
-        let endpoint = env::var("GT_PG_ADDR").unwrap_or_default();
+        let endpoint = env::var("GT_POSTGRES_ENDPOINTS").unwrap_or_default();
         let client = create_postgres_client(&endpoint).await.unwrap();
         client
             .execute(
@@ -335,7 +335,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_postgres_crud() {
-        let endpoint = env::var("GT_PG_ADDR").unwrap_or_default();
+        let endpoint = env::var("GT_POSTGRES_ENDPOINTS").unwrap_or_default();
         let client = create_postgres_client(&endpoint).await.unwrap();
         client
             .execute(
@@ -414,7 +414,7 @@ mod tests {
     }
 
     async fn candidate(leader_value: String) {
-        let endpoint = env::var("GT_PG_ADDR").unwrap_or_default();
+        let endpoint = env::var("GT_POSTGRES_ENDPOINTS").unwrap_or_default();
         let client = create_postgres_client(&endpoint).await.unwrap();
 
         let (tx, _) = broadcast::channel(100);
@@ -449,7 +449,7 @@ mod tests {
         // Wait for candidates registrating themselves.
         tokio::time::sleep(Duration::from_secs(3)).await;
 
-        let endpoint = env::var("GT_PG_ADDR").unwrap_or_default();
+        let endpoint = env::var("GT_POSTGRES_ENDPOINTS").unwrap_or_default();
         let client = create_postgres_client(&endpoint).await.unwrap();
 
         let (tx, _) = broadcast::channel(100);

--- a/src/meta-srv/src/election/postgres.rs
+++ b/src/meta-srv/src/election/postgres.rs
@@ -40,7 +40,7 @@ struct ValueWithLease {
 }
 
 /// PostgreSql implementation of Election.
-/// TODO: Currently only support candidate registration. Add election logic.
+/// TODO(CookiePie): Currently only support candidate registration. Add election logic.
 pub struct PgElection {
     leader_value: String,
     client: Client,

--- a/src/meta-srv/src/election/postgres.rs
+++ b/src/meta-srv/src/election/postgres.rs
@@ -304,7 +304,7 @@ mod tests {
             }
             .fail();
         }
-        let (client, connection) = tokio_postgres::connect(&addr, NoTls)
+        let (client, connection) = tokio_postgres::connect(addr, NoTls)
             .await
             .context(PostgresExecutionSnafu)?;
         tokio::spawn(async move {

--- a/src/meta-srv/src/election/postgres.rs
+++ b/src/meta-srv/src/election/postgres.rs
@@ -31,7 +31,7 @@ use crate::metasrv::{ElectionRef, LeaderValue, MetasrvNodeInfo};
 // Separator between value and expire time.
 const LEASE_SEP: &str = r#"||__metadata_lease_sep||"#;
 
-// SQL to put a value with expire time. Parameters: key, value, lease_prefix, expire_time
+// SQL to put a value with expire time. Parameters: key, value, LEASE_SEP, expire_time
 const PUT_IF_NOT_EXISTS_WITH_EXPIRE_TIME: &str = r#"
 WITH prev AS (
     SELECT k, v FROM greptime_metakv WHERE k = $1
@@ -44,7 +44,7 @@ WITH prev AS (
 SELECT k, v FROM prev;
 "#;
 
-// SQL to update a value with expire time. Parameters: key, prev_value_with_lease, updated_value, lease_prefix, expire_time
+// SQL to update a value with expire time. Parameters: key, prev_value_with_lease, updated_value, LEASE_SEP, expire_time
 const CAS_WITH_EXPIRE_TIME: &str = r#"
 UPDATE greptime_metakv
 SET k=$1,
@@ -59,7 +59,7 @@ const PREFIX_GET_WITH_CURRENT_TIMESTAMP: &str = r#"SELECT v, TO_CHAR(CURRENT_TIM
 
 const POINT_DELETE: &str = "DELETE FROM greptime_metakv WHERE k = $1 RETURNING k,v;";
 
-/// Parse the value and expire time from the given string. The value should be in the format "value || __metadata_lease_prefix || expire_time".
+/// Parse the value and expire time from the given string. The value should be in the format "value || LEASE_SEP || expire_time".
 fn parse_value_and_expire_time(value: &str) -> Result<(String, Timestamp)> {
     if let Some((value, expire_time)) = value.split(LEASE_SEP).collect_tuple() {
         // Given expire_time is in the format 'YYYY-MM-DD HH24:MI:SS.MS'

--- a/src/meta-srv/src/election/postgres.rs
+++ b/src/meta-srv/src/election/postgres.rs
@@ -1,0 +1,301 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{self, Duration};
+
+use common_meta::kv_backend::postgres::{
+    CAS, POINT_DELETE, POINT_GET, PREFIX_SCAN, PUT_IF_NOT_EXISTS,
+};
+use serde::{Deserialize, Serialize};
+use snafu::{ensure, ResultExt};
+use tokio::sync::broadcast;
+use tokio_postgres::Client;
+
+use crate::election::{
+    Election, LeaderChangeMessage, CANDIDATES_ROOT, CANDIDATE_LEASE_SECS, ELECTION_KEY,
+    KEEP_ALIVE_INTERVAL_SECS,
+};
+use crate::error::{
+    DeserializeFromJsonSnafu, PostgresExecutionSnafu, Result, SerializeToJsonSnafu, UnexpectedSnafu,
+};
+use crate::metasrv::{ElectionRef, LeaderValue, MetasrvNodeInfo};
+
+/// Value with a expire time. The expire time is in seconds since UNIX epoch.
+#[derive(Debug, Serialize, Deserialize, Default)]
+struct ValueWithLease {
+    value: String,
+    expire_time: f64,
+}
+
+/// PostgreSql implementation of Election.
+pub struct PgElection {
+    leader_value: String,
+    client: Client,
+    is_leader: AtomicBool,
+    infancy: AtomicBool,
+    leader_watcher: broadcast::Sender<LeaderChangeMessage>,
+    store_key_prefix: String,
+}
+
+impl PgElection {
+    pub async fn with_pg_client(
+        leader_value: String,
+        client: Client,
+        store_key_prefix: String,
+    ) -> Result<ElectionRef> {
+        let (tx, _) = broadcast::channel(100);
+        Ok(Arc::new(Self {
+            leader_value,
+            client,
+            is_leader: AtomicBool::new(false),
+            infancy: AtomicBool::new(true),
+            leader_watcher: tx,
+            store_key_prefix,
+        }))
+    }
+
+    fn _election_key(&self) -> String {
+        format!("{}{}", self.store_key_prefix, ELECTION_KEY)
+    }
+
+    fn candidate_root(&self) -> String {
+        format!("{}{}", self.store_key_prefix, CANDIDATES_ROOT)
+    }
+
+    fn candidate_key(&self) -> String {
+        format!("{}{}", self.candidate_root(), self.leader_value)
+    }
+}
+
+#[async_trait::async_trait]
+impl Election for PgElection {
+    type Leader = LeaderValue;
+
+    fn subscribe_leader_change(&self) -> broadcast::Receiver<LeaderChangeMessage> {
+        self.leader_watcher.subscribe()
+    }
+
+    fn is_leader(&self) -> bool {
+        self.is_leader.load(Ordering::Relaxed)
+    }
+
+    fn in_infancy(&self) -> bool {
+        self.infancy
+            .compare_exchange(true, false, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+    }
+
+    async fn register_candidate(&self, node_info: &MetasrvNodeInfo) -> Result<()> {
+        let key = self.candidate_key().into_bytes();
+        let node_info =
+            serde_json::to_string(node_info).with_context(|_| SerializeToJsonSnafu {
+                input: format!("{node_info:?}"),
+            })?;
+        let value_with_lease = ValueWithLease {
+            value: node_info,
+            expire_time: time::SystemTime::now()
+                .duration_since(time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs_f64()
+                + CANDIDATE_LEASE_SECS as f64,
+        };
+        let res = self.put_value_with_lease(&key, &value_with_lease).await?;
+        // May registered before, check if the lease expired. If so, delete and re-register.
+        if !res {
+            let prev = self.get_value_with_lease(&key).await?.unwrap_or_default();
+            if prev.expire_time
+                <= time::SystemTime::now()
+                    .duration_since(time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs_f64()
+            {
+                self.delete_value(&key).await?;
+                self.put_value_with_lease(&key, &value_with_lease).await?;
+            }
+        }
+
+        // Check if the current lease has expired and renew the lease.
+        let mut keep_alive_interval =
+            tokio::time::interval(Duration::from_secs(KEEP_ALIVE_INTERVAL_SECS));
+        loop {
+            let _ = keep_alive_interval.tick().await;
+
+            let prev = self.get_value_with_lease(&key).await?.unwrap_or_default();
+            let now = time::SystemTime::now()
+                .duration_since(time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs_f64();
+
+            ensure!(
+                prev.expire_time > now,
+                UnexpectedSnafu {
+                    violated: format!(
+                        "Candidate lease expired, key: {:?}",
+                        String::from_utf8_lossy(&key)
+                    ),
+                }
+            );
+
+            let updated = ValueWithLease {
+                value: prev.value.clone(),
+                expire_time: now + CANDIDATE_LEASE_SECS as f64,
+            };
+            self.update_value_with_lease(&key, &prev, &updated).await?;
+        }
+    }
+
+    async fn all_candidates(&self) -> Result<Vec<MetasrvNodeInfo>> {
+        let key_prefix = self.candidate_root().into_bytes();
+        let mut candidates = self.get_value_with_lease_by_prefix(&key_prefix).await?;
+        let now = time::SystemTime::now()
+            .duration_since(time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs_f64();
+        // Remove expired candidates
+        candidates.retain(|c| c.expire_time > now);
+        let mut valid_candidates = Vec::with_capacity(candidates.len());
+        for c in candidates {
+            let node_info: MetasrvNodeInfo =
+                serde_json::from_str(&c.value).with_context(|_| DeserializeFromJsonSnafu {
+                    input: format!("{:?}", c.value),
+                })?;
+            valid_candidates.push(node_info);
+        }
+        Ok(valid_candidates)
+    }
+
+    async fn campaign(&self) -> Result<()> {
+        todo!()
+    }
+
+    async fn leader(&self) -> Result<Self::Leader> {
+        todo!()
+    }
+
+    async fn resign(&self) -> Result<()> {
+        todo!()
+    }
+}
+
+impl PgElection {
+    async fn get_value_with_lease(&self, key: &Vec<u8>) -> Result<Option<ValueWithLease>> {
+        let prev = self
+            .client
+            .query(POINT_GET, &[&key])
+            .await
+            .context(PostgresExecutionSnafu)?;
+
+        if let Some(row) = prev.first() {
+            let value: String = row.get(0);
+            let value_with_lease: ValueWithLease =
+                serde_json::from_str(&value).with_context(|_| DeserializeFromJsonSnafu {
+                    input: format!("{value:?}"),
+                })?;
+            Ok(Some(value_with_lease))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn get_value_with_lease_by_prefix(
+        &self,
+        key_prefix: &Vec<u8>,
+    ) -> Result<Vec<ValueWithLease>> {
+        let prev = self
+            .client
+            .query(PREFIX_SCAN, &[key_prefix])
+            .await
+            .context(PostgresExecutionSnafu)?;
+
+        let mut res = Vec::new();
+        for row in prev {
+            let value: String = row.get(0);
+            let value_with_lease: ValueWithLease =
+                serde_json::from_str(&value).with_context(|_| DeserializeFromJsonSnafu {
+                    input: format!("{value:?}"),
+                })?;
+            res.push(value_with_lease);
+        }
+
+        Ok(res)
+    }
+
+    async fn update_value_with_lease(
+        &self,
+        key: &Vec<u8>,
+        prev: &ValueWithLease,
+        updated: &ValueWithLease,
+    ) -> Result<()> {
+        let prev = serde_json::to_string(prev)
+            .with_context(|_| SerializeToJsonSnafu {
+                input: format!("{prev:?}"),
+            })?
+            .into_bytes();
+
+        let updated = serde_json::to_string(updated)
+            .with_context(|_| SerializeToJsonSnafu {
+                input: format!("{updated:?}"),
+            })?
+            .into_bytes();
+
+        let res = self
+            .client
+            .query(CAS, &[key, &prev, &updated])
+            .await
+            .context(PostgresExecutionSnafu)?;
+
+        // CAS operation will return the updated value if the operation is successful
+        match res.is_empty() {
+            false => Ok(()),
+            true => UnexpectedSnafu {
+                violated: format!(
+                    "Failed to update value from key: {:?}",
+                    String::from_utf8_lossy(key)
+                ),
+            }
+            .fail(),
+        }
+    }
+
+    /// Returns `true` if the insertion is successful
+    async fn put_value_with_lease(&self, key: &Vec<u8>, value: &ValueWithLease) -> Result<bool> {
+        let value = serde_json::to_string(value)
+            .with_context(|_| SerializeToJsonSnafu {
+                input: format!("{value:?}"),
+            })?
+            .into_bytes();
+
+        let res = self
+            .client
+            .query(PUT_IF_NOT_EXISTS, &[key, &value])
+            .await
+            .context(PostgresExecutionSnafu)?;
+
+        Ok(res.is_empty())
+    }
+
+    /// Returns `true` if the deletion is successful.
+    /// Caution: Should only delete the key if the lease is expired.
+    async fn delete_value(&self, key: &Vec<u8>) -> Result<bool> {
+        let res = self
+            .client
+            .query(POINT_DELETE, &[key])
+            .await
+            .context(PostgresExecutionSnafu)?;
+
+        Ok(res.len() == 1)
+    }
+}

--- a/src/meta-srv/src/election/postgres.rs
+++ b/src/meta-srv/src/election/postgres.rs
@@ -205,9 +205,9 @@ impl PgElection {
 
     async fn get_value_with_lease_by_prefix(
         &self,
-        key_prefix: &String,
+        key_prefix: &str,
     ) -> Result<Vec<ValueWithLease>> {
-        let range_request = RangeRequest::new().with_prefix(key_prefix.clone());
+        let range_request = RangeRequest::new().with_prefix(key_prefix);
         let res = self
             .kv_backend
             .range(range_request)
@@ -229,7 +229,7 @@ impl PgElection {
 
     async fn update_value_with_lease(
         &self,
-        key: &String,
+        key: &str,
         prev: &ValueWithLease,
         updated: &ValueWithLease,
     ) -> Result<()> {
@@ -241,7 +241,7 @@ impl PgElection {
         })?;
 
         let cas_request = CompareAndPutRequest::new()
-            .with_key(key.clone())
+            .with_key(key)
             .with_expect(updated)
             .with_value(prev);
         let res = self
@@ -255,7 +255,7 @@ impl PgElection {
             false => UnexpectedSnafu {
                 violated: format!(
                     "CAS operation failed, key: {:?}",
-                    String::from_utf8_lossy(&key.clone().into_bytes())
+                    String::from_utf8_lossy(key.as_bytes())
                 ),
             }
             .fail(),
@@ -263,12 +263,12 @@ impl PgElection {
     }
 
     /// Returns `true` if the insertion is successful
-    async fn put_value_with_lease(&self, key: &String, value: &ValueWithLease) -> Result<bool> {
+    async fn put_value_with_lease(&self, key: &str, value: &ValueWithLease) -> Result<bool> {
         let value = serde_json::to_string(value).with_context(|_| SerializeToJsonSnafu {
             input: format!("{value:?}"),
         })?;
 
-        let put_request = PutRequest::new().with_key(key.clone()).with_value(value);
+        let put_request = PutRequest::new().with_key(key).with_value(value);
         let res = self
             .kv_backend
             .put(put_request)

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -24,7 +24,6 @@ use table::metadata::TableId;
 use tokio::sync::mpsc::error::SendError;
 use tonic::codegen::http;
 
-use crate::election::LeaderChangeMessage;
 use crate::metasrv::SelectTarget;
 use crate::pubsub::Message;
 
@@ -720,14 +719,6 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Failed to send leader change message"))]
-    SendLeaderChange {
-        #[snafu(implicit)]
-        location: Location,
-        #[snafu(source)]
-        error: tokio::sync::broadcast::error::SendError<LeaderChangeMessage>,
-    },
-
     #[snafu(display("Flow state handler error"))]
     FlowStateHandler {
         #[snafu(implicit)]
@@ -776,7 +767,6 @@ impl ErrorExt for Error {
             | Error::StartGrpc { .. }
             | Error::NoEnoughAvailableNode { .. }
             | Error::PublishMessage { .. }
-            | Error::SendLeaderChange { .. }
             | Error::Join { .. }
             | Error::PeerUnavailable { .. }
             | Error::ExceededDeadline { .. }

--- a/src/meta-srv/src/handler/on_leader_start_handler.rs
+++ b/src/meta-srv/src/handler/on_leader_start_handler.rs
@@ -36,7 +36,7 @@ impl HeartbeatHandler for OnLeaderStartHandler {
             return Ok(HandleControl::Continue);
         };
 
-        if election.in_infancy() {
+        if election.in_leader_infancy() {
             ctx.is_infancy = true;
             // TODO(weny): Unifies the multiple leader state between Context and Metasrv.
             // we can't ensure the in-memory kv has already been reset in the outside loop.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

As title. Part of #5208 

Previous pr #5201 

A candidate first write a (candidate_key, node info + expire time) pair into the pg kv backend, and regularly check the expire time.
- If the value expired, raise an error and re-registrate
- If not, just renew the expire time

For `all_candidates`, just get all candidate using candidate_key_prefix, and filter the expired value.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
