### PR TITLE
fix: row selection intersection removes trailing rows

### DIFF
--- a/src/mito2/src/sst/parquet/row_selection.rs
+++ b/src/mito2/src/sst/parquet/row_selection.rs
@@ -431,7 +431,7 @@ impl RowGroupSelection {
 /// other:     NYNNNNNNY
 ///
 /// returned:  NNNNNNNNY     (modified)
-///            NNNNNNNNYYNYN (orignal)
+///            NNNNNNNNYYNYN (original)
 fn intersect_row_selections(left: &RowSelection, right: &RowSelection) -> RowSelection {
     let mut l_iter = left.iter().copied().peekable();
     let mut r_iter = right.iter().copied().peekable();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

```rust
/// Ported from `parquet` but trailing rows are removed.
///
/// Combine two lists of `RowSelection` return the intersection of them
/// For example:
/// self:      NNYYYYNNYYNYN
/// other:     NYNNNNNNY
///
/// returned:  NNNNNNNNY     (modified)
///            NNNNNNNNYYNYN (original)
fn intersect_row_selections(left: &RowSelection, right: &RowSelection) -> RowSelection { ... }
```

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
