### PR TITLE
chore: suppress list warning

### DIFF
--- a/src/mito2/src/sst/index/intermediate.rs
+++ b/src/mito2/src/sst/index/intermediate.rs
@@ -16,7 +16,7 @@ use std::path::PathBuf;
 
 use async_trait::async_trait;
 use common_error::ext::BoxedError;
-use common_telemetry::warn;
+use common_telemetry::{debug, warn};
 use futures::{AsyncRead, AsyncWrite};
 use index::error as index_error;
 use index::error::Result as IndexResult;
@@ -189,7 +189,8 @@ impl ExternalTempFileProvider for TempFileProvider {
 
         for entry in entries {
             if entry.metadata().is_dir() {
-                warn!("Unexpected entry in index creation dir: {:?}", entry.path());
+                // todo(hl): we can keep this warning once we find a way to filter self in list result.
+                debug!("Unexpected entry in index creation dir: {:?}", entry.path());
                 continue;
             }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
- fixes #5269 

## What's changed and what's your intention?

 - Changed logging level from `warn` to `debug` for unexpected directory entries in index creation.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
