### PR TITLE
feat: support server-side keep-alive for mysql and pg protocols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10415,6 +10415,7 @@ dependencies = [
  "session",
  "snafu 0.8.5",
  "snap",
+ "socket2",
  "sql",
  "store-api",
  "strum 0.25.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,6 @@ shadow-rs = "0.38"
 similar-asserts = "1.6.0"
 smallvec = { version = "1", features = ["serde"] }
 snafu = "0.8"
-socket2 = "0.5"
 sysinfo = "0.30"
 # on branch v0.52.x
 sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "71dd86058d2af97b9925093d40c4e03360403170", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,7 @@ shadow-rs = "0.38"
 similar-asserts = "1.6.0"
 smallvec = { version = "1", features = ["serde"] }
 snafu = "0.8"
+socket2 = "0.5"
 sysinfo = "0.30"
 # on branch v0.52.x
 sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "71dd86058d2af97b9925093d40c4e03360403170", features = [

--- a/config/config.md
+++ b/config/config.md
@@ -40,6 +40,7 @@
 | `mysql.enable` | Bool | `true` | Whether to enable. |
 | `mysql.addr` | String | `127.0.0.1:4002` | The addr to bind the MySQL server. |
 | `mysql.runtime_size` | Integer | `2` | The number of server worker threads. |
+| `mysql.keep_alive_secs` | Integer | `0` | Server-side keep-alive time in seconds.<br/>Set to 0 (default) to disable. |
 | `mysql.tls` | -- | -- | -- |
 | `mysql.tls.mode` | String | `disable` | TLS mode, refer to https://www.postgresql.org/docs/current/libpq-ssl.html<br/>- `disable` (default value)<br/>- `prefer`<br/>- `require`<br/>- `verify-ca`<br/>- `verify-full` |
 | `mysql.tls.cert_path` | String | Unset | Certificate file path. |
@@ -49,6 +50,7 @@
 | `postgres.enable` | Bool | `true` | Whether to enable |
 | `postgres.addr` | String | `127.0.0.1:4003` | The addr to bind the PostgresSQL server. |
 | `postgres.runtime_size` | Integer | `2` | The number of server worker threads. |
+| `postgres.keep_alive_secs` | Integer | `0` | Server-side keep-alive time in seconds.<br/>Set to 0 (default) to disable. |
 | `postgres.tls` | -- | -- | PostgresSQL server TLS options, see `mysql.tls` section. |
 | `postgres.tls.mode` | String | `disable` | TLS mode. |
 | `postgres.tls.cert_path` | String | Unset | Certificate file path. |

--- a/config/config.md
+++ b/config/config.md
@@ -40,7 +40,7 @@
 | `mysql.enable` | Bool | `true` | Whether to enable. |
 | `mysql.addr` | String | `127.0.0.1:4002` | The addr to bind the MySQL server. |
 | `mysql.runtime_size` | Integer | `2` | The number of server worker threads. |
-| `mysql.keep_alive_secs` | Integer | `0` | Server-side keep-alive time in seconds.<br/>Set to 0 (default) to disable. |
+| `mysql.keep_alive` | String | `0s` | Server-side keep-alive time.<br/>Set to 0 (default) to disable. |
 | `mysql.tls` | -- | -- | -- |
 | `mysql.tls.mode` | String | `disable` | TLS mode, refer to https://www.postgresql.org/docs/current/libpq-ssl.html<br/>- `disable` (default value)<br/>- `prefer`<br/>- `require`<br/>- `verify-ca`<br/>- `verify-full` |
 | `mysql.tls.cert_path` | String | Unset | Certificate file path. |
@@ -50,7 +50,7 @@
 | `postgres.enable` | Bool | `true` | Whether to enable |
 | `postgres.addr` | String | `127.0.0.1:4003` | The addr to bind the PostgresSQL server. |
 | `postgres.runtime_size` | Integer | `2` | The number of server worker threads. |
-| `postgres.keep_alive_secs` | Integer | `0` | Server-side keep-alive time in seconds.<br/>Set to 0 (default) to disable. |
+| `postgres.keep_alive` | String | `0s` | Server-side keep-alive time.<br/>Set to 0 (default) to disable. |
 | `postgres.tls` | -- | -- | PostgresSQL server TLS options, see `mysql.tls` section. |
 | `postgres.tls.mode` | String | `disable` | TLS mode. |
 | `postgres.tls.cert_path` | String | Unset | Certificate file path. |
@@ -236,7 +236,7 @@
 | `mysql.enable` | Bool | `true` | Whether to enable. |
 | `mysql.addr` | String | `127.0.0.1:4002` | The addr to bind the MySQL server. |
 | `mysql.runtime_size` | Integer | `2` | The number of server worker threads. |
-| `mysql.keep_alive_secs` | Integer | `0` | Server-side keep-alive time in seconds.<br/>Set to 0 (default) to disable. |
+| `mysql.keep_alive` | String | `0s` | Server-side keep-alive time.<br/>Set to 0 (default) to disable. |
 | `mysql.tls` | -- | -- | -- |
 | `mysql.tls.mode` | String | `disable` | TLS mode, refer to https://www.postgresql.org/docs/current/libpq-ssl.html<br/>- `disable` (default value)<br/>- `prefer`<br/>- `require`<br/>- `verify-ca`<br/>- `verify-full` |
 | `mysql.tls.cert_path` | String | Unset | Certificate file path. |
@@ -246,7 +246,7 @@
 | `postgres.enable` | Bool | `true` | Whether to enable |
 | `postgres.addr` | String | `127.0.0.1:4003` | The addr to bind the PostgresSQL server. |
 | `postgres.runtime_size` | Integer | `2` | The number of server worker threads. |
-| `postgres.keep_alive_secs` | Integer | `0` | Server-side keep-alive time in seconds.<br/>Set to 0 (default) to disable. |
+| `postgres.keep_alive` | String | `0s` | Server-side keep-alive time.<br/>Set to 0 (default) to disable. |
 | `postgres.tls` | -- | -- | PostgresSQL server TLS options, see `mysql.tls` section. |
 | `postgres.tls.mode` | String | `disable` | TLS mode. |
 | `postgres.tls.cert_path` | String | Unset | Certificate file path. |

--- a/config/config.md
+++ b/config/config.md
@@ -234,6 +234,7 @@
 | `mysql.enable` | Bool | `true` | Whether to enable. |
 | `mysql.addr` | String | `127.0.0.1:4002` | The addr to bind the MySQL server. |
 | `mysql.runtime_size` | Integer | `2` | The number of server worker threads. |
+| `mysql.keep_alive_secs` | Integer | `0` | Server-side keep-alive time in seconds.<br/>Set to 0 (default) to disable. |
 | `mysql.tls` | -- | -- | -- |
 | `mysql.tls.mode` | String | `disable` | TLS mode, refer to https://www.postgresql.org/docs/current/libpq-ssl.html<br/>- `disable` (default value)<br/>- `prefer`<br/>- `require`<br/>- `verify-ca`<br/>- `verify-full` |
 | `mysql.tls.cert_path` | String | Unset | Certificate file path. |
@@ -243,6 +244,7 @@
 | `postgres.enable` | Bool | `true` | Whether to enable |
 | `postgres.addr` | String | `127.0.0.1:4003` | The addr to bind the PostgresSQL server. |
 | `postgres.runtime_size` | Integer | `2` | The number of server worker threads. |
+| `postgres.keep_alive_secs` | Integer | `0` | Server-side keep-alive time in seconds.<br/>Set to 0 (default) to disable. |
 | `postgres.tls` | -- | -- | PostgresSQL server TLS options, see `mysql.tls` section. |
 | `postgres.tls.mode` | String | `disable` | TLS mode. |
 | `postgres.tls.cert_path` | String | Unset | Certificate file path. |

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -74,9 +74,9 @@ enable = true
 addr = "127.0.0.1:4002"
 ## The number of server worker threads.
 runtime_size = 2
-## Server-side keep-alive time in seconds.
+## Server-side keep-alive time.
 ## Set to 0 (default) to disable.
-keep_alive_secs = 0
+keep_alive = "0s"
 
 # MySQL server TLS options.
 [mysql.tls]
@@ -108,9 +108,9 @@ enable = true
 addr = "127.0.0.1:4003"
 ## The number of server worker threads.
 runtime_size = 2
-## Server-side keep-alive time in seconds.
+## Server-side keep-alive time.
 ## Set to 0 (default) to disable.
-keep_alive_secs = 0
+keep_alive = "0s"
 
 ## PostgresSQL server TLS options, see `mysql.tls` section.
 [postgres.tls]

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -74,6 +74,9 @@ enable = true
 addr = "127.0.0.1:4002"
 ## The number of server worker threads.
 runtime_size = 2
+## Server-side keep-alive time in seconds.
+## Set to 0 (default) to disable.
+keep_alive_secs = 0
 
 # MySQL server TLS options.
 [mysql.tls]
@@ -105,6 +108,9 @@ enable = true
 addr = "127.0.0.1:4003"
 ## The number of server worker threads.
 runtime_size = 2
+## Server-side keep-alive time in seconds.
+## Set to 0 (default) to disable.
+keep_alive_secs = 0
 
 ## PostgresSQL server TLS options, see `mysql.tls` section.
 [postgres.tls]

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -78,9 +78,9 @@ enable = true
 addr = "127.0.0.1:4002"
 ## The number of server worker threads.
 runtime_size = 2
-## Server-side keep-alive time in seconds.
+## Server-side keep-alive time.
 ## Set to 0 (default) to disable.
-keep_alive_secs = 0
+keep_alive = "0s"
 
 # MySQL server TLS options.
 [mysql.tls]
@@ -112,9 +112,9 @@ enable = true
 addr = "127.0.0.1:4003"
 ## The number of server worker threads.
 runtime_size = 2
-## Server-side keep-alive time in seconds.
+## Server-side keep-alive time.
 ## Set to 0 (default) to disable.
-keep_alive_secs = 0
+keep_alive = "0s"
 
 ## PostgresSQL server TLS options, see `mysql.tls` section.
 [postgres.tls]

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -78,6 +78,9 @@ enable = true
 addr = "127.0.0.1:4002"
 ## The number of server worker threads.
 runtime_size = 2
+## Server-side keep-alive time in seconds.
+## Set to 0 (default) to disable.
+keep_alive_secs = 0
 
 # MySQL server TLS options.
 [mysql.tls]
@@ -109,6 +112,9 @@ enable = true
 addr = "127.0.0.1:4003"
 ## The number of server worker threads.
 runtime_size = 2
+## Server-side keep-alive time in seconds.
+## Set to 0 (default) to disable.
+keep_alive_secs = 0
 
 ## PostgresSQL server TLS options, see `mysql.tls` section.
 [postgres.tls]

--- a/src/frontend/src/server.rs
+++ b/src/frontend/src/server.rs
@@ -227,7 +227,7 @@ where
                 Arc::new(MysqlSpawnConfig::new(
                     opts.tls.should_force_tls(),
                     tls_server_config,
-                    opts.keep_alive_secs,
+                    opts.keep_alive.as_secs(),
                     opts.reject_no_database.unwrap_or(false),
                 )),
             );
@@ -249,7 +249,7 @@ where
                 ServerSqlQueryHandlerAdapter::arc(instance.clone()),
                 opts.tls.should_force_tls(),
                 tls_server_config,
-                opts.keep_alive_secs,
+                opts.keep_alive.as_secs(),
                 common_runtime::global_runtime(),
                 user_provider.clone(),
             )) as Box<dyn Server>;

