### PR TITLE
fix: promql join operation won't consider time index

### DIFF
--- a/tests/cases/standalone/common/promql/set_operation.result
+++ b/tests/cases/standalone/common/promql/set_operation.result
@@ -465,3 +465,57 @@ drop table t2;
 
 Affected Rows: 0
 
+create table cache_hit (
+    ts timestamp time index,
+    job string,
+    greptime_value double,
+    primary key (job)
+);
+
+Affected Rows: 0
+
+create table cache_miss (
+    ts timestamp time index,
+    job string,
+    greptime_value double,
+    primary key (job)
+);
+
+Affected Rows: 0
+
+insert into cache_hit values
+    (3000, "read", 1.0),
+    (3000, "write", 2.0),
+    (4000, "read", 3.0),
+    (4000, "write", 4.0);
+
+Affected Rows: 4
+
+insert into cache_miss values
+    (3000, "read", 1.0),
+    (3000, "write", 2.0),
+    (4000, "read", 1.0),
+    (4000, "write", 2.0);
+
+Affected Rows: 4
+
+-- SQLNESS SORT_RESULT 3 1
+tql eval (3, 4, '1s') cache_hit / (cache_miss + cache_hit);
+
++-------+---------------------+-------------------------------------------------------------------------------+
+| job   | ts                  | lhs.greptime_value / rhs.cache_miss.greptime_value + cache_hit.greptime_value |
++-------+---------------------+-------------------------------------------------------------------------------+
+| read  | 1970-01-01T00:00:03 | 0.5                                                                           |
+| read  | 1970-01-01T00:00:04 | 0.75                                                                          |
+| write | 1970-01-01T00:00:03 | 0.5                                                                           |
+| write | 1970-01-01T00:00:04 | 0.6666666666666666                                                            |
++-------+---------------------+-------------------------------------------------------------------------------+
+
+drop table cache_hit;
+
+Affected Rows: 0
+
+drop table cache_miss;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/promql/set_operation.sql
+++ b/tests/cases/standalone/common/promql/set_operation.sql
@@ -206,3 +206,36 @@ tql eval (0, 2000, '400') t2 or on(job) t1;
 drop table t1;
 
 drop table t2;
+
+create table cache_hit (
+    ts timestamp time index,
+    job string,
+    greptime_value double,
+    primary key (job)
+);
+
+create table cache_miss (
+    ts timestamp time index,
+    job string,
+    greptime_value double,
+    primary key (job)
+);
+
+insert into cache_hit values
+    (3000, "read", 1.0),
+    (3000, "write", 2.0),
+    (4000, "read", 3.0),
+    (4000, "write", 4.0);
+
+insert into cache_miss values
+    (3000, "read", 1.0),
+    (3000, "write", 2.0),
+    (4000, "read", 1.0),
+    (4000, "write", 2.0);
+
+-- SQLNESS SORT_RESULT 3 1
+tql eval (3, 4, '1s') cache_hit / (cache_miss + cache_hit);
+
+drop table cache_hit;
+
+drop table cache_miss;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Related to https://github.com/GreptimeTeam/greptimedb/pull/5398

## What's changed and what's your intention?

Conditions in https://github.com/GreptimeTeam/greptimedb/pull/5398 are too weak to distinguish between a normal join and a vector. This patch changes the logic to not branching on vector/non-vector functions, but to handle them uniform way.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
