### PR TITLE
feat: add limit for the number of running procedures

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -98,6 +98,7 @@
 | `procedure` | -- | -- | Procedure storage options. |
 | `procedure.max_retry_times` | Integer | `3` | Procedure max retry time. |
 | `procedure.retry_delay` | String | `500ms` | Initial retry delay of procedures, increases exponentially |
+| `procedure.max_running_procedures` | Integer | `128` | Max running procedures.<br/>The maximum number of procedures that can be running at the same time.<br/>If the number of running procedures exceeds this limit, the procedure will be rejected. |
 | `flow` | -- | -- | flow engine options. |
 | `flow.num_workers` | Integer | `0` | The number of flow worker in flownode.<br/>Not setting(or set to 0) this value will use the number of CPU cores divided by 2. |
 | `storage` | -- | -- | The data storage options. |
@@ -328,6 +329,7 @@
 | `procedure.max_retry_times` | Integer | `12` | Procedure max retry time. |
 | `procedure.retry_delay` | String | `500ms` | Initial retry delay of procedures, increases exponentially |
 | `procedure.max_metadata_value_size` | String | `1500KiB` | Auto split large value<br/>GreptimeDB procedure uses etcd as the default metadata storage backend.<br/>The etcd the maximum size of any request is 1.5 MiB<br/>1500KiB = 1536KiB (1.5MiB) - 36KiB (reserved size of key)<br/>Comments out the `max_metadata_value_size`, for don't split large value (no limit). |
+| `procedure.max_running_procedures` | Integer | `128` | Max running procedures.<br/>The maximum number of procedures that can be running at the same time.<br/>If the number of running procedures exceeds this limit, the procedure will be rejected. |
 | `failure_detector` | -- | -- | -- |
 | `failure_detector.threshold` | Float | `8.0` | The threshold value used by the failure detector to determine failure conditions. |
 | `failure_detector.min_std_deviation` | String | `100ms` | The minimum standard deviation of the heartbeat intervals, used to calculate acceptable variations. |

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -79,6 +79,11 @@ retry_delay = "500ms"
 ## Comments out the `max_metadata_value_size`, for don't split large value (no limit).
 max_metadata_value_size = "1500KiB"
 
+## Max running procedures.
+## The maximum number of procedures that can be running at the same time.
+## If the number of running procedures exceeds this limit, the procedure will be rejected.
+max_running_procedures = 128
+
 # Failure detectors options.
 [failure_detector]
 

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -302,6 +302,10 @@ purge_interval = "1m"
 max_retry_times = 3
 ## Initial retry delay of procedures, increases exponentially
 retry_delay = "500ms"
+## Max running procedures.
+## The maximum number of procedures that can be running at the same time.
+## If the number of running procedures exceeds this limit, the procedure will be rejected.
+max_running_procedures = 128
 
 ## flow engine options.
 [flow]

