### PR TITLE
fix(promql-planner): correct AND/UNLESS operator behavior

### DIFF
--- a/tests/cases/standalone/common/promql/set_operation.result
+++ b/tests/cases/standalone/common/promql/set_operation.result
@@ -465,6 +465,86 @@ drop table t2;
 
 Affected Rows: 0
 
+create table stats_used_bytes (
+    ts timestamp time index,
+    namespace string,
+    greptime_value double,
+    primary key (namespace)
+);
+
+Affected Rows: 0
+
+create table stats_capacity_bytes (
+    ts timestamp time index,
+    namespace string,
+    greptime_value double,
+    primary key (namespace)
+);
+
+Affected Rows: 0
+
+insert into stats_used_bytes values
+    (0, "namespace1", 1.0),
+    (0, "namespace2", 2.0),
+    (500000, "namespace1", 10.0),
+    (500000, "namespace2", 20.0),
+    (1000000, "namespace1", 25.0),
+    (1000000, "namespace2", 26.0);
+
+Affected Rows: 6
+
+insert into stats_capacity_bytes values
+    (0, "namespace1", 30.0),
+    (0, "namespace2", 30.0),
+    (500000, "namespace1", 30.0),
+    (500000, "namespace2", 30.0),
+    (1000000, "namespace1", 30.0),
+    (1000000, "namespace2", 30.0);
+
+Affected Rows: 6
+
+-- SQLNESS SORT_RESULT 3 1
+tql eval (0, 2000, '400') max by (namespace) (stats_used_bytes{namespace=~".+"}) / max by (namespace) (stats_capacity_bytes{namespace=~".+"}) >= (80 / 100);
+
++------------+---------------------+-----------------------------------------------------------------------------------------------------------------------+
+| namespace  | ts                  | stats_used_bytes.max(stats_used_bytes.greptime_value) / stats_capacity_bytes.max(stats_capacity_bytes.greptime_value) |
++------------+---------------------+-----------------------------------------------------------------------------------------------------------------------+
+| namespace1 | 1970-01-01T00:20:00 | 0.8333333333333334                                                                                                    |
+| namespace2 | 1970-01-01T00:20:00 | 0.8666666666666667                                                                                                    |
++------------+---------------------+-----------------------------------------------------------------------------------------------------------------------+
+
+-- SQLNESS SORT_RESULT 3 1
+tql eval (0, 2000, '400') max by (namespace) (stats_used_bytes{namespace=~".+"}) and (max by (namespace) (stats_used_bytes{namespace=~".+"}) / (max by (namespace) (stats_capacity_bytes{namespace=~".+"})) >= (80 / 100));
+
++------------+---------------------+--------------------------------------+
+| namespace  | ts                  | max(stats_used_bytes.greptime_value) |
++------------+---------------------+--------------------------------------+
+| namespace1 | 1970-01-01T00:20:00 | 25.0                                 |
+| namespace2 | 1970-01-01T00:20:00 | 26.0                                 |
++------------+---------------------+--------------------------------------+
+
+-- SQLNESS SORT_RESULT 3 1
+tql eval (0, 2000, '400') count(max by (namespace) (stats_used_bytes{namespace=~".+"}) and (max by (namespace) (stats_used_bytes{namespace=~".+"}) / (max by (namespace) (stats_capacity_bytes{namespace=~".+"})) >= (80 / 100))) or vector(0);
+
++---------------------+---------------------------------------------+
+| ts                  | count(max(stats_used_bytes.greptime_value)) |
++---------------------+---------------------------------------------+
+| 1970-01-01T00:00:00 | 0                                           |
+| 1970-01-01T00:06:40 | 0                                           |
+| 1970-01-01T00:13:20 | 0                                           |
+| 1970-01-01T00:20:00 | 2                                           |
+| 1970-01-01T00:26:40 | 0                                           |
+| 1970-01-01T00:33:20 | 0                                           |
++---------------------+---------------------------------------------+
+
+drop table stats_used_bytes;
+
+Affected Rows: 0
+
+drop table stats_capacity_bytes;
+
+Affected Rows: 0
+
 create table cache_hit (
     ts timestamp time index,
     job string,

--- a/tests/cases/standalone/common/promql/set_operation.result
+++ b/tests/cases/standalone/common/promql/set_operation.result
@@ -537,6 +537,25 @@ tql eval (0, 2000, '400') count(max by (namespace) (stats_used_bytes{namespace=~
 | 1970-01-01T00:33:20 | 0                                           |
 +---------------------+---------------------------------------------+
 
+-- SQLNESS SORT_RESULT 3 1
+tql eval (0, 2000, '400') count(max by (namespace) (stats_used_bytes{namespace=~".+"}) and (max by (namespace) (stats_used_bytes{namespace=~".+"}) / (max by (namespace) (stats_capacity_bytes{namespace=~".+"})) >= (80 / 100)));
+
++---------------------+---------------------------------------------+
+| ts                  | count(max(stats_used_bytes.greptime_value)) |
++---------------------+---------------------------------------------+
+| 1970-01-01T00:20:00 | 2                                           |
++---------------------+---------------------------------------------+
+
+-- SQLNESS SORT_RESULT 3 1
+tql eval (0, 2000, '400') count(max by (namespace) (stats_used_bytes{namespace=~".+"}) unless (max by (namespace) (stats_used_bytes{namespace=~".+"}) / (max by (namespace) (stats_capacity_bytes{namespace=~".+"})) >= (80 / 100)));
+
++---------------------+---------------------------------------------+
+| ts                  | count(max(stats_used_bytes.greptime_value)) |
++---------------------+---------------------------------------------+
+| 1970-01-01T00:00:00 | 2                                           |
+| 1970-01-01T00:13:20 | 2                                           |
++---------------------+---------------------------------------------+
+
 drop table stats_used_bytes;
 
 Affected Rows: 0

--- a/tests/cases/standalone/common/promql/set_operation.sql
+++ b/tests/cases/standalone/common/promql/set_operation.sql
@@ -246,6 +246,12 @@ tql eval (0, 2000, '400') max by (namespace) (stats_used_bytes{namespace=~".+"})
 -- SQLNESS SORT_RESULT 3 1
 tql eval (0, 2000, '400') count(max by (namespace) (stats_used_bytes{namespace=~".+"}) and (max by (namespace) (stats_used_bytes{namespace=~".+"}) / (max by (namespace) (stats_capacity_bytes{namespace=~".+"})) >= (80 / 100))) or vector(0);
 
+-- SQLNESS SORT_RESULT 3 1
+tql eval (0, 2000, '400') count(max by (namespace) (stats_used_bytes{namespace=~".+"}) and (max by (namespace) (stats_used_bytes{namespace=~".+"}) / (max by (namespace) (stats_capacity_bytes{namespace=~".+"})) >= (80 / 100)));
+
+-- SQLNESS SORT_RESULT 3 1
+tql eval (0, 2000, '400') count(max by (namespace) (stats_used_bytes{namespace=~".+"}) unless (max by (namespace) (stats_used_bytes{namespace=~".+"}) / (max by (namespace) (stats_capacity_bytes{namespace=~".+"})) >= (80 / 100)));
+
 drop table stats_used_bytes;
 
 drop table stats_capacity_bytes;

--- a/tests/cases/standalone/common/promql/set_operation.sql
+++ b/tests/cases/standalone/common/promql/set_operation.sql
@@ -207,6 +207,50 @@ drop table t1;
 
 drop table t2;
 
+create table stats_used_bytes (
+    ts timestamp time index,
+    namespace string,
+    greptime_value double,
+    primary key (namespace)
+);
+
+create table stats_capacity_bytes (
+    ts timestamp time index,
+    namespace string,
+    greptime_value double,
+    primary key (namespace)
+);
+
+insert into stats_used_bytes values
+    (0, "namespace1", 1.0),
+    (0, "namespace2", 2.0),
+    (500000, "namespace1", 10.0),
+    (500000, "namespace2", 20.0),
+    (1000000, "namespace1", 25.0),
+    (1000000, "namespace2", 26.0);
+
+insert into stats_capacity_bytes values
+    (0, "namespace1", 30.0),
+    (0, "namespace2", 30.0),
+    (500000, "namespace1", 30.0),
+    (500000, "namespace2", 30.0),
+    (1000000, "namespace1", 30.0),
+    (1000000, "namespace2", 30.0);
+
+-- SQLNESS SORT_RESULT 3 1
+tql eval (0, 2000, '400') max by (namespace) (stats_used_bytes{namespace=~".+"}) / max by (namespace) (stats_capacity_bytes{namespace=~".+"}) >= (80 / 100);
+
+-- SQLNESS SORT_RESULT 3 1
+tql eval (0, 2000, '400') max by (namespace) (stats_used_bytes{namespace=~".+"}) and (max by (namespace) (stats_used_bytes{namespace=~".+"}) / (max by (namespace) (stats_capacity_bytes{namespace=~".+"})) >= (80 / 100));
+
+-- SQLNESS SORT_RESULT 3 1
+tql eval (0, 2000, '400') count(max by (namespace) (stats_used_bytes{namespace=~".+"}) and (max by (namespace) (stats_used_bytes{namespace=~".+"}) / (max by (namespace) (stats_capacity_bytes{namespace=~".+"})) >= (80 / 100))) or vector(0);
+
+drop table stats_used_bytes;
+
+drop table stats_capacity_bytes;
+
+
 create table cache_hit (
     ts timestamp time index,
     job string,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#5525 
## What's changed and what's your intention?

This PR fixes the behavior of the AND/UNLESS operator.

For example: 
```
vector_1 and vector_2
```
The AND operator returns the time series from the left-hand vector (vector_1) in the right-hand vector (vector_2), retaining the values from the left-hand vector.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
