### PR TITLE
feat: submit node's cpu cores number to metasrv in heartbeat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3376,6 +3376,7 @@ dependencies = [
  "meta-client",
  "metric-engine",
  "mito2",
+ "num_cpus",
  "object-store",
  "prometheus",
  "prost 0.13.3",
@@ -4196,6 +4197,7 @@ dependencies = [
  "meta-client",
  "nom",
  "num-traits",
+ "num_cpus",
  "operator",
  "partition",
  "pretty_assertions",
@@ -4302,6 +4304,7 @@ dependencies = [
  "log-query",
  "log-store",
  "meta-client",
+ "num_cpus",
  "opentelemetry-proto 0.27.0",
  "operator",
  "partition",
@@ -4692,7 +4695,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=fc09a5696608d2a0aa718cc835d5cb9c4e8e9387#fc09a5696608d2a0aa718cc835d5cb9c4e8e9387"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=7497581feb1370b4c73606d0c4ad9f5fc42e03e3#7497581feb1370b4c73606d0c4ad9f5fc42e03e3"
 dependencies = [
  "prost 0.13.3",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4695,7 +4695,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=7497581feb1370b4c73606d0c4ad9f5fc42e03e3#7497581feb1370b4c73606d0c4ad9f5fc42e03e3"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=a25adc8a01340231121646d8f0a29d0e92f45461#a25adc8a01340231121646d8f0a29d0e92f45461"
 dependencies = [
  "prost 0.13.3",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,8 @@ etcd-client = "0.14"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "fc09a5696608d2a0aa718cc835d5cb9c4e8e9387" }
+# TODO(LFC): Wait for https://github.com/GreptimeTeam/greptime-proto/pull/217
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "7497581feb1370b4c73606d0c4ad9f5fc42e03e3" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,8 +129,7 @@ etcd-client = "0.14"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-# TODO(LFC): Wait for https://github.com/GreptimeTeam/greptime-proto/pull/217
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "7497581feb1370b4c73606d0c4ad9f5fc42e03e3" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "a25adc8a01340231121646d8f0a29d0e92f45461" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/src/cmd/src/metasrv.rs
+++ b/src/cmd/src/metasrv.rs
@@ -42,7 +42,7 @@ pub struct Instance {
 }
 
 impl Instance {
-    fn new(instance: MetasrvInstance, guard: Vec<WorkerGuard>) -> Self {
+    pub fn new(instance: MetasrvInstance, guard: Vec<WorkerGuard>) -> Self {
         Self {
             instance,
             _guard: guard,

--- a/src/datanode/Cargo.toml
+++ b/src/datanode/Cargo.toml
@@ -47,6 +47,7 @@ log-store.workspace = true
 meta-client.workspace = true
 metric-engine.workspace = true
 mito2.workspace = true
+num_cpus.workspace = true
 object-store.workspace = true
 prometheus.workspace = true
 prost.workspace = true

--- a/src/flow/Cargo.toml
+++ b/src/flow/Cargo.toml
@@ -53,6 +53,7 @@ lazy_static.workspace = true
 meta-client.workspace = true
 nom = "7.1.3"
 num-traits = "0.2"
+num_cpus.workspace = true
 operator.workspace = true
 partition.workspace = true
 prometheus.workspace = true

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -44,6 +44,7 @@ lazy_static.workspace = true
 log-query.workspace = true
 log-store.workspace = true
 meta-client.workspace = true
+num_cpus.workspace = true
 opentelemetry-proto.workspace = true
 operator.workspace = true
 partition.workspace = true


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

as title

metasrv then is aware of cluster's total cpus, and able to do something about it further

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
