### PR TITLE
feat: support `select session_user;`

### DIFF
--- a/src/common/function/src/system.rs
+++ b/src/common/function/src/system.rs
@@ -22,7 +22,7 @@ mod version;
 use std::sync::Arc;
 
 use build::BuildFunction;
-use database::{CurrentSchemaFunction, DatabaseFunction};
+use database::{CurrentSchemaFunction, DatabaseFunction, SessionUserFunction};
 use pg_catalog::PGCatalogFunction;
 use procedure_state::ProcedureStateFunction;
 use timezone::TimezoneFunction;
@@ -36,8 +36,9 @@ impl SystemFunction {
     pub fn register(registry: &FunctionRegistry) {
         registry.register(Arc::new(BuildFunction));
         registry.register(Arc::new(VersionFunction));
-        registry.register(Arc::new(DatabaseFunction));
         registry.register(Arc::new(CurrentSchemaFunction));
+        registry.register(Arc::new(DatabaseFunction));
+        registry.register(Arc::new(SessionUserFunction));
         registry.register(Arc::new(TimezoneFunction));
         registry.register_async(Arc::new(ProcedureStateFunction));
         PGCatalogFunction::register(registry);

--- a/src/common/function/src/system/database.rs
+++ b/src/common/function/src/system/database.rs
@@ -92,7 +92,6 @@ impl Function for SessionUserFunction {
 
         Ok(Arc::new(StringVector::from_slice(&[user.username()])) as _)
     }
-    
 }
 
 impl fmt::Display for DatabaseFunction {

--- a/src/common/function/src/system/database.rs
+++ b/src/common/function/src/system/database.rs
@@ -28,9 +28,11 @@ pub struct DatabaseFunction;
 
 #[derive(Clone, Debug, Default)]
 pub struct CurrentSchemaFunction;
+pub struct SessionUserFunction;
 
 const DATABASE_FUNCTION_NAME: &str = "database";
 const CURRENT_SCHEMA_FUNCTION_NAME: &str = "current_schema";
+const SESSION_USER_FUNCTION_NAME: &str = "session_user";
 
 impl Function for DatabaseFunction {
     fn name(&self) -> &str {
@@ -72,6 +74,27 @@ impl Function for CurrentSchemaFunction {
     }
 }
 
+impl Function for SessionUserFunction {
+    fn name(&self) -> &str {
+        SESSION_USER_FUNCTION_NAME
+    }
+
+    fn return_type(&self, _input_types: &[ConcreteDataType]) -> Result<ConcreteDataType> {
+        Ok(ConcreteDataType::string_datatype())
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::uniform(0, vec![], Volatility::Immutable)
+    }
+
+    fn eval(&self, func_ctx: FunctionContext, _columns: &[VectorRef]) -> Result<VectorRef> {
+        let user = func_ctx.query_ctx.current_user();
+
+        Ok(Arc::new(StringVector::from_slice(&[user.username()])) as _)
+    }
+    
+}
+
 impl fmt::Display for DatabaseFunction {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "DATABASE")
@@ -81,6 +104,12 @@ impl fmt::Display for DatabaseFunction {
 impl fmt::Display for CurrentSchemaFunction {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "CURRENT_SCHEMA")
+    }
+}
+
+impl fmt::Display for SessionUserFunction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SESSION_USER")
     }
 }
 

--- a/tests/cases/standalone/common/system/pg_catalog.result
+++ b/tests/cases/standalone/common/system/pg_catalog.result
@@ -3,6 +3,26 @@ create database pg_catalog;
 
 Error: 1004(InvalidArguments), Schema pg_catalog already exists
 
+-- session_user because session_user is based on the current user so is not null is for test 
+-- SQLNESS PROTOCOL POSTGRES
+SELECT session_user is not null;
+
++----------------------------+
+| session_user() IS NOT NULL |
++----------------------------+
+| t                          |
++----------------------------+
+
+-- session_user and current_schema
+-- SQLNESS PROTOCOL POSTGRES
+select current_schema();
+
++------------------+
+| current_schema() |
++------------------+
+| public           |
++------------------+
+
 -- make sure all the pg_catalog tables are only visible to postgres
 select * from pg_catalog.pg_class;
 

--- a/tests/cases/standalone/common/system/pg_catalog.sql
+++ b/tests/cases/standalone/common/system/pg_catalog.sql
@@ -1,6 +1,14 @@
 -- should not able to create pg_catalog
 create database pg_catalog;
 
+-- session_user because session_user is based on the current user so is not null is for test 
+-- SQLNESS PROTOCOL POSTGRES
+SELECT session_user is not null;
+
+-- session_user and current_schema
+-- SQLNESS PROTOCOL POSTGRES
+select current_schema();
+
 -- make sure all the pg_catalog tables are only visible to postgres
 select * from pg_catalog.pg_class;
 select * from pg_catalog.pg_namespace;


### PR DESCRIPTION
This commit is part of support DBeaver that support function select session_user like postgres did.

first part of https://github.com/GreptimeTeam/greptimedb/issues/5271#issuecomment-2575070285
will support `select pg_catalog.pg_database;` in next patch

screen shot;
![image](https://github.com/user-attachments/assets/ea32e9c6-8994-48fc-8a59-6b775454aae8)


I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
