### PR TITLE
feat: Address different Metrics for Prometheus queries in the Dashboard and fix typo in metric name

### DIFF
--- a/grafana/greptimedb-cluster.json
+++ b/grafana/greptimedb-cluster.json
@@ -1761,12 +1761,25 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum (rate(greptime_servers_http_promql_elapsed_counte{pod=~\"$frontend\"}[$__rate_interval]))",
+          "expr": "sum (rate(greptime_servers_http_promql_elapsed_count{pod=~\"$frontend\"}[$__rate_interval]))",
           "hide": false,
           "instant": false,
-          "legendFormat": "promql",
+          "legendFormat": "promql-native",
           "range": true,
           "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum (rate(greptime_servers_http_prometheus_promql_elapsed_count{pod=~\"$frontend\"}[$__rate_interval]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "promql-compatible-api",
+          "range": true,
+          "refId": "D"
         }
       ],
       "title": "Queries",


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

- Fixed a typo in the metric name on the default Grafana dashboard to ensure correct display and querying.
- Added a new metric for the Prometheus-compatible API, as only the PromQL endpoint HTTP metric was previously shown. This enhancement provides better visibility and monitoring of the Prometheus-compatible API.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