--- a/src/frontend/src/server.rs
+++ b/src/frontend/src/server.rs
@@ -227,6 +227,7 @@ where
                 Arc::new(MysqlSpawnConfig::new(
                     opts.tls.should_force_tls(),
                     tls_server_config,
+                    opts.keep_alive_secs,
                     opts.reject_no_database.unwrap_or(false),
                 )),
             );
@@ -248,6 +249,7 @@ where
                 ServerSqlQueryHandlerAdapter::arc(instance.clone()),
                 opts.tls.should_force_tls(),
                 tls_server_config,
+                opts.keep_alive_secs,
                 common_runtime::global_runtime(),
                 user_provider.clone(),
             )) as Box<dyn Server>;

--- a/src/frontend/src/service_config/mysql.rs
+++ b/src/frontend/src/service_config/mysql.rs
@@ -23,11 +23,12 @@ pub struct MysqlOptions {
     #[serde(default = "Default::default")]
     pub tls: TlsOption,
     pub reject_no_database: Option<bool>,
-    /// Server-side keep-alive time in seconds.
+    /// Server-side keep-alive time.
     ///
     /// Set to 0 (default) to disable.
     #[serde(default = "Default::default")]
-    pub keep_alive_secs: u64,
+    #[serde(with = "humantime_serde")]
+    pub keep_alive: std::time::Duration,
 }
 
 impl Default for MysqlOptions {
@@ -38,7 +39,7 @@ impl Default for MysqlOptions {
             runtime_size: 2,
             tls: TlsOption::default(),
             reject_no_database: None,
-            keep_alive_secs: 0,
+            keep_alive: std::time::Duration::from_secs(0),
         }
     }
 }

