### PR TITLE
feat: support export command export data to s3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1693,6 +1693,7 @@ dependencies = [
  "humantime",
  "meta-client",
  "nu-ansi-term",
+ "opendal",
  "query",
  "rand",
  "reqwest",

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -43,6 +43,10 @@ futures.workspace = true
 humantime.workspace = true
 meta-client.workspace = true
 nu-ansi-term = "0.46"
+opendal = { version = "0.51.1", features = [
+    "services-fs",
+    "services-s3",
+] }
 query.workspace = true
 rand.workspace = true
 reqwest.workspace = true

--- a/src/cli/src/error.rs
+++ b/src/cli/src/error.rs
@@ -276,6 +276,20 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+
+    #[snafu(display("OpenDAL operator failed"))]
+    OpenDal {
+        #[snafu(implicit)]
+        location: Location,
+        #[snafu(source)]
+        error: opendal::Error,
+    },
+    #[snafu(display("S3 config need be set"))]
+    S3ConfigNotSet {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -319,6 +333,8 @@ impl ErrorExt for Error {
             | Error::BuildClient { .. } => StatusCode::Unexpected,
 
             Error::Other { source, .. } => source.status_code(),
+            Error::OpenDal { .. } => StatusCode::Internal,
+            Error::S3ConfigNotSet { .. } => StatusCode::InvalidArguments,
 
             Error::BuildRuntime { source, .. } => source.status_code(),
 

--- a/src/cli/src/error.rs
+++ b/src/cli/src/error.rs
@@ -289,7 +289,11 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
-
+    #[snafu(display("Output directory not set"))]
+    OutputDirNotSet {
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -335,6 +339,7 @@ impl ErrorExt for Error {
             Error::Other { source, .. } => source.status_code(),
             Error::OpenDal { .. } => StatusCode::Internal,
             Error::S3ConfigNotSet { .. } => StatusCode::InvalidArguments,
+            Error::OutputDirNotSet { .. } => StatusCode::InvalidArguments,
 
             Error::BuildRuntime { source, .. } => source.status_code(),
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

This patch add S3 Export Support to export cli 

## desc 

This patch aim to support for exporting database data and schema using opendal

- use opendal crate not the object-store is because maybe cli can be a standalone tool to make it simple
- introduce three new errors
- about the database data this patch use a trick way( using connection to make the code easy)
- because we can export to s3 so this patch make the `output-dir` optional
- add some new args to command can check below

args now
```
pub struct ExportCommand {
    /// Server address to connect
    #[clap(long)]
    addr: String,

    /// Directory to put the exported data. E.g.: /tmp/greptimedb-export
    /// for local export.
    #[clap(long)]
    output_dir: Option<String>,

    /// The name of the catalog to export.
    #[clap(long, default_value = "greptime-*")]
    database: String,

    /// Parallelism of the export.
    #[clap(long, short = 'j', default_value = "1")]
    export_jobs: usize,

    /// Max retry times for each job.
    #[clap(long, default_value = "3")]
    max_retry: usize,

    /// Things to export
    #[clap(long, short = 't', value_enum, default_value = "all")]
    target: ExportTarget,

    /// A half-open time range: [start_time, end_time).
    /// The start of the time range (time-index column) for data export.
    #[clap(long)]
    start_time: Option<String>,

    /// A half-open time range: [start_time, end_time).
    /// The end of the time range (time-index column) for data export.
    #[clap(long)]
    end_time: Option<String>,

    /// The basic authentication for connecting to the server
    #[clap(long)]
    auth_basic: Option<String>,

    /// The timeout of invoking the database.
    ///
    /// It is used to override the server-side timeout setting.
    /// The default behavior will disable server-side default timeout(i.e. `0s`).
    #[clap(long, value_parser = humantime::parse_duration)]
    timeout: Option<Duration>,

    /// The proxy server address to connect, if set, will override the system proxy.
    ///
    /// The default behavior will use the system proxy if neither `proxy` nor `no_proxy` is set.
    #[clap(long)]
    proxy: Option<String>,

    /// Disable proxy server, if set, will not use any proxy.
    #[clap(long)]
    no_proxy: bool,

    /// if export data to s3
    #[clap(long)]
    s3: bool,

    /// The s3 bucket name
    /// if s3 is set, this is required
    #[clap(long)]
    s3_bucket: Option<String>,

    /// The s3 endpoint
    /// if s3 is set, this is required
    #[clap(long)]
    s3_endpoint: Option<String>,

    /// The s3 access key
    /// if s3 is set, this is required
    #[clap(long)]
    s3_access_key: Option<String>,

    /// The s3 secret key
    /// if s3 is set, this is required
    #[clap(long)]
    s3_secret_key: Option<String>,

    /// The s3 region
    /// if s3 is set, this is required
    #[clap(long)]
    s3_region: Option<String>,
}
```

## example command

```cli
./target/debug/greptime cli export --addr 127.0.0.1:4000 --s3 --s3-bucket ttt --s3-access-key minioadmin --s3-secret-key minioadmin --s3-region us-east-1 --s3-endpoint http://localhost:9000
```

future to do maybe the fs way also can use opendal to make code simple


## Refer to a related PR or issue link (optional)
close #5533 #5139 #5138

cc @fengjiachun @zyy17 


## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
