### PR TITLE
fix: skip nan in prom remote write pipeline

### DIFF
--- a/src/servers/src/proto.rs
+++ b/src/servers/src/proto.rs
@@ -390,6 +390,10 @@ impl PromSeriesProcessor {
         let one_sample = series.samples.len() == 1;
 
         for s in series.samples.iter() {
+            // skip NaN value
+            if s.value.is_nan() {
+                continue;
+            }
             let timestamp = s.timestamp;
             pipeline_map.insert(GREPTIME_TIMESTAMP.to_string(), Value::Int64(timestamp));
             pipeline_map.insert(GREPTIME_VALUE.to_string(), Value::Float64(s.value));


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Skip the NaN value in Prometheus remote write for pipeline execution.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
