### PR TITLE
feat: introduce `high_watermark` for remote wal logstore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6408,6 +6408,7 @@ dependencies = [
  "common-test-util",
  "common-time",
  "common-wal",
+ "dashmap",
  "delta-encoding",
  "derive_builder 0.20.1",
  "futures",

--- a/src/log-store/Cargo.toml
+++ b/src/log-store/Cargo.toml
@@ -26,6 +26,7 @@ common-runtime.workspace = true
 common-telemetry.workspace = true
 common-time.workspace = true
 common-wal.workspace = true
+dashmap.workspace = true
 delta-encoding = "0.4"
 derive_builder.workspace = true
 futures.workspace = true

--- a/src/log-store/src/kafka/log_store.rs
+++ b/src/log-store/src/kafka/log_store.rs
@@ -599,6 +599,8 @@ mod tests {
                 .for_each(|entry| entry.set_entry_id(0));
             assert_eq!(expected_entries, actual_entries);
         }
+        let high_wathermark = logstore.high_watermark(&provider).await.unwrap();
+        assert_eq!(high_wathermark, 99);
     }
 
     #[tokio::test]
@@ -672,5 +674,7 @@ mod tests {
                 .for_each(|entry| entry.set_entry_id(0));
             assert_eq!(expected_entries, actual_entries);
         }
+        let high_wathermark = logstore.high_watermark(&provider).await.unwrap();
+        assert_eq!(high_wathermark, (data_size_kb as u64 / 8 + 1) * 20 * 5 - 1);
     }
 }

--- a/src/log-store/src/raft_engine/log_store.rs
+++ b/src/log-store/src/raft_engine/log_store.rs
@@ -483,6 +483,10 @@ impl LogStore for RaftEngineLogStore {
         );
         Ok(())
     }
+
+    async fn high_watermark(&self, _provider: &Provider) -> Result<EntryId> {
+        unreachable!()
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -274,6 +274,7 @@ impl RegionOpener {
             last_flush_millis: AtomicI64::new(now),
             last_compaction_millis: AtomicI64::new(now),
             time_provider: self.time_provider.clone(),
+            high_watermark_since_flush: AtomicU64::new(0),
             memtable_builder,
             stats: self.stats,
         })
@@ -452,6 +453,7 @@ impl RegionOpener {
             last_flush_millis: AtomicI64::new(now),
             last_compaction_millis: AtomicI64::new(now),
             time_provider: self.time_provider.clone(),
+            high_watermark_since_flush: AtomicU64::new(0),
             memtable_builder,
             stats: self.stats.clone(),
         };

--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -747,6 +747,8 @@ pub(crate) enum BackgroundNotify {
     RegionChange(RegionChangeResult),
     /// Region edit result.
     RegionEdit(RegionEditResult),
+    /// Update high watermark.
+    UpdateHighWatermark,
 }
 
 /// Notifies a flush job is finished.

--- a/src/mito2/src/wal/raw_entry_reader.rs
+++ b/src/mito2/src/wal/raw_entry_reader.rs
@@ -196,6 +196,10 @@ mod tests {
         ) -> Result<Entry, Self::Error> {
             unreachable!()
         }
+
+        async fn high_watermark(&self, _provider: &Provider) -> Result<EntryId, Self::Error> {
+            unreachable!()
+        }
     }
 
     #[tokio::test]

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -915,6 +915,9 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                 self.handle_manifest_region_change_result(req).await
             }
             BackgroundNotify::RegionEdit(req) => self.handle_region_edit_result(req).await,
+            BackgroundNotify::UpdateHighWatermark => {
+                self.handle_update_high_watermark_request(region_id).await
+            }
         }
     }
 

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -22,6 +22,7 @@ use common_telemetry::info;
 use common_telemetry::tracing::warn;
 use humantime_serde::re::humantime;
 use snafu::ResultExt;
+use store_api::logstore::LogStore;
 use store_api::metadata::{
     InvalidSetRegionOptionRequestSnafu, MetadataError, RegionMetadata, RegionMetadataBuilder,
     RegionMetadataRef,
@@ -40,7 +41,7 @@ use crate::region::MitoRegionRef;
 use crate::request::{DdlRequest, OptionOutputTx, SenderDdlRequest};
 use crate::worker::RegionWorkerLoop;
 
-impl<S> RegionWorkerLoop<S> {
+impl<S: LogStore> RegionWorkerLoop<S> {
     pub(crate) async fn handle_alter_request(
         &mut self,
         region_id: RegionId,

--- a/src/mito2/src/worker/handle_flush.rs
+++ b/src/mito2/src/worker/handle_flush.rs
@@ -42,19 +42,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         };
 
         // Update high watermark for remote WAL if memtables are empty.
-        if region.provider.is_remote_wal() && region.version().memtables.is_empty() {
-            let high_watermark = self
-                .wal
-                .store()
-                .high_watermark(&region.provider)
-                .await
-                .unwrap_or_default();
-            if high_watermark != 0 {
-                region
-                    .high_watermark_since_flush
-                    .store(high_watermark, Ordering::Relaxed);
-            }
-        }
+        self.update_high_watermark(&region).await;
 
         let reason = if region.is_downgrading() {
             FlushReason::Downgrading
@@ -262,5 +250,30 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         self.schedule_compaction(&region).await;
 
         self.listener.on_flush_success(region_id);
+    }
+
+    pub(crate) async fn handle_update_high_watermark_request(&mut self, region_id: RegionId) {
+        let region = match self.regions.get_region(region_id) {
+            Some(region) => region,
+            None => return,
+        };
+        self.update_high_watermark(&region).await;
+    }
+
+    /// Updates high watermark of the region when a flush request is scheduled but the memtable is empty.
+    pub(crate) async fn update_high_watermark(&mut self, region: &MitoRegionRef) {
+        if region.provider.is_remote_wal() && region.version().memtables.is_empty() {
+            let high_watermark = self
+                .wal
+                .store()
+                .high_watermark(&region.provider)
+                .await
+                .unwrap_or(0);
+            if high_watermark != 0 {
+                region
+                    .high_watermark_since_flush
+                    .store(high_watermark, Ordering::Relaxed);
+            }
+        }
     }
 }

--- a/src/store-api/src/logstore.rs
+++ b/src/store-api/src/logstore.rs
@@ -94,6 +94,9 @@ pub trait LogStore: Send + Sync + 'static + std::fmt::Debug {
         region_id: RegionId,
         provider: &Provider,
     ) -> Result<Entry, Self::Error>;
+
+    /// Returns the highest entry id of the specified topic in remote WAL.
+    async fn high_watermark(&self, provider: &Provider) -> Result<EntryId, Self::Error>;
 }
 
 /// The response of an `append` operation.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

For regions without write for a long time, it will have a legacy `flush_entry_id`. This patch update a `high_watermark` for a region when a flush request found memtables are empty and then send it to metasrv for further active pruning.

Since the `high_watermark` is updated when memtables are empty, it's safe for metasrv to delete all records before `high_watermark` for this region.

Correspondingly, `log_store` will maintain the `topic-high_watermark` map for all topics. Regions retrieve them when they need to update the `high_watermark`s of themselves.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
