### PR TITLE
chore: test sleep longer

### DIFF
--- a/src/meta-srv/src/procedure/wal_prune/manager.rs
+++ b/src/meta-srv/src/procedure/wal_prune/manager.rs
@@ -343,7 +343,7 @@ mod test {
     #[tokio::test]
     async fn test_wal_prune_ticker() {
         let (tx, mut rx) = WalPruneManager::channel();
-        let interval = Duration::from_millis(10);
+        let interval = Duration::from_millis(50);
         let ticker = WalPruneTicker::new(interval, tx);
         assert_eq!(ticker.name(), "WalPruneTicker");
 

--- a/src/meta-srv/src/procedure/wal_prune/manager.rs
+++ b/src/meta-srv/src/procedure/wal_prune/manager.rs
@@ -349,7 +349,8 @@ mod test {
 
         for _ in 0..2 {
             ticker.start();
-            sleep(2 * interval).await;
+            // wait a bit longer to make sure not all ticks are skipped
+            sleep(4 * interval).await;
             assert!(!rx.is_empty());
             while let Ok(event) = rx.try_recv() {
                 assert_matches!(event, Event::Tick);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

as title, sleep longer for test `test_wal_prune_ticker` so that not all ticks are skipped, hence assert can almost certainly success(also longer interval since windows timer default resolution is 15.6ms)

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
