### PR TITLE
feat: add show search_path for pg

### DIFF
--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -565,6 +565,7 @@ pub fn check_permission(
             validate_db_permission!(stmt, query_ctx);
         }
         Statement::ShowStatus(_stmt) => {}
+        Statement::ShowSearchPath(_stmt) => {}
         Statement::DescribeTable(stmt) => {
             validate_param(stmt.name(), query_ctx)?;
         }

--- a/src/operator/src/statement.rs
+++ b/src/operator/src/statement.rs
@@ -352,6 +352,7 @@ impl StatementExecutor {
             }
             Statement::ShowIndex(show_index) => self.show_index(show_index, query_ctx).await,
             Statement::ShowStatus(_) => self.show_status(query_ctx).await,
+            Statement::ShowSearchPath(_) => self.show_search_path(query_ctx).await,
             Statement::Use(db) => self.use_database(db, query_ctx).await,
             Statement::Admin(admin) => self.execute_admin_command(admin, query_ctx).await,
         }

--- a/src/operator/src/statement/show.rs
+++ b/src/operator/src/statement/show.rs
@@ -289,6 +289,11 @@ impl StatementExecutor {
             .await
             .context(error::ExecuteStatementSnafu)
     }
+    pub async fn show_search_path(&self, query_ctx: QueryContextRef) -> Result<Output> {
+        query::sql::show_search_path(query_ctx)
+            .await
+            .context(error::ExecuteStatementSnafu)
+    }
 }
 
 pub(crate) fn create_partitions_stmt(partitions: Vec<PartitionInfo>) -> Result<Option<Partitions>> {

--- a/src/query/src/sql.rs
+++ b/src/query/src/sql.rs
@@ -726,6 +726,20 @@ pub async fn show_status(_query_ctx: QueryContextRef) -> Result<Output> {
     Ok(Output::new_with_record_batches(records))
 }
 
+pub async fn show_search_path(_query_ctx: QueryContextRef) -> Result<Output> {
+    let schema = Arc::new(Schema::new(vec![ColumnSchema::new(
+        "search_path",
+        ConcreteDataType::string_datatype(),
+        false,
+    )]));
+    let records = RecordBatches::try_from_columns(
+        schema,
+        vec![Arc::new(StringVector::from(vec![_query_ctx.current_schema()])) as _],
+    )
+    .context(error::CreateRecordBatchSnafu)?;
+    Ok(Output::new_with_record_batches(records))
+}
+
 pub fn show_create_database(database_name: &str, options: OptionMap) -> Result<Output> {
     let stmt = CreateDatabase {
         name: ObjectName(vec![Ident {

--- a/src/sql/src/parsers/show_parser.rs
+++ b/src/sql/src/parsers/show_parser.rs
@@ -22,8 +22,8 @@ use crate::error::{
 use crate::parser::ParserContext;
 use crate::statements::show::{
     ShowColumns, ShowCreateDatabase, ShowCreateFlow, ShowCreateTable, ShowCreateTableVariant,
-    ShowCreateView, ShowDatabases, ShowFlows, ShowIndex, ShowKind, ShowStatus, ShowTableStatus,
-    ShowTables, ShowVariables, ShowViews,
+    ShowCreateView, ShowDatabases, ShowFlows, ShowIndex, ShowKind, ShowSearchPath, ShowStatus,
+    ShowTableStatus, ShowTables, ShowVariables, ShowViews,
 };
 use crate::statements::statement::Statement;
 
@@ -107,6 +107,8 @@ impl ParserContext<'_> {
             Ok(Statement::ShowVariables(ShowVariables { variable }))
         } else if self.consume_token("STATUS") {
             Ok(Statement::ShowStatus(ShowStatus {}))
+        } else if self.consume_token("SEARCH_PATH") {
+            Ok(Statement::ShowSearchPath(ShowSearchPath {}))
         } else {
             self.unsupported(self.peek_token_as_string())
         }

--- a/src/sql/src/statements/show.rs
+++ b/src/sql/src/statements/show.rs
@@ -289,6 +289,16 @@ impl Display for ShowStatus {
     }
 }
 
+/// SQL structure for "SHOW SEARCH_PATH" postgres only
+#[derive(Debug, Clone, PartialEq, Eq, Visit, VisitMut, Serialize)]
+pub struct ShowSearchPath {}
+
+impl Display for ShowSearchPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SHOW SEARCH_PATH")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::assert_matches::assert_matches;

--- a/src/sql/src/statements/statement.rs
+++ b/src/sql/src/statements/statement.rs
@@ -36,8 +36,8 @@ use crate::statements::query::Query;
 use crate::statements::set_variables::SetVariables;
 use crate::statements::show::{
     ShowColumns, ShowCreateDatabase, ShowCreateFlow, ShowCreateTable, ShowCreateView,
-    ShowDatabases, ShowFlows, ShowIndex, ShowKind, ShowStatus, ShowTableStatus, ShowTables,
-    ShowVariables, ShowViews,
+    ShowDatabases, ShowFlows, ShowIndex, ShowKind, ShowSearchPath, ShowStatus, ShowTableStatus,
+    ShowTables, ShowVariables, ShowViews,
 };
 use crate::statements::tql::Tql;
 use crate::statements::truncate::TruncateTable;
@@ -102,6 +102,8 @@ pub enum Statement {
     ShowCreateView(ShowCreateView),
     // SHOW STATUS
     ShowStatus(ShowStatus),
+    // SHOW SEARCH_PATH
+    ShowSearchPath(ShowSearchPath),
     // SHOW VIEWS
     ShowViews(ShowViews),
     // DESCRIBE TABLE
@@ -159,6 +161,7 @@ impl Display for Statement {
             Statement::ShowCreateView(s) => s.fmt(f),
             Statement::ShowViews(s) => s.fmt(f),
             Statement::ShowStatus(s) => s.fmt(f),
+            Statement::ShowSearchPath(s) => s.fmt(f),
             Statement::DescribeTable(s) => s.fmt(f),
             Statement::Explain(s) => s.fmt(f),
             Statement::Copy(s) => s.fmt(f),

--- a/tests/cases/standalone/common/system/pg_catalog.result
+++ b/tests/cases/standalone/common/system/pg_catalog.result
@@ -23,6 +23,16 @@ select current_schema();
 | public           |
 +------------------+
 
+-- search_path for pg using schema for now FIXME when support real search_path
+-- SQLNESS PROTOCOL POSTGRES
+show search_path;
+
++-------------+
+| search_path |
++-------------+
+| public      |
++-------------+
+
 -- make sure all the pg_catalog tables are only visible to postgres
 select * from pg_catalog.pg_class;
 

--- a/tests/cases/standalone/common/system/pg_catalog.sql
+++ b/tests/cases/standalone/common/system/pg_catalog.sql
@@ -9,6 +9,10 @@ SELECT session_user is not null;
 -- SQLNESS PROTOCOL POSTGRES
 select current_schema();
 
+-- search_path for pg using schema for now FIXME when support real search_path
+-- SQLNESS PROTOCOL POSTGRES
+show search_path;
+
 -- make sure all the pg_catalog tables are only visible to postgres
 select * from pg_catalog.pg_class;
 select * from pg_catalog.pg_namespace;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

part of https://github.com/GreptimeTeam/greptimedb/issues/5271
for now `pg_database` is better to hold waiting for the upstream https://github.com/apache/datafusion/pull/13489

this patch support pg `show search_path` for now seems no search path for greptime so use database instead


## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