--- a/src/frontend/src/service_config/mysql.rs
+++ b/src/frontend/src/service_config/mysql.rs
@@ -23,6 +23,11 @@ pub struct MysqlOptions {
     #[serde(default = "Default::default")]
     pub tls: TlsOption,
     pub reject_no_database: Option<bool>,
+    /// Server-side keep-alive time in seconds.
+    ///
+    /// Set to 0 (default) to disable.
+    #[serde(default = "Default::default")]
+    pub keep_alive_secs: u64,
 }
 
 impl Default for MysqlOptions {
@@ -33,6 +38,7 @@ impl Default for MysqlOptions {
             runtime_size: 2,
             tls: TlsOption::default(),
             reject_no_database: None,
+            keep_alive_secs: 0,
         }
     }
 }

--- a/src/frontend/src/service_config/postgres.rs
+++ b/src/frontend/src/service_config/postgres.rs
@@ -22,6 +22,11 @@ pub struct PostgresOptions {
     pub runtime_size: usize,
     #[serde(default = "Default::default")]
     pub tls: TlsOption,
+    /// Server-side keep-alive time in seconds.
+    ///
+    /// Set to 0 (default) to disable.
+    #[serde(default = "Default::default")]
+    pub keep_alive_secs: u64,
 }
 
 impl Default for PostgresOptions {
@@ -31,6 +36,7 @@ impl Default for PostgresOptions {
             addr: "127.0.0.1:4003".to_string(),
             runtime_size: 2,
             tls: Default::default(),
+            keep_alive_secs: 0,
         }
     }
 }

