### PR TITLE
feat: flush leader region before downgrading

### DIFF
--- a/src/common/meta/src/instruction.rs
+++ b/src/common/meta/src/instruction.rs
@@ -217,7 +217,9 @@ pub enum Instruction {
     /// Invalidates batch cache.
     InvalidateCaches(Vec<CacheIdent>),
     /// Flushes regions.
-    FlushRegion(FlushRegions),
+    FlushRegions(FlushRegions),
+    /// Flushes a single region.
+    FlushRegion(RegionId),
 }
 
 /// The reply of [UpgradeRegion].
@@ -248,6 +250,7 @@ pub enum InstructionReply {
     CloseRegion(SimpleReply),
     UpgradeRegion(UpgradeRegionReply),
     DowngradeRegion(DowngradeRegionReply),
+    FlushRegion(SimpleReply),
 }
 
 impl Display for InstructionReply {
@@ -259,6 +262,7 @@ impl Display for InstructionReply {
             Self::DowngradeRegion(reply) => {
                 write!(f, "InstructionReply::DowngradeRegion({})", reply)
             }
+            Self::FlushRegion(reply) => write!(f, "InstructionReply::FlushRegion({})", reply),
         }
     }
 }

--- a/src/datanode/src/heartbeat/handler/flush_region.rs
+++ b/src/datanode/src/heartbeat/handler/flush_region.rs
@@ -12,16 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_meta::instruction::{FlushRegions, InstructionReply};
+use common_meta::instruction::{FlushRegions, InstructionReply, SimpleReply};
 use common_telemetry::warn;
 use futures_util::future::BoxFuture;
 use store_api::region_request::{RegionFlushRequest, RegionRequest};
+use store_api::storage::RegionId;
 
 use crate::error;
 use crate::heartbeat::handler::HandlerContext;
 
 impl HandlerContext {
-    pub(crate) fn handle_flush_region_instruction(
+    pub(crate) fn handle_flush_regions_instruction(
         self,
         flush_regions: FlushRegions,
     ) -> BoxFuture<'static, Option<InstructionReply>> {
@@ -47,6 +48,59 @@ impl HandlerContext {
                 }
             }
             None
+        })
+    }
+
+    pub(crate) fn handle_flush_region_instruction(
+        self,
+        region_id: RegionId,
+    ) -> BoxFuture<'static, Option<InstructionReply>> {
+        Box::pin(async move {
+            let Some(writable) = self.region_server.is_region_leader(region_id) else {
+                return Some(InstructionReply::FlushRegion(SimpleReply {
+                    result: false,
+                    error: Some("Region is not leader".to_string()),
+                }));
+            };
+
+            if !writable {
+                return Some(InstructionReply::FlushRegion(SimpleReply {
+                    result: false,
+                    error: Some("Region is not writable".to_string()),
+                }));
+            }
+
+            let region_server_moved = self.region_server.clone();
+            let register_result = self
+                .flush_tasks
+                .try_register(
+                    region_id,
+                    Box::pin(async move {
+                        let request = RegionRequest::Flush(RegionFlushRequest {
+                            row_group_size: None,
+                        });
+                        region_server_moved
+                            .handle_request(region_id, request)
+                            .await?;
+                        Ok(())
+                    }),
+                )
+                .await;
+            if register_result.is_busy() {
+                warn!("Another flush task is running for the region: {region_id}");
+            }
+            let mut watcher = register_result.into_watcher();
+            let result = self.flush_tasks.wait_until_finish(&mut watcher).await;
+            match result {
+                Ok(()) => Some(InstructionReply::FlushRegion(SimpleReply {
+                    result: true,
+                    error: None,
+                })),
+                Err(err) => Some(InstructionReply::FlushRegion(SimpleReply {
+                    result: false,
+                    error: Some(format!("{err:?}")),
+                })),
+            }
         })
     }
 }
