### PR TITLE
fix(flow): deal with flow drop leftover

### DIFF
--- a/src/flow/src/adapter.rs
+++ b/src/flow/src/adapter.rs
@@ -300,7 +300,7 @@ impl FlowWorkerManager {
                     {
                         // deal with both flow&sink table no longer exists
                         // but some output is still in output buf
-                        common_telemetry::warn!(e; "Table `{}` no longer exists, skip writeback", table_name);
+                        common_telemetry::warn!(e; "Table `{}` no longer exists, skip writeback", table_name.join("."));
                         continue;
                     } else {
                         return Err(e);

--- a/src/flow/src/adapter.rs
+++ b/src/flow/src/adapter.rs
@@ -300,7 +300,7 @@ impl FlowWorkerManager {
                     {
                         // deal with both flow&sink table no longer exists
                         // but some output is still in output buf
-                        common_telemetry::warn!(e; "Table no longer exists, skip writeback");
+                        common_telemetry::warn!(e; "Table `{}` no longer exists, skip writeback", table_name);
                         continue;
                     } else {
                         return Err(e);

--- a/src/flow/src/adapter.rs
+++ b/src/flow/src/adapter.rs
@@ -300,7 +300,7 @@ impl FlowWorkerManager {
                     {
                         // deal with both flow&sink table no longer exists
                         // but some output is still in output buf
-                        common_telemetry::error!(e; "Table no longer exists, skip writeback");
+                        common_telemetry::warn!(e; "Table no longer exists, skip writeback");
                         continue;
                     } else {
                         return Err(e);

--- a/src/flow/src/adapter.rs
+++ b/src/flow/src/adapter.rs
@@ -284,12 +284,29 @@ impl FlowWorkerManager {
             let (catalog, schema) = (table_name[0].clone(), table_name[1].clone());
             let ctx = Arc::new(QueryContext::with(&catalog, &schema));
 
-            let (is_ts_placeholder, proto_schema) = self
+            let (is_ts_placeholder, proto_schema) = match self
                 .try_fetch_existing_table(&table_name)
                 .await?
                 .context(UnexpectedSnafu {
                     reason: format!("Table not found: {}", table_name.join(".")),
-                })?;
+                }) {
+                Ok(r) => r,
+                Err(e) => {
+                    if self
+                        .table_info_source
+                        .get_opt_table_id_from_name(&table_name)
+                        .await?
+                        .is_none()
+                    {
+                        // deal with both flow&sink table no longer exists
+                        // but some output is still in output buf
+                        common_telemetry::error!(e; "Table no longer exists, skip writeback");
+                        continue;
+                    } else {
+                        return Err(e);
+                    }
+                }
+            };
             let schema_len = proto_schema.len();
 
             let total_rows = reqs.iter().map(|r| r.len()).sum::<usize>();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

previously, if a flow& it's sink table is dropped, but in flownode's output buf there is still leftover for this flow, calling flush_flow here will cause a bug which when send insert request back, can't found the sink table(as expected because sink table is dropped)
this is fixed now by check if table no longer exist and not make send back request failed
related failed test: https://github.com/GreptimeTeam/greptimedb/actions/runs/12825330060/job/35763543123

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
