### PR TITLE
fix: fix region follower procedure

### DIFF
--- a/src/meta-srv/src/procedure/region_follower.rs
+++ b/src/meta-srv/src/procedure/region_follower.rs
@@ -23,12 +23,12 @@ mod test_util;
 
 use common_error::ext::BoxedError;
 use common_meta::cache_invalidator::CacheInvalidatorRef;
-use common_meta::distributed_time_constants;
 use common_meta::key::datanode_table::{DatanodeTableKey, DatanodeTableValue, RegionInfo};
 use common_meta::key::table_route::{PhysicalTableRouteValue, TableRouteValue};
 use common_meta::key::{DeserializedValueWithBytes, TableMetadataManagerRef};
 use common_meta::lock_key::{CatalogLock, RegionLock, SchemaLock, TableLock};
 use common_meta::peer::Peer;
+use common_meta::{distributed_time_constants, DatanodeId};
 use common_procedure::StringKey;
 use serde::{Deserialize, Serialize};
 use snafu::{ensure, OptionExt, ResultExt};
@@ -129,9 +129,9 @@ impl AlterRegionFollowerData {
     pub(crate) async fn load_datanode_table_value(
         &self,
         ctx: &Context,
+        datanode_id: DatanodeId,
     ) -> Result<Option<DatanodeTableValue>> {
         let table_id = self.region_id.table_id();
-        let datanode_id = self.peer_id;
         let datanode_table_key = DatanodeTableKey {
             datanode_id,
             table_id,

--- a/src/meta-srv/src/procedure/region_follower/add_region_follower.rs
+++ b/src/meta-srv/src/procedure/region_follower/add_region_follower.rs
@@ -19,7 +19,7 @@ use common_procedure::{
     Result as ProcedureResult, Status,
 };
 use common_telemetry::info;
-use snafu::ResultExt;
+use snafu::{OptionExt, ResultExt};
 use store_api::storage::RegionId;
 
 use super::create::CreateFollower;
@@ -70,13 +70,21 @@ impl AddRegionFollowerProcedure {
         // loads the table route of the region
         self.data.table_route = self.data.load_table_route(&self.context).await?;
         let region_leader_datanode_id = {
+            // Safety: load table route is done before.
             let table_route = self.data.physical_table_route().unwrap();
             table_route
                 .region_routes
                 .iter()
                 .find(|region_route| region_route.region.id == self.data.region_id)
-                .map(|region_route| region_route.leader_peer.as_ref().unwrap().id)
-                .unwrap_or_default()
+                .context(error::RegionRouteNotFoundSnafu {
+                    region_id: self.data.region_id,
+                })?
+                .leader_peer
+                .as_ref()
+                .context(error::UnexpectedSnafu {
+                    violated: format!("No leader found for region: {}", self.data.region_id),
+                })?
+                .id
         };
 
         // loads the datanode table value

--- a/src/meta-srv/src/procedure/region_follower/add_region_follower.rs
+++ b/src/meta-srv/src/procedure/region_follower/add_region_follower.rs
@@ -67,12 +67,26 @@ impl AddRegionFollowerProcedure {
         // loads the datanode peer and check peer is alive
         self.data.peer = self.data.load_datanode_peer(&self.context).await?;
 
-        // loads the datanode table value
-        self.data.datanode_table_value = self.data.load_datanode_table_value(&self.context).await?;
-
         // loads the table route of the region
         self.data.table_route = self.data.load_table_route(&self.context).await?;
+        let region_leader_datanode_id = {
+            let table_route = self.data.physical_table_route().unwrap();
+            table_route
+                .region_routes
+                .iter()
+                .find(|region_route| region_route.region.id == self.data.region_id)
+                .map(|region_route| region_route.leader_peer.as_ref().unwrap().id)
+                .unwrap_or_default()
+        };
+
+        // loads the datanode table value
+        self.data.datanode_table_value = self
+            .data
+            .load_datanode_table_value(&self.context, region_leader_datanode_id)
+            .await?;
+
         let table_route = self.data.physical_table_route().unwrap();
+
         let datanode_peer = self.data.datanode_peer().unwrap();
 
         // check if the destination peer is already a leader/follower of the region
@@ -111,6 +125,7 @@ impl AddRegionFollowerProcedure {
             "Add region({}) follower procedure is preparing, peer: {datanode_peer:?}",
             self.data.region_id
         );
+        self.data.state = AlterRegionFollowerState::SubmitRequest;
 
         Ok(Status::executing(true))
     }
@@ -126,6 +141,7 @@ impl AddRegionFollowerProcedure {
         create_follower
             .send_open_region_instruction(&self.context, instruction)
             .await?;
+        self.data.state = AlterRegionFollowerState::UpdateMetadata;
 
         Ok(Status::executing(true))
     }
@@ -161,6 +177,7 @@ impl AddRegionFollowerProcedure {
             )
             .await
             .context(error::TableMetadataManagerSnafu)?;
+        self.data.state = AlterRegionFollowerState::InvalidateTableCache;
 
         Ok(Status::executing(true))
     }
@@ -174,7 +191,7 @@ impl AddRegionFollowerProcedure {
             .cache_invalidator
             .invalidate(&ctx, &[CacheIdent::TableId(table_id)])
             .await;
-        Ok(Status::executing(true))
+        Ok(Status::done())
     }
 }
 

--- a/src/meta-srv/src/procedure/region_follower/add_region_follower.rs
+++ b/src/meta-srv/src/procedure/region_follower/add_region_follower.rs
@@ -81,7 +81,7 @@ impl AddRegionFollowerProcedure {
                 })?
                 .leader_peer
                 .as_ref()
-                .context(error::UnexpectedSnafu {
+                .with_context(|| error::UnexpectedSnafu {
                     violated: format!("No leader found for region: {}", self.data.region_id),
                 })?
                 .id

--- a/src/meta-srv/src/procedure/region_follower/remove_region_follower.rs
+++ b/src/meta-srv/src/procedure/region_follower/remove_region_follower.rs
@@ -84,7 +84,7 @@ impl RemoveRegionFollowerProcedure {
                 })?
                 .leader_peer
                 .as_ref()
-                .context(error::UnexpectedSnafu {
+                .with_context(|| error::UnexpectedSnafu {
                     violated: format!("No leader found for region: {}", self.data.region_id),
                 })?
                 .id


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

#5739 
## What's changed and what's your intention?

This PR ensures that the procedure correctly fetches the DatanodeTable from the region leader datanode instead of the specified peer_id. Additionally, it corrects the logic controlling the procedure's state transitions.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
