### PR TITLE
fix: use fixed `tonistiigi/binfmt:qemu-v7.0.0-28` image version instead of latest version to avoid segmentation fault

### DIFF
--- a/.github/actions/build-greptime-images/action.yml
+++ b/.github/actions/build-greptime-images/action.yml
@@ -47,7 +47,11 @@ runs:
         password: ${{ inputs.image-registry-password }}
 
     - name: Set up qemu for multi-platform builds
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: linux/amd64,linux/arm64
+        # The latest version will lead to segmentation fault.
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
 
     - name: Set up buildx
       uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Resolve https://github.com/GreptimeTeam/greptimedb/issues/5513.

Use the fixed `tonistiigi/binfmt:qemu-v7.0.0-28` image version, which is used in the latest successfully [build](https://github.com/GreptimeTeam/greptimedb/actions/runs/13253038350/job/36997934191) instead of `tonistiigi/binfmt:latest` to avoid segmentation fault.

<img width="1159" alt="image" src="https://github.com/user-attachments/assets/1c679e39-8909-4bbf-b31f-8b988b7492d4" />


Upstream issue: https://github.com/tonistiigi/binfmt/issues/240.

The `tonistiigi/binfmt:qemu-v7.0.0-28` is a very old version(2022), although it's the previous "latest" binfmt image. The upstream update this "latest" version [recently](https://github.com/tonistiigi/binfmt/issues/165) and cause https://github.com/GreptimeTeam/greptimedb/issues/5513. Although the update will fix some segment faults, it still does not work in our scenario.

Although this PR may be the workaround solution, it just keeps the same building condition. We still keep watching for some better solutions upstream.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
