### PR TITLE
perf: introduce `simd_json` for parsing ndjson

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4074,6 +4074,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "float_eq"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4608,9 +4617,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4730,6 +4741,16 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "num-traits",
+]
+
+[[package]]
+name = "halfbrown"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2c385c6df70fd180bbb673d93039dbd2cd34e41d782600bdf6e1ca7bce39aa"
+dependencies = [
+ "hashbrown 0.15.2",
+ "serde",
 ]
 
 [[package]]
@@ -5797,10 +5818,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -8360,6 +8382,7 @@ dependencies = [
  "serde",
  "serde_json",
  "session",
+ "simd-json",
  "snafu 0.8.5",
  "sql",
  "table",
@@ -10567,6 +10590,7 @@ dependencies = [
  "serde",
  "serde_json",
  "session",
+ "simd-json",
  "snafu 0.8.5",
  "snap",
  "socket2",
@@ -10703,6 +10727,21 @@ dependencies = [
  "num-traits",
  "paste",
  "wide",
+]
+
+[[package]]
+name = "simd-json"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10b5602e4f1f7d358956f94cac1eff59220f34cf9e26d49f5fde5acef851cbed"
+dependencies = [
+ "getrandom 0.3.2",
+ "halfbrown",
+ "ref-cast",
+ "serde",
+ "serde_json",
+ "simdutf8",
+ "value-trait",
 ]
 
 [[package]]
@@ -13170,6 +13209,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "value-trait"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0508fce11ad19e0aab49ce20b6bec7f8f82902ded31df1c9fc61b90f0eb396b8"
+dependencies = [
+ "float-cmp",
+ "halfbrown",
+ "itoa",
+ "ryu",
+]
+
+[[package]]
 name = "variadics"
 version = "0.0.4"
 source = "git+https://github.com/GreptimeTeam/hydroflow.git?branch=main#b072ee026f97f8537165e1fb247101e0ab2fb320"
@@ -13259,24 +13310,24 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
@@ -13297,9 +13348,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -13307,9 +13358,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13320,9 +13371,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-streams"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,6 +185,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["float_roundtrip"] }
 serde_with = "3"
 shadow-rs = "1.1"
+simd-json = "0.15"
 similar-asserts = "1.6.0"
 smallvec = { version = "1", features = ["serde"] }
 snafu = "0.8"

--- a/src/pipeline/Cargo.toml
+++ b/src/pipeline/Cargo.toml
@@ -52,6 +52,7 @@ query.workspace = true
 regex.workspace = true
 serde_json.workspace = true
 session.workspace = true
+simd-json.workspace = true
 snafu.workspace = true
 sql.workspace = true
 table.workspace = true

--- a/src/pipeline/src/etl.rs
+++ b/src/pipeline/src/etl.rs
@@ -160,6 +160,23 @@ pub fn json_array_to_map(val: Vec<serde_json::Value>) -> Result<Vec<PipelineMap>
     val.into_iter().map(json_to_map).collect()
 }
 
+pub fn simd_json_to_map(val: simd_json::OwnedValue) -> Result<PipelineMap> {
+    match val {
+        simd_json::OwnedValue::Object(map) => {
+            let mut intermediate_state = PipelineMap::new();
+            for (k, v) in map.into_iter() {
+                intermediate_state.insert(k, Value::try_from(v)?);
+            }
+            Ok(intermediate_state)
+        }
+        _ => PrepareValueMustBeObjectSnafu.fail(),
+    }
+}
+
+pub fn simd_json_array_to_map(val: Vec<simd_json::OwnedValue>) -> Result<Vec<PipelineMap>> {
+    val.into_iter().map(simd_json_to_map).collect()
+}
+
 impl Pipeline {
     pub fn exec_mut(&self, val: &mut PipelineMap) -> Result<PipelineExecOutput> {
         for processor in self.processors.iter() {

--- a/src/pipeline/src/etl/value.rs
+++ b/src/pipeline/src/etl/value.rs
@@ -367,6 +367,37 @@ impl std::fmt::Display for Value {
     }
 }
 
+impl TryFrom<simd_json::value::OwnedValue> for Value {
+    type Error = Error;
+
+    fn try_from(v: simd_json::value::OwnedValue) -> Result<Self> {
+        match v {
+            simd_json::value::OwnedValue::Static(v) => match v {
+                simd_json::value::StaticNode::Null => Ok(Value::Null),
+                simd_json::value::StaticNode::Bool(v) => Ok(Value::Boolean(v)),
+                simd_json::value::StaticNode::I64(v) => Ok(Value::Int64(v)),
+                simd_json::value::StaticNode::U64(v) => Ok(Value::Uint64(v)),
+                simd_json::value::StaticNode::F64(v) => Ok(Value::Float64(v)),
+            },
+            simd_json::OwnedValue::String(s) => Ok(Value::String(s.to_string())),
+            simd_json::OwnedValue::Array(values) => {
+                let mut re = Vec::with_capacity(values.len());
+                for v in values.into_iter() {
+                    re.push(Value::try_from(v)?);
+                }
+                Ok(Value::Array(Array { values: re }))
+            }
+            simd_json::OwnedValue::Object(map) => {
+                let mut values = PipelineMap::new();
+                for (k, v) in map.into_iter() {
+                    values.insert(k, Value::try_from(v)?);
+                }
+                Ok(Value::Map(Map { values }))
+            }
+        }
+    }
+}
+
 impl TryFrom<serde_json::Value> for Value {
     type Error = Error;
 

--- a/src/pipeline/src/etl/value.rs
+++ b/src/pipeline/src/etl/value.rs
@@ -379,7 +379,7 @@ impl TryFrom<simd_json::value::OwnedValue> for Value {
                 simd_json::value::StaticNode::U64(v) => Ok(Value::Uint64(v)),
                 simd_json::value::StaticNode::F64(v) => Ok(Value::Float64(v)),
             },
-            simd_json::OwnedValue::String(s) => Ok(Value::String(s.to_string())),
+            simd_json::OwnedValue::String(s) => Ok(Value::String(s)),
             simd_json::OwnedValue::Array(values) => {
                 let mut re = Vec::with_capacity(values.len());
                 for v in values.into_iter() {

--- a/src/pipeline/src/lib.rs
+++ b/src/pipeline/src/lib.rs
@@ -24,8 +24,8 @@ pub use etl::transform::transformer::identity_pipeline;
 pub use etl::transform::GreptimeTransformer;
 pub use etl::value::{Array, Map, Value};
 pub use etl::{
-    json_array_to_map, json_to_map, parse, Content, DispatchedTo, Pipeline, PipelineExecOutput,
-    PipelineMap,
+    json_array_to_map, json_to_map, parse, simd_json_array_to_map, simd_json_to_map, Content,
+    DispatchedTo, Pipeline, PipelineExecOutput, PipelineMap,
 };
 pub use manager::{
     pipeline_operator, table, util, IdentityTimeIndex, PipelineDefinition, PipelineInfo,

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -77,6 +77,7 @@ notify.workspace = true
 object-pool = "0.5"
 once_cell.workspace = true
 openmetrics-parser = "0.4"
+simd-json.workspace = true
 socket2 = "0.5"
 # use crates.io version after current revision is merged in next release
 # opensrv-mysql = "0.7.0"

--- a/src/servers/src/elasticsearch.rs
+++ b/src/servers/src/elasticsearch.rs
@@ -534,7 +534,6 @@ mod tests {
 
         for (input, index, msg_field, expected) in test_cases {
             let requests = parse_bulk_request(input, &index, &msg_field);
-            println!("[DEBUG]requests: {:?}", requests);
             if expected.is_ok() {
                 assert_eq!(requests.unwrap(), expected.unwrap());
             } else {

--- a/src/servers/src/elasticsearch.rs
+++ b/src/servers/src/elasticsearch.rs
@@ -507,13 +507,13 @@ mod tests {
                     LogIngestRequest {
                         table: "logs-generic-default".to_string(),
                         values: vec![
-                            pipeline::json_to_map(json!("172.16.0.1 - - [25/May/2024:20:19:37 +0000] \"GET /contact HTTP/1.1\" 404 162 \"-\" \"Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1\"")).unwrap(),
+                            pipeline::json_to_map(json!({"message": "172.16.0.1 - - [25/May/2024:20:19:37 +0000] \"GET /contact HTTP/1.1\" 404 162 \"-\" \"Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1\""})).unwrap(),
                         ],
                     },
                     LogIngestRequest {
                         table: "logs-generic-default".to_string(),
                         values: vec![
-                            pipeline::json_to_map(json!("10.0.0.1 - - [25/May/2024:20:18:37 +0000] \"GET /images/logo.png HTTP/1.1\" 304 0 \"-\" \"Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:89.0) Gecko/20100101 Firefox/89.0\"")).unwrap(),
+                            pipeline::json_to_map(json!({"message": "10.0.0.1 - - [25/May/2024:20:18:37 +0000] \"GET /images/logo.png HTTP/1.1\" 304 0 \"-\" \"Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:89.0) Gecko/20100101 Firefox/89.0\""})).unwrap(),
                         ],
                     },
                 ]),
@@ -534,6 +534,7 @@ mod tests {
 
         for (input, index, msg_field, expected) in test_cases {
             let requests = parse_bulk_request(input, &index, &msg_field);
+            println!("[DEBUG]requests: {:?}", requests);
             if expected.is_ok() {
                 assert_eq!(requests.unwrap(), expected.unwrap());
             } else {

--- a/src/servers/src/elasticsearch.rs
+++ b/src/servers/src/elasticsearch.rs
@@ -30,7 +30,7 @@ use session::context::{Channel, QueryContext};
 use snafu::{ensure, ResultExt};
 
 use crate::error::{
-    status_code_to_http_status, InvalidElasticsearchInputSnafu, ParseJsonSnafu,
+    status_code_to_http_status, InvalidElasticsearchInputSnafu, ParseJsonSnafu, PipelineSnafu,
     Result as ServersResult,
 };
 use crate::http::event::{ingest_logs_inner, LogIngestRequest, LogIngesterQueryParams, LogState};
@@ -330,6 +330,7 @@ fn parse_bulk_request(
                 }
             );
 
+            let log_value = pipeline::json_to_map(log_value).context(PipelineSnafu)?;
             requests.push(LogIngestRequest {
                 table: index.unwrap_or_else(|| index_from_url.as_ref().unwrap().clone()),
                 values: vec![log_value],
@@ -404,12 +405,12 @@ mod tests {
                     LogIngestRequest {
                         table: "test".to_string(),
                         values: vec![
-                            json!({"foo1": "foo1_value", "bar1": "bar1_value"}),
+                            pipeline::json_to_map(json!({"foo1": "foo1_value", "bar1": "bar1_value"})).unwrap(),
                         ],
                     },
                     LogIngestRequest {
                         table: "test".to_string(),
-                        values: vec![json!({"foo2": "foo2_value", "bar2": "bar2_value"})],
+                        values: vec![pipeline::json_to_map(json!({"foo2": "foo2_value", "bar2": "bar2_value"})).unwrap()],
                     },
                 ]),
             ),
@@ -426,11 +427,11 @@ mod tests {
                 Ok(vec![
                     LogIngestRequest {
                         table: "test".to_string(),
-                        values: vec![json!({"foo1": "foo1_value", "bar1": "bar1_value"})],
+                        values: vec![pipeline::json_to_map(json!({"foo1": "foo1_value", "bar1": "bar1_value"})).unwrap()],
                     },
                     LogIngestRequest {
                         table: "logs".to_string(),
-                        values: vec![json!({"foo2": "foo2_value", "bar2": "bar2_value"})],
+                        values: vec![pipeline::json_to_map(json!({"foo2": "foo2_value", "bar2": "bar2_value"})).unwrap()],
                     },
                 ]),
             ),
@@ -447,11 +448,11 @@ mod tests {
                 Ok(vec![
                     LogIngestRequest {
                         table: "test".to_string(),
-                        values: vec![json!({"foo1": "foo1_value", "bar1": "bar1_value"})],
+                        values: vec![pipeline::json_to_map(json!({"foo1": "foo1_value", "bar1": "bar1_value"})).unwrap()],
                     },
                     LogIngestRequest {
                         table: "logs".to_string(),
-                        values: vec![json!({"foo2": "foo2_value", "bar2": "bar2_value"})],
+                        values: vec![pipeline::json_to_map(json!({"foo2": "foo2_value", "bar2": "bar2_value"})).unwrap()],
                     },
                 ]),
             ),
@@ -467,7 +468,7 @@ mod tests {
                 Ok(vec![
                     LogIngestRequest {
                         table: "test".to_string(),
-                        values: vec![json!({"foo1": "foo1_value", "bar1": "bar1_value"})],
+                        values: vec![pipeline::json_to_map(json!({"foo1": "foo1_value", "bar1": "bar1_value"})).unwrap()],
                     },
                 ]),
             ),
@@ -484,11 +485,11 @@ mod tests {
                 Ok(vec![
                     LogIngestRequest {
                         table: "test".to_string(),
-                        values: vec![json!({"foo1": "foo1_value", "bar1": "bar1_value"})],
+                        values: vec![pipeline::json_to_map(json!({"foo1": "foo1_value", "bar1": "bar1_value"})).unwrap()],
                     },
                     LogIngestRequest {
                         table: "test".to_string(),
-                        values: vec![json!({"foo2": "foo2_value", "bar2": "bar2_value"})],
+                        values: vec![pipeline::json_to_map(json!({"foo2": "foo2_value", "bar2": "bar2_value"})).unwrap()],
                     },
                 ]),
             ),
@@ -506,13 +507,13 @@ mod tests {
                     LogIngestRequest {
                         table: "logs-generic-default".to_string(),
                         values: vec![
-                            json!("172.16.0.1 - - [25/May/2024:20:19:37 +0000] \"GET /contact HTTP/1.1\" 404 162 \"-\" \"Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1\""),
+                            pipeline::json_to_map(json!("172.16.0.1 - - [25/May/2024:20:19:37 +0000] \"GET /contact HTTP/1.1\" 404 162 \"-\" \"Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1\"")).unwrap(),
                         ],
                     },
                     LogIngestRequest {
                         table: "logs-generic-default".to_string(),
                         values: vec![
-                            json!("10.0.0.1 - - [25/May/2024:20:18:37 +0000] \"GET /images/logo.png HTTP/1.1\" 304 0 \"-\" \"Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:89.0) Gecko/20100101 Firefox/89.0\""),
+                            pipeline::json_to_map(json!("10.0.0.1 - - [25/May/2024:20:18:37 +0000] \"GET /images/logo.png HTTP/1.1\" 304 0 \"-\" \"Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:89.0) Gecko/20100101 Firefox/89.0\"")).unwrap(),
                         ],
                     },
                 ]),

--- a/src/servers/src/elasticsearch.rs
+++ b/src/servers/src/elasticsearch.rs
@@ -372,8 +372,8 @@ fn get_log_value_from_msg_field(mut v: Value, msg_field: &str) -> Value {
         match message {
             Value::String(s) => match serde_json::from_str::<Value>(&s) {
                 Ok(s) => s,
-                // If the message is not a valid JSON, just use the original message as the log value.
-                Err(_) => Value::String(s),
+                // If the message is not a valid JSON, return a map with the original message key and value.
+                Err(_) => json!({msg_field: s}),
             },
             // If the message is not a string, just use the original message as the log value.
             _ => message,

--- a/src/servers/src/http/event.rs
+++ b/src/servers/src/http/event.rs
@@ -772,9 +772,11 @@ mod tests {
         let fail_only_wrong =
             extract_pipeline_value_by_content_type(NDJSON_CONTENT_TYPE.clone(), payload, true);
         assert!(fail_only_wrong.is_ok());
-        assert_eq!(
-            fail_only_wrong.unwrap(),
-            pipeline::json_array_to_map(vec![json!({"a": 1}), json!({"c": 1})]).unwrap()
-        );
+
+        let mut map1 = PipelineMap::new();
+        map1.insert("a".to_string(), pipeline::Value::Uint64(1));
+        let mut map2 = PipelineMap::new();
+        map2.insert("c".to_string(), pipeline::Value::Uint64(1));
+        assert_eq!(fail_only_wrong.unwrap(), vec![map1, map2]);
     }
 }

--- a/src/servers/src/http/event.rs
+++ b/src/servers/src/http/event.rs
@@ -606,7 +606,7 @@ fn extract_pipeline_value_by_content_type(
                     }
                 };
 
-                if let Ok(v) = unsafe { simd_json::to_owned_value(line.as_mut_vec()) } {
+                if let Ok(v) = simd_json::to_owned_value(unsafe { line.as_bytes_mut() }) {
                     let v = pipeline::simd_json_to_map(v).context(PipelineSnafu)?;
                     result.push(v);
                 } else if !ignore_errors {

--- a/src/servers/src/http/event.rs
+++ b/src/servers/src/http/event.rs
@@ -606,6 +606,8 @@ fn extract_pipeline_value_by_content_type(
                     }
                 };
 
+                // simd_json, according to description, only de-escapes string at character level,
+                // like any other json parser. So it should be safe here.
                 if let Ok(v) = simd_json::to_owned_value(unsafe { line.as_bytes_mut() }) {
                     let v = pipeline::simd_json_to_map(v).context(PipelineSnafu)?;
                     result.push(v);

--- a/src/servers/src/interceptor.rs
+++ b/src/servers/src/interceptor.rs
@@ -23,8 +23,8 @@ use common_error::ext::ErrorExt;
 use common_query::Output;
 use datafusion_expr::LogicalPlan;
 use log_query::LogQuery;
+use pipeline::PipelineMap;
 use query::parser::PromQuery;
-use serde_json::Value;
 use session::context::QueryContextRef;
 use sql::statements::statement::Statement;
 
@@ -385,9 +385,9 @@ pub trait LogIngestInterceptor {
     /// Called before pipeline execution.
     fn pre_pipeline(
         &self,
-        values: Vec<Value>,
+        values: Vec<PipelineMap>,
         _query_ctx: QueryContextRef,
-    ) -> Result<Vec<Value>, Self::Error> {
+    ) -> Result<Vec<PipelineMap>, Self::Error> {
         Ok(values)
     }
 
@@ -412,9 +412,9 @@ where
 
     fn pre_pipeline(
         &self,
-        values: Vec<Value>,
+        values: Vec<PipelineMap>,
         query_ctx: QueryContextRef,
-    ) -> Result<Vec<Value>, Self::Error> {
+    ) -> Result<Vec<PipelineMap>, Self::Error> {
         if let Some(this) = self {
             this.pre_pipeline(values, query_ctx)
         } else {

--- a/src/servers/src/lib.rs
+++ b/src/servers/src/lib.rs
@@ -18,6 +18,7 @@
 #![feature(let_chains)]
 #![feature(if_let_guard)]
 #![feature(trait_upcasting)]
+#![feature(slice_as_array)]
 
 use datafusion_expr::LogicalPlan;
 use datatypes::schema::Schema;

--- a/src/servers/src/lib.rs
+++ b/src/servers/src/lib.rs
@@ -18,7 +18,6 @@
 #![feature(let_chains)]
 #![feature(if_let_guard)]
 #![feature(trait_upcasting)]
-#![feature(slice_as_array)]
 
 use datafusion_expr::LogicalPlan;
 use datatypes::schema::Schema;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

As the title suggests. For reference, to load 10 x 100M data under the JSONBench scene
- before: 49,502 ms
- after: 37,620 ms

Note ⚠️: For positive integer numbers, `serde_json` will try to convert them into `int64` while `simd_json` will try to convert them into `uint64`. In most cases, we think it's ok.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
