### PR TITLE
feat: Implement a converter to converts KeyValues into BulkPart

### DIFF
--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -204,8 +204,9 @@ pub trait MemtableBuilder: Send + Sync + fmt::Debug {
     /// Builds a new memtable instance.
     fn build(&self, id: MemtableId, metadata: &RegionMetadataRef) -> MemtableRef;
 
-    /// Returns true if the memtable builder supports bulk insert.
-    fn supports_bulk_insert(&self) -> bool {
+    /// Returns true if the memtable supports bulk insert and benefits from it.
+    fn use_bulk_insert(&self, metadata: &RegionMetadataRef) -> bool {
+        let _metadata = metadata;
         false
     }
 }

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -195,11 +195,6 @@ pub trait Memtable: Send + Sync + fmt::Debug {
     ///
     /// A region must freeze the memtable before invoking this method.
     fn fork(&self, id: MemtableId, metadata: &RegionMetadataRef) -> MemtableRef;
-
-    /// Returns true if the memtable supports bulk insert.
-    fn supports_bulk_insert(&self) -> bool {
-        false
-    }
 }
 
 pub type MemtableRef = Arc<dyn Memtable>;
@@ -208,6 +203,11 @@ pub type MemtableRef = Arc<dyn Memtable>;
 pub trait MemtableBuilder: Send + Sync + fmt::Debug {
     /// Builds a new memtable instance.
     fn build(&self, id: MemtableId, metadata: &RegionMetadataRef) -> MemtableRef;
+
+    /// Returns true if the memtable builder supports bulk insert.
+    fn supports_bulk_insert(&self) -> bool {
+        false
+    }
 }
 
 pub type MemtableBuilderRef = Arc<dyn MemtableBuilder>;

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -195,6 +195,11 @@ pub trait Memtable: Send + Sync + fmt::Debug {
     ///
     /// A region must freeze the memtable before invoking this method.
     fn fork(&self, id: MemtableId, metadata: &RegionMetadataRef) -> MemtableRef;
+
+    /// Returns true if the memtable supports bulk insert.
+    fn supports_bulk_insert(&self) -> bool {
+        false
+    }
 }
 
 pub type MemtableRef = Arc<dyn Memtable>;

--- a/src/mito2/src/memtable/bulk.rs
+++ b/src/mito2/src/memtable/bulk.rs
@@ -93,8 +93,4 @@ impl Memtable for BulkMemtable {
             parts: RwLock::new(vec![]),
         })
     }
-
-    fn supports_bulk_insert(&self) -> bool {
-        true
-    }
 }

--- a/src/mito2/src/memtable/bulk.rs
+++ b/src/mito2/src/memtable/bulk.rs
@@ -93,4 +93,8 @@ impl Memtable for BulkMemtable {
             parts: RwLock::new(vec![]),
         })
     }
+
+    fn supports_bulk_insert(&self) -> bool {
+        true
+    }
 }

--- a/src/mito2/src/memtable/bulk.rs
+++ b/src/mito2/src/memtable/bulk.rs
@@ -29,7 +29,7 @@ use crate::memtable::{
 #[allow(unused)]
 mod context;
 #[allow(unused)]
-pub(crate) mod part;
+pub mod part;
 mod part_reader;
 mod row_group_reader;
 

--- a/src/mito2/src/memtable/bulk/part.rs
+++ b/src/mito2/src/memtable/bulk/part.rs
@@ -1428,20 +1428,6 @@ mod tests {
                 "__op_type"
             ]
         );
-
-        // Verify the primary key column data
-        let k0_column = bulk_part
-            .batch
-            .column_by_name("k0")
-            .expect("k0 column should exist");
-        let k1_column = bulk_part
-            .batch
-            .column_by_name("k1")
-            .expect("k1 column should exist");
-
-        // k0 should be a string dictionary array with values "key1" and "key2"
-        assert_eq!(k0_column.len(), 3);
-        assert_eq!(k1_column.len(), 3);
     }
 
     #[test]
@@ -1517,19 +1503,6 @@ mod tests {
                 "__op_type"
             ]
         );
