### PR TITLE
chore: support specifying `skipping` index in pipeline

### DIFF
--- a/src/api/src/v1/column_def.rs
+++ b/src/api/src/v1/column_def.rs
@@ -15,8 +15,8 @@
 use std::collections::HashMap;
 
 use datatypes::schema::{
-    ColumnDefaultConstraint, ColumnSchema, FulltextAnalyzer, FulltextOptions, SkippingIndexType,
-    COMMENT_KEY, FULLTEXT_KEY, INVERTED_INDEX_KEY, SKIPPING_INDEX_KEY,
+    ColumnDefaultConstraint, ColumnSchema, FulltextAnalyzer, FulltextOptions, SkippingIndexOptions,
+    SkippingIndexType, COMMENT_KEY, FULLTEXT_KEY, INVERTED_INDEX_KEY, SKIPPING_INDEX_KEY,
 };
 use greptime_proto::v1::{Analyzer, SkippingIndexType as PbSkippingIndexType};
 use snafu::ResultExt;
@@ -103,12 +103,31 @@ pub fn contains_fulltext(options: &Option<ColumnOptions>) -> bool {
         .is_some_and(|o| o.options.contains_key(FULLTEXT_GRPC_KEY))
 }
 
+/// Checks if the `ColumnOptions` contains skipping index options.
+pub fn contains_skipping(options: &Option<ColumnOptions>) -> bool {
+    options
+        .as_ref()
+        .is_some_and(|o| o.options.contains_key(SKIPPING_INDEX_GRPC_KEY))
+}
+
 /// Tries to construct a `ColumnOptions` from the given `FulltextOptions`.
 pub fn options_from_fulltext(fulltext: &FulltextOptions) -> Result<Option<ColumnOptions>> {
     let mut options = ColumnOptions::default();
 
     let v = serde_json::to_string(fulltext).context(error::SerializeJsonSnafu)?;
     options.options.insert(FULLTEXT_GRPC_KEY.to_string(), v);
+
+    Ok((!options.options.is_empty()).then_some(options))
+}
+
+/// Tries to construct a `ColumnOptions` from the given `SkippingIndexOptions`.
+pub fn options_from_skipping(skipping: &SkippingIndexOptions) -> Result<Option<ColumnOptions>> {
+    let mut options = ColumnOptions::default();
+
+    let v = serde_json::to_string(skipping).context(error::SerializeJsonSnafu)?;
+    options
+        .options
+        .insert(SKIPPING_INDEX_GRPC_KEY.to_string(), v);
 
     Ok((!options.options.is_empty()).then_some(options))
 }

--- a/src/common/grpc-expr/src/error.rs
+++ b/src/common/grpc-expr/src/error.rs
@@ -111,9 +111,9 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Fulltext index only supports string type, column: {column_name}, unexpected type: {column_type:?}"
+        "Fulltext or Skipping index only supports string type, column: {column_name}, unexpected type: {column_type:?}"
     ))]
