### PR TITLE
fix: record merge scan metrics even cancelled

### DIFF
--- a/src/query/src/analyze.rs
+++ b/src/query/src/analyze.rs
@@ -156,6 +156,9 @@ impl ExecutionPlan for DistAnalyzeExec {
             while let Some(batch) = input_stream.next().await.transpose()? {
                 total_rows += batch.num_rows();
             }
+            // must drop input stream before starting collect metrics to make sure
+            // all metrics are collected(especially for MergeScanExec which collect metrics on drop stream)
+            drop(input_stream);
 
             create_output_batch(total_rows, captured_input, captured_schema, format, verbose)
         };


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

as title, still need to record merge scan stream when stream is cancelled, previously if merge scan stream is cancelled for some reason, this stream's metrics will be lost

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
