### PR TITLE
fix(information_schema): set AUTO_INCREMENT column to NULL for all tables

### DIFF
--- a/src/catalog/src/system_schema/information_schema/tables.rs
+++ b/src/catalog/src/system_schema/information_schema/tables.rs
@@ -369,7 +369,7 @@ impl InformationSchemaTablesBuilder {
         self.checksum.push(Some(0));
         self.max_index_length.push(Some(0));
         self.data_free.push(Some(0));
-        self.auto_increment.push(Some(0));
+        self.auto_increment.push(None);
         self.row_format.push(Some("Fixed"));
         self.table_collation.push(Some("utf8_bin"));
         self.update_time.push(None);


### PR DESCRIPTION
- The AUTO_INCREMENT column in information_schema.tables is now always NULL.
- This matches MySQL compatibility expectations and resolves errors with database clients such as VSCode SQLTools and DBeaver.
- Fixes #6546

I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
