### PR TITLE
fix: unquote flow_name in create flow expr

### DIFF
--- a/src/operator/src/error.rs
+++ b/src/operator/src/error.rs
@@ -704,6 +704,13 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display("Invalid flow name: {name}"))]
+    InvalidFlowName {
+        name: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Empty {} expr", name))]
     EmptyDdlExpr {
         name: String,
@@ -821,6 +828,7 @@ impl ErrorExt for Error {
             | Error::UnsupportedRegionRequest { .. }
             | Error::InvalidTableName { .. }
             | Error::InvalidViewName { .. }
+            | Error::InvalidFlowName { .. }
             | Error::InvalidView { .. }
             | Error::InvalidExpr { .. }
             | Error::AdminFunctionNotFound { .. }

--- a/src/operator/src/expr_factory.rs
+++ b/src/operator/src/expr_factory.rs
@@ -745,17 +745,15 @@ pub fn to_create_flow_task_expr(
 }
 
 /// sanitize the flow name, remove possible quotes
-fn sanitize_flow_name(flow_name: ObjectName) -> Result<String> {
-    if flow_name.0.len() != 1 {
-        return InvalidFlowNameSnafu {
+fn sanitize_flow_name(mut flow_name: ObjectName) -> Result<String> {
+    ensure!(
+        flow_name.0.len() == 1,
+        InvalidFlowNameSnafu {
             name: flow_name.to_string(),
         }
-        .fail();
-    }
-    let ident = flow_name.0.first().context(InvalidFlowNameSnafu {
-        name: flow_name.to_string(),
-    })?;
-    Ok(ident.value.clone())
+    );
+    // safety: we've checked flow_name.0 has exactly one element.
+    Ok(flow_name.0.swap_remove(0).value)
 }
 
 #[cfg(test)]

--- a/src/operator/src/expr_factory.rs
+++ b/src/operator/src/expr_factory.rs
@@ -38,7 +38,7 @@ use query::sql::{
 use session::context::QueryContextRef;
 use session::table_name::table_idents_to_full_name;
 use snafu::{ensure, OptionExt, ResultExt};
-use sql::ast::ColumnOption;
+use sql::ast::{ColumnOption, ObjectName};
 use sql::statements::alter::{
     AlterDatabase, AlterDatabaseOperation, AlterTable, AlterTableOperation,
 };
@@ -55,8 +55,9 @@ use table::table_reference::TableReference;
 use crate::error::{
     BuildCreateExprOnInsertionSnafu, ColumnDataTypeSnafu, ConvertColumnDefaultConstraintSnafu,
     ConvertIdentifierSnafu, EncodeJsonSnafu, ExternalSnafu, IllegalPrimaryKeysDefSnafu,
-    InferFileTableSchemaSnafu, InvalidSqlSnafu, NotSupportedSnafu, ParseSqlSnafu,
-    PrepareFileTableSnafu, Result, SchemaIncompatibleSnafu, UnrecognizedTableOptionSnafu,
+    InferFileTableSchemaSnafu, InvalidFlowNameSnafu, InvalidSqlSnafu, NotSupportedSnafu,
+    ParseSqlSnafu, PrepareFileTableSnafu, Result, SchemaIncompatibleSnafu,
+    UnrecognizedTableOptionSnafu,
 };
 
 #[derive(Debug, Copy, Clone)]
@@ -731,7 +732,7 @@ pub fn to_create_flow_task_expr(
 
     Ok(CreateFlowExpr {
         catalog_name: query_ctx.current_catalog().to_string(),
-        flow_name: create_flow.flow_name.to_string(),
+        flow_name: sanitize_flow_name(create_flow.flow_name)?,
         source_table_names,
         sink_table_name: Some(sink_table_name),
         or_replace: create_flow.or_replace,
@@ -741,6 +742,14 @@ pub fn to_create_flow_task_expr(
         sql: create_flow.query.to_string(),
         flow_options: HashMap::new(),
     })
+}
+
+/// sanitize the flow name, remove possible quotes
+fn sanitize_flow_name(flow_name: ObjectName) -> Result<String> {
+    let ident = flow_name.0.first().context(InvalidFlowNameSnafu {
+        name: flow_name.to_string(),
+    })?;
+    Ok(ident.value.clone())
 }
 
 #[cfg(test)]
@@ -754,6 +763,40 @@ mod tests {
     use store_api::storage::ColumnDefaultConstraint;
 
     use super::*;
+
+    #[test]
+    fn test_create_flow_expr() {
+        let sql = r"
+CREATE FLOW `task_2`
+SINK TO schema_1.table_1
+AS
+SELECT max(c1), min(c2) FROM schema_2.table_2;";
+        let stmt =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap()
+                .pop()
+                .unwrap();
+
+        let Statement::CreateFlow(create_flow) = stmt else {
+            unreachable!()
+        };
+        let expr = to_create_flow_task_expr(create_flow, &QueryContext::arc()).unwrap();
+
+        let to_dot_sep =
+            |c: TableName| format!("{}.{}.{}", c.catalog_name, c.schema_name, c.table_name);
+        assert_eq!("task_2", expr.flow_name);
+        assert_eq!("greptime", expr.catalog_name);
+        assert_eq!(
+            "greptime.schema_1.table_1",
+            expr.sink_table_name.map(to_dot_sep).unwrap()
+        );
+        assert_eq!(1, expr.source_table_names.len());
+        assert_eq!(
+            "greptime.schema_2.table_2",
+            to_dot_sep(expr.source_table_names[0].clone())
+        );
+        assert_eq!("SELECT max(c1), min(c2) FROM schema_2.table_2", expr.sql);
+    }
 
     #[test]
     fn test_create_to_expr() {

--- a/src/sql/src/parsers/create_parser.rs
+++ b/src/sql/src/parsers/create_parser.rs
@@ -1306,7 +1306,7 @@ SELECT max(c1), min(c2) FROM schema_2.table_2;";
 
         // create flow without `OR REPLACE`, `IF NOT EXISTS`, `EXPIRE AFTER` and `COMMENT`
         let sql = r"
-CREATE FLOW task_2
+CREATE FLOW `task_2`
 SINK TO schema_1.table_1
 AS
 SELECT max(c1), min(c2) FROM schema_2.table_2;";
@@ -1322,6 +1322,7 @@ SELECT max(c1), min(c2) FROM schema_2.table_2;";
         assert!(!create_task.if_not_exists);
         assert!(create_task.expire_after.is_none());
         assert!(create_task.comment.is_none());
+        assert_eq!(create_task.flow_name.to_string(), "`task_2`");
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

fix and tested, flow name with quote will now be sanitize as normal

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
	- Enhanced flow name validation now supports legacy formats while providing clearer, user-friendly error feedback.
	- Flow creation has been improved through consistent sanitization of names (removing unwanted quotes and ensuring proper quoting) and case-insensitive keyword handling in SQL statements.
- Tests
	- Introduced new tests to verify robust flow name validation, sanitization, and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->