### PR TITLE
fix: unit test failed by adding necessary sleep function to ensure the time seqence

### DIFF
--- a/src/common/event-recorder/src/recorder.rs
+++ b/src/common/event-recorder/src/recorder.rs
@@ -466,11 +466,14 @@ mod tests {
         );
         event_recorder.record(Box::new(TestEvent {}));
 
-        // Cancel the event recorder to flush the buffer.
+        // Sleep for a while to let the event be sent to the event handler.
+        sleep(Duration::from_millis(500)).await;
+
+        // Close the event recorder to flush the buffer.
         event_recorder.close();
 
         // Sleep for a while to let the background task process the event.
-        sleep(Duration::from_millis(100)).await;
+        sleep(Duration::from_millis(500)).await;
 
         if let Some(handle) = event_recorder.handle.take() {
             assert!(handle.await.is_ok());
@@ -508,11 +511,14 @@ mod tests {
 
         event_recorder.record(Box::new(TestEvent {}));
 
+        // Sleep for a while to let the event be sent to the event handler.
+        sleep(Duration::from_millis(500)).await;
+
         // Close the event recorder to flush the buffer.
         event_recorder.close();
 
         // Sleep for a while to let the background task process the event.
-        sleep(Duration::from_millis(100)).await;
+        sleep(Duration::from_millis(500)).await;
 
         if let Some(handle) = event_recorder.handle.take() {
             assert!(handle.await.unwrap_err().is_panic());


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Add `sleep(Duration::from_millis(500)).await;` to sleep for a while to let the event be sent to the event handler.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
