### PR TITLE
chore: modify default `slow_query.threshold` from 5s to 30s

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -291,10 +291,10 @@
 | `logging.tracing_sample_ratio.default_ratio` | Float | `1.0` | -- |
 | `slow_query` | -- | -- | The slow query log options. |
 | `slow_query.enable` | Bool | `true` | Whether to enable slow query log. |
-| `slow_query.record_type` | String | Unset | The record type of slow queries. It can be `system_table` or `log`.<br/>If `system_table` is selected, the slow queries will be recorded in a system table `greptime_private.slow_queries`.<br/>If `log` is selected, the slow queries will be logged in a log file `greptimedb-slow-queries.*`. |
-| `slow_query.threshold` | String | Unset | The threshold of slow query. It can be human readable time string, for example: `10s`, `100ms`, `1s`. |
-| `slow_query.sample_ratio` | Float | Unset | The sampling ratio of slow query log. The value should be in the range of (0, 1]. For example, `0.1` means 10% of the slow queries will be logged and `1.0` means all slow queries will be logged. |
-| `slow_query.ttl` | String | Unset | The TTL of the `slow_queries` system table. Default is `30d` when `record_type` is `system_table`. |
+| `slow_query.record_type` | String | `system_table` | The record type of slow queries. It can be `system_table` or `log`.<br/>If `system_table` is selected, the slow queries will be recorded in a system table `greptime_private.slow_queries`.<br/>If `log` is selected, the slow queries will be logged in a log file `greptimedb-slow-queries.*`. |
+| `slow_query.threshold` | String | `30s` | The threshold of slow query. It can be human readable time string, for example: `10s`, `100ms`, `1s`. |
+| `slow_query.sample_ratio` | Float | `1.0` | The sampling ratio of slow query log. The value should be in the range of (0, 1]. For example, `0.1` means 10% of the slow queries will be logged and `1.0` means all slow queries will be logged. |
+| `slow_query.ttl` | String | `30d` | The TTL of the `slow_queries` system table. Default is `30d` when `record_type` is `system_table`. |
 | `export_metrics` | -- | -- | The datanode can export its metrics and send to Prometheus compatible service (e.g. send to `greptimedb` itself) from remote-write API.<br/>This is only used for `greptimedb` to export its own metrics internally. It's different from prometheus scrape. |
 | `export_metrics.enable` | Bool | `false` | whether enable export metrics. |
 | `export_metrics.write_interval` | String | `30s` | The interval of export metrics. |

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -230,19 +230,15 @@ enable = true
 ## The record type of slow queries. It can be `system_table` or `log`.
 ## If `system_table` is selected, the slow queries will be recorded in a system table `greptime_private.slow_queries`.
 ## If `log` is selected, the slow queries will be logged in a log file `greptimedb-slow-queries.*`.
-## @toml2docs:none-default
 record_type = "system_table"
 
 ## The threshold of slow query. It can be human readable time string, for example: `10s`, `100ms`, `1s`.
-## @toml2docs:none-default
-threshold = "5s"
+threshold = "30s"
 
 ## The sampling ratio of slow query log. The value should be in the range of (0, 1]. For example, `0.1` means 10% of the slow queries will be logged and `1.0` means all slow queries will be logged.
-## @toml2docs:none-default
 sample_ratio = 1.0
 
 ## The TTL of the `slow_queries` system table. Default is `30d` when `record_type` is `system_table`.
-## @toml2docs:none-default
 ttl = "30d"
 
 ## The datanode can export its metrics and send to Prometheus compatible service (e.g. send to `greptimedb` itself) from remote-write API.

--- a/src/common/telemetry/src/logging.rs
+++ b/src/common/telemetry/src/logging.rs
@@ -96,7 +96,7 @@ impl Default for SlowQueryOptions {
         Self {
             enable: true,
             record_type: SlowQueriesRecordType::SystemTable,
-            threshold: Some(Duration::from_secs(5)),
+            threshold: Some(Duration::from_secs(30)),
             sample_ratio: Some(1.0),
             ttl: Some("30d".to_string()),
         }

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -1151,7 +1151,7 @@ write_interval = "30s"
 [slow_query]
 enable = true
 record_type = "system_table"
-threshold = "5s"
+threshold = "30s"
 sample_ratio = 1.0
 ttl = "30d"
 "#,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

chore: modify slow_query.threshold from 5s to 30s.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
