### PR TITLE
feat: support special labels parsing in prom remote write

### DIFF
--- a/src/servers/src/http/prom_store.rs
+++ b/src/servers/src/http/prom_store.rs
@@ -232,8 +232,7 @@ async fn decode_remote_write_request(
     if processor.use_pipeline {
         processor.exec_pipeline().await
     } else {
-        let reqs = request.as_row_insert_requests();
-        Ok(ContextReq::default_opt_with_reqs(reqs))
+        Ok(request.as_row_insert_requests())
     }
 }
 

--- a/src/servers/src/pipeline.rs
+++ b/src/servers/src/pipeline.rs
@@ -167,7 +167,7 @@ async fn run_custom_pipeline(
         // `RowInsertRequest` and append to results. If the pipeline doesn't
         // have dispatch, this will be only output of the pipeline.
         for ((opt, table_name), rows) in transformed_map {
-            results.add_rows(
+            results.add_row(
                 opt,
                 RowInsertRequest {
                     rows: Some(Rows {

--- a/src/servers/src/prom_store.rs
+++ b/src/servers/src/prom_store.rs
@@ -39,8 +39,13 @@ use crate::error::{self, Result};
 use crate::row_writer::{self, MultiTableData};
 
 pub const METRIC_NAME_LABEL: &str = "__name__";
-
 pub const METRIC_NAME_LABEL_BYTES: &[u8] = b"__name__";
+
+pub const SCHEMA_LABEL: &str = "__schema__";
+pub const SCHEMA_LABEL_BYTES: &[u8] = b"__schema__";
+
+pub const PHYSICAL_TABLE_LABEL: &str = "__physical_table__";
+pub const PHYSICAL_TABLE_LABEL_BYTES: &[u8] = b"__physical_table__";
 
 /// The same as `FIELD_COLUMN_MATCHER` in `promql` crate
 pub const FIELD_NAME_LABEL: &str = "__field__";
@@ -505,6 +510,39 @@ pub fn mock_timeseries_new_label() -> Vec<TimeSeries> {
     };
 
     vec![ts_demo_metrics, ts_multi_labels]
+}
+
+/// Add new labels to the mock timeseries.
+pub fn mock_timeseries_special_labels() -> Vec<TimeSeries> {
+    let idc3_schema = TimeSeries {
+        labels: vec![
+            new_label(METRIC_NAME_LABEL.to_string(), "idc3_lo_table".to_string()),
+            new_label("__schema__".to_string(), "idc3".to_string()),
+            new_label("__physical_table__".to_string(), "f1".to_string()),
+        ],
+        samples: vec![Sample {
+            value: 42.0,
+            timestamp: 3000,
+        }],
+        ..Default::default()
+    };
+    let idc4_schema = TimeSeries {
+        labels: vec![
+            new_label(
+                METRIC_NAME_LABEL.to_string(),
+                "idc4_local_table".to_string(),
+            ),
+            new_label("__schema__".to_string(), "idc4".to_string()),
+            new_label("__physical_table__".to_string(), "f2".to_string()),
+        ],
+        samples: vec![Sample {
+            value: 99.0,
+            timestamp: 4000,
+        }],
+        ..Default::default()
+    };
+
+    vec![idc3_schema, idc4_schema]
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#6156 

## What's changed and what's your intention?
This PR adds support for parsing and setting the schema and physical table options from the Prom remote write's label value.
- `__database__` for setting the schema
- `__physical_table__` for setting the physical table info

Note: `__physical_table__` only takes effect upon first insertion(which is create-table-upon-insert process).

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
