### PR TITLE
fix: old typo

### DIFF
--- a/src/common/meta/src/ddl/tests/create_view.rs
+++ b/src/common/meta/src/ddl/tests/create_view.rs
@@ -219,7 +219,7 @@ async fn test_replace_view_metadata() {
         assert_eq!(err.status_code(), StatusCode::TableAlreadyExists);
     }
 
-    // Set `or_replce` to be `true` and try again
+    // Set `or_replace` to be `true` and try again
     task.create_view.or_replace = true;
     task.create_view.logical_plan = vec![4, 5, 6];
     task.create_view.definition = "new_definition".to_string();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The typo database seems updated just now
![image](https://github.com/user-attachments/assets/16b38dbc-a1dd-4b76-9fef-076e5692cf12)


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
