### PR TITLE
feat: Support export cli export to OSS

### DIFF
--- a/src/cli/src/export.rs
+++ b/src/cli/src/export.rs
@@ -181,10 +181,10 @@ impl ExportCommand {
     pub async fn build(&self) -> std::result::Result<Box<dyn Tool>, BoxedError> {
         if self.s3
             && (self.s3_bucket.is_none()
-            || self.s3_endpoint.is_none()
-            || self.s3_access_key.is_none()
-            || self.s3_secret_key.is_none()
-            || self.s3_region.is_none())
+                || self.s3_endpoint.is_none()
+                || self.s3_access_key.is_none()
+                || self.s3_secret_key.is_none()
+                || self.s3_region.is_none())
         {
             return Err(BoxedError::new(S3ConfigNotSetSnafu {}.build()));
         }

--- a/src/cli/src/export.rs
+++ b/src/cli/src/export.rs
@@ -180,10 +180,10 @@ impl ExportCommand {
     pub async fn build(&self) -> std::result::Result<Box<dyn Tool>, BoxedError> {
         if self.s3
             && (self.s3_bucket.is_none()
-            || self.s3_endpoint.is_none()
-            || self.s3_access_key.is_none()
-            || self.s3_secret_key.is_none()
-            || self.s3_region.is_none())
+                || self.s3_endpoint.is_none()
+                || self.s3_access_key.is_none()
+                || self.s3_secret_key.is_none()
+                || self.s3_region.is_none())
         {
             return Err(BoxedError::new(S3ConfigNotSetSnafu {}.build()));
         }

--- a/src/common/datasource/src/object_store.rs
+++ b/src/common/datasource/src/object_store.rs
@@ -80,7 +80,7 @@ pub fn build_backend(url: &str, connection: &HashMap<String, String>) -> Result<
             protocol: schema,
             url,
         }
-            .fail(),
+        .fail(),
     }
 }
 

--- a/src/common/datasource/src/object_store.rs
+++ b/src/common/datasource/src/object_store.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 pub mod fs;
+pub mod oss;
 pub mod s3;
+
 use std::collections::HashMap;
 
 use lazy_static::lazy_static;
@@ -25,10 +27,12 @@ use url::{ParseError, Url};
 use self::fs::build_fs_backend;
 use self::s3::build_s3_backend;
 use crate::error::{self, Result};
+use crate::object_store::oss::build_oss_backend;
 use crate::util::find_dir_and_filename;
 
 pub const FS_SCHEMA: &str = "FS";
 pub const S3_SCHEMA: &str = "S3";
+pub const OSS_SCHEMA: &str = "OSS";
 
 /// Returns `(schema, Option<host>, path)`
 pub fn parse_url(url: &str) -> Result<(String, Option<String>, String)> {
@@ -64,13 +68,19 @@ pub fn build_backend(url: &str, connection: &HashMap<String, String>) -> Result<
             })?;
             Ok(build_s3_backend(&host, &root, connection)?)
         }
+        OSS_SCHEMA => {
+            let host = host.context(error::EmptyHostPathSnafu {
+                url: url.to_string(),
+            })?;
+            Ok(build_oss_backend(&host, &root, connection)?)
+        }
         FS_SCHEMA => Ok(build_fs_backend(&root)?),
 
         _ => error::UnsupportedBackendProtocolSnafu {
             protocol: schema,
             url,
         }
-        .fail(),
+            .fail(),
     }
 }
 

--- a/src/common/datasource/src/object_store/oss.rs
+++ b/src/common/datasource/src/object_store/oss.rs
@@ -27,6 +27,7 @@ const ACCESS_KEY_SECRET: &str = "access_key_secret";
 const ROOT: &str = "root";
 const ALLOW_ANONYMOUS: &str = "allow_anonymous";
 