-
-        // Verify the primary key column data
-        let k0_column = bulk_part
-            .batch
-            .column_by_name("k0")
-            .expect("k0 column should exist");
-        let k1_column = bulk_part
-            .batch
-            .column_by_name("k1")
-            .expect("k1 column should exist");
-
-        assert_eq!(k0_column.len(), 3);
-        assert_eq!(k1_column.len(), 3);
     }
 
     #[test]
@@ -1565,19 +1538,6 @@ mod tests {
                 "__op_type"
             ]
         );
-
-        // Verify empty primary key columns exist
-        let k0_column = bulk_part
-            .batch
-            .column_by_name("k0")
-            .expect("k0 column should exist");
-        let k1_column = bulk_part
-            .batch
-            .column_by_name("k1")
-            .expect("k1 column should exist");
-
-        assert_eq!(k0_column.len(), 0);
-        assert_eq!(k1_column.len(), 0);
     }
 
     #[test]
@@ -1632,22 +1592,5 @@ mod tests {
             field_names,
             vec!["v0", "v1", "ts", "__primary_key", "__sequence", "__op_type"]
         );
-
-        // Verify individual primary key columns are not present
-        assert!(
-            bulk_part.batch.column_by_name("k0").is_none(),
-            "k0 column should not exist"
-        );
-        assert!(
-            bulk_part.batch.column_by_name("k1").is_none(),
-            "k1 column should not exist"
-        );
-
-        // But encoded primary key should exist
-        let pk_column = bulk_part
-            .batch
-            .column_by_name("__primary_key")
-            .expect("__primary_key column should exist");
-        assert_eq!(pk_column.len(), 3);
     }
 }

--- a/src/mito2/src/memtable/partition_tree.rs
+++ b/src/mito2/src/memtable/partition_tree.rs
@@ -351,7 +351,7 @@ impl MemtableBuilder for PartitionTreeMemtableBuilder {
         ))
     }
 
-    fn supports_bulk_insert(&self) -> bool {
+    fn use_bulk_insert(&self, _metadata: &RegionMetadataRef) -> bool {
         false
     }
 }

--- a/src/mito2/src/memtable/partition_tree.rs
+++ b/src/mito2/src/memtable/partition_tree.rs
@@ -350,6 +350,10 @@ impl MemtableBuilder for PartitionTreeMemtableBuilder {
             &self.config,
         ))
     }
+
+    fn supports_bulk_insert(&self) -> bool {
+        false
+    }
 }
 
 struct PartitionTreeIterBuilder {

--- a/src/mito2/src/memtable/simple_bulk_memtable.rs
+++ b/src/mito2/src/memtable/simple_bulk_memtable.rs
@@ -340,10 +340,6 @@ impl Memtable for SimpleBulkMemtable {
             self.merge_mode,
         ))
     }
-
-    fn supports_bulk_insert(&self) -> bool {
-        true
-    }
 }
 
 #[derive(Clone)]

--- a/src/mito2/src/memtable/simple_bulk_memtable.rs
+++ b/src/mito2/src/memtable/simple_bulk_memtable.rs
@@ -340,6 +340,10 @@ impl Memtable for SimpleBulkMemtable {
             self.merge_mode,
         ))
     }
+
+    fn supports_bulk_insert(&self) -> bool {
+        true
+    }
 }
 
 #[derive(Clone)]

--- a/src/mito2/src/memtable/time_partition.rs
+++ b/src/mito2/src/memtable/time_partition.rs
@@ -243,6 +243,7 @@ impl TimePartitions {
                 &self.metadata,
                 kvs.num_rows(),
                 self.primary_key_codec.clone(),
+                false,
             );
             converter.append_key_values(kvs)?;
             let part = converter.convert()?;

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -374,6 +374,10 @@ impl Memtable for TimeSeriesMemtable {
             self.merge_mode,
         ))
     }
+
+    fn supports_bulk_insert(&self) -> bool {
+        true
+    }
 }
 
 #[derive(Default)]

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -808,7 +808,7 @@ impl Series {
 }
 
 /// `ValueBuilder` holds all the vector builders for field columns.
