### PR TITLE
fix: implement a CacheStrategy to ensure compaction use cache correctly

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -163,7 +163,7 @@ jobs:
         run: |
           sudo apt-get install -y libfuzzer-14-dev
           rustup install nightly
-          cargo +nightly install cargo-fuzz cargo-gc-bin
+          cargo +nightly install cargo-fuzz cargo-gc-bin --force
       - name: Download pre-built binaries
         uses: actions/download-artifact@v4
         with:
@@ -220,7 +220,7 @@ jobs:
         shell: bash
         run: |
           sudo apt update && sudo apt install -y libfuzzer-14-dev
-          cargo install cargo-fuzz cargo-gc-bin
+          cargo install cargo-fuzz cargo-gc-bin --force
       - name: Download pre-built binariy
         uses: actions/download-artifact@v4
         with:
@@ -338,7 +338,7 @@ jobs:
         run: |
           sudo apt-get install -y libfuzzer-14-dev
           rustup install nightly
-          cargo +nightly install cargo-fuzz cargo-gc-bin
+          cargo +nightly install cargo-fuzz cargo-gc-bin --force
       # Downloads ci image
       - name: Download pre-built binariy
         uses: actions/download-artifact@v4
@@ -487,7 +487,7 @@ jobs:
         run: |
           sudo apt-get install -y libfuzzer-14-dev
           rustup install nightly
-          cargo +nightly install cargo-fuzz cargo-gc-bin
+          cargo +nightly install cargo-fuzz cargo-gc-bin --force
       # Downloads ci image
       - name: Download pre-built binariy
         uses: actions/download-artifact@v4

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -107,7 +107,7 @@ jobs:
           shared-key: "build-binaries"
       - name: Install cargo-gc-bin
         shell: bash
-        run: cargo install cargo-gc-bin
+        run: cargo install cargo-gc-bin --force
       - name: Build greptime binaries
         shell: bash
         # `cargo gc` will invoke `cargo build` with specified args
@@ -268,7 +268,7 @@ jobs:
           shared-key: "build-greptime-ci"
       - name: Install cargo-gc-bin
         shell: bash
-        run: cargo install cargo-gc-bin
+        run: cargo install cargo-gc-bin --force
       - name: Build greptime bianry
         shell: bash
         # `cargo gc` will invoke `cargo build` with specified args

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -84,7 +84,7 @@ jobs:
           # Shares across multiple jobs
           shared-key: "check-toml"
       - name: Install taplo
-        run: cargo +stable install taplo-cli --version ^0.9 --locked
+        run: cargo +stable install taplo-cli --version ^0.9 --locked --force
       - name: Run taplo
         run: taplo format --check
 