+/// Check if the key is supported in OSS configuration.
 pub fn is_supported_in_oss(key: &str) -> bool {
     [
         ROOT,
@@ -39,6 +40,7 @@ pub fn is_supported_in_oss(key: &str) -> bool {
     .contains(&key)
 }
 
+/// Build an OSS backend using the provided bucket, root, and connection parameters.
 pub fn build_oss_backend(
     bucket: &str,
     root: &str,

--- a/src/common/datasource/src/object_store/oss.rs
+++ b/src/common/datasource/src/object_store/oss.rs
@@ -100,32 +100,17 @@ mod tests {
     }
 
     #[test]
-    fn test_build_oss_backend_minimal() {
-        let connection = HashMap::new();
-
-        let result = build_oss_backend("test-bucket", "/test/root", &connection);
-
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_build_oss_backend_with_optional_params() {
+    fn test_build_oss_backend_all_fields_valid() {
         let mut connection = HashMap::new();
-        connection.insert(ROOT.to_string(), "/test/root".to_string());
-        connection.insert(ALLOW_ANONYMOUS.to_string(), "false".to_string());
+        connection.insert(
+            ENDPOINT.to_string(),
+            "http://oss-ap-southeast-1.aliyuncs.com".to_string(),
+        );
+        connection.insert(ACCESS_KEY_ID.to_string(), "key_id".to_string());
+        connection.insert(ACCESS_KEY_SECRET.to_string(), "key_secret".to_string());
+        connection.insert(ALLOW_ANONYMOUS.to_string(), "true".to_string());
 
-        let result = build_oss_backend("test-bucket", "oss-cn-hangzhou.aliyuncs.com", &connection);
-
+        let result = build_oss_backend("my-bucket", "my-root", &connection);
         assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_build_oss_backend_invalid_allow_anonymous() {
-        let mut connection = HashMap::new();
-        connection.insert(ALLOW_ANONYMOUS.to_string(), "invalid_bool".to_string());
-
-        let result = build_oss_backend("test-bucket", "oss-cn-hangzhou.aliyuncs.com", &connection);
-
-        assert!(result.is_err());
     }
 }

--- a/src/common/datasource/src/object_store/oss.rs
+++ b/src/common/datasource/src/object_store/oss.rs
@@ -1,0 +1,131 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use object_store::services::Oss;
+use object_store::ObjectStore;
+use snafu::ResultExt;
+
+use crate::error::{self, Result};
+
+const BUCKET: &str = "bucket";
+const ENDPOINT: &str = "endpoint";
+const ACCESS_KEY_ID: &str = "access_key_id";
+const ACCESS_KEY_SECRET: &str = "access_key_secret";
+const ROOT: &str = "root";
+const ALLOW_ANONYMOUS: &str = "allow_anonymous";
+
+pub fn is_supported_in_oss(key: &str) -> bool {
+    [
+        ROOT,
+        ALLOW_ANONYMOUS,
+        BUCKET,
+        ENDPOINT,
+        ACCESS_KEY_ID,
+        ACCESS_KEY_SECRET,
+    ]
+        .contains(&key)
+}
+
+pub fn build_oss_backend(
+    bucket: &str,
+    root: &str,
+    connection: &HashMap<String, String>,
+) -> Result<ObjectStore> {
+    let mut builder = Oss::default().bucket(bucket).root(root);
+
+    if let Some(endpoint) = connection.get(ENDPOINT) {
+        builder = builder.endpoint(endpoint);
+    }
+
+    if let Some(access_key_id) = connection.get(ACCESS_KEY_ID) {
+        builder = builder.access_key_id(access_key_id);
+    }
+
+    if let Some(access_key_secret) = connection.get(ACCESS_KEY_SECRET) {
+        builder = builder.access_key_secret(access_key_secret);
+    }
+
+    if let Some(allow_anonymous) = connection.get(ALLOW_ANONYMOUS) {
+        let allow = allow_anonymous.as_str().parse::<bool>().map_err(|e| {
+            error::InvalidConnectionSnafu {
+                msg: format!(
+                    "failed to parse the option {}={}, {}",
+                    ALLOW_ANONYMOUS, allow_anonymous, e
+                ),
+            }
+                .build()
+        })?;
+        if allow {
+            builder = builder.allow_anonymous();
+        }
+    }
+
+    let op = ObjectStore::new(builder)
+        .context(error::BuildBackendSnafu)?
+        .layer(object_store::layers::LoggingLayer::default())
+        .layer(object_store::layers::TracingLayer)
+        .layer(object_store::layers::build_prometheus_metrics_layer(true))
+        .finish();
+
+    Ok(op)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_supported_in_oss() {
+        assert!(is_supported_in_oss(ROOT));
+        assert!(is_supported_in_oss(ALLOW_ANONYMOUS));
+        assert!(is_supported_in_oss(BUCKET));
+        assert!(is_supported_in_oss(ENDPOINT));
+        assert!(is_supported_in_oss(ACCESS_KEY_ID));
+        assert!(is_supported_in_oss(ACCESS_KEY_SECRET));
+        assert!(!is_supported_in_oss("foo"));
+        assert!(!is_supported_in_oss("BAR"));
+    }
+
+    #[test]
+    fn test_build_oss_backend_minimal() {
+        let connection = HashMap::new();
+
+        let result = build_oss_backend("test-bucket", "/test/root", &connection);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_build_oss_backend_with_optional_params() {
+        let mut connection = HashMap::new();
+        connection.insert(ROOT.to_string(), "/test/root".to_string());
+        connection.insert(ALLOW_ANONYMOUS.to_string(), "false".to_string());
+
+        let result = build_oss_backend("test-bucket", "oss-cn-hangzhou.aliyuncs.com", &connection);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_build_oss_backend_invalid_allow_anonymous() {
+        let mut connection = HashMap::new();
+        connection.insert(ALLOW_ANONYMOUS.to_string(), "invalid_bool".to_string());
+
+        let result = build_oss_backend("test-bucket", "oss-cn-hangzhou.aliyuncs.com", &connection);
+
+        assert!(result.is_err());
+    }
+}

--- a/src/common/datasource/src/object_store/oss.rs
+++ b/src/common/datasource/src/object_store/oss.rs
@@ -36,7 +36,7 @@ pub fn is_supported_in_oss(key: &str) -> bool {
         ACCESS_KEY_ID,
         ACCESS_KEY_SECRET,
     ]
-        .contains(&key)
+    .contains(&key)
 }
 
 pub fn build_oss_backend(
@@ -66,7 +66,7 @@ pub fn build_oss_backend(
                     ALLOW_ANONYMOUS, allow_anonymous, e
                 ),
             }
-                .build()
+            .build()
         })?;
         if allow {
             builder = builder.allow_anonymous();

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -19,6 +19,7 @@ use std::fmt;
 use std::str::FromStr;
 
 use common_base::readable_size::ReadableSize;
+use common_datasource::object_store::oss::is_supported_in_oss;
 use common_datasource::object_store::s3::is_supported_in_s3;
 use common_query::AddColumnLocation;
 use common_time::range::TimestampRange;
@@ -67,6 +68,10 @@ pub const VALID_TABLE_OPTION_KEYS: [&str; 11] = [
 /// Returns true if the `key` is a valid key for any engine or storage.
 pub fn validate_table_option(key: &str) -> bool {
     if is_supported_in_s3(key) {
+        return true;
+    }
+
+    if is_supported_in_oss(key) {
         return true;
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#6105 
## What's changed and what's your intention?
Support export cli export to OSS

Currently, both copying from/to tables/databases and external tables utilize build_backend to create object storage, but only S3 is supported at this time. This PR extends support to OSS.
<img width="621" alt="image" src="https://github.com/user-attachments/assets/505da3a8-8614-42d0-b74c-adcbce302d59" />
<img width="1437" alt="image" src="https://github.com/user-attachments/assets/42d8c190-1f51-4389-a479-6cfbe03f5240" />
<img width="1433" alt="image" src="https://github.com/user-attachments/assets/cdc0518d-90e1-4eda-adf9-206a02a59782" />
<img width="1436" alt="image" src="https://github.com/user-attachments/assets/bfabde14-b381-4e77-bdc1-de5508aa167f" />

cli example:
`greptime cli export --addr 127.0.0.1:4000 --oss --oss-bucket <your-bucket> --oss-endpoint <your-endopint> --oss-access-key-id <id> --oss-access-key-secret <secret>`

`greptime cli export --addr 127.0.0.1:4000 --target data --oss --oss-bucket <your-bucket> --oss-endpoint <your-endopint> --oss-access-key-id <id> --oss-access-key-secret <secret>`

`greptime cli export --addr 127.0.0.1:4000 --target schema --oss --oss-bucket <your-bucket> --oss-endpoint <your-endopint> --oss-access-key-id <id> --oss-access-key-secret <secret>`
## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
