### PR TITLE
ci: move components to flakes so it won't affect builders

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,11 @@
           libgit2
           libz
         ];
-
+        lib = nixpkgs.lib;
+        rustToolchain = fenix.packages.${system}.fromToolchainName {
+          name = (lib.importTOML ./rust-toolchain.toml).toolchain.channel;
+          sha256 = "sha256-f/CVA1EC61EWbh0SjaRNhLL0Ypx2ObupbzigZp8NmL4=";
+        };
       in
       {
         devShells.default = pkgs.mkShell {
@@ -30,10 +34,15 @@
             protobuf
             gnumake
             mold
-            (fenix.packages.${system}.fromToolchainFile {
-              dir = ./.;
-              sha256 = "sha256-f/CVA1EC61EWbh0SjaRNhLL0Ypx2ObupbzigZp8NmL4=";
-            })
+            (rustToolchain.withComponents [
+              "cargo"
+              "clippy"
+              "rust-src"
+              "rustc"
+              "rustfmt"
+              "rust-analyzer"
+              "llvm-tools"
+            ])
             cargo-nextest
             cargo-llvm-cov
             taplo

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,7 @@
             cargo-llvm-cov
             taplo
             curl
+            gnuplot ## for cargo bench
           ];
 
           LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath buildInputs;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,2 @@
 [toolchain]
 channel = "nightly-2024-12-25"
-components = ["rust-analyzer", "llvm-tools"]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This change removes rust components from the toolchain file and add them to flake so the dev builders won't need to install components that required for dev and ci.  

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
