### PR TITLE
fix: carry process id in query ctx

### DIFF
--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -185,7 +185,7 @@ impl Instance {
             vec![query_ctx.current_schema()],
             stmt.to_string(),
             query_ctx.conn_info().to_string(),
-            None,
+            Some(query_ctx.process_id()),
         );
 
         let query_fut = async {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

 ### Commit Message

When registering MySQL queries, we should always respect the process id in session context.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
