### PR TITLE
refactor: replace FlightMessage with arrow `RecordBatch` and `Schema`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1889,6 +1889,7 @@ dependencies = [
  "common-query",
  "common-recordbatch",
  "common-telemetry",
+ "datatypes",
  "enum_dispatch",
  "futures",
  "futures-util",

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -25,6 +25,7 @@ common-meta.workspace = true
 common-query.workspace = true
 common-recordbatch.workspace = true
 common-telemetry.workspace = true
+datatypes.workspace = true
 enum_dispatch = "0.3"
 futures.workspace = true
 futures-util.workspace = true

--- a/src/client/src/error.rs
+++ b/src/client/src/error.rs
@@ -117,6 +117,13 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+
+    #[snafu(display("Failed to convert Schema"))]
+    ConvertSchema {
+        #[snafu(implicit)]
+        location: Location,
+        source: datatypes::error::Error,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -137,6 +144,7 @@ impl ErrorExt for Error {
             | Error::CreateTlsChannel { source, .. } => source.status_code(),
             Error::IllegalGrpcClientState { .. } => StatusCode::Unexpected,
             Error::InvalidTonicMetadataValue { .. } => StatusCode::InvalidArguments,
+            Error::ConvertSchema { source, .. } => source.status_code(),
         }
     }
 

--- a/src/common/grpc/src/error.rs
+++ b/src/common/grpc/src/error.rs
@@ -60,13 +60,6 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Failed to create RecordBatch"))]
-    CreateRecordBatch {
-        #[snafu(implicit)]
-        location: Location,
-        source: common_recordbatch::error::Error,
-    },
-
     #[snafu(display("Failed to convert Arrow type: {}", from))]
     Conversion {
         from: String,
@@ -87,13 +80,6 @@ pub enum Error {
         reason: String,
         #[snafu(implicit)]
         location: Location,
-    },
-
-    #[snafu(display("Failed to convert Arrow Schema"))]
-    ConvertArrowSchema {
-        #[snafu(implicit)]
-        location: Location,
-        source: datatypes::error::Error,
     },
 
     #[snafu(display("Not supported: {}", feat))]
@@ -130,8 +116,6 @@ impl ErrorExt for Error {
             | Error::DecodeFlightData { .. }
             | Error::SerdeJson { .. } => StatusCode::Internal,
 
-            Error::CreateRecordBatch { source, .. } => source.status_code(),
-            Error::ConvertArrowSchema { source, .. } => source.status_code(),
             Error::Arrow { .. } => StatusCode::Internal,
         }
     }

--- a/src/common/grpc/src/flight.rs
+++ b/src/common/grpc/src/flight.rs
@@ -21,28 +21,24 @@ use api::v1::{AffectedRows, FlightMetadata, Metrics};
 use arrow_flight::utils::flight_data_to_arrow_batch;
 use arrow_flight::{FlightData, SchemaAsIpc};
 use common_base::bytes::Bytes;
-use common_recordbatch::{DfRecordBatch, RecordBatch, RecordBatches};
+use common_recordbatch::DfRecordBatch;
 use datatypes::arrow;
 use datatypes::arrow::buffer::Buffer;
-use datatypes::arrow::datatypes::Schema as ArrowSchema;
+use datatypes::arrow::datatypes::{Schema as ArrowSchema, SchemaRef};
 use datatypes::arrow::error::ArrowError;
 use datatypes::arrow::ipc::{convert, reader, root_as_message, writer, MessageHeader};
-use datatypes::schema::{Schema, SchemaRef};
 use flatbuffers::FlatBufferBuilder;
 use prost::bytes::Bytes as ProstBytes;
 use prost::Message;
 use snafu::{OptionExt, ResultExt};
 
 use crate::error;
-use crate::error::{
-    ConvertArrowSchemaSnafu, CreateRecordBatchSnafu, DecodeFlightDataSnafu, InvalidFlightDataSnafu,
-    Result,
-};
+use crate::error::{DecodeFlightDataSnafu, InvalidFlightDataSnafu, Result};
 
 #[derive(Debug, Clone)]
 pub enum FlightMessage {
     Schema(SchemaRef),
-    Recordbatch(RecordBatch),
+    RecordBatch(DfRecordBatch),
     AffectedRows(usize),
     Metrics(String),
 }
@@ -70,14 +66,12 @@ impl Default for FlightEncoder {
 impl FlightEncoder {
     pub fn encode(&mut self, flight_message: FlightMessage) -> FlightData {
         match flight_message {
-            FlightMessage::Schema(schema) => {
-                SchemaAsIpc::new(schema.arrow_schema(), &self.write_options).into()
-            }
-            FlightMessage::Recordbatch(recordbatch) => {
+            FlightMessage::Schema(schema) => SchemaAsIpc::new(&schema, &self.write_options).into(),
+            FlightMessage::RecordBatch(record_batch) => {
                 let (encoded_dictionaries, encoded_batch) = self
                     .data_gen
                     .encoded_batch(
-                        recordbatch.df_record_batch(),
+                        &record_batch,
                         &mut self.dictionary_tracker,
                         &self.write_options,
                     )
@@ -135,9 +129,8 @@ impl FlightDecoder {
     pub fn try_from_schema_bytes(schema_bytes: &bytes::Bytes) -> Result<Self> {
         let arrow_schema = convert::try_schema_from_flatbuffer_bytes(&schema_bytes[..])
             .context(error::ArrowSnafu)?;
-        let schema = Arc::new(Schema::try_from(arrow_schema).context(ConvertArrowSchemaSnafu)?);
         Ok(Self {
-            schema: Some(schema),
+            schema: Some(Arc::new(arrow_schema)),
             schema_bytes: Some(schema_bytes.clone()),
         })
     }
@@ -154,7 +147,6 @@ impl FlightDecoder {
                 reason: "Should have decoded schema first!",
             })?
             .clone();
-        let arrow_schema = schema.arrow_schema().clone();
         let message = root_as_message(&data_header[..])
             .map_err(|err| {
                 ArrowError::ParseError(format!("Unable to get root as message: {err:?}"))
@@ -171,7 +163,7 @@ impl FlightDecoder {
                 reader::read_record_batch(
                     &Buffer::from(data_body.as_ref()),
                     batch,
-                    arrow_schema,
+                    schema,
                     &HashMap::new(),
                     None,
                     &message.version(),
@@ -206,36 +198,29 @@ impl FlightDecoder {
                 .fail()
             }
             MessageHeader::Schema => {
-                let arrow_schema = ArrowSchema::try_from(flight_data).map_err(|e| {
+                let arrow_schema = Arc::new(ArrowSchema::try_from(flight_data).map_err(|e| {
                     InvalidFlightDataSnafu {
                         reason: e.to_string(),
                     }
                     .build()
-                })?;
-                let schema =
-                    Arc::new(Schema::try_from(arrow_schema).context(ConvertArrowSchemaSnafu)?);
-
-                self.schema = Some(schema.clone());
+                })?);
+                self.schema = Some(arrow_schema.clone());
                 self.schema_bytes = Some(flight_data.data_header.clone());
-                Ok(FlightMessage::Schema(schema))
+                Ok(FlightMessage::Schema(arrow_schema))
             }
             MessageHeader::RecordBatch => {
                 let schema = self.schema.clone().context(InvalidFlightDataSnafu {
                     reason: "Should have decoded schema first!",
                 })?;
-                let arrow_schema = schema.arrow_schema().clone();
-
                 let arrow_batch =
-                    flight_data_to_arrow_batch(flight_data, arrow_schema, &HashMap::new())
+                    flight_data_to_arrow_batch(flight_data, schema.clone(), &HashMap::new())
                         .map_err(|e| {
                             InvalidFlightDataSnafu {
                                 reason: e.to_string(),
                             }
                             .build()
                         })?;
-                let recordbatch = RecordBatch::try_from_df_record_batch(schema, arrow_batch)
-                    .context(CreateRecordBatchSnafu)?;
-                Ok(FlightMessage::Recordbatch(recordbatch))
+                Ok(FlightMessage::RecordBatch(arrow_batch))
             }
             other => {
                 let name = other.variant_name().unwrap_or("UNKNOWN");
@@ -256,14 +241,16 @@ impl FlightDecoder {
     }
 }
 
-pub fn flight_messages_to_recordbatches(messages: Vec<FlightMessage>) -> Result<RecordBatches> {
+pub fn flight_messages_to_recordbatches(
+    messages: Vec<FlightMessage>,
+) -> Result<Vec<DfRecordBatch>> {
     if messages.is_empty() {
-        Ok(RecordBatches::empty())
+        Ok(vec![])
     } else {
         let mut recordbatches = Vec::with_capacity(messages.len() - 1);
 
-        let schema = match &messages[0] {
-            FlightMessage::Schema(schema) => schema.clone(),
+        match &messages[0] {
+            FlightMessage::Schema(_schema) => {}
             _ => {
                 return InvalidFlightDataSnafu {
                     reason: "First Flight Message must be schema!",
@@ -274,7 +261,7 @@ pub fn flight_messages_to_recordbatches(messages: Vec<FlightMessage>) -> Result<
 
         for message in messages.into_iter().skip(1) {
             match message {
-                FlightMessage::Recordbatch(recordbatch) => recordbatches.push(recordbatch),
+                FlightMessage::RecordBatch(recordbatch) => recordbatches.push(recordbatch),
                 _ => {
                     return InvalidFlightDataSnafu {
                         reason: "Expect the following Flight Messages are all Recordbatches!",
@@ -284,7 +271,7 @@ pub fn flight_messages_to_recordbatches(messages: Vec<FlightMessage>) -> Result<
             }
         }
 
-        RecordBatches::try_new(schema, recordbatches).context(CreateRecordBatchSnafu)
+        Ok(recordbatches)
     }
 }
 
@@ -305,38 +292,33 @@ fn build_none_flight_msg() -> Bytes {
 #[cfg(test)]
 mod test {
     use arrow_flight::utils::batches_to_flight_data;
-    use datatypes::arrow::datatypes::{DataType, Field};
-    use datatypes::prelude::ConcreteDataType;
-    use datatypes::schema::ColumnSchema;
-    use datatypes::vectors::Int32Vector;
+    use datatypes::arrow::array::Int32Array;
+    use datatypes::arrow::datatypes::{DataType, Field, Schema};
 
     use super::*;
     use crate::Error;
 
     #[test]
     fn test_try_decode() {
-        let arrow_schema = ArrowSchema::new(vec![Field::new("n", DataType::Int32, true)]);
-        let schema = Arc::new(Schema::try_from(arrow_schema.clone()).unwrap());
+        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            "n",
+            DataType::Int32,
+            true,
+        )]));
 
-        let batch1 = RecordBatch::new(
+        let batch1 = DfRecordBatch::try_new(
             schema.clone(),
-            vec![Arc::new(Int32Vector::from(vec![Some(1), None, Some(3)])) as _],
+            vec![Arc::new(Int32Array::from(vec![Some(1), None, Some(3)])) as _],
         )
         .unwrap();
-        let batch2 = RecordBatch::new(
+        let batch2 = DfRecordBatch::try_new(
             schema.clone(),
-            vec![Arc::new(Int32Vector::from(vec![None, Some(5)])) as _],
+            vec![Arc::new(Int32Array::from(vec![None, Some(5)])) as _],
         )
         .unwrap();
 
-        let flight_data = batches_to_flight_data(
-            &arrow_schema,
-            vec![
-                batch1.clone().into_df_record_batch(),
-                batch2.clone().into_df_record_batch(),
-            ],
-        )
-        .unwrap();
+        let flight_data =
+            batches_to_flight_data(&schema, vec![batch1.clone(), batch2.clone()]).unwrap();
         assert_eq!(flight_data.len(), 3);
         let [d1, d2, d3] = flight_data.as_slice() else {
             unreachable!()
@@ -362,15 +344,15 @@ mod test {
         let _ = decoder.schema.as_ref().unwrap();
 
         let message = decoder.try_decode(d2).unwrap();
-        assert!(matches!(message, FlightMessage::Recordbatch(_)));
-        let FlightMessage::Recordbatch(actual_batch) = message else {
+        assert!(matches!(message, FlightMessage::RecordBatch(_)));
+        let FlightMessage::RecordBatch(actual_batch) = message else {
             unreachable!()
         };
         assert_eq!(actual_batch, batch1);
 
         let message = decoder.try_decode(d3).unwrap();
-        assert!(matches!(message, FlightMessage::Recordbatch(_)));
-        let FlightMessage::Recordbatch(actual_batch) = message else {
+        assert!(matches!(message, FlightMessage::RecordBatch(_)));
+        let FlightMessage::RecordBatch(actual_batch) = message else {
             unreachable!()
         };
         assert_eq!(actual_batch, batch2);
@@ -378,27 +360,22 @@ mod test {
 
     #[test]
     fn test_flight_messages_to_recordbatches() {
-        let schema = Arc::new(Schema::new(vec![ColumnSchema::new(
-            "m",
-            ConcreteDataType::int32_datatype(),
-            true,
-        )]));
-        let batch1 = RecordBatch::new(
+        let schema = Arc::new(Schema::new(vec![Field::new("m", DataType::Int32, true)]));
+        let batch1 = DfRecordBatch::try_new(
             schema.clone(),
-            vec![Arc::new(Int32Vector::from(vec![Some(2), None, Some(4)])) as _],
+            vec![Arc::new(Int32Array::from(vec![Some(2), None, Some(4)])) as _],
         )
         .unwrap();
-        let batch2 = RecordBatch::new(
+        let batch2 = DfRecordBatch::try_new(
             schema.clone(),
-            vec![Arc::new(Int32Vector::from(vec![None, Some(6)])) as _],
+            vec![Arc::new(Int32Array::from(vec![None, Some(6)])) as _],
         )
         .unwrap();
-        let recordbatches =
-            RecordBatches::try_new(schema.clone(), vec![batch1.clone(), batch2.clone()]).unwrap();
+        let recordbatches = vec![batch1.clone(), batch2.clone()];
 
         let m1 = FlightMessage::Schema(schema);
-        let m2 = FlightMessage::Recordbatch(batch1);
-        let m3 = FlightMessage::Recordbatch(batch2);
+        let m2 = FlightMessage::RecordBatch(batch1);
+        let m3 = FlightMessage::RecordBatch(batch2);
 
         let result = flight_messages_to_recordbatches(vec![m2.clone(), m1.clone(), m3.clone()]);
         assert!(matches!(result, Err(Error::InvalidFlightData { .. })));

--- a/src/common/query/src/error.rs
+++ b/src/common/query/src/error.rs
@@ -103,13 +103,6 @@ pub enum Error {
         source: common_recordbatch::error::Error,
     },
 
-    #[snafu(display("Failed to convert arrow schema"))]
-    ConvertArrowSchema {
-        #[snafu(implicit)]
-        location: Location,
-        source: DataTypeError,
-    },
-
     #[snafu(display("Failed to cast array to {:?}", typ))]
     TypeCast {
         #[snafu(source)]
@@ -244,7 +237,6 @@ impl ErrorExt for Error {
             Error::InvalidInputType { source, .. }
             | Error::IntoVector { source, .. }
             | Error::FromScalarValue { source, .. }
-            | Error::ConvertArrowSchema { source, .. }
             | Error::FromArrowArray { source, .. }
             | Error::InvalidVectorString { source, .. } => source.status_code(),
 

--- a/src/operator/src/bulk_insert.rs
+++ b/src/operator/src/bulk_insert.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use ahash::{HashMap, HashMapExt};
 use api::v1::region::{
     bulk_insert_request, region_request, ArrowIpc, BulkInsertRequest, RegionRequest,
@@ -22,9 +20,7 @@ use api::v1::region::{
 use common_base::AffectedRows;
 use common_grpc::flight::{FlightDecoder, FlightEncoder, FlightMessage};
 use common_grpc::FlightData;
-use common_recordbatch::RecordBatch;
 use common_telemetry::tracing_context::TracingContext;
-use datatypes::schema::Schema;
 use snafu::ResultExt;
 use store_api::storage::RegionId;
 use table::metadata::TableId;
@@ -48,10 +44,9 @@ impl Inserter {
         let message = decoder
             .try_decode(&data)
             .context(error::DecodeFlightDataSnafu)?;
-        let FlightMessage::Recordbatch(rb) = message else {
+        let FlightMessage::RecordBatch(record_batch) = message else {
             return Ok(0);
         };
-        let record_batch = rb.df_record_batch();
         decode_timer.observe_duration();
         metrics::BULK_REQUEST_MESSAGE_SIZE.observe(body_size as f64);
         metrics::BULK_REQUEST_ROWS
@@ -71,7 +66,7 @@ impl Inserter {
 
         // find partitions for each row in the record batch
         let region_masks = partition_rule
-            .split_record_batch(record_batch)
+            .split_record_batch(&record_batch)
             .context(error::SplitInsertSnafu)?;
         partition_timer.observe_duration();
 
@@ -134,8 +129,6 @@ impl Inserter {
             .start_timer();
 
         let mut handles = Vec::with_capacity(mask_per_datanode.len());
-        let record_batch_schema =
-            Arc::new(Schema::try_from(record_batch.schema()).context(error::ConvertSchemaSnafu)?);
 
         // raw daya header and payload bytes.
         let mut raw_data_bytes = None;
@@ -143,7 +136,6 @@ impl Inserter {
             for (region_id, mask) in masks {
                 let rb = record_batch.clone();
                 let schema_bytes = schema_bytes.clone();
-                let record_batch_schema = record_batch_schema.clone();
                 let node_manager = self.node_manager.clone();
                 let peer = peer.clone();
                 let raw_header_and_data = if mask.select_all() {
@@ -166,21 +158,18 @@ impl Inserter {
                             let filter_timer = metrics::HANDLE_BULK_INSERT_ELAPSED
                                 .with_label_values(&["filter"])
                                 .start_timer();
-                            let rb = arrow::compute::filter_record_batch(&rb, mask.array())
+                            let batch = arrow::compute::filter_record_batch(&rb, mask.array())
                                 .context(error::ComputeArrowSnafu)?;
                             filter_timer.observe_duration();
                             metrics::BULK_REQUEST_ROWS
                                 .with_label_values(&["rows_per_region"])
-                                .observe(rb.num_rows() as f64);
+                                .observe(batch.num_rows() as f64);
 
                             let encode_timer = metrics::HANDLE_BULK_INSERT_ELAPSED
                                 .with_label_values(&["encode"])
                                 .start_timer();
-                            let batch =
-                                RecordBatch::try_from_df_record_batch(record_batch_schema, rb)
-                                    .context(error::BuildRecordBatchSnafu)?;
                             let flight_data =
-                                FlightEncoder::default().encode(FlightMessage::Recordbatch(batch));
+                                FlightEncoder::default().encode(FlightMessage::RecordBatch(batch));
                             encode_timer.observe_duration();
                             (flight_data.data_header, flight_data.data_body)
                         };

--- a/src/servers/src/grpc/flight/stream.rs
+++ b/src/servers/src/grpc/flight/stream.rs
@@ -71,7 +71,7 @@ impl FlightRecordBatchStream {
                 Ok(recordbatch) => {
                     if let Err(e) = tx
                         .send(Ok(FlightMessage::RecordBatch(
-                            recordbatch.df_record_batch().clone(),
+                            recordbatch.into_df_record_batch(),
                         )))
                         .await
                     {

--- a/tests-integration/src/grpc/flight.rs
+++ b/tests-integration/src/grpc/flight.rs
@@ -136,7 +136,7 @@ mod test {
 
     async fn test_put_record_batches(client: &Database, record_batches: Vec<RecordBatch>) {
         let requests_count = record_batches.len();
-        let schema = record_batches[0].schema.clone();
+        let schema = record_batches[0].schema.arrow_schema().clone();
 
         let stream = futures::stream::once(async move {
             let mut schema_data = FlightEncoder::default().encode(FlightMessage::Schema(schema));
@@ -155,7 +155,7 @@ mod test {
                 .enumerate()
                 .map(|(i, x)| {
                     let mut encoder = FlightEncoder::default();
-                    let message = FlightMessage::Recordbatch(x);
+                    let message = FlightMessage::RecordBatch(x.into_df_record_batch());
                     let mut data = encoder.encode(message);
                     let metadata = DoPutMetadata::new((i + 1) as i64);
                     data.app_metadata = serde_json::to_vec(&metadata).unwrap().into();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR replaces the `common_recordbatch::RecordBatch` and `datatypes::schema::Schema` in `FlightMessage` with arrow version. The motivation of this refactor is that flight is highly coupled with arrow structs and we should make the layers clear.

 - **Add `datatypes` Dependency**: Updated `Cargo.lock` and `Cargo.toml` to include the `datatypes` dependency.
 - **Schema Conversion and Error Handling**:
   - Updated `src/client/src/database.rs` and `src/client/src/region.rs` to handle schema conversion using `Arc` and added error handling for schema conversion.
   - Enhanced error handling in `src/client/src/error.rs` and `src/common/grpc/src/error.rs` by adding `ConvertSchema` error and removing unused errors.
 - **FlightMessage and RecordBatch Refactoring**:
   - Refactored `FlightMessage` enum in `src/common/grpc/src/flight.rs` to use `RecordBatch` instead of `Recordbatch`.
   - Updated related functions and tests in `src/common/grpc/benches/bench_flight_decoder.rs`, `src/operator/src/bulk_insert.rs`, `src/servers/src/grpc/flight/stream.rs`, and `tests-integration/src/grpc/flight.rs` to align with the new `FlightMessage` structure.
   - 
## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
