### PR TITLE
feat: don't hide atomic write dir

### DIFF
--- a/src/datanode/src/store.rs
+++ b/src/datanode/src/store.rs
@@ -25,6 +25,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use common_telemetry::{info, warn};
+use mito2::access_layer::ATOMIC_WRITE_DIR;
 use object_store::layers::{LruCacheLayer, RetryInterceptor, RetryLayer};
 use object_store::services::Fs;
 use object_store::util::{join_dir, normalize_dir, with_instrument_layers};
@@ -168,7 +169,7 @@ async fn build_cache_layer(
     if let Some(path) = cache_path.as_ref()
         && !path.trim().is_empty()
     {
-        let atomic_temp_dir = join_dir(path, ".tmp/");
+        let atomic_temp_dir = join_dir(path, ATOMIC_WRITE_DIR);
         clean_temp_dir(&atomic_temp_dir)?;
 
         let cache_store = Fs::default()

--- a/src/datanode/src/store.rs
+++ b/src/datanode/src/store.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use common_telemetry::{info, warn};
-use mito2::access_layer::ATOMIC_WRITE_DIR;
+use mito2::access_layer::{ATOMIC_WRITE_DIR, OLD_ATOMIC_WRITE_DIR};
 use object_store::layers::{LruCacheLayer, RetryInterceptor, RetryLayer};
 use object_store::services::Fs;
 use object_store::util::{join_dir, normalize_dir, with_instrument_layers};
@@ -171,6 +171,10 @@ async fn build_cache_layer(
     {
         let atomic_temp_dir = join_dir(path, ATOMIC_WRITE_DIR);
         clean_temp_dir(&atomic_temp_dir)?;
+
+        // Compatible code. Remove this after a major release.
+        let old_atomic_temp_dir = join_dir(path, OLD_ATOMIC_WRITE_DIR);
+        clean_temp_dir(&old_atomic_temp_dir)?;
 
         let cache_store = Fs::default()
             .root(path)

--- a/src/datanode/src/store/fs.rs
+++ b/src/datanode/src/store/fs.rs
@@ -15,7 +15,7 @@
 use std::{fs, path};
 
 use common_telemetry::info;
-use mito2::access_layer::ATOMIC_WRITE_DIR;
+use mito2::access_layer::{ATOMIC_WRITE_DIR, OLD_ATOMIC_WRITE_DIR};
 use object_store::services::Fs;
 use object_store::util::join_dir;
 use object_store::ObjectStore;
@@ -36,6 +36,10 @@ pub async fn new_fs_object_store(
 
     let atomic_write_dir = join_dir(data_home, ATOMIC_WRITE_DIR);
     store::clean_temp_dir(&atomic_write_dir)?;
+
+    // Compatible code. Remove this after a major release.
+    let old_atomic_temp_dir = join_dir(data_home, OLD_ATOMIC_WRITE_DIR);
+    store::clean_temp_dir(&old_atomic_temp_dir)?;
 
     let builder = Fs::default()
         .root(data_home)

--- a/src/datanode/src/store/fs.rs
+++ b/src/datanode/src/store/fs.rs
@@ -15,6 +15,7 @@
 use std::{fs, path};
 
 use common_telemetry::info;
+use mito2::access_layer::ATOMIC_WRITE_DIR;
 use object_store::services::Fs;
 use object_store::util::join_dir;
 use object_store::ObjectStore;
@@ -33,7 +34,7 @@ pub async fn new_fs_object_store(
         .context(error::CreateDirSnafu { dir: data_home })?;
     info!("The file storage home is: {}", data_home);
 
-    let atomic_write_dir = join_dir(data_home, ".tmp/");
+    let atomic_write_dir = join_dir(data_home, ATOMIC_WRITE_DIR);
     store::clean_temp_dir(&atomic_write_dir)?;
 
     let builder = Fs::default()

--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -42,6 +42,8 @@ pub type AccessLayerRef = Arc<AccessLayer>;
 /// SST write results.
 pub type SstInfoArray = SmallVec<[SstInfo; 2]>;
 
+pub const ATOMIC_WRITE_DIR: &'static str = "tmp/";
+
 /// A layer to access SST files under the same directory.
 pub struct AccessLayer {
     region_dir: String,
@@ -214,7 +216,7 @@ pub struct SstWriteRequest {
 }
 
 pub(crate) async fn new_fs_cache_store(root: &str) -> Result<ObjectStore> {
-    let atomic_write_dir = join_dir(root, ".tmp/");
+    let atomic_write_dir = join_dir(root, ATOMIC_WRITE_DIR);
     clean_dir(&atomic_write_dir).await?;
 
     let builder = Fs::default().root(root).atomic_write_dir(&atomic_write_dir);

--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -42,7 +42,9 @@ pub type AccessLayerRef = Arc<AccessLayer>;
 /// SST write results.
 pub type SstInfoArray = SmallVec<[SstInfo; 2]>;
 
-pub const ATOMIC_WRITE_DIR: &'static str = "tmp/";
+pub const ATOMIC_WRITE_DIR: &str = "tmp/";
+/// For compatibility. Remove this after a major version release.
+pub const OLD_ATOMIC_WRITE_DIR: &str = "tmp/";
 
 /// A layer to access SST files under the same directory.
 pub struct AccessLayer {
@@ -218,6 +220,10 @@ pub struct SstWriteRequest {
 pub(crate) async fn new_fs_cache_store(root: &str) -> Result<ObjectStore> {
     let atomic_write_dir = join_dir(root, ATOMIC_WRITE_DIR);
     clean_dir(&atomic_write_dir).await?;
+
+    // Compatible code. Remove this after a major release.
+    let old_atomic_temp_dir = join_dir(root, OLD_ATOMIC_WRITE_DIR);
+    clean_dir(&old_atomic_temp_dir).await?;
 
     let builder = Fs::default().root(root).atomic_write_dir(&atomic_write_dir);
     let store = ObjectStore::new(builder).context(OpenDalSnafu)?.finish();

--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -44,7 +44,7 @@ pub type SstInfoArray = SmallVec<[SstInfo; 2]>;
 
 pub const ATOMIC_WRITE_DIR: &str = "tmp/";
 /// For compatibility. Remove this after a major version release.
-pub const OLD_ATOMIC_WRITE_DIR: &str = "tmp/";
+pub const OLD_ATOMIC_WRITE_DIR: &str = ".tmp/";
 
 /// A layer to access SST files under the same directory.
 pub struct AccessLayer {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Change the atomic write dir from `.tmp` to `tmp`. Sometimes, a hidden dir may cause confusion. This is not a breaking change since this directory is "temporary"

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
