### PR TITLE
refactor: add `RegionMigrationTriggerReason` in `RegionMigrationProcedureTask`

### DIFF
--- a/src/meta-srv/src/procedure/region_migration.rs
+++ b/src/meta-srv/src/procedure/region_migration.rs
@@ -49,6 +49,7 @@ use common_telemetry::{error, info};
 use manager::RegionMigrationProcedureGuard;
 pub use manager::{
     RegionMigrationManagerRef, RegionMigrationProcedureTask, RegionMigrationProcedureTracker,
+    RegionMigrationTriggerReason,
 };
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt};
@@ -86,6 +87,9 @@ pub struct PersistentContext {
     /// The timeout for downgrading leader region and upgrading candidate region operations.
     #[serde(with = "humantime_serde", default = "default_timeout")]
     timeout: Duration,
+    /// The trigger reason of region migration.
+    #[serde(default)]
+    trigger_reason: RegionMigrationTriggerReason,
 }
 
 fn default_timeout() -> Duration {
@@ -617,6 +621,7 @@ impl RegionMigrationProcedure {
             from_peer: persistent_ctx.from_peer.clone(),
             to_peer: persistent_ctx.to_peer.clone(),
             timeout: persistent_ctx.timeout,
+            trigger_reason: persistent_ctx.trigger_reason,
         });
         let context = context_factory.new_context(persistent_ctx);
 
@@ -793,7 +798,7 @@ mod tests {
         let procedure = RegionMigrationProcedure::new(persistent_context, context, None);
 
         let serialized = procedure.dump().unwrap();
-        let expected = r#"{"persistent_ctx":{"catalog":"greptime","schema":"public","from_peer":{"id":1,"addr":""},"to_peer":{"id":2,"addr":""},"region_id":4398046511105,"timeout":"10s"},"state":{"region_migration_state":"RegionMigrationStart"}}"#;
+        let expected = r#"{"persistent_ctx":{"catalog":"greptime","schema":"public","from_peer":{"id":1,"addr":""},"to_peer":{"id":2,"addr":""},"region_id":4398046511105,"timeout":"10s","trigger_reason":"Unknown"},"state":{"region_migration_state":"RegionMigrationStart"}}"#;
         assert_eq!(expected, serialized);
     }
 

--- a/src/meta-srv/src/procedure/region_migration/close_downgraded_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/close_downgraded_region.rs
@@ -51,10 +51,11 @@ impl State for CloseDowngradedRegion {
             warn!(err; "Failed to close downgraded leader region: {region_id} on datanode {:?}", downgrade_leader_datanode);
         }
         info!(
-            "Region migration is finished: region_id: {}, from_peer: {}, to_peer: {}, {}",
+            "Region migration is finished: region_id: {}, from_peer: {}, to_peer: {}, trigger_reason: {}, {}",
             ctx.region_id(),
             ctx.persistent_ctx.from_peer,
             ctx.persistent_ctx.to_peer,
+            ctx.persistent_ctx.trigger_reason,
             ctx.volatile_ctx.metrics,
         );
         Ok((Box::new(RegionMigrationEnd), Status::done()))

