### PR TITLE
feat: change puffin stager eviction policy

### DIFF
--- a/src/puffin/src/puffin_manager/stager/bounded_stager.rs
+++ b/src/puffin/src/puffin_manager/stager/bounded_stager.rs
@@ -26,6 +26,7 @@ use common_runtime::runtime::RuntimeTrait;
 use common_telemetry::{info, warn};
 use futures::{FutureExt, StreamExt};
 use moka::future::Cache;
+use moka::policy::EvictionPolicy;
 use sha2::{Digest, Sha256};
 use snafu::ResultExt;
 use tokio::fs;
@@ -81,6 +82,7 @@ impl BoundedStager {
         let cache = Cache::builder()
             .max_capacity(capacity)
             .weigher(|_: &String, v: &CacheValue| v.weight())
+            .eviction_policy(EvictionPolicy::lru())
             .async_eviction_listener(move |k, v, _| {
                 let recycle_bin = recycle_bin_cloned.clone();
                 async move {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The original default strategy (tiny-lfu) might result in too many old entries being unable to be evicted, hence it has been changed to lru.

ref: https://docs.rs/moka/latest/moka/policy/struct.EvictionPolicy.html#impl-EvictionPolicy

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
