### PR TITLE
feat: support add if not exists in the gRPC alter kind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4556,7 +4556,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=a875e976441188028353f7274a46a7e6e065c5d4#a875e976441188028353f7274a46a7e6e065c5d4"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=7c01e4a8e64580707438dabc5cf7f4e2584c28b6#7c01e4a8e64580707438dabc5cf7f4e2584c28b6"
 dependencies = [
  "prost 0.12.6",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ etcd-client = "0.13"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "a875e976441188028353f7274a46a7e6e065c5d4" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "7c01e4a8e64580707438dabc5cf7f4e2584c28b6" }
 hex = "0.4"
 http = "0.2"
 humantime = "2.1"

--- a/src/common/grpc-expr/src/alter.rs
+++ b/src/common/grpc-expr/src/alter.rs
@@ -60,6 +60,7 @@ pub fn alter_expr_to_request(table_id: TableId, expr: AlterTableExpr) -> Result<
                         column_schema: schema,
                         is_key: column_def.semantic_type == SemanticType::Tag as i32,
                         location: parse_location(ac.location)?,
+                        add_if_not_exists: ac.add_if_not_exists,
                     })
                 })
                 .collect::<Result<Vec<_>>>()?;
@@ -220,6 +221,7 @@ mod tests {
                         ..Default::default()
                     }),
                     location: None,
+                    add_if_not_exists: true,
                 }],
             })),
         };
@@ -240,6 +242,7 @@ mod tests {
             add_column.column_schema.data_type
         );
         assert_eq!(None, add_column.location);
+        assert!(add_column.add_if_not_exists);
     }
 
     #[test]
@@ -265,6 +268,7 @@ mod tests {
                             location_type: LocationType::First.into(),
                             after_column_name: String::default(),
                         }),
+                        add_if_not_exists: false,
                     },
                     AddColumn {
                         column_def: Some(ColumnDef {
@@ -280,6 +284,7 @@ mod tests {
                             location_type: LocationType::After.into(),
                             after_column_name: "ts".to_string(),
                         }),
+                        add_if_not_exists: true,
                     },
                 ],
             })),
@@ -308,6 +313,7 @@ mod tests {
             }),
             add_column.location
         );
+        assert!(add_column.add_if_not_exists);
 
         let add_column = add_columns.pop().unwrap();
         assert!(!add_column.is_key);
@@ -317,6 +323,7 @@ mod tests {
             add_column.column_schema.data_type
         );
         assert_eq!(Some(AddColumnLocation::First), add_column.location);
+        assert!(!add_column.add_if_not_exists);
     }
 
     #[test]

--- a/src/common/grpc-expr/src/insert.rs
+++ b/src/common/grpc-expr/src/insert.rs
@@ -299,6 +299,7 @@ mod tests {
                 .unwrap()
             )
         );
+        assert!(host_column.add_if_not_exists);
 
         let memory_column = &add_columns.add_columns[1];
         assert_eq!(
@@ -311,6 +312,7 @@ mod tests {
                 .unwrap()
             )
         );
+        assert!(host_column.add_if_not_exists);
 
         let time_column = &add_columns.add_columns[2];
         assert_eq!(
@@ -323,6 +325,7 @@ mod tests {
                 .unwrap()
             )
         );
+        assert!(host_column.add_if_not_exists);
 
         let interval_column = &add_columns.add_columns[3];
         assert_eq!(
@@ -335,6 +338,7 @@ mod tests {
                 .unwrap()
             )
         );
+        assert!(host_column.add_if_not_exists);
 
         let decimal_column = &add_columns.add_columns[4];
         assert_eq!(
@@ -352,6 +356,7 @@ mod tests {
                 .unwrap()
             )
         );
+        assert!(host_column.add_if_not_exists);
     }
 
     #[test]

--- a/src/common/grpc-expr/src/util.rs
+++ b/src/common/grpc-expr/src/util.rs
@@ -192,6 +192,9 @@ pub fn build_create_table_expr(
     Ok(expr)
 }
 
+/// Find columns that are not present in the schema and return them as `AddColumns`
+/// for adding columns automatically.
+/// It always sets `add_if_not_exists` to `true` for now.
 pub fn extract_new_columns(
     schema: &Schema,
     column_exprs: Vec<ColumnExpr>,
@@ -213,6 +216,7 @@ pub fn extract_new_columns(
             AddColumn {
                 column_def,
                 location: None,
+                add_if_not_exists: true,
             }
         })
         .collect::<Vec<_>>();