-    InvalidFulltextColumnType {
+    InvalidStringIndexColumnType {
         column_name: String,
         column_type: ColumnDataType,
         #[snafu(implicit)]
@@ -173,7 +173,7 @@ impl ErrorExt for Error {
                 StatusCode::InvalidArguments
             }
 
-            Error::UnknownColumnDataType { .. } | Error::InvalidFulltextColumnType { .. } => {
+            Error::UnknownColumnDataType { .. } | Error::InvalidStringIndexColumnType { .. } => {
                 StatusCode::InvalidArguments
             }
             Error::InvalidSetTableOptionRequest { .. }

--- a/src/common/grpc-expr/src/util.rs
+++ b/src/common/grpc-expr/src/util.rs
@@ -15,7 +15,7 @@
 use std::collections::HashSet;
 
 use api::v1::column_data_type_extension::TypeExt;
-use api::v1::column_def::contains_fulltext;
+use api::v1::column_def::{contains_fulltext, contains_skipping};
 use api::v1::{
     AddColumn, AddColumns, Column, ColumnDataType, ColumnDataTypeExtension, ColumnDef,
     ColumnOptions, ColumnSchema, CreateTableExpr, JsonTypeExtension, SemanticType,
@@ -27,7 +27,7 @@ use table::table_reference::TableReference;
 
 use crate::error::{
     self, DuplicatedColumnNameSnafu, DuplicatedTimestampColumnSnafu,
-    InvalidFulltextColumnTypeSnafu, MissingTimestampColumnSnafu, Result,
+    InvalidStringIndexColumnTypeSnafu, MissingTimestampColumnSnafu, Result,
     UnknownColumnDataTypeSnafu,
 };
 pub struct ColumnExpr<'a> {
@@ -152,8 +152,9 @@ pub fn build_create_table_expr(
         let column_type = infer_column_datatype(datatype, datatype_extension)?;
 
         ensure!(
-            !contains_fulltext(options) || column_type == ColumnDataType::String,
-            InvalidFulltextColumnTypeSnafu {
+            (!contains_fulltext(options) && !contains_skipping(options))
+                || column_type == ColumnDataType::String,
+            InvalidStringIndexColumnTypeSnafu {
                 column_name,
                 column_type,
             }

--- a/src/pipeline/src/etl/transform/index.rs
+++ b/src/pipeline/src/etl/transform/index.rs
@@ -18,6 +18,7 @@ const INDEX_TIMESTAMP: &str = "timestamp";
 const INDEX_TIMEINDEX: &str = "time";
 const INDEX_TAG: &str = "tag";
 const INDEX_FULLTEXT: &str = "fulltext";
+const INDEX_SKIPPING: &str = "skipping";
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[allow(clippy::enum_variant_names)]
@@ -25,6 +26,7 @@ pub enum Index {
     Time,
     Tag,
     Fulltext,
+    Skipping,
 }
 
 impl std::fmt::Display for Index {
@@ -33,6 +35,7 @@ impl std::fmt::Display for Index {
             Index::Time => INDEX_TIMEINDEX,
             Index::Tag => INDEX_TAG,
             Index::Fulltext => INDEX_FULLTEXT,
+            Index::Skipping => INDEX_SKIPPING,
         };
 
         write!(f, "{}", index)
@@ -55,6 +58,7 @@ impl TryFrom<&str> for Index {
             INDEX_TIMESTAMP | INDEX_TIMEINDEX => Ok(Index::Time),
             INDEX_TAG => Ok(Index::Tag),
             INDEX_FULLTEXT => Ok(Index::Fulltext),
+            INDEX_SKIPPING => Ok(Index::Skipping),
             _ => UnsupportedIndexTypeSnafu { value }.fail(),
         }
     }

--- a/src/pipeline/src/etl/transform/transformer/greptime/coerce.rs
+++ b/src/pipeline/src/etl/transform/transformer/greptime/coerce.rs
@@ -104,7 +104,7 @@ fn coerce_semantic_type(transform: &Transform) -> SemanticType {
 
 fn coerce_options(transform: &Transform) -> Result<Option<ColumnOptions>> {
     match transform.index {
-        Some(Index::Tag) => options_from_fulltext(&FulltextOptions {
+        Some(Index::Fulltext) => options_from_fulltext(&FulltextOptions {
             enable: true,
             ..Default::default()
         })

--- a/src/pipeline/src/etl/transform/transformer/greptime/coerce.rs
+++ b/src/pipeline/src/etl/transform/transformer/greptime/coerce.rs
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use api::error::SerializeJsonSnafu;
 use api::v1::column_data_type_extension::TypeExt;
-use api::v1::column_def::options_from_fulltext;
+use api::v1::column_def::{options_from_fulltext, options_from_skipping};
 use api::v1::{ColumnDataTypeExtension, ColumnOptions, JsonTypeExtension};
-use datatypes::schema::{FulltextOptions, SkippingIndexOptions, SKIPPING_INDEX_KEY};
+use datatypes::schema::{FulltextOptions, SkippingIndexOptions};
 use greptime_proto::v1::value::ValueData;
 use greptime_proto::v1::{ColumnDataType, ColumnSchema, SemanticType};
 use snafu::ResultExt;
@@ -111,17 +110,8 @@ fn coerce_options(transform: &Transform) -> Result<Option<ColumnOptions>> {
         })
         .context(ColumnOptionsSnafu),
         Some(Index::Skipping) => {
-            let mut options = ColumnOptions::default();
-            let opts_str = serde_json::to_string(&SkippingIndexOptions::default())
-                .context(SerializeJsonSnafu)
-                .context(ColumnOptionsSnafu)?;
-
-            options
-                .options
-                .insert(SKIPPING_INDEX_KEY.to_string(), opts_str);
-            Ok(Some(options))
+            options_from_skipping(&SkippingIndexOptions::default()).context(ColumnOptionsSnafu)
         }
-
         _ => Ok(None),
     }
 }

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -1320,7 +1320,7 @@ transform:
 
     // 3. check schema
 
-    let expected_schema =  "[[\"logs1\",\"CREATE TABLE IF NOT EXISTS \\\"logs1\\\" (\\n  \\\"id1\\\" INT NULL,\\n  \\\"id2\\\" INT NULL,\\n  \\\"logger\\\" STRING NULL,\\n  \\\"type\\\" STRING NULL SKIPPING INDEX WITH(granularity = '0', type = 'BLOOM'),\\n  \\\"log\\\" STRING NULL,\\n  \\\"time\\\" TIMESTAMP(9) NOT NULL,\\n  TIME INDEX (\\\"time\\\")\\n)\\n\\nENGINE=mito\\nWITH(\\n  append_mode = 'true'\\n)\"]]";
+    let expected_schema =  "[[\"logs1\",\"CREATE TABLE IF NOT EXISTS \\\"logs1\\\" (\\n  \\\"id1\\\" INT NULL,\\n  \\\"id2\\\" INT NULL,\\n  \\\"logger\\\" STRING NULL,\\n  \\\"type\\\" STRING NULL SKIPPING INDEX WITH(granularity = '0', type = 'BLOOM'),\\n  \\\"log\\\" STRING NULL FULLTEXT INDEX WITH(analyzer = 'English', case_sensitive = 'false'),\\n  \\\"time\\\" TIMESTAMP(9) NOT NULL,\\n  TIME INDEX (\\\"time\\\")\\n)\\n\\nENGINE=mito\\nWITH(\\n  append_mode = 'true'\\n)\"]]";
     validate_data(
         "pipeline_schema",
         &client,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR mainly supports specifying `skipping` index in pipeline config file. For example
```yaml
transform:
  - field: type
    type: string
    index: skipping
  - field: log
    type: string
    index: fulltext
  - field: time
    type: time
    index: timestamp
```

It converts to the following clause in create table SQL
```SQL
`type` STRING NULL SKIPPING INDEX WITH(granularity = '0', type = 'BLOOM'),
```


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
