### PR TITLE
feat: skip printing full config content in sqlness

### DIFF
--- a/tests/runner/src/server_mode.rs
+++ b/tests/runner/src/server_mode.rs
@@ -308,7 +308,7 @@ impl ServerMode {
             .display()
             .to_string();
         println!(
-            "Generating id {}, {} config file in {conf_file}, full content:\n{rendered}",
+            "Generating id {}, {} config file in {conf_file}",
             id,
             self.name()
         );


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

It's soooo overwhelming with full config content. A full run can generate over 5000 lines of logs, making it super hard to find an actual error.

Since the config file is persisted, we can always check the content later when necessary anyway.

<img width="555" alt="image" src="https://github.com/user-attachments/assets/39d4af00-c3cf-4c00-9182-de2432477a0e" />


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
