### PR TITLE
refactor!: make pipeline a required parameter when ingesting trace

### DIFF
--- a/src/pipeline/src/error.rs
+++ b/src/pipeline/src/error.rs
@@ -710,6 +710,12 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+
+    #[snafu(display("Pipeline is required for this API."))]
+    PipelineMissing {
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -819,7 +825,8 @@ impl ErrorExt for Error {
             | ValueRequiredForDispatcherRule
             | ReachedMaxNestedLevels { .. }
             | RequiredTableSuffixTemplate
-            | InvalidTableSuffixTemplate { .. } => StatusCode::InvalidArguments,
+            | InvalidTableSuffixTemplate { .. }
+            | PipelineMissing { .. } => StatusCode::InvalidArguments,
         }
     }
 

--- a/src/servers/src/http/otlp.rs
+++ b/src/servers/src/http/otlp.rs
@@ -92,7 +92,7 @@ pub async fn traces(
     let pipeline = PipelineWay::from_name_and_default(
         pipeline_info.pipeline_name.as_deref(),
         pipeline_info.pipeline_version.as_deref(),
-        PipelineWay::OtlpTraceDirectV0,
+        None,
     )
     .context(PipelineSnafu)?;
 
@@ -142,7 +142,7 @@ pub async fn logs(
     let pipeline = PipelineWay::from_name_and_default(
         pipeline_info.pipeline_name.as_deref(),
         pipeline_info.pipeline_version.as_deref(),
-        PipelineWay::OtlpLogDirect(Box::new(select_info)),
+        Some(PipelineWay::OtlpLogDirect(Box::new(select_info))),
     )
     .context(PipelineSnafu)?;
     let pipeline_params = pipeline_info.pipeline_params;

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -2338,10 +2338,16 @@ pub async fn test_otlp_traces_v0(store_type: StorageType) {
     // write traces data
     let res = send_req(
         &client,
-        vec![(
-            HeaderName::from_static("content-type"),
-            HeaderValue::from_static("application/x-protobuf"),
-        )],
+        vec![
+            (
+                HeaderName::from_static("content-type"),
+                HeaderValue::from_static("application/x-protobuf"),
+            ),
+            (
+                HeaderName::from_static("x-greptime-pipeline-name"),
+                HeaderValue::from_static("greptime_trace_v0"),
+            ),
+        ],
         "/v1/otlp/v1/traces",
         body.clone(),
         false,
@@ -2369,10 +2375,16 @@ pub async fn test_otlp_traces_v0(store_type: StorageType) {
     // write traces data with gzip
     let res = send_req(
         &client,
-        vec![(
-            HeaderName::from_static("content-type"),
-            HeaderValue::from_static("application/x-protobuf"),
-        )],
+        vec![
+            (
+                HeaderName::from_static("content-type"),
+                HeaderValue::from_static("application/x-protobuf"),
+            ),
+            (
+                HeaderName::from_static("x-greptime-pipeline-name"),
+                HeaderValue::from_static("greptime_trace_v0"),
+            ),
+        ],
         "/v1/otlp/v1/traces",
         body.clone(),
         true,
@@ -3046,10 +3058,16 @@ pub async fn test_jaeger_query_api(store_type: StorageType) {
     // write traces data.
     let res = send_req(
         &client,
-        vec![(
-            HeaderName::from_static("content-type"),
-            HeaderValue::from_static("application/x-protobuf"),
-        )],
+        vec![
+            (
+                HeaderName::from_static("content-type"),
+                HeaderValue::from_static("application/x-protobuf"),
+            ),
+            (
+                HeaderName::from_static("x-greptime-pipeline-name"),
+                HeaderValue::from_static("greptime_trace_v0"),
+            ),
+        ],
         "/v1/otlp/v1/traces",
         body.clone(),
         false,

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -2392,6 +2392,20 @@ pub async fn test_otlp_traces_v0(store_type: StorageType) {
     .await;
     assert_eq!(StatusCode::OK, res.status());
 
+    // write traces data without pipeline
+    let res = send_req(
+        &client,
+        vec![(
+            HeaderName::from_static("content-type"),
+            HeaderValue::from_static("application/x-protobuf"),
+        )],
+        "/v1/otlp/v1/traces",
+        body.clone(),
+        true,
+    )
+    .await;
+    assert_eq!(StatusCode::BAD_REQUEST, res.status());
+
     // select traces data again
     validate_data(
         "otlp_traces_with_gzip",


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This patch propose the minor breaking change for existed trace users. It now requires all trace ingestion call to include a header `x-greptime-pipeline-name`. Legacy users will need to set it to `greptime_trace_v0`.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
