### PR TITLE
feat: speed up read/write cache and stager eviction

### DIFF
--- a/src/mito2/src/cache/file_cache.rs
+++ b/src/mito2/src/cache/file_cache.rs
@@ -24,6 +24,7 @@ use common_telemetry::{error, info, warn};
 use futures::{FutureExt, TryStreamExt};
 use moka::future::Cache;
 use moka::notification::RemovalCause;
+use moka::policy::EvictionPolicy;
 use object_store::util::join_path;
 use object_store::{ErrorKind, ObjectStore, Reader};
 use parquet::file::metadata::ParquetMetaData;
@@ -65,6 +66,7 @@ impl FileCache {
     ) -> FileCache {
         let cache_store = local_store.clone();
         let mut builder = Cache::builder()
+            .eviction_policy(EvictionPolicy::lru())
             .weigher(|_key, value: &IndexValue| -> u32 {
                 // We only measure space on local store.
                 value.file_size

--- a/src/object-store/src/layers/lru_cache/read_cache.rs
+++ b/src/object-store/src/layers/lru_cache/read_cache.rs
@@ -18,6 +18,7 @@ use common_telemetry::debug;
 use futures::{FutureExt, TryStreamExt};
 use moka::future::Cache;
 use moka::notification::ListenerFuture;
+use moka::policy::EvictionPolicy;
 use opendal::raw::oio::{Read, Reader, Write};
 use opendal::raw::{oio, Access, OpDelete, OpRead, OpStat, OpWrite, RpRead};
 use opendal::{Error as OpendalError, ErrorKind, OperatorBuilder, Result};
@@ -120,6 +121,7 @@ impl<C: Access> ReadCache<C> {
             file_cache,
             mem_cache: Cache::builder()
                 .max_capacity(capacity as u64)
+                .eviction_policy(EvictionPolicy::lru())
                 .weigher(|_key, value: &ReadResult| -> u32 {
                     // TODO(dennis): add key's length to weight?
                     value.size_bytes()

--- a/src/puffin/src/puffin_manager/stager/bounded_stager.rs
+++ b/src/puffin/src/puffin_manager/stager/bounded_stager.rs
@@ -335,6 +335,7 @@ impl BoundedStager {
         for (key, value) in elems {
             self.cache.insert(key, value).await;
         }
+        self.cache.run_pending_tasks().await;
 
         Ok(())
     }

--- a/src/puffin/src/puffin_manager/stager/bounded_stager.rs
+++ b/src/puffin/src/puffin_manager/stager/bounded_stager.rs
@@ -211,7 +211,15 @@ impl Stager for BoundedStager {
             })
             .await
             .map(|_| ())
-            .context(CacheGetSnafu)
+            .context(CacheGetSnafu)?;
+
+        // Dir is usually large.
+        // Runs pending tasks of the cache and recycle bin to free up space
+        // more quickly.
+        self.cache.run_pending_tasks().await;
+        self.recycle_bin.run_pending_tasks().await;
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

This PR changes the eviction policy of the read/write cache and also reclaims space eagerly:
- Use LRU policy for read/write cache
- Run all pending tasks of the cache when we put a new entry to the write cache and stager
  - This can evict files and directories faster than before
- Run pending tasks in the delete routine of the recycle bin to speed up eviction when there is no request
- The read cache doesn't call `run_pending_tasks()` now as it only caches object ranges that are usually smaller.


Moka maintenance task:
https://github.com/moka-rs/moka/blob/main/MIGRATION-GUIDE.md#the-maintenance-tasks


Before (staging size 3G)
```
$ du -sh ~/greptime/data-pipeline/index_intermediate/*
44K	/home/xxx/greptime/data-pipeline/index_intermediate/__intm
6.1G	/home/xxx/greptime/data-pipeline/index_intermediate/staging
```

After
```
$ du -sh ~/greptime/data-pipeline/index_intermediate/staging/
3.4G	/home/xxx/greptime/data-pipeline/index_intermediate/staging/

$ du -sh ~/greptime/data-pipeline/index_intermediate/*
344K	/home/xxx/greptime/data-pipeline/index_intermediate/__intm
3.1G	/home/xxx/greptime/data-pipeline/index_intermediate/staging

$ du -sh ~/greptime/data-pipeline/index_intermediate/*
344K	/home/xxx/greptime/data-pipeline/index_intermediate/__intm
3.0G	/home/xxx/greptime/data-pipeline/index_intermediate/staging
```

The recycle bin will hold evicted items for a while (1 min) so the staging size may be larger than 3G.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
