### PR TITLE
chore: remove etcd from acknowledgement as not recommended

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,4 +215,3 @@ Special thanks to all contributors! See [AUTHORS.md](https://github.com/Greptime
 - [Apache Parquet™](https://parquet.apache.org/) (file storage)
 - [Apache Arrow DataFusion™](https://arrow.apache.org/datafusion/) (query engine)
 - [Apache OpenDAL™](https://opendal.apache.org/) (data access abstraction)
-- [etcd](https://etcd.io/) (meta service)


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


etcd as a kv backend service is neither suitable nor recommended in GreptimeDB's use case. For replacement: https://docs.greptime.com/faq-and-others/faq/#will-metasrv-support-storage-backends-like-mysql-or-postgresql

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
