### PR TITLE
fix: alter table modify type should also modify default value

### DIFF
--- a/src/datatypes/src/schema/column_schema.rs
+++ b/src/datatypes/src/schema/column_schema.rs
@@ -61,7 +61,7 @@ pub struct ColumnSchema {
     pub data_type: ConcreteDataType,
     is_nullable: bool,
     is_time_index: bool,
-    pub default_constraint: Option<ColumnDefaultConstraint>,
+    default_constraint: Option<ColumnDefaultConstraint>,
     metadata: Metadata,
 }
 

--- a/src/datatypes/src/schema/column_schema.rs
+++ b/src/datatypes/src/schema/column_schema.rs
@@ -61,7 +61,7 @@ pub struct ColumnSchema {
     pub data_type: ConcreteDataType,
     is_nullable: bool,
     is_time_index: bool,
-    default_constraint: Option<ColumnDefaultConstraint>,
+    pub default_constraint: Option<ColumnDefaultConstraint>,
     metadata: Metadata,
 }
 

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -243,6 +243,8 @@ pub enum Error {
         region_id: RegionId,
         column: String,
         source: datatypes::Error,
+        #[snafu(implicit)]
+        location: Location,
     },
 
     #[snafu(display("Failed to build entry, region_id: {}", region_id))]

--- a/src/store-api/src/metadata.rs
+++ b/src/store-api/src/metadata.rs
@@ -705,9 +705,10 @@ impl RegionMetadataBuilder {
                             default_value
                                 .cast_to_datatype(&target_type)
                                 .with_context(|_| CastDefaultValueSnafu {
-                                    default_value: Some(default_value.clone()),
-                                    target_type: target_type.clone(),
-                                    reason: "Failed to cast default value",
+                                    reason: format!(
+                                        "Failed to cast default value from {:?} to type {:?}",
+                                        default_value, target_type
+                                    ),
                                 })?,
                         )
                     } else {
@@ -718,8 +719,6 @@ impl RegionMetadataBuilder {
                     .clone()
                     .with_default_constraint(new_default.clone())
                     .with_context(|_| CastDefaultValueSnafu {
-                        default_value: column_meta.column_schema.default_constraint().cloned(),
-                        target_type,
                         reason: format!("Failed to set new default: {:?}", new_default),
                     })?;
             }
@@ -996,15 +995,8 @@ pub enum MetadataError {
         location: Location,
     },
 
-    #[snafu(display(
-        "Failed to cast default value {:?} to {}, reason: {}",
-        default_value,
-        target_type,
-        reason
-    ))]
+    #[snafu(display("Failed to cast default value, reason: {}", reason))]
     CastDefaultValue {
-        default_value: Option<ColumnDefaultConstraint>,
-        target_type: ConcreteDataType,
         reason: String,
         source: datatypes::Error,
         #[snafu(implicit)]

--- a/src/store-api/src/metadata.rs
+++ b/src/store-api/src/metadata.rs
@@ -707,6 +707,7 @@ impl RegionMetadataBuilder {
                                 .with_context(|_| CastDefaultValueSnafu {
                                     default_value: Some(default_value.clone()),
                                     target_type: target_type.clone(),
+                                    reason: "Failed to cast default value",
                                 })?,
                         )
                     } else {
@@ -715,10 +716,11 @@ impl RegionMetadataBuilder {
                 column_meta.column_schema = column_meta
                     .column_schema
                     .clone()
-                    .with_default_constraint(new_default)
+                    .with_default_constraint(new_default.clone())
                     .with_context(|_| CastDefaultValueSnafu {
                         default_value: column_meta.column_schema.default_constraint().cloned(),
                         target_type,
+                        reason: format!("Failed to set new default: {:?}", new_default),
                     })?;
             }
         }
@@ -994,10 +996,16 @@ pub enum MetadataError {
         location: Location,
     },
 
