### PR TITLE
feat: apply terms with fulltext tantivy backend

### DIFF
--- a/src/index/src/fulltext_index/create/bloom_filter.rs
+++ b/src/index/src/fulltext_index/create/bloom_filter.rs
@@ -30,11 +30,9 @@ use crate::fulltext_index::error::{
     SerializeToJsonSnafu,
 };
 use crate::fulltext_index::tokenizer::{Analyzer, ChineseTokenizer, EnglishTokenizer};
-use crate::fulltext_index::Config;
+use crate::fulltext_index::{Config, KEY_FULLTEXT_CONFIG};
 
 const PIPE_BUFFER_SIZE_FOR_SENDING_BLOB: usize = 8192;
-
-pub const KEY_FULLTEXT_CONFIG: &str = "fulltext_config";
 
 /// `BloomFilterFulltextIndexCreator` is for creating a fulltext index using a bloom filter.
 pub struct BloomFilterFulltextIndexCreator {

--- a/src/index/src/fulltext_index/search/tantivy.rs
+++ b/src/index/src/fulltext_index/search/tantivy.rs
@@ -29,6 +29,7 @@ use crate::fulltext_index::error::{
     Result, TantivyDocNotFoundSnafu, TantivyParserSnafu, TantivySnafu,
 };
 use crate::fulltext_index::search::{FulltextIndexSearcher, RowId};
+use crate::fulltext_index::Config;
 
 /// `TantivyFulltextIndexSearcher` is a searcher using Tantivy.
 pub struct TantivyFulltextIndexSearcher {
@@ -42,10 +43,11 @@ pub struct TantivyFulltextIndexSearcher {
 
 impl TantivyFulltextIndexSearcher {
     /// Creates a new `TantivyFulltextIndexSearcher`.
-    pub fn new(path: impl AsRef<Path>) -> Result<Self> {
+    pub fn new(path: impl AsRef<Path>, config: Config) -> Result<Self> {
         let now = Instant::now();
 
-        let index = Index::open_in_dir(path.as_ref()).context(TantivySnafu)?;
+        let mut index = Index::open_in_dir(path.as_ref()).context(TantivySnafu)?;
+        index.set_tokenizers(config.build_tantivy_tokenizer());
         let reader = index
             .reader_builder()
             .reload_policy(ReloadPolicy::Manual)

--- a/src/index/src/fulltext_index/tests.rs
+++ b/src/index/src/fulltext_index/tests.rs
@@ -19,7 +19,7 @@ use common_test_util::temp_dir::{create_temp_dir, TempDir};
 use puffin::puffin_manager::file_accessor::MockFileAccessor;
 use puffin::puffin_manager::fs_puffin_manager::FsPuffinManager;
 use puffin::puffin_manager::stager::BoundedStager;
-use puffin::puffin_manager::{DirGuard, PuffinManager, PuffinReader, PuffinWriter, PutOptions};
+use puffin::puffin_manager::{PuffinManager, PuffinReader, PuffinWriter, PutOptions};
 
 use crate::fulltext_index::create::{FulltextIndexCreator, TantivyFulltextIndexCreator};
 use crate::fulltext_index::search::{FulltextIndexSearcher, RowId, TantivyFulltextIndexSearcher};
@@ -61,8 +61,7 @@ async fn test_search(
     prefix: &str,
     config: Config,
     texts: Vec<&str>,
-    query: &str,
-    expected: impl IntoIterator<Item = RowId>,
+    query_expected: Vec<(&str, impl IntoIterator<Item = RowId>)>,
 ) {
     let (_staging_dir, stager) = new_bounded_stager(prefix).await;
     let file_accessor = Arc::new(MockFileAccessor::new(prefix));
@@ -75,11 +74,12 @@ async fn test_search(
 
     let reader = puffin_manager.reader(&file_name).await.unwrap();
     let index_dir = reader.dir(&blob_key).await.unwrap();
-    let searcher = TantivyFulltextIndexSearcher::new(index_dir.path()).unwrap();
-    let results = searcher.search(query).await.unwrap();
-
-    let expected = expected.into_iter().collect::<BTreeSet<_>>();
-    assert_eq!(results, expected);
+    let searcher = TantivyFulltextIndexSearcher::new(index_dir.path(), config).unwrap();
+    for (query, expected) in query_expected {
+        let results = searcher.search(query).await.unwrap();
+        let expected = expected.into_iter().collect::<BTreeSet<_>>();
+        assert_eq!(results, expected);
+    }
 }
 
 #[tokio::test]
@@ -91,8 +91,7 @@ async fn test_simple_term() {
             "This is a sample text containing Barack Obama",
             "Another document mentioning Barack",
         ],
-        "Barack Obama",
-        [0, 1],
+        vec![("Barack Obama", [0, 1])],
     )
     .await;
 }
@@ -103,8 +102,7 @@ async fn test_negative_term() {
         "test_negative_term_",
         Config::default(),
         vec!["apple is a fruit", "I like apple", "fruit is healthy"],
-        "apple -fruit",
-        [1],
+        vec![("apple -fruit", [1])],
     )
     .await;
 }
@@ -119,8 +117,7 @@ async fn test_must_term() {
             "I love apples and fruits",
             "apple and fruit are good",
         ],
-        "+apple +fruit",
-        [2],
+        vec![("+apple +fruit", [2])],
     )
     .await;
 }
@@ -131,8 +128,7 @@ async fn test_boolean_operators() {
         "test_boolean_operators_",
         Config::default(),
         vec!["a b c", "a b", "b c", "c"],
-        "a AND b OR c",
-        [0, 1, 2, 3],
+        vec![("a AND b OR c", [0, 1, 2, 3])],
     )
     .await;
 }
@@ -146,8 +142,7 @@ async fn test_phrase_term() {
             "This is a sample text containing Barack Obama",
             "Another document mentioning Barack",
         ],
-        "\"Barack Obama\"",
-        [0],
+        vec![("\"Barack Obama\"", [0])],
     )
     .await;
 }
