### PR TITLE
refactor: remove `PipelineMap` and use `Value` instead

### DIFF
--- a/src/pipeline/src/dispatcher.rs
+++ b/src/pipeline/src/dispatcher.rs
@@ -21,7 +21,7 @@ use crate::error::{
     ValueRequiredForDispatcherRuleSnafu,
 };
 use crate::etl::ctx_req::TABLE_SUFFIX_KEY;
-use crate::{PipelineMap, Value};
+use crate::Value;
 
 const FIELD: &str = "field";
 const PIPELINE: &str = "pipeline";
@@ -109,7 +109,7 @@ impl TryFrom<&Yaml> for Dispatcher {
 
 impl Dispatcher {
     /// execute dispatcher and returns matched rule if any
-    pub(crate) fn exec(&self, data: &PipelineMap) -> Option<&Rule> {
+    pub(crate) fn exec(&self, data: &Value) -> Option<&Rule> {
         if let Some(value) = data.get(&self.field) {
             for rule in &self.rules {
                 if rule.value == *value {
@@ -119,7 +119,7 @@ impl Dispatcher {
 
             None
         } else {
-            debug!("field {} not found in keys {:?}", &self.field, data.keys());
+            debug!("field {} not found in keys {:?}", &self.field, data);
             None
         }
     }

--- a/src/pipeline/src/error.rs
+++ b/src/pipeline/src/error.rs
@@ -809,14 +809,13 @@ impl ErrorExt for Error {
         use Error::*;
         match self {
             CastType { .. } => StatusCode::Unexpected,
-            ValueMustBeMap { .. } => StatusCode::Unexpected,
             PipelineTableNotFound { .. } => StatusCode::TableNotFound,
             InsertPipeline { source, .. } => source.status_code(),
             CollectRecords { source, .. } => source.status_code(),
             PipelineNotFound { .. }
             | InvalidPipelineVersion { .. }
             | InvalidCustomTimeIndex { .. } => StatusCode::InvalidArguments,
-            MultiPipelineWithDiffSchema { .. } => StatusCode::IllegalState,
+            MultiPipelineWithDiffSchema { .. } | ValueMustBeMap { .. } => StatusCode::IllegalState,
             BuildDfLogicalPlan { .. } | RecordBatchLenNotMatch { .. } => StatusCode::Internal,
             ExecuteInternalStatement { source, .. } => source.status_code(),
             DataFrame { source, .. } => source.status_code(),

--- a/src/pipeline/src/error.rs
+++ b/src/pipeline/src/error.rs
@@ -734,6 +734,12 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display("Top level value must be map"))]
+    ValueMustBeMap {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Failed to build DataFusion logical plan"))]
     BuildDfLogicalPlan {
         #[snafu(source)]
@@ -803,6 +809,7 @@ impl ErrorExt for Error {
         use Error::*;
         match self {
             CastType { .. } => StatusCode::Unexpected,
+            ValueMustBeMap { .. } => StatusCode::Unexpected,
             PipelineTableNotFound { .. } => StatusCode::TableNotFound,
             InsertPipeline { source, .. } => source.status_code(),
             CollectRecords { source, .. } => source.status_code(),

--- a/src/pipeline/src/etl.rs
+++ b/src/pipeline/src/etl.rs
@@ -47,8 +47,6 @@ const TRANSFORMS: &str = "transforms";
 const DISPATCHER: &str = "dispatcher";
 const TABLESUFFIX: &str = "table_suffix";
 
-// pub type PipelineMap = std::collections::BTreeMap<String, Value>;
-
 pub enum Content<'a> {
     Json(&'a str),
     Yaml(&'a str),

--- a/src/pipeline/src/etl.rs
+++ b/src/pipeline/src/etl.rs
@@ -19,6 +19,8 @@ pub mod processor;
 pub mod transform;
 pub mod value;
 
+use std::collections::BTreeMap;
+
 use ahash::{HashMap, HashMapExt};
 use api::v1::Row;
 use common_time::timestamp::TimeUnit;
@@ -31,7 +33,7 @@ use yaml_rust::YamlLoader;
 use crate::dispatcher::{Dispatcher, Rule};
 use crate::error::{
     AutoTransformOneTimestampSnafu, InputValueMustBeObjectSnafu, IntermediateKeyIndexSnafu, Result,
-    YamlLoadSnafu, YamlParseSnafu,
+    ValueMustBeMapSnafu, YamlLoadSnafu, YamlParseSnafu,
 };
 use crate::etl::ctx_req::TABLE_SUFFIX_KEY;
 use crate::etl::processor::ProcessorKind;
@@ -45,7 +47,7 @@ const TRANSFORMS: &str = "transforms";
 const DISPATCHER: &str = "dispatcher";
 const TABLESUFFIX: &str = "table_suffix";
 
-pub type PipelineMap = std::collections::BTreeMap<String, Value>;
+// pub type PipelineMap = std::collections::BTreeMap<String, Value>;
 
 pub enum Content<'a> {
     Json(&'a str),
@@ -155,7 +157,7 @@ impl DispatchedTo {
 pub enum PipelineExecOutput {
     Transformed(TransformedOutput),
     AutoTransform(AutoTransformOutput),
-    DispatchedTo(DispatchedTo, PipelineMap),
+    DispatchedTo(DispatchedTo, Value),
 }
 
 #[derive(Debug)]
@@ -163,7 +165,7 @@ pub struct TransformedOutput {
     pub opt: ContextOpt,
     pub row: Row,
     pub table_suffix: Option<String>,
-    pub pipeline_map: PipelineMap,
+    pub pipeline_map: Value,
 }
 
 #[derive(Debug)]
@@ -171,7 +173,7 @@ pub struct AutoTransformOutput {
     pub table_suffix: Option<String>,
     // ts_column_name -> unit
     pub ts_unit_map: HashMap<String, TimeUnit>,
-    pub pipeline_map: PipelineMap,
+    pub pipeline_map: Value,
 }
 
 impl PipelineExecOutput {
@@ -197,42 +199,42 @@ impl PipelineExecOutput {
     }
 }
 
-pub fn json_to_map(val: serde_json::Value) -> Result<PipelineMap> {
+pub fn json_to_map(val: serde_json::Value) -> Result<Value> {
     match val {
         serde_json::Value::Object(map) => {
-            let mut intermediate_state = PipelineMap::new();
+            let mut intermediate_state = BTreeMap::new();
             for (k, v) in map {
                 intermediate_state.insert(k, Value::try_from(v)?);
             }
-            Ok(intermediate_state)
+            Ok(Value::Map(intermediate_state.into()))
         }
         _ => InputValueMustBeObjectSnafu.fail(),
     }
 }
 
-pub fn json_array_to_map(val: Vec<serde_json::Value>) -> Result<Vec<PipelineMap>> {
+pub fn json_array_to_map(val: Vec<serde_json::Value>) -> Result<Vec<Value>> {
     val.into_iter().map(json_to_map).collect()
 }
 
-pub fn simd_json_to_map(val: simd_json::OwnedValue) -> Result<PipelineMap> {
+pub fn simd_json_to_map(val: simd_json::OwnedValue) -> Result<Value> {
     match val {
         simd_json::OwnedValue::Object(map) => {
-            let mut intermediate_state = PipelineMap::new();
+            let mut intermediate_state = BTreeMap::new();
             for (k, v) in map.into_iter() {
                 intermediate_state.insert(k, Value::try_from(v)?);
             }
-            Ok(intermediate_state)
+            Ok(Value::Map(intermediate_state.into()))
         }
         _ => InputValueMustBeObjectSnafu.fail(),
     }
 }
 
-pub fn simd_json_array_to_map(val: Vec<simd_json::OwnedValue>) -> Result<Vec<PipelineMap>> {
+pub fn simd_json_array_to_map(val: Vec<simd_json::OwnedValue>) -> Result<Vec<Value>> {
     val.into_iter().map(simd_json_to_map).collect()
 }
 
 impl Pipeline {
-    pub fn exec_mut(&self, mut val: PipelineMap) -> Result<PipelineExecOutput> {
+    pub fn exec_mut(&self, mut val: Value) -> Result<PipelineExecOutput> {
         // process
         for processor in self.processors.iter() {
             val = processor.exec_mut(val)?;
@@ -263,7 +265,7 @@ impl Pipeline {
 
             let mut ts_unit_map = HashMap::with_capacity(4);
             // get all ts values
-            for (k, v) in val.iter() {
+            for (k, v) in val.as_map_mut().context(ValueMustBeMapSnafu)? {
                 if let Value::Timestamp(ts) = v {
                     if !ts_unit_map.contains_key(k) {
                         ts_unit_map.insert(k.clone(), ts.get_unit());
@@ -378,8 +380,9 @@ transform:
       type: timestamp, ns
       index: time"#;
         let pipeline: Pipeline = parse(&Content::Yaml(pipeline_str)).unwrap();
-        let mut payload = PipelineMap::new();
+        let mut payload = BTreeMap::new();
         payload.insert("message".to_string(), Value::String(message));
+        let payload = Value::Map(payload.into());
         let result = pipeline
             .exec_mut(payload)
             .unwrap()

--- a/src/pipeline/src/etl/processor.rs
+++ b/src/pipeline/src/etl/processor.rs
@@ -60,7 +60,7 @@ use crate::etl::processor::json_parse::JsonParseProcessor;
 use crate::etl::processor::select::SelectProcessor;
 use crate::etl::processor::simple_extract::SimpleExtractProcessor;
 use crate::etl::processor::vrl::VrlProcessor;
-use crate::etl::PipelineMap;
+use crate::Value;
 
 const FIELD_NAME: &str = "field";
 const FIELDS_NAME: &str = "fields";
@@ -125,7 +125,7 @@ pub trait Processor: std::fmt::Debug + Send + Sync + 'static {
     fn ignore_missing(&self) -> bool;
 
     /// Execute the processor on a vector which be preprocessed by the pipeline
-    fn exec_mut(&self, val: PipelineMap) -> Result<PipelineMap>;
+    fn exec_mut(&self, val: Value) -> Result<Value>;
 }
 
 #[derive(Debug)]

--- a/src/pipeline/src/etl/processor/date.rs
+++ b/src/pipeline/src/etl/processor/date.rs
@@ -30,7 +30,6 @@ use crate::etl::processor::{
     FIELD_NAME, IGNORE_MISSING_NAME,
 };
 use crate::etl::value::{Timestamp, Value};
-use crate::etl::PipelineMap;
 
 pub(crate) const PROCESSOR_DATE: &str = "date";
 
@@ -198,14 +197,14 @@ impl Processor for DateProcessor {
         self.ignore_missing
     }
 
-    fn exec_mut(&self, mut val: PipelineMap) -> Result<PipelineMap> {
+    fn exec_mut(&self, mut val: Value) -> Result<Value> {
         for field in self.fields.iter() {
             let index = field.input_field();
             match val.get(index) {
                 Some(Value::String(s)) => {
                     let timestamp = self.parse(s)?;
                     let output_key = field.target_or_input_field();
-                    val.insert(output_key.to_string(), Value::Timestamp(timestamp));
+                    val.insert(output_key.to_string(), Value::Timestamp(timestamp))?;
                 }
                 Some(Value::Null) | None => {
                     if !self.ignore_missing {

--- a/src/pipeline/src/etl/processor/decolorize.rs
+++ b/src/pipeline/src/etl/processor/decolorize.rs
@@ -30,7 +30,6 @@ use crate::etl::processor::{
     yaml_bool, yaml_new_field, yaml_new_fields, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME,
 };
 use crate::etl::value::Value;
-use crate::etl::PipelineMap;
 
 pub(crate) const PROCESSOR_DECOLORIZE: &str = "decolorize";
 
@@ -102,7 +101,7 @@ impl crate::etl::processor::Processor for DecolorizeProcessor {
         self.ignore_missing
     }
 
-    fn exec_mut(&self, mut val: PipelineMap) -> Result<PipelineMap> {
+    fn exec_mut(&self, mut val: Value) -> Result<Value> {
         for field in self.fields.iter() {
             let index = field.input_field();
             match val.get(index) {
@@ -118,7 +117,7 @@ impl crate::etl::processor::Processor for DecolorizeProcessor {
                 Some(v) => {
                     let result = self.process(v)?;
                     let output_index = field.target_or_input_field();
-                    val.insert(output_index.to_string(), result);
+                    val.insert(output_index.to_string(), result)?;
                 }
             }
         }

--- a/src/pipeline/src/etl/processor/digest.rs
+++ b/src/pipeline/src/etl/processor/digest.rs
@@ -33,7 +33,6 @@ use crate::etl::processor::{
     yaml_bool, yaml_new_field, yaml_new_fields, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME,
 };
 use crate::etl::value::Value;
-use crate::etl::PipelineMap;
 
 pub(crate) const PROCESSOR_DIGEST: &str = "digest";
 
@@ -201,7 +200,7 @@ impl crate::etl::processor::Processor for DigestProcessor {
         self.ignore_missing
     }
 
-    fn exec_mut(&self, mut val: PipelineMap) -> Result<PipelineMap> {
+    fn exec_mut(&self, mut val: Value) -> Result<Value> {
         for field in self.fields.iter() {
             let index = field.input_field();
             match val.get(index) {
@@ -217,7 +216,7 @@ impl crate::etl::processor::Processor for DigestProcessor {
                 Some(v) => {
                     let result = self.process(v)?;
                     let output_index = field.target_or_input_field();
-                    val.insert(output_index.to_string(), result);
+                    val.insert(output_index.to_string(), result)?;
                 }
             }
         }

--- a/src/pipeline/src/etl/processor/dissect.rs
+++ b/src/pipeline/src/etl/processor/dissect.rs
@@ -31,7 +31,6 @@ use crate::etl::processor::{
     Processor, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME, PATTERNS_NAME, PATTERN_NAME,
 };
 use crate::etl::value::Value;
-use crate::etl::PipelineMap;
 
 pub(crate) const PROCESSOR_DISSECT: &str = "dissect";
 
@@ -601,14 +600,14 @@ impl Processor for DissectProcessor {
         self.ignore_missing
     }
 
-    fn exec_mut(&self, mut val: PipelineMap) -> Result<PipelineMap> {
+    fn exec_mut(&self, mut val: Value) -> Result<Value> {
         for field in self.fields.iter() {
             let index = field.input_field();
             match val.get(index) {
                 Some(Value::String(val_str)) => {
                     let r = self.process(val_str)?;
                     for (k, v) in r {
-                        val.insert(k, v);
+                        val.insert(k, v)?;
                     }
                 }
                 Some(Value::Null) | None => {

--- a/src/pipeline/src/etl/processor/epoch.rs
+++ b/src/pipeline/src/etl/processor/epoch.rs
@@ -29,7 +29,6 @@ use crate::etl::value::time::{
     SEC_RESOLUTION, S_RESOLUTION, US_RESOLUTION,
 };
 use crate::etl::value::{Timestamp, Value};
-use crate::etl::PipelineMap;
 
 pub(crate) const PROCESSOR_EPOCH: &str = "epoch";
 const RESOLUTION_NAME: &str = "resolution";
@@ -167,7 +166,7 @@ impl Processor for EpochProcessor {
         self.ignore_missing
     }
 
-    fn exec_mut(&self, mut val: PipelineMap) -> Result<PipelineMap> {
+    fn exec_mut(&self, mut val: Value) -> Result<Value> {
         for field in self.fields.iter() {
             let index = field.input_field();
             match val.get(index) {
@@ -183,7 +182,7 @@ impl Processor for EpochProcessor {
                 Some(v) => {
                     let timestamp = self.parse(v)?;
                     let output_index = field.target_or_input_field();
-                    val.insert(output_index.to_string(), Value::Timestamp(timestamp));
+                    val.insert(output_index.to_string(), Value::Timestamp(timestamp))?;
                 }
             }
         }

--- a/src/pipeline/src/etl/processor/gsub.rs
+++ b/src/pipeline/src/etl/processor/gsub.rs
@@ -25,7 +25,6 @@ use crate::etl::processor::{
     IGNORE_MISSING_NAME, PATTERN_NAME,
 };
 use crate::etl::value::Value;
-use crate::etl::PipelineMap;
 
 pub(crate) const PROCESSOR_GSUB: &str = "gsub";
 
@@ -118,7 +117,7 @@ impl crate::etl::processor::Processor for GsubProcessor {
         self.ignore_missing
     }
 
-    fn exec_mut(&self, mut val: PipelineMap) -> Result<PipelineMap> {
+    fn exec_mut(&self, mut val: Value) -> Result<Value> {
         for field in self.fields.iter() {
             let index = field.input_field();
             match val.get(index) {
@@ -134,7 +133,7 @@ impl crate::etl::processor::Processor for GsubProcessor {
                 Some(v) => {
                     let result = self.process(v)?;
                     let output_index = field.target_or_input_field();
-                    val.insert(output_index.to_string(), result);
+                    val.insert(output_index.to_string(), result)?;
                 }
             }
         }

--- a/src/pipeline/src/etl/processor/join.rs
+++ b/src/pipeline/src/etl/processor/join.rs
@@ -24,7 +24,6 @@ use crate::etl::processor::{
     IGNORE_MISSING_NAME, SEPARATOR_NAME,
 };
 use crate::etl::value::{Array, Value};
-use crate::etl::PipelineMap;
 
 pub(crate) const PROCESSOR_JOIN: &str = "join";
 
@@ -95,14 +94,14 @@ impl Processor for JoinProcessor {
         self.ignore_missing
     }
 
-    fn exec_mut(&self, mut val: PipelineMap) -> Result<PipelineMap> {
+    fn exec_mut(&self, mut val: Value) -> Result<Value> {
         for field in self.fields.iter() {
             let index = field.input_field();
             match val.get(index) {
                 Some(Value::Array(arr)) => {
                     let result = self.process(arr)?;
                     let output_index = field.target_or_input_field();
-                    val.insert(output_index.to_string(), result);
+                    val.insert(output_index.to_string(), result)?;
                 }
                 Some(Value::Null) | None => {
                     if !self.ignore_missing {

--- a/src/pipeline/src/etl/processor/json_path.rs
+++ b/src/pipeline/src/etl/processor/json_path.rs
@@ -21,8 +21,8 @@ use crate::error::{
 };
 use crate::etl::field::Fields;
 use crate::etl::processor::{
-    yaml_bool, yaml_new_field, yaml_new_fields, yaml_string, PipelineMap, Processor, FIELDS_NAME,
-    FIELD_NAME, IGNORE_MISSING_NAME, JSON_PATH_NAME, JSON_PATH_RESULT_INDEX_NAME,
+    yaml_bool, yaml_new_field, yaml_new_fields, yaml_string, Processor, FIELDS_NAME, FIELD_NAME,
+    IGNORE_MISSING_NAME, JSON_PATH_NAME, JSON_PATH_RESULT_INDEX_NAME,
 };
 use crate::Value;
 
@@ -125,14 +125,14 @@ impl Processor for JsonPathProcessor {
         self.ignore_missing
     }
 
-    fn exec_mut(&self, mut val: PipelineMap) -> Result<PipelineMap> {
+    fn exec_mut(&self, mut val: Value) -> Result<Value> {
         for field in self.fields.iter() {
             let index = field.input_field();
             match val.get(index) {
                 Some(v) => {
                     let processed = self.process_field(v)?;
                     let output_index = field.target_or_input_field();
-                    val.insert(output_index.to_string(), processed);
+                    val.insert(output_index.to_string(), processed)?;
                 }
                 None => {
                     if !self.ignore_missing {

--- a/src/pipeline/src/etl/processor/letter.rs
+++ b/src/pipeline/src/etl/processor/letter.rs
@@ -24,7 +24,6 @@ use crate::etl::processor::{
     IGNORE_MISSING_NAME, METHOD_NAME,
 };
 use crate::etl::value::Value;
-use crate::etl::PipelineMap;
 
 pub(crate) const PROCESSOR_LETTER: &str = "letter";
 
@@ -126,14 +125,14 @@ impl Processor for LetterProcessor {
         self.ignore_missing
     }
 
-    fn exec_mut(&self, mut val: PipelineMap) -> Result<PipelineMap> {
+    fn exec_mut(&self, mut val: Value) -> Result<Value> {
         for field in self.fields.iter() {
             let index = field.input_field();
             match val.get(index) {
                 Some(Value::String(s)) => {
                     let result = self.process_field(s)?;
                     let output_key = field.target_or_input_field();
-                    val.insert(output_key.to_string(), result);
+                    val.insert(output_key.to_string(), result)?;
                 }
                 Some(Value::Null) | None => {
                     if !self.ignore_missing {

--- a/src/pipeline/src/etl/processor/simple_extract.rs
+++ b/src/pipeline/src/etl/processor/simple_extract.rs
@@ -20,7 +20,7 @@ use crate::etl::processor::{
     yaml_bool, yaml_new_field, yaml_new_fields, yaml_string, FIELDS_NAME, FIELD_NAME,
     IGNORE_MISSING_NAME, KEY_NAME,
 };
-use crate::{PipelineMap, Processor, Value};
+use crate::{Processor, Value};
 
 pub(crate) const PROCESSOR_SIMPLE_EXTRACT: &str = "simple_extract";
 
@@ -98,14 +98,14 @@ impl Processor for SimpleExtractProcessor {
         self.ignore_missing
     }
 
-    fn exec_mut(&self, mut val: PipelineMap) -> Result<PipelineMap> {
+    fn exec_mut(&self, mut val: Value) -> Result<Value> {
         for field in self.fields.iter() {
             let index = field.input_field();
             match val.get(index) {
                 Some(v) => {
                     let processed = self.process_field(v)?;
                     let output_index = field.target_or_input_field();
-                    val.insert(output_index.to_string(), processed);
+                    val.insert(output_index.to_string(), processed)?;
                 }
                 None => {
                     if !self.ignore_missing {

--- a/src/pipeline/src/etl/processor/timestamp.rs
+++ b/src/pipeline/src/etl/processor/timestamp.rs
@@ -36,7 +36,6 @@ use crate::etl::value::time::{
     SEC_RESOLUTION, S_RESOLUTION, US_RESOLUTION,
 };
 use crate::etl::value::{Timestamp, Value};
-use crate::etl::PipelineMap;
 
 pub(crate) const PROCESSOR_TIMESTAMP: &str = "timestamp";
 const RESOLUTION_NAME: &str = "resolution";
@@ -302,7 +301,7 @@ impl Processor for TimestampProcessor {
         self.ignore_missing
     }
 
-    fn exec_mut(&self, mut val: PipelineMap) -> Result<PipelineMap> {
+    fn exec_mut(&self, mut val: Value) -> Result<Value> {
         for field in self.fields.iter() {
             let index = field.input_field();
             match val.get(index) {
@@ -318,7 +317,7 @@ impl Processor for TimestampProcessor {
                 Some(v) => {
                     let result = self.parse(v)?;
                     let output_key = field.target_or_input_field();
-                    val.insert(output_key.to_string(), Value::Timestamp(result));
+                    val.insert(output_key.to_string(), Value::Timestamp(result))?;
                 }
             }
         }

--- a/src/pipeline/src/etl/processor/urlencoding.rs
+++ b/src/pipeline/src/etl/processor/urlencoding.rs
@@ -25,7 +25,6 @@ use crate::etl::processor::{
     IGNORE_MISSING_NAME, METHOD_NAME,
 };
 use crate::etl::value::Value;
-use crate::PipelineMap;
 
 pub(crate) const PROCESSOR_URL_ENCODING: &str = "urlencoding";
 
@@ -126,14 +125,14 @@ impl crate::etl::processor::Processor for UrlEncodingProcessor {
         self.ignore_missing
     }
 
-    fn exec_mut(&self, mut val: PipelineMap) -> Result<PipelineMap> {
+    fn exec_mut(&self, mut val: Value) -> Result<Value> {
         for field in self.fields.iter() {
             let index = field.input_field();
             match val.get(index) {
                 Some(Value::String(s)) => {
                     let result = self.process_field(s)?;
                     let output_index = field.target_or_input_field();
-                    val.insert(output_index.to_string(), result);
+                    val.insert(output_index.to_string(), result)?;
                 }
                 Some(Value::Null) | None => {
                     if !self.ignore_missing {

--- a/src/pipeline/src/etl/value/map.rs
+++ b/src/pipeline/src/etl/value/map.rs
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeMap;
+
 use crate::etl::value::Value;
-use crate::PipelineMap;
 
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Map {
-    pub values: PipelineMap,
+    pub values: BTreeMap<String, Value>,
 }
 
 impl Map {
@@ -36,14 +37,14 @@ impl Map {
     }
 }
 
-impl From<PipelineMap> for Map {
-    fn from(values: PipelineMap) -> Self {
+impl From<BTreeMap<String, Value>> for Map {
+    fn from(values: BTreeMap<String, Value>) -> Self {
         Self { values }
     }
 }
 
 impl std::ops::Deref for Map {
-    type Target = PipelineMap;
+    type Target = BTreeMap<String, Value>;
 
     fn deref(&self) -> &Self::Target {
         &self.values

--- a/src/pipeline/src/lib.rs
+++ b/src/pipeline/src/lib.rs
@@ -27,8 +27,7 @@ pub use etl::transform::GreptimeTransformer;
 pub use etl::value::{Array, Map, Value};
 pub use etl::{
     json_array_to_map, json_to_map, parse, simd_json_array_to_map, simd_json_to_map,
-    AutoTransformOutput, Content, DispatchedTo, Pipeline, PipelineExecOutput, PipelineMap,
-    TransformedOutput,
+    AutoTransformOutput, Content, DispatchedTo, Pipeline, PipelineExecOutput, TransformedOutput,
 };
 pub use manager::{
     pipeline_operator, table, util, IdentityTimeIndex, PipelineContext, PipelineDefinition,

--- a/src/pipeline/src/tablesuffix.rs
+++ b/src/pipeline/src/tablesuffix.rs
@@ -20,7 +20,7 @@ use yaml_rust::Yaml;
 use crate::error::{
     Error, InvalidTableSuffixTemplateSnafu, RequiredTableSuffixTemplateSnafu, Result,
 };
-use crate::{PipelineMap, Value};
+use crate::Value;
 
 const REPLACE_KEY: &str = "{}";
 
@@ -47,7 +47,7 @@ pub(crate) struct TableSuffixTemplate {
 }
 
 impl TableSuffixTemplate {
-    pub fn apply(&self, val: &PipelineMap) -> Option<String> {
+    pub fn apply(&self, val: &Value) -> Option<String> {
         let values = self
             .keys
             .iter()

--- a/src/servers/src/interceptor.rs
+++ b/src/servers/src/interceptor.rs
@@ -23,7 +23,7 @@ use common_error::ext::ErrorExt;
 use common_query::Output;
 use datafusion_expr::LogicalPlan;
 use log_query::LogQuery;
-use pipeline::PipelineMap;
+use pipeline::Value;
 use query::parser::PromQuery;
 use session::context::QueryContextRef;
 use sql::statements::statement::Statement;
@@ -385,9 +385,9 @@ pub trait LogIngestInterceptor {
     /// Called before pipeline execution.
     fn pre_pipeline(
         &self,
-        values: Vec<PipelineMap>,
+        values: Vec<Value>,
         _query_ctx: QueryContextRef,
-    ) -> Result<Vec<PipelineMap>, Self::Error> {
+    ) -> Result<Vec<Value>, Self::Error> {
         Ok(values)
     }
 
@@ -412,9 +412,9 @@ where
 
     fn pre_pipeline(
         &self,
-        values: Vec<PipelineMap>,
+        values: Vec<Value>,
         query_ctx: QueryContextRef,
-    ) -> Result<Vec<PipelineMap>, Self::Error> {
+    ) -> Result<Vec<Value>, Self::Error> {
         if let Some(this) = self {
             this.pre_pipeline(values, query_ctx)
         } else {

--- a/src/servers/src/pipeline.rs
+++ b/src/servers/src/pipeline.rs
@@ -21,7 +21,7 @@ use itertools::Itertools;
 use pipeline::error::AutoTransformOneTimestampSnafu;
 use pipeline::{
     AutoTransformOutput, ContextReq, DispatchedTo, IdentityTimeIndex, Pipeline, PipelineContext,
-    PipelineDefinition, PipelineExecOutput, PipelineMap, TransformedOutput,
+    PipelineDefinition, PipelineExecOutput, TransformedOutput, Value,
     GREPTIME_INTERNAL_IDENTITY_PIPELINE_NAME,
 };
 use session::context::{Channel, QueryContextRef};
@@ -116,7 +116,7 @@ async fn run_custom_pipeline(
     } = pipeline_req;
     let arr_len = pipeline_maps.len();
     let mut transformed_map = HashMap::new();
-    let mut dispatched: BTreeMap<DispatchedTo, Vec<PipelineMap>> = BTreeMap::new();
+    let mut dispatched: BTreeMap<DispatchedTo, Vec<Value>> = BTreeMap::new();
     let mut auto_map = HashMap::new();
     let mut auto_map_ts_keys = HashMap::new();
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
This is a pre PR to #6242, to replace `PipelineMap` with the upper level `Value`, so that we can later implement `Target` on the `Value` directly.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
