### PR TITLE
feat: enhance maintenance mode API and handling

### DIFF
--- a/src/meta-srv/src/region/supervisor.rs
+++ b/src/meta-srv/src/region/supervisor.rs
@@ -360,7 +360,7 @@ impl RegionSupervisor {
             Ok(false) => {}
             Ok(true) => {
                 warn!(
-                    "Maintenance mode is enabled, skip failover. Removing failure detectors for regions: {:?}",
+                    "Skipping failover since maintenance mode is enabled. Removing failure detectors for regions: {:?}",
                     regions
                 );
                 self.deregister_failure_detectors(regions).await;

--- a/src/meta-srv/src/region/supervisor.rs
+++ b/src/meta-srv/src/region/supervisor.rs
@@ -359,7 +359,11 @@ impl RegionSupervisor {
         match self.is_maintenance_mode_enabled().await {
             Ok(false) => {}
             Ok(true) => {
-                info!("Maintenance mode is enabled, skip failover");
+                warn!(
+                    "Maintenance mode is enabled, skip failover. Removing failure detectors for regions: {:?}",
+                    regions
+                );
+                self.deregister_failure_detectors(regions).await;
                 return;
             }
             Err(err) => {

--- a/src/meta-srv/src/service/admin/maintenance.rs
+++ b/src/meta-srv/src/service/admin/maintenance.rs
@@ -15,19 +15,36 @@
 use std::collections::HashMap;
 
 use common_meta::key::maintenance::MaintenanceModeManagerRef;
+use common_telemetry::{info, warn};
+use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt};
 use tonic::codegen::http;
 use tonic::codegen::http::Response;
 
 use crate::error::{
-    InvalidHttpBodySnafu, MaintenanceModeManagerSnafu, MissingRequiredParameterSnafu,
-    ParseBoolSnafu, UnsupportedSnafu,
+    self, InvalidHttpBodySnafu, MaintenanceModeManagerSnafu, MissingRequiredParameterSnafu,
+    ParseBoolSnafu, Result, UnsupportedSnafu,
 };
 use crate::service::admin::HttpHandler;
 
 #[derive(Clone)]
 pub struct MaintenanceHandler {
     pub manager: MaintenanceModeManagerRef,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct MaintenanceResponse {
+    enabled: bool,
+}
+
+impl TryFrom<MaintenanceResponse> for String {
+    type Error = error::Error;
+
+    fn try_from(response: MaintenanceResponse) -> Result<Self> {
+        serde_json::to_string(&response).context(error::SerializeToJsonSnafu {
+            input: format!("{response:?}"),
+        })
+    }
 }
 
 impl MaintenanceHandler {
@@ -37,14 +54,10 @@ impl MaintenanceHandler {
             .maintenance_mode()
             .await
             .context(MaintenanceModeManagerSnafu)?;
-        let response = if enabled {
-            "Maintenance mode is enabled"
-        } else {
-            "Maintenance mode is disabled"
-        };
+        let response = MaintenanceResponse { enabled }.try_into()?;
         http::Response::builder()
             .status(http::StatusCode::OK)
-            .body(response.into())
+            .body(response)
             .context(InvalidHttpBodySnafu)
     }
 
@@ -60,23 +73,24 @@ impl MaintenanceHandler {
                 err_msg: "'enable' must be 'true' or 'false'",
             })?;
 
-        let response = if enable {
+        if enable {
             self.manager
                 .set_maintenance_mode()
                 .await
                 .context(MaintenanceModeManagerSnafu)?;
-            "Maintenance mode enabled"
+            info!("Set maintenance mode to true");
         } else {
             self.manager
                 .unset_maintenance_mode()
                 .await
                 .context(MaintenanceModeManagerSnafu)?;
-            "Maintenance mode disabled"
+            info!("Set maintenance mode to false");
         };
 
+        let response = MaintenanceResponse { enabled: enable }.try_into()?;
         http::Response::builder()
             .status(http::StatusCode::OK)
-            .body(response.into())
+            .body(response)
             .context(InvalidHttpBodySnafu)
     }
 }
@@ -90,8 +104,23 @@ impl HttpHandler for MaintenanceHandler {
         params: &HashMap<String, String>,
     ) -> crate::Result<Response<String>> {
         match method {
-            http::Method::GET => self.get_maintenance().await,
-            http::Method::PUT => self.set_maintenance(params).await,
+            http::Method::GET => {
+                if params.is_empty() {
+                    self.get_maintenance().await
+                } else {
+                    warn!(
+                        "Found URL parameters in '/admin/maintenance' request, it's deprecated, will be removed in the future"
+                    );
+                    // The old version operator will send GET request with URL parameters,
+                    // so we need to support it.
+                    self.set_maintenance(params).await
+                }
+            }
+            http::Method::PUT => {
+                warn!("Found PUT request to '/admin/maintenance', it's deprecated, will be removed in the future");
+                self.set_maintenance(params).await
+            }
+            http::Method::POST => self.set_maintenance(params).await,
             _ => UnsupportedSnafu {
                 operation: format!("http method {method}"),
             }

--- a/src/meta-srv/src/service/admin/maintenance.rs
+++ b/src/meta-srv/src/service/admin/maintenance.rs
@@ -78,13 +78,13 @@ impl MaintenanceHandler {
                 .set_maintenance_mode()
                 .await
                 .context(MaintenanceModeManagerSnafu)?;
-            info!("Set maintenance mode to true");
+            info!("Enable the maintenance mode.");
         } else {
             self.manager
                 .unset_maintenance_mode()
                 .await
                 .context(MaintenanceModeManagerSnafu)?;
-            info!("Set maintenance mode to false");
+            info!("Disable the maintenance mode.");
         };
 
         let response = MaintenanceResponse { enabled: enable }.try_into()?;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

### Key Changes

1. **Improved Maintenance Mode Handling**
   - Added warning logs when skipping failover in maintenance mode
   - Added deregistration of failure detectors when maintenance mode is enabled
   - Enhanced logging for maintenance mode state changes

2. **API Improvements**
   - Changed maintenance mode API response format to JSON **Breaking Change** (However, no downstream component using it for now)
   - Added support for multiple HTTP methods:
     - GET (for querying status)
     - POST (recommended for setting status)
     - PUT (deprecated)
   - Added deprecation warnings for:
     - GET requests with parameters
     - PUT method usage

3. **Testing**
   - Added comprehensive tests for maintenance mode API
   - Tests cover all supported HTTP methods
   - Tests verify correct JSON response format
   - Tests ensure proper state transitions

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
