### PR TITLE
fix!: disable append mode in trace services table

### DIFF
--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -580,6 +580,10 @@ impl Inserter {
                 // for it's a very unexpected behavior and should be set by user explicitly
                 for mut create_table in create_tables {
                     if create_table.table_name == trace_services_table_name(trace_table_name) {
+                        // Disable append mode for trace services table since it requires upsert behavior.
+                        create_table
+                            .table_options
+                            .insert(APPEND_MODE_KEY.to_string(), "false".to_string());
                         let table = self
                             .create_physical_table(create_table, None, ctx, statement_executor)
                             .await?;

--- a/src/servers/src/otlp/trace/v1.rs
+++ b/src/servers/src/otlp/trace/v1.rs
@@ -176,9 +176,9 @@ fn write_trace_services_to_row(writer: &mut TableData, services: HashSet<String>
         )?;
 
         // Write the `service_name` column.
-        row_writer::write_fields(
+        row_writer::write_tags(
             writer,
-            std::iter::once(make_string_column_data(SERVICE_NAME_COLUMN, service_name)),
+            std::iter::once((SERVICE_NAME_COLUMN.to_string(), service_name)),
             &mut row,
         )?;
         writer.add_row(row);

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -2838,7 +2838,7 @@ pub async fn test_otlp_traces_v1(store_type: StorageType) {
     )
     .await;
 
-    let expected_ddl = r#"[["mytable_services","CREATE TABLE IF NOT EXISTS \"mytable_services\" (\n  \"timestamp\" TIMESTAMP(9) NOT NULL,\n  \"service_name\" STRING NULL,\n  TIME INDEX (\"timestamp\")\n)\n\nENGINE=mito\nWITH(\n  append_mode = 'true'\n)"]]"#;
+    let expected_ddl = r#"[["mytable_services","CREATE TABLE IF NOT EXISTS \"mytable_services\" (\n  \"timestamp\" TIMESTAMP(9) NOT NULL,\n  \"service_name\" STRING NULL,\n  TIME INDEX (\"timestamp\"),\n  PRIMARY KEY (\"service_name\")\n)\n\nENGINE=mito\nWITH(\n  append_mode = 'false'\n)"]]"#;
     validate_data(
         "otlp_traces",
         &client,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Duplicated `service_name` in default services table `opentelemetry_traces_services` since it turn on append only mode.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
