### PR TITLE
feat(meta): add pusher deregister signal to mailbox receiver

### DIFF
--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -26,6 +26,7 @@ use tonic::codegen::http;
 
 use crate::metasrv::SelectTarget;
 use crate::pubsub::Message;
+use crate::service::mailbox::Channel;
 
 #[derive(Snafu)]
 #[snafu(visibility(pub))]
@@ -591,6 +592,13 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display("Mailbox channel closed: {channel}"))]
+    MailboxChannelClosed {
+        channel: Channel,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Missing request header"))]
     MissingRequestHeader {
         #[snafu(implicit)]
@@ -894,6 +902,7 @@ impl ErrorExt for Error {
             | Error::MailboxClosed { .. }
             | Error::MailboxTimeout { .. }
             | Error::MailboxReceiver { .. }
+            | Error::MailboxChannelClosed { .. }
             | Error::RetryLater { .. }
             | Error::RetryLaterWithSource { .. }
             | Error::StartGrpc { .. }

--- a/src/meta-srv/src/procedure/region_migration/close_downgraded_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/close_downgraded_region.rs
@@ -113,7 +113,7 @@ impl CloseDowngradedRegion {
             .send(&ch, msg, CLOSE_DOWNGRADED_REGION_TIMEOUT)
             .await?;
 
-        match receiver.await? {
+        match receiver.await {
             Ok(msg) => {
                 let reply = HeartbeatMailbox::json_reply(&msg)?;
                 info!(

--- a/src/meta-srv/src/procedure/region_migration/downgrade_leader_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/downgrade_leader_region.rs
@@ -164,7 +164,7 @@ impl DowngradeLeaderRegion {
         let now = Instant::now();
         let receiver = ctx.mailbox.send(&ch, msg, operation_timeout).await?;
 
-        match receiver.await? {
+        match receiver.await {
             Ok(msg) => {
                 let reply = HeartbeatMailbox::json_reply(&msg)?;
                 info!(

--- a/src/meta-srv/src/procedure/region_migration/flush_leader_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/flush_leader_region.rs
@@ -107,7 +107,7 @@ impl PreFlushRegion {
         let result = ctx.mailbox.send(&ch, msg, operation_timeout).await;
 
         match result {
-            Ok(receiver) => match receiver.await? {
+            Ok(receiver) => match receiver.await {
                 Ok(msg) => {
                     let reply = HeartbeatMailbox::json_reply(&msg)?;
                     info!(

--- a/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
@@ -146,7 +146,7 @@ impl OpenCandidateRegion {
             .send(&ch, msg, OPEN_CANDIDATE_REGION_TIMEOUT)
             .await?;
 
-        match receiver.await? {
+        match receiver.await {
             Ok(msg) => {
                 let reply = HeartbeatMailbox::json_reply(&msg)?;
                 info!(

--- a/src/meta-srv/src/procedure/region_migration/upgrade_candidate_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/upgrade_candidate_region.rs
@@ -133,7 +133,7 @@ impl UpgradeCandidateRegion {
         let ch = Channel::Datanode(candidate.id);
         let receiver = ctx.mailbox.send(&ch, msg, operation_timeout).await?;
 
-        match receiver.await? {
+        match receiver.await {
             Ok(msg) => {
                 let reply = HeartbeatMailbox::json_reply(&msg)?;
                 let InstructionReply::UpgradeRegion(UpgradeRegionReply {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Add deregister signal to mailbox receiver to detect pusher deregistration. When pusher is dropped, it will send a signal through watch channel, and mailbox receiver will fail fast with MailboxChannelClosed error.

- Add watch channel in Pusher for deregister signal
- Use tokio::select! in MailboxReceiver to handle both message and deregister signal
- Add MailboxChannelClosed error for pusher deregister cases

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
