### PR TITLE
perf: close issue 4974 by do not delete columns when drop logical region about 100 times faster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4699,7 +4699,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=a25adc8a01340231121646d8f0a29d0e92f45461#a25adc8a01340231121646d8f0a29d0e92f45461"
+source = "git+https://github.com/yihong0618/greptime-proto.git?rev=76537cb469b905a5c20dad207315dadf69490adb#76537cb469b905a5c20dad207315dadf69490adb"
 dependencies = [
  "prost 0.13.3",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4699,7 +4699,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/yihong0618/greptime-proto.git?rev=4f35b36602d264839c8ddd14e0ac3b71f9b624f8#4f35b36602d264839c8ddd14e0ac3b71f9b624f8"
+source = "git+https://github.com/yihong0618/greptime-proto.git?rev=af611a859e337c076bc1bb9daad978e04b91891a#af611a859e337c076bc1bb9daad978e04b91891a"
 dependencies = [
  "prost 0.13.3",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4699,7 +4699,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/yihong0618/greptime-proto.git?rev=76537cb469b905a5c20dad207315dadf69490adb#76537cb469b905a5c20dad207315dadf69490adb"
+source = "git+https://github.com/yihong0618/greptime-proto.git?rev=4f35b36602d264839c8ddd14e0ac3b71f9b624f8#4f35b36602d264839c8ddd14e0ac3b71f9b624f8"
 dependencies = [
  "prost 0.13.3",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4699,7 +4699,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/yihong0618/greptime-proto.git?rev=af611a859e337c076bc1bb9daad978e04b91891a#af611a859e337c076bc1bb9daad978e04b91891a"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=072ce580502e015df1a6b03a185b60309a7c2a7a#072ce580502e015df1a6b03a185b60309a7c2a7a"
 dependencies = [
  "prost 0.13.3",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ etcd-client = "0.14"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/yihong0618/greptime-proto.git", rev = "4f35b36602d264839c8ddd14e0ac3b71f9b624f8" }
+greptime-proto = { git = "https://github.com/yihong0618/greptime-proto.git", rev = "af611a859e337c076bc1bb9daad978e04b91891a" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ etcd-client = "0.14"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "a25adc8a01340231121646d8f0a29d0e92f45461" }
+greptime-proto = { git = "https://github.com/yihong0618/greptime-proto.git", rev = "76537cb469b905a5c20dad207315dadf69490adb" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ etcd-client = "0.14"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/yihong0618/greptime-proto.git", rev = "76537cb469b905a5c20dad207315dadf69490adb" }
+greptime-proto = { git = "https://github.com/yihong0618/greptime-proto.git", rev = "4f35b36602d264839c8ddd14e0ac3b71f9b624f8" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ etcd-client = "0.14"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/yihong0618/greptime-proto.git", rev = "af611a859e337c076bc1bb9daad978e04b91891a" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "072ce580502e015df1a6b03a185b60309a7c2a7a" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/src/common/meta/src/ddl/drop_database/executor.rs
+++ b/src/common/meta/src/ddl/drop_database/executor.rs
@@ -128,7 +128,7 @@ impl State for DropDatabaseExecutor {
             .await?;
         executor.invalidate_table_cache(ddl_ctx).await?;
         executor
-            .on_drop_regions(ddl_ctx, &self.physical_region_routes)
+            .on_drop_regions(ddl_ctx, &self.physical_region_routes, true)
             .await?;
         info!("Table: {}({}) is dropped", self.table_name, self.table_id);
 

--- a/src/common/meta/src/ddl/drop_table.rs
+++ b/src/common/meta/src/ddl/drop_table.rs
@@ -156,7 +156,7 @@ impl DropTableProcedure {
 
     pub async fn on_datanode_drop_regions(&mut self) -> Result<Status> {
         self.executor
-            .on_drop_regions(&self.context, &self.data.physical_region_routes)
+            .on_drop_regions(&self.context, &self.data.physical_region_routes, false)
             .await?;
         self.data.state = DropTableState::DeleteTombstone;
         Ok(Status::executing(true))

--- a/src/common/meta/src/ddl/drop_table/executor.rs
+++ b/src/common/meta/src/ddl/drop_table/executor.rs
@@ -214,7 +214,7 @@ impl DropTableExecutor {
         &self,
         ctx: &DdlContext,
         region_routes: &[RegionRoute],
-        force_drop_all_logical_tables: bool,
+        fast_path: bool,
     ) -> Result<()> {
         let leaders = find_leaders(region_routes);
         let mut drop_region_tasks = Vec::with_capacity(leaders.len());
@@ -237,7 +237,7 @@ impl DropTableExecutor {
                     }),
                     body: Some(region_request::Body::Drop(PbDropRegionRequest {
                         region_id: region_id.as_u64(),
-                        force_drop_all_logical_tables,
+                        fast_path,
                     })),
                 };
                 let datanode = datanode.clone();

--- a/src/common/meta/src/ddl/drop_table/executor.rs
+++ b/src/common/meta/src/ddl/drop_table/executor.rs
@@ -214,7 +214,7 @@ impl DropTableExecutor {
         &self,
         ctx: &DdlContext,
         region_routes: &[RegionRoute],
-        fast_drop_database_path: bool,
+        fast_drop_path: bool,
     ) -> Result<()> {
         let leaders = find_leaders(region_routes);
         let mut drop_region_tasks = Vec::with_capacity(leaders.len());
@@ -237,7 +237,7 @@ impl DropTableExecutor {
                     }),
                     body: Some(region_request::Body::Drop(PbDropRegionRequest {
                         region_id: region_id.as_u64(),
-                        fast_drop_database_path,
+                        fast_drop_path,
                     })),
                 };
                 let datanode = datanode.clone();

--- a/src/common/meta/src/ddl/drop_table/executor.rs
+++ b/src/common/meta/src/ddl/drop_table/executor.rs
@@ -237,7 +237,7 @@ impl DropTableExecutor {
                     }),
                     body: Some(region_request::Body::Drop(PbDropRegionRequest {
                         region_id: region_id.as_u64(),
-                        fast_drop_database_path: fast_drop_database_path,
+                        fast_drop_database_path,
                     })),
                 };
                 let datanode = datanode.clone();

--- a/src/common/meta/src/ddl/drop_table/executor.rs
+++ b/src/common/meta/src/ddl/drop_table/executor.rs
@@ -214,7 +214,7 @@ impl DropTableExecutor {
         &self,
         ctx: &DdlContext,
         region_routes: &[RegionRoute],
-        fast_drop_path: bool,
+        force_drop_all_logical_tables: bool,
     ) -> Result<()> {
         let leaders = find_leaders(region_routes);
         let mut drop_region_tasks = Vec::with_capacity(leaders.len());
@@ -237,7 +237,7 @@ impl DropTableExecutor {
                     }),
                     body: Some(region_request::Body::Drop(PbDropRegionRequest {
                         region_id: region_id.as_u64(),
-                        fast_drop_path,
+                        force_drop_all_logical_tables,
                     })),
                 };
                 let datanode = datanode.clone();

--- a/src/common/meta/src/ddl/drop_table/executor.rs
+++ b/src/common/meta/src/ddl/drop_table/executor.rs
@@ -214,6 +214,7 @@ impl DropTableExecutor {
         &self,
         ctx: &DdlContext,
         region_routes: &[RegionRoute],
+        fast_drop_database_path: bool,
     ) -> Result<()> {
         let leaders = find_leaders(region_routes);
         let mut drop_region_tasks = Vec::with_capacity(leaders.len());
@@ -236,6 +237,7 @@ impl DropTableExecutor {
                     }),
                     body: Some(region_request::Body::Drop(PbDropRegionRequest {
                         region_id: region_id.as_u64(),
+                        fast_drop_database_path: fast_drop_database_path,
                     })),
                 };
                 let datanode = datanode.clone();

--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -1218,7 +1218,12 @@ mod tests {
         );
 
         let response = mock_region_server
-            .handle_request(region_id, RegionRequest::Drop(RegionDropRequest {}))
+            .handle_request(
+                region_id,
+                RegionRequest::Drop(RegionDropRequest {
+                    fast_drop_database_path: false,
+                }),
+            )
             .await
             .unwrap();
         assert_eq!(response.affected_rows, 0);
@@ -1310,7 +1315,12 @@ mod tests {
             .insert(region_id, RegionEngineWithStatus::Ready(engine.clone()));
 
         mock_region_server
-            .handle_request(region_id, RegionRequest::Drop(RegionDropRequest {}))
+            .handle_request(
+                region_id,
+                RegionRequest::Drop(RegionDropRequest {
+                    fast_drop_database_path: false,
+                }),
+            )
             .await
             .unwrap_err();
 

--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -1220,9 +1220,7 @@ mod tests {
         let response = mock_region_server
             .handle_request(
                 region_id,
-                RegionRequest::Drop(RegionDropRequest {
-                    force_drop_all_logical_tables: false,
-                }),
+                RegionRequest::Drop(RegionDropRequest { fast_path: false }),
             )
             .await
             .unwrap();
@@ -1317,9 +1315,7 @@ mod tests {
         mock_region_server
             .handle_request(
                 region_id,
-                RegionRequest::Drop(RegionDropRequest {
-                    force_drop_all_logical_tables: false,
-                }),
+                RegionRequest::Drop(RegionDropRequest { fast_path: false }),
             )
             .await
             .unwrap_err();

--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -1221,7 +1221,7 @@ mod tests {
             .handle_request(
                 region_id,
                 RegionRequest::Drop(RegionDropRequest {
-                    fast_drop_path: false,
+                    force_drop_all_logical_tables: false,
                 }),
             )
             .await
@@ -1318,7 +1318,7 @@ mod tests {
             .handle_request(
                 region_id,
                 RegionRequest::Drop(RegionDropRequest {
-                    fast_drop_path: false,
+                    force_drop_all_logical_tables: false,
                 }),
             )
             .await

--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -1221,7 +1221,7 @@ mod tests {
             .handle_request(
                 region_id,
                 RegionRequest::Drop(RegionDropRequest {
-                    fast_drop_database_path: false,
+                    fast_drop_path: false,
                 }),
             )
             .await
@@ -1318,7 +1318,7 @@ mod tests {
             .handle_request(
                 region_id,
                 RegionRequest::Drop(RegionDropRequest {
-                    fast_drop_database_path: false,
+                    fast_drop_path: false,
                 }),
             )
             .await

--- a/src/metric-engine/src/engine/drop.rs
+++ b/src/metric-engine/src/engine/drop.rs
@@ -33,6 +33,7 @@ impl MetricEngineInner {
         req: RegionDropRequest,
     ) -> Result<AffectedRows> {
         let data_region_id = utils::to_data_region_id(region_id);
+        let force_drop_all_logical_tables = req.force_drop_all_logical_tables;
 
         // enclose the guard in a block to prevent the guard from polluting the async context
         let (is_physical_region, is_physical_region_busy) = {
@@ -52,7 +53,7 @@ impl MetricEngineInner {
 
         if is_physical_region {
             // check if there is no logical region relates to this physical region
-            if is_physical_region_busy {
+            if is_physical_region_busy && !force_drop_all_logical_tables {
                 // reject if there is any present logical region
                 return Err(PhysicalRegionBusySnafu {
                     region_id: data_region_id,
@@ -60,9 +61,9 @@ impl MetricEngineInner {
                 .build());
             }
 
-            self.drop_physical_region(data_region_id).await
-        } else {
-            // cannot merge these two `if` otherwise the stupid type checker will complain
+            self.drop_physical_region(data_region_id, force_drop_all_logical_tables)
+                .await
+        } else if !force_drop_all_logical_tables {
             let metadata_region_id = self
                 .state
                 .read()
@@ -71,15 +72,21 @@ impl MetricEngineInner {
                 .get(&region_id)
                 .copied();
             if let Some(metadata_region_id) = metadata_region_id {
-                self.drop_logical_region(region_id, metadata_region_id, req.fast_drop_path)
+                self.drop_logical_region(region_id, metadata_region_id)
                     .await
             } else {
                 Err(LogicalRegionNotFoundSnafu { region_id }.build())
             }
+        } else {
+            Ok(0)
         }
     }
 
-    async fn drop_physical_region(&self, region_id: RegionId) -> Result<AffectedRows> {
+    async fn drop_physical_region(
+        &self,
+        region_id: RegionId,
+        force_drop_all_logical_tables: bool,
+    ) -> Result<AffectedRows> {
         let data_region_id = utils::to_data_region_id(region_id);
         let metadata_region_id = utils::to_metadata_region_id(region_id);
 
@@ -90,7 +97,7 @@ impl MetricEngineInner {
             .handle_request(
                 data_region_id,
                 RegionRequest::Drop(RegionDropRequest {
-                    fast_drop_path: false,
+                    force_drop_all_logical_tables,
                 }),
             )
             .await
@@ -99,7 +106,7 @@ impl MetricEngineInner {
             .handle_request(
                 metadata_region_id,
                 RegionRequest::Drop(RegionDropRequest {
-                    fast_drop_path: false,
+                    force_drop_all_logical_tables,
                 }),
             )
             .await
@@ -120,11 +127,10 @@ impl MetricEngineInner {
         &self,
         logical_region_id: RegionId,
         physical_region_id: RegionId,
-        fast_drop_path: bool,
     ) -> Result<AffectedRows> {
         // Update metadata
         self.metadata_region
-            .remove_logical_region(physical_region_id, logical_region_id, fast_drop_path)
+            .remove_logical_region(physical_region_id, logical_region_id)
             .await?;
 
         // Update engine state

--- a/src/metric-engine/src/engine/drop.rs
+++ b/src/metric-engine/src/engine/drop.rs
@@ -71,7 +71,7 @@ impl MetricEngineInner {
                 .get(&region_id)
                 .copied();
             if let Some(metadata_region_id) = metadata_region_id {
-                self.drop_logical_region(region_id, metadata_region_id, req.fast_drop_database_path)
+                self.drop_logical_region(region_id, metadata_region_id, req.fast_drop_path)
                     .await
             } else {
                 Err(LogicalRegionNotFoundSnafu { region_id }.build())
@@ -90,7 +90,7 @@ impl MetricEngineInner {
             .handle_request(
                 data_region_id,
                 RegionRequest::Drop(RegionDropRequest {
-                    fast_drop_database_path: false,
+                    fast_drop_path: false,
                 }),
             )
             .await
@@ -99,7 +99,7 @@ impl MetricEngineInner {
             .handle_request(
                 metadata_region_id,
                 RegionRequest::Drop(RegionDropRequest {
-                    fast_drop_database_path: false,
+                    fast_drop_path: false,
                 }),
             )
             .await
@@ -120,15 +120,11 @@ impl MetricEngineInner {
         &self,
         logical_region_id: RegionId,
         physical_region_id: RegionId,
-        fast_drop_database_path: bool,
+        fast_drop_path: bool,
     ) -> Result<AffectedRows> {
         // Update metadata
         self.metadata_region
-            .remove_logical_region(
-                physical_region_id,
-                logical_region_id,
-                fast_drop_database_path,
-            )
+            .remove_logical_region(physical_region_id, logical_region_id, fast_drop_path)
             .await?;
 
         // Update engine state

--- a/src/metric-engine/src/metadata_region.rs
+++ b/src/metric-engine/src/metadata_region.rs
@@ -124,9 +124,9 @@ impl MetadataRegion {
         &self,
         physical_region_id: RegionId,
         logical_region_id: RegionId,
-        fast_drop_database_path: bool,
+        fast_drop_path: bool,
     ) -> Result<()> {
-        if !fast_drop_database_path {
+        if !fast_drop_path {
             // concat region key
             let region_id = utils::to_metadata_region_id(physical_region_id);
             let region_key = Self::concat_region_key(logical_region_id);

--- a/src/metric-engine/src/metadata_region.rs
+++ b/src/metric-engine/src/metadata_region.rs
@@ -124,26 +124,23 @@ impl MetadataRegion {
         &self,
         physical_region_id: RegionId,
         logical_region_id: RegionId,
-        fast_drop_path: bool,
     ) -> Result<()> {
-        if !fast_drop_path {
-            // concat region key
-            let region_id = utils::to_metadata_region_id(physical_region_id);
-            let region_key = Self::concat_region_key(logical_region_id);
+        // concat region key
+        let region_id = utils::to_metadata_region_id(physical_region_id);
+        let region_key = Self::concat_region_key(logical_region_id);
 
-            // concat column keys
-            let logical_columns = self
-                .logical_columns(physical_region_id, logical_region_id)
-                .await?;
-            let mut column_keys = logical_columns
-                .into_iter()
-                .map(|(col, _)| Self::concat_column_key(logical_region_id, &col))
-                .collect::<Vec<_>>();
+        // concat column keys
+        let logical_columns = self
+            .logical_columns(physical_region_id, logical_region_id)
+            .await?;
+        let mut column_keys = logical_columns
+            .into_iter()
+            .map(|(col, _)| Self::concat_column_key(logical_region_id, &col))
+            .collect::<Vec<_>>();
 
-            // remove region key and column keys
-            column_keys.push(region_key);
-            self.delete(region_id, &column_keys).await?;
-        }
+        // remove region key and column keys
+        column_keys.push(region_key);
+        self.delete(region_id, &column_keys).await?;
 
         self.logical_region_lock
             .write()

--- a/src/metric-engine/src/metadata_region.rs
+++ b/src/metric-engine/src/metadata_region.rs
@@ -124,23 +124,26 @@ impl MetadataRegion {
         &self,
         physical_region_id: RegionId,
         logical_region_id: RegionId,
+        fast_drop_database_path: bool,
     ) -> Result<()> {
-        // concat region key
-        let region_id = utils::to_metadata_region_id(physical_region_id);
-        let region_key = Self::concat_region_key(logical_region_id);
+        if !fast_drop_database_path {
+            // concat region key
+            let region_id = utils::to_metadata_region_id(physical_region_id);
+            let region_key = Self::concat_region_key(logical_region_id);
 
-        // concat column keys
-        let logical_columns = self
-            .logical_columns(physical_region_id, logical_region_id)
-            .await?;
-        let mut column_keys = logical_columns
-            .into_iter()
-            .map(|(col, _)| Self::concat_column_key(logical_region_id, &col))
-            .collect::<Vec<_>>();
+            // concat column keys
+            let logical_columns = self
+                .logical_columns(physical_region_id, logical_region_id)
+                .await?;
+            let mut column_keys = logical_columns
+                .into_iter()
+                .map(|(col, _)| Self::concat_column_key(logical_region_id, &col))
+                .collect::<Vec<_>>();
 
-        // remove region key and column keys
-        column_keys.push(region_key);
-        self.delete(region_id, &column_keys).await?;
+            // remove region key and column keys
+            column_keys.push(region_key);
+            self.delete(region_id, &column_keys).await?;
+        }
 
         self.logical_region_lock
             .write()

--- a/src/mito2/src/engine/drop_test.rs
+++ b/src/mito2/src/engine/drop_test.rs
@@ -59,7 +59,7 @@ async fn test_engine_drop_region() {
         .handle_request(
             region_id,
             RegionRequest::Drop(RegionDropRequest {
-                fast_drop_database_path: false,
+                fast_drop_path: false,
             }),
         )
         .await
@@ -94,7 +94,7 @@ async fn test_engine_drop_region() {
         .handle_request(
             region_id,
             RegionRequest::Drop(RegionDropRequest {
-                fast_drop_database_path: false,
+                fast_drop_path: false,
             }),
         )
         .await
@@ -205,7 +205,7 @@ async fn test_engine_drop_region_for_custom_store() {
         .handle_request(
             custom_region_id,
             RegionRequest::Drop(RegionDropRequest {
-                fast_drop_database_path: false,
+                fast_drop_path: false,
             }),
         )
         .await

--- a/src/mito2/src/engine/drop_test.rs
+++ b/src/mito2/src/engine/drop_test.rs
@@ -56,7 +56,12 @@ async fn test_engine_drop_region() {
 
     // It's okay to drop a region doesn't exist.
     engine
-        .handle_request(region_id, RegionRequest::Drop(RegionDropRequest {}))
+        .handle_request(
+            region_id,
+            RegionRequest::Drop(RegionDropRequest {
+                fast_drop_database_path: false,
+            }),
+        )
         .await
         .unwrap_err();
 
@@ -86,7 +91,12 @@ async fn test_engine_drop_region() {
 
     // drop the created region.
     engine
-        .handle_request(region_id, RegionRequest::Drop(RegionDropRequest {}))
+        .handle_request(
+            region_id,
+            RegionRequest::Drop(RegionDropRequest {
+                fast_drop_database_path: false,
+            }),
+        )
         .await
         .unwrap();
     assert!(!engine.is_region_exists(region_id));
@@ -192,7 +202,12 @@ async fn test_engine_drop_region_for_custom_store() {
 
     // Drop the custom region.
     engine
-        .handle_request(custom_region_id, RegionRequest::Drop(RegionDropRequest {}))
+        .handle_request(
+            custom_region_id,
+            RegionRequest::Drop(RegionDropRequest {
+                fast_drop_database_path: false,
+            }),
+        )
         .await
         .unwrap();
     assert!(!engine.is_region_exists(custom_region_id));

--- a/src/mito2/src/engine/drop_test.rs
+++ b/src/mito2/src/engine/drop_test.rs
@@ -59,7 +59,7 @@ async fn test_engine_drop_region() {
         .handle_request(
             region_id,
             RegionRequest::Drop(RegionDropRequest {
-                fast_drop_path: false,
+                force_drop_all_logical_tables: false,
             }),
         )
         .await
@@ -94,7 +94,7 @@ async fn test_engine_drop_region() {
         .handle_request(
             region_id,
             RegionRequest::Drop(RegionDropRequest {
-                fast_drop_path: false,
+                force_drop_all_logical_tables: false,
             }),
         )
         .await
@@ -205,7 +205,7 @@ async fn test_engine_drop_region_for_custom_store() {
         .handle_request(
             custom_region_id,
             RegionRequest::Drop(RegionDropRequest {
-                fast_drop_path: false,
+                force_drop_all_logical_tables: false,
             }),
         )
         .await

--- a/src/mito2/src/engine/drop_test.rs
+++ b/src/mito2/src/engine/drop_test.rs
@@ -58,9 +58,7 @@ async fn test_engine_drop_region() {
     engine
         .handle_request(
             region_id,
-            RegionRequest::Drop(RegionDropRequest {
-                force_drop_all_logical_tables: false,
-            }),
+            RegionRequest::Drop(RegionDropRequest { fast_path: false }),
         )
         .await
         .unwrap_err();
@@ -93,9 +91,7 @@ async fn test_engine_drop_region() {
     engine
         .handle_request(
             region_id,
-            RegionRequest::Drop(RegionDropRequest {
-                force_drop_all_logical_tables: false,
-            }),
+            RegionRequest::Drop(RegionDropRequest { fast_path: false }),
         )
         .await
         .unwrap();
@@ -204,9 +200,7 @@ async fn test_engine_drop_region_for_custom_store() {
     engine
         .handle_request(
             custom_region_id,
-            RegionRequest::Drop(RegionDropRequest {
-                force_drop_all_logical_tables: false,
-            }),
+            RegionRequest::Drop(RegionDropRequest { fast_path: false }),
         )
         .await
         .unwrap();

--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -35,8 +35,8 @@ use store_api::metadata::{ColumnMetadata, RegionMetadata, RegionMetadataRef};
 use store_api::region_engine::{SetRegionRoleStateResponse, SettableRegionRoleState};
 use store_api::region_request::{
     AffectedRows, RegionAlterRequest, RegionCatchupRequest, RegionCloseRequest,
-    RegionCompactRequest, RegionCreateRequest, RegionDropRequest, RegionFlushRequest,
-    RegionOpenRequest, RegionRequest, RegionTruncateRequest,
+    RegionCompactRequest, RegionCreateRequest, RegionFlushRequest, RegionOpenRequest,
+    RegionRequest, RegionTruncateRequest,
 };
 use store_api::storage::{RegionId, SequenceNumber};
 use tokio::sync::oneshot::{self, Receiver, Sender};
@@ -624,10 +624,10 @@ impl WorkerRequest {
                 sender: sender.into(),
                 request: DdlRequest::Create(v),
             }),
-            RegionRequest::Drop(v) => WorkerRequest::Ddl(SenderDdlRequest {
+            RegionRequest::Drop(_) => WorkerRequest::Ddl(SenderDdlRequest {
                 region_id,
                 sender: sender.into(),
-                request: DdlRequest::Drop(v),
+                request: DdlRequest::Drop(()),
             }),
             RegionRequest::Open(v) => WorkerRequest::Ddl(SenderDdlRequest {
                 region_id,
@@ -690,8 +690,7 @@ impl WorkerRequest {
 #[derive(Debug)]
 pub(crate) enum DdlRequest {
     Create(RegionCreateRequest),
-    #[allow(dead_code)]
-    Drop(RegionDropRequest),
+    Drop(()), // 修改：原来为 RegionDropRequest
     Open((RegionOpenRequest, Option<WalEntryReceiver>)),
     Close(RegionCloseRequest),
     Alter(RegionAlterRequest),

--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -690,7 +690,7 @@ impl WorkerRequest {
 #[derive(Debug)]
 pub(crate) enum DdlRequest {
     Create(RegionCreateRequest),
-    Drop(()), // 修改：原来为 RegionDropRequest
+    Drop(()),
     Open((RegionOpenRequest, Option<WalEntryReceiver>)),
     Close(RegionCloseRequest),
     Alter(RegionAlterRequest),

--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -627,7 +627,7 @@ impl WorkerRequest {
             RegionRequest::Drop(_) => WorkerRequest::Ddl(SenderDdlRequest {
                 region_id,
                 sender: sender.into(),
-                request: DdlRequest::Drop(()),
+                request: DdlRequest::Drop,
             }),
             RegionRequest::Open(v) => WorkerRequest::Ddl(SenderDdlRequest {
                 region_id,
@@ -690,7 +690,7 @@ impl WorkerRequest {
 #[derive(Debug)]
 pub(crate) enum DdlRequest {
     Create(RegionCreateRequest),
-    Drop(()),
+    Drop,
     Open((RegionOpenRequest, Option<WalEntryReceiver>)),
     Close(RegionCloseRequest),
     Alter(RegionAlterRequest),

--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -690,6 +690,7 @@ impl WorkerRequest {
 #[derive(Debug)]
 pub(crate) enum DdlRequest {
     Create(RegionCreateRequest),
+    #[allow(dead_code)]
     Drop(RegionDropRequest),
     Open((RegionOpenRequest, Option<WalEntryReceiver>)),
     Close(RegionCloseRequest),

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -836,7 +836,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         for ddl in ddl_requests.drain(..) {
             let res = match ddl.request {
                 DdlRequest::Create(req) => self.handle_create_request(ddl.region_id, req).await,
-                DdlRequest::Drop(_) => self.handle_drop_request(ddl.region_id).await,
+                DdlRequest::Drop => self.handle_drop_request(ddl.region_id).await,
                 DdlRequest::Open((req, wal_entry_receiver)) => {
                     self.handle_open_request(ddl.region_id, req, wal_entry_receiver, ddl.sender)
                         .await;

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -222,8 +222,13 @@ fn make_region_creates(creates: CreateRequests) -> Result<Vec<(RegionId, RegionR
 
 fn parse_region_drop(drop: DropRequest) -> Result<(RegionId, RegionDropRequest)> {
     let region_id = drop.region_id.into();
-    let fast_drop_path = drop.fast_drop_path;
-    Ok((region_id, RegionDropRequest { fast_drop_path }))
+    let force_drop_all_logical_tables = drop.force_drop_all_logical_tables;
+    Ok((
+        region_id,
+        RegionDropRequest {
+            force_drop_all_logical_tables,
+        },
+    ))
 }
 
 fn make_region_drop(drop: DropRequest) -> Result<Vec<(RegionId, RegionRequest)>> {
@@ -402,7 +407,7 @@ impl RegionCreateRequest {
 pub struct RegionDropRequest {
     /// fast drop database path for the shortcut that do not need to delete logical
     /// columns first more to check issue #4974 and #5561
-    pub fast_drop_path: bool,
+    pub force_drop_all_logical_tables: bool,
 }
 
 /// Open region request.

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -222,7 +222,13 @@ fn make_region_creates(creates: CreateRequests) -> Result<Vec<(RegionId, RegionR
 
 fn parse_region_drop(drop: DropRequest) -> Result<(RegionId, RegionDropRequest)> {
     let region_id = drop.region_id.into();
-    Ok((region_id, RegionDropRequest {}))
+    let fast_drop_database_path = drop.fast_drop_database_path;
+    Ok((
+        region_id,
+        RegionDropRequest {
+            fast_drop_database_path,
+        },
+    ))
 }
 
 fn make_region_drop(drop: DropRequest) -> Result<Vec<(RegionId, RegionRequest)>> {
@@ -397,8 +403,12 @@ impl RegionCreateRequest {
     }
 }
 
-#[derive(Debug, Clone, Default)]
-pub struct RegionDropRequest {}
+#[derive(Debug, Clone)]
+pub struct RegionDropRequest {
+    /// fast drop database path for the shortcut that do not need to delete logical
+    /// columns first more to check issue #4974 and #5561
+    pub fast_drop_database_path: bool,
+}
 
 /// Open region request.
 #[derive(Debug, Clone)]

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -222,13 +222,8 @@ fn make_region_creates(creates: CreateRequests) -> Result<Vec<(RegionId, RegionR
 
 fn parse_region_drop(drop: DropRequest) -> Result<(RegionId, RegionDropRequest)> {
     let region_id = drop.region_id.into();
-    let fast_drop_database_path = drop.fast_drop_database_path;
-    Ok((
-        region_id,
-        RegionDropRequest {
-            fast_drop_database_path,
-        },
-    ))
+    let fast_drop_path = drop.fast_drop_path;
+    Ok((region_id, RegionDropRequest { fast_drop_path }))
 }
 
 fn make_region_drop(drop: DropRequest) -> Result<Vec<(RegionId, RegionRequest)>> {
@@ -407,7 +402,7 @@ impl RegionCreateRequest {
 pub struct RegionDropRequest {
     /// fast drop database path for the shortcut that do not need to delete logical
     /// columns first more to check issue #4974 and #5561
-    pub fast_drop_database_path: bool,
+    pub fast_drop_path: bool,
 }
 
 /// Open region request.

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -226,7 +226,7 @@ fn parse_region_drop(drop: DropRequest) -> Result<(RegionId, RegionDropRequest)>
     Ok((
         region_id,
         RegionDropRequest {
-            force_drop_all_logical_tables,
+            fast_path: force_drop_all_logical_tables,
         },
     ))
 }
@@ -405,9 +405,7 @@ impl RegionCreateRequest {
 
 #[derive(Debug, Clone)]
 pub struct RegionDropRequest {
-    /// fast drop database path for the shortcut that do not need to delete logical
-    /// columns first more to check issue #4974 and #5561
-    pub force_drop_all_logical_tables: bool,
+    pub fast_path: bool,
 }
 
 /// Open region request.

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -222,11 +222,10 @@ fn make_region_creates(creates: CreateRequests) -> Result<Vec<(RegionId, RegionR
 
 fn parse_region_drop(drop: DropRequest) -> Result<(RegionId, RegionDropRequest)> {
     let region_id = drop.region_id.into();
-    let force_drop_all_logical_tables = drop.force_drop_all_logical_tables;
     Ok((
         region_id,
         RegionDropRequest {
-            fast_path: force_drop_all_logical_tables,
+            fast_path: drop.fast_path,
         },
     ))
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

After some search and learn the region server found maybe we can skip the drop columns in drop logical region
since all data can be drop in `phy` table I wonder.

because the function `get_all` or `get_all_with_prefix` is very expensive, cost almost all the time for the drop database

before this patch

![image](https://github.com/user-attachments/assets/bcd3f53b-313a-481a-b9ae-99882636a710)

after this patch
![image](https://github.com/user-attachments/assets/c5b8651d-3e5e-4367-a902-6fc5d8bf0c1d)

the generate data scripts

```py
import psycopg2
import time
from datetime import datetime, timedelta

# --- Configuration ---
DB_HOST = "localhost"
DB_PORT = "4003"
DB_USER = "greptime"
DB_NAME = "public"
SENSORS_PER_LOCATION = 4000
SIMULATION_DURATION_HOURS = 5
INSERT_BATCH_SIZE = 4000




def insert_data_now(simulation_start_time):
    conn = create_connection()
    try:
        # First create physical table
        with conn.cursor() as cur:
            cur.execute("CREATE DATABASE test;")
            cur.execute("use test;")
            physical_table_sql = "CREATE TABLE phy (ts timestamp time index, val double) engine=metric with (\"physical_metric_table\" = \"\");"
            physical2_table_sql = "CREATE TABLE phy2 (ts timestamp time index, val double) engine=metric with (\"physical_metric_table\" = \"\");"
            try:
                cur.execute(physical_table_sql)
                cur.execute(physical2_table_sql)
                conn.commit()
            except Exception as e:
                print(f"Physical table creation error: {e}")

        current_time = simulation_start_time

        with conn.cursor() as cur:
            index = 1
            while current_time <= simulation_start_time + timedelta(seconds=200):
                insert_sql = f"CREATE TABLE t{index} (ts timestamp time index, val double, host string primary key) engine = metric with (\"on_physical_table\" = \"phy\");"
                insert2_sql = f"CREATE TABLE b{index} (ts timestamp time index, val double, host string primary key) engine = metric with (\"on_physical_table\" = \"phy2\");"
                index += 1
                try:
                    cur.execute(insert_sql)
                    cur.execute(insert2_sql)
                    conn.commit()
                except Exception as e:
                    print(f"Table creation error: {e}")
                    continue
                print(f"Created table t{index-1} at {current_time}")
                print(f"Created table b{index-1} at {current_time}")
                current_time += timedelta(seconds=1)
    finally:
        if conn:
            conn.close() # close connect in the thread.

def create_connection():
    """Creates a database connection."""
    conn = psycopg2.connect(
        host=DB_HOST,
        port=DB_PORT,
        user=DB_USER,
        dbname=DB_NAME
    )
    return conn

def main():
    """Main function."""
    simulation_start_time = datetime.utcnow() - timedelta(seconds=200)

    insert_data_now(simulation_start_time=simulation_start_time)

if __name__ == "__main__":
    main()
```


## Refer to a related PR or issue link (optional)

close #4974

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
