### PR TITLE
chore(nightly-ci): remove `pg_kvbackend` feature gate in windows ci

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           distribution: Ubuntu-22.04
       - name: Running tests
-        run: cargo nextest run -F dashboard -F pg_kvbackend
+        run: cargo nextest run -F dashboard
         env:
           CARGO_BUILD_RUSTFLAGS: "-C linker=lld-link"
           RUST_BACKTRACE: 1


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Remove the `pg_kvbackend` feature gate in the Windows CI. It is unlikely that anyone would run a distributed GreptimeDB cluster in a Windows environment.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
