### PR TITLE
feat: introduce `install_manifest_to` for `RegionManifestManager`

### DIFF
--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -781,6 +781,18 @@ pub enum Error {
     #[snafu(display("checksum mismatch (actual: {}, expected: {})", actual, expected))]
     ChecksumMismatch { actual: u32, expected: u32 },
 
+    #[snafu(display(
+        "No checkpoint found, region_id: {}, last_version: {}",
+        region_id,
+        last_version
+    ))]
+    NoCheckpoint {
+        region_id: RegionId,
+        last_version: ManifestVersion,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Region {} is stopped", region_id))]
     RegionStopped {
         region_id: RegionId,
@@ -1019,7 +1031,8 @@ impl ErrorExt for Error {
             | OperateAbortedIndex { .. }
             | UnexpectedReplay { .. }
             | IndexEncodeNull { .. }
-            | UnexpectedImpureDefault { .. } => StatusCode::Unexpected,
+            | UnexpectedImpureDefault { .. }
+            | NoCheckpoint { .. } => StatusCode::Unexpected,
             RegionNotFound { .. } => StatusCode::RegionNotFound,
             ObjectStoreNotFound { .. }
             | InvalidScanIndex { .. }

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -782,7 +782,7 @@ pub enum Error {
     ChecksumMismatch { actual: u32, expected: u32 },
 
     #[snafu(display(
-        "No checkpoint found, region_id: {}, last_version: {}",
+        "No checkpoint found, region: {}, last_version: {}",
         region_id,
         last_version
     ))]
@@ -791,6 +791,38 @@ pub enum Error {
         last_version: ManifestVersion,
         #[snafu(implicit)]
         location: Location,
+    },
+
+    #[snafu(display(
+        "No manifests found in range: [{}..{}), region: {}, last_version: {}",
+        start_version,
+        end_version,
+        region_id,
+        last_version
+    ))]
+    NoManifests {
+        region_id: RegionId,
+        start_version: ManifestVersion,
+        end_version: ManifestVersion,
+        last_version: ManifestVersion,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display(
+        "Failed to install manifest to {}, region: {}, available manifest version: {}, last version: {}",
+        target_version,
+        available_version,
+        region_id,
+        last_version
+    ))]
+    InstallManifestTo {
+        region_id: RegionId,
+        target_version: ManifestVersion,
+        available_version: ManifestVersion,
+        #[snafu(implicit)]
+        location: Location,
+        last_version: ManifestVersion,
     },
 
     #[snafu(display("Region {} is stopped", region_id))]
