### PR TITLE
feat: add metrics for request wait time and adjust stall metrics

### DIFF
--- a/src/mito2/src/compaction.rs
+++ b/src/mito2/src/compaction.rs
@@ -62,7 +62,7 @@ use crate::read::BoxedBatchReader;
 use crate::region::options::MergeMode;
 use crate::region::version::VersionControlRef;
 use crate::region::ManifestContextRef;
-use crate::request::{OptionOutputTx, OutputTx, WorkerRequest};
+use crate::request::{OptionOutputTx, OutputTx, WorkerRequestWithTime};
 use crate::schedule::remote_job_scheduler::{
     CompactionJob, DefaultNotifier, RemoteJob, RemoteJobSchedulerRef,
 };
@@ -77,7 +77,7 @@ pub struct CompactionRequest {
     pub(crate) current_version: CompactionVersion,
     pub(crate) access_layer: AccessLayerRef,
     /// Sender to send notification to the region worker.
-    pub(crate) request_sender: mpsc::Sender<WorkerRequest>,
+    pub(crate) request_sender: mpsc::Sender<WorkerRequestWithTime>,
     /// Waiters of the compaction request.
     pub(crate) waiters: Vec<OutputTx>,
     /// Start time of compaction task.
@@ -101,7 +101,7 @@ pub(crate) struct CompactionScheduler {
     /// Compacting regions.
     region_status: HashMap<RegionId, CompactionStatus>,
     /// Request sender of the worker that this scheduler belongs to.
-    request_sender: Sender<WorkerRequest>,
+    request_sender: Sender<WorkerRequestWithTime>,
     cache_manager: CacheManagerRef,
     engine_config: Arc<MitoConfig>,
     listener: WorkerListener,
@@ -112,7 +112,7 @@ pub(crate) struct CompactionScheduler {
 impl CompactionScheduler {
     pub(crate) fn new(
         scheduler: SchedulerRef,
-        request_sender: Sender<WorkerRequest>,
+        request_sender: Sender<WorkerRequestWithTime>,
         cache_manager: CacheManagerRef,
         engine_config: Arc<MitoConfig>,
         listener: WorkerListener,
@@ -560,7 +560,7 @@ impl CompactionStatus {
     #[allow(clippy::too_many_arguments)]
     fn new_compaction_request(
         &mut self,
-        request_sender: Sender<WorkerRequest>,
+        request_sender: Sender<WorkerRequestWithTime>,
         mut waiter: OptionOutputTx,
         engine_config: Arc<MitoConfig>,
         cache_manager: CacheManagerRef,

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -431,9 +431,10 @@ lazy_static! {
 // Use another block to avoid reaching the recursion limit.
 lazy_static! {
     /// Time waiting for requests to be handled by the region worker.
-    pub static ref REQUEST_WAIT_TIME: Histogram = register_histogram!(
+    pub static ref REQUEST_WAIT_TIME: HistogramVec = register_histogram_vec!(
             "greptime_mito_request_wait_time",
             "mito request wait time before being handled by region worker",
+            &[WORKER_LABEL],
             // 0.001 ~ 10000
             exponential_buckets(0.001, 10.0, 8).unwrap(),
         )

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -428,6 +428,18 @@ lazy_static! {
         ).unwrap();
 }
 
+// Use another block to avoid reaching the recursion limit.
+lazy_static! {
+    /// Time waiting for requests to be handled by the region worker.
+    pub static ref REQUEST_WAIT_TIME: Histogram = register_histogram!(
+            "greptime_mito_request_wait_time",
+            "mito request wait time before being handled by region worker",
+            // 0.001 ~ 10000
+            exponential_buckets(0.001, 10.0, 8).unwrap(),
+        )
+        .unwrap();
+}
+
 /// Stager notifier to collect metrics.
 pub struct StagerMetrics {
     cache_hit: IntCounter,

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -431,6 +431,11 @@ lazy_static! {
             "mito stalled write request in each worker",
             &[WORKER_LABEL]
         ).unwrap();
+    /// Total number of stalled write requests.
+    pub static ref WRITE_STALL_TOTAL: IntCounter = register_int_counter!(
+        "greptime_mito_write_stall_total",
+        "Total number of stalled write requests"
+    ).unwrap();
     /// Time waiting for requests to be handled by the region worker.
     pub static ref REQUEST_WAIT_TIME: HistogramVec = register_histogram_vec!(
             "greptime_mito_request_wait_time",

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -94,12 +94,7 @@ lazy_static! {
 
 
     // ------ Write related metrics
-    /// Number of stalled write requests in each worker.
-    pub static ref WRITE_STALL_TOTAL: IntGaugeVec = register_int_gauge_vec!(
-            "greptime_mito_write_stall_total",
-            "mito stalled write request in each worker",
-            &[WORKER_LABEL]
-        ).unwrap();
+    //
     /// Counter of rejected write requests.
     pub static ref WRITE_REJECT_TOTAL: IntCounter =
         register_int_counter!("greptime_mito_write_reject_total", "mito write reject total").unwrap();
@@ -430,6 +425,12 @@ lazy_static! {
 
 // Use another block to avoid reaching the recursion limit.
 lazy_static! {
+    /// Number of stalling write requests in each worker.
+    pub static ref WRITE_STALLING: IntGaugeVec = register_int_gauge_vec!(
+            "greptime_mito_write_stalling_count",
+            "mito stalled write request in each worker",
+            &[WORKER_LABEL]
+        ).unwrap();
     /// Time waiting for requests to be handled by the region worker.
     pub static ref REQUEST_WAIT_TIME: HistogramVec = register_histogram_vec!(
             "greptime_mito_request_wait_time",

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -397,6 +397,7 @@ lazy_static! {
 
 }
 
+// Use another block to avoid reaching the recursion limit.
 lazy_static! {
     /// Counter for compaction input file size.
     pub static ref COMPACTION_INPUT_BYTES: Counter = register_counter!(
@@ -421,10 +422,7 @@ lazy_static! {
         "greptime_mito_memtable_field_builder_count",
         "active field builder count in TimeSeriesMemtable",
         ).unwrap();
-}
 
-// Use another block to avoid reaching the recursion limit.
-lazy_static! {
     /// Number of stalling write requests in each worker.
     pub static ref WRITE_STALLING: IntGaugeVec = register_int_gauge_vec!(
             "greptime_mito_write_stalling_count",

--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -545,6 +545,22 @@ pub(crate) struct SenderBulkRequest {
     pub(crate) region_metadata: RegionMetadataRef,
 }
 
+/// Request sent to a worker with timestamp
+#[derive(Debug)]
+pub(crate) struct WorkerRequestWithTime {
+    pub(crate) request: WorkerRequest,
+    pub(crate) created_at: Instant,
+}
+
+impl WorkerRequestWithTime {
+    pub(crate) fn new(request: WorkerRequest) -> Self {
+        Self {
+            request,
+            created_at: Instant::now(),
+        }
+    }
+}
+
 /// Request sent to a worker
 #[derive(Debug)]
 pub(crate) enum WorkerRequest {

--- a/src/mito2/src/schedule/remote_job_scheduler.rs
+++ b/src/mito2/src/schedule/remote_job_scheduler.rs
@@ -31,6 +31,7 @@ use crate::manifest::action::RegionEdit;
 use crate::metrics::{COMPACTION_FAILURE_COUNT, INFLIGHT_COMPACTION_COUNT};
 use crate::request::{
     BackgroundNotify, CompactionFailed, CompactionFinished, OutputTx, WorkerRequest,
+    WorkerRequestWithTime,
 };
 
 pub type RemoteJobSchedulerRef = Arc<dyn RemoteJobScheduler>;
@@ -132,7 +133,7 @@ pub struct CompactionJobResult {
 /// DefaultNotifier is a default implementation of Notifier that sends WorkerRequest to the mito engine.
 pub(crate) struct DefaultNotifier {
     /// The sender to send WorkerRequest to the mito engine. This is used to notify the mito engine when a remote job is completed.
-    pub(crate) request_sender: Sender<WorkerRequest>,
+    pub(crate) request_sender: Sender<WorkerRequestWithTime>,
 }
 
 impl DefaultNotifier {
@@ -175,10 +176,10 @@ impl Notifier for DefaultNotifier {
 
                 if let Err(e) = self
                     .request_sender
-                    .send(WorkerRequest::Background {
+                    .send(WorkerRequestWithTime::new(WorkerRequest::Background {
                         region_id: result.region_id,
                         notify,
-                    })
+                    }))
                     .await
                 {
                     error!(

--- a/src/mito2/src/test_util/scheduler_util.rs
+++ b/src/mito2/src/test_util/scheduler_util.rs
@@ -32,7 +32,7 @@ use crate::error::Result;
 use crate::flush::FlushScheduler;
 use crate::manifest::manager::{RegionManifestManager, RegionManifestOptions};
 use crate::region::{ManifestContext, ManifestContextRef, RegionLeaderState, RegionRoleState};
-use crate::request::WorkerRequest;
+use crate::request::{WorkerRequest, WorkerRequestWithTime};
 use crate::schedule::scheduler::{Job, LocalScheduler, Scheduler, SchedulerRef};
 use crate::sst::index::intermediate::IntermediateManager;
 use crate::sst::index::puffin_manager::PuffinManagerFactory;
@@ -85,7 +85,7 @@ impl SchedulerEnv {
     /// Creates a new compaction scheduler.
     pub(crate) fn mock_compaction_scheduler(
         &self,
-        request_sender: Sender<WorkerRequest>,
+        request_sender: Sender<WorkerRequestWithTime>,
     ) -> CompactionScheduler {
         let scheduler = self.get_scheduler();
 

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -58,11 +58,11 @@ use crate::error;
 use crate::error::{CreateDirSnafu, JoinSnafu, Result, WorkerStoppedSnafu};
 use crate::flush::{FlushScheduler, WriteBufferManagerImpl, WriteBufferManagerRef};
 use crate::memtable::MemtableBuilderProvider;
-use crate::metrics::{REGION_COUNT, WRITE_STALL_TOTAL};
+use crate::metrics::{REGION_COUNT, REQUEST_WAIT_TIME, WRITE_STALL_TOTAL};
 use crate::region::{MitoRegionRef, OpeningRegions, OpeningRegionsRef, RegionMap, RegionMapRef};
 use crate::request::{
     BackgroundNotify, DdlRequest, SenderBulkRequest, SenderDdlRequest, SenderWriteRequest,
-    WorkerRequest,
+    WorkerRequest, WorkerRequestWithTime,
 };
 use crate::schedule::scheduler::{LocalScheduler, SchedulerRef};
 use crate::sst::file::FileId;
@@ -498,7 +498,7 @@ pub(crate) struct RegionWorker {
     /// The opening regions.
     opening_regions: OpeningRegionsRef,
     /// Request sender.
-    sender: Sender<WorkerRequest>,
+    sender: Sender<WorkerRequestWithTime>,
     /// Handle to the worker thread.
     handle: Mutex<Option<JoinHandle<()>>>,
     /// Whether to run the worker thread.
@@ -509,7 +509,8 @@ impl RegionWorker {
     /// Submits request to background worker thread.
     async fn submit_request(&self, request: WorkerRequest) -> Result<()> {
         ensure!(self.is_running(), WorkerStoppedSnafu { id: self.id });
-        if self.sender.send(request).await.is_err() {
+        let request_with_time = WorkerRequestWithTime::new(request);
+        if self.sender.send(request_with_time).await.is_err() {
             warn!(
                 "Worker {} is already exited but the running flag is still true",
                 self.id
@@ -531,7 +532,12 @@ impl RegionWorker {
             info!("Stop region worker {}", self.id);
 
             self.set_running(false);
-            if self.sender.send(WorkerRequest::Stop).await.is_err() {
+            if self
+                .sender
+                .send(WorkerRequestWithTime::new(WorkerRequest::Stop))
+                .await
+                .is_err()
+            {
                 warn!("Worker {} is already exited before stop", self.id);
             }
 
@@ -669,9 +675,9 @@ struct RegionWorkerLoop<S> {
     /// Regions that are opening.
     opening_regions: OpeningRegionsRef,
     /// Request sender.
-    sender: Sender<WorkerRequest>,
+    sender: Sender<WorkerRequestWithTime>,
     /// Request receiver.
-    receiver: Receiver<WorkerRequest>,
+    receiver: Receiver<WorkerRequestWithTime>,
     /// WAL of the engine.
     wal: Wal<S>,
     /// Manages object stores for manifest and SSTs.
@@ -749,10 +755,16 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             tokio::select! {
                 request_opt = self.receiver.recv() => {
                     match request_opt {
-                        Some(request) => match request {
-                            WorkerRequest::Write(sender_req) => write_req_buffer.push(sender_req),
-                            WorkerRequest::Ddl(sender_req) => ddl_req_buffer.push(sender_req),
-                            _ => general_req_buffer.push(request),
+                        Some(request_with_time) => {
+                            // Observe the wait time
+                            let wait_time = request_with_time.created_at.elapsed();
+                            REQUEST_WAIT_TIME.observe(wait_time.as_secs_f64());
+
+                            match request_with_time.request {
+                                WorkerRequest::Write(sender_req) => write_req_buffer.push(sender_req),
+                                WorkerRequest::Ddl(sender_req) => ddl_req_buffer.push(sender_req),
+                                req => general_req_buffer.push(req),
+                            }
                         },
                         // The channel is disconnected.
                         None => break,
@@ -791,11 +803,17 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             for _ in 1..self.config.worker_request_batch_size {
                 // We have received one request so we start from 1.
                 match self.receiver.try_recv() {
-                    Ok(req) => match req {
-                        WorkerRequest::Write(sender_req) => write_req_buffer.push(sender_req),
-                        WorkerRequest::Ddl(sender_req) => ddl_req_buffer.push(sender_req),
-                        _ => general_req_buffer.push(req),
-                    },
+                    Ok(request_with_time) => {
+                        // Observe the wait time
+                        let wait_time = request_with_time.created_at.elapsed();
+                        REQUEST_WAIT_TIME.observe(wait_time.as_secs_f64());
+
+                        match request_with_time.request {
+                            WorkerRequest::Write(sender_req) => write_req_buffer.push(sender_req),
+                            WorkerRequest::Ddl(sender_req) => ddl_req_buffer.push(sender_req),
+                            req => general_req_buffer.push(req),
+                        }
+                    }
                     // We still need to handle remaining requests.
                     Err(_) => break,
                 }

--- a/src/mito2/src/worker/handle_write.rs
+++ b/src/mito2/src/worker/handle_write.rs
@@ -57,7 +57,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         }
 
         if self.write_buffer_manager.should_stall() && allow_stall {
-            self.stalled_count
+            self.stalling_count
                 .add((write_requests.len() + bulk_requests.len()) as i64);
             self.stalled_requests.append(write_requests, bulk_requests);
             self.listener.on_write_stall();
@@ -161,7 +161,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
     pub(crate) async fn handle_stalled_requests(&mut self) {
         // Handle stalled requests.
         let stalled = std::mem::take(&mut self.stalled_requests);
-        self.stalled_count.sub(stalled.stalled_count() as i64);
+        self.stalling_count.sub(stalled.stalled_count() as i64);
         // We already stalled these requests, don't stall them again.
         for (_, (_, mut requests, mut bulk)) in stalled.requests {
             self.handle_write_requests(&mut requests, &mut bulk, false)
@@ -172,7 +172,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
     /// Rejects all stalled requests.
     pub(crate) fn reject_stalled_requests(&mut self) {
         let stalled = std::mem::take(&mut self.stalled_requests);
-        self.stalled_count.sub(stalled.stalled_count() as i64);
+        self.stalling_count.sub(stalled.stalled_count() as i64);
         for (_, (_, mut requests, mut bulk)) in stalled.requests {
             reject_write_requests(&mut requests, &mut bulk);
         }
@@ -182,7 +182,8 @@ impl<S: LogStore> RegionWorkerLoop<S> {
     pub(crate) fn reject_region_stalled_requests(&mut self, region_id: &RegionId) {
         debug!("Rejects stalled requests for region {}", region_id);
         let (mut requests, mut bulk) = self.stalled_requests.remove(region_id);
-        self.stalled_count.sub((requests.len() + bulk.len()) as i64);
+        self.stalling_count
+            .sub((requests.len() + bulk.len()) as i64);
         reject_write_requests(&mut requests, &mut bulk);
     }
 
@@ -190,7 +191,8 @@ impl<S: LogStore> RegionWorkerLoop<S> {
     pub(crate) async fn handle_region_stalled_requests(&mut self, region_id: &RegionId) {
         debug!("Handles stalled requests for region {}", region_id);
         let (mut requests, mut bulk) = self.stalled_requests.remove(region_id);
-        self.stalled_count.sub((requests.len() + bulk.len()) as i64);
+        self.stalling_count
+            .sub((requests.len() + bulk.len()) as i64);
         self.handle_write_requests(&mut requests, &mut bulk, true)
             .await;
     }
@@ -251,7 +253,7 @@ impl<S> RegionWorkerLoop<S> {
                             "Region {} is altering, add request to pending writes",
                             region.region_id
                         );
-                        self.stalled_count.add(1);
+                        self.stalling_count.add(1);
                         self.stalled_requests.push(sender_req);
                         continue;
                     }
@@ -353,7 +355,7 @@ impl<S> RegionWorkerLoop<S> {
                             "Region {} is altering, add request to pending writes",
                             region.region_id
                         );
-                        self.stalled_count.add(1);
+                        self.stalling_count.add(1);
                         self.stalled_requests.push_bulk(bulk_req);
                         continue;
                     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

This PR adds a new metric `greptime_mito_request_wait_time` to collect the wait time of requests submitted to the worker.

It also adjusts the write stall metrics:
- greptime_mito_write_stall_total now is the total stalled requests count
- greptime_mito_write_stalling_count is the current stalled requests count in the worker

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