--- a/src/common/meta/src/ddl/alter_logical_tables/update_metadata.rs
+++ b/src/common/meta/src/ddl/alter_logical_tables/update_metadata.rs
@@ -105,7 +105,7 @@ impl AlterLogicalTablesProcedure {
                 .context(ConvertAlterTableRequestSnafu)?;
         let new_meta = table_info
             .meta
-            .builder_with_alter_kind(table_ref.table, &request.alter_kind, true)
+            .builder_with_alter_kind(table_ref.table, &request.alter_kind)
             .context(error::TableSnafu)?
             .build()
             .with_context(|_| error::BuildTableMetaSnafu {

--- a/src/common/meta/src/ddl/alter_table/region_request.rs
+++ b/src/common/meta/src/ddl/alter_table/region_request.rs
@@ -168,6 +168,7 @@ mod tests {
     use crate::rpc::router::{Region, RegionRoute};
     use crate::test_util::{new_ddl_context, MockDatanodeManager};
 
+    /// Prepares a region with schema `[ts: Timestamp, host: Tag, cpu: Field]`.
     async fn prepare_ddl_context() -> (DdlContext, u64, TableId, RegionId, String) {
         let datanode_manager = Arc::new(MockDatanodeManager::new(()));
         let ddl_context = new_ddl_context(datanode_manager);
@@ -196,6 +197,7 @@ mod tests {
                     .name("cpu")
                     .data_type(ColumnDataType::Float64)
                     .semantic_type(SemanticType::Field)
+                    .is_nullable(true)
                     .build()
                     .unwrap()
                     .into(),
@@ -250,14 +252,14 @@ mod tests {
                             name: "my_tag3".to_string(),
                             data_type: ColumnDataType::String as i32,
                             is_nullable: true,
-                            default_constraint: b"hello".to_vec(),
+                            default_constraint: Vec::new(),
                             semantic_type: SemanticType::Tag as i32,
                             comment: String::new(),
                             ..Default::default()
                         }),
                         location: Some(AddColumnLocation {
                             location_type: LocationType::After as i32,
-                            after_column_name: "my_tag2".to_string(),
+                            after_column_name: "host".to_string(),
                         }),
                         add_if_not_exists: false,
                     }],
@@ -288,7 +290,7 @@ mod tests {
                                 name: "my_tag3".to_string(),
                                 data_type: ColumnDataType::String as i32,
                                 is_nullable: true,
-                                default_constraint: b"hello".to_vec(),
+                                default_constraint: Vec::new(),
                                 semantic_type: SemanticType::Tag as i32,
                                 comment: String::new(),
                                 ..Default::default()
@@ -297,7 +299,7 @@ mod tests {
                         }),
                         location: Some(AddColumnLocation {
                             location_type: LocationType::After as i32,
-                            after_column_name: "my_tag2".to_string(),
+                            after_column_name: "host".to_string(),
                         }),
                     }]
                 }

--- a/src/common/meta/src/ddl/alter_table/region_request.rs
+++ b/src/common/meta/src/ddl/alter_table/region_request.rs
@@ -28,6 +28,7 @@ use crate::error::{InvalidProtoMsgSnafu, Result};
 
 impl AlterTableProcedure {
     /// Makes alter region request.
+    /// Region alter request always add columns if not exist.
     pub(crate) fn make_alter_region_request(&self, region_id: RegionId) -> Result<RegionRequest> {
         // Safety: Checked in `AlterTableProcedure::new`.
         let alter_kind = self.data.task.alter_table.kind.as_ref().unwrap();
@@ -51,7 +52,7 @@ impl AlterTableProcedure {
 
 /// Creates region proto alter kind from `table_info` and `alter_kind`.
 ///
-/// Returns the kind and next column id if it adds new columns.
+/// It always adds column if not exists and drops column if exists.
 fn create_proto_alter_kind(
     table_info: &RawTableInfo,
     alter_kind: &Kind,
@@ -234,6 +235,7 @@ mod tests {
                             location_type: LocationType::After as i32,
                             after_column_name: "my_tag2".to_string(),
                         }),
+                        add_if_not_exists: false,
                     }],
                 })),
             },

--- a/src/common/meta/src/ddl/alter_table/region_request.rs
+++ b/src/common/meta/src/ddl/alter_table/region_request.rs
@@ -94,7 +94,7 @@ fn create_proto_alter_kind(
                         err_msg: "'column_def' is absent",
                     })?;
 
-                // Skips exisitng columns.
+                // Skips existing columns.
                 if existing_columns.contains(&column_def.name) {
                     continue;
                 }

