### PR TITLE
feat: more than one flow workers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3949,6 +3949,7 @@ dependencies = [
  "common-telemetry",
  "common-time",
  "common-version",
+ "config",
  "datafusion",
  "datafusion-common",
  "datafusion-expr",

--- a/config/config.md
+++ b/config/config.md
@@ -536,6 +536,7 @@
 | --- | -----| ------- | ----------- |
 | `mode` | String | `distributed` | The running mode of the flownode. It can be `standalone` or `distributed`. |
 | `node_id` | Integer | Unset | The flownode identifier and should be unique in the cluster. |
+| `num_workers` | Integer | `8` | The number of flow worker in flownode |
 | `grpc` | -- | -- | The gRPC server options. |
 | `grpc.addr` | String | `127.0.0.1:6800` | The address to bind the gRPC server. |
 | `grpc.hostname` | String | `127.0.0.1` | The hostname advertised to the metasrv,<br/>and used for connections from outside the host |

--- a/config/config.md
+++ b/config/config.md
@@ -536,7 +536,7 @@
 | --- | -----| ------- | ----------- |
 | `mode` | String | `distributed` | The running mode of the flownode. It can be `standalone` or `distributed`. |
 | `node_id` | Integer | Unset | The flownode identifier and should be unique in the cluster. |
-| `num_workers` | Integer | `8` | The number of flow worker in flownode |
+| `num_workers` | Integer | `8` | The number of flow worker in flownode.<br/>Not setting this value will use the number of CPU cores divided by 2. |
 | `grpc` | -- | -- | The gRPC server options. |
 | `grpc.addr` | String | `127.0.0.1:6800` | The address to bind the gRPC server. |
 | `grpc.hostname` | String | `127.0.0.1` | The hostname advertised to the metasrv,<br/>and used for connections from outside the host |

--- a/config/config.md
+++ b/config/config.md
@@ -91,6 +91,8 @@
 | `procedure` | -- | -- | Procedure storage options. |
 | `procedure.max_retry_times` | Integer | `3` | Procedure max retry time. |
 | `procedure.retry_delay` | String | `500ms` | Initial retry delay of procedures, increases exponentially |
+| `flow` | -- | -- | -- |
+| `flow.num_workers` | Integer | `8` | The number of flow worker in flownode.<br/>Not setting this value will use the number of CPU cores divided by 2. |
 | `storage` | -- | -- | The data storage options. |
 | `storage.data_home` | String | `/tmp/greptimedb/` | The working home directory. |
 | `storage.type` | String | `File` | The storage type used to store the data.<br/>- `File`: the data is stored in the local file system.<br/>- `S3`: the data is stored in the S3 object storage.<br/>- `Gcs`: the data is stored in the Google Cloud Storage.<br/>- `Azblob`: the data is stored in the Azure Blob Storage.<br/>- `Oss`: the data is stored in the Aliyun OSS. |
@@ -536,7 +538,8 @@
 | --- | -----| ------- | ----------- |
 | `mode` | String | `distributed` | The running mode of the flownode. It can be `standalone` or `distributed`. |
 | `node_id` | Integer | Unset | The flownode identifier and should be unique in the cluster. |
-| `num_workers` | Integer | `8` | The number of flow worker in flownode.<br/>Not setting this value will use the number of CPU cores divided by 2. |
+| `flow` | -- | -- | -- |
+| `flow.num_workers` | Integer | `8` | The number of flow worker in flownode.<br/>Not setting this value will use the number of CPU cores divided by 2. |
 | `grpc` | -- | -- | The gRPC server options. |
 | `grpc.addr` | String | `127.0.0.1:6800` | The address to bind the gRPC server. |
 | `grpc.hostname` | String | `127.0.0.1` | The hostname advertised to the metasrv,<br/>and used for connections from outside the host |

--- a/config/config.md
+++ b/config/config.md
@@ -92,7 +92,7 @@
 | `procedure.max_retry_times` | Integer | `3` | Procedure max retry time. |
 | `procedure.retry_delay` | String | `500ms` | Initial retry delay of procedures, increases exponentially |
 | `flow` | -- | -- | flow engine options. |
-| `flow.num_workers` | Integer | `8` | The number of flow worker in flownode.<br/>Not setting this value will use the number of CPU cores divided by 2. |
+| `flow.num_workers` | Integer | `0` | The number of flow worker in flownode.<br/>Not setting(or set to 0) this value will use the number of CPU cores divided by 2. |
 | `storage` | -- | -- | The data storage options. |
 | `storage.data_home` | String | `/tmp/greptimedb/` | The working home directory. |
 | `storage.type` | String | `File` | The storage type used to store the data.<br/>- `File`: the data is stored in the local file system.<br/>- `S3`: the data is stored in the S3 object storage.<br/>- `Gcs`: the data is stored in the Google Cloud Storage.<br/>- `Azblob`: the data is stored in the Azure Blob Storage.<br/>- `Oss`: the data is stored in the Aliyun OSS. |
@@ -539,7 +539,7 @@
 | `mode` | String | `distributed` | The running mode of the flownode. It can be `standalone` or `distributed`. |
 | `node_id` | Integer | Unset | The flownode identifier and should be unique in the cluster. |
 | `flow` | -- | -- | flow engine options. |
-| `flow.num_workers` | Integer | `8` | The number of flow worker in flownode.<br/>Not setting this value will use the number of CPU cores divided by 2. |
+| `flow.num_workers` | Integer | `0` | The number of flow worker in flownode.<br/>Not setting(or set to 0) this value will use the number of CPU cores divided by 2. |
 | `grpc` | -- | -- | The gRPC server options. |
 | `grpc.addr` | String | `127.0.0.1:6800` | The address to bind the gRPC server. |
 | `grpc.hostname` | String | `127.0.0.1` | The hostname advertised to the metasrv,<br/>and used for connections from outside the host |

--- a/config/config.md
+++ b/config/config.md
@@ -91,7 +91,7 @@
 | `procedure` | -- | -- | Procedure storage options. |
 | `procedure.max_retry_times` | Integer | `3` | Procedure max retry time. |
 | `procedure.retry_delay` | String | `500ms` | Initial retry delay of procedures, increases exponentially |
-| `flow` | -- | -- | -- |
+| `flow` | -- | -- | flow engine options. |
 | `flow.num_workers` | Integer | `8` | The number of flow worker in flownode.<br/>Not setting this value will use the number of CPU cores divided by 2. |
 | `storage` | -- | -- | The data storage options. |
 | `storage.data_home` | String | `/tmp/greptimedb/` | The working home directory. |
@@ -538,7 +538,7 @@
 | --- | -----| ------- | ----------- |
 | `mode` | String | `distributed` | The running mode of the flownode. It can be `standalone` or `distributed`. |
 | `node_id` | Integer | Unset | The flownode identifier and should be unique in the cluster. |
-| `flow` | -- | -- | -- |
+| `flow` | -- | -- | flow engine options. |
 | `flow.num_workers` | Integer | `8` | The number of flow worker in flownode.<br/>Not setting this value will use the number of CPU cores divided by 2. |
 | `grpc` | -- | -- | The gRPC server options. |
 | `grpc.addr` | String | `127.0.0.1:6800` | The address to bind the gRPC server. |

--- a/config/flownode.example.toml
+++ b/config/flownode.example.toml
@@ -5,6 +5,8 @@ mode = "distributed"
 ## @toml2docs:none-default
 node_id = 14
 
+## flow engine options.
+[flow]
 ## The number of flow worker in flownode.
 ## Not setting this value will use the number of CPU cores divided by 2.
 #+num_workers=8

--- a/config/flownode.example.toml
+++ b/config/flownode.example.toml
@@ -7,7 +7,7 @@ node_id = 14
 
 ## The number of flow worker in flownode.
 ## Not setting this value will use the number of CPU cores divided by 2.
-num_workers = 8
+#+num_workers=8
 
 ## The gRPC server options.
 [grpc]

--- a/config/flownode.example.toml
+++ b/config/flownode.example.toml
@@ -6,7 +6,7 @@ mode = "distributed"
 node_id = 14
 
 ## The number of flow worker in flownode
-num_workers = 2
+num_workers = 8
 
 ## The gRPC server options.
 [grpc]

--- a/config/flownode.example.toml
+++ b/config/flownode.example.toml
@@ -5,6 +5,9 @@ mode = "distributed"
 ## @toml2docs:none-default
 node_id = 14
 
+## The number of flow worker in flownode
+num_workers = 2
+
 ## The gRPC server options.
 [grpc]
 ## The address to bind the gRPC server.

--- a/config/flownode.example.toml
+++ b/config/flownode.example.toml
@@ -9,7 +9,7 @@ node_id = 14
 [flow]
 ## The number of flow worker in flownode.
 ## Not setting(or set to 0) this value will use the number of CPU cores divided by 2.
-#+num_workers=8
+#+num_workers=0
 
 ## The gRPC server options.
 [grpc]

--- a/config/flownode.example.toml
+++ b/config/flownode.example.toml
@@ -8,7 +8,7 @@ node_id = 14
 ## flow engine options.
 [flow]
 ## The number of flow worker in flownode.
-## Not setting this value will use the number of CPU cores divided by 2.
+## Not setting(or set to 0) this value will use the number of CPU cores divided by 2.
 #+num_workers=8
 
 ## The gRPC server options.

--- a/config/flownode.example.toml
+++ b/config/flownode.example.toml
@@ -5,7 +5,8 @@ mode = "distributed"
 ## @toml2docs:none-default
 node_id = 14
 
-## The number of flow worker in flownode
+## The number of flow worker in flownode.
+## Not setting this value will use the number of CPU cores divided by 2.
 num_workers = 8
 
 ## The gRPC server options.

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -287,7 +287,7 @@ retry_delay = "500ms"
 ## flow engine options.
 [flow]
 ## The number of flow worker in flownode.
-## Not setting this value will use the number of CPU cores divided by 2.
+## Not setting(or set to 0) this value will use the number of CPU cores divided by 2.
 #+num_workers=8
 
 # Example of using S3 as the storage.

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -284,6 +284,12 @@ max_retry_times = 3
 ## Initial retry delay of procedures, increases exponentially
 retry_delay = "500ms"
 
+## flow engine options.
+[flow]
+## The number of flow worker in flownode.
+## Not setting this value will use the number of CPU cores divided by 2.
+#+num_workers=8
+
 # Example of using S3 as the storage.
 # [storage]
 # type = "S3"

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -288,7 +288,7 @@ retry_delay = "500ms"
 [flow]
 ## The number of flow worker in flownode.
 ## Not setting(or set to 0) this value will use the number of CPU cores divided by 2.
-#+num_workers=8
+#+num_workers=0
 
 # Example of using S3 as the storage.
 # [storage]

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -526,7 +526,7 @@ impl StartCommand {
 
         let flow_metadata_manager = Arc::new(FlowMetadataManager::new(kv_backend.clone()));
         let flownode_options = FlownodeOptions {
-            opts: opts.flow.clone(),
+            flow: opts.flow.clone(),
             ..Default::default()
         };
         let flow_builder = FlownodeBuilder::new(

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -54,7 +54,7 @@ use datanode::config::{DatanodeOptions, ProcedureConfig, RegionEngineConfig, Sto
 use datanode::datanode::{Datanode, DatanodeBuilder};
 use datanode::region_server::RegionServer;
 use file_engine::config::EngineConfig as FileEngineConfig;
-use flow::{FlowWorkerManager, FlownodeBuilder, FrontendInvoker};
+use flow::{FlowConfig, FlowWorkerManager, FlownodeBuilder, FlownodeOptions, FrontendInvoker};
 use frontend::frontend::FrontendOptions;
 use frontend::instance::builder::FrontendBuilder;
 use frontend::instance::{FrontendInstance, Instance as FeInstance, StandaloneDatanodeManager};
@@ -145,6 +145,7 @@ pub struct StandaloneOptions {
     pub storage: StorageConfig,
     pub metadata_store: KvBackendConfig,
     pub procedure: ProcedureConfig,
+    pub flow: FlowConfig,
     pub logging: LoggingOptions,
     pub user_provider: Option<String>,
     /// Options for different store engines.
@@ -173,6 +174,7 @@ impl Default for StandaloneOptions {
             storage: StorageConfig::default(),
             metadata_store: KvBackendConfig::default(),
             procedure: ProcedureConfig::default(),
+            flow: FlowConfig::default(),
             logging: LoggingOptions::default(),
             export_metrics: ExportMetricsOption::default(),
             user_provider: None,
@@ -523,8 +525,12 @@ impl StartCommand {
             Self::create_table_metadata_manager(kv_backend.clone()).await?;
 
         let flow_metadata_manager = Arc::new(FlowMetadataManager::new(kv_backend.clone()));
+        let flownode_options = FlownodeOptions {
+            opts: opts.flow.clone(),
+            ..Default::default()
+        };
         let flow_builder = FlownodeBuilder::new(
-            Default::default(),
+            flownode_options,
             plugins.clone(),
             table_metadata_manager.clone(),
             catalog_manager.clone(),

--- a/src/common/config/src/config.rs
+++ b/src/common/config/src/config.rs
@@ -73,18 +73,18 @@ pub trait Configurable: Serialize + DeserializeOwned + Default + Sized {
             layered_config = layered_config.add_source(File::new(config_file, FileFormat::Toml));
         }
 
-        let opts: Self = layered_config
+        let mut opts: Self = layered_config
             .build()
             .and_then(|x| x.try_deserialize())
             .context(LoadLayeredConfigSnafu)?;
 
-        opts.validate()?;
+        opts.validate_sanitize()?;
 
         Ok(opts)
     }
 
-    /// Validate the configuration.
-    fn validate(&self) -> Result<()> {
+    /// Validate(and possibly sanitize) the configuration.
+    fn validate_sanitize(&mut self) -> Result<()> {
         Ok(())
     }
 

--- a/src/common/config/src/config.rs
+++ b/src/common/config/src/config.rs
@@ -73,12 +73,19 @@ pub trait Configurable: Serialize + DeserializeOwned + Default + Sized {
             layered_config = layered_config.add_source(File::new(config_file, FileFormat::Toml));
         }
 
-        let opts = layered_config
+        let opts: Self = layered_config
             .build()
             .and_then(|x| x.try_deserialize())
             .context(LoadLayeredConfigSnafu)?;
 
+        opts.validate()?;
+
         Ok(opts)
+    }
+
+    /// Validate the configuration.
+    fn validate(&self) -> Result<()> {
+        Ok(())
     }
 
     /// List of toml keys that should be parsed as a list.

--- a/src/flow/Cargo.toml
+++ b/src/flow/Cargo.toml
@@ -32,6 +32,7 @@ common-runtime.workspace = true
 common-telemetry.workspace = true
 common-time.workspace = true
 common-version.workspace = true
+config.workspace = true
 datafusion.workspace = true
 datafusion-common.workspace = true
 datafusion-expr.workspace = true

--- a/src/flow/src/adapter.rs
+++ b/src/flow/src/adapter.rs
@@ -102,7 +102,7 @@ impl Default for FlownodeOptions {
             mode: servers::Mode::Standalone,
             cluster_id: None,
             node_id: None,
-            num_workers: common_config::utils::get_cpus() / 2,
+            num_workers: (common_config::utils::get_cpus() / 2).max(1),
             grpc: GrpcOptions::default().with_addr("127.0.0.1:3004"),
             meta_client: None,
             logging: LoggingOptions::default(),

--- a/src/flow/src/adapter.rs
+++ b/src/flow/src/adapter.rs
@@ -102,7 +102,7 @@ impl Default for FlownodeOptions {
             mode: servers::Mode::Standalone,
             cluster_id: None,
             node_id: None,
-            num_workers: common_config::utils::get_cpus(),
+            num_workers: common_config::utils::get_cpus() / 2,
             grpc: GrpcOptions::default().with_addr("127.0.0.1:3004"),
             meta_client: None,
             logging: LoggingOptions::default(),

--- a/src/flow/src/adapter.rs
+++ b/src/flow/src/adapter.rs
@@ -27,7 +27,6 @@ use common_meta::key::TableMetadataManagerRef;
 use common_runtime::JoinHandle;
 use common_telemetry::logging::{LoggingOptions, TracingOptions};
 use common_telemetry::{debug, info, trace};
-use config::ConfigError;
 use datatypes::schema::ColumnSchema;
 use datatypes::value::Value;
 use greptime_proto::v1;
@@ -128,13 +127,9 @@ impl Default for FlownodeOptions {
 }
 
 impl Configurable for FlownodeOptions {
-    fn validate(&self) -> common_config::error::Result<()> {
-        use common_config::error::LoadLayeredConfigSnafu;
+    fn validate_sanitize(&mut self) -> common_config::error::Result<()> {
         if self.flow.num_workers == 0 {
-            Err(ConfigError::Message(
-                "num_workers must be at least 1".to_string(),
-            ))
-            .context(LoadLayeredConfigSnafu)?
+            self.flow.num_workers = (common_config::utils::get_cpus() / 2).max(1);
         }
         Ok(())
     }

--- a/src/flow/src/adapter.rs
+++ b/src/flow/src/adapter.rs
@@ -103,7 +103,7 @@ pub struct FlownodeOptions {
     pub mode: Mode,
     pub cluster_id: Option<u64>,
     pub node_id: Option<u64>,
-    pub opts: FlowConfig,
+    pub flow: FlowConfig,
     pub grpc: GrpcOptions,
     pub meta_client: Option<MetaClientOptions>,
     pub logging: LoggingOptions,
@@ -117,7 +117,7 @@ impl Default for FlownodeOptions {
             mode: servers::Mode::Standalone,
             cluster_id: None,
             node_id: None,
-            opts: FlowConfig::default(),
+            flow: FlowConfig::default(),
             grpc: GrpcOptions::default().with_addr("127.0.0.1:3004"),
             meta_client: None,
             logging: LoggingOptions::default(),
@@ -130,7 +130,7 @@ impl Default for FlownodeOptions {
 impl Configurable for FlownodeOptions {
     fn validate(&self) -> common_config::error::Result<()> {
         use common_config::error::LoadLayeredConfigSnafu;
-        if self.opts.num_workers == 0 {
+        if self.flow.num_workers == 0 {
             Err(ConfigError::Message(
                 "num_workers must be at least 1".to_string(),
             ))

--- a/src/flow/src/adapter/util.rs
+++ b/src/flow/src/adapter/util.rs
@@ -28,12 +28,27 @@ use snafu::{OptionExt, ResultExt};
 use table::table_reference::TableReference;
 
 use crate::adapter::table_source::TableDesc;
-use crate::adapter::{TableName, AUTO_CREATED_PLACEHOLDER_TS_COL};
+use crate::adapter::{TableName, WorkerHandle, AUTO_CREATED_PLACEHOLDER_TS_COL};
 use crate::error::{Error, ExternalSnafu, UnexpectedSnafu};
 use crate::repr::{ColumnType, RelationDesc, RelationType};
 use crate::FlowWorkerManager;
 
 impl FlowWorkerManager {
+    /// Get a worker handle for creating flow, using round robin to select a worker
+    pub(crate) async fn get_worker_handle_for_create_flow(
+        &self,
+    ) -> tokio::sync::MutexGuard<WorkerHandle> {
+        let mut selector = self.worker_selector.lock().await;
+
+        *selector += 1;
+        if *selector >= self.worker_handles.len() {
+            *selector = 0
+        };
+
+        let handle = self.worker_handles.get(*selector).unwrap();
+        handle.lock().await
+    }
+
     /// Create table from given schema(will adjust to add auto column if needed), return true if table is created
     pub(crate) async fn create_table_from_relation(
         &self,

--- a/src/flow/src/adapter/util.rs
+++ b/src/flow/src/adapter/util.rs
@@ -45,7 +45,8 @@ impl FlowWorkerManager {
             *selector = 0
         };
 
-        let handle = self.worker_handles.get(*selector).unwrap();
+        // Safety: selector is always in bound
+        let handle = &self.worker_handles[*selector];
         handle.lock().await
     }
 

--- a/src/flow/src/lib.rs
+++ b/src/flow/src/lib.rs
@@ -41,6 +41,6 @@ mod utils;
 #[cfg(test)]
 mod test_utils;
 
-pub use adapter::{FlowWorkerManager, FlowWorkerManagerRef, FlownodeOptions};
+pub use adapter::{FlowConfig, FlowWorkerManager, FlowWorkerManagerRef, FlownodeOptions};
 pub use error::{Error, Result};
 pub use server::{FlownodeBuilder, FlownodeInstance, FlownodeServer, FrontendInvoker};

--- a/src/flow/src/server.rs
+++ b/src/flow/src/server.rs
@@ -430,9 +430,9 @@ impl FlownodeBuilder {
                     info!("Flow Worker started in new thread");
                     worker.run();
                 });
-            let worker_handle = rx.await.map_err(|_e| {
+            let worker_handle = rx.await.map_err(|e| {
                 UnexpectedSnafu {
-                    reason: "sender is dropped, failed to create flow node manager",
+                    reason: format!("Failed to receive worker handle: {}", e),
                 }
                 .build()
             })?;

--- a/src/flow/src/server.rs
+++ b/src/flow/src/server.rs
@@ -414,7 +414,7 @@ impl FlownodeBuilder {
 
         register_function_to_query_engine(&query_engine);
 
-        let num_workers = self.opts.opts.num_workers;
+        let num_workers = self.opts.flow.num_workers;
 
         let node_id = self.opts.node_id.map(|id| id as u32);
 

--- a/src/flow/src/server.rs
+++ b/src/flow/src/server.rs
@@ -414,7 +414,7 @@ impl FlownodeBuilder {
 
         register_function_to_query_engine(&query_engine);
 
-        let num_workers = self.opts.num_workers;
+        let num_workers = self.opts.opts.num_workers;
 
         let node_id = self.opts.node_id.map(|id| id as u32);
 

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -874,6 +874,8 @@ purge_threshold = "4GiB"
 max_retry_times = 3
 retry_delay = "500ms"
 
+[flow]
+
 [logging]
 max_log_files = 720
 append_stdout = true


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

- more than one flow workers, configurable, using round robin to decide which flow goes to which worker

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for configurable number of workers in flow node initialization
	- Implemented round-robin worker selection mechanism for flow creation
	- Enhanced concurrent worker management with multi-threaded worker support

- **Improvements**
	- Simplified worker thread creation and management process
	- Improved error handling during worker initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->