### PR TITLE
fix(promql): handle field column projection with correct qualifier

### DIFF
--- a/tests/cases/standalone/common/promql/or_operation.result
+++ b/tests/cases/standalone/common/promql/or_operation.result
@@ -1,0 +1,64 @@
+create table http_requests (
+    ts timestamp time index,
+    job string,
+    instance string,
+    env string,
+    greptime_value double,
+    primary key (job, instance, env)
+);
+
+Affected Rows: 0
+
+insert into http_requests values 
+    (3000000, "api", "0", "production", 100),
+    (3000000, "api", "0", "production", 200),
+    (3000000, "api", "0", "canary", 300),
+    (3000000, "api", "0", "canary", 400),
+    (3000000, "app", "2", "production", 500),
+    (3000000, "app", "2", "production", 600),
+    (3000000, "app", "2", "canary", 700),
+    (3000000, "app", "2", "canary", 800);
+
+Affected Rows: 8
+
+tql eval (3000, 3000, '1s') http_requests{job="api",instance="0",env="production"} + 5;
+
++-----+----------+------------+---------------------+-----------------------------+
+| job | instance | env        | ts                  | greptime_value + Float64(5) |
++-----+----------+------------+---------------------+-----------------------------+
+| api | 0        | production | 1970-01-01T00:50:00 | 205.0                       |
++-----+----------+------------+---------------------+-----------------------------+
+
+tql eval (3000, 3000, '1s') http_requests{job="web",instance="1",env="production"} * 5;
+
+++
+++
+
+tql eval (3000, 3000, '1s') http_requests{job="web",instance="1",env="production"} * 5 or http_requests{job="api",instance="0",env="production"} + 5;
+
++---------------------+------------+-----------------------------+----------+-----+
+| ts                  | env        | greptime_value * Float64(5) | instance | job |
++---------------------+------------+-----------------------------+----------+-----+
+| 1970-01-01T00:50:00 | production | 205.0                       | 0        | api |
++---------------------+------------+-----------------------------+----------+-----+
+
+tql eval (3000, 3000, '1s') http_requests{job="api",instance="0",env="production"} + 5 or http_requests{job="web",instance="1",env="production"} * 5;
+
++---------------------+------------+-----------------------------+----------+-----+
+| ts                  | env        | greptime_value + Float64(5) | instance | job |
++---------------------+------------+-----------------------------+----------+-----+
+| 1970-01-01T00:50:00 | production | 205.0                       | 0        | api |
++---------------------+------------+-----------------------------+----------+-----+
+
+tql eval (3000, 3000, '1s') http_requests{job="web",instance="1",env="production"} * 5 or http_requests{job="web",instance="2",env="production"} * 3 or http_requests{job="api",instance="0",env="production"} + 5;
+
++---------------------+------------+-----------------------------+----------+-----+
+| ts                  | env        | greptime_value * Float64(5) | instance | job |
++---------------------+------------+-----------------------------+----------+-----+
+| 1970-01-01T00:50:00 | production | 205.0                       | 0        | api |
++---------------------+------------+-----------------------------+----------+-----+
+
+drop table http_requests;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/promql/or_operation.sql
+++ b/tests/cases/standalone/common/promql/or_operation.sql
@@ -1,0 +1,30 @@
+create table http_requests (
+    ts timestamp time index,
+    job string,
+    instance string,
+    env string,
+    greptime_value double,
+    primary key (job, instance, env)
+);
+
+insert into http_requests values 
+    (3000000, "api", "0", "production", 100),
+    (3000000, "api", "0", "production", 200),
+    (3000000, "api", "0", "canary", 300),
+    (3000000, "api", "0", "canary", 400),
+    (3000000, "app", "2", "production", 500),
+    (3000000, "app", "2", "production", 600),
+    (3000000, "app", "2", "canary", 700),
+    (3000000, "app", "2", "canary", 800);
+
+tql eval (3000, 3000, '1s') http_requests{job="api",instance="0",env="production"} + 5;
+
+tql eval (3000, 3000, '1s') http_requests{job="web",instance="1",env="production"} * 5;
+
+tql eval (3000, 3000, '1s') http_requests{job="web",instance="1",env="production"} * 5 or http_requests{job="api",instance="0",env="production"} + 5;
+
+tql eval (3000, 3000, '1s') http_requests{job="api",instance="0",env="production"} + 5 or http_requests{job="web",instance="1",env="production"} * 5;
+
+tql eval (3000, 3000, '1s') http_requests{job="web",instance="1",env="production"} * 5 or http_requests{job="web",instance="2",env="production"} * 3 or http_requests{job="api",instance="0",env="production"} + 5;
+
+drop table http_requests;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR fixes the issue with field column projection qualifiers in PromQL. When projecting field columns, we now properly find and use the correct qualifier from the schema instead of using potentially incorrect qualifiers.

The qualifiers might have been removed by previous operations:
```rust
        // alias the computation exprs to remove qualifier
        self.ctx.field_columns = result_field_columns
            .iter()
            .map(|expr| expr.schema_name().to_string())
            .collect();
        let field_columns_iter = result_field_columns
            .into_iter()
            .zip(self.ctx.field_columns.iter())
            .map(|(expr, name)| Ok(DfExpr::Alias(Alias::new(expr, None::<String>, name))));
```

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
