### PR TITLE
ci: only trigger downstream when release success

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -444,7 +444,7 @@ jobs:
   bump-doc-version:
     name: Bump doc version
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
-    needs: [allocate-runners]
+    needs: [publish-github-release]
     runs-on: ubuntu-latest
     # Permission reference: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
     permissions:
@@ -466,8 +466,8 @@ jobs:
 
   bump-website-version:
     name: Bump website version
-    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
-    needs: [allocate-runners]
+    if: ${{ github.event_name == 'push' }}
+    needs: [publish-github-release]
     runs-on: ubuntu-latest
     # Permission reference: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
     permissions:


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The release tasks may create patch for downstream projects when release failed. This patch fixes the issue. 

Also we don't update website for scheduled nightly release.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