@@ -1032,7 +1064,9 @@ impl ErrorExt for Error {
             | UnexpectedReplay { .. }
             | IndexEncodeNull { .. }
             | UnexpectedImpureDefault { .. }
-            | NoCheckpoint { .. } => StatusCode::Unexpected,
+            | NoCheckpoint { .. }
+            | NoManifests { .. }
+            | InstallManifestTo { .. } => StatusCode::Unexpected,
             RegionNotFound { .. } => StatusCode::RegionNotFound,
             ObjectStoreNotFound { .. }
             | InvalidScanIndex { .. }

--- a/src/mito2/src/manifest/manager.rs
+++ b/src/mito2/src/manifest/manager.rs
@@ -278,12 +278,14 @@ impl RegionManifestManager {
     /// Installs the manifest changes from the current version to the target version.
     ///
     /// Returns installed version.
-    pub async fn install_manifest_changes(
+    /// **Note**: This function is not guaranteed to install the target version strictly.
+    /// The installed version may be greater than the target version.
+    pub async fn install_manifest_to(
         &mut self,
         target_version: ManifestVersion,
     ) -> Result<ManifestVersion> {
         let _t = MANIFEST_OP_ELAPSED
-            .with_label_values(&["install_manifest_changes"])
+            .with_label_values(&["install_manifest_to"])
             .start_timer();
 
         // Case 1: If the target version is less than the current version, return the current version.

--- a/src/mito2/src/manifest/manager.rs
+++ b/src/mito2/src/manifest/manager.rs
@@ -491,6 +491,9 @@ impl RegionManifestManager {
     }
 
     /// Fetches the last [RegionCheckpoint] from storage.
+    ///
+    /// If the checkpoint is not found, returns `None`.
+    /// Otherwise, returns the checkpoint and the size of the checkpoint.
     pub(crate) async fn last_checkpoint(
         store: &mut ManifestObjectStore,
     ) -> Result<Option<(RegionCheckpoint, u64)>> {

--- a/src/mito2/src/manifest/manager.rs
+++ b/src/mito2/src/manifest/manager.rs
@@ -277,7 +277,7 @@ impl RegionManifestManager {
         self.stopped = true;
     }
 
-    /// Installs the manifest changes from the current version to the target version.
+    /// Installs the manifest changes from the current version to the target version (inclusive).
     ///
     /// Returns installed version.
     /// **Note**: This function is not guaranteed to install the target version strictly.

--- a/src/mito2/src/manifest/manager.rs
+++ b/src/mito2/src/manifest/manager.rs
@@ -312,7 +312,7 @@ impl RegionManifestManager {
 
         if manifests.is_empty() {
             debug!(
-                "Manifests is not strict from {}, region: {}, tries to install the last checkpoint",
+                "Manifests are not strict from {}, region: {}, tries to install the last checkpoint",
                 self.last_version, self.manifest.metadata.region_id
             );
             // Case 2: If there are no manifests in range: [last_version, target_version+1),

--- a/src/mito2/src/manifest/manager.rs
+++ b/src/mito2/src/manifest/manager.rs
@@ -307,13 +307,14 @@ impl RegionManifestManager {
         // Fetches manifests from the last version strictly.
         let mut manifests = self
             .store
-            .fetch_manifests_strict_from(self.last_version, target_version + 1)
+            // Invariant: last_version < target_version.
+            .fetch_manifests_strict_from(self.last_version + 1, target_version + 1)
             .await?;
 
-        // Case 2: No manifests in range: [last_version, target_version+1)
+        // Case 2: No manifests in range: [current_version+1, target_version+1)
         //
         // |---------Has been deleted------------|     [Checkpoint Version]...[Latest Version]
-        //                                                                     [Leader region]
+        //                                                                    [Leader region]
         // [Current Version]......[Target Version]
         // [Follower region]
         if manifests.is_empty() {
@@ -330,7 +331,8 @@ impl RegionManifestManager {
             // Fetches manifests from the installed version strictly.
             manifests = self
                 .store
-                .fetch_manifests_strict_from(last_version, target_version + 1)
+                // Invariant: last_version < target_version.
+                .fetch_manifests_strict_from(last_version + 1, target_version + 1)
                 .await?;
         }
 

--- a/src/mito2/src/manifest/storage.rs
+++ b/src/mito2/src/manifest/storage.rs
@@ -238,14 +238,14 @@ impl ManifestObjectStore {
 
     /// Fetches manifests in range [start_version, end_version).
     ///
-    /// This functions is guaranteed to return manifests from the `start_version` strictly.
+    /// This functions is guaranteed to return manifests from the `start_version` strictly (must contain `start_version`).
     pub async fn fetch_manifests_strict_from(
         &self,
         start_version: ManifestVersion,
         end_version: ManifestVersion,
     ) -> Result<Vec<(ManifestVersion, Vec<u8>)>> {
         let mut manifests = self.fetch_manifests(start_version, end_version).await?;
-        let start_index = manifests.iter().position(|(v, _)| *v == start_version + 1);
+        let start_index = manifests.iter().position(|(v, _)| *v == start_version);
         debug!(
             "fetches manifests in range [{},{}), start_index: {:?}",
             start_version, end_version, start_index

--- a/src/mito2/src/manifest/storage.rs
+++ b/src/mito2/src/manifest/storage.rs
@@ -247,7 +247,7 @@ impl ManifestObjectStore {
         let mut manifests = self.fetch_manifests(start_version, end_version).await?;
         let start_index = manifests.iter().position(|(v, _)| *v == start_version + 1);
         debug!(
-            "fetches manifess in range [{},{}), start_index: {:?}",
+            "fetches manifests in range [{},{}), start_index: {:?}",
             start_version, end_version, start_index
         );
         if let Some(start_index) = start_index {

--- a/src/mito2/src/manifest/tests/checkpoint.rs
+++ b/src/mito2/src/manifest/tests/checkpoint.rs
@@ -311,7 +311,7 @@ fn generate_action_lists(num: usize) -> (Vec<FileId>, Vec<RegionMetaActionList>)
 }
 
 #[tokio::test]
-async fn manifest_install_manifest_changes() {
+async fn manifest_install_manifest_to() {
     common_telemetry::init_default_ut_logging();
     let (env, mut manager) = build_manager(0, CompressionType::Uncompressed).await;
     let (files, actions) = generate_action_lists(10);
@@ -321,10 +321,7 @@ async fn manifest_install_manifest_changes() {
 
     // Nothing to install
     let target_version = manager.manifest().manifest_version;
-    let installed_version = manager
-        .install_manifest_changes(target_version)
-        .await
-        .unwrap();
+    let installed_version = manager.install_manifest_to(target_version).await.unwrap();
     assert_eq!(target_version, installed_version);
 
     let mut another_manager =
@@ -333,7 +330,7 @@ async fn manifest_install_manifest_changes() {
     // install manifest changes
     let target_version = manager.manifest().manifest_version;
     let installed_version = another_manager
-        .install_manifest_changes(target_version - 1)
+        .install_manifest_to(target_version - 1)
         .await
         .unwrap();
     assert_eq!(target_version - 1, installed_version);
@@ -342,7 +339,7 @@ async fn manifest_install_manifest_changes() {
     }
 
     let installed_version = another_manager
-        .install_manifest_changes(target_version)
+        .install_manifest_to(target_version)
         .await
         .unwrap();
     assert_eq!(target_version, installed_version);
@@ -352,7 +349,7 @@ async fn manifest_install_manifest_changes() {
 }
 
 #[tokio::test]
-async fn manifest_install_manifest_changes_with_checkpoint() {
+async fn manifest_install_manifest_to_with_checkpoint() {
     common_telemetry::init_default_ut_logging();
     let (env, mut manager) = build_manager(3, CompressionType::Uncompressed).await;
     let (files, actions) = generate_action_lists(10);
@@ -399,7 +396,7 @@ async fn manifest_install_manifest_changes_with_checkpoint() {
     // Install 9 manifests
     let target_version = manager.manifest().manifest_version;
     let installed_version = another_manager
-        .install_manifest_changes(target_version - 1)
+        .install_manifest_to(target_version - 1)
         .await
         .unwrap();
     assert_eq!(target_version - 1, installed_version);
@@ -410,7 +407,7 @@ async fn manifest_install_manifest_changes_with_checkpoint() {
     // Install all manifests
     let target_version = manager.manifest().manifest_version;
     let installed_version = another_manager
-        .install_manifest_changes(target_version)
+        .install_manifest_to(target_version)
         .await
         .unwrap();
     assert_eq!(target_version, installed_version);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#5739 
## What's changed and what's your intention?

Introduce `install_manifest_to` for `RegionManifestManager` to install latest manifest.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
