### PR TITLE
fix: bulk insert case sensitive

### DIFF
--- a/src/partition/src/expr.rs
+++ b/src/partition/src/expr.rs
@@ -61,7 +61,7 @@ impl From<Value> for Operand {
 impl Operand {
     pub fn try_as_logical_expr(&self) -> error::Result<Expr> {
         match self {
-            Self::Column(c) => Ok(datafusion_expr::col(c)),
+            Self::Column(c) => Ok(datafusion_expr::col(format!(r#""{}""#, c))),
             Self::Value(v) => {
                 let scalar_value = match v {
                     Value::Boolean(v) => ScalarValue::Boolean(Some(*v)),

--- a/src/servers/src/grpc/greptime_handler.rs
+++ b/src/servers/src/grpc/greptime_handler.rs
@@ -167,7 +167,8 @@ impl GreptimeRequestHandler {
                 let timer = metrics::GRPC_BULK_INSERT_ELAPSED.start_timer();
                 let result = handler
                     .put_record_batch(&table_name, &mut table_id, &mut decoder, data)
-                    .await;
+                    .await
+                    .inspect_err(|e| error!(e; "Failed to handle flight record batches"));
                 timer.observe_duration();
                 let result = result
                     .map(|x| DoPutResponse::new(request_id, x))

--- a/tests-integration/src/grpc/flight.rs
+++ b/tests-integration/src/grpc/flight.rs
@@ -59,10 +59,10 @@ mod test {
         let record_batches = create_record_batches(1);
         test_put_record_batches(&client, record_batches).await;
 
-        let sql = "select ts, a, b from foo order by ts";
+        let sql = "select ts, a, `B` from foo order by ts";
         let expected = "\
 +-------------------------+----+----+
-| ts                      | a  | b  |
+| ts                      | a  | B  |
 +-------------------------+----+----+
 | 1970-01-01T00:00:00.001 | -1 | s1 |
 | 1970-01-01T00:00:00.002 | -2 | s2 |
@@ -116,10 +116,10 @@ mod test {
         let record_batches = create_record_batches(1);
         test_put_record_batches(&client, record_batches).await;
 
-        let sql = "select ts, a, b from foo order by ts";
+        let sql = "select ts, a, `B` from foo order by ts";
         let expected = "\
 +-------------------------+----+----+
-| ts                      | a  | b  |
+| ts                      | a  | B  |
 +-------------------------+----+----+
 | 1970-01-01T00:00:00.001 | -1 | s1 |
 | 1970-01-01T00:00:00.002 | -2 | s2 |
@@ -192,7 +192,7 @@ mod test {
             )
             .with_time_index(true),
             ColumnSchema::new("a", ConcreteDataType::int32_datatype(), false),
-            ColumnSchema::new("b", ConcreteDataType::string_datatype(), true),
+            ColumnSchema::new("B", ConcreteDataType::string_datatype(), true),
         ]));
 
         let mut record_batches = Vec::with_capacity(3);
@@ -250,7 +250,7 @@ mod test {
                         ..Default::default()
                     },
                     ColumnDef {
-                        name: "b".to_string(),
+                        name: "B".to_string(),
                         data_type: ColumnDataType::String as i32,
                         semantic_type: SemanticType::Field as i32,
                         is_nullable: true,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Fix the problem when bulk ingesting record batch with uppercase columns, GreptimeDB will silently return an "internal error" to client.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
