### PR TITLE
feat: implement automatic region failure detector registrations

### DIFF
--- a/src/common/meta/src/key/table_route.rs
+++ b/src/common/meta/src/key/table_route.rs
@@ -48,6 +48,11 @@ impl TableRouteKey {
     pub fn new(table_id: TableId) -> Self {
         Self { table_id }
     }
+
+    /// Returns the range prefix of the table route key.
+    pub fn range_prefix() -> Vec<u8> {
+        format!("{}/", TABLE_ROUTE_PREFIX).into_bytes()
+    }
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -64,7 +64,7 @@ use crate::procedure::wal_prune::manager::{WalPruneManager, WalPruneTicker};
 use crate::procedure::wal_prune::Context as WalPruneContext;
 use crate::region::supervisor::{
     HeartbeatAcceptor, RegionFailureDetectorControl, RegionSupervisor, RegionSupervisorSelector,
-    RegionSupervisorTicker, DEFAULT_TICK_INTERVAL,
+    RegionSupervisorTicker, DEFAULT_INSPECT_INTERVAL, DEFAULT_TICK_INTERVAL,
 };
 use crate::selector::lease_based::LeaseBasedSelector;
 use crate::selector::round_robin::RoundRobinSelector;
@@ -299,6 +299,7 @@ impl MetasrvBuilder {
                 Arc::new(RegionFailureDetectorControl::new(tx.clone())) as _,
                 Some(Arc::new(RegionSupervisorTicker::new(
                     DEFAULT_TICK_INTERVAL,
+                    DEFAULT_INSPECT_INTERVAL,
                     tx.clone(),
                 ))),
             )
@@ -341,6 +342,7 @@ impl MetasrvBuilder {
                 region_migration_manager.clone(),
                 maintenance_mode_manager.clone(),
                 peer_lookup_service.clone(),
+                leader_cached_kv_backend.clone(),
             );
 
             Some(RegionFailureHandler::new(

--- a/src/meta-srv/src/region/supervisor.rs
+++ b/src/meta-srv/src/region/supervisor.rs
@@ -15,23 +15,31 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use common_meta::datanode::Stat;
 use common_meta::ddl::{DetectingRegion, RegionFailureDetectorController};
 use common_meta::key::maintenance::MaintenanceModeManagerRef;
+use common_meta::key::table_route::{TableRouteKey, TableRouteValue};
+use common_meta::key::{MetadataKey, MetadataValue};
+use common_meta::kv_backend::KvBackendRef;
 use common_meta::leadership_notifier::LeadershipChangeListener;
 use common_meta::peer::{Peer, PeerLookupServiceRef};
+use common_meta::range_stream::{PaginationStream, DEFAULT_PAGE_SIZE};
+use common_meta::rpc::store::RangeRequest;
 use common_meta::DatanodeId;
 use common_runtime::JoinHandle;
 use common_telemetry::{debug, error, info, warn};
 use common_time::util::current_time_millis;
 use error::Error::{LeaderPeerChanged, MigrationRunning, RegionMigrated, TableRouteNotFound};
-use snafu::{ensure, OptionExt, ResultExt};
+use futures::{StreamExt, TryStreamExt};
+use snafu::{ensure, ResultExt};
 use store_api::storage::RegionId;
+use tokio::select;
 use tokio::sync::mpsc::{Receiver, Sender};
-use tokio::time::{interval, MissedTickBehavior};
+use tokio::sync::oneshot;
+use tokio::time::{interval, interval_at, MissedTickBehavior};
 
 use crate::error::{self, Result};
 use crate::failure_detector::PhiAccrualFailureDetectorOptions;
@@ -70,6 +78,9 @@ impl From<&Stat> for DatanodeHeartbeat {
 ///
 /// Variants:
 /// - `Tick`: This event is used to trigger region failure detection periodically.
+/// - `InitializeAllRegions`: This event is used to initialize all region failure detectors.
+/// - `RegisterFailureDetectors`: This event is used to register failure detectors for regions.
+/// - `DeregisterFailureDetectors`: This event is used to deregister failure detectors for regions.
 /// - `HeartbeatArrived`: This event presents the metasrv received [`DatanodeHeartbeat`] from the datanodes.
 /// - `Clear`: This event is used to reset the state of the supervisor, typically used
 ///   when a system-wide reset or reinitialization is needed.
@@ -78,6 +89,7 @@ impl From<&Stat> for DatanodeHeartbeat {
 ///   of the supervisor during tests.
 pub(crate) enum Event {
     Tick,
+    InitializeAllRegions(tokio::sync::oneshot::Sender<()>),
     RegisterFailureDetectors(Vec<DetectingRegion>),
     DeregisterFailureDetectors(Vec<DetectingRegion>),
     HeartbeatArrived(DatanodeHeartbeat),
@@ -102,6 +114,7 @@ impl Debug for Event {
             Self::Tick => write!(f, "Tick"),
             Self::HeartbeatArrived(arg0) => f.debug_tuple("HeartbeatArrived").field(arg0).finish(),
             Self::Clear => write!(f, "Clear"),
+            Self::InitializeAllRegions(_) => write!(f, "InspectAndRegisterRegions"),
             Self::RegisterFailureDetectors(arg0) => f
                 .debug_tuple("RegisterFailureDetectors")
                 .field(arg0)
@@ -127,6 +140,9 @@ pub struct RegionSupervisorTicker {
     /// The interval of tick.
     tick_interval: Duration,
 
+    /// The interval of inspect and register regions.
+    inspect_interval: Duration,
+
     /// Sends [Event]s.
     sender: Sender<Event>,
 }
@@ -149,10 +165,19 @@ impl LeadershipChangeListener for RegionSupervisorTicker {
 }
 
 impl RegionSupervisorTicker {
-    pub(crate) fn new(tick_interval: Duration, sender: Sender<Event>) -> Self {
+    pub(crate) fn new(
+        tick_interval: Duration,
+        inspect_interval: Duration,
+        sender: Sender<Event>,
+    ) -> Self {
+        info!(
+            "RegionSupervisorTicker is created, tick_interval: {:?}, inspect_interval: {:?}",
+            tick_interval, inspect_interval
+        );
         Self {
             tick_handle: Mutex::new(None),
             tick_interval,
+            inspect_interval,
             sender,
         }
     }
@@ -163,18 +188,48 @@ impl RegionSupervisorTicker {
         if handle.is_none() {
             let sender = self.sender.clone();
             let tick_interval = self.tick_interval;
+            let inspect_interval = self.inspect_interval;
+
+            let mut inspect_interval = interval_at(
+                tokio::time::Instant::now() + inspect_interval,
+                inspect_interval,
+            );
+            inspect_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+            common_runtime::spawn_global(async move {
+                loop {
+                    select! {
+                        _ = inspect_interval.tick() => {
+                            let (tx, rx) = oneshot::channel();
+                            if sender.send(Event::InitializeAllRegions(tx)).await.is_err() {
+                                info!("EventReceiver is dropped, inspect and register regions loop is stopped");
+                                break;
+                            }
+                            if let Ok(_) = rx.await {
+                                info!("All region failure detectors are initialized.");
+                                break;
+                            }
+                        }
+                    }
+                }
+            });
+
+            let sender = self.sender.clone();
             let ticker_loop = tokio::spawn(async move {
-                let mut interval = interval(tick_interval);
-                interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+                let mut tick_interval = interval(tick_interval);
+                tick_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
                 if let Err(err) = sender.send(Event::Clear).await {
                     warn!(err; "EventReceiver is dropped, failed to send Event::Clear");
                     return;
                 }
                 loop {
-                    interval.tick().await;
-                    if sender.send(Event::Tick).await.is_err() {
-                        info!("EventReceiver is dropped, tick loop is stopped");
-                        break;
+                    select! {
+                        _ = tick_interval.tick() => {
+                            if sender.send(Event::Tick).await.is_err() {
+                                info!("EventReceiver is dropped, tick loop is stopped");
+                                break;
+                            }
+                        }
                     }
                 }
             });
@@ -202,6 +257,8 @@ pub type RegionSupervisorRef = Arc<RegionSupervisor>;
 
 /// The default tick interval.
 pub const DEFAULT_TICK_INTERVAL: Duration = Duration::from_secs(1);
+/// The default inspect interval.
+pub const DEFAULT_INSPECT_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Selector for region supervisor.
 pub enum RegionSupervisorSelector {
@@ -228,6 +285,8 @@ pub struct RegionSupervisor {
     maintenance_mode_manager: MaintenanceModeManagerRef,
     /// Peer lookup service
     peer_lookup: PeerLookupServiceRef,
+    /// The kv backend.
+    kv_backend: KvBackendRef,
 }
 
 /// Controller for managing failure detectors for regions.
@@ -290,6 +349,7 @@ impl RegionSupervisor {
         tokio::sync::mpsc::channel(1024)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         event_receiver: Receiver<Event>,
         options: PhiAccrualFailureDetectorOptions,
@@ -298,6 +358,7 @@ impl RegionSupervisor {
         region_migration_manager: RegionMigrationManagerRef,
         maintenance_mode_manager: MaintenanceModeManagerRef,
         peer_lookup: PeerLookupServiceRef,
+        kv_backend: KvBackendRef,
     ) -> Self {
         Self {
             failure_detector: RegionFailureDetector::new(options),
@@ -308,6 +369,7 @@ impl RegionSupervisor {
             region_migration_manager,
             maintenance_mode_manager,
             peer_lookup,
+            kv_backend,
         }
     }
 
@@ -315,6 +377,26 @@ impl RegionSupervisor {
     pub(crate) async fn run(&mut self) {
         while let Some(event) = self.receiver.recv().await {
             match event {
+                Event::InitializeAllRegions(sender) => {
+                    match self.is_maintenance_mode_enabled().await {
+                        Ok(false) => {}
+                        Ok(true) => {
+                            warn!("Skipping initialize all regions since maintenance mode is enabled.");
+                            continue;
+                        }
+                        Err(err) => {
+                            error!(err; "Failed to check maintenance mode during initialize all regions.");
+                            continue;
+                        }
+                    }
+
+                    if let Err(err) = self.initialize_all().await {
+                        error!(err; "Failed to initialize all regions.");
+                    } else {
+                        // Ignore the error.
+                        let _ = sender.send(());
+                    }
+                }
                 Event::Tick => {
                     let regions = self.detect_region_failure();
                     self.handle_region_failures(regions).await;
@@ -334,6 +416,59 @@ impl RegionSupervisor {
             }
         }
         info!("RegionSupervisor is stopped!");
+    }
+
+    async fn initialize_all(&self) -> Result<()> {
+        let now = Instant::now();
+        let regions = self.regions();
+        let req = RangeRequest::new().with_prefix(TableRouteKey::range_prefix());
+        let stream = PaginationStream::new(self.kv_backend.clone(), req, DEFAULT_PAGE_SIZE, |kv| {
+            TableRouteKey::from_bytes(&kv.key).map(|v| (v.table_id, kv.value))
+        })
+        .into_stream();
+
+        let mut stream = stream
+            .map_ok(|(_, value)| {
+                TableRouteValue::try_from_raw_value(&value)
+                    .context(error::TableMetadataManagerSnafu)
+            })
+            .boxed();
+        let mut detecting_regions = Vec::new();
+        while let Some(route) = stream
+            .try_next()
+            .await
+            .context(error::TableMetadataManagerSnafu)?
+        {
+            let route = route?;
+            if !route.is_physical() {
+                continue;
+            }
+
+            let physical_table_route = route.into_physical_table_route();
+            physical_table_route
+                .region_routes
+                .iter()
+                .for_each(|region_route| {
+                    if !regions.contains(&region_route.region.id) {
+                        if let Some(leader_peer) = &region_route.leader_peer {
+                            detecting_regions.push((leader_peer.id, region_route.region.id));
+                        }
+                    }
+                });
+        }
+
+        let num_detecting_regions = detecting_regions.len();
+        if !detecting_regions.is_empty() {
+            self.register_failure_detectors(detecting_regions).await;
+        }
+
+        info!(
+            "Initialize {} region failure detectors, elapsed: {:?}",
+            num_detecting_regions,
+            now.elapsed()
+        );
+
+        Ok(())
     }
 
     async fn register_failure_detectors(&self, detecting_regions: Vec<DetectingRegion>) {
@@ -497,12 +632,10 @@ impl RegionSupervisor {
             .peer_lookup
             .datanode(from_peer_id)
             .await
-            .context(error::LookupPeerSnafu {
-                peer_id: from_peer_id,
-            })?
-            .context(error::PeerUnavailableSnafu {
-                peer_id: from_peer_id,
-            })?;
+            .ok()
+            .flatten()
+            .unwrap_or_else(|| Peer::empty(from_peer_id));
+
         let region_peers = self
             .select_peers(from_peer_id, regions, failed_datanodes)
             .await?;
@@ -599,6 +732,14 @@ impl RegionSupervisor {
             .collect::<Vec<_>>()
     }
 
+    /// Returns all regions that registered in the failure detector.
+    fn regions(&self) -> HashSet<RegionId> {
+        self.failure_detector
+            .iter()
+            .map(|e| e.region_ident().1)
+            .collect::<HashSet<_>>()
+    }
+
     /// Updates the state of corresponding failure detectors.
     fn on_heartbeat_arrived(&self, heartbeat: DatanodeHeartbeat) {
         for region_id in heartbeat.regions {
@@ -625,6 +766,7 @@ pub(crate) mod tests {
     use common_meta::key::maintenance;
     use common_meta::peer::Peer;
     use common_meta::test_util::NoopPeerLookupService;
+    use common_telemetry::info;
     use common_time::util::current_time_millis;
     use rand::Rng;
     use store_api::storage::RegionId;
@@ -654,6 +796,7 @@ pub(crate) mod tests {
             Arc::new(maintenance::MaintenanceModeManager::new(env.kv_backend()));
         let peer_lookup = Arc::new(NoopPeerLookupService);
         let (tx, rx) = RegionSupervisor::channel();
+        let kv_backend = env.kv_backend();
 
         (
             RegionSupervisor::new(
@@ -664,6 +807,7 @@ pub(crate) mod tests {
                 region_migration_manager,
                 maintenance_mode_manager,
                 peer_lookup,
+                kv_backend,
             ),
             tx,
         )
@@ -748,6 +892,7 @@ pub(crate) mod tests {
         let ticker = RegionSupervisorTicker {
             tick_handle: Mutex::new(None),
             tick_interval: Duration::from_millis(10),
+            inspect_interval: Duration::from_millis(100),
             sender: tx,
         };
         // It's ok if we start the ticker again.
@@ -757,11 +902,63 @@ pub(crate) mod tests {
             ticker.stop();
             assert!(!rx.is_empty());
             while let Ok(event) = rx.try_recv() {
-                assert_matches!(event, Event::Tick | Event::Clear);
+                assert_matches!(
+                    event,
+                    Event::Tick | Event::Clear | Event::InitializeAllRegions(_)
+                );
             }
         }
     }
 
+    #[tokio::test]
+    async fn test_initialize_all_regions() {
+        common_telemetry::init_default_ut_logging();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(128);
+        let ticker = RegionSupervisorTicker {
+            tick_handle: Mutex::new(None),
+            tick_interval: Duration::from_millis(1000),
+            inspect_interval: Duration::from_millis(50),
+            sender: tx,
+        };
+        ticker.start();
+        sleep(Duration::from_millis(60)).await;
+        let handle = tokio::spawn(async move {
+            while let Some(event) = rx.recv().await {
+                match event {
+                    Event::InitializeAllRegions(tx) => {
+                        tx.send(()).unwrap();
+                        info!("Responded initialize all regions event");
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+            rx
+        });
+
+        let rx = handle.await.unwrap();
+        for _ in 0..3 {
+            sleep(Duration::from_millis(100)).await;
+            assert!(rx.is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_initialize_all_regions_with_maintenance_mode() {
+        common_telemetry::init_default_ut_logging();
+        let (mut supervisor, sender) = new_test_supervisor();
+
+        supervisor
+            .maintenance_mode_manager
+            .set_maintenance_mode()
+            .await
+            .unwrap();
+        tokio::spawn(async move { supervisor.run().await });
+        let (tx, rx) = oneshot::channel();
+        sender.send(Event::InitializeAllRegions(tx)).await.unwrap();
+        // The sender is dropped, so the receiver will receive an error.
+        assert!(rx.await.is_err());
+    }
     #[tokio::test]
     async fn test_region_failure_detector_controller() {
         let (mut supervisor, sender) = new_test_supervisor();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR adds automatic region failure detector registrations. The system now automatically discovers and registers failure detectors for all regions found in table routes, and ensures that metasrv leader will only register once throughout its lifecycle.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
