### PR TITLE
refactor: avoid empty display in errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1989,6 +1989,7 @@ dependencies = [
 name = "common-error"
 version = "0.14.0"
 dependencies = [
+ "common-macro",
  "http 1.1.0",
  "snafu 0.8.5",
  "strum 0.27.1",

--- a/src/common/error/Cargo.toml
+++ b/src/common/error/Cargo.toml
@@ -12,3 +12,6 @@ http.workspace = true
 snafu.workspace = true
 strum.workspace = true
 tonic.workspace = true
+
+[dev-dependencies]
+common-macro.workspace = true

--- a/src/common/error/src/ext.rs
+++ b/src/common/error/src/ext.rs
@@ -42,7 +42,7 @@ pub trait ErrorExt: StackError {
                 if let Some(external_error) = error.source() {
                     let external_root = external_error.sources().last().unwrap();
 
-                    if error.to_string().is_empty() {
+                    if error.transparent() {
                         format!("{external_root}")
                     } else {
                         format!("{error}: {external_root}")
@@ -85,6 +85,14 @@ pub trait StackError: std::error::Error {
             result = err;
         }
         result
+    }
+
+    /// Indicates whether this error is "transparent", that it delegates its "display" and "source"
+    /// to the underlying error. Could be useful when you are just wrapping some external error,
+    /// **AND** can not or would not provide meaningful contextual info. For example, the
+    /// `DataFusionError`.
+    fn transparent(&self) -> bool {
+        false
     }
 }
 

--- a/src/common/error/tests/ext.rs
+++ b/src/common/error/tests/ext.rs
@@ -14,7 +14,7 @@
 
 use std::any::Any;
 
-use common_error::ext::{ErrorExt, PlainError};
+use common_error::ext::{ErrorExt, PlainError, StackError};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use snafu::{Location, ResultExt, Snafu};
@@ -99,4 +99,13 @@ fn test_debug_format() {
         r#"0: <transparent>, at src/common/error/tests/ext.rs:60:5
 1: PlainError { msg: "<root cause>", status_code: Unexpected }"#
     );
+}
+
+#[test]
+fn test_transparent_flag() {
+    let result = normal_error();
+    assert!(!result.unwrap_err().transparent());
+
+    let result = transparent_error();
+    assert!(result.unwrap_err().transparent());
 }

--- a/src/common/error/tests/ext.rs
+++ b/src/common/error/tests/ext.rs
@@ -1,0 +1,102 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+
+use common_error::ext::{ErrorExt, PlainError};
+use common_error::status_code::StatusCode;
+use common_macro::stack_trace_debug;
+use snafu::{Location, ResultExt, Snafu};
+
+#[derive(Snafu)]
+#[stack_trace_debug]
+enum MyError {
+    #[snafu(display(r#"A normal error with "display" attribute, message "{}""#, message))]
+    Normal {
+        message: String,
+        #[snafu(source)]
+        error: PlainError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(transparent)]
+    Transparent {
+        #[snafu(source)]
+        error: PlainError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+}
+
+impl ErrorExt for MyError {
+    fn status_code(&self) -> StatusCode {
+        StatusCode::Unexpected
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+fn normal_error() -> Result<(), MyError> {
+    let plain_error = PlainError::new("<root cause>".to_string(), StatusCode::Unexpected);
+    Err(plain_error).context(NormalSnafu { message: "blabla" })
+}
+
+fn transparent_error() -> Result<(), MyError> {
+    let plain_error = PlainError::new("<root cause>".to_string(), StatusCode::Unexpected);
+    Err(plain_error)?
+}
+
+#[test]
+fn test_output_msg() {
+    let result = normal_error();
+    assert_eq!(
+        result.unwrap_err().output_msg(),
+        r#"A normal error with "display" attribute, message "blabla": <root cause>"#
+    );
+
+    let result = transparent_error();
+    assert_eq!(result.unwrap_err().output_msg(), "<root cause>");
+}
+
+#[test]
+fn test_to_string() {
+    let result = normal_error();
+    assert_eq!(
+        result.unwrap_err().to_string(),
+        r#"A normal error with "display" attribute, message "blabla""#
+    );
+
+    let result = transparent_error();
+    assert_eq!(result.unwrap_err().to_string(), "<root cause>");
+}
+
+#[test]
+fn test_debug_format() {
+    let result = normal_error();
+    assert_eq!(
+        format!("{:?}", result.unwrap_err()),
+        r#"0: A normal error with "display" attribute, message "blabla", at src/common/error/tests/ext.rs:55:22
+1: PlainError { msg: "<root cause>", status_code: Unexpected }"#
+    );
+
+    let result = transparent_error();
+    assert_eq!(
+        format!("{:?}", result.unwrap_err()),
+        r#"0: <transparent>, at src/common/error/tests/ext.rs:60:5
+1: PlainError { msg: "<root cause>", status_code: Unexpected }"#
+    );
+}

--- a/src/common/recordbatch/src/adapter.rs
+++ b/src/common/recordbatch/src/adapter.rs
@@ -298,7 +298,7 @@ impl Stream for RecordBatchStreamAdapter {
         match Pin::new(&mut self.stream).poll_next(cx) {
             Poll::Pending => Poll::Pending,
             Poll::Ready(Some(df_record_batch)) => {
-                let df_record_batch = df_record_batch.context(error::PollStreamSnafu)?;
+                let df_record_batch = df_record_batch?;
                 Poll::Ready(Some(RecordBatch::try_from_df_record_batch(
                     self.schema(),
                     df_record_batch,

--- a/src/common/recordbatch/src/error.rs
+++ b/src/common/recordbatch/src/error.rs
@@ -65,7 +65,7 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display(""))]
+    #[snafu(transparent)]
     PollStream {
         #[snafu(source)]
         error: datafusion::error::DataFusionError,

--- a/src/query/src/datafusion.rs
+++ b/src/query/src/datafusion.rs
@@ -50,9 +50,9 @@ use crate::dataframe::DataFrame;
 pub use crate::datafusion::planner::DfContextProviderAdapter;
 use crate::dist_plan::MergeScanLogicalPlan;
 use crate::error::{
-    CatalogSnafu, ConvertSchemaSnafu, CreateRecordBatchSnafu, DataFusionSnafu,
-    MissingTableMutationHandlerSnafu, MissingTimestampColumnSnafu, QueryExecutionSnafu, Result,
-    TableMutationSnafu, TableNotFoundSnafu, TableReadOnlySnafu, UnsupportedExprSnafu,
+    CatalogSnafu, ConvertSchemaSnafu, CreateRecordBatchSnafu, MissingTableMutationHandlerSnafu,
+    MissingTimestampColumnSnafu, QueryExecutionSnafu, Result, TableMutationSnafu,
+    TableNotFoundSnafu, TableReadOnlySnafu, UnsupportedExprSnafu,
 };
 use crate::executor::QueryExecutor;
 use crate::metrics::{OnDone, QUERY_STAGE_ELAPSED};
@@ -308,8 +308,7 @@ impl DatafusionQueryEngine {
         let physical_plan = state
             .query_planner()
             .create_physical_plan(&optimized_plan, state)
-            .await
-            .context(DataFusionSnafu)?;
+            .await?;
 
         Ok(physical_plan)
     }

--- a/src/query/src/datafusion/planner.rs
+++ b/src/query/src/datafusion/planner.rs
@@ -43,7 +43,7 @@ use datafusion_sql::parser::Statement as DfStatement;
 use session::context::QueryContextRef;
 use snafu::{Location, ResultExt};
 
-use crate::error::{CatalogSnafu, DataFusionSnafu, Result};
+use crate::error::{CatalogSnafu, Result};
 use crate::query_engine::{DefaultPlanDecoder, QueryEngineState};
 
 pub struct DfContextProviderAdapter {
@@ -70,9 +70,7 @@ impl DfContextProviderAdapter {
         query_ctx: QueryContextRef,
     ) -> Result<Self> {
         let table_names = if let Some(df_stmt) = df_stmt {
-            session_state
-                .resolve_table_references(df_stmt)
-                .context(DataFusionSnafu)?
+            session_state.resolve_table_references(df_stmt)?
         } else {
             vec![]
         };

--- a/src/query/src/error.rs
+++ b/src/query/src/error.rs
@@ -126,7 +126,7 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display(""))]
+    #[snafu(transparent)]
     DataFusion {
         #[snafu(source)]
         error: DataFusionError,

--- a/src/query/src/plan.rs
+++ b/src/query/src/plan.rs
@@ -19,12 +19,11 @@ use datafusion_common::tree_node::{Transformed, TreeNode, TreeNodeRewriter};
 use datafusion_common::TableReference;
 use datafusion_expr::{BinaryExpr, Expr, Join, LogicalPlan, Operator};
 use session::context::QueryContextRef;
-use snafu::ResultExt;
 pub use table::metadata::TableType;
 use table::table::adapter::DfTableProviderAdapter;
 use table::table_name::TableName;
 
-use crate::error::{DataFusionSnafu, Result};
+use crate::error::Result;
 
 struct TableNamesExtractAndRewriter {
     pub(crate) table_names: HashSet<TableName>,
@@ -119,7 +118,7 @@ pub fn extract_and_rewrite_full_table_names(
     query_ctx: QueryContextRef,
 ) -> Result<(HashSet<TableName>, LogicalPlan)> {
     let mut extractor = TableNamesExtractAndRewriter::new(query_ctx);
-    let plan = plan.rewrite(&mut extractor).context(DataFusionSnafu)?;
+    let plan = plan.rewrite(&mut extractor)?;
     Ok((extractor.table_names, plan.data))
 }
 

--- a/src/query/src/planner.rs
+++ b/src/query/src/planner.rs
@@ -31,7 +31,7 @@ use snafu::ResultExt;
 use sql::ast::Expr as SqlExpr;
 use sql::statements::statement::Statement;
 
-use crate::error::{DataFusionSnafu, PlanSqlSnafu, QueryPlanSnafu, Result, SqlSnafu};
+use crate::error::{PlanSqlSnafu, QueryPlanSnafu, Result, SqlSnafu};
 use crate::log_query::planner::LogQueryPlanner;
 use crate::parser::QueryStatement;
 use crate::promql::planner::PromPlanner;
@@ -118,8 +118,7 @@ impl DfLogicalPlanner {
         let context = QueryEngineContext::new(self.session_state.clone(), query_ctx);
         let plan = self
             .engine_state
-            .optimize_by_extension_rules(plan, &context)
-            .context(DataFusionSnafu)?;
+            .optimize_by_extension_rules(plan, &context)?;
         common_telemetry::debug!("Logical planner, optimize result: {plan}");
 
         Ok(plan)
@@ -154,9 +153,7 @@ impl DfLogicalPlanner {
 
         let sql_to_rel = SqlToRel::new_with_options(&context_provider, parser_options);
 
-        sql_to_rel
-            .sql_to_expr(sql.into(), schema, &mut PlannerContext::new())
-            .context(DataFusionSnafu)
+        Ok(sql_to_rel.sql_to_expr(sql.into(), schema, &mut PlannerContext::new())?)
     }
 
     #[tracing::instrument(skip_all)]
@@ -183,10 +180,7 @@ impl DfLogicalPlanner {
 
     #[tracing::instrument(skip_all)]
     fn optimize_logical_plan(&self, plan: LogicalPlan) -> Result<LogicalPlan> {
-        self.engine_state
-            .optimize_logical_plan(plan)
-            .context(DataFusionSnafu)
-            .map(Into::into)
+        Ok(self.engine_state.optimize_logical_plan(plan)?)
     }
 }
 

--- a/src/query/src/range_select/plan_rewrite.rs
+++ b/src/query/src/range_select/plan_rewrite.rs
@@ -43,8 +43,7 @@ use snafu::{ensure, OptionExt, ResultExt};
 use table::table::adapter::DfTableProviderAdapter;
 
 use crate::error::{
-    CatalogSnafu, DataFusionSnafu, RangeQuerySnafu, Result, TimeIndexNotFoundSnafu,
-    UnknownTableSnafu,
+    CatalogSnafu, RangeQuerySnafu, Result, TimeIndexNotFoundSnafu, UnknownTableSnafu,
 };
 use crate::plan::ExtractExpr;
 use crate::range_select::plan::{Fill, RangeFn, RangeSelect};
@@ -385,8 +384,7 @@ impl RangePlanRewriter {
                 let new_expr = expr
                     .iter()
                     .map(|expr| expr.clone().rewrite(&mut range_rewriter).map(|x| x.data))
-                    .collect::<DFResult<Vec<_>>>()
-                    .context(DataFusionSnafu)?;
+                    .collect::<DFResult<Vec<_>>>()?;
                 if range_rewriter.by.is_empty() {
                     range_rewriter.by = default_by;
                 }
@@ -408,9 +406,7 @@ impl RangePlanRewriter {
                 } else {
                     let project_plan = LogicalPlanBuilder::from(range_plan)
                         .project(new_expr)
-                        .context(DataFusionSnafu)?
-                        .build()
-                        .context(DataFusionSnafu)?;
+                        .and_then(|x| x.build())?;
                     Ok(Some(project_plan))
                 }
             }
@@ -436,8 +432,7 @@ impl RangePlanRewriter {
                                 }
                             );
                             LogicalPlanBuilder::from(inputs[0].clone())
-                                .explain(*verbose, true)
-                                .context(DataFusionSnafu)?
+                                .explain(*verbose, true)?
                                 .build()
                         }
                         LogicalPlan::Explain(Explain { verbose, .. }) => {
@@ -448,8 +443,7 @@ impl RangePlanRewriter {
                                 }
                             );
                             LogicalPlanBuilder::from(inputs[0].clone())
-                                .explain(*verbose, false)
-                                .context(DataFusionSnafu)?
+                                .explain(*verbose, false)?
                                 .build()
                         }
                         LogicalPlan::Distinct(Distinct::On(DistinctOn {
@@ -470,13 +464,11 @@ impl RangePlanRewriter {
                                     on_expr.clone(),
                                     select_expr.clone(),
                                     sort_expr.clone(),
-                                )
-                                .context(DataFusionSnafu)?
+                                )?
                                 .build()
                         }
                         _ => plan.with_new_exprs(plan.expressions_consider_join(), inputs),
-                    }
-                    .context(DataFusionSnafu)?;
+                    }?;
                     Ok(Some(plan))
                 } else {
                     Ok(None)
@@ -605,8 +597,6 @@ fn interval_only_in_expr(expr: &Expr) -> bool {
 
 #[cfg(test)]
 mod test {
-
-    use std::error::Error;
 
     use arrow::datatypes::IntervalUnit;
     use catalog::memory::MemoryCatalogManager;
@@ -825,12 +815,7 @@ mod test {
     /// the right argument is `range_fn(avg(field_0), '5m', 'NULL', '0', '1h')`
     async fn range_argument_err_1() {
         let query = r#"SELECT range_fn('5m', avg(field_0), 'NULL', '1', tag_0, '1h') FROM test group by tag_0;"#;
-        let error = do_query(query)
-            .await
-            .unwrap_err()
-            .source()
-            .unwrap()
-            .to_string();
+        let error = do_query(query).await.unwrap_err().to_string();
         assert_eq!(
             error,
             "Error during planning: Illegal argument `Utf8(\"5m\")` in range select query"
@@ -840,12 +825,7 @@ mod test {
     #[tokio::test]
     async fn range_argument_err_2() {
         let query = r#"SELECT range_fn(avg(field_0), 5, 'NULL', '1', tag_0, '1h') FROM test group by tag_0;"#;
-        let error = do_query(query)
-            .await
-            .unwrap_err()
-            .source()
-            .unwrap()
-            .to_string();
+        let error = do_query(query).await.unwrap_err().to_string();
         assert_eq!(
             error,
             "Error during planning: Illegal argument `Int64(5)` in range select query"

--- a/src/query/src/sql.rs
+++ b/src/query/src/sql.rs
@@ -301,8 +301,7 @@ async fn query_from_information_schema_table(
                     .state()
                     .clone(),
             )
-            .read_table(view)
-            .context(error::DataFusionSnafu)?;
+            .read_table(view)?;
 
             let planner = query_engine.planner();
             let planner = planner
@@ -319,10 +318,7 @@ async fn query_from_information_schema_table(
         }
     };
 
-    let stream = dataframe
-        .execute_stream()
-        .await
-        .context(error::DataFusionSnafu)?;
+    let stream = dataframe.execute_stream().await?;
 
     Ok(Output::new_with_stream(Box::pin(
         RecordBatchStreamAdapter::try_new(stream).context(error::CreateRecordBatchSnafu)?,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#5814 
## What's changed and what's your intention?

Some errors are annotated with `#[snafu(display("")]`, which could produce empty result if we accidently call `to_string` on it, like [here](https://github.com/GreptimeTeam/greptimedb/pull/5841/files). So it's not a good practice. This PR is trying to use Snafu's "transparent" attribute to avoid that.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
