### PR TITLE
fix: try to fix #6024 by forcing c11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ endif
 
 .PHONY: build
 build: ## Build debug version greptime.
-	cargo ${CARGO_EXTENSION} build ${CARGO_BUILD_OPTS}
+	CFLAGS="-std=c11" cargo ${CARGO_EXTENSION} build ${CARGO_BUILD_OPTS}
 
 .PHONY: build-by-dev-builder
 build-by-dev-builder: ## Build greptime by dev-builder.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

#6024

## What's changed and what's your intention?

this patch try to fix #6024 by forcing the `CFLAG` to c11

reason:

- hydro depend on [rust-sitter](https://github.com/hydro-project/rust-sitter)
- and rust-sitter is depending on [tree-sitter](https://github.com/tree-sitter/tree-sitter)
- the error is from https://github.com/tree-sitter/tree-sitter/blob/b1d2b7cfb807410871a3679ee36e412ed2451d72/lib/src/parser.h#L201 using c99 upper
- but the rust-sitter build the parser.c  https://github.com/hydro-project/rust-sitter/blob/6f7b1ec5c495a4607ae33deea411efb397df3ac8/tool/src/lib.rs#L122 and did not using the c99 or c11 upper
- there are two ways to fix them 1 let the compiler do itself 2 forcing to c11 like this fix https://github.com/airbus-cert/tree-sitter-powershell/pull/15
- but they need to the upstream fix

so this patch try to using env in Makefile and make a pull request on upstream when fix drop it

cc @sunng87 

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
