### PR TITLE
fix: add backward compatibility for `SkippingIndexOptions` deserialization

### DIFF
--- a/src/datatypes/src/schema/column_schema.rs
+++ b/src/datatypes/src/schema/column_schema.rs
@@ -527,7 +527,7 @@ pub struct FulltextOptions {
     #[serde(default = "fulltext_options_default_granularity")]
     pub granularity: u32,
     /// The false positive rate of the fulltext index (for bloom backend only)
-    #[serde(default = "fulltext_options_default_false_positive_rate_in_10000")]
+    #[serde(default = "index_options_default_false_positive_rate_in_10000")]
     pub false_positive_rate_in_10000: u32,
 }
 
@@ -535,7 +535,7 @@ fn fulltext_options_default_granularity() -> u32 {
     DEFAULT_GRANULARITY
 }
 
-fn fulltext_options_default_false_positive_rate_in_10000() -> u32 {
+fn index_options_default_false_positive_rate_in_10000() -> u32 {
     (DEFAULT_FALSE_POSITIVE_RATE * 10000.0) as u32
 }
 
@@ -773,15 +773,11 @@ pub struct SkippingIndexOptions {
     /// The granularity of the skip index.
     pub granularity: u32,
     /// The false positive rate of the skip index (in ten-thousandths, e.g., 100 = 1%).
-    #[serde(default = "skipping_index_options_default_false_positive_rate_in_10000")]
+    #[serde(default = "index_options_default_false_positive_rate_in_10000")]
     pub false_positive_rate_in_10000: u32,
     /// The type of the skip index.
     #[serde(default)]
     pub index_type: SkippingIndexType,
-}
-
-fn skipping_index_options_default_false_positive_rate_in_10000() -> u32 {
-    (DEFAULT_FALSE_POSITIVE_RATE * 10000.0) as u32
 }
 
 impl SkippingIndexOptions {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
