### PR TITLE
refactor: otlp logs insertion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6608,17 +6608,18 @@ dependencies = [
 [[package]]
 name = "meter-core"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-meter.git?rev=a10facb353b41460eeb98578868ebf19c2084fac#a10facb353b41460eeb98578868ebf19c2084fac"
+source = "git+https://github.com/GreptimeTeam/greptime-meter.git?rev=5618e779cf2bb4755b499c630fba4c35e91898cb#5618e779cf2bb4755b499c630fba4c35e91898cb"
 dependencies = [
  "anymap2",
  "once_cell",
  "parking_lot 0.12.3",
+ "tracing",
 ]
 
 [[package]]
 name = "meter-macros"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-meter.git?rev=a10facb353b41460eeb98578868ebf19c2084fac#a10facb353b41460eeb98578868ebf19c2084fac"
+source = "git+https://github.com/GreptimeTeam/greptime-meter.git?rev=5618e779cf2bb4755b499c630fba4c35e91898cb#5618e779cf2bb4755b499c630fba4c35e91898cb"
 dependencies = [
  "meter-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,7 @@ jsonb = { git = "https://github.com/databendlabs/jsonb.git", rev = "8c8d2fc294a3
 lazy_static = "1.4"
 local-ip-address = "0.6"
 loki-api = { git = "https://github.com/shuiyisong/tracing-loki", branch = "chore/prost_version" }
-meter-core = { git = "https://github.com/GreptimeTeam/greptime-meter.git", rev = "a10facb353b41460eeb98578868ebf19c2084fac" }
+meter-core = { git = "https://github.com/GreptimeTeam/greptime-meter.git", rev = "5618e779cf2bb4755b499c630fba4c35e91898cb" }
 mockall = "0.11.4"
 moka = "0.12"
 nalgebra = "0.33"
@@ -283,7 +283,7 @@ pprof = { git = "https://github.com/GreptimeTeam/pprof-rs", rev = "1bd1e21" }
 
 [workspace.dependencies.meter-macros]
 git = "https://github.com/GreptimeTeam/greptime-meter.git"
-rev = "a10facb353b41460eeb98578868ebf19c2084fac"
+rev = "5618e779cf2bb4755b499c630fba4c35e91898cb"
 
 [profile.release]
 debug = 1

--- a/src/pipeline/src/etl.rs
+++ b/src/pipeline/src/etl.rs
@@ -312,6 +312,7 @@ pub(crate) fn find_key_index(intermediate_keys: &[String], key: &str, kind: &str
 }
 
 /// SelectInfo is used to store the selected keys from OpenTelemetry record attrs
+/// The key is used to uplift value from the attributes and serve as column name in the table
 #[derive(Default)]
 pub struct SelectInfo {
     pub keys: Vec<String>,

--- a/src/pipeline/src/etl/transform/transformer/greptime.rs
+++ b/src/pipeline/src/etl/transform/transformer/greptime.rs
@@ -246,7 +246,7 @@ pub struct SchemaInfo {
 }
 
 impl SchemaInfo {
-    pub fn new_with_capacity(capacity: usize) -> Self {
+    pub fn with_capacity(capacity: usize) -> Self {
         Self {
             schema: Vec::with_capacity(capacity),
             index: HashMap::with_capacity(capacity),

--- a/src/pipeline/src/etl/transform/transformer/greptime.rs
+++ b/src/pipeline/src/etl/transform/transformer/greptime.rs
@@ -17,7 +17,7 @@ pub mod coerce;
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use ahash::HashMap;
+use ahash::{HashMap, HashMapExt};
 use api::helper::proto_value_type;
 use api::v1::column_data_type_extension::TypeExt;
 use api::v1::value::ValueData;
@@ -243,6 +243,15 @@ pub struct SchemaInfo {
     pub schema: Vec<ColumnSchema>,
     /// index of the column name
     pub index: HashMap<String, usize>,
+}
+
+impl SchemaInfo {
+    pub fn new_with_capacity(capacity: usize) -> Self {
+        Self {
+            schema: Vec::with_capacity(capacity),
+            index: HashMap::with_capacity(capacity),
+        }
+    }
 }
 
 fn resolve_schema(

--- a/src/servers/src/http/loki.rs
+++ b/src/servers/src/http/loki.rs
@@ -103,11 +103,7 @@ pub async fn loki_ingest(
 
     // fill Null for missing values
     for row in rows.iter_mut() {
-        if row.len() < schemas.len() {
-            for _ in row.len()..schemas.len() {
-                row.push(GreptimeValue { value_data: None });
-            }
-        }
+        row.resize(schemas.len(), GreptimeValue::default());
     }
 
     let rows = Rows {

--- a/src/servers/src/http/otlp.rs
+++ b/src/servers/src/http/otlp.rs
@@ -38,6 +38,7 @@ use snafu::prelude::*;
 use super::header::{write_cost_header_map, CONTENT_TYPE_PROTOBUF};
 use crate::error::{self, PipelineSnafu, Result};
 use crate::http::extractor::{LogTableName, PipelineInfo, SelectInfoWrapper, TraceTableName};
+use crate::metrics::METRIC_HTTP_OPENTELEMETRY_LOGS_ELAPSED;
 use crate::otlp::trace::TRACE_TABLE_NAME;
 use crate::query_handler::OpenTelemetryProtocolHandlerRef;
 
@@ -112,7 +113,7 @@ pub async fn logs(
     let db = query_ctx.get_db_string();
     query_ctx.set_channel(Channel::Otlp);
     let query_ctx = Arc::new(query_ctx);
-    let _timer = crate::metrics::METRIC_HTTP_OPENTELEMETRY_LOGS_ELAPSED
+    let _timer = METRIC_HTTP_OPENTELEMETRY_LOGS_ELAPSED
         .with_label_values(&[db.as_str()])
         .start_timer();
     let request = ExportLogsServiceRequest::decode(bytes).context(error::DecodeOtlpRequestSnafu)?;

--- a/src/servers/src/otlp/logs.rs
+++ b/src/servers/src/otlp/logs.rs
@@ -376,7 +376,7 @@ fn extract_field_from_attr_and_combine_schema(
     attrs: &jsonb::Value,
 ) -> Result<Vec<GreptimeValue>> {
     // note we use schema.len instead of select_keys.len
-    // becasue the len of the row value should always matches the len of the schema
+    // because the len of the row value should always matches the len of the schema
     let mut extracted_values = vec![GreptimeValue::default(); select_schema.schema.len()];
 
     for key in select_info.keys.iter() {

--- a/src/servers/src/otlp/logs.rs
+++ b/src/servers/src/otlp/logs.rs
@@ -393,7 +393,7 @@ fn extract_field_from_attr_and_combine_schema(
             ensure!(
                 column_schema.datatype == schema.datatype,
                 IncompatibleSchemaSnafu {
-                    column_name: key.clone(),
+                    column_name: key,
                     datatype: column_schema.datatype().as_str_name(),
                     expected: column_schema.datatype,
                     actual: schema.datatype,
@@ -401,11 +401,10 @@ fn extract_field_from_attr_and_combine_schema(
             );
             extracted_values[*index] = value;
         } else {
-            let key = key.clone();
             select_schema.schema.push(schema);
             select_schema
                 .index
-                .insert(key, select_schema.schema.len() - 1);
+                .insert(key.clone(), select_schema.schema.len() - 1);
             extracted_values.push(value);
         }
     }

--- a/src/servers/src/otlp/logs.rs
+++ b/src/servers/src/otlp/logs.rs
@@ -486,12 +486,10 @@ fn parse_export_logs_service_request_to_rows(
     let mut parse_ctx = ParseContext::new(select_info);
     let mut rows = parse_resource(&mut parse_ctx, request.resource_logs)?;
 
-    let extra_schema_len = parse_ctx.select_schema.schema.len();
     schemas.extend(parse_ctx.select_schema.schema);
 
     rows.iter_mut().for_each(|row| {
-        row.values
-            .resize(extra_schema_len, GreptimeValue::default());
+        row.values.resize(schemas.len(), GreptimeValue::default());
     });
 
     Ok(Rows {

--- a/src/servers/src/otlp/logs.rs
+++ b/src/servers/src/otlp/logs.rs
@@ -383,7 +383,7 @@ fn extract_field_from_attr_and_combine_schema(
         let Some(value) = attrs.get_by_name_ignore_case(key).cloned() else {
             continue;
         };
-        let Some((schema, value)) = decide_column_schema(key, value)? else {
+        let Some((schema, value)) = decide_column_schema_and_convert_value(key, value)? else {
             continue;
         };
 
@@ -413,7 +413,7 @@ fn extract_field_from_attr_and_combine_schema(
     Ok(extracted_values)
 }
 
-fn decide_column_schema(
+fn decide_column_schema_and_convert_value(
     column_name: &str,
     value: JsonbValue,
 ) -> Result<Option<(ColumnSchema, GreptimeValue)>> {

--- a/src/servers/src/otlp/logs.rs
+++ b/src/servers/src/otlp/logs.rs
@@ -621,8 +621,8 @@ fn parse_log(log_records: Vec<LogRecord>, parse_ctx: &mut ParseContext) -> Resul
 
 fn merge_values(
     log: Vec<GreptimeValue>,
-    scope: &Vec<GreptimeValue>,
-    resource: &Vec<GreptimeValue>,
+    scope: &[GreptimeValue],
+    resource: &[GreptimeValue],
 ) -> Vec<GreptimeValue> {
     log.into_iter()
         .enumerate()

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -1970,7 +1970,7 @@ pub async fn test_otlp_logs(store_type: StorageType) {
     }
 
     {
-        // test selector with same key
+        // test same selector with multiple value
         let content = r#"
         {"resourceLogs":[{"resource":{"attributes":[{"key":"fromwhere","value":{"stringValue":"resource"}}],"droppedAttributesCount":0},"scopeLogs":[{"scope":{"name":"","version":"","attributes":[{"key":"fromwhere","value":{"stringValue":"scope"}}],"droppedAttributesCount":0},"logRecords":[{"timeUnixNano":"1736413568497632000","observedTimeUnixNano":"0","severityNumber":9,"severityText":"Info","body":{"stringValue":"the message line one"},"attributes":[{"key":"app","value":{"stringValue":"server"}},{"key":"fromwhere","value":{"stringValue":"log_attr"}}],"droppedAttributesCount":0,"flags":0,"traceId":"f665100a612542b69cc362fe2ae9d3bf","spanId":"e58f01c4c69f4488"}],"schemaUrl":""}],"schemaUrl":"https://opentelemetry.io/schemas/1.4.0"}]}
         "#;
@@ -2001,7 +2001,7 @@ pub async fn test_otlp_logs(store_type: StorageType) {
 
         let expected = "[[1736413568497632000,\"f665100a612542b69cc362fe2ae9d3bf\",\"e58f01c4c69f4488\",\"Info\",9,\"the message line one\",{\"app\":\"server\",\"fromwhere\":\"log_attr\"},0,\"\",\"\",{\"fromwhere\":\"scope\"},\"\",{\"fromwhere\":\"resource\"},\"https://opentelemetry.io/schemas/1.4.0\",\"log_attr\"]]";
         validate_data(
-            "otlp_logs_with_same_selector",
+            "otlp_logs_with_selector_overlapping",
             &client,
             "select * from logs2;",
             expected,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR refactors the write path of OTLP Logs insertion. The main change is to eliminate the following three schemas and use one single `SchemaInfo`.
```Rust
let mut extra_resource_schema = SchemaInfo::default();
let mut extra_log_schema = SchemaInfo::default();
let mut extra_scope_schema = SchemaInfo::default();
```

The OTLP Logs request itself has 3 ordered layers: resource, scope, and log, and each has its own attributes. The attributes are stored using JSON datatype. However, we enable users to set `select keys` to find values in the attributes and uplift the values to the top level, which is an independent column, to speed up queries.

The original implementation uses three different `SchemaInfo` to store each layer's schema change and merge them in the end. If the select key appears in the multiple layers, say both resource and scope, it actually overrides the former one. Therefore we can use one single `SchemaInfo` to record the global extra schema information and perform an override in place if needed.

The second change is to build and return a `Row` structure in the `parse_log` function instead of returning an intermediate  `ParseInfo`. In the `parse_log` we actually have all we need to build a `Row`.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
