### PR TITLE
fix: correct stalled count

### DIFF
--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -583,6 +583,8 @@ type RequestBuffer = Vec<WorkerRequest>;
 #[derive(Default)]
 pub(crate) struct StalledRequests {
     /// Stalled requests.
+    /// Remember to use `StalledRequests::stalled_count()` to get the total number of stalled requests
+    /// instead of `StalledRequests::requests.len()`.
     ///
     /// Key: RegionId
     /// Value: (estimated size, stalled requests)
@@ -616,6 +618,11 @@ impl StalledRequests {
         } else {
             vec![]
         }
+    }
+
+    /// Returns the total number of all stalled requests.
+    pub(crate) fn stalled_count(&self) -> usize {
+        self.requests.values().map(|reqs| reqs.1.len()).sum()
     }
 }
 

--- a/src/mito2/src/worker/handle_write.rs
+++ b/src/mito2/src/worker/handle_write.rs
@@ -147,7 +147,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
     pub(crate) async fn handle_stalled_requests(&mut self) {
         // Handle stalled requests.
         let stalled = std::mem::take(&mut self.stalled_requests);
-        self.stalled_count.sub(stalled.requests.len() as i64);
+        self.stalled_count.sub(stalled.stalled_count() as i64);
         // We already stalled these requests, don't stall them again.
         for (_, (_, mut requests)) in stalled.requests {
             self.handle_write_requests(&mut requests, false).await;
@@ -157,7 +157,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
     /// Rejects all stalled requests.
     pub(crate) fn reject_stalled_requests(&mut self) {
         let stalled = std::mem::take(&mut self.stalled_requests);
-        self.stalled_count.sub(stalled.requests.len() as i64);
+        self.stalled_count.sub(stalled.stalled_count() as i64);
         for (_, (_, mut requests)) in stalled.requests {
             reject_write_requests(&mut requests);
         }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR sub the stall count gauge correctly.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
