### PR TITLE
refactor: make frontend instance clear

### DIFF
--- a/src/cmd/src/error.rs
+++ b/src/cmd/src/error.rs
@@ -100,6 +100,20 @@ pub enum Error {
         source: flow::Error,
     },
 
+    #[snafu(display("Frontend error"))]
+    Frontend {
+        #[snafu(implicit)]
+        location: Location,
+        source: frontend::error::Error,
+    },
+
+    #[snafu(display("Servers error"))]
+    Servers {
+        #[snafu(implicit)]
+        location: Location,
+        source: servers::error::Error,
+    },
+
     #[snafu(display("Failed to start frontend"))]
     StartFrontend {
         #[snafu(implicit)]
@@ -365,6 +379,8 @@ impl ErrorExt for Error {
             Error::ShutdownFrontend { source, .. } => source.status_code(),
             Error::StartMetaServer { source, .. } => source.status_code(),
             Error::ShutdownMetaServer { source, .. } => source.status_code(),
+            Error::Servers { source, .. } => source.status_code(),
+            Error::Frontend { source, .. } => source.status_code(),
             Error::BuildMetaServer { source, .. } => source.status_code(),
             Error::UnsupportedSelectorType { source, .. } => source.status_code(),
             Error::BuildCli { source, .. } => source.status_code(),

--- a/src/cmd/src/error.rs
+++ b/src/cmd/src/error.rs
@@ -100,13 +100,6 @@ pub enum Error {
         source: flow::Error,
     },
 
-    #[snafu(display("Frontend error"))]
-    Frontend {
-        #[snafu(implicit)]
-        location: Location,
-        source: frontend::error::Error,
-    },
-
     #[snafu(display("Servers error"))]
     Servers {
         #[snafu(implicit)]
@@ -380,7 +373,6 @@ impl ErrorExt for Error {
             Error::StartMetaServer { source, .. } => source.status_code(),
             Error::ShutdownMetaServer { source, .. } => source.status_code(),
             Error::Servers { source, .. } => source.status_code(),
-            Error::Frontend { source, .. } => source.status_code(),
             Error::BuildMetaServer { source, .. } => source.status_code(),
             Error::UnsupportedSelectorType { source, .. } => source.status_code(),
             Error::BuildCli { source, .. } => source.status_code(),

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -73,13 +73,19 @@ impl App for FrontendApp {
         let plugins = self.frontend.instance.plugins().clone();
         plugins::start_frontend_plugins(plugins)
             .await
-            .context(error::FrontendSnafu)?;
+            .context(error::StartFrontendSnafu)?;
 
-        self.frontend.start().await.context(error::FrontendSnafu)
+        self.frontend
+            .start()
+            .await
+            .context(error::StartFrontendSnafu)
     }
 
     async fn stop(&self) -> Result<()> {
-        self.frontend.stop().await.context(error::FrontendSnafu)
+        self.frontend
+            .stop()
+            .await
+            .context(error::StartFrontendSnafu)
     }
 }
 
@@ -267,7 +273,7 @@ impl StartCommand {
         let mut plugins = Plugins::new();
         plugins::setup_frontend_plugins(&mut plugins, &plugin_opts, &opts)
             .await
-            .context(error::FrontendSnafu)?;
+            .context(error::StartFrontendSnafu)?;
 
         set_default_timezone(opts.default_timezone.as_deref()).context(error::InitTimezoneSnafu)?;
 
@@ -357,13 +363,13 @@ impl StartCommand {
         .with_local_cache_invalidator(layered_cache_registry)
         .try_build()
         .await
-        .context(error::FrontendSnafu)?;
+        .context(error::StartFrontendSnafu)?;
         let instance = Arc::new(instance);
 
         let servers = Services::new(opts.clone(), instance.clone(), plugins.clone())
             .build()
             .await
-            .context(error::FrontendSnafu)?;
+            .context(error::StartFrontendSnafu)?;
 
         let export_metrics_task = ExportMetricsTask::try_new(&opts.export_metrics, Some(&plugins))
             .context(error::ServersSnafu)?;

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -32,70 +32,54 @@ use common_telemetry::info;
 use common_telemetry::logging::TracingOptions;
 use common_time::timezone::set_default_timezone;
 use common_version::{short_version, version};
+use frontend::frontend::Frontend;
 use frontend::heartbeat::HeartbeatTask;
 use frontend::instance::builder::FrontendBuilder;
-use frontend::instance::{FrontendInstance, Instance as FeInstance};
 use frontend::server::Services;
 use meta_client::{MetaClientOptions, MetaClientType};
 use query::stats::StatementStatistics;
+use servers::export_metrics::ExportMetricsTask;
 use servers::tls::{TlsMode, TlsOption};
 use snafu::{OptionExt, ResultExt};
 use tracing_appender::non_blocking::WorkerGuard;
 
-use crate::error::{
-    self, InitTimezoneSnafu, LoadLayeredConfigSnafu, MetaClientInitSnafu, MissingConfigSnafu,
-    Result, StartFrontendSnafu,
-};
+use crate::error::{self, Result};
 use crate::options::{GlobalOptions, GreptimeOptions};
 use crate::{log_versions, App};
 
 type FrontendOptions = GreptimeOptions<frontend::frontend::FrontendOptions>;
 
-pub struct Instance {
-    frontend: FeInstance,
-
+pub struct FrontendApp {
+    frontend: Frontend,
     // Keep the logging guard to prevent the worker from being dropped.
     _guard: Vec<WorkerGuard>,
 }
 
 pub const APP_NAME: &str = "greptime-frontend";
 
-impl Instance {
-    pub fn new(frontend: FeInstance, guard: Vec<WorkerGuard>) -> Self {
-        Self {
-            frontend,
-            _guard: guard,
-        }
-    }
-
-    pub fn mut_inner(&mut self) -> &mut FeInstance {
-        &mut self.frontend
-    }
-
-    pub fn inner(&self) -> &FeInstance {
-        &self.frontend
+impl FrontendApp {
+    pub fn new(frontend: Frontend, _guard: Vec<WorkerGuard>) -> Self {
+        Self { frontend, _guard }
     }
 }
 
 #[async_trait]
-impl App for Instance {
+impl App for FrontendApp {
     fn name(&self) -> &str {
         APP_NAME
     }
 
     async fn start(&mut self) -> Result<()> {
-        plugins::start_frontend_plugins(self.frontend.plugins().clone())
+        let plugins = self.frontend.instance.plugins().clone();
+        plugins::start_frontend_plugins(plugins)
             .await
-            .context(StartFrontendSnafu)?;
+            .context(error::FrontendSnafu)?;
 
-        self.frontend.start().await.context(StartFrontendSnafu)
+        self.frontend.start().await.context(error::FrontendSnafu)
     }
 
     async fn stop(&self) -> Result<()> {
-        self.frontend
-            .shutdown()
-            .await
-            .context(error::ShutdownFrontendSnafu)
+        self.frontend.stop().await.context(error::FrontendSnafu)
     }
 }
 
@@ -106,7 +90,7 @@ pub struct Command {
 }
 
 impl Command {
-    pub async fn build(&self, opts: FrontendOptions) -> Result<Instance> {
+    pub async fn build(&self, opts: FrontendOptions) -> Result<FrontendApp> {
         self.subcmd.build(opts).await
     }
 
@@ -121,7 +105,7 @@ enum SubCommand {
 }
 
 impl SubCommand {
-    async fn build(&self, opts: FrontendOptions) -> Result<Instance> {
+    async fn build(&self, opts: FrontendOptions) -> Result<FrontendApp> {
         match self {
             SubCommand::Start(cmd) => cmd.build(opts).await,
         }
@@ -178,7 +162,7 @@ impl StartCommand {
             self.config_file.as_deref(),
             self.env_prefix.as_ref(),
         )
-        .context(LoadLayeredConfigSnafu)?;
+        .context(error::LoadLayeredConfigSnafu)?;
 
         self.merge_with_cli_options(global_options, &mut opts)?;
 
@@ -263,7 +247,7 @@ impl StartCommand {
         Ok(())
     }
 
-    async fn build(&self, opts: FrontendOptions) -> Result<Instance> {
+    async fn build(&self, opts: FrontendOptions) -> Result<FrontendApp> {
         common_runtime::init_global_runtimes(&opts.runtime);
 
         let guard = common_telemetry::init_global_logging(
@@ -283,13 +267,16 @@ impl StartCommand {
         let mut plugins = Plugins::new();
         plugins::setup_frontend_plugins(&mut plugins, &plugin_opts, &opts)
             .await
-            .context(StartFrontendSnafu)?;
+            .context(error::FrontendSnafu)?;
 
-        set_default_timezone(opts.default_timezone.as_deref()).context(InitTimezoneSnafu)?;
+        set_default_timezone(opts.default_timezone.as_deref()).context(error::InitTimezoneSnafu)?;
 
-        let meta_client_options = opts.meta_client.as_ref().context(MissingConfigSnafu {
-            msg: "'meta_client'",
-        })?;
+        let meta_client_options = opts
+            .meta_client
+            .as_ref()
+            .context(error::MissingConfigSnafu {
+                msg: "'meta_client'",
+            })?;
 
         let cache_max_capacity = meta_client_options.metadata_cache_max_capacity;
         let cache_ttl = meta_client_options.metadata_cache_ttl;
@@ -298,7 +285,7 @@ impl StartCommand {
         let meta_client =
             meta_client::create_meta_client(MetaClientType::Frontend, meta_client_options)
                 .await
-                .context(MetaClientInitSnafu)?;
+                .context(error::MetaClientInitSnafu)?;
 
         // TODO(discord9): add helper function to ease the creation of cache registry&such
         let cached_meta_backend =
@@ -345,6 +332,7 @@ impl StartCommand {
             opts.heartbeat.clone(),
             Arc::new(executor),
         );
+        let heartbeat_task = Some(heartbeat_task);
 
         // frontend to datanode need not timeout.
         // Some queries are expected to take long time.
@@ -356,7 +344,7 @@ impl StartCommand {
         };
         let client = NodeClients::new(channel_config);
 
-        let mut instance = FrontendBuilder::new(
+        let instance = FrontendBuilder::new(
             opts.clone(),
             cached_meta_backend.clone(),
             layered_cache_registry.clone(),
@@ -367,20 +355,28 @@ impl StartCommand {
         )
         .with_plugin(plugins.clone())
         .with_local_cache_invalidator(layered_cache_registry)
-        .with_heartbeat_task(heartbeat_task)
         .try_build()
         .await
-        .context(StartFrontendSnafu)?;
+        .context(error::FrontendSnafu)?;
+        let instance = Arc::new(instance);
 
-        let servers = Services::new(opts, Arc::new(instance.clone()), plugins)
+        let servers = Services::new(opts.clone(), instance.clone(), plugins.clone())
             .build()
             .await
-            .context(StartFrontendSnafu)?;
-        instance
-            .build_servers(servers)
-            .context(StartFrontendSnafu)?;
+            .context(error::FrontendSnafu)?;
 
-        Ok(Instance::new(instance, guard))
+        let export_metrics_task = ExportMetricsTask::try_new(&opts.export_metrics, Some(&plugins))
+            .context(error::ServersSnafu)?;
+
+        let frontend = Frontend {
+            opts,
+            instance,
+            servers,
+            heartbeat_task,
+            export_metrics_task,
+        };
+
+        Ok(FrontendApp::new(frontend, guard))
     }
 }
 

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -49,7 +49,7 @@ use crate::{log_versions, App};
 
 type FrontendOptions = GreptimeOptions<frontend::frontend::FrontendOptions>;
 
-pub struct FrontendApp {
+pub struct Instance {
     frontend: Frontend,
     // Keep the logging guard to prevent the worker from being dropped.
     _guard: Vec<WorkerGuard>,
@@ -57,14 +57,14 @@ pub struct FrontendApp {
 
 pub const APP_NAME: &str = "greptime-frontend";
 
-impl FrontendApp {
+impl Instance {
     pub fn new(frontend: Frontend, _guard: Vec<WorkerGuard>) -> Self {
         Self { frontend, _guard }
     }
 }
 
 #[async_trait]
-impl App for FrontendApp {
+impl App for Instance {
     fn name(&self) -> &str {
         APP_NAME
     }
@@ -96,7 +96,7 @@ pub struct Command {
 }
 
 impl Command {
-    pub async fn build(&self, opts: FrontendOptions) -> Result<FrontendApp> {
+    pub async fn build(&self, opts: FrontendOptions) -> Result<Instance> {
         self.subcmd.build(opts).await
     }
 
@@ -111,7 +111,7 @@ enum SubCommand {
 }
 
 impl SubCommand {
-    async fn build(&self, opts: FrontendOptions) -> Result<FrontendApp> {
+    async fn build(&self, opts: FrontendOptions) -> Result<Instance> {
         match self {
             SubCommand::Start(cmd) => cmd.build(opts).await,
         }
@@ -253,7 +253,7 @@ impl StartCommand {
         Ok(())
     }
 
-    async fn build(&self, opts: FrontendOptions) -> Result<FrontendApp> {
+    async fn build(&self, opts: FrontendOptions) -> Result<Instance> {
         common_runtime::init_global_runtimes(&opts.runtime);
 
         let guard = common_telemetry::init_global_logging(
@@ -381,7 +381,7 @@ impl StartCommand {
             export_metrics_task,
         };
 
-        Ok(FrontendApp::new(frontend, guard))
+        Ok(Instance::new(frontend, guard))
     }
 }
 

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::net::SocketAddr;
 use std::sync::Arc;
 use std::{fs, path};
 
@@ -55,9 +54,9 @@ use datanode::datanode::{Datanode, DatanodeBuilder};
 use datanode::region_server::RegionServer;
 use file_engine::config::EngineConfig as FileEngineConfig;
 use flow::{FlowConfig, FlowWorkerManager, FlownodeBuilder, FlownodeOptions, FrontendInvoker};
-use frontend::frontend::FrontendOptions;
+use frontend::frontend::{Frontend, FrontendOptions};
 use frontend::instance::builder::FrontendBuilder;
-use frontend::instance::{FrontendInstance, Instance as FeInstance, StandaloneDatanodeManager};
+use frontend::instance::{Instance as FeInstance, StandaloneDatanodeManager};
 use frontend::server::Services;
 use frontend::service_config::{
     InfluxdbOptions, JaegerOptions, MysqlOptions, OpentsdbOptions, PostgresOptions,
@@ -67,7 +66,7 @@ use meta_srv::metasrv::{FLOW_ID_SEQ, TABLE_ID_SEQ};
 use mito2::config::MitoConfig;
 use query::stats::StatementStatistics;
 use serde::{Deserialize, Serialize};
-use servers::export_metrics::ExportMetricsOption;
+use servers::export_metrics::{ExportMetricsOption, ExportMetricsTask};
 use servers::grpc::GrpcOptions;
 use servers::http::HttpOptions;
 use servers::tls::{TlsMode, TlsOption};
@@ -76,15 +75,9 @@ use snafu::ResultExt;
 use tokio::sync::{broadcast, RwLock};
 use tracing_appender::non_blocking::WorkerGuard;
 
-use crate::error::{
-    BuildCacheRegistrySnafu, BuildWalOptionsAllocatorSnafu, CreateDirSnafu, IllegalConfigSnafu,
-    InitDdlManagerSnafu, InitMetadataSnafu, InitTimezoneSnafu, LoadLayeredConfigSnafu, OtherSnafu,
-    Result, ShutdownDatanodeSnafu, ShutdownFlownodeSnafu, ShutdownFrontendSnafu,
-    StartDatanodeSnafu, StartFlownodeSnafu, StartFrontendSnafu, StartProcedureManagerSnafu,
-    StartWalOptionsAllocatorSnafu, StopProcedureManagerSnafu,
-};
+use crate::error::Result;
 use crate::options::{GlobalOptions, GreptimeOptions};
-use crate::{log_versions, App};
+use crate::{error, log_versions, App};
 
 pub const APP_NAME: &str = "greptime-standalone";
 
@@ -95,7 +88,7 @@ pub struct Command {
 }
 
 impl Command {
-    pub async fn build(&self, opts: GreptimeOptions<StandaloneOptions>) -> Result<Instance> {
+    pub async fn build(&self, opts: GreptimeOptions<StandaloneOptions>) -> Result<StandaloneApp> {
         self.subcmd.build(opts).await
     }
 
@@ -113,7 +106,7 @@ enum SubCommand {
 }
 
 impl SubCommand {
-    async fn build(&self, opts: GreptimeOptions<StandaloneOptions>) -> Result<Instance> {
+    async fn build(&self, opts: GreptimeOptions<StandaloneOptions>) -> Result<StandaloneApp> {
         match self {
             SubCommand::Start(cmd) => cmd.build(opts).await,
         }
@@ -249,28 +242,20 @@ impl StandaloneOptions {
     }
 }
 
-pub struct Instance {
+pub struct StandaloneApp {
     datanode: Datanode,
-    frontend: FeInstance,
+    frontend: Frontend,
     // TODO(discord9): wrapped it in flownode instance instead
     flow_worker_manager: Arc<FlowWorkerManager>,
     flow_shutdown: broadcast::Sender<()>,
     procedure_manager: ProcedureManagerRef,
     wal_options_allocator: WalOptionsAllocatorRef,
-
     // Keep the logging guard to prevent the worker from being dropped.
     _guard: Vec<WorkerGuard>,
 }
 
-impl Instance {
-    /// Find the socket addr of a server by its `name`.
-    pub async fn server_addr(&self, name: &str) -> Option<SocketAddr> {
-        self.frontend.server_handlers().addr(name).await
-    }
-}
-
 #[async_trait]
-impl App for Instance {
+impl App for StandaloneApp {
     fn name(&self) -> &str {
         APP_NAME
     }
@@ -281,39 +266,39 @@ impl App for Instance {
         self.procedure_manager
             .start()
             .await
-            .context(StartProcedureManagerSnafu)?;
+            .context(error::StartProcedureManagerSnafu)?;
 
         self.wal_options_allocator
             .start()
             .await
-            .context(StartWalOptionsAllocatorSnafu)?;
+            .context(error::StartWalOptionsAllocatorSnafu)?;
 
-        plugins::start_frontend_plugins(self.frontend.plugins().clone())
+        plugins::start_frontend_plugins(self.frontend.instance.plugins().clone())
             .await
-            .context(StartFrontendSnafu)?;
+            .context(error::FrontendSnafu)?;
 
-        self.frontend.start().await.context(StartFrontendSnafu)?;
         self.flow_worker_manager
             .clone()
             .run_background(Some(self.flow_shutdown.subscribe()));
+
+        self.frontend.start().await.context(error::FrontendSnafu)?;
+
         Ok(())
     }
 
     async fn stop(&self) -> Result<()> {
-        self.frontend
-            .shutdown()
-            .await
-            .context(ShutdownFrontendSnafu)?;
+        self.frontend.stop().await.context(error::FrontendSnafu)?;
 
         self.procedure_manager
             .stop()
             .await
-            .context(StopProcedureManagerSnafu)?;
+            .context(error::StopProcedureManagerSnafu)?;
 
         self.datanode
             .shutdown()
             .await
-            .context(ShutdownDatanodeSnafu)?;
+            .context(error::ShutdownDatanodeSnafu)?;
+
         self.flow_shutdown
             .send(())
             .map_err(|_e| {
@@ -322,7 +307,8 @@ impl App for Instance {
                 }
                 .build()
             })
-            .context(ShutdownFlownodeSnafu)?;
+            .context(error::ShutdownFlownodeSnafu)?;
+
         info!("Datanode instance stopped.");
 
         Ok(())
@@ -368,7 +354,7 @@ impl StartCommand {
             self.config_file.as_deref(),
             self.env_prefix.as_ref(),
         )
-        .context(LoadLayeredConfigSnafu)?;
+        .context(error::LoadLayeredConfigSnafu)?;
 
         self.merge_with_cli_options(global_options, &mut opts.component)?;
 
@@ -415,7 +401,7 @@ impl StartCommand {
             // frontend grpc addr conflict with datanode default grpc addr
             let datanode_grpc_addr = DatanodeOptions::default().grpc.bind_addr;
             if addr.eq(&datanode_grpc_addr) {
-                return IllegalConfigSnafu {
+                return error::IllegalConfigSnafu {
                     msg: format!(
                         "gRPC listen address conflicts with datanode reserved gRPC addr: {datanode_grpc_addr}",
                     ),
@@ -451,7 +437,7 @@ impl StartCommand {
     #[allow(unused_variables)]
     #[allow(clippy::diverging_sub_expression)]
     /// Build GreptimeDB instance with the loaded options.
-    pub async fn build(&self, opts: GreptimeOptions<StandaloneOptions>) -> Result<Instance> {
+    pub async fn build(&self, opts: GreptimeOptions<StandaloneOptions>) -> Result<StandaloneApp> {
         common_runtime::init_global_runtimes(&opts.runtime);
 
         let guard = common_telemetry::init_global_logging(
@@ -474,18 +460,19 @@ impl StartCommand {
 
         plugins::setup_frontend_plugins(&mut plugins, &plugin_opts, &fe_opts)
             .await
-            .context(StartFrontendSnafu)?;
+            .context(error::FrontendSnafu)?;
 
         plugins::setup_datanode_plugins(&mut plugins, &plugin_opts, &dn_opts)
             .await
-            .context(StartDatanodeSnafu)?;
+            .context(error::StartDatanodeSnafu)?;
 
-        set_default_timezone(fe_opts.default_timezone.as_deref()).context(InitTimezoneSnafu)?;
+        set_default_timezone(fe_opts.default_timezone.as_deref())
+            .context(error::InitTimezoneSnafu)?;
 
         let data_home = &dn_opts.storage.data_home;
         // Ensure the data_home directory exists.
         fs::create_dir_all(path::Path::new(data_home))
-            .context(CreateDirSnafu { dir: data_home })?;
+            .context(error::CreateDirSnafu { dir: data_home })?;
 
         let metadata_dir = metadata_store_dir(data_home);
         let (kv_backend, procedure_manager) = FeInstance::try_build_standalone_components(
@@ -494,7 +481,7 @@ impl StartCommand {
             opts.procedure,
         )
         .await
-        .context(StartFrontendSnafu)?;
+        .context(error::StartFrontendSnafu)?;
 
         // Builds cache registry
         let layered_cache_builder = LayeredCacheRegistryBuilder::default();
@@ -503,7 +490,7 @@ impl StartCommand {
             with_default_composite_cache_registry(
                 layered_cache_builder.add_cache_registry(fundamental_cache_registry),
             )
-            .context(BuildCacheRegistrySnafu)?
+            .context(error::BuildCacheRegistrySnafu)?
             .build(),
         );
 
@@ -512,7 +499,7 @@ impl StartCommand {
             .with_cache_registry(layered_cache_registry.clone())
             .build()
             .await
-            .context(StartDatanodeSnafu)?;
+            .context(error::StartDatanodeSnafu)?;
 
         let information_extension = Arc::new(StandaloneInformationExtension::new(
             datanode.region_server(),
@@ -545,7 +532,7 @@ impl StartCommand {
                 .build()
                 .await
                 .map_err(BoxedError::new)
-                .context(OtherSnafu)?,
+                .context(error::OtherSnafu)?,
         );
 
         // set the ref to query for the local flow state
@@ -576,7 +563,7 @@ impl StartCommand {
         let kafka_options = opts.wal.clone().into();
         let wal_options_allocator = build_wal_options_allocator(&kafka_options, kv_backend.clone())
             .await
-            .context(BuildWalOptionsAllocatorSnafu)?;
+            .context(error::BuildWalOptionsAllocatorSnafu)?;
         let wal_options_allocator = Arc::new(wal_options_allocator);
         let table_meta_allocator = Arc::new(TableMetadataAllocator::new(
             table_id_sequence,
@@ -597,8 +584,8 @@ impl StartCommand {
         )
         .await?;
 
-        let mut frontend = FrontendBuilder::new(
-            fe_opts,
+        let fe_instance = FrontendBuilder::new(
+            fe_opts.clone(),
             kv_backend.clone(),
             layered_cache_registry.clone(),
             catalog_manager.clone(),
@@ -609,7 +596,8 @@ impl StartCommand {
         .with_plugin(plugins.clone())
         .try_build()
         .await
-        .context(StartFrontendSnafu)?;
+        .context(error::StartFrontendSnafu)?;
+        let fe_instance = Arc::new(fe_instance);
 
         let flow_worker_manager = flownode.flow_worker_manager();
         // flow server need to be able to use frontend to write insert requests back
@@ -622,20 +610,28 @@ impl StartCommand {
             node_manager,
         )
         .await
-        .context(StartFlownodeSnafu)?;
+        .context(error::StartFlownodeSnafu)?;
         flow_worker_manager.set_frontend_invoker(invoker).await;
 
         let (tx, _rx) = broadcast::channel(1);
 
-        let servers = Services::new(opts, Arc::new(frontend.clone()), plugins)
+        let servers = Services::new(opts.clone(), fe_instance.clone(), plugins.clone())
             .build()
             .await
-            .context(StartFrontendSnafu)?;
-        frontend
-            .build_servers(servers)
-            .context(StartFrontendSnafu)?;
+            .context(error::StartFrontendSnafu)?;
 
-        Ok(Instance {
+        let export_metrics_task = ExportMetricsTask::try_new(&opts.export_metrics, Some(&plugins))
+            .context(error::ServersSnafu)?;
+
+        let frontend = Frontend {
+            opts: fe_opts,
+            instance: fe_instance,
+            servers,
+            heartbeat_task: None,
+            export_metrics_task,
+        };
+
+        Ok(StandaloneApp {
             datanode,
             frontend,
             flow_worker_manager,
@@ -670,7 +666,7 @@ impl StartCommand {
                 procedure_manager,
                 true,
             )
-            .context(InitDdlManagerSnafu)?,
+            .context(error::InitDdlManagerSnafu)?,
         );
 
         Ok(procedure_executor)
@@ -684,7 +680,7 @@ impl StartCommand {
         table_metadata_manager
             .init()
             .await
-            .context(InitMetadataSnafu)?;
+            .context(error::InitMetadataSnafu)?;
 
         Ok(table_metadata_manager)
     }

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -293,7 +293,7 @@ impl App for Instance {
         self.frontend
             .shutdown()
             .await
-            .context(error::StartFrontendSnafu)?;
+            .context(error::ShutdownFrontendSnafu)?;
 
         self.procedure_manager
             .stop()

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -275,19 +275,25 @@ impl App for StandaloneApp {
 
         plugins::start_frontend_plugins(self.frontend.instance.plugins().clone())
             .await
-            .context(error::FrontendSnafu)?;
+            .context(error::StartFrontendSnafu)?;
 
         self.flow_worker_manager
             .clone()
             .run_background(Some(self.flow_shutdown.subscribe()));
 
-        self.frontend.start().await.context(error::FrontendSnafu)?;
+        self.frontend
+            .start()
+            .await
+            .context(error::StartFrontendSnafu)?;
 
         Ok(())
     }
 
     async fn stop(&self) -> Result<()> {
-        self.frontend.stop().await.context(error::FrontendSnafu)?;
+        self.frontend
+            .stop()
+            .await
+            .context(error::StartFrontendSnafu)?;
 
         self.procedure_manager
             .stop()
@@ -460,7 +466,7 @@ impl StartCommand {
 
         plugins::setup_frontend_plugins(&mut plugins, &plugin_opts, &fe_opts)
             .await
-            .context(error::FrontendSnafu)?;
+            .context(error::StartFrontendSnafu)?;
 
         plugins::setup_datanode_plugins(&mut plugins, &plugin_opts, &dn_opts)
             .await

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -277,14 +277,14 @@ impl App for Instance {
             .await
             .context(error::StartFrontendSnafu)?;
 
-        self.flow_worker_manager
-            .clone()
-            .run_background(Some(self.flow_shutdown.subscribe()));
-
         self.frontend
             .start()
             .await
             .context(error::StartFrontendSnafu)?;
+
+        self.flow_worker_manager
+            .clone()
+            .run_background(Some(self.flow_shutdown.subscribe()));
 
         Ok(())
     }

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -88,7 +88,7 @@ pub struct Command {
 }
 
 impl Command {
-    pub async fn build(&self, opts: GreptimeOptions<StandaloneOptions>) -> Result<StandaloneApp> {
+    pub async fn build(&self, opts: GreptimeOptions<StandaloneOptions>) -> Result<Instance> {
         self.subcmd.build(opts).await
     }
 
@@ -106,7 +106,7 @@ enum SubCommand {
 }
 
 impl SubCommand {
-    async fn build(&self, opts: GreptimeOptions<StandaloneOptions>) -> Result<StandaloneApp> {
+    async fn build(&self, opts: GreptimeOptions<StandaloneOptions>) -> Result<Instance> {
         match self {
             SubCommand::Start(cmd) => cmd.build(opts).await,
         }
@@ -242,7 +242,7 @@ impl StandaloneOptions {
     }
 }
 
-pub struct StandaloneApp {
+pub struct Instance {
     datanode: Datanode,
     frontend: Frontend,
     // TODO(discord9): wrapped it in flownode instance instead
@@ -255,7 +255,7 @@ pub struct StandaloneApp {
 }
 
 #[async_trait]
-impl App for StandaloneApp {
+impl App for Instance {
     fn name(&self) -> &str {
         APP_NAME
     }
@@ -443,7 +443,7 @@ impl StartCommand {
     #[allow(unused_variables)]
     #[allow(clippy::diverging_sub_expression)]
     /// Build GreptimeDB instance with the loaded options.
-    pub async fn build(&self, opts: GreptimeOptions<StandaloneOptions>) -> Result<StandaloneApp> {
+    pub async fn build(&self, opts: GreptimeOptions<StandaloneOptions>) -> Result<Instance> {
         common_runtime::init_global_runtimes(&opts.runtime);
 
         let guard = common_telemetry::init_global_logging(
@@ -636,7 +636,7 @@ impl StartCommand {
             export_metrics_task,
         };
 
-        Ok(StandaloneApp {
+        Ok(Instance {
             datanode,
             frontend,
             flow_worker_manager,

--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -93,6 +93,8 @@ impl Configurable for FrontendOptions {
     }
 }
 
+/// The [`Frontend`] struct is the main entry point for the frontend service
+/// which contains server handlers, frontend instance and some background tasks.
 pub struct Frontend {
     pub instance: Arc<Instance>,
     pub servers: ServerHandlers,

--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -12,17 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_base::readable_size::ReadableSize;
 use common_config::config::Configurable;
 use common_options::datanode::DatanodeClientOptions;
 use common_telemetry::logging::{LoggingOptions, TracingOptions};
 use meta_client::MetaClientOptions;
 use serde::{Deserialize, Serialize};
-use servers::export_metrics::ExportMetricsOption;
+use servers::export_metrics::{ExportMetricsOption, ExportMetricsTask};
 use servers::grpc::GrpcOptions;
 use servers::heartbeat_options::HeartbeatOptions;
 use servers::http::HttpOptions;
+use servers::server::ServerHandlers;
+use snafu::ResultExt;
 
+use crate::error;
+use crate::error::Result;
+use crate::heartbeat::HeartbeatTask;
+use crate::instance::prom_store::ExportMetricHandler;
+use crate::instance::Instance;
 use crate::service_config::{
     InfluxdbOptions, JaegerOptions, MysqlOptions, OpentsdbOptions, OtlpOptions, PostgresOptions,
     PromStoreOptions,
@@ -81,6 +90,45 @@ impl Default for FrontendOptions {
 impl Configurable for FrontendOptions {
     fn env_list_keys() -> Option<&'static [&'static str]> {
         Some(&["meta_client.metasrv_addrs"])
+    }
+}
+
+pub struct Frontend {
+    pub opts: FrontendOptions,
+    pub instance: Arc<Instance>,
+    pub servers: ServerHandlers,
+    pub heartbeat_task: Option<HeartbeatTask>,
+    pub export_metrics_task: Option<ExportMetricsTask>,
+}
+
+impl Frontend {
+    pub async fn start(&self) -> Result<()> {
+        if let Some(t) = &self.heartbeat_task {
+            t.start().await?;
+        }
+
+        if let Some(t) = self.export_metrics_task.as_ref() {
+            if t.send_by_handler {
+                let inserter = self.instance.inserter().clone();
+                let statement_executor = self.instance.statement_executor().clone();
+                let handler = ExportMetricHandler::new_handler(inserter, statement_executor);
+                t.start(Some(handler)).context(error::StartServerSnafu)?
+            } else {
+                t.start(None).context(error::StartServerSnafu)?;
+            }
+        }
+
+        self.servers
+            .start_all()
+            .await
+            .context(error::StartServerSnafu)
+    }
+
+    pub async fn stop(&self) -> Result<()> {
+        self.servers
+            .shutdown_all()
+            .await
+            .context(error::ShutdownServerSnafu)
     }
 }
 

--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -94,7 +94,6 @@ impl Configurable for FrontendOptions {
 }
 
 pub struct Frontend {
-    pub opts: FrontendOptions,
     pub instance: Arc<Instance>,
     pub servers: ServerHandlers,
     pub heartbeat_task: Option<HeartbeatTask>,
@@ -124,7 +123,7 @@ impl Frontend {
             .context(error::StartServerSnafu)
     }
 
-    pub async fn stop(&self) -> Result<()> {
+    pub async fn shutdown(&self) -> Result<()> {
         self.servers
             .shutdown_all()
             .await

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -155,7 +155,7 @@ impl Instance {
     }
 
     pub fn plugins(&self) -> &Plugins {
-        &&self.plugins
+        &self.plugins
     }
 
     pub fn statement_executor(&self) -> &StatementExecutorRef {

--- a/src/frontend/src/instance/builder.rs
+++ b/src/frontend/src/instance/builder.rs
@@ -35,12 +35,10 @@ use partition::manager::PartitionRuleManager;
 use pipeline::pipeline_operator::PipelineOperator;
 use query::stats::StatementStatistics;
 use query::QueryEngineFactory;
-use servers::server::ServerHandlers;
 use snafu::OptionExt;
 
 use crate::error::{self, Result};
 use crate::frontend::FrontendOptions;
-use crate::heartbeat::HeartbeatTask;
 use crate::instance::region_query::FrontendRegionQueryHandler;
 use crate::instance::Instance;
 use crate::limiter::Limiter;
@@ -55,7 +53,6 @@ pub struct FrontendBuilder {
     node_manager: NodeManagerRef,
     plugins: Option<Plugins>,
     procedure_executor: ProcedureExecutorRef,
-    heartbeat_task: Option<HeartbeatTask>,
     stats: StatementStatistics,
 }
 
@@ -78,7 +75,6 @@ impl FrontendBuilder {
             node_manager,
             plugins: None,
             procedure_executor,
-            heartbeat_task: None,
             stats,
         }
     }
@@ -93,13 +89,6 @@ impl FrontendBuilder {
     pub fn with_plugin(self, plugins: Plugins) -> Self {
         Self {
             plugins: Some(plugins),
-            ..self
-        }
-    }
-
-    pub fn with_heartbeat_task(self, heartbeat_task: HeartbeatTask) -> Self {
-        Self {
-            heartbeat_task: Some(heartbeat_task),
             ..self
         }
     }
@@ -202,17 +191,13 @@ impl FrontendBuilder {
             });
 
         Ok(Instance {
-            options: self.options,
             catalog_manager: self.catalog_manager,
             pipeline_operator,
             statement_executor,
             query_engine,
             plugins,
-            servers: ServerHandlers::default(),
-            heartbeat_task: self.heartbeat_task,
             inserter,
             deleter,
-            export_metrics_task: None,
             table_metadata_manager: Arc::new(TableMetadataManager::new(kv_backend)),
             stats: self.stats,
             limiter,

--- a/src/frontend/src/server.rs
+++ b/src/frontend/src/server.rs
@@ -36,26 +36,24 @@ use snafu::ResultExt;
 
 use crate::error::{self, Result, StartServerSnafu, TomlFormatSnafu};
 use crate::frontend::FrontendOptions;
-use crate::instance::FrontendInstance;
+use crate::instance::Instance;
 
-pub struct Services<T, U>
+pub struct Services<T>
 where
     T: Into<FrontendOptions> + Configurable + Clone,
-    U: FrontendInstance,
 {
     opts: T,
-    instance: Arc<U>,
+    instance: Arc<Instance>,
     grpc_server_builder: Option<GrpcServerBuilder>,
     http_server_builder: Option<HttpServerBuilder>,
     plugins: Plugins,
 }
 
-impl<T, U> Services<T, U>
+impl<T> Services<T>
 where
     T: Into<FrontendOptions> + Configurable + Clone,
-    U: FrontendInstance,
 {
-    pub fn new(opts: T, instance: Arc<U>, plugins: Plugins) -> Self {
+    pub fn new(opts: T, instance: Arc<Instance>, plugins: Plugins) -> Self {
         Self {
             opts,
             instance,

--- a/tests-integration/src/cluster.rs
+++ b/tests-integration/src/cluster.rs
@@ -48,6 +48,7 @@ use datanode::datanode::{Datanode, DatanodeBuilder, ProcedureConfig};
 use frontend::frontend::{Frontend, FrontendOptions};
 use frontend::heartbeat::HeartbeatTask;
 use frontend::instance::builder::FrontendBuilder;
+use frontend::instance::Instance as FeInstance;
 use hyper_util::rt::TokioIo;
 use meta_client::client::MetaClientBuilder;
 use meta_srv::cluster::MetaPeerClientRef;
@@ -79,6 +80,12 @@ pub struct GreptimeDbCluster {
     pub kv_backend: KvBackendRef,
     pub metasrv: Arc<Metasrv>,
     pub frontend: Arc<Frontend>,
+}
+
+impl GreptimeDbCluster {
+    pub fn fe_instance(&self) -> &Arc<FeInstance> {
+        &self.frontend.instance
+    }
 }
 
 pub struct GreptimeDbClusterBuilder {
@@ -404,7 +411,7 @@ impl GreptimeDbClusterBuilder {
         );
 
         let instance = FrontendBuilder::new(
-            options.clone(),
+            options,
             cached_meta_backend.clone(),
             cache_registry.clone(),
             catalog_manager,
@@ -419,7 +426,6 @@ impl GreptimeDbClusterBuilder {
         let instance = Arc::new(instance);
 
         Frontend {
-            opts: options,
             instance,
             servers: ServerHandlers::new(),
             heartbeat_task: Some(heartbeat_task),

--- a/tests-integration/src/grpc.rs
+++ b/tests-integration/src/grpc.rs
@@ -61,7 +61,7 @@ mod test {
         let standalone = GreptimeDbStandaloneBuilder::new("test_standalone_handle_ddl_request")
             .build()
             .await;
-        let instance = &standalone.instance;
+        let instance = standalone.fe_instance();
 
         test_handle_ddl_request(instance.as_ref()).await;
     }
@@ -83,7 +83,7 @@ mod test {
             GreptimeDbStandaloneBuilder::new("test_standalone_handle_multi_ddl_request")
                 .build()
                 .await;
-        let instance = &standalone.instance;
+        let instance = standalone.fe_instance();
 
         test_handle_multi_ddl_request(instance.as_ref()).await;
     }
@@ -478,7 +478,7 @@ CREATE TABLE {table_name} (
         let standalone = GreptimeDbStandaloneBuilder::new("test_standalone_insert_and_query")
             .build()
             .await;
-        let instance = &standalone.instance;
+        let instance = standalone.fe_instance();
 
         let table_name = "my_table";
         let sql = format!("CREATE TABLE {table_name} (a INT, b STRING, c JSON, ts TIMESTAMP, TIME INDEX (ts), PRIMARY KEY (a, b, c))");
@@ -1053,7 +1053,7 @@ CREATE TABLE {table_name} (
         let standalone = GreptimeDbStandaloneBuilder::new("test_standalone_promql_query")
             .build()
             .await;
-        let instance = &standalone.instance;
+        let instance = standalone.fe_instance();
 
         let table_name = "my_table";
         let sql = format!("CREATE TABLE {table_name} (h string, a double, ts TIMESTAMP, TIME INDEX (ts), PRIMARY KEY(h))");

--- a/tests-integration/src/instance.rs
+++ b/tests-integration/src/instance.rs
@@ -49,7 +49,7 @@ mod tests {
         let standalone = GreptimeDbStandaloneBuilder::new("test_standalone_exec_sql")
             .build()
             .await;
-        let instance = standalone.instance.as_ref();
+        let instance = standalone.fe_instance();
 
         let sql = r#"
             CREATE TABLE demo(
@@ -350,7 +350,7 @@ mod tests {
             .with_plugin(plugins)
             .build()
             .await;
-        let instance = standalone.instance;
+        let instance = standalone.fe_instance().clone();
 
         let sql = r#"CREATE TABLE demo(
                             host STRING,
@@ -412,7 +412,7 @@ mod tests {
             .with_plugin(plugins)
             .build()
             .await;
-        let instance = standalone.instance;
+        let instance = standalone.fe_instance().clone();
 
         let sql = r#"CREATE TABLE demo(
                             host STRING,

--- a/tests-integration/src/opentsdb.rs
+++ b/tests-integration/src/opentsdb.rs
@@ -33,7 +33,7 @@ mod tests {
         let standalone = GreptimeDbStandaloneBuilder::new("test_standalone_exec")
             .build()
             .await;
-        let instance = &standalone.instance;
+        let instance = standalone.fe_instance();
 
         test_exec(instance).await;
     }

--- a/tests-integration/src/otlp.rs
+++ b/tests-integration/src/otlp.rs
@@ -37,7 +37,7 @@ mod test {
         let standalone = GreptimeDbStandaloneBuilder::new("test_standalone_otlp")
             .build()
             .await;
-        let instance = &standalone.instance;
+        let instance = standalone.fe_instance();
 
         test_otlp(instance).await;
     }

--- a/tests-integration/src/prom_store.rs
+++ b/tests-integration/src/prom_store.rs
@@ -41,7 +41,7 @@ mod tests {
         )
         .build()
         .await;
-        let instance = &standalone.instance;
+        let instance = standalone.fe_instance();
 
         test_prom_store_remote_rw(instance, None).await;
     }
@@ -64,7 +64,7 @@ mod tests {
         )
         .build()
         .await;
-        let instance = &standalone.instance;
+        let instance = standalone.fe_instance();
 
         test_prom_store_remote_rw(instance, Some("my_custom_physical_table".to_string())).await;
     }

--- a/tests-integration/src/standalone.rs
+++ b/tests-integration/src/standalone.rs
@@ -259,8 +259,7 @@ impl GreptimeDbStandaloneBuilder {
         test_util::prepare_another_catalog_and_schema(&instance).await;
 
         let frontend = Frontend {
-            opts: opts.frontend_options(),
-            instance,
+            instance: instance.clone(),
             servers: ServerHandlers::new(),
             heartbeat_task: None,
             export_metrics_task: None,
@@ -269,7 +268,7 @@ impl GreptimeDbStandaloneBuilder {
         frontend.start().await.unwrap();
 
         GreptimeDbStandalone {
-            instance: frontend.instance.clone(),
+            instance,
             opts,
             guard,
             kv_backend,

--- a/tests-integration/src/tests.rs
+++ b/tests-integration/src/tests.rs
@@ -30,7 +30,7 @@ pub struct MockDistributedInstance(GreptimeDbCluster);
 
 impl MockDistributedInstance {
     pub fn frontend(&self) -> Arc<Instance> {
-        self.0.frontend.clone()
+        self.0.frontend.instance.clone()
     }
 
     pub fn datanodes(&self) -> &HashMap<u64, Datanode> {

--- a/tests-integration/src/tests.rs
+++ b/tests-integration/src/tests.rs
@@ -30,7 +30,7 @@ pub struct MockDistributedInstance(GreptimeDbCluster);
 
 impl MockDistributedInstance {
     pub fn frontend(&self) -> Arc<Instance> {
-        self.0.frontend.instance.clone()
+        self.0.fe_instance().clone()
     }
 
     pub fn datanodes(&self) -> &HashMap<u64, Datanode> {

--- a/tests-integration/src/tests/test_util.rs
+++ b/tests-integration/src/tests/test_util.rs
@@ -81,7 +81,7 @@ impl MockInstance for MockInstanceImpl {
     fn frontend(&self) -> Arc<Instance> {
         match self {
             MockInstanceImpl::Standalone(instance) => instance.frontend(),
-            MockInstanceImpl::Distributed(instance) => instance.frontend.clone(),
+            MockInstanceImpl::Distributed(instance) => instance.frontend.instance.clone(),
         }
     }
 

--- a/tests-integration/src/tests/test_util.rs
+++ b/tests-integration/src/tests/test_util.rs
@@ -47,7 +47,7 @@ pub trait MockInstance: Sync + Send {
 
 impl MockInstance for GreptimeDbStandalone {
     fn frontend(&self) -> Arc<Instance> {
-        self.instance.clone()
+        self.fe_instance().clone()
     }
 
     fn is_distributed_mode(&self) -> bool {

--- a/tests-integration/src/tests/test_util.rs
+++ b/tests-integration/src/tests/test_util.rs
@@ -81,7 +81,7 @@ impl MockInstance for MockInstanceImpl {
     fn frontend(&self) -> Arc<Instance> {
         match self {
             MockInstanceImpl::Standalone(instance) => instance.frontend(),
-            MockInstanceImpl::Distributed(instance) => instance.frontend.instance.clone(),
+            MockInstanceImpl::Distributed(instance) => instance.fe_instance().clone(),
         }
     }
 

--- a/tests-integration/tests/region_migration.rs
+++ b/tests-integration/tests/region_migration.rs
@@ -143,7 +143,7 @@ pub async fn test_region_migration(store_type: StorageType, endpoints: Vec<Strin
     let table_id = prepare_testing_table(&cluster).await;
 
     // Inserts data
-    let results = insert_values(&cluster.frontend, logical_timer).await;
+    let results = insert_values(&cluster.frontend.instance, logical_timer).await;
     logical_timer += 1000;
     for result in results {
         assert!(matches!(result.unwrap().data, OutputData::AffectedRows(1)));
@@ -204,13 +204,13 @@ pub async fn test_region_migration(store_type: StorageType, endpoints: Vec<Strin
     .await;
 
     // Inserts more table.
-    let results = insert_values(&cluster.frontend, logical_timer).await;
+    let results = insert_values(&cluster.frontend.instance, logical_timer).await;
     for result in results {
         assert!(matches!(result.unwrap().data, OutputData::AffectedRows(1)));
     }
 
     // Asserts the writes.
-    assert_values(&cluster.frontend).await;
+    assert_values(&cluster.frontend.instance).await;
 
     // Triggers again.
     let procedure = region_migration_manager
@@ -278,7 +278,7 @@ pub async fn test_metric_table_region_migration_by_sql(
 
     // Inserts values
     run_sql(
-        &cluster.frontend,
+        &cluster.frontend.instance,
         r#"INSERT INTO t1 VALUES ('host1',0, 0), ('host2', 1, 1);"#,
         query_ctx.clone(),
     )
@@ -286,7 +286,7 @@ pub async fn test_metric_table_region_migration_by_sql(
     .unwrap();
 
     run_sql(
-        &cluster.frontend,
+        &cluster.frontend.instance,
         r#"INSERT INTO t2 VALUES ('job1', 0, 0), ('job2', 1, 1);"#,
         query_ctx.clone(),
     )
@@ -310,7 +310,7 @@ pub async fn test_metric_table_region_migration_by_sql(
     info!("Started region procedure: {}!", procedure_id);
 
     // Waits condition by checking procedure state
-    let frontend = cluster.frontend.clone();
+    let frontend = cluster.frontend.instance.clone();
     wait_condition(
         Duration::from_secs(10),
         Box::pin(async move {
@@ -330,6 +330,7 @@ pub async fn test_metric_table_region_migration_by_sql(
 
     let result = cluster
         .frontend
+        .instance
         .do_query("select * from t1", query_ctx.clone())
         .await
         .remove(0);
@@ -345,6 +346,7 @@ pub async fn test_metric_table_region_migration_by_sql(
 
     let result = cluster
         .frontend
+        .instance
         .do_query("select * from t2", query_ctx)
         .await
         .remove(0);
@@ -409,7 +411,7 @@ pub async fn test_region_migration_by_sql(store_type: StorageType, endpoints: Ve
     let table_id = prepare_testing_table(&cluster).await;
 
     // Inserts data
-    let results = insert_values(&cluster.frontend, logical_timer).await;
+    let results = insert_values(&cluster.frontend.instance, logical_timer).await;
     logical_timer += 1000;
     for result in results {
         assert!(matches!(result.unwrap().data, OutputData::AffectedRows(1)));
@@ -446,7 +448,7 @@ pub async fn test_region_migration_by_sql(store_type: StorageType, endpoints: Ve
         Duration::from_secs(10),
         Box::pin(async move {
             loop {
-                let state = query_procedure_by_sql(&frontend, &procedure_id).await;
+                let state = query_procedure_by_sql(&frontend.instance, &procedure_id).await;
                 if state == "{\"status\":\"Done\"}" {
                     info!("Migration done: {state}");
                     break;
@@ -460,13 +462,13 @@ pub async fn test_region_migration_by_sql(store_type: StorageType, endpoints: Ve
     .await;
 
     // Inserts more table.
-    let results = insert_values(&cluster.frontend, logical_timer).await;
+    let results = insert_values(&cluster.frontend.instance, logical_timer).await;
     for result in results {
         assert!(matches!(result.unwrap().data, OutputData::AffectedRows(1)));
     }
 
     // Asserts the writes.
-    assert_values(&cluster.frontend).await;
+    assert_values(&cluster.frontend.instance).await;
 
     // Triggers again.
     let procedure = region_migration_manager
@@ -539,7 +541,7 @@ pub async fn test_region_migration_multiple_regions(
     let table_id = prepare_testing_table(&cluster).await;
 
     // Inserts data
-    let results = insert_values(&cluster.frontend, logical_timer).await;
+    let results = insert_values(&cluster.frontend.instance, logical_timer).await;
     logical_timer += 1000;
     for result in results {
         assert!(matches!(result.unwrap().data, OutputData::AffectedRows(1)));
@@ -610,13 +612,13 @@ pub async fn test_region_migration_multiple_regions(
     .await;
 
     // Inserts more table.
-    let results = insert_values(&cluster.frontend, logical_timer).await;
+    let results = insert_values(&cluster.frontend.instance, logical_timer).await;
     for result in results {
         assert!(matches!(result.unwrap().data, OutputData::AffectedRows(1)));
     }
 
     // Asserts the writes.
-    assert_values(&cluster.frontend).await;
+    assert_values(&cluster.frontend.instance).await;
 
     // Triggers again.
     let procedure = region_migration_manager
@@ -682,7 +684,7 @@ pub async fn test_region_migration_all_regions(store_type: StorageType, endpoint
     let table_id = prepare_testing_table(&cluster).await;
 
     // Inserts data
-    let results = insert_values(&cluster.frontend, logical_timer).await;
+    let results = insert_values(&cluster.frontend.instance, logical_timer).await;
     logical_timer += 1000;
     for result in results {
         assert!(matches!(result.unwrap().data, OutputData::AffectedRows(1)));
@@ -746,13 +748,13 @@ pub async fn test_region_migration_all_regions(store_type: StorageType, endpoint
     .await;
 
     // Inserts more table.
-    let results = insert_values(&cluster.frontend, logical_timer).await;
+    let results = insert_values(&cluster.frontend.instance, logical_timer).await;
     for result in results {
         assert!(matches!(result.unwrap().data, OutputData::AffectedRows(1)));
     }
 
     // Asserts the writes.
-    assert_values(&cluster.frontend).await;
+    assert_values(&cluster.frontend.instance).await;
 
     // Triggers again.
     let procedure = region_migration_manager
@@ -820,7 +822,7 @@ pub async fn test_region_migration_incorrect_from_peer(
     let table_id = prepare_testing_table(&cluster).await;
 
     // Inserts data
-    let results = insert_values(&cluster.frontend, logical_timer).await;
+    let results = insert_values(&cluster.frontend.instance, logical_timer).await;
     for result in results {
         assert!(matches!(result.unwrap().data, OutputData::AffectedRows(1)));
     }
@@ -902,7 +904,7 @@ pub async fn test_region_migration_incorrect_region_id(
     let table_id = prepare_testing_table(&cluster).await;
 
     // Inserts data
-    let results = insert_values(&cluster.frontend, logical_timer).await;
+    let results = insert_values(&cluster.frontend.instance, logical_timer).await;
     for result in results {
         assert!(matches!(result.unwrap().data, OutputData::AffectedRows(1)));
     }
@@ -986,22 +988,35 @@ async fn assert_values(instance: &Arc<Instance>) {
 
 async fn prepare_testing_metric_table(cluster: &GreptimeDbCluster) -> TableId {
     let sql = r#"CREATE TABLE phy (ts timestamp time index, val double) engine=metric with ("physical_metric_table" = "");"#;
-    let mut result = cluster.frontend.do_query(sql, QueryContext::arc()).await;
+    let mut result = cluster
+        .frontend
+        .instance
+        .do_query(sql, QueryContext::arc())
+        .await;
     let output = result.remove(0).unwrap();
     assert!(matches!(output.data, OutputData::AffectedRows(0)));
 
     let sql = r#"CREATE TABLE t1 (ts timestamp time index, val double, host string primary key) engine = metric with ("on_physical_table" = "phy");"#;
-    let mut result = cluster.frontend.do_query(sql, QueryContext::arc()).await;
+    let mut result = cluster
+        .frontend
+        .instance
+        .do_query(sql, QueryContext::arc())
+        .await;
     let output = result.remove(0).unwrap();
     assert!(matches!(output.data, OutputData::AffectedRows(0)));
 
     let sql = r#"CREATE TABLE t2 (ts timestamp time index, job string primary key, val double) engine = metric with ("on_physical_table" = "phy");"#;
-    let mut result = cluster.frontend.do_query(sql, QueryContext::arc()).await;
+    let mut result = cluster
+        .frontend
+        .instance
+        .do_query(sql, QueryContext::arc())
+        .await;
     let output = result.remove(0).unwrap();
     assert!(matches!(output.data, OutputData::AffectedRows(0)));
 
     let table = cluster
         .frontend
+        .instance
         .catalog_manager()
         .table(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, "phy", None)
         .await
@@ -1022,12 +1037,17 @@ async fn prepare_testing_table(cluster: &GreptimeDbCluster) -> TableId {
         i > 50
     )"
     );
-    let mut result = cluster.frontend.do_query(&sql, QueryContext::arc()).await;
+    let mut result = cluster
+        .frontend
+        .instance
+        .do_query(&sql, QueryContext::arc())
+        .await;
     let output = result.remove(0).unwrap();
     assert!(matches!(output.data, OutputData::AffectedRows(0)));
 
     let table = cluster
         .frontend
+        .instance
         .catalog_manager()
         .table(
             DEFAULT_CATALOG_NAME,
@@ -1061,7 +1081,7 @@ async fn find_region_distribution_by_sql(
     let query_ctx = QueryContext::arc();
 
     let OutputData::Stream(stream) = run_sql(
-        &cluster.frontend,
+        &cluster.frontend.instance,
         &format!(
             r#"select b.peer_id as datanode_id,
                            a.greptime_partition_id as region_id
@@ -1114,7 +1134,7 @@ async fn trigger_migration_by_sql(
     to_peer_id: u64,
 ) -> String {
     let OutputData::RecordBatches(recordbatches) = run_sql(
-        &cluster.frontend,
+        &cluster.frontend.instance,
         &format!("admin migrate_region({region_id}, {from_peer_id}, {to_peer_id})"),
         QueryContext::arc(),
     )

--- a/tests-integration/tests/region_migration.rs
+++ b/tests-integration/tests/region_migration.rs
@@ -143,7 +143,7 @@ pub async fn test_region_migration(store_type: StorageType, endpoints: Vec<Strin
     let table_id = prepare_testing_table(&cluster).await;
 
     // Inserts data
-    let results = insert_values(&cluster.frontend.instance, logical_timer).await;
+    let results = insert_values(cluster.fe_instance(), logical_timer).await;
     logical_timer += 1000;
     for result in results {
         assert!(matches!(result.unwrap().data, OutputData::AffectedRows(1)));
@@ -204,13 +204,13 @@ pub async fn test_region_migration(store_type: StorageType, endpoints: Vec<Strin
     .await;
 
     // Inserts more table.
-    let results = insert_values(&cluster.frontend.instance, logical_timer).await;
+    let results = insert_values(cluster.fe_instance(), logical_timer).await;
     for result in results {
         assert!(matches!(result.unwrap().data, OutputData::AffectedRows(1)));
     }
 
     // Asserts the writes.
-    assert_values(&cluster.frontend.instance).await;
+    assert_values(cluster.fe_instance()).await;
 
     // Triggers again.
     let procedure = region_migration_manager
@@ -278,7 +278,7 @@ pub async fn test_metric_table_region_migration_by_sql(
 
     // Inserts values
     run_sql(
-        &cluster.frontend.instance,
+        cluster.fe_instance(),
         r#"INSERT INTO t1 VALUES ('host1',0, 0), ('host2', 1, 1);"#,
         query_ctx.clone(),
     )
@@ -286,7 +286,7 @@ pub async fn test_metric_table_region_migration_by_sql(
     .unwrap();
 
     run_sql(
-        &cluster.frontend.instance,
+        cluster.fe_instance(),
         r#"INSERT INTO t2 VALUES ('job1', 0, 0), ('job2', 1, 1);"#,
         query_ctx.clone(),
     )
@@ -310,7 +310,7 @@ pub async fn test_metric_table_region_migration_by_sql(
     info!("Started region procedure: {}!", procedure_id);
 
     // Waits condition by checking procedure state
-    let frontend = cluster.frontend.instance.clone();
+    let frontend = cluster.fe_instance().clone();
     wait_condition(
         Duration::from_secs(10),
         Box::pin(async move {
@@ -411,7 +411,7 @@ pub async fn test_region_migration_by_sql(store_type: StorageType, endpoints: Ve
     let table_id = prepare_testing_table(&cluster).await;
 
     // Inserts data
-    let results = insert_values(&cluster.frontend.instance, logical_timer).await;
+    let results = insert_values(cluster.fe_instance(), logical_timer).await;
     logical_timer += 1000;
     for result in results {
         assert!(matches!(result.unwrap().data, OutputData::AffectedRows(1)));
@@ -443,12 +443,12 @@ pub async fn test_region_migration_by_sql(store_type: StorageType, endpoints: Ve
     info!("Started region procedure: {}!", procedure_id);
 
     // Waits condition by checking procedure state
-    let frontend = cluster.frontend.clone();
+    let frontend = cluster.fe_instance().clone();
     wait_condition(
         Duration::from_secs(10),
         Box::pin(async move {
             loop {
-                let state = query_procedure_by_sql(&frontend.instance, &procedure_id).await;
+                let state = query_procedure_by_sql(&frontend, &procedure_id).await;
                 if state == "{\"status\":\"Done\"}" {
                     info!("Migration done: {state}");
                     break;
@@ -462,13 +462,13 @@ pub async fn test_region_migration_by_sql(store_type: StorageType, endpoints: Ve
     .await;
 
     // Inserts more table.
-    let results = insert_values(&cluster.frontend.instance, logical_timer).await;
+    let results = insert_values(cluster.fe_instance(), logical_timer).await;
     for result in results {
         assert!(matches!(result.unwrap().data, OutputData::AffectedRows(1)));
     }
 
     // Asserts the writes.
-    assert_values(&cluster.frontend.instance).await;
+    assert_values(cluster.fe_instance()).await;
 
     // Triggers again.
     let procedure = region_migration_manager
@@ -541,7 +541,7 @@ pub async fn test_region_migration_multiple_regions(
     let table_id = prepare_testing_table(&cluster).await;
 
     // Inserts data
-    let results = insert_values(&cluster.frontend.instance, logical_timer).await;
+    let results = insert_values(cluster.fe_instance(), logical_timer).await;
     logical_timer += 1000;
     for result in results {
         assert!(matches!(result.unwrap().data, OutputData::AffectedRows(1)));
@@ -612,13 +612,13 @@ pub async fn test_region_migration_multiple_regions(
     .await;
 
     // Inserts more table.
-    let results = insert_values(&cluster.frontend.instance, logical_timer).await;
+    let results = insert_values(cluster.fe_instance(), logical_timer).await;
     for result in results {
         assert!(matches!(result.unwrap().data, OutputData::AffectedRows(1)));
     }
 
     // Asserts the writes.
-    assert_values(&cluster.frontend.instance).await;
+    assert_values(cluster.fe_instance()).await;
 
     // Triggers again.
     let procedure = region_migration_manager
@@ -684,7 +684,7 @@ pub async fn test_region_migration_all_regions(store_type: StorageType, endpoint
     let table_id = prepare_testing_table(&cluster).await;
 
     // Inserts data
-    let results = insert_values(&cluster.frontend.instance, logical_timer).await;
+    let results = insert_values(cluster.fe_instance(), logical_timer).await;
     logical_timer += 1000;
     for result in results {
         assert!(matches!(result.unwrap().data, OutputData::AffectedRows(1)));
@@ -748,13 +748,13 @@ pub async fn test_region_migration_all_regions(store_type: StorageType, endpoint
     .await;
 
     // Inserts more table.
-    let results = insert_values(&cluster.frontend.instance, logical_timer).await;
+    let results = insert_values(cluster.fe_instance(), logical_timer).await;
     for result in results {
         assert!(matches!(result.unwrap().data, OutputData::AffectedRows(1)));
     }
 
     // Asserts the writes.
-    assert_values(&cluster.frontend.instance).await;
+    assert_values(cluster.fe_instance()).await;
 
     // Triggers again.
     let procedure = region_migration_manager
@@ -822,7 +822,7 @@ pub async fn test_region_migration_incorrect_from_peer(
     let table_id = prepare_testing_table(&cluster).await;
 
     // Inserts data
-    let results = insert_values(&cluster.frontend.instance, logical_timer).await;
+    let results = insert_values(cluster.fe_instance(), logical_timer).await;
     for result in results {
         assert!(matches!(result.unwrap().data, OutputData::AffectedRows(1)));
     }
@@ -904,7 +904,7 @@ pub async fn test_region_migration_incorrect_region_id(
     let table_id = prepare_testing_table(&cluster).await;
 
     // Inserts data
-    let results = insert_values(&cluster.frontend.instance, logical_timer).await;
+    let results = insert_values(cluster.fe_instance(), logical_timer).await;
     for result in results {
         assert!(matches!(result.unwrap().data, OutputData::AffectedRows(1)));
     }
@@ -1081,7 +1081,7 @@ async fn find_region_distribution_by_sql(
     let query_ctx = QueryContext::arc();
 
     let OutputData::Stream(stream) = run_sql(
-        &cluster.frontend.instance,
+        cluster.fe_instance(),
         &format!(
             r#"select b.peer_id as datanode_id,
                            a.greptime_partition_id as region_id
@@ -1134,7 +1134,7 @@ async fn trigger_migration_by_sql(
     to_peer_id: u64,
 ) -> String {
     let OutputData::RecordBatches(recordbatches) = run_sql(
-        &cluster.frontend.instance,
+        cluster.fe_instance(),
         &format!("admin migrate_region({region_id}, {from_peer_id}, {to_peer_id})"),
         QueryContext::arc(),
     )


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

### Motivation

Currently, it looks like there might be a circular reference like this: [Instance](https://github.com/GreptimeTeam/greptimedb/blob/a0739a96e418147129528e5eff8a689b309a6f9d/src/frontend/src/instance.rs#L116) -> [Servers](https://github.com/GreptimeTeam/greptimedb/blob/a0739a96e418147129528e5eff8a689b309a6f9d/src/frontend/src/instance.rs#L123) -> [Instance](https://github.com/GreptimeTeam/greptimedb/blob/a0739a96e418147129528e5eff8a689b309a6f9d/src/frontend/src/instance.rs#L116). However, digging deeper into the code, find that we maintain two instances, one instance contains all servers, and the other instance does not have any servers. The instance without servers is passed to the servers, so the circular reference is eliminated, but it is confusing. The related code see [here](https://github.com/GreptimeTeam/greptimedb/blob/main/src/cmd/src/frontend.rs#L375-L381).

### What has changed 

1. Added a new structure, `Frontend`, which is responsible for starting and stopping services. It contains `Instance`, `Servers`, and some background tasks.
2. Remove `servers` and some background tasks from `Instance` struct. The `Instance` has only become the implementation of various `xxx handler `traits.
3. Finally `Frontend -> Servers -> Instance`, it make sense.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
