### PR TITLE
refactor: split up candidate registration and keep alive

### DIFF
--- a/src/meta-srv/src/election.rs
+++ b/src/meta-srv/src/election.rs
@@ -30,7 +30,7 @@ pub const ELECTION_KEY: &str = "__metasrv_election";
 pub const CANDIDATES_ROOT: &str = "__metasrv_election_candidates/";
 
 pub(crate) const CANDIDATE_LEASE_SECS: u64 = 600;
-const KEEP_ALIVE_INTERVAL_SECS: u64 = CANDIDATE_LEASE_SECS / 2;
+pub(crate) const CANDIDATE_KEEP_ALIVE_INTERVAL_SECS: u64 = CANDIDATE_LEASE_SECS / 2;
 
 /// Messages sent when the leader changes.
 #[derive(Debug, Clone)]
@@ -124,6 +124,9 @@ pub trait Election: Send + Sync {
 
     /// Registers a candidate for the election.
     async fn register_candidate(&self, node_info: &MetasrvNodeInfo) -> Result<()>;
+
+    /// Keep alive the candidate lease.
+    async fn candidate_keep_alive(&self, node_info: &MetasrvNodeInfo) -> Result<()>;
 
     /// Gets all candidates in the election.
     async fn all_candidates(&self) -> Result<Vec<MetasrvNodeInfo>>;

--- a/src/meta-srv/src/election/etcd.rs
+++ b/src/meta-srv/src/election/etcd.rs
@@ -28,7 +28,7 @@ use tokio::time::{timeout, MissedTickBehavior};
 
 use crate::election::{
     listen_leader_change, Election, LeaderChangeMessage, LeaderKey, CANDIDATES_ROOT,
-    CANDIDATE_LEASE_SECS, ELECTION_KEY, KEEP_ALIVE_INTERVAL_SECS,
+    CANDIDATE_KEEP_ALIVE_INTERVAL_SECS, CANDIDATE_LEASE_SECS, ELECTION_KEY,
 };
 use crate::error;
 use crate::error::Result;
@@ -153,7 +153,7 @@ impl Election for EtcdElection {
             .context(error::EtcdFailedSnafu)?;
 
         let mut keep_alive_interval =
-            tokio::time::interval(Duration::from_secs(KEEP_ALIVE_INTERVAL_SECS));
+            tokio::time::interval(Duration::from_secs(CANDIDATE_KEEP_ALIVE_INTERVAL_SECS));
 
         loop {
             let _ = keep_alive_interval.tick().await;
@@ -168,6 +168,10 @@ impl Election for EtcdElection {
         }
 
         Ok(())
+    }
+
+    async fn candidate_keep_alive(&self, _node_info: &MetasrvNodeInfo) -> Result<()> {
+        unimplemented!("Etcd keeps the candidate alive in register_candidate, so we don't need to call candidate_keep_alive.")
     }
 
     async fn all_candidates(&self) -> Result<Vec<MetasrvNodeInfo>> {

--- a/src/meta-srv/src/election/postgres.rs
+++ b/src/meta-srv/src/election/postgres.rs
@@ -733,7 +733,8 @@ mod tests {
     use tokio_postgres::{Client, NoTls};
 
     use super::*;
-    use crate::{election::CANDIDATE_KEEP_ALIVE_INTERVAL_SECS, error::PostgresExecutionSnafu};
+    use crate::election::CANDIDATE_KEEP_ALIVE_INTERVAL_SECS;
+    use crate::error::PostgresExecutionSnafu;
 
     async fn create_postgres_client(table_name: Option<&str>) -> Result<Client> {
         let endpoint = env::var("GT_POSTGRES_ENDPOINTS").unwrap_or_default();

--- a/src/meta-srv/src/election/postgres.rs
+++ b/src/meta-srv/src/election/postgres.rs
@@ -733,7 +733,7 @@ mod tests {
     use tokio_postgres::{Client, NoTls};
 
     use super::*;
-    use crate::error::PostgresExecutionSnafu;
+    use crate::{election::CANDIDATE_KEEP_ALIVE_INTERVAL_SECS, error::PostgresExecutionSnafu};
 
     async fn create_postgres_client(table_name: Option<&str>) -> Result<Client> {
         let endpoint = env::var("GT_POSTGRES_ENDPOINTS").unwrap_or_default();
@@ -869,8 +869,11 @@ mod tests {
             start_time_ms: 0,
         };
 
+        pg_election.register_candidate(&node_info).await.unwrap();
+
         loop {
-            pg_election.register_candidate(&node_info).await.unwrap();
+            pg_election.candidate_keep_alive(&node_info).await.unwrap();
+            tokio::time::sleep(Duration::from_secs(CANDIDATE_KEEP_ALIVE_INTERVAL_SECS)).await;
         }
     }
 

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -498,6 +498,7 @@ impl Metasrv {
                             let res = election.register_candidate(&node_info).await;
                             if let Err(e) = res {
                                 warn!(e; "Metasrv register candidate error");
+                                continue;
                             }
                             break;
                         }
@@ -510,7 +511,6 @@ impl Metasrv {
                             if let Err(e) = res {
                                 warn!(e; "Metasrv keep lease error");
                             }
-                            break;
                         }
                     }
                 });


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

#5208

## What's changed and what's your intention?

A refactor that has been discussed before. For etcd it's relatively complicated since the keep alive is operated through a keep alive stream returned by lease client. So the keep alive is still operated inside the `candidate registration`.

Not sure if it's the expected structure, so I just init a draft pr.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
