### PR TITLE
feat: window sort supports where on fields and time index

### DIFF
--- a/tests/cases/standalone/common/order/windowed_sort.result
+++ b/tests/cases/standalone/common/order/windowed_sort.result
@@ -173,6 +173,40 @@ EXPLAIN ANALYZE SELECT * FROM test where i > 2 ORDER BY t DESC LIMIT 4;
 |_|_| Total rows: 4_|
 +-+-+-+
 
+-- Filter on the time index.
+SELECT * FROM test where t > 8 ORDER BY t DESC LIMIT 4;
+
++---+-------------------------+
+| i | t                       |
++---+-------------------------+
+| 4 | 1970-01-01T00:00:00.012 |
+| 4 | 1970-01-01T00:00:00.011 |
+| 4 | 1970-01-01T00:00:00.010 |
+| 3 | 1970-01-01T00:00:00.009 |
++---+-------------------------+
+
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
+EXPLAIN ANALYZE SELECT * FROM test where t > 8 ORDER BY t DESC LIMIT 4;
+
++-+-+-+
+| stage | node | plan_|
++-+-+-+
+| 0_| 0_|_MergeScanExec: REDACTED
+|_|_|_|
+| 1_| 0_|_SortPreservingMergeExec: [t@1 DESC], fetch=4 REDACTED
+|_|_|_WindowedSortExec: expr=t@1 DESC num_ranges=2 fetch=4 REDACTED
+|_|_|_PartSortExec: expr=t@1 DESC num_ranges=2 limit=4 REDACTED
+|_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
+|_|_|_FilterExec: t@1 > 8 REDACTED
+|_|_|_SeqScan: region=REDACTED, partition_count=2 (1 memtable ranges, 1 file 1 ranges) REDACTED
+|_|_|_|
+|_|_| Total rows: 4_|
++-+-+-+
+
 DROP TABLE test;
 
 Affected Rows: 0

--- a/tests/cases/standalone/common/order/windowed_sort.result
+++ b/tests/cases/standalone/common/order/windowed_sort.result
@@ -286,6 +286,39 @@ EXPLAIN ANALYZE SELECT * FROM test_pk ORDER BY t DESC LIMIT 5;
 |_|_| Total rows: 5_|
 +-+-+-+
 
+-- Filter on a pk column.
+SELECT * FROM test_pk where pk > 7 ORDER BY t LIMIT 5;
+
++----+---+-------------------------+
+| pk | i | t                       |
++----+---+-------------------------+
+| 8  | 3 | 1970-01-01T00:00:00.008 |
+| 9  | 3 | 1970-01-01T00:00:00.009 |
+| 10 | 4 | 1970-01-01T00:00:00.010 |
+| 11 | 4 | 1970-01-01T00:00:00.011 |
+| 12 | 4 | 1970-01-01T00:00:00.012 |
++----+---+-------------------------+
+
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
+EXPLAIN ANALYZE SELECT * FROM test_pk where pk > 7 ORDER BY t LIMIT 5;
+
++-+-+-+
+| stage | node | plan_|
++-+-+-+
+| 0_| 0_|_MergeScanExec: REDACTED
+|_|_|_|
+| 1_| 0_|_SortPreservingMergeExec: [t@2 ASC NULLS LAST], fetch=5 REDACTED
+|_|_|_WindowedSortExec: expr=t@2 ASC NULLS LAST num_ranges=4 fetch=5 REDACTED
+|_|_|_PartSortExec: expr=t@2 ASC NULLS LAST num_ranges=4 limit=5 REDACTED
+|_|_|_SeqScan: region=REDACTED, partition_count=4 (1 memtable ranges, 3 file 3 ranges) REDACTED
+|_|_|_|
+|_|_| Total rows: 5_|
++-+-+-+
+
 DROP TABLE test_pk;
 
 Affected Rows: 0

--- a/tests/cases/standalone/common/order/windowed_sort.result
+++ b/tests/cases/standalone/common/order/windowed_sort.result
@@ -106,6 +106,73 @@ EXPLAIN ANALYZE SELECT * FROM test ORDER BY t DESC LIMIT 5;
 |_|_| Total rows: 5_|
 +-+-+-+
 
