### PR TITLE
feat: add format support for promql http api (not prometheus)

### DIFF
--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -483,7 +483,7 @@ pub async fn test_sql_api(store_type: StorageType) {
 }
 
 pub async fn test_prometheus_promql_api(store_type: StorageType) {
-    let (app, mut guard) = setup_test_http_app_with_frontend(store_type, "sql_api").await;
+    let (app, mut guard) = setup_test_http_app_with_frontend(store_type, "promql_api").await;
     let client = TestClient::new(app).await;
 
     let res = client
@@ -492,7 +492,18 @@ pub async fn test_prometheus_promql_api(store_type: StorageType) {
         .await;
     assert_eq!(res.status(), StatusCode::OK);
 
-    let _body = serde_json::from_str::<GreptimedbV1Response>(&res.text().await).unwrap();
+    let json_text = res.text().await;
+    assert!(serde_json::from_str::<GreptimedbV1Response>(&json_text).is_ok());
+
+    let res = client
+        .get("/v1/promql?query=1&start=0&end=100&step=5s&format=csv")
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let csv_body = &res.text().await;
+    assert_eq!("0,1.0\n5000,1.0\n10000,1.0\n15000,1.0\n20000,1.0\n25000,1.0\n30000,1.0\n35000,1.0\n40000,1.0\n45000,1.0\n50000,1.0\n55000,1.0\n60000,1.0\n65000,1.0\n70000,1.0\n75000,1.0\n80000,1.0\n85000,1.0\n90000,1.0\n95000,1.0\n100000,1.0\n", csv_body);
+
     guard.remove_all().await;
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

We hope to add support to dump promql query results to csv. This patch adds support for these format parameters from sql api.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
