### PR TITLE
feat: introduce `CurrentRegionManifest`

### DIFF
--- a/src/mito2/src/manifest.rs
+++ b/src/mito2/src/manifest.rs
@@ -17,6 +17,7 @@
 pub mod action;
 mod checkpointer;
 pub mod manager;
+pub mod notifier;
 pub mod storage;
 #[cfg(test)]
 mod tests;

--- a/src/mito2/src/manifest/manager.rs
+++ b/src/mito2/src/manifest/manager.rs
@@ -113,10 +113,141 @@ pub struct RegionManifestOptions {
 #[derive(Debug)]
 pub struct RegionManifestManager {
     store: ManifestObjectStore,
-    last_version: ManifestVersion,
     checkpointer: Checkpointer,
-    manifest: Arc<RegionManifest>,
+    current: CurrentRegionManifest,
     stopped: bool,
+}
+
+#[derive(Debug)]
+pub struct CurrentRegionManifest {
+    version: ManifestVersion,
+    manifest: Arc<RegionManifest>,
+}
+
+impl CurrentRegionManifest {
+    pub fn new(metadata: RegionMetadataRef) -> Result<Self> {
+        let version = MIN_VERSION;
+        let mut manifest_builder = RegionManifestBuilder::default();
+        // set the initial metadata.
+        manifest_builder.apply_change(
+            version,
+            RegionChange {
+                metadata: metadata.clone(),
+            },
+        );
+        let manifest = manifest_builder.try_build()?;
+        Ok(Self {
+            version,
+            manifest: Arc::new(manifest),
+        })
+    }
+
+    /// Returns the [`RegionManifest`] of the current version.
+    pub fn manifest(&self) -> &Arc<RegionManifest> {
+        &self.manifest
+    }
+
+    /// Returns the version of the current manifest.
+    pub fn version(&self) -> ManifestVersion {
+        self.version
+    }
+
+    /// Opens a [`CurrentRegionManifest`] from the given manifest directory and manifest builder.
+    ///
+    /// Returns `Ok(None)` if no manifest is found in the given directory.
+    pub fn open(
+        manifest_dir: &str,
+        mut manifest_builder: RegionManifestBuilder,
+        manifests: Vec<(ManifestVersion, RegionMetaActionList)>,
+    ) -> Result<Option<Self>> {
+        for (manifest_version, action_list) in manifests {
+            for action in action_list.actions {
+                match action {
+                    RegionMetaAction::Change(action) => {
+                        manifest_builder.apply_change(manifest_version, action);
+                    }
+                    RegionMetaAction::Edit(action) => {
+                        manifest_builder.apply_edit(manifest_version, action);
+                    }
+                    RegionMetaAction::Remove(_) => {
+                        debug!("Unhandled action in {}, action: {:?}", manifest_dir, action);
+                    }
+                    RegionMetaAction::Truncate(action) => {
+                        manifest_builder.apply_truncate(manifest_version, action);
+                    }
+                }
+            }
+        }
+
+        // Set the initial metadata if necessary
+        if !manifest_builder.contains_metadata() {
+            debug!("No region manifest in {}", manifest_dir);
+            return Ok(None);
+        }
+
+        let manifest = manifest_builder.try_build()?;
+        debug!(
+            "Recovered region manifest from {}, manifest: {:?}",
+            manifest_dir, manifest
+        );
+        let version = manifest.manifest_version;
+        Ok(Some(Self {
+            version,
+            manifest: Arc::new(manifest),
+        }))
+    }
+
+    fn apply_action(
+        maniefst_builder: &mut RegionManifestBuilder,
+        version: ManifestVersion,
+        manifest_dir: Option<&str>,
+        action: RegionMetaAction,
+    ) {
+        match action {
+            RegionMetaAction::Change(action) => {
+                maniefst_builder.apply_change(version, action);
+            }
+            RegionMetaAction::Edit(action) => {
+                maniefst_builder.apply_edit(version, action);
+            }
+            RegionMetaAction::Remove(action) => {
+                if let Some(manifest_dir) = manifest_dir {
+                    debug!(
+                        "Unhandled action for region:{}, dir: {}, action: {:?}",
+                        action.region_id, manifest_dir, action
+                    );
+                } else {
+                    debug!(
+                        "Unhandled action for region:{}, action: {:?}",
+                        action.region_id, action
+                    );
+                }
+            }
+            RegionMetaAction::Truncate(action) => {
+                maniefst_builder.apply_truncate(version, action);
+            }
+        }
+    }
+
+    /// Applies the manifest actions and returns the new manifest version.
+    pub fn apply(&mut self, action_list: RegionMetaActionList) -> Result<ManifestVersion> {
+        let new_version = self.increase_version();
+        let mut manifest_builder =
+            RegionManifestBuilder::with_checkpoint(Some(self.manifest.as_ref().clone()));
+        for action in action_list.actions {
+            Self::apply_action(&mut manifest_builder, new_version, None, action);
+        }
+
+        let manifest = manifest_builder.try_build()?;
+        self.manifest = Arc::new(manifest);
+        Ok(new_version)
+    }
+
+    /// Increases the version of the current manifest.
+    fn increase_version(&mut self) -> ManifestVersion {
+        self.version += 1;
+        self.version
+    }
 }
 
 impl RegionManifestManager {
@@ -139,21 +270,14 @@ impl RegionManifestManager {
             options.manifest_dir, metadata
         );
 
-        let version = MIN_VERSION;
-        let mut manifest_builder = RegionManifestBuilder::default();
-        // set the initial metadata.
-        manifest_builder.apply_change(
-            version,
-            RegionChange {
-                metadata: metadata.clone(),
-            },
-        );
-        let manifest = manifest_builder.try_build()?;
         let region_id = metadata.region_id;
+        let current = CurrentRegionManifest::new(metadata.clone())?;
+        let version = current.version();
 
         debug!(
             "Build region manifest in {}, manifest: {:?}",
-            options.manifest_dir, manifest
+            options.manifest_dir,
+            current.manifest()
         );
 
         // Persist region change.
@@ -164,9 +288,8 @@ impl RegionManifestManager {
         let checkpointer = Checkpointer::new(region_id, options, store.clone(), MIN_VERSION);
         Ok(Self {
             store,
-            last_version: version,
             checkpointer,
-            manifest: Arc::new(manifest),
+            current,
             stopped: false,
         })
     }
@@ -199,7 +322,7 @@ impl RegionManifestManager {
             .as_ref()
             .map(|checkpoint| checkpoint.last_version)
             .unwrap_or(MIN_VERSION);
-        let mut manifest_builder = if let Some(checkpoint) = checkpoint {
+        let manifest_builder = if let Some(checkpoint) = checkpoint {
             info!(
                 "Recover region manifest {} from checkpoint version {}",
                 options.manifest_dir, checkpoint.last_version
@@ -217,55 +340,31 @@ impl RegionManifestManager {
         // apply actions from storage
         let manifests = store.fetch_manifests(version, MAX_VERSION).await?;
 
-        for (manifest_version, raw_action_list) in manifests {
-            let action_list = RegionMetaActionList::decode(&raw_action_list)?;
-            // set manifest size after last checkpoint
-            store.set_delta_file_size(manifest_version, raw_action_list.len() as u64);
-            for action in action_list.actions {
-                match action {
-                    RegionMetaAction::Change(action) => {
-                        manifest_builder.apply_change(manifest_version, action);
-                    }
-                    RegionMetaAction::Edit(action) => {
-                        manifest_builder.apply_edit(manifest_version, action);
-                    }
-                    RegionMetaAction::Remove(_) => {
-                        debug!(
-                            "Unhandled action in {}, action: {:?}",
-                            options.manifest_dir, action
-                        );
-                    }
-                    RegionMetaAction::Truncate(action) => {
-                        manifest_builder.apply_truncate(manifest_version, action);
-                    }
-                }
-            }
-        }
+        let manifests = manifests
+            .into_iter()
+            .map(|(manifest_version, raw_action_list)| {
+                store.set_delta_file_size(manifest_version, raw_action_list.len() as u64);
+                let action_list = RegionMetaActionList::decode(&raw_action_list)?;
+                Ok((manifest_version, action_list))
+            })
+            .collect::<Result<Vec<_>>>()?;
 
-        // set the initial metadata if necessary
-        if !manifest_builder.contains_metadata() {
-            debug!("No region manifest in {}", options.manifest_dir);
+        let Some(current) =
+            CurrentRegionManifest::open(&options.manifest_dir, manifest_builder, manifests)?
+        else {
             return Ok(None);
-        }
-
-        let manifest = manifest_builder.try_build()?;
-        debug!(
-            "Recovered region manifest from {}, manifest: {:?}",
-            options.manifest_dir, manifest
-        );
-        let version = manifest.manifest_version;
+        };
 
         let checkpointer = Checkpointer::new(
-            manifest.metadata.region_id,
+            current.manifest().metadata.region_id,
             options,
             store.clone(),
             last_checkpoint_version,
         );
         Ok(Some(Self {
             store,
-            last_version: version,
             checkpointer,
-            manifest: Arc::new(manifest),
+            current,
             stopped: false,
         }))
     }
@@ -284,46 +383,26 @@ impl RegionManifestManager {
         ensure!(
             !self.stopped,
             RegionStoppedSnafu {
-                region_id: self.manifest.metadata.region_id,
+                region_id: self.current.manifest().metadata.region_id,
             }
         );
 
-        let version = self.increase_version();
-        self.store.save(version, &action_list.encode()?).await?;
+        let next_version = self.current.version + 1;
+        self.store
+            .save(next_version, &action_list.encode()?)
+            .await?;
 
-        let mut manifest_builder =
-            RegionManifestBuilder::with_checkpoint(Some(self.manifest.as_ref().clone()));
-        for action in action_list.actions {
-            match action {
-                RegionMetaAction::Change(action) => {
-                    manifest_builder.apply_change(version, action);
-                }
-                RegionMetaAction::Edit(action) => {
-                    manifest_builder.apply_edit(version, action);
-                }
-                RegionMetaAction::Remove(_) => {
-                    debug!(
-                        "Unhandled action for region {}, action: {:?}",
-                        self.manifest.metadata.region_id, action
-                    );
-                }
-                RegionMetaAction::Truncate(action) => {
-                    manifest_builder.apply_truncate(version, action);
-                }
-            }
-        }
-        let new_manifest = manifest_builder.try_build()?;
-        self.manifest = Arc::new(new_manifest);
+        let version = self.current.apply(action_list)?;
 
         self.checkpointer
-            .maybe_do_checkpoint(self.manifest.as_ref());
+            .maybe_do_checkpoint(self.current.manifest().as_ref());
 
         Ok(version)
     }
 
     /// Retrieves the current [RegionManifest].
     pub fn manifest(&self) -> Arc<RegionManifest> {
-        self.manifest.clone()
+        self.current.manifest().clone()
     }
 
     /// Returns total manifest size.
@@ -337,7 +416,7 @@ impl RegionManifestManager {
     /// It doesn't lock the manifest directory in the object store so the result
     /// may be inaccurate if there are concurrent writes.
     pub async fn has_update(&self) -> Result<bool> {
-        let last_version = self.last_version;
+        let last_version = self.current.version();
 
         let streamer =
             self.store
@@ -362,12 +441,6 @@ impl RegionManifestManager {
             .context(error::OpenDalSnafu)?;
 
         Ok(need_update)
-    }
-
-    /// Increases last version and returns the increased version.
-    fn increase_version(&mut self) -> ManifestVersion {
-        self.last_version += 1;
-        self.last_version
     }
 
     /// Fetches the last [RegionCheckpoint] from storage.
@@ -395,8 +468,8 @@ impl RegionManifestManager {
     fn validate_manifest(&self, expect: &RegionMetadataRef, last_version: ManifestVersion) {
         let manifest = self.manifest();
         assert_eq!(manifest.metadata, *expect);
-        assert_eq!(self.manifest.manifest_version, self.last_version);
-        assert_eq!(last_version, self.last_version);
+        assert_eq!(self.current.version(), last_version);
+        assert_eq!(last_version, self.current.version());
     }
 
     pub fn store(&self) -> ManifestObjectStore {

--- a/src/mito2/src/manifest/notifier.rs
+++ b/src/mito2/src/manifest/notifier.rs
@@ -1,0 +1,48 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use store_api::manifest::ManifestVersion;
+use strum::AsRefStr;
+
+use crate::error::Result;
+use crate::region::MitoRegion;
+
+pub(crate) type ManifestChangeNotifierRef = Arc<dyn ManifestChangeNotifier>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, AsRefStr)]
+pub(crate) enum ManifestChangeEvent {
+    Compcation,
+    Flush,
+    RegionEdit,
+    RegionChange,
+    Truncate,
+}
+
+/// Manifest change notifier used to notify the manifest change to the downstream.
+#[async_trait::async_trait]
+pub(crate) trait ManifestChangeNotifier: Send + Sync {
+    async fn notify(&self, region: &MitoRegion, manifest_version: ManifestVersion) -> Result<()>;
+}
+
+/// Noop manifest change notifier.
+pub(crate) struct NoopManifestChangeNotifier;
+
+#[async_trait::async_trait]
+impl ManifestChangeNotifier for NoopManifestChangeNotifier {
+    async fn notify(&self, _region: &MitoRegion, _manifest_version: ManifestVersion) -> Result<()> {
+        Ok(())
+    }
+}

--- a/src/mito2/src/region/version.rs
+++ b/src/mito2/src/region/version.rs
@@ -164,7 +164,11 @@ impl VersionControl {
     ///
     /// It replaces existing mutable memtable with a memtable that uses the
     /// new schema. Memtables of the version must be empty.
-    pub(crate) fn alter_schema(&self, metadata: RegionMetadataRef, builder: &MemtableBuilderRef) {
+    pub(crate) fn alter_schema(
+        &self,
+        metadata: RegionMetadataRef,
+        builder: &MemtableBuilderRef,
+    ) -> VersionRef {
         let version = self.current().version;
         let part_duration = version.memtables.mutable.part_duration();
         let next_memtable_id = version.memtables.mutable.next_memtable_id();
@@ -184,7 +188,8 @@ impl VersionControl {
         );
 
         let mut version_data = self.data.write().unwrap();
-        version_data.version = new_version;
+        version_data.version = new_version.clone();
+        new_version
     }
 
     /// Truncate current version.
@@ -193,7 +198,7 @@ impl VersionControl {
         truncated_entry_id: EntryId,
         truncated_sequence: SequenceNumber,
         memtable_builder: &MemtableBuilderRef,
-    ) {
+    ) -> VersionRef {
         let version = self.current().version;
 
         let part_duration = version.memtables.mutable.part_duration();
@@ -214,7 +219,8 @@ impl VersionControl {
 
         let mut version_data = self.data.write().unwrap();
         version_data.version.ssts.mark_all_deleted();
-        version_data.version = new_version;
+        version_data.version = new_version.clone();
+        new_version
     }
 }
 

--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -31,6 +31,7 @@ use prost::Message;
 use smallvec::SmallVec;
 use snafu::{ensure, OptionExt, ResultExt};
 use store_api::codec::{infer_primary_key_encoding_from_hint, PrimaryKeyEncoding};
+use store_api::manifest::ManifestVersion;
 use store_api::metadata::{ColumnMetadata, RegionMetadata, RegionMetadataRef};
 use store_api::region_engine::{SetRegionRoleStateResponse, SettableRegionRoleState};
 use store_api::region_request::{
@@ -743,6 +744,8 @@ pub(crate) struct FlushFinished {
     pub(crate) _timer: HistogramTimer,
     /// Region edit to apply.
     pub(crate) edit: RegionEdit,
+    /// Manifest version.
+    pub(crate) manifest_version: ManifestVersion,
     /// Memtables to remove.
     pub(crate) memtables_to_remove: SmallVec<[MemtableId; 2]>,
 }
@@ -785,6 +788,8 @@ pub(crate) struct CompactionFinished {
     pub(crate) start_time: Instant,
     /// Region edit to apply.
     pub(crate) edit: RegionEdit,
+    /// Manifest version.
+    pub(crate) manifest_version: ManifestVersion,
 }
 
 impl CompactionFinished {
@@ -827,7 +832,7 @@ pub(crate) struct TruncateResult {
     /// Result sender.
     pub(crate) sender: OptionOutputTx,
     /// Truncate result.
-    pub(crate) result: Result<()>,
+    pub(crate) result: Result<ManifestVersion>,
     /// Truncated entry id.
     pub(crate) truncated_entry_id: EntryId,
     /// Truncated sequence.
@@ -844,7 +849,7 @@ pub(crate) struct RegionChangeResult {
     /// Result sender.
     pub(crate) sender: OptionOutputTx,
     /// Result from the manifest manager.
-    pub(crate) result: Result<()>,
+    pub(crate) result: Result<ManifestVersion>,
 }
 
 /// Request to edit a region directly.
@@ -866,7 +871,7 @@ pub(crate) struct RegionEditResult {
     /// Region edit to apply.
     pub(crate) edit: RegionEdit,
     /// Result from the manifest manager.
-    pub(crate) result: Result<()>,
+    pub(crate) result: Result<ManifestVersion>,
 }
 
 #[cfg(test)]

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -21,6 +21,7 @@ use common_base::readable_size::ReadableSize;
 use common_telemetry::{debug, info};
 use humantime_serde::re::humantime;
 use snafu::ResultExt;
+use store_api::logstore::LogStore;
 use store_api::metadata::{
     InvalidSetRegionOptionRequestSnafu, MetadataError, RegionMetadata, RegionMetadataBuilder,
     RegionMetadataRef,
@@ -41,7 +42,7 @@ use crate::region::MitoRegionRef;
 use crate::request::{DdlRequest, OptionOutputTx, SenderDdlRequest};
 use crate::worker::RegionWorkerLoop;
 
-impl<S> RegionWorkerLoop<S> {
+impl<S: LogStore> RegionWorkerLoop<S> {
     pub(crate) async fn handle_alter_request(
         &mut self,
         region_id: RegionId,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#5739 

## What's changed and what's your intention?

1. Refactor `CurrentRegionManifest`.
2. Introduce `ManifestChangeNotifier` to notify manifest change to downstream.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
