### PR TITLE
refactor: scan `Batch`es directly

### DIFF
--- a/src/mito2/src/read/scan_util.rs
+++ b/src/mito2/src/read/scan_util.rs
@@ -360,8 +360,8 @@ impl Drop for PartitionMetricsInner {
         self.in_progress_scan.dec();
 
         debug!(
-            "{} finished, region_id: {}, partition: {}, metrics: {:?}",
-            self.scanner_type, self.region_id, self.partition, metrics
+            "{} finished, region_id: {}, partition: {}, scan_metrics: {:?}, convert_batch_costs: {}",
+            self.scanner_type, self.region_id, self.partition, metrics, self.convert_cost,
         );
     }
 }

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -20,14 +20,14 @@ use std::time::Instant;
 
 use async_stream::try_stream;
 use common_error::ext::BoxedError;
-use common_recordbatch::error::ExternalSnafu;
 use common_recordbatch::util::ChainedRecordBatchStream;
 use common_recordbatch::{RecordBatchStreamWrapper, SendableRecordBatchStream};
 use common_telemetry::tracing;
 use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
 use datafusion::physical_plan::{DisplayAs, DisplayFormatType};
 use datatypes::schema::SchemaRef;
-use snafu::ResultExt;
+use futures::StreamExt;
+use snafu::ensure;
 use store_api::metadata::RegionMetadataRef;
 use store_api::region_engine::{PartitionRange, PrepareRequest, RegionScanner, ScannerProperties};
 use store_api::storage::TimeSeriesRowSelector;
@@ -42,7 +42,8 @@ use crate::read::scan_region::{ScanInput, StreamContext};
 use crate::read::scan_util::{
     scan_file_ranges, scan_mem_ranges, PartitionMetrics, PartitionMetricsList,
 };
-use crate::read::{BatchReader, BoxedBatchReader, ScannerMetrics, Source};
+use crate::read::stream::{ConvertBatchStream, ScanBatch, ScanBatchStream};
+use crate::read::{Batch, BatchReader, BoxedBatchReader, ScannerMetrics, Source};
 use crate::region::options::MergeMode;
 
 /// Scans a region and returns rows in a sorted sequence.
@@ -93,6 +94,20 @@ impl SeqScan {
         Ok(Box::pin(aggr_stream))
     }
 