--- a/src/mito2/src/cache/write_cache.rs
+++ b/src/mito2/src/cache/write_cache.rs
@@ -495,7 +495,7 @@ mod tests {
 
         // Read metadata from write cache
         let builder = ParquetReaderBuilder::new(data_home, handle.clone(), mock_store.clone())
-            .cache(CacheStrategy::Normal(cache_manager.clone()));
+            .cache(CacheStrategy::EnableAll(cache_manager.clone()));
         let reader = builder.build().await.unwrap();
 
         // Check parquet metadata

--- a/src/mito2/src/cache/write_cache.rs
+++ b/src/mito2/src/cache/write_cache.rs
@@ -332,7 +332,7 @@ mod tests {
     use super::*;
     use crate::access_layer::OperationType;
     use crate::cache::test_util::new_fs_store;
-    use crate::cache::CacheManager;
+    use crate::cache::{CacheManager, CacheStrategy};
     use crate::region::options::IndexOptions;
     use crate::sst::file::FileId;
     use crate::sst::location::{index_file_path, sst_file_path};
@@ -495,7 +495,7 @@ mod tests {
 
         // Read metadata from write cache
         let builder = ParquetReaderBuilder::new(data_home, handle.clone(), mock_store.clone())
-            .cache(Some(cache_manager.clone()));
+            .cache(CacheStrategy::Normal(cache_manager.clone()));
         let reader = builder.build().await.unwrap();
 
         // Check parquet metadata

--- a/src/mito2/src/compaction/compactor.rs
+++ b/src/mito2/src/compaction/compactor.rs
@@ -307,6 +307,7 @@ impl Compactor for DefaultCompactor {
                 let reader = CompactionSstReaderBuilder {
                     metadata: region_metadata.clone(),
                     sst_layer: sst_layer.clone(),
+                    cache: cache_manager.clone(),
                     inputs: &output.inputs,
                     append_mode,
                     filter_deleted: output.filter_deleted,

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -429,7 +429,7 @@ impl EngineInner {
             version,
             region.access_layer.clone(),
             request,
-            CacheStrategy::Normal(cache_manager),
+            CacheStrategy::EnableAll(cache_manager),
         )
         .with_parallel_scan_channel_size(self.config.parallel_scan_channel_size)
         .with_ignore_inverted_index(self.config.inverted_index.apply_on_query.disabled())

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -84,6 +84,7 @@ use store_api::region_request::{AffectedRows, RegionOpenRequest, RegionRequest};
 use store_api::storage::{RegionId, ScanRequest};
 use tokio::sync::{oneshot, Semaphore};
 
+use crate::cache::CacheStrategy;
 use crate::config::MitoConfig;
 use crate::error::{
     InvalidRequestSnafu, JoinSnafu, RecvSnafu, RegionNotFoundSnafu, Result, SerdeJsonSnafu,
@@ -428,7 +429,7 @@ impl EngineInner {
             version,
             region.access_layer.clone(),
             request,
-            Some(cache_manager),
+            CacheStrategy::Normal(cache_manager),
         )
         .with_parallel_scan_channel_size(self.config.parallel_scan_channel_size)
         .with_ignore_inverted_index(self.config.inverted_index.apply_on_query.disabled())

--- a/src/mito2/src/read/projection.rs
+++ b/src/mito2/src/read/projection.rs
@@ -359,7 +359,7 @@ mod tests {
 
         // With vector cache.
         let cache = CacheManager::builder().vector_cache_size(1024).build();
-        let cache = CacheStrategy::Normal(Arc::new(cache));
+        let cache = CacheStrategy::EnableAll(Arc::new(cache));
         let batch = new_batch(0, &[1, 2], &[(3, 3), (4, 4)], 3);
         let record_batch = mapper.convert(&batch, &cache).unwrap();
         let expect = "\
@@ -403,7 +403,7 @@ mod tests {
 
         let batch = new_batch(0, &[1, 2], &[(4, 4)], 3);
         let cache = CacheManager::builder().vector_cache_size(1024).build();
-        let cache = CacheStrategy::Normal(Arc::new(cache));
+        let cache = CacheStrategy::EnableAll(Arc::new(cache));
         let record_batch = mapper.convert(&batch, &cache).unwrap();
         let expect = "\
 +----+----+

--- a/src/mito2/src/read/range.rs
+++ b/src/mito2/src/read/range.rs
@@ -22,7 +22,7 @@ use parquet::arrow::arrow_reader::RowSelection;
 use smallvec::{smallvec, SmallVec};
 use store_api::region_engine::PartitionRange;
 
-use crate::cache::CacheManager;
+use crate::cache::CacheStrategy;
 use crate::error::Result;
 use crate::memtable::{MemtableRange, MemtableRanges, MemtableStats};
 use crate::read::scan_region::ScanInput;
@@ -112,7 +112,7 @@ impl RangeMeta {
         Self::push_unordered_file_ranges(
             input.memtables.len(),
             &input.files,
-            input.cache_manager.as_deref(),
+            &input.cache_strategy,
             &mut ranges,
         );
 
@@ -203,16 +203,15 @@ impl RangeMeta {
     fn push_unordered_file_ranges(
         num_memtables: usize,
         files: &[FileHandle],
-        cache: Option<&CacheManager>,
+        cache: &CacheStrategy,
         ranges: &mut Vec<RangeMeta>,
     ) {
         // For append mode, we can parallelize reading row groups.
         for (i, file) in files.iter().enumerate() {
             let file_index = num_memtables + i;
             // Get parquet meta from the cache.
-            let parquet_meta = cache.and_then(|c| {
-                c.get_parquet_meta_data_from_mem_cache(file.region_id(), file.file_id())
-            });
+            let parquet_meta =
+                cache.get_parquet_meta_data_from_mem_cache(file.region_id(), file.file_id());
             if let Some(parquet_meta) = parquet_meta {
                 // Scans each row group.
                 for row_group_index in 0..file.meta_ref().num_row_groups {

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -564,7 +564,7 @@ impl ScanInput {
             predicate: None,
             memtables: Vec::new(),
             files: Vec::new(),
-            cache_strategy: CacheStrategy::Normal(CacheManagerRef::default()),
+            cache_strategy: CacheStrategy::EnableAll(CacheManagerRef::default()),
             ignore_file_not_found: false,
             parallel_scan_channel_size: DEFAULT_SCAN_CHANNEL_SIZE,
             inverted_index_applier: None,

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -33,7 +33,7 @@ use tokio_stream::wrappers::ReceiverStream;
 
 use crate::access_layer::AccessLayerRef;
 use crate::cache::file_cache::FileCacheRef;
-use crate::cache::{CacheManagerRef, CacheStrategy};
+use crate::cache::CacheStrategy;
 use crate::config::DEFAULT_SCAN_CHANNEL_SIZE;
 use crate::error::Result;
 use crate::memtable::MemtableRange;

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -564,7 +564,7 @@ impl ScanInput {
             predicate: None,
             memtables: Vec::new(),
             files: Vec::new(),
-            cache_strategy: CacheStrategy::EnableAll(CacheManagerRef::default()),
+            cache_strategy: CacheStrategy::Disabled,
             ignore_file_not_found: false,
             parallel_scan_channel_size: DEFAULT_SCAN_CHANNEL_SIZE,
             inverted_index_applier: None,

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -33,7 +33,7 @@ use tokio_stream::wrappers::ReceiverStream;
 
 use crate::access_layer::AccessLayerRef;
 use crate::cache::file_cache::FileCacheRef;
-use crate::cache::CacheManagerRef;
+use crate::cache::{CacheManagerRef, CacheStrategy};
 use crate::config::DEFAULT_SCAN_CHANNEL_SIZE;
 use crate::error::Result;
 use crate::memtable::MemtableRange;
@@ -171,7 +171,7 @@ pub(crate) struct ScanRegion {
     /// Scan request.
     request: ScanRequest,
     /// Cache.
-    cache_manager: Option<CacheManagerRef>,
+    cache_strategy: CacheStrategy,
     /// Capacity of the channel to send data from parallel scan tasks to the main task.
     parallel_scan_channel_size: usize,
     /// Whether to ignore inverted index.
@@ -190,13 +190,13 @@ impl ScanRegion {
         version: VersionRef,
         access_layer: AccessLayerRef,
         request: ScanRequest,
-        cache_manager: Option<CacheManagerRef>,
+        cache_strategy: CacheStrategy,
     ) -> ScanRegion {
         ScanRegion {
             version,
             access_layer,
             request,
-            cache_manager,
+            cache_strategy,
             parallel_scan_channel_size: DEFAULT_SCAN_CHANNEL_SIZE,
             ignore_inverted_index: false,
             ignore_fulltext_index: false,
@@ -357,7 +357,7 @@ impl ScanRegion {
             .with_predicate(Some(predicate))
             .with_memtables(memtables)
             .with_files(files)
-            .with_cache(self.cache_manager)
+            .with_cache(self.cache_strategy)
             .with_inverted_index_applier(inverted_index_applier)
             .with_bloom_filter_index_applier(bloom_filter_applier)
             .with_fulltext_index_applier(fulltext_index_applier)
@@ -421,23 +421,14 @@ impl ScanRegion {
         }
 
         let file_cache = || -> Option<FileCacheRef> {
-            let cache_manager = self.cache_manager.as_ref()?;
-            let write_cache = cache_manager.write_cache()?;
+            let write_cache = self.cache_strategy.write_cache()?;
             let file_cache = write_cache.file_cache();
             Some(file_cache)
         }();
 
-        let index_cache = self
-            .cache_manager
-            .as_ref()
-            .and_then(|c| c.index_cache())
-            .cloned();
+        let index_cache = self.cache_strategy.index_cache().cloned();
 
-        let puffin_metadata_cache = self
-            .cache_manager
-            .as_ref()
-            .and_then(|c| c.puffin_metadata_cache())
-            .cloned();
+        let puffin_metadata_cache = self.cache_strategy.puffin_metadata_cache().cloned();
 
         InvertedIndexApplierBuilder::new(
             self.access_layer.region_dir().to_string(),
@@ -470,23 +461,14 @@ impl ScanRegion {
         }
 
         let file_cache = || -> Option<FileCacheRef> {
-            let cache_manager = self.cache_manager.as_ref()?;
-            let write_cache = cache_manager.write_cache()?;
+            let write_cache = self.cache_strategy.write_cache()?;
             let file_cache = write_cache.file_cache();
             Some(file_cache)
         }();
 
-        let index_cache = self
-            .cache_manager
-            .as_ref()
-            .and_then(|c| c.bloom_filter_index_cache())
-            .cloned();
+        let index_cache = self.cache_strategy.bloom_filter_index_cache().cloned();
 
-        let puffin_metadata_cache = self
-            .cache_manager
-            .as_ref()
-            .and_then(|c| c.puffin_metadata_cache())
-            .cloned();
+        let puffin_metadata_cache = self.cache_strategy.puffin_metadata_cache().cloned();
 
         BloomFilterIndexApplierBuilder::new(
             self.access_layer.region_dir().to_string(),
@@ -550,7 +532,7 @@ pub(crate) struct ScanInput {
     /// Handles to SST files to scan.
     pub(crate) files: Vec<FileHandle>,
     /// Cache.
-    pub(crate) cache_manager: Option<CacheManagerRef>,
+    pub(crate) cache_strategy: CacheStrategy,
     /// Ignores file not found error.
     ignore_file_not_found: bool,
     /// Capacity of the channel to send data from parallel scan tasks to the main task.
@@ -582,7 +564,7 @@ impl ScanInput {
             predicate: None,
             memtables: Vec::new(),
             files: Vec::new(),
-            cache_manager: None,
+            cache_strategy: CacheStrategy::Normal(CacheManagerRef::default()),
             ignore_file_not_found: false,
             parallel_scan_channel_size: DEFAULT_SCAN_CHANNEL_SIZE,
             inverted_index_applier: None,
@@ -626,8 +608,8 @@ impl ScanInput {
 
     /// Sets cache for this query.
     #[must_use]
-    pub(crate) fn with_cache(mut self, cache: Option<CacheManagerRef>) -> Self {
-        self.cache_manager = cache;
+    pub(crate) fn with_cache(mut self, cache: CacheStrategy) -> Self {
+        self.cache_strategy = cache;
         self
     }
 
@@ -760,7 +742,7 @@ impl ScanInput {
             .read_sst(file.clone())
             .predicate(self.predicate.clone())
             .projection(Some(self.mapper.column_ids().to_vec()))
-            .cache(self.cache_manager.clone())
+            .cache(self.cache_strategy.clone())
             .inverted_index_applier(self.inverted_index_applier.clone())
             .bloom_filter_index_applier(self.bloom_filter_index_applier.clone())
             .fulltext_index_applier(self.fulltext_index_applier.clone())

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -257,7 +257,7 @@ impl SeqScan {
                         .await
                         .map_err(BoxedError::new)
                         .context(ExternalSnafu)?;
-                let cache = stream_ctx.input.cache_manager.as_deref();
+                let cache = &stream_ctx.input.cache_strategy;
                 let mut metrics = ScannerMetrics::default();
                 let mut fetch_start = Instant::now();
                 #[cfg(debug_assertions)]

--- a/src/mito2/src/read/unordered_scan.rs
+++ b/src/mito2/src/read/unordered_scan.rs
@@ -148,7 +148,7 @@ impl UnorderedScan {
         let stream = try_stream! {
             part_metrics.on_first_poll();
 
-            let cache = stream_ctx.input.cache_manager.as_deref();
+            let cache = &stream_ctx.input.cache_strategy;
             let range_builder_list = Arc::new(RangeBuilderList::new(
                 stream_ctx.input.num_memtables(),
                 stream_ctx.input.num_files(),

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -195,7 +195,7 @@ mod tests {
             .unwrap();
 
         // Enable page cache.
-        let cache = CacheStrategy::Normal(Arc::new(
+        let cache = CacheStrategy::EnableAll(Arc::new(
             CacheManager::builder()
                 .page_cache_size(64 * 1024 * 1024)
                 .build(),

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -95,7 +95,7 @@ mod tests {
     use tokio_util::compat::FuturesAsyncWriteCompatExt;
 
     use super::*;
-    use crate::cache::{CacheManager, PageKey};
+    use crate::cache::{CacheManager, CacheStrategy, PageKey};
     use crate::sst::index::Indexer;
     use crate::sst::parquet::format::WriteFormat;
     use crate::sst::parquet::reader::ParquetReaderBuilder;
@@ -195,7 +195,7 @@ mod tests {
             .unwrap();
 
         // Enable page cache.
-        let cache = Some(Arc::new(
+        let cache = CacheStrategy::Normal(Arc::new(
             CacheManager::builder()
                 .page_cache_size(64 * 1024 * 1024)
                 .build(),
@@ -219,15 +219,15 @@ mod tests {
 
         // Doesn't have compressed page cached.
         let page_key = PageKey::new_compressed(metadata.region_id, handle.file_id(), 0, 0);
-        assert!(cache.as_ref().unwrap().get_pages(&page_key).is_none());
+        assert!(cache.get_pages(&page_key).is_none());
 
         // Cache 4 row groups.
         for i in 0..4 {
             let page_key = PageKey::new_uncompressed(metadata.region_id, handle.file_id(), i, 0);
-            assert!(cache.as_ref().unwrap().get_pages(&page_key).is_some());
+            assert!(cache.get_pages(&page_key).is_some());
         }
         let page_key = PageKey::new_uncompressed(metadata.region_id, handle.file_id(), 5, 0);
-        assert!(cache.as_ref().unwrap().get_pages(&page_key).is_none());
+        assert!(cache.get_pages(&page_key).is_none());
     }
 
     #[tokio::test]

--- a/src/mito2/src/sst/parquet/file_range.rs
+++ b/src/mito2/src/sst/parquet/file_range.rs
@@ -114,7 +114,7 @@ impl FileRange {
             let reader = RowGroupLastRowCachedReader::new(
                 self.file_handle().file_id(),
                 self.row_group_idx,
-                self.context.reader_builder.cache_manager().clone(),
+                self.context.reader_builder.cache_strategy().clone(),
                 RowGroupReader::new(self.context.clone(), parquet_reader),
             );
             PruneReader::new_with_last_row_reader(self.context.clone(), reader)

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -38,7 +38,7 @@ use store_api::metadata::{RegionMetadata, RegionMetadataRef};
 use store_api::storage::ColumnId;
 use table::predicate::Predicate;
 
-use crate::cache::{CacheManagerRef, CacheStrategy};
+use crate::cache::CacheStrategy;
 use crate::error::{
     ArrowReaderSnafu, InvalidMetadataSnafu, InvalidParquetSnafu, ReadDataPartSnafu,
     ReadParquetSnafu, Result,
@@ -102,8 +102,7 @@ impl ParquetReaderBuilder {
             object_store,
             predicate: None,
             projection: None,
-            // TODO(yingwen): Maybe add a Disabled variant.
-            cache_strategy: CacheStrategy::Normal(CacheManagerRef::default()),
+            cache_strategy: CacheStrategy::Disabled,
             inverted_index_applier: None,
             bloom_filter_index_applier: None,
             fulltext_index_applier: None,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
Some changes revert https://github.com/GreptimeTeam/greptimedb/pull/5135/

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

This PR implements a `CompactionStrategy` to replace `Option<CacheManagerRef>` so we can control how compaction uses caches.
- For queries, the strategy forwards all operations to the cache manager.
- The strategy only uses the write cache and the metadata cache for compactions.
- The `Disabled` strategy means disable all caches.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
