### PR TITLE
chore: change default compaction output size limit to 2GB

### DIFF
--- a/src/mito2/src/region/options.rs
+++ b/src/mito2/src/region/options.rs
@@ -238,7 +238,7 @@ impl Default for TwcsOptions {
             max_inactive_window_runs: 1,
             max_inactive_window_files: 1,
             time_window: None,
-            max_output_file_size: None,
+            max_output_file_size: Some(ReadableSize::gb(2)),
             remote_compaction: false,
             fallback_to_local: true,
         }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

 ### Update `TwcsOptions` Default Configuration

 - Modified the default value of `max_output_file_size` in `TwcsOptions` to `Some(ReadableSize::gb(2))` in `src/mito2/src/region/options.rs`.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
