### PR TITLE
refactor(flow): limit the size of query

### DIFF
--- a/src/flow/src/batching_mode.rs
+++ b/src/flow/src/batching_mode.rs
@@ -30,9 +30,6 @@ pub const DEFAULT_BATCHING_ENGINE_QUERY_TIMEOUT: Duration = Duration::from_secs(
 /// will output a warn log for any query that runs for more that 1 minutes, and also every 1 minutes when that query is still running
 pub const SLOW_QUERY_THRESHOLD: Duration = Duration::from_secs(60);
 
-/// The maximum number of parallel queries that can be executed by one batching mode task
-pub const MAX_PARALLEL_QUERIES_PER_FLOW: usize = 3;
-
 /// The minimum duration between two queries execution by batching mode task
 pub const MIN_REFRESH_DURATION: Duration = Duration::new(5, 0);
 

--- a/src/flow/src/batching_mode.rs
+++ b/src/flow/src/batching_mode.rs
@@ -30,6 +30,9 @@ pub const DEFAULT_BATCHING_ENGINE_QUERY_TIMEOUT: Duration = Duration::from_secs(
 /// will output a warn log for any query that runs for more that 1 minutes, and also every 1 minutes when that query is still running
 pub const SLOW_QUERY_THRESHOLD: Duration = Duration::from_secs(60);
 
+/// The maximum number of parallel queries that can be executed by one batching mode task
+pub const MAX_PARALLEL_QUERIES_PER_FLOW: usize = 3;
+
 /// The minimum duration between two queries execution by batching mode task
 pub const MIN_REFRESH_DURATION: Duration = Duration::new(5, 0);
 

--- a/src/flow/src/batching_mode/state.rs
+++ b/src/flow/src/batching_mode/state.rs
@@ -127,10 +127,10 @@ impl DirtyTimeWindows {
     /// Time window merge distance
     ///
     /// TODO(discord9): make those configurable
-    const MERGE_DIST: i32 = 3;
+    pub const MERGE_DIST: i32 = 3;
 
     /// Maximum number of filters allowed in a single query
-    const MAX_FILTER_NUM: usize = 20;
+    pub const MAX_FILTER_NUM: usize = 20;
 
     /// Add lower bounds to the dirty time windows. Upper bounds are ignored.
     ///
@@ -154,11 +154,16 @@ impl DirtyTimeWindows {
     }
 
     /// Generate all filter expressions consuming all time windows
+    ///
+    /// there is two limits:
+    /// - shouldn't return a too long time range(<=`window_size * window_cnt`), so that the query can be executed in a reasonable time
+    /// - shouldn't return too many time range exprs, so that the query can be parsed properly instead of causing parser to overflow
     pub fn gen_filter_exprs(
         &mut self,
         col_name: &str,
         expire_lower_bound: Option<Timestamp>,
         window_size: chrono::Duration,
+        window_cnt: usize,
         flow_id: FlowId,
         task_ctx: Option<&BatchingTask>,
     ) -> Result<Option<datafusion_expr::Expr>, Error> {
@@ -196,12 +201,32 @@ impl DirtyTimeWindows {
             }
         }
 
-        // get the first `MAX_FILTER_NUM` time windows
-        let nth = self
-            .windows
-            .iter()
-            .nth(Self::MAX_FILTER_NUM)
-            .map(|(key, _)| *key);
+        // get the first `window_cnt` time windows
+        let max_time_range = window_size * window_cnt as i32;
+        let nth = {
+            let mut cur_time_range = chrono::Duration::zero();
+            let mut nth_key = None;
+            for (idx, (start, end)) in self.windows.iter().enumerate() {
+                // if time range is too long, stop
+                if cur_time_range > max_time_range {
+                    nth_key = Some(*start);
+                    break;
+                }
+
+                // if we have enough time windows, stop
+                if idx >= window_cnt {
+                    nth_key = Some(*start);
+                    break;
+                }
+
+                if let Some(end) = end {
+                    end.sub(start)
+                        .map(|cur_window_size| cur_time_range += cur_window_size);
+                }
+            }
+
+            nth_key
+        };
         let first_nth = {
             if let Some(nth) = nth {
                 let mut after = self.windows.split_off(&nth);
@@ -274,6 +299,8 @@ impl DirtyTimeWindows {
     }
 
     /// Merge time windows that overlaps or get too close
+    ///
+    /// TODO(discord9): not merge and prefer to send smaller time windows? how?
     pub fn merge_dirty_time_windows(
         &mut self,
         window_size: chrono::Duration,
@@ -472,7 +499,14 @@ mod test {
                 .unwrap();
             assert_eq!(expected, dirty.windows);
             let filter_expr = dirty
-                .gen_filter_exprs("ts", expire_lower_bound, window_size, 0, None)
+                .gen_filter_exprs(
+                    "ts",
+                    expire_lower_bound,
+                    window_size,
+                    DirtyTimeWindows::MAX_FILTER_NUM,
+                    0,
+                    None,
+                )
                 .unwrap();
 
             let unparser = datafusion::sql::unparser::Unparser::default();

--- a/src/flow/src/batching_mode/state.rs
+++ b/src/flow/src/batching_mode/state.rs
@@ -220,14 +220,9 @@ impl DirtyTimeWindows {
                 }
 
                 if let Some(end) = end {
-                    {
-                        let this = end.sub(start);
-                        if let Some(x) = this {
-                            Some((|cur_window_size| cur_time_range += cur_window_size)(x))
-                        } else {
-                            None
-                        }
-                    };
+                    if let Some(x) = end.sub(start) {
+                        cur_time_range += x;
+                    }
                 }
             }
 

--- a/src/flow/src/batching_mode/state.rs
+++ b/src/flow/src/batching_mode/state.rs
@@ -15,7 +15,6 @@
 //! Batching mode task state, which changes frequently
 
 use std::collections::BTreeMap;
-use std::sync::Arc;
 use std::time::Duration;
 
 use common_telemetry::debug;
@@ -24,7 +23,7 @@ use common_time::Timestamp;
 use datatypes::value::Value;
 use session::context::QueryContextRef;
 use snafu::{OptionExt, ResultExt};
-use tokio::sync::{oneshot, RwLock};
+use tokio::sync::oneshot;
 use tokio::time::Instant;
 
 use crate::batching_mode::task::BatchingTask;
@@ -122,14 +121,6 @@ pub struct DirtyTimeWindows {
     /// windows's `start -> end` and non-overlapping
     /// `end` is exclusive(and optional)
     windows: BTreeMap<Timestamp, Option<Timestamp>>,
-    /// Time ranges that are currently running queries, if the rwlock is held, it means
-    /// the time range is being queried and should not be modified.
-    /// if not held, the kv pair can be removed from `locked` and this time range can be
-    /// modified.
-    /// This is used to prevent concurrent queries on the same time range.
-    /// The key is the start time of the time range, and the value is a tuple of
-    /// (optional end time, RwLock).
-    locked: BTreeMap<Timestamp, (Option<Timestamp>, Arc<RwLock<()>>)>,
 }
 
 impl DirtyTimeWindows {

--- a/src/flow/src/batching_mode/state.rs
+++ b/src/flow/src/batching_mode/state.rs
@@ -220,8 +220,14 @@ impl DirtyTimeWindows {
                 }
 
                 if let Some(end) = end {
-                    end.sub(start)
-                        .map(|cur_window_size| cur_time_range += cur_window_size);
+                    {
+                        let this = end.sub(start);
+                        if let Some(x) = this {
+                            Some((|cur_window_size| cur_time_range += cur_window_size)(x))
+                        } else {
+                            None
+                        }
+                    };
                 }
             }
 

--- a/src/flow/src/batching_mode/state.rs
+++ b/src/flow/src/batching_mode/state.rs
@@ -23,7 +23,7 @@ use common_time::Timestamp;
 use datatypes::value::Value;
 use session::context::QueryContextRef;
 use snafu::{OptionExt, ResultExt};
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, RwLock};
 use tokio::time::Instant;
 
 use crate::batching_mode::task::BatchingTask;
@@ -121,6 +121,14 @@ pub struct DirtyTimeWindows {
     /// windows's `start -> end` and non-overlapping
     /// `end` is exclusive(and optional)
     windows: BTreeMap<Timestamp, Option<Timestamp>>,
+    /// Time ranges that are currently running queries, if the rwlock is held, it means
+    /// the time range is being queried and should not be modified.
+    /// if not held, the kv pair can be removed from `locked` and this time range can be
+    /// modified.
+    /// This is used to prevent concurrent queries on the same time range.
+    /// The key is the start time of the time range, and the value is a tuple of
+    /// (optional end time, RwLock).
+    locked: BTreeMap<Timestamp, (Option<Timestamp>, RwLock<()>)>,
 }
 
 impl DirtyTimeWindows {

--- a/src/flow/src/batching_mode/state.rs
+++ b/src/flow/src/batching_mode/state.rs
@@ -15,6 +15,7 @@
 //! Batching mode task state, which changes frequently
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 use common_telemetry::debug;
@@ -128,7 +129,7 @@ pub struct DirtyTimeWindows {
     /// This is used to prevent concurrent queries on the same time range.
     /// The key is the start time of the time range, and the value is a tuple of
     /// (optional end time, RwLock).
-    locked: BTreeMap<Timestamp, (Option<Timestamp>, RwLock<()>)>,
+    locked: BTreeMap<Timestamp, (Option<Timestamp>, Arc<RwLock<()>>)>,
 }
 
 impl DirtyTimeWindows {

--- a/src/flow/src/batching_mode/task.rs
+++ b/src/flow/src/batching_mode/task.rs
@@ -387,7 +387,6 @@ impl BatchingTask {
             METRIC_FLOW_BATCHING_ENGINE_SLOW_QUERY
                 .with_label_values(&[
                     flow_id.to_string().as_str(),
-                    &plan.to_string(),
                     &peer_desc.unwrap_or_default().to_string(),
                 ])
                 .observe(elapsed.as_secs_f64());

--- a/src/flow/src/metrics.rs
+++ b/src/flow/src/metrics.rs
@@ -38,10 +38,26 @@ lazy_static! {
     pub static ref METRIC_FLOW_BATCHING_ENGINE_SLOW_QUERY: HistogramVec = register_histogram_vec!(
         "greptime_flow_batching_engine_slow_query_secs",
         "flow batching engine slow query(seconds)",
-        &["flow_id", "sql", "peer"],
+        &["flow_id", "peer"],
         vec![60., 2. * 60., 3. * 60., 5. * 60., 10. * 60.]
     )
     .unwrap();
+    pub static ref METRIC_FLOW_BATCHING_ENGINE_QUERY_WINDOW_CNT: HistogramVec =
+        register_histogram_vec!(
+            "greptime_flow_batching_engine_query_window_cnt",
+            "flow batching engine query time window count",
+            &["flow_id"],
+            vec![0.0, 5., 10., 20., 40.]
+        )
+        .unwrap();
+    pub static ref METRIC_FLOW_BATCHING_ENGINE_QUERY_TIME_RANGE: HistogramVec =
+        register_histogram_vec!(
+            "greptime_flow_batching_engine_query_time_range_secs",
+            "flow batching engine query time range(seconds)",
+            &["flow_id"],
+            vec![60., 4. * 60., 16. * 60., 64. * 60., 256. * 60.]
+        )
+        .unwrap();
     pub static ref METRIC_FLOW_RUN_INTERVAL_MS: IntGauge =
         register_int_gauge!("greptime_flow_run_interval_ms", "flow run interval in ms").unwrap();
     pub static ref METRIC_FLOW_ROWS: IntCounterVec = register_int_counter_vec!(


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

as title, limit each flow's batching mode query to a limited time range, so each query can be run to complete within reasonable time

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
