### PR TITLE
feat: utilize blob metadata properties

### DIFF
--- a/src/index/src/fulltext_index/create/bloom_filter.rs
+++ b/src/index/src/fulltext_index/create/bloom_filter.rs
@@ -91,7 +91,8 @@ impl FulltextIndexCreator for BloomFilterFulltextIndexCreator {
 
         let (index_finish, puffin_add_blob) = futures::join!(
             creator.finish(tx.compat_write()),
-            puffin_writer.put_blob(blob_key, rx.compat(), put_options)
+            // TODO(zhongzc): add fulltext config properties
+            puffin_writer.put_blob(blob_key, rx.compat(), put_options, Default::default())
         );
 
         match (

--- a/src/index/src/fulltext_index/create/tantivy.rs
+++ b/src/index/src/fulltext_index/create/tantivy.rs
@@ -164,6 +164,8 @@ impl FulltextIndexCreator for TantivyFulltextIndexCreator {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use common_test_util::temp_dir::create_temp_dir;
     use futures::AsyncRead;
     use tantivy::collector::DocSetCollector;
@@ -182,6 +184,7 @@ mod tests {
             _key: &str,
             _raw_data: R,
             _options: PutOptions,
+            _properties: HashMap<String, String>,
         ) -> puffin::error::Result<u64>
         where
             R: AsyncRead + Send,

--- a/src/mito2/src/sst/index/bloom_filter/applier.rs
+++ b/src/mito2/src/sst/index/bloom_filter/applier.rs
@@ -24,7 +24,7 @@ use index::bloom_filter::applier::BloomFilterApplier;
 use index::bloom_filter::reader::{BloomFilterReader, BloomFilterReaderImpl};
 use object_store::ObjectStore;
 use puffin::puffin_manager::cache::PuffinMetadataCacheRef;
-use puffin::puffin_manager::{BlobGuard, PuffinManager, PuffinReader};
+use puffin::puffin_manager::{PuffinManager, PuffinReader};
 use snafu::ResultExt;
 use store_api::storage::{ColumnId, RegionId};
 

--- a/src/mito2/src/sst/index/bloom_filter/creator.rs
+++ b/src/mito2/src/sst/index/bloom_filter/creator.rs
@@ -304,7 +304,12 @@ impl BloomFilterIndexer {
         let blob_name = format!("{}-{}", INDEX_BLOB_TYPE, col_id);
         let (index_finish, puffin_add_blob) = futures::join!(
             creator.finish(tx.compat_write()),
-            puffin_writer.put_blob(&blob_name, rx.compat(), PutOptions::default())
+            puffin_writer.put_blob(
+                &blob_name,
+                rx.compat(),
+                PutOptions::default(),
+                Default::default(),
+            )
         );
 
         match (
@@ -351,7 +356,7 @@ pub(crate) mod tests {
     use index::bloom_filter::reader::{BloomFilterReader, BloomFilterReaderImpl};
     use object_store::services::Memory;
     use object_store::ObjectStore;
-    use puffin::puffin_manager::{BlobGuard, PuffinManager, PuffinReader};
+    use puffin::puffin_manager::{PuffinManager, PuffinReader};
     use store_api::metadata::{ColumnMetadata, RegionMetadataBuilder};
     use store_api::storage::RegionId;
 

--- a/src/mito2/src/sst/index/inverted_index/applier.rs
+++ b/src/mito2/src/sst/index/inverted_index/applier.rs
@@ -24,7 +24,7 @@ use index::inverted_index::search::index_apply::{
 };
 use object_store::ObjectStore;
 use puffin::puffin_manager::cache::PuffinMetadataCacheRef;
-use puffin::puffin_manager::{BlobGuard, PuffinManager, PuffinReader};
+use puffin::puffin_manager::{PuffinManager, PuffinReader};
 use snafu::ResultExt;
 use store_api::storage::RegionId;
 
@@ -250,7 +250,12 @@ mod tests {
         );
         let mut writer = puffin_manager.writer(&file_id).await.unwrap();
         writer
-            .put_blob(INDEX_BLOB_TYPE, Cursor::new(vec![]), Default::default())
+            .put_blob(
+                INDEX_BLOB_TYPE,
+                Cursor::new(vec![]),
+                Default::default(),
+                Default::default(),
+            )
             .await
             .unwrap();
         writer.finish().await.unwrap();
@@ -298,7 +303,12 @@ mod tests {
         );
         let mut writer = puffin_manager.writer(&file_id).await.unwrap();
         writer
-            .put_blob("invalid_blob_type", Cursor::new(vec![]), Default::default())
+            .put_blob(
+                "invalid_blob_type",
+                Cursor::new(vec![]),
+                Default::default(),
+                Default::default(),
+            )
             .await
             .unwrap();
         writer.finish().await.unwrap();

--- a/src/mito2/src/sst/index/inverted_index/creator.rs
+++ b/src/mito2/src/sst/index/inverted_index/creator.rs
@@ -280,7 +280,12 @@ impl InvertedIndexer {
             // TODO(zhongzc): config bitmap type
             self.index_creator
                 .finish(&mut index_writer, index::bitmap::BitmapType::Roaring),
-            puffin_writer.put_blob(INDEX_BLOB_TYPE, rx.compat(), PutOptions::default())
+            puffin_writer.put_blob(
+                INDEX_BLOB_TYPE,
+                rx.compat(),
+                PutOptions::default(),
+                Default::default(),
+            )
         );
 
         match (

--- a/src/mito2/src/sst/index/puffin_manager.rs
+++ b/src/mito2/src/sst/index/puffin_manager.rs
@@ -210,7 +210,12 @@ mod tests {
 
         let mut writer = manager.writer(&file_id).await.unwrap();
         writer
-            .put_blob(blob_key, Cursor::new(raw_data), PutOptions::default())
+            .put_blob(
+                blob_key,
+                Cursor::new(raw_data),
+                PutOptions::default(),
+                Default::default(),
+            )
             .await
             .unwrap();
         let dir_data = create_temp_dir("test_puffin_manager_factory_dir_data_");

--- a/src/puffin/src/puffin_manager/fs_puffin_manager/reader.rs
+++ b/src/puffin/src/puffin_manager/fs_puffin_manager/reader.rs
@@ -102,8 +102,7 @@ where
     }
 
     async fn blob(&self, key: &str) -> Result<BlobWithMetadata<Self::Blob>> {
-        let mut reader: <F as PuffinFileAccessor>::Reader =
-            self.puffin_file_accessor.reader(&self.handle).await?;
+        let mut reader = self.puffin_file_accessor.reader(&self.handle).await?;
         if let Some(file_size_hint) = self.file_size_hint {
             reader.with_file_size_hint(file_size_hint);
         }

--- a/src/puffin/src/puffin_manager/fs_puffin_manager/writer.rs
+++ b/src/puffin/src/puffin_manager/fs_puffin_manager/writer.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 use async_compression::futures::bufread::ZstdEncoder;
@@ -65,7 +65,13 @@ where
     S: Stager,
     W: AsyncWrite + Unpin + Send,
 {
-    async fn put_blob<R>(&mut self, key: &str, raw_data: R, options: PutOptions) -> Result<u64>
+    async fn put_blob<R>(
+        &mut self,
+        key: &str,
+        raw_data: R,
+        options: PutOptions,
+        properties: HashMap<String, String>,
+    ) -> Result<u64>
     where
         R: AsyncRead + Send,
     {
@@ -75,7 +81,7 @@ where
         );
 
         let written_bytes = self
-            .handle_compress(key.to_string(), raw_data, options.compression)
+            .handle_compress(key.to_string(), raw_data, options.compression, properties)
             .await?;
 
         self.blob_keys.insert(key.to_string());
@@ -111,7 +117,12 @@ where
 
             let file_key = Uuid::new_v4().to_string();
             written_bytes += self
-                .handle_compress(file_key.clone(), reader, options.compression)
+                .handle_compress(
+                    file_key.clone(),
+                    reader,
+                    options.compression,
+                    Default::default(),
+                )
                 .await?;
 
             let path = entry.path();
@@ -174,6 +185,7 @@ where
         key: String,
         raw_data: impl AsyncRead + Send,
         compression: Option<CompressionCodec>,
+        properties: HashMap<String, String>,
     ) -> Result<u64> {
         match compression {
             Some(CompressionCodec::Lz4) => UnsupportedCompressionSnafu { codec: "lz4" }.fail(),
@@ -182,7 +194,7 @@ where
                     blob_type: key,
                     compressed_data: ZstdEncoder::new(BufReader::new(raw_data)),
                     compression_codec: compression,
-                    properties: Default::default(),
+                    properties,
                 };
                 self.puffin_file_writer.add_blob(blob).await
             }
@@ -191,7 +203,7 @@ where
                     blob_type: key,
                     compressed_data: raw_data,
                     compression_codec: compression,
-                    properties: Default::default(),
+                    properties,
                 };
                 self.puffin_file_writer.add_blob(blob).await
             }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Adds infrastructure support for reading and writing blob metadata properties in the Puffin. This change prepares for future implementations of storing fulltext index configurations in blob metadata.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
