### PR TITLE
fix(query_range): skip data field on errors

### DIFF
--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -95,7 +95,7 @@ pub struct PromData {
     pub result: PromQueryResult,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum PrometheusResponse {
     PromData(PromData),
@@ -106,6 +106,7 @@ pub enum PrometheusResponse {
     BuildInfo(OwnedBuildInfo),
     #[serde(skip_deserializing)]
     ParseResult(promql_parser::parser::Expr),
+    #[default]
     None,
 }
 
@@ -148,12 +149,6 @@ impl PrometheusResponse {
 
     pub fn is_none(&self) -> bool {
         matches!(self, PrometheusResponse::None)
-    }
-}
-
-impl Default for PrometheusResponse {
-    fn default() -> Self {
-        PrometheusResponse::None
     }
 }
 

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -153,7 +153,7 @@ impl PrometheusResponse {
 
 impl Default for PrometheusResponse {
     fn default() -> Self {
-        PrometheusResponse::PromData(Default::default())
+        PrometheusResponse::None
     }
 }
 

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -106,6 +106,7 @@ pub enum PrometheusResponse {
     BuildInfo(OwnedBuildInfo),
     #[serde(skip_deserializing)]
     ParseResult(promql_parser::parser::Expr),
+    None,
 }
 
 impl PrometheusResponse {
@@ -143,6 +144,10 @@ impl PrometheusResponse {
                 // TODO(dennis): process other cases?
             }
         }
+    }
+
+    pub fn is_none(&self) -> bool {
+        matches!(self, PrometheusResponse::None)
     }
 }
 

--- a/src/servers/src/http/result/prometheus_resp.rs
+++ b/src/servers/src/http/result/prometheus_resp.rs
@@ -43,6 +43,7 @@ use crate::http::prometheus::{
 pub struct PrometheusJsonResponse {
     pub status: String,
     #[serde(skip_serializing_if = "PrometheusResponse::is_none")]
+    #[serde(default)]
     pub data: PrometheusResponse,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,

--- a/src/servers/src/http/result/prometheus_resp.rs
+++ b/src/servers/src/http/result/prometheus_resp.rs
@@ -42,6 +42,7 @@ use crate::http::prometheus::{
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct PrometheusJsonResponse {
     pub status: String,
+    #[serde(skip_serializing_if = "PrometheusResponse::is_none")]
     pub data: PrometheusResponse,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
@@ -90,7 +91,7 @@ impl PrometheusJsonResponse {
     {
         PrometheusJsonResponse {
             status: "error".to_string(),
-            data: PrometheusResponse::default(),
+            data: PrometheusResponse::None,
             error: Some(reason.into()),
             error_type: Some(error_type.to_string()),
             warnings: None,

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -765,7 +765,7 @@ pub async fn test_prom_http_api(store_type: StorageType) {
         .await;
     assert_eq!(res.status(), StatusCode::BAD_REQUEST);
     let data = res.text().await;
-    let expected = "{\"status\":\"error\",\"data\":{\"resultType\":\"\",\"result\":[]},\"error\":\"invalid promql query\",\"errorType\":\"InvalidArguments\"}";
+    let expected = "{\"status\":\"error\",\"error\":\"invalid promql query\",\"errorType\":\"InvalidArguments\"}";
     assert_eq!(expected, data);
 
     // range_query with __name__ not-equal matcher


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

When `PrometheusJsonResponse` returns an error, the data field (`PrometheusResponse`) is now skipped during serialization to align with Prometheus behavior. This ensures that Grafana displays specific error messages instead of the ambiguous "unknown result type: " message, improving user experience.

Before
<img width="1036" alt="Screenshot 2025-02-13 at 1 05 35" src="https://github.com/user-attachments/assets/2cf42ca3-5ec3-4be1-aace-23ae621448b6" />

After
<img width="889" alt="Screenshot 2025-02-13 at 1 05 45" src="https://github.com/user-attachments/assets/c0474acf-481b-491e-9fb6-3c0158c93723" />

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
