### PR TITLE
fix(promql-planner): remove le tag in ctx

### DIFF
--- a/src/query/src/promql/planner.rs
+++ b/src/query/src/promql/planner.rs
@@ -634,6 +634,7 @@ impl PromPlanner {
         let mut func_exprs = self.create_function_expr(func, args.literals, session_state)?;
         func_exprs.insert(0, self.create_time_index_column_expr()?);
         func_exprs.extend_from_slice(&self.create_tag_column_exprs()?);
+
         LogicalPlanBuilder::from(input)
             .project(func_exprs)
             .context(DataFusionPlanningSnafu)?

--- a/src/query/src/promql/planner.rs
+++ b/src/query/src/promql/planner.rs
@@ -1804,11 +1804,7 @@ impl PromPlanner {
             })?
             .clone();
         // remove le column from tag columns
-        let tag_columns = std::mem::take(&mut self.ctx.tag_columns);
-        self.ctx.tag_columns = tag_columns
-            .into_iter()
-            .filter(|col| col != LE_COLUMN_NAME)
-            .collect();
+        self.ctx.tag_columns.retain(|col| col != LE_COLUMN_NAME);
 
         Ok(LogicalPlan::Extension(Extension {
             node: Arc::new(

--- a/tests/cases/standalone/common/promql/simple_histogram.result
+++ b/tests/cases/standalone/common/promql/simple_histogram.result
@@ -115,6 +115,16 @@ tql eval (3000, 3000, '1s') histogram_quantile(0.8, histogram_bucket);
 | 1970-01-01T00:50:00 | positive | 0.72 |
 +---------------------+----------+------+
 
+-- SQLNESS SORT_RESULT 3 1
+tql eval (3000, 3000, '1s') label_replace(histogram_quantile(0.8, histogram_bucket), "s", "$1", "s", "(.*)tive");
+
++---------------------+------+------+
+| ts                  | val  | s    |
++---------------------+------+------+
+| 1970-01-01T00:50:00 | 0.3  | nega |
+| 1970-01-01T00:50:00 | 0.72 | posi |
++---------------------+------+------+
+
 -- More realistic with rates.
 -- This case doesn't contains value because other point are not inserted.
 -- quantile with rate is covered in other cases

--- a/tests/cases/standalone/common/promql/simple_histogram.sql
+++ b/tests/cases/standalone/common/promql/simple_histogram.sql
@@ -51,6 +51,9 @@ tql eval (3000, 3000, '1s') histogram_quantile(0.5, histogram_bucket);
 -- SQLNESS SORT_RESULT 3 1
 tql eval (3000, 3000, '1s') histogram_quantile(0.8, histogram_bucket);
 
+-- SQLNESS SORT_RESULT 3 1
+tql eval (3000, 3000, '1s') label_replace(histogram_quantile(0.8, histogram_bucket), "s", "$1", "s", "(.*)tive");
+
 -- More realistic with rates.
 -- This case doesn't contains value because other point are not inserted.
 -- quantile with rate is covered in other cases


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#5525 
## What's changed and what's your intention?

This PR removes the `le` tag in ctx after the planner returns a `HistogramFold` node to ensure consistency with the `HistogramFold` output schema, which also omits the le tag.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
