### PR TITLE
chore: check region wal provider on startup to avoid inconsistence

### DIFF
--- a/src/mito2/Cargo.toml
+++ b/src/mito2/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 
 [features]
 default = []
-test = ["common-test-util", "log-store", "rstest", "rstest_reuse", "rskafka"]
+test = ["common-test-util", "rstest", "rstest_reuse", "rskafka"]
 
 [lints]
 workspace = true
@@ -45,7 +45,7 @@ humantime-serde.workspace = true
 index.workspace = true
 itertools.workspace = true
 lazy_static = "1.4"
-log-store = { workspace = true, optional = true }
+log-store = { workspace = true }
 memcomparable = "0.2"
 moka = { workspace = true, features = ["sync", "future"] }
 object-store.workspace = true

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -968,6 +968,9 @@ pub enum Error {
 
     #[snafu(display("Manual compaction is override by following operations."))]
     ManualCompactionOverride {},
+
+    #[snafu(display("Incompatible WAL provider change. This is typically caused by changing WAL provider in database config file without completely cleaning existing files. Global provider: {}, region provider: {}", global, region))]
+    IncompatibleWalProviderChange { global: String, region: String },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -1114,6 +1117,8 @@ impl ErrorExt for Error {
             }
 
             ManualCompactionOverride {} => StatusCode::Cancelled,
+
+            IncompatibleWalProviderChange { .. } => StatusCode::InvalidArguments,
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

When user changes database wal provider from `raft_engine` to `kafka` without cleaning existing data, datanode will report confusing error while opening regions.
<img width="1276" alt="image" src="https://github.com/user-attachments/assets/ad8e808b-7541-41e0-a5f6-0b39e626007b" />

This PR adds simple check before opening regions to warn users of incompatible config changes.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
