### PR TITLE
feat: support not-equal matcher for PromQL metric names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10270,6 +10270,7 @@ dependencies = [
  "snafu 0.8.5",
  "snap",
  "sql",
+ "store-api",
  "strum 0.25.0",
  "table",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4078,6 +4078,7 @@ dependencies = [
  "partition",
  "pipeline",
  "prometheus",
+ "promql-parser",
  "prost 0.12.6",
  "query",
  "raft-engine",

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -37,6 +37,7 @@ common-time.workspace = true
 common-version.workspace = true
 datafusion-expr.workspace = true
 datanode.workspace = true
+datatypes.workspace = true
 humantime-serde.workspace = true
 lazy_static.workspace = true
 log-query.workspace = true

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -47,6 +47,7 @@ operator.workspace = true
 partition.workspace = true
 pipeline.workspace = true
 prometheus.workspace = true
+promql-parser.workspace = true
 prost.workspace = true
 query.workspace = true
 raft-engine.workspace = true

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -169,6 +169,13 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display("Failed to collect recordbatch"))]
+    CollectRecordbatch {
+        #[snafu(implicit)]
+        location: Location,
+        source: common_recordbatch::error::Error,
+    },
+
     #[snafu(display("Failed to plan statement"))]
     PlanStatement {
         #[snafu(implicit)]
@@ -219,6 +226,13 @@ pub enum Error {
 
     #[snafu(display("Failed to create logical plan for prometheus query"))]
     PromStoreRemoteQueryPlan {
+        #[snafu(implicit)]
+        location: Location,
+        source: servers::error::Error,
+    },
+
+    #[snafu(display("Failed to create logical plan for prometheus metric names query"))]
+    PrometheusMetricNamesQueryPlan {
         #[snafu(implicit)]
         location: Location,
         source: servers::error::Error,
@@ -349,7 +363,10 @@ impl ErrorExt for Error {
             Error::HandleHeartbeatResponse { source, .. } => source.status_code(),
 
             Error::PromStoreRemoteQueryPlan { source, .. }
+            | Error::PrometheusMetricNamesQueryPlan { source, .. }
             | Error::ExecutePromql { source, .. } => source.status_code(),
+
+            Error::CollectRecordbatch { .. } => StatusCode::EngineExecuteQuery,
 
             Error::SqlExecIntercepted { source, .. } => source.status_code(),
             Error::StartServer { source, .. } => source.status_code(),

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -20,6 +20,7 @@ mod logs;
 mod opentsdb;
 mod otlp;
 mod prom_store;
+mod promql;
 mod region_query;
 pub mod standalone;
 
@@ -451,13 +452,15 @@ impl PrometheusHandler for Instance {
         Ok(interceptor.post_execute(output, query_ctx)?)
     }
 
-    async fn query_metrics(
+    async fn query_metric_names(
         &self,
-        _catalog: &str,
-        _schema: &str,
-        _matchers: Vec<Matcher>,
+        matchers: Vec<Matcher>,
+        ctx: &QueryContextRef,
     ) -> server_error::Result<Vec<String>> {
-        todo!();
+        self.handle_query_metric_names(matchers, ctx)
+            .await
+            .map_err(BoxedError::new)
+            .context(ExecuteQuerySnafu)
     }
 
     fn catalog_manager(&self) -> CatalogManagerRef {

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -47,6 +47,7 @@ use operator::insert::InserterRef;
 use operator::statement::StatementExecutor;
 use pipeline::pipeline_operator::PipelineOperator;
 use prometheus::HistogramTimer;
+use promql_parser::label::Matcher;
 use query::metrics::OnDone;
 use query::parser::{PromQuery, QueryLanguageParser, QueryStatement};
 use query::query_engine::options::{validate_catalog_and_schema, QueryOptions};
@@ -448,6 +449,15 @@ impl PrometheusHandler for Instance {
             .context(ExecuteQuerySnafu)?;
 
         Ok(interceptor.post_execute(output, query_ctx)?)
+    }
+
+    async fn query_metrics(
+        &self,
+        _catalog: &str,
+        _schema: &str,
+        _matchers: Vec<Matcher>,
+    ) -> server_error::Result<Vec<String>> {
+        todo!();
     }
 
     fn catalog_manager(&self) -> CatalogManagerRef {

--- a/src/frontend/src/instance/promql.rs
+++ b/src/frontend/src/instance/promql.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use catalog::information_schema::TABLES;
 use client::OutputData;
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, INFORMATION_SCHEMA_NAME};

--- a/src/frontend/src/instance/promql.rs
+++ b/src/frontend/src/instance/promql.rs
@@ -1,0 +1,85 @@
+use catalog::information_schema::TABLES;
+use client::OutputData;
+use common_catalog::consts::{DEFAULT_CATALOG_NAME, INFORMATION_SCHEMA_NAME};
+use common_recordbatch::util;
+use common_telemetry::tracing;
+use datatypes::prelude::Value;
+use promql_parser::label::Matcher;
+use servers::prometheus;
+use session::context::QueryContextRef;
+use snafu::{OptionExt, ResultExt};
+
+use crate::error::{
+    CatalogSnafu, CollectRecordbatchSnafu, ExecLogicalPlanSnafu,
+    PrometheusMetricNamesQueryPlanSnafu, ReadTableSnafu, Result, TableNotFoundSnafu,
+};
+use crate::instance::Instance;
+
+impl Instance {
+    /// Handles metric names query request, returns the names.
+    #[tracing::instrument(skip_all)]
+    pub(crate) async fn handle_query_metric_names(
+        &self,
+        matchers: Vec<Matcher>,
+        ctx: &QueryContextRef,
+    ) -> Result<Vec<String>> {
+        let _timer = crate::metrics::PROMQL_QUERY_METRICS_ELAPSED
+            .with_label_values(&[ctx.get_db_string().as_str()])
+            .start_timer();
+
+        let table = self
+            .catalog_manager
+            .table(
+                DEFAULT_CATALOG_NAME,
+                INFORMATION_SCHEMA_NAME,
+                TABLES,
+                Some(ctx),
+            )
+            .await
+            .context(CatalogSnafu)?
+            .with_context(|| TableNotFoundSnafu {
+                table_name: "greptime.information_schema.tables",
+            })?;
+
+        let dataframe = self
+            .query_engine
+            .read_table(table)
+            .with_context(|_| ReadTableSnafu {
+                table_name: "greptime.information_schema.tables",
+            })?;
+
+        let logical_plan = prometheus::metric_name_matchers_to_plan(dataframe, matchers, ctx)
+            .context(PrometheusMetricNamesQueryPlanSnafu)?;
+
+        let results = self
+            .query_engine
+            .execute(logical_plan, ctx.clone())
+            .await
+            .context(ExecLogicalPlanSnafu)?;
+
+        let batches = match results.data {
+            OutputData::Stream(stream) => util::collect(stream)
+                .await
+                .context(CollectRecordbatchSnafu)?,
+            OutputData::RecordBatches(rbs) => rbs.take(),
+            _ => unreachable!("should not happen"),
+        };
+
+        let mut results = Vec::with_capacity(batches.iter().map(|b| b.num_rows()).sum());
+
+        for batch in batches {
+            // Only one column the results, ensured by `prometheus::metric_name_matchers_to_plan`.
+            let names = batch.column(0);
+
+            for i in 0..names.len() {
+                let Value::String(name) = names.get(i) else {
+                    unreachable!();
+                };
+
+                results.push(name.into_string());
+            }
+        }
+
+        Ok(results)
+    }
+}

--- a/src/frontend/src/instance/promql.rs
+++ b/src/frontend/src/instance/promql.rs
@@ -14,7 +14,7 @@
 
 use catalog::information_schema::TABLES;
 use client::OutputData;
-use common_catalog::consts::{DEFAULT_CATALOG_NAME, INFORMATION_SCHEMA_NAME};
+use common_catalog::consts::INFORMATION_SCHEMA_NAME;
 use common_recordbatch::util;
 use common_telemetry::tracing;
 use datatypes::prelude::Value;
@@ -44,7 +44,7 @@ impl Instance {
         let table = self
             .catalog_manager
             .table(
-                DEFAULT_CATALOG_NAME,
+                ctx.current_catalog(),
                 INFORMATION_SCHEMA_NAME,
                 TABLES,
                 Some(ctx),

--- a/src/frontend/src/metrics.rs
+++ b/src/frontend/src/metrics.rs
@@ -29,6 +29,13 @@ lazy_static! {
     pub static ref GRPC_HANDLE_PROMQL_ELAPSED: Histogram = GRPC_HANDLE_QUERY_ELAPSED
         .with_label_values(&["promql"]);
 
+    pub static ref PROMQL_QUERY_METRICS_ELAPSED: HistogramVec = register_histogram_vec!(
+        "greptime_frontend_promql_query_metrics_elapsed",
+        "frontend promql query metric names elapsed",
+        &["db"]
+    )
+    .unwrap();
+
     /// The number of OpenTelemetry metrics send by frontend node.
     pub static ref OTLP_METRICS_ROWS: IntCounter = register_int_counter!(
         "greptime_frontend_otlp_metrics_rows",

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -102,6 +102,7 @@ session.workspace = true
 snafu.workspace = true
 snap = "1"
 sql.workspace = true
+store-api.workspace = true
 strum.workspace = true
 table.workspace = true
 tokio.workspace = true

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -44,6 +44,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use session::context::{QueryContext, QueryContextRef};
 use snafu::{Location, OptionExt, ResultExt};
+use store_api::metric_engine_consts::{
+    DATA_SCHEMA_TABLE_ID_COLUMN_NAME, DATA_SCHEMA_TSID_COLUMN_NAME,
+};
 
 pub use super::result::prometheus_resp::PrometheusJsonResponse;
 use crate::error::{
@@ -583,7 +586,11 @@ async fn get_all_column_names(
             continue;
         };
         for column in table.primary_key_columns() {
-            labels.insert(column.name);
+            if column.name != DATA_SCHEMA_TABLE_ID_COLUMN_NAME
+                && column.name != DATA_SCHEMA_TSID_COLUMN_NAME
+            {
+                labels.insert(column.name);
+            }
         }
     }
 

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -1283,13 +1283,8 @@ pub async fn parse_query(
     Form(form_params): Form<ParseQuery>,
 ) -> PrometheusJsonResponse {
     if let Some(query) = params.query.or(form_params.query) {
-        match promql_parser::parser::parse(&query) {
-            Ok(ast) => PrometheusJsonResponse::success(PrometheusResponse::ParseResult(ast)),
-            Err(err) => {
-                let msg = err.to_string();
-                PrometheusJsonResponse::error(StatusCode::InvalidArguments, msg)
-            }
-        }
+        let ast = try_call_return_response!(promql_parser::parser::parse(&query));
+        PrometheusJsonResponse::success(PrometheusResponse::ParseResult(ast))
     } else {
         PrometheusJsonResponse::error(StatusCode::InvalidArguments, "query is required")
     }

--- a/src/servers/src/lib.rs
+++ b/src/servers/src/lib.rs
@@ -40,6 +40,7 @@ pub mod otlp;
 pub mod postgres;
 mod prom_row_builder;
 pub mod prom_store;
+pub mod prometheus;
 pub mod prometheus_handler;
 pub mod proto;
 pub mod query_handler;

--- a/src/servers/src/prometheus.rs
+++ b/src/servers/src/prometheus.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use catalog::system_schema::information_schema::tables::{
     ENGINE as TABLE_ENGINE, TABLE_CATALOG, TABLE_NAME, TABLE_SCHEMA,
 };

--- a/src/servers/src/prometheus.rs
+++ b/src/servers/src/prometheus.rs
@@ -1,0 +1,70 @@
+use catalog::system_schema::information_schema::tables::{
+    ENGINE as TABLE_ENGINE, TABLE_CATALOG, TABLE_NAME, TABLE_SCHEMA,
+};
+use common_telemetry::tracing;
+use datafusion::prelude::{col, lit, regexp_match, Expr};
+use datafusion_expr::LogicalPlan;
+use promql_parser::label::{MatchOp, Matcher};
+use query::dataframe::DataFrame;
+use session::context::QueryContextRef;
+use snafu::ResultExt;
+
+use crate::error::{self, Result};
+
+/// The maximum number of metrics at one time.
+const MAX_METRICS_NUM: usize = 1024;
+
+/// Create a DataFrame from promql `__name__` matchers.
+/// # Panics
+///  Panic when the machers contains `MatchOp::Equal`.
+#[tracing::instrument(skip_all)]
+pub fn metric_name_matchers_to_plan(
+    dataframe: DataFrame,
+    matchers: Vec<Matcher>,
+    ctx: &QueryContextRef,
+) -> Result<LogicalPlan> {
+    assert!(!matchers.is_empty());
+
+    let mut conditions = Vec::with_capacity(matchers.len() + 3);
+
+    conditions.push(col(TABLE_CATALOG).eq(lit(ctx.current_catalog())));
+    conditions.push(col(TABLE_SCHEMA).eq(lit(ctx.current_schema())));
+    // Must be metric engine
+    conditions.push(col(TABLE_ENGINE).eq(lit("metric")));
+
+    for m in matchers {
+        let value = &m.value;
+
+        match &m.op {
+            MatchOp::NotEqual => {
+                conditions.push(col(TABLE_NAME).not_eq(lit(value)));
+            }
+            // Case sensitive regexp match
+            MatchOp::Re(regex) => {
+                conditions.push(
+                    regexp_match(col(TABLE_NAME), lit(regex.to_string()), None).is_not_null(),
+                );
+            }
+            // Case sensitive regexp not match
+            MatchOp::NotRe(regex) => {
+                conditions
+                    .push(regexp_match(col(TABLE_NAME), lit(regex.to_string()), None).is_null());
+            }
+            _ => unreachable!("checked outside"),
+        }
+    }
+
+    // Safety: conditions MUST not be empty, reduce always return Some(expr).
+    let conditions = conditions.into_iter().reduce(Expr::and).unwrap();
+
+    let DataFrame::DataFusion(dataframe) = dataframe;
+    let dataframe = dataframe
+        .filter(conditions)
+        .context(error::DataFrameSnafu)?
+        .select(vec![col(TABLE_NAME)])
+        .context(error::DataFrameSnafu)?
+        .limit(0, Some(MAX_METRICS_NUM))
+        .context(error::DataFrameSnafu)?;
+
+    Ok(dataframe.into_parts().1)
+}

--- a/src/servers/src/prometheus_handler.rs
+++ b/src/servers/src/prometheus_handler.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use catalog::CatalogManagerRef;
 use common_query::Output;
+use promql_parser::label::Matcher;
 use query::parser::PromQuery;
 use session::context::QueryContextRef;
 
@@ -31,6 +32,14 @@ pub type PrometheusHandlerRef = Arc<dyn PrometheusHandler + Send + Sync>;
 #[async_trait]
 pub trait PrometheusHandler {
     async fn do_query(&self, query: &PromQuery, query_ctx: QueryContextRef) -> Result<Output>;
+
+    /// Query metric table names by the `__name__` matchers.
+    async fn query_metrics(
+        &self,
+        catalog: &str,
+        schema: &str,
+        matchers: Vec<Matcher>,
+    ) -> Result<Vec<String>>;
 
     fn catalog_manager(&self) -> CatalogManagerRef;
 }

--- a/src/servers/src/prometheus_handler.rs
+++ b/src/servers/src/prometheus_handler.rs
@@ -34,11 +34,10 @@ pub trait PrometheusHandler {
     async fn do_query(&self, query: &PromQuery, query_ctx: QueryContextRef) -> Result<Output>;
 
     /// Query metric table names by the `__name__` matchers.
-    async fn query_metrics(
+    async fn query_metric_names(
         &self,
-        catalog: &str,
-        schema: &str,
         matchers: Vec<Matcher>,
+        ctx: &QueryContextRef,
     ) -> Result<Vec<String>>;
 
     fn catalog_manager(&self) -> CatalogManagerRef;

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -457,13 +457,13 @@ pub async fn setup_test_prom_app_with_frontend(
     // build metric tables
     let sql = "CREATE TABLE demo (ts timestamp time index, val double, host string primary key) engine=metric with ('on_physical_table' = 'phy')";
     run_sql(sql, &instance).await;
-    let sql = "CREATE TABLE demo_metrics (ts timestamp time index, val double, host string primary key) engine=metric with ('on_physical_table' = 'phy')";
+    let sql = "CREATE TABLE demo_metrics (ts timestamp time index, val double, idc string primary key) engine=metric with ('on_physical_table' = 'phy')";
     run_sql(sql, &instance).await;
     // insert rows
     let sql = "INSERT INTO demo(host, val, ts) VALUES ('host1', 1.1, 0), ('host2', 2.1, 600000)";
     run_sql(sql, &instance).await;
     let sql =
-        "INSERT INTO demo_metrics(host, val, ts) VALUES ('host1', 1.1, 0), ('host2', 2.1, 600000)";
+        "INSERT INTO demo_metrics(idc, val, ts) VALUES ('idc1', 1.1, 0), ('idc2', 2.1, 600000)";
     run_sql(sql, &instance).await;
 
     let http_opts = HttpOptions {

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -454,7 +454,7 @@ pub async fn setup_test_prom_app_with_frontend(
     // build physical table
     let sql = "CREATE TABLE phy (ts timestamp time index, val double, host string primary key) engine=metric with ('physical_metric_table' = '')";
     run_sql(sql, &instance).await;
-    // builld metric tables
+    // build metric tables
     let sql = "CREATE TABLE demo (ts timestamp time index, val double, host string primary key) engine=metric with ('on_physical_table' = 'phy')";
     run_sql(sql, &instance).await;
     let sql = "CREATE TABLE demo_metrics (ts timestamp time index, val double, host string primary key) engine=metric with ('on_physical_table' = 'phy')";

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -438,6 +438,11 @@ pub async fn setup_test_http_app_with_frontend_and_user_provider(
     (app, instance.guard)
 }
 
+async fn run_sql(sql: &str, instance: &GreptimeDbStandalone) {
+    let result = instance.instance.do_query(sql, QueryContext::arc()).await;
+    let _ = result.first().unwrap().as_ref().unwrap();
+}
+
 pub async fn setup_test_prom_app_with_frontend(
     store_type: StorageType,
     name: &str,
@@ -446,11 +451,20 @@ pub async fn setup_test_prom_app_with_frontend(
 
     let instance = setup_standalone_instance(name, store_type).await;
 
-    create_test_table(instance.instance.as_ref(), "demo").await;
-
-    let sql = "INSERT INTO demo VALUES ('host1', 1.1, 2.2, 0), ('host2', 2.1, 4.3, 600000)";
-    let result = instance.instance.do_query(sql, QueryContext::arc()).await;
-    let _ = result.first().unwrap().as_ref().unwrap();
+    // build physical table
+    let sql = "CREATE TABLE phy (ts timestamp time index, val double, host string primary key) engine=metric with ('physical_metric_table' = '')";
+    run_sql(sql, &instance).await;
+    // builld metric tables
+    let sql = "CREATE TABLE demo (ts timestamp time index, val double, host string primary key) engine=metric with ('on_physical_table' = 'phy')";
+    run_sql(sql, &instance).await;
+    let sql = "CREATE TABLE demo_metrics (ts timestamp time index, val double, host string primary key) engine=metric with ('on_physical_table' = 'phy')";
+    run_sql(sql, &instance).await;
+    // insert rows
+    let sql = "INSERT INTO demo(host, val, ts) VALUES ('host1', 1.1, 0), ('host2', 2.1, 600000)";
+    run_sql(sql, &instance).await;
+    let sql =
+        "INSERT INTO demo_metrics(host, val, ts) VALUES ('host1', 1.1, 0), ('host2', 2.1, 600000)";
+    run_sql(sql, &instance).await;
 
     let http_opts = HttpOptions {
         addr: format!("127.0.0.1:{}", ports::get_port()),

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -613,7 +613,7 @@ pub async fn test_prom_http_api(store_type: StorageType) {
     assert_eq!(body.status, "success");
     assert_eq!(
         body.data,
-        serde_json::from_value::<PrometheusResponse>(json!(["cpu", "memory"])).unwrap()
+        serde_json::from_value::<PrometheusResponse>(json!(["val"])).unwrap()
     );
 
     // query an empty database should return nothing
@@ -697,6 +697,31 @@ pub async fn test_prom_http_api(store_type: StorageType) {
     let data = res.text().await;
     let expected = "{\"status\":\"error\",\"data\":{\"resultType\":\"\",\"result\":[]},\"error\":\"invalid promql query\",\"errorType\":\"InvalidArguments\"}";
     assert_eq!(expected, data);
+
+    // range_query with __name__ not-equal matcher
+    let res = client
+        .post("/v1/prometheus/api/v1/query_range?query=count by(__name__)({__name__=~'demo.*'})&start=1&end=100&step=5")
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+    let data = res.text().await;
+    assert!(
+        data.contains("{\"__name__\":\"demo_metrics\"}")
+            && data.contains("{\"__name__\":\"demo\"}")
+    );
+
+    let res = client
+        .post("/v1/prometheus/api/v1/query_range?query=count by(__name__)({__name__=~'demo_metrics'})&start=1&end=100&step=5")
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+    let data = res.text().await;
+    assert!(
+        data.contains("{\"__name__\":\"demo_metrics\"}")
+            && !data.contains("{\"__name__\":\"demo\"}")
+    );
 
     guard.remove_all().await;
 }

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -520,7 +520,7 @@ pub async fn test_prom_http_api(store_type: StorageType) {
     assert_eq!(body.status, "success");
     assert_eq!(
         body.data,
-        serde_json::from_value::<PrometheusResponse>(json!(["__name__", "host", "number",]))
+        serde_json::from_value::<PrometheusResponse>(json!(["__name__", "host", "idc", "number",]))
             .unwrap()
     );
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Close #5375 

## What's changed and what's your intention?

* Supports regex matches (or not) for `__name__` in Prometheus APIs, currently limited to `/api/v1/query_range` and `/api/v1/query`.

* Caps the query metric tables at a maximum of 1024.

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added support for querying Prometheus metric names
  - Enhanced Prometheus query handling with more flexible matcher support

- **Performance**
  - Introduced new performance tracking metrics for PromQL queries

- **Dependencies**
  - Updated workspace dependencies for frontend and servers packages

- **Error Handling**
  - Improved error management for Prometheus-related operations
  - Added new error variants for specific query and record batch scenarios

These changes expand the Prometheus query capabilities and improve overall system robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->