### PR TITLE
feat: organize EXPLAIN ANALYZE VERBOSE's output in JSON format

### DIFF
--- a/src/mito2/src/read/scan_util.rs
+++ b/src/mito2/src/read/scan_util.rs
@@ -142,36 +142,36 @@ impl fmt::Debug for ScanMetricsSet {
 
         write!(
             f,
-            "{{prepare_scan_cost={prepare_scan_cost:?}, \
-            build_reader_cost={build_reader_cost:?}, \
-            scan_cost={scan_cost:?}, \
-            convert_cost={convert_cost:?}, \
-            yield_cost={yield_cost:?}, \
-            total_cost={total_cost:?}, \
-            num_rows={num_rows}, \
-            num_batches={num_batches}, \
-            num_mem_ranges={num_mem_ranges}, \
-            num_file_ranges={num_file_ranges}, \
-            build_parts_cost={build_parts_cost:?}, \
-            rg_total={rg_total}, \
-            rg_fulltext_filtered={rg_fulltext_filtered}, \
-            rg_inverted_filtered={rg_inverted_filtered}, \
-            rg_minmax_filtered={rg_minmax_filtered}, \
-            rg_bloom_filtered={rg_bloom_filtered}, \
-            rows_before_filter={rows_before_filter}, \
-            rows_fulltext_filtered={rows_fulltext_filtered}, \
-            rows_inverted_filtered={rows_inverted_filtered}, \
-            rows_bloom_filtered={rows_bloom_filtered}, \
-            rows_precise_filtered={rows_precise_filtered}, \
-            num_sst_record_batches={num_sst_record_batches}, \
-            num_sst_batches={num_sst_batches}, \
-            num_sst_rows={num_sst_rows}, \
-            first_poll={first_poll:?}, \
-            num_series_send_timeout={num_series_send_timeout}, \
-            num_distributor_rows={num_distributor_rows}, \
-            num_distributor_batches={num_distributor_batches}, \
-            distributor_scan_cost={distributor_scan_cost:?}, \
-            distributor_yield_cost={distributor_yield_cost:?}}},"
+            "{{\"prepare_scan_cost\":\"{prepare_scan_cost:?}\", \
+            \"build_reader_cost\":\"{build_reader_cost:?}\", \
+            \"scan_cost\":\"{scan_cost:?}\", \
+            \"convert_cost\":\"{convert_cost:?}\", \
+            \"yield_cost\":\"{yield_cost:?}\", \
+            \"total_cost\":\"{total_cost:?}\", \
+            \"num_rows\":{num_rows}, \
+            \"num_batches\":{num_batches}, \
+            \"num_mem_ranges\":{num_mem_ranges}, \
+            \"num_file_ranges\":{num_file_ranges}, \
+            \"build_parts_cost\":\"{build_parts_cost:?}\", \
+            \"rg_total\":{rg_total}, \
+            \"rg_fulltext_filtered\":{rg_fulltext_filtered}, \
+            \"rg_inverted_filtered\":{rg_inverted_filtered}, \
+            \"rg_minmax_filtered\":{rg_minmax_filtered}, \
+            \"rg_bloom_filtered\":{rg_bloom_filtered}, \
+            \"rows_before_filter\":{rows_before_filter}, \
+            \"rows_fulltext_filtered\":{rows_fulltext_filtered}, \
+            \"rows_inverted_filtered\":{rows_inverted_filtered}, \
+            \"rows_bloom_filtered\":{rows_bloom_filtered}, \
+            \"rows_precise_filtered\":{rows_precise_filtered}, \
+            \"num_sst_record_batches\":{num_sst_record_batches}, \
+            \"num_sst_batches\":{num_sst_batches}, \
+            \"num_sst_rows\":{num_sst_rows}, \
+            \"first_poll\":\"{first_poll:?}\", \
+            \"num_series_send_timeout\":{num_series_send_timeout}, \
+            \"num_distributor_rows\":{num_distributor_rows}, \
+            \"num_distributor_batches\":{num_distributor_batches}, \
+            \"distributor_scan_cost\":\"{distributor_scan_cost:?}\", \
+            \"distributor_yield_cost\":\"{distributor_yield_cost:?}\"}}"
         )
     }
 }
@@ -390,10 +390,11 @@ impl PartitionMetricsList {
     /// Format verbose metrics for each partition for explain.
     pub(crate) fn format_verbose_metrics(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let list = self.0.lock().unwrap();
-        write!(f, ", metrics_per_partition: ")?;
+        write!(f, ", \"metrics_per_partition\": ")?;
         f.debug_list()
             .entries(list.iter().filter_map(|p| p.as_ref()))
-            .finish()
+            .finish()?;
+        write!(f, "}}")
     }
 }
 
@@ -488,7 +489,11 @@ impl PartitionMetrics {
 impl fmt::Debug for PartitionMetrics {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let metrics = self.0.metrics.lock().unwrap();
-        write!(f, "[partition={}, {:?}]", self.0.partition, metrics)
+        write!(
+            f,
+            r#"{{"partition":{}, "metrics":{:?}}}"#,
+            self.0.partition, metrics
+        )
     }
 }
 

