### PR TITLE
feat: add hint for logical region in RegionScanner

### DIFF
--- a/src/metric-engine/src/engine/read.rs
+++ b/src/metric-engine/src/engine/read.rs
@@ -79,10 +79,14 @@ impl MetricEngineInner {
         let request = self
             .transform_request(physical_region_id, logical_region_id, request)
             .await?;
-        self.mito
+        let mut scanner = self
+            .mito
             .handle_query(data_region_id, request)
             .await
-            .context(MitoReadOperationSnafu)
+            .context(MitoReadOperationSnafu)?;
+        scanner.set_logical_table(true);
+
+        Ok(scanner)
     }
 
     pub async fn get_last_seq_num(&self, region_id: RegionId) -> Result<Option<SequenceNumber>> {

--- a/src/metric-engine/src/engine/read.rs
+++ b/src/metric-engine/src/engine/read.rs
@@ -84,7 +84,7 @@ impl MetricEngineInner {
             .handle_query(data_region_id, request)
             .await
             .context(MitoReadOperationSnafu)?;
-        scanner.set_logical_table(true);
+        scanner.set_logical_region(true);
 
         Ok(scanner)
     }

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -434,6 +434,10 @@ impl RegionScanner for SeqScan {
         self.stream_ctx.input.mapper.output_schema()
     }
 
+    fn metadata(&self) -> RegionMetadataRef {
+        self.stream_ctx.input.mapper.metadata().clone()
+    }
+
     fn scan_partition(&self, partition: usize) -> Result<SendableRecordBatchStream, BoxedError> {
         self.scan_partition_impl(partition)
     }
@@ -448,8 +452,8 @@ impl RegionScanner for SeqScan {
         predicate.map(|p| !p.exprs().is_empty()).unwrap_or(false)
     }
 
-    fn metadata(&self) -> RegionMetadataRef {
-        self.stream_ctx.input.mapper.metadata().clone()
+    fn set_logical_table(&mut self, logical_table: bool) {
+        self.properties.set_logical_table(logical_table);
     }
 }
 

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -452,8 +452,8 @@ impl RegionScanner for SeqScan {
         predicate.map(|p| !p.exprs().is_empty()).unwrap_or(false)
     }
 
-    fn set_logical_table(&mut self, logical_table: bool) {
-        self.properties.set_logical_table(logical_table);
+    fn set_logical_region(&mut self, logical_region: bool) {
+        self.properties.set_logical_region(logical_region);
     }
 }
 

--- a/src/mito2/src/read/unordered_scan.rs
+++ b/src/mito2/src/read/unordered_scan.rs
@@ -248,8 +248,8 @@ impl RegionScanner for UnorderedScan {
         predicate.map(|p| !p.exprs().is_empty()).unwrap_or(false)
     }
 
-    fn set_logical_table(&mut self, logical_table: bool) {
-        self.properties.set_logical_table(logical_table);
+    fn set_logical_region(&mut self, logical_region: bool) {
+        self.properties.set_logical_region(logical_region);
     }
 }
 

--- a/src/mito2/src/read/unordered_scan.rs
+++ b/src/mito2/src/read/unordered_scan.rs
@@ -230,6 +230,10 @@ impl RegionScanner for UnorderedScan {
         self.stream_ctx.input.mapper.output_schema()
     }
 
+    fn metadata(&self) -> RegionMetadataRef {
+        self.stream_ctx.input.mapper.metadata().clone()
+    }
+
     fn prepare(&mut self, request: PrepareRequest) -> Result<(), BoxedError> {
         self.properties.prepare(request);
         Ok(())
@@ -244,8 +248,8 @@ impl RegionScanner for UnorderedScan {
         predicate.map(|p| !p.exprs().is_empty()).unwrap_or(false)
     }
 
-    fn metadata(&self) -> RegionMetadataRef {
-        self.stream_ctx.input.mapper.metadata().clone()
+    fn set_logical_table(&mut self, logical_table: bool) {
+        self.properties.set_logical_table(logical_table);
     }
 }
 

--- a/src/store-api/src/region_engine.rs
+++ b/src/store-api/src/region_engine.rs
@@ -213,8 +213,8 @@ pub struct ScannerProperties {
     /// The target partitions of the scanner. 0 indicates using the number of partitions as target partitions.
     target_partitions: usize,
 
-    /// Whether the region is scanning a logical table.
-    logical_table: bool,
+    /// Whether the scanner is scanning a logical region.
+    logical_region: bool,
 }
 
 impl ScannerProperties {
@@ -238,7 +238,7 @@ impl ScannerProperties {
             total_rows,
             distinguish_partition_range: false,
             target_partitions: 0,
-            logical_table: false,
+            logical_region: false,
         }
     }
 
@@ -268,9 +268,9 @@ impl ScannerProperties {
         self.total_rows
     }
 
-    /// Returns whether the region is scanning a logical table.
-    pub fn is_logical_table(&self) -> bool {
-        self.logical_table
+    /// Returns whether the scanner is scanning a logical region.
+    pub fn is_logical_region(&self) -> bool {
+        self.logical_region
     }
 
     /// Returns the target partitions of the scanner. If it is not set, returns the number of partitions.
@@ -282,9 +282,9 @@ impl ScannerProperties {
         }
     }
 
-    /// Sets whether the scanner is reading a logical table.
-    pub fn set_logical_table(&mut self, logical_table: bool) {
-        self.logical_table = logical_table;
+    /// Sets whether the scanner is reading a logical region.
+    pub fn set_logical_region(&mut self, logical_region: bool) {
+        self.logical_region = logical_region;
     }
 }
 
@@ -347,8 +347,8 @@ pub trait RegionScanner: Debug + DisplayAs + Send {
     /// Check if there is any predicate that may be executed in this scanner.
     fn has_predicate(&self) -> bool;
 
-    /// Sets whether the scanner is reading a logical table.
-    fn set_logical_table(&mut self, logical_table: bool);
+    /// Sets whether the scanner is reading a logical region.
+    fn set_logical_region(&mut self, logical_region: bool);
 }
 
 pub type RegionScannerRef = Box<dyn RegionScanner>;
@@ -580,8 +580,8 @@ impl RegionScanner for SinglePartitionScanner {
         self.metadata.clone()
     }
 
-    fn set_logical_table(&mut self, logical_table: bool) {
-        self.properties.set_logical_table(logical_table);
+    fn set_logical_region(&mut self, logical_region: bool) {
+        self.properties.set_logical_region(logical_region);
     }
 }
 

--- a/src/store-api/src/region_engine.rs
+++ b/src/store-api/src/region_engine.rs
@@ -212,6 +212,9 @@ pub struct ScannerProperties {
 
     /// The target partitions of the scanner. 0 indicates using the number of partitions as target partitions.
     target_partitions: usize,
+
+    /// Whether the region is scanning a logical table.
+    logical_table: bool,
 }
 
 impl ScannerProperties {
@@ -235,6 +238,7 @@ impl ScannerProperties {
             total_rows,
             distinguish_partition_range: false,
             target_partitions: 0,
+            logical_table: false,
         }
     }
 
@@ -264,6 +268,11 @@ impl ScannerProperties {
         self.total_rows
     }
 
+    /// Returns whether the region is scanning a logical table.
+    pub fn is_logical_table(&self) -> bool {
+        self.logical_table
+    }
+
     /// Returns the target partitions of the scanner. If it is not set, returns the number of partitions.
     pub fn target_partitions(&self) -> usize {
         if self.target_partitions == 0 {
@@ -271,6 +280,11 @@ impl ScannerProperties {
         } else {
             self.target_partitions
         }
+    }
+
+    /// Sets whether the scanner is reading a logical table.
+    pub fn set_logical_table(&mut self, logical_table: bool) {
+        self.logical_table = logical_table;
     }
 }
 
@@ -332,6 +346,9 @@ pub trait RegionScanner: Debug + DisplayAs + Send {
 
     /// Check if there is any predicate that may be executed in this scanner.
     fn has_predicate(&self) -> bool;
+
+    /// Sets whether the scanner is reading a logical table.
+    fn set_logical_table(&mut self, logical_table: bool);
 }
 
 pub type RegionScannerRef = Box<dyn RegionScanner>;
@@ -561,6 +578,10 @@ impl RegionScanner for SinglePartitionScanner {
 
     fn metadata(&self) -> RegionMetadataRef {
         self.metadata.clone()
+    }
+
+    fn set_logical_table(&mut self, logical_table: bool) {
+        self.properties.set_logical_table(logical_table);
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR adds a hint `logical_region` to the `ScannerProperties` and sets it in the metric engine to indicate we are scanning a logical region.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
