### PR TITLE
refactor: pull column filling logic out of mito worker loop

### DIFF
--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -416,7 +416,9 @@ impl EngineInner {
         region_id: RegionId,
         request: RegionRequest,
     ) -> Result<AffectedRows> {
-        let (request, receiver) = WorkerRequest::try_from_region_request(region_id, request)?;
+        let region_metadata = self.get_metadata(region_id).ok();
+        let (request, receiver) =
+            WorkerRequest::try_from_region_request(region_id, request, region_metadata)?;
         self.workers.submit_to_worker(region_id, request).await?;
 
         receiver.await.context(RecvSnafu)?

--- a/src/mito2/src/worker/handle_flush.rs
+++ b/src/mito2/src/worker/handle_flush.rs
@@ -230,13 +230,13 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         request.on_success();
 
         // Handle pending requests for the region.
-        if let Some((ddl_requests, write_requests)) =
+        if let Some((mut ddl_requests, mut write_requests)) =
             self.flush_scheduler.on_flush_success(region_id)
         {
             // Perform DDLs first because they require empty memtables.
-            self.handle_ddl_requests(ddl_requests).await;
+            self.handle_ddl_requests(&mut ddl_requests).await;
             // Handle pending write requests, we don't stall these requests.
-            self.handle_write_requests(write_requests, false).await;
+            self.handle_write_requests(&mut write_requests, false).await;
         }
 
         // Handle stalled requests.


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


As title says. Also with some other changes that reduce some overhead.

We can further pull more logic out of the worker, like primary key encoding or row to column conversion.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
