### PR TITLE
feat: impl COPY a query resultset to external file

### DIFF
--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -495,7 +495,8 @@ pub fn check_permission(
         | Statement::Explain(_)
         | Statement::Tql(_)
         | Statement::Delete(_)
-        | Statement::DeclareCursor(_) => {}
+        | Statement::DeclareCursor(_)
+        | Statement::Copy(sql::statements::copy::Copy::CopyQueryTo(_)) => {}
         // database ops won't be checked
         Statement::CreateDatabase(_)
         | Statement::ShowDatabases(_)

--- a/src/operator/src/statement.rs
+++ b/src/operator/src/statement.rs
@@ -14,6 +14,7 @@
 
 mod admin;
 mod copy_database;
+mod copy_query_to;
 mod copy_table_from;
 mod copy_table_to;
 mod cursor;
@@ -57,14 +58,16 @@ use session::context::{Channel, QueryContextRef};
 use session::table_name::table_idents_to_full_name;
 use set::set_query_timeout;
 use snafu::{ensure, OptionExt, ResultExt};
-use sql::statements::copy::{CopyDatabase, CopyDatabaseArgument, CopyTable, CopyTableArgument};
+use sql::statements::copy::{
+    CopyDatabase, CopyDatabaseArgument, CopyQueryToArgument, CopyTable, CopyTableArgument,
+};
 use sql::statements::set_variables::SetVariables;
 use sql::statements::show::ShowCreateTableVariant;
 use sql::statements::statement::Statement;
 use sql::statements::OptionMap;
 use sql::util::format_raw_object_name;
 use sqlparser::ast::ObjectName;
-use table::requests::{CopyDatabaseRequest, CopyDirection, CopyTableRequest};
+use table::requests::{CopyDatabaseRequest, CopyDirection, CopyQueryToRequest, CopyTableRequest};
 use table::table_name::TableName;
 use table::table_reference::TableReference;
 use table::TableRef;
@@ -164,6 +167,17 @@ impl StatementExecutor {
             Statement::ShowViews(stmt) => self.show_views(stmt, query_ctx).await,
 
             Statement::ShowFlows(stmt) => self.show_flows(stmt, query_ctx).await,
+
+            Statement::Copy(sql::statements::copy::Copy::CopyQueryTo(stmt)) => {
+                let query_output = self
+                    .plan_exec(QueryStatement::Sql(*stmt.query), query_ctx)
+                    .await?;
+                let req = to_copy_query_request(stmt.arg)?;
+
+                self.copy_query_to(req, query_output)
+                    .await
+                    .map(Output::new_with_affected_rows)
+            }
 
             Statement::Copy(sql::statements::copy::Copy::CopyTable(stmt)) => {
                 let req = to_copy_table_request(stmt, query_ctx.clone())?;
@@ -514,6 +528,20 @@ fn derive_timeout(stmt: &QueryStatement, query_ctx: &QueryContextRef) -> Option<
         | (Channel::Postgres, QueryStatement::Sql(_)) => Some(query_timeout),
         (_, _) => None,
     }
+}
+
+fn to_copy_query_request(stmt: CopyQueryToArgument) -> Result<CopyQueryToRequest> {
+    let CopyQueryToArgument {
+        with,
+        connection,
+        location,
+    } = stmt;
+
+    Ok(CopyQueryToRequest {
+        location,
+        with: with.into_map(),
+        connection: connection.into_map(),
+    })
 }
 
 fn to_copy_table_request(stmt: CopyTable, query_ctx: QueryContextRef) -> Result<CopyTableRequest> {

--- a/src/operator/src/statement/copy_query_to.rs
+++ b/src/operator/src/statement/copy_query_to.rs
@@ -1,0 +1,44 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_datasource::file_format::Format;
+use common_query::Output;
+use common_telemetry::{debug, tracing};
+use snafu::ResultExt;
+use table::requests::CopyQueryToRequest;
+
+use crate::error;
+use crate::error::Result;
+use crate::statement::StatementExecutor;
+
+impl StatementExecutor {
+    #[tracing::instrument(skip_all)]
+    pub(crate) async fn copy_query_to(
+        &self,
+        req: CopyQueryToRequest,
+        query_output: Output,
+    ) -> Result<usize> {
+        let CopyQueryToRequest {
+            with,
+            connection,
+            location,
+        } = &req;
+        let format = Format::try_from(with).context(error::ParseFileFormatSnafu)?;
+
+        self.copy_to_file(&format, query_output, location, connection, |path| {
+            debug!("Copy query to path: {path}")
+        })
+        .await
+    }
+}

--- a/src/operator/src/statement/copy_query_to.rs
+++ b/src/operator/src/statement/copy_query_to.rs
@@ -36,9 +36,8 @@ impl StatementExecutor {
         } = &req;
         let format = Format::try_from(with).context(error::ParseFileFormatSnafu)?;
 
-        self.copy_to_file(&format, query_output, location, connection, |path| {
-            debug!("Copy query to path: {path}")
-        })
-        .await
+        debug!("Copy query to location: {location}");
+        self.copy_to_file(&format, query_output, location, connection)
+            .await
     }
 }

