### PR TITLE
fix: clean files under the atomic write dir on failure

### DIFF
--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -252,7 +252,7 @@ impl TempFileCleaner {
     ) {
         // We don't know the actual suffix of the file under atomic dir, so we have
         // to list the dir. The cost should be acceptable as there won't be to many files.
-        let Ok(entries) = local_store.list(ATOMIC_FS_PATH).await.inspect_err(|e| {
+        let Ok(entries) = local_store.list(ATOMIC_WRITE_DIR).await.inspect_err(|e| {
             if e.kind() != ErrorKind::NotFound {
                 common_telemetry::error!(e; "Failed to list tmp files for {:?}", names_to_remove)
             }

--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use object_store::services::Fs;
-use object_store::util::{join_dir, join_path, with_instrument_layers};
+use object_store::util::{join_dir, with_instrument_layers};
 use object_store::ObjectStore;
 use smallvec::SmallVec;
 use snafu::ResultExt;
@@ -263,18 +263,6 @@ impl WriteCachePathProvider {
             region_id,
             file_cache,
         }
-    }
-
-    /// Returns the index file path in the atomic dir.
-    pub(crate) fn build_atomic_index_file_path(&self, file_id: FileId) -> String {
-        let puffin_key = IndexKey::new(self.region_id, file_id, FileType::Puffin);
-        join_path(ATOMIC_FS_PATH, &puffin_key.to_string())
-    }
-
-    /// Returns the sst file path in the atomic dir.
-    pub(crate) fn build_atomic_sst_file_path(&self, file_id: FileId) -> String {
-        let parquet_file_key = IndexKey::new(self.region_id, file_id, FileType::Parquet);
-        join_path(ATOMIC_FS_PATH, &parquet_file_key.to_string())
     }
 }
 

--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -16,14 +16,14 @@ use std::sync::Arc;
 
 use object_store::services::Fs;
 use object_store::util::{join_dir, with_instrument_layers};
-use object_store::ObjectStore;
+use object_store::{ErrorKind, ObjectStore};
 use smallvec::SmallVec;
 use snafu::ResultExt;
 use store_api::metadata::RegionMetadataRef;
 use store_api::storage::{RegionId, SequenceNumber};
 
 use crate::cache::file_cache::{FileCacheRef, FileType, IndexKey};
-use crate::cache::write_cache::{clean_atomic_dir_files, SstUploadRequest};
+use crate::cache::write_cache::SstUploadRequest;
 use crate::cache::CacheManagerRef;
 use crate::config::{BloomFilterConfig, FulltextIndexConfig, InvertedIndexConfig};
 use crate::error::{CleanDirSnafu, DeleteIndexSnafu, DeleteSstSnafu, OpenDalSnafu, Result};
@@ -163,28 +163,21 @@ impl AccessLayer {
                 fulltext_index_config: request.fulltext_index_config,
                 bloom_filter_index_config: request.bloom_filter_index_config,
             };
+            // We disable write cache on file system but we still use atomic write.
+            // TODO(yingwen): If we support other non-fs stores without the write cache, then
+            // we may have find a way to check whether we need the cleaner.
+            let cleaner = TempFileCleaner::new(region_id, self.object_store.clone());
             let mut writer = ParquetWriter::new_with_object_store(
                 self.object_store.clone(),
                 request.metadata,
                 indexer_builder,
                 path_provider,
             )
-            .await;
-            match writer
+            .await
+            .with_file_cleaner(cleaner);
+            writer
                 .write_all(request.source, request.max_sequence, write_opts)
-                .await
-            {
-                Ok(info) => info,
-                Err(e) => {
-                    let file_id = writer.current_file();
-                    let sst_key = IndexKey::new(region_id, file_id, FileType::Parquet).to_string();
-                    let index_key = IndexKey::new(region_id, file_id, FileType::Puffin).to_string();
-
-                    clean_atomic_dir_files(&self.object_store, &[&sst_key, &index_key]).await;
-
-                    return Err(e);
-                }
-            }
+                .await?
         };
 
         // Put parquet metadata to cache manager.
@@ -226,6 +219,77 @@ pub struct SstWriteRequest {
     pub inverted_index_config: InvertedIndexConfig,
     pub fulltext_index_config: FulltextIndexConfig,
     pub bloom_filter_index_config: BloomFilterConfig,
+}
+
+/// Cleaner to remove temp files on the atomic write dir.
+pub(crate) struct TempFileCleaner {
+    region_id: RegionId,
+    object_store: ObjectStore,
+}
+
+impl TempFileCleaner {
+    /// Constructs the cleaner for the region and store.
+    pub(crate) fn new(region_id: RegionId, object_store: ObjectStore) -> Self {
+        Self {
+            region_id,
+            object_store,
+        }
+    }
+
+    /// Removes the SST and index file from the local atomic dir by the file id.
+    pub(crate) async fn clean_by_file_id(&self, file_id: FileId) {
+        let sst_key = IndexKey::new(self.region_id, file_id, FileType::Parquet).to_string();
+        let index_key = IndexKey::new(self.region_id, file_id, FileType::Puffin).to_string();
+
+        Self::clean_atomic_dir_files(&self.object_store, &[&sst_key, &index_key]).await;
+    }
+
+    /// Removes the files from the local atomic dir by their names.
+    pub(crate) async fn clean_atomic_dir_files(
+        local_store: &ObjectStore,
+        names_to_remove: &[&str],
+    ) {
+        // We don't know the actual suffix of the file under atomic dir, so we have
+        // to list the dir. The cost should be acceptable as there won't be to many files.
+        let Ok(entries) = local_store.list(ATOMIC_FS_PATH).await.inspect_err(|e| {
+            if e.kind() != ErrorKind::NotFound {
+                common_telemetry::error!(e; "Failed to list tmp files for {:?}", names_to_remove)
+            }
+        }) else {
+            return;
+        };
+
+        // In our case, we can ensure the file id is unique so it is safe to remove all files
+        // with the same file id under the atomic write dir.
+        let actual_files: Vec<_> = entries
+            .into_iter()
+            .filter_map(|entry| {
+                if entry.metadata().is_dir() {
+                    return None;
+                }
+
+                // Remove name that matches files_to_remove.
+                let should_remove = names_to_remove
+                    .iter()
+                    .any(|file| entry.name().starts_with(file));
+                if should_remove {
+                    Some(entry.path().to_string())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        common_telemetry::warn!(
+            "Clean files {:?} under atomic write dir for {:?}",
+            actual_files,
+            names_to_remove
+        );
+
+        if let Err(e) = local_store.delete_iter(actual_files).await {
+            common_telemetry::error!(e; "Failed to delete tmp file for {:?}", names_to_remove);
+        }
+    }
 }
 
 pub(crate) async fn new_fs_cache_store(root: &str) -> Result<ObjectStore> {

--- a/src/mito2/src/cache/file_cache.rs
+++ b/src/mito2/src/cache/file_cache.rs
@@ -14,6 +14,7 @@
 
 //! A cache for files.
 
+use std::fmt;
 use std::ops::Range;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -339,6 +340,18 @@ impl IndexKey {
     }
 }
 
+impl fmt::Display for IndexKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}.{}.{}",
+            self.region_id.as_u64(),
+            self.file_id,
+            self.file_type.as_str()
+        )
+    }
+}
+
 /// Type of the file.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FileType {
@@ -380,15 +393,7 @@ pub(crate) struct IndexValue {
 ///
 /// The file name format is `{region_id}.{file_id}.{file_type}`
 fn cache_file_path(cache_file_dir: &str, key: IndexKey) -> String {
-    join_path(
-        cache_file_dir,
-        &format!(
-            "{}.{}.{}",
-            key.region_id.as_u64(),
-            key.file_id,
-            key.file_type.as_str()
-        ),
-    )
+    join_path(cache_file_dir, &key.to_string())
 }
 
 /// Parse index key from the file name.

--- a/src/mito2/src/cache/write_cache.rs
+++ b/src/mito2/src/cache/write_cache.rs
@@ -373,7 +373,7 @@ impl WriteCache {
         Ok(())
     }
 
-    /// Removes the file from the local atomic dir.
+    /// Removes the files from the local atomic dir by their names.
     async fn clean_atomic_dir_files(local_store: &ObjectStore, names_to_remove: &[&str]) {
         // We don't know the actual suffix of the file under atomic dir, so we have
         // to list the dir. The cost should be acceptable as there won't be to many files.

--- a/src/mito2/src/cache/write_cache.rs
+++ b/src/mito2/src/cache/write_cache.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 use common_base::readable_size::ReadableSize;
 use common_telemetry::{debug, info};
 use futures::AsyncWriteExt;
-use object_store::ObjectStore;
+use object_store::{ErrorKind, ObjectStore};
 use snafu::ResultExt;
 use store_api::storage::RegionId;
 
@@ -377,9 +377,11 @@ impl WriteCache {
     async fn clean_atomic_dir_files(local_store: &ObjectStore, names_to_remove: &[&str]) {
         // We don't know the actual suffix of the file under atomic dir, so we have
         // to list the dir. The cost should be acceptable as there won't be to many files.
-        let Ok(entries) = local_store.list(ATOMIC_FS_PATH).await.inspect_err(
-            |e| common_telemetry::error!(e; "Failed to list tmp files for {:?}", names_to_remove),
-        ) else {
+        let Ok(entries) = local_store.list(ATOMIC_FS_PATH).await.inspect_err(|e| {
+            if e.kind() != ErrorKind::NotFound {
+                common_telemetry::error!(e; "Failed to list tmp files for {:?}", names_to_remove)
+            }
+        }) else {
             return;
         };
 

--- a/src/mito2/src/cache/write_cache.rs
+++ b/src/mito2/src/cache/write_cache.rs
@@ -432,7 +432,7 @@ mod tests {
     use common_test_util::temp_dir::create_temp_dir;
 
     use super::*;
-    use crate::access_layer::{OperationType, ATOMIC_FS_PATH};
+    use crate::access_layer::{OperationType, ATOMIC_WRITE_DIR};
     use crate::cache::test_util::new_fs_store;
     use crate::cache::{CacheManager, CacheStrategy};
     use crate::error::InvalidBatchSnafu;
@@ -664,7 +664,7 @@ mod tests {
             .write_and_upload_sst(write_request, upload_request, &write_opts)
             .await
             .unwrap_err();
-        let atomic_write_dir = write_cache_dir.path().join(ATOMIC_FS_PATH);
+        let atomic_write_dir = write_cache_dir.path().join(ATOMIC_WRITE_DIR);
         let mut entries = tokio::fs::read_dir(&atomic_write_dir).await.unwrap();
         let mut has_files = false;
         while let Some(entry) = entries.next_entry().await.unwrap() {

--- a/src/mito2/src/sst/parquet/writer.rs
+++ b/src/mito2/src/sst/parquet/writer.rs
@@ -135,6 +135,11 @@ where
         }
     }
 
+    /// Returns current file to write.
+    pub(crate) fn current_file(&self) -> FileId {
+        self.current_file
+    }
+
     async fn get_or_create_indexer(&mut self) -> &mut Indexer {
         match self.current_indexer {
             None => {

--- a/src/mito2/src/sst/parquet/writer.rs
+++ b/src/mito2/src/sst/parquet/writer.rs
@@ -36,7 +36,7 @@ use store_api::storage::SequenceNumber;
 use tokio::io::AsyncWrite;
 use tokio_util::compat::{Compat, FuturesAsyncWriteCompatExt};
 
-use crate::access_layer::{FilePathProvider, SstInfoArray};
+use crate::access_layer::{FilePathProvider, SstInfoArray, TempFileCleaner};
 use crate::error::{InvalidMetadataSnafu, OpenDalSnafu, Result, WriteParquetSnafu};
 use crate::read::{Batch, Source};
 use crate::sst::file::FileId;
@@ -61,6 +61,8 @@ pub struct ParquetWriter<F: WriterFactory, I: IndexerBuilder, P: FilePathProvide
     /// Current active indexer.
     current_indexer: Option<Indexer>,
     bytes_written: Arc<AtomicUsize>,
+    /// Cleaner to remove temp files on failure.
+    file_cleaner: Option<TempFileCleaner>,
 }
 
 pub trait WriterFactory {
@@ -105,6 +107,11 @@ where
         )
         .await
     }
+
+    pub(crate) fn with_file_cleaner(mut self, cleaner: TempFileCleaner) -> Self {
+        self.file_cleaner = Some(cleaner);
+        self
+    }
 }
 
 impl<F, I, P> ParquetWriter<F, I, P>
@@ -132,12 +139,8 @@ where
             indexer_builder,
             current_indexer: Some(indexer),
             bytes_written: Arc::new(AtomicUsize::new(0)),
+            file_cleaner: None,
         }
-    }
-
-    /// Returns current file to write.
-    pub(crate) fn current_file(&self) -> FileId {
-        self.current_file
     }
 
     async fn get_or_create_indexer(&mut self) -> &mut Indexer {
@@ -157,6 +160,25 @@ where
     ///
     /// Returns the [SstInfo] if the SST is written.
     pub async fn write_all(
+        &mut self,
+        source: Source,
+        override_sequence: Option<SequenceNumber>, // override the `sequence` field from `Source`
+        opts: &WriteOptions,
+    ) -> Result<SstInfoArray> {
+        let res = self
+            .write_all_without_cleaning(source, override_sequence, opts)
+            .await;
+        if res.is_err() {
+            // Clean tmp files explicitly on failure.
+            let file_id = self.current_file;
+            if let Some(cleaner) = &self.file_cleaner {
+                cleaner.clean_by_file_id(file_id).await;
+            }
+        }
+        res
+    }
+
+    async fn write_all_without_cleaning(
         &mut self,
         mut source: Source,
         override_sequence: Option<SequenceNumber>, // override the `sequence` field from `Source`

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -659,6 +659,27 @@ impl TestEnv {
         Arc::new(write_cache)
     }
 
+    /// Creates a write cache from a path.
+    pub async fn create_write_cache_from_path(
+        &self,
+        path: &str,
+        capacity: ReadableSize,
+    ) -> WriteCacheRef {
+        let index_aux_path = self.data_home.path().join("index_aux");
+        let puffin_mgr = PuffinManagerFactory::new(&index_aux_path, 4096, None, None)
+            .await
+            .unwrap();
+        let intm_mgr = IntermediateManager::init_fs(index_aux_path.to_str().unwrap())
+            .await
+            .unwrap();
+
+        let write_cache = WriteCache::new_fs(path, capacity, None, puffin_mgr, intm_mgr)
+            .await
+            .unwrap();
+
+        Arc::new(write_cache)
+    }
+
     pub fn get_schema_metadata_manager(&self) -> SchemaMetadataManagerRef {
         self.schema_metadata_manager.clone()
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/pull/6109

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

The tmp files under the atomic write dir may leak if we can't close the parquet/puffin writer.

There are several challenges to fix this:
- Once we construct the parquet/puffin writer, we move out the opendal writer, so we can't use the opendal writer to abort the tmp file.
- The tmp file has a unique suffix under the atomic write dir that we can't know in advance.
- The `abort()` method of the opendal writer is not designed for this purpose.

This PR scans the tmp files under the atomic dir and deletes the files by matching the file names. Because the file id is an unique uuid, so it is safe to do it outside of the opendal writer.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
