### PR TITLE
feat(promql): add series count metrics

### DIFF
--- a/src/promql/src/extension_plan.rs
+++ b/src/promql/src/extension_plan.rs
@@ -36,3 +36,5 @@ pub use series_divide::{SeriesDivide, SeriesDivideExec, SeriesDivideStream};
 pub use union_distinct_on::{UnionDistinctOn, UnionDistinctOnExec, UnionDistinctOnStream};
 
 pub type Millisecond = <TimestampMillisecondType as ArrowPrimitiveType>::Native;
+
+const METRIC_NUM_SERIES: &str = "num_series";


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This change introduces series count metrics for various PromQL extension plan operators, including:
- InstantManipulateStream
- SeriesNormalizeStream
- RangeManipulateStream
- SeriesDivideStream

It looks like 
```
            PromInstantManipulateExec: range=[], lookback=[300000], interval=[15000], time index=[greptime_timestamp] metrics=[output_rows: 400, elapsed_compute: 788313, num_series: 20, ]
              PromSeriesNormalizeExec: offset=[0], time index=[greptime_timestamp], filter NaN: [false] metrics=[output_rows: 1200, elapsed_compute: 652542, num_series: 20, ]
                PromSeriesDivideExec: tags=[] metrics=[output_rows: 1200, elapsed_compute: 480161, num_series: 20, ]
```

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
