### PR TITLE
fix(test): concurrency issue in compaction tests

### DIFF
--- a/src/mito2/src/engine/compaction_test.rs
+++ b/src/mito2/src/engine/compaction_test.rs
@@ -485,7 +485,7 @@ async fn test_compaction_region_with_overlapping_delete_all() {
     put_and_flush(&engine, region_id, &column_schemas, 0..2400).await; // window 3600
     put_and_flush(&engine, region_id, &column_schemas, 0..3600).await; // window 3600
     delete_and_flush(&engine, region_id, &column_schemas, 0..10800).await; // window 10800
-
+    tokio::time::sleep(Duration::from_millis(2)).await;
     compact(&engine, region_id).await;
     let scanner = engine
         .scanner(region_id, ScanRequest::default())


### PR DESCRIPTION

I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Add delay before compaction in `compaction_test.rs`. In current implementation manual compaction requests would be merged with running compaction, so the results would be as expected.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
