### PR TITLE
ci: fix release job dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -444,7 +444,7 @@ jobs:
   bump-doc-version:
     name: Bump doc version
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
-    needs: [publish-github-release]
+    needs: [allocate-runners, publish-github-release]
     runs-on: ubuntu-latest
     # Permission reference: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
     permissions:
@@ -466,8 +466,8 @@ jobs:
 
   bump-website-version:
     name: Bump website version
-    if: ${{ github.event_name == 'push' }}
-    needs: [publish-github-release]
+    if: ${{ github.ref_type == 'tag' && !contains(github.ref_name, 'nightly') && github.event_name != 'schedule' }}
+    needs: [allocate-runners, publish-github-release]
     runs-on: ubuntu-latest
     # Permission reference: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
     permissions:
@@ -490,7 +490,7 @@ jobs:
   bump-helm-charts-version:
     name: Bump helm charts version
     if: ${{ github.ref_type == 'tag' && !contains(github.ref_name, 'nightly') && github.event_name != 'schedule' }}
-    needs: [publish-github-release]
+    needs: [allocate-runners, publish-github-release]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -511,7 +511,7 @@ jobs:
   bump-homebrew-greptime-version:
     name: Bump homebrew greptime version
     if: ${{ github.ref_type == 'tag' && !contains(github.ref_name, 'nightly') && github.event_name != 'schedule' }}
-    needs: [publish-github-release]
+    needs: [allocate-runners, publish-github-release]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The last step of release job is broken due to previous change. This patch fixes it by adding allocate-runners in `needs` so we can access its output.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
