### PR TITLE
chore: support `application/x-ndjson` for log ingest

### DIFF
--- a/src/servers/src/http/header.rs
+++ b/src/servers/src/http/header.rs
@@ -73,6 +73,8 @@ pub static CONTENT_TYPE_PROTOBUF_STR: &str = "application/x-protobuf";
 pub static CONTENT_TYPE_PROTOBUF: HeaderValue = HeaderValue::from_static(CONTENT_TYPE_PROTOBUF_STR);
 pub static CONTENT_ENCODING_SNAPPY: HeaderValue = HeaderValue::from_static("snappy");
 
+pub static CONTENT_TYPE_NDJSON_STR: &str = "application/x-ndjson";
+
 pub struct GreptimeDbName(Option<String>);
 
 impl Header for GreptimeDbName {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The current `application/json`(which is also NDJSON) uses serde's stream deserializer, which stops immediately when an error is encountered, leaving all the following possible valid JSON discarded.
In the real world, the data is often in the format of lines of JSON objects. We can simply skip one line of invalid JSON string and continue parsing.
See test for example difference.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
