### PR TITLE
chore: support `[<schema>.]<pipeline_name>` for cross reference pipeline

### DIFF
--- a/src/frontend/src/instance/log_handler.rs
+++ b/src/frontend/src/instance/log_handler.rs
@@ -21,7 +21,7 @@ use client::Output;
 use common_error::ext::BoxedError;
 use datatypes::timestamp::TimestampNanosecond;
 use pipeline::pipeline_operator::PipelineOperator;
-use pipeline::{Pipeline, PipelineInfo, PipelineVersion};
+use pipeline::{Pipeline, PipelineName, PipelineVersion};
 use servers::error::{
     AuthSnafu, Error as ServerError, ExecuteGrpcRequestSnafu, InFlightWriteBytesExceededSnafu,
     PipelineSnafu, Result as ServerResult,
@@ -70,7 +70,7 @@ impl PipelineHandler for Instance {
         content_type: &str,
         pipeline: &str,
         query_ctx: QueryContextRef,
-    ) -> ServerResult<PipelineInfo> {
+    ) -> ServerResult<PipelineName> {
         self.pipeline_operator
             .insert_pipeline(name, content_type, pipeline, query_ctx)
             .await

--- a/src/frontend/src/instance/log_handler.rs
+++ b/src/frontend/src/instance/log_handler.rs
@@ -21,7 +21,7 @@ use client::Output;
 use common_error::ext::BoxedError;
 use datatypes::timestamp::TimestampNanosecond;
 use pipeline::pipeline_operator::PipelineOperator;
-use pipeline::{Pipeline, PipelineName, PipelineVersion};
+use pipeline::{Pipeline, PipelineName};
 use servers::error::{
     AuthSnafu, Error as ServerError, ExecuteGrpcRequestSnafu, InFlightWriteBytesExceededSnafu,
     PipelineSnafu, Result as ServerResult,
@@ -54,12 +54,11 @@ impl PipelineHandler for Instance {
 
     async fn get_pipeline(
         &self,
-        name: &str,
-        version: PipelineVersion,
+        pipeline_name: &PipelineName,
         query_ctx: QueryContextRef,
     ) -> ServerResult<Arc<Pipeline>> {
         self.pipeline_operator
-            .get_pipeline(query_ctx, name, version)
+            .get_pipeline(query_ctx, pipeline_name)
             .await
             .context(PipelineSnafu)
     }
@@ -79,12 +78,11 @@ impl PipelineHandler for Instance {
 
     async fn delete_pipeline(
         &self,
-        name: &str,
-        version: PipelineVersion,
+        pipeline_name: &PipelineName,
         ctx: QueryContextRef,
     ) -> ServerResult<Option<()>> {
         self.pipeline_operator
-            .delete_pipeline(name, version, ctx)
+            .delete_pipeline(pipeline_name, ctx)
             .await
             .context(PipelineSnafu)
     }
@@ -107,12 +105,11 @@ impl PipelineHandler for Instance {
 
     async fn get_pipeline_str(
         &self,
-        name: &str,
-        version: PipelineVersion,
+        pipeline_name: &PipelineName,
         query_ctx: QueryContextRef,
     ) -> ServerResult<(String, TimestampNanosecond)> {
         self.pipeline_operator
-            .get_pipeline_str(name, version, query_ctx)
+            .get_pipeline_str(pipeline_name, query_ctx)
             .await
             .context(PipelineSnafu)
     }

--- a/src/pipeline/src/error.rs
+++ b/src/pipeline/src/error.rs
@@ -634,6 +634,21 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display("Invalid pipeline name: {}", reason))]
+    InvalidPipelineName {
+        reason: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Pipeline schema should be the same in pipeline name and db name, pipeline name's: {}, db's: {}", p_schema, schema))]
+    PipelineSchemaDiffer {
+        p_schema: String,
+        schema: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Failed to insert pipeline to pipelines table"))]
     InsertPipeline {
         #[snafu(source)]
@@ -749,7 +764,9 @@ impl ErrorExt for Error {
             CollectRecords { source, .. } => source.status_code(),
             PipelineNotFound { .. }
             | InvalidPipelineVersion { .. }
-            | InvalidCustomTimeIndex { .. } => StatusCode::InvalidArguments,
+            | InvalidCustomTimeIndex { .. }
+            | InvalidPipelineName { .. }
+            | PipelineSchemaDiffer { .. } => StatusCode::InvalidArguments,
             BuildDfLogicalPlan { .. } => StatusCode::Internal,
             ExecuteInternalStatement { source, .. } => source.status_code(),
             DataFrame { source, .. } => source.status_code(),

--- a/src/pipeline/src/lib.rs
+++ b/src/pipeline/src/lib.rs
@@ -30,6 +30,6 @@ pub use etl::{
 };
 pub use manager::{
     pipeline_operator, table, util, IdentityTimeIndex, PipelineContext, PipelineDefinition,
-    PipelineInfo, PipelineRef, PipelineTableRef, PipelineVersion, PipelineWay, SelectInfo,
+    PipelineName, PipelineRef, PipelineTableRef, PipelineVersion, PipelineWay, SelectInfo,
     GREPTIME_INTERNAL_IDENTITY_PIPELINE_NAME, GREPTIME_INTERNAL_TRACE_PIPELINE_V1_NAME,
 };

--- a/src/pipeline/src/manager.rs
+++ b/src/pipeline/src/manager.rs
@@ -40,8 +40,23 @@ pub mod util;
 /// When it used in cache key, it will be converted to i64 meaning the number of nanoseconds since the epoch.
 pub type PipelineVersion = Option<TimestampNanosecond>;
 
-/// Pipeline info. A tuple of timestamp and pipeline reference.
-pub type PipelineInfo = (Timestamp, PipelineRef);
+/// Unique reference to pipeline name.
+/// Note the version can be None while query, which means the latest version of the pipeline.
+pub struct PipelineName {
+    pub name: String,
+    pub schema: String,
+    pub version: PipelineVersion,
+}
+
+impl PipelineName {
+    pub fn new(name: String, schema: String, version: PipelineVersion) -> Self {
+        Self {
+            name,
+            schema,
+            version,
+        }
+    }
+}
 
 pub type PipelineTableRef = Arc<PipelineTable>;
 pub type PipelineRef = Arc<Pipeline>;

--- a/src/pipeline/src/manager/pipeline_operator.rs
+++ b/src/pipeline/src/manager/pipeline_operator.rs
@@ -30,7 +30,7 @@ use snafu::{OptionExt, ResultExt};
 use table::TableRef;
 
 use crate::error::{CatalogSnafu, CreateTableSnafu, PipelineTableNotFoundSnafu, Result};
-use crate::manager::{PipelineInfo, PipelineTableRef, PipelineVersion};
+use crate::manager::{PipelineName, PipelineTableRef, PipelineVersion};
 use crate::metrics::{
     METRIC_PIPELINE_CREATE_HISTOGRAM, METRIC_PIPELINE_DELETE_HISTOGRAM,
     METRIC_PIPELINE_RETRIEVE_HISTOGRAM,
@@ -229,7 +229,7 @@ impl PipelineOperator {
         content_type: &str,
         pipeline: &str,
         query_ctx: QueryContextRef,
-    ) -> Result<PipelineInfo> {
+    ) -> Result<PipelineName> {
         self.create_pipeline_table_if_not_exists(query_ctx.clone())
             .await?;
 

--- a/src/servers/src/elasticsearch.rs
+++ b/src/servers/src/elasticsearch.rs
@@ -161,23 +161,25 @@ async fn do_handle_bulk_api(
     };
     let log_num = requests.len();
 
-    let pipeline = match PipelineDefinition::from_name(&pipeline_name, None, None) {
-        Ok(pipeline) => pipeline,
-        Err(e) => {
-            // should be unreachable
-            error!(e; "Failed to ingest logs");
-            return (
-                status_code_to_http_status(&e.status_code()),
-                elasticsearch_headers(),
-                axum::Json(write_bulk_response(
-                    start.elapsed().as_millis() as i64,
-                    0,
-                    e.status_code() as u32,
-                    e.to_string().as_str(),
-                )),
-            );
-        }
-    };
+    let pipeline =
+        match PipelineDefinition::from_name(&pipeline_name, None, query_ctx.current_schema(), None)
+        {
+            Ok(pipeline) => pipeline,
+            Err(e) => {
+                // should be unreachable
+                error!(e; "Failed to ingest logs");
+                return (
+                    status_code_to_http_status(&e.status_code()),
+                    elasticsearch_headers(),
+                    axum::Json(write_bulk_response(
+                        start.elapsed().as_millis() as i64,
+                        0,
+                        e.status_code() as u32,
+                        e.to_string().as_str(),
+                    )),
+                );
+            }
+        };
     if let Err(e) = ingest_logs_inner(
         log_state.log_handler,
         pipeline,

--- a/src/servers/src/http/event.rs
+++ b/src/servers/src/http/event.rs
@@ -163,9 +163,11 @@ pub async fn query_pipeline(
         &pipeline_name,
         query_params.version.as_deref(),
         query_ctx.current_schema(),
-        true,
     )
     .context(PipelineSnafu)?;
+    p_name
+        .check_schema(&query_ctx.current_schema())
+        .context(PipelineSnafu)?;
 
     let (pipeline, pipeline_version) = handler.get_pipeline_str(&p_name, query_ctx.clone()).await?;
     p_name.set_timestamp(Some(pipeline_version));
@@ -192,9 +194,12 @@ pub async fn add_pipeline(
 
     // parse and check pipeline name
     let input_p_name =
-        PipelineName::from_name_and_version(&pipeline_name, None, query_ctx.current_schema(), true)
+        PipelineName::from_name_and_version(&pipeline_name, None, query_ctx.current_schema())
             .context(PipelineSnafu)?;
     input_p_name.check_internal_name().context(PipelineSnafu)?;
+    input_p_name
+        .check_schema(&query_ctx.current_schema())
+        .context(PipelineSnafu)?;
 
     ensure!(
         !payload.is_empty(),
@@ -246,9 +251,11 @@ pub async fn delete_pipeline(
         &pipeline_name,
         Some(&version_str),
         query_ctx.current_schema(),
-        true,
     )
     .context(PipelineSnafu)?;
+    p_name
+        .check_schema(&query_ctx.current_schema())
+        .context(PipelineSnafu)?;
 
     query_ctx.set_channel(Channel::Http);
     let query_ctx = Arc::new(query_ctx);
@@ -515,7 +522,6 @@ pub async fn pipeline_dryrun(
                         &check_pipeline_name_exists(params.pipeline_name)?,
                         params.pipeline_version.as_deref(),
                         query_ctx.current_schema(),
-                        false,
                     )
                     .context(PipelineSnafu)?;
 
@@ -559,7 +565,6 @@ pub async fn pipeline_dryrun(
                 &check_pipeline_name_exists(query_params.pipeline_name)?,
                 query_params.version.as_deref(),
                 query_ctx.current_schema(),
-                false,
             )
             .context(PipelineSnafu)?;
 

--- a/src/servers/src/http/otlp.rs
+++ b/src/servers/src/http/otlp.rs
@@ -94,6 +94,7 @@ pub async fn traces(
     let pipeline = PipelineWay::from_name_and_default(
         pipeline_info.pipeline_name.as_deref(),
         pipeline_info.pipeline_version.as_deref(),
+        query_ctx.current_schema(),
         None,
     )
     .context(PipelineSnafu)?;
@@ -144,6 +145,7 @@ pub async fn logs(
     let pipeline = PipelineWay::from_name_and_default(
         pipeline_info.pipeline_name.as_deref(),
         pipeline_info.pipeline_version.as_deref(),
+        query_ctx.current_schema(),
         Some(PipelineWay::OtlpLogDirect(Box::new(select_info))),
     )
     .context(PipelineSnafu)?;

--- a/src/servers/src/http/prom_store.rs
+++ b/src/servers/src/http/prom_store.rs
@@ -28,7 +28,6 @@ use common_telemetry::tracing;
 use hyper::HeaderMap;
 use lazy_static::lazy_static;
 use object_pool::Pool;
-use pipeline::util::to_pipeline_version;
 use pipeline::PipelineDefinition;
 use prost::Message;
 use serde::{Deserialize, Serialize};
@@ -120,8 +119,8 @@ pub async fn remote_write(
     if let Some(pipeline_name) = pipeline_info.pipeline_name {
         let pipeline_def = PipelineDefinition::from_name(
             &pipeline_name,
-            to_pipeline_version(pipeline_info.pipeline_version.as_deref())
-                .context(PipelineSnafu)?,
+            pipeline_info.pipeline_version.as_deref(),
+            query_ctx.current_schema(),
             None,
         )
         .context(PipelineSnafu)?;

--- a/src/servers/src/http/result/greptime_manage_resp.rs
+++ b/src/servers/src/http/result/greptime_manage_resp.rs
@@ -16,6 +16,7 @@ use axum::response::IntoResponse;
 use axum::Json;
 use http::header::CONTENT_TYPE;
 use http::HeaderValue;
+use pipeline::PipelineName;
 use serde::{Deserialize, Serialize};
 
 use crate::http::header::{GREPTIME_DB_HEADER_EXECUTION_TIME, GREPTIME_DB_HEADER_FORMAT};
@@ -30,17 +31,19 @@ pub struct GreptimedbManageResponse {
 }
 
 impl GreptimedbManageResponse {
-    pub fn from_pipeline(
-        name: String,
-        version: String,
+    pub fn from_pipeline_name(
+        p_name: PipelineName,
         execution_time_ms: u64,
         pipeline: Option<String>,
     ) -> Self {
         GreptimedbManageResponse {
             manage_result: ManageResult::Pipelines {
                 pipelines: vec![PipelineOutput {
-                    name,
-                    version,
+                    name: p_name.name,
+                    version: p_name
+                        .version
+                        .map(|v| v.0.to_timezone_aware_string(None))
+                        .unwrap_or_default(),
                     pipeline,
                 }],
             },

--- a/src/servers/src/query_handler.rs
+++ b/src/servers/src/query_handler.rs
@@ -40,7 +40,7 @@ use log_query::LogQuery;
 use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
 use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
 use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
-use pipeline::{GreptimePipelineParams, Pipeline, PipelineInfo, PipelineVersion, PipelineWay};
+use pipeline::{GreptimePipelineParams, Pipeline, PipelineName, PipelineVersion, PipelineWay};
 use serde_json::Value;
 use session::context::{QueryContext, QueryContextRef};
 
@@ -149,7 +149,7 @@ pub trait PipelineHandler {
         content_type: &str,
         pipeline: &str,
         query_ctx: QueryContextRef,
-    ) -> Result<PipelineInfo>;
+    ) -> Result<PipelineName>;
 
     async fn delete_pipeline(
         &self,

--- a/src/servers/src/query_handler.rs
+++ b/src/servers/src/query_handler.rs
@@ -40,7 +40,7 @@ use log_query::LogQuery;
 use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
 use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
 use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
-use pipeline::{GreptimePipelineParams, Pipeline, PipelineName, PipelineVersion, PipelineWay};
+use pipeline::{GreptimePipelineParams, Pipeline, PipelineName, PipelineWay};
 use serde_json::Value;
 use session::context::{QueryContext, QueryContextRef};
 
@@ -138,8 +138,7 @@ pub trait PipelineHandler {
 
     async fn get_pipeline(
         &self,
-        name: &str,
-        version: PipelineVersion,
+        pipeline_name: &PipelineName,
         query_ctx: QueryContextRef,
     ) -> Result<Arc<Pipeline>>;
 
@@ -153,8 +152,7 @@ pub trait PipelineHandler {
 
     async fn delete_pipeline(
         &self,
-        name: &str,
-        version: PipelineVersion,
+        pipeline_name: &PipelineName,
         query_ctx: QueryContextRef,
     ) -> Result<Option<()>>;
 
@@ -170,8 +168,7 @@ pub trait PipelineHandler {
     /// Get a original pipeline by name.
     async fn get_pipeline_str(
         &self,
-        name: &str,
-        version: PipelineVersion,
+        pipeline_name: &PipelineName,
         query_ctx: QueryContextRef,
     ) -> Result<(String, TimestampNanosecond)>;
 }

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -1428,7 +1428,7 @@ transform:
         res.json::<serde_json::Value>().await["error"]
             .as_str()
             .unwrap(),
-        "Invalid request parameter: pipeline_name cannot start with greptime_"
+        "Invalid pipeline name: custom pipeline name cannot start with 'greptime_'"
     );
 
     let res = client


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Introduce `PipelineName` to hold and reference the pipeline using name, schema, and version.
Now we can use `schema.pipeline_name` to refer to pipelines from other databases while ingesting logs.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
