### PR TITLE
feat: mem prof can gen flamegraph directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2285,8 +2285,11 @@ dependencies = [
 name = "common-mem-prof"
 version = "0.15.0"
 dependencies = [
+ "anyhow",
  "common-error",
  "common-macro",
+ "mappings",
+ "pprof_util",
  "snafu 0.8.5",
  "tempfile",
  "tikv-jemalloc-ctl",
@@ -3980,6 +3983,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "equator"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5649,6 +5671,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "inferno"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2094aecddc672e902cd773bad7071542f63641e01e9187c3bba4b43005e837e9"
+dependencies = [
+ "ahash 0.8.11",
+ "clap 4.5.19",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "dashmap",
+ "env_logger",
+ "indexmap 2.9.0",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml 0.37.5",
+ "rgb",
+ "str_stack",
+]
+
+[[package]]
 name = "influxdb_line_protocol"
 version = "0.1.0"
 source = "git+https://github.com/evenyag/influxdb_iox?branch=feat%2Fline-protocol#10ef0d0b02705ac7518717390939fa3a9bcfcacc"
@@ -6551,6 +6595,19 @@ checksum = "792ba667add2798c6c3e988e630f4eb921b5cbc735044825b7111ef1582c8730"
 dependencies = [
  "byteorder",
  "thiserror 1.0.64",
+]
+
+[[package]]
+name = "mappings"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e434981a332777c2b3062652d16a55f8e74fa78e6b1882633f0d77399c84fc2a"
+dependencies = [
+ "anyhow",
+ "libc",
+ "once_cell",
+ "pprof_util",
+ "tracing",
 ]
 
 [[package]]
@@ -8651,7 +8708,7 @@ dependencies = [
  "cfg-if",
  "criterion 0.5.1",
  "findshlibs",
- "inferno",
+ "inferno 0.11.21",
  "libc",
  "log",
  "nix 0.26.4",
@@ -8666,6 +8723,21 @@ dependencies = [
  "symbolic-demangle",
  "tempfile",
  "thiserror 1.0.64",
+]
+
+[[package]]
+name = "pprof_util"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa015c78eed2130951e22c58d2095849391e73817ab2e74f71b0b9f63dd8416"
+dependencies = [
+ "anyhow",
+ "backtrace",
+ "flate2",
+ "inferno 0.12.2",
+ "num",
+ "paste",
+ "prost 0.13.5",
 ]
 
 [[package]]
@@ -9250,6 +9322,15 @@ checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/docs/how-to/how-to-profile-memory.md
+++ b/docs/how-to/how-to-profile-memory.md
@@ -44,6 +44,10 @@ Dump memory profiling data through HTTP API:
 
 ```bash
 curl -X POST localhost:4000/debug/prof/mem > greptime.hprof
+# or output flamegraph directly
+curl -X POST "localhost:4000/debug/prof/mem?output=flamegraph" > greptime.svg
+# or output pprof format
+curl -X POST "localhost:4000/debug/prof/mem?output=proto" > greptime.pprof
 ```
 
 You can periodically dump profiling data and compare them to find the delta memory usage.

--- a/src/common/mem-prof/Cargo.toml
+++ b/src/common/mem-prof/Cargo.toml
@@ -16,6 +16,12 @@ tokio.workspace = true
 
 [target.'cfg(not(windows))'.dependencies]
 tikv-jemalloc-ctl = { version = "0.6", features = ["use_std", "stats"] }
+jemalloc-pprof-utils = { version = "0.7", package = "pprof_util", features = [
+    "flamegraph",
+    "symbolize",
+] } # for parsing jemalloc prof dump
+jemalloc-pprof-mappings = { version = "0.7", package = "mappings" } # for get the name of functions in the prof dump
+anyhow = "1"
 
 [target.'cfg(not(windows))'.dependencies.tikv-jemalloc-sys]
 features = ["stats", "profiling", "unprefixed_malloc_on_supported_platforms"]

--- a/src/common/mem-prof/src/error.rs
+++ b/src/common/mem-prof/src/error.rs
@@ -30,12 +30,25 @@ pub enum Error {
 
     #[snafu(display("Memory profiling is not supported"))]
     ProfilingNotSupported,
+
+    #[snafu(display("Failed to parse jeheap profile: {}", err))]
+    ParseJeHeap {
+        #[snafu(source)]
+        err: anyhow::Error,
+    },
+
+    #[snafu(display("Failed to dump profile data to flamegraph: {}", err))]
+    Flamegraph {
+        #[snafu(source)]
+        err: anyhow::Error,
+    },
 }
 
 impl ErrorExt for Error {
     fn status_code(&self) -> StatusCode {
         match self {
             Error::Internal { source } => source.status_code(),
+            Error::ParseJeHeap { .. } | Error::Flamegraph { .. } => StatusCode::Internal,
             Error::ProfilingNotSupported => StatusCode::Unsupported,
         }
     }

--- a/src/common/mem-prof/src/jemalloc.rs
+++ b/src/common/mem-prof/src/jemalloc.rs
@@ -15,16 +15,19 @@
 mod error;
 
 use std::ffi::{c_char, CString};
+use std::io::BufReader;
 use std::path::PathBuf;
 
 use error::{
     BuildTempPathSnafu, DumpProfileDataSnafu, OpenTempFileSnafu, ProfilingNotEnabledSnafu,
     ReadOptProfSnafu,
 };
+use jemalloc_pprof_mappings::MAPPINGS;
+use jemalloc_pprof_utils::{parse_jeheap, FlamegraphOptions, StackProfile};
 use snafu::{ensure, ResultExt};
 use tokio::io::AsyncReadExt;
 
-use crate::error::Result;
+use crate::error::{FlamegraphSnafu, ParseJeHeapSnafu, Result};
 
 const PROF_DUMP: &[u8] = b"prof.dump\0";
 const OPT_PROF: &[u8] = b"opt.prof\0";
@@ -70,6 +73,26 @@ pub async fn dump_profile() -> Result<Vec<u8>> {
     Ok(buf)
 }
 
+pub async fn dump_profile_to_stack_profile() -> Result<StackProfile> {
+    let profile = dump_profile().await?;
+    let profile = BufReader::new(profile.as_slice());
+    parse_jeheap(profile, MAPPINGS.as_deref()).context(ParseJeHeapSnafu)
+}
+
+pub async fn dump_pprof() -> Result<Vec<u8>> {
+    let profile = dump_profile_to_stack_profile().await?;
+    let pprof = profile.to_pprof(("inuse_space", "bytes"), ("space", "bytes"), None);
+    Ok(pprof)
+}
+
+pub async fn dump_flamegraph() -> Result<Vec<u8>> {
+    let profile = dump_profile_to_stack_profile().await?;
+    let mut opts = FlamegraphOptions::default();
+    opts.title = "inuse_space".to_string();
+    opts.count_name = "bytes".to_string();
+    let flamegraph = profile.to_flamegraph(&mut opts).context(FlamegraphSnafu)?;
+    Ok(flamegraph)
+}
 fn is_prof_enabled() -> Result<bool> {
     // safety: OPT_PROF variable, if present, is always a boolean value.
     Ok(unsafe { tikv_jemalloc_ctl::raw::read::<bool>(OPT_PROF).context(ReadOptProfSnafu)? })

--- a/src/common/mem-prof/src/jemalloc.rs
+++ b/src/common/mem-prof/src/jemalloc.rs
@@ -73,7 +73,7 @@ pub async fn dump_profile() -> Result<Vec<u8>> {
     Ok(buf)
 }
 
-pub async fn dump_profile_to_stack_profile() -> Result<StackProfile> {
+async fn dump_profile_to_stack_profile() -> Result<StackProfile> {
     let profile = dump_profile().await?;
     let profile = BufReader::new(profile.as_slice());
     parse_jeheap(profile, MAPPINGS.as_deref()).context(ParseJeHeapSnafu)

--- a/src/common/mem-prof/src/lib.rs
+++ b/src/common/mem-prof/src/lib.rs
@@ -17,7 +17,7 @@ pub mod error;
 #[cfg(not(windows))]
 mod jemalloc;
 #[cfg(not(windows))]
-pub use jemalloc::dump_profile;
+pub use jemalloc::{dump_flamegraph, dump_pprof, dump_profile};
 
 #[cfg(windows)]
 pub async fn dump_profile() -> error::Result<Vec<u8>> {

--- a/src/servers/src/http/mem_prof.rs
+++ b/src/servers/src/http/mem_prof.rs
@@ -30,16 +30,22 @@ pub enum Output {
     Flamegraph,
 }
 
+#[derive(Default, Serialize, Deserialize, Debug)]
+#[serde(default)]
+pub struct MemPprofQuery {
+    output: Output,
+}
+
 #[cfg(feature = "mem-prof")]
 #[axum_macros::debug_handler]
 pub async fn mem_prof_handler(
-    Query(req): Query<Output>,
+    Query(req): Query<MemPprofQuery>,
 ) -> crate::error::Result<impl IntoResponse> {
     use snafu::ResultExt;
 
     use crate::error::DumpProfileDataSnafu;
 
-    let dump = match req {
+    let dump = match req.output {
         Output::Proto => common_mem_prof::dump_pprof().await,
         Output::Text => common_mem_prof::dump_profile().await,
         Output::Flamegraph => common_mem_prof::dump_flamegraph().await,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

as title, also pprof format, might also add gen diff flamegraph in the future if needed, i.e.:
```bash
curl -X POST localhost:4000/debug/prof/mem > greptime.hprof
# or output flamegraph directly
curl -X POST "localhost:4000/debug/prof/mem?output=flamegraph" > greptime.svg
# or output pprof format
curl -X POST "localhost:4000/debug/prof/mem?output=proto" > greptime.pprof
```

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
