### PR TITLE
fix: empty statements hang

### DIFF
--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -383,6 +383,13 @@ impl SqlQueryHandler for Instance {
             .and_then(|stmts| query_interceptor.post_parsing(stmts, query_ctx.clone()))
         {
             Ok(stmts) => {
+                if stmts.is_empty() {
+                    return vec![InvalidSqlSnafu {
+                        err_msg: "empty statements",
+                    }
+                    .fail()];
+                }
+
                 let mut results = Vec::with_capacity(stmts.len());
                 for stmt in stmts {
                     if let Err(e) = checker

--- a/tests-integration/tests/sql.rs
+++ b/tests-integration/tests/sql.rs
@@ -152,6 +152,10 @@ pub async fn test_mysql_stmts(store_type: StorageType) {
 
     conn.execute("SET TRANSACTION READ ONLY").await.unwrap();
 
+    // empty statements
+    let err = conn.execute("----------\n;").await.unwrap_err();
+    assert!(err.to_string().contains("empty statements"));
+
     let _ = fe_mysql_server.shutdown().await;
     guard.remove_all().await;
 }

--- a/tests-integration/tests/sql.rs
+++ b/tests-integration/tests/sql.rs
@@ -153,7 +153,13 @@ pub async fn test_mysql_stmts(store_type: StorageType) {
     conn.execute("SET TRANSACTION READ ONLY").await.unwrap();
 
     // empty statements
+    let err = conn.execute("      -------  ;").await.unwrap_err();
+    assert!(err.to_string().contains("empty statements"));
     let err = conn.execute("----------\n;").await.unwrap_err();
+    assert!(err.to_string().contains("empty statements"));
+    let err = conn.execute("        ;").await.unwrap_err();
+    assert!(err.to_string().contains("empty statements"));
+    let err = conn.execute("    \n    ;").await.unwrap_err();
     assert!(err.to_string().contains("empty statements"));
 
     let _ = fe_mysql_server.shutdown().await;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Before this patch, empty query will cause the mysql command line hang:

<img width="391" alt="Screenshot 2025-07-08 at 19 19 54" src="https://github.com/user-attachments/assets/2dc21033-fbcb-474d-b2a5-98504fa67ab8" />

After patching, it will raise an error:

```sql
Invalid SQL, error: empty statements.
```

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
