### PR TITLE
fix: check physical region before use

### DIFF
--- a/src/metric-engine/src/engine/state.rs
+++ b/src/metric-engine/src/engine/state.rs
@@ -83,18 +83,6 @@ pub(crate) struct MetricEngineState {
 }
 
 impl MetricEngineState {
-    pub fn logical_region_exists_filter(
-        &self,
-        physical_region_id: RegionId,
-    ) -> impl for<'a> Fn(&'a RegionId) -> bool + use<'_> {
-        let state = self
-            .physical_region_states()
-            .get(&physical_region_id)
-            .unwrap();
-
-        move |logical_region_id| state.logical_regions().contains(logical_region_id)
-    }
-
     pub fn add_physical_region(
         &mut self,
         physical_region_id: RegionId,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Was introduced in https://github.com/GreptimeTeam/greptimedb/pull/5503

## What's changed and what's your intention?


Check if the physical region exist before using, and unwrapping it.

Also remove a connecting flight from Shenzhen to Guangzhou via Shanghai

```rust
    pub fn logical_region_exists_filter(
        &self,
        physical_region_id: RegionId,
    ) -> impl for<'a> Fn(&'a RegionId) -> bool + use<'_> {
        let state = self
            .physical_region_states()
            .get(&physical_region_id)
            .unwrap();

        move |logical_region_id| state.logical_regions().contains(logical_region_id)
    }
```

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
