### PR TITLE
feat: support setting FORMAT in TQL ANALYZE/VERBOSE

### DIFF
--- a/src/operator/src/statement/tql.rs
+++ b/src/operator/src/statement/tql.rs
@@ -46,6 +46,10 @@ impl StatementExecutor {
                 QueryLanguageParser::parse_promql(&promql, query_ctx).context(ParseQuerySnafu)?
             }
             Tql::Explain(explain) => {
+                if let Some(format) = &explain.format {
+                    query_ctx.set_explain_format(format.to_string());
+                }
+
                 let promql = PromQuery {
                     query: explain.query,
                     lookback: explain
@@ -66,6 +70,10 @@ impl StatementExecutor {
                     .unwrap()
             }
             Tql::Analyze(analyze) => {
+                if let Some(format) = &analyze.format {
+                    query_ctx.set_explain_format(format.to_string());
+                }
+
                 let promql = PromQuery {
                     start: analyze.start,
                     end: analyze.end,

--- a/src/sql/src/statements/tql.rs
+++ b/src/sql/src/statements/tql.rs
@@ -15,6 +15,7 @@
 use std::fmt::Display;
 
 use serde::Serialize;
+use sqlparser::ast::AnalyzeFormat;
 use sqlparser_derive::{Visit, VisitMut};
 
 #[derive(Debug, Clone, PartialEq, Eq, Visit, VisitMut, Serialize)]
@@ -73,7 +74,7 @@ impl Display for TqlEval {
     }
 }
 
-/// TQL EXPLAIN [VERBOSE] [<start>, <end>, <step>, [lookback]] <promql>
+/// TQL EXPLAIN [VERBOSE] [FORMAT format] [<start>, <end>, <step>, [lookback]] <promql>
 /// doesn't execute the query but tells how the query would be executed (similar to SQL EXPLAIN).
 #[derive(Debug, Clone, PartialEq, Eq, Visit, VisitMut, Serialize)]
 pub struct TqlExplain {
@@ -83,6 +84,7 @@ pub struct TqlExplain {
     pub lookback: Option<String>,
     pub query: String,
     pub is_verbose: bool,
+    pub format: Option<AnalyzeFormat>,
 }
 
 impl Display for TqlExplain {
@@ -90,6 +92,9 @@ impl Display for TqlExplain {
         write!(f, "TQL EXPLAIN ")?;
         if self.is_verbose {
             write!(f, "VERBOSE ")?;
+        }
+        if let Some(format) = &self.format {
+            write!(f, "FORMAT {} ", format)?;
         }
         format_tql(
             f,
@@ -102,7 +107,7 @@ impl Display for TqlExplain {
     }
 }
 
-/// TQL ANALYZE [VERBOSE] (<start>, <end>, <step>, [lookback]) <promql>
+/// TQL ANALYZE [VERBOSE] [FORMAT format] (<start>, <end>, <step>, [lookback]) <promql>
 /// executes the plan and tells the detailed per-step execution time (similar to SQL ANALYZE).
 #[derive(Debug, Clone, PartialEq, Eq, Visit, VisitMut, Serialize)]
 pub struct TqlAnalyze {
@@ -112,6 +117,7 @@ pub struct TqlAnalyze {
     pub lookback: Option<String>,
     pub query: String,
     pub is_verbose: bool,
+    pub format: Option<AnalyzeFormat>,
 }
 
 impl Display for TqlAnalyze {
@@ -119,6 +125,9 @@ impl Display for TqlAnalyze {
         write!(f, "TQL ANALYZE ")?;
         if self.is_verbose {
             write!(f, "VERBOSE ")?;
+        }
+        if let Some(format) = &self.format {
+            write!(f, "FORMAT {} ", format)?;
         }
         format_tql(
             f,
@@ -143,6 +152,7 @@ pub struct TqlParameters {
     lookback: Option<String>,
     query: String,
     pub is_verbose: bool,
+    pub format: Option<AnalyzeFormat>,
 }
 
 impl TqlParameters {
@@ -160,6 +170,7 @@ impl TqlParameters {
             lookback,
             query,
             is_verbose: false,
+            format: None,
         }
     }
 }
@@ -185,6 +196,7 @@ impl From<TqlParameters> for TqlExplain {
             query: params.query,
             lookback: params.lookback,
             is_verbose: params.is_verbose,
+            format: params.format,
         }
     }
 }
@@ -198,6 +210,7 @@ impl From<TqlParameters> for TqlAnalyze {
             query: params.query,
             lookback: params.lookback,
             is_verbose: params.is_verbose,
+            format: params.format,
         }
     }
 }

--- a/tests/cases/standalone/tql-explain-analyze/analyze.result
+++ b/tests/cases/standalone/tql-explain-analyze/analyze.result
@@ -163,6 +163,72 @@ TQL ANALYZE (0, 10, '5s') rate(test[10s]);
 |_|_| Total rows: 0_|
 +-+-+-+
 
+-- Test new FORMAT functionality for ANALYZE
+-- analyze with JSON format
+-- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
+TQL ANALYZE FORMAT JSON (0, 10, '5s') test;
+
++-+-+-+
+| stage | node | plan_|
++-+-+-+
+| 0_| 0_| {"name":"SortPreservingMergeExec","param":"[k@2 ASC, l@3 ASC, j@1 ASC]","output_rows":0,"elapsed_compute":1002,"REDACTED
+| 1_| 0_| {"name":"PromInstantManipulateExec","param":"range=[0..10000], lookback=[300000], interval=[5000], time index=[j]","output_rows":0,"elapsed_compute":32,"REDACTED
+| 1_| 1_| {"name":"PromInstantManipulateExec","param":"range=[0..10000], lookback=[300000], interval=[5000], time index=[j]","output_rows":0,"elapsed_compute":32,"REDACTED
+|_|_| Total rows: 0_|
++-+-+-+
+
+-- analyze verbose with JSON format
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE (elapsed_compute.*) REDACTED
+-- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
+-- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE (Duration.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
+TQL ANALYZE VERBOSE FORMAT JSON (0, 10, '5s') test;
+
++-+-+-+
+| stage | node | plan_|
++-+-+-+
+| 0_| 0_| {"name":"SortPreservingMergeExec","param":"[k@2 ASC, l@3 ASC, j@1 ASC]","output_rows":0,"REDACTED
+| 1_| 0_| {"name":"PromInstantManipulateExec","param":"range=[0..10000], lookback=[300000], interval=[5000], time index=[j]","output_rows":0,"REDACTED
+| 1_| 1_| {"name":"PromInstantManipulateExec","param":"range=[0..10000], lookback=[300000], interval=[5000], time index=[j]","output_rows":0,"REDACTED
+|_|_| Total rows: 0_|
++-+-+-+
+
+-- analyze with TEXT format (should be same as default)
+-- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
+TQL ANALYZE FORMAT TEXT (0, 10, '5s') test;
+
++-+-+-+
+| stage | node | plan_|
++-+-+-+
+| 0_| 0_|_SortPreservingMergeExec: [k@2 ASC, l@3 ASC, j@1 ASC] REDACTED
+|_|_|_SortExec: expr=[k@2 ASC, l@3 ASC, j@1 ASC], preserve_partitioning=[true] REDACTED
+|_|_|_MergeScanExec: REDACTED
+|_|_|_|
+| 1_| 0_|_PromInstantManipulateExec: range=[0..10000], lookback=[300000], interval=[5000], time index=[j] REDACTED
+|_|_|_PromSeriesDivideExec: tags=["k", "l"] REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
+|_|_|_|
+| 1_| 1_|_PromInstantManipulateExec: range=[0..10000], lookback=[300000], interval=[5000], time index=[j] REDACTED
+|_|_|_PromSeriesDivideExec: tags=["k", "l"] REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
+|_|_|_|
+|_|_| Total rows: 0_|
++-+-+-+
+
 drop table test;
 
 Affected Rows: 0

--- a/tests/cases/standalone/tql-explain-analyze/analyze.result
+++ b/tests/cases/standalone/tql-explain-analyze/analyze.result
@@ -166,6 +166,7 @@ TQL ANALYZE (0, 10, '5s') rate(test[10s]);
 -- Test new FORMAT functionality for ANALYZE
 -- analyze with JSON format
 -- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE (elapsed_compute.*) REDACTED
 -- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
 -- SQLNESS REPLACE (-+) -
 -- SQLNESS REPLACE (\s\s+) _
@@ -176,9 +177,9 @@ TQL ANALYZE FORMAT JSON (0, 10, '5s') test;
 +-+-+-+
 | stage | node | plan_|
 +-+-+-+
-| 0_| 0_| {"name":"SortPreservingMergeExec","param":"[k@2 ASC, l@3 ASC, j@1 ASC]","output_rows":0,"elapsed_compute":1002,"REDACTED
-| 1_| 0_| {"name":"PromInstantManipulateExec","param":"range=[0..10000], lookback=[300000], interval=[5000], time index=[j]","output_rows":0,"elapsed_compute":32,"REDACTED
-| 1_| 1_| {"name":"PromInstantManipulateExec","param":"range=[0..10000], lookback=[300000], interval=[5000], time index=[j]","output_rows":0,"elapsed_compute":32,"REDACTED
+| 0_| 0_| {"name":"SortPreservingMergeExec","param":"[k@2 ASC, l@3 ASC, j@1 ASC]","output_rows":0,"REDACTED
+| 1_| 0_| {"name":"PromInstantManipulateExec","param":"range=[0..10000], lookback=[300000], interval=[5000], time index=[j]","output_rows":0,"REDACTED
+| 1_| 1_| {"name":"PromInstantManipulateExec","param":"range=[0..10000], lookback=[300000], interval=[5000], time index=[j]","output_rows":0,"REDACTED
 |_|_| Total rows: 0_|
 +-+-+-+
 

--- a/tests/cases/standalone/tql-explain-analyze/analyze.sql
+++ b/tests/cases/standalone/tql-explain-analyze/analyze.sql
@@ -66,6 +66,7 @@ TQL ANALYZE (0, 10, '5s') rate(test[10s]);
 -- Test new FORMAT functionality for ANALYZE
 -- analyze with JSON format
 -- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE (elapsed_compute.*) REDACTED
 -- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
 -- SQLNESS REPLACE (-+) -
 -- SQLNESS REPLACE (\s\s+) _

--- a/tests/cases/standalone/tql-explain-analyze/analyze.sql
+++ b/tests/cases/standalone/tql-explain-analyze/analyze.sql
@@ -63,4 +63,34 @@ TQL ANALYZE (0, 10, '5s') test;
 -- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
 TQL ANALYZE (0, 10, '5s') rate(test[10s]);
 
+-- Test new FORMAT functionality for ANALYZE
+-- analyze with JSON format
+-- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
+TQL ANALYZE FORMAT JSON (0, 10, '5s') test;
+
+-- analyze verbose with JSON format
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE (elapsed_compute.*) REDACTED
+-- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
+-- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE (Duration.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
+TQL ANALYZE VERBOSE FORMAT JSON (0, 10, '5s') test;
+
+-- analyze with TEXT format (should be same as default)
+-- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
+TQL ANALYZE FORMAT TEXT (0, 10, '5s') test;
+
 drop table test;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


Support `TQL EXPLAIN [VERBOSE] [FORMAT] <format>`. But at present only `ANALYZE` supports changing output format.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
