### PR TITLE
refactor(mito): move wal sync task to background

### DIFF
--- a/src/log-store/src/error.rs
+++ b/src/log-store/src/error.rs
@@ -40,15 +40,17 @@ pub enum Error {
         actual: String,
     },
 
-    #[snafu(display("Failed to start log store gc task"))]
-    StartGcTask {
+    #[snafu(display("Failed to start log store task: {}", name))]
+    StartWalTask {
+        name: String,
         #[snafu(implicit)]
         location: Location,
         source: RuntimeError,
     },
 
-    #[snafu(display("Failed to stop log store gc task"))]
-    StopGcTask {
+    #[snafu(display("Failed to stop log store task: {}", name))]
+    StopWalTask {
+        name: String,
         #[snafu(implicit)]
         location: Location,
         source: RuntimeError,

--- a/src/log-store/src/raft_engine/backend.rs
+++ b/src/log-store/src/raft_engine/backend.rs
@@ -35,7 +35,7 @@ use common_runtime::RepeatedTask;
 use raft_engine::{Config, Engine, LogBatch, ReadableSize, RecoveryMode};
 use snafu::{IntoError, ResultExt};
 
-use crate::error::{self, Error, IoSnafu, RaftEngineSnafu, StartGcTaskSnafu};
+use crate::error::{self, Error, IoSnafu, RaftEngineSnafu, StartWalTaskSnafu};
 use crate::raft_engine::log_store::PurgeExpiredFilesFunction;
 
 pub(crate) const SYSTEM_NAMESPACE: u64 = 0;
@@ -93,7 +93,8 @@ impl RaftEngineBackend {
         );
         gc_task
             .start(common_runtime::global_runtime())
-            .context(StartGcTaskSnafu)?;
+            .context(StartWalTaskSnafu { name: "gc_task" })?;
+
         Ok(Self {
             engine: RwLock::new(engine),
             _gc_task: gc_task,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR moves the log file sync operation from `engine.write` to background to avoid synchronous IO operations blocking region worker loop, which may result to ingestion rate fluctuation.
 
## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
