### PR TITLE
fix: information_schema.cluster_info be covered by the same id

### DIFF
--- a/src/meta-srv/src/handler/collect_cluster_info_handler.rs
+++ b/src/meta-srv/src/handler/collect_cluster_info_handler.rs
@@ -169,7 +169,12 @@ fn extract_base_info(
                 Role::Frontend => cluster::Role::Frontend,
                 Role::Flownode => cluster::Role::Flownode,
             },
-            node_id: peer.id,
+            node_id: match role {
+                Role::Datanode => peer.id,
+                Role::Flownode => peer.id,
+                // The ID is solely for ensuring the key's uniqueness and serves no other purpose.
+                Role::Frontend => allocate_id_by_peer_addr(peer.addr.as_str()),
+            },
         },
         Peer::from(peer.clone()),
         info.clone(),
@@ -191,4 +196,41 @@ async fn put_into_memory_store(ctx: &mut Context, key: NodeInfoKey, value: NodeI
         .context(SaveClusterInfoSnafu)?;
 
     Ok(())
+}
+
+// Allocate id based on peer address using a hash function
+fn allocate_id_by_peer_addr(peer_addr: &str) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = DefaultHasher::new();
+    peer_addr.hash(&mut hasher);
+    hasher.finish()
+}
+
+#[cfg(test)]
+mod allocate_id_tests {
+    use super::*;
+
+    #[test]
+    fn test_allocate_id_by_peer_addr() {
+        // Test empty string
+        assert_eq!(allocate_id_by_peer_addr(""), allocate_id_by_peer_addr(""));
+
+        // Test same address returns same id
+        let addr1 = "127.0.0.1:8080";
+        let id1 = allocate_id_by_peer_addr(addr1);
+        let id2 = allocate_id_by_peer_addr(addr1);
+        assert_eq!(id1, id2);
+
+        // Test different addresses return different ids
+        let addr2 = "127.0.0.1:8081";
+        let id3 = allocate_id_by_peer_addr(addr2);
+        assert_ne!(id1, id3);
+
+        // Test long address
+        let long_addr = "very.long.domain.name.example.com:9999";
+        let id4 = allocate_id_by_peer_addr(long_addr);
+        assert!(id4 > 0);
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Close #5413 

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
