### PR TITLE
feat: persist column ids in table metadata

### DIFF
--- a/src/cli/src/bench.rs
+++ b/src/cli/src/bench.rs
@@ -160,6 +160,7 @@ fn create_table_info(table_id: TableId, table_name: TableName) -> RawTableInfo {
         options: Default::default(),
         region_numbers: (1..=100).collect(),
         partition_key_indices: vec![],
+        column_ids: vec![],
     };
 
     RawTableInfo {

--- a/src/common/meta/src/ddl/physical_table_metadata.rs
+++ b/src/common/meta/src/ddl/physical_table_metadata.rs
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use api::v1::SemanticType;
+use common_telemetry::debug;
+use common_telemetry::tracing::warn;
 use store_api::metadata::ColumnMetadata;
 use table::metadata::RawTableInfo;
 
@@ -23,6 +25,10 @@ pub(crate) fn build_new_physical_table_info(
     mut raw_table_info: RawTableInfo,
     physical_columns: &[ColumnMetadata],
 ) -> RawTableInfo {
+    debug!(
+        "building new physical table info for table: {}, table_id: {}",
+        raw_table_info.name, raw_table_info.ident.table_id
+    );
     let existing_columns = raw_table_info
         .meta
         .schema
@@ -36,6 +42,8 @@ pub(crate) fn build_new_physical_table_info(
     let time_index = &mut raw_table_info.meta.schema.timestamp_index;
     let columns = &mut raw_table_info.meta.schema.column_schemas;
     columns.clear();
+    let column_ids = &mut raw_table_info.meta.column_ids;
+    column_ids.clear();
 
     for (idx, col) in physical_columns.iter().enumerate() {
         match col.semantic_type {
@@ -50,6 +58,7 @@ pub(crate) fn build_new_physical_table_info(
         }
 
         columns.push(col.column_schema.clone());
+        column_ids.push(col.column_id);
     }
 
     if let Some(time_index) = *time_index {
@@ -57,4 +66,46 @@ pub(crate) fn build_new_physical_table_info(
     }
 
     raw_table_info
+}
+
+/// Update the column ids in the table info.
+pub(crate) fn update_table_info_column_ids(
+    raw_table_info: &mut RawTableInfo,
+    column_metadatas: &[ColumnMetadata],
+) {
+    if column_metadatas.len() != raw_table_info.meta.schema.column_schemas.len() {
+        warn!(
+            "Trying to update column ids for table {}, table_id: {}, column metadatas length({}) is not equal to column schemas length({})",
+            raw_table_info.name,
+            raw_table_info.ident.table_id,
+            column_metadatas.len(),
+            raw_table_info.meta.schema.column_schemas.len(),
+        );
+        return;
+    }
+
+    let name_to_id = column_metadatas
+        .iter()
+        .map(|c| (c.column_schema.name.clone(), c.column_id))
+        .collect::<HashMap<_, _>>();
+
+    let schema = &raw_table_info.meta.schema.column_schemas;
+    let mut column_ids = Vec::with_capacity(schema.len());
+    for column_schema in schema {
+        if let Some(id) = name_to_id.get(&column_schema.name) {
+            column_ids.push(*id);
+        }
+    }
+
+    if column_ids.len() != schema.len() {
+        warn!(
+            "Column metadata is not complete for table {}, table_id: {}, column ids length({}) is not equal to column schemas length({})",
+            raw_table_info.name,
+            raw_table_info.ident.table_id,
+            column_ids.len(),
+            schema.len(),
+        );
+    } else {
+        raw_table_info.meta.column_ids = column_ids;
+    }
 }

--- a/src/common/meta/src/ddl/table_meta.rs
+++ b/src/common/meta/src/ddl/table_meta.rs
@@ -122,6 +122,7 @@ impl TableMetadataAllocator {
         );
 
         let peers = self.peer_allocator.alloc(regions).await?;
+        debug!("Allocated peers {:?} for table {}", peers, table_id);
         let region_routes = task
             .partitions
             .iter()

--- a/src/common/meta/src/ddl/test_util/create_table.rs
+++ b/src/common/meta/src/ddl/test_util/create_table.rs
@@ -132,6 +132,7 @@ pub fn build_raw_table_info_from_expr(expr: &CreateTableExpr) -> RawTableInfo {
             options: TableOptions::try_from_iter(&expr.table_options).unwrap(),
             created_on: DateTime::default(),
             partition_key_indices: vec![],
+            column_ids: vec![],
         },
         table_type: TableType::Base,
     }

--- a/src/common/meta/src/ddl/utils.rs
+++ b/src/common/meta/src/ddl/utils.rs
@@ -29,6 +29,7 @@ use common_telemetry::{error, info, warn};
 use common_wal::options::WalOptions;
 use futures::future::join_all;
 use snafu::{ensure, OptionExt, ResultExt};
+use store_api::metadata::ColumnMetadata;
 use store_api::metric_engine_consts::{LOGICAL_TABLE_METADATA_KEY, MANIFEST_INFO_EXTENSION_KEY};
 use store_api::region_engine::RegionManifestInfo;
 use store_api::storage::{RegionId, RegionNumber};
@@ -37,8 +38,8 @@ use table::table_reference::TableReference;
 
 use crate::ddl::{DdlContext, DetectingRegion};
 use crate::error::{
-    self, Error, OperateDatanodeSnafu, ParseWalOptionsSnafu, Result, TableNotFoundSnafu,
-    UnsupportedSnafu,
+    self, DecodeJsonSnafu, Error, MetadataCorruptionSnafu, OperateDatanodeSnafu,
+    ParseWalOptionsSnafu, Result, TableNotFoundSnafu, UnsupportedSnafu,
 };
 use crate::key::datanode_table::DatanodeTableValue;
 use crate::key::table_name::TableNameKey;
@@ -314,11 +315,23 @@ pub fn parse_manifest_infos_from_extensions(
     Ok(data_manifest_version)
 }
 
+/// Parses column metadatas from extensions.
+pub fn parse_column_metadatas(
+    extensions: &HashMap<String, Vec<u8>>,
+    key: &str,
+) -> Result<Vec<ColumnMetadata>> {
+    let value = extensions.get(key).context(error::UnexpectedSnafu {
+        err_msg: format!("column metadata extension not found: {}", key),
+    })?;
+    let column_metadatas = ColumnMetadata::decode_list(value).context(error::SerdeJsonSnafu {})?;
+    Ok(column_metadatas)
+}
+
 /// Sync follower regions on datanodes.
 pub async fn sync_follower_regions(
     context: &DdlContext,
     table_id: TableId,
-    results: Vec<RegionResponse>,
+    results: &[RegionResponse],
     region_routes: &[RegionRoute],
     engine: &str,
 ) -> Result<()> {
@@ -331,7 +344,7 @@ pub async fn sync_follower_regions(
     }
 
     let results = results
-        .into_iter()
+        .iter()
         .map(|response| parse_manifest_infos_from_extensions(&response.extensions))
         .collect::<Result<Vec<_>>>()?
         .into_iter()
@@ -416,6 +429,38 @@ pub async fn sync_follower_regions(
     info!("Sync follower regions on datanodes, table_id: {}", table_id);
 
     Ok(())
+}
+
+/// Extracts column metadatas from extensions.
+pub fn extract_column_metadatas(
+    results: &mut [RegionResponse],
+    key: &str,
+) -> Result<Option<Vec<ColumnMetadata>>> {
+    let schemas = results
+        .iter_mut()
+        .map(|r| r.extensions.remove(key))
+        .collect::<Vec<_>>();
+
+    if schemas.is_empty() {
+        return Ok(None);
+    }
+
+    // Verify all the physical schemas are the same
+    // Safety: previous check ensures this vec is not empty
+    let first = schemas.first().unwrap();
+    ensure!(
+        schemas.iter().all(|x| x == first),
+        MetadataCorruptionSnafu {
+            err_msg: "The table column metadata schemas from datanodes are not the same."
+        }
+    );
+
+    if let Some(first) = first {
+        let column_metadatas = ColumnMetadata::decode_list(first).context(DecodeJsonSnafu)?;
+        Ok(Some(column_metadatas))
+    } else {
+        Ok(None)
+    }
 }
 
 #[cfg(test)]

--- a/src/common/meta/src/key/table_info.rs
+++ b/src/common/meta/src/key/table_info.rs
@@ -334,6 +334,7 @@ mod tests {
             options: Default::default(),
             region_numbers: vec![1],
             partition_key_indices: vec![],
+            column_ids: vec![],
         };
 
         RawTableInfo {

--- a/src/common/meta/src/rpc/ddl.rs
+++ b/src/common/meta/src/rpc/ddl.rs
@@ -1374,6 +1374,7 @@ mod tests {
             options: Default::default(),
             created_on: Default::default(),
             partition_key_indices: Default::default(),
+            column_ids: Default::default(),
         };
 
         // construct RawTableInfo

--- a/src/meta-srv/src/procedure/utils.rs
+++ b/src/meta-srv/src/procedure/utils.rs
@@ -196,6 +196,7 @@ pub mod test_data {
                 options: TableOptions::default(),
                 created_on: DateTime::default(),
                 partition_key_indices: vec![],
+                column_ids: vec![],
             },
             table_type: TableType::Base,
         }

--- a/src/operator/src/statement/ddl.rs
+++ b/src/operator/src/statement/ddl.rs
@@ -1681,6 +1681,7 @@ fn create_table_info(
         options: table_options,
         created_on: Utc::now(),
         partition_key_indices,
+        column_ids: vec![],
     };
 
     let desc = if create_table.desc.is_empty() {

--- a/src/store-api/src/metric_engine_consts.rs
+++ b/src/store-api/src/metric_engine_consts.rs
@@ -74,6 +74,10 @@ pub const LOGICAL_TABLE_METADATA_KEY: &str = "on_physical_table";
 pub const ALTER_PHYSICAL_EXTENSION_KEY: &str = "ALTER_PHYSICAL";
 
 /// HashMap key to be used in the region server's extension response.
+/// Represent the column metadata of a table.
+pub const TABLE_COLUMN_METADATA_EXTENSION_KEY: &str = "TABLE_COLUMN_METADATA";
+
+/// HashMap key to be used in the region server's extension response.
 /// Represent the manifest info of a region.
 pub const MANIFEST_INFO_EXTENSION_KEY: &str = "MANIFEST_INFO";
 

--- a/src/store-api/src/region_engine.rs
+++ b/src/store-api/src/region_engine.rs
@@ -460,7 +460,7 @@ pub struct RegionStatistic {
 }
 
 /// The manifest info of a region.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum RegionManifestInfo {
     Mito {
         manifest_version: u64,

--- a/src/table/src/metadata.rs
+++ b/src/table/src/metadata.rs
@@ -134,6 +134,8 @@ pub struct TableMeta {
     pub created_on: DateTime<Utc>,
     #[builder(default = "Vec::new()")]
     pub partition_key_indices: Vec<usize>,
+    #[builder(default = "Vec::new()")]
+    pub column_ids: Vec<ColumnId>,
 }
 
 impl TableMetaBuilder {
@@ -150,6 +152,7 @@ impl TableMetaBuilder {
             options: None,
             created_on: None,
             partition_key_indices: None,
+            column_ids: None,
         }
     }
 }
@@ -178,6 +181,7 @@ impl TableMetaBuilder {
             options: None,
             created_on: None,
             partition_key_indices: None,
+            column_ids: None,
         }
     }
 }
@@ -1088,7 +1092,7 @@ pub struct RawTableMeta {
     /// Engine type of this table. Usually in small case.
     pub engine: String,
     /// Next column id of a new column.
-    /// Deprecated. See https://github.com/GreptimeTeam/greptimedb/issues/2982
+    /// It's used to ensure all columns with the same name across all regions have the same column id.
     pub next_column_id: ColumnId,
     pub region_numbers: Vec<u32>,
     pub options: TableOptions,
@@ -1096,6 +1100,10 @@ pub struct RawTableMeta {
     /// Order doesn't matter to this array.
     #[serde(default)]
     pub partition_key_indices: Vec<usize>,
+    /// Map of column name to column id.
+    /// Note: This field may be empty for older versions that did not include this field.
+    #[serde(default)]
+    pub column_ids: Vec<ColumnId>,
 }
 
 impl From<TableMeta> for RawTableMeta {
@@ -1110,6 +1118,7 @@ impl From<TableMeta> for RawTableMeta {
             options: meta.options,
             created_on: meta.created_on,
             partition_key_indices: meta.partition_key_indices,
+            column_ids: meta.column_ids,
         }
     }
 }
@@ -1128,6 +1137,7 @@ impl TryFrom<RawTableMeta> for TableMeta {
             options: raw.options,
             created_on: raw.created_on,
             partition_key_indices: raw.partition_key_indices,
+            column_ids: raw.column_ids,
         })
     }
 }
