### PR TITLE
feat(http): lossy string validation in prom remote write

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -27,7 +27,7 @@
 | `http.body_limit` | String | `64MB` | HTTP request body limit.<br/>The following units are supported: `B`, `KB`, `KiB`, `MB`, `MiB`, `GB`, `GiB`, `TB`, `TiB`, `PB`, `PiB`.<br/>Set to 0 to disable limit. |
 | `http.enable_cors` | Bool | `true` | HTTP CORS support, it's turned on by default<br/>This allows browser to access http APIs without CORS restrictions |
 | `http.cors_allowed_origins` | Array | Unset | Customize allowed origins for HTTP CORS. |
-| `http.prom_validation_mode` | String | `unchecked` | Whether to enable validation for Prometheus remote write requests.<br/>Available options:<br/>- strict: deny invalid UTF-8 strings (default).<br/>- lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).<br/>- unchecked: do not valid strings. |
+| `http.prom_validation_mode` | String | `strict` | Whether to enable validation for Prometheus remote write requests.<br/>Available options:<br/>- strict: deny invalid UTF-8 strings (default).<br/>- lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).<br/>- unchecked: do not valid strings. |
 | `grpc` | -- | -- | The gRPC server options. |
 | `grpc.bind_addr` | String | `127.0.0.1:4001` | The address to bind the gRPC server. |
 | `grpc.runtime_size` | Integer | `8` | The number of server worker threads. |
@@ -227,7 +227,7 @@
 | `http.body_limit` | String | `64MB` | HTTP request body limit.<br/>The following units are supported: `B`, `KB`, `KiB`, `MB`, `MiB`, `GB`, `GiB`, `TB`, `TiB`, `PB`, `PiB`.<br/>Set to 0 to disable limit. |
 | `http.enable_cors` | Bool | `true` | HTTP CORS support, it's turned on by default<br/>This allows browser to access http APIs without CORS restrictions |
 | `http.cors_allowed_origins` | Array | Unset | Customize allowed origins for HTTP CORS. |
-| `http.prom_validation_mode` | String | `unchecked` | Whether to enable validation for Prometheus remote write requests.<br/>Available options:<br/>- strict: deny invalid UTF-8 strings (default).<br/>- lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).<br/>- unchecked: do not valid strings. |
+| `http.prom_validation_mode` | String | `strict` | Whether to enable validation for Prometheus remote write requests.<br/>Available options:<br/>- strict: deny invalid UTF-8 strings (default).<br/>- lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).<br/>- unchecked: do not valid strings. |
 | `grpc` | -- | -- | The gRPC server options. |
 | `grpc.bind_addr` | String | `127.0.0.1:4001` | The address to bind the gRPC server. |
 | `grpc.server_addr` | String | `127.0.0.1:4001` | The address advertised to the metasrv, and used for connections from outside the host.<br/>If left empty or unset, the server will automatically use the IP address of the first network interface<br/>on the host, with the same port number as the one specified in `grpc.bind_addr`. |

--- a/config/config.md
+++ b/config/config.md
@@ -27,6 +27,7 @@
 | `http.body_limit` | String | `64MB` | HTTP request body limit.<br/>The following units are supported: `B`, `KB`, `KiB`, `MB`, `MiB`, `GB`, `GiB`, `TB`, `TiB`, `PB`, `PiB`.<br/>Set to 0 to disable limit. |
 | `http.enable_cors` | Bool | `true` | HTTP CORS support, it's turned on by default<br/>This allows browser to access http APIs without CORS restrictions |
 | `http.cors_allowed_origins` | Array | Unset | Customize allowed origins for HTTP CORS. |
+| `http.prom_validation_mode` | String | `unchecked` | Whether to enable validation for Prometheus remote write requests.<br/>Available options:<br/>- strict: deny invalid UTF-8 strings.<br/>- lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).<br/>- unchecked: do not valid strings. |
 | `grpc` | -- | -- | The gRPC server options. |
 | `grpc.bind_addr` | String | `127.0.0.1:4001` | The address to bind the gRPC server. |
 | `grpc.runtime_size` | Integer | `8` | The number of server worker threads. |
