### PR TITLE
chore: bump opendal to fork version to fix prometheus layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7470,8 +7470,7 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 [[package]]
 name = "opendal"
 version = "0.50.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb28bb6c64e116ceaf8dd4e87099d3cfea4a58e85e62b104fef74c91afba0f44"
+source = "git+https://github.com/GreptimeTeam/opendal.git?rev=c82605177f2feec83e49dcaa537c505639d94024#c82605177f2feec83e49dcaa537c505639d94024"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/object-store/Cargo.toml
+++ b/src/object-store/Cargo.toml
@@ -17,7 +17,7 @@ futures.workspace = true
 lazy_static.workspace = true
 md5 = "0.7"
 moka = { workspace = true, features = ["future"] }
-opendal = { version = "0.50", features = [
+opendal = { git = "https://github.com/GreptimeTeam/opendal.git", rev = "c82605177f2feec83e49dcaa537c505639d94024", features = [
     "layers-tracing",
     "layers-prometheus",
     "services-azblob",


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


Switch opendal to our fork. It's based on `v0.50.2`, with one extra patch https://github.com/apache/opendal/pull/5433.

p.s.: we're not switching to `v0.51.0`, it looks like there are some ongoing huge breaking changes like https://github.com/apache/opendal/pull/3911/files?short_path=4c98752#diff-4c987528946a4644759e4f66b5027dea3cf61540dc64a73fa6c511a66b01a63f. And the concurrent limit of `list()` is missing.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
