### PR TITLE
perf: keep compiled regex in SimpleFilterEvaluator to avoid re-compiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2311,6 +2311,7 @@ dependencies = [
  "datatypes",
  "futures",
  "pin-project",
+ "regex",
  "serde",
  "serde_json",
  "snafu 0.8.5",

--- a/src/common/recordbatch/Cargo.toml
+++ b/src/common/recordbatch/Cargo.toml
@@ -17,6 +17,7 @@ datafusion-common.workspace = true
 datatypes.workspace = true
 futures.workspace = true
 pin-project.workspace = true
+regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 snafu.workspace = true

--- a/src/common/recordbatch/src/error.rs
+++ b/src/common/recordbatch/src/error.rs
@@ -23,7 +23,7 @@ use datatypes::prelude::ConcreteDataType;
 use datatypes::schema::SchemaRef;
 use snafu::{Location, Snafu};
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Snafu)]
 #[snafu(visibility(pub))]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR compiles the regex while building the `SimpleFilterEvaluator` and uses the pre-compiled `Regex` to evaluate datums.

It also slightly modifies the `regexp_is_match_scalar()` function to support reusing the `Regex`.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