--- a/src/common/meta/src/ddl/alter_table/update_metadata.rs
+++ b/src/common/meta/src/ddl/alter_table/update_metadata.rs
@@ -34,7 +34,7 @@ impl AlterTableProcedure {
 
         let new_meta = table_info
             .meta
-            .builder_with_alter_kind(table_ref.table, &request.alter_kind, false)
+            .builder_with_alter_kind(table_ref.table, &request.alter_kind)
             .context(error::TableSnafu)?
             .build()
             .with_context(|_| error::BuildTableMetaSnafu {
@@ -46,6 +46,9 @@ impl AlterTableProcedure {
         new_info.ident.version = table_info.ident.version + 1;
         match request.alter_kind {
             AlterKind::AddColumns { columns } => {
+                // Bumps the column id for the new columns.
+                // It may bump more than the actual number of columns added if there are
+                // existing columns, but it's fine.
                 new_info.meta.next_column_id += columns.len() as u32;
             }
             AlterKind::RenameTable { new_table_name } => {

--- a/src/common/meta/src/ddl/alter_table/update_metadata.rs
+++ b/src/common/meta/src/ddl/alter_table/update_metadata.rs
@@ -23,7 +23,9 @@ use crate::key::table_info::TableInfoValue;
 use crate::key::{DeserializedValueWithBytes, RegionDistribution};
 
 impl AlterTableProcedure {
-    /// Builds new_meta
+    /// Builds new table info after alteration.
+    /// It bumps the column id of the table by the number of the add column requests.
+    /// So there may be holes in the column id sequence.
     pub(crate) fn build_new_table_info(&self, table_info: &RawTableInfo) -> Result<TableInfo> {
         let table_info =
             TableInfo::try_from(table_info.clone()).context(error::ConvertRawTableInfoSnafu)?;

--- a/src/common/meta/src/ddl/test_util/alter_table.rs
+++ b/src/common/meta/src/ddl/test_util/alter_table.rs
@@ -30,6 +30,8 @@ pub struct TestAlterTableExpr {
     add_columns: Vec<ColumnDef>,
     #[builder(setter(into, strip_option))]
     new_table_name: Option<String>,
+    #[builder(setter)]
+    add_if_not_exists: bool,
 }
 
 impl From<TestAlterTableExpr> for AlterTableExpr {
@@ -53,7 +55,7 @@ impl From<TestAlterTableExpr> for AlterTableExpr {
                         .map(|col| AddColumn {
                             column_def: Some(col),
                             location: None,
-                            add_if_not_exists: false,
+                            add_if_not_exists: value.add_if_not_exists,
                         })
                         .collect(),
                 })),

--- a/src/common/meta/src/ddl/test_util/alter_table.rs
+++ b/src/common/meta/src/ddl/test_util/alter_table.rs
@@ -53,6 +53,7 @@ impl From<TestAlterTableExpr> for AlterTableExpr {
                         .map(|col| AddColumn {
                             column_def: Some(col),
                             location: None,
+                            add_if_not_exists: false,
                         })
                         .collect(),
                 })),

--- a/src/common/meta/src/ddl/tests/alter_logical_tables.rs
+++ b/src/common/meta/src/ddl/tests/alter_logical_tables.rs
@@ -56,6 +56,7 @@ fn make_alter_logical_table_add_column_task(
     let alter_table = alter_table
         .table_name(table.to_string())
         .add_columns(add_columns)
+        .add_if_not_exists(true)
         .build()
         .unwrap();
 

--- a/src/common/meta/src/ddl/tests/alter_table.rs
+++ b/src/common/meta/src/ddl/tests/alter_table.rs
@@ -330,6 +330,7 @@ async fn test_on_update_metadata_add_columns() {
                         ..Default::default()
                     }),
                     location: None,
+                    add_if_not_exists: false,
                 }],
             })),
         },

--- a/src/common/meta/src/ddl/tests/alter_table.rs
+++ b/src/common/meta/src/ddl/tests/alter_table.rs
@@ -139,7 +139,7 @@ async fn test_on_submit_alter_request() {
             table_name: table_name.to_string(),
             kind: Some(Kind::DropColumns(DropColumns {
                 drop_columns: vec![DropColumn {
-                    name: "my_field_column".to_string(),
+                    name: "cpu".to_string(),
                 }],
             })),
         },
@@ -225,7 +225,7 @@ async fn test_on_submit_alter_request_with_outdated_request() {
             table_name: table_name.to_string(),
             kind: Some(Kind::DropColumns(DropColumns {
                 drop_columns: vec![DropColumn {
-                    name: "my_field_column".to_string(),
+                    name: "cpu".to_string(),
                 }],
             })),
         },

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -145,10 +145,8 @@ impl<S> RegionWorkerLoop<S> {
         }
 
         info!(
-            "Try to alter region {} from version {} to {}",
-            region_id,
-            version.metadata.schema_version,
-            region.metadata().schema_version
+            "Try to alter region {}, version.metadata: {:?}, request: {:?}",
+            region_id, version.metadata, request,
         );
         self.handle_alter_region_metadata(region, version, request, sender);
     }

--- a/src/mito2/src/worker/handle_manifest.rs
+++ b/src/mito2/src/worker/handle_manifest.rs
@@ -101,10 +101,10 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                 .version_control
                 .alter_schema(change_result.new_meta, &region.memtable_builder);
 
+            let version = region.version();
             info!(
-                "Region {} is altered, schema version is {}",
-                region.region_id,
-                region.metadata().schema_version
+                "Region {} is altered, metadata is {:?}, options: {:?}",
+                region.region_id, version.metadata, version.options,
             );
         }
 

--- a/src/operator/src/expr_factory.rs
+++ b/src/operator/src/expr_factory.rs
@@ -505,7 +505,7 @@ pub(crate) fn to_alter_table_expr(
                         .context(ExternalSnafu)?,
                 ),
                 location: location.as_ref().map(From::from),
-                // We don't support `IF NOT EXISTS` for `ADD COLUMN` yet.
+                // TODO(yingwen): We don't support `IF NOT EXISTS` for `ADD COLUMN` yet.
                 add_if_not_exists: false,
             }],
         }),

--- a/src/operator/src/expr_factory.rs
+++ b/src/operator/src/expr_factory.rs
@@ -477,6 +477,7 @@ pub fn column_schemas_to_defs(
         .collect()
 }
 
