### PR TITLE
fix: better sqlness show, replace the unwarp with better show message

### DIFF
--- a/tests/runner/src/main.rs
+++ b/tests/runner/src/main.rs
@@ -172,7 +172,13 @@ async fn main() {
             store,
         ),
     );
-    runner.run().await.unwrap();
+    match runner.run().await {
+        Ok(_) => println!("\x1b[32mAll sqlness tests passed!\x1b[0m"),
+        Err(e) => {
+            println!("\x1b[31mTest failed: {}\x1b[0m", e);
+            std::process::exit(1);
+        }
+    }
 
     // clean up and exit
     if !args.preserve_state {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

This patch gives better sqness test show when succeed and failed by replacing `unwrap();`

after this patch:

succeed:

![image](https://github.com/user-attachments/assets/2a097346-2878-4ac3-90fd-0dd7c6655839)


failed:

![image](https://github.com/user-attachments/assets/9283c89c-6910-4bb7-bdfb-ef349c1dc723)


## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
