### PR TITLE
refactor: drop useless clone for some better performance using static chek

### DIFF
--- a/src/api/src/v1/column_def.rs
+++ b/src/api/src/v1/column_def.rs
@@ -57,13 +57,13 @@ pub fn try_as_column_schema(column_def: &ColumnDef) -> Result<ColumnSchema> {
     }
     if let Some(options) = column_def.options.as_ref() {
         if let Some(fulltext) = options.options.get(FULLTEXT_GRPC_KEY) {
-            metadata.insert(FULLTEXT_KEY.to_string(), fulltext.clone());
+            metadata.insert(FULLTEXT_KEY.to_string(), fulltext.to_owned());
         }
         if let Some(inverted_index) = options.options.get(INVERTED_INDEX_GRPC_KEY) {
-            metadata.insert(INVERTED_INDEX_KEY.to_string(), inverted_index.clone());
+            metadata.insert(INVERTED_INDEX_KEY.to_string(), inverted_index.to_owned());
         }
         if let Some(skipping_index) = options.options.get(SKIPPING_INDEX_GRPC_KEY) {
-            metadata.insert(SKIPPING_INDEX_KEY.to_string(), skipping_index.clone());
+            metadata.insert(SKIPPING_INDEX_KEY.to_string(), skipping_index.to_owned());
         }
     }
 
@@ -82,7 +82,7 @@ pub fn options_from_column_schema(column_schema: &ColumnSchema) -> Option<Column
     if let Some(fulltext) = column_schema.metadata().get(FULLTEXT_KEY) {
         options
             .options
-            .insert(FULLTEXT_GRPC_KEY.to_string(), fulltext.clone());
+            .insert(FULLTEXT_GRPC_KEY.to_string(), fulltext.to_owned());
     }
     if let Some(inverted_index) = column_schema.metadata().get(INVERTED_INDEX_KEY) {
         options

--- a/src/common/grpc-expr/src/util.rs
+++ b/src/common/grpc-expr/src/util.rs
@@ -119,29 +119,30 @@ pub fn build_create_table_expr(
     }
 
     let mut column_defs = Vec::with_capacity(column_exprs.len());
-    let mut primary_keys = Vec::default();
+    let mut primary_keys = Vec::with_capacity(column_exprs.len());
     let mut time_index = None;
 
-    for ColumnExpr {
-        column_name,
-        datatype,
-        semantic_type,
-        datatype_extension,
-        options,
-    } in column_exprs
-    {
+    for expr in column_exprs {
+        let ColumnExpr {
+            column_name,
+            datatype,
+            semantic_type,
+            datatype_extension,
+            options,
+        } = expr;
+
         let mut is_nullable = true;
         match semantic_type {
-            v if v == SemanticType::Tag as i32 => primary_keys.push(column_name.to_string()),
+            v if v == SemanticType::Tag as i32 => primary_keys.push(column_name.to_owned()),
             v if v == SemanticType::Timestamp as i32 => {
                 ensure!(
                     time_index.is_none(),
                     DuplicatedTimestampColumnSnafu {
-                        exists: time_index.unwrap(),
+                        exists: time_index.as_ref().unwrap(),
                         duplicated: column_name,
                     }
                 );
-                time_index = Some(column_name.to_string());
+                time_index = Some(column_name.to_owned());
                 // Timestamp column must not be null.
                 is_nullable = false;
             }
@@ -158,8 +159,8 @@ pub fn build_create_table_expr(
             }
         );
 
-        let column_def = ColumnDef {
-            name: column_name.to_string(),
+        column_defs.push(ColumnDef {
+            name: column_name.to_owned(),
             data_type: datatype,
             is_nullable,
             default_constraint: vec![],
@@ -167,15 +168,14 @@ pub fn build_create_table_expr(
             comment: String::new(),
             datatype_extension: datatype_extension.clone(),
             options: options.clone(),
-        };
-        column_defs.push(column_def);
+        });
     }
 
     let time_index = time_index.context(MissingTimestampColumnSnafu {
         msg: format!("table is {}", table_name.table),
     })?;
 
-    let expr = CreateTableExpr {
+    Ok(CreateTableExpr {
         catalog_name: table_name.catalog.to_string(),
         schema_name: table_name.schema.to_string(),
         table_name: table_name.table.to_string(),
@@ -187,9 +187,7 @@ pub fn build_create_table_expr(
         table_options: Default::default(),
         table_id: table_id.map(|id| api::v1::TableId { id }),
         engine: engine.to_string(),
-    };
-
-    Ok(expr)
+    })
 }
 
 /// Find columns that are not present in the schema and return them as `AddColumns`

--- a/src/common/query/src/logical_plan/expr.rs
+++ b/src/common/query/src/logical_plan/expr.rs
@@ -28,14 +28,13 @@ pub fn build_same_type_ts_filter(
     ts_schema: &ColumnSchema,
     time_range: Option<TimestampRange>,
 ) -> Option<Expr> {
-    let ts_type = ts_schema.data_type.clone();
     let time_range = time_range?;
     let start = time_range
         .start()
-        .and_then(|start| ts_type.try_cast(Value::Timestamp(start)));
+        .and_then(|start| ts_schema.data_type.try_cast(Value::Timestamp(start)));
     let end = time_range
         .end()
-        .and_then(|end| ts_type.try_cast(Value::Timestamp(end)));
+        .and_then(|end| ts_schema.data_type.try_cast(Value::Timestamp(end)));
 
     let time_range = match (start, end) {
         (Some(Value::Timestamp(start)), Some(Value::Timestamp(end))) => {

--- a/src/table/src/metadata.rs
+++ b/src/table/src/metadata.rs
@@ -1049,7 +1049,7 @@ fn unset_column_fulltext_options(
 ) -> Result<()> {
     ensure!(
         current_options
-            .clone()
+            .as_ref()
             .is_some_and(|options| options.enable),
         error::InvalidColumnOptionSnafu {
             column_name,


### PR DESCRIPTION
Some of them maybe need to disscuss.

Also using RAPX like #5383 
I try to drop some of un nucessary `clone` like I did in OpenDAL -> https://github.com/apache/opendal/pull/5554

but RAPX seems still have some problems when use `-opt` with greptime, I will try to figure why


some static check warning like below, if you have interest, you can also give a try with my patch
```
| 31 | let ts_type = ts_schema.data_type.clone(); | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cloning happens here. 32 | let time_range = time_range?; ... 35 | .and_then(|start| ts_type.try_cast(Value::Timestamp(start))); 36 | let end = time_range | ^ 37 | | .end() 38 | | .and_then(|end| ts_type.try_cast(Value::Timestamp(end))); | |_________________________________________________^ Used here | = help: Use borrowings instead.
```


I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
