### PR TITLE
fix: get root cause of the procedure when coverting to pb

### DIFF
--- a/src/common/meta/src/rpc/procedure.rs
+++ b/src/common/meta/src/rpc/procedure.rs
@@ -20,6 +20,7 @@ use api::v1::meta::{
     ProcedureMeta as PbProcedureMeta, ProcedureStateResponse as PbProcedureStateResponse,
     ProcedureStatus as PbProcedureStatus,
 };
+use common_error::ext::ErrorExt;
 use common_procedure::{ProcedureId, ProcedureInfo, ProcedureState};
 use snafu::ResultExt;
 
@@ -73,15 +74,15 @@ pub fn procedure_state_to_pb_state(state: &ProcedureState) -> (PbProcedureStatus
     match state {
         ProcedureState::Running => (PbProcedureStatus::Running, String::default()),
         ProcedureState::Done { .. } => (PbProcedureStatus::Done, String::default()),
-        ProcedureState::Retrying { error } => (PbProcedureStatus::Retrying, error.to_string()),
-        ProcedureState::Failed { error } => (PbProcedureStatus::Failed, error.to_string()),
+        ProcedureState::Retrying { error } => (PbProcedureStatus::Retrying, error.output_msg()),
+        ProcedureState::Failed { error } => (PbProcedureStatus::Failed, error.output_msg()),
         ProcedureState::PrepareRollback { error } => {
-            (PbProcedureStatus::PrepareRollback, error.to_string())
+            (PbProcedureStatus::PrepareRollback, error.output_msg())
         }
         ProcedureState::RollingBack { error } => {
-            (PbProcedureStatus::RollingBack, error.to_string())
+            (PbProcedureStatus::RollingBack, error.output_msg())
         }
-        ProcedureState::Poisoned { error, .. } => (PbProcedureStatus::Poisoned, error.to_string()),
+        ProcedureState::Poisoned { error, .. } => (PbProcedureStatus::Poisoned, error.output_msg()),
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

Output the root cause instead of the `Failed to execute procedure due to external error` message.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
