### PR TITLE
fix: pass unknown encoding in decompression layer

### DIFF
--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -747,7 +747,7 @@ impl HttpServer {
             .layer(
                 ServiceBuilder::new()
                     .layer(HandleErrorLayer::new(handle_error))
-                    .layer(RequestDecompressionLayer::new()),
+                    .layer(RequestDecompressionLayer::new().pass_through_unaccepted(true)),
             )
             .with_state(log_state)
     }
@@ -767,7 +767,7 @@ impl HttpServer {
             .layer(
                 ServiceBuilder::new()
                     .layer(HandleErrorLayer::new(handle_error))
-                    .layer(RequestDecompressionLayer::new()),
+                    .layer(RequestDecompressionLayer::new().pass_through_unaccepted(true)),
             )
             .with_state(log_state)
     }
@@ -860,7 +860,7 @@ impl HttpServer {
             .layer(
                 ServiceBuilder::new()
                     .layer(HandleErrorLayer::new(handle_error))
-                    .layer(RequestDecompressionLayer::new()),
+                    .layer(RequestDecompressionLayer::new().pass_through_unaccepted(true)),
             )
             .route("/ping", routing::get(influxdb_ping))
             .route("/health", routing::get(influxdb_health))
@@ -881,7 +881,7 @@ impl HttpServer {
             .layer(
                 ServiceBuilder::new()
                     .layer(HandleErrorLayer::new(handle_error))
-                    .layer(RequestDecompressionLayer::new()),
+                    .layer(RequestDecompressionLayer::new().pass_through_unaccepted(true)),
             )
             .with_state(otlp_handler)
     }

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -1899,6 +1899,14 @@ pub async fn test_loki_pb_logs(store_type: StorageType) {
                 HeaderValue::from_static("application/x-protobuf"),
             ),
             (
+                HeaderName::from_static("content-encoding"),
+                HeaderValue::from_static("snappy"),
+            ),
+            (
+                HeaderName::from_static("accept-encoding"),
+                HeaderValue::from_static("identity"),
+            ),
+            (
                 HeaderName::from_static(GREPTIME_LOG_TABLE_NAME_HEADER_NAME),
                 HeaderValue::from_static("loki_table_name"),
             ),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The default decompression layer will intercept unknown encodings like `snappy`. We have to manually set it to `true` for encodings like `snappy` to pass through.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
