### PR TITLE
feat: add json parse processor

### DIFF
--- a/src/pipeline/src/error.rs
+++ b/src/pipeline/src/error.rs
@@ -517,12 +517,7 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
-    #[snafu(display("Unsupported number type: {value}"))]
-    ValueUnsupportedNumberType {
-        value: serde_json::Number,
-        #[snafu(implicit)]
-        location: Location,
-    },
+
     #[snafu(display("Unsupported yaml type: {value:?}"))]
     ValueUnsupportedYamlType {
         value: yaml_rust::Yaml,
@@ -571,6 +566,13 @@ pub enum Error {
     #[snafu(display("Unsupported number type: {value:?}"))]
     UnsupportedNumberType {
         value: serde_json::Number,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Failed to parse json"))]
+    JsonParse {
+        #[snafu(source)]
+        error: serde_json::Error,
         #[snafu(implicit)]
         location: Location,
     },
@@ -808,7 +810,6 @@ impl ErrorExt for Error {
             | ValueParseFloat { .. }
             | ValueParseBoolean { .. }
             | ValueDefaultValueUnsupported { .. }
-            | ValueUnsupportedNumberType { .. }
             | ValueUnsupportedYamlType { .. }
             | ValueYamlKeyMustBeString { .. }
             | YamlLoad { .. }
@@ -818,6 +819,7 @@ impl ErrorExt for Error {
             | UnsupportedIndexType { .. }
             | UnsupportedNumberType { .. }
             | IdentifyPipelineColumnTypeMismatch { .. }
+            | JsonParse { .. }
             | JsonPathParse { .. }
             | JsonPathParseResultIndex { .. }
             | FieldRequiredForDispatcher

--- a/src/pipeline/src/etl/processor.rs
+++ b/src/pipeline/src/etl/processor.rs
@@ -21,6 +21,7 @@ pub mod dissect;
 pub mod epoch;
 pub mod gsub;
 pub mod join;
+pub mod json_parse;
 pub mod json_path;
 pub mod letter;
 pub mod regex;
@@ -50,6 +51,7 @@ use crate::error::{
     ProcessorMustBeMapSnafu, ProcessorMustHaveStringKeySnafu, Result, UnsupportedProcessorSnafu,
 };
 use crate::etl::field::{Field, Fields};
+use crate::etl::processor::json_parse::JsonParseProcessor;
 use crate::etl::processor::simple_extract::SimpleExtractProcessor;
 use crate::etl::PipelineMap;
 
@@ -98,6 +100,7 @@ pub enum ProcessorKind {
     Epoch(EpochProcessor),
     Date(DateProcessor),
     JsonPath(JsonPathProcessor),
+    JsonParse(JsonParseProcessor),
     SimpleJsonPath(SimpleExtractProcessor),
     Decolorize(DecolorizeProcessor),
     Digest(DigestProcessor),
@@ -178,6 +181,9 @@ fn parse_processor(doc: &yaml_rust::Yaml) -> Result<ProcessorKind> {
         digest::PROCESSOR_DIGEST => ProcessorKind::Digest(DigestProcessor::try_from(value)?),
         simple_extract::PROCESSOR_SIMPLE_EXTRACT => {
             ProcessorKind::SimpleJsonPath(SimpleExtractProcessor::try_from(value)?)
+        }
+        json_parse::PROCESSOR_JSON_PARSE => {
+            ProcessorKind::JsonParse(JsonParseProcessor::try_from(value)?)
         }
         _ => return UnsupportedProcessorSnafu { processor: str_key }.fail(),
     };

--- a/src/pipeline/src/etl/processor/json_parse.rs
+++ b/src/pipeline/src/etl/processor/json_parse.rs
@@ -12,34 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use snafu::OptionExt as _;
+use snafu::{OptionExt as _, ResultExt};
 
-use crate::error::{Error, KeyMustBeStringSnafu, ProcessorMissingFieldSnafu, Result};
+use crate::error::{
+    Error, FieldMustBeTypeSnafu, JsonParseSnafu, KeyMustBeStringSnafu, ProcessorMissingFieldSnafu,
+    Result,
+};
 use crate::etl::field::Fields;
 use crate::etl::processor::{
-    yaml_bool, yaml_new_field, yaml_new_fields, yaml_string, FIELDS_NAME, FIELD_NAME,
-    IGNORE_MISSING_NAME, SIMPLE_EXTRACT_KEY_NAME,
+    yaml_bool, yaml_new_field, yaml_new_fields, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME,
 };
-use crate::{PipelineMap, Processor, Value};
+use crate::{json_to_map, PipelineMap, Processor, Value};
 
-pub(crate) const PROCESSOR_SIMPLE_EXTRACT: &str = "simple_extract";
+pub(crate) const PROCESSOR_JSON_PARSE: &str = "json_parse";
 
 #[derive(Debug, Default)]
-pub struct SimpleExtractProcessor {
+pub struct JsonParseProcessor {
     fields: Fields,
-    /// simple keys to extract nested JSON field
-    /// key `a.b` is saved as  ['a', 'b'], each key represents a level of the JSON tree
-    key: Vec<String>,
     ignore_missing: bool,
 }
 
-impl TryFrom<&yaml_rust::yaml::Hash> for SimpleExtractProcessor {
+impl TryFrom<&yaml_rust::yaml::Hash> for JsonParseProcessor {
     type Error = Error;
 
     fn try_from(value: &yaml_rust::yaml::Hash) -> std::result::Result<Self, Self::Error> {
         let mut fields = Fields::default();
         let mut ignore_missing = false;
-        let mut keys = vec![];
 
         for (k, v) in value.iter() {
             let key = k
@@ -55,17 +53,12 @@ impl TryFrom<&yaml_rust::yaml::Hash> for SimpleExtractProcessor {
                 IGNORE_MISSING_NAME => {
                     ignore_missing = yaml_bool(v, IGNORE_MISSING_NAME)?;
                 }
-                SIMPLE_EXTRACT_KEY_NAME => {
-                    let key_str = yaml_string(v, SIMPLE_EXTRACT_KEY_NAME)?;
-                    keys.extend(key_str.split(".").map(|s| s.to_string()));
-                }
                 _ => {}
             }
         }
 
-        let processor = SimpleExtractProcessor {
+        let processor = JsonParseProcessor {
             fields,
-            key: keys,
             ignore_missing,
         };
 
@@ -73,25 +66,23 @@ impl TryFrom<&yaml_rust::yaml::Hash> for SimpleExtractProcessor {
     }
 }
 
-impl SimpleExtractProcessor {
+impl JsonParseProcessor {
     fn process_field(&self, val: &Value) -> Result<Value> {
-        let mut current = val;
-        for key in self.key.iter() {
-            let Value::Map(map) = current else {
-                return Ok(Value::Null);
-            };
-            let Some(v) = map.get(key) else {
-                return Ok(Value::Null);
-            };
-            current = v;
-        }
-        Ok(current.clone())
+        let Some(json_str) = val.as_str() else {
+            return FieldMustBeTypeSnafu {
+                field: val.to_str_type(),
+                ty: "string",
+            }
+            .fail();
+        };
+        let parsed: serde_json::Value = serde_json::from_str(json_str).context(JsonParseSnafu)?;
+        Ok(Value::Map(json_to_map(parsed)?.into()))
     }
 }
 
-impl Processor for SimpleExtractProcessor {
+impl Processor for JsonParseProcessor {
     fn kind(&self) -> &str {
-        PROCESSOR_SIMPLE_EXTRACT
+        PROCESSOR_JSON_PARSE
     }
 
     fn ignore_missing(&self) -> bool {
@@ -126,22 +117,23 @@ impl Processor for SimpleExtractProcessor {
 mod test {
 
     #[test]
-    fn test_simple_extract() {
+    fn test_json_parse() {
         use super::*;
-        use crate::{Map, Value};
+        use crate::Value;
 
-        let processor = SimpleExtractProcessor {
-            key: vec!["hello".to_string()],
+        let processor = JsonParseProcessor {
             ..Default::default()
         };
 
         let result = processor
-            .process_field(&Value::Map(Map::one(
-                "hello",
-                Value::String("world".to_string()),
-            )))
+            .process_field(&Value::String(r#"{"hello": "world"}"#.to_string()))
             .unwrap();
 
-        assert_eq!(result, Value::String("world".to_string()));
+        let expected = Value::Map(crate::Map::one(
+            "hello".to_string(),
+            Value::String("world".to_string()),
+        ));
+
+        assert_eq!(result, expected);
     }
 }

--- a/src/pipeline/src/etl/value.rs
+++ b/src/pipeline/src/etl/value.rs
@@ -29,9 +29,9 @@ use snafu::{OptionExt, ResultExt};
 pub use time::Timestamp;
 
 use crate::error::{
-    Error, Result, ValueDefaultValueUnsupportedSnafu, ValueInvalidResolutionSnafu,
-    ValueParseBooleanSnafu, ValueParseFloatSnafu, ValueParseIntSnafu, ValueParseTypeSnafu,
-    ValueUnsupportedNumberTypeSnafu, ValueUnsupportedYamlTypeSnafu, ValueYamlKeyMustBeStringSnafu,
+    Error, Result, UnsupportedNumberTypeSnafu, ValueDefaultValueUnsupportedSnafu,
+    ValueInvalidResolutionSnafu, ValueParseBooleanSnafu, ValueParseFloatSnafu, ValueParseIntSnafu,
+    ValueParseTypeSnafu, ValueUnsupportedYamlTypeSnafu, ValueYamlKeyMustBeStringSnafu,
 };
 use crate::etl::PipelineMap;
 
@@ -413,7 +413,7 @@ impl TryFrom<serde_json::Value> for Value {
                 } else if let Some(v) = v.as_f64() {
                     Ok(Value::Float64(v))
                 } else {
-                    ValueUnsupportedNumberTypeSnafu { value: v }.fail()
+                    UnsupportedNumberTypeSnafu { value: v }.fail()
                 }
             }
             serde_json::Value::String(v) => Ok(Value::String(v)),

--- a/src/pipeline/src/etl/value/array.rs
+++ b/src/pipeline/src/etl/value/array.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::error::{Error, Result};
 use crate::etl::value::Value;
 
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -64,5 +65,17 @@ impl IntoIterator for Array {
 impl From<Vec<Value>> for Array {
     fn from(values: Vec<Value>) -> Self {
         Array { values }
+    }
+}
+
+impl TryFrom<Vec<serde_json::Value>> for Array {
+    type Error = Error;
+
+    fn try_from(value: Vec<serde_json::Value>) -> Result<Self> {
+        let values = value
+            .into_iter()
+            .map(|v| v.try_into())
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Array { values })
     }
 }

--- a/src/pipeline/tests/common.rs
+++ b/src/pipeline/tests/common.rs
@@ -56,6 +56,7 @@ pub fn parse_and_exec(input_str: &str, pipeline_yaml: &str) -> Rows {
 }
 
 /// test util function to create column schema
+#[allow(dead_code)]
 pub fn make_column_schema(
     column_name: String,
     datatype: ColumnDataType,

--- a/src/pipeline/tests/json_parse.rs
+++ b/src/pipeline/tests/json_parse.rs
@@ -1,0 +1,136 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod common;
+
+use std::borrow::Cow;
+
+use api::v1::value::ValueData;
+use api::v1::ColumnDataType;
+
+const INPUT_VALUE_STR: &str = r#"
+[
+  {
+    "commit": "{\"commitTime\": \"1573840000.000\", \"commitAuthor\": \"test\"}"
+  }
+]
+"#;
+
+#[test]
+fn test_json_parse_inplace() {
+    let pipeline_yaml = r#"
+---
+processors:
+  - json_parse:
+      field: commit
+
+transform:
+  - field: commit
+    type: json
+"#;
+
+    let output = common::parse_and_exec(INPUT_VALUE_STR, pipeline_yaml);
+
+    // check schema
+    assert_eq!(output.schema[0].column_name, "commit");
+    let type_id: i32 = ColumnDataType::Binary.into();
+    assert_eq!(output.schema[0].datatype, type_id);
+
+    // check value
+    let ValueData::BinaryValue(json_value) = output.rows[0].values[0].value_data.clone().unwrap()
+    else {
+        panic!("expect binary value");
+    };
+    let v = jsonb::from_slice(&json_value).unwrap();
+
+    let mut expected = jsonb::Object::new();
+    expected.insert(
+        "commitTime".to_string(),
+        jsonb::Value::String(Cow::Borrowed("1573840000.000")),
+    );
+    expected.insert(
+        "commitAuthor".to_string(),
+        jsonb::Value::String(Cow::Borrowed("test")),
+    );
+    assert_eq!(v, jsonb::Value::Object(expected));
+}
+
+#[test]
+fn test_json_parse_new_var() {
+    let pipeline_yaml = r#"
+---
+processors:
+  - json_parse:
+      field: commit, commit_json
+
+transform:
+  - field: commit_json
+    type: json
+"#;
+
+    let output = common::parse_and_exec(INPUT_VALUE_STR, pipeline_yaml);
+
+    // check schema
+    assert_eq!(output.schema[0].column_name, "commit_json");
+    let type_id: i32 = ColumnDataType::Binary.into();
+    assert_eq!(output.schema[0].datatype, type_id);
+
+    // check value
+    let ValueData::BinaryValue(json_value) = output.rows[0].values[0].value_data.clone().unwrap()
+    else {
+        panic!("expect binary value");
+    };
+    let v = jsonb::from_slice(&json_value).unwrap();
+
+    let mut expected = jsonb::Object::new();
+    expected.insert(
+        "commitTime".to_string(),
+        jsonb::Value::String(Cow::Borrowed("1573840000.000")),
+    );
+    expected.insert(
+        "commitAuthor".to_string(),
+        jsonb::Value::String(Cow::Borrowed("test")),
+    );
+    assert_eq!(v, jsonb::Value::Object(expected));
+}
+
+#[test]
+fn test_json_parse_with_simple_extractor() {
+    let pipeline_yaml = r#"
+---
+processors:
+  - json_parse:
+      field: commit, commit_json
+  - simple_extract:
+      field: commit_json, commit_author
+      key: "commitAuthor"
+
+
+transform:
+  - field: commit_author
+    type: string
+"#;
+
+    let output = common::parse_and_exec(INPUT_VALUE_STR, pipeline_yaml);
+
+    // check schema
+    assert_eq!(output.schema[0].column_name, "commit_author");
+    let type_id: i32 = ColumnDataType::String.into();
+    assert_eq!(output.schema[0].datatype, type_id);
+
+    assert_eq!(
+        output.rows[0].values[0].value_data,
+        Some(ValueData::StringValue("test".to_string()))
+    );
+}

--- a/src/pipeline/tests/simple_extract.rs
+++ b/src/pipeline/tests/simple_extract.rs
@@ -34,7 +34,7 @@ lazy_static! {
 }
 
 #[test]
-fn test_gsub() {
+fn test_simple_extract() {
     let input_value_str = r#"
     [
       {

--- a/src/servers/src/http/loki.rs
+++ b/src/servers/src/http/loki.rs
@@ -345,7 +345,7 @@ pub fn parse_loki_labels(labels: &str) -> Result<BTreeMap<String, String>> {
 
     while !labels.is_empty() {
         // parse key
-        let first_index = labels.find("=").context(InvalidLokiLabelsSnafu {
+        let first_index = labels.find("=").with_context(|| InvalidLokiLabelsSnafu {
             msg: format!("missing `=` near: {}", labels),
         })?;
         let key = &labels[..first_index];


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
close #5897 

## What's changed and what's your intention?

As the title suggests. For an input JSON like 
```JSON
{
    "commit": "{\"commitTime\": \"1573840000.000\", \"commitAuthor\": \"test\"}"
}
```

Use the following config to use `json_parse` processor
```YAML
processors:
  - json_parse:
      field: commit
```

This would parse the JSON as expected
```JSON
{
  "commit": {
    "commitTime": "1573840000.000",
    "commitAuthor": "test"
  }
}
```



## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
