### PR TITLE
fix: alway rejects write while downgrading region

### DIFF
--- a/src/common/function/src/admin/migrate_region.rs
+++ b/src/common/function/src/admin/migrate_region.rs
@@ -25,12 +25,12 @@ use session::context::QueryContextRef;
 use crate::handlers::ProcedureServiceHandlerRef;
 use crate::helper::cast_u64;
 
-const DEFAULT_TIMEOUT_SECS: u64 = 30;
+const DEFAULT_TIMEOUT_SECS: u64 = 120;
 
 /// A function to migrate a region from source peer to target peer.
 /// Returns the submitted procedure id if success. Only available in cluster mode.
 ///
-/// - `migrate_region(region_id, from_peer, to_peer)`, with timeout(30 seconds).
+/// - `migrate_region(region_id, from_peer, to_peer)`, with timeout(120 seconds).
 /// - `migrate_region(region_id, from_peer, to_peer, timeout(secs))`.
 ///
 /// The parameters:

--- a/src/common/function/src/admin/migrate_region.rs
+++ b/src/common/function/src/admin/migrate_region.rs
@@ -25,12 +25,13 @@ use session::context::QueryContextRef;
 use crate::handlers::ProcedureServiceHandlerRef;
 use crate::helper::cast_u64;
 
-const DEFAULT_TIMEOUT_SECS: u64 = 120;
+/// The default timeout for migrate region procedure.
+const DEFAULT_TIMEOUT_SECS: u64 = 300;
 
 /// A function to migrate a region from source peer to target peer.
 /// Returns the submitted procedure id if success. Only available in cluster mode.
 ///
-/// - `migrate_region(region_id, from_peer, to_peer)`, with timeout(120 seconds).
+/// - `migrate_region(region_id, from_peer, to_peer)`, with timeout(300 seconds).
 /// - `migrate_region(region_id, from_peer, to_peer, timeout(secs))`.
 ///
 /// The parameters:

--- a/src/common/meta/src/instruction.rs
+++ b/src/common/meta/src/instruction.rs
@@ -57,6 +57,8 @@ impl Display for RegionIdent {
 pub struct DowngradeRegionReply {
     /// Returns the `last_entry_id` if available.
     pub last_entry_id: Option<u64>,
+    /// Returns the `metadata_last_entry_id` if available (Only available for metric engine).
+    pub metadata_last_entry_id: Option<u64>,
     /// Indicates whether the region exists.
     pub exists: bool,
     /// Return error if any during the operation.
@@ -136,16 +138,14 @@ pub struct DowngradeRegion {
     /// `None` stands for don't flush before downgrading the region.
     #[serde(default)]
     pub flush_timeout: Option<Duration>,
-    /// Rejects all write requests after flushing.
-    pub reject_write: bool,
 }
 
 impl Display for DowngradeRegion {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "DowngradeRegion(region_id={}, flush_timeout={:?}, rejct_write={})",
-            self.region_id, self.flush_timeout, self.reject_write
+            "DowngradeRegion(region_id={}, flush_timeout={:?})",
+            self.region_id, self.flush_timeout,
         )
     }
 }
