### PR TITLE
fix: reordered write cause incorrect kv

### DIFF
--- a/src/mito2/src/memtable/partition_tree.rs
+++ b/src/mito2/src/memtable/partition_tree.rs
@@ -905,15 +905,22 @@ mod tests {
             .write(&key_values(&metadata, ('a'..'h').map(|c| c.to_string())))
             .unwrap();
         memtable.freeze().unwrap();
+        assert_eq!(
+            collect_kvs(memtable.iter(None, None, None).unwrap(), &metadata),
+            ('a'..'h').map(|c| (c.to_string(), c.to_string())).collect()
+        );
         let forked = memtable.fork(2, &metadata);
 
-        forked
-            .write(&key_values(
-                &metadata,
-                ["c", "f", "i", "h", "b", "e", "g"].iter(),
-            ))
-            .unwrap();
+        let keys = ["c", "f", "i", "h", "b", "e", "g"];
+        forked.write(&key_values(&metadata, keys.iter())).unwrap();
         forked.freeze().unwrap();
+        assert_eq!(
+            collect_kvs(forked.iter(None, None, None).unwrap(), &metadata),
+            keys.iter()
+                .map(|c| (c.to_string(), c.to_string()))
+                .collect()
+        );
+
         let forked2 = forked.fork(3, &metadata);
 
         let keys = ["g", "e", "a", "f", "b", "c", "h"];

--- a/src/mito2/src/memtable/partition_tree.rs
+++ b/src/mito2/src/memtable/partition_tree.rs
@@ -840,138 +840,21 @@ mod tests {
         ]
     }
 
