### PR TITLE
feat: support to generate json output for explain analyze in http api

### DIFF
--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -237,6 +237,13 @@ impl Instance {
 
         let output = match stmt {
             Statement::Query(_) | Statement::Explain(_) | Statement::Delete(_) => {
+                // TODO: remove this when format is supported in datafusion
+                if let Statement::Explain(explain) = &stmt {
+                    if let Some(format) = explain.format() {
+                        query_ctx.set_explain_format(format.to_string());
+                    }
+                }
+
                 let stmt = QueryStatement::Sql(stmt);
                 let plan = self
                     .statement_executor

--- a/src/query/Cargo.toml
+++ b/src/query/Cargo.toml
@@ -57,6 +57,8 @@ promql-parser.workspace = true
 prost.workspace = true
 rand.workspace = true
 regex.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 session.workspace = true
 snafu.workspace = true
 sql.workspace = true
@@ -81,8 +83,6 @@ num-traits = "0.2"
 paste.workspace = true
 pretty_assertions = "1.4.0"
 rand.workspace = true
-serde.workspace = true
-serde_json.workspace = true
 session = { workspace = true, features = ["testing"] }
 statrs = "0.16"
 store-api.workspace = true

--- a/src/query/src/analyze.rs
+++ b/src/query/src/analyze.rs
@@ -17,11 +17,13 @@
 //! The code skeleton is taken from `datafusion/physical-plan/src/analyze.rs`
 
 use std::any::Any;
+use std::fmt::Display;
 use std::sync::Arc;
 
+use ahash::HashMap;
 use arrow::array::{StringBuilder, UInt32Builder};
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
-use common_recordbatch::adapter::{MetricCollector, RecordBatchMetrics};
+use common_recordbatch::adapter::{MetricCollector, PlanMetrics, RecordBatchMetrics};
 use common_recordbatch::{DfRecordBatch, DfSendableRecordBatchStream};
 use datafusion::error::Result as DfResult;
 use datafusion::execution::TaskContext;
@@ -34,6 +36,8 @@ use datafusion_common::tree_node::{TreeNode, TreeNodeRecursion};
 use datafusion_common::{internal_err, DataFusionError};
 use datafusion_physical_expr::{Distribution, EquivalenceProperties, Partitioning};
 use futures::StreamExt;
+use serde::Serialize;
+use sqlparser::ast::AnalyzeFormat;
 
 use crate::dist_plan::MergeScanExec;
 
@@ -46,11 +50,12 @@ pub struct DistAnalyzeExec {
     input: Arc<dyn ExecutionPlan>,
     schema: SchemaRef,
     properties: PlanProperties,
+    format: AnalyzeFormat,
 }
 
 impl DistAnalyzeExec {
     /// Create a new DistAnalyzeExec
-    pub fn new(input: Arc<dyn ExecutionPlan>) -> Self {
+    pub fn new(input: Arc<dyn ExecutionPlan>, format: AnalyzeFormat) -> Self {
         let schema = SchemaRef::new(Schema::new(vec![
             Field::new(STAGE, DataType::UInt32, true),
             Field::new(NODE, DataType::UInt32, true),
@@ -61,6 +66,7 @@ impl DistAnalyzeExec {
             input,
             schema,
             properties,
+            format,
         }
     }
 
@@ -110,7 +116,7 @@ impl ExecutionPlan for DistAnalyzeExec {
         self: Arc<Self>,
         mut children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> DfResult<Arc<dyn ExecutionPlan>> {
-        Ok(Arc::new(Self::new(children.pop().unwrap())))
+        Ok(Arc::new(Self::new(children.pop().unwrap(), self.format)))
     }
 
     fn execute(
@@ -131,6 +137,7 @@ impl ExecutionPlan for DistAnalyzeExec {
         let captured_schema = self.schema.clone();
 
         // Finish the input stream and create the output
+        let format = self.format;
         let mut input_stream = coalesce_partition_plan.execute(0, context)?;
         let output = async move {
             let mut total_rows = 0;
@@ -138,7 +145,7 @@ impl ExecutionPlan for DistAnalyzeExec {
                 total_rows += batch.num_rows();
             }
 
-            create_output_batch(total_rows, captured_input, captured_schema)
+            create_output_batch(total_rows, captured_input, captured_schema, format)
         };
 
         Ok(Box::pin(RecordBatchStreamAdapter::new(
@@ -166,10 +173,10 @@ impl AnalyzeOutputBuilder {
         }
     }
 
-    fn append_metric(&mut self, stage: u32, node: u32, metric: RecordBatchMetrics) {
+    fn append_metric(&mut self, stage: u32, node: u32, content: String) {
         self.stage_builder.append_value(stage);
         self.node_builder.append_value(node);
-        self.plan_builder.append_value(metric.to_string());
+        self.plan_builder.append_value(content);
     }
 
     fn append_total_rows(&mut self, total_rows: usize) {
@@ -197,6 +204,7 @@ fn create_output_batch(
     total_rows: usize,
     input: Arc<dyn ExecutionPlan>,
     schema: SchemaRef,
+    format: AnalyzeFormat,
 ) -> DfResult<DfRecordBatch> {
     let mut builder = AnalyzeOutputBuilder::new(schema);
 
@@ -207,14 +215,14 @@ fn create_output_batch(
     let stage_0_metrics = collector.record_batch_metrics;
 
     // Append the metrics of the current stage
-    builder.append_metric(0, 0, stage_0_metrics);
+    builder.append_metric(0, 0, metrics_to_string(stage_0_metrics, format));
 
     // Find merge scan and append its sub_stage_metrics
     input.apply(|plan| {
         if let Some(merge_scan) = plan.as_any().downcast_ref::<MergeScanExec>() {
             let sub_stage_metrics = merge_scan.sub_stage_metrics();
             for (node, metric) in sub_stage_metrics.into_iter().enumerate() {
-                builder.append_metric(1, node as _, metric);
+                builder.append_metric(1, node as _, metrics_to_string(metric, format));
             }
             return Ok(TreeNodeRecursion::Stop);
         }
@@ -225,4 +233,62 @@ fn create_output_batch(
     builder.append_total_rows(total_rows);
 
     builder.finish()
+}
+
+fn metrics_to_string(metrics: RecordBatchMetrics, format: AnalyzeFormat) -> String {
+    match format {
+        AnalyzeFormat::JSON => JsonMetrics::from_record_batch_metrics(metrics).to_string(),
+        _ => metrics.to_string(),
+    }
+}
+
+#[derive(Debug, Default, Serialize)]
+struct JsonMetrics {
+    name: String,
+    param: String,
+    metrics: HashMap<String, usize>,
+    children: Vec<JsonMetrics>,
+}
+
+impl JsonMetrics {
+    fn from_record_batch_metrics(record_batch_metrics: RecordBatchMetrics) -> Self {
+        let mut layers: HashMap<usize, Vec<Self>> = HashMap::default();
+
+        for plan_metrics in record_batch_metrics.plan_metrics.into_iter().rev() {
+            let (level, mut metrics) = Self::from_plan_metrics(plan_metrics);
+            if let Some(next_layer) = layers.remove(&(level + 1)) {
+                metrics.children = next_layer;
+            }
+            if level == 0 {
+                return metrics;
+            }
+            layers.entry(level).or_default().push(metrics);
+        }
+
+        // Unreachable path. Each metrics should contains at least one level 0.
+        Self::default()
+    }
+
+    /// Convert a [`PlanMetrics`] to a [`JsonMetrics`] without children.
+    ///
+    /// Returns the level of the plan and the [`JsonMetrics`].
+    fn from_plan_metrics(plan_metrics: PlanMetrics) -> (usize, Self) {
+        let raw_name = plan_metrics.plan.trim_end();
+        let (name, param) = raw_name.split_once(": ").unwrap_or_default();
+        (
+            plan_metrics.level,
+            Self {
+                name: name.to_string(),
+                param: param.to_string(),
+                metrics: plan_metrics.metrics.into_iter().collect(),
+                children: vec![],
+            },
+        )
+    }
+}
+
+impl Display for JsonMetrics {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", serde_json::to_string(self).unwrap())
+    }
 }

--- a/src/query/src/datafusion.rs
+++ b/src/query/src/datafusion.rs
@@ -40,7 +40,7 @@ use datafusion_expr::{DmlStatement, LogicalPlan as DfLogicalPlan, LogicalPlan, W
 use datatypes::prelude::VectorRef;
 use datatypes::schema::Schema;
 use futures_util::StreamExt;
-use session::context::{QueryContextRef, ANALYZE_FORMAT_HEADER_NAME};
+use session::context::QueryContextRef;
 use snafu::{ensure, OptionExt, ResultExt};
 use sqlparser::ast::AnalyzeFormat;
 use table::requests::{DeleteRequest, InsertRequest};
@@ -361,7 +361,7 @@ impl DatafusionQueryEngine {
         // skip optimize AnalyzeExec plan
         let optimized_plan = if let Some(analyze_plan) = plan.as_any().downcast_ref::<AnalyzeExec>()
         {
-            let format = if let Some(format) = ctx.query_ctx().extension(ANALYZE_FORMAT_HEADER_NAME)
+            let format = if let Some(format) = ctx.query_ctx().explain_format()
                 && format.to_lowercase() == "json"
             {
                 AnalyzeFormat::JSON

--- a/src/servers/src/http/hints.rs
+++ b/src/servers/src/http/hints.rs
@@ -25,7 +25,7 @@ pub async fn extract_hints(mut request: Request<Body>, next: Next) -> Response {
     let analyze_format = request
         .headers()
         .get(session::context::ANALYZE_FORMAT_HEADER_NAME)
-        .map(|v| v.to_str().unwrap().to_string());
+        .and_then(|v| v.to_str().ok().map(|s| s.to_string()));
     if let Some(query_ctx) = request.extensions_mut().get_mut::<QueryContext>() {
         for (key, value) in hints {
             query_ctx.set_extension(key, value);

--- a/src/servers/src/http/hints.rs
+++ b/src/servers/src/http/hints.rs
@@ -22,9 +22,17 @@ use crate::hint_headers;
 
 pub async fn extract_hints(mut request: Request<Body>, next: Next) -> Response {
     let hints = hint_headers::extract_hints(request.headers());
+    let analyze_format = request
+        .headers()
+        .get(session::context::ANALYZE_FORMAT_HEADER_NAME)
+        .map(|v| v.to_str().unwrap().to_string());
     if let Some(query_ctx) = request.extensions_mut().get_mut::<QueryContext>() {
         for (key, value) in hints {
             query_ctx.set_extension(key, value);
+        }
+
+        if let Some(value) = analyze_format {
+            query_ctx.set_extension(session::context::ANALYZE_FORMAT_HEADER_NAME, value);
         }
     }
     next.run(request).await

--- a/src/servers/src/http/hints.rs
+++ b/src/servers/src/http/hints.rs
@@ -22,17 +22,9 @@ use crate::hint_headers;
 
 pub async fn extract_hints(mut request: Request<Body>, next: Next) -> Response {
     let hints = hint_headers::extract_hints(request.headers());
-    let analyze_format = request
-        .headers()
-        .get(session::context::ANALYZE_FORMAT_HEADER_NAME)
-        .and_then(|v| v.to_str().ok().map(|s| s.to_string()));
     if let Some(query_ctx) = request.extensions_mut().get_mut::<QueryContext>() {
         for (key, value) in hints {
             query_ctx.set_extension(key, value);
-        }
-
-        if let Some(value) = analyze_format {
-            query_ctx.set_extension(session::context::ANALYZE_FORMAT_HEADER_NAME, value);
         }
     }
     next.run(request).await

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -38,8 +38,6 @@ pub type ConnInfoRef = Arc<ConnInfo>;
 
 const CURSOR_COUNT_WARNING_LIMIT: usize = 10;
 
-pub const ANALYZE_FORMAT_HEADER_NAME: &str = "x-greptime-analyze-format";
-
 #[derive(Debug, Builder, Clone)]
 #[builder(pattern = "owned")]
 #[builder(build_fn(skip))]
@@ -69,6 +67,8 @@ pub struct QueryContext {
 #[derive(Debug, Builder, Clone, Default)]
 pub struct QueryContextMutableFields {
     warning: Option<String>,
+    // TODO: remove this when format is supported in datafusion
+    explain_format: Option<String>,
 }
 
 impl Display for QueryContext {
@@ -302,6 +302,21 @@ impl QueryContext {
 
     pub fn set_warning(&self, msg: String) {
         self.mutable_query_context_data.write().unwrap().warning = Some(msg);
+    }
+
+    pub fn explain_format(&self) -> Option<String> {
+        self.mutable_query_context_data
+            .read()
+            .unwrap()
+            .explain_format
+            .clone()
+    }
+
+    pub fn set_explain_format(&self, format: String) {
+        self.mutable_query_context_data
+            .write()
+            .unwrap()
+            .explain_format = Some(format);
     }
 
     pub fn query_timeout(&self) -> Option<Duration> {

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -38,6 +38,8 @@ pub type ConnInfoRef = Arc<ConnInfo>;
 
 const CURSOR_COUNT_WARNING_LIMIT: usize = 10;
 
+pub const ANALYZE_FORMAT_HEADER_NAME: &str = "x-greptime-analyze-format";
+
 #[derive(Debug, Builder, Clone)]
 #[builder(pattern = "owned")]
 #[builder(build_fn(skip))]

--- a/src/sql/src/statements/explain.rs
+++ b/src/sql/src/statements/explain.rs
@@ -15,7 +15,7 @@
 use std::fmt::{Display, Formatter};
 
 use serde::Serialize;
-use sqlparser::ast::Statement as SpStatement;
+use sqlparser::ast::{AnalyzeFormat, Statement as SpStatement};
 use sqlparser_derive::{Visit, VisitMut};
 
 use crate::error::Error;
@@ -24,6 +24,15 @@ use crate::error::Error;
 #[derive(Debug, Clone, PartialEq, Eq, Visit, VisitMut, Serialize)]
 pub struct Explain {
     pub inner: SpStatement,
+}
+
+impl Explain {
+    pub fn format(&self) -> Option<AnalyzeFormat> {
+        match self.inner {
+            SpStatement::Explain { format, .. } => format,
+            _ => None,
+        }
+    }
 }
 
 impl TryFrom<SpStatement> for Explain {

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -40,7 +40,6 @@ use servers::http::result::influxdb_result_v1::{InfluxdbOutput, InfluxdbV1Respon
 use servers::http::test_helpers::{TestClient, TestResponse};
 use servers::http::GreptimeQueryOutput;
 use servers::prom_store;
-use session::context::ANALYZE_FORMAT_HEADER_NAME;
 use table::table_name::TableName;
 use tests_integration::test_util::{
     setup_test_http_app, setup_test_http_app_with_frontend,
@@ -416,8 +415,7 @@ pub async fn test_sql_api(store_type: StorageType) {
 
     // test analyze format
     let res = client
-        .get("/v1/sql?sql=explain analyze select cpu, ts from demo limit 1")
-        .header(ANALYZE_FORMAT_HEADER_NAME, "json")
+        .get("/v1/sql?sql=explain analyze format json select cpu, ts from demo limit 1")
         .send()
         .await;
     assert_eq!(res.status(), StatusCode::OK);


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Now the `/v1/sql` API can generate something like the following for `explain analyze` clause 
![image](https://github.com/user-attachments/assets/0d05ceb9-41d1-41ea-aa19-659832d3c61a)

It can be turned on with a new HTTP header `x-greptime-analyze-format`

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
