### PR TITLE
fix: flow mirror cache

### DIFF
--- a/src/common/meta/src/cache/flow/table_flownode.rs
+++ b/src/common/meta/src/cache/flow/table_flownode.rs
@@ -167,6 +167,7 @@ fn invalidator<'a>(
         match ident {
             CacheIdent::CreateFlow(create_flow) => handle_create_flow(cache, create_flow).await,
             CacheIdent::DropFlow(drop_flow) => handle_drop_flow(cache, drop_flow).await,
+            CacheIdent::FlowNode(_) => cache.invalidate_all(),
             _ => {}
         }
         Ok(())

--- a/src/common/meta/src/cache/flow/table_flownode.rs
+++ b/src/common/meta/src/cache/flow/table_flownode.rs
@@ -15,7 +15,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use common_telemetry::{info, warn};
+use common_telemetry::info;
 use futures::future::BoxFuture;
 use moka::future::Cache;
 use moka::ops::compute::Op;

--- a/src/common/meta/src/cache_invalidator.rs
+++ b/src/common/meta/src/cache_invalidator.rs
@@ -22,6 +22,7 @@ use crate::key::flow::flow_name::FlowNameKey;
 use crate::key::flow::flow_route::FlowRouteKey;
 use crate::key::flow::flownode_flow::FlownodeFlowKey;
 use crate::key::flow::table_flow::TableFlowKey;
+use crate::key::node_address::NodeAddressKey;
 use crate::key::schema_name::SchemaNameKey;
 use crate::key::table_info::TableInfoKey;
 use crate::key::table_name::TableNameKey;
@@ -135,6 +136,11 @@ where
                 }
                 CacheIdent::FlowId(flow_id) => {
                     let key = FlowInfoKey::new(*flow_id);
+                    self.invalidate_key(&key.to_bytes()).await;
+                }
+                CacheIdent::FlowNode(node_id) => {
+                    // TODO(discord9): table flow cache might also need to be invalidated
+                    let key = NodeAddressKey::with_flownode(*node_id);
                     self.invalidate_key(&key.to_bytes()).await;
                 }
             }

--- a/src/common/meta/src/cache_invalidator.rs
+++ b/src/common/meta/src/cache_invalidator.rs
@@ -139,7 +139,8 @@ where
                     self.invalidate_key(&key.to_bytes()).await;
                 }
                 CacheIdent::FlowNode(node_id) => {
-                    // TODO(discord9): table flow cache might also need to be invalidated
+                    // other caches doesn't need to be invalidated
+                    // since this is only for flownode address change not id change
                     let key = NodeAddressKey::with_flownode(*node_id);
                     self.invalidate_key(&key.to_bytes()).await;
                 }

--- a/src/common/meta/src/cache_invalidator.rs
+++ b/src/common/meta/src/cache_invalidator.rs
@@ -54,6 +54,10 @@ pub struct Context {
 #[async_trait::async_trait]
 pub trait CacheInvalidator: Send + Sync {
     async fn invalidate(&self, ctx: &Context, caches: &[CacheIdent]) -> Result<()>;
+
+    fn name(&self) -> &'static str {
+        std::any::type_name::<Self>()
+    }
 }
 
 pub type CacheInvalidatorRef = Arc<dyn CacheInvalidator>;
@@ -138,9 +142,10 @@ where
                     let key = FlowInfoKey::new(*flow_id);
                     self.invalidate_key(&key.to_bytes()).await;
                 }
