### PR TITLE
feat: don't allow creating logical table with partitions

### DIFF
--- a/src/common/meta/src/ddl/test_util.rs
+++ b/src/common/meta/src/ddl/test_util.rs
@@ -18,6 +18,7 @@ pub mod create_table;
 pub mod datanode_handler;
 pub mod flownode_handler;
 
+use std::assert_matches::assert_matches;
 use std::collections::HashMap;
 
 use api::v1::meta::Partition;
@@ -75,8 +76,6 @@ pub async fn create_logical_table(
     physical_table_id: TableId,
     table_name: &str,
 ) -> TableId {
-    use std::assert_matches::assert_matches;
-
     let tasks = vec![test_create_logical_table_task(table_name)];
     let mut procedure = CreateLogicalTablesProcedure::new(tasks, physical_table_id, ddl_context);
     let status = procedure.on_prepare().await.unwrap();

--- a/src/sql/src/statements/create.rs
+++ b/src/sql/src/statements/create.rs
@@ -211,6 +211,12 @@ impl ColumnExtensions {
     }
 }
 
+/// Partition on columns or values.
+///
+/// - `column_list` is the list of columns in `PARTITION ON COLUMNS` clause.
+/// - `exprs` is the list of expressions in `PARTITION ON VALUES` clause, like
+/// `host <= 'host1'`, `host > 'host1' and host <= 'host2'` or `host > 'host2'`.
+/// Each expression stands for a partition.
 #[derive(Debug, PartialEq, Eq, Clone, Visit, VisitMut, Serialize)]
 pub struct Partitions {
     pub column_list: Vec<Ident>,

--- a/tests/cases/standalone/common/create/metric_engine_partition.result
+++ b/tests/cases/standalone/common/create/metric_engine_partition.result
@@ -1,0 +1,81 @@
+create table metric_engine_partition (
+    ts timestamp time index,
+    host string primary key,
+    cpu double,
+)
+partition on columns (host) (
+    host <= 'host1',
+    host > 'host1' and host <= 'host2',
+    host > 'host2'
+)
+engine = metric
+with (
+    physical_metric_table = "true",
+);
+
+Affected Rows: 0
+
+select count(*) from metric_engine_partition;
+
++----------+
+| count(*) |
++----------+
+| 0        |
++----------+
+
+create table logical_table_1 (
+    ts timestamp time index,
+    host string primary key,
+    cpu double,
+)
+partition on columns (host) ()
+engine = metric
+with (
+    on_physical_table = "metric_engine_partition",
+);
+
+Error: 1004(InvalidArguments), Invalid partition rule: logical table in metric engine should not have partition rule, it will be inherited from physical table
+
+create table logical_table_2 (
+    ts timestamp time index,
+    host string primary key,
+    cpu double,
+)
+engine = metric
+with (
+    on_physical_table = "metric_engine_partition",
+);
+
+Affected Rows: 0
+
+show create table logical_table_2;
+
++-----------------+-------------------------------------------------+
+| Table           | Create Table                                    |
++-----------------+-------------------------------------------------+
+| logical_table_2 | CREATE TABLE IF NOT EXISTS "logical_table_2" (  |
+|                 |   "cpu" DOUBLE NULL,                            |
+|                 |   "host" STRING NULL,                           |
+|                 |   "ts" TIMESTAMP(3) NOT NULL,                   |
+|                 |   TIME INDEX ("ts"),                            |
+|                 |   PRIMARY KEY ("host")                          |
+|                 | )                                               |
+|                 | PARTITION ON COLUMNS ("host") (                 |
+|                 |   host <= 'host1',                              |
+|                 |   host > 'host2',                               |
+|                 |   host > 'host1' AND host <= 'host2'            |
+|                 | )                                               |
+|                 | ENGINE=metric                                   |
+|                 | WITH(                                           |
+|                 |   on_physical_table = 'metric_engine_partition' |
+|                 | )                                               |
++-----------------+-------------------------------------------------+
+
+drop table logical_table_2;
+
+Affected Rows: 0
+
+drop table metric_engine_partition;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/create/metric_engine_partition.sql
+++ b/tests/cases/standalone/common/create/metric_engine_partition.sql
@@ -1,0 +1,43 @@
+create table metric_engine_partition (
+    ts timestamp time index,
+    host string primary key,
+    cpu double,
+)
+partition on columns (host) (
+    host <= 'host1',
+    host > 'host1' and host <= 'host2',
+    host > 'host2'
+)
+engine = metric
+with (
+    physical_metric_table = "true",
+);
+
+select count(*) from metric_engine_partition;
+
+create table logical_table_1 (
+    ts timestamp time index,
+    host string primary key,
+    cpu double,
+)
+partition on columns (host) ()
+engine = metric
+with (
+    on_physical_table = "metric_engine_partition",
+);
+
+create table logical_table_2 (
+    ts timestamp time index,
+    host string primary key,
+    cpu double,
+)
+engine = metric
+with (
+    on_physical_table = "metric_engine_partition",
+);
+
+show create table logical_table_2;
+
+drop table logical_table_2;
+
+drop table metric_engine_partition;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


Logical table should inherit partition info from physical table. Hence this patch forbids creating logical table with partitions.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
