### PR TITLE
feat(config): make table name of pg backend configurable

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -296,8 +296,8 @@
 | `store_addrs` | Array | -- | Store server address default to etcd store.<br/>For postgres store, the format is:<br/>"password=password dbname=postgres user=postgres host=localhost port=5432"<br/>For etcd store, the format is:<br/>"127.0.0.1:2379" |
 | `store_key_prefix` | String | `""` | If it's not empty, the metasrv will store all data with this key prefix. |
 | `backend` | String | `etcd_store` | The datastore for meta server.<br/>Available values:<br/>- `etcd_store` (default value)<br/>- `memory_store`<br/>- `postgres_store` |
-| `meta_table_name` | String | `greptime_metakv` | Table name in RDS to store metadata. Effect when using a RDS kvbackend. |
-| `meta_election_lock_id` | Integer | `1` | Advisory lock id in PostgreSQL for election. Effect when using PostgreSQL as kvbackend |
+| `meta_table_name` | String | `greptime_metakv` | Table name in RDS to store metadata. Effect when using a RDS kvbackend.<br/>**Only used when backend is `postgres_store`.** |
+| `meta_election_lock_id` | Integer | `1` | Advisory lock id in PostgreSQL for election. Effect when using PostgreSQL as kvbackend<br/>Only used when backend is `postgres_store`. |
 | `selector` | String | `round_robin` | Datanode selector type.<br/>- `round_robin` (default value)<br/>- `lease_based`<br/>- `load_based`<br/>For details, please see "https://docs.greptime.com/developer-guide/metasrv/selector". |
 | `use_memory_store` | Bool | `false` | Store data in memory. |
 | `enable_region_failover` | Bool | `false` | Whether to enable region failover.<br/>This feature is only available on GreptimeDB running on cluster mode and<br/>- Using Remote WAL<br/>- Using shared storage (e.g., s3). |

--- a/config/config.md
+++ b/config/config.md
@@ -297,6 +297,7 @@
 | `store_key_prefix` | String | `""` | If it's not empty, the metasrv will store all data with this key prefix. |
 | `backend` | String | `etcd_store` | The datastore for meta server.<br/>Available values:<br/>- `etcd_store` (default value)<br/>- `memory_store`<br/>- `postgres_store` |
 | `meta_table_name` | String | `greptime_metakv` | Table name in RDS to store metadata. Effect when using a RDS kvbackend. |
+| `meta_election_lock_id` | Integer | `1` | Advisory lock id in PostgreSQL for election. Effect when using PostgreSQL as kvbackend |
 | `selector` | String | `round_robin` | Datanode selector type.<br/>- `round_robin` (default value)<br/>- `lease_based`<br/>- `load_based`<br/>For details, please see "https://docs.greptime.com/developer-guide/metasrv/selector". |
 | `use_memory_store` | Bool | `false` | Store data in memory. |
 | `enable_region_failover` | Bool | `false` | Whether to enable region failover.<br/>This feature is only available on GreptimeDB running on cluster mode and<br/>- Using Remote WAL<br/>- Using shared storage (e.g., s3). |

--- a/config/config.md
+++ b/config/config.md
@@ -296,6 +296,7 @@
 | `store_addrs` | Array | -- | Store server address default to etcd store.<br/>For postgres store, the format is:<br/>"password=password dbname=postgres user=postgres host=localhost port=5432"<br/>For etcd store, the format is:<br/>"127.0.0.1:2379" |
 | `store_key_prefix` | String | `""` | If it's not empty, the metasrv will store all data with this key prefix. |
 | `backend` | String | `etcd_store` | The datastore for meta server.<br/>Available values:<br/>- `etcd_store` (default value)<br/>- `memory_store`<br/>- `postgres_store` |
+| `meta_table_name` | String | `greptime_metakv` | Table name in RDS to store metadata. Effect when using a RDS kvbackend. |
 | `selector` | String | `round_robin` | Datanode selector type.<br/>- `round_robin` (default value)<br/>- `lease_based`<br/>- `load_based`<br/>For details, please see "https://docs.greptime.com/developer-guide/metasrv/selector". |
 | `use_memory_store` | Bool | `false` | Store data in memory. |
 | `enable_region_failover` | Bool | `false` | Whether to enable region failover.<br/>This feature is only available on GreptimeDB running on cluster mode and<br/>- Using Remote WAL<br/>- Using shared storage (e.g., s3). |

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -27,6 +27,9 @@ backend = "etcd_store"
 ## Table name in RDS to store metadata. Effect when using a RDS kvbackend.
 meta_table_name = "greptime_metakv"
 
