### PR TITLE
feat: remove default inverted index for physical table

### DIFF
--- a/src/metric-engine/src/data_region.rs
+++ b/src/metric-engine/src/data_region.rs
@@ -142,6 +142,7 @@ impl DataRegion {
                 c.column_id = new_column_id_start + delta as u32;
                 c.column_schema.set_nullable();
                 match index_options {
+                    IndexOptions::None => {}
                     IndexOptions::Inverted => {
                         c.column_schema.set_inverted_index(true);
                     }

--- a/src/metric-engine/src/engine/options.rs
+++ b/src/metric-engine/src/engine/options.rs
@@ -40,6 +40,7 @@ pub struct PhysicalRegionOptions {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum IndexOptions {
     #[default]
+    None,
     Inverted,
     Skipping {
         granularity: u32,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

- Don't create index for pk in physical table if not specified
- Change table id to use skipping index


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
