### PR TITLE
feat(promql): implement pushdown of promql plan for single partitioned tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2903,7 +2903,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 [[package]]
 name = "datafusion"
 version = "43.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=2464703c84c400a09cc59277018813f0e797bb4e#2464703c84c400a09cc59277018813f0e797bb4e"
+source = "git+https://github.com/WenyXu/arrow-datafusion.git?rev=b81c1d7e51be6a31cd293513a2f998841234841d#b81c1d7e51be6a31cd293513a2f998841234841d"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2954,7 +2954,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "43.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=2464703c84c400a09cc59277018813f0e797bb4e#2464703c84c400a09cc59277018813f0e797bb4e"
+source = "git+https://github.com/WenyXu/arrow-datafusion.git?rev=b81c1d7e51be6a31cd293513a2f998841234841d#b81c1d7e51be6a31cd293513a2f998841234841d"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -2968,7 +2968,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "43.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=2464703c84c400a09cc59277018813f0e797bb4e#2464703c84c400a09cc59277018813f0e797bb4e"
+source = "git+https://github.com/WenyXu/arrow-datafusion.git?rev=b81c1d7e51be6a31cd293513a2f998841234841d#b81c1d7e51be6a31cd293513a2f998841234841d"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -2992,7 +2992,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "43.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=2464703c84c400a09cc59277018813f0e797bb4e#2464703c84c400a09cc59277018813f0e797bb4e"
+source = "git+https://github.com/WenyXu/arrow-datafusion.git?rev=b81c1d7e51be6a31cd293513a2f998841234841d#b81c1d7e51be6a31cd293513a2f998841234841d"
 dependencies = [
  "log",
  "tokio",
@@ -3001,12 +3001,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "43.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=2464703c84c400a09cc59277018813f0e797bb4e#2464703c84c400a09cc59277018813f0e797bb4e"
+source = "git+https://github.com/WenyXu/arrow-datafusion.git?rev=b81c1d7e51be6a31cd293513a2f998841234841d#b81c1d7e51be6a31cd293513a2f998841234841d"
 
 [[package]]
 name = "datafusion-execution"
 version = "43.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=2464703c84c400a09cc59277018813f0e797bb4e#2464703c84c400a09cc59277018813f0e797bb4e"
+source = "git+https://github.com/WenyXu/arrow-datafusion.git?rev=b81c1d7e51be6a31cd293513a2f998841234841d#b81c1d7e51be6a31cd293513a2f998841234841d"
 dependencies = [
  "arrow",
  "chrono",
@@ -3025,7 +3025,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "43.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=2464703c84c400a09cc59277018813f0e797bb4e#2464703c84c400a09cc59277018813f0e797bb4e"
+source = "git+https://github.com/WenyXu/arrow-datafusion.git?rev=b81c1d7e51be6a31cd293513a2f998841234841d#b81c1d7e51be6a31cd293513a2f998841234841d"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3050,7 +3050,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "43.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=2464703c84c400a09cc59277018813f0e797bb4e#2464703c84c400a09cc59277018813f0e797bb4e"
+source = "git+https://github.com/WenyXu/arrow-datafusion.git?rev=b81c1d7e51be6a31cd293513a2f998841234841d#b81c1d7e51be6a31cd293513a2f998841234841d"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -3061,7 +3061,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "43.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=2464703c84c400a09cc59277018813f0e797bb4e#2464703c84c400a09cc59277018813f0e797bb4e"
+source = "git+https://github.com/WenyXu/arrow-datafusion.git?rev=b81c1d7e51be6a31cd293513a2f998841234841d#b81c1d7e51be6a31cd293513a2f998841234841d"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -3089,7 +3089,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "43.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=2464703c84c400a09cc59277018813f0e797bb4e#2464703c84c400a09cc59277018813f0e797bb4e"
+source = "git+https://github.com/WenyXu/arrow-datafusion.git?rev=b81c1d7e51be6a31cd293513a2f998841234841d#b81c1d7e51be6a31cd293513a2f998841234841d"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3110,7 +3110,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "43.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=2464703c84c400a09cc59277018813f0e797bb4e#2464703c84c400a09cc59277018813f0e797bb4e"
+source = "git+https://github.com/WenyXu/arrow-datafusion.git?rev=b81c1d7e51be6a31cd293513a2f998841234841d#b81c1d7e51be6a31cd293513a2f998841234841d"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3123,7 +3123,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "43.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=2464703c84c400a09cc59277018813f0e797bb4e#2464703c84c400a09cc59277018813f0e797bb4e"
+source = "git+https://github.com/WenyXu/arrow-datafusion.git?rev=b81c1d7e51be6a31cd293513a2f998841234841d#b81c1d7e51be6a31cd293513a2f998841234841d"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3145,7 +3145,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "43.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=2464703c84c400a09cc59277018813f0e797bb4e#2464703c84c400a09cc59277018813f0e797bb4e"
+source = "git+https://github.com/WenyXu/arrow-datafusion.git?rev=b81c1d7e51be6a31cd293513a2f998841234841d#b81c1d7e51be6a31cd293513a2f998841234841d"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3169,7 +3169,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "43.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=2464703c84c400a09cc59277018813f0e797bb4e#2464703c84c400a09cc59277018813f0e797bb4e"
+source = "git+https://github.com/WenyXu/arrow-datafusion.git?rev=b81c1d7e51be6a31cd293513a2f998841234841d#b81c1d7e51be6a31cd293513a2f998841234841d"
 dependencies = [
  "datafusion-common",
  "datafusion-expr",
@@ -3183,7 +3183,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "43.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=2464703c84c400a09cc59277018813f0e797bb4e#2464703c84c400a09cc59277018813f0e797bb4e"
+source = "git+https://github.com/WenyXu/arrow-datafusion.git?rev=b81c1d7e51be6a31cd293513a2f998841234841d#b81c1d7e51be6a31cd293513a2f998841234841d"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -3192,7 +3192,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "43.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=2464703c84c400a09cc59277018813f0e797bb4e#2464703c84c400a09cc59277018813f0e797bb4e"
+source = "git+https://github.com/WenyXu/arrow-datafusion.git?rev=b81c1d7e51be6a31cd293513a2f998841234841d#b81c1d7e51be6a31cd293513a2f998841234841d"
 dependencies = [
  "datafusion-doc",
  "proc-macro2",
@@ -3203,7 +3203,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "43.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=2464703c84c400a09cc59277018813f0e797bb4e#2464703c84c400a09cc59277018813f0e797bb4e"
+source = "git+https://github.com/WenyXu/arrow-datafusion.git?rev=b81c1d7e51be6a31cd293513a2f998841234841d#b81c1d7e51be6a31cd293513a2f998841234841d"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3222,7 +3222,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "43.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=2464703c84c400a09cc59277018813f0e797bb4e#2464703c84c400a09cc59277018813f0e797bb4e"
+source = "git+https://github.com/WenyXu/arrow-datafusion.git?rev=b81c1d7e51be6a31cd293513a2f998841234841d#b81c1d7e51be6a31cd293513a2f998841234841d"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3246,7 +3246,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "43.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=2464703c84c400a09cc59277018813f0e797bb4e#2464703c84c400a09cc59277018813f0e797bb4e"
+source = "git+https://github.com/WenyXu/arrow-datafusion.git?rev=b81c1d7e51be6a31cd293513a2f998841234841d#b81c1d7e51be6a31cd293513a2f998841234841d"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3259,7 +3259,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "43.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=2464703c84c400a09cc59277018813f0e797bb4e#2464703c84c400a09cc59277018813f0e797bb4e"
+source = "git+https://github.com/WenyXu/arrow-datafusion.git?rev=b81c1d7e51be6a31cd293513a2f998841234841d#b81c1d7e51be6a31cd293513a2f998841234841d"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -3275,7 +3275,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "43.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=2464703c84c400a09cc59277018813f0e797bb4e#2464703c84c400a09cc59277018813f0e797bb4e"
+source = "git+https://github.com/WenyXu/arrow-datafusion.git?rev=b81c1d7e51be6a31cd293513a2f998841234841d#b81c1d7e51be6a31cd293513a2f998841234841d"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3308,7 +3308,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "43.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=2464703c84c400a09cc59277018813f0e797bb4e#2464703c84c400a09cc59277018813f0e797bb4e"
+source = "git+https://github.com/WenyXu/arrow-datafusion.git?rev=b81c1d7e51be6a31cd293513a2f998841234841d#b81c1d7e51be6a31cd293513a2f998841234841d"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3325,7 +3325,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "43.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=2464703c84c400a09cc59277018813f0e797bb4e#2464703c84c400a09cc59277018813f0e797bb4e"
+source = "git+https://github.com/WenyXu/arrow-datafusion.git?rev=b81c1d7e51be6a31cd293513a2f998841234841d#b81c1d7e51be6a31cd293513a2f998841234841d"
 dependencies = [
  "arrow-buffer",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,15 +112,15 @@ clap = { version = "4.4", features = ["derive"] }
 config = "0.13.0"
 crossbeam-utils = "0.8"
 dashmap = "5.4"
-datafusion = { git = "https://github.com/apache/datafusion.git", rev = "2464703c84c400a09cc59277018813f0e797bb4e" }
-datafusion-common = { git = "https://github.com/apache/datafusion.git", rev = "2464703c84c400a09cc59277018813f0e797bb4e" }
-datafusion-expr = { git = "https://github.com/apache/datafusion.git", rev = "2464703c84c400a09cc59277018813f0e797bb4e" }
-datafusion-functions = { git = "https://github.com/apache/datafusion.git", rev = "2464703c84c400a09cc59277018813f0e797bb4e" }
-datafusion-optimizer = { git = "https://github.com/apache/datafusion.git", rev = "2464703c84c400a09cc59277018813f0e797bb4e" }
-datafusion-physical-expr = { git = "https://github.com/apache/datafusion.git", rev = "2464703c84c400a09cc59277018813f0e797bb4e" }
-datafusion-physical-plan = { git = "https://github.com/apache/datafusion.git", rev = "2464703c84c400a09cc59277018813f0e797bb4e" }
-datafusion-sql = { git = "https://github.com/apache/datafusion.git", rev = "2464703c84c400a09cc59277018813f0e797bb4e" }
-datafusion-substrait = { git = "https://github.com/apache/datafusion.git", rev = "2464703c84c400a09cc59277018813f0e797bb4e" }
+datafusion = { git = "https://github.com/WenyXu/arrow-datafusion.git", rev = "b81c1d7e51be6a31cd293513a2f998841234841d" }
+datafusion-common = { git = "https://github.com/WenyXu/arrow-datafusion.git", rev = "b81c1d7e51be6a31cd293513a2f998841234841d" }
+datafusion-expr = { git = "https://github.com/WenyXu/arrow-datafusion.git", rev = "b81c1d7e51be6a31cd293513a2f998841234841d" }
+datafusion-functions = { git = "https://github.com/WenyXu/arrow-datafusion.git", rev = "b81c1d7e51be6a31cd293513a2f998841234841d" }
+datafusion-optimizer = { git = "https://github.com/WenyXu/arrow-datafusion.git", rev = "b81c1d7e51be6a31cd293513a2f998841234841d" }
+datafusion-physical-expr = { git = "https://github.com/WenyXu/arrow-datafusion.git", rev = "b81c1d7e51be6a31cd293513a2f998841234841d" }
+datafusion-physical-plan = { git = "https://github.com/WenyXu/arrow-datafusion.git", rev = "b81c1d7e51be6a31cd293513a2f998841234841d" }
+datafusion-sql = { git = "https://github.com/WenyXu/arrow-datafusion.git", rev = "b81c1d7e51be6a31cd293513a2f998841234841d" }
+datafusion-substrait = { git = "https://github.com/WenyXu/arrow-datafusion.git", rev = "b81c1d7e51be6a31cd293513a2f998841234841d" }
 deadpool = "0.10"
 deadpool-postgres = "0.12"
 derive_builder = "0.12"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR improves PromQL query execution by pushing down the execution plan to the datanode for single-partitioned tables, enhancing performance. Additionally, it replaces DataFusion with a patched version that supports dictionary serialization.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
