### PR TITLE
fix: add tracing dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2531,6 +2531,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tonic 0.12.3",
+ "tracing",
  "typetag",
  "uuid",
 ]
@@ -3806,6 +3807,7 @@ dependencies = [
  "tokio",
  "toml 0.8.19",
  "tonic 0.12.3",
+ "tracing",
 ]
 
 [[package]]
@@ -4794,6 +4796,7 @@ dependencies = [
  "toml 0.8.19",
  "tonic 0.12.3",
  "tower 0.5.2",
+ "tracing",
  "uuid",
 ]
 
@@ -7297,6 +7300,7 @@ dependencies = [
  "snafu 0.8.5",
  "store-api",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -7445,6 +7449,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "toml 0.8.19",
+ "tracing",
  "uuid",
 ]
 
@@ -8524,6 +8529,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tonic 0.12.3",
+ "tracing",
 ]
 
 [[package]]
@@ -9925,6 +9931,7 @@ dependencies = [
  "table",
  "tokio",
  "tokio-stream",
+ "tracing",
  "unescaper",
  "uuid",
 ]
@@ -11358,6 +11365,7 @@ dependencies = [
  "tonic-reflection",
  "tower 0.5.2",
  "tower-http 0.6.2",
+ "tracing",
  "urlencoding",
  "uuid",
  "zstd 0.13.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,6 +223,7 @@ tokio-util = { version = "0.7", features = ["io-util", "compat"] }
 toml = "0.8.8"
 tonic = { version = "0.12", features = ["tls", "gzip", "zstd"] }
 tower = "0.5"
+tracing = "0.1"
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "fmt"] }
 typetag = "0.2"

--- a/src/common/meta/Cargo.toml
+++ b/src/common/meta/Cargo.toml
@@ -69,6 +69,7 @@ table = { workspace = true, features = ["testing"] }
 tokio.workspace = true
 tokio-postgres = { workspace = true, optional = true }
 tonic.workspace = true
+tracing.workspace = true
 typetag.workspace = true
 
 [dev-dependencies]

--- a/src/datanode/Cargo.toml
+++ b/src/datanode/Cargo.toml
@@ -66,6 +66,7 @@ table.workspace = true
 tokio.workspace = true
 toml.workspace = true
 tonic.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 cache.workspace = true

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -74,6 +74,7 @@ tokio.workspace = true
 tokio-util.workspace = true
 toml.workspace = true
 tonic.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 catalog = { workspace = true, features = ["testing"] }

--- a/src/metric-engine/Cargo.toml
+++ b/src/metric-engine/Cargo.toml
@@ -38,6 +38,7 @@ smallvec.workspace = true
 snafu.workspace = true
 store-api.workspace = true
 tokio.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 common-meta = { workspace = true, features = ["testing"] }

--- a/src/mito2/Cargo.toml
+++ b/src/mito2/Cargo.toml
@@ -75,6 +75,7 @@ table.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
 tokio-util.workspace = true
+tracing.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]

--- a/src/operator/Cargo.toml
+++ b/src/operator/Cargo.toml
@@ -69,6 +69,7 @@ table.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tonic.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 common-meta = { workspace = true, features = ["testing"] }

--- a/src/query/Cargo.toml
+++ b/src/query/Cargo.toml
@@ -71,6 +71,7 @@ store-api.workspace = true
 substrait.workspace = true
 table.workspace = true
 tokio.workspace = true
+tracing.workspace = true
 unescaper = "0.1"
 uuid.workspace = true
 

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -125,6 +125,7 @@ tonic.workspace = true
 tonic-reflection = "0.12"
 tower = { workspace = true, features = ["full"] }
 tower-http = { version = "0.6", features = ["full"] }
+tracing.workspace = true
 urlencoding = "2.1"
 uuid.workspace = true
 zstd.workspace = true


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

These modules are using tracing crate but they didn't declare it as a dependency. This becomes an issue when using them as a library.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
