### PR TITLE
feat: supports @@session.time_zone for mysql

### DIFF
--- a/src/operator/src/statement.rs
+++ b/src/operator/src/statement.rs
@@ -380,10 +380,13 @@ impl StatementExecutor {
 
     fn set_variables(&self, set_var: SetVariables, query_ctx: QueryContextRef) -> Result<Output> {
         let var_name = set_var.variable.to_string().to_uppercase();
+
         match var_name.as_str() {
             "READ_PREFERENCE" => set_read_preference(set_var.value, query_ctx)?,
 
-            "TIMEZONE" | "TIME_ZONE" => set_timezone(set_var.value, query_ctx)?,
+            "@@TIME_ZONE" | "@@SESSION.TIME_ZONE" | "TIMEZONE" | "TIME_ZONE" => {
+                set_timezone(set_var.value, query_ctx)?
+            }
 
             "BYTEA_OUTPUT" => set_bytea_output(set_var.value, query_ctx)?,
 
@@ -393,7 +396,7 @@ impl StatementExecutor {
             "DATESTYLE" => set_datestyle(set_var.value, query_ctx)?,
 
             "CLIENT_ENCODING" => validate_client_encoding(set_var)?,
-            "MAX_EXECUTION_TIME" => match query_ctx.channel() {
+            "@@SESSION.MAX_EXECUTION_TIME" | "MAX_EXECUTION_TIME" => match query_ctx.channel() {
                 Channel::Mysql => set_query_timeout(set_var.value, query_ctx)?,
                 Channel::Postgres => {
                     query_ctx.set_warning(format!("Unsupported set variable {}", var_name))
@@ -431,6 +434,9 @@ impl StatementExecutor {
                 //  of connection establishment
                 //
                 if query_ctx.channel() == Channel::Postgres {
+                    query_ctx.set_warning(format!("Unsupported set variable {}", var_name));
+                } else if query_ctx.channel() == Channel::Mysql && var_name.starts_with("@@") {
+                    // Just ignore `SET @@` commands for MySQL
                     query_ctx.set_warning(format!("Unsupported set variable {}", var_name));
                 } else {
                     return NotSupportedSnafu {

--- a/src/servers/src/mysql/federated.rs
+++ b/src/servers/src/mysql/federated.rs
@@ -64,7 +64,6 @@ static OTHER_NOT_SUPPORTED_STMT: Lazy<RegexSet> = Lazy::new(|| {
         "(?i)^(SET TRANSACTION(.*))",
         "(?i)^(SET sql_mode(.*))",
         "(?i)^(SET SQL_SELECT_LIMIT(.*))",
-        "(?i)^(SET @@(.*))",
         "(?i)^(SET PROFILING(.*))",
 
         // mysqlclient.

--- a/tests-integration/tests/sql.rs
+++ b/tests-integration/tests/sql.rs
@@ -373,6 +373,19 @@ pub async fn test_mysql_timezone(store_type: StorageType) {
         "2022-11-03T11:39:57.450Z"
     );
 
+    let _ = conn
+        .execute("SET @@SESSION.TIME_ZONE = '-7:00'")
+        .await
+        .unwrap();
+    let rows2 = conn.fetch_all("select ts from demo").await.unwrap();
+    // we use Utc here for format only
+    assert_eq!(
+        rows2[0]
+            .get::<chrono::DateTime<Utc>, usize>(0)
+            .to_rfc3339_opts(SecondsFormat::Millis, true),
+        "2022-11-02T20:39:57.450Z"
+    );
+
     let _ = fe_mysql_server.shutdown().await;
     guard.remove_all().await;
 }

--- a/tests-integration/tests/sql.rs
+++ b/tests-integration/tests/sql.rs
@@ -336,6 +336,7 @@ pub async fn test_mysql_timezone(store_type: StorageType) {
         .execute("SET time_zone = 'Asia/Shanghai'")
         .await
         .unwrap();
+
     let timezone = conn.fetch_all("SELECT @@time_zone").await.unwrap();
     assert_eq!(timezone[0].get::<String, usize>(0), "Asia/Shanghai");
     let timezone = conn.fetch_all("SELECT @@system_time_zone").await.unwrap();
@@ -364,6 +365,9 @@ pub async fn test_mysql_timezone(store_type: StorageType) {
     );
 
     let _ = conn.execute("SET time_zone = '+08:00'").await.unwrap();
+    let timezone = conn.fetch_all("SELECT @@time_zone").await.unwrap();
+    assert_eq!(timezone[0].get::<String, usize>(0), "+08:00");
+
     let rows2 = conn.fetch_all("select ts from demo").await.unwrap();
     // we use Utc here for format only
     assert_eq!(
@@ -385,6 +389,8 @@ pub async fn test_mysql_timezone(store_type: StorageType) {
             .to_rfc3339_opts(SecondsFormat::Millis, true),
         "2022-11-02T20:39:57.450Z"
     );
+    let timezone = conn.fetch_all("SELECT @@time_zone").await.unwrap();
+    assert_eq!(timezone[0].get::<String, usize>(0), "-07:00");
 
     let _ = fe_mysql_server.shutdown().await;
     guard.remove_all().await;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Close #6207

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

Impl `set @@session.time_zone` for MySQL protocol.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
