### PR TITLE
fix: FlowInfoValue's compatibility

### DIFF
--- a/src/common/meta/src/key/flow/flow_info.rs
+++ b/src/common/meta/src/key/flow/flow_info.rs
@@ -133,8 +133,10 @@ pub struct FlowInfoValue {
     /// The options.
     pub(crate) options: HashMap<String, String>,
     /// The created time
+    #[serde(default)]
     pub(crate) created_time: DateTime<Utc>,
     /// The updated time.
+    #[serde(default)]
     pub(crate) updated_time: DateTime<Utc>,
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

make the newly added `created_time`&`update_time` field of FlowInfoValue `serde(default)` so can read from old version's metadata
__edited__: local test with create on older version and reboot in newer version now work. P.S. maybe need to run `tests/upgrade-compat` test in a CI later

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
