### PR TITLE
fix: reset tags when creating an empty metric in prom call

### DIFF
--- a/src/query/src/promql/planner.rs
+++ b/src/query/src/promql/planner.rs
@@ -415,7 +415,6 @@ impl PromPlanner {
         session_state: &SessionState,
         binary_expr: &PromBinaryExpr,
     ) -> Result<LogicalPlan> {
-        common_telemetry::info!("prom_binary_expr_to_plan, binary_expr: {:?}", binary_expr);
         let PromBinaryExpr {
             lhs,
             rhs,
@@ -432,7 +431,6 @@ impl PromPlanner {
         };
         let is_comparison_op = Self::is_token_a_comparison_op(*op);
 
-        common_telemetry::info!("Try build literal expr, lhs: <{:?}>, rhs: <{:?}>", lhs, rhs);
         // we should build a filter plan here if the op is comparison op and need not
         // to return 0/1. Otherwise, we should build a projection plan
         match (
@@ -440,12 +438,6 @@ impl PromPlanner {
             Self::try_build_literal_expr(rhs),
         ) {
             (Some(lhs), Some(rhs)) => {
-                common_telemetry::info!(
-                    "prom_binary_expr_to_plan both literal, lhs: {}, rhs: {}",
-                    lhs,
-                    rhs
-                );
-
                 self.ctx.time_index_column = Some(DEFAULT_TIME_INDEX_COLUMN.to_string());
                 self.ctx.field_columns = vec![DEFAULT_FIELD_COLUMN.to_string()];
                 self.ctx.reset_table_name_and_schema();
@@ -475,17 +467,7 @@ impl PromPlanner {
             }
             // lhs is a literal, rhs is a column
             (Some(mut expr), None) => {
-                common_telemetry::info!(
-                    "prom_binary_expr_to_plan left literal, lhs: {}, None",
-                    expr
-                );
-
                 let input = self.prom_expr_to_plan(rhs, session_state).await?;
-                common_telemetry::info!(
-                    "prom_binary_expr_to_plan, lhs: {}, rhs_input: {}",
-                    expr,
-                    input,
-                );
                 // check if the literal is a special time expr
                 if let Some(time_expr) = Self::try_build_special_time_expr(
                     lhs,
@@ -514,17 +496,7 @@ impl PromPlanner {
             }
             // lhs is a column, rhs is a literal
             (None, Some(mut expr)) => {
-                common_telemetry::info!(
-                    "prom_binary_expr_to_plan right literal, None, rhs: {}",
-                    expr
-                );
-
                 let input = self.prom_expr_to_plan(lhs, session_state).await?;
-                common_telemetry::info!(
-                    "prom_binary_expr_to_plan, lhs_input: {}, rhs: {}",
-                    input,
-                    expr
-                );
                 // check if the literal is a special time expr
                 if let Some(time_expr) = Self::try_build_special_time_expr(
                     rhs,
@@ -553,8 +525,6 @@ impl PromPlanner {
             }
             // both are columns. join them on time index
             (None, None) => {
-                common_telemetry::info!("prom_binary_expr_to_plan no literal, None, None");
-
                 let left_input = self.prom_expr_to_plan(lhs, session_state).await?;
                 let left_field_columns = self.ctx.field_columns.clone();
                 let left_time_index_column = self.ctx.time_index_column.clone();
@@ -773,11 +743,6 @@ impl PromPlanner {
         session_state: &SessionState,
         call_expr: &Call,
     ) -> Result<LogicalPlan> {
-        common_telemetry::info!(
-            "Planning Prometheus call expression, call_expr: {:?}",
-            call_expr
-        );
-
         let Call { func, args } = call_expr;
         // some special functions that are not expression but a plan
         match func.name {
@@ -791,11 +756,9 @@ impl PromPlanner {
 
         // transform function arguments
         let args = self.create_function_args(&args.args)?;
-        common_telemetry::info!("Planning function args, args: {:?}", args);
         let input = if let Some(prom_expr) = &args.input {
             self.prom_expr_to_plan(prom_expr, session_state).await?
         } else {
-            common_telemetry::info!("Planning function args, no input, reset time index");
             self.ctx.time_index_column = Some(SPECIAL_TIME_FUNCTION.to_string());
             self.ctx.reset_table_name_and_schema();
             self.ctx.tag_columns = vec![];
@@ -818,19 +781,6 @@ impl PromPlanner {
             self.create_function_expr(func, args.literals.clone(), session_state)?;
         func_exprs.insert(0, self.create_time_index_column_expr()?);
         func_exprs.extend_from_slice(&self.create_tag_column_exprs()?);
-        common_telemetry::info!(
-            "Planning function with input, input: {}, func: {:?}",
-            input,
-            func_exprs
-        );
-
-        common_telemetry::info!(
-            "prom call expr to plan, input: {}, func: {:?}, args: {:?}, func_exprs: {:?}",
-            input,
-            func,
-            args,
-            func_exprs
-        );
 
         let builder = LogicalPlanBuilder::from(input)
             .project(func_exprs)
@@ -2880,12 +2830,6 @@ impl PromPlanner {
         let project_fields = non_field_columns_iter
             .chain(field_columns_iter)
             .collect::<Result<Vec<_>>>()?;
-
-        common_telemetry::info!(
-            "Project for each field, input: <{}>, project fields: {:?}",
-            input,
-            project_fields
-        );
 
         LogicalPlanBuilder::from(input)
             .project(project_fields)

--- a/src/query/src/promql/planner.rs
+++ b/src/query/src/promql/planner.rs
@@ -816,6 +816,11 @@ impl PromPlanner {
             self.create_function_expr(func, args.literals.clone(), session_state)?;
         func_exprs.insert(0, self.create_time_index_column_expr()?);
         func_exprs.extend_from_slice(&self.create_tag_column_exprs()?);
+        common_telemetry::info!(
+            "Planning function with input, input: {}, func: {:?}",
+            input,
+            func_exprs
+        );
 
         let builder = LogicalPlanBuilder::from(input)
             .project(func_exprs)

--- a/src/query/src/promql/planner.rs
+++ b/src/query/src/promql/planner.rs
@@ -798,6 +798,8 @@ impl PromPlanner {
             common_telemetry::info!("Planning function args, no input, reset time index");
             self.ctx.time_index_column = Some(SPECIAL_TIME_FUNCTION.to_string());
             self.ctx.reset_table_name_and_schema();
+            self.ctx.tag_columns = vec![];
+            self.ctx.field_columns = vec![DEFAULT_FIELD_COLUMN.to_string()];
             LogicalPlan::Extension(Extension {
                 node: Arc::new(
                     EmptyMetric::new(
@@ -819,6 +821,14 @@ impl PromPlanner {
         common_telemetry::info!(
             "Planning function with input, input: {}, func: {:?}",
             input,
+            func_exprs
+        );
+
+        common_telemetry::info!(
+            "prom call expr to plan, input: {}, func: {:?}, args: {:?}, func_exprs: {:?}",
+            input,
+            func,
+            args,
             func_exprs
         );
 

--- a/tests/cases/standalone/common/promql/binary_time_fn.result
+++ b/tests/cases/standalone/common/promql/binary_time_fn.result
@@ -45,15 +45,16 @@ VALUES
 
 Affected Rows: 28
 
+-- SQLNESS SORT_RESULT 3 1
 tql eval(1697731200, 1698595200, 120) max_over_time(test_metric[30s]) > 100 and on () (day_of_week() == 0 or day_of_week() == 6);
 
 +---------------------+-------------------------------------------+-------------+-----------+-------------+
 | timestamp           | prom_max_over_time(timestamp_range,value) | asset       | attribute | measurement |
 +---------------------+-------------------------------------------+-------------+-----------+-------------+
-| 2023-10-29T00:00:00 | 219.1                                     | Generator01 | voltage   | electrical  |
-| 2023-10-28T12:00:00 | 219.4                                     | Generator02 | voltage   | electrical  |
-| 2023-10-29T12:00:00 | 220.0                                     | Generator02 | voltage   | electrical  |
 | 2023-10-28T00:00:00 | 218.5                                     | Generator01 | voltage   | electrical  |
+| 2023-10-28T12:00:00 | 219.4                                     | Generator02 | voltage   | electrical  |
+| 2023-10-29T00:00:00 | 219.1                                     | Generator01 | voltage   | electrical  |
+| 2023-10-29T12:00:00 | 220.0                                     | Generator02 | voltage   | electrical  |
 +---------------------+-------------------------------------------+-------------+-----------+-------------+
 
 DROP TABLE test_metric;

--- a/tests/cases/standalone/common/promql/binary_time_fn.result
+++ b/tests/cases/standalone/common/promql/binary_time_fn.result
@@ -1,0 +1,62 @@
+CREATE TABLE IF NOT EXISTS `test_metric` (
+  `asset` STRING NULL,
+  `attribute` STRING NULL,
+  `timestamp` TIMESTAMP(3) NOT NULL,
+  `value` DOUBLE NULL,
+  `measurement` STRING NULL,
+  TIME INDEX (`timestamp`),
+  PRIMARY KEY (`asset`, `attribute`, `measurement`)
+);
+
+Affected Rows: 0
+
+-- Saturday 2023-10-28
+-- Sunday 2023-10-29
+INSERT INTO test_metric (asset, attribute, measurement, `timestamp`, `value`)
+VALUES
+('Generator01', 'voltage', 'electrical', '2023-10-23 00:00:00', 220.5),
+('Generator01', 'current', 'electrical', '2023-10-23 06:00:00', 15.2),
+('Generator02', 'voltage', 'electrical', '2023-10-23 12:00:00', 219.8),
+('Generator02', 'current', 'electrical', '2023-10-23 18:00:00', 14.9),
+('Generator01', 'voltage', 'electrical', '2023-10-24 00:00:00', 221.3),
+('Generator01', 'current', 'electrical', '2023-10-24 06:00:00', 15.4),
+('Generator02', 'voltage', 'electrical', '2023-10-24 12:00:00', 220.1),
+('Generator02', 'current', 'electrical', '2023-10-24 18:00:00', 15.0),
+('Generator01', 'voltage', 'electrical', '2023-10-25 00:00:00', 219.7),
+('Generator01', 'current', 'electrical', '2023-10-25 06:00:00', 15.3),
+('Generator02', 'voltage', 'electrical', '2023-10-25 12:00:00', 220.5),
+('Generator02', 'current', 'electrical', '2023-10-25 18:00:00', 15.1),
+('Generator01', 'voltage', 'electrical', '2023-10-26 00:00:00', 220.2),
+('Generator01', 'current', 'electrical', '2023-10-26 06:00:00', 15.5),
+('Generator02', 'voltage', 'electrical', '2023-10-26 12:00:00', 219.9),
+('Generator02', 'current', 'electrical', '2023-10-26 18:00:00', 14.8),
+('Generator01', 'voltage', 'electrical', '2023-10-27 00:00:00', 220.9),
+('Generator01', 'current', 'electrical', '2023-10-27 06:00:00', 15.6),
+('Generator02', 'voltage', 'electrical', '2023-10-27 12:00:00', 220.3),
+('Generator02', 'current', 'electrical', '2023-10-27 18:00:00', 15.2),
+('Generator01', 'voltage', 'electrical', '2023-10-28 00:00:00', 218.5),
+('Generator01', 'current', 'electrical', '2023-10-28 06:00:00', 14.9),
+('Generator02', 'voltage', 'electrical', '2023-10-28 12:00:00', 219.4),
+('Generator02', 'current', 'electrical', '2023-10-28 18:00:00', 14.7),
+('Generator01', 'voltage', 'electrical', '2023-10-29 00:00:00', 219.1),
+('Generator01', 'current', 'electrical', '2023-10-29 06:00:00', 14.8),
+('Generator02', 'voltage', 'electrical', '2023-10-29 12:00:00', 220.0),
+('Generator02', 'current', 'electrical', '2023-10-29 18:00:00', 14.6);
+
+Affected Rows: 28
+
+tql eval(1697731200, 1698595200, 120) max_over_time(test_metric[30s]) > 100 and on () (day_of_week() == 0 or day_of_week() == 6);
+
++---------------------+-------------------------------------------+-------------+-----------+-------------+
+| timestamp           | prom_max_over_time(timestamp_range,value) | asset       | attribute | measurement |
++---------------------+-------------------------------------------+-------------+-----------+-------------+
+| 2023-10-29T00:00:00 | 219.1                                     | Generator01 | voltage   | electrical  |
+| 2023-10-28T12:00:00 | 219.4                                     | Generator02 | voltage   | electrical  |
+| 2023-10-29T12:00:00 | 220.0                                     | Generator02 | voltage   | electrical  |
+| 2023-10-28T00:00:00 | 218.5                                     | Generator01 | voltage   | electrical  |
++---------------------+-------------------------------------------+-------------+-----------+-------------+
+
+DROP TABLE test_metric;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/promql/binary_time_fn.sql
+++ b/tests/cases/standalone/common/promql/binary_time_fn.sql
@@ -41,6 +41,7 @@ VALUES
 ('Generator02', 'voltage', 'electrical', '2023-10-29 12:00:00', 220.0),
 ('Generator02', 'current', 'electrical', '2023-10-29 18:00:00', 14.6);
 
+-- SQLNESS SORT_RESULT 3 1
 tql eval(1697731200, 1698595200, 120) max_over_time(test_metric[30s]) > 100 and on () (day_of_week() == 0 or day_of_week() == 6);
 
 DROP TABLE test_metric;

--- a/tests/cases/standalone/common/promql/binary_time_fn.sql
+++ b/tests/cases/standalone/common/promql/binary_time_fn.sql
@@ -1,0 +1,46 @@
+CREATE TABLE IF NOT EXISTS `test_metric` (
+  `asset` STRING NULL,
+  `attribute` STRING NULL,
+  `timestamp` TIMESTAMP(3) NOT NULL,
+  `value` DOUBLE NULL,
+  `measurement` STRING NULL,
+  TIME INDEX (`timestamp`),
+  PRIMARY KEY (`asset`, `attribute`, `measurement`)
+);
+
+-- Saturday 2023-10-28
+-- Sunday 2023-10-29
+INSERT INTO test_metric (asset, attribute, measurement, `timestamp`, `value`)
+VALUES
+('Generator01', 'voltage', 'electrical', '2023-10-23 00:00:00', 220.5),
+('Generator01', 'current', 'electrical', '2023-10-23 06:00:00', 15.2),
+('Generator02', 'voltage', 'electrical', '2023-10-23 12:00:00', 219.8),
+('Generator02', 'current', 'electrical', '2023-10-23 18:00:00', 14.9),
+('Generator01', 'voltage', 'electrical', '2023-10-24 00:00:00', 221.3),
+('Generator01', 'current', 'electrical', '2023-10-24 06:00:00', 15.4),
+('Generator02', 'voltage', 'electrical', '2023-10-24 12:00:00', 220.1),
+('Generator02', 'current', 'electrical', '2023-10-24 18:00:00', 15.0),
+('Generator01', 'voltage', 'electrical', '2023-10-25 00:00:00', 219.7),
+('Generator01', 'current', 'electrical', '2023-10-25 06:00:00', 15.3),
+('Generator02', 'voltage', 'electrical', '2023-10-25 12:00:00', 220.5),
+('Generator02', 'current', 'electrical', '2023-10-25 18:00:00', 15.1),
+('Generator01', 'voltage', 'electrical', '2023-10-26 00:00:00', 220.2),
+('Generator01', 'current', 'electrical', '2023-10-26 06:00:00', 15.5),
+('Generator02', 'voltage', 'electrical', '2023-10-26 12:00:00', 219.9),
+('Generator02', 'current', 'electrical', '2023-10-26 18:00:00', 14.8),
+('Generator01', 'voltage', 'electrical', '2023-10-27 00:00:00', 220.9),
+('Generator01', 'current', 'electrical', '2023-10-27 06:00:00', 15.6),
+('Generator02', 'voltage', 'electrical', '2023-10-27 12:00:00', 220.3),
+('Generator02', 'current', 'electrical', '2023-10-27 18:00:00', 15.2),
+('Generator01', 'voltage', 'electrical', '2023-10-28 00:00:00', 218.5),
+('Generator01', 'current', 'electrical', '2023-10-28 06:00:00', 14.9),
+('Generator02', 'voltage', 'electrical', '2023-10-28 12:00:00', 219.4),
+('Generator02', 'current', 'electrical', '2023-10-28 18:00:00', 14.7),
+('Generator01', 'voltage', 'electrical', '2023-10-29 00:00:00', 219.1),
+('Generator01', 'current', 'electrical', '2023-10-29 06:00:00', 14.8),
+('Generator02', 'voltage', 'electrical', '2023-10-29 12:00:00', 220.0),
+('Generator02', 'current', 'electrical', '2023-10-29 18:00:00', 14.6);
+
+tql eval(1697731200, 1698595200, 120) max_over_time(test_metric[30s]) > 100 and on () (day_of_week() == 0 or day_of_week() == 6);
+
+DROP TABLE test_metric;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/5998

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

This PR resets the tags and sets fields correctly when creating the empty metric for prom call.

This avoids errors like a tag column not found in the schema.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
