### PR TITLE
fix: add path exist check in copy_table_from (#6182)

### DIFF
--- a/src/operator/src/error.rs
+++ b/src/operator/src/error.rs
@@ -831,6 +831,13 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display("Path not found: {path}"))]
+    PathNotFound {
+        path: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[cfg(feature = "enterprise")]
     #[snafu(display("Trigger related operations are not currently supported"))]
     UnsupportedTrigger {
@@ -975,6 +982,7 @@ impl ErrorExt for Error {
             Error::ComputeArrow { .. } => StatusCode::Internal,
             Error::InvalidProcessId { .. } => StatusCode::InvalidArguments,
             Error::ProcessManagerMissing { .. } => StatusCode::Unexpected,
+            Error::PathNotFound { .. } => StatusCode::InvalidArguments,
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
Solves [Issue](https://github.com/GreptimeTeam/greptimedb/issues/6182) 

## What's changed and what's your intention?
This PR adds a validation step in the `copy_table_from`  to ensure that the source path exists before proceeding. If the specified path does not exist, the operation now fails early with a clear `PathNotFound` error.

The intention is to prevent unexpected side effects—such as automatically creating non-existent directories—when running copy from in standalone mode. 

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
