### PR TITLE
fix: properly give placeholder types

### DIFF
--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -195,6 +195,7 @@ impl MysqlInstanceShim {
 
         let params = if let Some(plan) = &mut plan {
             fix_placeholder_types(plan)?;
+            debug!("Plan after fix placeholder types: {:#?}", plan);
             prepared_params(
                 &plan
                     .get_parameter_types()

--- a/tests/cases/standalone/common/prepare/mysql_prepare.result
+++ b/tests/cases/standalone/common/prepare/mysql_prepare.result
@@ -13,16 +13,16 @@ affected_rows: 0
 -- SQLNESS PROTOCOL MYSQL
 EXECUTE stmt USING 1;
 
-+----------+
-| Int64(1) |
-+----------+
-| 1        |
-+----------+
++----+
+| $1 |
++----+
+| 1  |
++----+
 
 -- SQLNESS PROTOCOL MYSQL
 EXECUTE stmt USING 'a';
 
-Failed to parse query result, err: MySqlError { ERROR 1815 (HY000): (EngineExecuteQuery): Cast error: Cannot cast string 'a' to value of Int32 type }
+Failed to execute query, err: MySqlError { ERROR 1210 (HY000): (InvalidArguments): Invalid request parameter: Column  expect type: Int32(Int32Type), actual: String(StringType) }
 
 -- SQLNESS PROTOCOL MYSQL
 DEALLOCATE stmt;
@@ -59,11 +59,11 @@ affected_rows: 0
 -- SQLNESS PROTOCOL MYSQL
 EXECUTE stmt USING 1, 'hello';
 
-+----------+---------------+
-| Int64(1) | Utf8("hello") |
-+----------+---------------+
-| 1        | hello         |
-+----------+---------------+
++----+-------+
+| $1 | $2    |
++----+-------+
+| 1  | hello |
++----+-------+
 
 -- SQLNESS PROTOCOL MYSQL
 DEALLOCATE stmt;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

properly give placeholder types.

because it seems datafusion will not give data type to placeholder if it need to be cast to certain type(i.e. expr like `cast(placeholder)`, still unknown if this is a feature or a bug. And if a placeholder expr have no data type, datafusion will fail to extract it using `LogicalPlan::get_parameter_types`

After this fix, running the below command with any table in `public`
```
sea-orm-cli generate entity \
    -u mysql://root:root@localhost:4002/public \
    -o src/entities
```
will only cause `sea-orm-cli` to crash, before this command will cause db's thread to panic


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
