### PR TITLE
chore: bump version to 0.14.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ env:
   # The scheduled version is '${{ env.NEXT_RELEASE_VERSION }}-nightly-YYYYMMDD', like v0.2.0-nigthly-20230313;
   NIGHTLY_RELEASE_PREFIX: nightly
   # Note: The NEXT_RELEASE_VERSION should be modified manually by every formal release.
-  NEXT_RELEASE_VERSION: v0.13.0
+  NEXT_RELEASE_VERSION: v0.14.0
 
 jobs:
   allocate-runners:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "api"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "common-base",
  "common-decimal",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "auth"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "api",
  "async-trait",
@@ -1324,7 +1324,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "catalog",
  "common-error",
@@ -1348,7 +1348,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "api",
  "arrow",
@@ -1661,7 +1661,7 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "cli"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "auth",
@@ -1704,7 +1704,7 @@ dependencies = [
  "session",
  "snafu 0.8.5",
  "store-api",
- "substrait 0.13.0",
+ "substrait 0.14.0",
  "table",
  "tempfile",
  "tokio",
@@ -1713,7 +1713,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -1740,7 +1740,7 @@ dependencies = [
  "rand",
  "serde_json",
  "snafu 0.8.5",
- "substrait 0.13.0",
+ "substrait 0.14.0",
  "substrait 0.37.3",
  "tokio",
  "tokio-stream",
@@ -1781,7 +1781,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "auth",
@@ -1842,7 +1842,7 @@ dependencies = [
  "similar-asserts",
  "snafu 0.8.5",
  "store-api",
- "substrait 0.13.0",
+ "substrait 0.14.0",
  "table",
  "temp-env",
  "tempfile",
@@ -1888,7 +1888,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "common-base"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anymap2",
  "async-trait",
@@ -1910,11 +1910,11 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "0.13.0"
+version = "0.14.0"
 
 [[package]]
 name = "common-config"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "common-base",
  "common-error",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1975,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "common-decimal"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bigdecimal 0.4.5",
  "common-error",
@@ -1988,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "http 1.1.0",
  "snafu 0.8.5",
@@ -1998,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "common-frontend"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "common-error",
@@ -2008,7 +2008,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -2059,7 +2059,7 @@ dependencies = [
 
 [[package]]
 name = "common-greptimedb-telemetry"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "common-runtime",
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "api",
  "common-base",
@@ -2123,7 +2123,7 @@ dependencies = [
 
 [[package]]
 name = "common-macro"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "arc-swap",
  "common-query",
@@ -2137,7 +2137,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2150,7 +2150,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anymap2",
  "api",
@@ -2211,7 +2211,7 @@ dependencies = [
 
 [[package]]
 name = "common-options"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "common-grpc",
  "humantime-serde",
@@ -2220,11 +2220,11 @@ dependencies = [
 
 [[package]]
 name = "common-plugins"
-version = "0.13.0"
+version = "0.14.0"
 
 [[package]]
 name = "common-pprof"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2236,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2263,7 +2263,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -2271,7 +2271,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "api",
  "async-trait",
@@ -2297,7 +2297,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "arc-swap",
  "common-error",
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "clap 4.5.19",
@@ -2346,7 +2346,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "atty",
  "backtrace",
@@ -2374,7 +2374,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "client",
  "common-query",
@@ -2386,7 +2386,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "arrow",
  "chrono",
@@ -2404,7 +2404,7 @@ dependencies = [
 
 [[package]]
 name = "common-version"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "build-data",
  "const_format",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "common-wal"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "common-base",
  "common-error",
@@ -3345,7 +3345,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -3397,7 +3397,7 @@ dependencies = [
  "session",
  "snafu 0.8.5",
  "store-api",
- "substrait 0.13.0",
+ "substrait 0.14.0",
  "table",
  "tokio",
  "toml 0.8.19",
@@ -3406,7 +3406,7 @@ dependencies = [
 
 [[package]]
 name = "datatypes"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4050,7 +4050,7 @@ dependencies = [
 
 [[package]]
 name = "file-engine"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "api",
  "async-trait",
@@ -4160,7 +4160,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "flow"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "api",
  "arrow",
@@ -4222,7 +4222,7 @@ dependencies = [
  "snafu 0.8.5",
  "store-api",
  "strum 0.25.0",
- "substrait 0.13.0",
+ "substrait 0.14.0",
  "table",
  "tokio",
  "tonic 0.12.3",
@@ -4277,7 +4277,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frontend"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -5545,7 +5545,7 @@ dependencies = [
 
 [[package]]
 name = "index"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -6338,7 +6338,7 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "log-query"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "common-error",
@@ -6350,7 +6350,7 @@ dependencies = [
 
 [[package]]
 name = "log-store"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "api",
  "async-trait",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "api",
  "async-trait",
@@ -6757,7 +6757,7 @@ dependencies = [
 
 [[package]]
 name = "metric-engine"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -6855,7 +6855,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -7552,7 +7552,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7801,7 +7801,7 @@ dependencies = [
 
 [[package]]
 name = "operator"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -7849,7 +7849,7 @@ dependencies = [
  "sql",
  "sqlparser 0.52.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=71dd86058d2af97b9925093d40c4e03360403170)",
  "store-api",
- "substrait 0.13.0",
+ "substrait 0.14.0",
  "table",
  "tokio",
  "tokio-util",
@@ -8086,7 +8086,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "api",
  "async-trait",
@@ -8354,7 +8354,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeline"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -8494,7 +8494,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "auth",
  "clap 4.5.19",
@@ -8756,7 +8756,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -9003,7 +9003,7 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-compression 0.4.13",
  "async-trait",
@@ -9044,7 +9044,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -9109,7 +9109,7 @@ dependencies = [
  "sqlparser 0.52.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=71dd86058d2af97b9925093d40c4e03360403170)",
  "statrs",
  "store-api",
- "substrait 0.13.0",
+ "substrait 0.14.0",
  "table",
  "tokio",
  "tokio-stream",
@@ -10464,7 +10464,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -10581,7 +10581,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -10890,7 +10890,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "api",
  "chrono",
@@ -10944,7 +10944,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "clap 4.5.19",
@@ -11261,7 +11261,7 @@ dependencies = [
 
 [[package]]
 name = "store-api"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -11391,7 +11391,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -11572,7 +11572,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "api",
  "async-trait",
@@ -11823,7 +11823,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "tests-fuzz"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "arbitrary",
  "async-trait",
@@ -11867,7 +11867,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -11933,7 +11933,7 @@ dependencies = [
  "sql",
  "sqlx",
  "store-api",
- "substrait 0.13.0",
+ "substrait 0.14.0",
  "table",
  "tempfile",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Bump version to v0.14.0

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
