### PR TITLE
feat: introduce /v1/health for healthcheck from external

### DIFF
--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -117,7 +117,7 @@ const DEFAULT_BODY_LIMIT: ReadableSize = ReadableSize::mb(64);
 pub const AUTHORIZATION_HEADER: &str = "x-greptime-auth";
 
 // TODO(fys): This is a temporary workaround, it will be improved later
-pub static PUBLIC_APIS: [&str; 2] = ["/v1/influxdb/ping", "/v1/influxdb/health"];
+pub static PUBLIC_APIS: [&str; 3] = ["/v1/influxdb/ping", "/v1/influxdb/health", "/v1/health"];
 
 #[derive(Default)]
 pub struct HttpServer {
@@ -721,6 +721,10 @@ impl HttpServer {
                 routing::get(handler::health).post(handler::health),
             )
             .route(
+                &format!("/{HTTP_API_VERSION}/health"),
+                routing::get(handler::health).post(handler::health),
+            )
+            .route(
                 "/ready",
                 routing::get(handler::health).post(handler::health),
             );
@@ -1287,6 +1291,16 @@ mod test {
         let client = TestClient::new(app).await;
 
         let res = client.get("/health").send().await;
+
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(
+            res.headers()
+                .get(http::header::ACCESS_CONTROL_ALLOW_ORIGIN)
+                .expect("expect cors header origin"),
+            "*"
+        );
+
+        let res = client.get("/v1/health").send().await;
 
         assert_eq!(res.status(), StatusCode::OK);
         assert_eq!(


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

API users may need healthcheck endpoint for validating connections. However, our original `/health` check route is hidden as internal API. This patch duplicate it to `/v1/health` as well.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
