### PR TITLE
refactor: remove mode option in configuration files

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -12,7 +12,6 @@
 
 | Key | Type | Default | Descriptions |
 | --- | -----| ------- | ----------- |
-| `mode` | String | `standalone` | The running mode of the datanode. It can be `standalone` or `distributed`. |
 | `default_timezone` | String | Unset | The default timezone of the server. |
 | `init_regions_in_background` | Bool | `false` | Initialize all regions in the background during the startup.<br/>By default, it provides services after all regions have been initialized. |
 | `init_regions_parallelism` | Integer | `16` | Parallelism of initializing regions. |
@@ -383,7 +382,6 @@
 
 | Key | Type | Default | Descriptions |
 | --- | -----| ------- | ----------- |
-| `mode` | String | `standalone` | The running mode of the datanode. It can be `standalone` or `distributed`. |
 | `node_id` | Integer | Unset | The datanode identifier and should be unique in the cluster. |
 | `require_lease_before_startup` | Bool | `false` | Start services after regions have obtained leases.<br/>It will block the datanode start if it can't receive leases in the heartbeat from metasrv. |
 | `init_regions_in_background` | Bool | `false` | Initialize all regions in the background during the startup.<br/>By default, it provides services after all regions have been initialized. |
@@ -553,7 +551,6 @@
 
 | Key | Type | Default | Descriptions |
 | --- | -----| ------- | ----------- |
-| `mode` | String | `distributed` | The running mode of the flownode. It can be `standalone` or `distributed`. |
 | `node_id` | Integer | Unset | The flownode identifier and should be unique in the cluster. |
 | `flow` | -- | -- | flow engine options. |
 | `flow.num_workers` | Integer | `0` | The number of flow worker in flownode.<br/>Not setting(or set to 0) this value will use the number of CPU cores divided by 2. |

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -1,6 +1,3 @@
-## The running mode of the datanode. It can be `standalone` or `distributed`.
-mode = "standalone"
-
 ## The datanode identifier and should be unique in the cluster.
 ## @toml2docs:none-default
 node_id = 42

--- a/config/flownode.example.toml
+++ b/config/flownode.example.toml
@@ -1,6 +1,3 @@
-## The running mode of the flownode. It can be `standalone` or `distributed`.
-mode = "distributed"
-
 ## The flownode identifier and should be unique in the cluster.
 ## @toml2docs:none-default
 node_id = 14

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -1,6 +1,3 @@
-## The running mode of the datanode. It can be `standalone` or `distributed`.
-mode = "standalone"
-
 ## The default timezone of the server.
 ## @toml2docs:none-default
 default_timezone = "UTC"

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -520,6 +520,7 @@ mod tests {
             #[cfg(feature = "tokio-console")]
             tokio_console_addr: None,
         });
+        // Missing node_id.
         assert_matches!(result, Err(crate::error::Error::MissingConfig { .. }));
 
         cmd.node_id = Some(42);

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -30,7 +30,7 @@ use datanode::datanode::{Datanode, DatanodeBuilder};
 use datanode::service::DatanodeServiceBuilder;
 use meta_client::{MetaClientOptions, MetaClientType};
 use servers::Mode;
