### PR TITLE
ci: make install script to start greptimedb standalone by default

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -81,11 +81,20 @@ download_artifact() {
       mv "${PACKAGE_NAME%.tar.gz}/${BIN}" "${PWD}" && \
       rm -r "${PACKAGE_NAME}" && \
       rm -r "${PACKAGE_NAME%.tar.gz}" && \
-      echo "Run './${BIN} --help' to get started"
+      echo "Run './${BIN} --help' to print the help message"
     fi
+  fi
+}
+
+run_standalone() {
+  if [ -e ./${BIN} ]; then
+    echo "Starting GreptimeDB standalone via './${BIN} standalone start'"
+    echo "The data home is: ./greptimedb_data"
+    ./${BIN} standalone start
   fi
 }
 
 get_os_type
 get_arch_type
 download_artifact
+run_standalone


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
As the title said

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
