### PR TITLE
fix: only return the __name__ label when there is one

### DIFF
--- a/src/servers/src/grpc/prom_query_gateway.rs
+++ b/src/servers/src/grpc/prom_query_gateway.rs
@@ -122,7 +122,7 @@ impl PrometheusGatewayService {
         let result = self.handler.do_query(&query, ctx).await;
         let (metric_name, mut result_type) =
             match retrieve_metric_name_and_result_type(&query.query) {
-                Ok((metric_name, result_type)) => (metric_name.unwrap_or_default(), result_type),
+                Ok((metric_name, result_type)) => (metric_name, result_type),
                 Err(err) => {
                     return PrometheusJsonResponse::error(err.status_code(), err.output_msg())
                 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

queries like `metric_a + metric_b` will not have a `__name__` label now

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