-struct ValueBuilder {
+pub(crate) struct ValueBuilder {
     timestamp: Vec<i64>,
     timestamp_type: ConcreteDataType,
     sequence: Vec<u64>,
@@ -852,7 +852,7 @@ impl ValueBuilder {
     /// Returns the size of field values.
     ///
     /// In this method, we don't check the data type of the value, because it is already checked in the caller.
-    fn push<'a>(
+    pub(crate) fn push<'a>(
         &mut self,
         ts: ValueRef,
         sequence: u64,
@@ -1083,10 +1083,10 @@ impl ValueBuilder {
 /// [Values] holds an immutable vectors of field columns, including `sequence` and `op_type`.
 #[derive(Clone)]
 pub struct Values {
-    timestamp: VectorRef,
-    sequence: Arc<UInt64Vector>,
-    op_type: Arc<UInt8Vector>,
-    fields: Vec<VectorRef>,
+    pub(crate) timestamp: VectorRef,
+    pub(crate) sequence: Arc<UInt64Vector>,
+    pub(crate) op_type: Arc<UInt8Vector>,
+    pub(crate) fields: Vec<VectorRef>,
 }
 
 impl Values {

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -113,8 +113,12 @@ impl MemtableBuilder for TimeSeriesMemtableBuilder {
         }
     }
 
-    fn supports_bulk_insert(&self) -> bool {
-        true
+    fn use_bulk_insert(&self, metadata: &RegionMetadataRef) -> bool {
+        if metadata.primary_key.is_empty() {
+            true
+        } else {
+            false
+        }
     }
 }
 

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -112,6 +112,10 @@ impl MemtableBuilder for TimeSeriesMemtableBuilder {
             ))
         }
     }
+
+    fn supports_bulk_insert(&self) -> bool {
+        true
+    }
 }
 
 /// Memtable implementation that groups rows by their primary key.
@@ -373,10 +377,6 @@ impl Memtable for TimeSeriesMemtable {
             self.dedup,
             self.merge_mode,
         ))
-    }
-
-    fn supports_bulk_insert(&self) -> bool {
-        true
     }
 }
 

--- a/src/mito2/src/sst.rs
+++ b/src/mito2/src/sst.rs
@@ -63,6 +63,86 @@ pub fn to_sst_arrow_schema(metadata: &RegionMetadata) -> SchemaRef {
     Arc::new(Schema::new(fields))
 }
 