@@ -1145,6 +1155,24 @@ pub struct RawTableInfo {
 }
 
 impl RawTableInfo {
+    /// Returns the map of column name to column id.
+    ///
+    /// Note: This method may return an empty map for older versions that did not include this field.
+    pub fn name_to_ids(&self) -> Option<HashMap<String, ColumnId>> {
+        if self.meta.column_ids.len() != self.meta.schema.column_schemas.len() {
+            None
+        } else {
+            Some(
+                self.meta
+                    .column_ids
+                    .iter()
+                    .enumerate()
+                    .map(|(index, id)| (self.meta.schema.column_schemas[index].name.clone(), *id))
+                    .collect(),
+            )
+        }
+    }
+
     /// Sort the columns in [RawTableInfo], logical tables require it.
     pub fn sort_columns(&mut self) {
         let column_schemas = &self.meta.schema.column_schemas;
@@ -1155,6 +1183,7 @@ impl RawTableInfo {
             .map(|index| column_schemas[*index].name.clone())
             .collect::<HashSet<_>>();
 
+        let name_to_ids = self.name_to_ids().unwrap_or_default();
         self.meta
             .schema
             .column_schemas
@@ -1165,6 +1194,7 @@ impl RawTableInfo {
         let mut timestamp_index = None;
         let mut value_indices =
             Vec::with_capacity(self.meta.schema.column_schemas.len() - primary_keys.len() - 1);
+        let mut column_ids = Vec::with_capacity(self.meta.schema.column_schemas.len());
         for (index, column_schema) in self.meta.schema.column_schemas.iter().enumerate() {
             if primary_keys.contains(&column_schema.name) {
                 primary_key_indices.push(index);
@@ -1173,12 +1203,16 @@ impl RawTableInfo {
             } else {
                 value_indices.push(index);
             }
+            if let Some(id) = name_to_ids.get(&column_schema.name) {
+                column_ids.push(*id);
+            }
         }
 
         // Overwrite table meta
         self.meta.schema.timestamp_index = timestamp_index;
         self.meta.primary_key_indices = primary_key_indices;
         self.meta.value_indices = value_indices;
+        self.meta.column_ids = column_ids;
     }
 
     /// Extracts region options from table info.

--- a/src/table/src/table/numbers.rs
+++ b/src/table/src/table/numbers.rs
@@ -81,6 +81,7 @@ impl NumbersTable {
             options: Default::default(),
             created_on: Default::default(),
             partition_key_indices: vec![],
+            column_ids: vec![],
         };
 
         let table_info = TableInfoBuilder::default()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#6429
## What's changed and what's your intention?

This PR implements the persistence of column ids in table metadata.

### Change
  - Enhanced `build_new_physical_table_info` with column id handling
  - DDL Operations: Update all major DDL operations to handle column ids
  - Create table, alter table, create logical tables, alter logical tables
  - Testing: Add column ID validation tests for DDL operations


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