-                CacheIdent::FlowNode(node_id) => {
+                CacheIdent::FlowNodeAddressChange(node_id) => {
                     // other caches doesn't need to be invalidated
                     // since this is only for flownode address change not id change
+                    common_telemetry::info!("Invalidate flow node cache for node_id: {}", node_id);
                     let key = NodeAddressKey::with_flownode(*node_id);
                     self.invalidate_key(&key.to_bytes()).await;
                 }

--- a/src/common/meta/src/instruction.rs
+++ b/src/common/meta/src/instruction.rs
@@ -174,6 +174,8 @@ pub struct UpgradeRegion {
 /// The identifier of cache.
 pub enum CacheIdent {
     FlowId(FlowId),
+    /// Indicate change of address of flownode.
+    FlowNode(u64),
     FlowName(FlowName),
     TableId(TableId),
     TableName(TableName),

--- a/src/common/meta/src/instruction.rs
+++ b/src/common/meta/src/instruction.rs
@@ -175,7 +175,7 @@ pub struct UpgradeRegion {
 pub enum CacheIdent {
     FlowId(FlowId),
     /// Indicate change of address of flownode.
-    FlowNode(u64),
+    FlowNodeAddressChange(u64),
     FlowName(FlowName),
     TableId(TableId),
     TableName(TableName),

--- a/src/meta-srv/src/handler/remap_flow_peer_handler.rs
+++ b/src/meta-srv/src/handler/remap_flow_peer_handler.rs
@@ -82,9 +82,13 @@ async fn rewrite_node_address(ctx: &mut Context, peer: &Peer) {
                 info!("Successfully updated flow `NodeAddressValue`: {:?}", peer);
                 // broadcast invalidating cache to all frontends
                 let cache_idents = vec![CacheIdent::FlowNode(peer.id)];
-                ctx.cache_invalidator
+                if let Err(e) = ctx
+                    .cache_invalidator
                     .invalidate(&Context::default(), &cache_idents)
-                    .await?;
+                    .await
+                {
+                    error!(e; "Failed to invalidate {} `NodeAddressKey` cache, peer: {:?}", cache_idents.len(), peer);
+                }
             }
             Err(e) => {
                 error!(e; "Failed to update flow `NodeAddressValue`: {:?}", peer);

--- a/src/meta-srv/src/handler/remap_flow_peer_handler.rs
+++ b/src/meta-srv/src/handler/remap_flow_peer_handler.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use api::v1::meta::{HeartbeatRequest, Peer, Role};
+use common_meta::instruction::CacheIdent;
 use common_meta::key::node_address::{NodeAddressKey, NodeAddressValue};
 use common_meta::key::{MetadataKey, MetadataValue};
 use common_meta::rpc::store::PutRequest;
@@ -84,7 +85,7 @@ async fn rewrite_node_address(ctx: &mut Context, peer: &Peer) {
                 let cache_idents = vec![CacheIdent::FlowNode(peer.id)];
                 if let Err(e) = ctx
                     .cache_invalidator
-                    .invalidate(&Context::default(), &cache_idents)
+                    .invalidate(&Default::default(), &cache_idents)
                     .await
                 {
                     error!(e; "Failed to invalidate {} `NodeAddressKey` cache, peer: {:?}", cache_idents.len(), peer);

--- a/src/meta-srv/src/handler/remap_flow_peer_handler.rs
+++ b/src/meta-srv/src/handler/remap_flow_peer_handler.rs
@@ -82,7 +82,11 @@ async fn rewrite_node_address(ctx: &mut Context, peer: &Peer) {
             Ok(_) => {
                 info!("Successfully updated flow `NodeAddressValue`: {:?}", peer);
                 // broadcast invalidating cache to all frontends
-                let cache_idents = vec![CacheIdent::FlowNode(peer.id)];
+                let cache_idents = vec![CacheIdent::FlowNodeAddressChange(peer.id)];
+                info!(
+                    "Invalidate flow node cache for new address with cache idents: {:?}",
+                    cache_idents
+                );
                 if let Err(e) = ctx
                     .cache_invalidator
                     .invalidate(&Default::default(), &cache_idents)

--- a/src/meta-srv/src/handler/remap_flow_peer_handler.rs
+++ b/src/meta-srv/src/handler/remap_flow_peer_handler.rs
@@ -80,7 +80,11 @@ async fn rewrite_node_address(ctx: &mut Context, peer: &Peer) {
         match ctx.leader_cached_kv_backend.put(put).await {
             Ok(_) => {
                 info!("Successfully updated flow `NodeAddressValue`: {:?}", peer);
-                // TODO(discord): broadcast invalidating cache to all frontends
+                // broadcast invalidating cache to all frontends
+                let cache_idents = vec![CacheIdent::FlowNode(peer.id)];
+                ctx.cache_invalidator
+                    .invalidate(&Context::default(), &cache_idents)
+                    .await?;
             }
             Err(e) => {
                 error!(e; "Failed to update flow `NodeAddressValue`: {:?}", peer);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

fix flow mirror insert cache not updated when flownode's address change

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
