### PR TITLE
feat: supports null reponse format for http API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ greptimedb_data
 
 # github
 !/.github
+
+# Claude code
+CLAUDE.md

--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -43,6 +43,7 @@ use crate::http::result::error_result::ErrorResponse;
 use crate::http::result::greptime_result_v1::GreptimedbV1Response;
 use crate::http::result::influxdb_result_v1::InfluxdbV1Response;
 use crate::http::result::json_result::JsonResponse;
+use crate::http::result::null_result::NullResponse;
 use crate::http::result::table_result::TableResponse;
 use crate::http::{
     ApiState, Epoch, GreptimeOptionsConfigState, GreptimeQueryOutput, HttpRecordsOutput,
@@ -145,6 +146,7 @@ pub async fn sql(
         ResponseFormat::GreptimedbV1 => GreptimedbV1Response::from_output(outputs).await,
         ResponseFormat::InfluxdbV1 => InfluxdbV1Response::from_output(outputs, epoch).await,
         ResponseFormat::Json => JsonResponse::from_output(outputs).await,
+        ResponseFormat::Null => NullResponse::from_output(outputs).await,
     };
 
     if let Some(limit) = query_params.limit {
@@ -336,6 +338,7 @@ pub async fn promql(
             ResponseFormat::GreptimedbV1 => GreptimedbV1Response::from_output(outputs).await,
             ResponseFormat::InfluxdbV1 => InfluxdbV1Response::from_output(outputs, epoch).await,
             ResponseFormat::Json => JsonResponse::from_output(outputs).await,
+            ResponseFormat::Null => NullResponse::from_output(outputs).await,
         }
     };
 

--- a/src/servers/src/http/result.rs
+++ b/src/servers/src/http/result.rs
@@ -19,5 +19,6 @@ pub(crate) mod greptime_manage_resp;
 pub mod greptime_result_v1;
 pub mod influxdb_result_v1;
 pub(crate) mod json_result;
+pub(crate) mod null_result;
 pub(crate) mod prometheus_resp;
 pub(crate) mod table_result;

--- a/src/servers/src/http/result/null_result.rs
+++ b/src/servers/src/http/result/null_result.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::fmt::Write;
 
 use axum::http::{header, HeaderValue};
@@ -144,6 +158,6 @@ mod tests {
         let body_bytes = to_bytes(response.into_body(), 1024).await.unwrap();
         let body = String::from_utf8(body_bytes.to_vec()).unwrap();
         assert!(body.contains("42 rows in set."));
-        assert!(body.contains("1234 ms."));
+        assert!(body.contains("Elapsed: 1234 ms."));
     }
 }

--- a/src/servers/src/http/result/null_result.rs
+++ b/src/servers/src/http/result/null_result.rs
@@ -99,7 +99,8 @@ impl IntoResponse for NullResponse {
                 let _ = writeln!(body, "{} rows in set.", rows);
             }
         }
