### PR TITLE
feat: override batch sequence by the sequence in FileMeta

### DIFF
--- a/src/mito2/src/memtable/bulk/part.rs
+++ b/src/mito2/src/memtable/bulk/part.rs
@@ -694,7 +694,7 @@ mod tests {
         let read_format = ReadFormat::new_with_all_columns(metadata.clone());
         let mut batches = VecDeque::new();
         read_format
-            .convert_record_batch(&batch, &mut batches)
+            .convert_record_batch(&batch, None, &mut batches)
             .unwrap();
         if !dedup {
             assert_eq!(

--- a/src/mito2/src/sst/parquet/format.rs
+++ b/src/mito2/src/sst/parquet/format.rs
@@ -724,14 +724,10 @@ pub(crate) fn need_override_sequence(parquet_meta: &ParquetMetaData) -> bool {
     let sequence_pos = num_columns - 2;
 
     // Check row group 0
-    if let Some(row_group) = parquet_meta.row_groups().get(0) {
-        if let Some(stats) = row_group.column(sequence_pos).statistics() {
-            if let Statistics::Int64(value_stats) = stats {
-                if let (Some(min_val), Some(max_val)) =
-                    (value_stats.min_opt(), value_stats.max_opt())
-                {
-                    return *min_val == 0 && *max_val == 0;
-                }
+    if let Some(row_group) = parquet_meta.row_groups().first() {
+        if let Some(Statistics::Int64(value_stats)) = row_group.column(sequence_pos).statistics() {
+            if let (Some(min_val), Some(max_val)) = (value_stats.min_opt(), value_stats.max_opt()) {
+                return *min_val == 0 && *max_val == 0;
             }
         }
     }

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -1259,6 +1259,7 @@ where
 {
     /// Creates a new reader.
     pub(crate) fn create(context: T, reader: ParquetRecordBatchReader) -> Self {
+        // The batch length from the reader should be less than or equal to DEFAULT_READ_BATCH_SIZE.
         let override_sequence = context
             .read_format()
             .new_override_sequence_array(DEFAULT_READ_BATCH_SIZE);

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -23,6 +23,7 @@ use async_trait::async_trait;
 use common_recordbatch::filter::SimpleFilterEvaluator;
 use common_telemetry::{debug, warn};
 use datafusion_expr::Expr;
+use datatypes::arrow::array::ArrayRef;
 use datatypes::arrow::error::ArrowError;
 use datatypes::arrow::record_batch::RecordBatch;
 use datatypes::data_type::ConcreteDataType;
@@ -54,7 +55,7 @@ use crate::sst::index::bloom_filter::applier::BloomFilterIndexApplierRef;
 use crate::sst::index::fulltext_index::applier::FulltextIndexApplierRef;
 use crate::sst::index::inverted_index::applier::InvertedIndexApplierRef;
 use crate::sst::parquet::file_range::{FileRangeContext, FileRangeContextRef};
-use crate::sst::parquet::format::ReadFormat;
+use crate::sst::parquet::format::{need_override_sequence, ReadFormat};
 use crate::sst::parquet::metadata::MetadataLoader;
 use crate::sst::parquet::row_group::InMemoryRowGroup;
 use crate::sst::parquet::row_selection::RowGroupSelection;
@@ -220,7 +221,7 @@ impl ParquetReaderBuilder {
         let key_value_meta = parquet_meta.file_metadata().key_value_metadata();
         // Gets the metadata stored in the SST.
         let region_meta = Arc::new(Self::get_region_metadata(&file_path, key_value_meta)?);
-        let read_format = if let Some(column_ids) = &self.projection {
+        let mut read_format = if let Some(column_ids) = &self.projection {
             ReadFormat::new(region_meta.clone(), column_ids.iter().copied())
         } else {
             // Lists all column ids to read, we always use the expected metadata if possible.
@@ -233,6 +234,10 @@ impl ParquetReaderBuilder {
                     .map(|col| col.column_id),
             )
         };
+        if need_override_sequence(&parquet_meta) {
+            read_format
+                .set_override_sequence(self.file_handle.meta_ref().sequence.map(|x| x.get()));
+        }
 
         // Computes the projection mask.
         let parquet_schema_desc = parquet_meta.file_metadata().schema_descr();
@@ -1230,12 +1235,7 @@ pub(crate) type RowGroupReader = RowGroupReaderBase<FileRangeContextRef>;
 impl RowGroupReader {
     /// Creates a new reader from file range.
     pub(crate) fn new(context: FileRangeContextRef, reader: ParquetRecordBatchReader) -> Self {
-        Self {
-            context,
-            reader,
-            batches: VecDeque::new(),
-            metrics: ReaderMetrics::default(),
-        }
+        Self::create(context, reader)
     }
 }
 
@@ -1249,6 +1249,8 @@ pub(crate) struct RowGroupReaderBase<T> {
     batches: VecDeque<Batch>,
     /// Local scan metrics.
     metrics: ReaderMetrics,
+    /// Cached sequence array to override sequences.
+    override_sequence: Option<ArrayRef>,
 }
 
 impl<T> RowGroupReaderBase<T>
@@ -1257,11 +1259,15 @@ where
 {
     /// Creates a new reader.
     pub(crate) fn create(context: T, reader: ParquetRecordBatchReader) -> Self {
+        let override_sequence = context
+            .read_format()
+            .new_override_sequence_array(DEFAULT_READ_BATCH_SIZE);
         Self {
             context,
             reader,
             batches: VecDeque::new(),
             metrics: ReaderMetrics::default(),
+            override_sequence,
         }
     }
 
@@ -1297,9 +1303,11 @@ where
             };
             self.metrics.num_record_batches += 1;
 
-            self.context
-                .read_format()
-                .convert_record_batch(&record_batch, &mut self.batches)?;
+            self.context.read_format().convert_record_batch(
+                &record_batch,
+                self.override_sequence.as_ref(),
+                &mut self.batches,
+            )?;
             self.metrics.num_batches += self.batches.len();
         }
         let batch = self.batches.pop_front();

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -72,7 +72,7 @@ use crate::error::Result;
 use crate::flush::{WriteBufferManager, WriteBufferManagerRef};
 use crate::manifest::manager::{RegionManifestManager, RegionManifestOptions};
 use crate::read::{Batch, BatchBuilder, BatchReader};
-use crate::sst::file_purger::{FilePurger, FilePurgerRef, NoopFilePurger, PurgeRequest};
+use crate::sst::file_purger::{FilePurgerRef, NoopFilePurger};
 use crate::sst::index::intermediate::IntermediateManager;
 use crate::sst::index::puffin_manager::PuffinManagerFactory;
 use crate::time_provider::{StdTimeProvider, TimeProviderRef};

--- a/src/mito2/src/test_util/sst_util.rs
+++ b/src/mito2/src/test_util/sst_util.rs
@@ -138,16 +138,26 @@ pub fn sst_file_handle(start_ms: i64, end_ms: i64) -> FileHandle {
     sst_file_handle_with_file_id(FileId::random(), start_ms, end_ms)
 }
 
-pub fn new_batch_by_range(tags: &[&str], start: usize, end: usize) -> Batch {
+/// Creates a new batch with custom sequence for testing.
+pub fn new_batch_with_custom_sequence(
+    tags: &[&str],
+    start: usize,
+    end: usize,
+    sequence: u64,
+) -> Batch {
     assert!(end >= start);
     let pk = new_primary_key(tags);
     let timestamps: Vec<_> = (start..end).map(|v| v as i64).collect();
-    let sequences = vec![1000; end - start];
+    let sequences = vec![sequence; end - start];
     let op_types = vec![OpType::Put; end - start];
     let field: Vec<_> = (start..end).map(|v| v as u64).collect();
     new_batch_builder(&pk, &timestamps, &sequences, &op_types, 2, &field)
         .build()
         .unwrap()
+}
+
+pub fn new_batch_by_range(tags: &[&str], start: usize, end: usize) -> Batch {
+    new_batch_with_custom_sequence(tags, start, end, 1000)
 }
 
 pub fn new_batch_with_binary(tags: &[&str], start: usize, end: usize) -> Batch {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

Allow using the sequence in the FileMeta to set the Batch sequence when the sequence stored in the parquet is 0.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
