### PR TITLE
refactor: improve error code handling in status code conversion

### DIFF
--- a/src/client/src/error.rs
+++ b/src/client/src/error.rs
@@ -15,7 +15,7 @@
 use std::any::Any;
 
 use common_error::ext::{BoxedError, ErrorExt};
-use common_error::status_code::{convert_client_side_tonic_code_to_status_code, StatusCode};
+use common_error::status_code::{convert_tonic_code_to_status_code, StatusCode};
 use common_error::{GREPTIME_DB_HEADER_ERROR_CODE, GREPTIME_DB_HEADER_ERROR_MSG};
 use common_macro::stack_trace_debug;
 use snafu::{location, Location, Snafu};
@@ -160,8 +160,7 @@ impl From<Status> for Error {
             }
         });
         let tonic_code = e.code();
-        let code =
-            code.unwrap_or_else(|| convert_client_side_tonic_code_to_status_code(tonic_code));
+        let code = code.unwrap_or_else(|| convert_tonic_code_to_status_code(tonic_code));
 
         let msg = get_metadata_value(&e, GREPTIME_DB_HEADER_ERROR_MSG)
             .unwrap_or_else(|| e.message().to_string());

--- a/src/client/src/error.rs
+++ b/src/client/src/error.rs
@@ -187,9 +187,6 @@ impl Error {
             } | Self::RegionServer {
                 code: Code::Unavailable,
                 ..
-            } | Self::RegionServer {
-                code: Code::Unknown,
-                ..
             }
         )
     }

--- a/src/client/src/error.rs
+++ b/src/client/src/error.rs
@@ -15,7 +15,7 @@
 use std::any::Any;
 
 use common_error::ext::{BoxedError, ErrorExt};
-use common_error::status_code::{tonic_code_to_status_code, StatusCode};
+use common_error::status_code::{convert_client_side_tonic_code_to_status_code, StatusCode};
 use common_error::{GREPTIME_DB_HEADER_ERROR_CODE, GREPTIME_DB_HEADER_ERROR_MSG};
 use common_macro::stack_trace_debug;
 use snafu::{location, Location, Snafu};
@@ -160,7 +160,8 @@ impl From<Status> for Error {
             }
         });
         let tonic_code = e.code();
-        let code = code.unwrap_or_else(|| tonic_code_to_status_code(tonic_code));
+        let code =
+            code.unwrap_or_else(|| convert_client_side_tonic_code_to_status_code(tonic_code));
 
         let msg = get_metadata_value(&e, GREPTIME_DB_HEADER_ERROR_MSG)
             .unwrap_or_else(|| e.message().to_string());

--- a/src/client/src/error.rs
+++ b/src/client/src/error.rs
@@ -15,7 +15,7 @@
 use std::any::Any;
 
 use common_error::ext::{BoxedError, ErrorExt};
-use common_error::status_code::StatusCode;
+use common_error::status_code::{tonic_code_to_status_code, StatusCode};
 use common_error::{GREPTIME_DB_HEADER_ERROR_CODE, GREPTIME_DB_HEADER_ERROR_MSG};
 use common_macro::stack_trace_debug;
 use snafu::{location, Location, Snafu};
@@ -152,15 +152,15 @@ impl From<Status> for Error {
                 .and_then(|v| String::from_utf8(v.as_bytes().to_vec()).ok())
         }
 
-        let code = get_metadata_value(&e, GREPTIME_DB_HEADER_ERROR_CODE)
-            .and_then(|s| {
-                if let Ok(code) = s.parse::<u32>() {
-                    StatusCode::from_u32(code)
-                } else {
-                    None
-                }
-            })
-            .unwrap_or(StatusCode::Unknown);
+        let code = get_metadata_value(&e, GREPTIME_DB_HEADER_ERROR_CODE).and_then(|s| {
+            if let Ok(code) = s.parse::<u32>() {
+                StatusCode::from_u32(code)
+            } else {
+                None
+            }
+        });
+        let tonic_code = e.code();
+        let code = code.unwrap_or_else(|| tonic_code_to_status_code(tonic_code));
 
         let msg = get_metadata_value(&e, GREPTIME_DB_HEADER_ERROR_MSG)
             .unwrap_or_else(|| e.message().to_string());

