### PR TITLE
chore: revert initial capacity for TimeSeriesMemtable

### DIFF
--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -824,7 +824,10 @@ impl ValueBuilder {
                 } else {
                     let mut mutable_vector =
                         if let ConcreteDataType::String(_) = &self.field_types[idx] {
-                            FieldBuilder::String(StringBuilder::with_capacity(256, 4096))
+                            FieldBuilder::String(StringBuilder::with_capacity(
+                                num_rows.max(INITIAL_BUILDER_CAPACITY),
+                                0,
+                            ))
                         } else {
                             FieldBuilder::Other(
                                 self.field_types[idx]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

 ### Update `time_series.rs` to Improve StringBuilder Capacity Handling

 - **File Modified**: `src/mito2/src/memtable/time_series.rs`
 - **Key Change**: Adjusted the `StringBuilder` capacity initialization in the `ValueBuilder` implementation to use `num_rows.max(INITIAL_BUILDER_CAPACITY)` for more efficient memory allocation.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
