### PR TITLE
ci: docbot requires pull_request_target

### DIFF
--- a/.github/workflows/docbot.yml
+++ b/.github/workflows/docbot.yml
@@ -1,6 +1,6 @@
 name: Follow Up Docs
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited]
 
 jobs:


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This docbot tasks requires `pull_request_target` to be able to use secret to create issue.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
