### PR TITLE
fix: correct error status code

### DIFF
--- a/src/partition/src/error.rs
+++ b/src/partition/src/error.rs
@@ -178,8 +178,8 @@ pub enum Error {
 impl ErrorExt for Error {
     fn status_code(&self) -> StatusCode {
         match self {
-            Error::GetCache { .. } | Error::FindLeader { .. } => StatusCode::StorageUnavailable,
-            Error::FindRegionRoutes { .. } => StatusCode::RegionNotReady,
+            Error::GetCache { .. } => StatusCode::StorageUnavailable,
+            Error::FindLeader { .. } => StatusCode::TableUnavailable,
 
             Error::ConjunctExprWithNonExpr { .. }
             | Error::UnclosedValue { .. }
@@ -194,9 +194,10 @@ impl ErrorExt for Error {
             | Error::SerializeJson { .. }
             | Error::DeserializeJson { .. } => StatusCode::Internal,
 
-            Error::Unexpected { .. } => StatusCode::Unexpected,
-            Error::InvalidTableRouteData { .. } => StatusCode::TableUnavailable,
-            Error::FindTableRoutes { .. } => StatusCode::TableUnavailable,
+            Error::Unexpected { .. }
+            | Error::InvalidTableRouteData { .. }
+            | Error::FindTableRoutes { .. }
+            | Error::FindRegionRoutes { .. } => StatusCode::Unexpected,
             Error::TableRouteNotFound { .. } => StatusCode::TableNotFound,
             Error::TableRouteManager { source, .. } => source.status_code(),
             Error::UnexpectedLogicalRouteTable { source, .. } => source.status_code(),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The errors `InvalidTableRouteData` and `FindTableRoutes` should not be classified as `TableUnavailable` (Table is temporarily unable to handle the request.). These errors will persist even after retries, making `Unexpected` (Unexpected error, maybe there is a BUG.) a more appropriate classification. 

And, the error `FindLeader` should be classified as `TableUnavailable`, the error `FindRegionRoutes` should be 
classified as `Unexpected ` instead of `RegionNotReady`.

```rust
        ensure!(
            !region_routes.is_empty(),
            error::FindTableRoutesSnafu { table_id }
        );
...


    ensure!(
        partitions
            .windows(2)
            .all(|w| w[0].partition.partition_columns() == w[1].partition.partition_columns()),
        error::InvalidTableRouteDataSnafu {
            table_id,
            err_msg: "partition columns of all regions are not the same"
        }
    );

...
        router::find_region_leader(region_routes, region_id.region_number()).context(
            FindLeaderSnafu {
                region_id,
                table_id: region_id.table_id(),
            },
        )

...
    for r in region_routes {
        let partition = r
            .region
            .partition
            .as_ref()
            .context(error::FindRegionRoutesSnafu {
                region_id: r.region.id,
                table_id,
            })?;
```

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
