### PR TITLE
refactor(cli): simplify metadata command parameters

### DIFF
--- a/src/cli/src/metadata/control/del/key.rs
+++ b/src/cli/src/metadata/control/del/key.rs
@@ -27,7 +27,6 @@ use crate::Tool;
 #[derive(Debug, Default, Parser)]
 pub struct DelKeyCommand {
     /// The key to delete from the metadata store.
-    #[clap(long)]
     key: String,
 
     /// Delete key-value pairs with the given prefix.

--- a/src/cli/src/metadata/control/get.rs
+++ b/src/cli/src/metadata/control/get.rs
@@ -51,7 +51,7 @@ impl GetCommand {
 /// Get key-value pairs from the metadata store.
 #[derive(Debug, Default, Parser)]
 pub struct GetKeyCommand {
-    /// The key to get from the metadata store. If empty, returns all key-value pairs.
+    /// The key to get from the metadata store.
     #[clap(default_value = "")]
     key: String,
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

- Remove #[clap(long)] attribute from del key command parameter
- Correct key parameter documentation in get command

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