--- a/src/operator/src/statement/copy_table_to.rs
+++ b/src/operator/src/statement/copy_table_to.rs
@@ -143,19 +143,18 @@ impl StatementExecutor {
             connection,
             ..
         } = &req;
-        self.copy_to_file(&format, output, location, connection, |path| {
-            debug!("Copy table: {table_id} to path: {path}")
-        })
-        .await
+
+        debug!("Copy table: {table_id} to location: {location}");
+        self.copy_to_file(&format, output, location, connection)
+            .await
     }
 
-    pub(crate) async fn copy_to_file<F: FnOnce(String)>(
+    pub(crate) async fn copy_to_file(
         &self,
         format: &Format,
         output: Output,
         location: &str,
         connection: &HashMap<String, String>,
-        fn_debug: F,
     ) -> Result<usize> {
         let stream = match output.data {
             OutputData::Stream(stream) => stream,
@@ -169,7 +168,6 @@ impl StatementExecutor {
             violated: format!("Expected filename, path: {path}"),
         })?;
         let object_store = build_backend(location, connection).context(error::BuildBackendSnafu)?;
-        fn_debug(path);
         self.stream_to_file(stream, format, object_store, &filename)
             .await
     }

--- a/src/sql/src/parsers/copy_parser.rs
+++ b/src/sql/src/parsers/copy_parser.rs
@@ -532,4 +532,28 @@ mod tests {
             stmt.arg.connection.to_str_map()
         );
     }
+
+    #[test]
+    fn test_invalid_copy_query_to() {
+        {
+            let sql = "COPY SELECT * FROM tbl WHERE ts > 10) TO 'tbl_file.parquet' WITH (FORMAT = 'parquet') CONNECTION (FOO='Bar', ONE='two')";
+
+            assert!(ParserContext::create_with_dialect(
+                sql,
+                &GreptimeDbDialect {},
+                ParseOptions::default()
+            )
+            .is_err())
+        }
+        {
+            let sql = "COPY (SELECT * FROM tbl WHERE ts > 10 TO 'tbl_file.parquet' WITH (FORMAT = 'parquet') CONNECTION (FOO='Bar', ONE='two')";
+
+            assert!(ParserContext::create_with_dialect(
+                sql,
+                &GreptimeDbDialect {},
+                ParseOptions::default()
+            )
+            .is_err())
+        }
+    }
 }