--- a/tests/cases/distributed/explain/analyze.result
+++ b/tests/cases/distributed/explain/analyze.result
@@ -44,7 +44,7 @@ explain analyze SELECT count(*) FROM system_metrics;
 |_|_|_AggregateExec: mode=Final, gby=[], aggr=[count(system_REDACTED
 |_|_|_CoalescePartitionsExec REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[], aggr=[count(system_REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0} REDACTED
 |_|_|_|
 |_|_| Total rows: 1_|
 +-+-+-+

--- a/tests/cases/distributed/explain/order_by.result
+++ b/tests/cases/distributed/explain/order_by.result
@@ -111,7 +111,7 @@ EXPLAIN ANALYZE SELECT i, t AS alias_ts FROM test_pk ORDER BY t DESC LIMIT 5;
 |_|_|_WindowedSortExec: expr=test_pk.t__temp__0@2 DESC num_ranges=REDACTED fetch=5 REDACTED
 |_|_|_PartSortExec: expr=test_pk.t__temp__0@2 DESC num_ranges=REDACTED limit=5 REDACTED
 |_|_|_ProjectionExec: expr=[i@0 as i, t@1 as t, t@1 as test_pk.t__temp__0] REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0} REDACTED
 |_|_|_|
 |_|_| Total rows: 5_|
 +-+-+-+
@@ -133,7 +133,7 @@ EXPLAIN ANALYZE SELECT i, t AS alias_ts FROM test_pk ORDER BY alias_ts DESC LIMI
 |_|_|_SortPreservingMergeExec: [t@1 DESC], fetch=5 REDACTED
 |_|_|_WindowedSortExec: expr=t@1 DESC num_ranges=REDACTED fetch=5 REDACTED
 |_|_|_PartSortExec: expr=t@1 DESC num_ranges=REDACTED limit=5 REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0} REDACTED
 |_|_|_|
 |_|_| Total rows: 5_|
 +-+-+-+

--- a/tests/cases/distributed/optimizer/windowed_sort.result
+++ b/tests/cases/distributed/optimizer/windowed_sort.result
@@ -72,7 +72,7 @@ ORDER BY
 | 1_| 0_|_ProjectionExec: expr=[collect_time_utc@0 as collect_time, peak_current@1 as peak_current] REDACTED
 |_|_|_SortPreservingMergeExec: [collect_time_utc@0 ASC NULLS LAST] REDACTED
 |_|_|_SortExec: expr=[collect_time_utc@0 ASC NULLS LAST], preserve_partitioning=[true] REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0} REDACTED
 |_|_|_|
 |_|_| Total rows: 8_|
 +-+-+-+
@@ -121,7 +121,7 @@ ORDER BY
 | 1_| 0_|_ProjectionExec: expr=[collect_time_utc@0 as collect_time_0, peak_current@1 as peak_current] REDACTED
 |_|_|_SortPreservingMergeExec: [collect_time_utc@0 ASC NULLS LAST] REDACTED
 |_|_|_SortExec: expr=[collect_time_utc@0 ASC NULLS LAST], preserve_partitioning=[true] REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0} REDACTED
 |_|_|_|
 |_|_| Total rows: 8_|
 +-+-+-+
@@ -173,7 +173,7 @@ ORDER BY
 |_|_|_SortPreservingMergeExec: [collect_time@0 DESC] REDACTED
 |_|_|_WindowedSortExec: expr=collect_time@0 DESC num_ranges=REDACTED REDACTED
 |_|_|_PartSortExec: expr=collect_time@0 DESC num_ranges=REDACTED REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0} REDACTED
 |_|_|_|
 |_|_| Total rows: 8_|
 +-+-+-+
@@ -226,7 +226,7 @@ ORDER BY
 |_|_|_WindowedSortExec: expr=collect_time@1 DESC num_ranges=REDACTED REDACTED
 |_|_|_PartSortExec: expr=collect_time@1 DESC num_ranges=REDACTED REDACTED
 |_|_|_ProjectionExec: expr=[collect_time_utc@1 as collect_time_utc, collect_time@0 as collect_time, peak_current@2 as peak_current] REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0} REDACTED
 |_|_|_|
 |_|_| Total rows: 8_|
 +-+-+-+

--- a/tests/cases/distributed/tql-explain-analyze/analyze.result
+++ b/tests/cases/distributed/tql-explain-analyze/analyze.result
@@ -23,7 +23,7 @@ TQL ANALYZE (0, 10, '5s') test;
 |_|_|_|
 | 1_| 0_|_PromInstantManipulateExec: range=[0..10000], lookback=[300000], interval=[5000], time index=[j] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["k"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges), distribution=PerSeries REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+
@@ -45,7 +45,7 @@ TQL ANALYZE (0, 10, '1s', '2s') test;
 |_|_|_|
 | 1_| 0_|_PromInstantManipulateExec: range=[0..10000], lookback=[2000], interval=[1000], time index=[j] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["k"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges), distribution=PerSeries REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+
