### PR TITLE
feat: fallback when failed to push down using `DistPlanner`

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -281,6 +281,7 @@
 | `meta_client.metadata_cache_tti` | String | `5m` | -- |
 | `query` | -- | -- | The query engine options. |
 | `query.parallelism` | Integer | `0` | Parallelism of the query engine.<br/>Default to 0, which means the number of CPU cores. |
+| `query.allow_query_fallback` | Bool | `false` | Whether to allow query fallback when push down optimize fails.<br/>Default to false, meaning when push down optimize failed, return error msg |
 | `datanode` | -- | -- | Datanode options. |
 | `datanode.client` | -- | -- | Datanode client options. |
 | `datanode.client.connect_timeout` | String | `10s` | -- |

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -197,6 +197,9 @@ metadata_cache_tti = "5m"
 ## Parallelism of the query engine.
 ## Default to 0, which means the number of CPU cores.
 parallelism = 0
+## Whether to allow query fallback when push down optimize fails.
+## Default to false, meaning when push down optimize failed, return error msg
+allow_query_fallback = false
 
 ## Datanode options.
 [datanode]

--- a/src/cmd/tests/load_config_test.rs
+++ b/src/cmd/tests/load_config_test.rs
@@ -225,7 +225,10 @@ fn test_load_flownode_example_config() {
             heartbeat: Default::default(),
             // flownode deliberately use a slower query parallelism
             // to avoid overwhelming the frontend with too many queries
-            query: QueryOptions { parallelism: 1 },
+            query: QueryOptions {
+                parallelism: 1,
+                allow_query_fallback: false,
+            },
             meta_client: Some(MetaClientOptions {
                 metasrv_addrs: vec!["127.0.0.1:3002".to_string()],
                 timeout: Duration::from_secs(3),

--- a/src/flow/src/adapter.rs
+++ b/src/flow/src/adapter.rs
@@ -126,7 +126,10 @@ impl Default for FlownodeOptions {
             heartbeat: HeartbeatOptions::default(),
             // flownode's query option is set to 1 to throttle flow's query so
             // that it won't use too much cpu or memory
-            query: QueryOptions { parallelism: 1 },
+            query: QueryOptions {
+                parallelism: 1,
+                allow_query_fallback: false,
+            },
             user_provider: None,
         }
     }

--- a/src/operator/src/statement.rs
+++ b/src/operator/src/statement.rs
@@ -78,6 +78,7 @@ use crate::error::{
 };
 use crate::insert::InserterRef;
 use crate::statement::copy_database::{COPY_DATABASE_TIME_END_KEY, COPY_DATABASE_TIME_START_KEY};
+use crate::statement::set::set_allow_query_fallback;
 
 #[derive(Clone)]
 pub struct StatementExecutor {
@@ -409,6 +410,9 @@ impl StatementExecutor {
             // Not harmful since it only relates to how date is viewed in client app's output.
             // The tracked issue is https://github.com/GreptimeTeam/greptimedb/issues/3442.
             "DATESTYLE" => set_datestyle(set_var.value, query_ctx)?,
+
+            // Allow query to fallback when failed to push down.
+            "ALLOW_QUERY_FALLBACK" => set_allow_query_fallback(set_var.value, query_ctx)?,
 
             "CLIENT_ENCODING" => validate_client_encoding(set_var)?,
             "@@SESSION.MAX_EXECUTION_TIME" | "MAX_EXECUTION_TIME" => match query_ctx.channel() {

--- a/src/operator/src/statement/set.rs
+++ b/src/operator/src/statement/set.rs
@@ -230,6 +230,28 @@ fn try_parse_datestyle(expr: &Expr) -> Result<(Option<PGDateTimeStyle>, Option<P
     }
 }
 
+/// Set the allow query fallback configuration parameter to true or false based on the provided expressions.
+///
+pub fn set_allow_query_fallback(exprs: Vec<Expr>, ctx: QueryContextRef) -> Result<()> {
+    let allow_fallback_expr = exprs.first().context(NotSupportedSnafu {
+        feat: "No allow query fallback value find in set variable statement",
+    })?;
+    match allow_fallback_expr {
+        Expr::Value(Value::Boolean(allow)) => {
+            ctx.configuration_parameter()
+                .set_allow_query_fallback(*allow);
+            Ok(())
+        }
+        expr => NotSupportedSnafu {
+            feat: format!(
+                "Unsupported allow query fallback expr {} in set variable statement",
+                expr
+            ),
+        }
+        .fail(),
+    }
+}
+
 pub fn set_datestyle(exprs: Vec<Expr>, ctx: QueryContextRef) -> Result<()> {
     // ORDER,
     // STYLE,

--- a/src/query/src/datafusion.rs
+++ b/src/query/src/datafusion.rs
@@ -66,6 +66,9 @@ use crate::{metrics, QueryEngine};
 /// This hint can be set in the query context to control the parallelism of the query execution.
 pub const QUERY_PARALLELISM_HINT: &str = "query_parallelism";
 
+/// Whether to fallback to the original plan when failed to push down.
+pub const QUERY_FALLBACK_HINT: &str = "query_fallback";
+
 pub struct DatafusionQueryEngine {
     state: Arc<QueryEngineState>,
     plugins: Plugins,
@@ -505,6 +508,18 @@ impl QueryEngine for DatafusionQueryEngine {
                 .insert(DistPlannerOptions {
                     allow_query_fallback: true,
                 });
+        } else if let Some(fallback) = query_ctx.extension(QUERY_FALLBACK_HINT) {
+            // also check the query context for fallback hint
+            // if it is set, we will enable the fallback
+            if fallback.to_lowercase().parse::<bool>().unwrap_or(false) {
+                state
+                    .config_mut()
+                    .options_mut()
+                    .extensions
+                    .insert(DistPlannerOptions {
+                        allow_query_fallback: true,
+                    });
+            }
         }
         QueryEngineContext::new(state, query_ctx)
     }

--- a/src/query/src/datafusion.rs
+++ b/src/query/src/datafusion.rs
@@ -49,7 +49,7 @@ use table::TableRef;
 use crate::analyze::DistAnalyzeExec;
 use crate::dataframe::DataFrame;
 pub use crate::datafusion::planner::DfContextProviderAdapter;
-use crate::dist_plan::MergeScanLogicalPlan;
+use crate::dist_plan::{DistPlannerOptions, MergeScanLogicalPlan};
 use crate::error::{
     CatalogSnafu, ConvertSchemaSnafu, CreateRecordBatchSnafu, MissingTableMutationHandlerSnafu,
     MissingTimestampColumnSnafu, QueryExecutionSnafu, Result, TableMutationSnafu,
@@ -496,6 +496,15 @@ impl QueryEngine for DatafusionQueryEngine {
                     parallelism
                 );
             }
+        }
+        if query_ctx.configuration_parameter().allow_query_fallback() {
+            state
+                .config_mut()
+                .options_mut()
+                .extensions
+                .insert(DistPlannerOptions {
+                    allow_query_fallback: true,
+                });
         }
         QueryEngineContext::new(state, query_ctx)
     }

--- a/src/query/src/datafusion.rs
+++ b/src/query/src/datafusion.rs
@@ -500,6 +500,9 @@ impl QueryEngine for DatafusionQueryEngine {
                 );
             }
         }
+
+        // usually it's impossible to have both `set variable` set by sql client and
+        // hint in header by grpc client, so only need to deal with them separately
         if query_ctx.configuration_parameter().allow_query_fallback() {
             state
                 .config_mut()

--- a/src/query/src/dist_plan.rs
+++ b/src/query/src/dist_plan.rs
@@ -18,6 +18,6 @@ mod merge_scan;
 mod merge_sort;
 mod planner;
 
-pub use analyzer::DistPlannerAnalyzer;
+pub use analyzer::{DistPlannerAnalyzer, DistPlannerOptions};
 pub use merge_scan::{MergeScanExec, MergeScanLogicalPlan};
 pub use planner::{DistExtensionPlanner, MergeSortExtensionPlanner};

--- a/src/query/src/dist_plan/analyzer/fallback.rs
+++ b/src/query/src/dist_plan/analyzer/fallback.rs
@@ -1,0 +1,89 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Fallback dist plan analyzer, which will only push down table scan node
+//! This is used when `PlanRewriter` produce errors when trying to rewrite the plan
+//! This is a temporary solution, and will be removed once we have a more robust plan rewriter
+//!
+
+use common_telemetry::debug;
+use datafusion::datasource::DefaultTableSource;
+use datafusion_common::tree_node::{Transformed, TreeNodeRewriter};
+use datafusion_expr::LogicalPlan;
+use table::metadata::TableType;
+use table::table::adapter::DfTableProviderAdapter;
+
+use crate::dist_plan::MergeScanLogicalPlan;
+
+/// FallbackPlanRewriter is a plan rewriter that will only push down table scan node
+/// This is used when `PlanRewriter` produce errors when trying to rewrite the plan
+/// This is a temporary solution, and will be removed once we have a more robust plan rewriter
+/// It will traverse the logical plan and rewrite table scan node to merge scan node
+#[derive(Debug, Clone, Default)]
+pub struct FallbackPlanRewriter;
+
+impl TreeNodeRewriter for FallbackPlanRewriter {
+    type Node = LogicalPlan;
+
+    fn f_down(
+        &mut self,
+        node: Self::Node,
+    ) -> datafusion_common::Result<datafusion_common::tree_node::Transformed<Self::Node>> {
+        if let LogicalPlan::TableScan(table_scan) = &node {
+            let partition_cols = if let Some(source) = table_scan
+                .source
+                .as_any()
+                .downcast_ref::<DefaultTableSource>()
+            {
+                if let Some(provider) = source
+                    .table_provider
+                    .as_any()
+                    .downcast_ref::<DfTableProviderAdapter>()
+                {
+                    if provider.table().table_type() == TableType::Base {
+                        let info = provider.table().table_info();
+                        let partition_key_indices = info.meta.partition_key_indices.clone();
+                        let schema = info.meta.schema.clone();
+                        let partition_cols = partition_key_indices
+                            .into_iter()
+                            .map(|index| schema.column_name_by_index(index).to_string())
+                            .collect::<Vec<String>>();
+                        debug!(
+                            "FallbackPlanRewriter: table {} has partition columns: {:?}",
+                            info.name, partition_cols
+                        );
+                        Some(partition_cols)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+            let node = MergeScanLogicalPlan::new(
+                node,
+                false,
+                // at this stage, the partition cols should be set
+                // treat it as non-partitioned if None
+                partition_cols.clone().unwrap_or_default(),
+            )
+            .into_logical_plan();
+            Ok(Transformed::yes(node))
+        } else {
+            Ok(Transformed::no(node))
+        }
+    }
+}

--- a/src/query/src/dist_plan/analyzer/test.rs
+++ b/src/query/src/dist_plan/analyzer/test.rs
@@ -271,7 +271,7 @@ fn expand_sort_alias_limit() {
 }
 
 /// FIXME(discord9): alias to same name with col req makes it ambiguous
-#[should_panic(expected = "AmbiguousReference")]
+/// for now since it bugged, will use fallback plan rewriter to only push down table scan node
 #[test]
 fn expand_sort_alias_conflict_limit() {
     // use logging for better debugging
@@ -295,14 +295,11 @@ fn expand_sort_alias_conflict_limit() {
     let result = DistPlannerAnalyzer {}.analyze(plan, &config).unwrap();
 
     let expected = [
-        "Projection: something",
-        "  Limit: skip=0, fetch=10",
-        "    MergeSort: t.pk1 ASC NULLS LAST",
-        "      MergeScan [is_placeholder=false, remote_input=[",
         "Limit: skip=0, fetch=10",
-        "  Projection: t.pk2 AS pk1, t.pk1",
+        "  Projection: t.pk2 AS pk1",
         "    Sort: t.pk1 ASC NULLS LAST",
-        "      TableScan: t",
+        "      MergeScan [is_placeholder=false, remote_input=[",
+        "TableScan: t",
         "]]",
     ]
     .join("\n");

--- a/src/query/src/dist_plan/analyzer/test.rs
+++ b/src/query/src/dist_plan/analyzer/test.rs
@@ -292,6 +292,14 @@ fn expand_sort_alias_conflict_limit() {
         .unwrap();
 
     let config = ConfigOptions::default();
+    let result = DistPlannerAnalyzer {}.analyze(plan.clone(), &config);
+    assert!(result.is_err(), "Expected error for ambiguous alias");
+    assert!(format!("{result:?}").contains("AmbiguousReference"));
+
+    let mut config = ConfigOptions::default();
+    config.extensions.insert(DistPlannerOptions {
+        allow_query_fallback: true,
+    });
     let result = DistPlannerAnalyzer {}.analyze(plan, &config).unwrap();
 
     let expected = [

--- a/src/query/src/metrics.rs
+++ b/src/query/src/metrics.rs
@@ -57,6 +57,11 @@ lazy_static! {
         "query merge scan errors total"
     )
     .unwrap();
+    pub static ref PUSH_DOWN_FALLBACK_ERRORS_TOTAL: IntCounter = register_int_counter!(
+        "greptime_push_down_fallback_errors_total",
+        "query push down fallback errors total"
+    )
+    .unwrap();
 }
 
 /// A stream to call the callback once a RecordBatch stream is done.

--- a/src/query/src/options.rs
+++ b/src/query/src/options.rs
@@ -20,11 +20,16 @@ use serde::{Deserialize, Serialize};
 pub struct QueryOptions {
     /// Parallelism of query engine. Default to 0, which implies the number of logical CPUs.
     pub parallelism: usize,
+    /// Whether to allow query fallback when push down fails.
+    pub allow_query_fallback: bool,
 }
 
 #[allow(clippy::derivable_impls)]
 impl Default for QueryOptions {
     fn default() -> Self {
-        Self { parallelism: 0 }
+        Self {
+            parallelism: 0,
+            allow_query_fallback: false,
+        }
     }
 }

--- a/src/query/src/query_engine/state.rs
+++ b/src/query/src/query_engine/state.rs
@@ -44,7 +44,9 @@ use promql::extension_plan::PromExtensionPlanner;
 use table::table::adapter::DfTableProviderAdapter;
 use table::TableRef;
 
-use crate::dist_plan::{DistExtensionPlanner, DistPlannerAnalyzer, MergeSortExtensionPlanner};
+use crate::dist_plan::{
+    DistExtensionPlanner, DistPlannerAnalyzer, DistPlannerOptions, MergeSortExtensionPlanner,
+};
 use crate::optimizer::constant_term::MatchesConstantTermOptimizer;
 use crate::optimizer::count_wildcard::CountWildcardToTimeIndexRule;
 use crate::optimizer::parallelize_scan::ParallelizeScan;
@@ -99,6 +101,14 @@ impl QueryEngineState {
         let mut session_config = SessionConfig::new().with_create_default_catalog_and_schema(false);
         if options.parallelism > 0 {
             session_config = session_config.with_target_partitions(options.parallelism);
+        }
+        if options.allow_query_fallback {
+            session_config
+                .options_mut()
+                .extensions
+                .insert(DistPlannerOptions {
+                    allow_query_fallback: true,
+                });
         }
 
         // todo(hl): This serves as a workaround for https://github.com/GreptimeTeam/greptimedb/issues/5659

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -593,6 +593,7 @@ impl AsRef<str> for Channel {
 pub struct ConfigurationVariables {
     postgres_bytea_output: ArcSwap<PGByteaOutputValue>,
     pg_datestyle_format: ArcSwap<(PGDateTimeStyle, PGDateOrder)>,
+    allow_query_fallback: ArcSwap<bool>,
 }
 
 impl Clone for ConfigurationVariables {
@@ -600,6 +601,7 @@ impl Clone for ConfigurationVariables {
         Self {
             postgres_bytea_output: ArcSwap::new(self.postgres_bytea_output.load().clone()),
             pg_datestyle_format: ArcSwap::new(self.pg_datestyle_format.load().clone()),
+            allow_query_fallback: ArcSwap::new(self.allow_query_fallback.load().clone()),
         }
     }
 }
@@ -623,6 +625,14 @@ impl ConfigurationVariables {
 
     pub fn set_pg_datetime_style(&self, style: PGDateTimeStyle, order: PGDateOrder) {
         self.pg_datestyle_format.swap(Arc::new((style, order)));
+    }
+
+    pub fn allow_query_fallback(&self) -> bool {
+        **self.allow_query_fallback.load()
+    }
+
+    pub fn set_allow_query_fallback(&self, allow: bool) {
+        self.allow_query_fallback.swap(Arc::new(allow));
     }
 }
 

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -1220,6 +1220,7 @@ ttl = "30d"
 
 [query]
 parallelism = 0
+allow_query_fallback = false
 "#,
     )
     .trim()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

add a fallback to only push down table scan when `PlanRewriter` failed to push down as many node as possible, this is useful when we encounter a previously unknown bug in `PlanRewriter` or encounter known but unfixed bugs like alias bug to provide at least some level of usability  

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
