### PR TITLE
refactor: add process manager for prometheus query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1659,6 +1659,7 @@ dependencies = [
  "partition",
  "paste",
  "prometheus",
+ "promql-parser",
  "rustc-hash 2.0.0",
  "serde_json",
  "session",

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -44,6 +44,7 @@ moka = { workspace = true, features = ["future", "sync"] }
 partition.workspace = true
 paste.workspace = true
 prometheus.workspace = true
+promql-parser.workspace = true
 rustc-hash.workspace = true
 serde_json.workspace = true
 session.workspace = true

--- a/src/frontend/src/stream_wrapper.rs
+++ b/src/frontend/src/stream_wrapper.rs
@@ -81,7 +81,7 @@ mod tests {
     use std::task::{Context, Poll};
     use std::time::Duration;
 
-    use catalog::process_manager::ProcessManager;
+    use catalog::process_manager::{ProcessManager, QueryStatement as CatalogQueryStatement};
     use common_recordbatch::adapter::RecordBatchMetrics;
     use common_recordbatch::{OrderOption, RecordBatch, RecordBatchStream};
     use datatypes::data_type::ConcreteDataType;
@@ -89,6 +89,8 @@ mod tests {
     use datatypes::schema::{ColumnSchema, Schema, SchemaRef};
     use datatypes::vectors::Int32Vector;
     use futures::{Stream, StreamExt};
+    use sql::dialect::GreptimeDbDialect;
+    use sql::parser::{ParseOptions, ParserContext};
     use tokio::time::{sleep, timeout};
 
     use super::CancellableStreamWrapper;
@@ -184,7 +186,15 @@ mod tests {
         let ticket = process_manager.register_query(
             "catalog".to_string(),
             vec![],
-            "query".to_string(),
+            CatalogQueryStatement::Sql(
+                ParserContext::create_with_dialect(
+                    "SELECT * FROM test_table",
+                    &GreptimeDbDialect {},
+                    ParseOptions::default(),
+                )
+                .unwrap()[0]
+                    .clone(),
+            ),
             "client".to_string(),
             None,
         );
@@ -207,7 +217,15 @@ mod tests {
         let ticket = process_manager.register_query(
             "catalog".to_string(),
             vec![],
-            "query".to_string(),
+            CatalogQueryStatement::Sql(
+                ParserContext::create_with_dialect(
+                    "SELECT * FROM test_table",
+                    &GreptimeDbDialect {},
+                    ParseOptions::default(),
+                )
+                .unwrap()[0]
+                    .clone(),
+            ),
             "client".to_string(),
             None,
         );
@@ -231,7 +249,15 @@ mod tests {
         let ticket = process_manager.register_query(
             "catalog".to_string(),
             vec![],
-            "query".to_string(),
+            CatalogQueryStatement::Sql(
+                ParserContext::create_with_dialect(
+                    "SELECT * FROM test_table",
+                    &GreptimeDbDialect {},
+                    ParseOptions::default(),
+                )
+                .unwrap()[0]
+                    .clone(),
+            ),
             "client".to_string(),
             None,
         );
@@ -258,7 +284,15 @@ mod tests {
         let ticket = process_manager.register_query(
             "catalog".to_string(),
             vec![],
-            "query".to_string(),
+            CatalogQueryStatement::Sql(
+                ParserContext::create_with_dialect(
+                    "SELECT * FROM test_table",
+                    &GreptimeDbDialect {},
+                    ParseOptions::default(),
+                )
+                .unwrap()[0]
+                    .clone(),
+            ),
             "client".to_string(),
             None,
         );
@@ -286,7 +320,15 @@ mod tests {
         let ticket = process_manager.register_query(
             "catalog".to_string(),
             vec![],
-            "query".to_string(),
+            CatalogQueryStatement::Sql(
+                ParserContext::create_with_dialect(
+                    "SELECT * FROM test_table",
+                    &GreptimeDbDialect {},
+                    ParseOptions::default(),
+                )
+                .unwrap()[0]
+                    .clone(),
+            ),
             "client".to_string(),
             None,
         );
@@ -316,7 +358,15 @@ mod tests {
         let ticket = process_manager.register_query(
             "catalog".to_string(),
             vec![],
-            "query".to_string(),
+            CatalogQueryStatement::Sql(
+                ParserContext::create_with_dialect(
+                    "SELECT * FROM test_table",
+                    &GreptimeDbDialect {},
+                    ParseOptions::default(),
+                )
+                .unwrap()[0]
+                    .clone(),
+            ),
             "client".to_string(),
             None,
         );
@@ -344,7 +394,15 @@ mod tests {
         let ticket = process_manager.register_query(
             "catalog".to_string(),
             vec![],
-            "query".to_string(),
+            CatalogQueryStatement::Sql(
+                ParserContext::create_with_dialect(
+                    "SELECT * FROM test_table",
+                    &GreptimeDbDialect {},
+                    ParseOptions::default(),
+                )
+                .unwrap()[0]
+                    .clone(),
+            ),
             "client".to_string(),
             None,
         );

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -640,6 +640,12 @@ pub enum Error {
 
     #[snafu(display("Unknown hint: {}", hint))]
     UnknownHint { hint: String },
+
+    #[snafu(display("Query has been cancelled"))]
+    Cancelled {
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -765,6 +771,8 @@ impl ErrorExt for Error {
             DurationOverflow { .. } => StatusCode::InvalidArguments,
 
             HandleOtelArrowRequest { .. } => StatusCode::Internal,
+
+            Cancelled { .. } => StatusCode::Cancelled,
         }
     }
 


### PR DESCRIPTION
Signed-off-by: zyy17 <zyylsxm@gmail.com>I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Part of the https://github.com/GreptimeTeam/greptimedb/pull/6590.

1. Register the PromQL query in the ProcessManager;
2. Change the type of argument `query` in `ProcessManager::register_query()` from `String` to `QueryStatement` to take more metadata into ProcessManager;

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
