### PR TITLE
fix: skip building indexer when `indexed_column_ids` are empty

### DIFF
--- a/src/mito2/src/sst/index.rs
+++ b/src/mito2/src/sst/index.rs
@@ -222,9 +222,12 @@ impl<'a> IndexerBuilder<'a> {
             return None;
         }
 
-        if self.metadata.primary_key.is_empty() {
+        let indexed_column_ids = self.metadata.inverted_indexed_column_ids(
+            self.index_options.inverted_index.ignore_column_ids.iter(),
+        );
+        if indexed_column_ids.is_empty() {
             debug!(
-                "No tag columns, skip creating index, region_id: {}, file_id: {}",
+                "No columns to be indexed, skip creating inverted index, region_id: {}, file_id: {}",
                 self.metadata.region_id, self.file_id,
             );
             return None;
@@ -259,9 +262,7 @@ impl<'a> IndexerBuilder<'a> {
             self.intermediate_manager.clone(),
             self.inverted_index_config.mem_threshold_on_create(),
             segment_row_count,
-            self.metadata.inverted_indexed_column_ids(
-                self.index_options.inverted_index.ignore_column_ids.iter(),
-            ),
+            indexed_column_ids,
         );
 
         Some(indexer)


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Skip building indexer when `indexed_column_ids` are empty to avoid unnecessary primary key decoding overhead during index updating.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