--- a/src/frontend/src/service_config/postgres.rs
+++ b/src/frontend/src/service_config/postgres.rs
@@ -22,11 +22,12 @@ pub struct PostgresOptions {
     pub runtime_size: usize,
     #[serde(default = "Default::default")]
     pub tls: TlsOption,
-    /// Server-side keep-alive time in seconds.
+    /// Server-side keep-alive time.
     ///
     /// Set to 0 (default) to disable.
     #[serde(default = "Default::default")]
-    pub keep_alive_secs: u64,
+    #[serde(with = "humantime_serde")]
+    pub keep_alive: std::time::Duration,
 }
 
 impl Default for PostgresOptions {
@@ -36,7 +37,7 @@ impl Default for PostgresOptions {
             addr: "127.0.0.1:4003".to_string(),
             runtime_size: 2,
             tls: Default::default(),
-            keep_alive_secs: 0,
+            keep_alive: std::time::Duration::from_secs(0),
         }
     }
 }

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -76,6 +76,7 @@ notify.workspace = true
 object-pool = "0.5"
 once_cell.workspace = true
 openmetrics-parser = "0.4"
+socket2.workspace = true
 # use crates.io version after current revision is merged in next release
 # opensrv-mysql = "0.7.0"
 opensrv-mysql = { git = "https://github.com/datafuselabs/opensrv", rev = "6bbc3b65e6b19212c4f7fc4f40c20daf6f452deb" }

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -76,7 +76,7 @@ notify.workspace = true
 object-pool = "0.5"
 once_cell.workspace = true
 openmetrics-parser = "0.4"
