### PR TITLE
fix: typo for `existed` -> `exited`

### DIFF
--- a/src/servers/src/grpc.rs
+++ b/src/servers/src/grpc.rs
@@ -266,7 +266,7 @@ impl Server for GrpcServer {
         let mut shutdown_tx = self.shutdown_tx.lock().await;
         if let Some(tx) = shutdown_tx.take() {
             if tx.send(()).is_err() {
-                info!("Receiver dropped, the grpc server has already existed");
+                info!("Receiver dropped, the grpc server has already exited");
             }
         }
         info!("Shutdown grpc server");

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -1146,7 +1146,7 @@ impl Server for HttpServer {
         let mut shutdown_tx = self.shutdown_tx.lock().await;
         if let Some(tx) = shutdown_tx.take() {
             if tx.send(()).is_err() {
-                info!("Receiver dropped, the HTTP server has already existed");
+                info!("Receiver dropped, the HTTP server has already exited");
             }
         }
         info!("Shutdown HTTP server");


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Fix typo `existed` -> `exited`.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