@@ -66,7 +66,7 @@ TQL ANALYZE ('1970-01-01T00:00:00'::timestamp, '1970-01-01T00:00:00'::timestamp 
 |_|_|_|
 | 1_| 0_|_PromInstantManipulateExec: range=[0..10000], lookback=[300000], interval=[5000], time index=[j] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["k"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges), distribution=PerSeries REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+
@@ -89,7 +89,7 @@ TQL ANALYZE VERBOSE (0, 10, '5s') test;
 |_|_|_|
 | 1_| 0_|_PromInstantManipulateExec: range=[0..10000], lookback=[300000], interval=[5000], time index=[j] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["k"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges), distribution=PerSeries, projection=["i", "j", "k"], filters=[j >= TimestampMillisecond(-300000, None), j <= TimestampMillisecond(310000, None)], REDACTED
+|_|_|_SeriesScan: region=REDACTED, {"partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "distribution":"PerSeries", "projection": ["i", "j", "k"], "filters": ["j >= TimestampMillisecond(-300000, None)", "j <= TimestampMillisecond(310000, None)"], "REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+
@@ -120,11 +120,11 @@ TQL ANALYZE (0, 10, '5s') test;
 |_|_|_|
 | 1_| 0_|_PromInstantManipulateExec: range=[0..10000], lookback=[300000], interval=[5000], time index=[j] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["k", "l"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file 0 ranges), distribution=PerSeries REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
 |_|_|_|
 | 1_| 1_|_PromInstantManipulateExec: range=[0..10000], lookback=[300000], interval=[5000], time index=[j] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["k", "l"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file 0 ranges), distribution=PerSeries REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
 |_|_|_|
 |_|_| Total rows: 0_|
 +-+-+-+
@@ -151,7 +151,7 @@ TQL ANALYZE (0, 10, '5s') rate(test[10s]);
 |_|_|_PromRangeManipulateExec: req range=[0..10000], interval=[5000], eval range=[10000], time index=[j] REDACTED
 |_|_|_PromSeriesNormalizeExec: offset=[0], time index=[j], filter NaN: [true] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["k", "l"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file 0 ranges), distribution=PerSeries REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
 |_|_|_|
 | 1_| 1_|_ProjectionExec: expr=[j@0 as j, prom_rate(j_range,i,test.j,Int64(10000))@1 as prom_rate(j_range,i,j,Int64(10000)), k@2 as k, l@3 as l] REDACTED
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
@@ -160,7 +160,7 @@ TQL ANALYZE (0, 10, '5s') rate(test[10s]);
 |_|_|_PromRangeManipulateExec: req range=[0..10000], interval=[5000], eval range=[10000], time index=[j] REDACTED
 |_|_|_PromSeriesNormalizeExec: offset=[0], time index=[j], filter NaN: [true] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["k", "l"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file 0 ranges), distribution=PerSeries REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
 |_|_|_|
 |_|_| Total rows: 0_|
 +-+-+-+

--- a/tests/cases/standalone/common/aggregate/distinct.result
+++ b/tests/cases/standalone/common/aggregate/distinct.result
@@ -98,7 +98,7 @@ EXPLAIN ANALYZE SELECT DISTINCT a FROM test ORDER BY a;
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[a@0 as a], aggr=[] REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0} REDACTED
 |_|_|_|
 |_|_| Total rows: 2_|
 +-+-+-+

--- a/tests/cases/standalone/common/aggregate/multi_regions.result
+++ b/tests/cases/standalone/common/aggregate/multi_regions.result
@@ -32,14 +32,14 @@ select sum(val) from t group by host;
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[host@1 as host], aggr=[sum(t.val)] REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file 0 ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0} REDACTED
 |_|_|_|
 | 1_| 1_|_ProjectionExec: expr=[sum(t.val)@1 as sum(t.val)] REDACTED
 |_|_|_AggregateExec: mode=FinalPartitioned, gby=[host@0 as host], aggr=[sum(t.val)] REDACTED
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[host@1 as host], aggr=[sum(t.val)] REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file 0 ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0} REDACTED
 |_|_|_|
 |_|_| Total rows: 0_|
 +-+-+-+
@@ -62,9 +62,9 @@ select sum(val) from t;
 |_|_|_ProjectionExec: expr=[val@1 as val] REDACTED
 |_|_|_MergeScanExec: REDACTED
 |_|_|_|
-| 1_| 0_|_SeqScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file 0 ranges) REDACTED
+| 1_| 0_|_SeqScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0} REDACTED
 |_|_|_|
-| 1_| 1_|_SeqScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file 0 ranges) REDACTED
+| 1_| 1_|_SeqScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0} REDACTED
 |_|_|_|
 |_|_| Total rows: 1_|
 +-+-+-+
@@ -90,9 +90,9 @@ select sum(val) from t group by idc;
 |_|_|_ProjectionExec: expr=[val@1 as val, idc@3 as idc] REDACTED
 |_|_|_MergeScanExec: REDACTED
 |_|_|_|
-| 1_| 0_|_SeqScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file 0 ranges) REDACTED
+| 1_| 0_|_SeqScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0} REDACTED
 |_|_|_|
-| 1_| 1_|_SeqScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file 0 ranges) REDACTED
+| 1_| 1_|_SeqScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0} REDACTED
 |_|_|_|
 |_|_| Total rows: 0_|
 +-+-+-+

--- a/tests/cases/standalone/common/order/order_by.result
+++ b/tests/cases/standalone/common/order/order_by.result
@@ -302,13 +302,13 @@ explain analyze select tag from t where num > 6 order by ts desc limit 2;
 |_|_|_WindowedSortExec: expr=ts@1 DESC num_ranges=REDACTED fetch=2 REDACTED
 |_|_|_PartSortExec: expr=ts@1 DESC num_ranges=REDACTED limit=2 REDACTED
 |_|_|_FilterExec: num@2 > 6, projection=[tag@0, ts@1] REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0} REDACTED
 |_|_|_|
 | 1_| 1_|_SortPreservingMergeExec: [ts@1 DESC], fetch=2 REDACTED
 |_|_|_WindowedSortExec: expr=ts@1 DESC num_ranges=REDACTED fetch=2 REDACTED
 |_|_|_PartSortExec: expr=ts@1 DESC num_ranges=REDACTED limit=2 REDACTED
 |_|_|_FilterExec: num@2 > 6, projection=[tag@0, ts@1] REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0} REDACTED
 |_|_|_|
 |_|_| Total rows: 2_|
 +-+-+-+

