### PR TITLE
feat(bulk): write to multiple time partitions

### DIFF
--- a/src/mito2/Cargo.toml
+++ b/src/mito2/Cargo.toml
@@ -92,3 +92,8 @@ toml.workspace = true
 name = "memtable_bench"
 harness = false
 required-features = ["test"]
+
+[[bench]]
+name = "bench_filter_time_partition"
+harness = false
+required-features = ["test"]

--- a/src/mito2/benches/bench_filter_time_partition.rs
+++ b/src/mito2/benches/bench_filter_time_partition.rs
@@ -1,0 +1,109 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::str::FromStr;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use datatypes::arrow;
+use datatypes::arrow::array::{ArrayRef, BooleanArray, Int64Array};
+use datatypes::arrow::buffer::{BooleanBuffer, MutableBuffer};
+use datatypes::arrow::util::bit_util::ceil;
+
+fn random_array(num: usize) -> Int64Array {
+    let data: Vec<_> = (0..num).map(|_| rand::random::<i64>()).collect();
+    Int64Array::from(data)
+}
+
+fn filter_arrow_impl(array: &Int64Array, min: i64, max: i64) -> (ArrayRef, i64, i64) {
+    let gt_eq = arrow::compute::kernels::cmp::gt_eq(array, &Int64Array::new_scalar(min)).unwrap();
+    let lt = arrow::compute::kernels::cmp::lt(array, &Int64Array::new_scalar(max)).unwrap();
+    let res = arrow::compute::and(&gt_eq, &lt).unwrap();
+    let array = arrow::compute::filter(array, &res).unwrap();
+    let i64array = array.as_any().downcast_ref::<Int64Array>().unwrap();
+    let max = arrow::compute::max(i64array).unwrap_or(i64::MIN);
+    let min = arrow::compute::min(i64array).unwrap_or(i64::MAX);
+    (array, min, max)
+}
+
+fn filter_manual_impl(array: &Int64Array, min: i64, max: i64) -> (ArrayRef, i64, i64) {
+    let len = array.len();
+    let mut buffer = MutableBuffer::new(ceil(len, 64) * 8);
+
+    let f = |idx: usize| -> bool {
+        unsafe {
+            let val = array.value_unchecked(idx);
+            val >= min && val < max
+        }
+    };
+
+    let chunks = len / 64;
+    let remainder = len % 64;
+    for chunk in 0..chunks {
+        let mut packed = 0;
+        for bit_idx in 0..64 {
+            let i = bit_idx + chunk * 64;
+            packed |= (f(i) as u64) << bit_idx;
+        }
+        // SAFETY: Already allocated sufficient capacity
+        unsafe { buffer.push_unchecked(packed) }
+    }
+
+    if remainder != 0 {
+        let mut packed = 0;
+        for bit_idx in 0..remainder {
+            let i = bit_idx + chunks * 64;
+            packed |= (f(i) as u64) << bit_idx;
+        }
+
+        // SAFETY: Already allocated sufficient capacity
+        unsafe { buffer.push_unchecked(packed) }
+    }
+    let res = arrow::compute::filter(
+        array,
+        &BooleanArray::new(BooleanBuffer::new(buffer.into(), 0, len), None),
+    )
+    .unwrap();
+    let i64array = res.as_any().downcast_ref::<Int64Array>().unwrap();
+    let max = arrow::compute::max(i64array).unwrap_or(i64::MIN);
+    let min = arrow::compute::min(i64array).unwrap_or(i64::MAX);
+    (res, min, max)
+}
+
+fn filter_batch_by_time_range(c: &mut Criterion) {
+    let num = std::env::var("BENCH_FILTER_BATCH_TIME_RANGE_NUM")
+        .ok()
+        .and_then(|v| usize::from_str(&v).ok())
+        .unwrap_or(10000);
+    let array = random_array(num);
+    let min = 0;
+    let max = 10000;
+
+    let mut group = c.benchmark_group("filter_by_time_range");
+    group.bench_function("arrow_impl", |b| {
+        b.iter(|| {
+            let _ = black_box(filter_arrow_impl(&array, min, max));
+        });
+    });
+
+    group.bench_function("manual_impl", |b| {
+        b.iter(|| {
+            let _ = black_box(filter_manual_impl(&array, min, max));
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, filter_batch_by_time_range);
+criterion_main!(benches);

--- a/src/mito2/src/lib.rs
+++ b/src/mito2/src/lib.rs
@@ -19,6 +19,7 @@
 #![feature(let_chains)]
 #![feature(assert_matches)]
 #![feature(result_flattening)]
+#![feature(int_roundings)]
 
 #[cfg(any(test, feature = "test"))]
 #[cfg_attr(feature = "test", allow(unused))]

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -29,7 +29,6 @@ use table::predicate::Predicate;
 use crate::config::MitoConfig;
 use crate::error::Result;
 use crate::flush::WriteBufferManagerRef;
-use crate::memtable::bulk::part::BulkPart;
 use crate::memtable::key_values::KeyValue;
 pub use crate::memtable::key_values::KeyValues;
 use crate::memtable::partition_tree::{PartitionTreeConfig, PartitionTreeMemtableBuilder};
@@ -50,6 +49,11 @@ mod stats;
 pub mod time_partition;
 pub mod time_series;
 pub(crate) mod version;
+
+#[cfg(any(test, feature = "test"))]
+pub use bulk::part::BulkPart;
+#[cfg(any(test, feature = "test"))]
+pub use time_partition::filter_record_batch;
 
 /// Id for memtables.
 ///
@@ -142,7 +146,7 @@ pub trait Memtable: Send + Sync + fmt::Debug {
     fn write_one(&self, key_value: KeyValue) -> Result<()>;
 
     /// Writes an encoded batch of into memtable.
-    fn write_bulk(&self, part: BulkPart) -> Result<()>;
+    fn write_bulk(&self, part: crate::memtable::bulk::part::BulkPart) -> Result<()>;
 
     /// Scans the memtable.
     /// `projection` selects columns to read, `None` means reading all columns.

--- a/src/mito2/src/memtable/bulk/part.rs
+++ b/src/mito2/src/memtable/bulk/part.rs
@@ -58,12 +58,12 @@ use crate::sst::to_sst_arrow_schema;
 
 #[derive(Clone)]
 pub struct BulkPart {
-    pub(crate) batch: RecordBatch,
-    pub(crate) num_rows: usize,
-    pub(crate) max_ts: i64,
-    pub(crate) min_ts: i64,
-    pub(crate) sequence: u64,
-    pub(crate) timestamp_index: usize,
+    pub batch: RecordBatch,
+    pub num_rows: usize,
+    pub max_ts: i64,
+    pub min_ts: i64,
+    pub sequence: u64,
+    pub timestamp_index: usize,
 }
 
 impl BulkPart {
@@ -127,7 +127,7 @@ impl BulkPart {
         })
     }
 
-    pub(crate) fn timestamps(&self) -> &ArrayRef {
+    pub fn timestamps(&self) -> &ArrayRef {
         self.batch.column(self.timestamp_index)
     }
 }

--- a/src/mito2/src/memtable/bulk/part.rs
+++ b/src/mito2/src/memtable/bulk/part.rs
@@ -40,7 +40,7 @@ use parquet::arrow::ArrowWriter;
 use parquet::data_type::AsBytes;
 use parquet::file::metadata::ParquetMetaData;
 use parquet::file::properties::WriterProperties;
-use snafu::{OptionExt, ResultExt};
+use snafu::{OptionExt, ResultExt, Snafu};
 use store_api::metadata::RegionMetadataRef;
 use store_api::storage::SequenceNumber;
 use table::predicate::Predicate;
@@ -56,12 +56,14 @@ use crate::sst::parquet::format::{PrimaryKeyArray, ReadFormat};
 use crate::sst::parquet::helper::parse_parquet_metadata;
 use crate::sst::to_sst_arrow_schema;
 
+#[derive(Clone)]
 pub struct BulkPart {
     pub(crate) batch: RecordBatch,
     pub(crate) num_rows: usize,
     pub(crate) max_ts: i64,
     pub(crate) min_ts: i64,
     pub(crate) sequence: u64,
+    pub(crate) timestamp_index: usize,
 }
 
 impl BulkPart {
@@ -123,6 +125,10 @@ impl BulkPart {
             rows: Some(rows),
             write_hint: None,
         })
+    }
+
+    pub(crate) fn timestamps(&self) -> &ArrayRef {
+        self.batch.column(self.timestamp_index)
     }
 }
 

--- a/src/mito2/src/memtable/simple_bulk_memtable.rs
+++ b/src/mito2/src/memtable/simple_bulk_memtable.rs
@@ -564,6 +564,7 @@ mod tests {
             min_ts: 1,
             max_ts: 2,
             num_rows: 2,
+            timestamp_index: 0,
         };
         memtable.write_bulk(part).unwrap();
 

--- a/src/mito2/src/memtable/time_partition.rs
+++ b/src/mito2/src/memtable/time_partition.rs
@@ -296,22 +296,22 @@ impl TimePartitions {
 
         // Get all parts.
         let parts = self.list_partitions();
-        let (matchings, missings) = self.find_partitions_by_time_range(
+        let (matching_parts, missing_parts) = self.find_partitions_by_time_range(
             &parts,
             time_type.create_timestamp(part.min_ts),
             time_type.create_timestamp(part.max_ts),
         )?;
 
-        if matchings.len() == 1 && missings.is_empty() {
+        if matching_parts.len() == 1 && missing_parts.is_empty() {
             // fast path: all timestamps fall in one time partition.
-            return matchings[0].write_record_batch(part);
+            return matching_parts[0].write_record_batch(part);
         }
 
-        for matching in matchings {
+        for matching in matching_parts {
             matching.write_record_batch_partial(&part)?
         }
 
-        for missing in missings {
+        for missing in missing_parts {
             let new_part = {
                 let mut inner = self.inner.lock().unwrap();
                 self.get_or_create_time_partition(missing, &mut inner)?

--- a/src/mito2/src/memtable/time_partition.rs
+++ b/src/mito2/src/memtable/time_partition.rs
@@ -529,18 +529,18 @@ impl TimePartitions {
 
         let part_duration_sec = part_duration.as_secs() as i64;
         // SAFETY: Timestamps won't overflow when converting to Second.
-        let bulk_start_sec = min
+        let start_bucket = min
             .convert_to(TimeUnit::Second)
             .unwrap()
             .value()
             .div_euclid(part_duration_sec);
-        let bulk_end_sec = max
+        let end_bucket = max
             .convert_to(TimeUnit::Second)
             .unwrap()
             .value()
             .div_euclid(part_duration_sec);
 
-        let missing = (bulk_start_sec..=bulk_end_sec)
+        let missing = (start_bucket..=end_bucket)
             .filter_map(|start_sec| {
                 let Some(timestamp) =
                     Timestamp::new_second(start_sec * part_duration_sec).convert_to(timestamp_unit)

--- a/src/mito2/src/memtable/time_partition.rs
+++ b/src/mito2/src/memtable/time_partition.rs
@@ -296,25 +296,25 @@ impl TimePartitions {
 
         // Get all parts.
         let parts = self.list_partitions();
-        let (matching, missing) = self.find_partitions_by_time_range(
+        let (matchings, missings) = self.find_partitions_by_time_range(
             &parts,
             time_type.create_timestamp(part.min_ts),
             time_type.create_timestamp(part.max_ts),
         )?;
 
-        if matching.len() == 1 && missing.is_empty() {
+        if matchings.len() == 1 && missings.is_empty() {
             // fast path: all timestamps fall in one time partition.
-            return matching[0].write_record_batch(part);
+            return matchings[0].write_record_batch(part);
         }
 
-        for matching in matching {
+        for matching in matchings {
             matching.write_record_batch_partial(&part)?
         }
 
-        for missing_part_start in missing {
+        for missing in missings {
             let new_part = {
                 let mut inner = self.inner.lock().unwrap();
-                self.get_or_create_time_partition(missing_part_start, &mut inner)?
+                self.get_or_create_time_partition(missing, &mut inner)?
             };
             new_part.write_record_batch_partial(&part)?;
         }

--- a/src/store-api/src/metadata.rs
+++ b/src/store-api/src/metadata.rs
@@ -30,6 +30,7 @@ use common_macro::stack_trace_debug;
 use datatypes::arrow;
 use datatypes::arrow::datatypes::FieldRef;
 use datatypes::schema::{ColumnSchema, FulltextOptions, Schema, SchemaRef, SkippingIndexOptions};
+use datatypes::types::TimestampType;
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize};
 use snafu::{ensure, Location, OptionExt, ResultExt, Snafu};
@@ -239,6 +240,19 @@ impl RegionMetadata {
     pub fn time_index_column(&self) -> &ColumnMetadata {
         let index = self.id_to_index[&self.time_index];
         &self.column_metadatas[index]
+    }
+
+    /// Returns timestamp type of time index column
+    ///
+    /// # Panics
+    /// Panics if the time index column id is invalid.
+    pub fn time_index_type(&self) -> TimestampType {
+        let index = self.id_to_index[&self.time_index];
+        self.column_metadatas[index]
+            .column_schema
+            .data_type
+            .as_timestamp()
+            .unwrap()
     }
 
     /// Returns the position of the time index.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
- #5803

## What's changed and what's your intention?

This PR adds multiple time partition support in bulk insert ingestion path.

To exploit the performance of vectored ops, this PR manually implements gt_eq&&lt operation instead of using arrow kernel. The benchmark shows that it can be >20% faster:

```bash
cargo bench --bench 'bench_filter_time_partition' -F testing

filter_by_time_range/arrow_impl
                        time:   [108.70 µs 108.82 µs 108.96 µs]
                        change: [-0.1400% -0.0237% +0.0841%] (p = 0.71 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe
filter_by_time_range/manual_impl
                        time:   [88.380 µs 88.454 µs 88.550 µs]
                        change: [-0.2375% -0.0982% +0.0227%] (p = 0.15 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) high mild
  6 (6.00%) high severe
```


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