--- a/src/common/procedure/src/error.rs
+++ b/src/common/procedure/src/error.rs
@@ -58,6 +58,13 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display("Too many running procedures, max: {}", max_running_procedures))]
+    TooManyRunningProcedures {
+        max_running_procedures: usize,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Failed to put state, key: '{key}'"))]
     PutState {
         key: String,
@@ -192,7 +199,8 @@ impl ErrorExt for Error {
             | Error::FromJson { .. }
             | Error::WaitWatcher { .. }
             | Error::RetryLater { .. }
-            | Error::RollbackProcedureRecovered { .. } => StatusCode::Internal,
+            | Error::RollbackProcedureRecovered { .. }
+            | Error::TooManyRunningProcedures { .. } => StatusCode::Internal,
 
             Error::RetryTimesExceeded { .. }
             | Error::RollbackTimesExceeded { .. }

--- a/src/common/procedure/src/local/runner.rs
+++ b/src/common/procedure/src/local/runner.rs
@@ -348,24 +348,14 @@ impl Runner {
         &self,
         procedure_id: ProcedureId,
         procedure_state: ProcedureState,
-        mut procedure: BoxedProcedure,
+        procedure: BoxedProcedure,
     ) {
         if self.manager_ctx.contains_procedure(procedure_id) {
             // If the parent has already submitted this procedure, don't submit it again.
             return;
         }
 
-        let mut step = 0;
-        if let Some(loaded_procedure) = self.manager_ctx.load_one_procedure(procedure_id) {
-            // Try to load procedure state from the message to avoid re-run the subprocedure
-            // from initial state.
-            assert_eq!(self.meta.id, loaded_procedure.parent_id.unwrap());
-
-            // Use the dumped procedure from the procedure store.
-            procedure = loaded_procedure.procedure;
-            // Update step number.
-            step = loaded_procedure.step;
-        }
+        let step = 0;
 
         let meta = Arc::new(ProcedureMeta::new(
             procedure_id,

--- a/src/common/procedure/src/options.rs
+++ b/src/common/procedure/src/options.rs
@@ -29,6 +29,8 @@ pub struct ProcedureConfig {
     pub retry_delay: Duration,
     /// `None` stands for no limit.
     pub max_metadata_value_size: Option<ReadableSize>,
+    /// Max running procedures.
+    pub max_running_procedures: usize,
 }
 
 impl Default for ProcedureConfig {
@@ -37,6 +39,7 @@ impl Default for ProcedureConfig {
             max_retry_times: 3,
             retry_delay: Duration::from_millis(500),
             max_metadata_value_size: None,
+            max_running_procedures: 128,
         }
     }
 }

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -118,6 +118,7 @@ impl Instance {
         let manager_config = ManagerConfig {
             max_retry_times: procedure_config.max_retry_times,
             retry_delay: procedure_config.retry_delay,
+            max_running_procedures: procedure_config.max_running_procedures,
             ..Default::default()
         };
         let procedure_manager = Arc::new(LocalManager::new(manager_config, state_store));

--- a/src/log-store/src/error.rs
+++ b/src/log-store/src/error.rs
@@ -15,6 +15,7 @@
 use std::any::Any;
 
 use common_error::ext::ErrorExt;
+use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use common_runtime::error::Error as RuntimeError;
 use serde_json::error::Error as JsonError;
@@ -310,10 +311,72 @@ pub enum Error {
     },
 }
 
+pub type Result<T> = std::result::Result<T, Error>;
+
+fn rskafka_client_error_to_status_code(error: &rskafka::client::error::Error) -> StatusCode {
+    match error {
+        rskafka::client::error::Error::Connection(_)
+        | rskafka::client::error::Error::Request(_)
+        | rskafka::client::error::Error::InvalidResponse(_)
+        | rskafka::client::error::Error::ServerError { .. }
+        | rskafka::client::error::Error::RetryFailed(_) => StatusCode::Internal,
+        rskafka::client::error::Error::Timeout => StatusCode::StorageUnavailable,
+        _ => StatusCode::Internal,
+    }
+}
+
 impl ErrorExt for Error {
     fn as_any(&self) -> &dyn Any {
         self
     }
-}
 
-pub type Result<T> = std::result::Result<T, Error>;
+    fn status_code(&self) -> StatusCode {
+        use Error::*;
+
+        match self {
+            TlsConfig { .. }
+            | InvalidProvider { .. }
+            | IllegalNamespace { .. }
+            | MissingKey { .. }
+            | MissingValue { .. }
+            | OverrideCompactedEntry { .. } => StatusCode::InvalidArguments,
+            StartWalTask { .. }
+            | StopWalTask { .. }
+            | IllegalState { .. }
+            | ResolveKafkaEndpoint { .. }
+            | NoMaxValue { .. }
+            | Cast { .. }
+            | EncodeJson { .. }
+            | DecodeJson { .. }
+            | IllegalSequence { .. }
+            | DiscontinuousLogIndex { .. }
+            | OrderedBatchProducerStopped { .. }
+            | WaitProduceResultReceiver { .. }
+            | WaitDumpIndex { .. }
+            | MetaLengthExceededLimit { .. } => StatusCode::Internal,
+
+            // Object store related errors
+            CreateWriter { .. } | WriteIndex { .. } | ReadIndex { .. } | Io { .. } => {
+                StatusCode::StorageUnavailable
+            }
+            // Raft engine
+            FetchEntry { .. } | RaftEngine { .. } | AddEntryLogBatch { .. } => {
+                StatusCode::StorageUnavailable
+            }
+            // Kafka producer related errors
+            ProduceRecord { error, .. } => match error {
+                rskafka::client::producer::Error::Client(error) => {
+                    rskafka_client_error_to_status_code(error)
+                }
+                rskafka::client::producer::Error::Aggregator(_)
+                | rskafka::client::producer::Error::FlushError(_)
+                | rskafka::client::producer::Error::TooLarge => StatusCode::Internal,
+            },
+            BuildClient { error, .. }
+            | BuildPartitionClient { error, .. }
+            | BatchProduce { error, .. }
+            | GetOffset { error, .. }
+            | ConsumeRecord { error, .. } => rskafka_client_error_to_status_code(error),
+        }
+    }
+}

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -182,6 +182,7 @@ impl Default for MetasrvOptions {
                 // The etcd the maximum size of any request is 1.5 MiB
                 // 1500KiB = 1536KiB (1.5MiB) - 36KiB (reserved size of key)
                 max_metadata_value_size: Some(ReadableSize::kb(1500)),
+                max_running_procedures: 128,
             },
             failure_detector: PhiAccrualFailureDetectorOptions::default(),
             datanode: DatanodeClientOptions::default(),

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -430,6 +430,7 @@ fn build_procedure_manager(
     let manager_config = ManagerConfig {
         max_retry_times: options.procedure.max_retry_times,
         retry_delay: options.procedure.retry_delay,
+        max_running_procedures: options.procedure.max_running_procedures,
         ..Default::default()
     };
     let state_store = KvStateStore::new(kv_backend.clone()).with_max_value_size(

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -1047,11 +1047,10 @@ impl ErrorExt for Error {
         use Error::*;
 
         match self {
-            OpenDal { .. }
-            | ReadParquet { .. }
-            | WriteWal { .. }
-            | ReadWal { .. }
-            | DeleteWal { .. } => StatusCode::StorageUnavailable,
+            OpenDal { .. } | ReadParquet { .. } => StatusCode::StorageUnavailable,
+            WriteWal { source, .. } | ReadWal { source, .. } | DeleteWal { source, .. } => {
+                source.status_code()
+            }
             CompressObject { .. }
             | DecompressObject { .. }
             | SerdeJson { .. }

--- a/tests-integration/src/cluster.rs
+++ b/tests-integration/src/cluster.rs
@@ -191,6 +191,7 @@ impl GreptimeDbClusterBuilder {
                 max_retry_times: 5,
                 retry_delay: Duration::from_secs(1),
                 max_metadata_value_size: None,
+                max_running_procedures: 128,
             },
             wal: self.metasrv_wal_config.clone(),
             server_addr: "127.0.0.1:3002".to_string(),

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -1033,6 +1033,7 @@ purge_interval = "1m"
 [procedure]
 max_retry_times = 3
 retry_delay = "500ms"
+max_running_procedures = 128
 
 [flow]
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#5789
## What's changed and what's your intention?

If we do not impose a limit on the number of procedures, certain scenarios may lead to an uncontrolled increase in their count. **e.g.,** When the metric engine is enabled with remote WAL, if remote WAL becomes unavailable, the upper layer continues to return a "storage unavailable" error. In procedures, such errors trigger retries. Since table creation keeps failing, write operations continuously trigger the auto-create table procedure. Eventually, this leads to metasrv running out of memory.

This PR  
- Adds a limit on the number of running procedures.
- Implements ErrorExt::status_code for log-store to allow fine-grained control over error status codes.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
