### PR TITLE
fix: close issue #6586 make pg also show error as mysql

### DIFF
--- a/src/common/recordbatch/src/error.rs
+++ b/src/common/recordbatch/src/error.rs
@@ -44,7 +44,7 @@ pub enum Error {
         source: datatypes::error::Error,
     },
 
-    #[snafu(display("External error"))]
+    #[snafu(display("External error3 {:?}", source))]
     External {
         #[snafu(implicit)]
         location: Location,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

This patch try to fix #6586 but there are quite some same logic left
do not know need to fix or not.

after this patch
```cli
➜  ~ psql -h 127.0.0.1 -p 4003 -U public  -d public -c "select * from monitor where val in (select val from monitor) and ts >= now() - interval 30 minutes"
ERROR:  External error: External error3 0: Region query error, at src/frontend/src/instance/region_query.rs:57:14
1: Failed to query, at src/frontend/src/instance/region_query.rs:83:14
2: External error2, at src/frontend/src/instance/standalone.rs:106:14
3: Failed to execute logical plan, at src/datanode/src/region_server.rs:1196:14
4: <transparent>, at src/query/src/datafusion.rs:313:29
5: Plan("No installed planner was able to convert the custom node to an execution plan: MergeScanLogicalPlan { input: Projection(Projection { expr: [Column(Column { relation: Some(Bare { table: \"monitor\" }), name: \"val\" })], input: TableScan(TableScan { table_name: Bare { table: \"monitor\" }, source: \"...\", projection: None, projected_schema: DFSchema { inner: Schema { fields: [Field { name: \"ts\", data_type: Timestamp(Millisecond, None), nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {\"greptime:time_index\": \"true\"} }, Field { name: \"val\", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }], metadata: {\"greptime:version\": \"0\"} }, field_qualifiers: [Some(Bare { table: \"monitor\" }), Some(Bare { table: \"monitor\" })], functional_dependencies: FunctionalDependencies { deps: [] } }, filters: [], fetch: None, .. }), schema: DFSchema { inner: Schema { fields: [Field { name: \"val\", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }], metadata: {\"greptime:version\": \"0\"} }, field_qualifiers: [Some(Bare { table: \"monitor\" })], functional_dependencies: FunctionalDependencies { deps: [] } } }), is_placeholder: false, partition_cols: [] }")
➜  ~ mysql -h 127.0.0.1 -P 4002 -e "select * from monitor where val in (select val from monitor) and ts >= now() - interval 30 minutes"
ERROR 1815 (HY000) at line 1: (EngineExecuteQuery): Error during planning: No installed planner was able to convert the custom node to an execution plan: MergeScanLogicalPlan { input: Projection(Projection { expr: [Column(Column { relation: Some(Bare { table: "monitor" }), name: "val" })], input: TableScan(TableScan { table_name: Bare { table: "monitor" }, source: "...", projection: None, projected_schema: DFSchema { inner: Schema { fields: [Field { name: "ts", data_type: Timestamp(Millisecond, None), nullable: false, dict_id: 0, dict_
```

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
