### PR TITLE
fix(http): apply string validation mode to pipeline processor

### DIFF
--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -28,7 +28,7 @@ use axum::{middleware, routing, Router};
 use common_base::readable_size::ReadableSize;
 use common_base::Plugins;
 use common_recordbatch::RecordBatch;
-use common_telemetry::{error, info};
+use common_telemetry::{debug, error, info};
 use common_time::timestamp::TimeUnit;
 use common_time::Timestamp;
 use datatypes::data_type::DataType;
@@ -37,6 +37,7 @@ use datatypes::value::transform_value_ref_to_json_value;
 use event::{LogState, LogValidatorRef};
 use futures::FutureExt;
 use http::{HeaderValue, Method};
+use prost::DecodeError;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use snafu::{ensure, ResultExt};
@@ -163,6 +164,28 @@ pub enum PromValidationMode {
     Lossy,
     /// Do not validate UTF8 strings.
     Unchecked,
+}
+
+impl PromValidationMode {
+    /// Decodes provided bytes to [String] with optional UTF-8 validation.
+    pub fn decode_string(&self, bytes: &[u8]) -> std::result::Result<String, DecodeError> {
+        let result = match self {
+            PromValidationMode::Strict => match String::from_utf8(bytes.to_vec()) {
+                Ok(s) => s,
+                Err(e) => {
+                    debug!(
+                        "Invalid UTF-8 string value: {:?}, error: {:?}",
+                        &bytes[..],
+                        e
+                    );
+                    return Err(DecodeError::new("invalid utf-8"));
+                }
+            },
+            PromValidationMode::Lossy => String::from_utf8_lossy(bytes).to_string(),
+            PromValidationMode::Unchecked => unsafe { String::from_utf8_unchecked(bytes.to_vec()) },
+        };
+        Ok(result)
+    }
 }
 
 impl Default for HttpOptions {

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -173,11 +173,7 @@ impl PromValidationMode {
             PromValidationMode::Strict => match String::from_utf8(bytes.to_vec()) {
                 Ok(s) => s,
                 Err(e) => {
-                    debug!(
-                        "Invalid UTF-8 string value: {:?}, error: {:?}",
-                        &bytes[..],
-                        e
-                    );
+                    debug!("Invalid UTF-8 string value: {:?}, error: {:?}", bytes, e);
                     return Err(DecodeError::new("invalid utf-8"));
                 }
             },

--- a/src/servers/src/prom_row_builder.rs
+++ b/src/servers/src/prom_row_builder.rs
@@ -24,7 +24,7 @@ use pipeline::{ContextOpt, ContextReq};
 use prost::DecodeError;
 
 use crate::http::PromValidationMode;
-use crate::proto::{decode_string, PromLabel};
+use crate::proto::PromLabel;
 use crate::repeated_field::Clear;
 
 // Prometheus remote write context
@@ -150,8 +150,8 @@ impl TableBuilder {
         let mut row = vec![Value { value_data: None }; self.col_indexes.len()];
 
         for PromLabel { name, value } in labels {
-            let tag_name = decode_string(name, prom_validation_mode)?;
-            let tag_value = decode_string(value, prom_validation_mode)?;
+            let tag_name = prom_validation_mode.decode_string(name)?;
+            let tag_value = prom_validation_mode.decode_string(value)?;
             let tag_value = Some(ValueData::StringValue(tag_value));
             let tag_num = self.col_indexes.len();
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
 ### Commit Summary
 - Change how pipeline processor handles string validation according to configured string validaiton mode.
 - **Refactor `decode_string` Functionality**:
   - Moved `decode_string` logic into `PromValidationMode` as a method `decode_string`.
   - Updated all references to use the new method.
   - Files affected: `http.rs`, `prom_row_builder.rs`, `proto.rs`.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
