### PR TITLE
feat: alias for boolean

### DIFF
--- a/src/sql/src/statements/transform/type_alias.rs
+++ b/src/sql/src/statements/transform/type_alias.rs
@@ -167,6 +167,7 @@ pub(crate) fn get_type_by_alias(data_type: &DataType) -> Option<DataType> {
         DataType::UInt64 => Some(DataType::UnsignedBigInt(None)),
         DataType::Float32 => Some(DataType::Float(None)),
         DataType::Float64 => Some(DataType::Double),
+        DataType::Bool => Some(DataType::Boolean),
         DataType::Datetime(_) => Some(DataType::Timestamp(Some(6), TimezoneInfo::None)),
         _ => None,
     }
@@ -341,6 +342,20 @@ mod tests {
 
     fn test_timestamp_precision_type(precision: i32, expected: &str) {
         test_timestamp_alias(&format!("Timestamp({precision})"), expected);
+    }
+
+    #[test]
+    fn test_boolean_alias() {
+        let sql = "CREATE TABLE test(b bool, ts TIMESTAMP TIME INDEX)";
+        let mut stmts =
+            ParserContext::create_with_dialect(sql, &GenericDialect {}, ParseOptions::default())
+                .unwrap();
+        transform_statements(&mut stmts).unwrap();
+
+        match &stmts[0] {
+            Statement::CreateTable(c) => assert_eq!("CREATE TABLE test (\n  b BOOLEAN,\n  ts TIMESTAMP NOT NULL,\n  TIME INDEX (ts)\n)\nENGINE=mito\n", c.to_string()),
+            _ => unreachable!(),
+        }
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Close #5629 

## What's changed and what's your intention?

Adds `bool` as alias for `boolean`.

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
