### PR TITLE
feat: use a fixed quote style that suitable for most cases

### DIFF
--- a/src/cmd/src/cli.rs
+++ b/src/cmd/src/cli.rs
@@ -165,9 +165,9 @@ mod tests {
             .join("cli.export.create_table")
             .join("create_tables.sql");
         let res = std::fs::read_to_string(output_file).unwrap();
-        let expect = r#"CREATE TABLE IF NOT EXISTS "a.b.c" (
-  "ts" TIMESTAMP(3) NOT NULL,
-  TIME INDEX ("ts")
+        let expect = r#"CREATE TABLE IF NOT EXISTS `a.b.c` (
+  `ts` TIMESTAMP(3) NOT NULL,
+  TIME INDEX (`ts`)
 )
 
 ENGINE=mito

--- a/src/operator/src/statement.rs
+++ b/src/operator/src/statement.rs
@@ -341,12 +341,10 @@ impl StatementExecutor {
 
                 match show.variant {
                     ShowCreateTableVariant::Original => {
-                        self.show_create_table(table_name, table_ref, query_ctx)
-                            .await
+                        self.show_create_table(table_name, table_ref).await
                     }
                     ShowCreateTableVariant::PostgresForeignTable => {
-                        self.show_create_table_for_pg(table_name, table_ref, query_ctx)
-                            .await
+                        self.show_create_table_for_pg(table_name, table_ref).await
                     }
                 }
             }