--- a/src/client/src/region.rs
+++ b/src/client/src/region.rs
@@ -201,12 +201,11 @@ impl RegionRequester {
             .await
             .map_err(|e| {
                 let code = e.code();
-                let err: error::Error = e.into();
                 // Uses `Error::RegionServer` instead of `Error::Server`
                 error::Error::RegionServer {
                     addr,
                     code,
-                    source: BoxedError::new(err),
+                    source: BoxedError::new(error::Error::from(e)),
                     location: location!(),
                 }
             })?

--- a/src/common/error/src/status_code.rs
+++ b/src/common/error/src/status_code.rs
@@ -299,6 +299,27 @@ pub fn status_to_tonic_code(status_code: StatusCode) -> Code {
     }
 }
 
+/// Converts tonic [Code] to [StatusCode].
+pub fn tonic_code_to_status_code(code: Code) -> StatusCode {
+    match code {
+        Code::Ok => StatusCode::Success,
+        Code::Unknown => StatusCode::Unknown,
+        Code::PermissionDenied => StatusCode::PermissionDenied,
+        Code::ResourceExhausted => StatusCode::RateLimited,
+        Code::InvalidArgument | Code::FailedPrecondition | Code::OutOfRange => {
+            StatusCode::InvalidArguments
+        }
+        Code::DeadlineExceeded | Code::Cancelled | Code::Aborted => StatusCode::Cancelled,
+        Code::NotFound
+        | Code::Unavailable
+        | Code::AlreadyExists
+        | Code::Internal
+        | Code::Unauthenticated
+        | Code::DataLoss => StatusCode::Internal,
+        Code::Unimplemented => StatusCode::Unsupported,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use strum::IntoEnumIterator;

--- a/src/meta-client/src/client/cluster.rs
+++ b/src/meta-client/src/client/cluster.rs
@@ -30,7 +30,7 @@ use common_meta::rpc::store::{
     BatchPutResponse, DeleteRangeRequest, DeleteRangeResponse, PutRequest, PutResponse,
     RangeRequest, RangeResponse,
 };
-use common_telemetry::{info, warn};
+use common_telemetry::{error, info, warn};
 use snafu::{ensure, ResultExt};
 use tokio::sync::RwLock;
 use tonic::codec::CompressionEncoding;
@@ -237,6 +237,7 @@ impl Inner {
                             times += 1;
                             continue;
                         } else {
+                            error!("An error occurred in gRPC, status: {status}");
                             return Err(Error::from(status));
                         }
                     }

--- a/src/meta-client/src/client/procedure.rs
+++ b/src/meta-client/src/client/procedure.rs
@@ -24,7 +24,7 @@ use api::v1::meta::{
 };
 use common_grpc::channel_manager::ChannelManager;
 use common_telemetry::tracing_context::TracingContext;
-use common_telemetry::{info, warn};
+use common_telemetry::{error, info, warn};
 use snafu::{ensure, ResultExt};
 use tokio::sync::RwLock;
 use tonic::codec::CompressionEncoding;
@@ -199,7 +199,7 @@ impl Inner {
                             times += 1;
                             continue;
                         } else {
-                            warn!("An error occurred in gRPC, status: {status}");
+                            error!("An error occurred in gRPC, status: {status}");
                             return Err(error::Error::from(status));
                         }
                     }

--- a/src/meta-client/src/client/procedure.rs
+++ b/src/meta-client/src/client/procedure.rs
@@ -199,6 +199,7 @@ impl Inner {
                             times += 1;
                             continue;
                         } else {
+                            warn!("An error occurred in gRPC, status: {status}");
                             return Err(error::Error::from(status));
                         }
                     }

--- a/src/meta-client/src/error.rs
+++ b/src/meta-client/src/error.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use common_error::ext::ErrorExt;
-use common_error::status_code::{convert_client_side_tonic_code_to_status_code, StatusCode};
+use common_error::status_code::{convert_tonic_code_to_status_code, StatusCode};
 use common_error::{GREPTIME_DB_HEADER_ERROR_CODE, GREPTIME_DB_HEADER_ERROR_MSG};
 use common_macro::stack_trace_debug;
 use snafu::{location, Location, Snafu};
@@ -178,8 +178,7 @@ impl From<Status> for Error {
             }
         });
         let tonic_code = e.code();
-        let code =
-            code.unwrap_or_else(|| convert_client_side_tonic_code_to_status_code(tonic_code));
+        let code = code.unwrap_or_else(|| convert_tonic_code_to_status_code(tonic_code));
 
         let msg = get_metadata_value(&e, GREPTIME_DB_HEADER_ERROR_MSG)
             .unwrap_or_else(|| e.message().to_string());