@@ -84,7 +138,7 @@ mod tests {
 
         let reply = handler_context
             .clone()
-            .handle_flush_region_instruction(FlushRegions {
+            .handle_flush_regions_instruction(FlushRegions {
                 region_ids: region_ids.clone(),
             })
             .await;
@@ -94,7 +148,7 @@ mod tests {
         flushed_region_ids.write().unwrap().clear();
         let not_found_region_ids = (0..2).map(|i| RegionId::new(2048, i)).collect::<Vec<_>>();
         let reply = handler_context
-            .handle_flush_region_instruction(FlushRegions {
+            .handle_flush_regions_instruction(FlushRegions {
                 region_ids: not_found_region_ids.clone(),
             })
             .await;

--- a/src/datanode/src/heartbeat/task_tracker.rs
+++ b/src/datanode/src/heartbeat/task_tracker.rs
@@ -144,6 +144,11 @@ impl<T: Send + Sync + Clone + 'static> TaskTracker<T> {
         }
     }
 
+    /// Waits for a [RegisterResult] and returns a [WaitResult].
+    pub(crate) async fn wait_until_finish(&self, watcher: &mut TaskWatcher<T>) -> Result<T> {
+        wait(watcher).await
+    }
+
     /// Tries to register a new async task, returns [RegisterResult::Busy] if previous task is running.
     pub(crate) async fn try_register(
         &self,

--- a/src/meta-srv/src/procedure/region_migration.rs
+++ b/src/meta-srv/src/procedure/region_migration.rs
@@ -124,10 +124,14 @@ pub struct Metrics {
 
 impl Display for Metrics {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let total = self.flush_leader_region_elapsed
+            + self.downgrade_leader_region_elapsed
+            + self.open_candidate_region_elapsed
+            + self.upgrade_candidate_region_elapsed;
         write!(
             f,
-            "operations_elapsed: {:?}, flush_leader_region_elapsed: {:?}, downgrade_leader_region_elapsed: {:?}, open_candidate_region_elapsed: {:?}, upgrade_candidate_region_elapsed: {:?}",
-            self.operations_elapsed,
+            "total: {:?}, flush_leader_region_elapsed: {:?}, downgrade_leader_region_elapsed: {:?}, open_candidate_region_elapsed: {:?}, upgrade_candidate_region_elapsed: {:?}",
+            total,
             self.flush_leader_region_elapsed,
             self.downgrade_leader_region_elapsed,
             self.open_candidate_region_elapsed,
@@ -165,11 +169,13 @@ impl Metrics {
 
 impl Drop for Metrics {
     fn drop(&mut self) {
-        if !self.operations_elapsed.is_zero() {
-            METRIC_META_REGION_MIGRATION_STAGE_ELAPSED
-                .with_label_values(&["operations"])
-                .observe(self.operations_elapsed.as_secs_f64());
-        }
+        let total = self.flush_leader_region_elapsed
+            + self.downgrade_leader_region_elapsed
+            + self.open_candidate_region_elapsed
+            + self.upgrade_candidate_region_elapsed;
+        METRIC_META_REGION_MIGRATION_STAGE_ELAPSED
+            .with_label_values(&["total"])
+            .observe(total.as_secs_f64());
 
         if !self.flush_leader_region_elapsed.is_zero() {
             METRIC_META_REGION_MIGRATION_STAGE_ELAPSED

--- a/src/meta-srv/src/procedure/region_migration.rs
+++ b/src/meta-srv/src/procedure/region_migration.rs
@@ -722,7 +722,8 @@ mod tests {
     use crate::procedure::region_migration::open_candidate_region::OpenCandidateRegion;
     use crate::procedure::region_migration::test_util::*;
     use crate::procedure::test_util::{
-        new_downgrade_region_reply, new_open_region_reply, new_upgrade_region_reply,
+        new_downgrade_region_reply, new_flush_region_reply, new_open_region_reply,
+        new_upgrade_region_reply,
     };
     use crate::service::mailbox::Channel;
 
@@ -1229,6 +1230,15 @@ mod tests {
                 Some(mock_datanode_reply(
                     to_peer_id,
                     Arc::new(|id| Ok(new_open_region_reply(id, true, None))),
+                )),
+                Assertion::simple(assert_flush_leader_region, assert_no_persist),
+            ),
+            // Flush Leader Region
+            Step::next(
+                "Should be the flush leader region",
+                Some(mock_datanode_reply(
+                    from_peer_id,
+                    Arc::new(|id| Ok(new_flush_region_reply(id, true, None))),
                 )),
                 Assertion::simple(assert_update_metadata_downgrade, assert_no_persist),
             ),

--- a/src/meta-srv/src/procedure/region_migration/downgrade_leader_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/downgrade_leader_region.rs
@@ -170,7 +170,7 @@ impl DowngradeLeaderRegion {
                 if error.is_some() {
                     return error::RetryLaterSnafu {
                         reason: format!(
-                            "Failed to downgrade the region {} on Datanode {:?}, error: {:?}, elapsed: {:?}",
+                            "Failed to downgrade the region {} on datanode {:?}, error: {:?}, elapsed: {:?}",
                             region_id, leader, error, now.elapsed()
                         ),
                     }
@@ -179,13 +179,14 @@ impl DowngradeLeaderRegion {
 
                 if !exists {
                     warn!(
-                        "Trying to downgrade the region {} on Datanode {}, but region doesn't exist!, elapsed: {:?}",
+                        "Trying to downgrade the region {} on datanode {:?}, but region doesn't exist!, elapsed: {:?}",
                         region_id, leader, now.elapsed()
                     );
                 } else {
                     info!(
-                        "Region {} leader is downgraded, last_entry_id: {:?}, metadata_last_entry_id: {:?}, elapsed: {:?}",
+                        "Region {} leader is downgraded on datanode {:?}, last_entry_id: {:?}, metadata_last_entry_id: {:?}, elapsed: {:?}",
                         region_id,
+                        leader,
                         last_entry_id,
                         metadata_last_entry_id,
                         now.elapsed()

--- a/src/meta-srv/src/procedure/region_migration/flush_leader_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/flush_leader_region.rs
@@ -1,0 +1,154 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+
+use api::v1::meta::MailboxMessage;
+use common_meta::instruction::{Instruction, InstructionReply, SimpleReply};
+use common_procedure::Status;
+use common_telemetry::{info, warn};
+use serde::{Deserialize, Serialize};
+use snafu::{OptionExt, ResultExt};
+use tokio::time::Instant;
+
+use crate::error::{self, Error, Result};
+use crate::handler::HeartbeatMailbox;
+use crate::procedure::region_migration::update_metadata::UpdateMetadata;
+use crate::procedure::region_migration::{Context, State};
+use crate::service::mailbox::Channel;
+
+/// Flushes the leader region.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FlushLeaderRegion;
+
+#[async_trait::async_trait]
+#[typetag::serde]
+impl State for FlushLeaderRegion {
+    async fn next(&mut self, ctx: &mut Context) -> Result<(Box<dyn State>, Status)> {
+        let timer = Instant::now();
+        self.flush_region(ctx).await?;
+        ctx.volatile_ctx
+            .metrics
+            .update_flush_leader_region_elapsed(timer.elapsed());
+
+        Ok((
+            Box::new(UpdateMetadata::Downgrade),
+            Status::executing(false),
+        ))
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+impl FlushLeaderRegion {
+    /// Builds flush leader region instruction.
+    fn build_flush_leader_region_instruction(&self, ctx: &Context) -> Instruction {
+        let pc = &ctx.persistent_ctx;
+        let region_id = pc.region_id;
+        Instruction::FlushRegion(region_id)
+    }
+
+    /// Tries to flush a leader region.
+    ///
+    /// Ignore:
+    /// - [PusherNotFound](error::Error::PusherNotFound), The datanode is unreachable.
+    /// - [PushMessage](error::Error::PushMessage), The receiver is dropped.
+    /// - Failed to flush region on the Datanode.
+    ///
+    /// Abort:
+    /// - [MailboxTimeout](error::Error::MailboxTimeout), Timeout.
+    /// - [MailboxReceiver](error::Error::MailboxReceiver), The sender is dropped without sending (impossible).
+    /// - [UnexpectedInstructionReply](error::Error::UnexpectedInstructionReply).
+    /// - [ExceededDeadline](error::Error::ExceededDeadline)
+    /// - Invalid JSON.
+    async fn flush_region(&self, ctx: &mut Context) -> Result<()> {
+        let operation_timeout =
+            ctx.next_operation_timeout()
+                .context(error::ExceededDeadlineSnafu {
+                    operation: "Flush leader region",
+                })?;
+        let flush_instruction = self.build_flush_leader_region_instruction(ctx);
+        let region_id = ctx.persistent_ctx.region_id;
+        let leader = &ctx.persistent_ctx.from_peer;
+
+        let msg = MailboxMessage::json_message(
+            &format!("Flush leader region: {}", region_id),
+            &format!("Metasrv@{}", ctx.server_addr()),
+            &format!("Datanode-{}@{}", leader.id, leader.addr),
+            common_time::util::current_time_millis(),
+            &flush_instruction,
+        )
+        .with_context(|_| error::SerializeToJsonSnafu {
+            input: flush_instruction.to_string(),
+        })?;
+
+        let ch = Channel::Datanode(leader.id);
+        let now = Instant::now();
+        let result = ctx.mailbox.send(&ch, msg, operation_timeout).await;
+
+        match result {
+            Ok(receiver) => match receiver.await? {
+                Ok(msg) => {
+                    let reply = HeartbeatMailbox::json_reply(&msg)?;
+                    info!(
+                        "Received flush leader region reply: {:?}, region: {}, elapsed: {:?}",
+                        reply,
+                        region_id,
+                        now.elapsed()
+                    );
+
+                    let InstructionReply::FlushRegion(SimpleReply { result, error }) = reply else {
+                        return error::UnexpectedInstructionReplySnafu {
+                            mailbox_message: msg.to_string(),
+                            reason: "expect flush region reply",
+                        }
+                        .fail();
+                    };
+
+                    if error.is_some() {
+                        warn!(
+                            "Failed to flush leader region {} on datanode {:?}, error: {:?}. Skip flush operation.",
+                            region_id, leader, error
+                        );
+                    } else if result {
+                        info!(
+                            "The flush leader region {} on datanode {:?} is successful, elapsed: {:?}",
+                            region_id,
+                            leader,
+                            now.elapsed()
+                        );
+                    }
+
+                    Ok(())
+                }
+                Err(Error::MailboxTimeout { .. }) => error::ExceededDeadlineSnafu {
+                    operation: "Flush leader region",
+                }
+                .fail(),
+                Err(err) => Err(err),
+            },
+            Err(Error::PusherNotFound { .. }) => {
+                warn!(
+                    "Failed to flush leader region({}), the datanode({}) is unreachable(PusherNotFound). Skip flush operation.",
+                    region_id,
+                    leader
+                );
+                Ok(())
+            }
+            Err(err) => Err(err),
+        }
+    }
+}

--- a/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
@@ -396,7 +396,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_next_update_metadata_downgrade_state() {
+    async fn test_next_flush_leader_region_state() {
         let mut state = Box::new(OpenCandidateRegion);
         // from_peer: 1
         // to_peer: 2

--- a/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
@@ -28,7 +28,7 @@ use tokio::time::Instant;
 
 use crate::error::{self, Result};
 use crate::handler::HeartbeatMailbox;
-use crate::procedure::region_migration::flush_leader_region::FlushLeaderRegion;
+use crate::procedure::region_migration::flush_leader_region::PreFlushRegion;
 use crate::procedure::region_migration::{Context, State};
 use crate::service::mailbox::Channel;
 
@@ -47,7 +47,7 @@ impl State for OpenCandidateRegion {
         self.open_candidate_region(ctx, instruction).await?;
         ctx.update_open_candidate_region_elapsed(now);
 
-        Ok((Box::new(FlushLeaderRegion), Status::executing(false)))
+        Ok((Box::new(PreFlushRegion), Status::executing(false)))
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -442,7 +442,7 @@ mod tests {
             (to_peer_id, region_id)
         );
 
-        let flush_leader_region = next.as_any().downcast_ref::<FlushLeaderRegion>().unwrap();
-        assert_matches!(flush_leader_region, FlushLeaderRegion);
+        let flush_leader_region = next.as_any().downcast_ref::<PreFlushRegion>().unwrap();
+        assert_matches!(flush_leader_region, PreFlushRegion);
     }
 }

--- a/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
@@ -28,7 +28,7 @@ use tokio::time::Instant;
 
 use crate::error::{self, Result};
 use crate::handler::HeartbeatMailbox;
-use crate::procedure::region_migration::update_metadata::UpdateMetadata;
+use crate::procedure::region_migration::flush_leader_region::FlushLeaderRegion;
 use crate::procedure::region_migration::{Context, State};
 use crate::service::mailbox::Channel;
 
@@ -47,10 +47,7 @@ impl State for OpenCandidateRegion {
         self.open_candidate_region(ctx, instruction).await?;
         ctx.update_open_candidate_region_elapsed(now);
 
-        Ok((
-            Box::new(UpdateMetadata::Downgrade),
-            Status::executing(false),
-        ))
+        Ok((Box::new(FlushLeaderRegion), Status::executing(false)))
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -445,8 +442,7 @@ mod tests {
             (to_peer_id, region_id)
         );
 
-        let update_metadata = next.as_any().downcast_ref::<UpdateMetadata>().unwrap();
-
-        assert_matches!(update_metadata, UpdateMetadata::Downgrade);
+        let flush_leader_region = next.as_any().downcast_ref::<FlushLeaderRegion>().unwrap();
+        assert_matches!(flush_leader_region, FlushLeaderRegion);
     }
 }

--- a/src/meta-srv/src/procedure/region_migration/test_util.rs
+++ b/src/meta-srv/src/procedure/region_migration/test_util.rs
@@ -44,7 +44,7 @@ use crate::error::{self, Error, Result};
 use crate::metasrv::MetasrvInfo;
 use crate::procedure::region_migration::close_downgraded_region::CloseDowngradedRegion;
 use crate::procedure::region_migration::downgrade_leader_region::DowngradeLeaderRegion;
-use crate::procedure::region_migration::flush_leader_region::FlushLeaderRegion;
+use crate::procedure::region_migration::flush_leader_region::PreFlushRegion;
 use crate::procedure::region_migration::manager::RegionMigrationProcedureTracker;
 use crate::procedure::region_migration::migration_abort::RegionMigrationAbort;
 use crate::procedure::region_migration::migration_end::RegionMigrationEnd;
@@ -418,7 +418,7 @@ pub(crate) fn assert_open_candidate_region(next: &dyn State) {
 
 /// Asserts the [State] should be [FlushLeaderRegion].
 pub(crate) fn assert_flush_leader_region(next: &dyn State) {
-    let _ = next.as_any().downcast_ref::<FlushLeaderRegion>().unwrap();
+    let _ = next.as_any().downcast_ref::<PreFlushRegion>().unwrap();
 }
 
 /// Asserts the [State] should be [UpdateMetadata::Downgrade].

--- a/src/meta-srv/src/procedure/region_migration/test_util.rs
+++ b/src/meta-srv/src/procedure/region_migration/test_util.rs
@@ -44,6 +44,7 @@ use crate::error::{self, Error, Result};
 use crate::metasrv::MetasrvInfo;
 use crate::procedure::region_migration::close_downgraded_region::CloseDowngradedRegion;
 use crate::procedure::region_migration::downgrade_leader_region::DowngradeLeaderRegion;
+use crate::procedure::region_migration::flush_leader_region::FlushLeaderRegion;
 use crate::procedure::region_migration::manager::RegionMigrationProcedureTracker;
 use crate::procedure::region_migration::migration_abort::RegionMigrationAbort;
 use crate::procedure::region_migration::migration_end::RegionMigrationEnd;
@@ -413,6 +414,11 @@ pub(crate) fn assert_done(status: Status) {
 /// Asserts the [State] should be [OpenCandidateRegion].
 pub(crate) fn assert_open_candidate_region(next: &dyn State) {
     let _ = next.as_any().downcast_ref::<OpenCandidateRegion>().unwrap();
+}
+
+/// Asserts the [State] should be [FlushLeaderRegion].
+pub(crate) fn assert_flush_leader_region(next: &dyn State) {
+    let _ = next.as_any().downcast_ref::<FlushLeaderRegion>().unwrap();
 }
 
 /// Asserts the [State] should be [UpdateMetadata::Downgrade].

--- a/src/meta-srv/src/procedure/test_util.rs
+++ b/src/meta-srv/src/procedure/test_util.rs
@@ -101,6 +101,24 @@ pub fn new_open_region_reply(id: u64, result: bool, error: Option<String>) -> Ma
     }
 }
 
+/// Generates a [InstructionReply::FlushRegion] reply.
+pub fn new_flush_region_reply(id: u64, result: bool, error: Option<String>) -> MailboxMessage {
+    MailboxMessage {
+        id,
+        subject: "mock".to_string(),
+        from: "datanode".to_string(),
+        to: "meta".to_string(),
+        timestamp_millis: current_time_millis(),
+        payload: Some(Payload::Json(
+            serde_json::to_string(&InstructionReply::FlushRegion(SimpleReply {
+                result,
+                error,
+            }))
+            .unwrap(),
+        )),
+    }
+}
+
 /// Generates a [InstructionReply::CloseRegion] reply.
 pub fn new_close_region_reply(id: u64) -> MailboxMessage {
     MailboxMessage {

--- a/src/meta-srv/src/procedure/wal_prune.rs
+++ b/src/meta-srv/src/procedure/wal_prune.rs
@@ -181,7 +181,7 @@ impl WalPruneProcedure {
         let peer_and_instructions = peer_region_ids_map
             .into_iter()
             .map(|(peer, region_ids)| {
-                let flush_instruction = Instruction::FlushRegion(FlushRegions { region_ids });
+                let flush_instruction = Instruction::FlushRegions(FlushRegions { region_ids });
                 (peer.clone(), flush_instruction)
             })
             .collect();
@@ -536,7 +536,7 @@ mod tests {
         let msg = resp.mailbox_message.unwrap();
         let flush_instruction = HeartbeatMailbox::json_instruction(&msg).unwrap();
         let mut flush_requested_region_ids = match flush_instruction {
-            Instruction::FlushRegion(FlushRegions { region_ids, .. }) => region_ids,
+            Instruction::FlushRegions(FlushRegions { region_ids, .. }) => region_ids,
             _ => unreachable!(),
         };
         let sorted_region_ids = region_ids


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your 

This change helps the system handle region migration more smoothly. By flushing the leader region before downgrading it, we can:
- Minimize the time window where the region is not writable
- Reduce the impact on write operations during region migration

### Changes
- Added a new `FlushLeaderRegion` state in the region migration procedure
- Modified the region migration flow to flush the leader region before downgrading it
- Added new metrics for tracking flush leader region operation duration
- Added new test cases for the flush leader region functionality


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
