### PR TITLE
fix: disable recursion limit in prost

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,7 @@ paste = "1.0"
 pin-project = "1.0"
 prometheus = { version = "0.13.3", features = ["process"] }
 promql-parser = { version = "0.5.1", features = ["ser"] }
-prost = "0.13"
+prost = { version = "0.13", features = ["no-recursion-limit"] }
 raft-engine = { version = "0.4.1", default-features = false }
 rand = "0.9"
 ratelimit = "0.10"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Complex query in substrait will reach this decode limit (default to 32 and is not adjustable). Related code is https://github.com/tokio-rs/prost/blob/bdd03fcb8dbe514a3bc2ecfbc7cb8f335d21436c/prost/src/encoding.rs#L37-L44

Related error is something like
```
EngineExecuteQuery: Failed to decode substrait relation: failed to decode Protobuf message
...

PlanRel.rel_type: Plan.relations: recursion limit reached
```

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
