### PR TITLE
chore: extract `service_name` in OTLP traces by default

### DIFF
--- a/src/servers/src/otlp/trace/span.rs
+++ b/src/servers/src/otlp/trace/span.rs
@@ -27,6 +27,7 @@ use crate::otlp::utils::bytes_to_hex_string;
 #[derive(Debug, Clone)]
 pub struct TraceSpan {
     // the following are tags
+    pub service_name: Option<String>,
     pub trace_id: String,
     pub span_id: String,
     pub parent_span_id: String,
@@ -189,6 +190,7 @@ impl SpanEvents {
 }
 
 pub fn parse_span(
+    service_name: Option<String>,
     resource_attrs: &[KeyValue],
     scope: &InstrumentationScope,
     span: Span,
@@ -196,6 +198,7 @@ pub fn parse_span(
     let (span_status_code, span_status_message) = status_to_string(&span.status);
     let span_kind = span.kind().as_str_name().into();
     TraceSpan {
+        service_name,
         trace_id: bytes_to_hex_string(&span.trace_id),
         span_id: bytes_to_hex_string(&span.span_id),
         parent_span_id: bytes_to_hex_string(&span.parent_span_id),

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -1713,7 +1713,7 @@ pub async fn test_otlp_traces(store_type: StorageType) {
     assert_eq!(StatusCode::OK, res.status());
 
     // select traces data
-    let expected = r#"[[1726631197820927000,1726631197821050000,123000,"b5e5fb572cf0a3335dd194a14145fef5","3364d2da58c9fd2b","","SPAN_KIND_CLIENT","lets-go","STATUS_CODE_UNSET","","",{"net.peer.ip":"1.2.3.4","peer.service":"telemetrygen-server"},[],[],"telemetrygen","",{},{"service.name":"telemetrygen"}],[1726631197820927000,1726631197821050000,123000,"b5e5fb572cf0a3335dd194a14145fef5","74c82efa6f628e80","3364d2da58c9fd2b","SPAN_KIND_SERVER","okey-dokey-0","STATUS_CODE_UNSET","","",{"net.peer.ip":"1.2.3.4","peer.service":"telemetrygen-client"},[],[],"telemetrygen","",{},{"service.name":"telemetrygen"}]]"#;
+    let expected = r#"[[1726631197820927000,1726631197821050000,123000,"telemetrygen","b5e5fb572cf0a3335dd194a14145fef5","3364d2da58c9fd2b","","SPAN_KIND_CLIENT","lets-go","STATUS_CODE_UNSET","","",{"net.peer.ip":"1.2.3.4","peer.service":"telemetrygen-server"},[],[],"telemetrygen","",{},{"service.name":"telemetrygen"}],[1726631197820927000,1726631197821050000,123000,"telemetrygen","b5e5fb572cf0a3335dd194a14145fef5","74c82efa6f628e80","3364d2da58c9fd2b","SPAN_KIND_SERVER","okey-dokey-0","STATUS_CODE_UNSET","","",{"net.peer.ip":"1.2.3.4","peer.service":"telemetrygen-client"},[],[],"telemetrygen","",{},{"service.name":"telemetrygen"}]]"#;
     validate_data(
         "otlp_traces",
         &client,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Although OTeL doesn't treat `service.name` differently, the popular GUI tool for displaying traces, [Jaeger](https://www.jaegertracing.io/), seems to have a dedicated API for querying all distinct service names. In that case, we need to extract the `service_name` in advance for indexing.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
