### PR TITLE
perf: avoid some atomic operation on array slice

### DIFF
--- a/src/promql/src/functions/extrapolate_rate.rs
+++ b/src/promql/src/functions/extrapolate_rate.rs
@@ -36,12 +36,10 @@ use datafusion::arrow::array::{Float64Array, TimestampMillisecondArray};
 use datafusion::arrow::datatypes::TimeUnit;
 use datafusion::common::{DataFusionError, Result as DfResult};
 use datafusion::logical_expr::{ScalarUDF, Volatility};
-use datafusion::physical_plan::{values, ColumnarValue};
+use datafusion::physical_plan::ColumnarValue;
 use datafusion_expr::create_udf;
 use datatypes::arrow::array::{Array, Int64Array};
 use datatypes::arrow::datatypes::DataType;
-use datatypes::timestamp::TimestampMillisecond;
-use datatypes::value;
 
 use crate::extension_plan::Millisecond;
 use crate::functions::extract_array;
@@ -138,6 +136,7 @@ impl<const IS_COUNTER: bool, const IS_RATE: bool> ExtrapolatedRate<IS_COUNTER, I
             .unwrap()
             .values();
         for index in 0..ts_range.len() {
+            // Safety: we are inside `ts_range`'s iterator which guarantees the index is valid.
             let (offset, length) = ts_range.get_offset_length(index).unwrap();
 
             let timestamps = &all_timestamps[offset..offset + length];

--- a/src/promql/src/range_array.rs
+++ b/src/promql/src/range_array.rs
@@ -162,6 +162,17 @@ impl RangeArray {
         Some(array)
     }
 
+    pub fn get_offset_length(&self, index: usize) -> Option<(usize, usize)> {
+        if index >= self.len() {
+            return None;
+        }
+
+        let compound_key = self.array.keys().value(index);
+        let (offset, length) = unpack(compound_key);
+
+        Some((offset as usize, length as usize))
+    }
+
     /// Return the underlying Arrow's [DictionaryArray]. Notes the dictionary array might be
     /// invalid from Arrow's definition. Be care if try to access this dictionary through
     /// Arrow's API.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

a little 10% improvement. This can also apply to other range operators, but requires some changes to the `range_fn` macro.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