@@ -226,6 +227,7 @@
 | `http.body_limit` | String | `64MB` | HTTP request body limit.<br/>The following units are supported: `B`, `KB`, `KiB`, `MB`, `MiB`, `GB`, `GiB`, `TB`, `TiB`, `PB`, `PiB`.<br/>Set to 0 to disable limit. |
 | `http.enable_cors` | Bool | `true` | HTTP CORS support, it's turned on by default<br/>This allows browser to access http APIs without CORS restrictions |
 | `http.cors_allowed_origins` | Array | Unset | Customize allowed origins for HTTP CORS. |
+| `http.prom_validation_mode` | String | `unchecked` | Whether to enable validation for Prometheus remote write requests.<br/>Available options:<br/>- strict: deny invalid UTF-8 strings.<br/>- lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).<br/>- unchecked: do not valid strings. |
 | `grpc` | -- | -- | The gRPC server options. |
 | `grpc.bind_addr` | String | `127.0.0.1:4001` | The address to bind the gRPC server. |
 | `grpc.server_addr` | String | `127.0.0.1:4001` | The address advertised to the metasrv, and used for connections from outside the host.<br/>If left empty or unset, the server will automatically use the IP address of the first network interface<br/>on the host, with the same port number as the one specified in `grpc.bind_addr`. |

--- a/config/config.md
+++ b/config/config.md
@@ -27,7 +27,7 @@
 | `http.body_limit` | String | `64MB` | HTTP request body limit.<br/>The following units are supported: `B`, `KB`, `KiB`, `MB`, `MiB`, `GB`, `GiB`, `TB`, `TiB`, `PB`, `PiB`.<br/>Set to 0 to disable limit. |
 | `http.enable_cors` | Bool | `true` | HTTP CORS support, it's turned on by default<br/>This allows browser to access http APIs without CORS restrictions |
 | `http.cors_allowed_origins` | Array | Unset | Customize allowed origins for HTTP CORS. |
-| `http.prom_validation_mode` | String | `unchecked` | Whether to enable validation for Prometheus remote write requests.<br/>Available options:<br/>- strict: deny invalid UTF-8 strings.<br/>- lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).<br/>- unchecked: do not valid strings. |
+| `http.prom_validation_mode` | String | `unchecked` | Whether to enable validation for Prometheus remote write requests.<br/>Available options:<br/>- strict: deny invalid UTF-8 strings (default).<br/>- lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).<br/>- unchecked: do not valid strings. |
 | `grpc` | -- | -- | The gRPC server options. |
 | `grpc.bind_addr` | String | `127.0.0.1:4001` | The address to bind the gRPC server. |
 | `grpc.runtime_size` | Integer | `8` | The number of server worker threads. |
@@ -227,7 +227,7 @@
 | `http.body_limit` | String | `64MB` | HTTP request body limit.<br/>The following units are supported: `B`, `KB`, `KiB`, `MB`, `MiB`, `GB`, `GiB`, `TB`, `TiB`, `PB`, `PiB`.<br/>Set to 0 to disable limit. |
 | `http.enable_cors` | Bool | `true` | HTTP CORS support, it's turned on by default<br/>This allows browser to access http APIs without CORS restrictions |
 | `http.cors_allowed_origins` | Array | Unset | Customize allowed origins for HTTP CORS. |
-| `http.prom_validation_mode` | String | `unchecked` | Whether to enable validation for Prometheus remote write requests.<br/>Available options:<br/>- strict: deny invalid UTF-8 strings.<br/>- lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).<br/>- unchecked: do not valid strings. |
+| `http.prom_validation_mode` | String | `unchecked` | Whether to enable validation for Prometheus remote write requests.<br/>Available options:<br/>- strict: deny invalid UTF-8 strings (default).<br/>- lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).<br/>- unchecked: do not valid strings. |
 | `grpc` | -- | -- | The gRPC server options. |
 | `grpc.bind_addr` | String | `127.0.0.1:4001` | The address to bind the gRPC server. |
 | `grpc.server_addr` | String | `127.0.0.1:4001` | The address advertised to the metasrv, and used for connections from outside the host.<br/>If left empty or unset, the server will automatically use the IP address of the first network interface<br/>on the host, with the same port number as the one specified in `grpc.bind_addr`. |

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -37,6 +37,12 @@ enable_cors = true
 ## Customize allowed origins for HTTP CORS.
 ## @toml2docs:none-default
 cors_allowed_origins = ["https://example.com"]