+    /// Scan [`Batch`] in all partitions one by one.
+    pub(crate) fn scan_all_partitions(&self) -> Result<ScanBatchStream> {
+        let metrics_set = ExecutionPlanMetricsSet::new();
+
+        let streams = (0..self.properties.partitions.len())
+            .map(|partition| {
+                let metrics = self.new_partition_metrics(&metrics_set, partition);
+                self.scan_batch_in_partition(partition, metrics)
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(Box::pin(futures::stream::iter(streams).flatten()))
+    }
+
     /// Builds a [BoxedBatchReader] from sequential scan for compaction.
     ///
     /// # Panics
@@ -134,7 +149,7 @@ impl SeqScan {
                 part_metrics,
                 range_builder_list.clone(),
                 &mut sources,
-            );
+            )?;
         }
 
         common_telemetry::debug!(
@@ -196,23 +211,40 @@ impl SeqScan {
         &self,
         metrics_set: &ExecutionPlanMetricsSet,
         partition: usize,
-    ) -> Result<SendableRecordBatchStream, BoxedError> {
-        if partition >= self.properties.partitions.len() {
-            return Err(BoxedError::new(
-                PartitionOutOfRangeSnafu {
-                    given: partition,
-                    all: self.properties.partitions.len(),
-                }
-                .build(),
-            ));
-        }
+    ) -> Result<SendableRecordBatchStream> {
+        let metrics = self.new_partition_metrics(metrics_set, partition);
+
+        let batch_stream = self.scan_batch_in_partition(partition, metrics.clone())?;
+
+        let input = &self.stream_ctx.input;
+        let record_batch_stream = ConvertBatchStream::new(
+            batch_stream,
+            input.mapper.clone(),
+            input.cache_strategy.clone(),
+            metrics,
+        );
+
+        Ok(Box::pin(RecordBatchStreamWrapper::new(
+            input.mapper.output_schema(),
+            Box::pin(record_batch_stream),
+        )))
+    }
+
+    fn scan_batch_in_partition(
+        &self,
+        partition: usize,
+        part_metrics: PartitionMetrics,
+    ) -> Result<ScanBatchStream> {
+        ensure!(
+            partition < self.properties.partitions.len(),
+            PartitionOutOfRangeSnafu {
+                given: partition,
+                all: self.properties.partitions.len(),
+            }
+        );
+
         if self.properties.partitions[partition].is_empty() {
-            return Ok(Box::pin(RecordBatchStreamWrapper::new(
-                self.stream_ctx.input.mapper.output_schema(),
-                common_recordbatch::EmptyRecordBatchStream::new(
-                    self.stream_ctx.input.mapper.output_schema(),
-                ),
-            )));
+            return Ok(Box::pin(futures::stream::empty()));
         }
 
         let stream_ctx = self.stream_ctx.clone();
@@ -220,7 +252,6 @@ impl SeqScan {
         let partition_ranges = self.properties.partitions[partition].clone();
         let compaction = self.compaction;
         let distinguish_range = self.properties.distinguish_partition_range;
-        let part_metrics = self.new_partition_metrics(metrics_set, partition);
 
         let stream = try_stream! {
             part_metrics.on_first_poll();
@@ -239,27 +270,19 @@ impl SeqScan {
                     &part_metrics,
                     range_builder_list.clone(),
                     &mut sources,
-                );
+                )?;
 
                 let mut metrics = ScannerMetrics::default();
                 let mut fetch_start = Instant::now();
                 let mut reader =
                     Self::build_reader_from_sources(&stream_ctx, sources, semaphore.clone())
-                        .await
-                        .map_err(BoxedError::new)
-                        .context(ExternalSnafu)?;
-                let cache = &stream_ctx.input.cache_strategy;
+                        .await?;
                 #[cfg(debug_assertions)]
                 let mut checker = crate::read::BatchChecker::default()
                     .with_start(Some(part_range.start))
                     .with_end(Some(part_range.end));
 
-                while let Some(batch) = reader
-                    .next_batch()
-                    .await
-                    .map_err(BoxedError::new)
-                    .context(ExternalSnafu)?
-                {
+                while let Some(batch) = reader.next_batch().await? {
                     metrics.scan_cost += fetch_start.elapsed();
                     metrics.num_batches += 1;
                     metrics.num_rows += batch.num_rows();
@@ -278,11 +301,8 @@ impl SeqScan {
                         &batch,
                     );
 
-                    let convert_start = Instant::now();
-                    let record_batch = stream_ctx.input.mapper.convert(&batch, cache)?;
-                    metrics.convert_cost += convert_start.elapsed();
                     let yield_start = Instant::now();
-                    yield record_batch;
+                    yield ScanBatch::Normal(batch);
                     metrics.yield_cost += yield_start.elapsed();
 
                     fetch_start = Instant::now();
@@ -292,7 +312,7 @@ impl SeqScan {
                 // The query engine can use this to optimize some queries.
                 if distinguish_range {
                     let yield_start = Instant::now();
-                    yield stream_ctx.input.mapper.empty_record_batch();
+                    yield ScanBatch::Normal(Batch::empty());
                     metrics.yield_cost += yield_start.elapsed();
                 }
 
@@ -302,13 +322,7 @@ impl SeqScan {
 
             part_metrics.on_finish();
         };
-
-        let stream = Box::pin(RecordBatchStreamWrapper::new(
-            self.stream_ctx.input.mapper.output_schema(),
-            Box::pin(stream),
-        ));
-
-        Ok(stream)
+        Ok(Box::pin(stream))
     }
 
     fn new_semaphore(&self) -> Option<Arc<Semaphore>> {
@@ -368,6 +382,7 @@ impl RegionScanner for SeqScan {
         partition: usize,
     ) -> Result<SendableRecordBatchStream, BoxedError> {
         self.scan_partition_impl(metrics_set, partition)
+            .map_err(BoxedError::new)
     }
 
     fn prepare(&mut self, request: PrepareRequest) -> Result<(), BoxedError> {
@@ -418,7 +433,7 @@ pub(crate) fn build_sources(
     part_metrics: &PartitionMetrics,
     range_builder_list: Arc<RangeBuilderList>,
     sources: &mut Vec<Source>,
-) {
+) -> Result<()> {
     // Gets range meta.
     let range_meta = &stream_ctx.ranges[part_range.identifier];
     #[cfg(debug_assertions)]
@@ -462,6 +477,7 @@ pub(crate) fn build_sources(
         };
         sources.push(Source::Stream(stream));
     }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -149,7 +149,7 @@ impl SeqScan {
                 part_metrics,
                 range_builder_list.clone(),
                 &mut sources,
-            )?;
+            );
         }
 
         common_telemetry::debug!(
@@ -270,7 +270,7 @@ impl SeqScan {
                     &part_metrics,
                     range_builder_list.clone(),
                     &mut sources,
-                )?;
+                );
 
                 let mut metrics = ScannerMetrics::default();
                 let mut fetch_start = Instant::now();
@@ -433,7 +433,7 @@ pub(crate) fn build_sources(
     part_metrics: &PartitionMetrics,
     range_builder_list: Arc<RangeBuilderList>,
     sources: &mut Vec<Source>,
-) -> Result<()> {
+) {
     // Gets range meta.
     let range_meta = &stream_ctx.ranges[part_range.identifier];
     #[cfg(debug_assertions)]
@@ -477,7 +477,6 @@ pub(crate) fn build_sources(
         };
         sources.push(Source::Stream(stream));
     }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/mito2/src/read/series_scan.rs
+++ b/src/mito2/src/read/series_scan.rs
@@ -20,13 +20,12 @@ use std::time::{Duration, Instant};
 
 use async_stream::try_stream;
 use common_error::ext::BoxedError;
-use common_recordbatch::error::ExternalSnafu;
 use common_recordbatch::util::ChainedRecordBatchStream;
-use common_recordbatch::{RecordBatch, RecordBatchStreamWrapper, SendableRecordBatchStream};
+use common_recordbatch::{RecordBatchStreamWrapper, SendableRecordBatchStream};
 use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
 use datafusion::physical_plan::{DisplayAs, DisplayFormatType};
-use datatypes::compute::concat_batches;
 use datatypes::schema::SchemaRef;
+use futures::StreamExt;
 use smallvec::{smallvec, SmallVec};
 use snafu::{ensure, OptionExt, ResultExt};
 use store_api::metadata::RegionMetadataRef;
@@ -36,13 +35,14 @@ use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::sync::Semaphore;
 
 use crate::error::{
-    ComputeArrowSnafu, Error, InvalidSenderSnafu, PartitionOutOfRangeSnafu, Result,
-    ScanMultiTimesSnafu, ScanSeriesSnafu,
+    Error, InvalidSenderSnafu, PartitionOutOfRangeSnafu, Result, ScanMultiTimesSnafu,
+    ScanSeriesSnafu,
 };
 use crate::read::range::RangeBuilderList;
 use crate::read::scan_region::{ScanInput, StreamContext};
 use crate::read::scan_util::{PartitionMetrics, PartitionMetricsList, SeriesDistributorMetrics};
 use crate::read::seq_scan::{build_sources, SeqScan};
+use crate::read::stream::{ConvertBatchStream, ScanBatch, ScanBatchStream};
 use crate::read::{Batch, ScannerMetrics};
 
 /// Timeout to send a batch to a sender.
@@ -89,71 +89,65 @@ impl SeriesScan {
         &self,
         metrics_set: &ExecutionPlanMetricsSet,
         partition: usize,
-    ) -> Result<SendableRecordBatchStream, BoxedError> {
-        if partition >= self.properties.num_partitions() {
-            return Err(BoxedError::new(
-                PartitionOutOfRangeSnafu {
-                    given: partition,
-                    all: self.properties.num_partitions(),
-                }
-                .build(),
-            ));
-        }
+    ) -> Result<SendableRecordBatchStream> {
+        let metrics =
+            new_partition_metrics(&self.stream_ctx, metrics_set, partition, &self.metrics_list);
+
+        let batch_stream = self.scan_batch_in_partition(partition, metrics.clone(), metrics_set)?;
+
+        let input = &self.stream_ctx.input;
+        let record_batch_stream = ConvertBatchStream::new(
+            batch_stream,
+            input.mapper.clone(),
+            input.cache_strategy.clone(),
+            metrics,
+        );
+
+        Ok(Box::pin(RecordBatchStreamWrapper::new(
+            input.mapper.output_schema(),
+            Box::pin(record_batch_stream),
+        )))
+    }
+
+    fn scan_batch_in_partition(
+        &self,
+        partition: usize,
+        part_metrics: PartitionMetrics,
+        metrics_set: &ExecutionPlanMetricsSet,
+    ) -> Result<ScanBatchStream> {
+        ensure!(
+            partition < self.properties.num_partitions(),
+            PartitionOutOfRangeSnafu {
+                given: partition,
+                all: self.properties.num_partitions(),
+            }
+        );
 
         self.maybe_start_distributor(metrics_set, &self.metrics_list);
 
-        let part_metrics =
-            new_partition_metrics(&self.stream_ctx, metrics_set, partition, &self.metrics_list);
-        let mut receiver = self.take_receiver(partition).map_err(BoxedError::new)?;
-        let stream_ctx = self.stream_ctx.clone();
-
+        let mut receiver = self.take_receiver(partition)?;
         let stream = try_stream! {
             part_metrics.on_first_poll();
 
-            let cache = &stream_ctx.input.cache_strategy;
-            let mut df_record_batches = Vec::new();
             let mut fetch_start = Instant::now();
-            while let Some(result) = receiver.recv().await {
+            while let Some(series) = receiver.recv().await {
+                let series = series?;
+
                 let mut metrics = ScannerMetrics::default();
-                let series = result.map_err(BoxedError::new).context(ExternalSnafu)?;
                 metrics.scan_cost += fetch_start.elapsed();
                 fetch_start = Instant::now();
 
-                let convert_start = Instant::now();
-                df_record_batches.reserve(series.batches.len());
-                for batch in series.batches {
-                    metrics.num_batches += 1;
-                    metrics.num_rows += batch.num_rows();
-
-                    let record_batch = stream_ctx.input.mapper.convert(&batch, cache)?;
-                    df_record_batches.push(record_batch.into_df_record_batch());
-                }
-
-                let output_schema = stream_ctx.input.mapper.output_schema();
-                let df_record_batch =
-                    concat_batches(output_schema.arrow_schema(), &df_record_batches)
-                        .context(ComputeArrowSnafu)
-                        .map_err(BoxedError::new)
-                        .context(ExternalSnafu)?;
-                df_record_batches.clear();
-                let record_batch =
-                    RecordBatch::try_from_df_record_batch(output_schema, df_record_batch)?;
-                metrics.convert_cost += convert_start.elapsed();
+                metrics.num_batches += series.batches.len();
+                metrics.num_rows += series.batches.iter().map(|x| x.num_rows()).sum::<usize>();
 
                 let yield_start = Instant::now();
-                yield record_batch;
+                yield ScanBatch::Series(series);
                 metrics.yield_cost += yield_start.elapsed();
 
                 part_metrics.merge_metrics(&metrics);
             }
         };
-
-        let stream = Box::pin(RecordBatchStreamWrapper::new(
-            self.stream_ctx.input.mapper.output_schema(),
-            Box::pin(stream),
-        ));
-
-        Ok(stream)
+        Ok(Box::pin(stream))
     }
 
     /// Takes the receiver for the partition.
@@ -201,6 +195,26 @@ impl SeriesScan {
         let chained_stream = ChainedRecordBatchStream::new(streams).map_err(BoxedError::new)?;
         Ok(Box::pin(chained_stream))
     }
+
+    /// Scan [`Batch`] in all partitions one by one.
+    pub(crate) fn scan_all_partitions(&self) -> Result<ScanBatchStream> {
+        let metrics_set = ExecutionPlanMetricsSet::new();
+
+        let streams = (0..self.properties.partitions.len())
+            .map(|partition| {
+                let metrics = new_partition_metrics(
+                    &self.stream_ctx,
+                    &metrics_set,
+                    partition,
+                    &self.metrics_list,
+                );
+
+                self.scan_batch_in_partition(partition, metrics, &metrics_set)
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(Box::pin(futures::stream::iter(streams).flatten()))
+    }
 }
 
 fn new_channel_list(num_partitions: usize) -> (SenderList, ReceiverList) {
@@ -232,6 +246,7 @@ impl RegionScanner for SeriesScan {
         partition: usize,
     ) -> Result<SendableRecordBatchStream, BoxedError> {
         self.scan_partition_impl(metrics_set, partition)
+            .map_err(BoxedError::new)
     }
 
     fn prepare(&mut self, request: PrepareRequest) -> Result<(), BoxedError> {
@@ -335,7 +350,7 @@ impl SeriesDistributor {
                     &part_metrics,
                     range_builder_list.clone(),
                     &mut sources,
-                );
+                )?;
             }
         }
 
@@ -393,8 +408,8 @@ impl SeriesDistributor {
 
 /// Batches of the same series.
 #[derive(Default)]
-struct SeriesBatch {
-    batches: SmallVec<[Batch; 4]>,
+pub struct SeriesBatch {
+    pub batches: SmallVec<[Batch; 4]>,
 }
 
 impl SeriesBatch {

--- a/src/mito2/src/read/series_scan.rs
+++ b/src/mito2/src/read/series_scan.rs
@@ -350,7 +350,7 @@ impl SeriesDistributor {
                     &part_metrics,
                     range_builder_list.clone(),
                     &mut sources,
-                )?;
+                );
             }
         }
 

--- a/src/mito2/src/read/stream.rs
+++ b/src/mito2/src/read/stream.rs
@@ -1,0 +1,121 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::{Duration, Instant};
+
+use common_error::ext::BoxedError;
+use common_recordbatch::error::{ArrowComputeSnafu, ExternalSnafu};
+use common_recordbatch::RecordBatch;
+use datatypes::compute;
+use futures::stream::BoxStream;
+use futures::{Stream, StreamExt};
+use snafu::ResultExt;
+
+use crate::cache::CacheStrategy;
+use crate::error::Result;
+use crate::read::projection::ProjectionMapper;
+use crate::read::scan_util::PartitionMetrics;
+use crate::read::series_scan::SeriesBatch;
+use crate::read::Batch;
+
+/// All kinds of [`Batch`]es to produce in scanner.
+pub enum ScanBatch {
+    Normal(Batch),
+    Series(SeriesBatch),
+}
+
+pub type ScanBatchStream = BoxStream<'static, Result<ScanBatch>>;
+
+/// A stream that takes [`ScanBatch`]es and produces (converts them to) [`RecordBatch`]es.
+pub(crate) struct ConvertBatchStream {
+    inner: ScanBatchStream,
+    projection_mapper: Arc<ProjectionMapper>,
+    cache_strategy: CacheStrategy,
+    partition_metrics: PartitionMetrics,
+    convert_cost: Duration,
+}
+
+impl ConvertBatchStream {
+    pub(crate) fn new(
+        inner: ScanBatchStream,
+        projection_mapper: Arc<ProjectionMapper>,
+        cache_strategy: CacheStrategy,
+        partition_metrics: PartitionMetrics,
+    ) -> Self {
+        Self {
+            inner,
+            projection_mapper,
+            cache_strategy,
+            partition_metrics,
+            convert_cost: Duration::from_secs(0),
+        }
+    }
+
+    fn convert(&self, batch: ScanBatch) -> common_recordbatch::error::Result<RecordBatch> {
+        match batch {
+            ScanBatch::Normal(batch) => {
+                if batch.is_empty() {
+                    Ok(self.projection_mapper.empty_record_batch())
+                } else {
+                    self.projection_mapper.convert(&batch, &self.cache_strategy)
+                }
+            }
+            ScanBatch::Series(series) => {
+                let mut record_batches = Vec::with_capacity(series.batches.len());
+                for batch in series.batches {
+                    let record_batch = self
+                        .projection_mapper
+                        .convert(&batch, &self.cache_strategy)?;
+                    record_batches.push(record_batch.into_df_record_batch());
+                }
+
+                let output_schema = self.projection_mapper.output_schema();
+                let record_batch =
+                    compute::concat_batches(output_schema.arrow_schema(), &record_batches)
+                        .context(ArrowComputeSnafu)?;
+
+                RecordBatch::try_from_df_record_batch(output_schema, record_batch)
+            }
+        }
+    }
+}
+
+impl Stream for ConvertBatchStream {
+    type Item = common_recordbatch::error::Result<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let batch = futures::ready!(self.inner.poll_next_unpin(cx));
+        let Some(batch) = batch else {
+            self.partition_metrics
+                .inc_convert_batch_cost(self.convert_cost);
+            self.convert_cost = Duration::from_secs(0);
+
+            return Poll::Ready(None);
+        };
+
+        let record_batch = match batch {
+            Ok(batch) => {
+                let start = Instant::now();
+                let record_batch = self.convert(batch);
+                self.convert_cost += start.elapsed();
+                record_batch
+            }
+            Err(e) => Err(BoxedError::new(e)).context(ExternalSnafu),
+        };
+        Poll::Ready(Some(record_batch))
+    }
+}

--- a/src/mito2/src/read/unordered_scan.rs
+++ b/src/mito2/src/read/unordered_scan.rs
@@ -171,7 +171,7 @@ impl UnorderedScan {
         metrics_set: &ExecutionPlanMetricsSet,
         partition: usize,
     ) -> Result<SendableRecordBatchStream> {
-        let metrics = self.partition_metrics(partition, &metrics_set);
+        let metrics = self.partition_metrics(partition, metrics_set);
 
         let batch_stream = self.scan_batch_in_partition(partition, metrics.clone())?;
 

--- a/src/mito2/src/read/unordered_scan.rs
+++ b/src/mito2/src/read/unordered_scan.rs
@@ -20,23 +20,24 @@ use std::time::Instant;
 
 use async_stream::{stream, try_stream};
 use common_error::ext::BoxedError;
-use common_recordbatch::error::ExternalSnafu;
 use common_recordbatch::{RecordBatchStreamWrapper, SendableRecordBatchStream};
 use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
 use datafusion::physical_plan::{DisplayAs, DisplayFormatType};
 use datatypes::schema::SchemaRef;
 use futures::{Stream, StreamExt};
-use snafu::ResultExt;
+use snafu::ensure;
 use store_api::metadata::RegionMetadataRef;
 use store_api::region_engine::{PrepareRequest, RegionScanner, ScannerProperties};
 
 use crate::error::{PartitionOutOfRangeSnafu, Result};
-use crate::read::range::RangeBuilderList;
+use crate::read::range::{RangeBuilderList, RowGroupIndex};
 use crate::read::scan_region::{ScanInput, StreamContext};
 use crate::read::scan_util::{
     scan_file_ranges, scan_mem_ranges, PartitionMetrics, PartitionMetricsList,
 };
+use crate::read::stream::{ConvertBatchStream, ScanBatch, ScanBatchStream};
 use crate::read::{Batch, ScannerMetrics};
+use crate::sst::file::FileTimeRange;
 
 /// Scans a region without providing any output ordering guarantee.
 ///
@@ -93,52 +94,67 @@ impl UnorderedScan {
         part_range_id: usize,
         part_metrics: PartitionMetrics,
         range_builder_list: Arc<RangeBuilderList>,
-    ) -> impl Stream<Item = Result<Batch>> {
-        stream! {
+    ) -> Result<impl Stream<Item = Result<Batch>>> {
+        fn build_scan_stream(
+            context: Arc<StreamContext>,
+            index: RowGroupIndex,
+            time_range: FileTimeRange,
+            metrics: PartitionMetrics,
+            range_builder_list: Arc<RangeBuilderList>,
+        ) -> Result<impl Stream<Item = Result<Batch>>> {
+            let stream = if context.is_mem_range_index(index) {
+                scan_mem_ranges(context, metrics, index, time_range).boxed()
+            } else {
+                scan_file_ranges(
+                    context,
+                    metrics,
+                    index,
+                    "unordered_scan_files",
+                    range_builder_list,
+                )
+                .boxed()
+            };
+            Ok(stream)
+        }
+
+        let stream = stream! {
             // Gets range meta.
             let range_meta = &stream_ctx.ranges[part_range_id];
             for index in &range_meta.row_group_indices {
-                if stream_ctx.is_mem_range_index(*index) {
-                    let stream = scan_mem_ranges(
-                        stream_ctx.clone(),
-                        part_metrics.clone(),
-                        *index,
-                        range_meta.time_range,
-                    );
-                    for await batch in stream {
-                        yield batch;
-                    }
-                } else {
-                    let stream = scan_file_ranges(
-                        stream_ctx.clone(),
-                        part_metrics.clone(),
-                        *index,
-                        "unordered_scan_files",
-                        range_builder_list.clone(),
-                    );
-                    for await batch in stream {
-                        yield batch;
-                    }
+                let stream = build_scan_stream(
+                    stream_ctx.clone(),
+                    *index,
+                    range_meta.time_range,
+                    part_metrics.clone(),
+                    range_builder_list.clone(),
+                )?;
+                for await batch in stream {
+                    yield batch;
                 }
             }
-        }
+        };
+        Ok(stream)
     }
 
-    fn scan_partition_impl(
-        &self,
-        metrics_set: &ExecutionPlanMetricsSet,
-        partition: usize,
-    ) -> Result<SendableRecordBatchStream, BoxedError> {
-        if partition >= self.properties.partitions.len() {
-            return Err(BoxedError::new(
-                PartitionOutOfRangeSnafu {
-                    given: partition,
-                    all: self.properties.partitions.len(),
-                }
-                .build(),
-            ));
-        }
+    /// Scan [`Batch`] in all partitions one by one.
+    pub(crate) fn scan_all_partitions(&self) -> Result<ScanBatchStream> {
+        let metrics_set = ExecutionPlanMetricsSet::new();
 
+        let streams = (0..self.properties.partitions.len())
+            .map(|partition| {
+                let metrics = self.partition_metrics(partition, &metrics_set);
+                self.scan_batch_in_partition(partition, metrics)
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(Box::pin(futures::stream::iter(streams).flatten()))
+    }
+
+    fn partition_metrics(
+        &self,
+        partition: usize,
+        metrics_set: &ExecutionPlanMetricsSet,
+    ) -> PartitionMetrics {
         let part_metrics = PartitionMetrics::new(
             self.stream_ctx.input.mapper.metadata().region_id,
             partition,
@@ -147,6 +163,45 @@ impl UnorderedScan {
             metrics_set,
         );
         self.metrics_list.set(partition, part_metrics.clone());
+        part_metrics
+    }
+
+    fn scan_partition_impl(
+        &self,
+        metrics_set: &ExecutionPlanMetricsSet,
+        partition: usize,
+    ) -> Result<SendableRecordBatchStream> {
+        let metrics = self.partition_metrics(partition, &metrics_set);
+
+        let batch_stream = self.scan_batch_in_partition(partition, metrics.clone())?;
+
+        let input = &self.stream_ctx.input;
+        let record_batch_stream = ConvertBatchStream::new(
+            batch_stream,
+            input.mapper.clone(),
+            input.cache_strategy.clone(),
+            metrics,
+        );
+
+        Ok(Box::pin(RecordBatchStreamWrapper::new(
+            input.mapper.output_schema(),
+            Box::pin(record_batch_stream),
+        )))
+    }
+
+    fn scan_batch_in_partition(
+        &self,
+        partition: usize,
+        part_metrics: PartitionMetrics,
+    ) -> Result<ScanBatchStream> {
+        ensure!(
+            partition < self.properties.partitions.len(),
+            PartitionOutOfRangeSnafu {
+                given: partition,
+                all: self.properties.partitions.len(),
+            }
+        );
+
         let stream_ctx = self.stream_ctx.clone();
         let part_ranges = self.properties.partitions[partition].clone();
         let distinguish_range = self.properties.distinguish_partition_range;
@@ -154,7 +209,6 @@ impl UnorderedScan {
         let stream = try_stream! {
             part_metrics.on_first_poll();
 
-            let cache = &stream_ctx.input.cache_strategy;
             let range_builder_list = Arc::new(RangeBuilderList::new(
                 stream_ctx.input.num_memtables(),
                 stream_ctx.input.num_files(),
@@ -173,9 +227,9 @@ impl UnorderedScan {
                     part_range.identifier,
                     part_metrics.clone(),
                     range_builder_list.clone(),
-                );
+                )?;
                 for await batch in stream {
-                    let batch = batch.map_err(BoxedError::new).context(ExternalSnafu)?;
+                    let batch = batch?;
                     metrics.scan_cost += fetch_start.elapsed();
                     metrics.num_batches += 1;
                     metrics.num_rows += batch.num_rows();
@@ -194,11 +248,8 @@ impl UnorderedScan {
                         &batch,
                     );
 
-                    let convert_start = Instant::now();
-                    let record_batch = stream_ctx.input.mapper.convert(&batch, cache)?;
-                    metrics.convert_cost += convert_start.elapsed();
                     let yield_start = Instant::now();
-                    yield record_batch;
+                    yield ScanBatch::Normal(batch);
                     metrics.yield_cost += yield_start.elapsed();
 
                     fetch_start = Instant::now();
@@ -208,22 +259,15 @@ impl UnorderedScan {
                 // The query engine can use this to optimize some queries.
                 if distinguish_range {
                     let yield_start = Instant::now();
-                    yield stream_ctx.input.mapper.empty_record_batch();
+                    yield ScanBatch::Normal(Batch::empty());
                     metrics.yield_cost += yield_start.elapsed();
                 }
 
                 metrics.scan_cost += fetch_start.elapsed();
                 part_metrics.merge_metrics(&metrics);
             }
-
-            part_metrics.on_finish();
         };
-        let stream = Box::pin(RecordBatchStreamWrapper::new(
-            self.stream_ctx.input.mapper.output_schema(),
-            Box::pin(stream),
-        ));
-
-        Ok(stream)
+        Ok(Box::pin(stream))
     }
 }
 
@@ -251,6 +295,7 @@ impl RegionScanner for UnorderedScan {
         partition: usize,
     ) -> Result<SendableRecordBatchStream, BoxedError> {
         self.scan_partition_impl(metrics_set, partition)
+            .map_err(BoxedError::new)
     }
 
     fn has_predicate(&self) -> bool {

--- a/src/store-api/src/storage/requests.rs
+++ b/src/store-api/src/storage/requests.rs
@@ -67,14 +67,34 @@ pub struct ScanRequest {
 
 impl Display for ScanRequest {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "ScanRequest {{")?;
+        enum Delimiter {
+            None,
+            Init,
+        }
+
+        impl Delimiter {
+            fn as_str(&mut self) -> &str {
+                match self {
+                    Delimiter::None => {
+                        *self = Delimiter::Init;
+                        ""
+                    }
+                    Delimiter::Init => ", ",
+                }
+            }
+        }
+
+        let mut delimiter = Delimiter::None;
+
+        write!(f, "ScanRequest {{ ")?;
         if let Some(projection) = &self.projection {
-            write!(f, "projection: {:?}", projection)?;
+            write!(f, "{}projection: {:?}", delimiter.as_str(), projection)?;
         }
         if !self.filters.is_empty() {
             write!(
                 f,
-                ", filters: [{}]",
+                "{}filters: [{}]",
+                delimiter.as_str(),
                 self.filters
                     .iter()
                     .map(|f| f.to_string())
@@ -83,23 +103,90 @@ impl Display for ScanRequest {
             )?;
         }
         if let Some(output_ordering) = &self.output_ordering {
-            write!(f, ", output_ordering: {:?}", output_ordering)?;
+            write!(
+                f,
+                "{}output_ordering: {:?}",
+                delimiter.as_str(),
+                output_ordering
+            )?;
         }
         if let Some(limit) = &self.limit {
-            write!(f, ", limit: {}", limit)?;
+            write!(f, "{}limit: {}", delimiter.as_str(), limit)?;
         }
         if let Some(series_row_selector) = &self.series_row_selector {
-            write!(f, ", series_row_selector: {}", series_row_selector)?;
+            write!(
+                f,
+                "{}series_row_selector: {}",
+                delimiter.as_str(),
+                series_row_selector
+            )?;
         }
         if let Some(sequence) = &self.sequence {
-            write!(f, ", sequence: {}", sequence)?;
+            write!(f, "{}sequence: {}", delimiter.as_str(), sequence)?;
         }
         if let Some(sst_min_sequence) = &self.sst_min_sequence {
-            write!(f, ", sst_min_sequence: {}", sst_min_sequence)?;
+            write!(
+                f,
+                "{}sst_min_sequence: {}",
+                delimiter.as_str(),
+                sst_min_sequence
+            )?;
         }
         if let Some(distribution) = &self.distribution {
-            write!(f, ", distribution: {}", distribution)?;
+            write!(f, "{}distribution: {}", delimiter.as_str(), distribution)?;
         }
-        write!(f, "}}")
+        write!(f, " }}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion_expr::{binary_expr, col, lit, Operator};
+
+    use super::*;
+
+    #[test]
+    fn test_display_scan_request() {
+        let request = ScanRequest {
+            ..Default::default()
+        };
+        assert_eq!(request.to_string(), "ScanRequest {  }");
+
+        let request = ScanRequest {
+            projection: Some(vec![1, 2]),
+            filters: vec![
+                binary_expr(col("i"), Operator::Gt, lit(1)),
+                binary_expr(col("s"), Operator::Eq, lit("x")),
+            ],
+            limit: Some(10),
+            ..Default::default()
+        };
+        assert_eq!(
+            request.to_string(),
+            r#"ScanRequest { projection: [1, 2], filters: [i > Int32(1), s = Utf8("x")], limit: 10 }"#
+        );
+
+        let request = ScanRequest {
+            filters: vec![
+                binary_expr(col("i"), Operator::Gt, lit(1)),
+                binary_expr(col("s"), Operator::Eq, lit("x")),
+            ],
+            limit: Some(10),
+            ..Default::default()
+        };
+        assert_eq!(
+            request.to_string(),
+            r#"ScanRequest { filters: [i > Int32(1), s = Utf8("x")], limit: 10 }"#
+        );
+
+        let request = ScanRequest {
+            projection: Some(vec![1, 2]),
+            limit: Some(10),
+            ..Default::default()
+        };
+        assert_eq!(
+            request.to_string(),
+            "ScanRequest { projection: [1, 2], limit: 10 }"
+        );
     }
 }

--- a/src/store-api/src/storage/requests.rs
+++ b/src/store-api/src/storage/requests.rs
@@ -69,7 +69,7 @@ impl Display for ScanRequest {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "ScanRequest {{")?;
         if let Some(projection) = &self.projection {
-            write!(f, "projection: {:?},", projection)?;
+            write!(f, "projection: {:?}", projection)?;
         }
         if !self.filters.is_empty() {
             write!(


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Because sometimes we want to scan out `Batch` directly, instead of getting a `RecordBatch` stream. So this PR split out the `Batch` to `RecordBatch` convention from scan stream.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