--- a/tests/cases/standalone/common/order/windowed_sort.result
+++ b/tests/cases/standalone/common/order/windowed_sort.result
@@ -70,7 +70,7 @@ EXPLAIN ANALYZE SELECT * FROM test ORDER BY t LIMIT 5;
 |_|_|_|
 | 1_| 0_|_SortPreservingMergeExec: [t@1 ASC NULLS LAST], fetch=5 REDACTED
 |_|_|_WindowedSortExec: expr=t@1 ASC NULLS LAST num_ranges=REDACTED fetch=5 REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=4 (1 memtable ranges, 3 file 3 ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":4, "mem_ranges":1, "files":3, "file_ranges":3} REDACTED
 |_|_|_|
 |_|_| Total rows: 5_|
 +-+-+-+
@@ -103,7 +103,7 @@ EXPLAIN ANALYZE SELECT * FROM test ORDER BY t DESC LIMIT 5;
 | 1_| 0_|_SortPreservingMergeExec: [t@1 DESC], fetch=5 REDACTED
 |_|_|_WindowedSortExec: expr=t@1 DESC num_ranges=REDACTED fetch=5 REDACTED
 |_|_|_PartSortExec: expr=t@1 DESC num_ranges=REDACTED limit=5 REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=4 (1 memtable ranges, 3 file 3 ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":4, "mem_ranges":1, "files":3, "file_ranges":3} REDACTED
 |_|_|_|
 |_|_| Total rows: 5_|
 +-+-+-+
@@ -136,7 +136,7 @@ EXPLAIN ANALYZE SELECT * FROM test where i > 2 ORDER BY t LIMIT 4;
 | 1_| 0_|_SortPreservingMergeExec: [t@1 ASC NULLS LAST], fetch=4 REDACTED
 |_|_|_WindowedSortExec: expr=t@1 ASC NULLS LAST num_ranges=REDACTED fetch=4 REDACTED
 |_|_|_FilterExec: i@0 > 2 REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=4 (1 memtable ranges, 3 file 3 ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":4, "mem_ranges":1, "files":3, "file_ranges":3} REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+
@@ -170,7 +170,7 @@ EXPLAIN ANALYZE SELECT * FROM test where i > 2 ORDER BY t DESC LIMIT 4;
 |_|_|_WindowedSortExec: expr=t@1 DESC num_ranges=REDACTED fetch=4 REDACTED
 |_|_|_PartSortExec: expr=t@1 DESC num_ranges=REDACTED limit=4 REDACTED
 |_|_|_FilterExec: i@0 > 2 REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=4 (1 memtable ranges, 3 file 3 ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":4, "mem_ranges":1, "files":3, "file_ranges":3} REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+
@@ -203,7 +203,7 @@ EXPLAIN ANALYZE SELECT * FROM test where t > 8 ORDER BY t DESC LIMIT 4;
 | 1_| 0_|_SortPreservingMergeExec: [t@1 DESC], fetch=4 REDACTED
 |_|_|_WindowedSortExec: expr=t@1 DESC num_ranges=REDACTED fetch=4 REDACTED
 |_|_|_PartSortExec: expr=t@1 DESC num_ranges=REDACTED limit=4 REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=2 (1 memtable ranges, 1 file 1 ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":2, "mem_ranges":1, "files":1, "file_ranges":1} REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+
@@ -285,7 +285,7 @@ EXPLAIN ANALYZE SELECT * FROM test_pk ORDER BY t LIMIT 5;
 | 1_| 0_|_SortPreservingMergeExec: [t@2 ASC NULLS LAST], fetch=5 REDACTED
 |_|_|_WindowedSortExec: expr=t@2 ASC NULLS LAST num_ranges=REDACTED fetch=5 REDACTED
 |_|_|_PartSortExec: expr=t@2 ASC NULLS LAST num_ranges=REDACTED limit=5 REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=4 (1 memtable ranges, 3 file 3 ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":4, "mem_ranges":1, "files":3, "file_ranges":3} REDACTED
 |_|_|_|
 |_|_| Total rows: 5_|
 +-+-+-+
@@ -307,7 +307,7 @@ EXPLAIN ANALYZE VERBOSE SELECT * FROM test_pk ORDER BY t LIMIT 5;
 | 1_| 0_|_SortPreservingMergeExec: [t@2 ASC NULLS LAST], fetch=5 REDACTED
 |_|_|_WindowedSortExec: expr=t@2 ASC NULLS LAST num_ranges=REDACTED fetch=5 REDACTED
 |_|_|_PartSortExec: expr=t@2 ASC NULLS LAST num_ranges=REDACTED limit=5 REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=4 (1 memtable ranges, 3 file 3 ranges), projection=["pk", "i", "t"], REDACTED
+|_|_|_SeqScan: region=REDACTED, {"partition_count":{"count":4, "mem_ranges":1, "REDACTED
 |_|_|_|
 |_|_| Total rows: 5_|
 +-+-+-+
@@ -340,7 +340,7 @@ EXPLAIN ANALYZE SELECT * FROM test_pk ORDER BY t DESC LIMIT 5;
 | 1_| 0_|_SortPreservingMergeExec: [t@2 DESC], fetch=5 REDACTED
 |_|_|_WindowedSortExec: expr=t@2 DESC num_ranges=REDACTED fetch=5 REDACTED
 |_|_|_PartSortExec: expr=t@2 DESC num_ranges=REDACTED limit=5 REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=4 (1 memtable ranges, 3 file 3 ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":4, "mem_ranges":1, "files":3, "file_ranges":3} REDACTED
 |_|_|_|
 |_|_| Total rows: 5_|
 +-+-+-+
@@ -374,7 +374,7 @@ EXPLAIN ANALYZE SELECT * FROM test_pk where pk > 7 ORDER BY t LIMIT 5;
 | 1_| 0_|_SortPreservingMergeExec: [t@2 ASC NULLS LAST], fetch=5 REDACTED
 |_|_|_WindowedSortExec: expr=t@2 ASC NULLS LAST num_ranges=REDACTED fetch=5 REDACTED
 |_|_|_PartSortExec: expr=t@2 ASC NULLS LAST num_ranges=REDACTED limit=5 REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=4 (1 memtable ranges, 3 file 3 ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":4, "mem_ranges":1, "files":3, "file_ranges":3} REDACTED
 |_|_|_|
 |_|_| Total rows: 5_|
 +-+-+-+
@@ -396,7 +396,7 @@ EXPLAIN ANALYZE VERBOSE SELECT * FROM test_pk where pk > 7 ORDER BY t LIMIT 5;
 | 1_| 0_|_SortPreservingMergeExec: [t@2 ASC NULLS LAST], fetch=5 REDACTED
 |_|_|_WindowedSortExec: expr=t@2 ASC NULLS LAST num_ranges=REDACTED fetch=5 REDACTED
 |_|_|_PartSortExec: expr=t@2 ASC NULLS LAST num_ranges=REDACTED limit=5 REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=4 (1 memtable ranges, 3 file 3 ranges), projection=["pk", "i", "t"], filters=[pk > Int32(7)], REDACTED
+|_|_|_SeqScan: region=REDACTED, {"partition_count":{"count":4, "mem_ranges":1, "REDACTED
 |_|_|_|
 |_|_| Total rows: 5_|
 +-+-+-+

--- a/tests/cases/standalone/common/range/nest.result
+++ b/tests/cases/standalone/common/range/nest.result
@@ -78,7 +78,7 @@ EXPLAIN ANALYZE SELECT ts, host, min(val) RANGE '5s' FROM host ALIGN '5s';
 |_|_|_CoalescePartitionsExec REDACTED
 |_|_|_MergeScanExec: REDACTED
 |_|_|_|
-| 1_| 0_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges) REDACTED
+| 1_| 0_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0} REDACTED
 |_|_|_|
 |_|_| Total rows: 10_|
 +-+-+-+

--- a/tests/cases/standalone/common/select/prune.result
+++ b/tests/cases/standalone/common/select/prune.result
@@ -89,7 +89,7 @@ explain analyze select * from demo where idc='idc1';
 +-+-+-+
 | 0_| 0_|_MergeScanExec: REDACTED
 |_|_|_|
-| 1_| 0_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges) REDACTED
+| 1_| 0_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0} REDACTED
 |_|_|_|
 |_|_| Total rows: 2_|
 +-+-+-+
@@ -115,7 +115,7 @@ explain analyze SELECT * FROM demo where host in ('test1');
 +-+-+-+
 | 0_| 0_|_MergeScanExec: REDACTED
 |_|_|_|
-| 1_| 0_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges) REDACTED
+| 1_| 0_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0} REDACTED
 |_|_|_|
 |_|_| Total rows: 1_|
 +-+-+-+

--- a/tests/cases/standalone/common/select/skipping_index.result
+++ b/tests/cases/standalone/common/select/skipping_index.result
@@ -62,7 +62,7 @@ EXPLAIN ANALYZE SELECT * FROM skipping_table WHERE id = 'id2' ORDER BY `name`;
 |_|_|_SortExec: expr=[name@2 ASC NULLS LAST], preserve_partitioning=[true] REDACTED
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_FilterExec: id@1 = id2 REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=3 (0 memtable ranges, 3 file 3 ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":3, "mem_ranges":0, "files":3, "file_ranges":3} REDACTED
 |_|_|_|
 |_|_| Total rows: 1_|
 +-+-+-+
@@ -84,7 +84,7 @@ EXPLAIN ANALYZE SELECT * FROM skipping_table WHERE id = 'id5' ORDER BY `name`;
 |_|_|_SortExec: expr=[name@2 ASC NULLS LAST], preserve_partitioning=[true] REDACTED
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_FilterExec: id@1 = id5 REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=3 (0 memtable ranges, 3 file 3 ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":3, "mem_ranges":0, "files":3, "file_ranges":3} REDACTED
 |_|_|_|
 |_|_| Total rows: 0_|
 +-+-+-+

--- a/tests/cases/standalone/common/select/tql_filter.result
+++ b/tests/cases/standalone/common/select/tql_filter.result
@@ -21,7 +21,7 @@ tql analyze (1, 3, '1s') t1{ a = "a" };
 |_|_|_|
 | 1_| 0_|_PromInstantManipulateExec: range=[1000..3000], lookback=[300000], interval=[1000], time index=[b] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["a"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges), distribution=PerSeries REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
 |_|_|_|
 |_|_| Total rows: 3_|
 +-+-+-+
@@ -41,7 +41,7 @@ tql analyze (1, 3, '1s') t1{ a =~ ".*" };
 |_|_|_|
 | 1_| 0_|_PromInstantManipulateExec: range=[1000..3000], lookback=[300000], interval=[1000], time index=[b] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["a"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges), distribution=PerSeries REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
 |_|_|_|
 |_|_| Total rows: 6_|
 +-+-+-+
@@ -61,7 +61,7 @@ tql analyze (1, 3, '1s') t1{ a =~ "a.*" };
 |_|_|_|
 | 1_| 0_|_PromInstantManipulateExec: range=[1000..3000], lookback=[300000], interval=[1000], time index=[b] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["a"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges), distribution=PerSeries REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
 |_|_|_|
 |_|_| Total rows: 3_|
 +-+-+-+

--- a/tests/cases/standalone/common/tql/general_table.result
+++ b/tests/cases/standalone/common/tql/general_table.result
@@ -47,7 +47,7 @@ TQL analyze (0, 10, '1s')  sum by(job) (irate(cpu_usage{job="fire"}[5s])) / 1e9;
 |_|_|_FilterExec: job@0 = fire AND ts@2 >= -305000000000 AND ts@2 <= 310000000000 REDACTED
 |_|_|_MergeScanExec: REDACTED
 |_|_|_|
-| 1_| 0_|_SeqScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file 0 ranges) REDACTED
+| 1_| 0_|_SeqScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0} REDACTED
 |_|_|_|
 |_|_| Total rows: 0_|
 +-+-+-+

--- a/tests/cases/standalone/common/tql/partition.result
+++ b/tests/cases/standalone/common/tql/partition.result
@@ -35,7 +35,7 @@ tql analyze (0, 10, '1s') 100 - (avg by (k) (irate(t[1m])) * 100);
 |_|_|_PromRangeManipulateExec: req range=[0..10000], interval=[1000], eval range=[60000], time index=[j] REDACTED
 |_|_|_PromSeriesNormalizeExec: offset=[0], time index=[j], filter NaN: [true] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["k"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file 0 ranges), distribution=PerSeries REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
 |_|_|_|
 |_|_| Total rows: 0_|
 +-+-+-+
@@ -86,7 +86,7 @@ tql analyze (0, 10, '1s') 100 - (avg by (k) (irate(t[1m])) * 100);
 |_|_|_PromRangeManipulateExec: req range=[0..10000], interval=[1000], eval range=[60000], time index=[j] REDACTED
 |_|_|_PromSeriesNormalizeExec: offset=[0], time index=[j], filter NaN: [true] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["k", "l"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file 0 ranges), distribution=PerSeries REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
 |_|_|_|
 | 1_| 1_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_FilterExec: prom_irate(j_range,i)@1 IS NOT NULL REDACTED
@@ -94,7 +94,7 @@ tql analyze (0, 10, '1s') 100 - (avg by (k) (irate(t[1m])) * 100);
 |_|_|_PromRangeManipulateExec: req range=[0..10000], interval=[1000], eval range=[60000], time index=[j] REDACTED
 |_|_|_PromSeriesNormalizeExec: offset=[0], time index=[j], filter NaN: [true] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["k", "l"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file 0 ranges), distribution=PerSeries REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
 |_|_|_|
 |_|_| Total rows: 0_|
 +-+-+-+
@@ -146,10 +146,10 @@ tql analyze (0, 10, '1s') 100 - (avg by (k) (irate(t[1m])) * 100);
 |_|_|_MergeScanExec: REDACTED
 |_|_|_|
 | 1_| 0_|_SortPreservingMergeExec: [k@2 ASC, l@3 ASC, j@1 ASC] REDACTED
-|_|_|_SeriesScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file 0 ranges), distribution=PerSeries REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
 |_|_|_|
 | 1_| 1_|_SortPreservingMergeExec: [k@2 ASC, l@3 ASC, j@1 ASC] REDACTED
-|_|_|_SeriesScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file 0 ranges), distribution=PerSeries REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
 |_|_|_|
 |_|_| Total rows: 0_|
 +-+-+-+

--- a/tests/cases/standalone/optimizer/last_value.result
+++ b/tests/cases/standalone/optimizer/last_value.result
@@ -46,7 +46,7 @@ explain analyze
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_RepartitionExec: REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[host@1 as host], aggr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST], last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges), selector=LastRow REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "selector":"LastRow" REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+

--- a/tests/cases/standalone/optimizer/order_by.result
+++ b/tests/cases/standalone/optimizer/order_by.result
@@ -104,7 +104,7 @@ EXPLAIN ANALYZE SELECT i, t AS alias_ts FROM test_pk ORDER BY t DESC LIMIT 5;
 |_|_|_WindowedSortExec: expr=t@2 DESC num_ranges=REDACTED fetch=5 REDACTED
 |_|_|_PartSortExec: expr=t@2 DESC num_ranges=REDACTED limit=5 REDACTED
 |_|_|_ProjectionExec: expr=[i@0 as i, t@1 as alias_ts, t@1 as t] REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0} REDACTED
 |_|_|_|
 |_|_| Total rows: 5_|
 +-+-+-+
@@ -126,7 +126,7 @@ EXPLAIN ANALYZE SELECT i, t AS alias_ts FROM test_pk ORDER BY alias_ts DESC LIMI
 |_|_|_WindowedSortExec: expr=alias_ts@1 DESC num_ranges=REDACTED fetch=5 REDACTED
 |_|_|_PartSortExec: expr=alias_ts@1 DESC num_ranges=REDACTED limit=5 REDACTED
 |_|_|_ProjectionExec: expr=[i@0 as i, t@1 as alias_ts] REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0} REDACTED
 |_|_|_|
 |_|_| Total rows: 5_|
 +-+-+-+

