### PR TITLE
fix: parse flow expire after interval

### DIFF
--- a/src/sql/src/parsers/create_parser.rs
+++ b/src/sql/src/parsers/create_parser.rs
@@ -292,7 +292,9 @@ impl<'a> ParserContext<'a> {
                 Some(
                     interval.nanoseconds / 1_000_000_000
                         + interval.days as i64 * 60 * 60 * 24
-                        + interval.months as i64 * 60 * 60 * 24 * 36525 / 12_00, // 1 month=365.25/12=30.44 days
+                        + interval.months as i64 * 60 * 60 * 24 * 3044 / 1000, // 1 month=365.25/12=30.44 days
+                                                                               // this is to keep the same as https://docs.rs/humantime/latest/humantime/fn.parse_duration.html
+                                                                               // which we use in database to parse i.e. ttl interval and many other intervals
                 )
             } else {
                 unreachable!()
@@ -1344,7 +1346,7 @@ SELECT max(c1), min(c2) FROM schema_2.table_2;";
         assert!(!create_task.if_not_exists);
         assert_eq!(
             create_task.expire_after,
-            Some(86400 * 36525 / 1200 + 2 * 86400 + 3600 + 2 * 60)
+            Some(86400 * 3044 / 1000 + 2 * 86400 + 3600 + 2 * 60)
         );
         assert!(create_task.comment.is_none());
         assert_eq!(create_task.flow_name.to_string(), "`task_2`");


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

fix flow parse expire after ignore month/days problem, notice use 1 month = 30.44 days to keep in line with https://docs.rs/humantime/latest/humantime/fn.parse_duration.html which we also use in many other places in codebase

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
