### PR TITLE
chore: clarify default OTLP endpoint value

### DIFF
--- a/src/common/telemetry/src/logging.rs
+++ b/src/common/telemetry/src/logging.rs
@@ -71,7 +71,7 @@ pub struct LoggingOptions {
     /// Whether to enable tracing with OTLP. Default is false.
     pub enable_otlp_tracing: bool,
 
-    /// The endpoint of OTLP. Default is "http://localhost:4317".
+    /// The endpoint of OTLP. Default is "http://localhost:4318".
     pub otlp_endpoint: Option<String>,
 
     /// The tracing sample ratio.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The default otlp_endpoint is `http://localhost:4318` if otlp_export_protocol not exist: https://github.com/GreptimeTeam/greptimedb/blob/main/src/common/telemetry/src/logging.rs#L434

DEFAULT_OTLP_HTTP_ENDPOINT: https://github.com/GreptimeTeam/greptimedb/blob/main/src/common/telemetry/src/logging.rs#L43

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
