### PR TITLE
fix: prevent failover of regions to the same peer

### DIFF
--- a/src/meta-srv/src/region/supervisor.rs
+++ b/src/meta-srv/src/region/supervisor.rs
@@ -416,6 +416,12 @@ impl RegionSupervisor {
             )
             .await?;
         let to_peer = peers.remove(0);
+        if to_peer.id == from_peer.id {
+            warn!(
+                "Skip failover for region: {region_id}, from_peer: {from_peer}, trying to failover to the same peer."
+            );
+            return Ok(());
+        }
         let task = RegionMigrationProcedureTask {
             cluster_id,
             region_id,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Prevent failover to the same peer for region

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
