### PR TITLE
fix: properly display CJK characters in table/column comments

### DIFF
--- a/src/sql/src/statements/option_map.rs
+++ b/src/sql/src/statements/option_map.rs
@@ -82,9 +82,9 @@ impl OptionMap {
         let mut result = Vec::with_capacity(self.options.len() + self.secrets.len());
         for (k, v) in self.options.iter() {
             if k.contains(".") {
-                result.push(format!("'{k}' = '{}'", v.escape_default()));
+                result.push(format!("'{k}' = '{}'", v.escape_debug()));
             } else {
-                result.push(format!("{k} = '{}'", v.escape_default()));
+                result.push(format!("{k} = '{}'", v.escape_debug()));
             }
         }
         for (k, _) in self.secrets.iter() {
@@ -152,5 +152,25 @@ impl VisitMut for OptionMap {
             v.expose_secret_mut().visit(visitor)?;
         }
         ControlFlow::Continue(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::statements::OptionMap;
+
+    #[test]
+    fn test_format() {
+        let mut map = OptionMap::default();
+        map.insert("comment".to_string(), "中文comment".to_string());
+        assert_eq!("comment = '中文comment'", map.kv_pairs()[0]);
+
+        let mut map = OptionMap::default();
+        map.insert("a.b".to_string(), "中文comment".to_string());
+        assert_eq!("'a.b' = '中文comment'", map.kv_pairs()[0]);
+
+        let mut map = OptionMap::default();
+        map.insert("a.b".to_string(), "中文comment\n".to_string());
+        assert_eq!("'a.b' = '中文comment\\n'", map.kv_pairs()[0]);
     }
 }

--- a/tests/cases/standalone/common/show/show_create.result
+++ b/tests/cases/standalone/common/show/show_create.result
@@ -392,3 +392,32 @@ drop table test_column_constrain_composite_indexes;
 
 Affected Rows: 0
 
+CREATE TABLE `table_comment_in_cjk` (
+    `ts` TIMESTAMP(3) NOT NULL COMMENT '时间戳',
+    `val` DOUBLE NULL COMMENT '值',
+    TIME INDEX ("ts"),
+) WITH (comment = '你好\nこんにちは\n안녕하세요');
+
+Affected Rows: 0
+
+show create table table_comment_in_cjk;
+
++----------------------+-----------------------------------------------------+
+| Table                | Create Table                                        |
++----------------------+-----------------------------------------------------+
+| table_comment_in_cjk | CREATE TABLE IF NOT EXISTS "table_comment_in_cjk" ( |
+|                      |   "ts" TIMESTAMP(3) NOT NULL COMMENT '时间戳',      |
+|                      |   "val" DOUBLE NULL COMMENT '值',                   |
+|                      |   TIME INDEX ("ts")                                 |
+|                      | )                                                   |
+|                      |                                                     |
+|                      | ENGINE=mito                                         |
+|                      | WITH(                                               |
+|                      |   comment = '你好\\nこんにちは\\n안녕하세요'        |
+|                      | )                                                   |
++----------------------+-----------------------------------------------------+
+
+drop table table_comment_in_cjk;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/show/show_create.sql
+++ b/tests/cases/standalone/common/show/show_create.sql
@@ -153,3 +153,14 @@ CREATE TABLE test_column_constrain_composite_indexes (
 show create table test_column_constrain_composite_indexes;
 
 drop table test_column_constrain_composite_indexes;
+
+
+CREATE TABLE `table_comment_in_cjk` (
+    `ts` TIMESTAMP(3) NOT NULL COMMENT '时间戳',
+    `val` DOUBLE NULL COMMENT '值',
+    TIME INDEX ("ts"),
+) WITH (comment = '你好\nこんにちは\n안녕하세요');
+
+show create table table_comment_in_cjk;
+
+drop table table_comment_in_cjk;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
- fixes #5631

## What's changed and what's your intention?

 ### Update `OptionMap` Formatting and Add Tests

 - **Enhancements in `OptionMap`**:
   - Changed formatting from `escape_default` to `escape_debug` for better handling of special characters in `src/sql/src/statements/option_map.rs`.
   - Added unit tests to verify the new formatting behavior.

 - **Test Cases for CJK Comments**:
   - Added test cases for tables with comments in CJK (Chinese, Japanese, Korean) characters in `tests/cases/standalone/common/show/show_create.sql` and `show_create.result`.
## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
