### PR TITLE
feat: add/correct some kafka-related metrics

### DIFF
--- a/src/log-store/src/kafka/producer.rs
+++ b/src/log-store/src/kafka/producer.rs
@@ -24,7 +24,10 @@ use tokio::sync::mpsc::{self, Receiver, Sender};
 use crate::error::{self, Result};
 use crate::kafka::index::IndexCollector;
 use crate::kafka::worker::{BackgroundProducerWorker, ProduceResultHandle, WorkerRequest};
-use crate::metrics::{METRIC_KAFKA_CLIENT_BYTES_TOTAL, METRIC_KAFKA_CLIENT_TRAFFIC_TOTAL};
+use crate::metrics::{
+    METRIC_KAFKA_CLIENT_BYTES_TOTAL, METRIC_KAFKA_CLIENT_PRODUCE_ELAPSED,
+    METRIC_KAFKA_CLIENT_TRAFFIC_TOTAL,
+};
 
 pub type OrderedBatchProducerRef = Arc<OrderedBatchProducer>;
 
@@ -115,6 +118,9 @@ impl ProducerClient for PartitionClient {
         METRIC_KAFKA_CLIENT_TRAFFIC_TOTAL
             .with_label_values(&[self.topic(), &partition])
             .inc();
+        let _timer = METRIC_KAFKA_CLIENT_PRODUCE_ELAPSED
+            .with_label_values(&[self.topic(), &partition])
+            .start_timer();
 
         self.produce(records, compression).await
     }

