### PR TITLE
fix: remove duplicate column exprs in projection

### DIFF
--- a/src/query/src/dist_plan/analyzer.rs
+++ b/src/query/src/dist_plan/analyzer.rs
@@ -326,12 +326,15 @@ impl TreeNodeRewriter for EnforceDistRequirementRewriter {
                 return Ok(Transformed::no(node));
             }
 
-            let mut new_exprs = projection.expr.clone();
+            let mut new_exprs: HashSet<Expr> =
+                HashSet::from_iter(projection.expr.clone().into_iter());
             for col in &column_requirements {
-                new_exprs.push(col_fn(col));
+                new_exprs.insert(col_fn(col));
             }
-            let new_node =
-                node.with_new_exprs(new_exprs, node.inputs().into_iter().cloned().collect())?;
+            let new_node = node.with_new_exprs(
+                new_exprs.into_iter().collect(),
+                node.inputs().into_iter().cloned().collect(),
+            )?;
             return Ok(Transformed::yes(new_node));
         }
 

--- a/src/query/src/dist_plan/analyzer.rs
+++ b/src/query/src/dist_plan/analyzer.rs
@@ -326,8 +326,7 @@ impl TreeNodeRewriter for EnforceDistRequirementRewriter {
                 return Ok(Transformed::no(node));
             }
 
-            let mut new_exprs: HashSet<Expr> =
-                HashSet::from_iter(projection.expr.clone().into_iter());
+            let mut new_exprs: HashSet<Expr> = HashSet::from_iter(projection.expr.clone());
             for col in &column_requirements {
                 new_exprs.insert(col_fn(col));
             }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
- fixes #5668

## What's changed and what's your intention?
 
Avoid pushing duplicated column exprs

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
