### PR TITLE
feat: expose virtual_host_style config for s3 storage

### DIFF
--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -231,6 +231,7 @@ overwrite_entry_start_id = false
 # secret_access_key = "123456"
 # endpoint = "https://s3.amazonaws.com"
 # region = "us-west-2"
+# enable_virtual_host_style = false
 
 # Example of using Oss as the storage.
 # [storage]

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -318,6 +318,7 @@ retry_delay = "500ms"
 # secret_access_key = "123456"
 # endpoint = "https://s3.amazonaws.com"
 # region = "us-west-2"
+# enable_virtual_host_style = false
 
 # Example of using Oss as the storage.
 # [storage]

--- a/src/datanode/src/config.rs
+++ b/src/datanode/src/config.rs
@@ -171,6 +171,10 @@ pub struct S3Config {
     pub secret_access_key: SecretString,
     pub endpoint: Option<String>,
     pub region: Option<String>,
+    /// Enable virtual host style so that opendal will send API requests in virtual host style instead of path style.
+    /// By default, opendal will send API to https://s3.us-east-1.amazonaws.com/bucket_name
+    /// Enabled, opendal will send API to https://bucket_name.s3.us-east-1.amazonaws.com
+    pub enable_virtual_host_style: bool,
     #[serde(flatten)]
     pub cache: ObjectStorageCacheConfig,
     pub http_client: HttpClientConfig,
@@ -185,6 +189,7 @@ impl PartialEq for S3Config {
             && self.secret_access_key.expose_secret() == other.secret_access_key.expose_secret()
             && self.endpoint == other.endpoint
             && self.region == other.region
+            && self.enable_virtual_host_style == other.enable_virtual_host_style
             && self.cache == other.cache
             && self.http_client == other.http_client
     }
@@ -289,6 +294,7 @@ impl Default for S3Config {
             root: String::default(),
             access_key_id: SecretString::from(String::default()),
             secret_access_key: SecretString::from(String::default()),
+            enable_virtual_host_style: false,
             endpoint: Option::default(),
             region: Option::default(),
             cache: ObjectStorageCacheConfig::default(),

--- a/src/datanode/src/store/s3.rs
+++ b/src/datanode/src/store/s3.rs
@@ -41,10 +41,13 @@ pub(crate) async fn new_s3_object_store(s3_config: &S3Config) -> Result<ObjectSt
 
     if s3_config.endpoint.is_some() {
         builder = builder.endpoint(s3_config.endpoint.as_ref().unwrap());
-    };
+    }
     if s3_config.region.is_some() {
         builder = builder.region(s3_config.region.as_ref().unwrap());
-    };
+    }
+    if s3_config.enable_virtual_host_style {
+        builder = builder.enable_virtual_host_style();
+    }
 
     Ok(ObjectStore::new(builder)
         .context(error::InitBackendSnafu)?

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -1098,6 +1098,7 @@ fn drop_lines_with_inconsistent_results(input: String) -> String {
         "root =",
         "endpoint =",
         "region =",
+        "enable_virtual_host_style =",
         "cache_path =",
         "cache_capacity =",
         "sas_token =",


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR expose the `enable_virtual_host_style` flag.
- By default, opendal will send API to https://s3.us-east-1.amazonaws.com/bucket_name
- Enabled, opendal will send API to https://bucket_name.s3.us-east-1.amazonaws.com


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
