### PR TITLE
feat: flow's http server

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -546,6 +546,10 @@
 | `grpc.runtime_size` | Integer | `2` | The number of server worker threads. |
 | `grpc.max_recv_message_size` | String | `512MB` | The maximum receive message size for gRPC server. |
 | `grpc.max_send_message_size` | String | `512MB` | The maximum send message size for gRPC server. |
+| `http` | -- | -- | The HTTP server options. |
+| `http.addr` | String | `127.0.0.1:4000` | The address to bind the HTTP server. |
+| `http.timeout` | String | `30s` | HTTP request timeout. Set to 0 to disable timeout. |
+| `http.body_limit` | String | `64MB` | HTTP request body limit.<br/>The following units are supported: `B`, `KB`, `KiB`, `MB`, `MiB`, `GB`, `GiB`, `TB`, `TiB`, `PB`, `PiB`.<br/>Set to 0 to disable limit. |
 | `meta_client` | -- | -- | The metasrv client options. |
 | `meta_client.metasrv_addrs` | Array | -- | The addresses of the metasrv. |
 | `meta_client.timeout` | String | `3s` | Operation timeout. |

--- a/config/flownode.example.toml
+++ b/config/flownode.example.toml
@@ -25,6 +25,16 @@ max_recv_message_size = "512MB"
 ## The maximum send message size for gRPC server.
 max_send_message_size = "512MB"
 
+## The HTTP server options.
+[http]
+## The address to bind the HTTP server.
+addr = "127.0.0.1:4000"
+## HTTP request timeout. Set to 0 to disable timeout.
+timeout = "30s"
+## HTTP request body limit.
+## The following units are supported: `B`, `KB`, `KiB`, `MB`, `MiB`, `GB`, `GiB`, `TB`, `TiB`, `PB`, `PiB`.
+## Set to 0 to disable limit.
+body_limit = "64MB"
 
 ## The metasrv client options.
 [meta_client]

--- a/src/cmd/src/flownode.rs
+++ b/src/cmd/src/flownode.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use cache::{build_fundamental_cache_registry, with_default_composite_cache_registry};
 use catalog::information_extension::DistributedInformationExtension;
