### PR TITLE
docs: fix memory perf command wrong

### DIFF
--- a/docs/how-to/how-to-profile-memory.md
+++ b/docs/how-to/how-to-profile-memory.md
@@ -23,7 +23,7 @@ curl https://raw.githubusercontent.com/brendangregg/FlameGraph/master/flamegraph
 Start GreptimeDB instance with environment variables:
 
 ```bash
-MALLOC_CONF=prof:true ./target/debug/greptime standalone start
+_RJEM_MALLOC_CONF=prof:true ./target/debug/greptime standalone start
 ```
 
 Dump memory profiling data through HTTP API:

--- a/docs/how-to/how-to-profile-memory.md
+++ b/docs/how-to/how-to-profile-memory.md
@@ -4,6 +4,16 @@ This crate provides an easy approach to dump memory profiling info.
 
 ## Prerequisites
 ### jemalloc
+jeprof is already compiled in the target directory of GreptimeDB. You can find the binary and use it.
+```
+# find jeprof binary
+find . -name 'jeprof'
+# add executable permission
+chmod +x <path_to_jeprof>
+```
+The path is usually under `./target/${PROFILE}/build/tikv-jemalloc-sys-${HASH}/out/build/bin/jeprof`.
+The default version of jemalloc installed from the package manager may not have the `--collapsed` option.
+You may need to check the whether the `jeprof` version is >= `5.3.0` if you want to install it from the package manager.
 ```bash
 # for macOS
 brew install jemalloc

--- a/docs/how-to/how-to-profile-memory.md
+++ b/docs/how-to/how-to-profile-memory.md
@@ -5,7 +5,7 @@ This crate provides an easy approach to dump memory profiling info.
 ## Prerequisites
 ### jemalloc
 ```bash
-# for macOS
+# for MacOS
 brew install jemalloc
 
 # for Ubuntu
@@ -22,6 +22,13 @@ curl https://raw.githubusercontent.com/brendangregg/FlameGraph/master/flamegraph
 
 Start GreptimeDB instance with environment variables:
 
+# for Linux
+
+```bash
+MALLOC_CONF=prof:true ./target/debug/greptime standalone start
+```
+
+# for MacOS
 ```bash
 _RJEM_MALLOC_CONF=prof:true ./target/debug/greptime standalone start
 ```

--- a/docs/how-to/how-to-profile-memory.md
+++ b/docs/how-to/how-to-profile-memory.md
@@ -5,7 +5,7 @@ This crate provides an easy approach to dump memory profiling info.
 ## Prerequisites
 ### jemalloc
 ```bash
-# for MacOS
+# for macOS
 brew install jemalloc
 
 # for Ubuntu
@@ -26,7 +26,7 @@ Start GreptimeDB instance with environment variables:
 # for Linux
 MALLOC_CONF=prof:true ./target/debug/greptime standalone start
 
-# for MacOS
+# for macOS
 _RJEM_MALLOC_CONF=prof:true ./target/debug/greptime standalone start
 ```
 

--- a/docs/how-to/how-to-profile-memory.md
+++ b/docs/how-to/how-to-profile-memory.md
@@ -22,14 +22,11 @@ curl https://raw.githubusercontent.com/brendangregg/FlameGraph/master/flamegraph
 
 Start GreptimeDB instance with environment variables:
 
-# for Linux
-
 ```bash
+# for Linux
 MALLOC_CONF=prof:true ./target/debug/greptime standalone start
-```
 
 # for MacOS
-```bash
 _RJEM_MALLOC_CONF=prof:true ./target/debug/greptime standalone start
 ```
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

for now the memory perf command using `tikv-jemallocator` had been changed
using the doc or blog way get error ` {"error":"Memory profiling is not enabled"}` and very hard to debug.
this patch fix it. about the `greptime blog` side I do not fix

more info:

- blog: https://magiroux.com/posts/rust-jemalloc-profiling
- issue: https://github.com/tikv/jemallocator/issues/65


## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
