### PR TITLE
chore: print series count after wal replay

### DIFF
--- a/src/mito2/src/memtable/time_partition.rs
+++ b/src/mito2/src/memtable/time_partition.rs
@@ -656,6 +656,11 @@ impl TimePartitions {
 
         Ok(())
     }
+
+    /// Timeseries count in all time partitions.
+    pub(crate) fn series_count(&self) -> usize {
+        self.inner.lock().unwrap().series_count()
+    }
 }
 
 /// Computes the start timestamp of the partition for `ts`.
@@ -696,6 +701,13 @@ impl PartitionsInner {
         let id = self.next_memtable_id;
         self.next_memtable_id += 1;
         id
+    }
+
+    pub(crate) fn series_count(&self) -> usize {
+        self.parts
+            .iter()
+            .map(|p| p.memtable.stats().series_count)
+            .sum()
     }
 }
 

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -665,9 +665,10 @@ where
     // to avoid reading potentially incomplete entries in the future.
     (on_region_opened)(region_id, flushed_entry_id, provider).await?;
 
+    let series_count = version_control.current().series_count();
     info!(
-        "Replay WAL for region: {}, rows recovered: {}, last entry id: {}",
-        region_id, rows_replayed, last_entry_id
+        "Replay WAL for region: {}, rows recovered: {}, last entry id: {}, total timeseries replayed: {}",
+        region_id, rows_replayed, last_entry_id, series_count
     );
     Ok(last_entry_id)
 }

--- a/src/mito2/src/region/version.rs
+++ b/src/mito2/src/region/version.rs
@@ -249,6 +249,13 @@ pub(crate) struct VersionControlData {
     pub(crate) is_dropped: bool,
 }
 
+impl VersionControlData {
+    /// Approximate timeseries count in current version.
+    pub(crate) fn series_count(&self) -> usize {
+        self.version.memtables.mutable.series_count()
+    }
+}
+
 /// Static metadata of a region.
 #[derive(Clone, Debug)]
 pub(crate) struct Version {

--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -25,7 +25,7 @@ use common_error::status_code::StatusCode;
 use common_plugins::GREPTIME_EXEC_WRITE_COST;
 use common_query::{Output, OutputData};
 use common_recordbatch::util;
-use common_telemetry::{info, tracing};
+use common_telemetry::tracing;
 use query::parser::{PromQuery, DEFAULT_LOOKBACK_STRING};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -25,7 +25,7 @@ use common_error::status_code::StatusCode;
 use common_plugins::GREPTIME_EXEC_WRITE_COST;
 use common_query::{Output, OutputData};
 use common_recordbatch::util;
-use common_telemetry::tracing;
+use common_telemetry::{info, tracing};
 use query::parser::{PromQuery, DEFAULT_LOOKBACK_STRING};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

 ### Add Series Count Functionality and Logging Enhancements

 - **`time_partition.rs`**: Introduced `series_count` method to calculate the total timeseries count across all time partitions.
 - **`opener.rs`**: Enhanced logging to include the total timeseries replayed during WAL replay.
 - **`version.rs`**: Added `series_count` method to `VersionControlData` for approximating timeseries count in the current version.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