-    #[snafu(display("Failed to cast default value {:?} to {}", default_value, target_type))]
+    #[snafu(display(
+        "Failed to cast default value {:?} to {}, reason: {}",
+        default_value,
+        target_type,
+        reason
+    ))]
     CastDefaultValue {
         default_value: Option<ColumnDefaultConstraint>,
         target_type: ConcreteDataType,
+        reason: String,
         source: datatypes::Error,
         #[snafu(implicit)]
         location: Location,

--- a/src/store-api/src/metadata.rs
+++ b/src/store-api/src/metadata.rs
@@ -29,10 +29,7 @@ use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use datatypes::arrow;
 use datatypes::arrow::datatypes::FieldRef;
-use datatypes::prelude::ConcreteDataType;
-use datatypes::schema::{
-    ColumnDefaultConstraint, ColumnSchema, FulltextOptions, Schema, SchemaRef, SkippingIndexOptions,
-};
+use datatypes::schema::{ColumnSchema, FulltextOptions, Schema, SchemaRef, SkippingIndexOptions};
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize};
 use snafu::{ensure, Location, OptionExt, ResultExt, Snafu};

--- a/tests-fuzz/src/validator/column.rs
+++ b/tests-fuzz/src/validator/column.rs
@@ -14,7 +14,6 @@
 
 use common_telemetry::debug;
 use datatypes::data_type::DataType;
-use datatypes::value::Value;
 use snafu::{ensure, ResultExt};
 use sqlx::MySqlPool;
 
@@ -213,17 +212,17 @@ pub async fn fetch_columns(
 }
 
 /// validate that apart from marker column(if it still exists, every thing else is just default value)
