### PR TITLE
feat: supports select @@session.time_zone

### DIFF
--- a/src/servers/src/mysql/federated.rs
+++ b/src/servers/src/mysql/federated.rs
@@ -183,7 +183,7 @@ fn select_variable(query: &str, query_context: QueryContextRef) -> Option<Output
 
         // get value of variables from known sources or fallback to defaults
         let value = match var_as[0] {
-            "time_zone" => query_context.timezone().to_string(),
+            "session.time_zone" | "time_zone" => query_context.timezone().to_string(),
             "system_time_zone" => system_timezone_name(),
             _ => VAR_VALUES
                 .get(var_as[0])

--- a/tests-integration/tests/sql.rs
+++ b/tests-integration/tests/sql.rs
@@ -339,6 +339,8 @@ pub async fn test_mysql_timezone(store_type: StorageType) {
 
     let timezone = conn.fetch_all("SELECT @@time_zone").await.unwrap();
     assert_eq!(timezone[0].get::<String, usize>(0), "Asia/Shanghai");
+    let timezone = conn.fetch_all("SELECT @@session.time_zone").await.unwrap();
+    assert_eq!(timezone[0].get::<String, usize>(0), "Asia/Shanghai");
     let timezone = conn.fetch_all("SELECT @@system_time_zone").await.unwrap();
     assert_eq!(timezone[0].get::<String, usize>(0), "UTC");
     let _ = conn.execute("SET time_zone = 'UTC'").await.unwrap();
@@ -367,6 +369,8 @@ pub async fn test_mysql_timezone(store_type: StorageType) {
     let _ = conn.execute("SET time_zone = '+08:00'").await.unwrap();
     let timezone = conn.fetch_all("SELECT @@time_zone").await.unwrap();
     assert_eq!(timezone[0].get::<String, usize>(0), "+08:00");
+    let timezone = conn.fetch_all("SELECT @@session.time_zone").await.unwrap();
+    assert_eq!(timezone[0].get::<String, usize>(0), "+08:00");
 
     let rows2 = conn.fetch_all("select ts from demo").await.unwrap();
     // we use Utc here for format only
@@ -390,6 +394,8 @@ pub async fn test_mysql_timezone(store_type: StorageType) {
         "2022-11-02T20:39:57.450Z"
     );
     let timezone = conn.fetch_all("SELECT @@time_zone").await.unwrap();
+    assert_eq!(timezone[0].get::<String, usize>(0), "-07:00");
+    let timezone = conn.fetch_all("SELECT @@session.time_zone").await.unwrap();
     assert_eq!(timezone[0].get::<String, usize>(0), "-07:00");
 
     let _ = fe_mysql_server.shutdown().await;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

The following PR of #6210 

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

Forgot to support `select @@session.time_zone` to query the session timezone, which is used by mysql python connector:

https://github.com/mysql/mysql-connector-python/blob/5e47983957b0ba833b9428dd542bbecba8898347/mysql-connector-python/lib/mysql/connector/abstracts.py#L1115

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
