### PR TITLE
perf: rm coalesce batch when target_batch_size > fetch limit

### DIFF
--- a/src/query/src/optimizer/windowed_sort.rs
+++ b/src/query/src/optimizer/windowed_sort.rs
@@ -80,6 +80,9 @@ impl WindowedSortPhysicalRule {
                     let preserve_partitioning = sort_exec.preserve_partitioning();
 
                     let sort_input = remove_repartition(sort_exec.input().clone())?.data;
+                    let sort_input =
+                        remove_coalesce_batches_exec(sort_input, sort_exec.fetch())?.data;
+
                     // Gets scanner info from the input without repartition before filter.
                     let Some(scanner_info) = fetch_partition_range(sort_input.clone())? else {
                         return Ok(Transformed::no(plan));
@@ -230,6 +233,29 @@ fn remove_repartition(
                     let new_filter = plan.clone().with_new_children(vec![maybe_scan.clone()])?;
                     return Ok(Transformed::yes(new_filter));
                 }
+            }
+        }
+
+        Ok(Transformed::no(plan))
+    })
+}
+
+/// Remove `CoalesceBatchesExec` if the limit is less than the batch size.
+///
+/// so that if limit is too small we can avoid need to scan for more rows than necessary
+fn remove_coalesce_batches_exec(
+    plan: Arc<dyn ExecutionPlan>,
+    fetch: Option<usize>,
+) -> DataFusionResult<Transformed<Arc<dyn ExecutionPlan>>> {
+    let Some(fetch) = fetch else {
+        return Ok(Transformed::no(plan));
+    };
+
+    plan.transform_down(|plan| {
+        if let Some(coalesce_batches_exec) = plan.as_any().downcast_ref::<CoalesceBatchesExec>() {
+            let target_batch_size = coalesce_batches_exec.target_batch_size();
+            if fetch < target_batch_size {
+                return Ok(Transformed::yes(coalesce_batches_exec.input().clone()));
             }
         }
 

--- a/tests/cases/standalone/common/order/order_by.result
+++ b/tests/cases/standalone/common/order/order_by.result
@@ -299,14 +299,12 @@ explain analyze select tag from t where num > 6 order by ts desc limit 2;
 | 1_| 0_|_SortPreservingMergeExec: [ts@1 DESC], fetch=2 REDACTED
 |_|_|_WindowedSortExec: expr=ts@1 DESC num_ranges=1 fetch=2 REDACTED
 |_|_|_PartSortExec: expr=ts@1 DESC num_ranges=1 limit=2 REDACTED
-|_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_FilterExec: num@2 > 6, projection=[tag@0, ts@1] REDACTED
 |_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges) REDACTED
 |_|_|_|
 | 1_| 1_|_SortPreservingMergeExec: [ts@1 DESC], fetch=2 REDACTED
 |_|_|_WindowedSortExec: expr=ts@1 DESC num_ranges=1 fetch=2 REDACTED
 |_|_|_PartSortExec: expr=ts@1 DESC num_ranges=1 limit=2 REDACTED
-|_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_FilterExec: num@2 > 6, projection=[tag@0, ts@1] REDACTED
 |_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges) REDACTED
 |_|_|_|

--- a/tests/cases/standalone/common/order/windowed_sort.result
+++ b/tests/cases/standalone/common/order/windowed_sort.result
@@ -132,7 +132,6 @@ EXPLAIN ANALYZE SELECT * FROM test where i > 2 ORDER BY t LIMIT 4;
 |_|_|_|
 | 1_| 0_|_SortPreservingMergeExec: [t@1 ASC NULLS LAST], fetch=4 REDACTED
 |_|_|_WindowedSortExec: expr=t@1 ASC NULLS LAST num_ranges=4 fetch=4 REDACTED
-|_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_FilterExec: i@0 > 2 REDACTED
 |_|_|_SeqScan: region=REDACTED, partition_count=4 (1 memtable ranges, 3 file 3 ranges) REDACTED
 |_|_|_|
@@ -166,7 +165,6 @@ EXPLAIN ANALYZE SELECT * FROM test where i > 2 ORDER BY t DESC LIMIT 4;
 | 1_| 0_|_SortPreservingMergeExec: [t@1 DESC], fetch=4 REDACTED
 |_|_|_WindowedSortExec: expr=t@1 DESC num_ranges=4 fetch=4 REDACTED
 |_|_|_PartSortExec: expr=t@1 DESC num_ranges=4 limit=4 REDACTED
-|_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_FilterExec: i@0 > 2 REDACTED
 |_|_|_SeqScan: region=REDACTED, partition_count=4 (1 memtable ranges, 3 file 3 ranges) REDACTED
 |_|_|_|
@@ -200,7 +198,6 @@ EXPLAIN ANALYZE SELECT * FROM test where t > 8 ORDER BY t DESC LIMIT 4;
 | 1_| 0_|_SortPreservingMergeExec: [t@1 DESC], fetch=4 REDACTED
 |_|_|_WindowedSortExec: expr=t@1 DESC num_ranges=2 fetch=4 REDACTED
 |_|_|_PartSortExec: expr=t@1 DESC num_ranges=2 limit=4 REDACTED
-|_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_FilterExec: t@1 > 8 REDACTED
 |_|_|_SeqScan: region=REDACTED, partition_count=2 (1 memtable ranges, 1 file 1 ranges) REDACTED
 |_|_|_|


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

remove `CoalesceBatchesExec` if limit < target_batch_size when optimize window sort, i.e, before removal `CoalesceBatchesExec` will forced to read more rows than necessary before fulfill a batch, causing too much slow down in combination with `FilterExec` which filtered most rows before output.
This shouldn't hurt perf much as limit is usually small enough so the benefits of coalesce batch is not significant.

Before removal:
```mysql
mysql> explain analyze SELECT message,timestamp FROM `logsbench`.`logsbench1` WHERE (message LIKE '%hello%') AND timestamp between '2025-03-05 07:07:55' and '2025-03-06 08:07:55' AND app = 'app-10' order by timestamp desc limit 10;
+-------+------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| stage | node | plan                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+-------+------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|     0 |    0 |  MergeScanExec: peers=[4415226380288(1028, 0), ] metrics=[output_rows: 10, greptime_exec_read_cost: 0, finish_time: 75068821156, first_consume_time: 75068759230, ready_time: 62116447, ]
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
|     1 |    0 |  SortPreservingMergeExec: [timestamp@1 DESC], fetch=10 metrics=[output_rows: 10, elapsed_compute: 28860, ]
  WindowedSortExec: expr=timestamp@1 DESC num_ranges=16 fetch=10 metrics=[output_rows: 390, elapsed_compute: 463259, ]
    PartSortExec: expr=timestamp@1 DESC num_ranges=16 limit=10 metrics=[output_rows: 2218, elapsed_compute: 5960895, row_replacements: 1884, ]
      ProjectionExec: expr=[message@1 as message, timestamp@0 as timestamp] metrics=[output_rows: 2295, elapsed_compute: 37237, ]
        CoalesceBatchesExec: target_batch_size=8192 metrics=[output_rows: 2295, elapsed_compute: 1056059, ]
          FilterExec: message@1 LIKE %hello% AND timestamp@0 >= 1741158475000000000 AND timestamp@0 <= 1741248475000000000 metrics=[output_rows: 2295, elapsed_compute: 112161257, ]
            UnorderedScan: region=4415226380288(1028, 0), partition_count=3861 (0 memtable ranges, 257 file 3861 ranges) metrics=[output_rows: 319920, mem_used: 1537823918, elapsed_await: 887487141451, elapsed_poll: 21939793970, ]
 |
|  NULL | NULL | Total rows: 10                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+-------+------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
3 rows in set (1 min 15.07 sec)
```
after:
```mysql
mysql> explain analyze SELECT message, timestamp FROM `logsbench`.`logsbench1` WHERE (message LIKE '%hello%') AND timestamp between '2025-03-05 12:28:20' and '2025-03-06 12:28:20' AND app = 'app-10' order by timestamp desc limit 10;
+-------+------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| stage | node | plan                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+-------+------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|     0 |    0 |  MergeScanExec: peers=[4415226380288(1028, 0), ] metrics=[output_rows: 10, greptime_exec_read_cost: 0, finish_time: 9726159928, first_consume_time: 9726105873, ready_time: 26389930, ]
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
|     1 |    0 |  SortPreservingMergeExec: [timestamp@1 DESC], fetch=10 metrics=[output_rows: 10, elapsed_compute: 36794, ]
  WindowedSortExec: expr=timestamp@1 DESC num_ranges=16 fetch=10 metrics=[output_rows: 207, elapsed_compute: 162474, ]
    PartSortExec: expr=timestamp@1 DESC num_ranges=16 limit=10 metrics=[output_rows: 1248, elapsed_compute: 8783295, row_replacements: 1046, ]
      ProjectionExec: expr=[message@1 as message, timestamp@0 as timestamp] metrics=[output_rows: 1237, elapsed_compute: 436819, ]
        FilterExec: message@1 LIKE %hello% AND timestamp@0 >= 1741177700000000000 AND timestamp@0 <= 1741264100000000000 metrics=[output_rows: 1237, elapsed_compute: 74079717, ]
          UnorderedScan: region=4415226380288(1028, 0), partition_count=2264 (2 memtable ranges, 167 file 2262 ranges) metrics=[output_rows: 178593, mem_used: 804478079, elapsed_await: 79279746360, elapsed_poll: 61795982387, ]
 |
|  NULL | NULL | Total rows: 10                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+-------+------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
3 rows in set (9.73 sec)
```
## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
