### PR TITLE
fix: enable max_execution time for other read only statements

### DIFF
--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -317,9 +317,13 @@ impl Instance {
 /// For MySQL, it applies only to read-only statements.
 fn derive_timeout(stmt: &Statement, query_ctx: &QueryContextRef) -> Option<Duration> {
     let query_timeout = query_ctx.query_timeout()?;
-    match (query_ctx.channel(), stmt) {
-        (Channel::Mysql, Statement::Query(_)) | (Channel::Postgres, _) => Some(query_timeout),
-        (_, _) => None,
+    if query_timeout.is_zero() {
+        return None;
+    }
+    match query_ctx.channel() {
+        Channel::Mysql if stmt.is_readonly() => Some(query_timeout),
+        Channel::Postgres => Some(query_timeout),
+        _ => None,
     }
 }
 

--- a/src/sql/src/statements/statement.rs
+++ b/src/sql/src/statements/statement.rs
@@ -148,6 +148,67 @@ pub enum Statement {
     ShowProcesslist(ShowProcessList),
 }
 
+impl Statement {
+    pub fn is_readonly(&self) -> bool {
+        match self {
+            // Read-only operations
+            Statement::Query(_)
+            | Statement::ShowDatabases(_)
+            | Statement::ShowTables(_)
+            | Statement::ShowTableStatus(_)
+            | Statement::ShowColumns(_)
+            | Statement::ShowCharset(_)
+            | Statement::ShowCollation(_)
+            | Statement::ShowIndex(_)
+            | Statement::ShowRegion(_)
+            | Statement::ShowCreateDatabase(_)
+            | Statement::ShowCreateTable(_)
+            | Statement::ShowCreateFlow(_)
+            | Statement::ShowFlows(_)
+            | Statement::ShowCreateView(_)
+            | Statement::ShowStatus(_)
+            | Statement::ShowSearchPath(_)
+            | Statement::ShowViews(_)
+            | Statement::DescribeTable(_)
+            | Statement::Explain(_)
+            | Statement::ShowVariables(_)
+            | Statement::ShowProcesslist(_)
+            | Statement::FetchCursor(_)
+            | Statement::Tql(_) => true,
+
+            #[cfg(feature = "enterprise")]
+            Statement::ShowTriggers(_) => true,
+
+            // Write operations
+            Statement::Insert(_)
+            | Statement::Delete(_)
+            | Statement::CreateTable(_)
+            | Statement::CreateExternalTable(_)
+            | Statement::CreateTableLike(_)
+            | Statement::CreateFlow(_)
+            | Statement::CreateView(_)
+            | Statement::DropTable(_)
+            | Statement::DropDatabase(_)
+            | Statement::DropFlow(_)
+            | Statement::DropView(_)
+            | Statement::CreateDatabase(_)
+            | Statement::AlterTable(_)
+            | Statement::AlterDatabase(_)
+            | Statement::Copy(_)
+            | Statement::TruncateTable(_)
+            | Statement::SetVariables(_)
+            | Statement::Use(_)
+            | Statement::DeclareCursor(_)
+            | Statement::CloseCursor(_)
+            | Statement::Kill(_)
+            | Statement::Admin(_) => false,
+
+            #[cfg(feature = "enterprise")]
+            Statement::CreateTrigger(_) | Statement::DropTrigger(_) => false,
+        }
+    }
+}
+
 impl Display for Statement {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {


### PR DESCRIPTION
Also disable the timeout when timeout is 0

I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/pull/6444

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

Enable MAX_EXECUTION_TIME for other read-only statements such as TQL.

Also supports disabling the timeout by setting it to 0.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
