### PR TITLE
test: update configs to enable auto wal prune

### DIFF
--- a/.github/actions/setup-greptimedb-cluster/with-remote-wal.yaml
+++ b/.github/actions/setup-greptimedb-cluster/with-remote-wal.yaml
@@ -7,7 +7,8 @@ meta:
     provider = "kafka"
     broker_endpoints = ["kafka.kafka-cluster.svc.cluster.local:9092"]
     num_topics = 3
-    auto_prune_topic_records = true
+    auto_prune_interval = "30s"
+    trigger_flush_threshold = 100
 
     [datanode]
     [datanode.client]

--- a/.github/actions/setup-greptimedb-cluster/with-remote-wal.yaml
+++ b/.github/actions/setup-greptimedb-cluster/with-remote-wal.yaml
@@ -9,6 +9,7 @@ meta:
     num_topics = 3
     auto_prune_interval = "30s"
     trigger_flush_threshold = 100
+    overwrite_entry_start_id = true
 
     [datanode]
     [datanode.client]

--- a/.github/actions/setup-greptimedb-cluster/with-remote-wal.yaml
+++ b/.github/actions/setup-greptimedb-cluster/with-remote-wal.yaml
@@ -9,7 +9,6 @@ meta:
     num_topics = 3
     auto_prune_interval = "30s"
     trigger_flush_threshold = 100
-    overwrite_entry_start_id = true
 
     [datanode]
     [datanode.client]
@@ -24,6 +23,7 @@ datanode:
     provider = "kafka"
     broker_endpoints = ["kafka.kafka-cluster.svc.cluster.local:9092"]
     linger = "2ms"
+    overwrite_entry_start_id = true
 frontend:
   configData: |-
     [runtime]

--- a/src/common/wal/src/config/kafka/common.rs
+++ b/src/common/wal/src/config/kafka/common.rs
@@ -30,9 +30,9 @@ pub const DEFAULT_BACKOFF_CONFIG: BackoffConfig = BackoffConfig {
     deadline: Some(Duration::from_secs(120)),
 };
 
-/// Default interval for active WAL pruning.
+/// Default interval for auto WAL pruning.
 pub const DEFAULT_AUTO_PRUNE_INTERVAL: Duration = Duration::ZERO;
-/// Default limit for concurrent active pruning tasks.
+/// Default limit for concurrent auto pruning tasks.
 pub const DEFAULT_AUTO_PRUNE_PARALLELISM: usize = 10;
 /// Default interval for sending flush request to regions when pruning remote WAL.
 pub const DEFAULT_TRIGGER_FLUSH_THRESHOLD: u64 = 0;

--- a/src/common/wal/src/config/kafka/common.rs
+++ b/src/common/wal/src/config/kafka/common.rs
@@ -31,9 +31,9 @@ pub const DEFAULT_BACKOFF_CONFIG: BackoffConfig = BackoffConfig {
 };
 
 /// Default interval for active WAL pruning.
-pub const DEFAULT_ACTIVE_PRUNE_INTERVAL: Duration = Duration::ZERO;
+pub const DEFAULT_AUTO_PRUNE_INTERVAL: Duration = Duration::ZERO;
 /// Default limit for concurrent active pruning tasks.
-pub const DEFAULT_ACTIVE_PRUNE_TASK_LIMIT: usize = 10;
+pub const DEFAULT_AUTO_PRUNE_PARALLELISM: usize = 10;
 /// Default interval for sending flush request to regions when pruning remote WAL.
 pub const DEFAULT_TRIGGER_FLUSH_THRESHOLD: u64 = 0;
 

--- a/src/common/wal/src/config/kafka/datanode.rs
+++ b/src/common/wal/src/config/kafka/datanode.rs
@@ -47,8 +47,6 @@ pub struct DatanodeKafkaConfig {
     pub dump_index_interval: Duration,
     /// Ignore missing entries during read WAL.
     pub overwrite_entry_start_id: bool,
-    // Active WAL pruning.
-    pub auto_prune_topic_records: bool,
     // Interval of WAL pruning.
     pub auto_prune_interval: Duration,
     // Threshold for sending flush request when pruning remote WAL.
@@ -70,7 +68,6 @@ impl Default for DatanodeKafkaConfig {
             create_index: true,
             dump_index_interval: Duration::from_secs(60),
             overwrite_entry_start_id: false,
-            auto_prune_topic_records: false,
             auto_prune_interval: DEFAULT_ACTIVE_PRUNE_INTERVAL,
             trigger_flush_threshold: DEFAULT_TRIGGER_FLUSH_THRESHOLD,
             auto_prune_parallelism: DEFAULT_ACTIVE_PRUNE_TASK_LIMIT,

--- a/src/common/wal/src/config/kafka/datanode.rs
+++ b/src/common/wal/src/config/kafka/datanode.rs
@@ -18,8 +18,8 @@ use common_base::readable_size::ReadableSize;
 use serde::{Deserialize, Serialize};
 
 use crate::config::kafka::common::{
-    KafkaConnectionConfig, KafkaTopicConfig, DEFAULT_ACTIVE_PRUNE_INTERVAL,
-    DEFAULT_ACTIVE_PRUNE_TASK_LIMIT, DEFAULT_TRIGGER_FLUSH_THRESHOLD,
+    KafkaConnectionConfig, KafkaTopicConfig, DEFAULT_AUTO_PRUNE_INTERVAL,
+    DEFAULT_AUTO_PRUNE_PARALLELISM, DEFAULT_TRIGGER_FLUSH_THRESHOLD,
 };
 
 /// Kafka wal configurations for datanode.
@@ -69,9 +69,9 @@ impl Default for DatanodeKafkaConfig {
             create_index: true,
             dump_index_interval: Duration::from_secs(60),
             overwrite_entry_start_id: false,
-            auto_prune_interval: DEFAULT_ACTIVE_PRUNE_INTERVAL,
+            auto_prune_interval: DEFAULT_AUTO_PRUNE_INTERVAL,
             trigger_flush_threshold: DEFAULT_TRIGGER_FLUSH_THRESHOLD,
-            auto_prune_parallelism: DEFAULT_ACTIVE_PRUNE_TASK_LIMIT,
+            auto_prune_parallelism: DEFAULT_AUTO_PRUNE_PARALLELISM,
         }
     }
 }

