### PR TITLE
fix: remove metadata region options

### DIFF
--- a/src/store-api/src/mito_engine_options.rs
+++ b/src/store-api/src/mito_engine_options.rs
@@ -61,6 +61,7 @@ pub const MEMTABLE_PARTITION_TREE_FORK_DICTIONARY_BYTES: &str =
     "memtable.partition_tree.fork_dictionary_bytes";
 /// Option key for skipping WAL.
 pub const SKIP_WAL_KEY: &str = "skip_wal";
+// Note: Adding new options here should also check if this option should be removed in [metric_engine::engine::create::region_options_for_metadata_region].
 
 /// Returns true if the `key` is a valid option key for the mito engine.
 pub fn is_mito_engine_option_key(key: &str) -> bool {

--- a/src/store-api/src/mito_engine_options.rs
+++ b/src/store-api/src/mito_engine_options.rs
@@ -59,6 +59,8 @@ pub const MEMTABLE_PARTITION_TREE_DATA_FREEZE_THRESHOLD: &str =
 /// Option key for memtable partition tree fork dictionary bytes.
 pub const MEMTABLE_PARTITION_TREE_FORK_DICTIONARY_BYTES: &str =
     "memtable.partition_tree.fork_dictionary_bytes";
+/// Option key for skipping WAL.
+pub const SKIP_WAL_KEY: &str = "skip_wal";
 
 /// Returns true if the `key` is a valid option key for the mito engine.
 pub fn is_mito_engine_option_key(key: &str) -> bool {

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -99,7 +99,7 @@ pub const TTL_KEY: &str = store_api::mito_engine_options::TTL_KEY;
 pub const STORAGE_KEY: &str = "storage";
 pub const COMMENT_KEY: &str = "comment";
 pub const AUTO_CREATE_TABLE_KEY: &str = "auto_create_table";
-pub const SKIP_WAL_KEY: &str = "skip_wal";
+pub const SKIP_WAL_KEY: &str = store_api::mito_engine_options::SKIP_WAL_KEY;
 
 impl TableOptions {
     pub fn try_from_iter<T: ToString, U: IntoIterator<Item = (T, T)>>(


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
 ### Add `SKIP_WAL_KEY` Option to Metric Engine

 - **Enhancements**:
   - Introduced `SKIP_WAL_KEY` to the metric engine options in `create.rs` and `mito_engine_options.rs`.
   - Updated test cases in `create.rs` to include `skip_wal` option and ensure it is removed for metadata regions.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
