### PR TITLE
fix: increase in progress scan gauge and adjust histogram buckets

### DIFF
--- a/src/metric-engine/src/metrics.rs
+++ b/src/metric-engine/src/metrics.rs
@@ -46,7 +46,8 @@ lazy_static! {
         "greptime_metric_engine_mito_op_elapsed",
         "metric engine's mito operation elapsed",
         &[OPERATION_LABEL],
-        vec![0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 60.0, 300.0]
+        // 0.01 ~ 10000
+        exponential_buckets(0.01, 10.0, 7).unwrap(),
     )
     .unwrap();
 }

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -48,7 +48,8 @@ lazy_static! {
             "greptime_mito_handle_request_elapsed",
             "mito handle request elapsed",
             &[TYPE_LABEL],
-            vec![0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 2.5, 5.0, 10.0, 60.0, 300.0]
+            // 0.01 ~ 10000
+            exponential_buckets(0.01, 10.0, 7).unwrap(),
         )
         .unwrap();
 
@@ -69,7 +70,8 @@ lazy_static! {
             "greptime_mito_flush_elapsed",
             "mito flush elapsed",
             &[TYPE_LABEL],
-            vec![0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 60.0, 300.0]
+            // 1 ~ 625
+            exponential_buckets(1.0, 5.0, 6).unwrap(),
         )
         .unwrap();
     /// Histogram of flushed bytes.
@@ -99,7 +101,8 @@ lazy_static! {
             "greptime_mito_write_stage_elapsed",
             "mito write stage elapsed",
             &[STAGE_LABEL],
-            vec![0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 60.0, 300.0]
+            // 0.01 ~ 1000
+            exponential_buckets(0.01, 10.0, 6).unwrap(),
         )
         .unwrap();
     /// Counter of rows to write.
@@ -118,12 +121,18 @@ lazy_static! {
         "greptime_mito_compaction_stage_elapsed",
         "mito compaction stage elapsed",
         &[STAGE_LABEL],
-        vec![0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 60.0, 300.0]
+        // 1 ~ 100000
+        exponential_buckets(1.0, 10.0, 6).unwrap(),
     )
     .unwrap();
     /// Timer of whole compaction task.
     pub static ref COMPACTION_ELAPSED_TOTAL: Histogram =
-        register_histogram!("greptime_mito_compaction_total_elapsed", "mito compaction total elapsed").unwrap();
+        register_histogram!(
+        "greptime_mito_compaction_total_elapsed",
+        "mito compaction total elapsed",
+        // 1 ~ 100000
+        exponential_buckets(1.0, 10.0, 6).unwrap(),
+    ).unwrap();
     /// Counter of all requested compaction task.
     pub static ref COMPACTION_REQUEST_COUNT: IntCounter =
         register_int_counter!("greptime_mito_compaction_requests_total", "mito compaction requests total").unwrap();
@@ -145,7 +154,8 @@ lazy_static! {
         "greptime_mito_read_stage_elapsed",
         "mito read stage elapsed",
         &[STAGE_LABEL],
-        vec![0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 60.0, 300.0]
+        // 0.01 ~ 10000
+        exponential_buckets(0.01, 10.0, 7).unwrap(),
     )
     .unwrap();
     pub static ref READ_STAGE_FETCH_PAGES: Histogram = READ_STAGE_ELAPSED.with_label_values(&["fetch_pages"]);
@@ -222,6 +232,8 @@ lazy_static! {
         "mito_write_cache_download_elapsed",
         "mito write cache download elapsed",
         &[TYPE_LABEL],
+        // 0.1 ~ 10000
+        exponential_buckets(0.1, 10.0, 6).unwrap(),
     ).unwrap();
     /// Upload bytes counter.
     pub static ref UPLOAD_BYTES_TOTAL: IntCounter = register_int_counter!(
@@ -243,6 +255,8 @@ lazy_static! {
         "greptime_index_apply_elapsed",
         "index apply elapsed",
         &[TYPE_LABEL],
+        // 0.01 ~ 1000
+        exponential_buckets(0.01, 10.0, 6).unwrap(),
     )
     .unwrap();
     /// Gauge of index apply memory usage.
@@ -256,7 +270,8 @@ lazy_static! {
         "greptime_index_create_elapsed",
         "index create elapsed",
         &[STAGE_LABEL, TYPE_LABEL],
-        vec![0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 60.0, 300.0]
+        // 0.1 ~ 10000
+        exponential_buckets(0.1, 10.0, 6).unwrap(),
     )
     .unwrap();
     /// Counter of rows indexed.
@@ -337,7 +352,8 @@ lazy_static! {
         "greptime_partition_tree_buffer_freeze_stage_elapsed",
         "mito partition tree data buffer freeze stage elapsed",
         &[STAGE_LABEL],
-        vec![0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 60.0]
+        // 0.01 ~ 1000
+        exponential_buckets(0.01, 10.0, 6).unwrap(),
     )
     .unwrap();
 
@@ -346,7 +362,8 @@ lazy_static! {
         "greptime_partition_tree_read_stage_elapsed",
         "mito partition tree read stage elapsed",
         &[STAGE_LABEL],
-        vec![0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 60.0]
+        // 0.01 ~ 1000
+        exponential_buckets(0.01, 10.0, 6).unwrap(),
     )
     .unwrap();
 
@@ -359,6 +376,8 @@ lazy_static! {
     pub static ref MANIFEST_OP_ELAPSED: HistogramVec = register_histogram_vec!(
         "greptime_manifest_op_elapsed",
         "mito manifest operation elapsed",
-        &["op"]
+        &["op"],
+        // 0.01 ~ 1000
+        exponential_buckets(0.01, 10.0, 6).unwrap(),
     ).unwrap();
 }

--- a/src/mito2/src/read/scan_util.rs
+++ b/src/mito2/src/read/scan_util.rs
@@ -82,6 +82,7 @@ impl PartitionMetrics {
     ) -> Self {
         let partition_str = partition.to_string();
         let in_progress_scan = IN_PROGRESS_SCAN.with_label_values(&[scanner_type, &partition_str]);
+        in_progress_scan.inc();
         let inner = PartitionMetricsInner {
             region_id,
             partition,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR fixes an issue that `PartitionMetrics` doesn't increase the in progress scan gauge.

It also adjusts some histogram buckets of mito and metric engine.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
