### PR TITLE
fix: avoid suppress manual compaction

### DIFF
--- a/src/mito2/src/compaction.rs
+++ b/src/mito2/src/compaction.rs
@@ -9,7 +9,7 @@
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific langucage governing permissions and
+// See the License for the specific language governing permissions and
 // limitations under the License.
 
 mod buckets;

--- a/src/mito2/src/compaction.rs
+++ b/src/mito2/src/compaction.rs
@@ -9,7 +9,7 @@
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
+// See the License for the specific langucage governing permissions and
 // limitations under the License.
 
 mod buckets;
@@ -545,12 +545,12 @@ impl CompactionStatus {
             }));
         }
 
-        if let Some(mut pending_compaction) = self.pending_request
-            && let Some(waiter) = pending_compaction.waiter.take_inner()
-        {
-            waiter.send(Err(err.clone()).context(CompactRegionSnafu {
-                region_id: self.region_id,
-            }));
+        if let Some(pending_compaction) = self.pending_request {
+            pending_compaction
+                .waiter
+                .send(Err(err.clone()).context(CompactRegionSnafu {
+                    region_id: self.region_id,
+                }));
         }
     }
 

--- a/src/mito2/src/compaction.rs
+++ b/src/mito2/src/compaction.rs
@@ -51,9 +51,9 @@ use crate::compaction::picker::{new_picker, CompactionTask};
 use crate::compaction::task::CompactionTaskImpl;
 use crate::config::MitoConfig;
 use crate::error::{
-    CompactRegionSnafu, Error, GetSchemaMetadataSnafu, RegionClosedSnafu, RegionDroppedSnafu,
-    RegionTruncatedSnafu, RemoteCompactionSnafu, Result, TimeRangePredicateOverflowSnafu,
-    TimeoutSnafu,
+    CompactRegionSnafu, Error, GetSchemaMetadataSnafu, ManualCompactionOverrideSnafu,
+    RegionClosedSnafu, RegionDroppedSnafu, RegionTruncatedSnafu, RemoteCompactionSnafu, Result,
+    TimeRangePredicateOverflowSnafu, TimeoutSnafu,
 };
 use crate::metrics::{COMPACTION_STAGE_ELAPSED, INFLIGHT_COMPACTION_COUNT};
 use crate::read::projection::ProjectionMapper;
@@ -533,7 +533,7 @@ impl CompactionStatus {
                 prev.options, self.region_id
             );
             if let Some(waiter) = prev.waiter.take_inner() {
-                waiter.send(Err(Error::ManualCompactionOverride {}));
+                waiter.send(ManualCompactionOverrideSnafu.fail());
             }
         }
     }

--- a/src/mito2/src/compaction.rs
+++ b/src/mito2/src/compaction.rs
@@ -544,6 +544,14 @@ impl CompactionStatus {
                 region_id: self.region_id,
             }));
         }
+
+        if let Some(mut pending_compaction) = self.pending_request
+            && let Some(waiter) = pending_compaction.waiter.take_inner()
+        {
+            waiter.send(Err(err.clone()).context(CompactRegionSnafu {
+                region_id: self.region_id,
+            }));
+        }
     }
 
     /// Creates a new compaction request for compaction picker.

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -939,6 +939,9 @@ pub enum Error {
         column: String,
         default_value: String,
     },
+
+    #[snafu(display("Manual compaction is override by following operations."))]
+    ManualCompactionOverride {},
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -1082,6 +1085,8 @@ impl ErrorExt for Error {
             PushBloomFilterValue { source, .. } | BloomFilterFinish { source, .. } => {
                 source.status_code()
             }
+
+            ManualCompactionOverride {} => StatusCode::Cancelled,
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR fixes the issue that manually triggered compaction will be ignored when compaction is in progress.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
