### PR TITLE
fix: clean up queries when MySQL client session quits unexpectedly

### DIFF
--- a/src/catalog/src/process_manager.rs
+++ b/src/catalog/src/process_manager.rs
@@ -163,7 +163,7 @@ impl ProcessManager {
         id: ProcessId,
     ) -> error::Result<bool> {
         if server_addr == self.server_addr {
-            self.kill_local_process(catalog, id).await
+            self.kill_local_process(catalog, id)
         } else {
             let mut nodes = self
                 .frontend_selector
@@ -191,7 +191,7 @@ impl ProcessManager {
     }
 
     /// Kills local query with provided catalog and id.
-    pub async fn kill_local_process(&self, catalog: String, id: ProcessId) -> error::Result<bool> {
+    pub fn kill_local_process(&self, catalog: String, id: ProcessId) -> error::Result<bool> {
         if let Some(catalogs) = self.catalogs.write().unwrap().get_mut(&catalog) {
             if let Some(process) = catalogs.remove(&id) {
                 process.handle.cancel();

--- a/src/operator/src/statement/kill.rs
+++ b/src/operator/src/statement/kill.rs
@@ -71,7 +71,6 @@ impl StatementExecutor {
         connection_id: u32,
     ) -> error::Result<bool> {
         pm.kill_local_process(query_ctx.current_catalog().to_string(), connection_id)
-            .await
             .context(error::CatalogSnafu)
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

 Refactor Process Management in MySQL Server

 - Removed `async` from `kill_local_process` in `process_manager.rs` to simplify process termination logic.
 - Updated `kill.rs` to remove unnecessary `await` for `kill_local_process`.
 - Enhanced `MysqlInstanceShim` in `handler.rs` to include a `ProcessManagerRef` and implemented a `Drop` trait to ensure local processes are killed upon instance drop.
 - Modified `MysqlServer` in `server.rs` to pass `ProcessManagerRef` to `MysqlInstanceShim` and handle process management during connection handling.
 
## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