+-- Filter on a field.
+SELECT * FROM test where i > 2 ORDER BY t LIMIT 4;
+
++---+-------------------------+
+| i | t                       |
++---+-------------------------+
+| 3 | 1970-01-01T00:00:00.007 |
+| 3 | 1970-01-01T00:00:00.008 |
+| 3 | 1970-01-01T00:00:00.009 |
+| 4 | 1970-01-01T00:00:00.010 |
++---+-------------------------+
+
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
+EXPLAIN ANALYZE SELECT * FROM test where i > 2 ORDER BY t LIMIT 4;
+
++-+-+-+
+| stage | node | plan_|
++-+-+-+
+| 0_| 0_|_MergeScanExec: REDACTED
+|_|_|_|
+| 1_| 0_|_SortPreservingMergeExec: [t@1 ASC NULLS LAST], fetch=4 REDACTED
+|_|_|_WindowedSortExec: expr=t@1 ASC NULLS LAST num_ranges=4 fetch=4 REDACTED
+|_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
+|_|_|_FilterExec: i@0 > 2 REDACTED
+|_|_|_SeqScan: region=REDACTED, partition_count=4 (1 memtable ranges, 3 file 3 ranges) REDACTED
+|_|_|_|
+|_|_| Total rows: 4_|
++-+-+-+
+
+-- Filter on a field.
+SELECT * FROM test where i > 2 ORDER BY t DESC LIMIT 4;
+
++---+-------------------------+
+| i | t                       |
++---+-------------------------+
+| 4 | 1970-01-01T00:00:00.012 |
+| 4 | 1970-01-01T00:00:00.011 |
+| 4 | 1970-01-01T00:00:00.010 |
+| 3 | 1970-01-01T00:00:00.009 |
++---+-------------------------+
+
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
+EXPLAIN ANALYZE SELECT * FROM test where i > 2 ORDER BY t DESC LIMIT 4;
+
++-+-+-+
+| stage | node | plan_|
++-+-+-+
+| 0_| 0_|_MergeScanExec: REDACTED
+|_|_|_|
+| 1_| 0_|_SortPreservingMergeExec: [t@1 DESC], fetch=4 REDACTED
+|_|_|_WindowedSortExec: expr=t@1 DESC num_ranges=4 fetch=4 REDACTED
+|_|_|_PartSortExec: expr=t@1 DESC num_ranges=4 limit=4 REDACTED
+|_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
+|_|_|_FilterExec: i@0 > 2 REDACTED
+|_|_|_SeqScan: region=REDACTED, partition_count=4 (1 memtable ranges, 3 file 3 ranges) REDACTED
+|_|_|_|
+|_|_| Total rows: 4_|
++-+-+-+
+
 DROP TABLE test;
 
 Affected Rows: 0

--- a/tests/cases/standalone/common/order/windowed_sort.sql
+++ b/tests/cases/standalone/common/order/windowed_sort.sql
@@ -90,4 +90,14 @@ SELECT * FROM test_pk ORDER BY t DESC LIMIT 5;
 -- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
 EXPLAIN ANALYZE SELECT * FROM test_pk ORDER BY t DESC LIMIT 5;
 
+-- Filter on a pk column.
+SELECT * FROM test_pk where pk > 7 ORDER BY t LIMIT 5;
+
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
+EXPLAIN ANALYZE SELECT * FROM test_pk where pk > 7 ORDER BY t LIMIT 5;
+
 DROP TABLE test_pk;

--- a/tests/cases/standalone/common/order/windowed_sort.sql
+++ b/tests/cases/standalone/common/order/windowed_sort.sql
@@ -33,6 +33,26 @@ SELECT * FROM test ORDER BY t DESC LIMIT 5;
 -- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
 EXPLAIN ANALYZE SELECT * FROM test ORDER BY t DESC LIMIT 5;
 
+-- Filter on a field.
+SELECT * FROM test where i > 2 ORDER BY t LIMIT 4;
+
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
+EXPLAIN ANALYZE SELECT * FROM test where i > 2 ORDER BY t LIMIT 4;
+
+-- Filter on a field.
+SELECT * FROM test where i > 2 ORDER BY t DESC LIMIT 4;
+
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
+EXPLAIN ANALYZE SELECT * FROM test where i > 2 ORDER BY t DESC LIMIT 4;
+
 DROP TABLE test;
 
 -- Test with PK, with a windowed sort query.

--- a/tests/cases/standalone/common/order/windowed_sort.sql
+++ b/tests/cases/standalone/common/order/windowed_sort.sql
@@ -53,6 +53,16 @@ SELECT * FROM test where i > 2 ORDER BY t DESC LIMIT 4;
 -- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
 EXPLAIN ANALYZE SELECT * FROM test where i > 2 ORDER BY t DESC LIMIT 4;
 
+-- Filter on the time index.
+SELECT * FROM test where t > 8 ORDER BY t DESC LIMIT 4;
+
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
+EXPLAIN ANALYZE SELECT * FROM test where t > 8 ORDER BY t DESC LIMIT 4;
+
 DROP TABLE test;
 
 -- Test with PK, with a windowed sort query.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/5463

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

This PR fixes some cases that can't use window sort in #5463. The repartition plan between `FilterExec` and `RegionScanExec` prevents the window sort. We match this pattern and remove the repartition plan before checking region partitions so we can apply window sort optimization.

Using window sort usually should have more benefits than adding repartition before the filter.

We need to check there is no regression in performance.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
