### PR TITLE
fix: windows path in error tests

### DIFF
--- a/src/common/error/tests/ext.rs
+++ b/src/common/error/tests/ext.rs
@@ -84,29 +84,32 @@ fn test_to_string() {
     assert_eq!(result.unwrap_err().to_string(), "<root cause>");
 }
 
+fn normalize_path(s: &str) -> String {
+    s.replace('\\', "/")
+}
+
 #[test]
 fn test_debug_format() {
     let result = normal_error();
     let debug_output = format!("{:?}", result.unwrap_err());
-    let normalized_output = debug_output.replace('\\', "/");
+
     assert_eq!(
-        normalized_output,
+        normalize_path(&debug_output),
         format!(
             r#"0: A normal error with "display" attribute, message "blabla", at {}:55:22
 1: PlainError {{ msg: "<root cause>", status_code: Unexpected }}"#,
-            file!()
+            normalize_path(file!())
         )
     );
 
     let result = transparent_error();
     let debug_output = format!("{:?}", result.unwrap_err());
-    let normalized_output = debug_output.replace('\\', "/");
     assert_eq!(
-        normalized_output,
+        normalize_path(&debug_output),
         format!(
             r#"0: <transparent>, at {}:60:5
 1: PlainError {{ msg: "<root cause>", status_code: Unexpected }}"#,
-            file!()
+            normalize_path(file!())
         )
     );
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Fixes #6562 

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
