### PR TITLE
fix: only start one instance one regrex sqlness test

### DIFF
--- a/tests/runner/src/env.rs
+++ b/tests/runner/src/env.rs
@@ -140,7 +140,7 @@ impl Env {
     }
 
     async fn start_standalone(&self, id: usize) -> GreptimeDB {
-        println!("Starting standalone instance {id}");
+        println!("Starting standalone instance id: {id}");
 
         if self.server_addrs.server_addr.is_some() {
             self.connect_db(&self.server_addrs, id).await

--- a/tests/runner/src/main.rs
+++ b/tests/runner/src/main.rs
@@ -153,9 +153,10 @@ async fn main() {
         || args.setup_pg
         || args.setup_mysql
         || args.kafka_wal_broker_endpoints.is_some()
+        || args.test_filter != ".*"
     {
         args.jobs = 1;
-        println!("Normalizing parallelism to 1 due to server addresses or etcd/pg/mysql setup");
+        println!("Normalizing parallelism to 1 due to server addresses, etcd/pg/mysql setup, or test filter usage");
     }
 
     let config = ConfigBuilder::default()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

This patch for better experience when sqlness test for regrex

like : 

```cli
cargo sqlness -t simple_histogram
```

start one instance is fine, also make a print message better

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
