### PR TITLE
test: use random seed for window sort fuzz test

### DIFF
--- a/src/query/src/window_sort.rs
+++ b/src/query/src/window_sort.rs
@@ -3156,7 +3156,8 @@ mod test {
         let fetch_bound = 100;
 
         let mut rng = fastrand::Rng::new();
-        rng.seed(1337);
+        let rng_seed = rng.u64(..);
+        rng.seed(rng_seed);
         let mut bound_val = None;
         // construct testcases
         type CmpFn<T> = Box<dyn FnMut(&T, &T) -> std::cmp::Ordering>;
@@ -3299,8 +3300,8 @@ mod test {
             }
             assert_eq!(
                 res_concat, expected_concat,
-                "case failed, case id: {}",
-                case_id
+                "case failed, case id: {}, rng seed: {}",
+                case_id, rng_seed
             );
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

as title, use random seed for window sort's fuzz(ish) test just in case

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