+## Advisory lock id in PostgreSQL for election. Effect when using PostgreSQL as kvbackend
+meta_election_lock_id = 1
+
 ## Datanode selector type.
 ## - `round_robin` (default value)
 ## - `lease_based`

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -24,6 +24,9 @@ store_key_prefix = ""
 ## - `postgres_store`
 backend = "etcd_store"
 
+## Table name in RDS to store metadata. Effect when using a RDS kvbackend.
+meta_table_name = "greptime_metakv"
+
 ## Datanode selector type.
 ## - `round_robin` (default value)
 ## - `lease_based`

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -25,9 +25,11 @@ store_key_prefix = ""
 backend = "etcd_store"
 
 ## Table name in RDS to store metadata. Effect when using a RDS kvbackend.
+## **Only used when backend is `postgres_store`.**
 meta_table_name = "greptime_metakv"
 
 ## Advisory lock id in PostgreSQL for election. Effect when using PostgreSQL as kvbackend
+## Only used when backend is `postgres_store`.
 meta_election_lock_id = 1
 
 ## Datanode selector type.

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -240,7 +240,7 @@ pub async fn metasrv_builder(
                 election_client,
                 opts.store_key_prefix.clone(),
                 CANDIDATE_LEASE_SECS,
-                opts.meta_table_name.clone(),
+                &opts.meta_table_name,
                 opts.meta_election_lock_id,
             )
             .await?;

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -241,6 +241,7 @@ pub async fn metasrv_builder(
                 opts.store_key_prefix.clone(),
                 CANDIDATE_LEASE_SECS,
                 opts.meta_table_name.clone(),
+                opts.meta_election_lock_id,
             )
             .await?;
             (kv_backend, Some(election))

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -230,7 +230,7 @@ pub async fn metasrv_builder(
         (None, BackendImpl::PostgresStore) => {
             let pool = create_postgres_pool(opts).await?;
             // TODO(CookiePie): use table name from config.
-            let kv_backend = PgStore::with_pg_pool(pool, "greptime_metakv", opts.max_txn_ops)
+            let kv_backend = PgStore::with_pg_pool(pool, &opts.meta_table_name, opts.max_txn_ops)
                 .await
                 .context(error::KvBackendSnafu)?;
             // Client for election should be created separately since we need a different session keep-alive idle time.
@@ -240,6 +240,7 @@ pub async fn metasrv_builder(
                 election_client,
                 opts.store_key_prefix.clone(),
                 CANDIDATE_LEASE_SECS,
+                opts.meta_table_name.clone(),
             )
             .await?;
             (kv_backend, Some(election))

--- a/src/meta-srv/src/election/postgres.rs
+++ b/src/meta-srv/src/election/postgres.rs
@@ -39,13 +39,12 @@ use crate::metasrv::{ElectionRef, LeaderValue, MetasrvNodeInfo};
 const LEASE_SEP: &str = r#"||__metadata_lease_sep||"#;
 
 struct ElectionSqlFactory {
-    // TODO(CookiePie): The lock id should be configurable.
-    lock_id: i64,
+    lock_id: u64,
     table_name: String,
 }
 
 impl ElectionSqlFactory {
-    fn new(lock_id: i64, table_name: String) -> Self {
+    fn new(lock_id: u64, table_name: String) -> Self {
         Self {
             lock_id,
             table_name,
@@ -215,9 +214,9 @@ impl PgElection {
         store_key_prefix: String,
         candidate_lease_ttl_secs: u64,
         table_name: String,
+        lock_id: u64,
     ) -> Result<ElectionRef> {
-        // TODO(CookiePie): The lock id should be configurable.
-        let sql_factory = ElectionSqlFactory::new(28319, table_name.clone());
+        let sql_factory = ElectionSqlFactory::new(lock_id, table_name.clone());
         // Set idle session timeout to IDLE_SESSION_TIMEOUT to avoid dead advisory lock.
         client
             .execute(&sql_factory.set_idle_session_timeout_sql(), &[])

--- a/src/meta-srv/src/election/postgres.rs
+++ b/src/meta-srv/src/election/postgres.rs
@@ -81,7 +81,7 @@ impl ElectionSqlFactory {
                 SELECT k, v FROM {} WHERE k = $1
             ), insert AS (
                 INSERT INTO {}
-                VALUES($1, convert_to($2 || {} || TO_CHAR(CURRENT_TIMESTAMP + INTERVAL '1 second' * $3, 'YYYY-MM-DD HH24:MI:SS.MS'), 'UTF8'))
+                VALUES($1, convert_to($2 || '{}' || TO_CHAR(CURRENT_TIMESTAMP + INTERVAL '1 second' * $3, 'YYYY-MM-DD HH24:MI:SS.MS'), 'UTF8'))
                 ON CONFLICT (k) DO NOTHING
             )
             SELECT k, v FROM prev;
@@ -100,7 +100,7 @@ impl ElectionSqlFactory {
     fn update_value_with_lease_sql(&self) -> String {
         format!(
             r#"UPDATE {} 
-               SET v = convert_to($3 || {} || TO_CHAR(CURRENT_TIMESTAMP + INTERVAL '1 second' * $4, 'YYYY-MM-DD HH24:MI:SS.MS'), 'UTF8')
+               SET v = convert_to($3 || '{}' || TO_CHAR(CURRENT_TIMESTAMP + INTERVAL '1 second' * $4, 'YYYY-MM-DD HH24:MI:SS.MS'), 'UTF8')
                WHERE k = $1 AND v = $2"#,
             self.table_name, LEASE_SEP
         )

--- a/src/meta-srv/src/election/postgres.rs
+++ b/src/meta-srv/src/election/postgres.rs
@@ -426,10 +426,7 @@ impl PgElection {
         let key = key.as_bytes();
         let res = self
             .client
-            .query(
-                &self.sql_set.get_value_with_lease,
-                &[&key as &(dyn ToSql + Sync)],
-            )
+            .query(&self.sql_set.get_value_with_lease, &[&key])
             .await
             .context(PostgresExecutionSnafu)?;
 
@@ -471,10 +468,7 @@ impl PgElection {
         let key_prefix = format!("{}%", key_prefix).as_bytes().to_vec();
         let res = self
             .client
-            .query(
-                &self.sql_set.get_value_with_lease_by_prefix,
-                &[(&key_prefix as &(dyn ToSql + Sync))],
-            )
+            .query(&self.sql_set.get_value_with_lease_by_prefix, &[&key_prefix])
             .await
             .context(PostgresExecutionSnafu)?;
 
@@ -506,8 +500,8 @@ impl PgElection {
             .execute(
                 &self.sql_set.update_value_with_lease,
                 &[
-                    &key as &(dyn ToSql + Sync),
-                    &prev as &(dyn ToSql + Sync),
+                    &key,
+                    &prev,
                     &updated,
                     &(self.candidate_lease_ttl_secs as f64),
                 ],
@@ -534,11 +528,7 @@ impl PgElection {
     ) -> Result<bool> {
         let key = key.as_bytes();
         let lease_ttl_secs = lease_ttl_secs as f64;
-        let params: Vec<&(dyn ToSql + Sync)> = vec![
-            &key as &(dyn ToSql + Sync),
-            &value as &(dyn ToSql + Sync),
-            &lease_ttl_secs,
-        ];
+        let params: Vec<&(dyn ToSql + Sync)> = vec![&key, &value, &lease_ttl_secs];
         let res = self
             .client
             .query(&self.sql_set.put_value_with_lease, &params)
@@ -553,7 +543,7 @@ impl PgElection {
         let key = key.as_bytes();
         let res = self
             .client
-            .query(&self.sql_set.delete_value, &[&key as &(dyn ToSql + Sync)])
+            .query(&self.sql_set.delete_value, &[&key])
             .await
             .context(PostgresExecutionSnafu)?;
 

--- a/src/meta-srv/src/election/postgres.rs
+++ b/src/meta-srv/src/election/postgres.rs
@@ -401,7 +401,7 @@ impl PgElection {
         key: &str,
         with_origin: bool,
     ) -> Result<Option<(String, Timestamp, Timestamp, Option<String>)>> {
-        let key = key.as_bytes().to_vec();
+        let key = key.as_bytes();
         let res = self
             .client
             .query(
@@ -477,8 +477,8 @@ impl PgElection {
     }
 
     async fn update_value_with_lease(&self, key: &str, prev: &str, updated: &str) -> Result<()> {
-        let key = key.as_bytes().to_vec();
-        let prev = prev.as_bytes().to_vec();
+        let key = key.as_bytes();
+        let prev = prev.as_bytes();
         let res = self
             .client
             .execute(
@@ -496,7 +496,7 @@ impl PgElection {
         ensure!(
             res == 1,
             UnexpectedSnafu {
-                violated: format!("Failed to update key: {}", String::from_utf8_lossy(&key)),
+                violated: format!("Failed to update key: {}", String::from_utf8_lossy(key)),
             }
         );
 
@@ -510,7 +510,7 @@ impl PgElection {
         value: &str,
         lease_ttl_secs: u64,
     ) -> Result<bool> {
-        let key = key.as_bytes().to_vec();
+        let key = key.as_bytes();
         let lease_ttl_secs = lease_ttl_secs as f64;
         let params: Vec<&(dyn ToSql + Sync)> = vec![
             &key as &(dyn ToSql + Sync),
@@ -528,7 +528,7 @@ impl PgElection {
     /// Returns `true` if the deletion is successful.
     /// Caution: Should only delete the key if the lease is expired.
     async fn delete_value(&self, key: &str) -> Result<bool> {
-        let key = key.as_bytes().to_vec();
+        let key = key.as_bytes();
         let res = self
             .client
             .query(

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -73,6 +73,8 @@ pub const METASRV_HOME: &str = "/tmp/metasrv";
 
 #[cfg(feature = "pg_kvbackend")]
 pub const DEFAULT_META_TABLE_NAME: &str = "greptime_metakv";
+#[cfg(feature = "pg_kvbackend")]
+pub const DEFAULT_META_ELECTION_LOCK_ID: u64 = 1;
 
 // The datastores that implements metadata kvbackend.
 #[derive(Clone, Debug, PartialEq, Serialize, Default, Deserialize, ValueEnum)]
@@ -146,6 +148,9 @@ pub struct MetasrvOptions {
     #[cfg(feature = "pg_kvbackend")]
     /// Table name of rds kv backend.
     pub meta_table_name: String,
+    #[cfg(feature = "pg_kvbackend")]
+    /// Lock id for meta kv election. Only effect when using pg_kvbackend.
+    pub meta_election_lock_id: u64,
 }
 
 impl Default for MetasrvOptions {
@@ -182,6 +187,8 @@ impl Default for MetasrvOptions {
             backend: BackendImpl::EtcdStore,
             #[cfg(feature = "pg_kvbackend")]
             meta_table_name: DEFAULT_META_TABLE_NAME.to_string(),
+            #[cfg(feature = "pg_kvbackend")]
+            meta_election_lock_id: DEFAULT_META_ELECTION_LOCK_ID,
         }
     }
 }

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -71,6 +71,9 @@ pub const TABLE_ID_SEQ: &str = "table_id";
 pub const FLOW_ID_SEQ: &str = "flow_id";
 pub const METASRV_HOME: &str = "/tmp/metasrv";
 
+#[cfg(feature = "pg_kvbackend")]
+pub const DEFAULT_META_TABLE_NAME: &str = "greptime_metakv";
+
 // The datastores that implements metadata kvbackend.
 #[derive(Clone, Debug, PartialEq, Serialize, Default, Deserialize, ValueEnum)]
 #[serde(rename_all = "snake_case")]
@@ -140,6 +143,9 @@ pub struct MetasrvOptions {
     pub tracing: TracingOptions,
     /// The datastore for kv metadata.
     pub backend: BackendImpl,
+    #[cfg(feature = "pg_kvbackend")]
+    /// Table name of rds kv backend.
+    pub meta_table_name: String,
 }
 
 impl Default for MetasrvOptions {
@@ -174,6 +180,8 @@ impl Default for MetasrvOptions {
             flush_stats_factor: 3,
             tracing: TracingOptions::default(),
             backend: BackendImpl::EtcdStore,
+            #[cfg(feature = "pg_kvbackend")]
+            meta_table_name: DEFAULT_META_TABLE_NAME.to_string(),
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

#5208 

## What's changed and what's your intention?

As title. I init a separate config, but seems it's better to place the table name under the previous kvbackend config?

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