+## Whether to enable validation for Prometheus remote write requests.
+## Available options:
+## - strict: deny invalid UTF-8 strings.
+## - lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).
+## - unchecked: do not valid strings.
+prom_validation_mode = "unchecked"
 
 ## The gRPC server options.
 [grpc]

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -42,7 +42,7 @@ cors_allowed_origins = ["https://example.com"]
 ## - strict: deny invalid UTF-8 strings (default).
 ## - lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).
 ## - unchecked: do not valid strings.
-prom_validation_mode = "unchecked"
+prom_validation_mode = "strict"
 
 ## The gRPC server options.
 [grpc]

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -39,7 +39,7 @@ enable_cors = true
 cors_allowed_origins = ["https://example.com"]
 ## Whether to enable validation for Prometheus remote write requests.
 ## Available options:
-## - strict: deny invalid UTF-8 strings.
+## - strict: deny invalid UTF-8 strings (default).
 ## - lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).
 ## - unchecked: do not valid strings.
 prom_validation_mode = "unchecked"

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -45,7 +45,7 @@ cors_allowed_origins = ["https://example.com"]
 
 ## Whether to enable validation for Prometheus remote write requests.
 ## Available options:
-## - strict: deny invalid UTF-8 strings.
+## - strict: deny invalid UTF-8 strings (default).
 ## - lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).
 ## - unchecked: do not valid strings.
 prom_validation_mode = "unchecked"

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -43,6 +43,13 @@ enable_cors = true
 ## @toml2docs:none-default
 cors_allowed_origins = ["https://example.com"]
 
+## Whether to enable validation for Prometheus remote write requests.
+## Available options:
+## - strict: deny invalid UTF-8 strings.
+## - lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).
+## - unchecked: do not valid strings.
+prom_validation_mode = "unchecked"
+
 ## The gRPC server options.
 [grpc]
 ## The address to bind the gRPC server.

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -48,7 +48,7 @@ cors_allowed_origins = ["https://example.com"]
 ## - strict: deny invalid UTF-8 strings (default).
 ## - lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).
 ## - unchecked: do not valid strings.
-prom_validation_mode = "unchecked"
+prom_validation_mode = "strict"
 
 ## The gRPC server options.
 [grpc]

--- a/src/frontend/src/server.rs
+++ b/src/frontend/src/server.rs
@@ -104,7 +104,7 @@ where
                     self.instance.clone(),
                     Some(self.instance.clone()),
                     opts.prom_store.with_metric_engine,
-                    opts.http.is_strict_mode,
+                    opts.http.prom_validation_mode,
                 )
                 .with_prometheus_handler(self.instance.clone());
         }

--- a/src/servers/benches/prom_decode.rs
+++ b/src/servers/benches/prom_decode.rs
@@ -16,79 +16,55 @@ use std::time::Duration;
 
 use api::prom_store::remote::WriteRequest;
 use bytes::Bytes;
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use prost::Message;
 use servers::http::PromValidationMode;
 use servers::prom_store::to_grpc_row_insert_requests;
 use servers::proto::{PromSeriesProcessor, PromWriteRequest};
 