--- a/tests/cases/standalone/optimizer/windowed_sort.result
+++ b/tests/cases/standalone/optimizer/windowed_sort.result
@@ -72,7 +72,7 @@ ORDER BY
 | 1_| 0_|_SortPreservingMergeExec: [collect_time@0 ASC NULLS LAST] REDACTED
 |_|_|_SortExec: expr=[collect_time@0 ASC NULLS LAST], preserve_partitioning=[true] REDACTED
 |_|_|_ProjectionExec: expr=[collect_time_utc@0 as collect_time, peak_current@1 as peak_current] REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0} REDACTED
 |_|_|_|
 |_|_| Total rows: 8_|
 +-+-+-+
@@ -120,7 +120,7 @@ ORDER BY
 | 1_| 0_|_SortPreservingMergeExec: [collect_time_0@0 ASC NULLS LAST] REDACTED
 |_|_|_SortExec: expr=[collect_time_0@0 ASC NULLS LAST], preserve_partitioning=[true] REDACTED
 |_|_|_ProjectionExec: expr=[collect_time_utc@0 as collect_time_0, peak_current@1 as peak_current] REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0} REDACTED
 |_|_|_|
 |_|_| Total rows: 8_|
 +-+-+-+
@@ -172,7 +172,7 @@ ORDER BY
 |_|_|_WindowedSortExec: expr=true_collect_time@0 DESC num_ranges=REDACTED REDACTED
 |_|_|_PartSortExec: expr=true_collect_time@0 DESC num_ranges=REDACTED REDACTED
 |_|_|_ProjectionExec: expr=[collect_time@0 as true_collect_time, collect_time_utc@1 as collect_time, peak_current@2 as peak_current] REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0} REDACTED
 |_|_|_|
 |_|_| Total rows: 8_|
 +-+-+-+
