### PR TITLE
fix: avoid double schema projection in file format readers

### DIFF
--- a/tests/cases/standalone/common/copy/copy_from_fs_csv.result
+++ b/tests/cases/standalone/common/copy/copy_from_fs_csv.result
@@ -66,6 +66,42 @@ select * from with_pattern order by ts;
 | host3 | 99.9 | 444.4  | 2024-07-27T10:47:43 |
 +-------+------+--------+---------------------+
 
+CREATE TABLE demo_with_external_column(host string, cpu double, memory double, ts timestamp time index, external_column string default 'default_value');
+
+Affected Rows: 0
+
+Copy demo_with_external_column FROM '${SQLNESS_HOME}/demo/export/csv/demo.csv' WITH (format='csv');
+
+Affected Rows: 3
+
+select * from demo_with_external_column order by ts;
+
++-------+------+--------+---------------------+-----------------+
+| host  | cpu  | memory | ts                  | external_column |
++-------+------+--------+---------------------+-----------------+
+| host1 | 66.6 | 1024.0 | 2022-06-15T07:02:37 | default_value   |
+| host2 | 88.8 | 333.3  | 2022-06-15T07:02:38 | default_value   |
+| host3 | 99.9 | 444.4  | 2024-07-27T10:47:43 | default_value   |
++-------+------+--------+---------------------+-----------------+
+
+CREATE TABLE demo_with_less_columns(host string, memory double, ts timestamp time index);
+
+Affected Rows: 0
+
+Copy demo_with_less_columns FROM '${SQLNESS_HOME}/demo/export/csv/demo.csv' WITH (format='csv');
+
+Affected Rows: 3
+
+select * from demo_with_less_columns order by ts;
+
++-------+--------+---------------------+
+| host  | memory | ts                  |
++-------+--------+---------------------+
+| host1 | 1024.0 | 2022-06-15T07:02:37 |
+| host2 | 333.3  | 2022-06-15T07:02:38 |
+| host3 | 444.4  | 2024-07-27T10:47:43 |
++-------+--------+---------------------+
+
 drop table demo;
 
 Affected Rows: 0
@@ -79,6 +115,14 @@ drop table with_path;
 Affected Rows: 0
 
 drop table with_pattern;
+
+Affected Rows: 0
+
+drop table demo_with_external_column;
+
+Affected Rows: 0
+
+drop table demo_with_less_columns;
 
 Affected Rows: 0
 