-fn bench_decode_prom_request_without_strict_mode(c: &mut Criterion) {
+fn bench_decode_prom_request(c: &mut Criterion) {
     let mut d = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     d.push("benches");
     d.push("write_request.pb.data");
 
     let data = Bytes::from(std::fs::read(d).unwrap());
 
-    let mut request = WriteRequest::default();
-    let mut prom_request = PromWriteRequest::default();
-    let mut p = PromSeriesProcessor::default_processor();
+    let mut group = c.benchmark_group("decode_prom_request");
+    group.measurement_time(Duration::from_secs(3));
 
-    c.benchmark_group("decode")
-        .measurement_time(Duration::from_secs(3))
-        .bench_function("write_request", |b| {
-            b.iter(|| {
-                request.clear();
-                let data = data.clone();
-                request.merge(data).unwrap();
-                to_grpc_row_insert_requests(&request).unwrap();
-            });
-        })
-        .bench_function("prom_write_request", |b| {
-            b.iter(|| {
-                let data = data.clone();
-                prom_request
-                    .merge(data, PromValidationMode::Unchecked, &mut p)
-                    .unwrap();
-                prom_request.as_row_insert_requests();
-            });
+    // Benchmark standard WriteRequest decoding as a baseline
+    let mut request = WriteRequest::default();
+    group.bench_function("standard_write_request", |b| {
+        b.iter(|| {
+            let data = data.clone();
+            request.merge(data).unwrap();
+            to_grpc_row_insert_requests(&request).unwrap();
         });
+    });
+
+    // Benchmark each validation mode
+    for mode in [
+        PromValidationMode::Strict,
+        PromValidationMode::Lossy,
+        PromValidationMode::Unchecked,
+    ] {
+        let mut prom_request = PromWriteRequest::default();
+        let mut p = PromSeriesProcessor::default_processor();
+        group.bench_with_input(
+            BenchmarkId::new("validation_mode", format!("{:?}", mode)),
+            &mode,
+            |b, &mode| {
+                b.iter(|| {
+                    let data = data.clone();
+                    prom_request.merge(data, mode, &mut p).unwrap();
+                    prom_request.as_row_insert_requests();
+                });
+            },
+        );
+    }
+
+    group.finish();
 }
 
-fn bench_decode_prom_request_with_strict_mode(c: &mut Criterion) {
-    let mut d = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    d.push("benches");
-    d.push("write_request.pb.data");
-
-    let data = Bytes::from(std::fs::read(d).unwrap());
-
-    let mut request = WriteRequest::default();
-    let mut prom_request = PromWriteRequest::default();
-    let mut p = PromSeriesProcessor::default_processor();
-
-    c.benchmark_group("decode")
-        .measurement_time(Duration::from_secs(3))
-        .bench_function("write_request", |b| {
-            b.iter(|| {
-                request.clear();
-                let data = data.clone();
-                request.merge(data).unwrap();
-                to_grpc_row_insert_requests(&request).unwrap();
-            });
-        })
-        .bench_function("prom_write_request", |b| {
-            b.iter(|| {
-                let data = data.clone();
-                prom_request
-                    .merge(data, PromValidationMode::Unchecked, &mut p)
-                    .unwrap();
-                prom_request.as_row_insert_requests();
-            });
-        });
-}
-
-criterion_group!(
-    benches,
-    bench_decode_prom_request_without_strict_mode,
-    bench_decode_prom_request_with_strict_mode
-);
+criterion_group!(benches, bench_decode_prom_request);
 criterion_main!(benches);

--- a/src/servers/benches/prom_decode.rs
+++ b/src/servers/benches/prom_decode.rs
@@ -18,6 +18,7 @@ use api::prom_store::remote::WriteRequest;
 use bytes::Bytes;
 use criterion::{criterion_group, criterion_main, Criterion};
 use prost::Message;
+use servers::http::PromValidationMode;
 use servers::prom_store::to_grpc_row_insert_requests;
 use servers::proto::{PromSeriesProcessor, PromWriteRequest};
 
@@ -30,7 +31,6 @@ fn bench_decode_prom_request_without_strict_mode(c: &mut Criterion) {
 
     let mut request = WriteRequest::default();
     let mut prom_request = PromWriteRequest::default();
-    let is_strict_mode = false;
     let mut p = PromSeriesProcessor::default_processor();
 
     c.benchmark_group("decode")
@@ -46,7 +46,9 @@ fn bench_decode_prom_request_without_strict_mode(c: &mut Criterion) {
         .bench_function("prom_write_request", |b| {
             b.iter(|| {
                 let data = data.clone();
-                prom_request.merge(data, is_strict_mode, &mut p).unwrap();
+                prom_request
+                    .merge(data, PromValidationMode::Unchecked, &mut p)
+                    .unwrap();
                 prom_request.as_row_insert_requests();
             });
         });
@@ -61,7 +63,6 @@ fn bench_decode_prom_request_with_strict_mode(c: &mut Criterion) {
 
     let mut request = WriteRequest::default();
     let mut prom_request = PromWriteRequest::default();
-    let is_strict_mode = true;
     let mut p = PromSeriesProcessor::default_processor();
 
     c.benchmark_group("decode")
@@ -77,7 +78,9 @@ fn bench_decode_prom_request_with_strict_mode(c: &mut Criterion) {
         .bench_function("prom_write_request", |b| {
             b.iter(|| {
                 let data = data.clone();
-                prom_request.merge(data, is_strict_mode, &mut p).unwrap();
+                prom_request
+                    .merge(data, PromValidationMode::Unchecked, &mut p)
+                    .unwrap();
                 prom_request.as_row_insert_requests();
             });
         });

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -146,11 +146,23 @@ pub struct HttpOptions {
 
     pub body_limit: ReadableSize,
 
-    pub is_strict_mode: bool,
+    /// Validation mode while decoding Prometheus remote write requests.
+    pub prom_validation_mode: PromValidationMode,
 
     pub cors_allowed_origins: Vec<String>,
 
     pub enable_cors: bool,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PromValidationMode {
+    /// Force UTF8 validation
+    Strict,
+    /// Allow lossy UTF8 strings
+    Lossy,
+    /// Do not validate UTF8 strings.
+    Unchecked,
 }
 
 impl Default for HttpOptions {
@@ -160,9 +172,9 @@ impl Default for HttpOptions {
             timeout: Duration::from_secs(0),
             disable_dashboard: false,
             body_limit: DEFAULT_BODY_LIMIT,
-            is_strict_mode: false,
             cors_allowed_origins: Vec::new(),
             enable_cors: true,
+            prom_validation_mode: PromValidationMode::Unchecked,
         }
     }
 }
@@ -556,13 +568,13 @@ impl HttpServerBuilder {
         handler: PromStoreProtocolHandlerRef,
         pipeline_handler: Option<PipelineHandlerRef>,
         prom_store_with_metric_engine: bool,
-        is_strict_mode: bool,
+        prom_validation_mode: PromValidationMode,
     ) -> Self {
         let state = PromStoreState {
             prom_store_handler: handler,
             pipeline_handler,
             prom_store_with_metric_engine,
-            is_strict_mode,
+            prom_validation_mode,
         };
 
         Self {

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -174,7 +174,7 @@ impl Default for HttpOptions {
             body_limit: DEFAULT_BODY_LIMIT,
             cors_allowed_origins: Vec::new(),
             enable_cors: true,
-            prom_validation_mode: PromValidationMode::Unchecked,
+            prom_validation_mode: PromValidationMode::Strict,
         }
     }
 }

--- a/src/servers/src/http/prom_store.rs
+++ b/src/servers/src/http/prom_store.rs
@@ -38,6 +38,7 @@ use snafu::prelude::*;
 use crate::error::{self, InternalSnafu, PipelineSnafu, Result};
 use crate::http::extractor::PipelineInfo;
 use crate::http::header::{write_cost_header_map, GREPTIME_DB_HEADER_METRICS};
+use crate::http::PromValidationMode;
 use crate::prom_store::{snappy_decompress, zstd_decompress};
 use crate::proto::{PromSeriesProcessor, PromWriteRequest};
 use crate::query_handler::{PipelineHandlerRef, PromStoreProtocolHandlerRef, PromStoreResponse};
@@ -57,7 +58,7 @@ pub struct PromStoreState {
     pub prom_store_handler: PromStoreProtocolHandlerRef,
     pub pipeline_handler: Option<PipelineHandlerRef>,
     pub prom_store_with_metric_engine: bool,
-    pub is_strict_mode: bool,
+    pub prom_validation_mode: PromValidationMode,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -97,7 +98,7 @@ pub async fn remote_write(
         prom_store_handler,
         pipeline_handler,
         prom_store_with_metric_engine,
-        is_strict_mode,
+        prom_validation_mode,
     } = state;
 
     if let Some(_vm_handshake) = params.get_vm_proto_version {
@@ -133,7 +134,7 @@ pub async fn remote_write(
     }
 
     let (request, samples) =
-        decode_remote_write_request(is_zstd, body, is_strict_mode, &mut processor).await?;
+        decode_remote_write_request(is_zstd, body, prom_validation_mode, &mut processor).await?;
 
     let output = prom_store_handler
         .write(request, query_ctx, prom_store_with_metric_engine)
@@ -199,7 +200,7 @@ fn try_decompress(is_zstd: bool, body: &[u8]) -> Result<Bytes> {
 async fn decode_remote_write_request(
     is_zstd: bool,
     body: Bytes,
-    is_strict_mode: bool,
+    prom_validation_mode: PromValidationMode,
     processor: &mut PromSeriesProcessor,
 ) -> Result<(RowInsertRequests, usize)> {
     let _timer = crate::metrics::METRIC_HTTP_PROM_STORE_DECODE_ELAPSED.start_timer();
@@ -220,7 +221,7 @@ async fn decode_remote_write_request(
     let mut request = PROM_WRITE_REQUEST_POOL.pull(PromWriteRequest::default);
 
     request
-        .merge(buf, is_strict_mode, processor)
+        .merge(buf, prom_validation_mode, processor)
         .context(error::DecodePromRemoteRequestSnafu)?;
 
     if processor.use_pipeline {

--- a/src/servers/src/metrics.rs
+++ b/src/servers/src/metrics.rs
@@ -209,7 +209,8 @@ lazy_static! {
     pub static ref METRIC_MYSQL_QUERY_TIMER: HistogramVec = register_histogram_vec!(
         "greptime_servers_mysql_query_elapsed",
         "servers mysql query elapsed",
-        &[METRIC_MYSQL_SUBPROTOCOL_LABEL, METRIC_DB_LABEL]
+        &[METRIC_MYSQL_SUBPROTOCOL_LABEL, METRIC_DB_LABEL],
+        vec![0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 60.0, 300.0]
     )
     .unwrap();
     pub static ref METRIC_MYSQL_PREPARED_COUNT: IntCounterVec = register_int_counter_vec!(
@@ -226,7 +227,8 @@ lazy_static! {
     pub static ref METRIC_POSTGRES_QUERY_TIMER: HistogramVec = register_histogram_vec!(
         "greptime_servers_postgres_query_elapsed",
         "servers postgres query elapsed",
-        &[METRIC_POSTGRES_SUBPROTOCOL_LABEL, METRIC_DB_LABEL]
+        &[METRIC_POSTGRES_SUBPROTOCOL_LABEL, METRIC_DB_LABEL],
+        vec![0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 60.0, 300.0]
     )
     .unwrap();
     pub static ref METRIC_POSTGRES_PREPARED_COUNT: IntCounter = register_int_counter!(
@@ -243,7 +245,8 @@ lazy_static! {
     pub static ref METRIC_SERVER_GRPC_PROM_REQUEST_TIMER: HistogramVec = register_histogram_vec!(
         "greptime_servers_grpc_prom_request_elapsed",
         "servers grpc prom request elapsed",
-        &[METRIC_DB_LABEL]
+        &[METRIC_DB_LABEL],
+        vec![0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 60.0, 300.0]
     )
     .unwrap();
     pub static ref METRIC_HTTP_REQUESTS_TOTAL: IntCounterVec = register_int_counter_vec!(

--- a/src/servers/src/prom_row_builder.rs
+++ b/src/servers/src/prom_row_builder.rs
@@ -25,7 +25,8 @@ use api::v1::{
 use common_query::prelude::{GREPTIME_TIMESTAMP, GREPTIME_VALUE};
 use prost::DecodeError;
 
-use crate::proto::PromLabel;
+use crate::http::PromValidationMode;
+use crate::proto::{decode_string, PromLabel};
 use crate::repeated_field::Clear;
 
 /// [TablesBuilder] serves as an intermediate container to build [RowInsertRequests].
@@ -125,27 +126,13 @@ impl TableBuilder {
         &mut self,
         labels: &[PromLabel],
         samples: &[Sample],
-        is_strict_mode: bool,
+        prom_validation_mode: PromValidationMode,
     ) -> Result<(), DecodeError> {
         let mut row = vec![Value { value_data: None }; self.col_indexes.len()];
 
         for PromLabel { name, value } in labels {
-            let (tag_name, tag_value) = if is_strict_mode {
-                let tag_name = match String::from_utf8(name.to_vec()) {
-                    Ok(s) => s,
-                    Err(_) => return Err(DecodeError::new("invalid utf-8")),
-                };
-                let tag_value = match String::from_utf8(value.to_vec()) {
-                    Ok(s) => s,
-                    Err(_) => return Err(DecodeError::new("invalid utf-8")),
-                };
-                (tag_name, tag_value)
-            } else {
-                let tag_name = unsafe { String::from_utf8_unchecked(name.to_vec()) };
-                let tag_value = unsafe { String::from_utf8_unchecked(value.to_vec()) };
-                (tag_name, tag_value)
-            };
-
+            let tag_name = decode_string(name, prom_validation_mode)?;
+            let tag_value = decode_string(value, prom_validation_mode)?;
             let tag_value = Some(ValueData::StringValue(tag_value));
             let tag_num = self.col_indexes.len();
 
@@ -215,12 +202,12 @@ mod tests {
     use bytes::Bytes;
     use prost::DecodeError;
 
+    use crate::http::PromValidationMode;
     use crate::prom_row_builder::TableBuilder;
     use crate::proto::PromLabel;
     #[test]
     fn test_table_builder() {
         let mut builder = TableBuilder::default();
-        let is_strict_mode = true;
         let _ = builder.add_labels_and_samples(
             &[
                 PromLabel {
@@ -236,7 +223,7 @@ mod tests {
                 value: 0.0,
                 timestamp: 0,
             }],
-            is_strict_mode,
+            PromValidationMode::Strict,
         );
 
         let _ = builder.add_labels_and_samples(
@@ -254,7 +241,7 @@ mod tests {
                 value: 0.1,
                 timestamp: 1,
             }],
-            is_strict_mode,
+            PromValidationMode::Strict,
         );
 
         let request = builder.as_row_insert_request("test".to_string());
@@ -310,7 +297,7 @@ mod tests {
                 value: 0.1,
                 timestamp: 1,
             }],
-            is_strict_mode,
+            PromValidationMode::Strict,
         );
         assert_eq!(res, Err(DecodeError::new("invalid utf-8")));
     }

--- a/src/servers/tests/http/prom_store_test.rs
+++ b/src/servers/tests/http/prom_store_test.rs
@@ -29,7 +29,7 @@ use query::query_engine::DescribeResult;
 use servers::error::{Error, Result};
 use servers::http::header::{CONTENT_ENCODING_SNAPPY, CONTENT_TYPE_PROTOBUF};
 use servers::http::test_helpers::TestClient;
-use servers::http::{HttpOptions, HttpServerBuilder};
+use servers::http::{HttpOptions, HttpServerBuilder, PromValidationMode};
 use servers::prom_store;
 use servers::prom_store::{snappy_compress, Metrics};
 use servers::query_handler::sql::SqlQueryHandler;
@@ -120,11 +120,10 @@ fn make_test_app(tx: mpsc::Sender<(String, Vec<u8>)>) -> Router {
         ..Default::default()
     };
 
-    let is_strict_mode = false;
     let instance = Arc::new(DummyInstance { tx });
     let server = HttpServerBuilder::new(http_opts)
         .with_sql_handler(instance.clone())
-        .with_prom_handler(instance, None, true, is_strict_mode)
+        .with_prom_handler(instance, None, true, PromValidationMode::Unchecked)
         .build();
     server.build(server.make_app()).unwrap()
 }

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -43,7 +43,7 @@ use object_store::ObjectStore;
 use servers::grpc::builder::GrpcServerBuilder;
 use servers::grpc::greptime_handler::GreptimeRequestHandler;
 use servers::grpc::{GrpcOptions, GrpcServer, GrpcServerConfig};
-use servers::http::{HttpOptions, HttpServerBuilder};
+use servers::http::{HttpOptions, HttpServerBuilder, PromValidationMode};
 use servers::metrics_handler::MetricsHandler;
 use servers::mysql::server::{MysqlServer, MysqlSpawnConfig, MysqlSpawnRef};
 use servers::postgres::PostgresServer;
@@ -533,7 +533,6 @@ pub async fn setup_test_prom_app_with_frontend(
         ..Default::default()
     };
     let frontend_ref = instance.fe_instance().clone();
-    let is_strict_mode = true;
     let http_server = HttpServerBuilder::new(http_opts)
         .with_sql_handler(ServerSqlQueryHandlerAdapter::arc(frontend_ref.clone()))
         .with_logs_handler(instance.fe_instance().clone())
@@ -541,7 +540,7 @@ pub async fn setup_test_prom_app_with_frontend(
             frontend_ref.clone(),
             Some(frontend_ref.clone()),
             true,
-            is_strict_mode,
+            PromValidationMode::Strict,
         )
         .with_prometheus_handler(frontend_ref)
         .with_greptime_config_options(instance.opts.datanode_options().to_toml().unwrap())

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -1011,7 +1011,7 @@ init_regions_parallelism = 16
 addr = "127.0.0.1:4000"
 timeout = "0s"
 body_limit = "64MiB"
-is_strict_mode = false
+prom_validation_mode = "unchecked"
 cors_allowed_origins = []
 enable_cors = true
 

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -1011,7 +1011,7 @@ init_regions_parallelism = 16
 addr = "127.0.0.1:4000"
 timeout = "0s"
 body_limit = "64MiB"
-prom_validation_mode = "unchecked"
+prom_validation_mode = "strict"
 cors_allowed_origins = []
 enable_cors = true
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

 ### Add Prometheus Validation Mode                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      
 - **Code Enhancements**:                                                                                                                                                                                                                                                                                           
   - Updated `src/frontend/src/server.rs` and `src/servers/src/http.rs` to support `PromValidationMode` with options: `strict`(default), `lossy`, and `unchecked`.                                                                                                                                                           
   - Modified `src/servers/src/http/prom_store.rs` and `src/servers/src/proto.rs` to handle Prometheus request decoding based on the selected validation mode.                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                    
 - **Benchmark and Testing**:                                                                                                                                                                                                                                                                                       
   - Refactored benchmarks in `src/servers/benches/prom_decode.rs` to include validation mode testing.                                                                                                                                                                                                              
   - Added comprehensive tests for `decode_string` function in `src/servers/src/proto.rs` to ensure correct behavior across different validation modes. 

 - **Configuration Updates**:                                                                                                                                                                                                                                                                                       
   - Added `http.prom_validation_mode` to `config/config.md`, `config/frontend.example.toml`, and `config/standalone.example.toml` to configure Prometheus remote write request validation.                                                                                                                         

 - **Other Changes**:                                                                                                                                                                                                                                                                                       
  - Update buckets for MySQL/Postgres/Prom queries.

## Performance Comparisons
Takeaways: `Unchecked` has the best performance while `Lossy` has the poorest.

```
decode_prom_request/validation_mode/Strict
                        time:   [625.85 µs 626.52 µs 627.44 µs]
                        change: [+0.8514% +1.2879% +1.7238%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
Benchmarking decode_prom_request/validation_mode/Lossy: Warming up for 3.0000 s
decode_prom_request/validation_mode/Lossy
                        time:   [657.52 µs 658.11 µs 658.73 µs]
                        change: [+1.8887% +1.9907% +2.0969%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe
decode_prom_request/validation_mode/Unchecked
                        time:   [584.81 µs 585.17 µs 585.55 µs]
                        change: [+0.7886% +1.2887% +1.8523%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  5 (5.00%) high severe
```

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
