### PR TITLE
chore: bump rskafka version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9908,6 +9908,7 @@ dependencies = [
  "hmac",
  "pbkdf2",
  "rand 0.8.5",
+ "serde",
  "serde_json",
  "sha2",
  "stringprep",
@@ -9916,8 +9917,8 @@ dependencies = [
 
 [[package]]
 name = "rskafka"
-version = "0.5.0"
-source = "git+https://github.com/influxdata/rskafka.git?rev=75535b5ad9bae4a5dbb582c82e44dfd81ec10105#75535b5ad9bae4a5dbb582c82e44dfd81ec10105"
+version = "0.6.0"
+source = "git+https://github.com/influxdata/rskafka.git?rev=8dbd01ed809f5a791833a594e85b144e36e45820#8dbd01ed809f5a791833a594e85b144e36e45820"
 dependencies = [
  "bytes",
  "chrono",
@@ -9927,11 +9928,11 @@ dependencies = [
  "integer-encoding 4.0.2",
  "lz4",
  "parking_lot 0.12.3",
- "rand 0.8.5",
+ "rand 0.9.0",
  "rsasl",
  "rustls",
  "snap",
- "thiserror 1.0.64",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-rustls",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,7 +176,7 @@ reqwest = { version = "0.12", default-features = false, features = [
     "stream",
     "multipart",
 ] }
-rskafka = { git = "https://github.com/influxdata/rskafka.git", rev = "75535b5ad9bae4a5dbb582c82e44dfd81ec10105", features = [
+rskafka = { git = "https://github.com/influxdata/rskafka.git", rev = "8dbd01ed809f5a791833a594e85b144e36e45820", features = [
     "transport-tls",
 ] }
 rstest = "0.25"

--- a/tests-integration/fixtures/docker-compose.yml
+++ b/tests-integration/fixtures/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - ALLOW_ANONYMOUS_LOGIN=yes
 
   kafka:
-    image: docker.io/bitnami/kafka:3.6.0
+    image: docker.io/bitnami/kafka:3.9.0
     container_name: kafka
     ports:
       - 9092:9092


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

bump rskafka version

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