--- a/src/operator/src/statement/show.rs
+++ b/src/operator/src/statement/show.rs
@@ -118,7 +118,6 @@ impl StatementExecutor {
         &self,
         table_name: TableName,
         table: TableRef,
-        query_ctx: QueryContextRef,
     ) -> Result<Output> {
         let table_info = table.table_info();
         if table_info.table_type != TableType::Base {
@@ -150,7 +149,7 @@ impl StatementExecutor {
 
         let partitions = create_partitions_stmt(partitions)?;
 
-        query::sql::show_create_table(table, schema_options, partitions, query_ctx)
+        query::sql::show_create_table(table, schema_options, partitions)
             .context(ExecuteStatementSnafu)
     }
 
@@ -159,7 +158,6 @@ impl StatementExecutor {
         &self,
         table_name: TableName,
         table: TableRef,
-        query_ctx: QueryContextRef,
     ) -> Result<Output> {
         let table_info = table.table_info();
         if table_info.table_type != TableType::Base {
@@ -170,8 +168,7 @@ impl StatementExecutor {
             .fail();
         }
 
-        query::sql::show_create_foreign_table_for_pg(table, query_ctx)
-            .context(ExecuteStatementSnafu)
+        query::sql::show_create_foreign_table_for_pg(table).context(ExecuteStatementSnafu)
     }
 
     #[tracing::instrument(skip_all)]

--- a/src/query/src/sql.rs
+++ b/src/query/src/sql.rs
@@ -784,12 +784,11 @@ pub fn show_create_table(
     table: TableRef,
     schema_options: Option<SchemaOptions>,
     partitions: Option<Partitions>,
-    _query_ctx: QueryContextRef,
 ) -> Result<Output> {
     let table_info = table.table_info();
     let table_name = &table_info.name;
 
-    // Always use backquotes for identifiers in SHOW CREATE TABLE, regardless of dialect
+    // Always use backquotes for identifiers in SHOW CREATE TABLE for better compatibility, regardless of dialect
     let quote_style = '`';
 
     let mut stmt = create_table_stmt(&table_info, schema_options, quote_style)?;
@@ -808,10 +807,7 @@ pub fn show_create_table(
     Ok(Output::new_with_record_batches(records))
 }
 
-pub fn show_create_foreign_table_for_pg(
-    table: TableRef,
-    _query_ctx: QueryContextRef,
-) -> Result<Output> {
+pub fn show_create_foreign_table_for_pg(table: TableRef) -> Result<Output> {
     let table_info = table.table_info();
 
     let table_meta = &table_info.meta;

--- a/src/query/src/sql.rs
+++ b/src/query/src/sql.rs
@@ -784,12 +784,13 @@ pub fn show_create_table(
     table: TableRef,
     schema_options: Option<SchemaOptions>,
     partitions: Option<Partitions>,
-    query_ctx: QueryContextRef,
+    _query_ctx: QueryContextRef,
 ) -> Result<Output> {
     let table_info = table.table_info();
     let table_name = &table_info.name;
 
-    let quote_style = query_ctx.quote_style();
+    // Always use backquotes for identifiers in SHOW CREATE TABLE, regardless of dialect
+    let quote_style = '`';
 
     let mut stmt = create_table_stmt(&table_info, schema_options, quote_style)?;
     stmt.partitions = partitions.map(|mut p| {

--- a/tests-integration/src/tests/instance_test.rs
+++ b/tests-integration/src/tests/instance_test.rs
@@ -120,13 +120,13 @@ PARTITION ON COLUMNS (n) (
         r#"+-------+-------------------------------------+
 | Table | Create Table                        |
 +-------+-------------------------------------+
-| demo  | CREATE TABLE IF NOT EXISTS "demo" ( |
-|       |   "n" INT NULL,                     |
-|       |   "ts" TIMESTAMP(3) NOT NULL,       |
-|       |   TIME INDEX ("ts"),                |
-|       |   PRIMARY KEY ("n")                 |
+| demo  | CREATE TABLE IF NOT EXISTS `demo` ( |
+|       |   `n` INT NULL,                     |
+|       |   `ts` TIMESTAMP(3) NOT NULL,       |
+|       |   TIME INDEX (`ts`),                |
+|       |   PRIMARY KEY (`n`)                 |
 |       | )                                   |
-|       | PARTITION ON COLUMNS ("n") (        |
+|       | PARTITION ON COLUMNS (`n`) (        |
 |       |   n < 1,                            |
 |       |   n >= 100,                         |
 |       |   n >= 1 AND n < 10,                |
@@ -139,12 +139,12 @@ PARTITION ON COLUMNS (n) (
         r#"+-------+-------------------------------------+
 | Table | Create Table                        |
 +-------+-------------------------------------+
-| demo  | CREATE TABLE IF NOT EXISTS "demo" ( |
-|       |   "host" STRING NULL,               |
-|       |   "cpu" DOUBLE NULL,                |
-|       |   "memory" DOUBLE NULL,             |
-|       |   "ts" TIMESTAMP(3) NOT NULL,       |
-|       |   TIME INDEX ("ts")                 |
+| demo  | CREATE TABLE IF NOT EXISTS `demo` ( |
+|       |   `host` STRING NULL,               |
+|       |   `cpu` DOUBLE NULL,                |
+|       |   `memory` DOUBLE NULL,             |
+|       |   `ts` TIMESTAMP(3) NOT NULL,       |
+|       |   TIME INDEX (`ts`)                 |
 |       | )                                   |
 |       |                                     |
 |       | ENGINE=mito                         |
@@ -209,15 +209,15 @@ async fn test_show_create_external_table(instance: Arc<dyn MockInstance>) {
     let column = record_batches[0].column_by_name("Create Table").unwrap();
     let actual = column.get(0);
     let expect = format!(
-        r#"CREATE EXTERNAL TABLE IF NOT EXISTS "various_type_csv" (
-  "c_int" BIGINT NULL,
-  "c_float" DOUBLE NULL,
-  "c_string" DOUBLE NULL,
-  "c_bool" BOOLEAN NULL,
-  "c_date" DATE NULL,
-  "c_datetime" TIMESTAMP(0) NULL,
-  "greptime_timestamp" TIMESTAMP(3) NOT NULL DEFAULT '1970-01-01 00:00:00+0000',
-  TIME INDEX ("greptime_timestamp")
+        r#"CREATE EXTERNAL TABLE IF NOT EXISTS `various_type_csv` (
+  `c_int` BIGINT NULL,
+  `c_float` DOUBLE NULL,
+  `c_string` DOUBLE NULL,
+  `c_bool` BOOLEAN NULL,
+  `c_date` DATE NULL,
+  `c_datetime` TIMESTAMP(0) NULL,
+  `greptime_timestamp` TIMESTAMP(3) NOT NULL DEFAULT '1970-01-01 00:00:00+0000',
+  TIME INDEX (`greptime_timestamp`)
 )
 
 ENGINE=file

--- a/tests-integration/tests/grpc.rs
+++ b/tests-integration/tests/grpc.rs
@@ -435,13 +435,13 @@ async fn insert_with_hints_and_assert(db: &Database) {
 +-------+-------------------------------------+
 | Table | Create Table                        |
 +-------+-------------------------------------+
-| demo  | CREATE TABLE IF NOT EXISTS \"demo\" ( |
-|       |   \"host\" STRING NULL,               |
-|       |   \"cpu\" DOUBLE NULL,                |
-|       |   \"memory\" DOUBLE NULL,             |
-|       |   \"ts\" TIMESTAMP(3) NOT NULL,       |
-|       |   TIME INDEX (\"ts\"),                |
-|       |   PRIMARY KEY (\"host\")              |
+| demo  | CREATE TABLE IF NOT EXISTS `demo` ( |
+|       |   `host` STRING NULL,               |
+|       |   `cpu` DOUBLE NULL,                |
+|       |   `memory` DOUBLE NULL,             |
+|       |   `ts` TIMESTAMP(3) NOT NULL,       |
+|       |   TIME INDEX (`ts`),                |
+|       |   PRIMARY KEY (`host`)              |
 |       | )                                   |
 |       |                                     |
 |       | ENGINE=mito                         |

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -1551,7 +1551,7 @@ transform:
     assert_eq!(res.status(), StatusCode::OK);
 
     // 3. check schema
-    let expected_schema = "[[\"logs1\",\"CREATE TABLE IF NOT EXISTS \\\"logs1\\\" (\\n  \\\"id1\\\" INT NULL INVERTED INDEX,\\n  \\\"id2\\\" INT NULL INVERTED INDEX,\\n  \\\"logger\\\" STRING NULL,\\n  \\\"type\\\" STRING NULL SKIPPING INDEX WITH(granularity = '10240', type = 'BLOOM'),\\n  \\\"log\\\" STRING NULL FULLTEXT INDEX WITH(analyzer = 'English', backend = 'bloom', case_sensitive = 'false'),\\n  \\\"time\\\" TIMESTAMP(9) NOT NULL,\\n  TIME INDEX (\\\"time\\\"),\\n  PRIMARY KEY (\\\"type\\\", \\\"log\\\")\\n)\\n\\nENGINE=mito\\nWITH(\\n  append_mode = 'true'\\n)\"]]";
+    let expected_schema = "[[\"logs1\",\"CREATE TABLE IF NOT EXISTS `logs1` (\\n  `id1` INT NULL INVERTED INDEX,\\n  `id2` INT NULL INVERTED INDEX,\\n  `logger` STRING NULL,\\n  `type` STRING NULL SKIPPING INDEX WITH(granularity = '10240', type = 'BLOOM'),\\n  `log` STRING NULL FULLTEXT INDEX WITH(analyzer = 'English', backend = 'bloom', case_sensitive = 'false'),\\n  `time` TIMESTAMP(9) NOT NULL,\\n  TIME INDEX (`time`),\\n  PRIMARY KEY (`type`, `log`)\\n)\\n\\nENGINE=mito\\nWITH(\\n  append_mode = 'true'\\n)\"]]";
     validate_data(
         "pipeline_schema",
         &client,
@@ -3110,7 +3110,7 @@ pub async fn test_otlp_traces_v1(store_type: StorageType) {
     let expected = r#"[[1736480942444376000,1736480942444499000,123000,null,"c05d7a4ec8e1f231f02ed6e8da8655b4","d24f921c75f68e23","SPAN_KIND_CLIENT","lets-go","STATUS_CODE_UNSET","","","telemetrygen","","telemetrygen","1.2.3.4","telemetrygen-server",[],[]],[1736480942444376000,1736480942444499000,123000,"d24f921c75f68e23","c05d7a4ec8e1f231f02ed6e8da8655b4","9630f2916e2f7909","SPAN_KIND_SERVER","okey-dokey-0","STATUS_CODE_UNSET","","","telemetrygen","","telemetrygen","1.2.3.4","telemetrygen-client",[],[]],[1736480942444589000,1736480942444712000,123000,null,"cc9e0991a2e63d274984bd44ee669203","eba7be77e3558179","SPAN_KIND_CLIENT","lets-go","STATUS_CODE_UNSET","","","telemetrygen","","telemetrygen","1.2.3.4","telemetrygen-server",[],[]],[1736480942444589000,1736480942444712000,123000,"eba7be77e3558179","cc9e0991a2e63d274984bd44ee669203","8f847259b0f6e1ab","SPAN_KIND_SERVER","okey-dokey-0","STATUS_CODE_UNSET","","","telemetrygen","","telemetrygen","1.2.3.4","telemetrygen-client",[],[]]]"#;
     validate_data("otlp_traces", &client, "select * from mytable;", expected).await;
 
-    let expected_ddl = r#"[["mytable","CREATE TABLE IF NOT EXISTS \"mytable\" (\n  \"timestamp\" TIMESTAMP(9) NOT NULL,\n  \"timestamp_end\" TIMESTAMP(9) NULL,\n  \"duration_nano\" BIGINT UNSIGNED NULL,\n  \"parent_span_id\" STRING NULL SKIPPING INDEX WITH(granularity = '10240', type = 'BLOOM'),\n  \"trace_id\" STRING NULL SKIPPING INDEX WITH(granularity = '10240', type = 'BLOOM'),\n  \"span_id\" STRING NULL,\n  \"span_kind\" STRING NULL,\n  \"span_name\" STRING NULL,\n  \"span_status_code\" STRING NULL,\n  \"span_status_message\" STRING NULL,\n  \"trace_state\" STRING NULL,\n  \"scope_name\" STRING NULL,\n  \"scope_version\" STRING NULL,\n  \"service_name\" STRING NULL SKIPPING INDEX WITH(granularity = '10240', type = 'BLOOM'),\n  \"span_attributes.net.peer.ip\" STRING NULL,\n  \"span_attributes.peer.service\" STRING NULL,\n  \"span_events\" JSON NULL,\n  \"span_links\" JSON NULL,\n  TIME INDEX (\"timestamp\"),\n  PRIMARY KEY (\"service_name\")\n)\nPARTITION ON COLUMNS (\"trace_id\") (\n  trace_id < '1',\n  trace_id >= 'f',\n  trace_id >= '1' AND trace_id < '2',\n  trace_id >= '2' AND trace_id < '3',\n  trace_id >= '3' AND trace_id < '4',\n  trace_id >= '4' AND trace_id < '5',\n  trace_id >= '5' AND trace_id < '6',\n  trace_id >= '6' AND trace_id < '7',\n  trace_id >= '7' AND trace_id < '8',\n  trace_id >= '8' AND trace_id < '9',\n  trace_id >= '9' AND trace_id < 'a',\n  trace_id >= 'a' AND trace_id < 'b',\n  trace_id >= 'b' AND trace_id < 'c',\n  trace_id >= 'c' AND trace_id < 'd',\n  trace_id >= 'd' AND trace_id < 'e',\n  trace_id >= 'e' AND trace_id < 'f'\n)\nENGINE=mito\nWITH(\n  append_mode = 'true',\n  table_data_model = 'greptime_trace_v1'\n)"]]"#;
+    let expected_ddl = r#"[["mytable","CREATE TABLE IF NOT EXISTS `mytable` (\n  `timestamp` TIMESTAMP(9) NOT NULL,\n  `timestamp_end` TIMESTAMP(9) NULL,\n  `duration_nano` BIGINT UNSIGNED NULL,\n  `parent_span_id` STRING NULL SKIPPING INDEX WITH(granularity = '10240', type = 'BLOOM'),\n  `trace_id` STRING NULL SKIPPING INDEX WITH(granularity = '10240', type = 'BLOOM'),\n  `span_id` STRING NULL,\n  `span_kind` STRING NULL,\n  `span_name` STRING NULL,\n  `span_status_code` STRING NULL,\n  `span_status_message` STRING NULL,\n  `trace_state` STRING NULL,\n  `scope_name` STRING NULL,\n  `scope_version` STRING NULL,\n  `service_name` STRING NULL SKIPPING INDEX WITH(granularity = '10240', type = 'BLOOM'),\n  `span_attributes.net.peer.ip` STRING NULL,\n  `span_attributes.peer.service` STRING NULL,\n  `span_events` JSON NULL,\n  `span_links` JSON NULL,\n  TIME INDEX (`timestamp`),\n  PRIMARY KEY (`service_name`)\n)\nPARTITION ON COLUMNS (`trace_id`) (\n  trace_id < '1',\n  trace_id >= 'f',\n  trace_id >= '1' AND trace_id < '2',\n  trace_id >= '2' AND trace_id < '3',\n  trace_id >= '3' AND trace_id < '4',\n  trace_id >= '4' AND trace_id < '5',\n  trace_id >= '5' AND trace_id < '6',\n  trace_id >= '6' AND trace_id < '7',\n  trace_id >= '7' AND trace_id < '8',\n  trace_id >= '8' AND trace_id < '9',\n  trace_id >= '9' AND trace_id < 'a',\n  trace_id >= 'a' AND trace_id < 'b',\n  trace_id >= 'b' AND trace_id < 'c',\n  trace_id >= 'c' AND trace_id < 'd',\n  trace_id >= 'd' AND trace_id < 'e',\n  trace_id >= 'e' AND trace_id < 'f'\n)\nENGINE=mito\nWITH(\n  append_mode = 'true',\n  table_data_model = 'greptime_trace_v1'\n)"]]"#;
     validate_data(
         "otlp_traces",
         &client,
@@ -3119,7 +3119,7 @@ pub async fn test_otlp_traces_v1(store_type: StorageType) {
     )
     .await;
 
-    let expected_ddl = r#"[["mytable_services","CREATE TABLE IF NOT EXISTS \"mytable_services\" (\n  \"timestamp\" TIMESTAMP(9) NOT NULL,\n  \"service_name\" STRING NULL,\n  TIME INDEX (\"timestamp\"),\n  PRIMARY KEY (\"service_name\")\n)\n\nENGINE=mito\nWITH(\n  append_mode = 'false'\n)"]]"#;
+    let expected_ddl = r#"[["mytable_services","CREATE TABLE IF NOT EXISTS `mytable_services` (\n  `timestamp` TIMESTAMP(9) NOT NULL,\n  `service_name` STRING NULL,\n  TIME INDEX (`timestamp`),\n  PRIMARY KEY (`service_name`)\n)\n\nENGINE=mito\nWITH(\n  append_mode = 'false'\n)"]]"#;
     validate_data(
         "otlp_traces",
         &client,
@@ -3362,7 +3362,7 @@ pub async fn test_loki_pb_logs(store_type: StorageType) {
     assert_eq!(StatusCode::OK, res.status());
 
     // test schema
-    let expected = "[[\"loki_table_name\",\"CREATE TABLE IF NOT EXISTS \\\"loki_table_name\\\" (\\n  \\\"greptime_timestamp\\\" TIMESTAMP(9) NOT NULL,\\n  \\\"line\\\" STRING NULL,\\n  \\\"structured_metadata\\\" JSON NULL,\\n  \\\"service\\\" STRING NULL,\\n  \\\"source\\\" STRING NULL,\\n  \\\"wadaxi\\\" STRING NULL,\\n  TIME INDEX (\\\"greptime_timestamp\\\"),\\n  PRIMARY KEY (\\\"service\\\", \\\"source\\\", \\\"wadaxi\\\")\\n)\\n\\nENGINE=mito\\nWITH(\\n  append_mode = 'true'\\n)\"]]";
+    let expected = "[[\"loki_table_name\",\"CREATE TABLE IF NOT EXISTS `loki_table_name` (\\n  `greptime_timestamp` TIMESTAMP(9) NOT NULL,\\n  `line` STRING NULL,\\n  `structured_metadata` JSON NULL,\\n  `service` STRING NULL,\\n  `source` STRING NULL,\\n  `wadaxi` STRING NULL,\\n  TIME INDEX (`greptime_timestamp`),\\n  PRIMARY KEY (`service`, `source`, `wadaxi`)\\n)\\n\\nENGINE=mito\\nWITH(\\n  append_mode = 'true'\\n)\"]]";
     validate_data(
         "loki_pb_schema",
         &client,
@@ -3432,7 +3432,7 @@ pub async fn test_loki_json_logs(store_type: StorageType) {
     assert_eq!(StatusCode::OK, res.status());
 
     // test schema
-    let expected =  "[[\"loki_table_name\",\"CREATE TABLE IF NOT EXISTS \\\"loki_table_name\\\" (\\n  \\\"greptime_timestamp\\\" TIMESTAMP(9) NOT NULL,\\n  \\\"line\\\" STRING NULL,\\n  \\\"structured_metadata\\\" JSON NULL,\\n  \\\"sender\\\" STRING NULL,\\n  \\\"source\\\" STRING NULL,\\n  TIME INDEX (\\\"greptime_timestamp\\\"),\\n  PRIMARY KEY (\\\"sender\\\", \\\"source\\\")\\n)\\n\\nENGINE=mito\\nWITH(\\n  append_mode = 'true'\\n)\"]]";
+    let expected =  "[[\"loki_table_name\",\"CREATE TABLE IF NOT EXISTS `loki_table_name` (\\n  `greptime_timestamp` TIMESTAMP(9) NOT NULL,\\n  `line` STRING NULL,\\n  `structured_metadata` JSON NULL,\\n  `sender` STRING NULL,\\n  `source` STRING NULL,\\n  TIME INDEX (`greptime_timestamp`),\\n  PRIMARY KEY (`sender`, `source`)\\n)\\n\\nENGINE=mito\\nWITH(\\n  append_mode = 'true'\\n)\"]]";
     validate_data(
         "loki_json_schema",
         &client,

--- a/tests/cases/standalone/common/alter/alter_physical_table.result
+++ b/tests/cases/standalone/common/alter/alter_physical_table.result
@@ -19,12 +19,12 @@ SHOW CREATE TABLE phy;
 +-------+------------------------------------+
 | Table | Create Table                       |
 +-------+------------------------------------+
-| phy   | CREATE TABLE IF NOT EXISTS "phy" ( |
-|       |   "ts" TIMESTAMP(3) NOT NULL,      |
-|       |   "val" DOUBLE NULL,               |
-|       |   "a_label" STRING NULL,           |
-|       |   TIME INDEX ("ts"),               |
-|       |   PRIMARY KEY ("a_label")          |
+| phy   | CREATE TABLE IF NOT EXISTS `phy` ( |
+|       |   `ts` TIMESTAMP(3) NOT NULL,      |
+|       |   `val` DOUBLE NULL,               |
+|       |   `a_label` STRING NULL,           |
+|       |   TIME INDEX (`ts`),               |
+|       |   PRIMARY KEY (`a_label`)          |
 |       | )                                  |
 |       |                                    |
 |       | ENGINE=metric                      |
@@ -43,12 +43,12 @@ SHOW CREATE TABLE phy;
 +-------+------------------------------------+
 | Table | Create Table                       |
 +-------+------------------------------------+
-| phy   | CREATE TABLE IF NOT EXISTS "phy" ( |
-|       |   "ts" TIMESTAMP(3) NOT NULL,      |
-|       |   "val" DOUBLE NULL,               |
-|       |   "a_label" STRING NULL,           |
-|       |   TIME INDEX ("ts"),               |
-|       |   PRIMARY KEY ("a_label")          |
+| phy   | CREATE TABLE IF NOT EXISTS `phy` ( |
+|       |   `ts` TIMESTAMP(3) NOT NULL,      |
+|       |   `val` DOUBLE NULL,               |
+|       |   `a_label` STRING NULL,           |
+|       |   TIME INDEX (`ts`),               |
+|       |   PRIMARY KEY (`a_label`)          |
 |       | )                                  |
 |       |                                    |
 |       | ENGINE=metric                      |
@@ -66,12 +66,12 @@ SHOW CREATE TABLE phy;
 +-------+-----------------------------------------+
 | Table | Create Table                            |
 +-------+-----------------------------------------+
-| phy   | CREATE TABLE IF NOT EXISTS "phy" (      |
-|       |   "ts" TIMESTAMP(3) NOT NULL,           |
-|       |   "val" DOUBLE NULL,                    |
-|       |   "a_label" STRING NULL INVERTED INDEX, |
-|       |   TIME INDEX ("ts"),                    |
-|       |   PRIMARY KEY ("a_label")               |
+| phy   | CREATE TABLE IF NOT EXISTS `phy` (      |
+|       |   `ts` TIMESTAMP(3) NOT NULL,           |
+|       |   `val` DOUBLE NULL,                    |
+|       |   `a_label` STRING NULL INVERTED INDEX, |
+|       |   TIME INDEX (`ts`),                    |
+|       |   PRIMARY KEY (`a_label`)               |
 |       | )                                       |
 |       |                                         |
 |       | ENGINE=metric                           |
@@ -89,12 +89,12 @@ SHOW CREATE TABLE phy;
 +-------+------------------------------------+
 | Table | Create Table                       |
 +-------+------------------------------------+
-| phy   | CREATE TABLE IF NOT EXISTS "phy" ( |
-|       |   "ts" TIMESTAMP(3) NOT NULL,      |
-|       |   "val" DOUBLE NULL,               |
-|       |   "a_label" STRING NULL,           |
-|       |   TIME INDEX ("ts"),               |
-|       |   PRIMARY KEY ("a_label")          |
+| phy   | CREATE TABLE IF NOT EXISTS `phy` ( |
+|       |   `ts` TIMESTAMP(3) NOT NULL,      |
+|       |   `val` DOUBLE NULL,               |
+|       |   `a_label` STRING NULL,           |
+|       |   TIME INDEX (`ts`),               |
+|       |   PRIMARY KEY (`a_label`)          |
 |       | )                                  |
 |       |                                    |
 |       | ENGINE=metric                      |

--- a/tests/cases/standalone/common/alter/alter_table_options.result
+++ b/tests/cases/standalone/common/alter/alter_table_options.result
@@ -33,11 +33,11 @@ SHOW CREATE TABLE ato;
 +-------+------------------------------------+
 | Table | Create Table                       |
 +-------+------------------------------------+
-| ato   | CREATE TABLE IF NOT EXISTS "ato" ( |
-|       |   "i" INT NULL,                    |
-|       |   "j" TIMESTAMP(3) NOT NULL,       |
-|       |   TIME INDEX ("j"),                |
-|       |   PRIMARY KEY ("i")                |
+| ato   | CREATE TABLE IF NOT EXISTS `ato` ( |
+|       |   `i` INT NULL,                    |
+|       |   `j` TIMESTAMP(3) NOT NULL,       |
+|       |   TIME INDEX (`j`),                |
+|       |   PRIMARY KEY (`i`)                |
 |       | )                                  |
 |       |                                    |
 |       | ENGINE=mito                        |
@@ -64,11 +64,11 @@ SHOW CREATE TABLE ato;
 +-------+------------------------------------+
 | Table | Create Table                       |
 +-------+------------------------------------+
-| ato   | CREATE TABLE IF NOT EXISTS "ato" ( |
-|       |   "i" INT NULL,                    |
-|       |   "j" TIMESTAMP(3) NOT NULL,       |
-|       |   TIME INDEX ("j"),                |
-|       |   PRIMARY KEY ("i")                |
+| ato   | CREATE TABLE IF NOT EXISTS `ato` ( |
+|       |   `i` INT NULL,                    |
+|       |   `j` TIMESTAMP(3) NOT NULL,       |
+|       |   TIME INDEX (`j`),                |
+|       |   PRIMARY KEY (`i`)                |
 |       | )                                  |
 |       |                                    |
 |       | ENGINE=mito                        |
@@ -95,11 +95,11 @@ SHOW CREATE TABLE ato;
 +-------+------------------------------------+
 | Table | Create Table                       |
 +-------+------------------------------------+
-| ato   | CREATE TABLE IF NOT EXISTS "ato" ( |
-|       |   "i" INT NULL,                    |
-|       |   "j" TIMESTAMP(3) NOT NULL,       |
-|       |   TIME INDEX ("j"),                |
-|       |   PRIMARY KEY ("i")                |
+| ato   | CREATE TABLE IF NOT EXISTS `ato` ( |
+|       |   `i` INT NULL,                    |
+|       |   `j` TIMESTAMP(3) NOT NULL,       |
+|       |   TIME INDEX (`j`),                |
+|       |   PRIMARY KEY (`i`)                |
 |       | )                                  |
 |       |                                    |
 |       | ENGINE=mito                        |
@@ -117,11 +117,11 @@ SHOW CREATE TABLE ato;
 +-------+------------------------------------+
 | Table | Create Table                       |
 +-------+------------------------------------+
-| ato   | CREATE TABLE IF NOT EXISTS "ato" ( |
-|       |   "i" INT NULL,                    |
-|       |   "j" TIMESTAMP(3) NOT NULL,       |
-|       |   TIME INDEX ("j"),                |
-|       |   PRIMARY KEY ("i")                |
+| ato   | CREATE TABLE IF NOT EXISTS `ato` ( |
+|       |   `i` INT NULL,                    |
+|       |   `j` TIMESTAMP(3) NOT NULL,       |
+|       |   TIME INDEX (`j`),                |
+|       |   PRIMARY KEY (`i`)                |
 |       | )                                  |
 |       |                                    |
 |       | ENGINE=mito                        |
@@ -164,11 +164,11 @@ SHOW CREATE TABLE ato;
 +-------+-----------------------------------------------------+
 | Table | Create Table                                        |
 +-------+-----------------------------------------------------+
-| ato   | CREATE TABLE IF NOT EXISTS "ato" (                  |
-|       |   "i" INT NULL,                                     |
-|       |   "j" TIMESTAMP(3) NOT NULL,                        |
-|       |   TIME INDEX ("j"),                                 |
-|       |   PRIMARY KEY ("i")                                 |
+| ato   | CREATE TABLE IF NOT EXISTS `ato` (                  |
+|       |   `i` INT NULL,                                     |
+|       |   `j` TIMESTAMP(3) NOT NULL,                        |
+|       |   TIME INDEX (`j`),                                 |
+|       |   PRIMARY KEY (`i`)                                 |
 |       | )                                                   |
 |       |                                                     |
 |       | ENGINE=mito                                         |
@@ -194,11 +194,11 @@ SHOW CREATE TABLE ato;
 +-------+-----------------------------------------------------+
 | Table | Create Table                                        |
 +-------+-----------------------------------------------------+
-| ato   | CREATE TABLE IF NOT EXISTS "ato" (                  |
-|       |   "i" INT NULL,                                     |
-|       |   "j" TIMESTAMP(3) NOT NULL,                        |
-|       |   TIME INDEX ("j"),                                 |
-|       |   PRIMARY KEY ("i")                                 |
+| ato   | CREATE TABLE IF NOT EXISTS `ato` (                  |
+|       |   `i` INT NULL,                                     |
+|       |   `j` TIMESTAMP(3) NOT NULL,                        |
+|       |   TIME INDEX (`j`),                                 |
+|       |   PRIMARY KEY (`i`)                                 |
 |       | )                                                   |
 |       |                                                     |
 |       | ENGINE=mito                                         |
@@ -219,11 +219,11 @@ SHOW CREATE TABLE ato;
 +-------+-----------------------------------------------------+
 | Table | Create Table                                        |
 +-------+-----------------------------------------------------+
-| ato   | CREATE TABLE IF NOT EXISTS "ato" (                  |
-|       |   "i" INT NULL,                                     |
-|       |   "j" TIMESTAMP(3) NOT NULL,                        |
-|       |   TIME INDEX ("j"),                                 |
-|       |   PRIMARY KEY ("i")                                 |
+| ato   | CREATE TABLE IF NOT EXISTS `ato` (                  |
+|       |   `i` INT NULL,                                     |
+|       |   `j` TIMESTAMP(3) NOT NULL,                        |
+|       |   TIME INDEX (`j`),                                 |
+|       |   PRIMARY KEY (`i`)                                 |
 |       | )                                                   |
 |       |                                                     |
 |       | ENGINE=mito                                         |
@@ -240,11 +240,11 @@ SHOW CREATE TABLE ato;
 +-------+-----------------------------------------------------+
 | Table | Create Table                                        |
 +-------+-----------------------------------------------------+
-| ato   | CREATE TABLE IF NOT EXISTS "ato" (                  |
-|       |   "i" INT NULL,                                     |
-|       |   "j" TIMESTAMP(3) NOT NULL,                        |
-|       |   TIME INDEX ("j"),                                 |
-|       |   PRIMARY KEY ("i")                                 |
+| ato   | CREATE TABLE IF NOT EXISTS `ato` (                  |
+|       |   `i` INT NULL,                                     |
+|       |   `j` TIMESTAMP(3) NOT NULL,                        |
+|       |   TIME INDEX (`j`),                                 |
+|       |   PRIMARY KEY (`i`)                                 |
 |       | )                                                   |
 |       |                                                     |
 |       | ENGINE=mito                                         |
@@ -272,10 +272,10 @@ SHOW CREATE TABLE phy;
 +-------+------------------------------------+
 | Table | Create Table                       |
 +-------+------------------------------------+
-| phy   | CREATE TABLE IF NOT EXISTS "phy" ( |
-|       |   "ts" TIMESTAMP(3) NOT NULL,      |
-|       |   "val" DOUBLE NULL,               |
-|       |   TIME INDEX ("ts")                |
+| phy   | CREATE TABLE IF NOT EXISTS `phy` ( |
+|       |   `ts` TIMESTAMP(3) NOT NULL,      |
+|       |   `val` DOUBLE NULL,               |
+|       |   TIME INDEX (`ts`)                |
 |       | )                                  |
 |       |                                    |
 |       | ENGINE=metric                      |
@@ -294,10 +294,10 @@ SHOW CREATE TABLE phy;
 +-------+------------------------------------+
 | Table | Create Table                       |
 +-------+------------------------------------+
-| phy   | CREATE TABLE IF NOT EXISTS "phy" ( |
-|       |   "ts" TIMESTAMP(3) NOT NULL,      |
-|       |   "val" DOUBLE NULL,               |
-|       |   TIME INDEX ("ts")                |
+| phy   | CREATE TABLE IF NOT EXISTS `phy` ( |
+|       |   `ts` TIMESTAMP(3) NOT NULL,      |
+|       |   `val` DOUBLE NULL,               |
+|       |   TIME INDEX (`ts`)                |
 |       | )                                  |
 |       |                                    |
 |       | ENGINE=metric                      |

--- a/tests/cases/standalone/common/alter/change_col_fulltext_options.result
+++ b/tests/cases/standalone/common/alter/change_col_fulltext_options.result
@@ -12,10 +12,10 @@ SHOW CREATE TABLE test;
 +-------+-------------------------------------+
 | Table | Create Table                        |
 +-------+-------------------------------------+
-| test  | CREATE TABLE IF NOT EXISTS "test" ( |
-|       |   "message" STRING NULL,            |
-|       |   "time" TIMESTAMP(3) NOT NULL,     |
-|       |   TIME INDEX ("time")               |
+| test  | CREATE TABLE IF NOT EXISTS `test` ( |
+|       |   `message` STRING NULL,            |
+|       |   `time` TIMESTAMP(3) NOT NULL,     |
+|       |   TIME INDEX (`time`)               |
 |       | )                                   |
 |       |                                     |
 |       | ENGINE=mito                         |
@@ -82,10 +82,10 @@ SHOW CREATE TABLE test;
 +-------+----------------------------------------------------------------------------------------------------------------+
 | Table | Create Table                                                                                                   |
 +-------+----------------------------------------------------------------------------------------------------------------+
-| test  | CREATE TABLE IF NOT EXISTS "test" (                                                                            |
-|       |   "message" STRING NULL FULLTEXT INDEX WITH(analyzer = 'Chinese', backend = 'bloom', case_sensitive = 'true'), |
-|       |   "time" TIMESTAMP(3) NOT NULL,                                                                                |
-|       |   TIME INDEX ("time")                                                                                          |
+| test  | CREATE TABLE IF NOT EXISTS `test` (                                                                            |
+|       |   `message` STRING NULL FULLTEXT INDEX WITH(analyzer = 'Chinese', backend = 'bloom', case_sensitive = 'true'), |
+|       |   `time` TIMESTAMP(3) NOT NULL,                                                                                |
+|       |   TIME INDEX (`time`)                                                                                          |
 |       | )                                                                                                              |
 |       |                                                                                                                |
 |       | ENGINE=mito                                                                                                    |
@@ -112,10 +112,10 @@ SHOW CREATE TABLE test;
 +-------+-------------------------------------+
 | Table | Create Table                        |
 +-------+-------------------------------------+
-| test  | CREATE TABLE IF NOT EXISTS "test" ( |
-|       |   "message" STRING NULL,            |
-|       |   "time" TIMESTAMP(3) NOT NULL,     |
-|       |   TIME INDEX ("time")               |
+| test  | CREATE TABLE IF NOT EXISTS `test` ( |
+|       |   `message` STRING NULL,            |
+|       |   `time` TIMESTAMP(3) NOT NULL,     |
+|       |   TIME INDEX (`time`)               |
 |       | )                                   |
 |       |                                     |
 |       | ENGINE=mito                         |
@@ -141,10 +141,10 @@ SHOW CREATE TABLE test;
 +-------+----------------------------------------------------------------------------------------------------------------+
 | Table | Create Table                                                                                                   |
 +-------+----------------------------------------------------------------------------------------------------------------+
-| test  | CREATE TABLE IF NOT EXISTS "test" (                                                                            |
-|       |   "message" STRING NULL FULLTEXT INDEX WITH(analyzer = 'Chinese', backend = 'bloom', case_sensitive = 'true'), |
-|       |   "time" TIMESTAMP(3) NOT NULL,                                                                                |
-|       |   TIME INDEX ("time")                                                                                          |
+| test  | CREATE TABLE IF NOT EXISTS `test` (                                                                            |
+|       |   `message` STRING NULL FULLTEXT INDEX WITH(analyzer = 'Chinese', backend = 'bloom', case_sensitive = 'true'), |
+|       |   `time` TIMESTAMP(3) NOT NULL,                                                                                |
+|       |   TIME INDEX (`time`)                                                                                          |
 |       | )                                                                                                              |
 |       |                                                                                                                |
 |       | ENGINE=mito                                                                                                    |
@@ -175,10 +175,10 @@ SHOW CREATE TABLE test;
 +-------+-------------------------------------+
 | Table | Create Table                        |
 +-------+-------------------------------------+
-| test  | CREATE TABLE IF NOT EXISTS "test" ( |
-|       |   "message" STRING NULL,            |
-|       |   "time" TIMESTAMP(3) NOT NULL,     |
-|       |   TIME INDEX ("time")               |
+| test  | CREATE TABLE IF NOT EXISTS `test` ( |
+|       |   `message` STRING NULL,            |
+|       |   `time` TIMESTAMP(3) NOT NULL,     |
+|       |   TIME INDEX (`time`)               |
 |       | )                                   |
 |       |                                     |
 |       | ENGINE=mito                         |
@@ -204,10 +204,10 @@ SHOW CREATE TABLE test;
 +-------+----------------------------------------------------------------------------------------------------------------+
 | Table | Create Table                                                                                                   |
 +-------+----------------------------------------------------------------------------------------------------------------+
-| test  | CREATE TABLE IF NOT EXISTS "test" (                                                                            |
-|       |   "message" STRING NULL FULLTEXT INDEX WITH(analyzer = 'Chinese', backend = 'bloom', case_sensitive = 'true'), |
-|       |   "time" TIMESTAMP(3) NOT NULL,                                                                                |
-|       |   TIME INDEX ("time")                                                                                          |
+| test  | CREATE TABLE IF NOT EXISTS `test` (                                                                            |
+|       |   `message` STRING NULL FULLTEXT INDEX WITH(analyzer = 'Chinese', backend = 'bloom', case_sensitive = 'true'), |
+|       |   `time` TIMESTAMP(3) NOT NULL,                                                                                |
+|       |   TIME INDEX (`time`)                                                                                          |
 |       | )                                                                                                              |
 |       |                                                                                                                |
 |       | ENGINE=mito                                                                                                    |
@@ -234,10 +234,10 @@ SHOW CREATE TABLE test;
 +-------+------------------------------------------------------------------------------------------------------------------+
 | Table | Create Table                                                                                                     |
 +-------+------------------------------------------------------------------------------------------------------------------+
-| test  | CREATE TABLE IF NOT EXISTS "test" (                                                                              |
-|       |   "message" STRING NULL FULLTEXT INDEX WITH(analyzer = 'Chinese', backend = 'tantivy', case_sensitive = 'true'), |
-|       |   "time" TIMESTAMP(3) NOT NULL,                                                                                  |
-|       |   TIME INDEX ("time")                                                                                            |
+| test  | CREATE TABLE IF NOT EXISTS `test` (                                                                              |
+|       |   `message` STRING NULL FULLTEXT INDEX WITH(analyzer = 'Chinese', backend = 'tantivy', case_sensitive = 'true'), |
+|       |   `time` TIMESTAMP(3) NOT NULL,                                                                                  |
+|       |   TIME INDEX (`time`)                                                                                            |
 |       | )                                                                                                                |
 |       |                                                                                                                  |
 |       | ENGINE=mito                                                                                                      |

--- a/tests/cases/standalone/common/alter/change_col_inverted_index.result
+++ b/tests/cases/standalone/common/alter/change_col_inverted_index.result
@@ -37,10 +37,10 @@ SHOW CREATE TABLE fox;
 +-------+-------------------------------------+
 | Table | Create Table                        |
 +-------+-------------------------------------+
-| fox   | CREATE TABLE IF NOT EXISTS "fox" (  |
-|       |   "ts" TIMESTAMP(3) NOT NULL,       |
-|       |   "fox" STRING NULL INVERTED INDEX, |
-|       |   TIME INDEX ("ts")                 |
+| fox   | CREATE TABLE IF NOT EXISTS `fox` (  |
+|       |   `ts` TIMESTAMP(3) NOT NULL,       |
+|       |   `fox` STRING NULL INVERTED INDEX, |
+|       |   TIME INDEX (`ts`)                 |
 |       | )                                   |
 |       |                                     |
 |       | ENGINE=mito                         |
@@ -53,10 +53,10 @@ SHOW CREATE TABLE fox;
 +-------+-------------------------------------+
 | Table | Create Table                        |
 +-------+-------------------------------------+
-| fox   | CREATE TABLE IF NOT EXISTS "fox" (  |
-|       |   "ts" TIMESTAMP(3) NOT NULL,       |
-|       |   "fox" STRING NULL INVERTED INDEX, |
-|       |   TIME INDEX ("ts")                 |
+| fox   | CREATE TABLE IF NOT EXISTS `fox` (  |
+|       |   `ts` TIMESTAMP(3) NOT NULL,       |
+|       |   `fox` STRING NULL INVERTED INDEX, |
+|       |   TIME INDEX (`ts`)                 |
 |       | )                                   |
 |       |                                     |
 |       | ENGINE=mito                         |
@@ -81,10 +81,10 @@ SHOW CREATE TABLE fox;
 +-------+------------------------------------+
 | Table | Create Table                       |
 +-------+------------------------------------+
-| fox   | CREATE TABLE IF NOT EXISTS "fox" ( |
-|       |   "ts" TIMESTAMP(3) NOT NULL,      |
-|       |   "fox" STRING NULL,               |
-|       |   TIME INDEX ("ts")                |
+| fox   | CREATE TABLE IF NOT EXISTS `fox` ( |
+|       |   `ts` TIMESTAMP(3) NOT NULL,      |
+|       |   `fox` STRING NULL,               |
+|       |   TIME INDEX (`ts`)                |
 |       | )                                  |
 |       |                                    |
 |       | ENGINE=mito                        |
@@ -97,10 +97,10 @@ SHOW CREATE TABLE fox;
 +-------+------------------------------------+
 | Table | Create Table                       |
 +-------+------------------------------------+
-| fox   | CREATE TABLE IF NOT EXISTS "fox" ( |
-|       |   "ts" TIMESTAMP(3) NOT NULL,      |
-|       |   "fox" STRING NULL,               |
-|       |   TIME INDEX ("ts")                |
+| fox   | CREATE TABLE IF NOT EXISTS `fox` ( |
+|       |   `ts` TIMESTAMP(3) NOT NULL,      |
+|       |   `fox` STRING NULL,               |
+|       |   TIME INDEX (`ts`)                |
 |       | )                                  |
 |       |                                    |
 |       | ENGINE=mito                        |

--- a/tests/cases/standalone/common/alter/change_col_skipping_options.result
+++ b/tests/cases/standalone/common/alter/change_col_skipping_options.result
@@ -13,12 +13,12 @@ SHOW CREATE TABLE test;
 +-------+-------------------------------------+
 | Table | Create Table                        |
 +-------+-------------------------------------+
-| test  | CREATE TABLE IF NOT EXISTS "test" ( |
-|       |   "value" DOUBLE NULL,              |
-|       |   "category" STRING NULL,           |
-|       |   "metric" BIGINT NULL,             |
-|       |   "time" TIMESTAMP(3) NOT NULL,     |
-|       |   TIME INDEX ("time")               |
+| test  | CREATE TABLE IF NOT EXISTS `test` ( |
+|       |   `value` DOUBLE NULL,              |
+|       |   `category` STRING NULL,           |
+|       |   `metric` BIGINT NULL,             |
+|       |   `time` TIMESTAMP(3) NOT NULL,     |
+|       |   TIME INDEX (`time`)               |
 |       | )                                   |
 |       |                                     |
 |       | ENGINE=mito                         |
@@ -127,12 +127,12 @@ SHOW CREATE TABLE test;
 +-------+-----------------------------------------------------------------------------------+
 | Table | Create Table                                                                      |
 +-------+-----------------------------------------------------------------------------------+
-| test  | CREATE TABLE IF NOT EXISTS "test" (                                               |
-|       |   "value" DOUBLE NULL SKIPPING INDEX WITH(granularity = '1024', type = 'BLOOM'),  |
-|       |   "category" STRING NULL,                                                         |
-|       |   "metric" BIGINT NULL SKIPPING INDEX WITH(granularity = '1024', type = 'BLOOM'), |
-|       |   "time" TIMESTAMP(3) NOT NULL,                                                   |
-|       |   TIME INDEX ("time")                                                             |
+| test  | CREATE TABLE IF NOT EXISTS `test` (                                               |
+|       |   `value` DOUBLE NULL SKIPPING INDEX WITH(granularity = '1024', type = 'BLOOM'),  |
+|       |   `category` STRING NULL,                                                         |
+|       |   `metric` BIGINT NULL SKIPPING INDEX WITH(granularity = '1024', type = 'BLOOM'), |
+|       |   `time` TIMESTAMP(3) NOT NULL,                                                   |
+|       |   TIME INDEX (`time`)                                                             |
 |       | )                                                                                 |
 |       |                                                                                   |
 |       | ENGINE=mito                                                                       |
@@ -159,12 +159,12 @@ SHOW CREATE TABLE test;
 +-------+-----------------------------------------------------------------------------------+
 | Table | Create Table                                                                      |
 +-------+-----------------------------------------------------------------------------------+
-| test  | CREATE TABLE IF NOT EXISTS "test" (                                               |
-|       |   "value" DOUBLE NULL SKIPPING INDEX WITH(granularity = '8192', type = 'BLOOM'),  |
-|       |   "category" STRING NULL,                                                         |
-|       |   "metric" BIGINT NULL SKIPPING INDEX WITH(granularity = '1024', type = 'BLOOM'), |
-|       |   "time" TIMESTAMP(3) NOT NULL,                                                   |
-|       |   TIME INDEX ("time")                                                             |
+| test  | CREATE TABLE IF NOT EXISTS `test` (                                               |
+|       |   `value` DOUBLE NULL SKIPPING INDEX WITH(granularity = '8192', type = 'BLOOM'),  |
+|       |   `category` STRING NULL,                                                         |
+|       |   `metric` BIGINT NULL SKIPPING INDEX WITH(granularity = '1024', type = 'BLOOM'), |
+|       |   `time` TIMESTAMP(3) NOT NULL,                                                   |
+|       |   TIME INDEX (`time`)                                                             |
 |       | )                                                                                 |
 |       |                                                                                   |
 |       | ENGINE=mito                                                                       |
@@ -195,12 +195,12 @@ SHOW CREATE TABLE test;
 +-------+-----------------------------------------------------------------------------------+
 | Table | Create Table                                                                      |
 +-------+-----------------------------------------------------------------------------------+
-| test  | CREATE TABLE IF NOT EXISTS "test" (                                               |
-|       |   "value" DOUBLE NULL SKIPPING INDEX WITH(granularity = '2048', type = 'BLOOM'),  |
-|       |   "category" STRING NULL,                                                         |
-|       |   "metric" BIGINT NULL SKIPPING INDEX WITH(granularity = '1024', type = 'BLOOM'), |
-|       |   "time" TIMESTAMP(3) NOT NULL,                                                   |
-|       |   TIME INDEX ("time")                                                             |
+| test  | CREATE TABLE IF NOT EXISTS `test` (                                               |
+|       |   `value` DOUBLE NULL SKIPPING INDEX WITH(granularity = '2048', type = 'BLOOM'),  |
+|       |   `category` STRING NULL,                                                         |
+|       |   `metric` BIGINT NULL SKIPPING INDEX WITH(granularity = '1024', type = 'BLOOM'), |
+|       |   `time` TIMESTAMP(3) NOT NULL,                                                   |
+|       |   TIME INDEX (`time`)                                                             |
 |       | )                                                                                 |
 |       |                                                                                   |
 |       | ENGINE=mito                                                                       |

--- a/tests/cases/standalone/common/create/create.result
+++ b/tests/cases/standalone/common/create/create.result
@@ -251,13 +251,13 @@ SHOW CREATE TABLE monitor;
 +---------+-----------------------------------------------------------+
 | Table   | Create Table                                              |
 +---------+-----------------------------------------------------------+
-| monitor | CREATE TABLE IF NOT EXISTS "monitor" (                    |
-|         |   "host" STRING NULL,                                     |
-|         |   "ts" TIMESTAMP(9) NOT NULL DEFAULT current_timestamp(), |
-|         |   "cpu" DOUBLE NULL DEFAULT 0,                            |
-|         |   "memory" DOUBLE NULL,                                   |
-|         |   TIME INDEX ("ts"),                                      |
-|         |   PRIMARY KEY ("host")                                    |
+| monitor | CREATE TABLE IF NOT EXISTS `monitor` (                    |
+|         |   `host` STRING NULL,                                     |
+|         |   `ts` TIMESTAMP(9) NOT NULL DEFAULT current_timestamp(), |
+|         |   `cpu` DOUBLE NULL DEFAULT 0,                            |
+|         |   `memory` DOUBLE NULL,                                   |
+|         |   TIME INDEX (`ts`),                                      |
+|         |   PRIMARY KEY (`host`)                                    |
 |         | )                                                         |
 |         |                                                           |
 |         | ENGINE=mito                                               |

--- a/tests/cases/standalone/common/create/create_database_opts.result
+++ b/tests/cases/standalone/common/create/create_database_opts.result
@@ -48,11 +48,11 @@ SHOW CREATE TABLE test;
 +-------+-------------------------------------+
 | Table | Create Table                        |
 +-------+-------------------------------------+
-| test  | CREATE TABLE IF NOT EXISTS "test" ( |
-|       |   "host" STRING NULL,               |
-|       |   "cpu" DOUBLE NULL,                |
-|       |   "ts" TIMESTAMP(3) NOT NULL,       |
-|       |   TIME INDEX ("ts")                 |
+| test  | CREATE TABLE IF NOT EXISTS `test` ( |
+|       |   `host` STRING NULL,               |
+|       |   `cpu` DOUBLE NULL,                |
+|       |   `ts` TIMESTAMP(3) NOT NULL,       |
+|       |   TIME INDEX (`ts`)                 |
 |       | )                                   |
 |       |                                     |
 |       | ENGINE=mito                         |

--- a/tests/cases/standalone/common/create/create_metric_table.result
+++ b/tests/cases/standalone/common/create/create_metric_table.result
@@ -81,13 +81,13 @@ SHOW CREATE TABLE phy;
 +-------+------------------------------------+
 | Table | Create Table                       |
 +-------+------------------------------------+
-| phy   | CREATE TABLE IF NOT EXISTS "phy" ( |
-|       |   "ts" TIMESTAMP(3) NOT NULL,      |
-|       |   "val" DOUBLE NULL,               |
-|       |   "host" STRING NULL,              |
-|       |   "job" STRING NULL,               |
-|       |   TIME INDEX ("ts"),               |
-|       |   PRIMARY KEY ("host", "job")      |
+| phy   | CREATE TABLE IF NOT EXISTS `phy` ( |
+|       |   `ts` TIMESTAMP(3) NOT NULL,      |
+|       |   `val` DOUBLE NULL,               |
+|       |   `host` STRING NULL,              |
+|       |   `job` STRING NULL,               |
+|       |   TIME INDEX (`ts`),               |
+|       |   PRIMARY KEY (`host`, `job`)      |
 |       | )                                  |
 |       |                                    |
 |       | ENGINE=metric                      |
@@ -253,10 +253,10 @@ SHOW CREATE TABLE phy;
 +-------+------------------------------------+
 | Table | Create Table                       |
 +-------+------------------------------------+
-| phy   | CREATE TABLE IF NOT EXISTS "phy" ( |
-|       |   "ts" TIMESTAMP(3) NOT NULL,      |
-|       |   "val" DOUBLE NULL,               |
-|       |   TIME INDEX ("ts")                |
+| phy   | CREATE TABLE IF NOT EXISTS `phy` ( |
+|       |   `ts` TIMESTAMP(3) NOT NULL,      |
+|       |   `val` DOUBLE NULL,               |
+|       |   TIME INDEX (`ts`)                |
 |       | )                                  |
 |       |                                    |
 |       | ENGINE=metric                      |
@@ -276,12 +276,12 @@ SHOW CREATE TABLE phy;
 +-------+---------------------------------------------------------------------------------+
 | Table | Create Table                                                                    |
 +-------+---------------------------------------------------------------------------------+
-| phy   | CREATE TABLE IF NOT EXISTS "phy" (                                              |
-|       |   "ts" TIMESTAMP(3) NOT NULL,                                                   |
-|       |   "val" DOUBLE NULL,                                                            |
-|       |   "host" STRING NULL SKIPPING INDEX WITH(granularity = '8192', type = 'BLOOM'), |
-|       |   TIME INDEX ("ts"),                                                            |
-|       |   PRIMARY KEY ("host")                                                          |
+| phy   | CREATE TABLE IF NOT EXISTS `phy` (                                              |
+|       |   `ts` TIMESTAMP(3) NOT NULL,                                                   |
+|       |   `val` DOUBLE NULL,                                                            |
+|       |   `host` STRING NULL SKIPPING INDEX WITH(granularity = '8192', type = 'BLOOM'), |
+|       |   TIME INDEX (`ts`),                                                            |
+|       |   PRIMARY KEY (`host`)                                                          |
 |       | )                                                                               |
 |       |                                                                                 |
 |       | ENGINE=metric                                                                   |

--- a/tests/cases/standalone/common/create/create_type_alias.result
+++ b/tests/cases/standalone/common/create/create_type_alias.result
@@ -24,25 +24,25 @@ SHOW CREATE TABLE data_types;
 +------------+------------------------------------------------------------+
 | Table      | Create Table                                               |
 +------------+------------------------------------------------------------+
-| data_types | CREATE TABLE IF NOT EXISTS "data_types" (                  |
-|            |   "s" STRING NULL,                                         |
-|            |   "tint" TINYINT NULL,                                     |
-|            |   "sint" SMALLINT NULL,                                    |
-|            |   "i" INT NULL,                                            |
-|            |   "bint" BIGINT NULL,                                      |
-|            |   "v" STRING NULL,                                         |
-|            |   "f" FLOAT NULL,                                          |
-|            |   "d" DOUBLE NULL,                                         |
-|            |   "b" BOOLEAN NULL,                                        |
-|            |   "vb" VARBINARY NULL,                                     |
-|            |   "dt" DATE NULL,                                          |
-|            |   "dtt" TIMESTAMP(6) NULL,                                 |
-|            |   "ts0" TIMESTAMP(0) NULL,                                 |
-|            |   "ts3" TIMESTAMP(3) NULL,                                 |
-|            |   "ts6" TIMESTAMP(6) NULL,                                 |
-|            |   "ts9" TIMESTAMP(9) NOT NULL DEFAULT current_timestamp(), |
-|            |   TIME INDEX ("ts9"),                                      |
-|            |   PRIMARY KEY ("s")                                        |
+| data_types | CREATE TABLE IF NOT EXISTS `data_types` (                  |
+|            |   `s` STRING NULL,                                         |
+|            |   `tint` TINYINT NULL,                                     |
+|            |   `sint` SMALLINT NULL,                                    |
+|            |   `i` INT NULL,                                            |
+|            |   `bint` BIGINT NULL,                                      |
+|            |   `v` STRING NULL,                                         |
+|            |   `f` FLOAT NULL,                                          |
+|            |   `d` DOUBLE NULL,                                         |
+|            |   `b` BOOLEAN NULL,                                        |
+|            |   `vb` VARBINARY NULL,                                     |
+|            |   `dt` DATE NULL,                                          |
+|            |   `dtt` TIMESTAMP(6) NULL,                                 |
+|            |   `ts0` TIMESTAMP(0) NULL,                                 |
+|            |   `ts3` TIMESTAMP(3) NULL,                                 |
+|            |   `ts6` TIMESTAMP(6) NULL,                                 |
+|            |   `ts9` TIMESTAMP(9) NOT NULL DEFAULT current_timestamp(), |
+|            |   TIME INDEX (`ts9`),                                      |
+|            |   PRIMARY KEY (`s`)                                        |
 |            | )                                                          |
 |            |                                                            |
 |            | ENGINE=mito                                                |

--- a/tests/cases/standalone/common/create/create_with_fulltext.result
+++ b/tests/cases/standalone/common/create/create_with_fulltext.result
@@ -10,10 +10,10 @@ SHOW CREATE TABLE log;
 +-------+-------------------------------------------------------------------------------------------------------------+
 | Table | Create Table                                                                                                |
 +-------+-------------------------------------------------------------------------------------------------------------+
-| log   | CREATE TABLE IF NOT EXISTS "log" (                                                                          |
-|       |   "ts" TIMESTAMP(3) NOT NULL,                                                                               |
-|       |   "msg" STRING NULL FULLTEXT INDEX WITH(analyzer = 'English', backend = 'bloom', case_sensitive = 'false'), |
-|       |   TIME INDEX ("ts")                                                                                         |
+| log   | CREATE TABLE IF NOT EXISTS `log` (                                                                          |
+|       |   `ts` TIMESTAMP(3) NOT NULL,                                                                               |
+|       |   `msg` STRING NULL FULLTEXT INDEX WITH(analyzer = 'English', backend = 'bloom', case_sensitive = 'false'), |
+|       |   TIME INDEX (`ts`)                                                                                         |
 |       | )                                                                                                           |
 |       |                                                                                                             |
 |       | ENGINE=mito                                                                                                 |
@@ -36,10 +36,10 @@ SHOW CREATE TABLE log_with_opts;
 +---------------+------------------------------------------------------------------------------------------------------------+
 | Table         | Create Table                                                                                               |
 +---------------+------------------------------------------------------------------------------------------------------------+
-| log_with_opts | CREATE TABLE IF NOT EXISTS "log_with_opts" (                                                               |
-|               |   "ts" TIMESTAMP(3) NOT NULL,                                                                              |
-|               |   "msg" STRING NULL FULLTEXT INDEX WITH(analyzer = 'English', backend = 'bloom', case_sensitive = 'true'), |
-|               |   TIME INDEX ("ts")                                                                                        |
+| log_with_opts | CREATE TABLE IF NOT EXISTS `log_with_opts` (                                                               |
+|               |   `ts` TIMESTAMP(3) NOT NULL,                                                                              |
+|               |   `msg` STRING NULL FULLTEXT INDEX WITH(analyzer = 'English', backend = 'bloom', case_sensitive = 'true'), |
+|               |   TIME INDEX (`ts`)                                                                                        |
 |               | )                                                                                                          |
 |               |                                                                                                            |
 |               | ENGINE=mito                                                                                                |
@@ -63,11 +63,11 @@ SHOW CREATE TABLE log_multi_fulltext_cols;
 +-------------------------+--------------------------------------------------------------------------------------------------------------+
 | Table                   | Create Table                                                                                                 |
 +-------------------------+--------------------------------------------------------------------------------------------------------------+
-| log_multi_fulltext_cols | CREATE TABLE IF NOT EXISTS "log_multi_fulltext_cols" (                                                       |
-|                         |   "ts" TIMESTAMP(3) NOT NULL,                                                                                |
-|                         |   "msg" STRING NULL FULLTEXT INDEX WITH(analyzer = 'English', backend = 'bloom', case_sensitive = 'false'),  |
-|                         |   "msg2" STRING NULL FULLTEXT INDEX WITH(analyzer = 'English', backend = 'bloom', case_sensitive = 'false'), |
-|                         |   TIME INDEX ("ts")                                                                                          |
+| log_multi_fulltext_cols | CREATE TABLE IF NOT EXISTS `log_multi_fulltext_cols` (                                                       |
+|                         |   `ts` TIMESTAMP(3) NOT NULL,                                                                                |
+|                         |   `msg` STRING NULL FULLTEXT INDEX WITH(analyzer = 'English', backend = 'bloom', case_sensitive = 'false'),  |
+|                         |   `msg2` STRING NULL FULLTEXT INDEX WITH(analyzer = 'English', backend = 'bloom', case_sensitive = 'false'), |
+|                         |   TIME INDEX (`ts`)                                                                                          |
 |                         | )                                                                                                            |
 |                         |                                                                                                              |
 |                         | ENGINE=mito                                                                                                  |

--- a/tests/cases/standalone/common/create/create_with_skipping_index.result
+++ b/tests/cases/standalone/common/create/create_with_skipping_index.result
@@ -16,11 +16,11 @@ create table
 +----------------+---------------------------------------------------------------------------------+
 | Table          | Create Table                                                                    |
 +----------------+---------------------------------------------------------------------------------+
-| skipping_table | CREATE TABLE IF NOT EXISTS "skipping_table" (                                   |
-|                |   "ts" TIMESTAMP(3) NOT NULL,                                                   |
-|                |   "id" STRING NULL SKIPPING INDEX WITH(granularity = '10240', type = 'BLOOM'),  |
-|                |   "name" STRING NULL SKIPPING INDEX WITH(granularity = '8192', type = 'BLOOM'), |
-|                |   TIME INDEX ("ts")                                                             |
+| skipping_table | CREATE TABLE IF NOT EXISTS `skipping_table` (                                   |
+|                |   `ts` TIMESTAMP(3) NOT NULL,                                                   |
+|                |   `id` STRING NULL SKIPPING INDEX WITH(granularity = '10240', type = 'BLOOM'),  |
+|                |   `name` STRING NULL SKIPPING INDEX WITH(granularity = '8192', type = 'BLOOM'), |
+|                |   TIME INDEX (`ts`)                                                             |
 |                | )                                                                               |
 |                |                                                                                 |
 |                | ENGINE=mito                                                                     |

--- a/tests/cases/standalone/common/create/current_timestamp.result
+++ b/tests/cases/standalone/common/create/current_timestamp.result
@@ -7,9 +7,9 @@ show create table t1;
 +-------+-----------------------------------------------------------+
 | Table | Create Table                                              |
 +-------+-----------------------------------------------------------+
-| t1    | CREATE TABLE IF NOT EXISTS "t1" (                         |
-|       |   "ts" TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
-|       |   TIME INDEX ("ts")                                       |
+| t1    | CREATE TABLE IF NOT EXISTS `t1` (                         |
+|       |   `ts` TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
+|       |   TIME INDEX (`ts`)                                       |
 |       | )                                                         |
 |       |                                                           |
 |       | ENGINE=mito                                               |
@@ -25,9 +25,9 @@ show create table t2;
 +-------+-----------------------------------------------------------+
 | Table | Create Table                                              |
 +-------+-----------------------------------------------------------+
-| t2    | CREATE TABLE IF NOT EXISTS "t2" (                         |
-|       |   "ts" TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
-|       |   TIME INDEX ("ts")                                       |
+| t2    | CREATE TABLE IF NOT EXISTS `t2` (                         |
+|       |   `ts` TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
+|       |   TIME INDEX (`ts`)                                       |
 |       | )                                                         |
 |       |                                                           |
 |       | ENGINE=mito                                               |
@@ -43,9 +43,9 @@ show create table t3;
 +-------+---------------------------------------------+
 | Table | Create Table                                |
 +-------+---------------------------------------------+
-| t3    | CREATE TABLE IF NOT EXISTS "t3" (           |
-|       |   "ts" TIMESTAMP(3) NOT NULL DEFAULT now(), |
-|       |   TIME INDEX ("ts")                         |
+| t3    | CREATE TABLE IF NOT EXISTS `t3` (           |
+|       |   `ts` TIMESTAMP(3) NOT NULL DEFAULT now(), |
+|       |   TIME INDEX (`ts`)                         |
 |       | )                                           |
 |       |                                             |
 |       | ENGINE=mito                                 |

--- a/tests/cases/standalone/common/flow/flow_advance_ttl.result
+++ b/tests/cases/standalone/common/flow/flow_advance_ttl.result
@@ -33,11 +33,11 @@ SHOW CREATE TABLE distinct_basic;
 +----------------+-----------------------------------------------------------+
 | Table          | Create Table                                              |
 +----------------+-----------------------------------------------------------+
-| distinct_basic | CREATE TABLE IF NOT EXISTS "distinct_basic" (             |
-|                |   "number" INT NULL,                                      |
-|                |   "ts" TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
-|                |   TIME INDEX ("ts"),                                      |
-|                |   PRIMARY KEY ("number")                                  |
+| distinct_basic | CREATE TABLE IF NOT EXISTS `distinct_basic` (             |
+|                |   `number` INT NULL,                                      |
+|                |   `ts` TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
+|                |   TIME INDEX (`ts`),                                      |
+|                |   PRIMARY KEY (`number`)                                  |
 |                | )                                                         |
 |                |                                                           |
 |                | ENGINE=mito                                               |
@@ -51,12 +51,12 @@ SHOW CREATE TABLE out_distinct_basic;
 +--------------------+---------------------------------------------------+
 | Table              | Create Table                                      |
 +--------------------+---------------------------------------------------+
-| out_distinct_basic | CREATE TABLE IF NOT EXISTS "out_distinct_basic" ( |
-|                    |   "dis" INT NULL,                                 |
-|                    |   "update_at" TIMESTAMP(3) NULL,                  |
-|                    |   "__ts_placeholder" TIMESTAMP(3) NOT NULL,       |
-|                    |   TIME INDEX ("__ts_placeholder"),                |
-|                    |   PRIMARY KEY ("dis")                             |
+| out_distinct_basic | CREATE TABLE IF NOT EXISTS `out_distinct_basic` ( |
+|                    |   `dis` INT NULL,                                 |
+|                    |   `update_at` TIMESTAMP(3) NULL,                  |
+|                    |   `__ts_placeholder` TIMESTAMP(3) NOT NULL,       |
+|                    |   TIME INDEX (`__ts_placeholder`),                |
+|                    |   PRIMARY KEY (`dis`)                             |
 |                    | )                                                 |
 |                    |                                                   |
 |                    | ENGINE=mito                                       |
@@ -215,11 +215,11 @@ SHOW CREATE TABLE distinct_basic;
 +----------------+-----------------------------------------------------------+
 | Table          | Create Table                                              |
 +----------------+-----------------------------------------------------------+
-| distinct_basic | CREATE TABLE IF NOT EXISTS "distinct_basic" (             |
-|                |   "number" INT NULL,                                      |
-|                |   "ts" TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
-|                |   TIME INDEX ("ts"),                                      |
-|                |   PRIMARY KEY ("number")                                  |
+| distinct_basic | CREATE TABLE IF NOT EXISTS `distinct_basic` (             |
+|                |   `number` INT NULL,                                      |
+|                |   `ts` TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
+|                |   TIME INDEX (`ts`),                                      |
+|                |   PRIMARY KEY (`number`)                                  |
 |                | )                                                         |
 |                |                                                           |
 |                | ENGINE=mito                                               |
@@ -233,12 +233,12 @@ SHOW CREATE TABLE out_distinct_basic;
 +--------------------+---------------------------------------------------+
 | Table              | Create Table                                      |
 +--------------------+---------------------------------------------------+
-| out_distinct_basic | CREATE TABLE IF NOT EXISTS "out_distinct_basic" ( |
-|                    |   "dis" INT NULL,                                 |
-|                    |   "update_at" TIMESTAMP(3) NULL,                  |
-|                    |   "__ts_placeholder" TIMESTAMP(3) NOT NULL,       |
-|                    |   TIME INDEX ("__ts_placeholder"),                |
-|                    |   PRIMARY KEY ("dis")                             |
+| out_distinct_basic | CREATE TABLE IF NOT EXISTS `out_distinct_basic` ( |
+|                    |   `dis` INT NULL,                                 |
+|                    |   `update_at` TIMESTAMP(3) NULL,                  |
+|                    |   `__ts_placeholder` TIMESTAMP(3) NOT NULL,       |
+|                    |   TIME INDEX (`__ts_placeholder`),                |
+|                    |   PRIMARY KEY (`dis`)                             |
 |                    | )                                                 |
 |                    |                                                   |
 |                    | ENGINE=mito                                       |

--- a/tests/cases/standalone/common/flow/flow_auto_sink_table.result
+++ b/tests/cases/standalone/common/flow/flow_auto_sink_table.result
@@ -23,11 +23,11 @@ SHOW CREATE TABLE out_num_cnt_basic;
 +-------------------+--------------------------------------------------+
 | Table             | Create Table                                     |
 +-------------------+--------------------------------------------------+
-| out_num_cnt_basic | CREATE TABLE IF NOT EXISTS "out_num_cnt_basic" ( |
-|                   |   "sum(numbers_input_basic.number)" BIGINT NULL, |
-|                   |   "time_window" TIMESTAMP(9) NOT NULL,           |
-|                   |   "update_at" TIMESTAMP(3) NULL,                 |
-|                   |   TIME INDEX ("time_window")                     |
+| out_num_cnt_basic | CREATE TABLE IF NOT EXISTS `out_num_cnt_basic` ( |
+|                   |   `sum(numbers_input_basic.number)` BIGINT NULL, |
+|                   |   `time_window` TIMESTAMP(9) NOT NULL,           |
+|                   |   `update_at` TIMESTAMP(3) NULL,                 |
+|                   |   TIME INDEX (`time_window`)                     |
 |                   | )                                                |
 |                   |                                                  |
 |                   | ENGINE=mito                                      |
@@ -58,11 +58,11 @@ SHOW CREATE TABLE out_num_cnt_basic;
 +-------------------+--------------------------------------------------+
 | Table             | Create Table                                     |
 +-------------------+--------------------------------------------------+
-| out_num_cnt_basic | CREATE TABLE IF NOT EXISTS "out_num_cnt_basic" ( |
-|                   |   "sum(numbers_input_basic.number)" BIGINT NULL, |
-|                   |   "time_window" TIMESTAMP(9) NOT NULL,           |
-|                   |   "update_at" TIMESTAMP(3) NULL,                 |
-|                   |   TIME INDEX ("time_window")                     |
+| out_num_cnt_basic | CREATE TABLE IF NOT EXISTS `out_num_cnt_basic` ( |
+|                   |   `sum(numbers_input_basic.number)` BIGINT NULL, |
+|                   |   `time_window` TIMESTAMP(9) NOT NULL,           |
+|                   |   `update_at` TIMESTAMP(3) NULL,                 |
+|                   |   TIME INDEX (`time_window`)                     |
 |                   | )                                                |
 |                   |                                                  |
 |                   | ENGINE=mito                                      |
@@ -125,11 +125,11 @@ SHOW CREATE TABLE out_num_cnt_basic;
 +-------------------+--------------------------------------------------+
 | Table             | Create Table                                     |
 +-------------------+--------------------------------------------------+
-| out_num_cnt_basic | CREATE TABLE IF NOT EXISTS "out_num_cnt_basic" ( |
-|                   |   "sumup" BIGINT NULL,                           |
-|                   |   "event_time" TIMESTAMP(3) NOT NULL,            |
-|                   |   "update_at" TIMESTAMP(3) NULL,                 |
-|                   |   TIME INDEX ("event_time")                      |
+| out_num_cnt_basic | CREATE TABLE IF NOT EXISTS `out_num_cnt_basic` ( |
+|                   |   `sumup` BIGINT NULL,                           |
+|                   |   `event_time` TIMESTAMP(3) NOT NULL,            |
+|                   |   `update_at` TIMESTAMP(3) NULL,                 |
+|                   |   TIME INDEX (`event_time`)                      |
 |                   | )                                                |
 |                   |                                                  |
 |                   | ENGINE=mito                                      |
@@ -161,11 +161,11 @@ SHOW CREATE TABLE out_num_cnt_basic;
 +-------------------+--------------------------------------------------+
 | Table             | Create Table                                     |
 +-------------------+--------------------------------------------------+
-| out_num_cnt_basic | CREATE TABLE IF NOT EXISTS "out_num_cnt_basic" ( |
-|                   |   "sumup" BIGINT NULL,                           |
-|                   |   "event_time" TIMESTAMP(3) NOT NULL,            |
-|                   |   "update_at" TIMESTAMP(3) NULL,                 |
-|                   |   TIME INDEX ("event_time")                      |
+| out_num_cnt_basic | CREATE TABLE IF NOT EXISTS `out_num_cnt_basic` ( |
+|                   |   `sumup` BIGINT NULL,                           |
+|                   |   `event_time` TIMESTAMP(3) NOT NULL,            |
+|                   |   `update_at` TIMESTAMP(3) NULL,                 |
+|                   |   TIME INDEX (`event_time`)                      |
 |                   | )                                                |
 |                   |                                                  |
 |                   | ENGINE=mito                                      |

--- a/tests/cases/standalone/common/flow/flow_basic.result
+++ b/tests/cases/standalone/common/flow/flow_basic.result
@@ -23,11 +23,11 @@ SHOW CREATE TABLE out_num_cnt_basic;
 +-------------------+--------------------------------------------------+
 | Table             | Create Table                                     |
 +-------------------+--------------------------------------------------+
-| out_num_cnt_basic | CREATE TABLE IF NOT EXISTS "out_num_cnt_basic" ( |
-|                   |   "sum(numbers_input_basic.number)" BIGINT NULL, |
-|                   |   "time_window" TIMESTAMP(9) NOT NULL,           |
-|                   |   "update_at" TIMESTAMP(3) NULL,                 |
-|                   |   TIME INDEX ("time_window")                     |
+| out_num_cnt_basic | CREATE TABLE IF NOT EXISTS `out_num_cnt_basic` ( |
+|                   |   `sum(numbers_input_basic.number)` BIGINT NULL, |
+|                   |   `time_window` TIMESTAMP(9) NOT NULL,           |
+|                   |   `update_at` TIMESTAMP(3) NULL,                 |
+|                   |   TIME INDEX (`time_window`)                     |
 |                   | )                                                |
 |                   |                                                  |
 |                   | ENGINE=mito                                      |
@@ -50,11 +50,11 @@ SHOW CREATE TABLE out_num_cnt_basic;
 +-------------------+--------------------------------------------------+
 | Table             | Create Table                                     |
 +-------------------+--------------------------------------------------+
-| out_num_cnt_basic | CREATE TABLE IF NOT EXISTS "out_num_cnt_basic" ( |
-|                   |   "sum(numbers_input_basic.number)" BIGINT NULL, |
-|                   |   "time_window" TIMESTAMP(9) NOT NULL,           |
-|                   |   "update_at" TIMESTAMP(3) NULL,                 |
-|                   |   TIME INDEX ("time_window")                     |
+| out_num_cnt_basic | CREATE TABLE IF NOT EXISTS `out_num_cnt_basic` ( |
+|                   |   `sum(numbers_input_basic.number)` BIGINT NULL, |
+|                   |   `time_window` TIMESTAMP(9) NOT NULL,           |
+|                   |   `update_at` TIMESTAMP(3) NULL,                 |
+|                   |   TIME INDEX (`time_window`)                     |
 |                   | )                                                |
 |                   |                                                  |
 |                   | ENGINE=mito                                      |
@@ -175,11 +175,11 @@ SHOW CREATE TABLE out_basic;
 +-----------+---------------------------------------------+
 | Table     | Create Table                                |
 +-----------+---------------------------------------------+
-| out_basic | CREATE TABLE IF NOT EXISTS "out_basic" (    |
-|           |   "wildcard" BIGINT NULL,                   |
-|           |   "update_at" TIMESTAMP(3) NULL,            |
-|           |   "__ts_placeholder" TIMESTAMP(3) NOT NULL, |
-|           |   TIME INDEX ("__ts_placeholder")           |
+| out_basic | CREATE TABLE IF NOT EXISTS `out_basic` (    |
+|           |   `wildcard` BIGINT NULL,                   |
+|           |   `update_at` TIMESTAMP(3) NULL,            |
+|           |   `__ts_placeholder` TIMESTAMP(3) NOT NULL, |
+|           |   TIME INDEX (`__ts_placeholder`)           |
 |           | )                                           |
 |           |                                             |
 |           | ENGINE=mito                                 |
@@ -203,11 +203,11 @@ SHOW CREATE TABLE out_basic;
 +-----------+---------------------------------------------+
 | Table     | Create Table                                |
 +-----------+---------------------------------------------+
-| out_basic | CREATE TABLE IF NOT EXISTS "out_basic" (    |
-|           |   "wildcard" BIGINT NULL,                   |
-|           |   "update_at" TIMESTAMP(3) NULL,            |
-|           |   "__ts_placeholder" TIMESTAMP(3) NOT NULL, |
-|           |   TIME INDEX ("__ts_placeholder")           |
+| out_basic | CREATE TABLE IF NOT EXISTS `out_basic` (    |
+|           |   `wildcard` BIGINT NULL,                   |
+|           |   `update_at` TIMESTAMP(3) NULL,            |
+|           |   `__ts_placeholder` TIMESTAMP(3) NOT NULL, |
+|           |   TIME INDEX (`__ts_placeholder`)           |
 |           | )                                           |
 |           |                                             |
 |           | ENGINE=mito                                 |
@@ -246,11 +246,11 @@ SHOW CREATE TABLE out_basic;
 +-----------+---------------------------------------------+
 | Table     | Create Table                                |
 +-----------+---------------------------------------------+
-| out_basic | CREATE TABLE IF NOT EXISTS "out_basic" (    |
-|           |   "wildcard" BIGINT NULL,                   |
-|           |   "update_at" TIMESTAMP(3) NULL,            |
-|           |   "__ts_placeholder" TIMESTAMP(3) NOT NULL, |
-|           |   TIME INDEX ("__ts_placeholder")           |
+| out_basic | CREATE TABLE IF NOT EXISTS `out_basic` (    |
+|           |   `wildcard` BIGINT NULL,                   |
+|           |   `update_at` TIMESTAMP(3) NULL,            |
+|           |   `__ts_placeholder` TIMESTAMP(3) NOT NULL, |
+|           |   TIME INDEX (`__ts_placeholder`)           |
 |           | )                                           |
 |           |                                             |
 |           | ENGINE=mito                                 |
@@ -300,12 +300,12 @@ SHOW CREATE TABLE out_distinct_basic;
 +--------------------+---------------------------------------------------+
 | Table              | Create Table                                      |
 +--------------------+---------------------------------------------------+
-| out_distinct_basic | CREATE TABLE IF NOT EXISTS "out_distinct_basic" ( |
-|                    |   "dis" INT NULL,                                 |
-|                    |   "update_at" TIMESTAMP(3) NULL,                  |
-|                    |   "__ts_placeholder" TIMESTAMP(3) NOT NULL,       |
-|                    |   TIME INDEX ("__ts_placeholder"),                |
-|                    |   PRIMARY KEY ("dis")                             |
+| out_distinct_basic | CREATE TABLE IF NOT EXISTS `out_distinct_basic` ( |
+|                    |   `dis` INT NULL,                                 |
+|                    |   `update_at` TIMESTAMP(3) NULL,                  |
+|                    |   `__ts_placeholder` TIMESTAMP(3) NOT NULL,       |
+|                    |   TIME INDEX (`__ts_placeholder`),                |
+|                    |   PRIMARY KEY (`dis`)                             |
 |                    | )                                                 |
 |                    |                                                   |
 |                    | ENGINE=mito                                       |
@@ -356,12 +356,12 @@ SHOW CREATE TABLE out_distinct_basic;
 +--------------------+---------------------------------------------------+
 | Table              | Create Table                                      |
 +--------------------+---------------------------------------------------+
-| out_distinct_basic | CREATE TABLE IF NOT EXISTS "out_distinct_basic" ( |
-|                    |   "dis" INT NULL,                                 |
-|                    |   "update_at" TIMESTAMP(3) NULL,                  |
-|                    |   "__ts_placeholder" TIMESTAMP(3) NOT NULL,       |
-|                    |   TIME INDEX ("__ts_placeholder"),                |
-|                    |   PRIMARY KEY ("dis")                             |
+| out_distinct_basic | CREATE TABLE IF NOT EXISTS `out_distinct_basic` ( |
+|                    |   `dis` INT NULL,                                 |
+|                    |   `update_at` TIMESTAMP(3) NULL,                  |
+|                    |   `__ts_placeholder` TIMESTAMP(3) NOT NULL,       |
+|                    |   TIME INDEX (`__ts_placeholder`),                |
+|                    |   PRIMARY KEY (`dis`)                             |
 |                    | )                                                 |
 |                    |                                                   |
 |                    | ENGINE=mito                                       |
@@ -468,11 +468,11 @@ SHOW CREATE TABLE approx_rate;
 +-------------+--------------------------------------------+
 | Table       | Create Table                               |
 +-------------+--------------------------------------------+
-| approx_rate | CREATE TABLE IF NOT EXISTS "approx_rate" ( |
-|             |   "rate" DOUBLE NULL,                      |
-|             |   "time_window" TIMESTAMP(3) NOT NULL,     |
-|             |   "update_at" TIMESTAMP(3) NULL,           |
-|             |   TIME INDEX ("time_window")               |
+| approx_rate | CREATE TABLE IF NOT EXISTS `approx_rate` ( |
+|             |   `rate` DOUBLE NULL,                      |
+|             |   `time_window` TIMESTAMP(3) NOT NULL,     |
+|             |   `update_at` TIMESTAMP(3) NULL,           |
+|             |   TIME INDEX (`time_window`)               |
 |             | )                                          |
 |             |                                            |
 |             | ENGINE=mito                                |
@@ -636,12 +636,12 @@ SHOW CREATE TABLE ngx_country;
 +-------------+---------------------------------------------+
 | Table       | Create Table                                |
 +-------------+---------------------------------------------+
-| ngx_country | CREATE TABLE IF NOT EXISTS "ngx_country" (  |
-|             |   "country" STRING NULL,                    |
-|             |   "update_at" TIMESTAMP(3) NULL,            |
-|             |   "__ts_placeholder" TIMESTAMP(3) NOT NULL, |
-|             |   TIME INDEX ("__ts_placeholder"),          |
-|             |   PRIMARY KEY ("country")                   |
+| ngx_country | CREATE TABLE IF NOT EXISTS `ngx_country` (  |
+|             |   `country` STRING NULL,                    |
+|             |   `update_at` TIMESTAMP(3) NULL,            |
+|             |   `__ts_placeholder` TIMESTAMP(3) NOT NULL, |
+|             |   TIME INDEX (`__ts_placeholder`),          |
+|             |   PRIMARY KEY (`country`)                   |
 |             | )                                           |
 |             |                                             |
 |             | ENGINE=mito                                 |
@@ -669,12 +669,12 @@ SHOW CREATE TABLE ngx_country;
 +-------------+---------------------------------------------+
 | Table       | Create Table                                |
 +-------------+---------------------------------------------+
-| ngx_country | CREATE TABLE IF NOT EXISTS "ngx_country" (  |
-|             |   "country" STRING NULL,                    |
-|             |   "update_at" TIMESTAMP(3) NULL,            |
-|             |   "__ts_placeholder" TIMESTAMP(3) NOT NULL, |
-|             |   TIME INDEX ("__ts_placeholder"),          |
-|             |   PRIMARY KEY ("country")                   |
+| ngx_country | CREATE TABLE IF NOT EXISTS `ngx_country` (  |
+|             |   `country` STRING NULL,                    |
+|             |   `update_at` TIMESTAMP(3) NULL,            |
+|             |   `__ts_placeholder` TIMESTAMP(3) NOT NULL, |
+|             |   TIME INDEX (`__ts_placeholder`),          |
+|             |   PRIMARY KEY (`country`)                   |
 |             | )                                           |
 |             |                                             |
 |             | ENGINE=mito                                 |
@@ -786,12 +786,12 @@ SHOW CREATE TABLE ngx_country;
 +-------------+--------------------------------------------+
 | Table       | Create Table                               |
 +-------------+--------------------------------------------+
-| ngx_country | CREATE TABLE IF NOT EXISTS "ngx_country" ( |
-|             |   "country" STRING NULL,                   |
-|             |   "time_window" TIMESTAMP(3) NOT NULL,     |
-|             |   "update_at" TIMESTAMP(3) NULL,           |
-|             |   TIME INDEX ("time_window"),              |
-|             |   PRIMARY KEY ("country")                  |
+| ngx_country | CREATE TABLE IF NOT EXISTS `ngx_country` ( |
+|             |   `country` STRING NULL,                   |
+|             |   `time_window` TIMESTAMP(3) NOT NULL,     |
+|             |   `update_at` TIMESTAMP(3) NULL,           |
+|             |   TIME INDEX (`time_window`),              |
+|             |   PRIMARY KEY (`country`)                  |
 |             | )                                          |
 |             |                                            |
 |             | ENGINE=mito                                |
@@ -819,12 +819,12 @@ SHOW CREATE TABLE ngx_country;
 +-------------+--------------------------------------------+
 | Table       | Create Table                               |
 +-------------+--------------------------------------------+
-| ngx_country | CREATE TABLE IF NOT EXISTS "ngx_country" ( |
-|             |   "country" STRING NULL,                   |
-|             |   "time_window" TIMESTAMP(3) NOT NULL,     |
-|             |   "update_at" TIMESTAMP(3) NULL,           |
-|             |   TIME INDEX ("time_window"),              |
-|             |   PRIMARY KEY ("country")                  |
+| ngx_country | CREATE TABLE IF NOT EXISTS `ngx_country` ( |
+|             |   `country` STRING NULL,                   |
+|             |   `time_window` TIMESTAMP(3) NOT NULL,     |
+|             |   `update_at` TIMESTAMP(3) NULL,           |
+|             |   TIME INDEX (`time_window`),              |
+|             |   PRIMARY KEY (`country`)                  |
 |             | )                                          |
 |             |                                            |
 |             | ENGINE=mito                                |
@@ -955,13 +955,13 @@ SHOW CREATE TABLE temp_alerts;
 +-------------+--------------------------------------------+
 | Table       | Create Table                               |
 +-------------+--------------------------------------------+
-| temp_alerts | CREATE TABLE IF NOT EXISTS "temp_alerts" ( |
-|             |   "sensor_id" INT NULL,                    |
-|             |   "loc" STRING NULL,                       |
-|             |   "max_temp" DOUBLE NULL,                  |
-|             |   "event_ts" TIMESTAMP(3) NOT NULL,        |
-|             |   "update_at" TIMESTAMP(3) NULL,           |
-|             |   TIME INDEX ("event_ts")                  |
+| temp_alerts | CREATE TABLE IF NOT EXISTS `temp_alerts` ( |
+|             |   `sensor_id` INT NULL,                    |
+|             |   `loc` STRING NULL,                       |
+|             |   `max_temp` DOUBLE NULL,                  |
+|             |   `event_ts` TIMESTAMP(3) NOT NULL,        |
+|             |   `update_at` TIMESTAMP(3) NULL,           |
+|             |   TIME INDEX (`event_ts`)                  |
 |             | )                                          |
 |             |                                            |
 |             | ENGINE=mito                                |
@@ -1116,14 +1116,14 @@ SHOW CREATE TABLE ngx_distribution;
 +------------------+-------------------------------------------------+
 | Table            | Create Table                                    |
 +------------------+-------------------------------------------------+
-| ngx_distribution | CREATE TABLE IF NOT EXISTS "ngx_distribution" ( |
-|                  |   "stat" INT NULL,                              |
-|                  |   "bucket_size" INT NULL,                       |
-|                  |   "total_logs" BIGINT NULL,                     |
-|                  |   "time_window" TIMESTAMP(3) NOT NULL,          |
-|                  |   "update_at" TIMESTAMP(3) NULL,                |
-|                  |   TIME INDEX ("time_window"),                   |
-|                  |   PRIMARY KEY ("stat", "bucket_size")           |
+| ngx_distribution | CREATE TABLE IF NOT EXISTS `ngx_distribution` ( |
+|                  |   `stat` INT NULL,                              |
+|                  |   `bucket_size` INT NULL,                       |
+|                  |   `total_logs` BIGINT NULL,                     |
+|                  |   `time_window` TIMESTAMP(3) NOT NULL,          |
+|                  |   `update_at` TIMESTAMP(3) NULL,                |
+|                  |   TIME INDEX (`time_window`),                   |
+|                  |   PRIMARY KEY (`stat`, `bucket_size`)           |
 |                  | )                                               |
 |                  |                                                 |
 |                  | ENGINE=mito                                     |
@@ -1244,12 +1244,12 @@ SHOW CREATE TABLE requests_without_ip;
 +---------------------+----------------------------------------------------+
 | Table               | Create Table                                       |
 +---------------------+----------------------------------------------------+
-| requests_without_ip | CREATE TABLE IF NOT EXISTS "requests_without_ip" ( |
-|                     |   "service_name" STRING NULL,                      |
-|                     |   "val" INT NULL,                                  |
-|                     |   "ts" TIMESTAMP(3) NOT NULL,                      |
-|                     |   TIME INDEX ("ts"),                               |
-|                     |   PRIMARY KEY ("service_name")                     |
+| requests_without_ip | CREATE TABLE IF NOT EXISTS `requests_without_ip` ( |
+|                     |   `service_name` STRING NULL,                      |
+|                     |   `val` INT NULL,                                  |
+|                     |   `ts` TIMESTAMP(3) NOT NULL,                      |
+|                     |   TIME INDEX (`ts`),                               |
+|                     |   PRIMARY KEY (`service_name`)                     |
 |                     | )                                                  |
 |                     |                                                    |
 |                     | ENGINE=mito                                        |
@@ -1462,14 +1462,14 @@ SHOW CREATE TABLE android_log_abnormal;
 +----------------------+-----------------------------------------------------+
 | Table                | Create Table                                        |
 +----------------------+-----------------------------------------------------+
-| android_log_abnormal | CREATE TABLE IF NOT EXISTS "android_log_abnormal" ( |
-|                      |   "crash" BIGINT NULL,                              |
-|                      |   "fatal" BIGINT NULL,                              |
-|                      |   "backtrace" BIGINT NULL,                          |
-|                      |   "anr" BIGINT NULL,                                |
-|                      |   "time_window" TIMESTAMP(9) NOT NULL,              |
-|                      |   "update_at" TIMESTAMP(3) NULL,                    |
-|                      |   TIME INDEX ("time_window")                        |
+| android_log_abnormal | CREATE TABLE IF NOT EXISTS `android_log_abnormal` ( |
+|                      |   `crash` BIGINT NULL,                              |
+|                      |   `fatal` BIGINT NULL,                              |
+|                      |   `backtrace` BIGINT NULL,                          |
+|                      |   `anr` BIGINT NULL,                                |
+|                      |   `time_window` TIMESTAMP(9) NOT NULL,              |
+|                      |   `update_at` TIMESTAMP(3) NULL,                    |
+|                      |   TIME INDEX (`time_window`)                        |
 |                      | )                                                   |
 |                      |                                                     |
 |                      | ENGINE=mito                                         |
@@ -1575,14 +1575,14 @@ SHOW CREATE TABLE android_log_abnormal;
 +----------------------+-----------------------------------------------------+
 | Table                | Create Table                                        |
 +----------------------+-----------------------------------------------------+
-| android_log_abnormal | CREATE TABLE IF NOT EXISTS "android_log_abnormal" ( |
-|                      |   "crash" BIGINT NULL,                              |
-|                      |   "fatal" BIGINT NULL,                              |
-|                      |   "backtrace" BIGINT NULL,                          |
-|                      |   "anr" BIGINT NULL,                                |
-|                      |   "time_window" TIMESTAMP(9) NOT NULL,              |
-|                      |   "update_at" TIMESTAMP(3) NULL,                    |
-|                      |   TIME INDEX ("time_window")                        |
+| android_log_abnormal | CREATE TABLE IF NOT EXISTS `android_log_abnormal` ( |
+|                      |   `crash` BIGINT NULL,                              |
+|                      |   `fatal` BIGINT NULL,                              |
+|                      |   `backtrace` BIGINT NULL,                          |
+|                      |   `anr` BIGINT NULL,                                |
+|                      |   `time_window` TIMESTAMP(9) NOT NULL,              |
+|                      |   `update_at` TIMESTAMP(3) NULL,                    |
+|                      |   TIME INDEX (`time_window`)                        |
 |                      | )                                                   |
 |                      |                                                     |
 |                      | ENGINE=mito                                         |
@@ -1669,11 +1669,11 @@ SHOW CREATE TABLE out_num_cnt_basic;
 +-------------------+--------------------------------------------------+
 | Table             | Create Table                                     |
 +-------------------+--------------------------------------------------+
-| out_num_cnt_basic | CREATE TABLE IF NOT EXISTS "out_num_cnt_basic" ( |
-|                   |   "avg_after_filter_num" BIGINT NULL,            |
-|                   |   "update_at" TIMESTAMP(3) NULL,                 |
-|                   |   "__ts_placeholder" TIMESTAMP(3) NOT NULL,      |
-|                   |   TIME INDEX ("__ts_placeholder")                |
+| out_num_cnt_basic | CREATE TABLE IF NOT EXISTS `out_num_cnt_basic` ( |
+|                   |   `avg_after_filter_num` BIGINT NULL,            |
+|                   |   `update_at` TIMESTAMP(3) NULL,                 |
+|                   |   `__ts_placeholder` TIMESTAMP(3) NOT NULL,      |
+|                   |   TIME INDEX (`__ts_placeholder`)                |
 |                   | )                                                |
 |                   |                                                  |
 |                   | ENGINE=mito                                      |

--- a/tests/cases/standalone/common/flow/flow_insert.result
+++ b/tests/cases/standalone/common/flow/flow_insert.result
@@ -34,11 +34,11 @@ SHOW CREATE TABLE approx_rate;
 +-------------+--------------------------------------------+
 | Table       | Create Table                               |
 +-------------+--------------------------------------------+
-| approx_rate | CREATE TABLE IF NOT EXISTS "approx_rate" ( |
-|             |   "rate" DOUBLE NULL,                      |
-|             |   "time_window" TIMESTAMP(3) NOT NULL,     |
-|             |   "update_at" TIMESTAMP(3) NULL,           |
-|             |   TIME INDEX ("time_window")               |
+| approx_rate | CREATE TABLE IF NOT EXISTS `approx_rate` ( |
+|             |   `rate` DOUBLE NULL,                      |
+|             |   `time_window` TIMESTAMP(3) NOT NULL,     |
+|             |   `update_at` TIMESTAMP(3) NULL,           |
+|             |   TIME INDEX (`time_window`)               |
 |             | )                                          |
 |             |                                            |
 |             | ENGINE=mito                                |

--- a/tests/cases/standalone/common/flow/flow_tql.result
+++ b/tests/cases/standalone/common/flow/flow_tql.result
@@ -18,13 +18,13 @@ SHOW CREATE TABLE cnt_reqs;
 +----------+-------------------------------------------+
 | Table    | Create Table                              |
 +----------+-------------------------------------------+
-| cnt_reqs | CREATE TABLE IF NOT EXISTS "cnt_reqs" (   |
-|          |   "count(http_requests.val)" BIGINT NULL, |
-|          |   "ts" TIMESTAMP(3) NOT NULL,             |
-|          |   "status_code" BIGINT NULL,              |
-|          |   "update_at" TIMESTAMP(3) NULL,          |
-|          |   TIME INDEX ("ts"),                      |
-|          |   PRIMARY KEY ("status_code")             |
+| cnt_reqs | CREATE TABLE IF NOT EXISTS `cnt_reqs` (   |
+|          |   `count(http_requests.val)` BIGINT NULL, |
+|          |   `ts` TIMESTAMP(3) NOT NULL,             |
+|          |   `status_code` BIGINT NULL,              |
+|          |   `update_at` TIMESTAMP(3) NULL,          |
+|          |   TIME INDEX (`ts`),                      |
+|          |   PRIMARY KEY (`status_code`)             |
 |          | )                                         |
 |          |                                           |
 |          | ENGINE=mito                               |
@@ -101,13 +101,13 @@ SHOW CREATE TABLE cnt_reqs;
 +----------+-------------------------------------------+
 | Table    | Create Table                              |
 +----------+-------------------------------------------+
-| cnt_reqs | CREATE TABLE IF NOT EXISTS "cnt_reqs" (   |
-|          |   "count(http_requests.val)" BIGINT NULL, |
-|          |   "ts" TIMESTAMP(3) NOT NULL,             |
-|          |   "status_code" BIGINT NULL,              |
-|          |   "update_at" TIMESTAMP(3) NULL,          |
-|          |   TIME INDEX ("ts"),                      |
-|          |   PRIMARY KEY ("status_code")             |
+| cnt_reqs | CREATE TABLE IF NOT EXISTS `cnt_reqs` (   |
+|          |   `count(http_requests.val)` BIGINT NULL, |
+|          |   `ts` TIMESTAMP(3) NOT NULL,             |
+|          |   `status_code` BIGINT NULL,              |
+|          |   `update_at` TIMESTAMP(3) NULL,          |
+|          |   TIME INDEX (`ts`),                      |
+|          |   PRIMARY KEY (`status_code`)             |
 |          | )                                         |
 |          |                                           |
 |          | ENGINE=mito                               |

--- a/tests/cases/standalone/common/show/show_create.result
+++ b/tests/cases/standalone/common/show/show_create.result
@@ -25,16 +25,16 @@ SHOW CREATE TABLE system_metrics;
 +----------------+-----------------------------------------------------------+
 | Table          | Create Table                                              |
 +----------------+-----------------------------------------------------------+
-| system_metrics | CREATE TABLE IF NOT EXISTS "system_metrics" (             |
-|                |   "id" INT UNSIGNED NULL,                                 |
-|                |   "host" STRING NULL,                                     |
-|                |   "cpu" DOUBLE NULL,                                      |
-|                |   "disk" FLOAT NULL COMMENT 'comment',                    |
-|                |   "ts" TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
-|                |   TIME INDEX ("ts"),                                      |
-|                |   PRIMARY KEY ("id", "host")                              |
+| system_metrics | CREATE TABLE IF NOT EXISTS `system_metrics` (             |
+|                |   `id` INT UNSIGNED NULL,                                 |
+|                |   `host` STRING NULL,                                     |
+|                |   `cpu` DOUBLE NULL,                                      |
+|                |   `disk` FLOAT NULL COMMENT 'comment',                    |
+|                |   `ts` TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
+|                |   TIME INDEX (`ts`),                                      |
+|                |   PRIMARY KEY (`id`, `host`)                              |
 |                | )                                                         |
-|                | PARTITION ON COLUMNS ("id") (                             |
+|                | PARTITION ON COLUMNS (`id`) (                             |
 |                |   id < 5,                                                 |
 |                |   id >= 9,                                                |
 |                |   id >= 5 AND id < 9                                      |
@@ -77,9 +77,9 @@ show create table table_without_partition;
 +-------------------------+-----------------------------------------------------------+
 | Table                   | Create Table                                              |
 +-------------------------+-----------------------------------------------------------+
-| table_without_partition | CREATE TABLE IF NOT EXISTS "table_without_partition" (    |
-|                         |   "ts" TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
-|                         |   TIME INDEX ("ts")                                       |
+| table_without_partition | CREATE TABLE IF NOT EXISTS `table_without_partition` (    |
+|                         |   `ts` TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
+|                         |   TIME INDEX (`ts`)                                       |
 |                         | )                                                         |
 |                         |                                                           |
 |                         | ENGINE=mito                                               |
@@ -124,12 +124,12 @@ show create table phy;
 +-------+------------------------------------+
 | Table | Create Table                       |
 +-------+------------------------------------+
-| phy   | CREATE TABLE IF NOT EXISTS "phy" ( |
-|       |   "ts" TIMESTAMP(3) NOT NULL,      |
-|       |   "val" DOUBLE NULL,               |
-|       |   "host" STRING NULL,              |
-|       |   TIME INDEX ("ts"),               |
-|       |   PRIMARY KEY ("host")             |
+| phy   | CREATE TABLE IF NOT EXISTS `phy` ( |
+|       |   `ts` TIMESTAMP(3) NOT NULL,      |
+|       |   `val` DOUBLE NULL,               |
+|       |   `host` STRING NULL,              |
+|       |   TIME INDEX (`ts`),               |
+|       |   PRIMARY KEY (`host`)             |
 |       | )                                  |
 |       |                                    |
 |       | ENGINE=metric                      |
@@ -143,12 +143,12 @@ show create table t1;
 +-------+-----------------------------------+
 | Table | Create Table                      |
 +-------+-----------------------------------+
-| t1    | CREATE TABLE IF NOT EXISTS "t1" ( |
-|       |   "host" STRING NULL,             |
-|       |   "ts" TIMESTAMP(3) NOT NULL,     |
-|       |   "val" DOUBLE NULL,              |
-|       |   TIME INDEX ("ts"),              |
-|       |   PRIMARY KEY ("host")            |
+| t1    | CREATE TABLE IF NOT EXISTS `t1` ( |
+|       |   `host` STRING NULL,             |
+|       |   `ts` TIMESTAMP(3) NOT NULL,     |
+|       |   `val` DOUBLE NULL,              |
+|       |   TIME INDEX (`ts`),              |
+|       |   PRIMARY KEY (`host`)            |
 |       | )                                 |
 |       |                                   |
 |       | ENGINE=metric                     |
@@ -201,15 +201,15 @@ show create table phy;
 +-------+-------------------------------------------------------+
 | Table | Create Table                                          |
 +-------+-------------------------------------------------------+
-| phy   | CREATE TABLE IF NOT EXISTS "phy" (                    |
-|       |   "ts" TIMESTAMP(3) NOT NULL,                         |
-|       |   "val" DOUBLE NULL,                                  |
-|       |   "__table_id" INT UNSIGNED NOT NULL,                 |
-|       |   "__tsid" BIGINT UNSIGNED NOT NULL,                  |
-|       |   "host" STRING NULL,                                 |
-|       |   "job" STRING NULL,                                  |
-|       |   TIME INDEX ("ts"),                                  |
-|       |   PRIMARY KEY ("__table_id", "__tsid", "host", "job") |
+| phy   | CREATE TABLE IF NOT EXISTS `phy` (                    |
+|       |   `ts` TIMESTAMP(3) NOT NULL,                         |
+|       |   `val` DOUBLE NULL,                                  |
+|       |   `__table_id` INT UNSIGNED NOT NULL,                 |
+|       |   `__tsid` BIGINT UNSIGNED NOT NULL,                  |
+|       |   `host` STRING NULL,                                 |
+|       |   `job` STRING NULL,                                  |
+|       |   TIME INDEX (`ts`),                                  |
+|       |   PRIMARY KEY (`__table_id`, `__tsid`, `host`, `job`) |
 |       | )                                                     |
 |       |                                                       |
 |       | ENGINE=mito                                           |
@@ -243,12 +243,12 @@ show create table phy;
 +-------+---------------------------------------------------------------------------------+
 | Table | Create Table                                                                    |
 +-------+---------------------------------------------------------------------------------+
-| phy   | CREATE TABLE IF NOT EXISTS "phy" (                                              |
-|       |   "ts" TIMESTAMP(3) NOT NULL,                                                   |
-|       |   "val" DOUBLE NULL,                                                            |
-|       |   "host" STRING NULL SKIPPING INDEX WITH(granularity = '8192', type = 'BLOOM'), |
-|       |   TIME INDEX ("ts"),                                                            |
-|       |   PRIMARY KEY ("host")                                                          |
+| phy   | CREATE TABLE IF NOT EXISTS `phy` (                                              |
+|       |   `ts` TIMESTAMP(3) NOT NULL,                                                   |
+|       |   `val` DOUBLE NULL,                                                            |
+|       |   `host` STRING NULL SKIPPING INDEX WITH(granularity = '8192', type = 'BLOOM'), |
+|       |   TIME INDEX (`ts`),                                                            |
+|       |   PRIMARY KEY (`host`)                                                          |
 |       | )                                                                               |
 |       |                                                                                 |
 |       | ENGINE=metric                                                                   |
@@ -313,13 +313,13 @@ show create table specify_invereted_index_cols;
 +------------------------------+-------------------------------------------------------------+
 | Table                        | Create Table                                                |
 +------------------------------+-------------------------------------------------------------+
-| specify_invereted_index_cols | CREATE TABLE IF NOT EXISTS "specify_invereted_index_cols" ( |
-|                              |   "ts" TIMESTAMP(3) NOT NULL,                               |
-|                              |   "val" DOUBLE NULL,                                        |
-|                              |   "host" STRING NULL,                                       |
-|                              |   "job" STRING NULL INVERTED INDEX,                         |
-|                              |   TIME INDEX ("ts"),                                        |
-|                              |   PRIMARY KEY ("host", "job")                               |
+| specify_invereted_index_cols | CREATE TABLE IF NOT EXISTS `specify_invereted_index_cols` ( |
+|                              |   `ts` TIMESTAMP(3) NOT NULL,                               |
+|                              |   `val` DOUBLE NULL,                                        |
+|                              |   `host` STRING NULL,                                       |
+|                              |   `job` STRING NULL INVERTED INDEX,                         |
+|                              |   TIME INDEX (`ts`),                                        |
+|                              |   PRIMARY KEY (`host`, `job`)                               |
 |                              | )                                                           |
 |                              |                                                             |
 |                              | ENGINE=mito                                                 |
@@ -346,13 +346,13 @@ show create table specify_empty_invereted_index_cols;
 +------------------------------------+-------------------------------------------------------------------+
 | Table                              | Create Table                                                      |
 +------------------------------------+-------------------------------------------------------------------+
-| specify_empty_invereted_index_cols | CREATE TABLE IF NOT EXISTS "specify_empty_invereted_index_cols" ( |
-|                                    |   "ts" TIMESTAMP(3) NOT NULL,                                     |
-|                                    |   "val" DOUBLE NULL,                                              |
-|                                    |   "host" STRING NULL,                                             |
-|                                    |   "job" STRING NULL,                                              |
-|                                    |   TIME INDEX ("ts"),                                              |
-|                                    |   PRIMARY KEY ("host", "job")                                     |
+| specify_empty_invereted_index_cols | CREATE TABLE IF NOT EXISTS `specify_empty_invereted_index_cols` ( |
+|                                    |   `ts` TIMESTAMP(3) NOT NULL,                                     |
+|                                    |   `val` DOUBLE NULL,                                              |
+|                                    |   `host` STRING NULL,                                             |
+|                                    |   `job` STRING NULL,                                              |
+|                                    |   TIME INDEX (`ts`),                                              |
+|                                    |   PRIMARY KEY (`host`, `job`)                                     |
 |                                    | )                                                                 |
 |                                    |                                                                   |
 |                                    | ENGINE=mito                                                       |
@@ -376,12 +376,12 @@ show create table test_column_constrain_composite_indexes;
 +-----------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Table                                   | Create Table                                                                                                                                                                           |
 +-----------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| test_column_constrain_composite_indexes | CREATE TABLE IF NOT EXISTS "test_column_constrain_composite_indexes" (                                                                                                                 |
-|                                         |   "id" INT NULL SKIPPING INDEX WITH(granularity = '10240', type = 'BLOOM') INVERTED INDEX,                                                                                             |
-|                                         |   "host" STRING NULL FULLTEXT INDEX WITH(analyzer = 'English', backend = 'bloom', case_sensitive = 'false') SKIPPING INDEX WITH(granularity = '10240', type = 'BLOOM') INVERTED INDEX, |
-|                                         |   "ts" TIMESTAMP(3) NOT NULL,                                                                                                                                                          |
-|                                         |   TIME INDEX ("ts"),                                                                                                                                                                   |
-|                                         |   PRIMARY KEY ("host")                                                                                                                                                                 |
+| test_column_constrain_composite_indexes | CREATE TABLE IF NOT EXISTS `test_column_constrain_composite_indexes` (                                                                                                                 |
+|                                         |   `id` INT NULL SKIPPING INDEX WITH(granularity = '10240', type = 'BLOOM') INVERTED INDEX,                                                                                             |
+|                                         |   `host` STRING NULL FULLTEXT INDEX WITH(analyzer = 'English', backend = 'bloom', case_sensitive = 'false') SKIPPING INDEX WITH(granularity = '10240', type = 'BLOOM') INVERTED INDEX, |
+|                                         |   `ts` TIMESTAMP(3) NOT NULL,                                                                                                                                                          |
+|                                         |   TIME INDEX (`ts`),                                                                                                                                                                   |
+|                                         |   PRIMARY KEY (`host`)                                                                                                                                                                 |
 |                                         | )                                                                                                                                                                                      |
 |                                         |                                                                                                                                                                                        |
 |                                         | ENGINE=mito                                                                                                                                                                            |
@@ -405,10 +405,10 @@ show create table table_comment_in_cjk;
 +----------------------+-----------------------------------------------------+
 | Table                | Create Table                                        |
 +----------------------+-----------------------------------------------------+
-| table_comment_in_cjk | CREATE TABLE IF NOT EXISTS "table_comment_in_cjk" ( |
-|                      |   "ts" TIMESTAMP(3) NOT NULL COMMENT '时间戳',      |
-|                      |   "val" DOUBLE NULL COMMENT '值',                   |
-|                      |   TIME INDEX ("ts")                                 |
+| table_comment_in_cjk | CREATE TABLE IF NOT EXISTS `table_comment_in_cjk` ( |
+|                      |   `ts` TIMESTAMP(3) NOT NULL COMMENT '时间戳',      |
+|                      |   `val` DOUBLE NULL COMMENT '值',                   |
+|                      |   TIME INDEX (`ts`)                                 |
 |                      | )                                                   |
 |                      |                                                     |
 |                      | ENGINE=mito                                         |

--- a/tests/cases/standalone/common/show/show_index.result
+++ b/tests/cases/standalone/common/show/show_index.result
@@ -41,13 +41,13 @@ show create table test_no_inverted_index;
 +------------------------+-------------------------------------------------------------------------------+
 | Table                  | Create Table                                                                  |
 +------------------------+-------------------------------------------------------------------------------+
-| test_no_inverted_index | CREATE TABLE IF NOT EXISTS "test_no_inverted_index" (                         |
-|                        |   "a" STRING NULL,                                                            |
-|                        |   "b" STRING NULL SKIPPING INDEX WITH(granularity = '10240', type = 'BLOOM'), |
-|                        |   "c" DOUBLE NULL,                                                            |
-|                        |   "ts" TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(),                     |
-|                        |   TIME INDEX ("ts"),                                                          |
-|                        |   PRIMARY KEY ("a", "b")                                                      |
+| test_no_inverted_index | CREATE TABLE IF NOT EXISTS `test_no_inverted_index` (                         |
+|                        |   `a` STRING NULL,                                                            |
+|                        |   `b` STRING NULL SKIPPING INDEX WITH(granularity = '10240', type = 'BLOOM'), |
+|                        |   `c` DOUBLE NULL,                                                            |
+|                        |   `ts` TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(),                     |
+|                        |   TIME INDEX (`ts`),                                                          |
+|                        |   PRIMARY KEY (`a`, `b`)                                                      |
 |                        | )                                                                             |
 |                        |                                                                               |
 |                        | ENGINE=mito                                                                   |

--- a/tests/cases/standalone/common/ttl/show_ttl.result
+++ b/tests/cases/standalone/common/ttl/show_ttl.result
@@ -15,10 +15,10 @@ SHOW CREATE TABLE test_ttl;
 +----------+-----------------------------------------+
 | Table    | Create Table                            |
 +----------+-----------------------------------------+
-| test_ttl | CREATE TABLE IF NOT EXISTS "test_ttl" ( |
-|          |   "ts" TIMESTAMP(3) NOT NULL,           |
-|          |   "val" INT NULL,                       |
-|          |   TIME INDEX ("ts")                     |
+| test_ttl | CREATE TABLE IF NOT EXISTS `test_ttl` ( |
+|          |   `ts` TIMESTAMP(3) NOT NULL,           |
+|          |   `val` INT NULL,                       |
+|          |   TIME INDEX (`ts`)                     |
 |          | )                                       |
 |          |                                         |
 |          | ENGINE=mito                             |
@@ -47,10 +47,10 @@ SHOW CREATE TABLE test_ttl;
 +----------+-----------------------------------------+
 | Table    | Create Table                            |
 +----------+-----------------------------------------+
-| test_ttl | CREATE TABLE IF NOT EXISTS "test_ttl" ( |
-|          |   "ts" TIMESTAMP(3) NOT NULL,           |
-|          |   "val" INT NULL,                       |
-|          |   TIME INDEX ("ts")                     |
+| test_ttl | CREATE TABLE IF NOT EXISTS `test_ttl` ( |
+|          |   `ts` TIMESTAMP(3) NOT NULL,           |
+|          |   `val` INT NULL,                       |
+|          |   TIME INDEX (`ts`)                     |
 |          | )                                       |
 |          |                                         |
 |          | ENGINE=mito                             |
@@ -79,10 +79,10 @@ SHOW CREATE TABLE test_ttl;
 +----------+-----------------------------------------+
 | Table    | Create Table                            |
 +----------+-----------------------------------------+
-| test_ttl | CREATE TABLE IF NOT EXISTS "test_ttl" ( |
-|          |   "ts" TIMESTAMP(3) NOT NULL,           |
-|          |   "val" INT NULL,                       |
-|          |   TIME INDEX ("ts")                     |
+| test_ttl | CREATE TABLE IF NOT EXISTS `test_ttl` ( |
+|          |   `ts` TIMESTAMP(3) NOT NULL,           |
+|          |   `val` INT NULL,                       |
+|          |   TIME INDEX (`ts`)                     |
 |          | )                                       |
 |          |                                         |
 |          | ENGINE=mito                             |
@@ -100,10 +100,10 @@ SHOW CREATE TABLE test_ttl;
 +----------+-----------------------------------------+
 | Table    | Create Table                            |
 +----------+-----------------------------------------+
-| test_ttl | CREATE TABLE IF NOT EXISTS "test_ttl" ( |
-|          |   "ts" TIMESTAMP(3) NOT NULL,           |
-|          |   "val" INT NULL,                       |
-|          |   TIME INDEX ("ts")                     |
+| test_ttl | CREATE TABLE IF NOT EXISTS `test_ttl` ( |
+|          |   `ts` TIMESTAMP(3) NOT NULL,           |
+|          |   `val` INT NULL,                       |
+|          |   TIME INDEX (`ts`)                     |
 |          | )                                       |
 |          |                                         |
 |          | ENGINE=mito                             |
@@ -121,10 +121,10 @@ SHOW CREATE TABLE test_ttl;
 +----------+-----------------------------------------+
 | Table    | Create Table                            |
 +----------+-----------------------------------------+
-| test_ttl | CREATE TABLE IF NOT EXISTS "test_ttl" ( |
-|          |   "ts" TIMESTAMP(3) NOT NULL,           |
-|          |   "val" INT NULL,                       |
-|          |   TIME INDEX ("ts")                     |
+| test_ttl | CREATE TABLE IF NOT EXISTS `test_ttl` ( |
+|          |   `ts` TIMESTAMP(3) NOT NULL,           |
+|          |   `val` INT NULL,                       |
+|          |   TIME INDEX (`ts`)                     |
 |          | )                                       |
 |          |                                         |
 |          | ENGINE=mito                             |
@@ -142,10 +142,10 @@ SHOW CREATE TABLE test_ttl;
 +----------+-----------------------------------------+
 | Table    | Create Table                            |
 +----------+-----------------------------------------+
-| test_ttl | CREATE TABLE IF NOT EXISTS "test_ttl" ( |
-|          |   "ts" TIMESTAMP(3) NOT NULL,           |
-|          |   "val" INT NULL,                       |
-|          |   TIME INDEX ("ts")                     |
+| test_ttl | CREATE TABLE IF NOT EXISTS `test_ttl` ( |
+|          |   `ts` TIMESTAMP(3) NOT NULL,           |
+|          |   `val` INT NULL,                       |
+|          |   TIME INDEX (`ts`)                     |
 |          | )                                       |
 |          |                                         |
 |          | ENGINE=mito                             |
@@ -174,10 +174,10 @@ SHOW CREATE TABLE test_ttl;
 +----------+-----------------------------------------+
 | Table    | Create Table                            |
 +----------+-----------------------------------------+
-| test_ttl | CREATE TABLE IF NOT EXISTS "test_ttl" ( |
-|          |   "ts" TIMESTAMP(3) NOT NULL,           |
-|          |   "val" INT NULL,                       |
-|          |   TIME INDEX ("ts")                     |
+| test_ttl | CREATE TABLE IF NOT EXISTS `test_ttl` ( |
+|          |   `ts` TIMESTAMP(3) NOT NULL,           |
+|          |   `val` INT NULL,                       |
+|          |   TIME INDEX (`ts`)                     |
 |          | )                                       |
 |          |                                         |
 |          | ENGINE=mito                             |
@@ -206,10 +206,10 @@ SHOW CREATE TABLE test_ttl;
 +----------+-----------------------------------------+
 | Table    | Create Table                            |
 +----------+-----------------------------------------+
-| test_ttl | CREATE TABLE IF NOT EXISTS "test_ttl" ( |
-|          |   "ts" TIMESTAMP(3) NOT NULL,           |
-|          |   "val" INT NULL,                       |
-|          |   TIME INDEX ("ts")                     |
+| test_ttl | CREATE TABLE IF NOT EXISTS `test_ttl` ( |
+|          |   `ts` TIMESTAMP(3) NOT NULL,           |
+|          |   `val` INT NULL,                       |
+|          |   TIME INDEX (`ts`)                     |
 |          | )                                       |
 |          |                                         |
 |          | ENGINE=mito                             |
@@ -238,10 +238,10 @@ SHOW CREATE TABLE test_ttl;
 +----------+-----------------------------------------+
 | Table    | Create Table                            |
 +----------+-----------------------------------------+
-| test_ttl | CREATE TABLE IF NOT EXISTS "test_ttl" ( |
-|          |   "ts" TIMESTAMP(3) NOT NULL,           |
-|          |   "val" INT NULL,                       |
-|          |   TIME INDEX ("ts")                     |
+| test_ttl | CREATE TABLE IF NOT EXISTS `test_ttl` ( |
+|          |   `ts` TIMESTAMP(3) NOT NULL,           |
+|          |   `val` INT NULL,                       |
+|          |   TIME INDEX (`ts`)                     |
 |          | )                                       |
 |          |                                         |
 |          | ENGINE=mito                             |
@@ -270,10 +270,10 @@ SHOW CREATE TABLE test_ttl;
 +----------+-----------------------------------------+
 | Table    | Create Table                            |
 +----------+-----------------------------------------+
-| test_ttl | CREATE TABLE IF NOT EXISTS "test_ttl" ( |
-|          |   "ts" TIMESTAMP(3) NOT NULL,           |
-|          |   "val" INT NULL,                       |
-|          |   TIME INDEX ("ts")                     |
+| test_ttl | CREATE TABLE IF NOT EXISTS `test_ttl` ( |
+|          |   `ts` TIMESTAMP(3) NOT NULL,           |
+|          |   `val` INT NULL,                       |
+|          |   TIME INDEX (`ts`)                     |
 |          | )                                       |
 |          |                                         |
 |          | ENGINE=mito                             |
@@ -302,10 +302,10 @@ SHOW CREATE TABLE test_ttl;
 +----------+-----------------------------------------+
 | Table    | Create Table                            |
 +----------+-----------------------------------------+
-| test_ttl | CREATE TABLE IF NOT EXISTS "test_ttl" ( |
-|          |   "ts" TIMESTAMP(3) NOT NULL,           |
-|          |   "val" INT NULL,                       |
-|          |   TIME INDEX ("ts")                     |
+| test_ttl | CREATE TABLE IF NOT EXISTS `test_ttl` ( |
+|          |   `ts` TIMESTAMP(3) NOT NULL,           |
+|          |   `val` INT NULL,                       |
+|          |   TIME INDEX (`ts`)                     |
 |          | )                                       |
 |          |                                         |
 |          | ENGINE=mito                             |
@@ -329,10 +329,10 @@ SHOW CREATE TABLE test_ttl;
 +----------+-----------------------------------------+
 | Table    | Create Table                            |
 +----------+-----------------------------------------+
-| test_ttl | CREATE TABLE IF NOT EXISTS "test_ttl" ( |
-|          |   "ts" TIMESTAMP(3) NOT NULL,           |
-|          |   "val" INT NULL,                       |
-|          |   TIME INDEX ("ts")                     |
+| test_ttl | CREATE TABLE IF NOT EXISTS `test_ttl` ( |
+|          |   `ts` TIMESTAMP(3) NOT NULL,           |
+|          |   `val` INT NULL,                       |
+|          |   TIME INDEX (`ts`)                     |
 |          | )                                       |
 |          |                                         |
 |          | ENGINE=mito                             |

--- a/tests/cases/standalone/common/ttl/ttl_instant.result
+++ b/tests/cases/standalone/common/ttl/ttl_instant.result
@@ -11,11 +11,11 @@ SHOW CREATE TABLE test_ttl;
 +----------+-----------------------------------------+
 | Table    | Create Table                            |
 +----------+-----------------------------------------+
-| test_ttl | CREATE TABLE IF NOT EXISTS "test_ttl" ( |
-|          |   "ts" TIMESTAMP(3) NOT NULL,           |
-|          |   "val" INT NULL,                       |
-|          |   TIME INDEX ("ts"),                    |
-|          |   PRIMARY KEY ("val")                   |
+| test_ttl | CREATE TABLE IF NOT EXISTS `test_ttl` ( |
+|          |   `ts` TIMESTAMP(3) NOT NULL,           |
+|          |   `val` INT NULL,                       |
+|          |   TIME INDEX (`ts`),                    |
+|          |   PRIMARY KEY (`val`)                   |
 |          | )                                       |
 |          |                                         |
 |          | ENGINE=mito                             |
@@ -116,11 +116,11 @@ SHOW CREATE TABLE test_ttl;
 +----------+-----------------------------------------+
 | Table    | Create Table                            |
 +----------+-----------------------------------------+
-| test_ttl | CREATE TABLE IF NOT EXISTS "test_ttl" ( |
-|          |   "ts" TIMESTAMP(3) NOT NULL,           |
-|          |   "val" INT NULL,                       |
-|          |   TIME INDEX ("ts"),                    |
-|          |   PRIMARY KEY ("val")                   |
+| test_ttl | CREATE TABLE IF NOT EXISTS `test_ttl` ( |
+|          |   `ts` TIMESTAMP(3) NOT NULL,           |
+|          |   `val` INT NULL,                       |
+|          |   TIME INDEX (`ts`),                    |
+|          |   PRIMARY KEY (`val`)                   |
 |          | )                                       |
 |          |                                         |
 |          | ENGINE=mito                             |


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


Use a fixed quote style (back quote ```) for `SHOW CREATE TABLE`. Back quote is valid for both MySQL and PG.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
