### PR TITLE
feat: override `__sequence` on creating SST to save space and CPU

### DIFF
--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -19,6 +19,7 @@ use object_store::util::{join_dir, with_instrument_layers};
 use object_store::ObjectStore;
 use snafu::ResultExt;
 use store_api::metadata::RegionMetadataRef;
+use store_api::storage::SequenceNumber;
 
 use crate::cache::write_cache::SstUploadRequest;
 use crate::cache::CacheManagerRef;
@@ -164,7 +165,9 @@ impl AccessLayer {
                 request.metadata,
                 indexer,
             );
-            writer.write_all(request.source, write_opts).await?
+            writer
+                .write_all(request.source, request.max_sequence, write_opts)
+                .await?
         };
 
         // Put parquet metadata to cache manager.
@@ -194,6 +197,7 @@ pub(crate) struct SstWriteRequest {
     pub(crate) cache_manager: CacheManagerRef,
     #[allow(dead_code)]
     pub(crate) storage: Option<String>,
+    pub(crate) max_sequence: Option<SequenceNumber>,
 
     /// Configs for index
     pub(crate) index_options: IndexOptions,

--- a/src/mito2/src/cache/write_cache.rs
+++ b/src/mito2/src/cache/write_cache.rs
@@ -138,7 +138,9 @@ impl WriteCache {
             indexer,
         );
 
-        let sst_info = writer.write_all(write_request.source, write_opts).await?;
+        let sst_info = writer
+            .write_all(write_request.source, write_request.max_sequence, write_opts)
+            .await?;
 
         timer.stop_and_record();
 
@@ -375,6 +377,7 @@ mod tests {
             metadata,
             source,
             storage: None,
+            max_sequence: None,
             cache_manager: Default::default(),
             index_options: IndexOptions::default(),
             inverted_index_config: Default::default(),
@@ -468,6 +471,7 @@ mod tests {
             metadata,
             source,
             storage: None,
+            max_sequence: None,
             cache_manager: cache_manager.clone(),
             index_options: IndexOptions::default(),
             inverted_index_config: Default::default(),

--- a/src/mito2/src/compaction/compactor.rs
+++ b/src/mito2/src/compaction/compactor.rs
@@ -324,6 +324,7 @@ impl Compactor for DefaultCompactor {
                             source: Source::Reader(reader),
                             cache_manager,
                             storage,
+                            max_sequence: None,
                             index_options,
                             inverted_index_config,
                             fulltext_index_config,

--- a/src/mito2/src/compaction/test_util.rs
+++ b/src/mito2/src/compaction/test_util.rs
@@ -39,7 +39,7 @@ pub fn new_file_handle(
             index_file_size: 0,
             num_rows: 0,
             num_row_groups: 0,
-            max_sequence: 0,
+            sequence: None,
         },
         file_purger,
     )
@@ -64,7 +64,7 @@ pub(crate) fn new_file_handles(file_specs: &[(i64, i64, u64)]) -> Vec<FileHandle
                     index_file_size: 0,
                     num_rows: 0,
                     num_row_groups: 0,
-                    max_sequence: 0,
+                    sequence: None,
                 },
                 file_purger.clone(),
             )

--- a/src/mito2/src/compaction/test_util.rs
+++ b/src/mito2/src/compaction/test_util.rs
@@ -39,6 +39,7 @@ pub fn new_file_handle(
             index_file_size: 0,
             num_rows: 0,
             num_row_groups: 0,
+            max_sequence: 0,
         },
         file_purger,
     )
@@ -63,6 +64,7 @@ pub(crate) fn new_file_handles(file_specs: &[(i64, i64, u64)]) -> Vec<FileHandle
                     index_file_size: 0,
                     num_rows: 0,
                     num_row_groups: 0,