+/// Options of flat schema.
+pub struct FlatSchemaOptions {
+    /// Whether to store primary key columns additionally instead of an encoded column.
+    pub raw_pk_columns: bool,
+    /// Whether to use dictionary encoding for string primary key columns
+    /// when storing primary key columns.
+    pub string_pk_use_dict: bool,
+}
+
+impl Default for FlatSchemaOptions {
+    fn default() -> Self {
+        Self {
+            raw_pk_columns: true,
+            string_pk_use_dict: true,
+        }
+    }
+}
+
+/// Gets the arrow schema to store in parquet.
+///
+/// The schema is:
+/// ```text
+/// primary key columns, field columns, time index, __prmary_key, __sequence, __op_type
+/// ```
+///
+/// # Panics
+/// Panics if the metadata is invalid.
+pub fn to_flat_sst_arrow_schema(
+    metadata: &RegionMetadata,
+    options: &FlatSchemaOptions,
+) -> SchemaRef {
+    let num_fields = if options.raw_pk_columns {
+        metadata.column_metadatas.len() + 3
+    } else {
+        metadata.column_metadatas.len() + 3 - metadata.primary_key.len()
+    };
+    let mut fields = Vec::with_capacity(num_fields);
+    let schema = metadata.schema.arrow_schema();
+    if options.raw_pk_columns {
+        for pk_id in &metadata.primary_key {
+            let pk_index = metadata.column_index_by_id(*pk_id).unwrap();
+            if options.string_pk_use_dict
+                && metadata.column_metadatas[pk_index]
+                    .column_schema
+                    .data_type
+                    .is_string()
+            {
+                let field = &schema.fields[pk_index];
+                let field = Arc::new(Field::new_dictionary(
+                    field.name(),
+                    datatypes::arrow::datatypes::DataType::UInt32,
+                    field.data_type().clone(),
+                    field.is_nullable(),
+                ));
+                fields.push(field);
+            } else {
+                fields.push(schema.fields[pk_index].clone());
+            }
+        }
+    }
+    let remaining_fields = schema
+        .fields()
+        .iter()
+        .zip(&metadata.column_metadatas)
+        .filter_map(|(field, column_meta)| {
+            if column_meta.semantic_type == SemanticType::Field {
+                Some(field.clone())
+            } else {
+                None
+            }
+        })
+        .chain([metadata.time_index_field()])
+        .chain(internal_fields());
+    for field in remaining_fields {
+        fields.push(field);
+    }
+
+    Arc::new(Schema::new(fields))
+}
+
 /// Fields for internal columns.
 fn internal_fields() -> [FieldRef; 3] {
     // Internal columns are always not null.

--- a/src/mito2/src/test_util/memtable_util.rs
+++ b/src/mito2/src/test_util/memtable_util.rs
@@ -127,7 +127,7 @@ impl MemtableBuilder for EmptyMemtableBuilder {
         Arc::new(EmptyMemtable::new(id))
     }
 
-    fn supports_bulk_insert(&self) -> bool {
+    fn use_bulk_insert(&self, _metadata: &RegionMetadataRef) -> bool {
         true
     }
 }

--- a/src/mito2/src/test_util/memtable_util.rs
+++ b/src/mito2/src/test_util/memtable_util.rs
@@ -116,6 +116,10 @@ impl Memtable for EmptyMemtable {
     fn fork(&self, id: MemtableId, _metadata: &RegionMetadataRef) -> MemtableRef {
         Arc::new(EmptyMemtable::new(id))
     }
+
+    fn supports_bulk_insert(&self) -> bool {
+        true
+    }
 }
 
 /// Empty memtable builder.

--- a/src/mito2/src/test_util/memtable_util.rs
+++ b/src/mito2/src/test_util/memtable_util.rs
@@ -116,10 +116,6 @@ impl Memtable for EmptyMemtable {
     fn fork(&self, id: MemtableId, _metadata: &RegionMetadataRef) -> MemtableRef {
         Arc::new(EmptyMemtable::new(id))
     }
-
-    fn supports_bulk_insert(&self) -> bool {
-        true
-    }
 }
 
 /// Empty memtable builder.
@@ -129,6 +125,10 @@ pub(crate) struct EmptyMemtableBuilder {}
 impl MemtableBuilder for EmptyMemtableBuilder {
     fn build(&self, id: MemtableId, _metadata: &RegionMetadataRef) -> MemtableRef {
         Arc::new(EmptyMemtable::new(id))
+    }
+
+    fn supports_bulk_insert(&self) -> bool {
+        true
     }
 }
 

--- a/src/mito2/src/test_util/scheduler_util.rs
+++ b/src/mito2/src/test_util/scheduler_util.rs
@@ -33,7 +33,7 @@ use crate::error::Result;
 use crate::flush::FlushScheduler;
 use crate::manifest::manager::{RegionManifestManager, RegionManifestOptions};
 use crate::region::{ManifestContext, ManifestContextRef, RegionLeaderState, RegionRoleState};
-use crate::request::{WorkerRequest, WorkerRequestWithTime};
+use crate::request::WorkerRequestWithTime;
 use crate::schedule::scheduler::{Job, LocalScheduler, Scheduler, SchedulerRef};
 use crate::sst::index::intermediate::IntermediateManager;
 use crate::sst::index::puffin_manager::PuffinManagerFactory;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/6505

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

This PR implements a BulkPartConverter and necessary utilities to convert KeyValues into BulkPart.
- The BulkPartConverter can store primary keys additionally, it uses DictionaryArray for string columns in memory.
- It adds a use_bulk_insert method to the memtable builder to control whether to use bulk insert with BulkPartConverter.
- It defines a new function `to_flat_sst_arrow_schema()` to generate the new schema for the format with the primary key.

It introduced a new format that contains both the primary key and the raw primary key columns (It flattens the primary key, thus the flat format). This new format stores all key columns according to their position in the primary key before fields.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