-        let _ = writeln!(body, "Elapsed: {} ms.", self.execution_time_ms);
+        let elapsed_secs = (self.execution_time_ms as f64) / 1000.0;
+        let _ = writeln!(body, "Elapsed: {:.3} sec.", elapsed_secs);
 
         let mut resp = (
             [(
@@ -158,6 +159,6 @@ mod tests {
         let body_bytes = to_bytes(response.into_body(), 1024).await.unwrap();
         let body = String::from_utf8(body_bytes.to_vec()).unwrap();
         assert!(body.contains("42 rows in set."));
-        assert!(body.contains("Elapsed: 1234 ms."));
+        assert!(body.contains("Elapsed: 1.234 sec."));
     }
 }

--- a/src/servers/src/http/result/null_result.rs
+++ b/src/servers/src/http/result/null_result.rs
@@ -1,0 +1,149 @@
+use std::fmt::Write;
+
+use axum::http::{header, HeaderValue};
+use axum::response::{IntoResponse, Response};
+use common_error::status_code::StatusCode;
+use common_query::Output;
+use mime_guess::mime;
+use serde::{Deserialize, Serialize};
+
+use crate::http::header::{GREPTIME_DB_HEADER_EXECUTION_TIME, GREPTIME_DB_HEADER_FORMAT};
+use crate::http::result::error_result::ErrorResponse;
+use crate::http::{handler, GreptimeQueryOutput, HttpResponse, ResponseFormat};
+
+#[derive(Serialize, Deserialize, Debug)]
+enum Rows {
+    Affected(usize),
+    Queried(usize),
+}
+
+/// The null format is a simple text format that outputs the number of affected rows or queried rows
+#[derive(Serialize, Deserialize, Debug)]
+pub struct NullResponse {
+    rows: Rows,
+    execution_time_ms: u64,
+}
+
+impl NullResponse {
+    pub async fn from_output(outputs: Vec<crate::error::Result<Output>>) -> HttpResponse {
+        match handler::from_output(outputs).await {
+            Err(err) => HttpResponse::Error(err),
+            Ok((mut output, _)) => {
+                if output.len() > 1 {
+                    HttpResponse::Error(ErrorResponse::from_error_message(
+                        StatusCode::InvalidArguments,
+                        "cannot output multi-statements result in null format".to_string(),
+                    ))
+                } else {
+                    match output.pop() {
+                        Some(GreptimeQueryOutput::AffectedRows(rows)) => {
+                            HttpResponse::Null(NullResponse {
+                                rows: Rows::Affected(rows),
+                                execution_time_ms: 0,
+                            })
+                        }
+
+                        Some(GreptimeQueryOutput::Records(records)) => {
+                            HttpResponse::Null(NullResponse {
+                                rows: Rows::Queried(records.num_rows()),
+                                execution_time_ms: 0,
+                            })
+                        }
+                        _ => HttpResponse::Error(ErrorResponse::from_error_message(
+                            StatusCode::Unexpected,
+                            "unexpected output type".to_string(),
+                        )),
+                    }
+                }
+            }
+        }
+    }
+
+    /// Returns the number of rows affected or queried.
+    pub fn rows(&self) -> usize {
+        match &self.rows {
+            Rows::Affected(rows) => *rows,
+            Rows::Queried(rows) => *rows,
+        }
+    }
+
+    /// Consumes `self`, updates the execution time in milliseconds, and returns the updated instance.
+    pub(crate) fn with_execution_time(mut self, execution_time: u64) -> Self {
+        self.execution_time_ms = execution_time;
+        self
+    }
+}
+
+impl IntoResponse for NullResponse {
+    fn into_response(self) -> Response {
+        let mut body = String::new();
+        match self.rows {
+            Rows::Affected(rows) => {
+                let _ = writeln!(body, "{} rows affected.", rows);
+            }
+            Rows::Queried(rows) => {
+                let _ = writeln!(body, "{} rows in set.", rows);
+            }
+        }
+        let _ = writeln!(body, "Elapsed: {} ms.", self.execution_time_ms);
+
+        let mut resp = (
+            [(
+                header::CONTENT_TYPE,
+                HeaderValue::from_static(mime::TEXT_PLAIN_UTF_8.as_ref()),
+            )],
+            body,
+        )
+            .into_response();
+        resp.headers_mut().insert(
+            &GREPTIME_DB_HEADER_FORMAT,
+            HeaderValue::from_static(ResponseFormat::Null.as_str()),
+        );
+        resp.headers_mut().insert(
+            &GREPTIME_DB_HEADER_EXECUTION_TIME,
+            HeaderValue::from(self.execution_time_ms),
+        );
+
+        resp
+    }
+}
+#[cfg(test)]
+mod tests {
+    use axum::body::to_bytes;
+    use axum::http;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_into_response_format() {
+        let result = NullResponse {
+            rows: Rows::Queried(42),
+            execution_time_ms: 1234,
+        };
+        let response = result.into_response();
+
+        // Check status code
+        assert_eq!(response.status(), http::StatusCode::OK);
+
+        // Check headers
+        let headers = response.headers();
+        assert_eq!(
+            headers.get(axum::http::header::CONTENT_TYPE).unwrap(),
+            mime::TEXT_PLAIN_UTF_8.as_ref()
+        );
+        assert_eq!(
+            headers.get(&GREPTIME_DB_HEADER_FORMAT).unwrap(),
+            ResponseFormat::Null.as_str()
+        );
+        assert_eq!(
+            headers.get(&GREPTIME_DB_HEADER_EXECUTION_TIME).unwrap(),
+            "1234"
+        );
+
+        // Check body
+        let body_bytes = to_bytes(response.into_body(), 1024).await.unwrap();
+        let body = String::from_utf8(body_bytes.to_vec()).unwrap();
+        assert!(body.contains("42 rows in set."));
+        assert!(body.contains("1234 ms."));
+    }
+}

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -480,6 +480,14 @@ pub async fn test_sql_api(store_type: StorageType) {
         body,
         "cpu,ts,host\r\nFloat64,TimestampMillisecond,String\r\n66.6,0,\"host, \"\"name\"\r\n"
     );
+    // test null format
+    let res = client
+        .get("/v1/sql?format=null&sql=select cpu,ts,host from demo limit 1")
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = &res.text().await;
+    assert!(body.contains("1 rows in set."));
 
     // test parse method
     let res = client.get("/v1/sql/parse?sql=desc table t").send().await;

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -488,6 +488,7 @@ pub async fn test_sql_api(store_type: StorageType) {
     assert_eq!(res.status(), StatusCode::OK);
     let body = &res.text().await;
     assert!(body.contains("1 rows in set."));
+    assert!(body.ends_with("sec.\n"));
 
     // test parse method
     let res = client.get("/v1/sql/parse?sql=desc table t").send().await;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Close #6528 

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

Introduces a `null` format, like ClickHouse's, that concisely displays only the row count and elapsed time, making it useful for evaluating query performance.

```bash
curl -X POST \
  -H 'Authorization: Basic {{authorization if exists}}' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d "sql=SELECT * FROM monitor" \
  http://localhost:4000/v1/sql\?db\=public\&format\=null

1 rows in set.
Elapsed: 0.006 ms.
```

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
