### PR TITLE
feat: export to s3 add more options

### DIFF
--- a/src/cli/src/export.rs
+++ b/src/cli/src/export.rs
@@ -596,8 +596,13 @@ impl Export {
     fn format_output_path(&self, file_path: &str) -> String {
         if self.s3 {
             format!(
-                "s3://{}/{}",
+                "s3://{}{}/{}",
                 self.s3_bucket.as_ref().unwrap_or(&String::new()),
+                if let Some(root) = &self.s3_root {
+                    format!("/{}", root)
+                } else {
+                    String::new()
+                },
                 file_path
             )
         } else {
@@ -621,9 +626,14 @@ impl Export {
     fn get_storage_params(&self, schema: &str) -> (String, String) {
         if self.s3 {
             let s3_path = format!(
-                "s3://{}/{}/{}/",
+                "s3://{}{}/{}/{}/",
                 // Safety: s3_bucket is required when s3 is enabled
                 self.s3_bucket.as_ref().unwrap(),
+                if let Some(root) = &self.s3_root {
+                    format!("/{}", root)
+                } else {
+                    String::new()
+                },
                 self.catalog,
                 schema
             );

--- a/src/cli/src/export.rs
+++ b/src/cli/src/export.rs
@@ -489,9 +489,9 @@ impl Export {
                 .finish();
             Ok(op)
         } else if self.s3 {
-            return self.build_s3_operator().await;
+            self.build_s3_operator().await
         } else {
-            OutputDirNotSetSnafu.fail()
+            self.build_fs_operator().await
         }
     }
 

--- a/src/cli/src/export.rs
+++ b/src/cli/src/export.rs
@@ -376,7 +376,7 @@ impl Export {
         let timer = Instant::now();
         let db_names = self.get_db_names().await?;
         let db_count = db_names.len();
-        let operator = self.build_prefer_fs_operator().await?;
+        let operator = self.build_operator().await?;
 
         for schema in db_names {
             let create_database = self
@@ -406,7 +406,7 @@ impl Export {
         let semaphore = Arc::new(Semaphore::new(self.parallelism));
         let db_names = self.get_db_names().await?;
         let db_count = db_names.len();
-        let operator = Arc::new(self.build_prefer_fs_operator().await?);
+        let operator = Arc::new(self.build_operator().await?);
         let mut tasks = Vec::with_capacity(db_names.len());
 
         for schema in db_names {
@@ -468,17 +468,6 @@ impl Export {
             self.build_s3_operator().await
         } else {
             self.build_fs_operator().await
-        }
-    }
-
-    /// build operator with preference for file system
-    async fn build_prefer_fs_operator(&self) -> Result<Operator> {
-        if self.output_dir.is_some() {
-            return self.build_fs_operator().await;
-        } else if self.s3 {
-            return self.build_s3_operator().await;
-        } else {
-            OutputDirNotSetSnafu.fail()
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

#6070

## What's changed and what's your intention?

-- add `--s3-ddl-local-dir` to export sql to local even when `s3` is set and is exporting parquet data file to s3, this is useful for when export client can't access s3 directly(because the *.sql files is created by export client directly)
-- add `--s3-root` to allow state root path separately 
tested locally with and without `--s3-root` option

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
