### PR TITLE
fix: remap column indices on overriding logical table partitions

### DIFF
--- a/src/catalog/src/kvbackend/manager.rs
+++ b/src/catalog/src/kvbackend/manager.rs
@@ -167,17 +167,6 @@ impl KvBackendCatalogManager {
         {
             let mut new_table_info = (*table.table_info()).clone();
 
-            // Create a mapping from column name to index in the logical table
-            let logical_column_name_to_index: std::collections::HashMap<&str, usize> =
-                new_table_info
-                    .meta
-                    .schema
-                    .column_schemas()
-                    .iter()
-                    .enumerate()
-                    .map(|(index, col)| (col.name.as_str(), index))
-                    .collect();
-
             // Remap partition key indices from physical table to logical table
             new_table_info.meta.partition_key_indices = physical_table_info_value
                 .table_info
@@ -194,9 +183,10 @@ impl KvBackendCatalogManager {
                         .get(physical_index)
                         .and_then(|physical_column| {
                             // Find the corresponding index in the logical table schema
-                            logical_column_name_to_index
-                                .get(physical_column.name.as_str())
-                                .copied()
+                            new_table_info
+                                .meta
+                                .schema
+                                .column_index_by_name(physical_column.name.as_str())
                         })
                 })
                 .collect();

--- a/tests/cases/standalone/common/create/metric_engine_partition.result
+++ b/tests/cases/standalone/common/create/metric_engine_partition.result
@@ -1,9 +1,12 @@
 create table metric_engine_partition (
     ts timestamp time index,
-    host string primary key,
+    host string,
     cpu double,
+    `one_partition_key` string,
+    `another_partition_key` string,
+    primary key(host, `one_partition_key`, `another_partition_key`)
 )
-partition on columns (host) (
+partition on columns (host, `one_partition_key`, `another_partition_key`) (
     host <= 'host1',
     host > 'host1' and host <= 'host2',
     host > 'host2'
@@ -64,26 +67,26 @@ Affected Rows: 0
 
 show create table logical_table_2;
 
-+-----------------+-------------------------------------------------+
-| Table           | Create Table                                    |
-+-----------------+-------------------------------------------------+
-| logical_table_2 | CREATE TABLE IF NOT EXISTS "logical_table_2" (  |
-|                 |   "cpu" DOUBLE NULL,                            |
-|                 |   "host" STRING NULL,                           |
-|                 |   "ts" TIMESTAMP(3) NOT NULL,                   |
-|                 |   TIME INDEX ("ts"),                            |
-|                 |   PRIMARY KEY ("host")                          |
-|                 | )                                               |
-|                 | PARTITION ON COLUMNS ("host") (                 |
-|                 |   host <= 'host1',                              |
-|                 |   host > 'host2',                               |
-|                 |   host > 'host1' AND host <= 'host2'            |
-|                 | )                                               |
-|                 | ENGINE=metric                                   |
-|                 | WITH(                                           |
-|                 |   on_physical_table = 'metric_engine_partition' |
-|                 | )                                               |
-+-----------------+-------------------------------------------------+
++-----------------+-------------------------------------------------------------------------------+
+| Table           | Create Table                                                                  |
++-----------------+-------------------------------------------------------------------------------+
+| logical_table_2 | CREATE TABLE IF NOT EXISTS "logical_table_2" (                                |
+|                 |   "cpu" DOUBLE NULL,                                                          |
+|                 |   "host" STRING NULL,                                                         |
+|                 |   "ts" TIMESTAMP(3) NOT NULL,                                                 |
+|                 |   TIME INDEX ("ts"),                                                          |
+|                 |   PRIMARY KEY ("host")                                                        |
+|                 | )                                                                             |
+|                 | PARTITION ON COLUMNS ("host", "one_partition_key", "another_partition_key") ( |
+|                 |   host <= 'host1',                                                            |
+|                 |   host > 'host2',                                                             |
+|                 |   host > 'host1' AND host <= 'host2'                                          |
+|                 | )                                                                             |
+|                 | ENGINE=metric                                                                 |
+|                 | WITH(                                                                         |
+|                 |   on_physical_table = 'metric_engine_partition'                               |
+|                 | )                                                                             |
++-----------------+-------------------------------------------------------------------------------+
 
 select count(*) from logical_table_2;
 

--- a/tests/cases/standalone/common/create/metric_engine_partition.sql
+++ b/tests/cases/standalone/common/create/metric_engine_partition.sql
@@ -1,9 +1,12 @@
 create table metric_engine_partition (
     ts timestamp time index,
-    host string primary key,
+    host string,
     cpu double,
+    `one_partition_key` string,
+    `another_partition_key` string,
+    primary key(host, `one_partition_key`, `another_partition_key`)
 )
-partition on columns (host) (
+partition on columns (host, `one_partition_key`, `another_partition_key`) (
     host <= 'host1',
     host > 'host1' and host <= 'host2',
     host > 'host2'


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

follow up of https://github.com/GreptimeTeam/greptimedb/pull/6385

## What's changed and what's your intention?


Remap the column index to the correct one in logical table's schema. Otherwise it may panic or get an incorrect result when retrieving column from logical table's schema with index from physical table's schema

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