@@ -224,7 +224,7 @@ ORDER BY
 |_|_|_WindowedSortExec: expr=true_collect_time@1 DESC num_ranges=REDACTED REDACTED
 |_|_|_PartSortExec: expr=true_collect_time@1 DESC num_ranges=REDACTED REDACTED
 |_|_|_ProjectionExec: expr=[collect_time_utc@1 as collect_time, collect_time@0 as true_collect_time, peak_current@2 as peak_current] REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0} REDACTED
 |_|_|_|
 |_|_| Total rows: 8_|
 +-+-+-+

--- a/tests/cases/standalone/tql-explain-analyze/analyze.result
+++ b/tests/cases/standalone/tql-explain-analyze/analyze.result
@@ -23,7 +23,7 @@ TQL ANALYZE (0, 10, '5s') test;
 |_|_|_|
 | 1_| 0_|_PromInstantManipulateExec: range=[0..10000], lookback=[300000], interval=[5000], time index=[j] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["k"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges), distribution=PerSeries REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+
@@ -45,7 +45,7 @@ TQL ANALYZE (0, 10, '1s', '2s') test;
 |_|_|_|
 | 1_| 0_|_PromInstantManipulateExec: range=[0..10000], lookback=[2000], interval=[1000], time index=[j] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["k"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges), distribution=PerSeries REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+
