### PR TITLE
refactor: add time range for jager get operations API

### DIFF
--- a/src/servers/src/http/jaeger.rs
+++ b/src/servers/src/http/jaeger.rs
@@ -50,7 +50,7 @@ pub const JAEGER_QUERY_TABLE_NAME_KEY: &str = "jaeger_query_table_name";
 
 const REF_TYPE_CHILD_OF: &str = "CHILD_OF";
 const SPAN_KIND_TIME_FMTS: [&str; 2] = ["%Y-%m-%d %H:%M:%S%.6f%z", "%Y-%m-%d %H:%M:%S%.9f%z"];
-const JAEGER_TIME_RANGE_FOR_OPERATIONS_HEADER: &str = "x-greptime-jaeger-time-range-for-operations";
+pub const JAEGER_TIME_RANGE_FOR_OPERATIONS_HEADER: &str = "x-greptime-jaeger-query-time-range";
 
 /// JaegerAPIResponse is the response of Jaeger HTTP API.
 /// The original version is `structuredResponse` which is defined in https://github.com/jaegertracing/jaeger/blob/main/cmd/query/app/http_handler.go.

--- a/src/servers/src/http/jaeger.rs
+++ b/src/servers/src/http/jaeger.rs
@@ -16,9 +16,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use axum::extract::{Path, Query, State};
-use axum::http::StatusCode as HttpStatusCode;
+use axum::http::{HeaderMap, StatusCode as HttpStatusCode};
 use axum::response::IntoResponse;
 use axum::Extension;
+use chrono::Utc;
 use common_catalog::consts::PARENT_SPAN_ID_COLUMN;
 use common_error::ext::ErrorExt;
 use common_error::status_code::StatusCode;
@@ -49,6 +50,7 @@ pub const JAEGER_QUERY_TABLE_NAME_KEY: &str = "jaeger_query_table_name";
 
 const REF_TYPE_CHILD_OF: &str = "CHILD_OF";
 const SPAN_KIND_TIME_FMTS: [&str; 2] = ["%Y-%m-%d %H:%M:%S%.6f%z", "%Y-%m-%d %H:%M:%S%.9f%z"];
+const JAEGER_TIME_RANGE_FOR_OPERATIONS_HEADER: &str = "x-greptime-jaeger-time-range-for-operations";
 
 /// JaegerAPIResponse is the response of Jaeger HTTP API.
 /// The original version is `structuredResponse` which is defined in https://github.com/jaegertracing/jaeger/blob/main/cmd/query/app/http_handler.go.
