### PR TITLE
ci: upload .pdb files too for better windows debug

### DIFF
--- a/.github/actions/build-windows-artifacts/action.yml
+++ b/.github/actions/build-windows-artifacts/action.yml
@@ -76,5 +76,5 @@ runs:
       uses: ./.github/actions/upload-artifacts
       with:
         artifacts-dir: ${{ inputs.artifacts-dir }}
-        target-files: target/${{ inputs.arch }}/${{ inputs.cargo-profile }}/greptime
+        target-files: target/${{ inputs.arch }}/${{ inputs.cargo-profile }}/greptime,target/${{ inputs.arch }}/${{ inputs.cargo-profile }}/greptime.pdb
         version: ${{ inputs.version }}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

`.pdb` file is the windows debug info file(unlike linux is in a separate file)
and cargo copy it to target directory if compile on windows(see [this](https://github.com/rust-lang/cargo/pull/5179) and [cargo's source code](https://github.com/rust-lang/cargo/blob/0c157e0c481e62c09874e0169c28da4c3b1ef406/src/cargo/core/compiler/build_context/target_info.rs#L503))

Please explain IN DETAIL what the changes are in this PR and why they are needed:
- very helpful when debuggin on windows
- doesn't take up much space(binary ~238 MB, pdb ~60MB) and merely few MB after compressed

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
