### PR TITLE
fix: disable path label in opendal for now

### DIFF
--- a/src/object-store/src/layers.rs
+++ b/src/object-store/src/layers.rs
@@ -30,13 +30,18 @@ mod prometheus {
     /// pattern `<data|index>/catalog/schema/table_id/...` OR `greptimedb/object_cache/<read|write>/...`
     ///
     /// We'll get the data/catalog/schema from path.
-    pub fn build_prometheus_metrics_layer(with_path_label: bool) -> PrometheusLayer {
+    pub fn build_prometheus_metrics_layer(_with_path_label: bool) -> PrometheusLayer {
         PROMETHEUS_LAYER
             .get_or_init(|| {
-                let path_level = if with_path_label { 3 } else { 0 };
+                // let path_level = if with_path_label { 3 } else { 0 };
+
+                // opendal doesn't support dynamic path label trim
+                // we have uuid in index path, which casues the label size to explode
+                // remove path label first, waiting for later fix
+                // TODO(shuiyisong): add dynamic path label trim for opendal
 
                 let layer = PrometheusLayer::builder()
-                    .path_label(path_level)
+                    .path_label(0)
                     .register_default()
                     .unwrap();
 

--- a/src/object-store/src/layers.rs
+++ b/src/object-store/src/layers.rs
@@ -36,7 +36,7 @@ mod prometheus {
                 // let path_level = if with_path_label { 3 } else { 0 };
 
                 // opendal doesn't support dynamic path label trim
-                // we have uuid in index path, which casues the label size to explode
+                // we have uuid in index path, which causes the label size to explode
                 // remove path label first, waiting for later fix
                 // TODO(shuiyisong): add dynamic path label trim for opendal
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Since switching to openDAL's Prometheus layer, we have not been able to set the layer multiple times, causing the path label to include the index`s uuid symbol, which causes the size of the label to explode.

Disable the path label for now because we're not using it for debugging anyway. We may reopen it later if openDAL supports dynamic path trim or some hook to decide path label dynamically.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