@@ -157,6 +157,8 @@ pub struct UpgradeRegion {
     pub region_id: RegionId,
     /// The `last_entry_id` of old leader region.
     pub last_entry_id: Option<u64>,
+    /// The `last_entry_id` of old leader metadata region (Only used for metrics).
+    pub metadata_last_entry_id: Option<u64>,
     /// The timeout of waiting for a wal replay.
     ///
     /// `None` stands for no wait,

--- a/src/common/meta/src/instruction.rs
+++ b/src/common/meta/src/instruction.rs
@@ -157,7 +157,7 @@ pub struct UpgradeRegion {
     pub region_id: RegionId,
     /// The `last_entry_id` of old leader region.
     pub last_entry_id: Option<u64>,
-    /// The `last_entry_id` of old leader metadata region (Only used for metrics).
+    /// The `last_entry_id` of old leader metadata region (Only used for metric engine).
     pub metadata_last_entry_id: Option<u64>,
     /// The timeout of waiting for a wal replay.
     ///

--- a/src/datanode/src/heartbeat/handler.rs
+++ b/src/datanode/src/heartbeat/handler.rs
@@ -220,7 +220,6 @@ mod tests {
         let instruction = Instruction::DowngradeRegion(DowngradeRegion {
             region_id: RegionId::new(2048, 1),
             flush_timeout: Some(Duration::from_secs(1)),
-            reject_write: false,
         });
         assert!(heartbeat_handler
             .is_acceptable(&heartbeat_env.create_handler_ctx((meta.clone(), instruction))));
@@ -229,6 +228,7 @@ mod tests {
         let instruction = Instruction::UpgradeRegion(UpgradeRegion {
             region_id,
             last_entry_id: None,
+            metadata_last_entry_id: None,
             replay_timeout: None,
             location_id: None,
         });
@@ -419,7 +419,6 @@ mod tests {
             let instruction = Instruction::DowngradeRegion(DowngradeRegion {
                 region_id,
                 flush_timeout: Some(Duration::from_secs(1)),
-                reject_write: false,
             });
 
             let mut ctx = heartbeat_env.create_handler_ctx((meta, instruction));
@@ -442,7 +441,6 @@ mod tests {
         let instruction = Instruction::DowngradeRegion(DowngradeRegion {
             region_id: RegionId::new(2048, 1),
             flush_timeout: Some(Duration::from_secs(1)),
-            reject_write: false,
         });
         let mut ctx = heartbeat_env.create_handler_ctx((meta, instruction));
         let control = heartbeat_handler.handle(&mut ctx).await.unwrap();

--- a/src/datanode/src/heartbeat/handler/downgrade_region.rs
+++ b/src/datanode/src/heartbeat/handler/downgrade_region.rs
@@ -14,7 +14,7 @@
 
 use common_meta::instruction::{DowngradeRegion, DowngradeRegionReply, InstructionReply};
 use common_telemetry::tracing::info;
-use common_telemetry::warn;
+use common_telemetry::{error, warn};
 use futures_util::future::BoxFuture;
 use store_api::region_engine::{SetRegionRoleStateResponse, SettableRegionRoleState};
 use store_api::region_request::{RegionFlushRequest, RegionRequest};
@@ -51,7 +51,7 @@ impl HandlerContext {
                 }))
             }
             Err(err) => {
-                warn!(err; "Failed to convert region to {}", SettableRegionRoleState::Follower);
+                error!(err; "Failed to convert region to {}", SettableRegionRoleState::Follower);
                 Some(InstructionReply::DowngradeRegion(DowngradeRegionReply {
                     last_entry_id: None,
                     metadata_last_entry_id: None,
@@ -118,7 +118,7 @@ impl HandlerContext {
                     }));
                 }
                 Err(err) => {
-                    warn!(err; "Failed to convert region to downgrading leader");
+                    error!(err; "Failed to convert region to downgrading leader");
                     return Some(InstructionReply::DowngradeRegion(DowngradeRegionReply {
                         last_entry_id: None,
                         metadata_last_entry_id: None,

--- a/src/datanode/src/heartbeat/handler/upgrade_region.rs
+++ b/src/datanode/src/heartbeat/handler/upgrade_region.rs
@@ -26,6 +26,7 @@ impl HandlerContext {
         UpgradeRegion {
             region_id,
             last_entry_id,
+            metadata_last_entry_id,
             replay_timeout,
             location_id,
         }: UpgradeRegion,
@@ -63,6 +64,7 @@ impl HandlerContext {
                                 RegionRequest::Catchup(RegionCatchupRequest {
                                     set_writable: true,
                                     entry_id: last_entry_id,
+                                    metadata_entry_id: metadata_last_entry_id,
                                     location_id,
                                 }),
                             )
@@ -147,6 +149,7 @@ mod tests {
                 .handle_upgrade_region_instruction(UpgradeRegion {
                     region_id,
                     last_entry_id: None,
+                    metadata_last_entry_id: None,
                     replay_timeout,
                     location_id: None,
                 })
@@ -185,6 +188,7 @@ mod tests {
                 .handle_upgrade_region_instruction(UpgradeRegion {
                     region_id,
                     last_entry_id: None,
+                    metadata_last_entry_id: None,
                     replay_timeout,
                     location_id: None,
                 })
@@ -224,6 +228,7 @@ mod tests {
                 .handle_upgrade_region_instruction(UpgradeRegion {
                     region_id,
                     last_entry_id: None,
+                    metadata_last_entry_id: None,
                     replay_timeout,
                     location_id: None,
                 })
@@ -267,6 +272,7 @@ mod tests {
                     region_id,
                     replay_timeout,
                     last_entry_id: None,
+                    metadata_last_entry_id: None,
                     location_id: None,
                 })
                 .await;
@@ -284,6 +290,7 @@ mod tests {
             .handle_upgrade_region_instruction(UpgradeRegion {
                 region_id,
                 last_entry_id: None,
+                metadata_last_entry_id: None,
                 replay_timeout: Some(Duration::from_millis(500)),
                 location_id: None,
             })
@@ -326,6 +333,7 @@ mod tests {
             .handle_upgrade_region_instruction(UpgradeRegion {
                 region_id,
                 last_entry_id: None,
+                metadata_last_entry_id: None,
                 replay_timeout: None,
                 location_id: None,
             })
@@ -344,6 +352,7 @@ mod tests {
             .handle_upgrade_region_instruction(UpgradeRegion {
                 region_id,
                 last_entry_id: None,
+                metadata_last_entry_id: None,
                 replay_timeout: Some(Duration::from_millis(200)),
                 location_id: None,
             })

--- a/src/file-engine/src/engine.rs
+++ b/src/file-engine/src/engine.rs
@@ -27,7 +27,8 @@ use snafu::{ensure, OptionExt};
 use store_api::metadata::RegionMetadataRef;
 use store_api::region_engine::{
     RegionEngine, RegionManifestInfo, RegionRole, RegionScannerRef, RegionStatistic,
-    SetRegionRoleStateResponse, SettableRegionRoleState, SinglePartitionScanner,
+    SetRegionRoleStateResponse, SetRegionRoleStateSuccess, SettableRegionRoleState,
+    SinglePartitionScanner,
 };
 use store_api::region_request::{
     AffectedRows, RegionCloseRequest, RegionCreateRequest, RegionDropRequest, RegionOpenRequest,
@@ -132,7 +133,9 @@ impl RegionEngine for FileRegionEngine {
         let exists = self.inner.get_region(region_id).await.is_some();
 
         if exists {
-            Ok(SetRegionRoleStateResponse::success(None))
+            Ok(SetRegionRoleStateResponse::success(
+                SetRegionRoleStateSuccess::file(),
+            ))
         } else {
             Ok(SetRegionRoleStateResponse::NotFound)
         }

--- a/src/meta-srv/src/procedure/region_migration.rs
+++ b/src/meta-srv/src/procedure/region_migration.rs
@@ -127,6 +127,8 @@ pub struct VolatileContext {
     leader_region_lease_deadline: Option<Instant>,
     /// The last_entry_id of leader region.
     leader_region_last_entry_id: Option<u64>,
+    /// The last_entry_id of leader metadata region (Only used for metrics).
+    leader_region_metadata_last_entry_id: Option<u64>,
     /// Elapsed time of downgrading region and upgrading region.
     operations_elapsed: Duration,
 }
@@ -147,6 +149,11 @@ impl VolatileContext {
     /// Sets the `leader_region_last_entry_id`.
     pub fn set_last_entry_id(&mut self, last_entry_id: u64) {
         self.leader_region_last_entry_id = Some(last_entry_id)
+    }
+
+    /// Sets the `leader_region_metadata_last_entry_id`.
+    pub fn set_metadata_last_entry_id(&mut self, last_entry_id: u64) {
+        self.leader_region_metadata_last_entry_id = Some(last_entry_id);
     }
 }
 

--- a/src/meta-srv/src/procedure/region_migration.rs
+++ b/src/meta-srv/src/procedure/region_migration.rs
@@ -127,7 +127,7 @@ pub struct VolatileContext {
     leader_region_lease_deadline: Option<Instant>,
     /// The last_entry_id of leader region.
     leader_region_last_entry_id: Option<u64>,
-    /// The last_entry_id of leader metadata region (Only used for metrics).
+    /// The last_entry_id of leader metadata region (Only used for metric engine).
     leader_region_metadata_last_entry_id: Option<u64>,
     /// Elapsed time of downgrading region and upgrading region.
     operations_elapsed: Duration,

--- a/src/meta-srv/src/procedure/region_migration/close_downgraded_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/close_downgraded_region.rs
@@ -16,7 +16,7 @@ use std::any::Any;
 use std::time::Duration;
 
 use api::v1::meta::MailboxMessage;
-use common_meta::distributed_time_constants::MAILBOX_RTT_SECS;
+use common_meta::distributed_time_constants::REGION_LEASE_SECS;
 use common_meta::instruction::{Instruction, InstructionReply, SimpleReply};
 use common_meta::key::datanode_table::RegionInfo;
 use common_meta::RegionIdent;
@@ -31,7 +31,8 @@ use crate::procedure::region_migration::migration_end::RegionMigrationEnd;
 use crate::procedure::region_migration::{Context, State};
 use crate::service::mailbox::Channel;
 
-const CLOSE_DOWNGRADED_REGION_TIMEOUT: Duration = Duration::from_secs(MAILBOX_RTT_SECS);
+/// Uses lease time of a region as the timeout of closing a downgraded region.
+const CLOSE_DOWNGRADED_REGION_TIMEOUT: Duration = Duration::from_secs(REGION_LEASE_SECS);
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CloseDowngradedRegion;

--- a/src/meta-srv/src/procedure/region_migration/downgrade_leader_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/downgrade_leader_region.rs
@@ -22,10 +22,8 @@ use common_meta::instruction::{
 };
 use common_procedure::Status;
 use common_telemetry::{error, info, warn};
-use common_wal::options::WalOptions;
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt};
-use store_api::storage::RegionId;
 use tokio::time::{sleep, Instant};
 
 use super::update_metadata::UpdateMetadata;
@@ -97,30 +95,13 @@ impl DowngradeLeaderRegion {
         &self,
         ctx: &Context,
         flush_timeout: Duration,
-        reject_write: bool,
     ) -> Instruction {
         let pc = &ctx.persistent_ctx;
         let region_id = pc.region_id;
         Instruction::DowngradeRegion(DowngradeRegion {
             region_id,
             flush_timeout: Some(flush_timeout),
-            reject_write,
         })
-    }
-
-    async fn should_reject_write(ctx: &mut Context, region_id: RegionId) -> Result<bool> {
-        let datanode_table_value = ctx.get_from_peer_datanode_table_value().await?;
-        if let Some(wal_option) = datanode_table_value
-            .region_info
-            .region_wal_options
-            .get(&region_id.region_number())
-        {
-            let options: WalOptions = serde_json::from_str(wal_option)
-                .with_context(|_| error::DeserializeFromJsonSnafu { input: wal_option })?;
-            return Ok(matches!(options, WalOptions::RaftEngine));
-        }
-
-        Ok(true)
     }
 
     /// Tries to downgrade a leader region.
@@ -143,9 +124,7 @@ impl DowngradeLeaderRegion {
                 .context(error::ExceededDeadlineSnafu {
                     operation: "Downgrade region",
                 })?;
-        let reject_write = Self::should_reject_write(ctx, region_id).await?;
-        let downgrade_instruction =
-            self.build_downgrade_region_instruction(ctx, operation_timeout, reject_write);
+        let downgrade_instruction = self.build_downgrade_region_instruction(ctx, operation_timeout);
 
         let leader = &ctx.persistent_ctx.from_peer;
         let msg = MailboxMessage::json_message(
@@ -174,6 +153,7 @@ impl DowngradeLeaderRegion {
                 );
                 let InstructionReply::DowngradeRegion(DowngradeRegionReply {
                     last_entry_id,
+                    metadata_last_entry_id,
                     exists,
                     error,
                 }) = reply
@@ -202,15 +182,21 @@ impl DowngradeLeaderRegion {
                     );
                 } else {
                     info!(
-                        "Region {} leader is downgraded, last_entry_id: {:?}, elapsed: {:?}",
+                        "Region {} leader is downgraded, last_entry_id: {:?}, metadata_last_entry_id: {:?}, elapsed: {:?}",
                         region_id,
                         last_entry_id,
+                        metadata_last_entry_id,
                         now.elapsed()
                     );
                 }
 
                 if let Some(last_entry_id) = last_entry_id {
                     ctx.volatile_ctx.set_last_entry_id(last_entry_id);
+                }
+
+                if let Some(metadata_last_entry_id) = metadata_last_entry_id {
+                    ctx.volatile_ctx
+                        .set_metadata_last_entry_id(metadata_last_entry_id);
                 }
 
                 Ok(())
@@ -276,7 +262,6 @@ mod tests {
     use common_meta::key::test_utils::new_test_table_info;
     use common_meta::peer::Peer;
     use common_meta::rpc::router::{Region, RegionRoute};
-    use common_wal::options::KafkaWalOptions;
     use store_api::storage::RegionId;
     use tokio::time::Instant;
 
@@ -329,41 +314,6 @@ mod tests {
 
         assert_matches!(err, Error::PusherNotFound { .. });
         assert!(!err.is_retryable());
-    }
-
-    #[tokio::test]
-    async fn test_should_reject_writes() {
-        let persistent_context = new_persistent_context();
-        let region_id = persistent_context.region_id;
-        let env = TestingEnv::new();
-        let mut ctx = env.context_factory().new_context(persistent_context);
-        let wal_options =
-            HashMap::from([(1, serde_json::to_string(&WalOptions::RaftEngine).unwrap())]);
-        prepare_table_metadata(&ctx, wal_options).await;
-
-        let reject_write = DowngradeLeaderRegion::should_reject_write(&mut ctx, region_id)
-            .await
-            .unwrap();
-        assert!(reject_write);
-
-        // Remote WAL
-        let persistent_context = new_persistent_context();
-        let region_id = persistent_context.region_id;
-        let env = TestingEnv::new();
-        let mut ctx = env.context_factory().new_context(persistent_context);
-        let wal_options = HashMap::from([(
-            1,
-            serde_json::to_string(&WalOptions::Kafka(KafkaWalOptions {
-                topic: "my_topic".to_string(),
-            }))
-            .unwrap(),
-        )]);
-        prepare_table_metadata(&ctx, wal_options).await;
-
-        let reject_write = DowngradeLeaderRegion::should_reject_write(&mut ctx, region_id)
-            .await
-            .unwrap();
-        assert!(!reject_write);
     }
 
     #[tokio::test]

--- a/src/meta-srv/src/procedure/region_migration/upgrade_candidate_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/upgrade_candidate_region.rs
@@ -76,10 +76,12 @@ impl UpgradeCandidateRegion {
         let pc = &ctx.persistent_ctx;
         let region_id = pc.region_id;
         let last_entry_id = ctx.volatile_ctx.leader_region_last_entry_id;
+        let metadata_last_entry_id = ctx.volatile_ctx.leader_region_metadata_last_entry_id;
 
         Instruction::UpgradeRegion(UpgradeRegion {
             region_id,
             last_entry_id,
+            metadata_last_entry_id,
             replay_timeout: Some(replay_timeout),
             location_id: Some(ctx.persistent_ctx.from_peer.id),
         })

--- a/src/meta-srv/src/procedure/test_util.rs
+++ b/src/meta-srv/src/procedure/test_util.rs
@@ -135,6 +135,7 @@ pub fn new_downgrade_region_reply(
         payload: Some(Payload::Json(
             serde_json::to_string(&InstructionReply::DowngradeRegion(DowngradeRegionReply {
                 last_entry_id,
+                metadata_last_entry_id: None,
                 exists: exist,
                 error,
             }))

--- a/src/metric-engine/src/engine/catchup.rs
+++ b/src/metric-engine/src/engine/catchup.rs
@@ -56,7 +56,8 @@ impl MetricEngineInner {
                 metadata_region_id,
                 RegionRequest::Catchup(RegionCatchupRequest {
                     set_writable: req.set_writable,
-                    entry_id: None,
+                    entry_id: req.metadata_entry_id,
+                    metadata_entry_id: None,
                     location_id: req.location_id,
                 }),
             )
@@ -70,6 +71,7 @@ impl MetricEngineInner {
                 RegionRequest::Catchup(RegionCatchupRequest {
                     set_writable: req.set_writable,
                     entry_id: req.entry_id,
+                    metadata_entry_id: None,
                     location_id: req.location_id,
                 }),
             )

--- a/src/mito2/src/engine/catchup_test.rs
+++ b/src/mito2/src/engine/catchup_test.rs
@@ -35,8 +35,8 @@ use crate::test_util::{
 use crate::wal::EntryId;
 
 fn get_last_entry_id(resp: SetRegionRoleStateResponse) -> Option<EntryId> {
-    if let SetRegionRoleStateResponse::Success { last_entry_id } = resp {
-        last_entry_id
+    if let SetRegionRoleStateResponse::Success(success) = resp {
+        success.last_entry_id()
     } else {
         unreachable!();
     }
@@ -118,6 +118,7 @@ async fn test_catchup_with_last_entry_id(factory: Option<LogStoreFactory>) {
             RegionRequest::Catchup(RegionCatchupRequest {
                 set_writable: false,
                 entry_id: last_entry_id,
+                metadata_entry_id: None,
                 location_id: None,
             }),
         )
@@ -150,6 +151,7 @@ async fn test_catchup_with_last_entry_id(factory: Option<LogStoreFactory>) {
             RegionRequest::Catchup(RegionCatchupRequest {
                 set_writable: true,
                 entry_id: last_entry_id,
+                metadata_entry_id: None,
                 location_id: None,
             }),
         )
@@ -237,6 +239,7 @@ async fn test_catchup_with_incorrect_last_entry_id(factory: Option<LogStoreFacto
             RegionRequest::Catchup(RegionCatchupRequest {
                 set_writable: false,
                 entry_id: incorrect_last_entry_id,
+                metadata_entry_id: None,
                 location_id: None,
             }),
         )
@@ -254,6 +257,7 @@ async fn test_catchup_with_incorrect_last_entry_id(factory: Option<LogStoreFacto
             RegionRequest::Catchup(RegionCatchupRequest {
                 set_writable: false,
                 entry_id: incorrect_last_entry_id,
+                metadata_entry_id: None,
                 location_id: None,
             }),
         )
@@ -322,6 +326,7 @@ async fn test_catchup_without_last_entry_id(factory: Option<LogStoreFactory>) {
             RegionRequest::Catchup(RegionCatchupRequest {
                 set_writable: false,
                 entry_id: None,
+                metadata_entry_id: None,
                 location_id: None,
             }),
         )
@@ -353,6 +358,7 @@ async fn test_catchup_without_last_entry_id(factory: Option<LogStoreFactory>) {
             RegionRequest::Catchup(RegionCatchupRequest {
                 set_writable: true,
                 entry_id: None,
+                metadata_entry_id: None,
                 location_id: None,
             }),
         )
@@ -442,6 +448,7 @@ async fn test_catchup_with_manifest_update(factory: Option<LogStoreFactory>) {
             RegionRequest::Catchup(RegionCatchupRequest {
                 set_writable: false,
                 entry_id: None,
+                metadata_entry_id: None,
                 location_id: None,
             }),
         )
@@ -479,6 +486,7 @@ async fn test_catchup_with_manifest_update(factory: Option<LogStoreFactory>) {
             RegionRequest::Catchup(RegionCatchupRequest {
                 set_writable: true,
                 entry_id: None,
+                metadata_entry_id: None,
                 location_id: None,
             }),
         )
@@ -501,6 +509,7 @@ async fn test_catchup_not_exist() {
             RegionRequest::Catchup(RegionCatchupRequest {
                 set_writable: true,
                 entry_id: None,
+                metadata_entry_id: None,
                 location_id: None,
             }),
         )

--- a/src/mito2/src/engine/set_role_state_test.rs
+++ b/src/mito2/src/engine/set_role_state_test.rs
@@ -16,7 +16,8 @@ use api::v1::Rows;
 use common_error::ext::ErrorExt;
 use common_error::status_code::StatusCode;
 use store_api::region_engine::{
-    RegionEngine, RegionRole, SetRegionRoleStateResponse, SettableRegionRoleState,
+    RegionEngine, RegionRole, SetRegionRoleStateResponse, SetRegionRoleStateSuccess,
+    SettableRegionRoleState,
 };
 use store_api::region_request::{RegionPutRequest, RegionRequest};
 use store_api::storage::RegionId;
@@ -48,9 +49,7 @@ async fn test_set_role_state_gracefully() {
             .await
             .unwrap();
         assert_eq!(
-            SetRegionRoleStateResponse::Success {
-                last_entry_id: Some(0)
-            },
+            SetRegionRoleStateResponse::success(SetRegionRoleStateSuccess::mito(0)),
             result
         );
 
@@ -60,9 +59,7 @@ async fn test_set_role_state_gracefully() {
             .await
             .unwrap();
         assert_eq!(
-            SetRegionRoleStateResponse::Success {
-                last_entry_id: Some(0)
-            },
+            SetRegionRoleStateResponse::success(SetRegionRoleStateSuccess::mito(0)),
             result
         );
 
@@ -96,9 +93,7 @@ async fn test_set_role_state_gracefully() {
             .unwrap();
 
         assert_eq!(
-            SetRegionRoleStateResponse::Success {
-                last_entry_id: Some(1)
-            },
+            SetRegionRoleStateResponse::success(SetRegionRoleStateSuccess::mito(1)),
             result
         );
     }
@@ -144,9 +139,7 @@ async fn test_write_downgrading_region() {
         .await
         .unwrap();
     assert_eq!(
-        SetRegionRoleStateResponse::Success {
-            last_entry_id: Some(1)
-        },
+        SetRegionRoleStateResponse::success(SetRegionRoleStateSuccess::mito(1)),
         result
     );
 

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -41,7 +41,9 @@ use prometheus::IntGauge;
 use rand::{rng, Rng};
 use snafu::{ensure, ResultExt};
 use store_api::logstore::LogStore;
-use store_api::region_engine::{SetRegionRoleStateResponse, SettableRegionRoleState};
+use store_api::region_engine::{
+    SetRegionRoleStateResponse, SetRegionRoleStateSuccess, SettableRegionRoleState,
+};
 use store_api::storage::RegionId;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::{mpsc, oneshot, watch, Mutex};
@@ -931,7 +933,9 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                 region.set_role_state_gracefully(region_role_state).await;
 
                 let last_entry_id = region.version_control.current().last_entry_id;
-                let _ = sender.send(SetRegionRoleStateResponse::success(Some(last_entry_id)));
+                let _ = sender.send(SetRegionRoleStateResponse::success(
+                    SetRegionRoleStateSuccess::mito(last_entry_id),
+                ));
             });
         } else {
             let _ = sender.send(SetRegionRoleStateResponse::NotFound);

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -1105,6 +1105,10 @@ pub struct RegionCatchupRequest {
     /// The `entry_id` that was expected to reply to.
     /// `None` stands replaying to latest.
     pub entry_id: Option<entry::Id>,
+    /// Used for metrics metadata region.
+    /// The `entry_id` that was expected to reply to.
+    /// `None` stands replaying to latest.
+    pub metadata_entry_id: Option<entry::Id>,
     /// The hint for replaying memtable.
     pub location_id: Option<u64>,
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR makes the datanode immediately reject write operations while handling downgrade region instructions.

**Previous behavior:**
A region would only transition to a "downgraded leader" state after discovering its downgrade status through heartbeats, creating a potential timing gap.

**New behavior:**
Write operations are now immediately rejected when handling downgrade region instructions, and then flushes the memtable data.

With write operations rejected and memtable data flushed, the upgrade candidate process becomes faster since there's no data that would need to be replayed during the upgrade candidate region operation.

This PR also 
- Changes the default region migration timeout from 30s to 300s.
- Changes the `CLOSE_DOWNGRADED_REGION_TIMEOUT` to 10s.
- Introduces metadata region last entry id to improve replay speed of metadata regions.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
