### PR TITLE
feat: add a gauge for download tasks

### DIFF
--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -242,6 +242,11 @@ lazy_static! {
         // 0.1 ~ 10000
         exponential_buckets(0.1, 10.0, 6).unwrap(),
     ).unwrap();
+    /// Number of inflight download tasks.
+    pub static ref WRITE_CACHE_INFLIGHT_DOWNLOAD: IntGauge = register_int_gauge!(
+        "mito_write_cache_inflight_download_count",
+        "mito write cache inflight download tasks",
+    ).unwrap();
     /// Upload bytes counter.
     pub static ref UPLOAD_BYTES_TOTAL: IntCounter = register_int_counter!(
         "mito_upload_bytes_total",


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Add a gauge for inflight downloading tasks.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