+                    max_sequence: 0,
                 },
                 file_purger.clone(),
             )

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -760,6 +760,7 @@ mod tests {
                         index_file_size: 0,
                         num_rows: 0,
                         num_row_groups: 0,
+                        max_sequence: 0,
                     },
                     Arc::new(NoopFilePurger),
                 )

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -760,7 +760,7 @@ mod tests {
                         index_file_size: 0,
                         num_rows: 0,
                         num_row_groups: 0,
-                        max_sequence: 0,
+                        sequence: None,
                     },
                     Arc::new(NoopFilePurger),
                 )

--- a/src/mito2/src/engine/basic_test.rs
+++ b/src/mito2/src/engine/basic_test.rs
@@ -580,7 +580,7 @@ async fn test_region_usage() {
     flush_region(&engine, region_id, None).await;
 
     let region_stat = region.region_statistic();
-    assert_eq!(region_stat.sst_size, 2773);
+    assert!(region_stat.sst_size > 0); // Chief says this assert can ensure the size is counted.
     assert_eq!(region_stat.num_rows, 10);
 
     // region total usage

--- a/src/mito2/src/engine/basic_test.rs
+++ b/src/mito2/src/engine/basic_test.rs
@@ -580,7 +580,7 @@ async fn test_region_usage() {
     flush_region(&engine, region_id, None).await;
 
     let region_stat = region.region_statistic();
-    assert_eq!(region_stat.sst_size, 2790);
+    assert_eq!(region_stat.sst_size, 2773);
     assert_eq!(region_stat.num_rows, 10);
 
     // region total usage

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -337,6 +337,18 @@ impl RegionFlushTask {
         }
 
         let memtables = version.memtables.immutables();
+        // get max_sequence from all non-empty memetables
+        let max_sequence = memtables
+            .iter()
+            .filter_map(|m| {
+                if !m.is_empty() {
+                    Some(m.stats().max_sequence())
+                } else {
+                    None
+                }
+            })
+            .max();
+
         let mut file_metas = Vec::with_capacity(memtables.len());
         let mut flushed_bytes = 0;
         for mem in memtables {
@@ -357,6 +369,7 @@ impl RegionFlushTask {
                 source,
                 cache_manager: self.cache_manager.clone(),
                 storage: version.options.storage.clone(),
+                max_sequence,
                 index_options: self.index_options.clone(),
                 inverted_index_config: self.engine_config.inverted_index.clone(),
                 fulltext_index_config: self.engine_config.fulltext_index.clone(),

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -395,6 +395,7 @@ impl RegionFlushTask {
                 index_file_size: sst_info.index_metadata.file_size,
                 num_rows: sst_info.num_rows as u64,
                 num_row_groups: sst_info.num_row_groups,
+                max_sequence: max_sequence.unwrap_or(0),
             };
             file_metas.push(file_meta);
         }

--- a/src/mito2/src/manifest/tests/checkpoint.rs
+++ b/src/mito2/src/manifest/tests/checkpoint.rs
@@ -225,6 +225,7 @@ async fn checkpoint_with_different_compression_types() {
             index_file_size: 0,
             num_rows: 0,
             num_row_groups: 0,
+            max_sequence: 0,
         };
         let action = RegionMetaActionList::new(vec![RegionMetaAction::Edit(RegionEdit {
             files_to_add: vec![file_meta],

--- a/src/mito2/src/manifest/tests/checkpoint.rs
+++ b/src/mito2/src/manifest/tests/checkpoint.rs
@@ -225,7 +225,7 @@ async fn checkpoint_with_different_compression_types() {
             index_file_size: 0,
             num_rows: 0,
             num_row_groups: 0,
-            max_sequence: 0,
+            sequence: None,
         };
         let action = RegionMetaActionList::new(vec![RegionMetaAction::Edit(RegionEdit {
             files_to_add: vec![file_meta],

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -23,7 +23,7 @@ pub use bulk::part::BulkPart;
 use common_time::Timestamp;
 use serde::{Deserialize, Serialize};
 use store_api::metadata::RegionMetadataRef;
-use store_api::storage::ColumnId;
+use store_api::storage::{ColumnId, SequenceNumber};
 use table::predicate::Predicate;
 
 use crate::config::MitoConfig;
@@ -77,6 +77,8 @@ pub struct MemtableStats {
     num_rows: usize,
     /// Total number of ranges in the memtable.
     num_ranges: usize,
+    /// The maximum sequence number in the memtable.
+    max_sequence: SequenceNumber,
 }
 
 impl MemtableStats {
@@ -105,6 +107,11 @@ impl MemtableStats {
     /// Returns the number of ranges in the memtable.
     pub fn num_ranges(&self) -> usize {
         self.num_ranges
+    }
+
+    /// Returns the maximum sequence number in the memtable.
+    pub fn max_sequence(&self) -> SequenceNumber {
+        self.max_sequence
     }
 }
 

--- a/src/mito2/src/memtable/key_values.rs
+++ b/src/mito2/src/memtable/key_values.rs
@@ -68,6 +68,20 @@ impl KeyValues {
     pub fn is_empty(&self) -> bool {
         self.mutation.rows.is_none()
     }
+
+    /// Return the max sequence in this container.
+    ///
+    /// When the mutation has no rows, the sequence is the same as the mutation sequence.
+    pub fn max_sequence(&self) -> SequenceNumber {
+        let mut sequence = self.mutation.sequence;
+        let num_rows = self.mutation.rows.as_ref().unwrap().rows.len() as u64;
+        sequence += num_rows;
+        if num_rows > 0 {
+            sequence -= 1;
+        }
+
+        sequence
+    }
 }
 
 /// Key value view of a mutation.

--- a/src/mito2/src/memtable/key_values.rs
+++ b/src/mito2/src/memtable/key_values.rs
@@ -63,6 +63,11 @@ impl KeyValues {
         // Safety: rows is not None.
         self.mutation.rows.as_ref().unwrap().rows.len()
     }
+
+    /// Returns if this container is empty
+    pub fn is_empty(&self) -> bool {
+        self.mutation.rows.is_none()
+    }
 }
 
 /// Key value view of a mutation.

--- a/src/mito2/src/memtable/partition_tree.rs
+++ b/src/mito2/src/memtable/partition_tree.rs
@@ -147,7 +147,7 @@ impl Memtable for PartitionTreeMemtable {
 
         // update max_sequence
         if res.is_ok() {
-            let sequence = kvs.mutation.sequence + kvs.num_rows() as u64 - 1;
+            let sequence = kvs.max_sequence();
             self.max_sequence.fetch_max(sequence, Ordering::Relaxed);
         }
 

--- a/src/mito2/src/memtable/partition_tree.rs
+++ b/src/mito2/src/memtable/partition_tree.rs
@@ -24,7 +24,7 @@ mod shard_builder;
 mod tree;
 
 use std::fmt;
-use std::sync::atomic::{AtomicI64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicI64, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use common_base::readable_size::ReadableSize;
@@ -113,6 +113,7 @@ pub struct PartitionTreeMemtable {
     alloc_tracker: AllocTracker,
     max_timestamp: AtomicI64,
     min_timestamp: AtomicI64,
+    max_sequence: AtomicU64,
     /// Total written rows in memtable. This also includes deleted and duplicated rows.
     num_rows: AtomicUsize,
 }
@@ -140,6 +141,12 @@ impl Memtable for PartitionTreeMemtable {
 
         self.update_stats(&metrics);
 
+        // update max_sequence
+        if res.is_ok() {
+            let sequence = kvs.mutation.sequence;
+            self.max_sequence.fetch_max(sequence, Ordering::Relaxed);
+        }
+
         self.num_rows.fetch_add(kvs.num_rows(), Ordering::Relaxed);
         res
     }
@@ -151,6 +158,12 @@ impl Memtable for PartitionTreeMemtable {
         let res = self.tree.write_one(key_value, &mut pk_buffer, &mut metrics);
 
         self.update_stats(&metrics);
+
+        // update max_sequence
+        if res.is_ok() {
+            self.max_sequence
+                .fetch_max(key_value.sequence(), Ordering::Relaxed);
+        }
 
         self.num_rows.fetch_add(1, Ordering::Relaxed);
         res
@@ -210,6 +223,7 @@ impl Memtable for PartitionTreeMemtable {
                 time_range: None,
                 num_rows: 0,
                 num_ranges: 0,
+                max_sequence: 0,
             };
         }
 
@@ -229,6 +243,7 @@ impl Memtable for PartitionTreeMemtable {
             time_range: Some((min_timestamp, max_timestamp)),
             num_rows: self.num_rows.load(Ordering::Relaxed),
             num_ranges: 1,
+            max_sequence: self.max_sequence.load(Ordering::Relaxed),
         }
     }
 
@@ -267,6 +282,7 @@ impl PartitionTreeMemtable {
             max_timestamp: AtomicI64::new(i64::MIN),
             min_timestamp: AtomicI64::new(i64::MAX),
             num_rows: AtomicUsize::new(0),
+            max_sequence: AtomicU64::new(0),
         }
     }
 

--- a/src/mito2/src/memtable/partition_tree.rs
+++ b/src/mito2/src/memtable/partition_tree.rs
@@ -132,6 +132,10 @@ impl Memtable for PartitionTreeMemtable {
     }
 
     fn write(&self, kvs: &KeyValues) -> Result<()> {
+        if kvs.is_empty() {
+            return Ok(());
+        }
+
         // TODO(yingwen): Validate schema while inserting rows.
 
         let mut metrics = WriteMetrics::default();
@@ -143,7 +147,7 @@ impl Memtable for PartitionTreeMemtable {
 
         // update max_sequence
         if res.is_ok() {
-            let sequence = kvs.mutation.sequence;
+            let sequence = kvs.mutation.sequence + kvs.num_rows() as u64 - 1;
             self.max_sequence.fetch_max(sequence, Ordering::Relaxed);
         }
 

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -188,6 +188,10 @@ impl Memtable for TimeSeriesMemtable {
     }
 
     fn write(&self, kvs: &KeyValues) -> Result<()> {
+        if kvs.is_empty() {
+            return Ok(());
+        }
+
         let mut local_stats = WriteMetrics::default();
 
         for kv in kvs.iter() {
@@ -202,7 +206,7 @@ impl Memtable for TimeSeriesMemtable {
         self.update_stats(local_stats);
 
         // update max_sequence
-        let sequence = kvs.mutation.sequence;
+        let sequence = kvs.mutation.sequence + kvs.num_rows() as u64 - 1;
         self.max_sequence.fetch_max(sequence, Ordering::Relaxed);
 
         self.num_rows.fetch_add(kvs.num_rows(), Ordering::Relaxed);

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -206,7 +206,7 @@ impl Memtable for TimeSeriesMemtable {
         self.update_stats(local_stats);
 
         // update max_sequence
-        let sequence = kvs.mutation.sequence + kvs.num_rows() as u64 - 1;
+        let sequence = kvs.max_sequence();
         self.max_sequence.fetch_max(sequence, Ordering::Relaxed);
 
         self.num_rows.fetch_add(kvs.num_rows(), Ordering::Relaxed);

--- a/src/mito2/src/sst/file.rs
+++ b/src/mito2/src/sst/file.rs
@@ -134,6 +134,8 @@ pub struct FileMeta {
     /// the default value `0` doesn't means the file doesn't contains any rows,
     /// but instead means the number of rows is unknown.
     pub num_row_groups: u64,
+    /// Max sequence in this file
+    pub max_sequence: u64,
 }
 
 /// Type of index.
@@ -343,6 +345,7 @@ mod tests {
             index_file_size: 0,
             num_rows: 0,
             num_row_groups: 0,
+            max_sequence: 0,
         }
     }
 

--- a/src/mito2/src/sst/file.rs
+++ b/src/mito2/src/sst/file.rs
@@ -137,7 +137,7 @@ pub struct FileMeta {
     pub num_row_groups: u64,
     /// Sequence in this file.
     ///
-    /// This sequence is the only sequence in this file. And it's retrived from the max
+    /// This sequence is the only sequence in this file. And it's retrieved from the max
     /// sequence of the rows on generating this file.
     pub sequence: Option<NonZeroU64>,
 }

--- a/src/mito2/src/sst/file.rs
+++ b/src/mito2/src/sst/file.rs
@@ -15,6 +15,7 @@
 //! Structures to describe metadata of files.
 
 use std::fmt;
+use std::num::NonZeroU64;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -134,8 +135,11 @@ pub struct FileMeta {
     /// the default value `0` doesn't means the file doesn't contains any rows,
     /// but instead means the number of rows is unknown.
     pub num_row_groups: u64,
-    /// Max sequence in this file
-    pub max_sequence: u64,
+    /// Sequence in this file.
+    ///
+    /// This sequence is the only sequence in this file. And it's retrived from the max
+    /// sequence of the rows on generating this file.
+    pub sequence: Option<NonZeroU64>,
 }
 
 /// Type of index.
@@ -345,7 +349,7 @@ mod tests {
             index_file_size: 0,
             num_rows: 0,
             num_row_groups: 0,
-            max_sequence: 0,
+            sequence: None,
         }
     }
 

--- a/src/mito2/src/sst/file_purger.rs
+++ b/src/mito2/src/sst/file_purger.rs
@@ -176,6 +176,7 @@ mod tests {
                     index_file_size: 0,
                     num_rows: 0,
                     num_row_groups: 0,
+                    max_sequence: 0,
                 },
                 file_purger,
             );
@@ -238,6 +239,7 @@ mod tests {
                     index_file_size: 4096,
                     num_rows: 1024,
                     num_row_groups: 1,
+                    max_sequence: 4096,
                 },
                 file_purger,
             );

--- a/src/mito2/src/sst/file_purger.rs
+++ b/src/mito2/src/sst/file_purger.rs
@@ -119,6 +119,8 @@ impl FilePurger for LocalFilePurger {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU64;
+
     use common_test_util::temp_dir::create_temp_dir;
     use object_store::services::Fs;
     use object_store::ObjectStore;
@@ -176,7 +178,7 @@ mod tests {
                     index_file_size: 0,
                     num_rows: 0,
                     num_row_groups: 0,
-                    max_sequence: 0,
+                    sequence: None,
                 },
                 file_purger,
             );
@@ -239,7 +241,7 @@ mod tests {
                     index_file_size: 4096,
                     num_rows: 1024,
                     num_row_groups: 1,
-                    max_sequence: 4096,
+                    sequence: NonZeroU64::new(4096),
                 },
                 file_purger,
             );

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -134,7 +134,7 @@ mod tests {
         );
 
         let info = writer
-            .write_all(source, &write_opts)
+            .write_all(source, None, &write_opts)
             .await
             .unwrap()
             .unwrap();
@@ -189,7 +189,7 @@ mod tests {
         );
 
         writer
-            .write_all(source, &write_opts)
+            .write_all(source, None, &write_opts)
             .await
             .unwrap()
             .unwrap();
@@ -258,7 +258,7 @@ mod tests {
         );
 
         let sst_info = writer
-            .write_all(source, &write_opts)
+            .write_all(source, None, &write_opts)
             .await
             .unwrap()
             .expect("write_all should return sst info");
@@ -297,7 +297,7 @@ mod tests {
             Indexer::default(),
         );
         writer
-            .write_all(source, &write_opts)
+            .write_all(source, None, &write_opts)
             .await
             .unwrap()
             .unwrap();
@@ -350,7 +350,7 @@ mod tests {
             Indexer::default(),
         );
         writer
-            .write_all(source, &write_opts)
+            .write_all(source, None, &write_opts)
             .await
             .unwrap()
             .unwrap();
@@ -386,7 +386,7 @@ mod tests {
         );
 
         writer
-            .write_all(source, &write_opts)
+            .write_all(source, None, &write_opts)
             .await
             .unwrap()
             .unwrap();

--- a/src/mito2/src/sst/parquet/writer.rs
+++ b/src/mito2/src/sst/parquet/writer.rs
@@ -31,6 +31,7 @@ use parquet::schema::types::ColumnPath;
 use snafu::ResultExt;
 use store_api::metadata::RegionMetadataRef;
 use store_api::storage::consts::SEQUENCE_COLUMN_NAME;
+use store_api::storage::SequenceNumber;
 use tokio::io::AsyncWrite;
 use tokio_util::compat::{Compat, FuturesAsyncWriteCompatExt};
 
@@ -112,9 +113,11 @@ where
     pub async fn write_all(
         &mut self,
         mut source: Source,
+        override_sequence: Option<SequenceNumber>, // override the `sequence` field from `Source`
         opts: &WriteOptions,
     ) -> Result<Option<SstInfo>> {
-        let write_format = WriteFormat::new(self.metadata.clone());
+        let write_format =
+            WriteFormat::new(self.metadata.clone()).with_override_sequence(override_sequence);
         let mut stats = SourceStats::default();
 
         while let Some(res) = self

--- a/src/mito2/src/test_util/sst_util.rs
+++ b/src/mito2/src/test_util/sst_util.rs
@@ -116,6 +116,7 @@ pub fn sst_file_handle(start_ms: i64, end_ms: i64) -> FileHandle {
             index_file_size: 0,
             num_rows: 0,
             num_row_groups: 0,
+            max_sequence: 0,
         },
         file_purger,
     )

--- a/src/mito2/src/test_util/sst_util.rs
+++ b/src/mito2/src/test_util/sst_util.rs
@@ -14,6 +14,7 @@
 
 //! Utilities for testing SSTs.
 
+use std::num::NonZeroU64;
 use std::sync::Arc;
 
 use api::v1::{OpType, SemanticType};
@@ -116,7 +117,7 @@ pub fn sst_file_handle(start_ms: i64, end_ms: i64) -> FileHandle {
             index_file_size: 0,
             num_rows: 0,
             num_row_groups: 0,
-            max_sequence: 0,
+            sequence: None,
         },
         file_purger,
     )

--- a/src/mito2/src/test_util/version_util.rs
+++ b/src/mito2/src/test_util/version_util.rs
@@ -15,6 +15,7 @@
 //! Utilities to mock version.
 
 use std::collections::HashMap;
+use std::num::NonZeroU64;
 use std::sync::Arc;
 
 use api::v1::value::ValueData;
@@ -103,7 +104,7 @@ impl VersionControlBuilder {
                 index_file_size: 0,
                 num_rows: 0,
                 num_row_groups: 0,
-                max_sequence: 0,
+                sequence: None,
             },
         );
         self
@@ -195,7 +196,7 @@ pub(crate) fn apply_edit(
                 index_file_size: 0,
                 num_rows: 0,
                 num_row_groups: 0,
-                max_sequence: 0,
+                sequence: None,
             }
         })
         .collect();

--- a/src/mito2/src/test_util/version_util.rs
+++ b/src/mito2/src/test_util/version_util.rs
@@ -103,6 +103,7 @@ impl VersionControlBuilder {
                 index_file_size: 0,
                 num_rows: 0,
                 num_row_groups: 0,
+                max_sequence: 0,
             },
         );
         self
@@ -194,6 +195,7 @@ pub(crate) fn apply_edit(
                 index_file_size: 0,
                 num_rows: 0,
                 num_row_groups: 0,
+                max_sequence: 0,
             }
         })
         .collect();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The sequence is `u64` and is allocated with write request. They are different from row to row and thus has bad compression efficiency in both CPU and space. We can assign the greatest sequence number to the file to reduce this overhead while keeping this mechanism works.

In TSBS test scenario with 100M rows, it can save 48MB of disk space. And in the metric monitor scenario, it can save up to 50%~60% in file size. We can also observe an (unstable) flush performance improvement.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
