### PR TITLE
feat: replace `DensePrimaryKeyCodec` with `Arc<dyn PrimaryKeyCodec>`

### DIFF
--- a/src/mito2/src/memtable/bulk/context.rs
+++ b/src/mito2/src/memtable/bulk/context.rs
@@ -22,7 +22,7 @@ use store_api::metadata::RegionMetadataRef;
 use store_api::storage::ColumnId;
 use table::predicate::Predicate;
 
-use crate::row_converter::DensePrimaryKeyCodec;
+use crate::row_converter::{build_primary_key_codec, DensePrimaryKeyCodec};
 use crate::sst::parquet::file_range::RangeBase;
 use crate::sst::parquet::format::ReadFormat;
 use crate::sst::parquet::reader::SimpleFilterContext;
@@ -41,7 +41,7 @@ impl BulkIterContext {
         projection: &Option<&[ColumnId]>,
         predicate: Option<Predicate>,
     ) -> Self {
-        let codec = DensePrimaryKeyCodec::new(&region_metadata);
+        let codec = build_primary_key_codec(&region_metadata);
 
         let simple_filters = predicate
             .as_ref()

--- a/src/mito2/src/memtable/bulk/part.rs
+++ b/src/mito2/src/memtable/bulk/part.rs
@@ -562,7 +562,7 @@ mod tests {
         let batch_values = batches
             .into_iter()
             .map(|b| {
-                let pk_values = pk_encoder.decode_dense(b.primary_key()).unwrap();
+                let pk_values = pk_encoder.decode(b.primary_key()).unwrap().into_dense();
                 let timestamps = b
                     .timestamps()
                     .as_any()

--- a/src/mito2/src/memtable/partition_tree.rs
+++ b/src/mito2/src/memtable/partition_tree.rs
@@ -31,9 +31,8 @@ use std::sync::atomic::{AtomicI64, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use common_base::readable_size::ReadableSize;
-pub(crate) use primary_key_filter::DensePrimaryKeyFilter;
+pub(crate) use primary_key_filter::{DensePrimaryKeyFilter, SparsePrimaryKeyFilter};
 use serde::{Deserialize, Serialize};
-use store_api::codec::PrimaryKeyEncoding;
 use store_api::metadata::RegionMetadataRef;
 use store_api::storage::{ColumnId, SequenceNumber};
 use table::predicate::Predicate;
@@ -48,7 +47,7 @@ use crate::memtable::{
     MemtableId, MemtableRange, MemtableRangeContext, MemtableRanges, MemtableRef, MemtableStats,
 };
 use crate::region::options::MergeMode;
-use crate::row_converter::{DensePrimaryKeyCodec, PrimaryKeyCodec};
+use crate::row_converter::{build_primary_key_codec, PrimaryKeyCodec};
 
 /// Use `1/DICTIONARY_SIZE_FACTOR` of OS memory as dictionary size.
 pub(crate) const DICTIONARY_SIZE_FACTOR: u64 = 8;
@@ -330,22 +329,14 @@ impl PartitionTreeMemtableBuilder {
 
 impl MemtableBuilder for PartitionTreeMemtableBuilder {
     fn build(&self, id: MemtableId, metadata: &RegionMetadataRef) -> MemtableRef {
-        match metadata.primary_key_encoding {
-            PrimaryKeyEncoding::Dense => {
-                let codec = Arc::new(DensePrimaryKeyCodec::new(metadata));
-                Arc::new(PartitionTreeMemtable::new(
-                    id,
-                    codec,
-                    metadata.clone(),
-                    self.write_buffer_manager.clone(),
-                    &self.config,
-                ))
-            }
-            PrimaryKeyEncoding::Sparse => {
-                //TODO(weny): Implement sparse primary key encoding.
-                todo!()
-            }
-        }
+        let codec = build_primary_key_codec(metadata);
+        Arc::new(PartitionTreeMemtable::new(
+            id,
+            codec,
+            metadata.clone(),
+            self.write_buffer_manager.clone(),
+            &self.config,
+        ))
     }
 }
 
@@ -382,7 +373,7 @@ mod tests {
     use store_api::storage::RegionId;
 
     use super::*;
-    use crate::row_converter::{DensePrimaryKeyCodec, PrimaryKeyCodecExt};
+    use crate::row_converter::DensePrimaryKeyCodec;
     use crate::test_util::memtable_util::{
         self, collect_iter_timestamps, region_metadata_to_row_schema,
     };
@@ -794,7 +785,7 @@ mod tests {
 
         let mut reader = new_memtable.iter(None, None, None).unwrap();
         let batch = reader.next().unwrap().unwrap();
-        let pk = codec.decode(batch.primary_key()).unwrap();
+        let pk = codec.decode(batch.primary_key()).unwrap().into_dense();
         if let Value::String(s) = &pk[2] {
             assert_eq!("10min", s.as_utf8());
         } else {

--- a/src/mito2/src/memtable/partition_tree/tree.rs
+++ b/src/mito2/src/memtable/partition_tree/tree.rs
@@ -97,6 +97,7 @@ impl PartitionTree {
     }
 
     fn verify_primary_key_length(&self, kv: &KeyValue) -> Result<()> {
+        // The sparse primary key codec does not have a fixed number of fields.
         if let Some(expected_num_fields) = self.row_codec.num_fields() {
             ensure!(
                 expected_num_fields == kv.num_primary_keys(),
@@ -106,6 +107,7 @@ impl PartitionTree {
                 }
             );
         }
+        // TODO(weny): verify the primary key length for sparse primary key codec.
         Ok(())
     }
 

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -585,7 +585,7 @@ fn prune_primary_key(
     let pk_values = if let Some(pk_values) = series.pk_cache.as_ref() {
         pk_values
     } else {
-        let pk_values = codec.decode(pk);
+        let pk_values = codec.decode_dense_without_column_id(pk);
         if let Err(e) = pk_values {
             error!(e; "Failed to decode primary key");
             return true;
@@ -1176,7 +1176,12 @@ mod tests {
         let row_codec = Arc::new(DensePrimaryKeyCodec::with_fields(
             schema
                 .primary_key_columns()
-                .map(|c| SortField::new(c.column_schema.data_type.clone()))
+                .map(|c| {
+                    (
+                        c.column_id,
+                        SortField::new(c.column_schema.data_type.clone()),
+                    )
+                })
                 .collect(),
         ));
         let set = Arc::new(SeriesSet::new(schema.clone(), row_codec));

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -51,7 +51,7 @@ use crate::metrics::{READ_ROWS_TOTAL, READ_STAGE_ELAPSED};
 use crate::read::dedup::LastNonNullIter;
 use crate::read::{Batch, BatchBuilder, BatchColumn};
 use crate::region::options::MergeMode;
-use crate::row_converter::{DensePrimaryKeyCodec, PrimaryKeyCodec, PrimaryKeyCodecExt};
+use crate::row_converter::{DensePrimaryKeyCodec, PrimaryKeyCodecExt};
 
 /// Initial vector builder capacity.
 const INITIAL_BUILDER_CAPACITY: usize = 0;
@@ -146,12 +146,13 @@ impl TimeSeriesMemtable {
 
     fn write_key_value(&self, kv: KeyValue, stats: &mut WriteMetrics) -> Result<()> {
         ensure!(
-            kv.num_primary_keys() == self.row_codec.num_fields(),
+            self.row_codec.num_fields() == kv.num_primary_keys(),
             PrimaryKeyLengthMismatchSnafu {
                 expect: self.row_codec.num_fields(),
-                actual: kv.num_primary_keys()
+                actual: kv.num_primary_keys(),
             }
         );
+
         let primary_key_encoded = self.row_codec.encode(kv.primary_keys())?;
         let fields = kv.fields().collect::<Vec<_>>();
 

--- a/src/mito2/src/read.rs
+++ b/src/mito2/src/read.rs
@@ -40,7 +40,7 @@ use datatypes::arrow::compute::SortOptions;
 use datatypes::arrow::row::{RowConverter, SortField};
 use datatypes::prelude::{ConcreteDataType, DataType, ScalarVector};
 use datatypes::types::TimestampType;
-use datatypes::value::{Value, ValueRef};
+use datatypes::value::ValueRef;
 use datatypes::vectors::{
     BooleanVector, Helper, TimestampMicrosecondVector, TimestampMillisecondVector,
     TimestampNanosecondVector, TimestampSecondVector, UInt32Vector, UInt64Vector, UInt8Vector,
@@ -58,6 +58,7 @@ use crate::error::{
 use crate::memtable::BoxedBatchIterator;
 use crate::metrics::{READ_BATCHES_RETURN, READ_ROWS_RETURN, READ_STAGE_ELAPSED};
 use crate::read::prune::PruneReader;
+use crate::row_converter::CompositeValues;
 
 /// Storage internal representation of a batch of rows for a primary key (time series).
 ///
@@ -68,7 +69,7 @@ pub struct Batch {
     /// Primary key encoded in a comparable form.
     primary_key: Vec<u8>,
     /// Possibly decoded `primary_key` values. Some places would decode it in advance.
-    pk_values: Option<Vec<Value>>,
+    pk_values: Option<CompositeValues>,
     /// Timestamps of rows, should be sorted and not null.
     timestamps: VectorRef,
     /// Sequences of rows
@@ -114,12 +115,12 @@ impl Batch {
     }
 
     /// Returns possibly decoded primary-key values.
-    pub fn pk_values(&self) -> Option<&[Value]> {
-        self.pk_values.as_deref()
+    pub fn pk_values(&self) -> Option<&CompositeValues> {
+        self.pk_values.as_ref()
     }
 
     /// Sets possibly decoded primary-key values.
-    pub fn set_pk_values(&mut self, pk_values: Vec<Value>) {
+    pub fn set_pk_values(&mut self, pk_values: CompositeValues) {
         self.pk_values = Some(pk_values);
     }
 

--- a/src/mito2/src/read/projection.rs
+++ b/src/mito2/src/read/projection.rs
@@ -33,7 +33,7 @@ use store_api::storage::ColumnId;
 use crate::cache::CacheStrategy;
 use crate::error::{InvalidRequestSnafu, Result};
 use crate::read::Batch;
-use crate::row_converter::{DensePrimaryKeyCodec, PrimaryKeyCodec};
+use crate::row_converter::{build_primary_key_codec, CompositeValues, PrimaryKeyCodec};
 
 /// Only cache vector when its length `<=` this value.
 const MAX_VECTOR_LENGTH_TO_CACHE: usize = 16384;
@@ -47,7 +47,7 @@ pub struct ProjectionMapper {
     /// Output record batch contains tags.
     has_tags: bool,
     /// Decoder for primary key.
-    codec: DensePrimaryKeyCodec,
+    codec: Arc<dyn PrimaryKeyCodec>,
     /// Schema for converted [RecordBatch].
     output_schema: SchemaRef,
     /// Ids of columns to project. It keeps ids in the same order as the `projection`
@@ -92,8 +92,8 @@ impl ProjectionMapper {
             // Safety: idx is valid.
             column_schemas.push(metadata.schema.column_schemas()[*idx].clone());
         }
-        let codec = DensePrimaryKeyCodec::new(metadata);
 
+        let codec = build_primary_key_codec(metadata);
         if is_empty_projection {
             // If projection is empty, we don't output any column.
             return Ok(ProjectionMapper {
@@ -134,7 +134,7 @@ impl ProjectionMapper {
                     has_tags = true;
                     // We always read all primary key so the column always exists and the tag
                     // index is always valid.
-                    BatchIndex::Tag(index)
+                    BatchIndex::Tag((index, column.column_id))
                 }
                 SemanticType::Timestamp => BatchIndex::Timestamp,
                 SemanticType::Field => {
@@ -213,15 +213,15 @@ impl ProjectionMapper {
         // Skips decoding pk if we don't need to output it.
         let pk_values = if self.has_tags {
             match batch.pk_values() {
-                Some(v) => v.to_vec(),
+                Some(v) => v.clone(),
                 None => self
                     .codec
-                    .decode_dense(batch.primary_key())
+                    .decode(batch.primary_key())
                     .map_err(BoxedError::new)
                     .context(ExternalSnafu)?,
             }
         } else {
-            Vec::new()
+            CompositeValues::Dense(vec![])
         };
 
         let mut columns = Vec::with_capacity(self.output_schema.num_columns());
@@ -232,8 +232,11 @@ impl ProjectionMapper {
             .zip(self.output_schema.column_schemas())
         {
             match index {
-                BatchIndex::Tag(idx) => {
-                    let value = &pk_values[*idx];
+                BatchIndex::Tag((idx, column_id)) => {
+                    let value = match &pk_values {
+                        CompositeValues::Dense(v) => &v[*idx].1,
+                        CompositeValues::Sparse(v) => v.get_or_null(*column_id),
+                    };
                     let vector = repeated_vector_with_cache(
                         &column_schema.data_type,
                         value,
@@ -259,7 +262,7 @@ impl ProjectionMapper {
 #[derive(Debug, Clone, Copy)]
 enum BatchIndex {
     /// Index in primary keys.
-    Tag(usize),
+    Tag((usize, ColumnId)),
     /// The time index column.
     Timestamp,
     /// Index in fields.
@@ -321,7 +324,7 @@ mod tests {
     use super::*;
     use crate::cache::CacheManager;
     use crate::read::BatchBuilder;
-    use crate::row_converter::{PrimaryKeyCodecExt, SortField};
+    use crate::row_converter::{DensePrimaryKeyCodec, PrimaryKeyCodecExt, SortField};
     use crate::test_util::meta_util::TestRegionMetadataBuilder;
 
     fn new_batch(
@@ -332,7 +335,12 @@ mod tests {
     ) -> Batch {
         let converter = DensePrimaryKeyCodec::with_fields(
             (0..tags.len())
-                .map(|_| SortField::new(ConcreteDataType::int64_datatype()))
+                .map(|idx| {
+                    (
+                        idx as u32,
+                        SortField::new(ConcreteDataType::int64_datatype()),
+                    )
+                })
                 .collect(),
         );
         let primary_key = converter

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -767,7 +767,7 @@ impl ScanInput {
                 }
             }
         };
-        if !compat::has_same_columns(
+        if !compat::has_same_columns_and_pk_encoding(
             self.mapper.metadata(),
             file_range_ctx.read_format().metadata(),
         ) {

--- a/src/mito2/src/row_converter.rs
+++ b/src/mito2/src/row_converter.rs
@@ -111,7 +111,7 @@ pub trait PrimaryKeyCodec: Send + Sync + Debug {
     ) -> Result<()>;
 
     /// Returns the number of fields in the primary key.
-    fn num_fields(&self) -> usize;
+    fn num_fields(&self) -> Option<usize>;
 
     /// Returns a primary key filter factory.
     fn primary_key_filter(

--- a/src/mito2/src/row_converter.rs
+++ b/src/mito2/src/row_converter.rs
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 mod dense;
-// TODO(weny): remove it.
-#[allow(unused)]
 mod sparse;
-
+use std::fmt::Debug;
 use std::sync::Arc;
 
 use common_recordbatch::filter::SimpleFilterEvaluator;
@@ -25,6 +23,7 @@ pub use dense::{DensePrimaryKeyCodec, SortField};
 pub use sparse::{SparsePrimaryKeyCodec, SparseValues};
 use store_api::codec::PrimaryKeyEncoding;
 use store_api::metadata::RegionMetadataRef;
+use store_api::storage::ColumnId;
 
 use crate::error::Result;
 use crate::memtable::key_values::KeyValue;
@@ -49,9 +48,6 @@ pub trait PrimaryKeyCodecExt {
     fn encode_to_vec<'a, I>(&self, row: I, buffer: &mut Vec<u8>) -> Result<()>
     where
         I: Iterator<Item = ValueRef<'a>>;
-
-    /// Decode row values from bytes.
-    fn decode(&self, bytes: &[u8]) -> Result<Vec<Value>>;
 }
 
 pub trait PrimaryKeyFilter: Send + Sync {
@@ -59,12 +55,53 @@ pub trait PrimaryKeyFilter: Send + Sync {
     fn matches(&mut self, pk: &[u8]) -> bool;
 }
 
-pub trait PrimaryKeyCodec: Send + Sync {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CompositeValues {
+    Dense(Vec<(ColumnId, Value)>),
+    Sparse(SparseValues),
+}
+
+impl CompositeValues {
+    /// Extends the composite values with the given values.
+    pub fn extend(&mut self, values: &[(ColumnId, Value)]) {
+        match self {
+            CompositeValues::Dense(dense_values) => {
+                for (column_id, value) in values {
+                    dense_values.push((*column_id, value.clone()));
+                }
+            }
+            CompositeValues::Sparse(sprase_value) => {
+                for (column_id, value) in values {
+                    sprase_value.insert(*column_id, value.clone());
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+impl CompositeValues {
+    pub fn into_sparse(self) -> SparseValues {
+        match self {
+            CompositeValues::Sparse(v) => v,
+            _ => panic!("CompositeValues is not sparse"),
+        }
+    }
+
+    pub fn into_dense(self) -> Vec<Value> {
+        match self {
+            CompositeValues::Dense(v) => v.into_iter().map(|(_, v)| v).collect(),
+            _ => panic!("CompositeValues is not dense"),
+        }
+    }
+}
+
+pub trait PrimaryKeyCodec: Send + Sync + Debug {
     /// Encodes a key value to bytes.
     fn encode_key_value(&self, key_value: &KeyValue, buffer: &mut Vec<u8>) -> Result<()>;
 
     /// Encodes values to bytes.
-    fn encode_values(&self, values: &[Value], buffer: &mut Vec<u8>) -> Result<()>;
+    fn encode_values(&self, values: &[(ColumnId, Value)], buffer: &mut Vec<u8>) -> Result<()>;
 
     /// Returns the number of fields in the primary key.
     fn num_fields(&self) -> usize;
@@ -86,9 +123,33 @@ pub trait PrimaryKeyCodec: Send + Sync {
 
     /// Decodes the primary key from the given bytes.
     ///
-    /// Returns a [`Vec<Value>`] that follows the primary key ordering.
-    fn decode_dense(&self, bytes: &[u8]) -> Result<Vec<Value>>;
+    /// Returns a [`CompositeValues`] that follows the primary key ordering.
+    fn decode(&self, bytes: &[u8]) -> Result<CompositeValues>;
 
     /// Decode the leftmost value from bytes.
     fn decode_leftmost(&self, bytes: &[u8]) -> Result<Option<Value>>;
+}
+
+/// Builds a primary key codec from region metadata.
+pub fn build_primary_key_codec(region_metadata: &RegionMetadataRef) -> Arc<dyn PrimaryKeyCodec> {
+    let fields = region_metadata.primary_key_columns().map(|col| {
+        (
+            col.column_id,
+            SortField::new(col.column_schema.data_type.clone()),
+        )
+    });
+    build_primary_key_codec_with_fields(region_metadata.primary_key_encoding, fields)
+}
+
+/// Builds a primary key codec from region metadata.
+pub fn build_primary_key_codec_with_fields(
+    encoding: PrimaryKeyEncoding,
+    fields: impl Iterator<Item = (ColumnId, SortField)>,
+) -> Arc<dyn PrimaryKeyCodec> {
+    match encoding {
+        PrimaryKeyEncoding::Dense => Arc::new(DensePrimaryKeyCodec::with_fields(fields.collect())),
+        PrimaryKeyEncoding::Sparse => {
+            Arc::new(SparsePrimaryKeyCodec::with_fields(fields.collect()))
+        }
+    }
 }

--- a/src/mito2/src/row_converter.rs
+++ b/src/mito2/src/row_converter.rs
@@ -22,7 +22,7 @@ use datatypes::value::{Value, ValueRef};
 pub use dense::{DensePrimaryKeyCodec, SortField};
 pub use sparse::{SparsePrimaryKeyCodec, SparseValues};
 use store_api::codec::PrimaryKeyEncoding;
-use store_api::metadata::RegionMetadataRef;
+use store_api::metadata::{RegionMetadata, RegionMetadataRef};
 use store_api::storage::ColumnId;
 
 use crate::error::Result;
@@ -103,6 +103,13 @@ pub trait PrimaryKeyCodec: Send + Sync + Debug {
     /// Encodes values to bytes.
     fn encode_values(&self, values: &[(ColumnId, Value)], buffer: &mut Vec<u8>) -> Result<()>;
 
+    /// Encodes values to bytes.
+    fn encode_value_refs(
+        &self,
+        values: &[(ColumnId, ValueRef)],
+        buffer: &mut Vec<u8>,
+    ) -> Result<()>;
+
     /// Returns the number of fields in the primary key.
     fn num_fields(&self) -> usize;
 
@@ -131,7 +138,7 @@ pub trait PrimaryKeyCodec: Send + Sync + Debug {
 }
 
 /// Builds a primary key codec from region metadata.
-pub fn build_primary_key_codec(region_metadata: &RegionMetadataRef) -> Arc<dyn PrimaryKeyCodec> {
+pub fn build_primary_key_codec(region_metadata: &RegionMetadata) -> Arc<dyn PrimaryKeyCodec> {
     let fields = region_metadata.primary_key_columns().map(|col| {
         (
             col.column_id,

--- a/src/mito2/src/row_converter/dense.rs
+++ b/src/mito2/src/row_converter/dense.rs
@@ -324,21 +324,17 @@ pub struct DensePrimaryKeyCodec {
 
 impl DensePrimaryKeyCodec {
     pub fn new(metadata: &RegionMetadata) -> Self {
-        let ordered_primary_key_columns = Arc::new(
-            metadata
-                .primary_key_columns()
-                .map(|c| {
-                    (
-                        c.column_id,
-                        SortField::new(c.column_schema.data_type.clone()),
-                    )
-                })
-                .collect::<Vec<_>>(),
-        );
+        let ordered_primary_key_columns = metadata
+            .primary_key_columns()
+            .map(|c| {
+                (
+                    c.column_id,
+                    SortField::new(c.column_schema.data_type.clone()),
+                )
+            })
+            .collect::<Vec<_>>();
 
-        Self {
-            ordered_primary_key_columns,
-        }
+        Self::with_fields(ordered_primary_key_columns)
     }
 
     pub fn with_fields(fields: Vec<(ColumnId, SortField)>) -> Self {
@@ -444,6 +440,10 @@ impl DensePrimaryKeyCodec {
             .map(|(_, f)| f.estimated_size())
             .sum()
     }
+
+    pub fn num_fields(&self) -> usize {
+        self.ordered_primary_key_columns.len()
+    }
 }
 
 impl PrimaryKeyCodec for DensePrimaryKeyCodec {
@@ -468,8 +468,8 @@ impl PrimaryKeyCodec for DensePrimaryKeyCodec {
         Some(self.estimated_size())
     }
 
-    fn num_fields(&self) -> usize {
-        self.ordered_primary_key_columns.len()
+    fn num_fields(&self) -> Option<usize> {
+        Some(self.num_fields())
     }
 
     fn encoding(&self) -> PrimaryKeyEncoding {

--- a/src/mito2/src/row_converter/dense.rs
+++ b/src/mito2/src/row_converter/dense.rs
@@ -455,6 +455,15 @@ impl PrimaryKeyCodec for DensePrimaryKeyCodec {
         self.encode_dense(values.iter().map(|(_, v)| v.as_value_ref()), buffer)
     }
 
+    fn encode_value_refs(
+        &self,
+        values: &[(ColumnId, ValueRef)],
+        buffer: &mut Vec<u8>,
+    ) -> Result<()> {
+        let iter = values.iter().map(|(_, v)| *v);
+        self.encode_dense(iter, buffer)
+    }
+
     fn estimated_size(&self) -> Option<usize> {
         Some(self.estimated_size())
     }

--- a/src/mito2/src/row_converter/dense.rs
+++ b/src/mito2/src/row_converter/dense.rs
@@ -30,8 +30,9 @@ use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use store_api::codec::PrimaryKeyEncoding;
 use store_api::metadata::{RegionMetadata, RegionMetadataRef};
+use store_api::storage::ColumnId;
 
-use super::PrimaryKeyFilter;
+use super::{CompositeValues, PrimaryKeyFilter};
 use crate::error::{
     self, FieldTypeMismatchSnafu, NotSupportedFieldSnafu, Result, SerializeFieldSnafu,
 };
@@ -312,17 +313,13 @@ impl PrimaryKeyCodecExt for DensePrimaryKeyCodec {
     {
         self.encode_dense(row, buffer)
     }
-
-    fn decode(&self, bytes: &[u8]) -> Result<Vec<Value>> {
-        self.decode_dense(bytes)
-    }
 }
 
 /// A memory-comparable row [`Value`] encoder/decoder.
 #[derive(Clone, Debug)]
 pub struct DensePrimaryKeyCodec {
     /// Primary key fields.
-    ordered_primary_key_columns: Arc<Vec<SortField>>,
+    ordered_primary_key_columns: Arc<Vec<(ColumnId, SortField)>>,
 }
 
 impl DensePrimaryKeyCodec {
@@ -330,7 +327,12 @@ impl DensePrimaryKeyCodec {
         let ordered_primary_key_columns = Arc::new(
             metadata
                 .primary_key_columns()
-                .map(|c| SortField::new(c.column_schema.data_type.clone()))
+                .map(|c| {
+                    (
+                        c.column_id,
+                        SortField::new(c.column_schema.data_type.clone()),
+                    )
+                })
                 .collect::<Vec<_>>(),
         );
 
@@ -339,7 +341,7 @@ impl DensePrimaryKeyCodec {
         }
     }
 
-    pub fn with_fields(fields: Vec<SortField>) -> Self {
+    pub fn with_fields(fields: Vec<(ColumnId, SortField)>) -> Self {
         Self {
             ordered_primary_key_columns: Arc::new(fields),
         }
@@ -350,10 +352,40 @@ impl DensePrimaryKeyCodec {
         I: Iterator<Item = ValueRef<'a>>,
     {
         let mut serializer = Serializer::new(buffer);
-        for (value, field) in row.zip(self.ordered_primary_key_columns.iter()) {
+        for (value, (_, field)) in row.zip(self.ordered_primary_key_columns.iter()) {
             field.serialize(&mut serializer, &value)?;
         }
         Ok(())
+    }
+
+    /// Decode primary key values from bytes.
+    pub fn decode_dense(&self, bytes: &[u8]) -> Result<Vec<(ColumnId, Value)>> {
+        let mut deserializer = Deserializer::new(bytes);
+        let mut values = Vec::with_capacity(self.ordered_primary_key_columns.len());
+        for (column_id, field) in self.ordered_primary_key_columns.iter() {
+            let value = field.deserialize(&mut deserializer)?;
+            values.push((*column_id, value));
+        }
+        Ok(values)
+    }
+
+    /// Decode primary key values from bytes without column id.
+    pub fn decode_dense_without_column_id(&self, bytes: &[u8]) -> Result<Vec<Value>> {
+        let mut deserializer = Deserializer::new(bytes);
+        let mut values = Vec::with_capacity(self.ordered_primary_key_columns.len());
+        for (_, field) in self.ordered_primary_key_columns.iter() {
+            let value = field.deserialize(&mut deserializer)?;
+            values.push(value);
+        }
+        Ok(values)
+    }
+
+    /// Returns the field at `pos`.
+    ///
+    /// # Panics
+    /// Panics if `pos` is out of bounds.
+    fn field_at(&self, pos: usize) -> &SortField {
+        &self.ordered_primary_key_columns[pos].1
     }
 
     /// Decode value at `pos` in `bytes`.
@@ -370,7 +402,7 @@ impl DensePrimaryKeyCodec {
             // We computed the offset before.
             let to_skip = offsets_buf[pos];
             deserializer.advance(to_skip);
-            return self.ordered_primary_key_columns[pos].deserialize(&mut deserializer);
+            return self.field_at(pos).deserialize(&mut deserializer);
         }
 
         if offsets_buf.is_empty() {
@@ -379,7 +411,8 @@ impl DensePrimaryKeyCodec {
             for i in 0..pos {
                 // Offset to skip before reading value i.
                 offsets_buf.push(offset);
-                let skip = self.ordered_primary_key_columns[i]
+                let skip = self
+                    .field_at(i)
                     .skip_deserialize(bytes, &mut deserializer)?;
                 offset += skip;
             }
@@ -393,7 +426,8 @@ impl DensePrimaryKeyCodec {
             deserializer.advance(offset);
             for i in value_start..pos {
                 // Skip value i.
-                let skip = self.ordered_primary_key_columns[i]
+                let skip = self
+                    .field_at(i)
                     .skip_deserialize(bytes, &mut deserializer)?;
                 // Offset for the value at i + 1.
                 offset += skip;
@@ -401,13 +435,13 @@ impl DensePrimaryKeyCodec {
             }
         }
 
-        self.ordered_primary_key_columns[pos].deserialize(&mut deserializer)
+        self.field_at(pos).deserialize(&mut deserializer)
     }
 
     pub fn estimated_size(&self) -> usize {
         self.ordered_primary_key_columns
             .iter()
-            .map(|f| f.estimated_size())
+            .map(|(_, f)| f.estimated_size())
             .sum()
     }
 }
@@ -417,8 +451,8 @@ impl PrimaryKeyCodec for DensePrimaryKeyCodec {
         self.encode_dense(key_value.primary_keys(), buffer)
     }
 
-    fn encode_values(&self, values: &[Value], buffer: &mut Vec<u8>) -> Result<()> {
-        self.encode_dense(values.iter().map(|v| v.as_value_ref()), buffer)
+    fn encode_values(&self, values: &[(ColumnId, Value)], buffer: &mut Vec<u8>) -> Result<()> {
+        self.encode_dense(values.iter().map(|(_, v)| v.as_value_ref()), buffer)
     }
 
     fn estimated_size(&self) -> Option<usize> {
@@ -445,20 +479,14 @@ impl PrimaryKeyCodec for DensePrimaryKeyCodec {
         ))
     }
 
-    fn decode_dense(&self, bytes: &[u8]) -> Result<Vec<Value>> {
-        let mut deserializer = Deserializer::new(bytes);
-        let mut values = Vec::with_capacity(self.ordered_primary_key_columns.len());
-        for f in self.ordered_primary_key_columns.iter() {
-            let value = f.deserialize(&mut deserializer)?;
-            values.push(value);
-        }
-        Ok(values)
+    fn decode(&self, bytes: &[u8]) -> Result<CompositeValues> {
+        Ok(CompositeValues::Dense(self.decode_dense(bytes)?))
     }
 
     fn decode_leftmost(&self, bytes: &[u8]) -> Result<Option<Value>> {
         // TODO(weny, yinwen): avoid decoding the whole primary key.
         let mut values = self.decode_dense(bytes)?;
-        Ok(values.pop())
+        Ok(values.pop().map(|(_, v)| v))
     }
 }
 
@@ -476,14 +504,14 @@ mod tests {
         let encoder = DensePrimaryKeyCodec::with_fields(
             data_types
                 .iter()
-                .map(|t| SortField::new(t.clone()))
+                .map(|t| (0, SortField::new(t.clone())))
                 .collect::<Vec<_>>(),
         );
 
         let value_ref = row.iter().map(|v| v.as_value_ref()).collect::<Vec<_>>();
 
         let result = encoder.encode(value_ref.iter().cloned()).unwrap();
-        let decoded = encoder.decode(&result).unwrap();
+        let decoded = encoder.decode(&result).unwrap().into_dense();
         assert_eq!(decoded, row);
         let mut decoded = Vec::new();
         let mut offsets = Vec::new();
@@ -502,14 +530,14 @@ mod tests {
     #[test]
     fn test_memcmp() {
         let encoder = DensePrimaryKeyCodec::with_fields(vec![
-            SortField::new(ConcreteDataType::string_datatype()),
-            SortField::new(ConcreteDataType::int64_datatype()),
+            (0, SortField::new(ConcreteDataType::string_datatype())),
+            (1, SortField::new(ConcreteDataType::int64_datatype())),
         ]);
         let values = [Value::String("abcdefgh".into()), Value::Int64(128)];
         let value_ref = values.iter().map(|v| v.as_value_ref()).collect::<Vec<_>>();
         let result = encoder.encode(value_ref.iter().cloned()).unwrap();
 
-        let decoded = encoder.decode(&result).unwrap();
+        let decoded = encoder.decode(&result).unwrap().into_dense();
         assert_eq!(&values, &decoded as &[Value]);
     }
 

--- a/src/mito2/src/row_converter/sparse.rs
+++ b/src/mito2/src/row_converter/sparse.rs
@@ -124,7 +124,7 @@ impl SparsePrimaryKeyCodec {
     pub fn with_fields(fields: Vec<(ColumnId, SortField)>) -> Self {
         Self {
             inner: Arc::new(SparsePrimaryKeyCodecInner {
-                columns: fields.iter().map(|f| f.0).collect(),
+                columns: Some(fields.iter().map(|f| f.0).collect()),
                 table_id_field: SortField::new(ConcreteDataType::uint32_datatype()),
                 tsid_field: SortField::new(ConcreteDataType::uint64_datatype()),
                 label_field: SortField::new(ConcreteDataType::string_datatype()),

--- a/src/mito2/src/row_converter/sparse.rs
+++ b/src/mito2/src/row_converter/sparse.rs
@@ -26,7 +26,7 @@ use store_api::metadata::RegionMetadataRef;
 use store_api::storage::consts::ReservedColumnId;
 use store_api::storage::ColumnId;
 
-use crate::error::{DeserializeFieldSnafu, Result, SerializeFieldSnafu};
+use crate::error::{DeserializeFieldSnafu, Result, SerializeFieldSnafu, UnsupportedOperationSnafu};
 use crate::memtable::key_values::KeyValue;
 use crate::memtable::partition_tree::SparsePrimaryKeyFilter;
 use crate::row_converter::dense::SortField;
@@ -247,7 +247,10 @@ impl SparsePrimaryKeyCodec {
 
 impl PrimaryKeyCodec for SparsePrimaryKeyCodec {
     fn encode_key_value(&self, _key_value: &KeyValue, _buffer: &mut Vec<u8>) -> Result<()> {
-        todo!()
+        UnsupportedOperationSnafu {
+            err_msg: "The encode_key_value method is not supported in SparsePrimaryKeyCodec.",
+        }
+        .fail()
     }
 
     fn encode_values(&self, values: &[(ColumnId, Value)], buffer: &mut Vec<u8>) -> Result<()> {
@@ -266,8 +269,8 @@ impl PrimaryKeyCodec for SparsePrimaryKeyCodec {
         None
     }
 
-    fn num_fields(&self) -> usize {
-        todo!()
+    fn num_fields(&self) -> Option<usize> {
+        None
     }
 
     fn encoding(&self) -> PrimaryKeyEncoding {

--- a/src/mito2/src/row_converter/sparse.rs
+++ b/src/mito2/src/row_converter/sparse.rs
@@ -15,25 +15,30 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use common_recordbatch::filter::SimpleFilterEvaluator;
 use datatypes::prelude::ConcreteDataType;
 use datatypes::value::{Value, ValueRef};
 use memcomparable::{Deserializer, Serializer};
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
+use store_api::codec::PrimaryKeyEncoding;
 use store_api::metadata::RegionMetadataRef;
 use store_api::storage::consts::ReservedColumnId;
 use store_api::storage::ColumnId;
 
 use crate::error::{DeserializeFieldSnafu, Result, SerializeFieldSnafu};
+use crate::memtable::key_values::KeyValue;
+use crate::memtable::partition_tree::SparsePrimaryKeyFilter;
 use crate::row_converter::dense::SortField;
-use crate::row_converter::PrimaryKeyCodec;
+use crate::row_converter::{CompositeValues, PrimaryKeyCodec, PrimaryKeyFilter};
 
 /// A codec for sparse key of metrics.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct SparsePrimaryKeyCodec {
     inner: Arc<SparsePrimaryKeyCodecInner>,
 }
 
+#[derive(Debug)]
 struct SparsePrimaryKeyCodecInner {
     // Internal fields
     table_id_field: SortField,
@@ -64,6 +69,11 @@ impl SparseValues {
     /// Returns the value of the given column, or [`Value::Null`] if the column is not present.
     pub fn get_or_null(&self, column_id: ColumnId) -> &Value {
         self.values.get(&column_id).unwrap_or(&Value::Null)
+    }
+
+    /// Returns the value of the given column, or [`None`] if the column is not present.
+    pub fn get(&self, column_id: &ColumnId) -> Option<&Value> {
+        self.values.get(column_id)
     }
 
     /// Inserts a new value into the [`SparseValues`].
@@ -107,6 +117,17 @@ impl SparsePrimaryKeyCodec {
                 tsid_field: SortField::new(ConcreteDataType::uint64_datatype()),
                 label_field: SortField::new(ConcreteDataType::string_datatype()),
                 columns: None,
+            }),
+        }
+    }
+
+    pub fn with_fields(fields: Vec<(ColumnId, SortField)>) -> Self {
+        Self {
+            inner: Arc::new(SparsePrimaryKeyCodecInner {
+                columns: fields.iter().map(|f| f.0).collect(),
+                table_id_field: SortField::new(ConcreteDataType::uint32_datatype()),
+                tsid_field: SortField::new(ConcreteDataType::uint64_datatype()),
+                label_field: SortField::new(ConcreteDataType::string_datatype()),
             }),
         }
     }
@@ -221,6 +242,48 @@ impl SparsePrimaryKeyCodec {
         // Safety: checked by `has_column`
         let field = self.get_field(column_id).unwrap();
         field.deserialize(&mut deserializer)
+    }
+}
+
+impl PrimaryKeyCodec for SparsePrimaryKeyCodec {
+    fn encode_key_value(&self, _key_value: &KeyValue, _buffer: &mut Vec<u8>) -> Result<()> {
+        todo!()
+    }
+
+    fn encode_values(&self, values: &[(ColumnId, Value)], buffer: &mut Vec<u8>) -> Result<()> {
+        self.encode_to_vec(values.iter().map(|v| (v.0, v.1.as_value_ref())), buffer)
+    }
+
+    fn estimated_size(&self) -> Option<usize> {
+        None
+    }
+
+    fn num_fields(&self) -> usize {
+        todo!()
+    }
+
+    fn encoding(&self) -> PrimaryKeyEncoding {
+        PrimaryKeyEncoding::Sparse
+    }
+
+    fn primary_key_filter(
+        &self,
+        metadata: &RegionMetadataRef,
+        filters: Arc<Vec<SimpleFilterEvaluator>>,
+    ) -> Box<dyn PrimaryKeyFilter> {
+        Box::new(SparsePrimaryKeyFilter::new(
+            metadata.clone(),
+            filters,
+            self.clone(),
+        ))
+    }
+
+    fn decode(&self, bytes: &[u8]) -> Result<CompositeValues> {
+        Ok(CompositeValues::Sparse(self.decode_sparse(bytes)?))
+    }
+
+    fn decode_leftmost(&self, bytes: &[u8]) -> Result<Option<Value>> {
+        self.decode_leftmost(bytes)
     }
 }
 

--- a/src/mito2/src/row_converter/sparse.rs
+++ b/src/mito2/src/row_converter/sparse.rs
@@ -254,6 +254,14 @@ impl PrimaryKeyCodec for SparsePrimaryKeyCodec {
         self.encode_to_vec(values.iter().map(|v| (v.0, v.1.as_value_ref())), buffer)
     }
 
+    fn encode_value_refs(
+        &self,
+        values: &[(ColumnId, ValueRef)],
+        buffer: &mut Vec<u8>,
+    ) -> Result<()> {
+        self.encode_to_vec(values.iter().map(|v| (v.0, v.1)), buffer)
+    }
+
     fn estimated_size(&self) -> Option<usize> {
         None
     }

--- a/src/mito2/src/sst/index/bloom_filter/creator.rs
+++ b/src/mito2/src/sst/index/bloom_filter/creator.rs
@@ -30,7 +30,7 @@ use crate::error::{
     PuffinAddBlobSnafu, PushBloomFilterValueSnafu, Result,
 };
 use crate::read::Batch;
-use crate::row_converter::SortField;
+use crate::row_converter::{CompositeValues, SortField};
 use crate::sst::file::FileId;
 use crate::sst::index::bloom_filter::INDEX_BLOB_TYPE;
 use crate::sst::index::codec::{IndexValueCodec, IndexValuesCodec};
@@ -192,11 +192,26 @@ impl BloomFilterIndexer {
         let n = batch.num_rows();
         guard.inc_row_count(n);
 
+        // TODO(weny, zhenchi): lazy decode
+        let values = self.codec.decode(batch.primary_key())?;
         // Tags
-        for ((col_id, _), field, value) in self.codec.decode(batch.primary_key())? {
+        for (idx, (col_id, field)) in self.codec.fields().iter().enumerate() {
             let Some(creator) = self.creators.get_mut(col_id) else {
                 continue;
             };
+
+            let value = match &values {
+                CompositeValues::Dense(vec) => {
+                    let value = &vec[idx].1;
+                    if value.is_null() {
+                        None
+                    } else {
+                        Some(value)
+                    }
+                }
+                CompositeValues::Sparse(sparse_values) => sparse_values.get(col_id),
+            };
+
             let elems = value
                 .map(|v| {
                     let mut buf = vec![];
@@ -411,7 +426,7 @@ pub(crate) mod tests {
     }
 
     pub fn new_batch(str_tag: impl AsRef<str>, u64_field: impl IntoIterator<Item = u64>) -> Batch {
-        let fields = vec![SortField::new(ConcreteDataType::string_datatype())];
+        let fields = vec![(0, SortField::new(ConcreteDataType::string_datatype()))];
         let codec = DensePrimaryKeyCodec::with_fields(fields);
         let row: [ValueRef; 1] = [str_tag.as_ref().into()];
         let primary_key = codec.encode(row.into_iter()).unwrap();

--- a/src/mito2/src/sst/index/bloom_filter/creator.rs
+++ b/src/mito2/src/sst/index/bloom_filter/creator.rs
@@ -108,7 +108,10 @@ impl BloomFilterIndexer {
             return Ok(None);
         }
 
-        let codec = IndexValuesCodec::from_tag_columns(metadata.primary_key_columns());
+        let codec = IndexValuesCodec::from_tag_columns(
+            metadata.primary_key_encoding,
+            metadata.primary_key_columns(),
+        );
         let indexer = Self {
             creators,
             temp_file_provider,

--- a/src/mito2/src/sst/index/codec.rs
+++ b/src/mito2/src/sst/index/codec.rs
@@ -13,16 +13,20 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use datatypes::data_type::ConcreteDataType;
 use datatypes::value::ValueRef;
 use memcomparable::Serializer;
 use snafu::{ensure, OptionExt, ResultExt};
+use store_api::codec::PrimaryKeyEncoding;
 use store_api::metadata::ColumnMetadata;
 use store_api::storage::ColumnId;
 
 use crate::error::{FieldTypeMismatchSnafu, IndexEncodeNullSnafu, Result};
-use crate::row_converter::{CompositeValues, DensePrimaryKeyCodec, PrimaryKeyCodec, SortField};
+use crate::row_converter::{
+    build_primary_key_codec_with_fields, CompositeValues, PrimaryKeyCodec, SortField,
+};
 
 /// Encodes index values according to their data types for sorting and storage use.
 pub struct IndexValueCodec;
@@ -68,12 +72,15 @@ pub struct IndexValuesCodec {
     /// The data types of tag columns.
     fields: Vec<(ColumnId, SortField)>,
     /// The decoder for the primary key.
-    decoder: DensePrimaryKeyCodec,
+    decoder: Arc<dyn PrimaryKeyCodec>,
 }
 
 impl IndexValuesCodec {
     /// Creates a new `IndexValuesCodec` from a list of `ColumnMetadata` of tag columns.
-    pub fn from_tag_columns<'a>(tag_columns: impl Iterator<Item = &'a ColumnMetadata>) -> Self {
+    pub fn from_tag_columns<'a>(
+        primary_key_encoding: PrimaryKeyEncoding,
+        tag_columns: impl Iterator<Item = &'a ColumnMetadata>,
+    ) -> Self {
         let (column_ids, fields): (Vec<_>, Vec<_>) = tag_columns
             .map(|column| {
                 (
@@ -87,8 +94,9 @@ impl IndexValuesCodec {
             .unzip();
 
         let column_ids = column_ids.into_iter().collect();
+        let decoder =
+            build_primary_key_codec_with_fields(primary_key_encoding, fields.clone().into_iter());
 
-        let decoder = DensePrimaryKeyCodec::with_fields(fields.clone());
         Self {
             column_ids,
             fields,
@@ -115,10 +123,13 @@ impl IndexValuesCodec {
 #[cfg(test)]
 mod tests {
     use datatypes::data_type::ConcreteDataType;
+    use datatypes::schema::ColumnSchema;
+    use datatypes::value::Value;
+    use store_api::metadata::ColumnMetadata;
 
     use super::*;
     use crate::error::Error;
-    use crate::row_converter::SortField;
+    use crate::row_converter::{DensePrimaryKeyCodec, PrimaryKeyCodecExt, SortField};
 
     #[test]
     fn test_encode_value_basic() {
@@ -152,42 +163,32 @@ mod tests {
 
     #[test]
     fn test_decode_primary_key_basic() {
-        // TODO(weny, zhenchi): rewrite the test.
-        // let tag_columns = vec![
-        //     ColumnMetadata {
-        //         column_schema: ColumnSchema::new("tag0", ConcreteDataType::string_datatype(), true),
-        //         semantic_type: api::v1::SemanticType::Tag,
-        //         column_id: 1,
-        //     },
-        //     ColumnMetadata {
-        //         column_schema: ColumnSchema::new("tag1", ConcreteDataType::int64_datatype(), false),
-        //         semantic_type: api::v1::SemanticType::Tag,
-        //         column_id: 2,
-        //     },
-        // ];
+        let tag_columns = vec![
+            ColumnMetadata {
+                column_schema: ColumnSchema::new("tag0", ConcreteDataType::string_datatype(), true),
+                semantic_type: api::v1::SemanticType::Tag,
+                column_id: 1,
+            },
+            ColumnMetadata {
+                column_schema: ColumnSchema::new("tag1", ConcreteDataType::int64_datatype(), false),
+                semantic_type: api::v1::SemanticType::Tag,
+                column_id: 2,
+            },
+        ];
 
-        // let primary_key = DensePrimaryKeyCodec::with_fields(vec![
-        //     (0, SortField::new(ConcreteDataType::string_datatype())),
-        //     (1, SortField::new(ConcreteDataType::int64_datatype())),
-        // ])
-        // .encode([ValueRef::Null, ValueRef::Int64(10)].into_iter())
-        // .unwrap();
+        let primary_key = DensePrimaryKeyCodec::with_fields(vec![
+            (0, SortField::new(ConcreteDataType::string_datatype())),
+            (1, SortField::new(ConcreteDataType::int64_datatype())),
+        ])
+        .encode([ValueRef::Null, ValueRef::Int64(10)].into_iter())
+        .unwrap();
 
-        // let codec = IndexValuesCodec::from_tag_columns(tag_columns.iter());
-        // let mut iter = codec.decode(&primary_key).unwrap();
+        let codec =
+            IndexValuesCodec::from_tag_columns(PrimaryKeyEncoding::Dense, tag_columns.iter());
+        let values = codec.decode(&primary_key).unwrap().into_dense();
 
-        // let ((column_id, col_id_str), field, value) = iter.next().unwrap();
-        // assert_eq!(*column_id, 1);
-        // assert_eq!(col_id_str, "1");
-        // assert_eq!(field, &SortField::new(ConcreteDataType::string_datatype()));
-        // assert_eq!(value, None);
-
-        // let ((column_id, col_id_str), field, value) = iter.next().unwrap();
-        // assert_eq!(*column_id, 2);
-        // assert_eq!(col_id_str, "2");
-        // assert_eq!(field, &SortField::new(ConcreteDataType::int64_datatype()));
-        // assert_eq!(value, Some(Value::Int64(10)));
-
-        // assert!(iter.next().is_none());
+        assert_eq!(values.len(), 2);
+        assert_eq!(values[0], Value::Null);
+        assert_eq!(values[1], Value::Int64(10));
     }
 }

--- a/src/mito2/src/sst/index/inverted_index/creator.rs
+++ b/src/mito2/src/sst/index/inverted_index/creator.rs
@@ -101,7 +101,10 @@ impl InvertedIndexer {
         );
         let index_creator = Box::new(SortIndexCreator::new(sorter, segment_row_count));
 
-        let codec = IndexValuesCodec::from_tag_columns(metadata.primary_key_columns());
+        let codec = IndexValuesCodec::from_tag_columns(
+            metadata.primary_key_encoding,
+            metadata.primary_key_columns(),
+        );
         Self {
             codec,
             index_creator,

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -49,7 +49,7 @@ use crate::metrics::{
 };
 use crate::read::prune::{PruneReader, Source};
 use crate::read::{Batch, BatchReader};
-use crate::row_converter::DensePrimaryKeyCodec;
+use crate::row_converter::build_primary_key_codec;
 use crate::sst::file::FileHandle;
 use crate::sst::index::bloom_filter::applier::BloomFilterIndexApplierRef;
 use crate::sst::index::fulltext_index::applier::FulltextIndexApplierRef;
@@ -253,7 +253,7 @@ impl ParquetReaderBuilder {
             vec![]
         };
 
-        let codec = DensePrimaryKeyCodec::new(read_format.metadata());
+        let codec = build_primary_key_codec(read_format.metadata());
 
         let context = FileRangeContext::new(reader_builder, filters, read_format, codec);
 

--- a/src/mito2/src/test_util/memtable_util.rs
+++ b/src/mito2/src/test_util/memtable_util.rs
@@ -326,8 +326,8 @@ pub(crate) fn encode_keys(
 /// Encode one key.
 pub(crate) fn encode_key_by_kv(key_value: &KeyValue) -> Vec<u8> {
     let row_codec = DensePrimaryKeyCodec::with_fields(vec![
-        SortField::new(ConcreteDataType::string_datatype()),
-        SortField::new(ConcreteDataType::uint32_datatype()),
+        (0, SortField::new(ConcreteDataType::string_datatype())),
+        (1, SortField::new(ConcreteDataType::uint32_datatype())),
     ]);
     row_codec.encode(key_value.primary_keys()).unwrap()
 }

--- a/src/mito2/src/test_util/sst_util.rs
+++ b/src/mito2/src/test_util/sst_util.rs
@@ -85,7 +85,12 @@ pub fn sst_region_metadata() -> RegionMetadata {
 /// Encodes a primary key for specific tags.
 pub fn new_primary_key(tags: &[&str]) -> Vec<u8> {
     let fields = (0..tags.len())
-        .map(|_| SortField::new(ConcreteDataType::string_datatype()))
+        .map(|idx| {
+            (
+                idx as u32,
+                SortField::new(ConcreteDataType::string_datatype()),
+            )
+        })
         .collect();
     let converter = DensePrimaryKeyCodec::with_fields(fields);
     converter


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#5282 

## What's changed and what's your intention?

1. Replaced `DensePrimaryKeyCodec` with `Arc<dyn PrimaryKeyCodec>` to enable support for various primary key codec implementations.
2. Introduced `RewritePrimaryKey` to ensure backward compatibility.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
