### PR TITLE
chore: add connection info to `QueryContext`

### DIFF
--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -183,7 +183,7 @@ impl Instance {
             query_ctx.current_catalog().to_string(),
             vec![query_ctx.current_schema()],
             stmt.to_string(),
-            "unknown".to_string(),
+            query_ctx.conn_info().to_string(),
             None,
         );
 

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -67,6 +67,9 @@ pub struct QueryContext {
     /// Process id for managing on-going queries
     #[builder(default)]
     process_id: u64,
+    /// Connection information
+    #[builder(default)]
+    conn_info: ConnInfo,
 }
 
 /// This fields hold data that is only valid to current query context
@@ -439,6 +442,11 @@ impl QueryContext {
     pub fn process_id(&self) -> u64 {
         self.process_id
     }
+
+    /// Get client information
+    pub fn conn_info(&self) -> &ConnInfo {
+        &self.conn_info
+    }
 }
 
 impl QueryContextBuilder {
@@ -461,6 +469,7 @@ impl QueryContextBuilder {
                 .unwrap_or_else(|| Arc::new(ConfigurationVariables::default())),
             channel,
             process_id: self.process_id.unwrap_or_default(),
+            conn_info: self.conn_info.unwrap_or_default(),
         }
     }
 
@@ -472,7 +481,7 @@ impl QueryContextBuilder {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Default)]
 pub struct ConnInfo {
     pub client_addr: Option<SocketAddr>,
     pub channel: Channel,

--- a/src/session/src/lib.rs
+++ b/src/session/src/lib.rs
@@ -98,6 +98,7 @@ impl Session {
             .configuration_parameter(self.configuration_variables.clone())
             .channel(self.conn_info.channel)
             .process_id(self.process_id)
+            .conn_info(self.conn_info.clone())
             .build()
             .into()
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
- #5866 

## What's changed and what's your intention?
### Add Connection Information to Query Context
This update enhances the query context by incorporating connection information, which allows for more detailed session management. Key changes include:

- **`src/frontend/src/instance.rs`**: Updated to utilize `query_ctx.conn_info().to_string()` for retrieving connection information instead of using a placeholder string.
- **`src/session/src/context.rs`**: Added a `conn_info` field to `QueryContext` and introduced a `conn_info()` method for accessing it. The `QueryContextBuilder` was also updated to handle `conn_info`.
- **`src/session/src/lib.rs`**: Adjusted the `Session` to include `conn_info` during the query context construction process.

Now we can display client info in `information_schema.process_list` tables:

```sql
mysql> select * from information_schema.process_list order by elapsed_time asc;
+-----------------------+----------+---------+-------------------------------------------------------------------------+------------------------+---------------------+----------------------------+-----------------+
| id                    | catalog  | schemas | query                                                                   | client                 | frontend            | start_timestamp            | elapsed_time    |
+-----------------------+----------+---------+-------------------------------------------------------------------------+------------------------+---------------------+----------------------------+-----------------+
| 192.168.50.164:4101/5 | greptime | public  | SELECT * FROM information_schema.process_list ORDER BY elapsed_time ASC | mysql[127.0.0.1:41750] | 192.168.50.164:4101 | 2025-06-13 12:01:34.183000 | 00:00:00.009000 |
| 192.168.50.164:4001/0 | greptime | public  | INSERT INTO my_bench_table2 SELECT * FROM my_bench_table                | mysql[127.0.0.1:43248] | 192.168.50.164:4001 | 2025-06-13 12:01:26.403000 | 00:00:07.789000 |
+-----------------------+----------+---------+-------------------------------------------------------------------------+------------------------+---------------------+----------------------------+-----------------+
2 rows in set (0.01 sec)

```

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
