### PR TITLE
chore: bump version to 0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "api"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "common-base",
  "common-decimal",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "auth"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "async-trait",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "catalog",
  "common-error",
@@ -1610,7 +1610,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "arrow 54.2.1",
@@ -1948,7 +1948,7 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "cli"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1993,7 +1993,7 @@ dependencies = [
  "session",
  "snafu 0.8.5",
  "store-api",
- "substrait 0.15.0",
+ "substrait 0.16.0",
  "table",
  "tempfile",
  "tokio",
@@ -2002,7 +2002,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -2032,7 +2032,7 @@ dependencies = [
  "rand 0.9.0",
  "serde_json",
  "snafu 0.8.5",
- "substrait 0.15.0",
+ "substrait 0.16.0",
  "substrait 0.37.3",
  "tokio",
  "tokio-stream",
@@ -2073,7 +2073,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "auth",
@@ -2135,7 +2135,7 @@ dependencies = [
  "snafu 0.8.5",
  "stat",
  "store-api",
- "substrait 0.15.0",
+ "substrait 0.16.0",
  "table",
  "temp-env",
  "tempfile",
@@ -2182,7 +2182,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "common-base"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anymap2",
  "async-trait",
@@ -2204,11 +2204,11 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "0.15.0"
+version = "0.16.0"
 
 [[package]]
 name = "common-config"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "common-base",
  "common-error",
@@ -2234,7 +2234,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "arrow 54.2.1",
  "arrow-schema 54.3.1",
@@ -2271,7 +2271,7 @@ dependencies = [
 
 [[package]]
 name = "common-decimal"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bigdecimal 0.4.8",
  "common-error",
@@ -2284,7 +2284,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "common-macro",
  "http 1.1.0",
@@ -2295,7 +2295,7 @@ dependencies = [
 
 [[package]]
 name = "common-frontend"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "common-error",
@@ -2311,7 +2311,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "common-greptimedb-telemetry"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "common-runtime",
@@ -2382,7 +2382,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "common-base",
@@ -2433,7 +2433,7 @@ dependencies = [
 
 [[package]]
 name = "common-macro"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "arc-swap",
  "common-query",
@@ -2447,7 +2447,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "common-error",
@@ -2463,7 +2463,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anymap2",
  "api",
@@ -2528,7 +2528,7 @@ dependencies = [
 
 [[package]]
 name = "common-options"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "common-grpc",
  "humantime-serde",
@@ -2537,11 +2537,11 @@ dependencies = [
 
 [[package]]
 name = "common-plugins"
-version = "0.15.0"
+version = "0.16.0"
 
 [[package]]
 name = "common-pprof"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2553,7 +2553,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2580,7 +2580,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -2589,7 +2589,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "async-trait",
@@ -2615,7 +2615,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "arc-swap",
  "common-error",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "clap 4.5.19",
@@ -2665,14 +2665,14 @@ dependencies = [
 
 [[package]]
 name = "common-session"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "strum 0.27.1",
 ]
 
 [[package]]
 name = "common-telemetry"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "backtrace",
  "common-error",
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "client",
  "common-grpc",
@@ -2712,7 +2712,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "arrow 54.2.1",
  "chrono",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "common-version"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "build-data",
  "const_format",
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "common-wal"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "common-base",
  "common-error",
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "common-workload"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "common-telemetry",
@@ -3719,7 +3719,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -3772,7 +3772,7 @@ dependencies = [
  "session",
  "snafu 0.8.5",
  "store-api",
- "substrait 0.15.0",
+ "substrait 0.16.0",
  "table",
  "tokio",
  "toml 0.8.19",
@@ -3781,7 +3781,7 @@ dependencies = [
 
 [[package]]
 name = "datatypes"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "arrow 54.2.1",
  "arrow-array 54.2.1",
@@ -4441,7 +4441,7 @@ checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "file-engine"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "async-trait",
@@ -4578,7 +4578,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "flow"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "arrow 54.2.1",
@@ -4643,7 +4643,7 @@ dependencies = [
  "sql",
  "store-api",
  "strum 0.27.1",
- "substrait 0.15.0",
+ "substrait 0.16.0",
  "table",
  "tokio",
  "tonic 0.12.3",
@@ -4698,7 +4698,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frontend"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -4757,7 +4757,7 @@ dependencies = [
  "sqlparser 0.54.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=0cf6c04490d59435ee965edd2078e8855bd8471e)",
  "store-api",
  "strfmt",
- "substrait 0.15.0",
+ "substrait 0.16.0",
  "table",
  "tokio",
  "tokio-util",
@@ -5918,7 +5918,7 @@ dependencies = [
 
 [[package]]
 name = "index"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -6803,7 +6803,7 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "log-query"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "common-error",
@@ -6815,7 +6815,7 @@ dependencies = [
 
 [[package]]
 name = "log-store"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7113,7 +7113,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "async-trait",
@@ -7141,7 +7141,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "async-trait",
@@ -7232,7 +7232,7 @@ dependencies = [
 
 [[package]]
 name = "metric-engine"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -7322,7 +7322,7 @@ dependencies = [
 
 [[package]]
 name = "mito-codec"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "bytes",
@@ -7345,7 +7345,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -8095,7 +8095,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -8431,7 +8431,7 @@ dependencies = [
 
 [[package]]
 name = "operator"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -8486,7 +8486,7 @@ dependencies = [
  "sql",
  "sqlparser 0.54.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=0cf6c04490d59435ee965edd2078e8855bd8471e)",
  "store-api",
- "substrait 0.15.0",
+ "substrait 0.16.0",
  "table",
  "tokio",
  "tokio-util",
@@ -8753,7 +8753,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "async-trait",
@@ -9041,7 +9041,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeline"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -9184,7 +9184,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "auth",
  "clap 4.5.19",
@@ -9497,7 +9497,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -9779,7 +9779,7 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-compression 0.4.13",
  "async-trait",
@@ -9821,7 +9821,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -9887,7 +9887,7 @@ dependencies = [
  "sqlparser 0.54.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=0cf6c04490d59435ee965edd2078e8855bd8471e)",
  "statrs",
  "store-api",
- "substrait 0.15.0",
+ "substrait 0.16.0",
  "table",
  "tokio",
  "tokio-stream",
@@ -11209,7 +11209,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -11330,7 +11330,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -11669,7 +11669,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "chrono",
@@ -11724,7 +11724,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "clap 4.5.19",
@@ -12024,7 +12024,7 @@ dependencies = [
 
 [[package]]
 name = "stat"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "nix 0.30.1",
 ]
@@ -12050,7 +12050,7 @@ dependencies = [
 
 [[package]]
 name = "store-api"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -12211,7 +12211,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -12412,7 +12412,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "async-trait",
@@ -12673,7 +12673,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "tests-fuzz"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "arbitrary",
  "async-trait",
@@ -12717,7 +12717,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -12784,7 +12784,7 @@ dependencies = [
  "sql",
  "sqlx",
  "store-api",
- "substrait 0.15.0",
+ "substrait 0.16.0",
  "table",
  "tempfile",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/6354

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

Bump main repo version to 0.16.0

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