--- a/tests/cases/standalone/common/copy/copy_from_fs_csv.sql
+++ b/tests/cases/standalone/common/copy/copy_from_fs_csv.sql
@@ -27,6 +27,18 @@ Copy with_pattern FROM '${SQLNESS_HOME}/demo/export/csv/' WITH (pattern = 'demo.
 
 select * from with_pattern order by ts;
 
+CREATE TABLE demo_with_external_column(host string, cpu double, memory double, ts timestamp time index, external_column string default 'default_value');
+
+Copy demo_with_external_column FROM '${SQLNESS_HOME}/demo/export/csv/demo.csv' WITH (format='csv');
+
+select * from demo_with_external_column order by ts;
+
+CREATE TABLE demo_with_less_columns(host string, memory double, ts timestamp time index);
+
+Copy demo_with_less_columns FROM '${SQLNESS_HOME}/demo/export/csv/demo.csv' WITH (format='csv');
+
+select * from demo_with_less_columns order by ts;
+
 drop table demo;
 
 drop table with_filename;
@@ -34,3 +46,7 @@ drop table with_filename;
 drop table with_path;
 
 drop table with_pattern;
+
+drop table demo_with_external_column;
+
+drop table demo_with_less_columns;

--- a/tests/cases/standalone/common/copy/copy_from_fs_json.result
+++ b/tests/cases/standalone/common/copy/copy_from_fs_json.result
@@ -66,6 +66,42 @@ select * from with_pattern order by ts;
 | host2 | 88.8 | 333.3  | 2022-06-15T07:02:38 |
 +-------+------+--------+---------------------+
 
+CREATE TABLE demo_with_external_column(host string, cpu double, memory double, ts timestamp time index, external_column string default 'default_value');
+
+Affected Rows: 0
+
+Copy demo_with_external_column FROM '${SQLNESS_HOME}/demo/export/json/demo.json' WITH (format='json');
+
+Affected Rows: 3
+
+select * from demo_with_external_column order by ts;
+
++-------+------+--------+---------------------+-----------------+
+| host  | cpu  | memory | ts                  | external_column |
++-------+------+--------+---------------------+-----------------+
+| host1 | 66.6 | 1024.0 | 2022-06-15T07:02:37 | default_value   |
+| host2 | 88.8 | 333.3  | 2022-06-15T07:02:38 | default_value   |
+| host3 | 99.9 | 444.4  | 2024-07-27T10:47:43 | default_value   |
++-------+------+--------+---------------------+-----------------+
+
+CREATE TABLE demo_with_less_columns(host string, memory double, ts timestamp time index);
+
+Affected Rows: 0
+
+Copy demo_with_less_columns FROM '${SQLNESS_HOME}/demo/export/json/demo.json' WITH (format='json');
+
+Affected Rows: 3
+
+select * from demo_with_less_columns order by ts;
+
++-------+--------+---------------------+
+| host  | memory | ts                  |
++-------+--------+---------------------+
+| host1 | 1024.0 | 2022-06-15T07:02:37 |
+| host2 | 333.3  | 2022-06-15T07:02:38 |
+| host3 | 444.4  | 2024-07-27T10:47:43 |
++-------+--------+---------------------+
+
 drop table demo;
 
 Affected Rows: 0
@@ -79,6 +115,14 @@ drop table with_path;
 Affected Rows: 0
 
 drop table with_pattern;
+
+Affected Rows: 0
+
+drop table demo_with_external_column;
+
+Affected Rows: 0
+
+drop table demo_with_less_columns;
 
 Affected Rows: 0
 

--- a/tests/cases/standalone/common/copy/copy_from_fs_json.sql
+++ b/tests/cases/standalone/common/copy/copy_from_fs_json.sql
@@ -27,6 +27,18 @@ Copy with_pattern FROM '${SQLNESS_HOME}/demo/export/json/' WITH (pattern = 'demo
 
 select * from with_pattern order by ts;
 
+CREATE TABLE demo_with_external_column(host string, cpu double, memory double, ts timestamp time index, external_column string default 'default_value');
+
+Copy demo_with_external_column FROM '${SQLNESS_HOME}/demo/export/json/demo.json' WITH (format='json');
+
+select * from demo_with_external_column order by ts;
+
+CREATE TABLE demo_with_less_columns(host string, memory double, ts timestamp time index);
+
+Copy demo_with_less_columns FROM '${SQLNESS_HOME}/demo/export/json/demo.json' WITH (format='json');
+
+select * from demo_with_less_columns order by ts;
+
 drop table demo;
 
 drop table with_filename;
@@ -34,3 +46,7 @@ drop table with_filename;
 drop table with_path;
 
 drop table with_pattern;
+
+drop table demo_with_external_column;
+
+drop table demo_with_less_columns;

--- a/tests/cases/standalone/common/copy/copy_from_fs_parquet.result
+++ b/tests/cases/standalone/common/copy/copy_from_fs_parquet.result
@@ -123,6 +123,42 @@ Copy with_limit_rows_segment FROM '${SQLNESS_HOME}/demo/export/parquet_files/' L
 
 Error: 2000(InvalidSyntax), Unexpected token while parsing SQL statement, expected: 'the number of maximum rows', found: ;: sql parser error: Expected: literal int, found: hello at Line: 1, Column: 86
 
+CREATE TABLE demo_with_external_column(host string, cpu double, memory double, ts timestamp time index, external_column string default 'default_value');
+
+Affected Rows: 0
+
+Copy demo_with_external_column FROM '${SQLNESS_HOME}/demo/export/parquet_files/demo.parquet';
+
+Affected Rows: 3
+
+select * from demo_with_external_column order by ts;
+
++-------+-------+--------+---------------------+-----------------+
+| host  | cpu   | memory | ts                  | external_column |
++-------+-------+--------+---------------------+-----------------+
+| host1 | 66.6  | 1024.0 | 2022-06-15T07:02:37 | default_value   |
+| host2 | 88.8  | 333.3  | 2022-06-15T07:02:38 | default_value   |
+| host3 | 111.1 | 444.4  | 2024-07-27T10:47:43 | default_value   |
++-------+-------+--------+---------------------+-----------------+
+
+CREATE TABLE demo_with_less_columns(host string, memory double, ts timestamp time index);
+
+Affected Rows: 0
+
+Copy demo_with_less_columns FROM '${SQLNESS_HOME}/demo/export/parquet_files/demo.parquet';
+
+Affected Rows: 3
+
+select * from demo_with_less_columns order by ts;
+
++-------+--------+---------------------+
+| host  | memory | ts                  |
++-------+--------+---------------------+
+| host1 | 1024.0 | 2022-06-15T07:02:37 |
+| host2 | 333.3  | 2022-06-15T07:02:38 |
+| host3 | 444.4  | 2024-07-27T10:47:43 |
++-------+--------+---------------------+
+
 drop table demo;
 
 Affected Rows: 0
@@ -148,6 +184,14 @@ drop table without_limit_rows;
 Affected Rows: 0
 
 drop table with_limit_rows_segment;
+
+Affected Rows: 0
+
+drop table demo_with_external_column;
+
+Affected Rows: 0
+
+drop table demo_with_less_columns;
 
 Affected Rows: 0
 

--- a/tests/cases/standalone/common/copy/copy_from_fs_parquet.sql
+++ b/tests/cases/standalone/common/copy/copy_from_fs_parquet.sql
@@ -52,6 +52,18 @@ select count(*) from with_limit_rows_segment;
 
 Copy with_limit_rows_segment FROM '${SQLNESS_HOME}/demo/export/parquet_files/' LIMIT hello;
 
+CREATE TABLE demo_with_external_column(host string, cpu double, memory double, ts timestamp time index, external_column string default 'default_value');
+
+Copy demo_with_external_column FROM '${SQLNESS_HOME}/demo/export/parquet_files/demo.parquet';
+
+select * from demo_with_external_column order by ts;
+
+CREATE TABLE demo_with_less_columns(host string, memory double, ts timestamp time index);
+
+Copy demo_with_less_columns FROM '${SQLNESS_HOME}/demo/export/parquet_files/demo.parquet';
+
+select * from demo_with_less_columns order by ts;
+
 drop table demo;
 
 drop table demo_2;
@@ -65,3 +77,7 @@ drop table with_pattern;
 drop table without_limit_rows;
 
 drop table with_limit_rows_segment;
+
+drop table demo_with_external_column;
+
+drop table demo_with_less_columns;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR fixes a schema projection issue in the file format readers (CSV and JSON) used by the `Copy From` statement. The readers were incorrectly applying schema projection twice, which could lead to schema mismatch errors.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
