### PR TITLE
feat(log-query): implement pagination with limit and offset parameters

### DIFF
--- a/src/log-query/src/log_query.rs
+++ b/src/log-query/src/log_query.rs
@@ -30,8 +30,8 @@ pub struct LogQuery {
     pub time_filter: TimeFilter,
     /// Columns with filters to query.
     pub columns: Vec<ColumnFilters>,
-    /// Maximum number of logs to return. If not provided, it will return all matched logs.
-    pub limit: Option<usize>,
+    /// Controls row skipping and fetch count for logs.
+    pub limit: Limit,
     /// Adjacent lines to return.
     pub context: Context,
 }
@@ -42,7 +42,7 @@ impl Default for LogQuery {
             table: TableName::new("", "", ""),
             time_filter: Default::default(),
             columns: vec![],
-            limit: None,
+            limit: Limit::default(),
             context: Default::default(),
         }
     }
@@ -264,6 +264,15 @@ pub enum Context {
     Lines(usize, usize),
     /// Specify the number of seconds before and after the matched line occurred.
     Seconds(usize, usize),
+}
+
+/// Represents limit and offset parameters for query pagination.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct Limit {
+    /// Optional number of items to skip before starting to return results
+    pub skip: Option<usize>,
+    /// Optional number of items to return after skipping
+    pub fetch: Option<usize>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


Implement pagination with limit and offset parameters. A similar use case in Elasticsearch is `/my-index-000001/_search?from=40&size=20`

This is a breaking change but since `log-query` is highly experimental I only categorize it as a normal change.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
