### PR TITLE
feat: try cast timestamp types from number string

### DIFF
--- a/src/sql/src/statements.rs
+++ b/src/sql/src/statements.rs
@@ -107,6 +107,8 @@ fn parse_string_to_value(
                         target_unit: t.unit(),
                     },
                 )?))
+            } else if let Ok(ts) = i64::from_str(s.as_str()) {
+                Ok(Value::Timestamp(Timestamp::new(ts, t.unit())))
             } else {
                 ParseSqlValueSnafu {
                     msg: format!("Failed to parse {s} to Timestamp value"),

--- a/tests/cases/standalone/common/insert/mysql_insert.result
+++ b/tests/cases/standalone/common/insert/mysql_insert.result
@@ -13,7 +13,7 @@ INSERT INTO integers VALUES (11, 1), (12, 2);
 affected_rows: 2
 
 -- SQLNESS PROTOCOL MYSQL
-INSERT INTO integers VALUES ('13', 3), ('14', 4);
+INSERT INTO integers VALUES ('13', '3'), ('14', '4');
 
 affected_rows: 2
 

--- a/tests/cases/standalone/common/insert/mysql_insert.sql
+++ b/tests/cases/standalone/common/insert/mysql_insert.sql
@@ -9,7 +9,7 @@ CREATE TABLE integers (
 INSERT INTO integers VALUES (11, 1), (12, 2);
 
 -- SQLNESS PROTOCOL MYSQL
-INSERT INTO integers VALUES ('13', 3), ('14', 4);
+INSERT INTO integers VALUES ('13', '3'), ('14', '4');
 
 -- SQLNESS PROTOCOL MYSQL
 INSERT INTO integers VALUES ('15a', 5), ('16', 6);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow up of https://github.com/GreptimeTeam/greptimedb/pull/6015/files

## What's changed and what's your intention?

In addition to https://github.com/GreptimeTeam/greptimedb/pull/6015 , this patch further parses number string from input for timestamp type family

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
