### PR TITLE
fix: fix state transition in create table procedure

### DIFF
--- a/src/common/datasource/src/object_store/oss.rs
+++ b/src/common/datasource/src/object_store/oss.rs
@@ -77,6 +77,11 @@ pub fn build_oss_backend(
 
     let op = ObjectStore::new(builder)
         .context(error::BuildBackendSnafu)?
+        .layer(
+            object_store::layers::RetryLayer::new()
+                .with_jitter()
+                .with_notify(object_store::util::PrintDetailedError),
+        )
         .layer(object_store::layers::LoggingLayer::default())
         .layer(object_store::layers::TracingLayer)
         .layer(object_store::layers::build_prometheus_metrics_layer(true))

--- a/src/common/datasource/src/object_store/s3.rs
+++ b/src/common/datasource/src/object_store/s3.rs
@@ -85,6 +85,11 @@ pub fn build_s3_backend(
     // TODO(weny): Consider finding a better way to eliminate duplicate code.
     Ok(ObjectStore::new(builder)
         .context(error::BuildBackendSnafu)?
+        .layer(
+            object_store::layers::RetryLayer::new()
+                .with_jitter()
+                .with_notify(object_store::util::PrintDetailedError),
+        )
         .layer(object_store::layers::LoggingLayer::new(
             DefaultLoggingInterceptor,
         ))

--- a/src/common/meta/src/ddl/alter_table.rs
+++ b/src/common/meta/src/ddl/alter_table.rs
@@ -227,7 +227,6 @@ impl AlterTableProcedure {
     }
 
     fn handle_alter_region_response(&mut self, mut results: Vec<RegionResponse>) -> Result<()> {
-        self.data.state = AlterTableState::UpdateMetadata;
         if let Some(column_metadatas) =
             extract_column_metadatas(&mut results, TABLE_COLUMN_METADATA_EXTENSION_KEY)?
         {
@@ -235,7 +234,7 @@ impl AlterTableProcedure {
         } else {
             warn!("altering table result doesn't contains extension key `{TABLE_COLUMN_METADATA_EXTENSION_KEY}`,leaving the table's column metadata unchanged");
         }
-
+        self.data.state = AlterTableState::UpdateMetadata;
         Ok(())
     }
 

--- a/src/common/meta/src/ddl/utils.rs
+++ b/src/common/meta/src/ddl/utils.rs
@@ -446,6 +446,7 @@ pub fn extract_column_metadatas(
         .collect::<Vec<_>>();
 
     if schemas.is_empty() {
+        warn!("extract_column_metadatas: no extension key `{key}` found in results");
         return Ok(None);
     }
 

--- a/src/datanode/src/store.rs
+++ b/src/datanode/src/store.rs
@@ -16,15 +16,14 @@
 
 use std::path::Path;
 use std::sync::Arc;
-use std::time::Duration;
 
-use common_telemetry::{info, warn};
+use common_telemetry::info;
 use object_store::factory::new_raw_object_store;
-use object_store::layers::{LruCacheLayer, RetryInterceptor, RetryLayer};
+use object_store::layers::{LruCacheLayer, RetryLayer};
 use object_store::services::Fs;
-use object_store::util::{clean_temp_dir, join_dir, with_instrument_layers};
+use object_store::util::{clean_temp_dir, join_dir, with_instrument_layers, PrintDetailedError};
 use object_store::{
-    Access, Error, ObjectStore, ObjectStoreBuilder, ATOMIC_WRITE_DIR, OLD_ATOMIC_WRITE_DIR,
+    Access, ObjectStore, ObjectStoreBuilder, ATOMIC_WRITE_DIR, OLD_ATOMIC_WRITE_DIR,
 };
 use snafu::prelude::*;
 
@@ -174,14 +173,5 @@ async fn build_cache_layer(
         Ok(Some(cache_layer))
     } else {
         Ok(None)
-    }
-}
-
-struct PrintDetailedError;
-
-// PrintDetailedError is a retry interceptor that prints error in Debug format in retrying.
-impl RetryInterceptor for PrintDetailedError {
-    fn intercept(&self, err: &Error, dur: Duration) {
-        warn!("Retry after {}s, error: {:#?}", dur.as_secs_f64(), err);
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

- Add `RetryLayer` with jitter and PrintDetailedError notification to OSS and S3 backends
- Move PrintDetailedError from datanode store to object-store util module for reuse
- Improve logging in create_table and alter_table procedures with procedure_id
- Add warning when no extension key found in extract_column_metadatas
- Fix state transition in create table procedure

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
