### PR TITLE
chore: set now as timestamp field default value

### DIFF
--- a/src/pipeline/src/etl/transform.rs
+++ b/src/pipeline/src/etl/transform.rs
@@ -170,16 +170,11 @@ impl Transform {
     }
 
     pub(crate) fn get_default_value_when_data_is_none(&self) -> Option<Value> {
-        match &self.type_ {
-            Value::Timestamp(_) => {
-                if self.index.is_some_and(|i| i == Index::Time) {
-                    Some(Value::Timestamp(Timestamp::default()))
-                } else {
-                    None
-                }
-            }
-            _ => None,
+        if matches!(self.type_, Value::Timestamp(_)) && self.index.is_some_and(|i| i == Index::Time)
+        {
+            return Some(Value::Timestamp(Timestamp::default()));
         }
+        None
     }
 }
 

--- a/src/pipeline/src/etl/transform/transformer/greptime/coerce.rs
+++ b/src/pipeline/src/etl/transform/transformer/greptime/coerce.rs
@@ -159,19 +159,7 @@ fn coerce_type(transform: &Transform) -> Result<(ColumnDataType, Option<ColumnDa
 
 pub(crate) fn coerce_value(val: &Value, transform: &Transform) -> Result<Option<ValueData>> {
     match val {
-        Value::Null => match &transform.default {
-            Some(default) => coerce_value(default, transform),
-            None => match transform.on_failure {
-                Some(OnFailure::Ignore) => Ok(None),
-                Some(OnFailure::Default) => transform
-                    .get_default()
-                    .map(|default| coerce_value(default, transform))
-                    .unwrap_or_else(|| {
-                        coerce_value(transform.get_type_matched_default_val(), transform)
-                    }),
-                None => Ok(None),
-            },
-        },
+        Value::Null => Ok(None),
 
         Value::Int8(n) => coerce_i64_value(*n as i64, transform),
         Value::Int16(n) => coerce_i64_value(*n as i64, transform),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

* if not set the timestamp default value use now()

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