--- a/src/log-store/src/kafka/producer.rs
+++ b/src/log-store/src/kafka/producer.rs
@@ -110,10 +110,10 @@ impl ProducerClient for PartitionClient {
         let total_size = records.iter().map(|r| r.approximate_size()).sum::<usize>();
         let partition = self.partition().to_string();
         METRIC_KAFKA_CLIENT_BYTES_TOTAL
-            .with_label_values(&[&self.topic(), &partition])
+            .with_label_values(&[self.topic(), &partition])
             .inc_by(total_size as u64);
         METRIC_KAFKA_CLIENT_TRAFIC_TOTAL
-            .with_label_values(&[&self.topic(), &partition])
+            .with_label_values(&[self.topic(), &partition])
             .inc_by(total_size as u64);
 
         self.produce(records, compression).await

--- a/src/log-store/src/kafka/producer.rs
+++ b/src/log-store/src/kafka/producer.rs
@@ -24,7 +24,7 @@ use tokio::sync::mpsc::{self, Receiver, Sender};
 use crate::error::{self, Result};
 use crate::kafka::index::IndexCollector;
 use crate::kafka::worker::{BackgroundProducerWorker, ProduceResultHandle, WorkerRequest};
-use crate::metrics::{METRIC_KAFKA_CLIENT_BYTES_TOTAL, METRIC_KAFKA_CLIENT_TRAFIC_TOTAL};
+use crate::metrics::{METRIC_KAFKA_CLIENT_BYTES_TOTAL, METRIC_KAFKA_CLIENT_TRAFFIC_TOTAL};
 
 pub type OrderedBatchProducerRef = Arc<OrderedBatchProducer>;
 
@@ -112,9 +112,9 @@ impl ProducerClient for PartitionClient {
         METRIC_KAFKA_CLIENT_BYTES_TOTAL
             .with_label_values(&[self.topic(), &partition])
             .inc_by(total_size as u64);
-        METRIC_KAFKA_CLIENT_TRAFIC_TOTAL
+        METRIC_KAFKA_CLIENT_TRAFFIC_TOTAL
             .with_label_values(&[self.topic(), &partition])
-            .inc_by(total_size as u64);
+            .inc();
 
         self.produce(records, compression).await
     }

--- a/src/log-store/src/metrics.rs
+++ b/src/log-store/src/metrics.rs
@@ -73,8 +73,8 @@ lazy_static! {
         &[LOGSTORE_LABEL, PARTITION_LABEL],
     )
     .unwrap();
-    pub static ref METRIC_KAFKA_CLIENT_TRAFIC_TOTAL: IntCounterVec = register_int_counter_vec!(
-        "greptime_logstore_kafka_client_trafic_total",
+    pub static ref METRIC_KAFKA_CLIENT_TRAFFIC_TOTAL: IntCounterVec = register_int_counter_vec!(
+        "greptime_logstore_kafka_client_traffic_total",
         "kafka logstore's request count traffic total",
         &[LOGSTORE_LABEL, PARTITION_LABEL],
     )

--- a/src/log-store/src/metrics.rs
+++ b/src/log-store/src/metrics.rs
@@ -19,6 +19,10 @@ use prometheus::*;
 pub const LOGSTORE_LABEL: &str = "logstore";
 /// Operation type label.
 pub const OPTYPE_LABEL: &str = "optype";
+/// Kafka topic label.
+pub const TOPIC_LABEL: &str = "topic";
+/// Kafka partition label.
+pub const PARTITION_LABEL: &str = "partition";
 
 lazy_static! {
     /// Counters of bytes of each operation on a logstore.
@@ -62,4 +66,17 @@ lazy_static! {
     /// Timer of the append_batch operation on the raft-engine logstore.
     /// This timer only measures the duration of the read operation, not measures the total duration of replay.
     pub static ref METRIC_RAFT_ENGINE_READ_ELAPSED: Histogram = METRIC_LOGSTORE_OP_ELAPSED.with_label_values(&["raft-engine", "read"]);
+
+    pub static ref METRIC_KAFKA_CLIENT_BYTES_TOTAL: IntCounterVec = register_int_counter_vec!(
+        "greptime_logstore_kafka_client_bytes_total",
+        "kafka logstore's bytes traffic total",
+        &[LOGSTORE_LABEL, PARTITION_LABEL],
+    )
+    .unwrap();
+    pub static ref METRIC_KAFKA_CLIENT_TRAFIC_TOTAL: IntCounterVec = register_int_counter_vec!(
+        "greptime_logstore_kafka_client_trafic_total",
+        "kafka logstore's request count traffic total",
+        &[LOGSTORE_LABEL, PARTITION_LABEL],
+    )
+    .unwrap();
 }

--- a/src/log-store/src/metrics.rs
+++ b/src/log-store/src/metrics.rs
@@ -79,4 +79,10 @@ lazy_static! {
         &[LOGSTORE_LABEL, PARTITION_LABEL],
     )
     .unwrap();
+    pub static ref METRIC_KAFKA_CLIENT_PRODUCE_ELAPSED: HistogramVec = register_histogram_vec!(
+        "greptime_logstore_kafka_client_produce_elapsed",
+        "kafka logstore produce operation elapsed",
+        &[LOGSTORE_LABEL, PARTITION_LABEL],
+    )
+    .unwrap();
 }

--- a/src/store-api/src/logstore/entry.rs
+++ b/src/store-api/src/logstore/entry.rs
@@ -57,8 +57,9 @@ pub struct NaiveEntry {
 }
 
 impl NaiveEntry {
+    /// Estimates the persisted size of the entry.
     fn estimated_size(&self) -> usize {
-        size_of::<Self>() + self.data.capacity() * size_of::<u8>()
+        size_of::<Self>() + self.data.len() * size_of::<u8>()
     }
 }
 
@@ -84,14 +85,15 @@ impl MultiplePartEntry {
             && self.headers.contains(&MultiplePartHeader::Last)
     }
 
+    /// Estimates the persisted size of the entry.
     fn estimated_size(&self) -> usize {
         size_of::<Self>()
             + self
                 .parts
                 .iter()
-                .map(|data| data.capacity() * size_of::<u8>())
+                .map(|data| data.len() * size_of::<u8>())
                 .sum::<usize>()
-            + self.headers.capacity() * size_of::<MultiplePartHeader>()
+            + self.headers.len() * size_of::<MultiplePartHeader>()
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


- Use actual used data structure's size instead of allocated memory size (`.len()` vs. `.capacity()`)
- Add per-partition traffic and workload metrics

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
