### PR TITLE
fix: event api content type only check type and subtype

### DIFF
--- a/src/servers/src/http/event.rs
+++ b/src/servers/src/http/event.rs
@@ -670,11 +670,11 @@ impl TryFrom<&ContentType> for EventPayloadResolverInner {
     fn try_from(content_type: &ContentType) -> Result<Self> {
         let mime: mime_guess::Mime = content_type.clone().into();
         match (mime.type_(), mime.subtype()) {
-            (mime::APPLICATION, mime::JSON) => return Ok(EventPayloadResolverInner::Json),
+            (mime::APPLICATION, mime::JSON) => Ok(EventPayloadResolverInner::Json),
             (mime::APPLICATION, subtype) if subtype == CONTENT_TYPE_NDJSON_SUBTYPE_STR => {
-                return Ok(EventPayloadResolverInner::Ndjson)
+                Ok(EventPayloadResolverInner::Ndjson)
             }
-            (mime::TEXT, mime::PLAIN) => return Ok(EventPayloadResolverInner::Text),
+            (mime::TEXT, mime::PLAIN) => Ok(EventPayloadResolverInner::Text),
             _ => InvalidParameterSnafu {
                 reason: format!(
                     "invalid content type: {}, expected: one of {}",

--- a/src/servers/src/http/header.rs
+++ b/src/servers/src/http/header.rs
@@ -87,6 +87,7 @@ pub static CONTENT_TYPE_PROTOBUF: HeaderValue = HeaderValue::from_static(CONTENT
 pub static CONTENT_ENCODING_SNAPPY: HeaderValue = HeaderValue::from_static("snappy");
 
 pub static CONTENT_TYPE_NDJSON_STR: &str = "application/x-ndjson";
+pub static CONTENT_TYPE_NDJSON_SUBTYPE_STR: &str = "x-ndjson";
 
 pub struct GreptimeDbName(Option<String>);
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

* we need to accept `application/json; charset=utf-8` header
* now we can only handler `UTF-8` charset string. But the header is not forced to be consistent with the body. So I think we can do without the charset restriction.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
