### PR TITLE
fix: conn pool leak

### DIFF
--- a/src/common/grpc/src/channel_manager.rs
+++ b/src/common/grpc/src/channel_manager.rs
@@ -446,7 +446,11 @@ impl Pool {
 async fn recycle_channel_in_loop(pool: Arc<Pool>, interval_secs: u64) {
     let mut interval = tokio::time::interval(Duration::from_secs(interval_secs));
     // use weak ref here to prevent pool being leaked
-    let pool_weak = Arc::downgrade(&pool);
+    let pool_weak = {
+        let weak = Arc::downgrade(&pool);
+        drop(pool);
+        weak
+    };
     loop {
         let _ = interval.tick().await;
         if let Some(pool) = pool_weak.upgrade() {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

fix a bug when `ChannelManager` starting recycle connection pool, the pool can't be released even all ChannelManager using it dropped, hence cause pool being leaked

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
