### PR TITLE
fix: filter empty batch in bulk insert api

### DIFF
--- a/src/mito2/src/worker/handle_bulk_insert.rs
+++ b/src/mito2/src/worker/handle_bulk_insert.rs
@@ -41,6 +41,10 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             .with_label_values(&["process_bulk_req"])
             .start_timer();
         let batch = request.payload;
+        if batch.num_rows() == 0 {
+            sender.send(Ok(0));
+            return;
+        }
 
         let Some((ts_index, ts)) = batch
             .schema()

--- a/src/operator/src/bulk_insert.rs
+++ b/src/operator/src/bulk_insert.rs
@@ -159,6 +159,9 @@ impl Inserter {
         let mut raw_data_bytes = None;
         for (peer, masks) in mask_per_datanode {
             for (region_id, mask) in masks {
+                if mask.select_none() {
+                    continue;
+                }
                 let rb = record_batch.clone();
                 let schema_bytes = schema_bytes.clone();
                 let node_manager = self.node_manager.clone();

--- a/src/operator/src/bulk_insert.rs
+++ b/src/operator/src/bulk_insert.rs
@@ -62,6 +62,10 @@ impl Inserter {
         };
         decode_timer.observe_duration();
 
+        if record_batch.num_rows() == 0 {
+            return Ok(0);
+        }
+
         // notify flownode to update dirty timestamps if flow is configured.
         self.maybe_update_flow_dirty_window(table_info, record_batch.clone());
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

 **Handle Empty Batches in Bulk Insert Operations**                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                            
 - Updated `handle_bulk_insert.rs` to handle cases where the batch has zero rows by sending an immediate response and returning early.                                                                                                                                                                                      
 - Modified `bulk_insert.rs` to return early when `record_batch` has zero rows, ensuring efficient processing.                                                                                                                                                                                                              
 - Enhanced logic in `bulk_insert.rs` to skip processing when `mask.select_none()` is true, optimizing data handling.                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                            
 These changes improve the efficiency and robustness of bulk insert operations by handling edge cases where no data is present.      

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