-    fn key_values_0() -> Vec<(String, String)> {
-        vec![
-            (
-                "__column_4406636445696_aW5zdGFuY2U".to_string(),
-                r#"{"column_schema":{"name":"instance","data_type":{"String":null},"is_nullable":true,"is_time_index":false,"default_constraint":null,"metadata":{"greptime:inverted_index":"true"}},"semantic_type":"Tag","column_id":7}"#.to_string(),
-            ),
-            (
-                "__column_4406636445696_aG9zdA".to_string(),
-                r#"{"column_schema":{"name":"host","data_type":{"String":null},"is_nullable":true,"is_time_index":false,"default_constraint":null,"metadata":{"greptime:inverted_index":"true"}},"semantic_type":"Tag","column_id":6}"#.to_string(),
-            ),
-            (
-                "__column_4406636445696_bmFtZXNwYWNl".to_string(),
-                r#"{"column_schema":{"name":"namespace","data_type":{"String":null},"is_nullable":true,"is_time_index":false,"default_constraint":null,"metadata":{"greptime:inverted_index":"true"}},"semantic_type":"Tag","column_id":2}"#.to_string(),
-            ),
-            (
-                "__column_4406636445696_am9i".to_string(),
-                r#"{"column_schema":{"name":"job","data_type":{"String":null},"is_nullable":true,"is_time_index":false,"default_constraint":null,"metadata":{"greptime:inverted_index":"true"}},"semantic_type":"Tag","column_id":8}"#.to_string(),
-            ),
-            (
-                "__column_4406636445696_ZW52".to_string(),
-                r#"{"column_schema":{"name":"env","data_type":{"String":null},"is_nullable":true,"is_time_index":false,"default_constraint":null,"metadata":{"greptime:inverted_index":"true"}},"semantic_type":"Tag","column_id":5}"#.to_string(),
-            ),
-            (
-                "__column_4406636445696_Z3JlcHRpbWVfdmFsdWU".to_string(),
-                r#"{"column_schema":{"name":"greptime_value","data_type":{"Float64":{}},"is_nullable":true,"is_time_index":false,"default_constraint":null,"metadata":{}},"semantic_type":"Field","column_id":1}"#.to_string(),
-            ),
-            (
-                "__column_4406636445696_Z3JlcHRpbWVfdGltZXN0YW1w".to_string(),
-                r#"{"column_schema":{"name":"greptime_timestamp","data_type":{"Timestamp":{"Millisecond":null}},"is_nullable":false,"is_time_index":true,"default_constraint":null,"metadata":{"greptime:time_index":"true"}},"semantic_type":"Timestamp","column_id":0}"#.to_string(),
-            ),
-            (
-                "__column_4406636445696_YXBw".to_string(),
-                r#"{"column_schema":{"name":"app","data_type":{"String":null},"is_nullable":true,"is_time_index":false,"default_constraint":null,"metadata":{"greptime:inverted_index":"true"}},"semantic_type":"Tag","column_id":3}"#.to_string(),
-            ),
-            (
-                "__region_4406636445696".to_string(),
-                "".to_string(),
-            ),
-        ]
-    }
-
-    fn key_values_1() -> Vec<(String, String)> {
-        vec![
-            (
-                "__column_4402341478400_bmFtZXNwYWNl".to_string(),
-                r#"{"column_schema":{"name":"namespace","data_type":{"String":null},"is_nullable":true,"is_time_index":false,"default_constraint":null,"metadata":{"greptime:inverted_index":"true"}},"semantic_type":"Tag","column_id":2}"#.to_string(),
-            ),
-            (
-                "__column_4402341478400_Z3JlcHRpbWVfdmFsdWU".to_string(),
-                r#"{"column_schema":{"name":"greptime_value","data_type":{"Float64":{}},"is_nullable":true,"is_time_index":false,"default_constraint":null,"metadata":{}},"semantic_type":"Field","column_id":1}"#.to_string(),
-            ),
-            (
-                "__column_4402341478400_Y2xvdWRfcHJvdmlkZXI".to_string(),
-                r#"{"column_schema":{"name":"cloud_provider","data_type":{"String":null},"is_nullable":true,"is_time_index":false,"default_constraint":null,"metadata":{"greptime:inverted_index":"true"}},"semantic_type":"Tag","column_id":4}"#.to_string(),
-            ),
-            (
-                "__column_4402341478400_YXBw".to_string(),
-                r#"{"column_schema":{"name":"app","data_type":{"String":null},"is_nullable":true,"is_time_index":false,"default_constraint":null,"metadata":{"greptime:inverted_index":"true"}},"semantic_type":"Tag","column_id":3}"#.to_string(),
-            ),
-            (
-                "__column_4402341478400_aG9zdA".to_string(),
-                r#"{"column_schema":{"name":"host","data_type":{"String":null},"is_nullable":true,"is_time_index":false,"default_constraint":null,"metadata":{"greptime:inverted_index":"true"}},"semantic_type":"Tag","column_id":6}"#.to_string(),
-            ),
-            (
-                "__column_4402341478400_ZW52".to_string(),
-                r#"{"column_schema":{"name":"env","data_type":{"String":null},"is_nullable":true,"is_time_index":false,"default_constraint":null,"metadata":{"greptime:inverted_index":"true"}},"semantic_type":"Tag","column_id":5}"#.to_string(),
-            ),
-            (
-                "__column_4402341478400_Z3JlcHRpbWVfdGltZXN0YW1w".to_string(),
-                r#"{"column_schema":{"name":"greptime_timestamp","data_type":{"Timestamp":{"Millisecond":null}},"is_nullable":false,"is_time_index":true,"default_constraint":null,"metadata":{"greptime:time_index":"true"}},"semantic_type":"Timestamp","column_id":0}"#.to_string(),
-            ),
-            (
-                "__region_4402341478400".to_string(),
-                "".to_string(),
-            )
-        ]
-    }
-
-    fn key_values_2() -> Vec<(String, String)> {
-        vec![
-            (
-                "__column_4406636445696_Z3JlcHRpbWVfdGltZXN0YW1w".to_string(),
-                r#"{"column_schema":{"name":"greptime_timestamp","data_type":{"Timestamp":{"Millisecond":null}},"is_nullable":false,"is_time_index":true,"default_constraint":null,"metadata":{"greptime:time_index":"true"}},"semantic_type":"Timestamp","column_id":0}"#.to_string(),
-            ),
-            (
-                "__column_4406636445696_aG9zdA".to_string(),
-                r#"{"column_schema":{"name":"host","data_type":{"String":null},"is_nullable":true,"is_time_index":false,"default_constraint":null,"metadata":{"greptime:inverted_index":"true"}},"semantic_type":"Tag","column_id":6}"#.to_string(),
-            ),
-            (
-                "__column_4406636445696_bmFtZXNwYWNl".to_string(),
-                r#"{"column_schema":{"name":"namespace","data_type":{"String":null},"is_nullable":true,"is_time_index":false,"default_constraint":null,"metadata":{"greptime:inverted_index":"true"}},"semantic_type":"Tag","column_id":2}"#.to_string(),
-            ),
-            (
-                "__column_4406636445696_am9i".to_string(),
-                r#"{"column_schema":{"name":"job","data_type":{"String":null},"is_nullable":true,"is_time_index":false,"default_constraint":null,"metadata":{"greptime:inverted_index":"true"}},"semantic_type":"Tag","column_id":8}"#.to_string(),
-            ),
-            (
-                "__column_4406636445696_aW5zdGFuY2U".to_string(),
-                r#"{"column_schema":{"name":"instance","data_type":{"String":null},"is_nullable":true,"is_time_index":false,"default_constraint":null,"metadata":{"greptime:inverted_index":"true"}},"semantic_type":"Tag","column_id":7}"#.to_string(),
-            ),
-            (
-                "__column_4406636445696_ZW52".to_string(),
-                r#"{"column_schema":{"name":"env","data_type":{"String":null},"is_nullable":true,"is_time_index":false,"default_constraint":null,"metadata":{"greptime:inverted_index":"true"}},"semantic_type":"Tag","column_id":5}"#.to_string(),
-            ),
-            (
-                "__column_4406636445696_Z3JlcHRpbWVfdmFsdWU".to_string(),
-                r#"{"column_schema":{"name":"greptime_value","data_type":{"Float64":{}},"is_nullable":true,"is_time_index":false,"default_constraint":null,"metadata":{}},"semantic_type":"Field","column_id":1}"#.to_string(),
-            ),
-            (
-                "__column_4406636445696_YXBw".to_string(),
-                r#"{"column_schema":{"name":"app","data_type":{"String":null},"is_nullable":true,"is_time_index":false,"default_constraint":null,"metadata":{"greptime:inverted_index":"true"}},"semantic_type":"Tag","column_id":3}"#.to_string(),
-            ),
-            (
-                "__region_4406636445696".to_string(),
-                "".to_string(),
-            ),
-        ]
-    }
-
-    fn key_values(metadata: RegionMetadataRef, kv: Vec<(String, String)>) -> KeyValues {
-        let rows = kv
-            .into_iter()
-            .map(|(k, v)| Row {
+    fn key_values<T: AsRef<str>>(
+        metadata: &RegionMetadataRef,
+        keys: impl Iterator<Item = T>,
+    ) -> KeyValues {
+        let rows = keys
+            .map(|c| Row {
                 values: vec![
                     api::v1::Value {
                         value_data: Some(ValueData::TimestampMillisecondValue(0)),
                     },
                     api::v1::Value {
-                        value_data: Some(ValueData::StringValue(k)),
+                        value_data: Some(ValueData::StringValue(c.as_ref().to_string())),
                     },
                     api::v1::Value {
-                        value_data: Some(ValueData::StringValue(v)),
+                        value_data: Some(ValueData::StringValue(c.as_ref().to_string())),
                     },
                 ],
             })
@@ -985,7 +868,7 @@ mod tests {
             }),
             write_hint: None,
         };
-        KeyValues::new(&metadata, mutation).unwrap()
+        KeyValues::new(metadata, mutation).unwrap()
     }
 
     fn collect_kvs(
@@ -1019,23 +902,28 @@ mod tests {
             .build(1, &metadata);
 
         memtable
-            .write(&key_values(metadata.clone(), key_values_0()))
+            .write(&key_values(&metadata, ('a'..'h').map(|c| c.to_string())))
             .unwrap();
         memtable.freeze().unwrap();
         let forked = memtable.fork(2, &metadata);
 
         forked
-            .write(&key_values(metadata.clone(), key_values_1()))
+            .write(&key_values(
+                &metadata,
+                ["c", "f", "i", "h", "b", "e", "g"].iter(),
+            ))
             .unwrap();
         forked.freeze().unwrap();
         let forked2 = forked.fork(3, &metadata);
 
-        forked2
-            .write(&key_values(metadata.clone(), key_values_2()))
-            .unwrap();
+        let keys = ["g", "e", "a", "f", "b", "c", "h"];
+        forked2.write(&key_values(&metadata, keys.iter())).unwrap();
 
         let kvs = collect_kvs(forked2.iter(None, None, None).unwrap(), &metadata);
-        let expected = key_values_2().into_iter().collect::<HashMap<_, _>>();
+        let expected = keys
+            .iter()
+            .map(|c| (c.to_string(), c.to_string()))
+            .collect::<HashMap<_, _>>();
         assert_eq!(kvs, expected);
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
Fixes the kv mismatch issue caused by outdated pk index in dictionary in `PartitionTreeMemtable`.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