+/// Converts a SQL alter table statement into a gRPC alter table expression.
 pub(crate) fn to_alter_table_expr(
     alter_table: AlterTable,
     query_ctx: &QueryContextRef,
@@ -504,6 +505,8 @@ pub(crate) fn to_alter_table_expr(
                         .context(ExternalSnafu)?,
                 ),
                 location: location.as_ref().map(From::from),
+                // We don't support `IF NOT EXISTS` for `ADD COLUMN` yet.
+                add_if_not_exists: false,
             }],
         }),
         AlterTableOperation::ModifyColumnType {

--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -741,6 +741,8 @@ impl Inserter {
         Ok(create_table_expr)
     }
 
+    /// Returns an alter table expression if it finds new columns in the request.
+    /// It always add columns if not exist.
     fn get_alter_table_expr_on_demand(
         &self,
         req: &RowInsertRequest,

--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -742,7 +742,7 @@ impl Inserter {
     }
 
     /// Returns an alter table expression if it finds new columns in the request.
-    /// It always add columns if not exist.
+    /// It always adds columns if not exist.
     fn get_alter_table_expr_on_demand(
         &self,
         req: &RowInsertRequest,

--- a/src/operator/src/statement/ddl.rs
+++ b/src/operator/src/statement/ddl.rs
@@ -911,7 +911,7 @@ impl StatementExecutor {
 
         let _ = table_info
             .meta
-            .builder_with_alter_kind(table_name, &request.alter_kind, false)
+            .builder_with_alter_kind(table_name, &request.alter_kind)
             .context(error::TableSnafu)?
             .build()
             .context(error::BuildTableMetaSnafu { table_name })?;

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -625,8 +625,8 @@ impl AddColumn {
                 InvalidRegionRequestSnafu {
                     region_id: metadata.region_id,
                     err: format!(
-                        "column {} already exists with different metadata",
-                        self.column_metadata.column_schema.name
+                        "column {} already exists with different metadata, existing: {:?}, got: {:?}",
+                        self.column_metadata.column_schema.name, existing_column, self.column_metadata,
                     ),
                 }
             );

--- a/src/table/src/metadata.rs
+++ b/src/table/src/metadata.rs
@@ -414,8 +414,8 @@ impl TableMeta {
                     error::InvalidAlterRequestSnafu {
                         table: table_name,
                         err: format!(
-                            "column {} already exists with different type",
-                            col_to_add.column_schema.name
+                            "column {} already exists with different type {:?}",
+                            col_to_add.column_schema.name, column_schema.data_type,
                         ),
                     }
                 );

--- a/src/table/src/metadata.rs
+++ b/src/table/src/metadata.rs
@@ -194,12 +194,9 @@ impl TableMeta {
         &self,
         table_name: &str,
         alter_kind: &AlterKind,
-        add_if_not_exists: bool,
     ) -> Result<TableMetaBuilder> {
         match alter_kind {
-            AlterKind::AddColumns { columns } => {
-                self.add_columns(table_name, columns, add_if_not_exists)
-            }
+            AlterKind::AddColumns { columns } => self.add_columns(table_name, columns),
             AlterKind::DropColumns { names } => self.remove_columns(table_name, names),
             AlterKind::ModifyColumnTypes { columns } => {
                 self.modify_column_types(table_name, columns)
@@ -340,6 +337,7 @@ impl TableMeta {
         Ok(meta_builder)
     }
 
+    // TODO(yingwen): Remove this.
     /// Allocate a new column for the table.
     ///
     /// This method would bump the `next_column_id` of the meta.
@@ -384,11 +382,11 @@ impl TableMeta {
         builder
     }
 
+    // TODO(yingwen): Tests add if not exists.
     fn add_columns(
         &self,
         table_name: &str,
         requests: &[AddColumnRequest],
-        add_if_not_exists: bool,
     ) -> Result<TableMetaBuilder> {
         let table_schema = &self.schema;
         let mut meta_builder = self.new_meta_builder();
@@ -396,63 +394,61 @@ impl TableMeta {
             self.primary_key_indices.iter().collect();
 
         let mut names = HashSet::with_capacity(requests.len());
-        let mut new_requests = Vec::with_capacity(requests.len());
-        let requests = if add_if_not_exists {
-            for col_to_add in requests {
-                if let Some(column_schema) =
-                    table_schema.column_schema_by_name(&col_to_add.column_schema.name)
-                {
-                    // If the column already exists, we should check if the type is the same.
-                    ensure!(
-                        column_schema.data_type == col_to_add.column_schema.data_type,
-                        error::InvalidAlterRequestSnafu {
-                            table: table_name,
-                            err: format!(
-                                "column {} already exists with different type",
-                                col_to_add.column_schema.name
-                            ),
-                        }
-                    );
-                } else {
-                    new_requests.push(col_to_add.clone());
-                }
-            }
-            &new_requests[..]
-        } else {
-            requests
-        };
+        let mut new_columns = Vec::with_capacity(requests.len());
         for col_to_add in requests {
-            ensure!(
-                names.insert(&col_to_add.column_schema.name),
-                error::InvalidAlterRequestSnafu {
-                    table: table_name,
-                    err: format!(
-                        "add column {} more than once",
-                        col_to_add.column_schema.name
-                    ),
-                }
-            );
+            if let Some(column_schema) =
+                table_schema.column_schema_by_name(&col_to_add.column_schema.name)
+            {
+                // If the column already exists.
+                ensure!(
+                    col_to_add.add_if_not_exists,
+                    error::ColumnExistsSnafu {
+                        table_name,
+                        column_name: &col_to_add.column_schema.name
+                    },
+                );
 
-            ensure!(
-                !table_schema.contains_column(&col_to_add.column_schema.name),
-                error::ColumnExistsSnafu {
-                    table_name,
-                    column_name: col_to_add.column_schema.name.to_string()
-                },
-            );
+                // Checks if the type is the same
+                ensure!(
+                    column_schema.data_type == col_to_add.column_schema.data_type,
+                    error::InvalidAlterRequestSnafu {
+                        table: table_name,
+                        err: format!(
+                            "column {} already exists with different type",
+                            col_to_add.column_schema.name
+                        ),
+                    }
+                );
+            } else {
+                // A new column.
+                // Ensures we only add a column once.
+                ensure!(
+                    names.insert(&col_to_add.column_schema.name),
+                    error::InvalidAlterRequestSnafu {
+                        table: table_name,
+                        err: format!(
+                            "add column {} more than once",
+                            col_to_add.column_schema.name
+                        ),
+                    }
+                );
 
-            ensure!(
-                col_to_add.column_schema.is_nullable()
-                    || col_to_add.column_schema.default_constraint().is_some(),
-                error::InvalidAlterRequestSnafu {
-                    table: table_name,
-                    err: format!(
-                        "no default value for column {}",
-                        col_to_add.column_schema.name
-                    ),
-                },
-            );
+                ensure!(
+                    col_to_add.column_schema.is_nullable()
+                        || col_to_add.column_schema.default_constraint().is_some(),
+                    error::InvalidAlterRequestSnafu {
+                        table: table_name,
+                        err: format!(
+                            "no default value for column {}",
+                            col_to_add.column_schema.name
+                        ),
+                    },
+                );
+
+                new_columns.push(col_to_add.clone());
+            }
         }
+        let requests = &new_columns[..];
 
         let SplitResult {
             columns_at_first,
@@ -881,6 +877,7 @@ pub struct RawTableMeta {
     pub value_indices: Vec<usize>,
     /// Engine type of this table. Usually in small case.
     pub engine: String,
+    /// Next column id of a new column.
     /// Deprecated. See https://github.com/GreptimeTeam/greptimedb/issues/2982
     pub next_column_id: ColumnId,
     pub region_numbers: Vec<u32>,
@@ -1078,6 +1075,7 @@ mod tests {
 
     use super::*;
 
+    /// Create a test schema with 3 columns: `[col1 int32, ts timestampmills, col2 int32]`.
     fn new_test_schema() -> Schema {
         let column_schemas = vec![
             ColumnSchema::new("col1", ConcreteDataType::int32_datatype(), true),
@@ -1129,17 +1127,19 @@ mod tests {
                     column_schema: new_tag,
                     is_key: true,
                     location: None,
+                    add_if_not_exists: false,
                 },
                 AddColumnRequest {
                     column_schema: new_field,
                     is_key: false,
                     location: None,
+                    add_if_not_exists: false,
                 },
             ],
         };
 
         let builder = meta
-            .builder_with_alter_kind("my_table", &alter_kind, false)
+            .builder_with_alter_kind("my_table", &alter_kind)
             .unwrap();
         builder.build().unwrap()
     }
@@ -1157,6 +1157,7 @@ mod tests {
                     column_schema: new_tag,
                     is_key: true,
                     location: Some(AddColumnLocation::First),
+                    add_if_not_exists: false,
                 },
                 AddColumnRequest {
                     column_schema: new_field,
@@ -1164,12 +1165,13 @@ mod tests {
                     location: Some(AddColumnLocation::After {
                         column_name: "ts".to_string(),
                     }),
+                    add_if_not_exists: false,
                 },
             ],
         };
 
         let builder = meta
-            .builder_with_alter_kind("my_table", &alter_kind, false)
+            .builder_with_alter_kind("my_table", &alter_kind)
             .unwrap();
         builder.build().unwrap()
     }
@@ -1200,6 +1202,48 @@ mod tests {
     }
 
     #[test]
+    fn test_add_columns_multiple_times() {
+        let schema = Arc::new(new_test_schema());
+        let meta = TableMetaBuilder::default()
+            .schema(schema)
+            .primary_key_indices(vec![0])
+            .engine("engine")
+            .next_column_id(3)
+            .build()
+            .unwrap();
+
+        let alter_kind = AlterKind::AddColumns {
+            columns: vec![
+                AddColumnRequest {
+                    column_schema: ColumnSchema::new(
+                        "col3",
+                        ConcreteDataType::int32_datatype(),
+                        true,
+                    ),
+                    is_key: true,
+                    location: None,
+                    add_if_not_exists: true,
+                },
+                AddColumnRequest {
+                    column_schema: ColumnSchema::new(
+                        "col3",
+                        ConcreteDataType::int32_datatype(),
+                        true,
+                    ),
+                    is_key: true,
+                    location: None,
+                    add_if_not_exists: true,
+                },
+            ],
+        };
+        let err = meta
+            .builder_with_alter_kind("my_table", &alter_kind)
+            .err()
+            .unwrap();
+        assert_eq!(StatusCode::InvalidArguments, err.status_code());
+    }
+
+    #[test]
     fn test_remove_columns() {
         let schema = Arc::new(new_test_schema());
         let meta = TableMetaBuilder::default()
@@ -1216,7 +1260,7 @@ mod tests {
             names: vec![String::from("col2"), String::from("my_field")],
         };
         let new_meta = meta
-            .builder_with_alter_kind("my_table", &alter_kind, false)
+            .builder_with_alter_kind("my_table", &alter_kind)
             .unwrap()
             .build()
             .unwrap();
@@ -1271,7 +1315,7 @@ mod tests {
             names: vec![String::from("col3"), String::from("col1")],
         };
         let new_meta = meta
-            .builder_with_alter_kind("my_table", &alter_kind, false)
+            .builder_with_alter_kind("my_table", &alter_kind)
             .unwrap()
             .build()
             .unwrap();
@@ -1307,14 +1351,62 @@ mod tests {
                 column_schema: ColumnSchema::new("col1", ConcreteDataType::string_datatype(), true),
                 is_key: false,
                 location: None,
+                add_if_not_exists: false,
             }],
         };
 
         let err = meta
-            .builder_with_alter_kind("my_table", &alter_kind, false)
+            .builder_with_alter_kind("my_table", &alter_kind)
             .err()
             .unwrap();
         assert_eq!(StatusCode::TableColumnExists, err.status_code());
+
+        // Add if not exists
+        let alter_kind = AlterKind::AddColumns {
+            columns: vec![AddColumnRequest {
+                column_schema: ColumnSchema::new("col1", ConcreteDataType::int32_datatype(), true),
+                is_key: true,
+                location: None,
+                add_if_not_exists: true,
+            }],
+        };
+        let new_meta = meta
+            .builder_with_alter_kind("my_table", &alter_kind)
+            .unwrap()
+            .build()
+            .unwrap();
+        assert_eq!(
+            meta.schema.column_schemas(),
+            new_meta.schema.column_schemas()
+        );
+        assert_eq!(meta.schema.version() + 1, new_meta.schema.version());
+    }
+
+    #[test]
+    fn test_add_different_type_column() {
+        let schema = Arc::new(new_test_schema());
+        let meta = TableMetaBuilder::default()
+            .schema(schema)
+            .primary_key_indices(vec![0])
+            .engine("engine")
+            .next_column_id(3)
+            .build()
+            .unwrap();
+
+        // Add if not exists, but different type.
+        let alter_kind = AlterKind::AddColumns {
+            columns: vec![AddColumnRequest {
+                column_schema: ColumnSchema::new("col1", ConcreteDataType::string_datatype(), true),
+                is_key: false,
+                location: None,
+                add_if_not_exists: true,
+            }],
+        };
+        let err = meta
+            .builder_with_alter_kind("my_table", &alter_kind)
+            .err()
+            .unwrap();
+        assert_eq!(StatusCode::InvalidArguments, err.status_code());
     }
 
     #[test]
@@ -1328,6 +1420,7 @@ mod tests {
             .build()
             .unwrap();
 
+        // Not nullable and no default value.
         let alter_kind = AlterKind::AddColumns {
             columns: vec![AddColumnRequest {
                 column_schema: ColumnSchema::new(
@@ -1337,11 +1430,12 @@ mod tests {
                 ),
                 is_key: false,
                 location: None,
+                add_if_not_exists: false,
             }],
         };
 
         let err = meta
-            .builder_with_alter_kind("my_table", &alter_kind, false)
+            .builder_with_alter_kind("my_table", &alter_kind)
             .err()
             .unwrap();
         assert_eq!(StatusCode::InvalidArguments, err.status_code());
@@ -1363,7 +1457,7 @@ mod tests {
         };
 
         let err = meta
-            .builder_with_alter_kind("my_table", &alter_kind, false)
+            .builder_with_alter_kind("my_table", &alter_kind)
             .err()
             .unwrap();
         assert_eq!(StatusCode::TableColumnNotFound, err.status_code());
@@ -1388,7 +1482,7 @@ mod tests {
         };
 
         let err = meta
-            .builder_with_alter_kind("my_table", &alter_kind, false)
+            .builder_with_alter_kind("my_table", &alter_kind)
             .err()
             .unwrap();
         assert_eq!(StatusCode::TableColumnNotFound, err.status_code());
@@ -1411,7 +1505,7 @@ mod tests {
         };
 
         let err = meta
-            .builder_with_alter_kind("my_table", &alter_kind, false)
+            .builder_with_alter_kind("my_table", &alter_kind)
             .err()
             .unwrap();
         assert_eq!(StatusCode::InvalidArguments, err.status_code());
@@ -1422,7 +1516,7 @@ mod tests {
         };
 
         let err = meta
-            .builder_with_alter_kind("my_table", &alter_kind, false)
+            .builder_with_alter_kind("my_table", &alter_kind)
             .err()
             .unwrap();
         assert_eq!(StatusCode::InvalidArguments, err.status_code());
@@ -1448,7 +1542,7 @@ mod tests {
         };
 
         let err = meta
-            .builder_with_alter_kind("my_table", &alter_kind, false)
+            .builder_with_alter_kind("my_table", &alter_kind)
             .err()
             .unwrap();
         assert_eq!(StatusCode::InvalidArguments, err.status_code());
@@ -1462,7 +1556,7 @@ mod tests {
         };
 
         let err = meta
-            .builder_with_alter_kind("my_table", &alter_kind, false)
+            .builder_with_alter_kind("my_table", &alter_kind)
             .err()
             .unwrap();
         assert_eq!(StatusCode::InvalidArguments, err.status_code());
@@ -1531,7 +1625,7 @@ mod tests {
             options: FulltextOptions::default(),
         };
         let err = meta
-            .builder_with_alter_kind("my_table", &alter_kind, false)
+            .builder_with_alter_kind("my_table", &alter_kind)
             .err()
             .unwrap();
         assert_eq!(
@@ -1552,7 +1646,7 @@ mod tests {
             },
         };
         let new_meta = new_meta
-            .builder_with_alter_kind("my_table", &alter_kind, false)
+            .builder_with_alter_kind("my_table", &alter_kind)
             .unwrap()
             .build()
             .unwrap();
@@ -1572,7 +1666,7 @@ mod tests {
             column_name: "my_tag_first".to_string(),
         };
         let new_meta = new_meta
-            .builder_with_alter_kind("my_table", &alter_kind, false)
+            .builder_with_alter_kind("my_table", &alter_kind)
             .unwrap()
             .build()
             .unwrap();

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -185,6 +185,8 @@ pub struct AddColumnRequest {
     pub column_schema: ColumnSchema,
     pub is_key: bool,
     pub location: Option<AddColumnLocation>,
+    /// Add column if not exists.
+    pub add_if_not_exists: bool,
 }
 
 /// Change column datatype request

--- a/tests-integration/src/grpc.rs
+++ b/tests-integration/src/grpc.rs
@@ -161,6 +161,7 @@ mod test {
                                 ..Default::default()
                             }),
                             location: None,
+                            add_if_not_exists: true,
                         },
                         AddColumn {
                             column_def: Some(ColumnDef {
@@ -172,6 +173,7 @@ mod test {
                                 ..Default::default()
                             }),
                             location: None,
+                            add_if_not_exists: true,
                         },
                     ],
                 })),
@@ -196,6 +198,7 @@ mod test {
                                 ..Default::default()
                             }),
                             location: None,
+                            add_if_not_exists: true,
                         },
                         AddColumn {
                             column_def: Some(ColumnDef {
@@ -207,6 +210,7 @@ mod test {
                                 ..Default::default()
                             }),
                             location: None,
+                            add_if_not_exists: true,
                         },
                     ],
                 })),
