### PR TITLE
perf: parse Loki labels in protobuf write path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9171,6 +9171,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quoted-string"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a206a30ce37189d1340e7da2ee0b4d65e342590af676541c23a4f3959ba272e"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10883,7 +10889,6 @@ dependencies = [
  "hyper 0.14.30",
  "influxdb_line_protocol",
  "itertools 0.10.5",
- "json5",
  "jsonb",
  "lazy_static",
  "log-query",
@@ -10907,6 +10912,7 @@ dependencies = [
  "promql-parser",
  "prost 0.12.6",
  "query",
+ "quoted-string",
  "rand",
  "regex",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10889,6 +10889,7 @@ dependencies = [
  "hyper 0.14.30",
  "influxdb_line_protocol",
  "itertools 0.10.5",
+ "json5",
  "jsonb",
  "lazy_static",
  "log-query",

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -123,6 +123,7 @@ client = { workspace = true, features = ["testing"] }
 common-base.workspace = true
 common-test-util.workspace = true
 criterion = "0.5"
+json5 = "0.4"
 mysql_async = { version = "0.33", default-features = false, features = [
     "default-rustls",
 ] }
@@ -148,4 +149,8 @@ harness = false
 
 [[bench]]
 name = "to_http_output"
+harness = false
+
+[[bench]]
+name = "loki_labels"
 harness = false

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -63,7 +63,6 @@ humantime-serde.workspace = true
 hyper = { version = "0.14", features = ["full"] }
 influxdb_line_protocol = { git = "https://github.com/evenyag/influxdb_iox", branch = "feat/line-protocol" }
 itertools.workspace = true
-json5 = "0.4"
 jsonb.workspace = true
 lazy_static.workspace = true
 log-query.workspace = true
@@ -86,6 +85,7 @@ prometheus.workspace = true
 promql-parser.workspace = true
 prost.workspace = true
 query.workspace = true
+quoted-string = "0.6"
 rand.workspace = true
 regex.workspace = true
 reqwest.workspace = true

--- a/src/servers/benches/loki_labels.rs
+++ b/src/servers/benches/loki_labels.rs
@@ -1,0 +1,41 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use servers::error::Result;
+use servers::http::loki::parse_loki_labels;
+
+// cargo bench loki_labels
+
+fn json5_parse(input: &str) -> Result<BTreeMap<String, String>> {
+    let input = input.replace("=", ":");
+    let result: BTreeMap<String, String> = json5::from_str(&input).unwrap();
+    Ok(result)
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("loki_labels");
+    let input = r#"{job="foobar", cluster="foo-central1", namespace="bar", container_name="buzz"}"#;
+
+    group.bench_function("json5", |b| b.iter(|| json5_parse(black_box(input))));
+    group.bench_function("hand_parse", |b| {
+        b.iter(|| parse_loki_labels(black_box(input)))
+    });
+    group.finish(); // Important to call finish() on the group
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -506,7 +506,7 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Invalid Loki lables: {}", msg))]
+    #[snafu(display("Invalid Loki labels: {}", msg))]
     InvalidLokiLabels {
         msg: String,
         #[snafu(implicit)]

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -506,10 +506,9 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Failed to parse payload as json5"))]
-    ParseJson5 {
-        #[snafu(source)]
-        error: json5::Error,
+    #[snafu(display("Invalid Loki lables: {}", msg))]
+    InvalidLokiLabels {
+        msg: String,
         #[snafu(implicit)]
         location: Location,
     },
@@ -666,7 +665,7 @@ impl ErrorExt for Error {
             | MissingQueryContext { .. }
             | MysqlValueConversion { .. }
             | ParseJson { .. }
-            | ParseJson5 { .. }
+            | InvalidLokiLabels { .. }
             | InvalidLokiPayload { .. }
             | UnsupportedContentType { .. }
             | TimestampOverflow { .. }

--- a/src/servers/src/http/loki.rs
+++ b/src/servers/src/http/loki.rs
@@ -287,7 +287,7 @@ async fn handle_pb_req(
 /// ref:
 /// 1. encoding: https://github.com/grafana/alloy/blob/be34410b9e841cc0c37c153f9550d9086a304bca/internal/component/common/loki/client/batch.go#L114-L145
 /// 2. test data: https://github.com/grafana/loki/blob/a24ef7b206e0ca63ee74ca6ecb0a09b745cd2258/pkg/push/types_test.go
-fn parse_loki_labels(labels: &str) -> Result<BTreeMap<String, String>> {
+pub fn parse_loki_labels(labels: &str) -> Result<BTreeMap<String, String>> {
     let mut labels = labels.trim();
     ensure!(
         labels.len() >= 2,

--- a/src/servers/src/http/loki.rs
+++ b/src/servers/src/http/loki.rs
@@ -320,9 +320,11 @@ pub fn parse_loki_labels(labels: &str) -> Result<BTreeMap<String, String>> {
         // parse value
         let qs = quoted_string::parse::<TestSpec>(labels)
             .map_err(|e| {
-                error!(e.1; "failed to parse quoted string");
                 InvalidLokiLabelsSnafu {
-                    msg: format!("failed to parse quoted string near: {}", labels),
+                    msg: format!(
+                        "failed to parse quoted string near: {}, reason: {}",
+                        labels, e.1
+                    ),
                 }
                 .build()
             })?
@@ -331,9 +333,8 @@ pub fn parse_loki_labels(labels: &str) -> Result<BTreeMap<String, String>> {
         labels = &labels[qs.len()..];
 
         let value = quoted_string::to_content::<TestSpec>(qs).map_err(|e| {
-            error!(e; "failed to unquote the string");
             InvalidLokiLabelsSnafu {
-                msg: format!("failed to unquote the string: {}", qs),
+                msg: format!("failed to unquote the string: {}, reason: {}", qs, e),
             }
             .build()
         })?;

--- a/src/servers/src/http/loki.rs
+++ b/src/servers/src/http/loki.rs
@@ -284,6 +284,7 @@ async fn handle_pb_req(
 }
 
 /// since we're hand-parsing the labels, if any error is encountered, we'll just skip the label
+/// note: pub here for bench usage
 /// ref:
 /// 1. encoding: https://github.com/grafana/alloy/blob/be34410b9e841cc0c37c153f9550d9086a304bca/internal/component/common/loki/client/batch.go#L114-L145
 /// 2. test data: https://github.com/grafana/loki/blob/a24ef7b206e0ca63ee74ca6ecb0a09b745cd2258/pkg/push/types_test.go

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -1873,7 +1873,7 @@ pub async fn test_loki_pb_logs(store_type: StorageType) {
     // init loki request
     let req: PushRequest = PushRequest {
         streams: vec![StreamAdapter {
-            labels: r#"{service="test",source="integration","wadaxi"="do anything"}"#.to_string(),
+            labels: r#"{service="test",source="integration",wadaxi="do anything"}"#.to_string(),
             entries: vec![
                 EntryAdapter {
                     timestamp: Some(Timestamp::from_str("2024-11-07T10:53:50").unwrap()),

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -1953,7 +1953,8 @@ pub async fn test_loki_json_logs(store_type: StorageType) {
   "streams": [
     {
       "stream": {
-        "source": "test"
+        "source": "test",
+        "sender": "integration"
       },
       "values": [
           [ "1735901380059465984", "this is line one" ],
@@ -1987,7 +1988,7 @@ pub async fn test_loki_json_logs(store_type: StorageType) {
     assert_eq!(StatusCode::OK, res.status());
 
     // test schema
-    let expected = "[[\"loki_table_name\",\"CREATE TABLE IF NOT EXISTS \\\"loki_table_name\\\" (\\n  \\\"greptime_timestamp\\\" TIMESTAMP(9) NOT NULL,\\n  \\\"line\\\" STRING NULL,\\n  \\\"source\\\" STRING NULL,\\n  TIME INDEX (\\\"greptime_timestamp\\\"),\\n  PRIMARY KEY (\\\"source\\\")\\n)\\n\\nENGINE=mito\\nWITH(\\n  append_mode = 'true'\\n)\"]]";
+    let expected = "[[\"loki_table_name\",\"CREATE TABLE IF NOT EXISTS \\\"loki_table_name\\\" (\\n  \\\"greptime_timestamp\\\" TIMESTAMP(9) NOT NULL,\\n  \\\"line\\\" STRING NULL,\\n  \\\"sender\\\" STRING NULL,\\n  \\\"source\\\" STRING NULL,\\n  TIME INDEX (\\\"greptime_timestamp\\\"),\\n  PRIMARY KEY (\\\"sender\\\", \\\"source\\\")\\n)\\n\\nENGINE=mito\\nWITH(\\n  append_mode = 'true'\\n)\"]]";
     validate_data(
         "loki_json_schema",
         &client,
@@ -1997,7 +1998,7 @@ pub async fn test_loki_json_logs(store_type: StorageType) {
     .await;
 
     // test content
-    let expected = "[[1735901380059465984,\"this is line one\",\"test\"],[1735901398478897920,\"this is line two\",\"test\"]]";
+    let expected = "[[1735901380059465984,\"this is line one\",\"integration\",\"test\"],[1735901398478897920,\"this is line two\",\"integration\",\"test\"]]";
     validate_data(
         "loki_json_content",
         &client,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#5287 

## What's changed and what's your intention?

Parse Loki labels directly in protobuf write path instead of converting and decoding using JSON5, roughly 10x better performance-wise while ensuring correctness.

```
loki_labels/json5       time:   [3.9928 µs 3.9939 µs 3.9950 µs]
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) low mild
  2 (2.00%) high severe
loki_labels/hand_parse  time:   [392.19 ns 392.54 ns 392.93 ns]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
```

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
