### PR TITLE
refactor: optimize out partition split insert requests

### DIFF
--- a/src/operator/src/req_convert/insert/row_to_region.rs
+++ b/src/operator/src/req_convert/insert/row_to_region.rs
@@ -55,7 +55,6 @@ impl<'a> RowToRegion<'a> {
             let table_id = self.get_table_id(&request.table_name)?;
             let region_numbers = self.region_numbers(&request.table_name)?;
             let requests = if let Some(region_id) = match region_numbers[..] {
-                [] => Some(RegionId::new(table_id, 0)),
                 [singular] => Some(RegionId::new(table_id, singular)),
                 _ => None,
             } {

--- a/src/operator/src/req_convert/insert/row_to_region.rs
+++ b/src/operator/src/req_convert/insert/row_to_region.rs
@@ -13,30 +13,31 @@
 // limitations under the License.
 
 use ahash::{HashMap, HashSet};
-use api::v1::region::InsertRequests as RegionInsertRequests;
+use api::v1::region::{InsertRequest, InsertRequests as RegionInsertRequests};
 use api::v1::RowInsertRequests;
 use partition::manager::PartitionRuleManager;
 use snafu::OptionExt;
-use table::metadata::TableId;
+use store_api::storage::{RegionId, RegionNumber};
+use table::metadata::{TableId, TableInfoRef};
 
 use crate::error::{Result, TableNotFoundSnafu};
 use crate::insert::InstantAndNormalInsertRequests;
 use crate::req_convert::common::partitioner::Partitioner;
 
 pub struct RowToRegion<'a> {
-    table_name_to_ids: HashMap<String, TableId>,
+    tables_info: HashMap<String, TableInfoRef>,
     instant_table_ids: HashSet<TableId>,
     partition_manager: &'a PartitionRuleManager,
 }
 
 impl<'a> RowToRegion<'a> {
     pub fn new(
-        table_name_to_ids: HashMap<String, TableId>,
+        tables_info: HashMap<String, TableInfoRef>,
         instant_table_ids: HashSet<TableId>,
         partition_manager: &'a PartitionRuleManager,
     ) -> Self {
         Self {
-            table_name_to_ids,
+            tables_info,
             instant_table_ids,
             partition_manager,
         }
@@ -49,10 +50,25 @@ impl<'a> RowToRegion<'a> {
         let mut region_request = Vec::with_capacity(requests.inserts.len());
         let mut instant_request = Vec::with_capacity(requests.inserts.len());
         for request in requests.inserts {
+            let Some(rows) = request.rows else { continue };
+
             let table_id = self.get_table_id(&request.table_name)?;
-            let requests = Partitioner::new(self.partition_manager)
-                .partition_insert_requests(table_id, request.rows.unwrap_or_default())
-                .await?;
+            let region_numbers = self.region_numbers(&request.table_name)?;
+            let requests = if let Some(region_id) = match region_numbers[..] {
+                [] => Some(RegionId::new(table_id, 0)),
+                [singular] => Some(RegionId::new(table_id, singular)),
+                _ => None,
+            } {
+                vec![InsertRequest {
+                    region_id: region_id.as_u64(),
+                    rows: Some(rows),
+                }]
+            } else {
+                Partitioner::new(self.partition_manager)
+                    .partition_insert_requests(table_id, rows)
+                    .await?
+            };
+
             if self.instant_table_ids.contains(&table_id) {
                 instant_request.extend(requests);
             } else {
@@ -71,9 +87,16 @@ impl<'a> RowToRegion<'a> {
     }
 
     fn get_table_id(&self, table_name: &str) -> Result<TableId> {
-        self.table_name_to_ids
+        self.tables_info
             .get(table_name)
-            .cloned()
+            .map(|x| x.table_id())
+            .context(TableNotFoundSnafu { table_name })
+    }
+
+    fn region_numbers(&self, table_name: &str) -> Result<&Vec<RegionNumber>> {
+        self.tables_info
+            .get(table_name)
+            .map(|x| &x.meta.region_numbers)
             .context(TableNotFoundSnafu { table_name })
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

If there's only one region in the table, skip spliting insert request rows by partition rules.

Saves about 0.4% cpu on our testing device.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