--- a/src/meta-client/src/error.rs
+++ b/src/meta-client/src/error.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use common_error::ext::ErrorExt;
-use common_error::status_code::{tonic_code_to_status_code, StatusCode};
+use common_error::status_code::{convert_client_side_tonic_code_to_status_code, StatusCode};
 use common_error::{GREPTIME_DB_HEADER_ERROR_CODE, GREPTIME_DB_HEADER_ERROR_MSG};
 use common_macro::stack_trace_debug;
 use snafu::{location, Location, Snafu};
@@ -178,7 +178,8 @@ impl From<Status> for Error {
             }
         });
         let tonic_code = e.code();
-        let code = code.unwrap_or_else(|| tonic_code_to_status_code(tonic_code));
+        let code =
+            code.unwrap_or_else(|| convert_client_side_tonic_code_to_status_code(tonic_code));
 
         let msg = get_metadata_value(&e, GREPTIME_DB_HEADER_ERROR_MSG)
             .unwrap_or_else(|| e.message().to_string());

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -779,7 +779,7 @@ pub fn status_code_to_http_status(status_code: &StatusCode) -> HttpStatusCode {
 
         // When a request is cancelled by the client (e.g., by a client side timeout),
         // we should return a gateway timeout status code to the external client.
-        StatusCode::Cancelled => HttpStatusCode::GATEWAY_TIMEOUT,
+        StatusCode::Cancelled | StatusCode::DeadlineExceeded => HttpStatusCode::GATEWAY_TIMEOUT,
 
         StatusCode::Unsupported
         | StatusCode::InvalidArguments

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -772,9 +772,14 @@ impl IntoResponse for Error {
     }
 }
 
+/// Converts [StatusCode] to [HttpStatusCode].
 pub fn status_code_to_http_status(status_code: &StatusCode) -> HttpStatusCode {
     match status_code {
-        StatusCode::Success | StatusCode::Cancelled => HttpStatusCode::OK,
+        StatusCode::Success => HttpStatusCode::OK,
+
+        // When a request is cancelled by the client (e.g., by a client side timeout),
+        // we should return a gateway timeout status code to the external client.
+        StatusCode::Cancelled => HttpStatusCode::GATEWAY_TIMEOUT,
 
         StatusCode::Unsupported
         | StatusCode::InvalidArguments

--- a/src/servers/src/mysql/writer.rs
+++ b/src/servers/src/mysql/writer.rs
@@ -334,7 +334,7 @@ fn mysql_error_kind(status_code: &StatusCode) -> ErrorKind {
         StatusCode::Success => ErrorKind::ER_YES,
         StatusCode::Unknown | StatusCode::External => ErrorKind::ER_UNKNOWN_ERROR,
         StatusCode::Unsupported => ErrorKind::ER_NOT_SUPPORTED_YET,
-        StatusCode::Cancelled => ErrorKind::ER_QUERY_INTERRUPTED,
+        StatusCode::Cancelled | StatusCode::DeadlineExceeded => ErrorKind::ER_QUERY_INTERRUPTED,
         StatusCode::RuntimeResourcesExhausted => ErrorKind::ER_OUT_OF_RESOURCES,
         StatusCode::InvalidSyntax => ErrorKind::ER_SYNTAX_ERROR,
         StatusCode::RegionAlreadyExists | StatusCode::TableAlreadyExists => {

--- a/src/servers/src/postgres/types/error.rs
+++ b/src/servers/src/postgres/types/error.rs
@@ -374,6 +374,7 @@ impl From<StatusCode> for PgErrorCode {
             StatusCode::Unsupported => PgErrorCode::Ec0A000,
             StatusCode::InvalidArguments => PgErrorCode::Ec22023,
             StatusCode::Cancelled => PgErrorCode::Ec57000,
+            StatusCode::DeadlineExceeded => PgErrorCode::Ec57000,
             StatusCode::External => PgErrorCode::Ec58000,
 
             StatusCode::Unknown


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR improve error code handling in status code conversion.

We first attempt to extract the status code from gRPC response metadata (`GREPTIME_DB_HEADER_ERROR_CODE`). If not available, we fall back to converting the tonic status code to our internal representation, ensuring proper handling of client-side cancellations and other error states.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
