### PR TITLE
feat: enable gzip for prometheus query handlers and ignore NaN values in prometheus response

### DIFF
--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -991,7 +991,7 @@ impl HttpServer {
                 "/label/{label_name}/values",
                 routing::get(label_values_query),
             )
-            .layer(ServiceBuilder::new().layer(CompressionLayer::new().gzip(true)))
+            .layer(ServiceBuilder::new().layer(CompressionLayer::new()))
             .with_state(prometheus_handler)
     }
 

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -43,6 +43,7 @@ use snafu::{ensure, ResultExt};
 use tokio::sync::oneshot::{self, Sender};
 use tokio::sync::Mutex;
 use tower::ServiceBuilder;
+use tower_http::compression::CompressionLayer;
 use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 use tower_http::decompression::RequestDecompressionLayer;
 use tower_http::trace::TraceLayer;
@@ -990,6 +991,7 @@ impl HttpServer {
                 "/label/{label_name}/values",
                 routing::get(label_values_query),
             )
+            .layer(ServiceBuilder::new().layer(CompressionLayer::new().gzip(true)))
             .with_state(prometheus_handler)
     }
 

--- a/src/servers/src/http/result/prometheus_resp.rs
+++ b/src/servers/src/http/result/prometheus_resp.rs
@@ -264,23 +264,29 @@ impl PrometheusJsonResponse {
 
             // assemble rows
             for row_index in 0..batch.num_rows() {
-                // retrieve tags
-                // TODO(ruihang): push table name `__metric__`
-                let mut tags = Vec::with_capacity(num_label_columns + 1);
-                tags.push(metric_name);
-                for (tag_column, tag_name) in tag_columns.iter().zip(tag_names.iter()) {
-                    // TODO(ruihang): add test for NULL tag
-                    if let Some(tag_value) = tag_column.get_data(row_index) {
-                        tags.push((tag_name, tag_value));
-                    }
-                }
-
-                // retrieve timestamp
-                let timestamp_millis: i64 = timestamp_column.get_data(row_index).unwrap().into();
-                let timestamp = timestamp_millis as f64 / 1000.0;
-
                 // retrieve value
                 if let Some(v) = field_column.get_data(row_index) {
+                    // ignore all NaN values to reduce the amount of data to be sent.
+                    if v.is_nan() {
+                        continue;
+                    }
+
+                    // retrieve tags
+                    // TODO(ruihang): push table name `__metric__`
+                    let mut tags = Vec::with_capacity(num_label_columns + 1);
+                    tags.push(metric_name);
+                    for (tag_column, tag_name) in tag_columns.iter().zip(tag_names.iter()) {
+                        // TODO(ruihang): add test for NULL tag
+                        if let Some(tag_value) = tag_column.get_data(row_index) {
+                            tags.push((tag_name, tag_value));
+                        }
+                    }
+
+                    // retrieve timestamp
+                    let timestamp_millis: i64 =
+                        timestamp_column.get_data(row_index).unwrap().into();
+                    let timestamp = timestamp_millis as f64 / 1000.0;
+
                     buffer
                         .entry(tags)
                         .or_default()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#5525 
## What's changed and what's your intention?

By default, **Grafana executes multiple PromQL queries within a request sequentially**. However, the **VictoriaMetrics datasource plugin executes them in parallel**. When Grafana and the datasource are deployed in different data centers, parallel execution can significantly reduce network latency and improve query efficiency.

This PR aims to minimize retrieval overhead as much as possible.
1. Enable Gzip Compression for Prometheus Query Handlers
- Enables Gzip compression to reduce response payload size, thereby lowering retrieval overhead.
2. Ignore NaN values in Prometheus Responses
- Aligns behavior with VictoriaMetrics and also helps reduce retrieval overhead.

**Disable gzip, with NaN values**
<img width="1397" alt="Screenshot 2025-02-20 at 14 22 00" src="https://github.com/user-attachments/assets/352bbd45-773c-4039-800f-893d7126ade6" />
Response size: 186 KiB, with an 800ms gap between the first request's response and the second request.

**Enable gzip, with NaN values**
<img width="1486" alt="Screenshot 2025-02-20 at 14 26 51" src="https://github.com/user-attachments/assets/caee0ca5-fd7c-4228-a191-2a49fae455c0" />
Response size: 24 KiB (original 186KiB), with an 440ms gap between the first request's response and the second request.

**Enable gzip, without NaN values**
<img width="1461" alt="Screenshot 2025-02-20 at 14 25 24" src="https://github.com/user-attachments/assets/d101f77e-1c56-4155-902d-d55ccc7cfd20" />
Response size: 7 KiB (original 56KiB), with an 200ms gap between the first request's response and the second request.









## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