@@ -310,6 +314,7 @@ mod test {
                             ..Default::default()
                         }),
                         location: None,
+                        add_if_not_exists: false,
                     }],
                 })),
             })),

--- a/tests-integration/src/grpc.rs
+++ b/tests-integration/src/grpc.rs
@@ -96,7 +96,9 @@ mod test {
 
     /// Runs the query and ignores the error.
     async fn query_ignore_err(instance: &Instance, request: Request) {
-        let _ = GrpcQueryHandler::do_query(instance, request, QueryContext::arc()).await;
+        if let Err(e) = GrpcQueryHandler::do_query(instance, request, QueryContext::arc()).await {
+            common_telemetry::error!(e; "Failed to query");
+        }
     }
 
     async fn test_handle_multi_ddl_request(instance: &Instance) {

--- a/tests-integration/src/grpc.rs
+++ b/tests-integration/src/grpc.rs
@@ -66,10 +66,187 @@ mod test {
         test_handle_ddl_request(instance.as_ref()).await;
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_distributed_handle_multi_ddl_request() {
+        common_telemetry::init_default_ut_logging();
+        let instance =
+            tests::create_distributed_instance("test_distributed_handle_multi_ddl_request").await;
+
+        test_handle_multi_ddl_request(instance.frontend().as_ref()).await;
+
+        verify_table_is_dropped(&instance).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_standalone_handle_multi_ddl_request() {
+        let standalone =
+            GreptimeDbStandaloneBuilder::new("test_standalone_handle_multi_ddl_request")
+                .build()
+                .await;
+        let instance = &standalone.instance;
+
+        test_handle_multi_ddl_request(instance.as_ref()).await;
+    }
+
     async fn query(instance: &Instance, request: Request) -> Output {
         GrpcQueryHandler::do_query(instance, request, QueryContext::arc())
             .await
             .unwrap()
+    }
+
+    /// Runs the query and ignores the error.
+    async fn query_ignore_err(instance: &Instance, request: Request) {
+        let _ = GrpcQueryHandler::do_query(instance, request, QueryContext::arc()).await;
+    }
+
+    async fn test_handle_multi_ddl_request(instance: &Instance) {
+        let request = Request::Ddl(DdlRequest {
+            expr: Some(DdlExpr::CreateDatabase(CreateDatabaseExpr {
+                catalog_name: "greptime".to_string(),
+                schema_name: "database_created_through_grpc".to_string(),
+                create_if_not_exists: true,
+                options: Default::default(),
+            })),
+        });
+        let output = query(instance, request).await;
+        assert!(matches!(output.data, OutputData::AffectedRows(1)));
+
+        let request = Request::Ddl(DdlRequest {
+            expr: Some(DdlExpr::CreateTable(CreateTableExpr {
+                catalog_name: "greptime".to_string(),
+                schema_name: "database_created_through_grpc".to_string(),
+                table_name: "table_created_through_grpc".to_string(),
+                column_defs: vec![
+                    ColumnDef {
+                        name: "a".to_string(),
+                        data_type: ColumnDataType::String as _,
+                        is_nullable: true,
+                        default_constraint: vec![],
+                        semantic_type: SemanticType::Field as i32,
+                        ..Default::default()
+                    },
+                    ColumnDef {
+                        name: "ts".to_string(),
+                        data_type: ColumnDataType::TimestampMillisecond as _,
+                        is_nullable: false,
+                        default_constraint: vec![],
+                        semantic_type: SemanticType::Timestamp as i32,
+                        ..Default::default()
+                    },
+                ],
+                time_index: "ts".to_string(),
+                engine: MITO_ENGINE.to_string(),
+                ..Default::default()
+            })),
+        });
+        let output = query(instance, request).await;
+        assert!(matches!(output.data, OutputData::AffectedRows(0)));
+
+        let request = Request::Ddl(DdlRequest {
+            expr: Some(DdlExpr::AlterTable(AlterTableExpr {
+                catalog_name: "greptime".to_string(),
+                schema_name: "database_created_through_grpc".to_string(),
+                table_name: "table_created_through_grpc".to_string(),
+                kind: Some(alter_table_expr::Kind::AddColumns(AddColumns {
+                    add_columns: vec![
+                        AddColumn {
+                            column_def: Some(ColumnDef {
+                                name: "b".to_string(),
+                                data_type: ColumnDataType::Int32 as _,
+                                is_nullable: true,
+                                default_constraint: vec![],
+                                semantic_type: SemanticType::Field as i32,
+                                ..Default::default()
+                            }),
+                            location: None,
+                        },
+                        AddColumn {
+                            column_def: Some(ColumnDef {
+                                name: "a".to_string(),
+                                data_type: ColumnDataType::Int32 as _,
+                                is_nullable: true,
+                                default_constraint: vec![],
+                                semantic_type: SemanticType::Field as i32,
+                                ..Default::default()
+                            }),
+                            location: None,
+                        },
+                    ],
+                })),
+            })),
+        });
+        query_ignore_err(instance, request).await;
+
+        let request = Request::Ddl(DdlRequest {
+            expr: Some(DdlExpr::AlterTable(AlterTableExpr {
+                catalog_name: "greptime".to_string(),
+                schema_name: "database_created_through_grpc".to_string(),
+                table_name: "table_created_through_grpc".to_string(),
+                kind: Some(alter_table_expr::Kind::AddColumns(AddColumns {
+                    add_columns: vec![
+                        AddColumn {
+                            column_def: Some(ColumnDef {
+                                name: "c".to_string(),
+                                data_type: ColumnDataType::Int32 as _,
+                                is_nullable: true,
+                                default_constraint: vec![],
+                                semantic_type: SemanticType::Field as i32,
+                                ..Default::default()
+                            }),
+                            location: None,
+                        },
+                        AddColumn {
+                            column_def: Some(ColumnDef {
+                                name: "d".to_string(),
+                                data_type: ColumnDataType::Int32 as _,
+                                is_nullable: true,
+                                default_constraint: vec![],
+                                semantic_type: SemanticType::Field as i32,
+                                ..Default::default()
+                            }),
+                            location: None,
+                        },
+                    ],
+                })),
+            })),
+        });
+        query_ignore_err(instance, request).await;
+
+        let request = Request::Query(QueryRequest {
+            query: Some(Query::Sql("INSERT INTO database_created_through_grpc.table_created_through_grpc (a, b, c, d, ts) VALUES ('s', 1, 1, 1, 1672816466000)".to_string()))
+        });
+        let output = query(instance, request).await;
+        assert!(matches!(output.data, OutputData::AffectedRows(1)));
+
+        let request = Request::Query(QueryRequest {
+            query: Some(Query::Sql(
+                "SELECT ts, a, b FROM database_created_through_grpc.table_created_through_grpc"
+                    .to_string(),
+            )),
+        });
+        let output = query(instance, request).await;
+        let OutputData::Stream(stream) = output.data else {
+            unreachable!()
+        };
+        let recordbatches = RecordBatches::try_collect(stream).await.unwrap();
+        let expected = "\
++---------------------+---+---+
+| ts                  | a | b |
++---------------------+---+---+
+| 2023-01-04T07:14:26 | s | 1 |
++---------------------+---+---+";
+        assert_eq!(recordbatches.pretty_print().unwrap(), expected);
+
+        let request = Request::Ddl(DdlRequest {
+            expr: Some(DdlExpr::DropTable(DropTableExpr {
+                catalog_name: "greptime".to_string(),
+                schema_name: "database_created_through_grpc".to_string(),
+                table_name: "table_created_through_grpc".to_string(),
+                ..Default::default()
+            })),
+        });
+        let output = query(instance, request).await;
+        assert!(matches!(output.data, OutputData::AffectedRows(0)));
     }
 
     async fn test_handle_ddl_request(instance: &Instance) {

--- a/tests-integration/tests/grpc.rs
+++ b/tests-integration/tests/grpc.rs
@@ -372,6 +372,7 @@ pub async fn test_insert_and_select(store_type: StorageType) {
         add_columns: vec![AddColumn {
             column_def: Some(add_column),
             location: None,
+            add_if_not_exists: false,
         }],
     });
     let expr = AlterTableExpr {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
- fixes https://github.com/GreptimeTeam/greptimedb/issues/5248
- the proto branch: https://github.com/GreptimeTeam/greptime-proto/pull/207

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

This PR adds the `add_if_not_exists` flag to the AddColumn alter kind and validates the alteration to the table in the prepare step of the AlterTableProcedure. Before this PR, the procedure may not be able to build table info in the update metadata step, which causes regions to have an inconsistent schema with the meta server.

It also fixes an issue that the procedure always alters tables without `add_if_not_exists` which is different from the behavior of auto alteration.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
