### PR TITLE
fix: panic and interval when do not have keyword `interval`

### DIFF
--- a/src/sql/src/error.rs
+++ b/src/sql/src/error.rs
@@ -132,6 +132,12 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display("ConcreteDataType not supported yet: {:?}", t))]
+    ConcreteTypeNotSupported {
+        t: ConcreteDataType,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("Failed to parse value: {}", msg))]
     ParseSqlValue {
@@ -355,6 +361,7 @@ impl ErrorExt for Error {
             | InvalidSql { .. }
             | ParseSqlValue { .. }
             | SqlTypeNotSupported { .. }
+            | ConcreteTypeNotSupported { .. }
             | UnexpectedToken { .. }
             | InvalidDefault { .. } => StatusCode::InvalidSyntax,
 

--- a/src/sql/src/statements.rs
+++ b/src/sql/src/statements.rs
@@ -265,8 +265,8 @@ pub fn sql_value_to_value(
                 !matches!(data_type, ConcreteDataType::Interval(_)),
                 ColumnTypeMismatchSnafu {
                     column_name,
-                    expect: ConcreteDataType::string_datatype(),
-                    actual: data_type.clone(),
+                    expect: data_type.clone(),
+                    actual: ConcreteDataType::string_datatype(),
                 }
             );
             parse_string_to_value(column_name, s.clone(), data_type, timezone)?

--- a/src/sql/src/statements.rs
+++ b/src/sql/src/statements.rs
@@ -261,15 +261,6 @@ pub fn sql_value_to_value(
             (*b).into()
         }
         SqlValue::DoubleQuotedString(s) | SqlValue::SingleQuotedString(s) => {
-            // ensure data_type is not interval type when parsing string
-            ensure!(
-                !matches!(data_type, ConcreteDataType::Interval(_)),
-                ColumnTypeMismatchSnafu {
-                    column_name,
-                    expect: data_type.clone(),
-                    actual: ConcreteDataType::string_datatype(),
-                }
-            );
             parse_string_to_value(column_name, s.clone(), data_type, timezone)?
         }
         SqlValue::HexStringLiteral(s) => {

--- a/src/sql/src/statements.rs
+++ b/src/sql/src/statements.rs
@@ -260,6 +260,15 @@ pub fn sql_value_to_value(
             (*b).into()
         }
         SqlValue::DoubleQuotedString(s) | SqlValue::SingleQuotedString(s) => {
+            // ensure data_type is not interval type when parsing string
+            ensure!(
+                !matches!(data_type, ConcreteDataType::Interval(_)),
+                ColumnTypeMismatchSnafu {
+                    column_name,
+                    expect: ConcreteDataType::string_datatype(),
+                    actual: data_type.clone(),
+                }
+            );
             parse_string_to_value(column_name, s.clone(), data_type, timezone)?
         }
         SqlValue::HexStringLiteral(s) => {

--- a/tests/cases/standalone/common/insert/insert_wrong_type.result
+++ b/tests/cases/standalone/common/insert/insert_wrong_type.result
@@ -1,0 +1,19 @@
+-- test for issue #3235
+CREATE TABLE b(i interval, ts timestamp time index);
+
+Affected Rows: 0
+
+-- should fail
+INSERT INTO b VALUES ('1 year', 1000);
+
+Error: 2000(InvalidSyntax), Failed to parse value: Failed to parse 1 year to IntervalMonthDayNano value
+
+-- success
+INSERT INTO b VALUES (interval '1 year', 1000);
+
+Affected Rows: 1
+
+DROP TABLE b;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/insert/insert_wrong_type.sql
+++ b/tests/cases/standalone/common/insert/insert_wrong_type.sql
@@ -1,0 +1,8 @@
+-- test for issue #3235
+CREATE TABLE b(i interval, ts timestamp time index);
+-- should fail
+INSERT INTO b VALUES ('1 year', 1000);
+-- success
+INSERT INTO b VALUES (interval '1 year', 1000);
+
+DROP TABLE b;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

close #5338 by ensure on interval type

screen shot after this patch.

![image](https://github.com/user-attachments/assets/67fd902f-73d6-4f04-a9f3-a5c6fa907211)

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