--- a/src/meta-srv/src/procedure/region_migration/downgrade_leader_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/downgrade_leader_region.rs
@@ -352,6 +352,7 @@ mod tests {
 
     use super::*;
     use crate::error::Error;
+    use crate::procedure::region_migration::manager::RegionMigrationTriggerReason;
     use crate::procedure::region_migration::test_util::{new_procedure_context, TestingEnv};
     use crate::procedure::region_migration::{ContextFactory, PersistentContext};
     use crate::procedure::test_util::{
@@ -366,6 +367,7 @@ mod tests {
             to_peer: Peer::empty(2),
             region_id: RegionId::new(1024, 1),
             timeout: Duration::from_millis(1000),
+            trigger_reason: RegionMigrationTriggerReason::Manual,
         }
     }
 

--- a/src/meta-srv/src/procedure/region_migration/migration_abort.rs
+++ b/src/meta-srv/src/procedure/region_migration/migration_abort.rs
@@ -44,11 +44,12 @@ impl State for RegionMigrationAbort {
         _procedure_ctx: &ProcedureContext,
     ) -> Result<(Box<dyn State>, Status)> {
         warn!(
-            "Region migration is aborted: {}, region_id: {}, from_peer: {}, to_peer: {}, {}",
+            "Region migration is aborted: {}, region_id: {}, from_peer: {}, to_peer: {}, trigger_reason: {}, {}",
             self.reason,
             ctx.region_id(),
             ctx.persistent_ctx.from_peer,
             ctx.persistent_ctx.to_peer,
+            ctx.persistent_ctx.trigger_reason,
             ctx.volatile_ctx.metrics,
         );
         error::MigrationAbortSnafu {

--- a/src/meta-srv/src/procedure/region_migration/test_util.rs
+++ b/src/meta-srv/src/procedure/region_migration/test_util.rs
@@ -45,7 +45,9 @@ use crate::metasrv::MetasrvInfo;
 use crate::procedure::region_migration::close_downgraded_region::CloseDowngradedRegion;
 use crate::procedure::region_migration::downgrade_leader_region::DowngradeLeaderRegion;
 use crate::procedure::region_migration::flush_leader_region::PreFlushRegion;
-use crate::procedure::region_migration::manager::RegionMigrationProcedureTracker;
+use crate::procedure::region_migration::manager::{
+    RegionMigrationProcedureTracker, RegionMigrationTriggerReason,
+};
 use crate::procedure::region_migration::migration_abort::RegionMigrationAbort;
 use crate::procedure::region_migration::migration_end::RegionMigrationEnd;
 use crate::procedure::region_migration::open_candidate_region::OpenCandidateRegion;
@@ -189,6 +191,7 @@ pub fn new_persistent_context(from: u64, to: u64, region_id: RegionId) -> Persis
         to_peer: Peer::empty(to),
         region_id,
         timeout: Duration::from_secs(10),
+        trigger_reason: RegionMigrationTriggerReason::default(),
     }
 }
 

--- a/src/meta-srv/src/procedure/region_migration/upgrade_candidate_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/upgrade_candidate_region.rs
@@ -235,6 +235,7 @@ mod tests {
 
     use super::*;
     use crate::error::Error;
+    use crate::procedure::region_migration::manager::RegionMigrationTriggerReason;
     use crate::procedure::region_migration::test_util::{new_procedure_context, TestingEnv};
     use crate::procedure::region_migration::{ContextFactory, PersistentContext};
     use crate::procedure::test_util::{
@@ -249,6 +250,7 @@ mod tests {
             to_peer: Peer::empty(2),
             region_id: RegionId::new(1024, 1),
             timeout: Duration::from_millis(1000),
+            trigger_reason: RegionMigrationTriggerReason::Manual,
         }
     }
 

--- a/src/meta-srv/src/region/supervisor.rs
+++ b/src/meta-srv/src/region/supervisor.rs
@@ -43,7 +43,9 @@ use tokio::time::{interval, interval_at, MissedTickBehavior};
 use crate::error::{self, Result};
 use crate::failure_detector::PhiAccrualFailureDetectorOptions;
 use crate::metasrv::{RegionStatAwareSelectorRef, SelectTarget, SelectorContext, SelectorRef};
-use crate::procedure::region_migration::manager::RegionMigrationManagerRef;
+use crate::procedure::region_migration::manager::{
+    RegionMigrationManagerRef, RegionMigrationTriggerReason,
+};
 use crate::procedure::region_migration::{
     RegionMigrationProcedureTask, DEFAULT_REGION_MIGRATION_TIMEOUT,
 };
@@ -649,6 +651,7 @@ impl RegionSupervisor {
                 from_peer: from_peer.clone(),
                 to_peer: peer,
                 timeout: DEFAULT_REGION_MIGRATION_TIMEOUT * count,
+                trigger_reason: RegionMigrationTriggerReason::Failover,
             };
             tasks.push((task, count));
         }

--- a/src/meta-srv/src/service/procedure.rs
+++ b/src/meta-srv/src/service/procedure.rs
@@ -30,7 +30,9 @@ use tonic::{Request, Response};
 
 use crate::error;
 use crate::metasrv::Metasrv;
-use crate::procedure::region_migration::manager::RegionMigrationProcedureTask;
+use crate::procedure::region_migration::manager::{
+    RegionMigrationProcedureTask, RegionMigrationTriggerReason,
+};
 use crate::service::GrpcResult;
 
 #[async_trait::async_trait]
@@ -154,6 +156,7 @@ impl procedure_service_server::ProcedureService for Metasrv {
                 from_peer,
                 to_peer,
                 timeout: Duration::from_secs(timeout_secs.into()),
+                trigger_reason: RegionMigrationTriggerReason::Manual,
             })
             .await?
             .map(procedure::pid_to_pb_pid);