--- a/src/common/wal/src/config/kafka/datanode.rs
+++ b/src/common/wal/src/config/kafka/datanode.rs
@@ -48,6 +48,7 @@ pub struct DatanodeKafkaConfig {
     /// Ignore missing entries during read WAL.
     pub overwrite_entry_start_id: bool,
     // Interval of WAL pruning.
+    #[serde(with = "humantime_serde")]
     pub auto_prune_interval: Duration,
     // Threshold for sending flush request when pruning remote WAL.
     // `None` stands for never sending flush request.

--- a/src/common/wal/src/config/kafka/metasrv.rs
+++ b/src/common/wal/src/config/kafka/metasrv.rs
@@ -17,8 +17,8 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 
 use crate::config::kafka::common::{
-    KafkaConnectionConfig, KafkaTopicConfig, DEFAULT_ACTIVE_PRUNE_INTERVAL,
-    DEFAULT_ACTIVE_PRUNE_TASK_LIMIT, DEFAULT_TRIGGER_FLUSH_THRESHOLD,
+    KafkaConnectionConfig, KafkaTopicConfig, DEFAULT_AUTO_PRUNE_INTERVAL,
+    DEFAULT_AUTO_PRUNE_PARALLELISM, DEFAULT_TRIGGER_FLUSH_THRESHOLD,
 };
 
 /// Kafka wal configurations for metasrv.
@@ -49,9 +49,9 @@ impl Default for MetasrvKafkaConfig {
             connection: Default::default(),
             kafka_topic: Default::default(),
             auto_create_topics: true,
-            auto_prune_interval: DEFAULT_ACTIVE_PRUNE_INTERVAL,
+            auto_prune_interval: DEFAULT_AUTO_PRUNE_INTERVAL,
             trigger_flush_threshold: DEFAULT_TRIGGER_FLUSH_THRESHOLD,
-            auto_prune_parallelism: DEFAULT_ACTIVE_PRUNE_TASK_LIMIT,
+            auto_prune_parallelism: DEFAULT_AUTO_PRUNE_PARALLELISM,
         }
     }
 }

--- a/src/common/wal/src/config/kafka/metasrv.rs
+++ b/src/common/wal/src/config/kafka/metasrv.rs
@@ -34,6 +34,7 @@ pub struct MetasrvKafkaConfig {
     // Automatically create topics for WAL.
     pub auto_create_topics: bool,
     // Interval of WAL pruning.
+    #[serde(with = "humantime_serde")]
     pub auto_prune_interval: Duration,
     // Threshold for sending flush request when pruning remote WAL.
     // `None` stands for never sending flush request.

--- a/tests/conf/datanode-test.toml.template
+++ b/tests/conf/datanode-test.toml.template
@@ -11,6 +11,7 @@ purge_interval = '10m'
 purge_threshold = '10GB'
 read_batch_size = 128
 sync_write = false
+overwrite_entry_start_id = true
 {{ else }}
 provider = "kafka"
 broker_endpoints = {kafka_wal_broker_endpoints | unescaped}

--- a/tests/conf/datanode-test.toml.template
+++ b/tests/conf/datanode-test.toml.template
@@ -11,11 +11,11 @@ purge_interval = '10m'
 purge_threshold = '10GB'
 read_batch_size = 128
 sync_write = false
-overwrite_entry_start_id = true
 {{ else }}
 provider = "kafka"
 broker_endpoints = {kafka_wal_broker_endpoints | unescaped}
 linger = "5ms"
+overwrite_entry_start_id = true
 {{ endif }}
 
 [storage]

--- a/tests/conf/metasrv-test.toml.template
+++ b/tests/conf/metasrv-test.toml.template
@@ -18,5 +18,6 @@ broker_endpoints = {kafka_wal_broker_endpoints | unescaped}
 num_topics = 3
 selector_type = "round_robin"
 topic_name_prefix = "distributed_test_greptimedb_wal_topic"
-auto_prune_topic_records = true
+auto_prune_interval = "30s"
+trigger_flush_threshold = 100
 {{ endif }}

--- a/tests/conf/metasrv-test.toml.template
+++ b/tests/conf/metasrv-test.toml.template
@@ -20,4 +20,5 @@ selector_type = "round_robin"
 topic_name_prefix = "distributed_test_greptimedb_wal_topic"
 auto_prune_interval = "30s"
 trigger_flush_threshold = 100
+overwrite_entry_start_id = true
 {{ endif }}

--- a/tests/conf/metasrv-test.toml.template
+++ b/tests/conf/metasrv-test.toml.template
@@ -20,5 +20,4 @@ selector_type = "round_robin"
 topic_name_prefix = "distributed_test_greptimedb_wal_topic"
 auto_prune_interval = "30s"
 trigger_flush_threshold = 100
-overwrite_entry_start_id = true
 {{ endif }}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

#5474

## What's changed and what's your intention?

Enable auto wal prune in ci cluster to trigger test for it.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
