### PR TITLE
feat(mito): allow skipping wal while creating tables

### DIFF
--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -1471,7 +1471,8 @@ mod tests {
             new_test_table_info(region_routes.iter().map(|r| r.region.id.region_number())).into();
         let wal_allocator = WalOptionsAllocator::RaftEngine;
         let regions = (0..16).collect();
-        let region_wal_options = allocate_region_wal_options(regions, &wal_allocator, false).unwrap();
+        let region_wal_options =
+            allocate_region_wal_options(regions, &wal_allocator, false).unwrap();
         create_physical_table_metadata(
             &table_metadata_manager,
             table_info.clone(),

--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -1471,7 +1471,7 @@ mod tests {
             new_test_table_info(region_routes.iter().map(|r| r.region.id.region_number())).into();
         let wal_allocator = WalOptionsAllocator::RaftEngine;
         let regions = (0..16).collect();
-        let region_wal_options = allocate_region_wal_options(regions, &wal_allocator).unwrap();
+        let region_wal_options = allocate_region_wal_options(regions, &wal_allocator, false).unwrap();
         create_physical_table_metadata(
             &table_metadata_manager,
             table_info.clone(),

--- a/src/common/meta/src/key/topic_region.rs
+++ b/src/common/meta/src/key/topic_region.rs
@@ -224,6 +224,7 @@ impl TopicRegionManager {
                         Some((region_id, kafka.topic.as_str()))
                     }
                     Some(WalOptions::RaftEngine) => None,
+                    Some(WalOptions::Noop) => None,
                     None => None,
                 },
             )

--- a/src/common/meta/src/wal_options_allocator.rs
+++ b/src/common/meta/src/wal_options_allocator.rs
@@ -248,9 +248,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_allocator_with_skip_wal() {
-        let kv_backend = Arc::new(MemoryKvBackend::new()) as KvBackendRef;
-        let wal_config = MetasrvWalConfig::RaftEngine;
-        let allocator = WalOptionsAllocator::new(wal_config, kv_backend);
+        let allocator = WalOptionsAllocator::RaftEngine;
         allocator.start().await.unwrap();
 
         let num_regions = 32;

--- a/src/common/meta/src/wal_options_allocator.rs
+++ b/src/common/meta/src/wal_options_allocator.rs
@@ -53,19 +53,6 @@ impl WalOptionsAllocator {
         }
     }
 
-    /// Allocates a wal options for a region.
-    pub fn alloc(&self) -> Result<WalOptions> {
-        match self {
-            Self::RaftEngine => Ok(WalOptions::RaftEngine),
-            Self::Kafka(topic_manager) => {
-                let topic = topic_manager.select()?;
-                Ok(WalOptions::Kafka(KafkaWalOptions {
-                    topic: topic.clone(),
-                }))
-            }
-        }
-    }
-
     /// Allocates a batch of wal options where each wal options goes to a region.
     pub fn alloc_batch(&self, num_regions: usize) -> Result<Vec<WalOptions>> {
         match self {

--- a/src/common/wal/src/options.rs
+++ b/src/common/wal/src/options.rs
@@ -33,6 +33,7 @@ pub enum WalOptions {
     RaftEngine,
     #[serde(with = "kafka_prefix")]
     Kafka(KafkaWalOptions),
+    Noop,
 }
 
 with_prefix!(kafka_prefix "wal.kafka.");
@@ -58,6 +59,15 @@ mod tests {
         });
         let encoded = serde_json::to_string(&wal_options).unwrap();
         let expected = r#"{"wal.provider":"kafka","wal.kafka.topic":"test_topic"}"#;
+        assert_eq!(&encoded, expected);
+
+        let decoded: WalOptions = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, wal_options);
+
+        // Test serde noop wal options.
+        let wal_options = WalOptions::Noop;
+        let encoded = serde_json::to_string(&wal_options).unwrap();
+        let expected = r#"{"wal.provider":"noop"}"#;
         assert_eq!(&encoded, expected);
 
         let decoded: WalOptions = serde_json::from_str(&encoded).unwrap();

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -272,7 +272,7 @@ fn prepare_batch_open_requests(
                     .or_default()
                     .push((region_id, request));
             }
-            WalOptions::RaftEngine => {
+            WalOptions::RaftEngine | WalOptions::Noop => {
                 remaining_regions.push((region_id, request));
             }
         }

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -331,6 +331,7 @@ impl RegionOpener {
                 );
                 Ok(Provider::kafka_provider(options.topic.to_string()))
             }
+            WalOptions::Noop => Ok(Provider::noop_provider()),
         }
     }
 

