### PR TITLE
feat: unify puffin name passed to stager

### DIFF
--- a/src/index/src/fulltext_index/tests.rs
+++ b/src/index/src/fulltext_index/tests.rs
@@ -25,7 +25,7 @@ use crate::fulltext_index::create::{FulltextIndexCreator, TantivyFulltextIndexCr
 use crate::fulltext_index::search::{FulltextIndexSearcher, RowId, TantivyFulltextIndexSearcher};
 use crate::fulltext_index::{Analyzer, Config};
 
-async fn new_bounded_stager(prefix: &str) -> (TempDir, Arc<BoundedStager>) {
+async fn new_bounded_stager(prefix: &str) -> (TempDir, Arc<BoundedStager<String>>) {
     let staging_dir = create_temp_dir(prefix);
     let path = staging_dir.path().to_path_buf();
     (
@@ -68,13 +68,13 @@ async fn test_search(
     let file_accessor = Arc::new(MockFileAccessor::new(prefix));
     let puffin_manager = FsPuffinManager::new(stager, file_accessor);
 
-    let file_name = "fulltext_index";
-    let blob_key = "fulltext_index";
-    let mut writer = puffin_manager.writer(file_name).await.unwrap();
-    create_index(prefix, &mut writer, blob_key, texts, config).await;
+    let file_name = "fulltext_index".to_string();
+    let blob_key = "fulltext_index".to_string();
+    let mut writer = puffin_manager.writer(&file_name).await.unwrap();
+    create_index(prefix, &mut writer, &blob_key, texts, config).await;
 
-    let reader = puffin_manager.reader(file_name).await.unwrap();
-    let index_dir = reader.dir(blob_key).await.unwrap();
+    let reader = puffin_manager.reader(&file_name).await.unwrap();
+    let index_dir = reader.dir(&blob_key).await.unwrap();
     let searcher = TantivyFulltextIndexSearcher::new(index_dir.path()).unwrap();
     let results = searcher.search(query).await.unwrap();
 

--- a/src/mito2/src/sst/file.rs
+++ b/src/mito2/src/sst/file.rs
@@ -174,31 +174,8 @@ impl FileMeta {
             .contains(&IndexType::BloomFilterIndex)
     }
 
-    /// Returns the size of the inverted index file
-    pub fn inverted_index_size(&self) -> Option<u64> {
-        if self.available_indexes.len() == 1 && self.inverted_index_available() {
-            Some(self.index_file_size)
-        } else {
-            None
-        }
-    }
-
-    /// Returns the size of the fulltext index file
-    pub fn fulltext_index_size(&self) -> Option<u64> {
-        if self.available_indexes.len() == 1 && self.fulltext_index_available() {
-            Some(self.index_file_size)
-        } else {
-            None
-        }
-    }
-
-    /// Returns the size of the bloom filter index file
-    pub fn bloom_filter_index_size(&self) -> Option<u64> {
-        if self.available_indexes.len() == 1 && self.bloom_filter_index_available() {
-            Some(self.index_file_size)
-        } else {
-            None
-        }
+    pub fn index_file_size(&self) -> u64 {
+        self.index_file_size
     }
 }
 

--- a/src/mito2/src/sst/file_purger.rs
+++ b/src/mito2/src/sst/file_purger.rs
@@ -113,11 +113,9 @@ impl FilePurger for LocalFilePurger {
             }
 
             // Purges index content in the stager.
-            let puffin_file_name =
-                crate::sst::location::index_file_path(sst_layer.region_dir(), file_meta.file_id);
             if let Err(e) = sst_layer
                 .puffin_manager_factory()
-                .purge_stager(&puffin_file_name)
+                .purge_stager(file_meta.file_id)
                 .await
             {
                 error!(e; "Failed to purge stager with index file, file_id: {}, region: {}",

--- a/src/mito2/src/sst/index/fulltext_index/applier.rs
+++ b/src/mito2/src/sst/index/fulltext_index/applier.rs
@@ -17,17 +17,19 @@ use std::sync::Arc;
 
 use index::fulltext_index::search::{FulltextIndexSearcher, RowId, TantivyFulltextIndexSearcher};
 use object_store::ObjectStore;
+use puffin::puffin_manager::cache::PuffinMetadataCacheRef;
 use puffin::puffin_manager::{DirGuard, PuffinManager, PuffinReader};
 use snafu::ResultExt;
-use store_api::storage::ColumnId;
+use store_api::storage::{ColumnId, RegionId};
 
+use crate::access_layer::{RegionFilePathFactory, WriteCachePathProvider};
+use crate::cache::file_cache::{FileCacheRef, FileType, IndexKey};
 use crate::error::{ApplyFulltextIndexSnafu, PuffinBuildReaderSnafu, PuffinReadBlobSnafu, Result};
 use crate::metrics::INDEX_APPLY_ELAPSED;
 use crate::sst::file::FileId;
 use crate::sst::index::fulltext_index::INDEX_BLOB_TYPE_TANTIVY;
 use crate::sst::index::puffin_manager::{PuffinManagerFactory, SstPuffinDir};
 use crate::sst::index::TYPE_FULLTEXT_INDEX;
-use crate::sst::location;
 
 pub mod builder;
 
@@ -35,6 +37,9 @@ pub mod builder;
 pub struct FulltextIndexApplier {
     /// The root directory of the region.
     region_dir: String,
+
+    /// The region ID.
+    region_id: RegionId,
 
     /// Queries to apply to the index.
     queries: Vec<(ColumnId, String)>,
@@ -44,6 +49,12 @@ pub struct FulltextIndexApplier {
 
     /// Store responsible for accessing index files.
     store: ObjectStore,
+
+    /// File cache to be used by the `FulltextIndexApplier`.
+    file_cache: Option<FileCacheRef>,
+
+    /// The puffin metadata cache.
+    puffin_metadata_cache: Option<PuffinMetadataCacheRef>,
 }
 
 pub type FulltextIndexApplierRef = Arc<FulltextIndexApplier>;
@@ -52,20 +63,43 @@ impl FulltextIndexApplier {
     /// Creates a new `FulltextIndexApplier`.
     pub fn new(
         region_dir: String,
+        region_id: RegionId,
         store: ObjectStore,
         queries: Vec<(ColumnId, String)>,
         puffin_manager_factory: PuffinManagerFactory,
     ) -> Self {
         Self {
             region_dir,
+            region_id,
             store,
             queries,
             puffin_manager_factory,
+            file_cache: None,
+            puffin_metadata_cache: None,
         }
     }
 
+    /// Sets the file cache.
+    pub fn with_file_cache(mut self, file_cache: Option<FileCacheRef>) -> Self {
+        self.file_cache = file_cache;
+        self
+    }
+
+    /// Sets the puffin metadata cache.
+    pub fn with_puffin_metadata_cache(
+        mut self,
+        puffin_metadata_cache: Option<PuffinMetadataCacheRef>,
+    ) -> Self {
+        self.puffin_metadata_cache = puffin_metadata_cache;
+        self
+    }
+
     /// Applies the queries to the fulltext index of the specified SST file.
-    pub async fn apply(&self, file_id: FileId) -> Result<BTreeSet<RowId>> {
+    pub async fn apply(
+        &self,
+        file_id: FileId,
+        file_size_hint: Option<u64>,
+    ) -> Result<BTreeSet<RowId>> {
         let _timer = INDEX_APPLY_ELAPSED
             .with_label_values(&[TYPE_FULLTEXT_INDEX])
             .start_timer();
@@ -74,7 +108,9 @@ impl FulltextIndexApplier {
         let mut row_ids = BTreeSet::new();
 
         for (column_id, query) in &self.queries {
-            let dir = self.index_dir_path(file_id, *column_id).await?;
+            let dir = self
+                .index_dir_path(file_id, *column_id, file_size_hint)
+                .await?;
             let path = match &dir {
                 Some(dir) => dir.path(),
                 None => {
@@ -110,14 +146,32 @@ impl FulltextIndexApplier {
         &self,
         file_id: FileId,
         column_id: ColumnId,
+        file_size_hint: Option<u64>,
     ) -> Result<Option<SstPuffinDir>> {
-        let puffin_manager = self.puffin_manager_factory.build(self.store.clone());
-        let file_path = location::index_file_path(&self.region_dir, file_id);
+        let mut puffin_manager = None;
+        if let Some(file_cache) = &self.file_cache {
+            let index_key = IndexKey::new(self.region_id, file_id, FileType::Puffin);
+            if file_cache.get(index_key).await.is_some() {
+                puffin_manager = Some(self.puffin_manager_factory.build(
+                    file_cache.local_store(),
+                    WriteCachePathProvider::new(self.region_id, file_cache.clone()),
+                ));
+            }
+        }
+
+        if puffin_manager.is_none() {
+            puffin_manager = Some(self.puffin_manager_factory.build(
+                self.store.clone(),
+                RegionFilePathFactory::new(self.region_dir.clone()),
+            ));
+        }
 
         match puffin_manager
-            .reader(&file_path)
+            .unwrap()
+            .reader(&file_id)
             .await
             .context(PuffinBuildReaderSnafu)?
+            .with_file_size_hint(file_size_hint)
             .dir(&format!("{INDEX_BLOB_TYPE_TANTIVY}-{column_id}"))
             .await
         {

--- a/src/mito2/src/sst/index/fulltext_index/applier/builder.rs
+++ b/src/mito2/src/sst/index/fulltext_index/applier/builder.rs
@@ -15,9 +15,11 @@
 use datafusion_common::ScalarValue;
 use datafusion_expr::Expr;
 use object_store::ObjectStore;
+use puffin::puffin_manager::cache::PuffinMetadataCacheRef;
 use store_api::metadata::RegionMetadata;
-use store_api::storage::{ColumnId, ConcreteDataType};
+use store_api::storage::{ColumnId, ConcreteDataType, RegionId};
 
+use crate::cache::file_cache::FileCacheRef;
 use crate::error::Result;
 use crate::sst::index::fulltext_index::applier::FulltextIndexApplier;
 use crate::sst::index::puffin_manager::PuffinManagerFactory;
@@ -25,25 +27,47 @@ use crate::sst::index::puffin_manager::PuffinManagerFactory;
 /// `FulltextIndexApplierBuilder` is a builder for `FulltextIndexApplier`.
 pub struct FulltextIndexApplierBuilder<'a> {
     region_dir: String,
+    region_id: RegionId,
     store: ObjectStore,
     puffin_manager_factory: PuffinManagerFactory,
     metadata: &'a RegionMetadata,
+    file_cache: Option<FileCacheRef>,
+    puffin_metadata_cache: Option<PuffinMetadataCacheRef>,
 }
 
 impl<'a> FulltextIndexApplierBuilder<'a> {
     /// Creates a new `FulltextIndexApplierBuilder`.
     pub fn new(
         region_dir: String,
+        region_id: RegionId,
         store: ObjectStore,
         puffin_manager_factory: PuffinManagerFactory,
         metadata: &'a RegionMetadata,
     ) -> Self {
         Self {
             region_dir,
+            region_id,
             store,
             puffin_manager_factory,
             metadata,
+            file_cache: None,
+            puffin_metadata_cache: None,
         }
+    }
+
+    /// Sets the file cache to be used by the `FulltextIndexApplier`.
+    pub fn with_file_cache(mut self, file_cache: Option<FileCacheRef>) -> Self {
+        self.file_cache = file_cache;
+        self
+    }
+
+    /// Sets the puffin metadata cache to be used by the `FulltextIndexApplier`.
+    pub fn with_puffin_metadata_cache(
+        mut self,
+        puffin_metadata_cache: Option<PuffinMetadataCacheRef>,
+    ) -> Self {
+        self.puffin_metadata_cache = puffin_metadata_cache;
+        self
     }
 
     /// Builds `SstIndexApplier` from the given expressions.
@@ -58,10 +82,13 @@ impl<'a> FulltextIndexApplierBuilder<'a> {
         Ok((!queries.is_empty()).then(|| {
             FulltextIndexApplier::new(
                 self.region_dir,
+                self.region_id,
                 self.store,
                 queries,
                 self.puffin_manager_factory,
             )
+            .with_file_cache(self.file_cache)
+            .with_puffin_metadata_cache(self.puffin_metadata_cache)
         }))
     }
 

--- a/src/mito2/src/sst/index/indexer/finish.rs
+++ b/src/mito2/src/sst/index/indexer/finish.rs
@@ -62,7 +62,7 @@ impl Indexer {
     async fn build_puffin_writer(&mut self) -> Option<SstPuffinWriter> {
         let puffin_manager = self.puffin_manager.take()?;
 
-        let err = match puffin_manager.writer(&self.file_path).await {
+        let err = match puffin_manager.writer(&self.file_id).await {
             Ok(writer) => return Some(writer),
             Err(err) => err,
         };

--- a/src/mito2/src/sst/index/inverted_index/creator.rs
+++ b/src/mito2/src/sst/index/inverted_index/creator.rs
@@ -336,13 +336,13 @@ mod tests {
     use store_api::storage::RegionId;
 
     use super::*;
+    use crate::access_layer::RegionFilePathFactory;
     use crate::cache::index::inverted_index::InvertedIndexCache;
     use crate::metrics::CACHE_BYTES;
     use crate::read::BatchColumn;
     use crate::row_converter::{DensePrimaryKeyCodec, PrimaryKeyCodecExt};
     use crate::sst::index::inverted_index::applier::builder::InvertedIndexApplierBuilder;
     use crate::sst::index::puffin_manager::PuffinManagerFactory;
-    use crate::sst::location;
 
     fn mock_object_store() -> ObjectStore {
         ObjectStore::new(Memory::default()).unwrap().finish()
@@ -438,7 +438,6 @@ mod tests {
         let (d, factory) = PuffinManagerFactory::new_for_test_async(prefix).await;
         let region_dir = "region0".to_string();
         let sst_file_id = FileId::random();
-        let file_path = location::index_file_path(&region_dir, sst_file_id);
         let object_store = mock_object_store();
         let region_metadata = mock_region_metadata();
         let intm_mgr = new_intm_mgr(d.path().to_string_lossy()).await;
@@ -460,8 +459,11 @@ mod tests {
             creator.update(&mut batch).await.unwrap();
         }
 
-        let puffin_manager = factory.build(object_store.clone());
-        let mut writer = puffin_manager.writer(&file_path).await.unwrap();
+        let puffin_manager = factory.build(
+            object_store.clone(),
+            RegionFilePathFactory::new(region_dir.clone()),
+        );
+        let mut writer = puffin_manager.writer(&sst_file_id).await.unwrap();
         let (row_count, _) = creator.finish(&mut writer).await.unwrap();
         assert_eq!(row_count, rows.len() * segment_row_count);
         writer.finish().await.unwrap();

--- a/src/mito2/src/sst/index/puffin_manager.rs
+++ b/src/mito2/src/sst/index/puffin_manager.rs
@@ -25,18 +25,20 @@ use puffin::puffin_manager::stager::{BoundedStager, Stager};
 use puffin::puffin_manager::{BlobGuard, PuffinManager, PuffinReader};
 use snafu::ResultExt;
 
+use crate::access_layer::FilePathProvider;
 use crate::error::{PuffinInitStagerSnafu, PuffinPurgeStagerSnafu, Result};
 use crate::metrics::{
     StagerMetrics, INDEX_PUFFIN_FLUSH_OP_TOTAL, INDEX_PUFFIN_READ_BYTES_TOTAL,
     INDEX_PUFFIN_READ_OP_TOTAL, INDEX_PUFFIN_WRITE_BYTES_TOTAL, INDEX_PUFFIN_WRITE_OP_TOTAL,
 };
+use crate::sst::file::FileId;
 use crate::sst::index::store::{self, InstrumentedStore};
 
 type InstrumentedRangeReader = store::InstrumentedRangeReader<'static>;
 type InstrumentedAsyncWrite = store::InstrumentedAsyncWrite<'static, FuturesAsyncWriter>;
 
 pub(crate) type SstPuffinManager =
-    FsPuffinManager<Arc<BoundedStager>, ObjectStorePuffinFileAccessor>;
+    FsPuffinManager<Arc<BoundedStager<FileId>>, ObjectStorePuffinFileAccessor>;
 pub(crate) type SstPuffinReader = <SstPuffinManager as PuffinManager>::Reader;
 pub(crate) type SstPuffinWriter = <SstPuffinManager as PuffinManager>::Writer;
 pub(crate) type SstPuffinBlob = <SstPuffinReader as PuffinReader>::Blob;
@@ -49,7 +51,7 @@ const STAGING_DIR: &str = "staging";
 #[derive(Clone)]
 pub struct PuffinManagerFactory {
     /// The stager used by the puffin manager.
-    stager: Arc<BoundedStager>,
+    stager: Arc<BoundedStager<FileId>>,
 
     /// The size of the write buffer used to create object store.
     write_buffer_size: Option<usize>,
@@ -76,15 +78,20 @@ impl PuffinManagerFactory {
         })
     }
 
-    pub(crate) fn build(&self, store: ObjectStore) -> SstPuffinManager {
+    pub(crate) fn build(
+        &self,
+        store: ObjectStore,
+        path_provider: impl FilePathProvider + 'static,
+    ) -> SstPuffinManager {
         let store = InstrumentedStore::new(store).with_write_buffer_size(self.write_buffer_size);
-        let puffin_file_accessor = ObjectStorePuffinFileAccessor::new(store);
+        let puffin_file_accessor =
+            ObjectStorePuffinFileAccessor::new(store, Arc::new(path_provider));
         SstPuffinManager::new(self.stager.clone(), puffin_file_accessor)
     }
 
-    pub(crate) async fn purge_stager(&self, puffin_file_name: &str) -> Result<()> {
+    pub(crate) async fn purge_stager(&self, file_id: FileId) -> Result<()> {
         self.stager
-            .purge(puffin_file_name)
+            .purge(&file_id)
             .await
             .context(PuffinPurgeStagerSnafu)
     }
@@ -116,11 +123,15 @@ impl PuffinManagerFactory {
 #[derive(Clone)]
 pub(crate) struct ObjectStorePuffinFileAccessor {
     object_store: InstrumentedStore,
+    path_provider: Arc<dyn FilePathProvider>,
 }
 
 impl ObjectStorePuffinFileAccessor {
-    pub fn new(object_store: InstrumentedStore) -> Self {
-        Self { object_store }
+    pub fn new(object_store: InstrumentedStore, path_provider: Arc<dyn FilePathProvider>) -> Self {
+        Self {
+            object_store,
+            path_provider,
+        }
     }
 }
 
@@ -128,11 +139,13 @@ impl ObjectStorePuffinFileAccessor {
 impl PuffinFileAccessor for ObjectStorePuffinFileAccessor {
     type Reader = InstrumentedRangeReader;
     type Writer = InstrumentedAsyncWrite;
+    type FileHandle = FileId;
 
-    async fn reader(&self, puffin_file_name: &str) -> PuffinResult<Self::Reader> {
+    async fn reader(&self, handle: &FileId) -> PuffinResult<Self::Reader> {
+        let file_path = self.path_provider.build_index_file_path(*handle);
         self.object_store
             .range_reader(
-                puffin_file_name,
+                &file_path,
                 &INDEX_PUFFIN_READ_BYTES_TOTAL,
                 &INDEX_PUFFIN_READ_OP_TOTAL,
             )
@@ -141,10 +154,11 @@ impl PuffinFileAccessor for ObjectStorePuffinFileAccessor {
             .context(puffin_error::ExternalSnafu)
     }
 
-    async fn writer(&self, puffin_file_name: &str) -> PuffinResult<Self::Writer> {
+    async fn writer(&self, handle: &FileId) -> PuffinResult<Self::Writer> {
+        let file_path = self.path_provider.build_index_file_path(*handle);
         self.object_store
             .writer(
-                puffin_file_name,
+                &file_path,
                 &INDEX_PUFFIN_WRITE_BYTES_TOTAL,
                 &INDEX_PUFFIN_WRITE_OP_TOTAL,
                 &INDEX_PUFFIN_FLUSH_OP_TOTAL,
@@ -166,20 +180,32 @@ mod tests {
 
     use super::*;
 
+    struct TestFilePathProvider;
+
+    impl FilePathProvider for TestFilePathProvider {
+        fn build_index_file_path(&self, file_id: FileId) -> String {
+            file_id.to_string()
+        }
+
+        fn build_sst_file_path(&self, file_id: FileId) -> String {
+            file_id.to_string()
+        }
+    }
+
     #[tokio::test]
     async fn test_puffin_manager_factory() {
         let (_dir, factory) =
             PuffinManagerFactory::new_for_test_async("test_puffin_manager_factory_").await;
 
         let object_store = ObjectStore::new(Memory::default()).unwrap().finish();
-        let manager = factory.build(object_store);
+        let manager = factory.build(object_store, TestFilePathProvider);
 
-        let file_name = "my-puffin-file";
+        let file_id = FileId::random();
         let blob_key = "blob-key";
         let dir_key = "dir-key";
         let raw_data = b"hello world!";
 
-        let mut writer = manager.writer(file_name).await.unwrap();
+        let mut writer = manager.writer(&file_id).await.unwrap();
         writer
             .put_blob(blob_key, Cursor::new(raw_data), PutOptions::default())
             .await
@@ -200,7 +226,7 @@ mod tests {
             .unwrap();
         writer.finish().await.unwrap();
 
-        let reader = manager.reader(file_name).await.unwrap();
+        let reader = manager.reader(&file_id).await.unwrap();
         let blob_guard = reader.blob(blob_key).await.unwrap();
         let blob_reader = blob_guard.reader().await.unwrap();
         let meta = blob_reader.metadata().await.unwrap();

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -131,7 +131,7 @@ mod tests {
 
     #[async_trait::async_trait]
     impl IndexerBuilder for NoopIndexBuilder {
-        async fn build(&self, _file_id: FileId, _path: String) -> Indexer {
+        async fn build(&self, _file_id: FileId) -> Indexer {
             Indexer::default()
         }
     }

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -387,7 +387,11 @@ impl ParquetReaderBuilder {
             return false;
         }
 
-        let apply_res = match index_applier.apply(self.file_handle.file_id()).await {
+        let file_size_hint = self.file_handle.meta_ref().index_file_size();
+        let apply_res = match index_applier
+            .apply(self.file_handle.file_id(), Some(file_size_hint))
+            .await
+        {
             Ok(res) => res,
             Err(err) => {
                 if cfg!(any(test, feature = "test")) {
@@ -467,9 +471,9 @@ impl ParquetReaderBuilder {
         if !self.file_handle.meta_ref().inverted_index_available() {
             return false;
         }
-        let file_size_hint = self.file_handle.meta_ref().inverted_index_size();
+        let file_size_hint = self.file_handle.meta_ref().index_file_size();
         let apply_output = match index_applier
-            .apply(self.file_handle.file_id(), file_size_hint)
+            .apply(self.file_handle.file_id(), Some(file_size_hint))
             .await
         {
             Ok(output) => output,
@@ -578,11 +582,11 @@ impl ParquetReaderBuilder {
             return false;
         }
 
-        let file_size_hint = self.file_handle.meta_ref().bloom_filter_index_size();
+        let file_size_hint = self.file_handle.meta_ref().index_file_size();
         let apply_output = match index_applier
             .apply(
                 self.file_handle.file_id(),
-                file_size_hint,
+                Some(file_size_hint),
                 parquet_meta
                     .row_groups()
                     .iter()

--- a/src/mito2/src/sst/parquet/writer.rs
+++ b/src/mito2/src/sst/parquet/writer.rs
@@ -121,8 +121,7 @@ where
         path_provider: P,
     ) -> ParquetWriter<F, I, P> {
         let init_file = FileId::random();
-        let index_file_path = path_provider.build_index_file_path(init_file);
-        let indexer = indexer_builder.build(init_file, index_file_path).await;
+        let indexer = indexer_builder.build(init_file).await;
 
         ParquetWriter {
             path_provider,
@@ -140,11 +139,7 @@ where
         match self.current_indexer {
             None => {
                 self.current_file = FileId::random();
-                let index_file_path = self.path_provider.build_index_file_path(self.current_file);
-                let indexer = self
-                    .indexer_builder
-                    .build(self.current_file, index_file_path)
-                    .await;
+                let indexer = self.indexer_builder.build(self.current_file).await;
                 self.current_indexer = Some(indexer);
                 // safety: self.current_indexer already set above.
                 self.current_indexer.as_mut().unwrap()

--- a/src/puffin/src/puffin_manager.rs
+++ b/src/puffin/src/puffin_manager.rs
@@ -36,12 +36,13 @@ use crate::file_metadata::FileMetadata;
 pub trait PuffinManager {
     type Reader: PuffinReader;
     type Writer: PuffinWriter;
+    type FileHandle: ToString + Clone + Send + Sync;
 
-    /// Creates a `PuffinReader` for the specified `puffin_file_name`.
-    async fn reader(&self, puffin_file_name: &str) -> Result<Self::Reader>;
+    /// Creates a `PuffinReader` for the specified `handle`.
+    async fn reader(&self, handle: &Self::FileHandle) -> Result<Self::Reader>;
 
-    /// Creates a `PuffinWriter` for the specified `puffin_file_name`.
-    async fn writer(&self, puffin_file_name: &str) -> Result<Self::Writer>;
+    /// Creates a `PuffinWriter` for the specified `handle`.
+    async fn writer(&self, handle: &Self::FileHandle) -> Result<Self::Writer>;
 }
 
 /// The `PuffinWriter` trait provides methods for writing blobs and directories to a Puffin file.

--- a/src/puffin/src/puffin_manager/fs_puffin_manager.rs
+++ b/src/puffin/src/puffin_manager/fs_puffin_manager.rs
@@ -61,25 +61,26 @@ impl<S, F> FsPuffinManager<S, F> {
 #[async_trait]
 impl<S, F> PuffinManager for FsPuffinManager<S, F>
 where
-    S: Stager + Clone + 'static,
     F: PuffinFileAccessor + Clone,
+    S: Stager<FileHandle = F::FileHandle> + Clone + 'static,
 {
     type Reader = FsPuffinReader<S, F>;
     type Writer = FsPuffinWriter<S, F::Writer>;
+    type FileHandle = F::FileHandle;
 
-    async fn reader(&self, puffin_file_name: &str) -> Result<Self::Reader> {
+    async fn reader(&self, handle: &Self::FileHandle) -> Result<Self::Reader> {
         Ok(FsPuffinReader::new(
-            puffin_file_name.to_string(),
+            handle.clone(),
             self.stager.clone(),
             self.puffin_file_accessor.clone(),
             self.puffin_metadata_cache.clone(),
         ))
     }
 
-    async fn writer(&self, puffin_file_name: &str) -> Result<Self::Writer> {
-        let writer = self.puffin_file_accessor.writer(puffin_file_name).await?;
+    async fn writer(&self, handle: &Self::FileHandle) -> Result<Self::Writer> {
+        let writer = self.puffin_file_accessor.writer(handle).await?;
         Ok(FsPuffinWriter::new(
-            puffin_file_name.to_string(),
+            handle.clone(),
             self.stager.clone(),
             writer,
         ))

--- a/src/puffin/src/puffin_manager/stager.rs
+++ b/src/puffin/src/puffin_manager/stager.rs
@@ -57,6 +57,7 @@ pub trait InitDirFn = FnOnce(DirWriterProviderRef) -> WriteResult;
 pub trait Stager: Send + Sync {
     type Blob: BlobGuard + Sync;
     type Dir: DirGuard;
+    type FileHandle: ToString + Clone + Send + Sync;
 
     /// Retrieves a blob, initializing it if necessary using the provided `init_fn`.
     ///
@@ -64,7 +65,7 @@ pub trait Stager: Send + Sync {
     /// The caller is responsible for holding the `BlobGuard` until they are done with the blob.
     async fn get_blob<'a>(
         &self,
-        puffin_file_name: &str,
+        handle: &Self::FileHandle,
         key: &str,
         init_factory: Box<dyn InitBlobFn + Send + Sync + 'a>,
     ) -> Result<Self::Blob>;
@@ -75,7 +76,7 @@ pub trait Stager: Send + Sync {
     /// The caller is responsible for holding the `DirGuard` until they are done with the directory.
     async fn get_dir<'a>(
         &self,
-        puffin_file_name: &str,
+        handle: &Self::FileHandle,
         key: &str,
         init_fn: Box<dyn InitDirFn + Send + Sync + 'a>,
     ) -> Result<Self::Dir>;
@@ -83,14 +84,14 @@ pub trait Stager: Send + Sync {
     /// Stores a directory in the staging area.
     async fn put_dir(
         &self,
-        puffin_file_name: &str,
+        handle: &Self::FileHandle,
         key: &str,
         dir_path: PathBuf,
         dir_size: u64,
     ) -> Result<()>;
 
     /// Purges all content for the given puffin file from the staging area.
-    async fn purge(&self, puffin_file_name: &str) -> Result<()>;
+    async fn purge(&self, handle: &Self::FileHandle) -> Result<()>;
 }
 
 /// `StagerNotifier` provides a way to notify the caller of the staging events.

--- a/src/puffin/src/puffin_manager/stager/bounded_stager.rs
+++ b/src/puffin/src/puffin_manager/stager/bounded_stager.rs
@@ -50,7 +50,7 @@ const CACHE_TTL: Duration = Duration::from_secs(2 * 24 * 60 * 3600); // 2d
 const RECYCLE_BIN_TTL: Duration = Duration::from_secs(60);
 
 /// `BoundedStager` is a `Stager` that uses `moka` to manage staging area.
-pub struct BoundedStager {
+pub struct BoundedStager<H> {
     /// The base directory of the staging area.
     base_dir: PathBuf,
 
@@ -76,9 +76,11 @@ pub struct BoundedStager {
 
     /// The file mapping between puffin files and keys.
     file_mapping: FileMapping,
+
+    _phantom: std::marker::PhantomData<H>,
 }
 
-impl BoundedStager {
+impl<H: 'static> BoundedStager<H> {
     pub async fn new(
         base_dir: PathBuf,
         capacity: u64,
@@ -107,9 +109,7 @@ impl BoundedStager {
                     notifier.on_recycle_insert(v.size());
                 }
                 async move {
-                    file_mapping
-                        .remove(v.puffin_file_name(), v.blob_key())
-                        .await;
+                    file_mapping.remove(v.handle(), v.blob_key()).await;
                     recycle_bin.insert(k.as_str().to_string(), v).await;
                 }
                 .boxed()
@@ -130,6 +130,7 @@ impl BoundedStager {
             recycle_bin,
             notifier,
             file_mapping,
+            _phantom: std::marker::PhantomData,
         };
 
         stager.recover().await?;
@@ -139,17 +140,19 @@ impl BoundedStager {
 }
 
 #[async_trait]
-impl Stager for BoundedStager {
+impl<H: ToString + Clone + Send + Sync> Stager for BoundedStager<H> {
     type Blob = Arc<FsBlobGuard>;
     type Dir = Arc<FsDirGuard>;
+    type FileHandle = H;
 
     async fn get_blob<'a>(
         &self,
-        puffin_file_name: &str,
+        handle: &Self::FileHandle,
         key: &str,
         init_fn: Box<dyn InitBlobFn + Send + Sync + 'a>,
     ) -> Result<Self::Blob> {
-        let cache_key = Self::encode_cache_key(puffin_file_name, key);
+        let handle_str = handle.to_string();
+        let cache_key = Self::encode_cache_key(&handle_str, key);
 
         let mut miss = false;
         let v = self
@@ -174,9 +177,9 @@ impl Stager for BoundedStager {
                     notifier.on_cache_insert(size);
                     notifier.on_load_blob(timer.elapsed());
                 }
-                self.file_mapping.insert(puffin_file_name, key).await;
+                self.file_mapping.insert(&handle_str, key).await;
                 let guard = Arc::new(FsBlobGuard {
-                    puffin_file_name: puffin_file_name.to_string(),
+                    handle: handle_str.to_string(),
                     blob_key: key.to_string(),
                     path,
                     delete_queue: self.delete_queue.clone(),
@@ -202,11 +205,13 @@ impl Stager for BoundedStager {
 
     async fn get_dir<'a>(
         &self,
-        puffin_file_name: &str,
+        handle: &Self::FileHandle,
         key: &str,
         init_fn: Box<dyn InitDirFn + Send + Sync + 'a>,
     ) -> Result<Self::Dir> {
-        let cache_key = Self::encode_cache_key(puffin_file_name, key);
+        let handle_str = handle.to_string();
+
+        let cache_key = Self::encode_cache_key(&handle_str, key);
 
         let mut miss = false;
         let v = self
@@ -231,9 +236,9 @@ impl Stager for BoundedStager {
                     notifier.on_cache_insert(size);
                     notifier.on_load_dir(timer.elapsed());
                 }
-                self.file_mapping.insert(puffin_file_name, key).await;
+                self.file_mapping.insert(&handle_str, key).await;
                 let guard = Arc::new(FsDirGuard {
-                    puffin_file_name: puffin_file_name.to_string(),
+                    handle: handle_str,
                     blob_key: key.to_string(),
                     path,
                     size,
@@ -259,12 +264,13 @@ impl Stager for BoundedStager {
 
     async fn put_dir(
         &self,
-        puffin_file_name: &str,
+        handle: &Self::FileHandle,
         key: &str,
         dir_path: PathBuf,
         size: u64,
     ) -> Result<()> {
-        let cache_key = Self::encode_cache_key(puffin_file_name, key);
+        let handle_str = handle.to_string();
+        let cache_key = Self::encode_cache_key(&handle_str, key);
 
         self.cache
             .try_get_with(cache_key.clone(), async move {
@@ -284,9 +290,9 @@ impl Stager for BoundedStager {
                 if let Some(notifier) = self.notifier.as_ref() {
                     notifier.on_cache_insert(size);
                 }
-                self.file_mapping.insert(puffin_file_name, key).await;
+                self.file_mapping.insert(&handle_str, key).await;
                 let guard = Arc::new(FsDirGuard {
-                    puffin_file_name: puffin_file_name.to_string(),
+                    handle: handle_str,
                     blob_key: key.to_string(),
                     path,
                     size,
@@ -307,17 +313,18 @@ impl Stager for BoundedStager {
         Ok(())
     }
 
-    async fn purge(&self, puffin_file_name: &str) -> Result<()> {
-        let keys = self.file_mapping.take_keys(puffin_file_name).await;
+    async fn purge(&self, handle: &Self::FileHandle) -> Result<()> {
+        let handle_str = handle.to_string();
+        let keys = self.file_mapping.take_keys(&handle_str).await;
         for key in keys {
-            let cache_key = Self::encode_cache_key(puffin_file_name, &key);
+            let cache_key = Self::encode_cache_key(&handle_str, &key);
             self.cache.invalidate(&cache_key).await;
         }
         Ok(())
     }
 }
 
-impl BoundedStager {
+impl<H> BoundedStager<H> {
     fn encode_cache_key(puffin_file_name: &str, key: &str) -> String {
         let mut hasher = Sha256::new();
         hasher.update(puffin_file_name);
@@ -412,7 +419,7 @@ impl BoundedStager {
                         delete_queue: self.delete_queue.clone(),
 
                         // placeholder
-                        puffin_file_name: String::new(),
+                        handle: String::new(),
                         blob_key: String::new(),
                     }));
                     // A duplicate dir will be moved to the delete queue.
@@ -425,7 +432,7 @@ impl BoundedStager {
                         delete_queue: self.delete_queue.clone(),
 
                         // placeholder
-                        puffin_file_name: String::new(),
+                        handle: String::new(),
                         blob_key: String::new(),
                     }));
                     // A duplicate file will be moved to the delete queue.
@@ -525,7 +532,7 @@ impl BoundedStager {
     }
 }
 
-impl Drop for BoundedStager {
+impl<H> Drop for BoundedStager<H> {
     fn drop(&mut self) {
         let _ = self.delete_queue.try_send(DeleteTask::Terminate);
     }
@@ -549,10 +556,10 @@ impl CacheValue {
         self.size().try_into().unwrap_or(u32::MAX)
     }
 
-    fn puffin_file_name(&self) -> &str {
+    fn handle(&self) -> &str {
         match self {
-            CacheValue::File(guard) => &guard.puffin_file_name,
-            CacheValue::Dir(guard) => &guard.puffin_file_name,
+            CacheValue::File(guard) => &guard.handle,
+            CacheValue::Dir(guard) => &guard.handle,
         }
     }
 
@@ -574,7 +581,7 @@ enum DeleteTask {
 /// automatically deleting the file on drop.
 #[derive(Debug)]
 pub struct FsBlobGuard {
-    puffin_file_name: String,
+    handle: String,
     blob_key: String,
     path: PathBuf,
     size: u64,
@@ -608,7 +615,7 @@ impl Drop for FsBlobGuard {
 /// automatically deleting the directory on drop.
 #[derive(Debug)]
 pub struct FsDirGuard {
-    puffin_file_name: String,
+    handle: String,
     blob_key: String,
     path: PathBuf,
     size: u64,
@@ -659,7 +666,7 @@ impl DirWriterProvider for MokaDirWriterProvider {
 }
 
 #[cfg(test)]
-impl BoundedStager {
+impl<H> BoundedStager<H> {
     pub async fn must_get_file(&self, puffin_file_name: &str, key: &str) -> fs::File {
         let cache_key = Self::encode_cache_key(puffin_file_name, key);
         let value = self.cache.get(&cache_key).await.unwrap();
@@ -854,11 +861,11 @@ mod tests {
         .await
         .unwrap();
 
-        let puffin_file_name = "test_get_blob";
+        let puffin_file_name = "test_get_blob".to_string();
         let key = "key";
         let reader = stager
             .get_blob(
-                puffin_file_name,
+                &puffin_file_name,
                 key,
                 Box::new(|mut writer| {
                     Box::pin(async move {
@@ -877,7 +884,7 @@ mod tests {
         let buf = reader.read(0..m.content_length).await.unwrap();
         assert_eq!(&*buf, b"hello world");
 
-        let mut file = stager.must_get_file(puffin_file_name, key).await;
+        let mut file = stager.must_get_file(&puffin_file_name, key).await;
         let mut buf = Vec::new();
         file.read_to_end(&mut buf).await.unwrap();
         assert_eq!(buf, b"hello world");
@@ -918,11 +925,11 @@ mod tests {
             ("subdir/subsubdir/file_e", "¡Hola mundo!".as_bytes()),
         ];
 
-        let puffin_file_name = "test_get_dir";
+        let puffin_file_name = "test_get_dir".to_string();
         let key = "key";
         let dir_path = stager
             .get_dir(
-                puffin_file_name,
+                &puffin_file_name,
                 key,
                 Box::new(|writer_provider| {
                     Box::pin(async move {
@@ -947,7 +954,7 @@ mod tests {
             assert_eq!(buf, *content);
         }
 
-        let dir_path = stager.must_get_dir(puffin_file_name, key).await;
+        let dir_path = stager.must_get_dir(&puffin_file_name, key).await;
         for (rel_path, content) in &files_in_dir {
             let file_path = dir_path.join(rel_path);
             let mut file = tokio::fs::File::open(&file_path).await.unwrap();
@@ -985,11 +992,11 @@ mod tests {
         .unwrap();
 
         // initialize stager
-        let puffin_file_name = "test_recover";
+        let puffin_file_name = "test_recover".to_string();
         let blob_key = "blob_key";
         let guard = stager
             .get_blob(
-                puffin_file_name,
+                &puffin_file_name,
                 blob_key,
                 Box::new(|mut writer| {
                     Box::pin(async move {
@@ -1013,7 +1020,7 @@ mod tests {
         let dir_key = "dir_key";
         let guard = stager
             .get_dir(
-                puffin_file_name,
+                &puffin_file_name,
                 dir_key,
                 Box::new(|writer_provider| {
                     Box::pin(async move {
@@ -1039,7 +1046,7 @@ mod tests {
 
         let reader = stager
             .get_blob(
-                puffin_file_name,
+                &puffin_file_name,
                 blob_key,
                 Box::new(|_| Box::pin(async { Ok(0) })),
             )
@@ -1055,7 +1062,7 @@ mod tests {
 
         let dir_path = stager
             .get_dir(
-                puffin_file_name,
+                &puffin_file_name,
                 dir_key,
                 Box::new(|_| Box::pin(async { Ok(0) })),
             )
@@ -1097,13 +1104,13 @@ mod tests {
         .await
         .unwrap();
 
-        let puffin_file_name = "test_eviction";
+        let puffin_file_name = "test_eviction".to_string();
         let blob_key = "blob_key";
 
         // First time to get the blob
         let reader = stager
             .get_blob(
-                puffin_file_name,
+                &puffin_file_name,
                 blob_key,
                 Box::new(|mut writer| {
                     Box::pin(async move {
@@ -1120,7 +1127,7 @@ mod tests {
 
         // The blob should be evicted
         stager.cache.run_pending_tasks().await;
-        assert!(!stager.in_cache(puffin_file_name, blob_key));
+        assert!(!stager.in_cache(&puffin_file_name, blob_key));
 
         let stats = notifier.stats();
         assert_eq!(
@@ -1144,7 +1151,7 @@ mod tests {
         // Second time to get the blob, get from recycle bin
         let reader = stager
             .get_blob(
-                puffin_file_name,
+                &puffin_file_name,
                 blob_key,
                 Box::new(|_| async { Ok(0) }.boxed()),
             )
@@ -1156,7 +1163,7 @@ mod tests {
 
         // The blob should be evicted
         stager.cache.run_pending_tasks().await;
-        assert!(!stager.in_cache(puffin_file_name, blob_key));
+        assert!(!stager.in_cache(&puffin_file_name, blob_key));
 
         let stats = notifier.stats();
         assert_eq!(
@@ -1189,7 +1196,7 @@ mod tests {
         // First time to get the directory
         let guard_0 = stager
             .get_dir(
-                puffin_file_name,
+                &puffin_file_name,
                 dir_key,
                 Box::new(|writer_provider| {
                     Box::pin(async move {
@@ -1216,7 +1223,7 @@ mod tests {
 
         // The directory should be evicted
         stager.cache.run_pending_tasks().await;
-        assert!(!stager.in_cache(puffin_file_name, dir_key));
+        assert!(!stager.in_cache(&puffin_file_name, dir_key));
 
         let stats = notifier.stats();
         assert_eq!(
@@ -1236,7 +1243,7 @@ mod tests {
         // Second time to get the directory
         let guard_1 = stager
             .get_dir(
-                puffin_file_name,
+                &puffin_file_name,
                 dir_key,
                 Box::new(|_| async { Ok(0) }.boxed()),
             )
@@ -1253,7 +1260,7 @@ mod tests {
 
         // Still hold the guard
         stager.cache.run_pending_tasks().await;
-        assert!(!stager.in_cache(puffin_file_name, dir_key));
+        assert!(!stager.in_cache(&puffin_file_name, dir_key));
 
         let stats = notifier.stats();
         assert_eq!(
@@ -1275,7 +1282,7 @@ mod tests {
         drop(guard_1);
         let guard_2 = stager
             .get_dir(
-                puffin_file_name,
+                &puffin_file_name,
                 dir_key,
                 Box::new(|_| Box::pin(async move { Ok(0) })),
             )
@@ -1284,7 +1291,7 @@ mod tests {
 
         // Still hold the guard, so the directory should not be removed even if it's evicted
         stager.cache.run_pending_tasks().await;
-        assert!(!stager.in_cache(puffin_file_name, blob_key));
+        assert!(!stager.in_cache(&puffin_file_name, blob_key));
 
         for (rel_path, content) in &files_in_dir {
             let file_path = guard_2.path().join(rel_path);
@@ -1317,13 +1324,14 @@ mod tests {
             .await
             .unwrap();
 
-        let puffin_file_name = "test_get_blob_concurrency_on_fail";
+        let puffin_file_name = "test_get_blob_concurrency_on_fail".to_string();
         let key = "key";
 
         let stager = Arc::new(stager);
         let handles = (0..10)
             .map(|_| {
                 let stager = stager.clone();
+                let puffin_file_name = puffin_file_name.clone();
                 let task = async move {
                     let failed_init = Box::new(|_| {
                         async {
@@ -1332,7 +1340,7 @@ mod tests {
                         }
                         .boxed()
                     });
-                    stager.get_blob(puffin_file_name, key, failed_init).await
+                    stager.get_blob(&puffin_file_name, key, failed_init).await
                 };
 
                 tokio::spawn(task)
@@ -1344,7 +1352,7 @@ mod tests {
             assert!(r.is_err());
         }
 
-        assert!(!stager.in_cache(puffin_file_name, key));
+        assert!(!stager.in_cache(&puffin_file_name, key));
     }
 
     #[tokio::test]
@@ -1354,13 +1362,14 @@ mod tests {
             .await
             .unwrap();
 
-        let puffin_file_name = "test_get_dir_concurrency_on_fail";
+        let puffin_file_name = "test_get_dir_concurrency_on_fail".to_string();
         let key = "key";
 
         let stager = Arc::new(stager);
         let handles = (0..10)
             .map(|_| {
                 let stager = stager.clone();
+                let puffin_file_name = puffin_file_name.clone();
                 let task = async move {
                     let failed_init = Box::new(|_| {
                         async {
@@ -1369,7 +1378,7 @@ mod tests {
                         }
                         .boxed()
                     });
-                    stager.get_dir(puffin_file_name, key, failed_init).await
+                    stager.get_dir(&puffin_file_name, key, failed_init).await
                 };
 
                 tokio::spawn(task)
@@ -1381,7 +1390,7 @@ mod tests {
             assert!(r.is_err());
         }
 
-        assert!(!stager.in_cache(puffin_file_name, key));
+        assert!(!stager.in_cache(&puffin_file_name, key));
     }
 
     #[tokio::test]
@@ -1397,11 +1406,11 @@ mod tests {
         .unwrap();
 
         // initialize stager
-        let puffin_file_name = "test_purge";
+        let puffin_file_name = "test_purge".to_string();
         let blob_key = "blob_key";
         let guard = stager
             .get_blob(
-                puffin_file_name,
+                &puffin_file_name,
                 blob_key,
                 Box::new(|mut writer| {
                     Box::pin(async move {
@@ -1425,7 +1434,7 @@ mod tests {
         let dir_key = "dir_key";
         let guard = stager
             .get_dir(
-                puffin_file_name,
+                &puffin_file_name,
                 dir_key,
                 Box::new(|writer_provider| {
                     Box::pin(async move {
@@ -1444,7 +1453,7 @@ mod tests {
         drop(guard);
 
         // purge the stager
-        stager.purge(puffin_file_name).await.unwrap();
+        stager.purge(&puffin_file_name).await.unwrap();
 
         let stats = notifier.stats();
         assert_eq!(

--- a/src/puffin/src/puffin_manager/tests.rs
+++ b/src/puffin/src/puffin_manager/tests.rs
@@ -27,7 +27,7 @@ use crate::puffin_manager::{
     BlobGuard, DirGuard, PuffinManager, PuffinReader, PuffinWriter, PutOptions,
 };
 
-async fn new_bounded_stager(prefix: &str, capacity: u64) -> (TempDir, Arc<BoundedStager>) {
+async fn new_bounded_stager(prefix: &str, capacity: u64) -> (TempDir, Arc<BoundedStager<String>>) {
     let staging_dir = create_temp_dir(prefix);
     let path = staging_dir.path().to_path_buf();
     (
@@ -48,8 +48,8 @@ async fn test_put_get_file() {
 
             let puffin_manager = FsPuffinManager::new(stager.clone(), file_accessor.clone());
 
-            let puffin_file_name = "puffin_file";
-            let mut writer = puffin_manager.writer(puffin_file_name).await.unwrap();
+            let puffin_file_name = "puffin_file".to_string();
+            let mut writer = puffin_manager.writer(&puffin_file_name).await.unwrap();
 
             let key = "blob_a";
             let raw_data = "Hello, world!".as_bytes();
@@ -57,9 +57,9 @@ async fn test_put_get_file() {
 
             writer.finish().await.unwrap();
 
-            let reader = puffin_manager.reader(puffin_file_name).await.unwrap();
+            let reader = puffin_manager.reader(&puffin_file_name).await.unwrap();
             check_blob(
-                puffin_file_name,
+                &puffin_file_name,
                 key,
                 raw_data,
                 &stager,
@@ -72,9 +72,9 @@ async fn test_put_get_file() {
             let (_staging_dir, stager) = new_bounded_stager("test_put_get_file_", capacity).await;
             let puffin_manager = FsPuffinManager::new(stager.clone(), file_accessor);
 
-            let reader = puffin_manager.reader(puffin_file_name).await.unwrap();
+            let reader = puffin_manager.reader(&puffin_file_name).await.unwrap();
             check_blob(
-                puffin_file_name,
+                &puffin_file_name,
                 key,
                 raw_data,
                 &stager,
@@ -98,8 +98,8 @@ async fn test_put_get_files() {
 
             let puffin_manager = FsPuffinManager::new(stager.clone(), file_accessor.clone());
 
-            let puffin_file_name = "puffin_file";
-            let mut writer = puffin_manager.writer(puffin_file_name).await.unwrap();
+            let puffin_file_name = "puffin_file".to_string();
+            let mut writer = puffin_manager.writer(&puffin_file_name).await.unwrap();
 
             let blobs = [
                 ("blob_a", "Hello, world!".as_bytes()),
@@ -115,10 +115,10 @@ async fn test_put_get_files() {
 
             writer.finish().await.unwrap();
 
-            let reader = puffin_manager.reader(puffin_file_name).await.unwrap();
+            let reader = puffin_manager.reader(&puffin_file_name).await.unwrap();
             for (key, raw_data) in &blobs {
                 check_blob(
-                    puffin_file_name,
+                    &puffin_file_name,
                     key,
                     raw_data,
                     &stager,
@@ -131,10 +131,10 @@ async fn test_put_get_files() {
             // renew cache manager
             let (_staging_dir, stager) = new_bounded_stager("test_put_get_files_", capacity).await;
             let puffin_manager = FsPuffinManager::new(stager.clone(), file_accessor);
-            let reader = puffin_manager.reader(puffin_file_name).await.unwrap();
+            let reader = puffin_manager.reader(&puffin_file_name).await.unwrap();
             for (key, raw_data) in &blobs {
                 check_blob(
-                    puffin_file_name,
+                    &puffin_file_name,
                     key,
                     raw_data,
                     &stager,
@@ -160,8 +160,8 @@ async fn test_put_get_dir() {
 
             let puffin_manager = FsPuffinManager::new(stager.clone(), file_accessor.clone());
 
-            let puffin_file_name = "puffin_file";
-            let mut writer = puffin_manager.writer(puffin_file_name).await.unwrap();
+            let puffin_file_name = "puffin_file".to_string();
+            let mut writer = puffin_manager.writer(&puffin_file_name).await.unwrap();
 
             let key = "dir_a";
 
@@ -177,15 +177,15 @@ async fn test_put_get_dir() {
 
             writer.finish().await.unwrap();
 
-            let reader = puffin_manager.reader(puffin_file_name).await.unwrap();
-            check_dir(puffin_file_name, key, &files_in_dir, &stager, &reader).await;
+            let reader = puffin_manager.reader(&puffin_file_name).await.unwrap();
+            check_dir(&puffin_file_name, key, &files_in_dir, &stager, &reader).await;
 
             // renew cache manager
             let (_staging_dir, stager) = new_bounded_stager("test_put_get_dir_", capacity).await;
             let puffin_manager = FsPuffinManager::new(stager.clone(), file_accessor);
 
-            let reader = puffin_manager.reader(puffin_file_name).await.unwrap();
-            check_dir(puffin_file_name, key, &files_in_dir, &stager, &reader).await;
+            let reader = puffin_manager.reader(&puffin_file_name).await.unwrap();
+            check_dir(&puffin_file_name, key, &files_in_dir, &stager, &reader).await;
         }
     }
 }
@@ -203,8 +203,8 @@ async fn test_put_get_mix_file_dir() {
 
             let puffin_manager = FsPuffinManager::new(stager.clone(), file_accessor.clone());
 
-            let puffin_file_name = "puffin_file";
-            let mut writer = puffin_manager.writer(puffin_file_name).await.unwrap();
+            let puffin_file_name = "puffin_file".to_string();
+            let mut writer = puffin_manager.writer(&puffin_file_name).await.unwrap();
 
             let blobs = [
                 ("blob_a", "Hello, world!".as_bytes()),
@@ -230,10 +230,10 @@ async fn test_put_get_mix_file_dir() {
 
             writer.finish().await.unwrap();
 
-            let reader = puffin_manager.reader(puffin_file_name).await.unwrap();
+            let reader = puffin_manager.reader(&puffin_file_name).await.unwrap();
             for (key, raw_data) in &blobs {
                 check_blob(
-                    puffin_file_name,
+                    &puffin_file_name,
                     key,
                     raw_data,
                     &stager,
@@ -242,17 +242,17 @@ async fn test_put_get_mix_file_dir() {
                 )
                 .await;
             }
-            check_dir(puffin_file_name, dir_key, &files_in_dir, &stager, &reader).await;
+            check_dir(&puffin_file_name, dir_key, &files_in_dir, &stager, &reader).await;
 
             // renew cache manager
             let (_staging_dir, stager) =
                 new_bounded_stager("test_put_get_mix_file_dir_", capacity).await;
             let puffin_manager = FsPuffinManager::new(stager.clone(), file_accessor);
 
-            let reader = puffin_manager.reader(puffin_file_name).await.unwrap();
+            let reader = puffin_manager.reader(&puffin_file_name).await.unwrap();
             for (key, raw_data) in &blobs {
                 check_blob(
-                    puffin_file_name,
+                    &puffin_file_name,
                     key,
                     raw_data,
                     &stager,
@@ -261,7 +261,7 @@ async fn test_put_get_mix_file_dir() {
                 )
                 .await;
             }
-            check_dir(puffin_file_name, dir_key, &files_in_dir, &stager, &reader).await;
+            check_dir(&puffin_file_name, dir_key, &files_in_dir, &stager, &reader).await;
         }
     }
 }
@@ -288,7 +288,7 @@ async fn check_blob(
     puffin_file_name: &str,
     key: &str,
     raw_data: &[u8],
-    stager: &BoundedStager,
+    stager: &BoundedStager<String>,
     puffin_reader: &impl PuffinReader,
     compressed: bool,
 ) {
@@ -342,7 +342,7 @@ async fn check_dir(
     puffin_file_name: &str,
     key: &str,
     files_in_dir: &[(&str, &[u8])],
-    stager: &BoundedStager,
+    stager: &BoundedStager<String>,
     puffin_reader: &impl PuffinReader,
 ) {
     let res_dir = puffin_reader.dir(key).await.unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

1. Change `puffin_file_name` to `handle` in a series of traits related to Puffin Manager, and introduce an associated type `FileHandle`.
2. Instance `FileHandle` as `FileId` in mito2.
3. Add a member `path_provider` to `ObjectStorePuffinFileAccessor` to generate a file path using `path_provider` when constructing a `reader` or `writer` based on `FileId`

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
