### PR TITLE
fix: redirect /dashboard to /dashboard/

### DIFF
--- a/src/servers/src/http/dashboard.rs
+++ b/src/servers/src/http/dashboard.rs
@@ -15,8 +15,6 @@
 use axum::body::{boxed, Full};
 use axum::http::{header, StatusCode, Uri};
 use axum::response::Response;
-use axum::routing;
-use axum::routing::Router;
 use common_telemetry::debug;
 use rust_embed::RustEmbed;
 use snafu::ResultExt;
@@ -27,17 +25,11 @@ use crate::error::{BuildHttpResponseSnafu, Result};
 #[folder = "dashboard/dist/"]
 pub struct Assets;
 
-pub(crate) fn dashboard() -> Router {
-    Router::new()
-        .route("/", routing::get(static_handler).post(static_handler))
-        .route("/*x", routing::get(static_handler).post(static_handler))
-}
-
 #[axum_macros::debug_handler]
 pub async fn static_handler(uri: Uri) -> Result<Response> {
     debug!("[dashboard] requesting: {}", uri.path());
 
-    let mut path = uri.path().trim_start_matches('/');
+    let mut path = uri.path().trim_start_matches("/dashboard/");
     if path.is_empty() {
         path = "index.html";
     }

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -999,9 +999,11 @@ pub async fn test_dashboard_path(store_type: StorageType) {
     let (app, _guard) = setup_test_http_app_with_frontend(store_type, "dashboard_path").await;
     let client = TestClient::new(app);
 
-    let res_post = client.post("/dashboard").send().await;
-    assert_eq!(res_post.status(), StatusCode::OK);
     let res_get = client.get("/dashboard").send().await;
+    assert_eq!(res_get.status(), StatusCode::PERMANENT_REDIRECT);
+    let res_post = client.post("/dashboard/").send().await;
+    assert_eq!(res_post.status(), StatusCode::OK);
+    let res_get = client.get("/dashboard/").send().await;
     assert_eq!(res_get.status(), StatusCode::OK);
 
     // both `GET` and `POST` method return same result


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Our dashboard now requires trailing slash for `/dashboard/` path. This path redirects `/dashboard` to `/dashboard/`.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