-socket2.workspace = true
+socket2 = "0.5"
 # use crates.io version after current revision is merged in next release
 # opensrv-mysql = "0.7.0"
 opensrv-mysql = { git = "https://github.com/datafuselabs/opensrv", rev = "6bbc3b65e6b19212c4f7fc4f40c20daf6f452deb" }

--- a/src/servers/tests/mysql/mysql_server_test.rs
+++ b/src/servers/tests/mysql/mysql_server_test.rs
@@ -71,6 +71,7 @@ fn create_mysql_server(table: TableRef, opts: MysqlOpts<'_>) -> Result<Box<dyn S
         Arc::new(MysqlSpawnConfig::new(
             opts.tls.should_force_tls(),
             tls_server_config,
+            0,
             opts.reject_no_database,
         )),
     ))

--- a/src/servers/tests/postgres/mod.rs
+++ b/src/servers/tests/postgres/mod.rs
@@ -69,6 +69,7 @@ fn create_postgres_server(
         instance,
         tls.should_force_tls(),
         tls_server_config,
+        0,
         io_runtime,
         user_provider,
     )))

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -589,6 +589,7 @@ pub async fn setup_mysql_server_with_user_provider(
                 ReloadableTlsServerConfig::try_new(opts.tls.clone())
                     .expect("Failed to load certificates and keys"),
             ),
+            0,
             opts.reject_no_database.unwrap_or(false),
         )),
     ));
@@ -641,6 +642,7 @@ pub async fn setup_pg_server_with_user_provider(
         ServerSqlQueryHandlerAdapter::arc(fe_instance_ref),
         opts.tls.should_force_tls(),
         tls_server_config,
+        0,
         runtime,
         user_provider,
     )) as Box<dyn Server>);

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -922,7 +922,7 @@ watch = false
 enable = true
 addr = "127.0.0.1:4002"
 runtime_size = 2
-keep_alive_secs = 0
+keep_alive = "0s"
 
 [mysql.tls]
 mode = "disable"
@@ -934,7 +934,7 @@ watch = false
 enable = true
 addr = "127.0.0.1:4003"
 runtime_size = 2
-keep_alive_secs = 0
+keep_alive = "0s"
 
 [postgres.tls]
 mode = "disable"

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -922,6 +922,7 @@ watch = false
 enable = true
 addr = "127.0.0.1:4002"
 runtime_size = 2
+keep_alive_secs = 0
 
 [mysql.tls]
 mode = "disable"
@@ -933,6 +934,7 @@ watch = false
 enable = true
 addr = "127.0.0.1:4003"
 runtime_size = 2
+keep_alive_secs = 0
 
 [postgres.tls]
 mode = "disable"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/5493

## What's changed and what's your intention?


Add a new option `keep_alive_secs` to MySQL and PostgreSQL protocol for server-side keep-alive. Similar to `tcp_keepalives_idle` and `tcp_keepalives_interval` in PostgreSQL server.

Verified by `tcpdump`:

<img width="1170" alt="image" src="https://github.com/user-attachments/assets/10b58f16-d89c-444e-892e-5d22bb24b168" />


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
