### PR TITLE
fix: store flow query ctx on creation

### DIFF
--- a/src/common/meta/src/cache/flow/table_flownode.rs
+++ b/src/common/meta/src/cache/flow/table_flownode.rs
@@ -187,6 +187,7 @@ mod tests {
                     },
                     flownode_ids: BTreeMap::from([(0, 1), (1, 2), (2, 3)]),
                     catalog_name: DEFAULT_CATALOG_NAME.to_string(),
+                    schema_name: Some(DEFAULT_SCHEMA_NAME.to_string()),
                     flow_name: "my_flow".to_string(),
                     raw_sql: "sql".to_string(),
                     expire_after: Some(300),

--- a/src/common/meta/src/cache/flow/table_flownode.rs
+++ b/src/common/meta/src/cache/flow/table_flownode.rs
@@ -187,7 +187,7 @@ mod tests {
                     },
                     flownode_ids: BTreeMap::from([(0, 1), (1, 2), (2, 3)]),
                     catalog_name: DEFAULT_CATALOG_NAME.to_string(),
-                    schema_name: Some(DEFAULT_SCHEMA_NAME.to_string()),
+                    query_context: None,
                     flow_name: "my_flow".to_string(),
                     raw_sql: "sql".to_string(),
                     expire_after: Some(300),

