### PR TITLE
fix: no need for special case since datafusion updated

### DIFF
--- a/src/servers/src/postgres/fixtures.rs
+++ b/src/servers/src/postgres/fixtures.rs
@@ -115,11 +115,7 @@ pub(crate) fn process<'a>(query: &str, query_ctx: QueryContextRef) -> Option<Vec
     }
 }
 
-static LIMIT_CAST_PATTERN: Lazy<Regex> =
-    Lazy::new(|| Regex::new("(?i)(LIMIT\\s+\\d+)::bigint").unwrap());
 pub(crate) fn rewrite_sql(query: &str) -> Cow<'_, str> {
-    //TODO(sunng87): remove this when we upgraded datafusion to 43 or newer
-    let query = LIMIT_CAST_PATTERN.replace_all(query, "$1");
     // DBeaver tricky replacement for datafusion not support sql
     // TODO: add more here
     query

--- a/src/servers/src/postgres/fixtures.rs
+++ b/src/servers/src/postgres/fixtures.rs
@@ -214,11 +214,6 @@ mod test {
 
     #[test]
     fn test_rewrite() {
-        let sql = "SELECT * FROM number LIMIT 1::bigint";
-        let sql2 = "SELECT * FROM number limit      1::BIGINT";
-
-        assert_eq!("SELECT * FROM number LIMIT 1", rewrite_sql(sql));
-        assert_eq!("SELECT * FROM number limit      1", rewrite_sql(sql2));
         assert_eq!(
             "SELECT db.oid as _oid,db.* FROM pg_catalog.pg_database db",
             rewrite_sql("SELECT db.oid,db.* FROM pg_catalog.pg_database db")


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

since https://github.com/GreptimeTeam/greptimedb/pull/5417 had been merged the case is no longer needed.

just found by https://github.com/GreptimeTeam/greptimedb/pull/5448

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
