### PR TITLE
fix: remove obsolete failover detectors after region leader change

### DIFF
--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -336,8 +336,8 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Region leader changed: {}", msg))]
-    RegionLeaderChanged {
+    #[snafu(display("Region's leader peer changed: {}", msg))]
+    LeaderPeerChanged {
         msg: String,
         #[snafu(implicit)]
         location: Location,
@@ -922,7 +922,7 @@ impl ErrorExt for Error {
             | Error::TooManyPartitions { .. }
             | Error::TomlFormat { .. }
             | Error::HandlerNotFound { .. }
-            | Error::RegionLeaderChanged { .. } => StatusCode::InvalidArguments,
+            | Error::LeaderPeerChanged { .. } => StatusCode::InvalidArguments,
             Error::LeaseKeyFromUtf8 { .. }
             | Error::LeaseValueFromUtf8 { .. }
             | Error::InvalidRegionKeyFromUtf8 { .. }

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -336,6 +336,13 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display("Region leader changed: {}", msg))]
+    RegionLeaderChanged {
+        msg: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Invalid arguments: {}", err_msg))]
     InvalidArguments {
         err_msg: String,
@@ -914,7 +921,8 @@ impl ErrorExt for Error {
             | Error::ProcedureNotFound { .. }
             | Error::TooManyPartitions { .. }
             | Error::TomlFormat { .. }
-            | Error::HandlerNotFound { .. } => StatusCode::InvalidArguments,
+            | Error::HandlerNotFound { .. }
+            | Error::RegionLeaderChanged { .. } => StatusCode::InvalidArguments,
             Error::LeaseKeyFromUtf8 { .. }
             | Error::LeaseValueFromUtf8 { .. }
             | Error::InvalidRegionKeyFromUtf8 { .. }

--- a/src/meta-srv/src/procedure/region_migration/manager.rs
+++ b/src/meta-srv/src/procedure/region_migration/manager.rs
@@ -267,8 +267,8 @@ impl RegionMigrationManager {
 
         ensure!(
             leader_peer.id == task.from_peer.id,
-            error::InvalidArgumentsSnafu {
-                err_msg: format!(
+            error::RegionLeaderChangedSnafu {
+                msg: format!(
                     "Region's leader peer({}) is not the `from_peer`({}), region: {}",
                     leader_peer.id, task.from_peer.id, task.region_id
                 ),
@@ -507,8 +507,8 @@ mod test {
             .await;
 
         let err = manager.submit_procedure(task).await.unwrap_err();
-        assert_matches!(err, error::Error::InvalidArguments { .. });
-        assert_eq!(err.to_string(), "Invalid arguments: Region's leader peer(3) is not the `from_peer`(1), region: 4398046511105(1024, 1)");
+        assert_matches!(err, error::Error::RegionLeaderChanged { .. });
+        assert_eq!(err.to_string(), "Region leader changed: Region's leader peer(3) is not the `from_peer`(1), region: 4398046511105(1024, 1)");
     }
 
     #[tokio::test]

--- a/src/meta-srv/src/procedure/region_migration/manager.rs
+++ b/src/meta-srv/src/procedure/region_migration/manager.rs
@@ -508,7 +508,7 @@ mod test {
 
         let err = manager.submit_procedure(task).await.unwrap_err();
         assert_matches!(err, error::Error::LeaderPeerChanged { .. });
-        assert_eq!(err.to_string(), "Region leader changed: Region's leader peer(3) is not the `from_peer`(1), region: 4398046511105(1024, 1)");
+        assert_eq!(err.to_string(), "Region's leader peer changed: Region's leader peer(3) is not the `from_peer`(1), region: 4398046511105(1024, 1)");
     }
 
     #[tokio::test]

--- a/src/meta-srv/src/procedure/region_migration/manager.rs
+++ b/src/meta-srv/src/procedure/region_migration/manager.rs
@@ -267,7 +267,7 @@ impl RegionMigrationManager {
 
         ensure!(
             leader_peer.id == task.from_peer.id,
-            error::RegionLeaderChangedSnafu {
+            error::LeaderPeerChangedSnafu {
                 msg: format!(
                     "Region's leader peer({}) is not the `from_peer`({}), region: {}",
                     leader_peer.id, task.from_peer.id, task.region_id
@@ -507,7 +507,7 @@ mod test {
             .await;
 
         let err = manager.submit_procedure(task).await.unwrap_err();
-        assert_matches!(err, error::Error::RegionLeaderChanged { .. });
+        assert_matches!(err, error::Error::LeaderPeerChanged { .. });
         assert_eq!(err.to_string(), "Region leader changed: Region's leader peer(3) is not the `from_peer`(1), region: 4398046511105(1024, 1)");
     }
 

--- a/src/meta-srv/src/region/supervisor.rs
+++ b/src/meta-srv/src/region/supervisor.rs
@@ -26,7 +26,7 @@ use common_meta::DatanodeId;
 use common_runtime::JoinHandle;
 use common_telemetry::{error, info, warn};
 use common_time::util::current_time_millis;
-use error::Error::{MigrationRunning, RegionLeaderChanged, TableRouteNotFound};
+use error::Error::{LeaderPeerChanged, MigrationRunning, TableRouteNotFound};
 use snafu::{OptionExt, ResultExt};
 use store_api::storage::RegionId;
 use tokio::sync::mpsc::{Receiver, Sender};
@@ -432,11 +432,11 @@ impl RegionSupervisor {
                     );
                     Ok(())
                 }
-                RegionLeaderChanged { .. } => {
+                LeaderPeerChanged { .. } => {
                     self.deregister_failure_detectors(vec![(datanode_id, region_id)])
                         .await;
                     info!(
-                        "Region leader changed, removed failover detector for region: {}, datanode: {}",
+                        "Region's leader peer changed, removed failover detector for region: {}, datanode: {}",
                         region_id, from_peer_id
                     );
                     Ok(())

--- a/tests-integration/tests/region_migration.rs
+++ b/tests-integration/tests/region_migration.rs
@@ -847,7 +847,7 @@ pub async fn test_region_migration_incorrect_from_peer(
 
     assert!(matches!(
         err,
-        meta_srv::error::Error::InvalidArguments { .. }
+        meta_srv::error::Error::LeaderPeerChanged { .. }
     ));
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

remove obsolete failover detectors after region leader change

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