@@ -66,7 +66,7 @@ TQL ANALYZE ('1970-01-01T00:00:00'::timestamp, '1970-01-01T00:00:00'::timestamp 
 |_|_|_|
 | 1_| 0_|_PromInstantManipulateExec: range=[0..10000], lookback=[300000], interval=[5000], time index=[j] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["k"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges), distribution=PerSeries REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+
@@ -89,7 +89,7 @@ TQL ANALYZE VERBOSE (0, 10, '5s') test;
 |_|_|_|
 | 1_| 0_|_PromInstantManipulateExec: range=[0..10000], lookback=[300000], interval=[5000], time index=[j] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["k"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges), distribution=PerSeries, projection=["i", "j", "k"], filters=[j >= TimestampMillisecond(-300000, None), j <= TimestampMillisecond(310000, None)], REDACTED
+|_|_|_SeriesScan: region=REDACTED, {"partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "distribution":"PerSeries", "projection": ["i", "j", "k"], "filters": ["j >= TimestampMillisecond(-300000, None)", "j <= TimestampMillisecond(310000, None)"], "REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+
@@ -120,11 +120,11 @@ TQL ANALYZE (0, 10, '5s') test;
 |_|_|_|
 | 1_| 0_|_PromInstantManipulateExec: range=[0..10000], lookback=[300000], interval=[5000], time index=[j] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["k", "l"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file 0 ranges), distribution=PerSeries REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
 |_|_|_|
 | 1_| 1_|_PromInstantManipulateExec: range=[0..10000], lookback=[300000], interval=[5000], time index=[j] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["k", "l"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file 0 ranges), distribution=PerSeries REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
 |_|_|_|
 |_|_| Total rows: 0_|
 +-+-+-+
@@ -150,7 +150,7 @@ TQL ANALYZE (0, 10, '5s') rate(test[10s]);
 |_|_|_PromRangeManipulateExec: req range=[0..10000], interval=[5000], eval range=[10000], time index=[j] REDACTED
 |_|_|_PromSeriesNormalizeExec: offset=[0], time index=[j], filter NaN: [true] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["k", "l"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file 0 ranges), distribution=PerSeries REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
 |_|_|_|
 | 1_| 1_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_FilterExec: prom_rate(j_range,i,j,Int64(10000))@1 IS NOT NULL REDACTED
@@ -158,7 +158,7 @@ TQL ANALYZE (0, 10, '5s') rate(test[10s]);
 |_|_|_PromRangeManipulateExec: req range=[0..10000], interval=[5000], eval range=[10000], time index=[j] REDACTED
 |_|_|_PromSeriesNormalizeExec: offset=[0], time index=[j], filter NaN: [true] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["k", "l"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file 0 ranges), distribution=PerSeries REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
 |_|_|_|
 |_|_| Total rows: 0_|
 +-+-+-+


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


Make it more readable. An example (try copy and format it in your editor):

```json
{"partition_count":0, "num_mem_ranges":0, "num_files":0, "num_file_ranges":0, "projection": ["ts", "log_uid", "log_message", "log_status", "p", "host_id", "host_name", "service_id", "service_name", "service_instance_id", "service_instance_name", "container_id", "container_name", "pod_id", "pod_name", "cluster_id", "cluster_name", "node_id", "node_name", "ns_id", "ns_name", "workload_id", "workload_name"], "metrics_per_partition": [{"partition":0, "metrics":{"prepare_scan_cost":"272.571µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"275.236µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"275.186µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":1, "metrics":{"prepare_scan_cost":"131.016µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"140.974µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"140.924µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":2, "metrics":{"prepare_scan_cost":"143.399µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"144.791µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"144.761µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":3, "metrics":{"prepare_scan_cost":"147.386µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"148.328µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"148.298µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":4, "metrics":{"prepare_scan_cost":"119.684µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"122.58µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"122.51µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":5, "metrics":{"prepare_scan_cost":"509.325µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"517.25µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"517.12µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":6, "metrics":{"prepare_scan_cost":"179.787µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"206.157µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"206.076µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":7, "metrics":{"prepare_scan_cost":"542.708µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"544.892µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"544.822µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":8, "metrics":{"prepare_scan_cost":"234.991µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"247.624µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"247.554µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":9, "metrics":{"prepare_scan_cost":"281.077µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"282.82µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"282.79µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":10, "metrics":{"prepare_scan_cost":"584.256µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"586.45µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"586.4µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":11, "metrics":{"prepare_scan_cost":"214.232µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"215.494µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"215.444µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":12, "metrics":{"prepare_scan_cost":"553.708µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"563.156µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"563.126µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":13, "metrics":{"prepare_scan_cost":"156.714µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"168.736µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"168.686µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":14, "metrics":{"prepare_scan_cost":"211.877µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"214.302µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"214.272µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":15, "metrics":{"prepare_scan_cost":"286.688µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"288.07µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"288.04µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":16, "metrics":{"prepare_scan_cost":"591.509µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"595.887µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"595.837µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":17, "metrics":{"prepare_scan_cost":"492.604µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"505.117µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"505.077µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":18, "metrics":{"prepare_scan_cost":"223.86µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"224.581µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"224.541µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":19, "metrics":{"prepare_scan_cost":"613.861µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"631.154µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"631.093µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":20, "metrics":{"prepare_scan_cost":"526.467µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"537.117µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"537.067µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":21, "metrics":{"prepare_scan_cost":"302.698µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"322.915µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"322.675µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":22, "metrics":{"prepare_scan_cost":"207.699µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"210.224µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"210.194µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":23, "metrics":{"prepare_scan_cost":"576.19µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"578.765µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"578.695µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":24, "metrics":{"prepare_scan_cost":"548.298µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"560.411µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"560.371µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":25, "metrics":{"prepare_scan_cost":"566.382µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"568.837µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"568.787µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":26, "metrics":{"prepare_scan_cost":"326.853µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"387.176µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"386.926µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":27, "metrics":{"prepare_scan_cost":"465.904µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"484.328µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"484.158µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":28, "metrics":{"prepare_scan_cost":"284.774µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"286.327µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"286.277µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":29, "metrics":{"prepare_scan_cost":"256µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"275.026µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"274.915µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":30, "metrics":{"prepare_scan_cost":"416.701µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"428.243µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"428.183µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}, {"partition":31, "metrics":{"prepare_scan_cost":"217.097µs", "build_reader_cost":"0ns", "scan_cost":"0ns", "convert_cost":"0ns", "yield_cost":"0ns", "total_cost":"219.431µs", "num_rows":0, "num_batches":0, "num_mem_ranges":0, "num_file_ranges":0, "build_parts_cost":"0ns", "rg_total":0, "rg_fulltext_filtered":0, "rg_inverted_filtered":0, "rg_minmax_filtered":0, "rg_bloom_filtered":0, "rows_before_filter":0, "rows_fulltext_filtered":0, "rows_inverted_filtered":0, "rows_bloom_filtered":0, "rows_precise_filtered":0, "num_sst_record_batches":0, "num_sst_batches":0, "num_sst_rows":0, "first_poll":"219.361µs", "num_series_send_timeout":0, "num_distributor_rows":0, "num_distributor_batches":0, "distributor_scan_cost":"0ns", "distributor_yield_cost":"0ns"}}]}
```

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