--- a/tests-integration/tests/region_migration.rs
+++ b/tests-integration/tests/region_migration.rs
@@ -35,7 +35,9 @@ use futures::future::BoxFuture;
 use meta_srv::error;
 use meta_srv::error::Result as MetaResult;
 use meta_srv::metasrv::SelectorContext;
-use meta_srv::procedure::region_migration::RegionMigrationProcedureTask;
+use meta_srv::procedure::region_migration::{
+    RegionMigrationProcedureTask, RegionMigrationTriggerReason,
+};
 use meta_srv::selector::{Selector, SelectorOptions};
 use servers::query_handler::sql::SqlQueryHandler;
 use session::context::{QueryContext, QueryContextRef};
@@ -174,6 +176,7 @@ pub async fn test_region_migration(store_type: StorageType, endpoints: Vec<Strin
             peer_factory(from_peer_id),
             peer_factory(to_peer_id),
             Duration::from_millis(1000),
+            RegionMigrationTriggerReason::Manual,
         ))
         .await
         .unwrap();
@@ -225,6 +228,7 @@ pub async fn test_region_migration(store_type: StorageType, endpoints: Vec<Strin
             peer_factory(from_peer_id),
             peer_factory(to_peer_id),
             Duration::from_millis(1000),
+            RegionMigrationTriggerReason::Manual,
         ))
         .await
         .unwrap_err();
@@ -483,6 +487,7 @@ pub async fn test_region_migration_by_sql(store_type: StorageType, endpoints: Ve
             peer_factory(from_peer_id),
             peer_factory(to_peer_id),
             Duration::from_millis(1000),
+            RegionMigrationTriggerReason::Manual,
         ))
         .await
         .unwrap_err();
@@ -587,6 +592,7 @@ pub async fn test_region_migration_multiple_regions(
             peer_factory(from_peer_id),
             peer_factory(to_peer_id),
             Duration::from_millis(1000),
+            RegionMigrationTriggerReason::Manual,
         ))
         .await
         .unwrap();
@@ -638,6 +644,7 @@ pub async fn test_region_migration_multiple_regions(
             peer_factory(from_peer_id),
             peer_factory(to_peer_id),
             Duration::from_millis(1000),
+            RegionMigrationTriggerReason::Manual,
         ))
         .await
         .unwrap_err();
@@ -727,6 +734,7 @@ pub async fn test_region_migration_all_regions(store_type: StorageType, endpoint
             peer_factory(from_peer_id),
             peer_factory(to_peer_id),
             Duration::from_millis(1000),
+            RegionMigrationTriggerReason::Manual,
         ))
         .await
         .unwrap();
@@ -776,6 +784,7 @@ pub async fn test_region_migration_all_regions(store_type: StorageType, endpoint
             peer_factory(from_peer_id),
             peer_factory(to_peer_id),
             Duration::from_millis(1000),
+            RegionMigrationTriggerReason::Manual,
         ))
         .await
         .unwrap_err();
@@ -854,6 +863,7 @@ pub async fn test_region_migration_incorrect_from_peer(
             peer_factory(5),
             peer_factory(1),
             Duration::from_millis(1000),
+            RegionMigrationTriggerReason::Manual,
         ))
         .await
         .unwrap_err();
@@ -936,6 +946,7 @@ pub async fn test_region_migration_incorrect_region_id(
             peer_factory(2),
             peer_factory(1),
             Duration::from_millis(1000),
+            RegionMigrationTriggerReason::Manual,
         ))
         .await
         .unwrap_err();


### PR DESCRIPTION


I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Add `RegionMigrationTriggerReason` in `RegionMigrationProcedureTask`

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