@@ -161,8 +156,7 @@ async fn test_config_english_analyzer_case_insensitive() {
             ..Config::default()
         },
         vec!["Banana is a fruit", "I like apple", "Fruit is healthy"],
-        "banana",
-        [0],
+        vec![("banana", [0]), ("Banana", [0]), ("BANANA", [0])],
     )
     .await;
 }
@@ -175,9 +169,8 @@ async fn test_config_english_analyzer_case_sensitive() {
             case_sensitive: true,
             ..Config::default()
         },
-        vec!["Banana is a fruit", "I like apple", "Fruit is healthy"],
-        "banana",
-        [],
+        vec!["Banana is a fruit", "I like banana", "Fruit is healthy"],
+        vec![("banana", [1]), ("Banana", [0])],
     )
     .await;
 }
@@ -191,8 +184,7 @@ async fn test_config_chinese_analyzer() {
             ..Default::default()
         },
         vec!["苹果是一种水果", "我喜欢苹果", "水果很健康"],
-        "苹果",
-        [0, 1],
+        vec![("苹果", [0, 1])],
     )
     .await;
 }

--- a/src/index/src/fulltext_index/tests.rs
+++ b/src/index/src/fulltext_index/tests.rs
@@ -71,6 +71,7 @@ async fn test_search(
     let blob_key = "fulltext_index".to_string();
     let mut writer = puffin_manager.writer(&file_name).await.unwrap();
     create_index(prefix, &mut writer, &blob_key, texts, config).await;
+    writer.finish().await.unwrap();
 
     let reader = puffin_manager.reader(&file_name).await.unwrap();
     let index_dir = reader.dir(&blob_key).await.unwrap();

--- a/src/mito2/src/sst/index/puffin_manager.rs
+++ b/src/mito2/src/sst/index/puffin_manager.rs
@@ -174,12 +174,13 @@ impl PuffinFileAccessor for ObjectStorePuffinFileAccessor {
 
 #[cfg(test)]
 mod tests {
+
     use common_base::range_read::RangeReader;
     use common_test_util::temp_dir::create_temp_dir;
     use futures::io::Cursor;
     use object_store::services::Memory;
     use puffin::blob_metadata::CompressionCodec;
-    use puffin::puffin_manager::{DirGuard, PuffinManager, PuffinReader, PuffinWriter, PutOptions};
+    use puffin::puffin_manager::{PuffinManager, PuffinReader, PuffinWriter, PutOptions};
 
     use super::*;
 
@@ -229,6 +230,7 @@ mod tests {
                 PutOptions {
                     compression: Some(CompressionCodec::Zstd),
                 },
+                Default::default(),
             )
             .await
             .unwrap();

--- a/src/puffin/src/puffin_manager/fs_puffin_manager/writer.rs
+++ b/src/puffin/src/puffin_manager/fs_puffin_manager/writer.rs
@@ -88,7 +88,13 @@ where
         Ok(written_bytes)
     }
 
-    async fn put_dir(&mut self, key: &str, dir_path: PathBuf, options: PutOptions) -> Result<u64> {
+    async fn put_dir(
+        &mut self,
+        key: &str,
+        dir_path: PathBuf,
+        options: PutOptions,
+        properties: HashMap<String, String>,
+    ) -> Result<u64> {
         ensure!(
             !self.blob_keys.contains(key),
             DuplicateBlobSnafu { blob: key }
@@ -150,7 +156,7 @@ where
             blob_type: key.to_string(),
             compressed_data: encoded.as_slice(),
             compression_codec: None,
-            properties: Default::default(),
+            properties,
         };
 
         written_bytes += self.puffin_file_writer.add_blob(dir_meta_blob).await?;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Add support for applying term-based queries to the tantivy backend. The implementation introduces a streamlined way to filter search results using terms.

The critical functionality is in the `apply_one_column` method, where terms are now properly processed:

```rust
// 2. Apply terms
let query = request.terms_as_query(config.case_sensitive);
if !query.0.is_empty() {
    let result = searcher
        .search(&query.0)
        .await
        .context(ApplyFulltextIndexSnafu)?;

    if let Some(ids) = row_ids.as_mut() {
        ids.retain(|id| result.contains(id));
    } else {
        row_ids = Some(result);
    }
}
```

This implementation:
1. Converts term criteria to query syntax using `terms_as_query()`
2. Respects the index's case sensitivity configuration
3. Applies term-based filtering after any direct queries
4. Properly intersects results when both queries and terms are provided


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
