### PR TITLE
fix: refactor region leader state validation

### DIFF
--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -490,6 +490,18 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display(
+        "Region {} is in {:?} state, which does not permit manifest updates.",
+        region_id,
+        state
+    ))]
+    UpdateManifest {
+        region_id: RegionId,
+        state: RegionRoleState,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Region {} is in {:?} state, expect: {:?}", region_id, state, expect))]
     RegionLeaderState {
         region_id: RegionId,
@@ -1055,7 +1067,7 @@ impl ErrorExt for Error {
             CompactRegion { source, .. } => source.status_code(),
             CompatReader { .. } => StatusCode::Unexpected,
             InvalidRegionRequest { source, .. } => source.status_code(),
-            RegionLeaderState { .. } => StatusCode::RegionNotReady,
+            RegionLeaderState { .. } | UpdateManifest { .. } => StatusCode::RegionNotReady,
             &FlushableRegionState { .. } => StatusCode::RegionNotReady,
             JsonOptions { .. } => StatusCode::InvalidArguments,
             EmptyRegionDir { .. } | EmptyManifestDir { .. } => StatusCode::RegionNotFound,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The region state may change when a downgrading instruction is received from the metasrv. For example:
1. A region flush is triggered (when the buffer is full).
2. The region is set to downgrading (upon receiving the downgrading instruction).
3. The flush completes, but the manifest update fails (due to an unexpected state).
While a failure to update the manifest is unexpected, a downgrading leader rejects user writes but still allows flushing the memtable and updating the manifest. This enhancement aims to reduce the number of flush failures caused by unexpected states.

This PR introduces a conditional check for when the expected state is writable, allowing the current state to be either writable or downgrading.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