--- a/src/mito2/src/wal.rs
+++ b/src/mito2/src/wal.rs
@@ -24,6 +24,7 @@ use std::sync::Arc;
 
 use api::v1::WalEntry;
 use common_error::ext::BoxedError;
+use common_telemetry::debug;
 use entry_reader::NoopEntryReader;
 use futures::future::BoxFuture;
 use futures::stream::BoxStream;
@@ -89,6 +90,7 @@ impl<S: LogStore> Wal<S> {
         let store = self.store.clone();
         move |region_id, last_entry_id, provider| -> BoxFuture<'_, Result<()>> {
             if let Provider::Noop = provider {
+                debug!("Skip obsolete for region: {}", region_id);
                 return Box::pin(async move { Ok(()) });
             }
             Box::pin(async move {

--- a/src/mito2/src/wal/entry_reader.rs
+++ b/src/mito2/src/wal/entry_reader.rs
@@ -50,6 +50,14 @@ pub(crate) trait WalEntryReader: Send + Sync {
     fn read(&mut self, ns: &'_ Provider, start_id: EntryId) -> Result<WalEntryStream<'static>>;
 }
 
+pub(crate) struct NoopEntryReader;
+
+impl WalEntryReader for NoopEntryReader {
+    fn read(&mut self, _ns: &'_ Provider, _start_id: EntryId) -> Result<WalEntryStream<'static>> {
+        Ok(futures::stream::empty().boxed())
+    }
+}
+
 /// A Reader reads the [RawEntry] from [RawEntryReader] and decodes [RawEntry] into [WalEntry].
 pub struct LogStoreEntryReader<R> {
     reader: R,

--- a/src/mito2/src/worker/handle_write.rs
+++ b/src/mito2/src/worker/handle_write.rs
@@ -87,6 +87,10 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             match wal_writer.write_to_wal().await.map_err(Arc::new) {
                 Ok(response) => {
                     for (region_id, region_ctx) in region_ctxs.iter_mut() {
+                        if let WalOptions::Noop = &region_ctx.version().options.wal_options {
+                            continue;
+                        }
+
                         // Safety: the log store implementation ensures that either the `write_to_wal` fails and no
                         // response is returned or the last entry ids for each region do exist.
                         let last_entry_id = response.last_entry_ids.get(region_id).unwrap();

--- a/src/mito2/src/worker/handle_write.rs
+++ b/src/mito2/src/worker/handle_write.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 use api::v1::OpType;
 use common_telemetry::{debug, error};
+use common_wal::options::WalOptions;
 use snafu::ensure;
 use store_api::codec::PrimaryKeyEncoding;
 use store_api::logstore::LogStore;
@@ -75,6 +76,10 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                 .start_timer();
             let mut wal_writer = self.wal.writer();
             for region_ctx in region_ctxs.values_mut() {
+                if let WalOptions::Noop = &region_ctx.version().options.wal_options {
+                    // Skip wal write for noop region.
+                    continue;
+                }
                 if let Err(e) = region_ctx.add_wal_entry(&mut wal_writer).map_err(Arc::new) {
                     region_ctx.set_error(e);
                 }

--- a/src/store-api/src/logstore/provider.rs
+++ b/src/store-api/src/logstore/provider.rs
@@ -62,6 +62,7 @@ impl RaftEngineProvider {
 pub enum Provider {
     RaftEngine(RaftEngineProvider),
     Kafka(Arc<KafkaProvider>),
+    Noop,
 }
 
 impl Display for Provider {
@@ -71,6 +72,7 @@ impl Display for Provider {
                 write!(f, "region: {}", RegionId::from_u64(provider.id))
             }
             Provider::Kafka(provider) => write!(f, "topic: {}", provider.topic),
+            Provider::Noop => write!(f, "noop"),
         }
     }
 }
@@ -84,6 +86,10 @@ impl Provider {
         Provider::Kafka(Arc::new(KafkaProvider { topic }))
     }
 
+    pub fn noop_provider() -> Provider {
+        Provider::Noop
+    }
+
     /// Returns true if it's remote WAL.
     pub fn is_remote_wal(&self) -> bool {
         matches!(self, Provider::Kafka(_))
@@ -94,6 +100,7 @@ impl Provider {
         match self {
             Provider::RaftEngine(_) => RaftEngineProvider::type_name(),
             Provider::Kafka(_) => KafkaProvider::type_name(),
+            Provider::Noop => "Noop",
         }
     }
 

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -452,7 +452,7 @@ mod tests {
         };
 
         assert_eq!(
-            "write_buffer_size=128.0MiB ttl=16m 40s skip_wal=false",
+            "write_buffer_size=128.0MiB ttl=16m 40s",
             options.to_string()
         );
 
@@ -464,7 +464,18 @@ mod tests {
         };
 
         assert_eq!(
-            "write_buffer_size=128.0MiB ttl=16m 40s skip_wal=false a=A",
+            "write_buffer_size=128.0MiB ttl=16m 40s a=A",
+            options.to_string()
+        );
+
+        let options = TableOptions {
+            write_buffer_size: Some(ReadableSize::mb(128)),
+            ttl: Some(Duration::from_secs(1000).into()),
+            extra_options: HashMap::new(),
+            skip_wal: true,
+        };
+        assert_eq!(
+            "write_buffer_size=128.0MiB ttl=16m 40s skip_wal=true",
             options.to_string()
         );
     }

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -21,6 +21,7 @@ use std::str::FromStr;
 use common_base::readable_size::ReadableSize;
 use common_datasource::object_store::s3::is_supported_in_s3;
 use common_query::AddColumnLocation;
+use common_telemetry::warn;
 use common_time::range::TimestampRange;
 use common_time::TimeToLive;
 use datatypes::data_type::ConcreteDataType;
@@ -86,6 +87,8 @@ pub struct TableOptions {
     pub write_buffer_size: Option<ReadableSize>,
     /// Time-to-live of table. Expired data will be automatically purged.
     pub ttl: Option<TimeToLive>,
+    /// Skip wal write for this table.
+    pub skip_wal: bool,
     /// Extra options that may not applicable to all table engines.
     pub extra_options: HashMap<String, String>,
 }
@@ -95,6 +98,7 @@ pub const TTL_KEY: &str = store_api::mito_engine_options::TTL_KEY;
 pub const STORAGE_KEY: &str = "storage";
 pub const COMMENT_KEY: &str = "comment";
 pub const AUTO_CREATE_TABLE_KEY: &str = "auto_create_table";
+pub const SKIP_WAL_KEY: &str = "skip_wal";
 
 impl TableOptions {
     pub fn try_from_iter<T: ToString, U: IntoIterator<Item = (T, T)>>(
@@ -129,6 +133,16 @@ impl TableOptions {
             options.ttl = Some(ttl_value);
         }
 
+        if let Some(skip_wal) = kvs.get(SKIP_WAL_KEY) {
+            options.skip_wal = skip_wal.parse().unwrap_or_else(|_| {
+                warn!(
+                    "Invalid value for skip_wal: {}, using default value: false",
+                    skip_wal
+                );
+                false
+            });
+        }
+
         options.extra_options = HashMap::from_iter(
             kvs.into_iter()
                 .filter(|(k, _)| k != WRITE_BUFFER_SIZE_KEY && k != TTL_KEY),
@@ -148,6 +162,8 @@ impl fmt::Display for TableOptions {
         if let Some(ttl) = self.ttl.map(|ttl| ttl.to_string()) {
             key_vals.push(format!("{}={}", TTL_KEY, ttl));
         }
+
+        key_vals.push(format!("{}={}", SKIP_WAL_KEY, self.skip_wal));
 
         for (k, v) in &self.extra_options {
             key_vals.push(format!("{}={}", k, v));
@@ -383,6 +399,7 @@ mod tests {
             write_buffer_size: None,
             ttl: Some(Duration::from_secs(1000).into()),
             extra_options: HashMap::new(),
+            skip_wal: false,
         };
         let serialized = serde_json::to_string(&options).unwrap();
         let deserialized: TableOptions = serde_json::from_str(&serialized).unwrap();
@@ -395,6 +412,7 @@ mod tests {
             write_buffer_size: Some(ReadableSize::mb(128)),
             ttl: Some(Duration::from_secs(1000).into()),
             extra_options: HashMap::new(),
+            skip_wal: false,
         };
         let serialized_map = HashMap::from(&options);
         let serialized = TableOptions::try_from_iter(&serialized_map).unwrap();
@@ -404,6 +422,7 @@ mod tests {
             write_buffer_size: None,
             ttl: Default::default(),
             extra_options: HashMap::new(),
+            skip_wal: false,
         };
         let serialized_map = HashMap::from(&options);
         let serialized = TableOptions::try_from_iter(&serialized_map).unwrap();
@@ -413,6 +432,7 @@ mod tests {
             write_buffer_size: Some(ReadableSize::mb(128)),
             ttl: Some(Duration::from_secs(1000).into()),
             extra_options: HashMap::from([("a".to_string(), "A".to_string())]),
+            skip_wal: false,
         };
         let serialized_map = HashMap::from(&options);
         let serialized = TableOptions::try_from_iter(&serialized_map).unwrap();
@@ -425,10 +445,11 @@ mod tests {
             write_buffer_size: Some(ReadableSize::mb(128)),
             ttl: Some(Duration::from_secs(1000).into()),
             extra_options: HashMap::new(),
+            skip_wal: false,
         };
 
         assert_eq!(
-            "write_buffer_size=128.0MiB ttl=16m 40s",
+            "write_buffer_size=128.0MiB ttl=16m 40s skip_wal=false",
             options.to_string()
         );
 
@@ -436,10 +457,11 @@ mod tests {
             write_buffer_size: Some(ReadableSize::mb(128)),
             ttl: Some(Duration::from_secs(1000).into()),
             extra_options: HashMap::from([("a".to_string(), "A".to_string())]),
+            skip_wal: false,
         };
 
         assert_eq!(
-            "write_buffer_size=128.0MiB ttl=16m 40s a=A",
+            "write_buffer_size=128.0MiB ttl=16m 40s skip_wal=false a=A",
             options.to_string()
         );
     }

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -67,6 +67,7 @@ pub fn validate_table_option(key: &str) -> bool {
         TTL_KEY,
         STORAGE_KEY,
         COMMENT_KEY,
+        SKIP_WAL_KEY,
         // file engine keys:
         FILE_TABLE_LOCATION_KEY,
         FILE_TABLE_FORMAT_KEY,

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -164,7 +164,9 @@ impl fmt::Display for TableOptions {
             key_vals.push(format!("{}={}", TTL_KEY, ttl));
         }
 
-        key_vals.push(format!("{}={}", SKIP_WAL_KEY, self.skip_wal));
+        if self.skip_wal {
+            key_vals.push(format!("{}={}", SKIP_WAL_KEY, self.skip_wal));
+        }
 
         for (k, v) in &self.extra_options {
             key_vals.push(format!("{}={}", k, v));

--- a/tests/cases/standalone/common/skip_wal.result
+++ b/tests/cases/standalone/common/skip_wal.result
@@ -1,0 +1,58 @@
+CREATE TABLE system_metrics (
+    host STRING,
+    idc STRING,
+    cpu_util DOUBLE,
+    memory_util DOUBLE,
+    disk_util DOUBLE,
+    ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP(),
+    PRIMARY KEY(host, idc),
+    TIME INDEX(ts)
+) WITH (skip_wal = "true");
+
+Affected Rows: 0
+
+INSERT INTO system_metrics
+VALUES
+    ("host1", "idc_a", 11.8, 10.3, 10.3, 1667446797450),
+    ("host2", "idc_a", 80.0, 70.3, 90.0, 1667446797450),
+    ("host1", "idc_b", 50.0, 66.7, 40.6, 1667446797450);
+
+Affected Rows: 3
+
+-- SQLNESS ARG restart=true
+SELECT * FROM system_metrics;
+
+++
+++
+
+INSERT INTO system_metrics
+VALUES
+    ("host1", "idc_a", 11.8, 10.3, 10.3, 1667446797450),
+    ("host2", "idc_a", 80.0, 70.3, 90.0, 1667446797450),
+    ("host1", "idc_b", 50.0, 66.7, 40.6, 1667446797450);
+
+Affected Rows: 3
+
+ADMIN flush_table('system_metrics');
+
++-------------------------------------+
+| ADMIN flush_table('system_metrics') |
++-------------------------------------+
+| 0                                   |
++-------------------------------------+
+
+-- SQLNESS ARG restart=true
+SELECT * FROM system_metrics;
+
++-------+-------+----------+-------------+-----------+-------------------------+
+| host  | idc   | cpu_util | memory_util | disk_util | ts                      |
++-------+-------+----------+-------------+-----------+-------------------------+
+| host1 | idc_a | 11.8     | 10.3        | 10.3      | 2022-11-03T03:39:57.450 |
+| host1 | idc_b | 50.0     | 66.7        | 40.6      | 2022-11-03T03:39:57.450 |
+| host2 | idc_a | 80.0     | 70.3        | 90.0      | 2022-11-03T03:39:57.450 |
++-------+-------+----------+-------------+-----------+-------------------------+
+
+DROP TABLE system_metrics;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/skip_wal.sql
+++ b/tests/cases/standalone/common/skip_wal.sql
@@ -1,0 +1,32 @@
+CREATE TABLE system_metrics (
+    host STRING,
+    idc STRING,
+    cpu_util DOUBLE,
+    memory_util DOUBLE,
+    disk_util DOUBLE,
+    ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP(),
+    PRIMARY KEY(host, idc),
+    TIME INDEX(ts)
+) WITH (skip_wal = "true");
+
+INSERT INTO system_metrics
+VALUES
+    ("host1", "idc_a", 11.8, 10.3, 10.3, 1667446797450),
+    ("host2", "idc_a", 80.0, 70.3, 90.0, 1667446797450),
+    ("host1", "idc_b", 50.0, 66.7, 40.6, 1667446797450);
+
+-- SQLNESS ARG restart=true
+SELECT * FROM system_metrics;
+
+INSERT INTO system_metrics
+VALUES
+    ("host1", "idc_a", 11.8, 10.3, 10.3, 1667446797450),
+    ("host2", "idc_a", 80.0, 70.3, 90.0, 1667446797450),
+    ("host1", "idc_b", 50.0, 66.7, 40.6, 1667446797450);
+
+ADMIN flush_table('system_metrics');
+
+-- SQLNESS ARG restart=true
+SELECT * FROM system_metrics;
+
+DROP TABLE system_metrics;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

close #1267

## What's changed and what's your intention?

Allow users to create tables with `skip_wal` set to true to disable WAL per table.



## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
