### PR TITLE
chore: flake build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2694,7 +2694,7 @@ dependencies = [
  "hex",
  "jsonb",
  "snafu 0.8.5",
- "sqlparser 0.54.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=0cf6c04490d59435ee965edd2078e8855bd8471e)",
+ "sqlparser 0.54.0-greptime",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2615,7 +2615,7 @@ dependencies = [
  "futures-util",
  "serde",
  "snafu 0.8.5",
- "sqlparser 0.54.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=0cf6c04490d59435ee965edd2078e8855bd8471e)",
+ "sqlparser 0.54.0-greptime",
  "sqlparser_derive 0.1.1",
  "statrs",
  "store-api",
@@ -3331,7 +3331,7 @@ dependencies = [
  "parquet",
  "rand 0.8.5",
  "regex",
- "sqlparser 0.54.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sqlparser 0.54.0",
  "tempfile",
  "tokio",
  "tokio-util",
@@ -3358,7 +3358,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "parking_lot 0.12.3",
- "sqlparser 0.54.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sqlparser 0.54.0",
 ]
 
 [[package]]
@@ -3404,7 +3404,7 @@ dependencies = [
  "parquet",
  "paste",
  "recursive",
- "sqlparser 0.54.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sqlparser 0.54.0",
  "tokio",
  "web-time 1.1.0",
 ]
@@ -3458,7 +3458,7 @@ dependencies = [
  "paste",
  "recursive",
  "serde_json",
- "sqlparser 0.54.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sqlparser 0.54.0",
 ]
 
 [[package]]
@@ -3726,7 +3726,7 @@ dependencies = [
  "log",
  "recursive",
  "regex",
- "sqlparser 0.54.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sqlparser 0.54.0",
 ]
 
 [[package]]
@@ -3833,7 +3833,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu 0.8.5",
- "sqlparser 0.54.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=0cf6c04490d59435ee965edd2078e8855bd8471e)",
+ "sqlparser 0.54.0-greptime",
  "sqlparser_derive 0.1.1",
 ]
 
@@ -4784,7 +4784,7 @@ dependencies = [
  "session",
  "snafu 0.8.5",
  "sql",
- "sqlparser 0.54.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=0cf6c04490d59435ee965edd2078e8855bd8471e)",
+ "sqlparser 0.54.0-greptime",
  "store-api",
  "strfmt",
  "substrait 0.16.0",
@@ -8517,7 +8517,7 @@ dependencies = [
  "session",
  "snafu 0.8.5",
  "sql",
- "sqlparser 0.54.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=0cf6c04490d59435ee965edd2078e8855bd8471e)",
+ "sqlparser 0.54.0-greptime",
  "store-api",
  "substrait 0.16.0",
  "table",
@@ -8806,7 +8806,7 @@ dependencies = [
  "session",
  "snafu 0.8.5",
  "sql",
- "sqlparser 0.54.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=0cf6c04490d59435ee965edd2078e8855bd8471e)",
+ "sqlparser 0.54.0-greptime",
  "store-api",
  "table",
 ]
@@ -9918,7 +9918,7 @@ dependencies = [
  "session",
  "snafu 0.8.5",
  "sql",
- "sqlparser 0.54.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=0cf6c04490d59435ee965edd2078e8855bd8471e)",
+ "sqlparser 0.54.0-greptime",
  "statrs",
  "store-api",
  "substrait 0.16.0",
@@ -11733,7 +11733,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu 0.8.5",
- "sqlparser 0.54.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=0cf6c04490d59435ee965edd2078e8855bd8471e)",
+ "sqlparser 0.54.0-greptime",
  "sqlparser_derive 0.1.1",
  "store-api",
  "table",
@@ -11790,27 +11790,27 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66e3b7374ad4a6af849b08b3e7a6eda0edbd82f0fd59b57e22671bf16979899"
-dependencies = [
- "log",
- "recursive",
- "sqlparser_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "sqlparser"
-version = "0.54.0"
-source = "git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=0cf6c04490d59435ee965edd2078e8855bd8471e#0cf6c04490d59435ee965edd2078e8855bd8471e"
+version = "0.54.0-greptime"
+source = "git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=e4e9f49f52dbca4b67f8a83a3a209227d44f3cd9#e4e9f49f52dbca4b67f8a83a3a209227d44f3cd9"
 dependencies = [
  "lazy_static",
  "log",
  "recursive",
  "regex",
  "serde",
- "sqlparser 0.54.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sqlparser_derive 0.3.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=0cf6c04490d59435ee965edd2078e8855bd8471e)",
+ "sqlparser 0.54.0",
+ "sqlparser_derive 0.3.0-greptime",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66e3b7374ad4a6af849b08b3e7a6eda0edbd82f0fd59b57e22671bf16979899"
+dependencies = [
+ "log",
+ "recursive",
+ "sqlparser_derive 0.3.0",
 ]
 
 [[package]]
@@ -11826,9 +11826,8 @@ dependencies = [
 
 [[package]]
 name = "sqlparser_derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
+version = "0.3.0-greptime"
+source = "git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=e4e9f49f52dbca4b67f8a83a3a209227d44f3cd9#e4e9f49f52dbca4b67f8a83a3a209227d44f3cd9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11838,7 +11837,8 @@ dependencies = [
 [[package]]
 name = "sqlparser_derive"
 version = "0.3.0"
-source = "git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=0cf6c04490d59435ee965edd2078e8855bd8471e#0cf6c04490d59435ee965edd2078e8855bd8471e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12743,7 +12743,7 @@ dependencies = [
  "serde_yaml",
  "snafu 0.8.5",
  "sql",
- "sqlparser 0.54.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=0cf6c04490d59435ee965edd2078e8855bd8471e)",
+ "sqlparser 0.54.0-greptime",
  "sqlx",
  "store-api",
  "strum 0.27.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,7 +202,7 @@ simd-json = "0.15"
 similar-asserts = "1.6.0"
 smallvec = { version = "1", features = ["serde"] }
 snafu = "0.8"
-sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "0cf6c04490d59435ee965edd2078e8855bd8471e", features = [
+sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "e4e9f49f52dbca4b67f8a83a3a209227d44f3cd9", features = [
     "visitor",
     "serde",
 ] } # branch = "v0.54.x"

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1745735608,
-        "narHash": "sha256-L0jzm815XBFfF2wCFmR+M1CF+beIEFj6SxlqVKF59Ec=",
+        "lastModified": 1751352216,
+        "narHash": "sha256-dJj8TUoZGj55Ttro37vvFGF2L+xlYNfspQ9u4BfqTFw=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "c39a78eba6ed2a022cc3218db90d485077101496",
+        "rev": "61b4f1e21bd631da91981f1ed74c959d6993f554",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748162331,
-        "narHash": "sha256-rqc2RKYTxP3tbjA+PB3VMRQNnjesrT0pEofXQTrMsS8=",
+        "lastModified": 1751211869,
+        "narHash": "sha256-1Cu92i1KSPbhPCKxoiVG5qnoRiKTgR5CcGSRyLpOd7Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7c43f080a7f28b2774f3b3f43234ca11661bf334",
+        "rev": "b43c397f6c213918d6cfe6e3550abfe79b5d1c51",
         "type": "github"
       },
       "original": {
@@ -65,11 +65,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1745694049,
-        "narHash": "sha256-fxvRYH/tS7hGQeg9zCVh5RBcSWT+JGJet7RA8Ss+rC0=",
+        "lastModified": 1751296293,
+        "narHash": "sha256-oaGMVdCcI32y6jQ7RE0+CqshZngfI19XnY31eYjdinI=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "d8887c0758bbd2d5f752d5bd405d4491e90e7ed6",
+        "rev": "eaf37e2c98b66ff7f7a0ac04e4cada39e51fde4b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -74,7 +74,6 @@
               "orc-rust-0.6.0" = "sha256-uPG94OF5l6JxWbjiejqJ6Zz+vOX9hL3pamomz2hkrG8=";
               "otel-arrow-rust-0.1.0" = "sha256-PB6zInde/ASQR7fqMs44IhaXqMpKW5AILMZOnaPN2eY=";
               "pgwire-0.30.2" = "sha256-TJMYAleRrXp8nW5l/OXfHji+AgyBGsxUamrhMLn8hps=";
-              "promql-parser-0.5.1" = "sha256-5OYSL2iPKRS4hE8OoG6w93KtOBtKuwoGZYo/2iqcNps=";
               "rskafka-0.6.0" = "sha256-wjJ+FuHSBu5a5tSYq22ZrQGLHou/aIcsmUT0j1OinJw=";
               "sqlness-0.6.1" = "sha256-ZtUVLJ1U4A6mNR+iNvRtkhIPWHe2ZSJ+kt533B6vivQ=";
               "sqlparser-0.54.0-greptime" = "sha256-l2Szp9ytcbXJDyvYR+jKFwa+AYqtwZvFqQ3KzgGbH2A=";

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Development environment flake";
+  description = "GreptimeDB as nix flake";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
@@ -18,37 +18,88 @@
           libgit2
           libz
         ];
+        nativeBuildInputs = with pkgs; [
+          pkg-config
+          git
+          clang
+          gcc
+          protobuf
+          gnumake
+          mold
+          (rustToolchain.withComponents [
+            "cargo"
+            "clippy"
+            "rust-src"
+            "rustc"
+            "rustfmt"
+            "rust-analyzer"
+            "llvm-tools"
+          ])
+          cargo-nextest
+          cargo-llvm-cov
+          taplo
+          curl
+          gnuplot ## for cargo bench
+        ];
+
         lib = nixpkgs.lib;
         rustToolchain = fenix.packages.${system}.fromToolchainName {
           name = (lib.importTOML ./rust-toolchain.toml).toolchain.channel;
           sha256 = "sha256-tJJr8oqX3YD+ohhPK7jlt/7kvKBnBqJVjYtoFr520d4=";
         };
+
+        # Read Cargo.toml to get package name and version
+        cargoToml = lib.importTOML ./Cargo.toml;
+        packageName = "greptimedb";
+        packageVersion = cargoToml.workspace.package.version;
       in
       {
+        packages.default = pkgs.rustPlatform.buildRustPackage {
+          pname = packageName;
+          version = packageVersion;
+
+          src = lib.cleanSource ./.;
+
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+            allowBuiltinFetchGit = true;
+            outputHashes = {
+              "datafusion-45.0.0" = "sha256-Js5E0m0igvpo6WcOws6sRs3JGreNTxPOFjRSsBQnJfk=";
+              "greptime-proto-0.1.0" = "sha256-gLgzqreOeDQmwMHkZu+iYUSmMRN0qdFKm8JwCNugI6w=";
+              "influxdb_line_protocol-0.1.0" = "sha256-RvPS4erQDrMxzPbZu8gT4g5q9UHMaq9DS5P0kb0UhD4=";
+              "jsonb-0.4.3" = "sha256-/nBUhsbDtuKqDpPNeP5dAqDaIFKMGoIsqv07qHZmkug=";
+              "loki-proto-0.1.0" = "sha256-puwIdzwZ9zKh6BCgXZ2iE1f3f733GtByNbr3GvTrTkw=";
+              "meter-core-0.1.0" = "sha256-E2lvqsfY5nEKgXcHAubzNKcZveX8VI0GMT9OSRvIFgs=";
+              "opensrv-mysql-0.8.0" = "sha256-UJcihra+L7L5bOOtayjMqKKpkTYYxPre8Fwd1lvOc18=";
+              "orc-rust-0.6.0" = "sha256-uPG94OF5l6JxWbjiejqJ6Zz+vOX9hL3pamomz2hkrG8=";
+              "otel-arrow-rust-0.1.0" = "sha256-PB6zInde/ASQR7fqMs44IhaXqMpKW5AILMZOnaPN2eY=";
+              "pgwire-0.30.2" = "sha256-TJMYAleRrXp8nW5l/OXfHji+AgyBGsxUamrhMLn8hps=";
+              "promql-parser-0.5.1" = "sha256-5OYSL2iPKRS4hE8OoG6w93KtOBtKuwoGZYo/2iqcNps=";
+              "rskafka-0.6.0" = "sha256-wjJ+FuHSBu5a5tSYq22ZrQGLHou/aIcsmUT0j1OinJw=";
+              "sqlness-0.6.1" = "sha256-ZtUVLJ1U4A6mNR+iNvRtkhIPWHe2ZSJ+kt533B6vivQ=";
+              "sqlparser-0.54.0-greptime" = "sha256-l2Szp9ytcbXJDyvYR+jKFwa+AYqtwZvFqQ3KzgGbH2A=";
+              "uddsketch-0.1.0" = "sha256-VEub0vUF3w7U5LZsmBueegHNiuAE6jSgyo+x5r1C4h8=";
+            };
+          };
+
+          inherit buildInputs;
+          inherit nativeBuildInputs;
+
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath buildInputs;
+          NIX_HARDENING_ENABLE = "";
+
+          cargoBuildFlags = [ "--bin" "greptime" ];
+
+          meta = with lib; {
+            description = "Cloud-native database for observability.";
+            license = licenses.asl20;
+            maintainers = [ "sunning@greptime.com" ];
+            platforms = platforms.all;
+          };
+        };
+
         devShells.default = pkgs.mkShell {
-          nativeBuildInputs = with pkgs; [
-            pkg-config
-            git
-            clang
-            gcc
-            protobuf
-            gnumake
-            mold
-            (rustToolchain.withComponents [
-              "cargo"
-              "clippy"
-              "rust-src"
-              "rustc"
-              "rustfmt"
-              "rust-analyzer"
-              "llvm-tools"
-            ])
-            cargo-nextest
-            cargo-llvm-cov
-            taplo
-            curl
-            gnuplot ## for cargo bench
-          ];
+          inherit nativeBuildInputs;
 
           LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath buildInputs;
           NIX_HARDENING_ENABLE = "";


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

#6088 

## What's changed and what's your intention?

This PR is to make greptimedb buildable in nix flake environment.

It:

- update sqlparser version to add greptime suffix
- add buildRustPackages section in nix flake

@happysalada this is only a draft, feel free to fork and optimize it.

I'm currently blocked by a compile issue that only happens with `nix build`:

```
       > error: failed to run custom build command for `otel-arrow-rust v0.1.0 (https://github.com/open-telemetry/otel-arrow?rev=5d551412d2a12e689cde4d84c14ef29e36784e51#5d551412)`
       >
       > Caused by:
       >   process didn't exit successfully: `/build/source/target/release/build/otel-arrow-rust-b3314aee2ac07afd/build-script-build` (exit status: 101)
       >   --- stdout
       >   cargo:rerun-if-changed=experimental/arrow/v1/arrow_service.proto
       >   cargo:rerun-if-changed=/build/cargo-vendor-dir/otel-arrow-rust-0.1.0/../../proto/opentelemetry/proto/
       >
       >   --- stderr
       >
       >   thread 'main' panicked at /build/cargo-vendor-dir/otel-arrow-rust-0.1.0/build.rs:32:10:
       >   Failed to compile protos.: Custom { kind: Other, error: "protoc failed: Could not make proto path relative: experimental/arrow/v1/arrow_service.proto: No such file or directory\n" }
       >   note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
