### PR TITLE
chore: shared pipeline under same catalog with compatibility

### DIFF
--- a/src/pipeline/src/error.rs
+++ b/src/pipeline/src/error.rs
@@ -660,6 +660,14 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display(
+        "The return value's length of the record batch does not match, see debug log for details"
+    ))]
+    RecordBatchLenNotMatch {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Failed to collect record batch"))]
     CollectRecords {
         #[snafu(implicit)]
@@ -761,7 +769,7 @@ impl ErrorExt for Error {
             | InvalidPipelineVersion { .. }
             | InvalidCustomTimeIndex { .. } => StatusCode::InvalidArguments,
             MultiPipelineWithDiffSchema { .. } => StatusCode::IllegalState,
-            BuildDfLogicalPlan { .. } => StatusCode::Internal,
+            BuildDfLogicalPlan { .. } | RecordBatchLenNotMatch { .. } => StatusCode::Internal,
             ExecuteInternalStatement { source, .. } => source.status_code(),
             DataFrame { source, .. } => source.status_code(),
             Catalog { source, .. } => source.status_code(),

--- a/src/pipeline/src/error.rs
+++ b/src/pipeline/src/error.rs
@@ -650,6 +650,16 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display(
+        "Multiple pipelines with different schemas found, but none under current schema. Please replicate one of them under current schema or delete until only one schema left. schemas: {}",
+        schemas
+    ))]
+    MultiPipelineWithDiffSchema {
+        schemas: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Failed to collect record batch"))]
     CollectRecords {
         #[snafu(implicit)]
@@ -750,6 +760,7 @@ impl ErrorExt for Error {
             PipelineNotFound { .. }
             | InvalidPipelineVersion { .. }
             | InvalidCustomTimeIndex { .. } => StatusCode::InvalidArguments,
+            MultiPipelineWithDiffSchema { .. } => StatusCode::IllegalState,
             BuildDfLogicalPlan { .. } => StatusCode::Internal,
             ExecuteInternalStatement { source, .. } => source.status_code(),
             DataFrame { source, .. } => source.status_code(),

--- a/src/pipeline/src/error.rs
+++ b/src/pipeline/src/error.rs
@@ -651,7 +651,7 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Multiple pipelines with different schemas found, but none under current schema. Please replicate one of them under current schema or delete until only one schema left. schemas: {}",
+        "Multiple pipelines with different schemas found, but none under current schema. Please replicate one of them or delete until only one schema left. schemas: {}",
         schemas
     ))]
     MultiPipelineWithDiffSchema {

--- a/src/pipeline/src/manager.rs
+++ b/src/pipeline/src/manager.rs
@@ -29,6 +29,7 @@ use crate::etl::value::time::{MS_RESOLUTION, NS_RESOLUTION, S_RESOLUTION, US_RES
 use crate::table::PipelineTable;
 use crate::{GreptimePipelineParams, Pipeline, Value};
 
+mod pipeline_cache;
 pub mod pipeline_operator;
 pub mod table;
 pub mod util;

--- a/src/pipeline/src/manager/pipeline_cache.rs
+++ b/src/pipeline/src/manager/pipeline_cache.rs
@@ -1,0 +1,186 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use common_catalog::consts::DEFAULT_SCHEMA_NAME;
+use datatypes::timestamp::TimestampNanosecond;
+use moka::sync::Cache;
+
+use crate::error::{MultiPipelineWithDiffSchemaSnafu, Result};
+use crate::etl::Pipeline;
+use crate::manager::PipelineVersion;
+use crate::util::{generate_pipeline_cache_key, generate_pipeline_cache_key_suffix};
+
+/// Pipeline table cache size.
+const PIPELINES_CACHE_SIZE: u64 = 10000;
+/// Pipeline table cache time to live.
+const PIPELINES_CACHE_TTL: Duration = Duration::from_secs(10);
+
+/// Pipeline cache is located on a separate file on purpose,
+/// to encapsulate inner cache. Only public methods are exposed.
+pub(crate) struct PipelineCache {
+    pipelines: Cache<String, Arc<Pipeline>>,
+    original_pipelines: Cache<String, (String, TimestampNanosecond)>,
+}
+
+impl PipelineCache {
+    pub(crate) fn new() -> Self {
+        Self {
+            pipelines: Cache::builder()
+                .max_capacity(PIPELINES_CACHE_SIZE)
+                .time_to_live(PIPELINES_CACHE_TTL)
+                .build(),
+            original_pipelines: Cache::builder()
+                .max_capacity(PIPELINES_CACHE_SIZE)
+                .time_to_live(PIPELINES_CACHE_TTL)
+                .build(),
+        }
+    }
+
+    pub(crate) fn insert_pipeline_cache(
+        &self,
+        schema: &str,
+        name: &str,
+        version: PipelineVersion,
+        pipeline: Arc<Pipeline>,
+        with_latest: bool,
+    ) {
+        insert_cache_generic(
+            &self.pipelines,
+            schema,
+            name,
+            version,
+            pipeline,
+            with_latest,
+        );
+    }
+
+    pub(crate) fn insert_pipeline_str_cache(
+        &self,
+        schema: &str,
+        name: &str,
+        version: PipelineVersion,
+        pipeline: (String, TimestampNanosecond),
+        with_latest: bool,
+    ) {
+        insert_cache_generic(
+            &self.original_pipelines,
+            schema,
+            name,
+            version,
+            pipeline,
+            with_latest,
+        );
+    }
+
+    pub(crate) fn get_pipeline_cache(
+        &self,
+        schema: &str,
+        name: &str,
+        version: PipelineVersion,
+    ) -> Result<Option<Arc<Pipeline>>> {
+        get_cache_generic(&self.pipelines, schema, name, version)
+    }
+
+    pub(crate) fn get_pipeline_str_cache(
+        &self,
+        schema: &str,
+        name: &str,
+        version: PipelineVersion,
+    ) -> Result<Option<(String, TimestampNanosecond)>> {
+        get_cache_generic(&self.original_pipelines, schema, name, version)
+    }
+
+    // remove cache with version and latest in all schemas
+    pub(crate) fn remove_cache(&self, name: &str, version: PipelineVersion) {
+        let version_suffix = generate_pipeline_cache_key_suffix(name, version);
+        let latest_suffix = generate_pipeline_cache_key_suffix(name, None);
+
+        let ks = self
+            .pipelines
+            .iter()
+            .filter_map(|(k, _)| {
+                if k.ends_with(&version_suffix) || k.ends_with(&latest_suffix) {
+                    Some(k.clone())
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        for k in ks {
+            let k = k.as_str();
+            self.pipelines.remove(k);
+            self.original_pipelines.remove(k);
+        }
+    }
+}
+
+fn insert_cache_generic<T: Clone + Send + Sync + 'static>(
+    cache: &Cache<String, T>,
+    schema: &str,
+    name: &str,
+    version: PipelineVersion,
+    value: T,
+    with_latest: bool,
+) {
+    let k = generate_pipeline_cache_key(schema, name, version);
+    cache.insert(k, value.clone());
+    if with_latest {
+        let k = generate_pipeline_cache_key(schema, name, None);
+        cache.insert(k, value);
+    }
+}
+
+fn get_cache_generic<T: Clone + Send + Sync + 'static>(
+    cache: &Cache<String, T>,
+    schema: &str,
+    name: &str,
+    version: PipelineVersion,
+) -> Result<Option<T>> {
+    // lets try public first
+    let k = generate_pipeline_cache_key(DEFAULT_SCHEMA_NAME, name, version);
+    if let Some(value) = cache.get(&k) {
+        return Ok(Some(value));
+    }
+    // use input schema
+    if schema != DEFAULT_SCHEMA_NAME {
+        let k = generate_pipeline_cache_key(schema, name, version);
+        if let Some(value) = cache.get(&k) {
+            return Ok(Some(value));
+        }
+    }
+
+    // try all schemas
+    let suffix_key = generate_pipeline_cache_key_suffix(name, version);
+    let mut ks = cache
+        .iter()
+        .filter(|e| e.0.ends_with(&suffix_key))
+        .collect::<Vec<_>>();
+
+    match ks.len() {
+        0 => Ok(None),
+        1 => Ok(Some(ks.remove(0).1)),
+        _ => MultiPipelineWithDiffSchemaSnafu {
+            schemas: ks
+                .iter()
+                .map(|(k, _)| k.split_once('/').unwrap().0)
+                .collect::<Vec<_>>()
+                .join(","),
+        }
+        .fail()?,
+    }
+}

--- a/src/pipeline/src/manager/pipeline_cache.rs
+++ b/src/pipeline/src/manager/pipeline_cache.rs
@@ -175,7 +175,7 @@ fn get_cache_generic<T: Clone + Send + Sync + 'static>(
         _ => MultiPipelineWithDiffSchemaSnafu {
             schemas: ks
                 .iter()
-                .map(|(k, _)| k.split_once('/').unwrap().0)
+                .filter_map(|(k, _)| k.split_once('/').map(|k| k.0))
                 .collect::<Vec<_>>()
                 .join(","),
         }

--- a/src/pipeline/src/manager/pipeline_operator.rs
+++ b/src/pipeline/src/manager/pipeline_operator.rs
@@ -259,7 +259,7 @@ impl PipelineOperator {
         let timer = Instant::now();
         self.get_pipeline_table_from_cache(query_ctx.current_catalog())
             .context(PipelineTableNotFoundSnafu)?
-            .delete_pipeline(&query_ctx.current_schema(), name, version)
+            .delete_pipeline(name, version)
             .inspect(|re| {
                 METRIC_PIPELINE_DELETE_HISTOGRAM
                     .with_label_values(&[&re.is_ok().to_string()])

--- a/src/pipeline/src/manager/pipeline_operator.rs
+++ b/src/pipeline/src/manager/pipeline_operator.rs
@@ -236,7 +236,7 @@ impl PipelineOperator {
         let timer = Instant::now();
         self.get_pipeline_table_from_cache(query_ctx.current_catalog())
             .context(PipelineTableNotFoundSnafu)?
-            .insert_and_compile(&query_ctx.current_schema(), name, content_type, pipeline)
+            .insert_and_compile(name, content_type, pipeline)
             .inspect(|re| {
                 METRIC_PIPELINE_CREATE_HISTOGRAM
                     .with_label_values(&[&re.is_ok().to_string()])

--- a/src/pipeline/src/manager/table.rs
+++ b/src/pipeline/src/manager/table.rs
@@ -313,10 +313,7 @@ impl PipelineTable {
         // throw an error
         let (pipeline_content, found_schema, version) =
             pipeline.context(MultiPipelineWithDiffSchemaSnafu {
-                schemas: pipeline_vec
-                    .iter()
-                    .map(|v| v.1.split_once('/').unwrap().0)
-                    .join(","),
+                schemas: pipeline_vec.iter().map(|v| v.1.clone()).join(","),
             })?;
 
         let v = *version;

--- a/src/pipeline/src/manager/util.rs
+++ b/src/pipeline/src/manager/util.rs
@@ -19,7 +19,6 @@ use datatypes::timestamp::TimestampNanosecond;
 use crate::error::{InvalidPipelineVersionSnafu, Result};
 use crate::table::{
     PIPELINE_TABLE_CREATED_AT_COLUMN_NAME, PIPELINE_TABLE_PIPELINE_NAME_COLUMN_NAME,
-    PIPELINE_TABLE_PIPELINE_SCHEMA_COLUMN_NAME,
 };
 use crate::PipelineVersion;
 
@@ -34,15 +33,8 @@ pub fn to_pipeline_version(version_str: Option<&str>) -> Result<PipelineVersion>
     }
 }
 
-pub(crate) fn prepare_dataframe_conditions(
-    schema: &str,
-    name: &str,
-    version: PipelineVersion,
-) -> Expr {
-    let mut conditions = vec![
-        col(PIPELINE_TABLE_PIPELINE_NAME_COLUMN_NAME).eq(lit(name)),
-        col(PIPELINE_TABLE_PIPELINE_SCHEMA_COLUMN_NAME).eq(lit(schema)),
-    ];
+pub(crate) fn prepare_dataframe_conditions(name: &str, version: PipelineVersion) -> Expr {
+    let mut conditions = vec![col(PIPELINE_TABLE_PIPELINE_NAME_COLUMN_NAME).eq(lit(name))];
 
     if let Some(v) = version {
         conditions
@@ -60,6 +52,13 @@ pub(crate) fn generate_pipeline_cache_key(
     match version {
         Some(version) => format!("{}/{}/{}", schema, name, i64::from(version)),
         None => format!("{}/{}/latest", schema, name),
+    }
+}
+
+pub(crate) fn generate_pipeline_cache_key_suffix(name: &str, version: PipelineVersion) -> String {
+    match version {
+        Some(version) => format!("/{}/{}", name, i64::from(version)),
+        None => format!("/{}/latest", name),
     }
 }
 

--- a/src/servers/src/http/event.rs
+++ b/src/servers/src/http/event.rs
@@ -177,7 +177,7 @@ pub async fn query_pipeline(
         pipeline_name,
         query_params
             .version
-            .unwrap_or(pipeline_version.0.to_iso8601_string()),
+            .unwrap_or(pipeline_version.0.to_timezone_aware_string(None)),
         start.elapsed().as_millis() as u64,
         Some(pipeline),
     ))


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

~~As mentioned [here](https://github.com/GreptimeTeam/greptimedb/pull/6141#issuecomment-2894561441), remove the schema in the pipeline information and cache key, so that all databases under the same catalog can access the shared pipelines.~~

~~**Note**: This is a breaking change. If the pipeline is already in use, check if pipelines have the same names but different schemas before upgrading.~~

Allow shared pipeline under the same catalog.
1. The newly created pipeline would be labeled under an empty string schema. **Note**, this would include the 'update' process, which means only the empty string schema is getting 'updated' or created.
2. The query of the pipeline would try to be as compatible as possible

**cache**
1. Try to find the pipeline labeled empty string schema, return if found.
2. Try to find the pipeline with the current schema, return if found.
3. Search all pipelines with the name and version suffix: if exactly one is found, return; else, throw an error.

**database**
1. Find all pipelines with the given name and version
2. If only one result is found, use the result
3. Check if there's an empty string schema result, use it if found
4. Check if there's a result labeled with the current schema, use it if found
5. Throw an error for multiple schema pipelines are found, but none of them is under the empty string schema and the current schema

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
