### PR TITLE
fix: override logical table's partition column with physical table's

### DIFF
--- a/src/catalog/src/lib.rs
+++ b/src/catalog/src/lib.rs
@@ -14,6 +14,7 @@
 
 #![feature(assert_matches)]
 #![feature(try_blocks)]
+#![feature(let_chains)]
 
 use std::any::Any;
 use std::fmt::{Debug, Formatter};

--- a/tests/cases/standalone/common/create/metric_engine_partition.result
+++ b/tests/cases/standalone/common/create/metric_engine_partition.result
@@ -71,6 +71,14 @@ show create table logical_table_2;
 |                 | )                                               |
 +-----------------+-------------------------------------------------+
 
+select count(*) from logical_table_2;
+
++----------+
+| count(*) |
++----------+
+| 0        |
++----------+
+
 drop table logical_table_2;
 
 Affected Rows: 0

--- a/tests/cases/standalone/common/create/metric_engine_partition.result
+++ b/tests/cases/standalone/common/create/metric_engine_partition.result
@@ -48,6 +48,20 @@ with (
 
 Affected Rows: 0
 
+create table logical_table_3 (
+    ts timestamp time index,
+    a string,
+    z string,
+    cpu double,
+    primary key(a, z) -- trigger a physical table change with smaller and bigger column ids
+)
+engine = metric
+with (
+    on_physical_table = "metric_engine_partition",
+);
+
+Affected Rows: 0
+
 show create table logical_table_2;
 
 +-----------------+-------------------------------------------------+
@@ -80,6 +94,10 @@ select count(*) from logical_table_2;
 +----------+
 
 drop table logical_table_2;
+
+Affected Rows: 0
+
+drop table logical_table_3;
 
 Affected Rows: 0
 

--- a/tests/cases/standalone/common/create/metric_engine_partition.sql
+++ b/tests/cases/standalone/common/create/metric_engine_partition.sql
@@ -38,6 +38,8 @@ with (
 
 show create table logical_table_2;
 
+select count(*) from logical_table_2;
+
 drop table logical_table_2;
 
 drop table metric_engine_partition;

--- a/tests/cases/standalone/common/create/metric_engine_partition.sql
+++ b/tests/cases/standalone/common/create/metric_engine_partition.sql
@@ -36,10 +36,24 @@ with (
     on_physical_table = "metric_engine_partition",
 );
 
+create table logical_table_3 (
+    ts timestamp time index,
+    a string,
+    z string,
+    cpu double,
+    primary key(a, z) -- trigger a physical table change with smaller and bigger column ids
+)
+engine = metric
+with (
+    on_physical_table = "metric_engine_partition",
+);
+
 show create table logical_table_2;
 
 select count(*) from logical_table_2;
 
 drop table logical_table_2;
+
+drop table logical_table_3;
 
 drop table metric_engine_partition;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


Logical table should inherit the partition column from physical's. Otherwise it will affect dist planner and other components that depends on partitioning.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