@@ -142,6 +143,11 @@ struct StartCommand {
     /// The prefix of environment variables, default is `GREPTIMEDB_FLOWNODE`;
     #[clap(long, default_value = "GREPTIMEDB_FLOWNODE")]
     env_prefix: String,
+    #[clap(long)]
+    http_addr: Option<String>,
+    /// HTTP request timeout in seconds.
+    #[clap(long)]
+    http_timeout: Option<u64>,
 }
 
 impl StartCommand {
@@ -196,6 +202,14 @@ impl StartCommand {
                 .metasrv_addrs
                 .clone_from(metasrv_addrs);
             opts.mode = Mode::Distributed;
+        }
+
+        if let Some(http_addr) = &self.http_addr {
+            opts.http.addr.clone_from(http_addr);
+        }
+
+        if let Some(http_timeout) = self.http_timeout {
+            opts.http.timeout = Duration::from_secs(http_timeout);
         }
 
         if let (Mode::Distributed, None) = (&opts.mode, &opts.node_id) {

--- a/src/flow/src/adapter.rs
+++ b/src/flow/src/adapter.rs
@@ -36,6 +36,7 @@ use query::QueryEngine;
 use serde::{Deserialize, Serialize};
 use servers::grpc::GrpcOptions;
 use servers::heartbeat_options::HeartbeatOptions;
+use servers::http::HttpOptions;
 use servers::Mode;
 use session::context::QueryContext;
 use snafu::{ensure, OptionExt, ResultExt};
@@ -106,6 +107,7 @@ pub struct FlownodeOptions {
     pub node_id: Option<u64>,
     pub flow: FlowConfig,
     pub grpc: GrpcOptions,
+    pub http: HttpOptions,
     pub meta_client: Option<MetaClientOptions>,
     pub logging: LoggingOptions,
     pub tracing: TracingOptions,
@@ -120,6 +122,7 @@ impl Default for FlownodeOptions {
             node_id: None,
             flow: FlowConfig::default(),
             grpc: GrpcOptions::default().with_addr("127.0.0.1:3004"),
+            http: HttpOptions::default(),
             meta_client: None,
             logging: LoggingOptions::default(),
             tracing: TracingOptions::default(),

--- a/src/flow/src/server.rs
+++ b/src/flow/src/server.rs
@@ -40,6 +40,7 @@ use partition::manager::PartitionRuleManager;
 use query::{QueryEngine, QueryEngineFactory};
 use servers::error::{AlreadyStartedSnafu, StartGrpcSnafu, TcpBindSnafu, TcpIncomingSnafu};
 use servers::http::{HttpServer, HttpServerBuilder};
+use servers::metrics_handler::MetricsHandler;
 use servers::server::Server;
 use session::context::{QueryContextBuilder, QueryContextRef};
 use snafu::{ensure, OptionExt, ResultExt};
@@ -318,7 +319,9 @@ impl FlownodeBuilder {
         let http_addr = self.opts.http.addr.parse().context(ParseAddrSnafu {
             addr: self.opts.http.addr.clone(),
         })?;
-        let http_server = HttpServerBuilder::new(self.opts.http).build();
+        let http_server = HttpServerBuilder::new(self.opts.http)
+            .with_metrics_handler(MetricsHandler)
+            .build();
 
         let heartbeat_task = self.heartbeat_task;
 

--- a/src/flow/src/server.rs
+++ b/src/flow/src/server.rs
@@ -39,6 +39,7 @@ use operator::statement::StatementExecutor;
 use partition::manager::PartitionRuleManager;
 use query::{QueryEngine, QueryEngineFactory};
 use servers::error::{AlreadyStartedSnafu, StartGrpcSnafu, TcpBindSnafu, TcpIncomingSnafu};
+use servers::http::{HttpServer, HttpServerBuilder};
 use servers::server::Server;
 use session::context::{QueryContextBuilder, QueryContextRef};
 use snafu::{ensure, OptionExt, ResultExt};
@@ -210,6 +211,9 @@ impl servers::server::Server for FlownodeServer {
 pub struct FlownodeInstance {
     server: FlownodeServer,
     addr: SocketAddr,
+    /// only used for health check
+    http_server: HttpServer,
+    http_addr: SocketAddr,
     heartbeat_task: Option<HeartbeatTask>,
 }
 
@@ -224,6 +228,12 @@ impl FlownodeInstance {
             .start(self.addr)
             .await
             .context(StartServerSnafu)?;
+
+        self.http_server
+            .start(self.http_addr)
+            .await
+            .context(StartServerSnafu)?;
+
         Ok(())
     }
     pub async fn shutdown(&self) -> Result<(), crate::Error> {
@@ -305,12 +315,19 @@ impl FlownodeBuilder {
 
         let server = FlownodeServer::new(FlowService::new(manager.clone()));
 
+        let http_addr = self.opts.http.addr.parse().context(ParseAddrSnafu {
+            addr: self.opts.http.addr.clone(),
+        })?;
+        let http_server = HttpServerBuilder::new(self.opts.http).build();
+
         let heartbeat_task = self.heartbeat_task;
 
         let addr = self.opts.grpc.addr;
         let instance = FlownodeInstance {
             server,
             addr: addr.parse().context(ParseAddrSnafu { addr })?,
+            http_server,
+            http_addr,
             heartbeat_task,
         };
         Ok(instance)

--- a/src/flow/src/server.rs
+++ b/src/flow/src/server.rs
@@ -244,6 +244,11 @@ impl FlownodeInstance {
             task.shutdown();
         }
 
+        self.http_server
+            .shutdown()
+            .await
+            .context(ShutdownServerSnafu)?;
+
         Ok(())
     }
 

--- a/tests/runner/src/env.rs
+++ b/tests/runner/src/env.rs
@@ -490,6 +490,7 @@ impl Env {
             sqlness_home.display()
         ));
         args.push("--metasrv-addrs=127.0.0.1:29302".to_string());
+        args.push(format!("--http-addr=127.0.0.1:2951{id}"));
         (args, format!("127.0.0.1:2968{id}"))
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

as title, only have default routers and metrics handler, can `curl` `/health` and `/metrics` and get expected metrics info with flownode

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
