### PR TITLE
fix: update show create table output for fulltext index

### DIFF
--- a/src/query/src/sql/show_create_table.rs
+++ b/src/query/src/sql/show_create_table.rs
@@ -327,7 +327,7 @@ CREATE TABLE IF NOT EXISTS "system_metrics" (
   "host" STRING NULL INVERTED INDEX,
   "cpu" DOUBLE NULL,
   "disk" FLOAT NULL,
-  "msg" STRING NULL FULLTEXT WITH(analyzer = 'English', case_sensitive = 'false'),
+  "msg" STRING NULL FULLTEXT INDEX WITH(analyzer = 'English', case_sensitive = 'false'),
   "ts" TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(),
   TIME INDEX ("ts"),
   PRIMARY KEY ("id", "host")

--- a/src/sql/src/statements/create.rs
+++ b/src/sql/src/statements/create.rs
@@ -156,9 +156,9 @@ impl Display for Column {
         if let Some(fulltext_options) = &self.extensions.fulltext_index_options {
             if !fulltext_options.is_empty() {
                 let options = fulltext_options.kv_pairs();
-                write!(f, " FULLTEXT WITH({})", format_list_comma!(options))?;
+                write!(f, " FULLTEXT INDEX WITH({})", format_list_comma!(options))?;
             } else {
-                write!(f, " FULLTEXT")?;
+                write!(f, " FULLTEXT INDEX")?;
             }
         }
 

--- a/tests/cases/standalone/common/alter/change_col_fulltext_options.result
+++ b/tests/cases/standalone/common/alter/change_col_fulltext_options.result
@@ -79,20 +79,20 @@ SELECT * FROM test WHERE MATCHES(message, 'hello') ORDER BY message;
 -- SQLNESS ARG restart=true
 SHOW CREATE TABLE test;
 
-+-------+---------------------------------------------------------------------------------------+
-| Table | Create Table                                                                          |
-+-------+---------------------------------------------------------------------------------------+
-| test  | CREATE TABLE IF NOT EXISTS "test" (                                                   |
-|       |   "message" STRING NULL FULLTEXT WITH(analyzer = 'Chinese', case_sensitive = 'true'), |
-|       |   "time" TIMESTAMP(3) NOT NULL,                                                       |
-|       |   TIME INDEX ("time")                                                                 |
-|       | )                                                                                     |
-|       |                                                                                       |
-|       | ENGINE=mito                                                                           |
-|       | WITH(                                                                                 |
-|       |   append_mode = 'true'                                                                |
-|       | )                                                                                     |
-+-------+---------------------------------------------------------------------------------------+
++-------+---------------------------------------------------------------------------------------------+
+| Table | Create Table                                                                                |
++-------+---------------------------------------------------------------------------------------------+
+| test  | CREATE TABLE IF NOT EXISTS "test" (                                                         |
+|       |   "message" STRING NULL FULLTEXT INDEX WITH(analyzer = 'Chinese', case_sensitive = 'true'), |
+|       |   "time" TIMESTAMP(3) NOT NULL,                                                             |
+|       |   TIME INDEX ("time")                                                                       |
+|       | )                                                                                           |
+|       |                                                                                             |
+|       | ENGINE=mito                                                                                 |
+|       | WITH(                                                                                       |
+|       |   append_mode = 'true'                                                                      |
+|       | )                                                                                           |
++-------+---------------------------------------------------------------------------------------------+
 
 SHOW INDEX FROM test;
 
@@ -138,20 +138,20 @@ Affected Rows: 0
 
 SHOW CREATE TABLE test;
 
-+-------+---------------------------------------------------------------------------------------+
-| Table | Create Table                                                                          |
-+-------+---------------------------------------------------------------------------------------+
-| test  | CREATE TABLE IF NOT EXISTS "test" (                                                   |
-|       |   "message" STRING NULL FULLTEXT WITH(analyzer = 'Chinese', case_sensitive = 'true'), |
-|       |   "time" TIMESTAMP(3) NOT NULL,                                                       |
-|       |   TIME INDEX ("time")                                                                 |
-|       | )                                                                                     |
-|       |                                                                                       |
-|       | ENGINE=mito                                                                           |
-|       | WITH(                                                                                 |
-|       |   append_mode = 'true'                                                                |
-|       | )                                                                                     |
-+-------+---------------------------------------------------------------------------------------+
++-------+---------------------------------------------------------------------------------------------+
+| Table | Create Table                                                                                |
++-------+---------------------------------------------------------------------------------------------+
+| test  | CREATE TABLE IF NOT EXISTS "test" (                                                         |
+|       |   "message" STRING NULL FULLTEXT INDEX WITH(analyzer = 'Chinese', case_sensitive = 'true'), |
+|       |   "time" TIMESTAMP(3) NOT NULL,                                                             |
+|       |   TIME INDEX ("time")                                                                       |
+|       | )                                                                                           |
+|       |                                                                                             |
+|       | ENGINE=mito                                                                                 |
+|       | WITH(                                                                                       |
+|       |   append_mode = 'true'                                                                      |
+|       | )                                                                                           |
++-------+---------------------------------------------------------------------------------------------+
 
 SHOW INDEX FROM test;
 

--- a/tests/cases/standalone/common/create/create_with_fulltext.result
+++ b/tests/cases/standalone/common/create/create_with_fulltext.result
@@ -7,18 +7,18 @@ Affected Rows: 0
 
 SHOW CREATE TABLE log;
 
-+-------+------------------------------------------------------------------------------------+
-| Table | Create Table                                                                       |
-+-------+------------------------------------------------------------------------------------+
-| log   | CREATE TABLE IF NOT EXISTS "log" (                                                 |
-|       |   "ts" TIMESTAMP(3) NOT NULL,                                                      |
-|       |   "msg" STRING NULL FULLTEXT WITH(analyzer = 'English', case_sensitive = 'false'), |
-|       |   TIME INDEX ("ts")                                                                |
-|       | )                                                                                  |
-|       |                                                                                    |
-|       | ENGINE=mito                                                                        |
-|       |                                                                                    |
-+-------+------------------------------------------------------------------------------------+
++-------+------------------------------------------------------------------------------------------+
+| Table | Create Table                                                                             |
++-------+------------------------------------------------------------------------------------------+
+| log   | CREATE TABLE IF NOT EXISTS "log" (                                                       |
+|       |   "ts" TIMESTAMP(3) NOT NULL,                                                            |
+|       |   "msg" STRING NULL FULLTEXT INDEX WITH(analyzer = 'English', case_sensitive = 'false'), |
+|       |   TIME INDEX ("ts")                                                                      |
+|       | )                                                                                        |
+|       |                                                                                          |
+|       | ENGINE=mito                                                                              |
+|       |                                                                                          |
++-------+------------------------------------------------------------------------------------------+
 
 DROP TABLE log;
 
@@ -33,18 +33,18 @@ Affected Rows: 0
 
 SHOW CREATE TABLE log_with_opts;
 
-+---------------+-----------------------------------------------------------------------------------+
-| Table         | Create Table                                                                      |
-+---------------+-----------------------------------------------------------------------------------+
-| log_with_opts | CREATE TABLE IF NOT EXISTS "log_with_opts" (                                      |
-|               |   "ts" TIMESTAMP(3) NOT NULL,                                                     |
-|               |   "msg" STRING NULL FULLTEXT WITH(analyzer = 'English', case_sensitive = 'true'), |
-|               |   TIME INDEX ("ts")                                                               |
-|               | )                                                                                 |
-|               |                                                                                   |
-|               | ENGINE=mito                                                                       |
-|               |                                                                                   |
-+---------------+-----------------------------------------------------------------------------------+
++---------------+-----------------------------------------------------------------------------------------+
+| Table         | Create Table                                                                            |
++---------------+-----------------------------------------------------------------------------------------+
+| log_with_opts | CREATE TABLE IF NOT EXISTS "log_with_opts" (                                            |
+|               |   "ts" TIMESTAMP(3) NOT NULL,                                                           |
+|               |   "msg" STRING NULL FULLTEXT INDEX WITH(analyzer = 'English', case_sensitive = 'true'), |
+|               |   TIME INDEX ("ts")                                                                     |
+|               | )                                                                                       |
+|               |                                                                                         |
+|               | ENGINE=mito                                                                             |
+|               |                                                                                         |
++---------------+-----------------------------------------------------------------------------------------+
 
 DROP TABLE log_with_opts;
 
@@ -60,19 +60,19 @@ Affected Rows: 0
 
 SHOW CREATE TABLE log_multi_fulltext_cols;
 
-+-------------------------+-------------------------------------------------------------------------------------+
-| Table                   | Create Table                                                                        |
-+-------------------------+-------------------------------------------------------------------------------------+
-| log_multi_fulltext_cols | CREATE TABLE IF NOT EXISTS "log_multi_fulltext_cols" (                              |
-|                         |   "ts" TIMESTAMP(3) NOT NULL,                                                       |
-|                         |   "msg" STRING NULL FULLTEXT WITH(analyzer = 'English', case_sensitive = 'false'),  |
-|                         |   "msg2" STRING NULL FULLTEXT WITH(analyzer = 'English', case_sensitive = 'false'), |
-|                         |   TIME INDEX ("ts")                                                                 |
-|                         | )                                                                                   |
-|                         |                                                                                     |
-|                         | ENGINE=mito                                                                         |
-|                         |                                                                                     |
-+-------------------------+-------------------------------------------------------------------------------------+
++-------------------------+-------------------------------------------------------------------------------------------+
+| Table                   | Create Table                                                                              |
++-------------------------+-------------------------------------------------------------------------------------------+
+| log_multi_fulltext_cols | CREATE TABLE IF NOT EXISTS "log_multi_fulltext_cols" (                                    |
+|                         |   "ts" TIMESTAMP(3) NOT NULL,                                                             |
+|                         |   "msg" STRING NULL FULLTEXT INDEX WITH(analyzer = 'English', case_sensitive = 'false'),  |
+|                         |   "msg2" STRING NULL FULLTEXT INDEX WITH(analyzer = 'English', case_sensitive = 'false'), |
+|                         |   TIME INDEX ("ts")                                                                       |
+|                         | )                                                                                         |
+|                         |                                                                                           |
+|                         | ENGINE=mito                                                                               |
+|                         |                                                                                           |
++-------------------------+-------------------------------------------------------------------------------------------+
 
 DROP TABLE log_multi_fulltext_cols;
 

--- a/tests/cases/standalone/common/show/show_create.result
+++ b/tests/cases/standalone/common/show/show_create.result
@@ -373,20 +373,20 @@ Affected Rows: 0
 
 show create table test_column_constrain_composite_indexes;
 
-+-----------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Table                                   | Create Table                                                                                                                                                  |
-+-----------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| test_column_constrain_composite_indexes | CREATE TABLE IF NOT EXISTS "test_column_constrain_composite_indexes" (                                                                                        |
-|                                         |   "id" INT NULL SKIPPING INDEX WITH(granularity = '10240', type = 'BLOOM') INVERTED INDEX,                                                                    |
-|                                         |   "host" STRING NULL FULLTEXT WITH(analyzer = 'English', case_sensitive = 'false') SKIPPING INDEX WITH(granularity = '10240', type = 'BLOOM') INVERTED INDEX, |
-|                                         |   "ts" TIMESTAMP(3) NOT NULL,                                                                                                                                 |
-|                                         |   TIME INDEX ("ts"),                                                                                                                                          |
-|                                         |   PRIMARY KEY ("host")                                                                                                                                        |
-|                                         | )                                                                                                                                                             |
-|                                         |                                                                                                                                                               |
-|                                         | ENGINE=mito                                                                                                                                                   |
-|                                         |                                                                                                                                                               |
-+-----------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
++-----------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Table                                   | Create Table                                                                                                                                                        |
++-----------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| test_column_constrain_composite_indexes | CREATE TABLE IF NOT EXISTS "test_column_constrain_composite_indexes" (                                                                                              |
+|                                         |   "id" INT NULL SKIPPING INDEX WITH(granularity = '10240', type = 'BLOOM') INVERTED INDEX,                                                                          |
+|                                         |   "host" STRING NULL FULLTEXT INDEX WITH(analyzer = 'English', case_sensitive = 'false') SKIPPING INDEX WITH(granularity = '10240', type = 'BLOOM') INVERTED INDEX, |
+|                                         |   "ts" TIMESTAMP(3) NOT NULL,                                                                                                                                       |
+|                                         |   TIME INDEX ("ts"),                                                                                                                                                |
+|                                         |   PRIMARY KEY ("host")                                                                                                                                              |
+|                                         | )                                                                                                                                                                   |
+|                                         |                                                                                                                                                                     |
+|                                         | ENGINE=mito                                                                                                                                                         |
+|                                         |                                                                                                                                                                     |
++-----------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 drop table test_column_constrain_composite_indexes;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/5332

## What's changed and what's your intention?

The output of the show create table should also adds `INDEX` after `FULLTEXT`

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