--- a/src/sql/src/parsers/copy_parser.rs
+++ b/src/sql/src/parsers/copy_parser.rs
@@ -536,6 +536,16 @@ mod tests {
     #[test]
     fn test_invalid_copy_query_to() {
         {
+            let sql = "COPY SELECT * FROM tbl WHERE ts > 10 TO 'tbl_file.parquet' WITH (FORMAT = 'parquet') CONNECTION (FOO='Bar', ONE='two')";
+
+            assert!(ParserContext::create_with_dialect(
+                sql,
+                &GreptimeDbDialect {},
+                ParseOptions::default()
+            )
+            .is_err())
+        }
+        {
             let sql = "COPY SELECT * FROM tbl WHERE ts > 10) TO 'tbl_file.parquet' WITH (FORMAT = 'parquet') CONNECTION (FOO='Bar', ONE='two')";
 
             assert!(ParserContext::create_with_dialect(

--- a/src/sql/src/statements/copy.rs
+++ b/src/sql/src/statements/copy.rs
@@ -46,7 +46,7 @@ pub struct CopyQueryTo {
 
 impl Display for CopyQueryTo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "COPY {} TO {}", &self.query, &self.arg.location)?;
+        write!(f, "COPY ({}) TO {}", &self.query, &self.arg.location)?;
         if !self.arg.with.is_empty() {
             let options = self.arg.with.kv_pairs();
             write!(f, " WITH ({})", options.join(", "))?;
@@ -261,6 +261,31 @@ mod tests {
                 let new_sql = format!("{}", copy);
                 assert_eq!(
                     r#"COPY DATABASE db1 TO s3://my-bucket/data.parquet WITH (format = 'parquet', pattern = '.*parquet.*') CONNECTION (region = 'us-west-2', secret_access_key = '******')"#,
+                    &new_sql
+                );
+            }
+            _ => {
+                unreachable!();
+            }
+        }
+    }
+
+    #[test]
+    fn test_display_copy_query_to() {
+        let sql = r"copy (SELECT * FROM tbl WHERE ts > 10) to 's3://my-bucket/data.parquet'
+            with (format = 'parquet', pattern = '.*parquet.*')
+            connection(region = 'us-west-2', secret_access_key = '12345678');";
+        let stmts =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
+        assert_eq!(1, stmts.len());
+        assert_matches!(&stmts[0], Statement::Copy { .. });
+
+        match &stmts[0] {
+            Statement::Copy(copy) => {
+                let new_sql = format!("{}", copy);
+                assert_eq!(
+                    r#"COPY (SELECT * FROM tbl WHERE ts > 10) TO s3://my-bucket/data.parquet WITH (format = 'parquet', pattern = '.*parquet.*') CONNECTION (region = 'us-west-2', secret_access_key = '******')"#,
                     &new_sql
                 );
             }

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -319,6 +319,13 @@ pub struct CopyDatabaseRequest {
     pub time_range: Option<TimestampRange>,
 }
 
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct CopyQueryToRequest {
+    pub location: String,
+    pub with: HashMap<String, String>,
+    pub connection: HashMap<String, String>,
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;

--- a/tests/cases/standalone/common/copy/copy_to_fs.result
+++ b/tests/cases/standalone/common/copy/copy_to_fs.result
@@ -18,6 +18,18 @@ COPY demo TO '${SQLNESS_HOME}/export/demo.json' WITH (format='json', start_time=
 
 Affected Rows: 1
 
+COPY (select host, cpu, ts from demo where host = 'host2') TO '${SQLNESS_HOME}/export/demo.parquet';
+
+Affected Rows: 1
+
+COPY (select host, cpu, ts from demo where host = 'host2') TO '${SQLNESS_HOME}/export/demo.csv' WITH (format='csv');
+
+Affected Rows: 1
+
+COPY (select host, cpu, ts from demo where host = 'host2') TO '${SQLNESS_HOME}/export/demo.json' WITH (format='json');
+
+Affected Rows: 1
+
 drop table demo;
 
 Affected Rows: 0

--- a/tests/cases/standalone/common/copy/copy_to_fs.sql
+++ b/tests/cases/standalone/common/copy/copy_to_fs.sql
@@ -8,4 +8,10 @@ COPY demo TO '${SQLNESS_HOME}/export/demo.csv' WITH (format='csv', start_time='2
 
 COPY demo TO '${SQLNESS_HOME}/export/demo.json' WITH (format='json', start_time='2022-06-15 07:02:37', end_time='2022-06-15 07:02:38');
 
+COPY (select host, cpu, ts from demo where host = 'host2') TO '${SQLNESS_HOME}/export/demo.parquet';
+
+COPY (select host, cpu, ts from demo where host = 'host2') TO '${SQLNESS_HOME}/export/demo.csv' WITH (format='csv');
+
+COPY (select host, cpu, ts from demo where host = 'host2') TO '${SQLNESS_HOME}/export/demo.json' WITH (format='json');
+
 drop table demo;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

https://github.com/GreptimeTeam/greptimedb/issues/5075

## What's changed and what's your intention?

support `CopyQueryTo`
```sql
COPY (SELECT * FROM tbl WHERE ...) TO '/xxx/xxx/output.parquet' WITH (FORMAT = 'parquet');
```

example:

```shell
COPY (select host, cpu, ts from demo where host = 'host2') TO '/tmp/export/demo.parquet';

Affected Rows: 1
```

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
