### PR TITLE
refactor: remove prom store write dispatch

### DIFF
--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -57,6 +57,7 @@ use crate::error::{
     ToJsonSnafu,
 };
 use crate::http::influxdb::{influxdb_health, influxdb_ping, influxdb_write_v1, influxdb_write_v2};
+use crate::http::prom_store::PromStoreState;
 use crate::http::prometheus::{
     build_info_query, format_query, instant_query, label_values_query, labels_query, parse_query,
     range_query, series_query,
@@ -554,10 +555,16 @@ impl HttpServerBuilder {
         prom_store_with_metric_engine: bool,
         is_strict_mode: bool,
     ) -> Self {
+        let state = PromStoreState {
+            prom_store_handler: handler,
+            prom_store_with_metric_engine,
+            is_strict_mode,
+        };
+
         Self {
             router: self.router.nest(
                 &format!("/{HTTP_API_VERSION}/prometheus"),
-                HttpServer::route_prom(handler, prom_store_with_metric_engine, is_strict_mode),
+                HttpServer::route_prom(state),
             ),
             ..self
         }
@@ -1000,36 +1007,11 @@ impl HttpServer {
     ///
     /// [read]: https://prometheus.io/docs/prometheus/latest/querying/remote_read_api/
     /// [write]: https://prometheus.io/docs/concepts/remote_write_spec/
-    fn route_prom<S>(
-        prom_handler: PromStoreProtocolHandlerRef,
-        prom_store_with_metric_engine: bool,
-        is_strict_mode: bool,
-    ) -> Router<S> {
-        let mut router = Router::new().route("/read", routing::post(prom_store::remote_read));
-        match (prom_store_with_metric_engine, is_strict_mode) {
-            (true, true) => {
-                router = router.route("/write", routing::post(prom_store::remote_write))
-            }
-            (true, false) => {
-                router = router.route(
-                    "/write",
-                    routing::post(prom_store::remote_write_without_strict_mode),
-                )
-            }
-            (false, true) => {
-                router = router.route(
-                    "/write",
-                    routing::post(prom_store::route_write_without_metric_engine),
-                )
-            }
-            (false, false) => {
-                router = router.route(
-                    "/write",
-                    routing::post(prom_store::route_write_without_metric_engine_and_strict_mode),
-                )
-            }
-        }
-        router.with_state(prom_handler)
+    fn route_prom<S>(state: PromStoreState) -> Router<S> {
+        Router::new()
+            .route("/read", routing::post(prom_store::remote_read))
+            .route("/write", routing::post(prom_store::remote_write))
+            .with_state(state)
     }
 
     fn route_influxdb<S>(influxdb_handler: InfluxdbLineProtocolHandlerRef) -> Router<S> {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

As the title suggests, this PR removes the prom store remote write dispatch using a state struct to wrap the config `bool`s.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
