### PR TITLE
fix: estimate mem size for bulk ingester

### DIFF
--- a/src/mito2/src/memtable/bulk/part.rs
+++ b/src/mito2/src/memtable/bulk/part.rs
@@ -136,7 +136,12 @@ impl TryFrom<&BulkPart> for BulkWalEntry {
 
 impl BulkPart {
     pub(crate) fn estimated_size(&self) -> usize {
-        self.batch.get_array_memory_size()
+        self.batch
+            .columns()
+            .iter()
+            // If can not get slice memory size, assume 0 here.
+            .map(|c| c.to_data().get_slice_memory_size().unwrap_or(0))
+            .sum()
     }
 
     /// Converts [BulkPart] to [Mutation] for fallback `write_bulk` implementation.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

I encountered a problem: under the same write load, bluk ingester has much higher CPU than row-based gRPC ingester.

After some investigation, the reasons are as follows:

Bulk ingester estimates memory usage that is much larger than the actual memory usage, resulting in excessive flush and compact operations.

> The statistics of `get_array_memory_size` will include the underlying bytes, which causes duplicate statistics.

<img width="2011" height="1896" alt="image" src="https://github.com/user-attachments/assets/86e0c60e-d139-43cb-b9cd-013010785695" />

To the left of the red arrow is row-based ingester, and to the right is bulk ingester. It is clear that under the same write load, the bulk ingester flushes more.




## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
