### PR TITLE
fix: improve region migration error handling and optimize leader downgrade with lease check

### DIFF
--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -336,6 +336,15 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display("Failed to downgrade region leader, region: {}", region_id))]
+    DowngradeLeader {
+        region_id: RegionId,
+        #[snafu(implicit)]
+        location: Location,
+        #[snafu(source)]
+        source: BoxedError,
+    },
+
     #[snafu(display("Region's leader peer changed: {}", msg))]
     LeaderPeerChanged {
         msg: String,
@@ -956,7 +965,7 @@ impl ErrorExt for Error {
             Error::StartTelemetryTask { source, .. } => source.status_code(),
 
             Error::NextSequence { source, .. } => source.status_code(),
-
+            Error::DowngradeLeader { source, .. } => source.status_code(),
             Error::RegisterProcedureLoader { source, .. } => source.status_code(),
             Error::SubmitDdlTask { source, .. } => source.status_code(),
             Error::ConvertProtoData { source, .. }

--- a/src/meta-srv/src/handler/keep_lease_handler.rs
+++ b/src/meta-srv/src/handler/keep_lease_handler.rs
@@ -113,3 +113,88 @@ async fn put_into_memory_store(ctx: &mut Context, key: Vec<u8>, value: Vec<u8>, 
         warn!(err; "Failed to update lease KV, peer: {peer:?}");
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use api::v1::meta::RequestHeader;
+    use common_meta::cache_invalidator::DummyCacheInvalidator;
+    use common_meta::datanode::Stat;
+    use common_meta::key::TableMetadataManager;
+    use common_meta::kv_backend::memory::MemoryKvBackend;
+    use common_meta::region_registry::LeaderRegionRegistry;
+    use common_meta::sequence::SequenceBuilder;
+
+    use super::*;
+    use crate::cluster::MetaPeerClientBuilder;
+    use crate::handler::{HeartbeatMailbox, Pushers};
+    use crate::lease::find_datanode_lease_value;
+    use crate::service::store::cached_kv::LeaderCachedKvBackend;
+
+    #[tokio::test]
+    async fn test_put_into_memory_store() {
+        let in_memory = Arc::new(MemoryKvBackend::new());
+        let kv_backend = Arc::new(MemoryKvBackend::new());
+        let leader_cached_kv_backend = Arc::new(LeaderCachedKvBackend::with_always_leader(
+            kv_backend.clone(),
+        ));
+        let seq = SequenceBuilder::new("test_seq", kv_backend.clone()).build();
+        let mailbox = HeartbeatMailbox::create(Pushers::default(), seq);
+        let meta_peer_client = MetaPeerClientBuilder::default()
+            .election(None)
+            .in_memory(in_memory.clone())
+            .build()
+            .map(Arc::new)
+            // Safety: all required fields set at initialization
+            .unwrap();
+        let ctx = Context {
+            server_addr: "127.0.0.1:0000".to_string(),
+            in_memory,
+            kv_backend: kv_backend.clone(),
+            leader_cached_kv_backend,
+            meta_peer_client,
+            mailbox,
+            election: None,
+            is_infancy: false,
+            table_metadata_manager: Arc::new(TableMetadataManager::new(kv_backend.clone())),
+            cache_invalidator: Arc::new(DummyCacheInvalidator),
+            leader_region_registry: Arc::new(LeaderRegionRegistry::new()),
+        };
+
+        let handler = DatanodeKeepLeaseHandler;
+        handle_request_many_times(ctx.clone(), &handler, 1).await;
+
+        let lease_value = find_datanode_lease_value(1, &ctx.in_memory)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(lease_value.node_addr, "127.0.0.1:1");
+        assert!(lease_value.timestamp_millis != 0);
+    }
+
+    async fn handle_request_many_times(
+        mut ctx: Context,
+        handler: &DatanodeKeepLeaseHandler,
+        loop_times: i32,
+    ) {
+        let req = HeartbeatRequest {
+            header: Some(RequestHeader::new(1, Role::Datanode, HashMap::new())),
+            peer: Some(Peer::new(1, "127.0.0.1:1")),
+            ..Default::default()
+        };
+
+        for i in 1..=loop_times {
+            let mut acc = HeartbeatAccumulator {
+                stat: Some(Stat {
+                    id: 101,
+                    region_num: i as _,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+            handler.handle(&req, &mut ctx, &mut acc).await.unwrap();
+        }
+    }
+}

--- a/src/meta-srv/src/lease.rs
+++ b/src/meta-srv/src/lease.rs
@@ -41,7 +41,7 @@ pub async fn find_datanode_lease_value(
     let lease_key = DatanodeLeaseKey {
         node_id: datanode_id,
     };
-    let lease_key_bytes: Vec<u8> = lease_key.clone().try_into()?;
+    let lease_key_bytes: Vec<u8> = lease_key.try_into()?;
     let Some(kv) = in_memory_key
         .get(&lease_key_bytes)
         .await

--- a/src/meta-srv/src/lease.rs
+++ b/src/meta-srv/src/lease.rs
@@ -16,14 +16,14 @@ use std::collections::HashMap;
 use std::hash::Hash;
 
 use common_error::ext::BoxedError;
-use common_meta::kv_backend::KvBackend;
+use common_meta::kv_backend::{KvBackend, ResettableKvBackendRef};
 use common_meta::peer::{Peer, PeerLookupService};
 use common_meta::{util, DatanodeId, FlownodeId};
 use common_time::util as time_util;
 use snafu::ResultExt;
 
 use crate::cluster::MetaPeerClientRef;
-use crate::error::{Error, Result};
+use crate::error::{Error, KvBackendSnafu, Result};
 use crate::key::{DatanodeLeaseKey, FlownodeLeaseKey, LeaseValue};
 
 fn build_lease_filter(lease_secs: u64) -> impl Fn(&LeaseValue) -> bool {
@@ -31,6 +31,28 @@ fn build_lease_filter(lease_secs: u64) -> impl Fn(&LeaseValue) -> bool {
         ((time_util::current_time_millis() - v.timestamp_millis) as u64)
             < lease_secs.checked_mul(1000).unwrap_or(u64::MAX)
     }
+}
+
+/// Returns the lease value of the given datanode id, if the datanode is not found, returns None.
+pub async fn find_datanode_lease_value(
+    datanode_id: DatanodeId,
+    in_memory_key: &ResettableKvBackendRef,
+) -> Result<Option<LeaseValue>> {
+    let lease_key = DatanodeLeaseKey {
+        node_id: datanode_id,
+    };
+    let lease_key_bytes: Vec<u8> = lease_key.clone().try_into()?;
+    let Some(kv) = in_memory_key
+        .get(&lease_key_bytes)
+        .await
+        .context(KvBackendSnafu)?
+    else {
+        return Ok(None);
+    };
+
+    let lease_value: LeaseValue = kv.value.try_into()?;
+
+    Ok(Some(lease_value))
 }
 
 /// look up [`Peer`] given [`ClusterId`] and [`DatanodeId`], will only return if it's alive under given `lease_secs`

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -311,6 +311,7 @@ impl MetasrvBuilder {
         let region_migration_manager = Arc::new(RegionMigrationManager::new(
             procedure_manager.clone(),
             DefaultContextFactory::new(
+                in_memory.clone(),
                 table_metadata_manager.clone(),
                 memory_region_keeper.clone(),
                 region_failure_detector_controller.clone(),

--- a/src/meta-srv/src/procedure/region_migration.rs
+++ b/src/meta-srv/src/procedure/region_migration.rs
@@ -705,6 +705,8 @@ impl Procedure for RegionMigrationProcedure {
                         .inc();
                     Err(ProcedureError::retry_later(e))
                 } else {
+                    // Consumes the opening region guard before deregistering the failure detectors.
+                    self.context.volatile_ctx.opening_region_guard.take();
                     self.context
                         .deregister_failure_detectors_for_candidate_region()
                         .await;

--- a/src/meta-srv/src/procedure/region_migration.rs
+++ b/src/meta-srv/src/procedure/region_migration.rs
@@ -37,6 +37,7 @@ use common_meta::key::datanode_table::{DatanodeTableKey, DatanodeTableValue};
 use common_meta::key::table_info::TableInfoValue;
 use common_meta::key::table_route::TableRouteValue;
 use common_meta::key::{DeserializedValueWithBytes, TableMetadataManagerRef};
+use common_meta::kv_backend::ResettableKvBackendRef;
 use common_meta::lock_key::{CatalogLock, RegionLock, SchemaLock};
 use common_meta::peer::Peer;
 use common_meta::region_keeper::{MemoryRegionKeeperRef, OperatingRegionGuard};
@@ -266,6 +267,7 @@ pub trait ContextFactory {
 #[derive(Clone)]
 pub struct DefaultContextFactory {
     volatile_ctx: VolatileContext,
+    in_memory_key: ResettableKvBackendRef,
     table_metadata_manager: TableMetadataManagerRef,
     opening_region_keeper: MemoryRegionKeeperRef,
     region_failure_detector_controller: RegionFailureDetectorControllerRef,
@@ -277,6 +279,7 @@ pub struct DefaultContextFactory {
 impl DefaultContextFactory {
     /// Returns an [`DefaultContextFactory`].
     pub fn new(
+        in_memory_key: ResettableKvBackendRef,
         table_metadata_manager: TableMetadataManagerRef,
         opening_region_keeper: MemoryRegionKeeperRef,
         region_failure_detector_controller: RegionFailureDetectorControllerRef,
@@ -286,6 +289,7 @@ impl DefaultContextFactory {
     ) -> Self {
         Self {
             volatile_ctx: VolatileContext::default(),
+            in_memory_key,
             table_metadata_manager,
             opening_region_keeper,
             region_failure_detector_controller,
@@ -301,6 +305,7 @@ impl ContextFactory for DefaultContextFactory {
         Context {
             persistent_ctx,
             volatile_ctx: self.volatile_ctx,
+            in_memory: self.in_memory_key,
             table_metadata_manager: self.table_metadata_manager,
             opening_region_keeper: self.opening_region_keeper,
             region_failure_detector_controller: self.region_failure_detector_controller,
@@ -315,6 +320,7 @@ impl ContextFactory for DefaultContextFactory {
 pub struct Context {
     persistent_ctx: PersistentContext,
     volatile_ctx: VolatileContext,
+    in_memory: ResettableKvBackendRef,
     table_metadata_manager: TableMetadataManagerRef,
     opening_region_keeper: MemoryRegionKeeperRef,
     region_failure_detector_controller: RegionFailureDetectorControllerRef,
@@ -417,14 +423,27 @@ impl Context {
 
     /// Notifies the RegionSupervisor to deregister failure detectors.
     ///
-    /// The original failure detectors was removed once the procedure was triggered.
-    /// However, the `from_peer` may still send the heartbeats contains the failed region.
+    /// The original failure detectors won't be removed once the procedure was triggered.
+    /// We need to deregister the failure detectors for the original region if the procedure is finished.
     pub async fn deregister_failure_detectors(&self) {
         let datanode_id = self.persistent_ctx.from_peer.id;
         let region_id = self.persistent_ctx.region_id;
 
         self.region_failure_detector_controller
             .deregister_failure_detectors(vec![(datanode_id, region_id)])
+            .await;
+    }
+
+    /// Notifies the RegionSupervisor to deregister failure detectors for the candidate region on the destination peer.
+    ///
+    /// The candidate region may be created on the destination peer,
+    /// so we need to deregister the failure detectors for the candidate region if the procedure is aborted.
+    pub async fn deregister_failure_detectors_for_candidate_region(&self) {
+        let to_peer_id = self.persistent_ctx.to_peer.id;
+        let region_id = self.persistent_ctx.region_id;
+
+        self.region_failure_detector_controller
+            .deregister_failure_detectors(vec![(to_peer_id, region_id)])
             .await;
     }
 
@@ -674,30 +693,36 @@ impl Procedure for RegionMigrationProcedure {
         let _timer = METRIC_META_REGION_MIGRATION_EXECUTE
             .with_label_values(&[name])
             .start_timer();
-        let (next, status) = state.next(&mut self.context, ctx).await.map_err(|e| {
-            if e.is_retryable() {
-                METRIC_META_REGION_MIGRATION_ERROR
-                    .with_label_values(&[name, "retryable"])
-                    .inc();
-                ProcedureError::retry_later(e)
-            } else {
-                error!(
-                    e;
-                    "Region migration procedure failed, region_id: {}, from_peer: {}, to_peer: {}, {}",
-                    self.context.region_id(),
-                    self.context.persistent_ctx.from_peer,
-                    self.context.persistent_ctx.to_peer,
-                    self.context.volatile_ctx.metrics,
-                );
-                METRIC_META_REGION_MIGRATION_ERROR
-                    .with_label_values(&[name, "external"])
-                    .inc();
-                ProcedureError::external(e)
+        match state.next(&mut self.context, ctx).await {
+            Ok((next, status)) => {
+                *state = next;
+                Ok(status)
             }
-        })?;
-
-        *state = next;
-        Ok(status)
+            Err(e) => {
+                if e.is_retryable() {
+                    METRIC_META_REGION_MIGRATION_ERROR
+                        .with_label_values(&[name, "retryable"])
+                        .inc();
+                    Err(ProcedureError::retry_later(e))
+                } else {
+                    self.context
+                        .deregister_failure_detectors_for_candidate_region()
+                        .await;
+                    error!(
+                        e;
+                        "Region migration procedure failed, region_id: {}, from_peer: {}, to_peer: {}, {}",
+                        self.context.region_id(),
+                        self.context.persistent_ctx.from_peer,
+                        self.context.persistent_ctx.to_peer,
+                        self.context.volatile_ctx.metrics,
+                    );
+                    METRIC_META_REGION_MIGRATION_ERROR
+                        .with_label_values(&[name, "external"])
+                        .inc();
+                    Err(ProcedureError::external(e))
+                }
+            }
+        }
     }
 
     fn dump(&self) -> ProcedureResult<String> {

--- a/src/meta-srv/src/procedure/region_migration/downgrade_leader_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/downgrade_leader_region.rs
@@ -272,7 +272,7 @@ impl DowngradeLeaderRegion {
                 ctx.volatile_ctx.reset_leader_region_lease_deadline();
                 ctx.volatile_ctx.set_leader_region_lease_deadline(deadline);
                 info!(
-                    "Datanode {}({}) last connected {:?}, updated leader region lease deadline to {:?}, region: {}",
+                    "Datanode {}({}) last connected {:?} ago, updated leader region lease deadline to {:?}, region: {}",
                     leader, last_connection_at, elapsed, ctx.volatile_ctx.leader_region_lease_deadline, ctx.persistent_ctx.region_id
                 );
             } else {

--- a/src/meta-srv/src/procedure/region_migration/test_util.rs
+++ b/src/meta-srv/src/procedure/region_migration/test_util.rs
@@ -121,6 +121,7 @@ impl TestingEnv {
             table_metadata_manager: self.table_metadata_manager.clone(),
             opening_region_keeper: self.opening_region_keeper.clone(),
             volatile_ctx: Default::default(),
+            in_memory_key: Arc::new(MemoryKvBackend::default()),
             mailbox: self.mailbox_ctx.mailbox().clone(),
             server_addr: self.server_addr.to_string(),
             region_failure_detector_controller: Arc::new(NoopRegionFailureDetectorControl),

--- a/src/meta-srv/src/region/supervisor.rs
+++ b/src/meta-srv/src/region/supervisor.rs
@@ -360,10 +360,9 @@ impl RegionSupervisor {
             Ok(false) => {}
             Ok(true) => {
                 warn!(
-                    "Skipping failover since maintenance mode is enabled. Removing failure detectors for regions: {:?}",
+                    "Skipping failover since maintenance mode is enabled. Detected region failures: {:?}",
                     regions
                 );
-                self.deregister_failure_detectors(regions).await;
                 return;
             }
             Err(err) => {

--- a/src/mito2/src/worker/handle_catchup.rs
+++ b/src/mito2/src/worker/handle_catchup.rs
@@ -51,6 +51,13 @@ impl<S: LogStore> RegionWorkerLoop<S> {
 
         // Utilizes the short circuit evaluation.
         let region = if !is_empty_memtable || region.manifest_ctx.has_update().await? {
+            if !is_empty_memtable {
+                warn!("Region {} memtables is not empty, which should not happen, manifest version: {}, last entry id: {}",
+                    region.region_id,
+                    region.manifest_ctx.manifest_version().await,
+                    region.version_control.current().last_entry_id
+                );
+            }
             self.reopen_region(&region).await?
         } else {
             region

--- a/src/mito2/src/worker/handle_manifest.rs
+++ b/src/mito2/src/worker/handle_manifest.rs
@@ -150,9 +150,10 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         };
         let version = region.version();
         if !version.memtables.is_empty() {
+            let current = region.version_control.current();
             warn!(
-                "Region {} memtables is not empty, which should not happen, manifest version: {}",
-                region.region_id, manifest.manifest_version
+                "Region {} memtables is not empty, which should not happen, manifest version: {}, last entry id: {}",
+                region.region_id, manifest.manifest_version, current.last_entry_id
             );
         }
         let region_options = version.options.clone();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR improves the region migration error handling and lease management in the meta server. 

### Changes

1. **Enhanced Lease Management**
   - Added `find_datanode_lease_value` helper to check when a datanode last contacted the meta server
   - Improved leader downgrade process:
     - If datanode has been disconnected longer than region lease period, skip the sleep wait
     - If datanode disconnected recently, adjust sleep time based on remaining lease period
     - This ensures we don't wait unnecessarily when the datanode is already considered dead
   - Added proper error handling for unreachable datanodes (PusherNotFound)

2. **Better Error Handling**
   - Added new `DowngradeLeader` error type for better error tracking
   - Added deregistration of failure detectors for candidate regions
   - Enhanced logging with more context and RegionId
   - Improved error propagation for non-retryable errors

3. **Additional Logging**
   - Added logging for memtable state during region operations
   - Enhanced logging for region migration status and errors

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