+#[allow(unused)]
 pub async fn valid_marker_value(
     db: &MySqlPool,
-    schema_name: Ident,
+    _schema_name: Ident,
     table_name: Ident,
-    marker_column: &Column,
-    marker_value: &Value,
 ) -> Result<bool> {
-    let sql = "SELECT * FROM ?.?";
-    let res = sqlx::query(sql)
-        .bind(schema_name.value.to_string())
-        .bind(table_name.value.to_string())
+    let sql = format!("SELECT * FROM {table_name}");
+    // cache is useless and buggy anyway since alter happens all the time
+    // TODO(discord9): invalid prepared sql after alter
+    let res = sqlx::query(&sql)
+        .persistent(false)
         .fetch_all(db)
         .await
         .context(error::ExecuteQuerySnafu { sql })?;

--- a/tests/cases/standalone/common/alter/alter_table.result
+++ b/tests/cases/standalone/common/alter/alter_table.result
@@ -145,7 +145,7 @@ INSERT INTO test_alt_table_default (h, j) VALUES (1, 0), (2, 1);
 
 Affected Rows: 2
 
-SELECT * FROM test_alt_table_default;
+SELECT * FROM test_alt_table_default ORDER BY h;
 
 +---+-------+-------------------------+
 | h | i     | j                       |
@@ -153,6 +153,60 @@ SELECT * FROM test_alt_table_default;
 | 1 | false | 1970-01-01T00:00:00     |
 | 2 | false | 1970-01-01T00:00:00.001 |
 +---+-------+-------------------------+
+
+ALTER TABLE test_alt_table_default MODIFY COLUMN i INTEGER;
+
+Affected Rows: 0
+
+DESC TABLE test_alt_table_default;
+
++--------+----------------------+-----+------+---------+---------------+
+| Column | Type                 | Key | Null | Default | Semantic Type |
++--------+----------------------+-----+------+---------+---------------+
+| h      | Int32                | PRI | YES  |         | TAG           |
+| i      | Int32                |     | YES  | 0       | FIELD         |
+| j      | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
++--------+----------------------+-----+------+---------+---------------+
+
+INSERT INTO test_alt_table_default (h, j) VALUES (3, 0), (4, 1);
+
+Affected Rows: 2
+
+SELECT * FROM test_alt_table_default ORDER BY h;
+
++---+---+-------------------------+
+| h | i | j                       |
++---+---+-------------------------+
+| 1 | 0 | 1970-01-01T00:00:00     |
+| 2 | 0 | 1970-01-01T00:00:00.001 |
+| 3 | 0 | 1970-01-01T00:00:00     |
+| 4 | 0 | 1970-01-01T00:00:00.001 |
++---+---+-------------------------+
+
+ALTER TABLE test_alt_table_default MODIFY COLUMN i STRING;
+
+Affected Rows: 0
+
+INSERT INTO test_alt_table_default (h, j) VALUES (5, 0);
+
+Affected Rows: 1
+
+INSERT INTO test_alt_table_default (h, i, j) VALUES (6, "word" ,1);
+
+Affected Rows: 1
+
+SELECT * FROM test_alt_table_default ORDER BY h;
+
++---+------+-------------------------+
+| h | i    | j                       |
++---+------+-------------------------+
+| 1 | 0    | 1970-01-01T00:00:00     |
+| 2 | 0    | 1970-01-01T00:00:00.001 |
+| 3 | 0    | 1970-01-01T00:00:00     |
+| 4 | 0    | 1970-01-01T00:00:00.001 |
+| 5 | 0    | 1970-01-01T00:00:00     |
+| 6 | word | 1970-01-01T00:00:00.001 |
++---+------+-------------------------+
 
 DROP TABLE test_alt_table_default;
 

--- a/tests/cases/standalone/common/alter/alter_table.result
+++ b/tests/cases/standalone/common/alter/alter_table.result
@@ -69,6 +69,52 @@ ALTER TABLE test_alt_table MODIFY COLUMN m interval;
 
 Error: 1001(Unsupported), Not supported: Modify column type to interval type
 
+INSERT INTO test_alt_table (h, i, j, m, dt) VALUES (42, 42, 0, 11, 0);
+
+Affected Rows: 1
+
+ALTER TABLE test_alt_table MODIFY COLUMN m Float64;
+
+Affected Rows: 0
+
+SELECT * FROM test_alt_table;
+
++----+----+-------------------------+---+------+---------------------+
+| h  | i  | j                       | k | m    | dt                  |
++----+----+-------------------------+---+------+---------------------+
+| 1  | 1  | 1970-01-01T00:00:00     |   |      |                     |
+| 2  | 2  | 1970-01-01T00:00:00.001 |   |      |                     |
+| 42 | 42 | 1970-01-01T00:00:00     |   | 11.0 | 1970-01-01T00:00:00 |
++----+----+-------------------------+---+------+---------------------+
+
+ALTER TABLE test_alt_table MODIFY COLUMN m INTEGER;
+
+Affected Rows: 0
+
+SELECT * FROM test_alt_table;
+
++----+----+-------------------------+---+----+---------------------+
+| h  | i  | j                       | k | m  | dt                  |
++----+----+-------------------------+---+----+---------------------+
+| 1  | 1  | 1970-01-01T00:00:00     |   |    |                     |
+| 2  | 2  | 1970-01-01T00:00:00.001 |   |    |                     |
+| 42 | 42 | 1970-01-01T00:00:00     |   | 11 | 1970-01-01T00:00:00 |
++----+----+-------------------------+---+----+---------------------+
+
+ALTER TABLE test_alt_table MODIFY COLUMN m BOOLEAN;
+
+Affected Rows: 0
+
+SELECT * FROM test_alt_table;
+
++----+----+-------------------------+---+------+---------------------+
+| h  | i  | j                       | k | m    | dt                  |
++----+----+-------------------------+---+------+---------------------+
+| 1  | 1  | 1970-01-01T00:00:00     |   |      |                     |
+| 2  | 2  | 1970-01-01T00:00:00.001 |   |      |                     |
+| 42 | 42 | 1970-01-01T00:00:00     |   | true | 1970-01-01T00:00:00 |
++----+----+-------------------------+---+------+---------------------+
+
 DESC TABLE test_alt_table;
 
 +--------+----------------------+-----+------+---------+---------------+
@@ -78,11 +124,37 @@ DESC TABLE test_alt_table;
 | i      | Int32                | PRI | YES  |         | TAG           |
 | j      | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
 | k      | String               | PRI | YES  |         | TAG           |
-| m      | Int32                |     | YES  |         | FIELD         |
+| m      | Boolean              |     | YES  |         | FIELD         |
 | dt     | TimestampMicrosecond |     | YES  |         | FIELD         |
 +--------+----------------------+-----+------+---------+---------------+
 
 DROP TABLE test_alt_table;
+
+Affected Rows: 0
+
+-- test if column with default value can change type properly
+CREATE TABLE test_alt_table_default(h INTEGER, i INTEGER DEFAULT 0, j TIMESTAMP TIME INDEX, PRIMARY KEY (h));
+
+Affected Rows: 0
+
+ALTER TABLE test_alt_table_default MODIFY COLUMN i BOOLEAN;
+
+Affected Rows: 0
+
+INSERT INTO test_alt_table_default (h, j) VALUES (1, 0), (2, 1);
+
+Affected Rows: 2
+
+SELECT * FROM test_alt_table_default;
+
++---+-------+-------------------------+
+| h | i     | j                       |
++---+-------+-------------------------+
+| 1 | false | 1970-01-01T00:00:00     |
+| 2 | false | 1970-01-01T00:00:00.001 |
++---+-------+-------------------------+
+
+DROP TABLE test_alt_table_default;
 
 Affected Rows: 0
 

--- a/tests/cases/standalone/common/alter/alter_table.sql
+++ b/tests/cases/standalone/common/alter/alter_table.sql
@@ -50,7 +50,23 @@ ALTER TABLE test_alt_table_default MODIFY COLUMN i BOOLEAN;
 
 INSERT INTO test_alt_table_default (h, j) VALUES (1, 0), (2, 1);
 
-SELECT * FROM test_alt_table_default;
+SELECT * FROM test_alt_table_default ORDER BY h;
+
+ALTER TABLE test_alt_table_default MODIFY COLUMN i INTEGER;
+
+DESC TABLE test_alt_table_default;
+
+INSERT INTO test_alt_table_default (h, j) VALUES (3, 0), (4, 1);
+
+SELECT * FROM test_alt_table_default ORDER BY h;
+
+ALTER TABLE test_alt_table_default MODIFY COLUMN i STRING;
+
+INSERT INTO test_alt_table_default (h, j) VALUES (5, 0);
+
+INSERT INTO test_alt_table_default (h, i, j) VALUES (6, "word" ,1);
+
+SELECT * FROM test_alt_table_default ORDER BY h;
 
 DROP TABLE test_alt_table_default;
 

--- a/tests/cases/standalone/common/alter/alter_table.sql
+++ b/tests/cases/standalone/common/alter/alter_table.sql
@@ -25,9 +25,34 @@ ALTER TABLE test_alt_table ADD COLUMN n interval;
 -- Should fail issue #5422
 ALTER TABLE test_alt_table MODIFY COLUMN m interval;
 
+INSERT INTO test_alt_table (h, i, j, m, dt) VALUES (42, 42, 0, 11, 0);
+
+ALTER TABLE test_alt_table MODIFY COLUMN m Float64;
+
+SELECT * FROM test_alt_table;
+
+ALTER TABLE test_alt_table MODIFY COLUMN m INTEGER;
+
+SELECT * FROM test_alt_table;
+
+ALTER TABLE test_alt_table MODIFY COLUMN m BOOLEAN;
+
+SELECT * FROM test_alt_table;
+
 DESC TABLE test_alt_table;
 
 DROP TABLE test_alt_table;
+
+-- test if column with default value can change type properly
+CREATE TABLE test_alt_table_default(h INTEGER, i INTEGER DEFAULT 0, j TIMESTAMP TIME INDEX, PRIMARY KEY (h));
+
+ALTER TABLE test_alt_table_default MODIFY COLUMN i BOOLEAN;
+
+INSERT INTO test_alt_table_default (h, j) VALUES (1, 0), (2, 1);
+
+SELECT * FROM test_alt_table_default;
+
+DROP TABLE test_alt_table_default;
 
 -- to test if same name column can be added
 CREATE TABLE phy (ts timestamp time index, val double) engine = metric with ("physical_metric_table" = "");


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

- fix a bug when alter table modify datatype should also modify default value
- added sqlness for aforementioned bug
- actually insert a row in fuzz_alter_table test
- add a `SELECT *` after alter table in fuzz_alter_table to see if data is ok after alter, to debugging a bug in distributed mode that only occur in CI and is also very rare(can't reproduce yet), see https://github.com/GreptimeTeam/greptimedb/actions/runs/14753095448/job/41415159460 this one still haven't been reproduced

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