--- a/src/common/meta/src/ddl/create_flow.rs
+++ b/src/common/meta/src/ddl/create_flow.rs
@@ -437,6 +437,7 @@ impl From<&CreateFlowData> for (FlowInfoValue, Vec<(FlowPartitionId, FlowRouteVa
             sink_table_name,
             flownode_ids,
             catalog_name,
+            schema_name: Some(value.query_context.current_schema.clone()),
             flow_name,
             raw_sql: sql,
             expire_after,

--- a/src/common/meta/src/ddl/create_flow.rs
+++ b/src/common/meta/src/ddl/create_flow.rs
@@ -437,7 +437,7 @@ impl From<&CreateFlowData> for (FlowInfoValue, Vec<(FlowPartitionId, FlowRouteVa
             sink_table_name,
             flownode_ids,
             catalog_name,
-            schema_name: Some(value.query_context.current_schema.clone()),
+            query_context: Some(value.query_context.clone()),
             flow_name,
             raw_sql: sql,
             expire_after,

--- a/src/common/meta/src/error.rs
+++ b/src/common/meta/src/error.rs
@@ -783,6 +783,14 @@ pub enum Error {
         #[snafu(source)]
         source: common_procedure::error::Error,
     },
+
+    #[snafu(display("Failed to parse timezone"))]
+    InvalidTimeZone {
+        #[snafu(implicit)]
+        location: Location,
+        #[snafu(source)]
+        error: common_time::error::Error,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -853,7 +861,8 @@ impl ErrorExt for Error {
             | TlsConfig { .. }
             | InvalidSetDatabaseOption { .. }
             | InvalidUnsetDatabaseOption { .. }
-            | InvalidTopicNamePrefix { .. } => StatusCode::InvalidArguments,
+            | InvalidTopicNamePrefix { .. }
+            | InvalidTimeZone { .. } => StatusCode::InvalidArguments,
 
             FlowNotFound { .. } => StatusCode::FlowNotFound,
             FlowRouteNotFound { .. } => StatusCode::Unexpected,

--- a/src/common/meta/src/key/flow.rs
+++ b/src/common/meta/src/key/flow.rs
@@ -452,6 +452,7 @@ mod tests {
         };
         FlowInfoValue {
             catalog_name: catalog_name.to_string(),
+            schema_name: Some("my_schema".to_string()),
             flow_name: flow_name.to_string(),
             source_table_ids,
             sink_table_name,
@@ -625,6 +626,7 @@ mod tests {
         };
         let flow_value = FlowInfoValue {
             catalog_name: "greptime".to_string(),
+            schema_name: Some("my_schema".to_string()),
             flow_name: "flow".to_string(),
             source_table_ids: vec![1024, 1025, 1026],
             sink_table_name: another_sink_table_name,
@@ -864,6 +866,7 @@ mod tests {
         };
         let flow_value = FlowInfoValue {
             catalog_name: "greptime".to_string(),
+            schema_name: Some("my_schema".to_string()),
             flow_name: "flow".to_string(),
             source_table_ids: vec![1024, 1025, 1026],
             sink_table_name: another_sink_table_name,

--- a/src/common/meta/src/key/flow.rs
+++ b/src/common/meta/src/key/flow.rs
@@ -452,7 +452,7 @@ mod tests {
         };
         FlowInfoValue {
             catalog_name: catalog_name.to_string(),
-            schema_name: Some("my_schema".to_string()),
+            query_context: None,
             flow_name: flow_name.to_string(),
             source_table_ids,
             sink_table_name,
@@ -626,7 +626,7 @@ mod tests {
         };
         let flow_value = FlowInfoValue {
             catalog_name: "greptime".to_string(),
-            schema_name: Some("my_schema".to_string()),
+            query_context: None,
             flow_name: "flow".to_string(),
             source_table_ids: vec![1024, 1025, 1026],
             sink_table_name: another_sink_table_name,
@@ -866,7 +866,7 @@ mod tests {
         };
         let flow_value = FlowInfoValue {
             catalog_name: "greptime".to_string(),
-            schema_name: Some("my_schema".to_string()),
+            query_context: None,
             flow_name: "flow".to_string(),
             source_table_ids: vec![1024, 1025, 1026],
             sink_table_name: another_sink_table_name,

--- a/src/common/meta/src/key/flow/flow_info.rs
+++ b/src/common/meta/src/key/flow/flow_info.rs
@@ -121,11 +121,13 @@ pub struct FlowInfoValue {
     pub(crate) flownode_ids: BTreeMap<FlowPartitionId, FlownodeId>,
     /// The catalog name.
     pub(crate) catalog_name: String,
-    /// The schema name. Although flow doesn't belong to any schema, this schema_name is needed to record
-    /// the database when `create_flow` is executed for recovering flow after db restart.
-    /// if none, should use `PUBLIC` by default.
+    /// The query context used when create flow.
+    /// Although flow doesn't belong to any schema, this query_context is needed to remember
+    /// the query context when `create_flow` is executed
+    /// for recovering flow using the same sql&query_context after db restart.
+    /// if none, should use default query context
     #[serde(default)]
-    pub(crate) schema_name: Option<String>,
+    pub(crate) query_context: Option<crate::rpc::ddl::QueryContext>,
     /// The flow name.
     pub(crate) flow_name: String,
     /// The raw sql.
@@ -160,8 +162,8 @@ impl FlowInfoValue {
         &self.catalog_name
     }
 
-    pub fn schema_name(&self) -> &Option<String> {
-        &self.schema_name
+    pub fn query_context(&self) -> &Option<crate::rpc::ddl::QueryContext> {
+        &self.query_context
     }
 
     pub fn flow_name(&self) -> &String {

--- a/src/common/meta/src/key/flow/flow_info.rs
+++ b/src/common/meta/src/key/flow/flow_info.rs
@@ -121,6 +121,11 @@ pub struct FlowInfoValue {
     pub(crate) flownode_ids: BTreeMap<FlowPartitionId, FlownodeId>,
     /// The catalog name.
     pub(crate) catalog_name: String,
+    /// The schema name. Although flow doesn't belong to any schema, this schema_name is needed to record
+    /// the database when `create_flow` is executed for recovering flow after db restart.
+    /// if none, should use `PUBLIC` by default.
+    #[serde(default)]
+    pub(crate) schema_name: Option<String>,
     /// The flow name.
     pub(crate) flow_name: String,
     /// The raw sql.
@@ -153,6 +158,10 @@ impl FlowInfoValue {
 
     pub fn catalog_name(&self) -> &String {
         &self.catalog_name
+    }
+
+    pub fn schema_name(&self) -> &Option<String> {
+        &self.schema_name
     }
 
     pub fn flow_name(&self) -> &String {

--- a/src/common/meta/src/rpc/ddl.rs
+++ b/src/common/meta/src/rpc/ddl.rs
@@ -1207,8 +1207,8 @@ impl From<DropFlowTask> for PbDropFlowTask {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct QueryContext {
-    pub current_catalog: String,
-    pub current_schema: String,
+    current_catalog: String,
+    current_schema: String,
     timezone: String,
     extensions: HashMap<String, String>,
     channel: u8,

--- a/src/common/meta/src/rpc/ddl.rs
+++ b/src/common/meta/src/rpc/ddl.rs
@@ -35,17 +35,20 @@ use api::v1::{
 };
 use base64::engine::general_purpose;
 use base64::Engine as _;
-use common_time::DatabaseTimeToLive;
+use common_time::{DatabaseTimeToLive, Timezone};
 use prost::Message;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DefaultOnNull};
-use session::context::QueryContextRef;
+use session::context::{QueryContextBuilder, QueryContextRef};
 use snafu::{OptionExt, ResultExt};
 use table::metadata::{RawTableInfo, TableId};
 use table::table_name::TableName;
 use table::table_reference::TableReference;
 
-use crate::error::{self, InvalidSetDatabaseOptionSnafu, InvalidUnsetDatabaseOptionSnafu, Result};
+use crate::error::{
+    self, InvalidSetDatabaseOptionSnafu, InvalidTimeZoneSnafu, InvalidUnsetDatabaseOptionSnafu,
+    Result,
+};
 use crate::key::FlowId;
 
 /// DDL tasks
@@ -1202,7 +1205,7 @@ impl From<DropFlowTask> for PbDropFlowTask {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct QueryContext {
     pub current_catalog: String,
     pub current_schema: String,
@@ -1220,6 +1223,19 @@ impl From<QueryContextRef> for QueryContext {
             extensions: query_context.extensions(),
             channel: query_context.channel() as u8,
         }
+    }
+}
+
+impl TryFrom<QueryContext> for session::context::QueryContext {
+    type Error = error::Error;
+    fn try_from(value: QueryContext) -> std::result::Result<Self, Self::Error> {
+        Ok(QueryContextBuilder::default()
+            .current_catalog(value.current_catalog)
+            .current_schema(value.current_schema)
+            .timezone(Timezone::from_tz_string(&value.timezone).context(InvalidTimeZoneSnafu)?)
+            .extensions(value.extensions)
+            .channel((value.channel as u32).into())
+            .build())
     }
 }
 

--- a/src/common/meta/src/rpc/ddl.rs
+++ b/src/common/meta/src/rpc/ddl.rs
@@ -1204,8 +1204,8 @@ impl From<DropFlowTask> for PbDropFlowTask {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueryContext {
-    current_catalog: String,
-    current_schema: String,
+    pub current_catalog: String,
+    pub current_schema: String,
     timezone: String,
     extensions: HashMap<String, String>,
     channel: u8,

--- a/src/flow/src/server.rs
+++ b/src/flow/src/server.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use api::v1::{RowDeleteRequests, RowInsertRequests};
 use cache::{TABLE_FLOWNODE_SET_CACHE_NAME, TABLE_ROUTE_CACHE_NAME};
 use catalog::CatalogManagerRef;
+use client::DEFAULT_SCHEMA_NAME;
 use common_base::Plugins;
 use common_error::ext::BoxedError;
 use common_meta::cache::{LayeredCacheRegistryRef, TableFlownodeSetCacheRef, TableRouteCacheRef};
@@ -401,6 +402,7 @@ impl FlownodeBuilder {
         let cnt = to_be_recovered.len();
 
         // TODO(discord9): recover in parallel
+        info!("Recovering {} flows: {:?}", cnt, to_be_recovered);
         for flow_id in to_be_recovered {
             let info = self
                 .flow_metadata_manager
@@ -432,6 +434,11 @@ impl FlownodeBuilder {
                 query_ctx: Some(
                     QueryContextBuilder::default()
                         .current_catalog(info.catalog_name().clone())
+                        .current_schema(
+                            info.schema_name()
+                                .clone()
+                                .unwrap_or(DEFAULT_SCHEMA_NAME.to_string()),
+                        )
                         .build(),
                 ),
             };

--- a/tests/cases/standalone/common/flow/flow_rebuild.result
+++ b/tests/cases/standalone/common/flow/flow_rebuild.result
@@ -576,3 +576,119 @@ DROP TABLE out_basic;
 
 Affected Rows: 0
 
+-- check if different schema is working as expected
+CREATE DATABASE jsdp_log;
+
+Affected Rows: 1
+
+USE jsdp_log;
+
+Affected Rows: 0
+
+CREATE TABLE IF NOT EXISTS `api_log` (
+  `time` TIMESTAMP(9) NOT NULL,
+  `key` STRING NULL SKIPPING INDEX WITH(granularity = '1024', type = 'BLOOM'),
+  `status_code` TINYINT NULL,
+  `method` STRING NULL,
+  `path` STRING NULL,
+  `raw_query` STRING NULL,
+  `user_agent` STRING NULL,
+  `client_ip` STRING NULL,
+  `duration` INT NULL,
+  `count` INT NULL,
+  TIME INDEX (`time`)
+) ENGINE=mito WITH(
+  append_mode = 'true'
+);
+
+Affected Rows: 0
+
+/* 创建 sink 表 */
+CREATE TABLE IF NOT EXISTS `api_stats` (
+  `time` TIMESTAMP(0) NOT NULL,
+  `key` STRING NULL,
+  `qpm` BIGINT NULL,
+  `rpm` BIGINT NULL,
+  `update_at` TIMESTAMP(3) NULL,
+  TIME INDEX (`time`),
+  PRIMARY KEY (`key`)
+) ENGINE=mito WITH(
+  append_mode = 'false',
+  merge_mode = 'last_row'
+);
+
+Affected Rows: 0
+
+/* 创建 flow  */
+CREATE FLOW IF NOT EXISTS api_stats_flow
+SINK TO api_stats EXPIRE AFTER '10 minute'::INTERVAL AS
+SELECT date_trunc('minute', `time`::TimestampSecond) AS `time1`, `key`, count(*), sum(`count`)
+FROM api_log
+GROUP BY `time1`, `key`;
+
+Affected Rows: 0
+
+INSERT INTO `api_log` (`time`, `key`, `status_code`, `method`, `path`, `raw_query`, `user_agent`, `client_ip`, `duration`, `count`) VALUES (now(), '1', 0, 'GET', '/lightning/v1/query', 'key=1&since=600', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36', '1', 21, 1);
+
+Affected Rows: 1
+
+-- SQLNESS REPLACE (ADMIN\sFLUSH_FLOW\('\w+'\)\s+\|\n\+-+\+\n\|\s+)[0-9]+\s+\| $1 FLOW_FLUSHED  |
+admin flush_flow('api_stats_flow');
+
++------------------------------------+
+| ADMIN flush_flow('api_stats_flow') |
++------------------------------------+
+| 1                                  |
++------------------------------------+
+
+SELECT key FROM api_stats;
+
++-----+
+| key |
++-----+
+| 1   |
++-----+
+
+-- SQLNESS ARG restart=true
+INSERT INTO `api_log` (`time`, `key`, `status_code`, `method`, `path`, `raw_query`, `user_agent`, `client_ip`, `duration`, `count`) VALUES (now(), '2', 0, 'GET', '/lightning/v1/query', 'key=1&since=600', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36', '1', 21, 1);
+
+Affected Rows: 1
+
+-- SQLNESS REPLACE (ADMIN\sFLUSH_FLOW\('\w+'\)\s+\|\n\+-+\+\n\|\s+)[0-9]+\s+\| $1 FLOW_FLUSHED  |
+admin flush_flow('api_stats_flow');
+
++------------------------------------+
+| ADMIN flush_flow('api_stats_flow') |
++------------------------------------+
+| 1                                  |
++------------------------------------+
+
+SELECT key FROM api_stats;
+
++-----+
+| key |
++-----+
+| 1   |
+| 2   |
++-----+
+
+DROP FLOW api_stats_flow;
+
+Affected Rows: 0
+
+DROP TABLE api_log;
+
+Affected Rows: 0
+
+DROP TABLE api_stats;
+
+Affected Rows: 0
+
+USE public;
+
+Affected Rows: 0
+
+DROP DATABASE jsdp_log;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/flow/flow_rebuild.result
+++ b/tests/cases/standalone/common/flow/flow_rebuild.result
@@ -603,7 +603,6 @@ CREATE TABLE IF NOT EXISTS `api_log` (
 
 Affected Rows: 0
 
-/* 创建 sink 表 */
 CREATE TABLE IF NOT EXISTS `api_stats` (
   `time` TIMESTAMP(0) NOT NULL,
   `key` STRING NULL,
@@ -619,7 +618,6 @@ CREATE TABLE IF NOT EXISTS `api_stats` (
 
 Affected Rows: 0
 
-/* 创建 flow  */
 CREATE FLOW IF NOT EXISTS api_stats_flow
 SINK TO api_stats EXPIRE AFTER '10 minute'::INTERVAL AS
 SELECT date_trunc('minute', `time`::TimestampSecond) AS `time1`, `key`, count(*), sum(`count`)

--- a/tests/cases/standalone/common/flow/flow_rebuild.result
+++ b/tests/cases/standalone/common/flow/flow_rebuild.result
@@ -631,12 +631,12 @@ INSERT INTO `api_log` (`time`, `key`, `status_code`, `method`, `path`, `raw_quer
 Affected Rows: 1
 
 -- SQLNESS REPLACE (ADMIN\sFLUSH_FLOW\('\w+'\)\s+\|\n\+-+\+\n\|\s+)[0-9]+\s+\| $1 FLOW_FLUSHED  |
-admin flush_flow('api_stats_flow');
+ADMIN FLUSH_FLOW('api_stats_flow');
 
 +------------------------------------+
-| ADMIN flush_flow('api_stats_flow') |
+| ADMIN FLUSH_FLOW('api_stats_flow') |
 +------------------------------------+
-| 1                                  |
+|  FLOW_FLUSHED  |
 +------------------------------------+
 
 SELECT key FROM api_stats;
@@ -653,12 +653,12 @@ INSERT INTO `api_log` (`time`, `key`, `status_code`, `method`, `path`, `raw_quer
 Affected Rows: 1
 
 -- SQLNESS REPLACE (ADMIN\sFLUSH_FLOW\('\w+'\)\s+\|\n\+-+\+\n\|\s+)[0-9]+\s+\| $1 FLOW_FLUSHED  |
-admin flush_flow('api_stats_flow');
+ADMIN FLUSH_FLOW('api_stats_flow');
 
 +------------------------------------+
-| ADMIN flush_flow('api_stats_flow') |
+| ADMIN FLUSH_FLOW('api_stats_flow') |
 +------------------------------------+
-| 1                                  |
+|  FLOW_FLUSHED  |
 +------------------------------------+
 
 SELECT key FROM api_stats;

--- a/tests/cases/standalone/common/flow/flow_rebuild.sql
+++ b/tests/cases/standalone/common/flow/flow_rebuild.sql
@@ -361,7 +361,7 @@ GROUP BY `time1`, `key`;
 INSERT INTO `api_log` (`time`, `key`, `status_code`, `method`, `path`, `raw_query`, `user_agent`, `client_ip`, `duration`, `count`) VALUES (now(), '1', 0, 'GET', '/lightning/v1/query', 'key=1&since=600', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36', '1', 21, 1);
 
 -- SQLNESS REPLACE (ADMIN\sFLUSH_FLOW\('\w+'\)\s+\|\n\+-+\+\n\|\s+)[0-9]+\s+\| $1 FLOW_FLUSHED  |
-admin flush_flow('api_stats_flow');
+ADMIN FLUSH_FLOW('api_stats_flow');
 
 SELECT key FROM api_stats;
 
@@ -369,7 +369,7 @@ SELECT key FROM api_stats;
 INSERT INTO `api_log` (`time`, `key`, `status_code`, `method`, `path`, `raw_query`, `user_agent`, `client_ip`, `duration`, `count`) VALUES (now(), '2', 0, 'GET', '/lightning/v1/query', 'key=1&since=600', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36', '1', 21, 1);
 
 -- SQLNESS REPLACE (ADMIN\sFLUSH_FLOW\('\w+'\)\s+\|\n\+-+\+\n\|\s+)[0-9]+\s+\| $1 FLOW_FLUSHED  |
-admin flush_flow('api_stats_flow');
+ADMIN FLUSH_FLOW('api_stats_flow');
 
 SELECT key FROM api_stats;
 

--- a/tests/cases/standalone/common/flow/flow_rebuild.sql
+++ b/tests/cases/standalone/common/flow/flow_rebuild.sql
@@ -317,3 +317,66 @@ DROP FLOW test_wildcard_basic;
 DROP TABLE input_basic;
 
 DROP TABLE out_basic;
+
+-- check if different schema is working as expected
+
+CREATE DATABASE jsdp_log;
+USE jsdp_log;
+
+CREATE TABLE IF NOT EXISTS `api_log` (
+  `time` TIMESTAMP(9) NOT NULL,
+  `key` STRING NULL SKIPPING INDEX WITH(granularity = '1024', type = 'BLOOM'),
+  `status_code` TINYINT NULL,
+  `method` STRING NULL,
+  `path` STRING NULL,
+  `raw_query` STRING NULL,
+  `user_agent` STRING NULL,
+  `client_ip` STRING NULL,
+  `duration` INT NULL,
+  `count` INT NULL,
+  TIME INDEX (`time`)
+) ENGINE=mito WITH(
+  append_mode = 'true'
+);
+
+CREATE TABLE IF NOT EXISTS `api_stats` (
+  `time` TIMESTAMP(0) NOT NULL,
+  `key` STRING NULL,
+  `qpm` BIGINT NULL,
+  `rpm` BIGINT NULL,
+  `update_at` TIMESTAMP(3) NULL,
+  TIME INDEX (`time`),
+  PRIMARY KEY (`key`)
+) ENGINE=mito WITH(
+  append_mode = 'false',
+  merge_mode = 'last_row'
+);
+
+CREATE FLOW IF NOT EXISTS api_stats_flow
+SINK TO api_stats EXPIRE AFTER '10 minute'::INTERVAL AS
+SELECT date_trunc('minute', `time`::TimestampSecond) AS `time1`, `key`, count(*), sum(`count`)
+FROM api_log
+GROUP BY `time1`, `key`;
+
+INSERT INTO `api_log` (`time`, `key`, `status_code`, `method`, `path`, `raw_query`, `user_agent`, `client_ip`, `duration`, `count`) VALUES (now(), '1', 0, 'GET', '/lightning/v1/query', 'key=1&since=600', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36', '1', 21, 1);
+
+-- SQLNESS REPLACE (ADMIN\sFLUSH_FLOW\('\w+'\)\s+\|\n\+-+\+\n\|\s+)[0-9]+\s+\| $1 FLOW_FLUSHED  |
+admin flush_flow('api_stats_flow');
+
+SELECT key FROM api_stats;
+
+-- SQLNESS ARG restart=true
+INSERT INTO `api_log` (`time`, `key`, `status_code`, `method`, `path`, `raw_query`, `user_agent`, `client_ip`, `duration`, `count`) VALUES (now(), '2', 0, 'GET', '/lightning/v1/query', 'key=1&since=600', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36', '1', 21, 1);
+
+-- SQLNESS REPLACE (ADMIN\sFLUSH_FLOW\('\w+'\)\s+\|\n\+-+\+\n\|\s+)[0-9]+\s+\| $1 FLOW_FLUSHED  |
+admin flush_flow('api_stats_flow');
+
+SELECT key FROM api_stats;
+
+DROP FLOW api_stats_flow;
+
+DROP TABLE api_log;
+DROP TABLE api_stats;
+
+USE public;
+DROP DATABASE jsdp_log;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#5959
## What's changed and what's your intention?

flow need to parse `raw_sql`, ~hence if `schema!=public`, on recover flows it will failed to find correct table if `raw_sql` ref to tables not in `public` schema, fix is to store schema for flows, and when recover flows using it~
hence when recovering flow using `raw_sql`, need the same `QueryContext` so that the sql can be parsed as the same logical plan

- local test confirm upgrade metadata is compatible(the new query context field is `#[serde(default)]`)


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
