### PR TITLE
refactor: change traversal order during index construction

### DIFF
--- a/src/mito2/src/read.rs
+++ b/src/mito2/src/read.rs
@@ -626,8 +626,11 @@ impl Batch {
             );
         }
 
-        let idx = self.fields_idx.as_ref().unwrap().get(&column_id)?;
-        Some(&self.fields[*idx])
+        self.fields_idx
+            .as_ref()
+            .unwrap()
+            .get(&column_id)
+            .map(|&idx| &self.fields[idx])
     }
 }
 

--- a/src/mito2/src/row_converter.rs
+++ b/src/mito2/src/row_converter.rs
@@ -55,6 +55,7 @@ pub trait PrimaryKeyFilter: Send + Sync {
     fn matches(&mut self, pk: &[u8]) -> bool;
 }
 
+/// Composite values decoded from primary key bytes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CompositeValues {
     Dense(Vec<(ColumnId, Value)>),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Previously, the default was to build an index for the tag column, hence the traversal method involved iterating through all tag columns.

Now, this assumption has been invalidated as the process has shifted to building indexes for specified columns. Therefore, it is no longer appropriate to continue traversing all tag columns, especially in scenarios where the number of columns is vast but only a few columns require index construction.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