@@ -489,11 +491,20 @@ pub async fn handle_get_operations(
     Query(query_params): Query<JaegerQueryParams>,
     Extension(mut query_ctx): Extension<QueryContext>,
     TraceTableName(table_name): TraceTableName,
+    headers: HeaderMap,
 ) -> impl IntoResponse {
     debug!(
-        "Received Jaeger '/api/operations' request, query_params: {:?}, query_ctx: {:?}",
-        query_params, query_ctx
+        "Received Jaeger '/api/operations' request, query_params: {:?}, query_ctx: {:?}, headers: {:?}",
+        query_params, query_ctx, headers
     );
+
+    let (start, end) = match parse_jaeger_time_range_for_operations(&headers, &query_params) {
+        Ok((start, end)) => (start, end),
+        Err(e) => return error_response(e),
+    };
+
+    debug!("Get operations with start: {:?}, end: {:?}", start, end);
+
     if let Some(service_name) = &query_params.service_name {
         update_query_context(&mut query_ctx, table_name);
         let query_ctx = Arc::new(query_ctx);
@@ -505,7 +516,13 @@ pub async fn handle_get_operations(
             .start_timer();
 
         match handler
-            .get_operations(query_ctx, service_name, query_params.span_kind.as_deref())
+            .get_operations(
+                query_ctx,
+                service_name,
+                query_params.span_kind.as_deref(),
+                start,
+                end,
+            )
             .await
         {
             Ok(output) => match covert_to_records(output).await {
@@ -562,10 +579,11 @@ pub async fn handle_get_operations_by_service(
     Query(query_params): Query<JaegerQueryParams>,
     Extension(mut query_ctx): Extension<QueryContext>,
     TraceTableName(table_name): TraceTableName,
+    headers: HeaderMap,
 ) -> impl IntoResponse {
     debug!(
-        "Received Jaeger '/api/services/{}/operations' request, query_params: {:?}, query_ctx: {:?}",
-        service_name, query_params, query_ctx
+        "Received Jaeger '/api/services/{}/operations' request, query_params: {:?}, query_ctx: {:?}, headers: {:?}",
+        service_name, query_params, query_ctx, headers
     );
 
     update_query_context(&mut query_ctx, table_name);
@@ -577,7 +595,15 @@ pub async fn handle_get_operations_by_service(
         .with_label_values(&[&db, "/api/services"])
         .start_timer();
 
-    match handler.get_operations(query_ctx, &service_name, None).await {
+    let (start, end) = match parse_jaeger_time_range_for_operations(&headers, &query_params) {
+        Ok((start, end)) => (start, end),
+        Err(e) => return error_response(e),
+    };
+
+    match handler
+        .get_operations(query_ctx, &service_name, None, start, end)
+        .await
+    {
         Ok(output) => match covert_to_records(output).await {
             Ok(Some(records)) => match operations_from_records(records, false) {
                 Ok(operations) => {
@@ -969,11 +995,7 @@ fn operations_from_records(
     records: HttpRecordsOutput,
     contain_span_kind: bool,
 ) -> Result<Vec<Operation>> {
-    let expected_schema = vec![
-        (SPAN_NAME_COLUMN, "String"),
-        (SPAN_KIND_COLUMN, "String"),
-        (SERVICE_NAME_COLUMN, "String"),
-    ];
+    let expected_schema = vec![(SPAN_NAME_COLUMN, "String"), (SPAN_KIND_COLUMN, "String")];
     check_schema(&records, &expected_schema)?;
 
     let mut operations = Vec::with_capacity(records.total_rows);
@@ -1062,6 +1084,42 @@ fn convert_string_to_boolean(input: &serde_json::Value) -> Option<serde_json::Va
     }
 
     None
+}
+
+fn parse_jaeger_time_range_for_operations(
+    headers: &HeaderMap,
+    query_params: &JaegerQueryParams,
+) -> Result<(Option<i64>, Option<i64>)> {
+    if let Some(time_range) = headers.get(JAEGER_TIME_RANGE_FOR_OPERATIONS_HEADER) {
+        match time_range.to_str() {
+            Ok(time_range) => match humantime::parse_duration(time_range) {
+                Ok(duration) => {
+                    debug!(
+                        "Get operations with time range: {:?}, duration: {:?}",
+                        time_range, duration
+                    );
+                    let now = Utc::now().timestamp_micros();
+                    Ok((Some(now - duration.as_micros() as i64), Some(now)))
+                }
+                Err(e) => {
+                    error!("Failed to parse time range header: {:?}", e);
+                    Err(InvalidJaegerQuerySnafu {
+                        reason: format!("invalid time range header: {:?}", time_range),
+                    }
+                    .build())
+                }
+            },
+            Err(e) => {
+                error!("Failed to convert time range header to string: {:?}", e);
+                Err(InvalidJaegerQuerySnafu {
+                    reason: format!("invalid time range header: {:?}", time_range),
+                }
+                .build())
+            }
+        }
+    } else {
+        Ok((query_params.start, query_params.end))
+    }
 }
 
 #[cfg(test)]

--- a/src/servers/src/query_handler.rs
+++ b/src/servers/src/query_handler.rs
@@ -189,6 +189,8 @@ pub trait JaegerQueryHandler {
         ctx: QueryContextRef,
         service_name: &str,
         span_kind: Option<&str>,
+        start_time: Option<i64>,
+        end_time: Option<i64>,
     ) -> Result<Output>;
 
     /// Get trace by trace id. It's used for `/api/traces/{trace_id}` API.

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -35,6 +35,7 @@ use serde_json::{json, Value};
 use servers::http::handler::HealthResponse;
 use servers::http::header::constants::GREPTIME_LOG_TABLE_NAME_HEADER_NAME;
 use servers::http::header::{GREPTIME_DB_HEADER_NAME, GREPTIME_TIMEZONE_HEADER_NAME};
+use servers::http::jaeger::JAEGER_TIME_RANGE_FOR_OPERATIONS_HEADER;
 use servers::http::prometheus::{PrometheusJsonResponse, PrometheusResponse};
 use servers::http::result::error_result::ErrorResponse;
 use servers::http::result::greptime_result_v1::GreptimedbV1Response;
@@ -3543,7 +3544,7 @@ pub async fn test_jaeger_query_api_for_trace_v1(store_type: StorageType) {
     let res = client
         .get("/v1/jaeger/api/operations?service=test-jaeger-query-api")
         .header("x-greptime-trace-table-name", "mytable")
-        .header("x-greptime-jaeger-time-range-for-operations", "3 days")
+        .header(JAEGER_TIME_RANGE_FOR_OPERATIONS_HEADER, "3 days")
         .send()
         .await;
     assert_eq!(StatusCode::OK, res.status());

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -3139,10 +3139,10 @@ pub async fn test_jaeger_query_api(store_type: StorageType) {
       "spans": [
         {
           "traceID": "5611dce1bc9ebed65352d99a027b08ea",
-          "spanID": "008421dbbd33a3e9",
-          "operationName": "access-mysql",
+          "spanID": "ffa03416a7b9ea48",
+          "operationName": "access-redis",
           "references": [],
-          "startTime": 1738726754492421,
+          "startTime": 1738726754492422,
           "duration": 100000,
           "tags": [
             {
@@ -3153,7 +3153,7 @@ pub async fn test_jaeger_query_api(store_type: StorageType) {
             {
               "key": "operation.type",
               "type": "string",
-              "value": "access-mysql"
+              "value": "access-redis"
             },
             {
               "key": "otel.scope.name",
@@ -3181,10 +3181,10 @@ pub async fn test_jaeger_query_api(store_type: StorageType) {
         },
         {
           "traceID": "5611dce1bc9ebed65352d99a027b08ea",
-          "spanID": "ffa03416a7b9ea48",
-          "operationName": "access-redis",
+          "spanID": "008421dbbd33a3e9",
+          "operationName": "access-mysql",
           "references": [],
-          "startTime": 1738726754492422,
+          "startTime": 1738726754492421,
           "duration": 100000,
           "tags": [
             {
@@ -3195,7 +3195,7 @@ pub async fn test_jaeger_query_api(store_type: StorageType) {
             {
               "key": "operation.type",
               "type": "string",
-              "value": "access-redis"
+              "value": "access-mysql"
             },
             {
               "key": "otel.scope.name",
@@ -3602,10 +3602,10 @@ pub async fn test_jaeger_query_api_for_trace_v1(store_type: StorageType) {
       "spans": [
         {
           "traceID": "5611dce1bc9ebed65352d99a027b08ea",
-          "spanID": "008421dbbd33a3e9",
-          "operationName": "access-mysql",
+          "spanID": "ffa03416a7b9ea48",
+          "operationName": "access-redis",
           "references": [],
-          "startTime": 1738726754492421,
+          "startTime": 1738726754492422,
           "duration": 100000,
           "tags": [
             {
@@ -3616,7 +3616,7 @@ pub async fn test_jaeger_query_api_for_trace_v1(store_type: StorageType) {
             {
               "key": "operation.type",
               "type": "string",
-              "value": "access-mysql"
+              "value": "access-redis"
             },
             {
               "key": "otel.scope.name",
@@ -3644,10 +3644,10 @@ pub async fn test_jaeger_query_api_for_trace_v1(store_type: StorageType) {
         },
         {
           "traceID": "5611dce1bc9ebed65352d99a027b08ea",
-          "spanID": "ffa03416a7b9ea48",
-          "operationName": "access-redis",
+          "spanID": "008421dbbd33a3e9",
+          "operationName": "access-mysql",
           "references": [],
-          "startTime": 1738726754492422,
+          "startTime": 1738726754492421,
           "duration": 100000,
           "tags": [
             {
@@ -3658,7 +3658,7 @@ pub async fn test_jaeger_query_api_for_trace_v1(store_type: StorageType) {
             {
               "key": "operation.type",
               "type": "string",
-              "value": "access-redis"
+              "value": "access-mysql"
             },
             {
               "key": "otel.scope.name",


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The native Jaeger query API doesn't have a parameter to limit the time range for getting operations(span) for a specific service. When the trace table gets larger, its performance will be terrible.

In this PR, I add the http header `x-greptime-jaeger-time-range-for-operations` to add a time range explicitly. For example:

```
x-greptime-jaeger-time-range-for-operations: 3 days
```

We don't add the time range by default and let the user configure it based on their scenarios.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
