### PR TITLE
fix: force streaming mode for instant source table

### DIFF
--- a/tests/cases/standalone/common/flow/flow_advance_ttl.result
+++ b/tests/cases/standalone/common/flow/flow_advance_ttl.result
@@ -8,7 +8,7 @@ CREATE TABLE distinct_basic (
 
 Affected Rows: 0
 
--- should fail
+-- should fallback to streaming mode
 -- SQLNESS REPLACE id=\d+ id=REDACTED
 CREATE FLOW test_distinct_basic SINK TO out_distinct_basic AS
 SELECT
@@ -16,9 +16,151 @@ SELECT
 FROM
     distinct_basic;
 
-Error: 3001(EngineExecuteQuery), Unsupported: Source table `greptime.public.distinct_basic`(id=REDACTED) has instant TTL, Instant TTL is not supported under batching mode. Consider using a TTL longer than flush interval
+Affected Rows: 0
 
-ALTER TABLE distinct_basic SET 'ttl' = '5s';
+-- flow_options should have a flow_type:streaming
+-- since source table's ttl=instant
+SELECT flow_name, options FROM INFORMATION_SCHEMA.FLOWS;
+
++---------------------+---------------------------+
+| flow_name           | options                   |
++---------------------+---------------------------+
+| test_distinct_basic | {"flow_type":"streaming"} |
++---------------------+---------------------------+
+
+SHOW CREATE TABLE distinct_basic;
+
++----------------+-----------------------------------------------------------+
+| Table          | Create Table                                              |
++----------------+-----------------------------------------------------------+
+| distinct_basic | CREATE TABLE IF NOT EXISTS "distinct_basic" (             |
+|                |   "number" INT NULL,                                      |
+|                |   "ts" TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
+|                |   TIME INDEX ("ts"),                                      |
+|                |   PRIMARY KEY ("number")                                  |
+|                | )                                                         |
+|                |                                                           |
+|                | ENGINE=mito                                               |
+|                | WITH(                                                     |
+|                |   ttl = 'instant'                                         |
+|                | )                                                         |
++----------------+-----------------------------------------------------------+
+
+SHOW CREATE TABLE out_distinct_basic;
+
++--------------------+---------------------------------------------------+
+| Table              | Create Table                                      |
++--------------------+---------------------------------------------------+
+| out_distinct_basic | CREATE TABLE IF NOT EXISTS "out_distinct_basic" ( |
+|                    |   "dis" INT NULL,                                 |
+|                    |   "update_at" TIMESTAMP(3) NULL,                  |
+|                    |   "__ts_placeholder" TIMESTAMP(3) NOT NULL,       |
+|                    |   TIME INDEX ("__ts_placeholder"),                |
+|                    |   PRIMARY KEY ("dis")                             |
+|                    | )                                                 |
+|                    |                                                   |
+|                    | ENGINE=mito                                       |
+|                    |                                                   |
++--------------------+---------------------------------------------------+
+
+-- SQLNESS SLEEP 3s
+INSERT INTO
+    distinct_basic
+VALUES
+    (20, "2021-07-01 00:00:00.200"),
+    (20, "2021-07-01 00:00:00.200"),
+    (22, "2021-07-01 00:00:00.600");
+
+Affected Rows: 0
+
+-- SQLNESS REPLACE (ADMIN\sFLUSH_FLOW\('\w+'\)\s+\|\n\+-+\+\n\|\s+)[0-9]+\s+\| $1 FLOW_FLUSHED  |
+ADMIN FLUSH_FLOW('test_distinct_basic');
+
++-----------------------------------------+
+| ADMIN FLUSH_FLOW('test_distinct_basic') |
++-----------------------------------------+
+|  FLOW_FLUSHED  |
++-----------------------------------------+
+
+SELECT
+    dis
+FROM
+    out_distinct_basic;
+
++-----+
+| dis |
++-----+
+| 20  |
+| 22  |
++-----+
+
+SELECT number FROM distinct_basic;
+
+++
+++
+
+-- SQLNESS SLEEP 6s
+ADMIN FLUSH_TABLE('distinct_basic');
+
++-------------------------------------+
+| ADMIN FLUSH_TABLE('distinct_basic') |
++-------------------------------------+
+| 0                                   |
++-------------------------------------+
+
+INSERT INTO
+    distinct_basic
+VALUES
+    (23, "2021-07-01 00:00:01.600");
+
+Affected Rows: 0
+
+-- SQLNESS REPLACE (ADMIN\sFLUSH_FLOW\('\w+'\)\s+\|\n\+-+\+\n\|\s+)[0-9]+\s+\| $1 FLOW_FLUSHED  |
+ADMIN FLUSH_FLOW('test_distinct_basic');
+
++-----------------------------------------+
+| ADMIN FLUSH_FLOW('test_distinct_basic') |
++-----------------------------------------+
+|  FLOW_FLUSHED  |
++-----------------------------------------+
+
+SELECT
+    dis
+FROM
+    out_distinct_basic;
+
++-----+
+| dis |
++-----+
+| 20  |
+| 22  |
+| 23  |
++-----+
+
+SELECT number FROM distinct_basic;
+
+++
+++
+
+DROP FLOW test_distinct_basic;
+
+Affected Rows: 0
+
+DROP TABLE distinct_basic;
+
+Affected Rows: 0
+
+DROP TABLE out_distinct_basic;
+
+Affected Rows: 0
+
+-- test ttl = 5s
+CREATE TABLE distinct_basic (
+    number INT,
+    ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY(number),
+    TIME INDEX(ts)
+)WITH ('ttl' = '5s');
 
 Affected Rows: 0
 
@@ -29,6 +171,16 @@ FROM
     distinct_basic;
 
 Affected Rows: 0
+
+-- flow_options should have a flow_type:batching
+-- since source table's ttl=instant
+SELECT flow_name, options FROM INFORMATION_SCHEMA.FLOWS;
+
++---------------------+--------------------------+
+| flow_name           | options                  |
++---------------------+--------------------------+
+| test_distinct_basic | {"flow_type":"batching"} |
++---------------------+--------------------------+
 
 -- SQLNESS ARG restart=true
 SELECT 1;
@@ -138,41 +290,6 @@ ADMIN FLUSH_FLOW('test_distinct_basic');
 +-----------------------------------------+
 |  FLOW_FLUSHED  |
 +-----------------------------------------+
-
-SHOW CREATE TABLE distinct_basic;
-
-+----------------+-----------------------------------------------------------+
-| Table          | Create Table                                              |
-+----------------+-----------------------------------------------------------+
-| distinct_basic | CREATE TABLE IF NOT EXISTS "distinct_basic" (             |
-|                |   "number" INT NULL,                                      |
-|                |   "ts" TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
-|                |   TIME INDEX ("ts"),                                      |
-|                |   PRIMARY KEY ("number")                                  |
-|                | )                                                         |
-|                |                                                           |
-|                | ENGINE=mito                                               |
-|                | WITH(                                                     |
-|                |   ttl = '5s'                                              |
-|                | )                                                         |
-+----------------+-----------------------------------------------------------+
-
-SHOW CREATE TABLE out_distinct_basic;
-
-+--------------------+---------------------------------------------------+
-| Table              | Create Table                                      |
-+--------------------+---------------------------------------------------+
-| out_distinct_basic | CREATE TABLE IF NOT EXISTS "out_distinct_basic" ( |
-|                    |   "dis" INT NULL,                                 |
-|                    |   "update_at" TIMESTAMP(3) NULL,                  |
-|                    |   "__ts_placeholder" TIMESTAMP(3) NOT NULL,       |
-|                    |   TIME INDEX ("__ts_placeholder"),                |
-|                    |   PRIMARY KEY ("dis")                             |
-|                    | )                                                 |
-|                    |                                                   |
-|                    | ENGINE=mito                                       |
-|                    |                                                   |
-+--------------------+---------------------------------------------------+
 
 SELECT
     dis

--- a/tests/cases/standalone/common/flow/flow_advance_ttl.sql
+++ b/tests/cases/standalone/common/flow/flow_advance_ttl.sql
@@ -6,7 +6,7 @@ CREATE TABLE distinct_basic (
     TIME INDEX(ts)
 )WITH ('ttl' = 'instant');
 
--- should fail
+-- should fallback to streaming mode
 -- SQLNESS REPLACE id=\d+ id=REDACTED
 CREATE FLOW test_distinct_basic SINK TO out_distinct_basic AS
 SELECT
@@ -14,13 +14,71 @@ SELECT
 FROM
     distinct_basic;
 
-ALTER TABLE distinct_basic SET 'ttl' = '5s';
+-- flow_options should have a flow_type:streaming
+-- since source table's ttl=instant
+SELECT flow_name, options FROM INFORMATION_SCHEMA.FLOWS;
+
+SHOW CREATE TABLE distinct_basic;
+
+SHOW CREATE TABLE out_distinct_basic;
+
+-- SQLNESS SLEEP 3s
+INSERT INTO
+    distinct_basic
+VALUES
+    (20, "2021-07-01 00:00:00.200"),
+    (20, "2021-07-01 00:00:00.200"),
+    (22, "2021-07-01 00:00:00.600");
+
+-- SQLNESS REPLACE (ADMIN\sFLUSH_FLOW\('\w+'\)\s+\|\n\+-+\+\n\|\s+)[0-9]+\s+\| $1 FLOW_FLUSHED  |
+ADMIN FLUSH_FLOW('test_distinct_basic');
+
+SELECT
+    dis
+FROM
+    out_distinct_basic;
+
+SELECT number FROM distinct_basic;
+
+-- SQLNESS SLEEP 6s
+ADMIN FLUSH_TABLE('distinct_basic');
+
+INSERT INTO
+    distinct_basic
+VALUES
+    (23, "2021-07-01 00:00:01.600");
+
+-- SQLNESS REPLACE (ADMIN\sFLUSH_FLOW\('\w+'\)\s+\|\n\+-+\+\n\|\s+)[0-9]+\s+\| $1 FLOW_FLUSHED  |
+ADMIN FLUSH_FLOW('test_distinct_basic');
+
+SELECT
+    dis
+FROM
+    out_distinct_basic;
+
+SELECT number FROM distinct_basic;
+
+DROP FLOW test_distinct_basic;
+DROP TABLE distinct_basic;
+DROP TABLE out_distinct_basic;
+
+-- test ttl = 5s
+CREATE TABLE distinct_basic (
+    number INT,
+    ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY(number),
+    TIME INDEX(ts)
+)WITH ('ttl' = '5s');
 
 CREATE FLOW test_distinct_basic SINK TO out_distinct_basic AS
 SELECT
     DISTINCT number as dis
 FROM
     distinct_basic;
+
+-- flow_options should have a flow_type:batching
+-- since source table's ttl=instant
+SELECT flow_name, options FROM INFORMATION_SCHEMA.FLOWS;
 
 -- SQLNESS ARG restart=true
 SELECT 1;
@@ -57,10 +115,6 @@ VALUES
 
 -- SQLNESS REPLACE (ADMIN\sFLUSH_FLOW\('\w+'\)\s+\|\n\+-+\+\n\|\s+)[0-9]+\s+\| $1 FLOW_FLUSHED  |
 ADMIN FLUSH_FLOW('test_distinct_basic');
-
-SHOW CREATE TABLE distinct_basic;
-
-SHOW CREATE TABLE out_distinct_basic;
 
 SELECT
     dis


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

fix a unintentional breaking change and use streaming mode for flow when found source table have a ttl=instant

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
