### PR TITLE
fix: ensures logical and physical region have the same timestamp unit

### DIFF
--- a/src/metric-engine/src/engine/create.rs
+++ b/src/metric-engine/src/engine/create.rs
@@ -211,7 +211,7 @@ impl MetricEngineInner {
                 region_id: data_region_id,
             })?;
         // Checks the time index unit of each request.
-        for (logical_region_id, request) in &requests {
+        for (_, request) in &requests {
             // Safety: verify_region_create_request() ensures that the request is valid.
             let time_index_column = request
                 .column_metadatas

--- a/tests/cases/standalone/common/alter/alter_table.result
+++ b/tests/cases/standalone/common/alter/alter_table.result
@@ -155,9 +155,9 @@ ADD
 
 Affected Rows: 0
 
-ALTER TABLE 
-    t2 
-ADD 
+ALTER TABLE
+    t2
+ADD
     COLUMN at4 UINT16;
 
 Affected Rows: 0
@@ -215,7 +215,7 @@ SELECT * FROM grpc_latencies;
 | 2024-07-11T20:00:06 | host1 | GetUser     | 103.0   |
 +---------------------+-------+-------------+---------+
 
-ALTER TABLE grpc_latencies SET ttl = '10d';
+ALTER TABLE grpc_latencies SET ttl = '10000d';
 
 Affected Rows: 0
 

--- a/tests/cases/standalone/common/alter/alter_table.sql
+++ b/tests/cases/standalone/common/alter/alter_table.sql
@@ -75,9 +75,9 @@ ALTER TABLE
 ADD
     COLUMN at2 STRING;
 
-ALTER TABLE 
-    t2 
-ADD 
+ALTER TABLE
+    t2
+ADD
     COLUMN at4 UINT16;
 
 INSERT INTO
@@ -109,7 +109,7 @@ INSERT INTO grpc_latencies (ts, host, method_name, latency) VALUES
 
 SELECT * FROM grpc_latencies;
 
-ALTER TABLE grpc_latencies SET ttl = '10d';
+ALTER TABLE grpc_latencies SET ttl = '10000d';
 
 ALTER TABLE grpc_latencies ADD COLUMN home INTEGER FIRST;
 

--- a/tests/cases/standalone/common/create/create_metric_table.result
+++ b/tests/cases/standalone/common/create/create_metric_table.result
@@ -48,6 +48,11 @@ CREATE TABLE t5 (ts timestamp time index, valval double, host string primary key
 
 Error: 1004(InvalidArguments), Adding field column valval to physical table
 
+-- create logical table with different time unit on time index column
+CREATE TABLE t6 (ts timestamp(6) time index, job string primary key, val double) engine = metric with ("on_physical_table" = "phy");
+
+Error: 1004(InvalidArguments), Unexpected request: Metric has differenttime unit (Microsecond) than the physical region (Millisecond)
+
 SELECT table_catalog, table_schema, table_name, table_type, engine FROM information_schema.tables WHERE engine = 'metric' order by table_name;
 
 +---------------+--------------+------------+------------+--------+
@@ -204,7 +209,7 @@ CREATE TABLE t1(ts timestamp time index, val double, host string primary key) en
 
 Affected Rows: 0
 
-INSERT INTO t1 (ts, val, host) VALUES 
+INSERT INTO t1 (ts, val, host) VALUES
   ('2022-01-01 00:00:00', 1.23, 'example.com'),
   ('2022-01-02 00:00:00', 4.56, 'example.com'),
   ('2022-01-03 00:00:00', 7.89, 'example.com'),

--- a/tests/cases/standalone/common/create/create_metric_table.sql
+++ b/tests/cases/standalone/common/create/create_metric_table.sql
@@ -20,6 +20,9 @@ CREATE TABLE t4 (ts timestamp time index, val double, host double, primary key (
 -- create logical table with different column name on field column
 CREATE TABLE t5 (ts timestamp time index, valval double, host string primary key) engine = metric with ("on_physical_table" = "phy");
 
+-- create logical table with different time unit on time index column
+CREATE TABLE t6 (ts timestamp(6) time index, job string primary key, val double) engine = metric with ("on_physical_table" = "phy");
+
 SELECT table_catalog, table_schema, table_name, table_type, engine FROM information_schema.tables WHERE engine = 'metric' order by table_name;
 
 DESC TABLE phy;
@@ -73,7 +76,7 @@ with
 
 CREATE TABLE t1(ts timestamp time index, val double, host string primary key) engine=metric with ("on_physical_table" = "phy");
 
-INSERT INTO t1 (ts, val, host) VALUES 
+INSERT INTO t1 (ts, val, host) VALUES
   ('2022-01-01 00:00:00', 1.23, 'example.com'),
   ('2022-01-02 00:00:00', 4.56, 'example.com'),
   ('2022-01-03 00:00:00', 7.89, 'example.com'),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

This PR ensures the logical and physical regions have the same timestamp unit. Otherwise, users can create a logical region without a different time unit but finally get an error when they try to insert a record.

To check the time unit, it stores the unit in the state of the physical region.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
