### PR TITLE
refactor: `run_pipeline` parameters

### DIFF
--- a/src/pipeline/src/lib.rs
+++ b/src/pipeline/src/lib.rs
@@ -29,7 +29,7 @@ pub use etl::{
     DispatchedTo, Pipeline, PipelineExecOutput, PipelineMap,
 };
 pub use manager::{
-    pipeline_operator, table, util, IdentityTimeIndex, PipelineDefinition, PipelineInfo,
-    PipelineRef, PipelineTableRef, PipelineVersion, PipelineWay, SelectInfo,
+    pipeline_operator, table, util, IdentityTimeIndex, PipelineContext, PipelineDefinition,
+    PipelineInfo, PipelineRef, PipelineTableRef, PipelineVersion, PipelineWay, SelectInfo,
     GREPTIME_INTERNAL_IDENTITY_PIPELINE_NAME, GREPTIME_INTERNAL_TRACE_PIPELINE_V1_NAME,
 };

--- a/src/pipeline/src/manager.rs
+++ b/src/pipeline/src/manager.rs
@@ -26,7 +26,7 @@ use util::to_pipeline_version;
 use crate::error::{CastTypeSnafu, InvalidCustomTimeIndexSnafu, PipelineMissingSnafu, Result};
 use crate::etl::value::time::{MS_RESOLUTION, NS_RESOLUTION, S_RESOLUTION, US_RESOLUTION};
 use crate::table::PipelineTable;
-use crate::{Pipeline, Value};
+use crate::{GreptimePipelineParams, Pipeline, Value};
 
 pub mod pipeline_operator;
 pub mod table;
@@ -104,6 +104,22 @@ impl PipelineDefinition {
     }
 }
 
+pub struct PipelineContext<'a> {
+    pub pipeline_definition: &'a PipelineDefinition,
+    pub pipeline_param: &'a GreptimePipelineParams,
+}
+
+impl<'a> PipelineContext<'a> {
+    pub fn new(
+        pipeline_definition: &'a PipelineDefinition,
+        pipeline_param: &'a GreptimePipelineParams,
+    ) -> Self {
+        Self {
+            pipeline_definition,
+            pipeline_param,
+        }
+    }
+}
 pub enum PipelineWay {
     OtlpLogDirect(Box<SelectInfo>),
     Pipeline(PipelineDefinition),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR mainly
1. Introduce `PipelineContext` to reduce the number of parameters of `run_pipeline`
2. Use `PipelineIngestRequest`(originally `LogIngestRequest`) in `run_pipeline`
3. Remove the unnecessary `remote_write_impl`

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
