### PR TITLE
fix: use `DateTime` instead of `NaiveDateTime`

### DIFF
--- a/src/servers/src/http/jaeger.rs
+++ b/src/servers/src/http/jaeger.rs
@@ -798,8 +798,8 @@ fn traces_from_records(records: HttpRecordsOutput) -> Result<Vec<Trace>> {
                     let Some(t) = obj.get("time").and_then(|t| t.as_str()).and_then(|s| {
                         SPAN_KIND_TIME_FMTS
                             .iter()
-                            .find_map(|fmt| chrono::NaiveDateTime::parse_from_str(s, fmt).ok())
-                            .map(|dt| dt.and_utc().timestamp_micros() as u64)
+                            .find_map(|fmt| chrono::DateTime::parse_from_str(s, fmt).ok())
+                            .map(|dt| dt.timestamp_micros() as u64)
                     }) else {
                         continue;
                     };


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Quick fix, as the title suggests.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
