### PR TITLE
fix: flaky test in sqlness by fix random port

### DIFF
--- a/tests/runner/src/server_mode.rs
+++ b/tests/runner/src/server_mode.rs
@@ -33,7 +33,7 @@ fn get_used_ports() -> &'static Mutex<HashSet<u16>> {
 fn get_unique_random_port() -> u16 {
     loop {
         let p = util::get_random_port();
-        // Safty: We are the only one that can access the used ports
+        // Safety: We are the only one that can access the used ports
         let mut used = get_used_ports().lock().unwrap();
         if !used.contains(&p) {
             used.insert(p);

--- a/tests/runner/src/server_mode.rs
+++ b/tests/runner/src/server_mode.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
 use std::path::Path;
+use std::sync::{Mutex, OnceLock};
 
 use serde::Serialize;
 use tinytemplate::TinyTemplate;
@@ -21,6 +23,24 @@ use crate::env::{Env, GreptimeDBContext};
 use crate::{util, ServerAddr};
 
 const DEFAULT_LOG_LEVEL: &str = "--log-level=debug,hyper=warn,tower=warn,datafusion=warn,reqwest=warn,sqlparser=warn,h2=info,opendal=info";
+
+static USED_PORTS: OnceLock<Mutex<HashSet<u16>>> = OnceLock::new();
+
+fn get_used_ports() -> &'static Mutex<HashSet<u16>> {
+    USED_PORTS.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+fn get_unique_random_port() -> u16 {
+    loop {
+        let p = util::get_random_port();
+        // Safty: We are the only one that can access the used ports
+        let mut used = get_used_ports().lock().unwrap();
+        if !used.contains(&p) {
+            used.insert(p);
+            return p;
+        }
+    }
+}
 
 #[derive(Clone)]
 pub enum ServerMode {
@@ -81,10 +101,10 @@ struct ConfigContext {
 
 impl ServerMode {
     pub fn random_standalone() -> Self {
-        let http_port = util::get_random_port();
-        let rpc_port = util::get_random_port();
-        let mysql_port = util::get_random_port();
-        let postgres_port = util::get_random_port();
+        let http_port = get_unique_random_port();
+        let rpc_port = get_unique_random_port();
+        let mysql_port = get_unique_random_port();
+        let postgres_port = get_unique_random_port();
 
         ServerMode::Standalone {
             http_addr: format!("127.0.0.1:{http_port}"),
@@ -95,10 +115,10 @@ impl ServerMode {
     }
 
     pub fn random_frontend(metasrv_port: u16) -> Self {
-        let http_port = util::get_random_port();
-        let rpc_port = util::get_random_port();
-        let mysql_port = util::get_random_port();
-        let postgres_port = util::get_random_port();
+        let http_port = get_unique_random_port();
+        let rpc_port = get_unique_random_port();
+        let mysql_port = get_unique_random_port();
+        let postgres_port = get_unique_random_port();
 
         ServerMode::Frontend {
             http_addr: format!("127.0.0.1:{http_port}"),
@@ -110,8 +130,8 @@ impl ServerMode {
     }
 
     pub fn random_metasrv() -> Self {
-        let bind_port = util::get_random_port();
-        let http_port = util::get_random_port();
+        let bind_port = get_unique_random_port();
+        let http_port = get_unique_random_port();
 
         ServerMode::Metasrv {
             rpc_bind_addr: format!("127.0.0.1:{bind_port}"),
@@ -121,8 +141,8 @@ impl ServerMode {
     }
 
     pub fn random_datanode(metasrv_port: u16, node_id: u32) -> Self {
-        let rpc_port = util::get_random_port();
-        let http_port = util::get_random_port();
+        let rpc_port = get_unique_random_port();
+        let http_port = get_unique_random_port();
 
         ServerMode::Datanode {
             rpc_bind_addr: format!("127.0.0.1:{rpc_port}"),
@@ -134,8 +154,8 @@ impl ServerMode {
     }
 
     pub fn random_flownode(metasrv_port: u16, node_id: u32) -> Self {
-        let rpc_port = util::get_random_port();
-        let http_port = util::get_random_port();
+        let rpc_port = get_unique_random_port();
+        let http_port = get_unique_random_port();
 
         ServerMode::Flownode {
             rpc_bind_addr: format!("127.0.0.1:{rpc_port}"),

--- a/tests/runner/src/server_mode.rs
+++ b/tests/runner/src/server_mode.rs
@@ -31,15 +31,22 @@ fn get_used_ports() -> &'static Mutex<HashSet<u16>> {
 }
 
 fn get_unique_random_port() -> u16 {
-    loop {
+    // Tricky loop 100 times to find an unused port instead of infinite loop.
+    const MAX_ATTEMPTS: usize = 100;
+
+    for _ in 0..MAX_ATTEMPTS {
         let p = util::get_random_port();
-        // Safety: We are the only one that can access the used ports
         let mut used = get_used_ports().lock().unwrap();
         if !used.contains(&p) {
             used.insert(p);
             return p;
         }
     }
+
+    panic!(
+        "Failed to find an unused port after {} attempts",
+        MAX_ATTEMPTS
+    );
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

This patch fix flaky test in sqlness tests by make sure the random port do not use.

fix: https://github.com/GreptimeTeam/greptimedb/issues/5638

more: https://github.com/yihong0618/greptimedb/actions/runs/13679014304

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
