### PR TITLE
chore: metasrv starting not blocking

### DIFF
--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -160,8 +160,8 @@ impl MetasrvInstance {
     }
 
     pub async fn shutdown(&self) -> Result<()> {
-        if let Some(mut rx) = self.serve_state.lock().await.take(){
-            if let Ok(Err(err)) = rx.try_recv(){
+        if let Some(mut rx) = self.serve_state.lock().await.take() {
+            if let Ok(Err(err)) = rx.try_recv() {
                 common_telemetry::error!(err; "Metasrv start failed")
             }
         }

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -188,6 +188,9 @@ impl MetasrvInstance {
     pub fn get_inner(&self) -> &Metasrv {
         &self.metasrv
     }
+    pub fn bind_addr(&self) -> &Option<SocketAddr> {
+        &self.bind_addr
+    }
 }
 
 pub async fn bootstrap_metasrv_with_router(
@@ -217,7 +220,7 @@ pub async fn bootstrap_metasrv_with_router(
             .await
             .inspect_err(|err| common_telemetry::error!(err;"Failed to start metasrv"))
             .context(error::StartGrpcSnafu);
-        serve_state_tx.send(result).unwrap();
+        let _ = serve_state_tx.send(result);
     });
 
     Ok(real_bind_addr)


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

make metasrv `start` not blocking, so that shutdown can properly happen since `start` use `&mut self` and blocking everything after it

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