-use snafu::{OptionExt, ResultExt};
+use snafu::{ensure, OptionExt, ResultExt};
 use tracing_appender::non_blocking::WorkerGuard;
 
 use crate::error::{
@@ -223,15 +223,14 @@ impl StartCommand {
                 .get_or_insert_with(MetaClientOptions::default)
                 .metasrv_addrs
                 .clone_from(metasrv_addrs);
-            opts.mode = Mode::Distributed;
         }
 
-        if let (Mode::Distributed, None) = (&opts.mode, &opts.node_id) {
-            return MissingConfigSnafu {
-                msg: "Missing node id option",
+        ensure!(
+            opts.node_id.is_some(),
+            MissingConfigSnafu {
+                msg: "Missing node id option"
             }
-            .fail();
-        }
+        );
 
         if let Some(data_home) = &self.data_home {
             opts.storage.data_home.clone_from(data_home);
@@ -314,7 +313,7 @@ impl StartCommand {
                 .build(),
         );
 
-        let mut datanode = DatanodeBuilder::new(opts.clone(), plugins)
+        let mut datanode = DatanodeBuilder::new(opts.clone(), plugins, Mode::Distributed)
             .with_meta_client(meta_client)
             .with_kv_backend(meta_backend)
             .with_cache_registry(layered_cache_registry)
@@ -336,6 +335,7 @@ impl StartCommand {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches::assert_matches;
     use std::io::Write;
     use std::time::Duration;
 
@@ -343,7 +343,6 @@ mod tests {
     use common_test_util::temp_dir::create_named_temp_file;
     use datanode::config::{FileConfig, GcsConfig, ObjectStoreConfig, S3Config};
     use servers::heartbeat_options::HeartbeatOptions;
-    use servers::Mode;
 
     use super::*;
     use crate::options::GlobalOptions;
@@ -494,22 +493,6 @@ mod tests {
 
     #[test]
     fn test_try_from_cmd() {
-        let opt = StartCommand::default()
-            .load_options(&GlobalOptions::default())
-            .unwrap()
-            .component;
-        assert_eq!(Mode::Standalone, opt.mode);
-
-        let opt = (StartCommand {
-            node_id: Some(42),
-            metasrv_addrs: Some(vec!["127.0.0.1:3002".to_string()]),
-            ..Default::default()
-        })
-        .load_options(&GlobalOptions::default())
-        .unwrap()
-        .component;
-        assert_eq!(Mode::Distributed, opt.mode);
-
         assert!((StartCommand {
             metasrv_addrs: Some(vec!["127.0.0.1:3002".to_string()]),
             ..Default::default()
@@ -528,7 +511,18 @@ mod tests {
 
     #[test]
     fn test_load_log_options_from_cli() {
-        let cmd = StartCommand::default();
+        let mut cmd = StartCommand::default();
+
+        let result = cmd.load_options(&GlobalOptions {
+            log_dir: Some("./greptimedb_data/test/logs".to_string()),
+            log_level: Some("debug".to_string()),
+
+            #[cfg(feature = "tokio-console")]
+            tokio_console_addr: None,
+        });
+        assert_matches!(result, Err(crate::error::Error::MissingConfig { .. }));
+
+        cmd.node_id = Some(42);
 
         let options = cmd
             .load_options(&GlobalOptions {

--- a/src/cmd/src/flownode.rs
+++ b/src/cmd/src/flownode.rs
@@ -34,8 +34,7 @@ use common_telemetry::logging::TracingOptions;
 use common_version::{short_version, version};
 use flow::{FlownodeBuilder, FlownodeInstance, FrontendInvoker};
 use meta_client::{MetaClientOptions, MetaClientType};
-use servers::Mode;
-use snafu::{OptionExt, ResultExt};
+use snafu::{ensure, OptionExt, ResultExt};
 use tracing_appender::non_blocking::WorkerGuard;
 
 use crate::error::{
@@ -203,7 +202,6 @@ impl StartCommand {
                 .get_or_insert_with(MetaClientOptions::default)
                 .metasrv_addrs
                 .clone_from(metasrv_addrs);
-            opts.mode = Mode::Distributed;
         }
 
         if let Some(http_addr) = &self.http_addr {
@@ -214,12 +212,12 @@ impl StartCommand {
             opts.http.timeout = Duration::from_secs(http_timeout);
         }
 
-        if let (Mode::Distributed, None) = (&opts.mode, &opts.node_id) {
-            return MissingConfigSnafu {
-                msg: "Missing node id option",
+        ensure!(
+            opts.node_id.is_some(),
+            MissingConfigSnafu {
+                msg: "Missing node id option"
             }
-            .fail();
-        }
+        );
 
         Ok(())
     }

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -126,7 +126,6 @@ impl SubCommand {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct StandaloneOptions {
-    pub mode: Mode,
     pub enable_telemetry: bool,
     pub default_timezone: Option<String>,
     pub http: HttpOptions,
@@ -156,7 +155,6 @@ pub struct StandaloneOptions {
 impl Default for StandaloneOptions {
     fn default() -> Self {
         Self {
-            mode: Mode::Standalone,
             enable_telemetry: true,
             default_timezone: None,
             http: HttpOptions::default(),
@@ -380,9 +378,6 @@ impl StartCommand {
         global_options: &GlobalOptions,
         opts: &mut StandaloneOptions,
     ) -> Result<()> {
-        // Should always be standalone mode.
-        opts.mode = Mode::Standalone;
-
         if let Some(dir) = &global_options.log_dir {
             opts.logging.dir.clone_from(dir);
         }
@@ -1062,7 +1057,6 @@ mod tests {
         let options =
             StandaloneOptions::load_layered_options(None, "GREPTIMEDB_STANDALONE").unwrap();
         let default_options = StandaloneOptions::default();
-        assert_eq!(options.mode, default_options.mode);
         assert_eq!(options.enable_telemetry, default_options.enable_telemetry);
         assert_eq!(options.http, default_options.http);
         assert_eq!(options.grpc, default_options.grpc);

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -237,7 +237,6 @@ impl StandaloneOptions {
             grpc: cloned_opts.grpc,
             init_regions_in_background: cloned_opts.init_regions_in_background,
             init_regions_parallelism: cloned_opts.init_regions_parallelism,
-            mode: Mode::Standalone,
             ..Default::default()
         }
     }
@@ -508,7 +507,7 @@ impl StartCommand {
             .build(),
         );
 
-        let datanode = DatanodeBuilder::new(dn_opts, plugins.clone())
+        let datanode = DatanodeBuilder::new(dn_opts, plugins.clone(), Mode::Standalone)
             .with_kv_backend(kv_backend.clone())
             .with_cache_registry(layered_cache_registry.clone())
             .build()

--- a/src/datanode/src/config.rs
+++ b/src/datanode/src/config.rs
@@ -31,7 +31,6 @@ use servers::export_metrics::ExportMetricsOption;
 use servers::grpc::GrpcOptions;
 use servers::heartbeat_options::HeartbeatOptions;
 use servers::http::HttpOptions;
-use servers::Mode;
 
 pub const DEFAULT_OBJECT_STORE_CACHE_SIZE: ReadableSize = ReadableSize::gb(5);
 
@@ -359,7 +358,6 @@ impl Default for ObjectStoreConfig {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct DatanodeOptions {
-    pub mode: Mode,
     pub node_id: Option<u64>,
     pub require_lease_before_startup: bool,
     pub init_regions_in_background: bool,
@@ -395,7 +393,6 @@ impl Default for DatanodeOptions {
     #[allow(deprecated)]
     fn default() -> Self {
         Self {
-            mode: Mode::Standalone,
             node_id: None,
             require_lease_before_startup: false,
             init_regions_in_background: false,

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -157,6 +157,7 @@ impl Datanode {
 
 pub struct DatanodeBuilder {
     opts: DatanodeOptions,
+    mode: Mode,
     plugins: Plugins,
     meta_client: Option<MetaClientRef>,
     kv_backend: Option<KvBackendRef>,
@@ -166,9 +167,10 @@ pub struct DatanodeBuilder {
 impl DatanodeBuilder {
     /// `kv_backend` is optional. If absent, the builder will try to build one
     /// by using the given `opts`
-    pub fn new(opts: DatanodeOptions, plugins: Plugins) -> Self {
+    pub fn new(opts: DatanodeOptions, plugins: Plugins, mode: Mode) -> Self {
         Self {
             opts,
+            mode,
             plugins,
             meta_client: None,
             kv_backend: None,
@@ -198,7 +200,7 @@ impl DatanodeBuilder {
     }
 
     pub async fn build(mut self) -> Result<Datanode> {
-        let mode = &self.opts.mode;
+        let mode = &self.mode;
         let node_id = self.opts.node_id.context(MissingNodeIdSnafu)?;
 
         let meta_client = self.meta_client.take();
@@ -629,6 +631,7 @@ mod tests {
     use common_meta::kv_backend::memory::MemoryKvBackend;
     use common_meta::kv_backend::KvBackendRef;
     use mito2::engine::MITO_ENGINE_NAME;
+    use servers::Mode;
     use store_api::region_request::RegionRequest;
     use store_api::storage::RegionId;
 
@@ -674,6 +677,7 @@ mod tests {
                 ..Default::default()
             },
             Plugins::default(),
+            Mode::Standalone,
         )
         .with_cache_registry(layered_cache_registry);
 

--- a/src/flow/src/adapter.rs
+++ b/src/flow/src/adapter.rs
@@ -37,7 +37,6 @@ use serde::{Deserialize, Serialize};
 use servers::grpc::GrpcOptions;
 use servers::heartbeat_options::HeartbeatOptions;
 use servers::http::HttpOptions;
-use servers::Mode;
 use session::context::QueryContext;
 use snafu::{ensure, OptionExt, ResultExt};
 use store_api::storage::{ConcreteDataType, RegionId};
@@ -102,7 +101,6 @@ impl Default for FlowConfig {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(default)]
 pub struct FlownodeOptions {
-    pub mode: Mode,
     pub node_id: Option<u64>,
     pub flow: FlowConfig,
     pub grpc: GrpcOptions,
@@ -116,7 +114,6 @@ pub struct FlownodeOptions {
 impl Default for FlownodeOptions {
     fn default() -> Self {
         Self {
-            mode: servers::Mode::Standalone,
             node_id: None,
             flow: FlowConfig::default(),
             grpc: GrpcOptions::default().with_bind_addr("127.0.0.1:3004"),

--- a/tests-integration/src/cluster.rs
+++ b/tests-integration/src/cluster.rs
@@ -251,7 +251,6 @@ impl GreptimeDbClusterBuilder {
 
         for i in 0..datanodes {
             let datanode_id = i as u64 + 1;
-            let mode = Mode::Distributed;
             let mut opts = if let Some(store_config) = &self.store_config {
                 let home_dir = if let Some(home_dir) = &self.shared_home_dir {
                     home_dir.path().to_str().unwrap().to_string()
@@ -264,7 +263,6 @@ impl GreptimeDbClusterBuilder {
                 };
 
                 create_datanode_opts(
-                    mode,
                     store_config.clone(),
                     vec![],
                     home_dir,
@@ -272,7 +270,6 @@ impl GreptimeDbClusterBuilder {
                 )
             } else {
                 let (opts, guard) = create_tmp_dir_and_datanode_opts(
-                    mode,
                     StorageType::File,
                     self.store_providers.clone().unwrap_or_default(),
                     &format!("{}-dn-{}", self.cluster_name, datanode_id),
@@ -345,7 +342,7 @@ impl GreptimeDbClusterBuilder {
                 .build(),
         );
 
-        let mut datanode = DatanodeBuilder::new(opts, Plugins::default())
+        let mut datanode = DatanodeBuilder::new(opts, Plugins::default(), Mode::Distributed)
             .with_kv_backend(meta_backend)
             .with_cache_registry(layered_cache_registry)
             .with_meta_client(meta_client)

--- a/tests-integration/src/standalone.rs
+++ b/tests-integration/src/standalone.rs
@@ -143,12 +143,13 @@ impl GreptimeDbStandaloneBuilder {
                 .build(),
         );
 
-        let datanode = DatanodeBuilder::new(opts.datanode_options(), plugins.clone())
-            .with_kv_backend(kv_backend.clone())
-            .with_cache_registry(layered_cache_registry)
-            .build()
-            .await
-            .unwrap();
+        let datanode =
+            DatanodeBuilder::new(opts.datanode_options(), plugins.clone(), Mode::Standalone)
+                .with_kv_backend(kv_backend.clone())
+                .with_cache_registry(layered_cache_registry)
+                .build()
+                .await
+                .unwrap();
 
         let table_metadata_manager = Arc::new(TableMetadataManager::new(kv_backend.clone()));
         table_metadata_manager.init().await.unwrap();
@@ -288,7 +289,6 @@ impl GreptimeDbStandaloneBuilder {
         let store_types = self.store_providers.clone().unwrap_or_default();
 
         let (opts, guard) = create_tmp_dir_and_datanode_opts(
-            Mode::Standalone,
             default_store_type,
             store_types,
             &self.instance_name,

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -52,7 +52,6 @@ use servers::query_handler::grpc::ServerGrpcQueryHandlerAdapter;
 use servers::query_handler::sql::{ServerSqlQueryHandlerAdapter, SqlQueryHandler};
 use servers::server::Server;
 use servers::tls::ReloadableTlsServerConfig;
-use servers::Mode;
 use session::context::QueryContext;
 
 use crate::standalone::{GreptimeDbStandalone, GreptimeDbStandaloneBuilder};
@@ -301,7 +300,6 @@ impl TestGuard {
 }
 
 pub fn create_tmp_dir_and_datanode_opts(
-    mode: Mode,
     default_store_type: StorageType,
     store_provider_types: Vec<StorageType>,
     name: &str,
@@ -323,7 +321,7 @@ pub fn create_tmp_dir_and_datanode_opts(
         store_providers.push(store);
         storage_guards.push(StorageGuard(data_tmp_dir))
     }
-    let opts = create_datanode_opts(mode, default_store, store_providers, home_dir, wal_config);
+    let opts = create_datanode_opts(default_store, store_providers, home_dir, wal_config);
 
     (
         opts,
@@ -335,7 +333,6 @@ pub fn create_tmp_dir_and_datanode_opts(
 }
 
 pub(crate) fn create_datanode_opts(
-    mode: Mode,
     default_store: ObjectStoreConfig,
     providers: Vec<ObjectStoreConfig>,
     home_dir: String,
@@ -352,7 +349,6 @@ pub(crate) fn create_datanode_opts(
         grpc: GrpcOptions::default()
             .with_bind_addr(PEER_PLACEHOLDER_ADDR)
             .with_server_addr(PEER_PLACEHOLDER_ADDR),
-        mode,
         wal: wal_config,
         ..Default::default()
     }

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -951,7 +951,6 @@ providers = []"#,
 
     let expected_toml_str = format!(
         r#"
-mode = "standalone"
 enable_telemetry = true
 init_regions_in_background = false
 init_regions_parallelism = 16


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This pr mainly remove `mode` option from the configuration file of datanode, standalone and flownode.

For example:
`./greptime datanode start` must be a distributed scenario.
`./greptime standalone start` must be a standalone scenario.
And there is no need for `mode` option to exist.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
