### PR TITLE
fix: only consider the datanode that reports the failure

### DIFF
--- a/src/meta-srv/src/region/supervisor.rs
+++ b/src/meta-srv/src/region/supervisor.rs
@@ -403,7 +403,7 @@ impl RegionSupervisor {
             // We can't use `grouped_regions.keys().cloned().collect::<Vec<_>>()` here
             // because there may be false positives in failure detection on the datanode.
             // So we only consider the datanode that reports the failure.
-            let failed_datanodes = HashSet::from([datanode_id]);
+            let failed_datanodes = [datanode_id];
             match self
                 .generate_failover_tasks(datanode_id, &regions, &failed_datanodes)
                 .await

--- a/src/meta-srv/src/region/supervisor.rs
+++ b/src/meta-srv/src/region/supervisor.rs
@@ -395,12 +395,15 @@ impl RegionSupervisor {
                 .push(region_id);
         }
 
-        let failed_datanodes = grouped_regions.keys().cloned().collect::<Vec<_>>();
         for (datanode_id, regions) in grouped_regions {
             warn!(
                 "Detects region failures on datanode: {}, regions: {:?}",
                 datanode_id, regions
             );
+            // We can't use `grouped_regions.keys().cloned().collect::<Vec<_>>()` here
+            // because there may be false positives in failure detection on the datanode.
+            // So we only consider the datanode that reports the failure.
+            let failed_datanodes = HashSet::from([datanode_id]);
             match self
                 .generate_failover_tasks(datanode_id, &regions, &failed_datanodes)
                 .await


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Only consider the datanode that reports the failure

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
