### PR TITLE
feat: truncate files when flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "api"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "common-base",
  "common-decimal",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "auth"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "async-trait",
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "catalog",
  "common-error",
@@ -1652,7 +1652,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "arrow 54.2.1",
@@ -1690,8 +1690,6 @@ dependencies = [
  "partition",
  "paste",
  "prometheus",
- "promql-parser",
- "rand 0.9.0",
  "rustc-hash 2.0.0",
  "serde_json",
  "session",
@@ -1992,7 +1990,7 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "cli"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2036,7 +2034,7 @@ dependencies = [
  "session",
  "snafu 0.8.5",
  "store-api",
- "substrait 0.17.0",
+ "substrait 0.16.0",
  "table",
  "tempfile",
  "tokio",
@@ -2045,7 +2043,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -2075,7 +2073,7 @@ dependencies = [
  "rand 0.9.0",
  "serde_json",
  "snafu 0.8.5",
- "substrait 0.17.0",
+ "substrait 0.16.0",
  "substrait 0.37.3",
  "tokio",
  "tokio-stream",
@@ -2116,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "auth",
@@ -2178,7 +2176,7 @@ dependencies = [
  "snafu 0.8.5",
  "stat",
  "store-api",
- "substrait 0.17.0",
+ "substrait 0.16.0",
  "table",
  "temp-env",
  "tempfile",
@@ -2225,7 +2223,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "common-base"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "anymap2",
  "async-trait",
@@ -2247,11 +2245,11 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "0.17.0"
+version = "0.16.0"
 
 [[package]]
 name = "common-config"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "common-base",
  "common-error",
@@ -2277,7 +2275,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "arrow 54.2.1",
  "arrow-schema 54.3.1",
@@ -2314,7 +2312,7 @@ dependencies = [
 
 [[package]]
 name = "common-decimal"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "bigdecimal 0.4.8",
  "common-error",
@@ -2327,7 +2325,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "common-macro",
  "http 1.1.0",
@@ -2338,13 +2336,15 @@ dependencies = [
 
 [[package]]
 name = "common-event-recorder"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "async-trait",
  "backon",
+ "client",
  "common-error",
  "common-macro",
+ "common-meta",
  "common-telemetry",
  "common-time",
  "serde",
@@ -2357,7 +2357,7 @@ dependencies = [
 
 [[package]]
 name = "common-frontend"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "common-error",
@@ -2366,7 +2366,6 @@ dependencies = [
  "common-meta",
  "greptime-proto",
  "meta-client",
- "session",
  "snafu 0.8.5",
  "tokio",
  "tonic 0.12.3",
@@ -2374,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -2433,7 +2432,7 @@ dependencies = [
 
 [[package]]
 name = "common-greptimedb-telemetry"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "common-runtime",
@@ -2450,7 +2449,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -2483,7 +2482,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "common-base",
@@ -2503,7 +2502,7 @@ dependencies = [
 
 [[package]]
 name = "common-macro"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "arc-swap",
  "common-query",
@@ -2517,7 +2516,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "common-error",
@@ -2533,7 +2532,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "anymap2",
  "api",
@@ -2604,7 +2603,7 @@ dependencies = [
 
 [[package]]
 name = "common-options"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "common-grpc",
  "humantime-serde",
@@ -2613,11 +2612,11 @@ dependencies = [
 
 [[package]]
 name = "common-plugins"
-version = "0.17.0"
+version = "0.16.0"
 
 [[package]]
 name = "common-pprof"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2629,15 +2628,13 @@ dependencies = [
 
 [[package]]
 name = "common-procedure"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
- "api",
  "async-stream",
  "async-trait",
  "backon",
  "common-base",
  "common-error",
- "common-event-recorder",
  "common-macro",
  "common-runtime",
  "common-telemetry",
@@ -2658,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -2668,7 +2665,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "async-trait",
@@ -2694,7 +2691,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "arc-swap",
  "common-error",
@@ -2715,7 +2712,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "clap 4.5.19",
@@ -2745,15 +2742,14 @@ dependencies = [
 
 [[package]]
 name = "common-session"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
- "serde",
  "strum 0.27.1",
 ]
 
 [[package]]
 name = "common-sql"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "common-base",
  "common-datasource",
@@ -2772,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "backtrace",
  "common-error",
@@ -2800,7 +2796,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "client",
  "common-grpc",
@@ -2813,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "arrow 54.2.1",
  "chrono",
@@ -2831,7 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "common-version"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "build-data",
  "cargo-manifest",
@@ -2842,7 +2838,7 @@ dependencies = [
 
 [[package]]
 name = "common-wal"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "common-base",
  "common-error",
@@ -2865,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "common-workload"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "common-telemetry",
@@ -3864,7 +3860,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -3918,7 +3914,7 @@ dependencies = [
  "session",
  "snafu 0.8.5",
  "store-api",
- "substrait 0.17.0",
+ "substrait 0.16.0",
  "table",
  "tokio",
  "toml 0.8.19",
@@ -3928,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "datatypes"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "arrow 54.2.1",
  "arrow-array 54.2.1",
@@ -4603,7 +4599,7 @@ checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "file-engine"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "async-trait",
@@ -4740,7 +4736,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "flow"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "arrow 54.2.1",
@@ -4807,7 +4803,7 @@ dependencies = [
  "sql",
  "store-api",
  "strum 0.27.1",
- "substrait 0.17.0",
+ "substrait 0.16.0",
  "table",
  "tokio",
  "tonic 0.12.3",
@@ -4862,7 +4858,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frontend"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -4923,7 +4919,7 @@ dependencies = [
  "sqlparser 0.54.0-greptime",
  "store-api",
  "strfmt",
- "substrait 0.17.0",
+ "substrait 0.16.0",
  "table",
  "tokio",
  "tokio-util",
@@ -6108,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "index"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -6120,7 +6116,6 @@ dependencies = [
  "common-runtime",
  "common-telemetry",
  "common-test-util",
- "criterion 0.4.0",
  "fastbloom",
  "fst",
  "futures",
@@ -6237,17 +6232,6 @@ dependencies = [
  "nom",
  "smallvec",
  "snafu 0.7.5",
-]
-
-[[package]]
-name = "inherent"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c38228f24186d9cc68c729accb4d413be9eaed6ad07ff79e0270d9e56f3de13"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
 ]
 
 [[package]]
@@ -7034,7 +7018,7 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "log-query"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "common-error",
@@ -7046,7 +7030,7 @@ dependencies = [
 
 [[package]]
 name = "log-store"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7289,12 +7273,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
-name = "md5"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
-
-[[package]]
 name = "measure_time"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7349,7 +7327,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "async-trait",
@@ -7377,7 +7355,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "async-trait",
@@ -7392,7 +7370,6 @@ dependencies = [
  "common-catalog",
  "common-config",
  "common-error",
- "common-event-recorder",
  "common-greptimedb-telemetry",
  "common-grpc",
  "common-macro",
@@ -7475,7 +7452,7 @@ dependencies = [
 
 [[package]]
 name = "metric-engine"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -7500,7 +7477,6 @@ dependencies = [
  "lazy_static",
  "mito-codec",
  "mito2",
- "moka",
  "mur3",
  "object-store",
  "prometheus",
@@ -7568,7 +7544,7 @@ dependencies = [
 
 [[package]]
 name = "mito-codec"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "bytes",
@@ -7591,7 +7567,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -8344,7 +8320,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -8356,7 +8332,7 @@ dependencies = [
  "futures",
  "humantime-serde",
  "lazy_static",
- "md5 0.7.0",
+ "md5",
  "moka",
  "opendal",
  "prometheus",
@@ -8680,7 +8656,7 @@ dependencies = [
 
 [[package]]
 name = "operator"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -8736,7 +8712,7 @@ dependencies = [
  "sql",
  "sqlparser 0.54.0-greptime",
  "store-api",
- "substrait 0.17.0",
+ "substrait 0.16.0",
  "table",
  "tokio",
  "tokio-util",
@@ -8995,7 +8971,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "async-trait",
@@ -9189,9 +9165,8 @@ dependencies = [
 
 [[package]]
 name = "pgwire"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "017b8b74f9e8c7aff0087d4ef2b91676a5509e8928100d6a3510fd472210feb5"
+version = "0.30.2"
+source = "git+https://github.com/sunng87/pgwire?rev=127573d997228cfb70c7699881c568eae8131270#127573d997228cfb70c7699881c568eae8131270"
 dependencies = [
  "async-trait",
  "bytes",
@@ -9200,7 +9175,7 @@ dependencies = [
  "futures",
  "hex",
  "lazy-regex",
- "md5 0.8.0",
+ "md5",
  "postgres-types",
  "rand 0.9.0",
  "ring",
@@ -9323,7 +9298,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeline"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -9467,7 +9442,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "auth",
  "clap 4.5.19",
@@ -9780,7 +9755,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -10063,7 +10038,7 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "async-compression 0.4.13",
  "async-trait",
@@ -10105,7 +10080,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -10171,7 +10146,7 @@ dependencies = [
  "sqlparser 0.54.0-greptime",
  "statrs",
  "store-api",
- "substrait 0.17.0",
+ "substrait 0.16.0",
  "table",
  "tokio",
  "tokio-stream",
@@ -11283,30 +11258,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sea-query"
-version = "0.32.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c91783d1514b99754fc6a4079081dcc2c587dadbff65c48c7f62297443536a"
-dependencies = [
- "inherent",
- "sea-query-derive",
-]
-
-[[package]]
-name = "sea-query-derive"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae0cbad6ab996955664982739354128c58d16e126114fe88c2a493642502aab"
-dependencies = [
- "darling 0.20.10",
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11524,7 +11475,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -11648,7 +11599,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -11988,7 +11939,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "chrono",
@@ -12045,7 +11996,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "clap 4.5.19",
@@ -12345,7 +12296,7 @@ dependencies = [
 
 [[package]]
 name = "stat"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "nix 0.30.1",
 ]
@@ -12371,7 +12322,7 @@ dependencies = [
 
 [[package]]
 name = "store-api"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -12534,7 +12485,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -12735,7 +12686,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "async-trait",
@@ -13004,7 +12955,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "tests-fuzz"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "arbitrary",
  "async-trait",
@@ -13048,7 +12999,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "0.17.0"
+version = "0.16.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -13066,7 +13017,6 @@ dependencies = [
  "common-catalog",
  "common-config",
  "common-error",
- "common-event-recorder",
  "common-grpc",
  "common-meta",
  "common-procedure",
@@ -13109,7 +13059,6 @@ dependencies = [
  "rand 0.9.0",
  "rstest",
  "rstest_reuse",
- "sea-query",
  "serde_json",
  "servers",
  "session",
@@ -13118,7 +13067,7 @@ dependencies = [
  "sql",
  "sqlx",
  "store-api",
- "substrait 0.17.0",
+ "substrait 0.16.0",
  "table",
  "tempfile",
  "time",
@@ -13128,7 +13077,6 @@ dependencies = [
  "tonic 0.12.3",
  "tower 0.5.2",
  "url",
- "urlencoding",
  "uuid",
  "yaml-rust",
  "zstd 0.13.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "api"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "common-base",
  "common-decimal",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "auth"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "api",
  "async-trait",
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "catalog",
  "common-error",
@@ -1652,7 +1652,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "api",
  "arrow 54.2.1",
@@ -1690,6 +1690,8 @@ dependencies = [
  "partition",
  "paste",
  "prometheus",
+ "promql-parser",
+ "rand 0.9.0",
  "rustc-hash 2.0.0",
  "serde_json",
  "session",
@@ -1990,7 +1992,7 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "cli"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2034,7 +2036,7 @@ dependencies = [
  "session",
  "snafu 0.8.5",
  "store-api",
- "substrait 0.16.0",
+ "substrait 0.17.0",
  "table",
  "tempfile",
  "tokio",
@@ -2043,7 +2045,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -2073,7 +2075,7 @@ dependencies = [
  "rand 0.9.0",
  "serde_json",
  "snafu 0.8.5",
- "substrait 0.16.0",
+ "substrait 0.17.0",
  "substrait 0.37.3",
  "tokio",
  "tokio-stream",
@@ -2114,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "auth",
@@ -2176,7 +2178,7 @@ dependencies = [
  "snafu 0.8.5",
  "stat",
  "store-api",
- "substrait 0.16.0",
+ "substrait 0.17.0",
  "table",
  "temp-env",
  "tempfile",
@@ -2223,7 +2225,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "common-base"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anymap2",
  "async-trait",
@@ -2245,11 +2247,11 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "0.16.0"
+version = "0.17.0"
 
 [[package]]
 name = "common-config"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "common-base",
  "common-error",
@@ -2275,7 +2277,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "arrow 54.2.1",
  "arrow-schema 54.3.1",
@@ -2312,7 +2314,7 @@ dependencies = [
 
 [[package]]
 name = "common-decimal"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "bigdecimal 0.4.8",
  "common-error",
@@ -2325,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "common-macro",
  "http 1.1.0",
@@ -2336,15 +2338,13 @@ dependencies = [
 
 [[package]]
 name = "common-event-recorder"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "api",
  "async-trait",
  "backon",
- "client",
  "common-error",
  "common-macro",
- "common-meta",
  "common-telemetry",
  "common-time",
  "serde",
@@ -2357,7 +2357,7 @@ dependencies = [
 
 [[package]]
 name = "common-frontend"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "common-error",
@@ -2366,6 +2366,7 @@ dependencies = [
  "common-meta",
  "greptime-proto",
  "meta-client",
+ "session",
  "snafu 0.8.5",
  "tokio",
  "tonic 0.12.3",
@@ -2373,7 +2374,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -2432,7 +2433,7 @@ dependencies = [
 
 [[package]]
 name = "common-greptimedb-telemetry"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "common-runtime",
@@ -2449,7 +2450,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -2482,7 +2483,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "api",
  "common-base",
@@ -2502,7 +2503,7 @@ dependencies = [
 
 [[package]]
 name = "common-macro"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "arc-swap",
  "common-query",
@@ -2516,7 +2517,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "common-error",
@@ -2532,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anymap2",
  "api",
@@ -2603,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "common-options"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "common-grpc",
  "humantime-serde",
@@ -2612,11 +2613,11 @@ dependencies = [
 
 [[package]]
 name = "common-plugins"
-version = "0.16.0"
+version = "0.17.0"
 
 [[package]]
 name = "common-pprof"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2628,13 +2629,15 @@ dependencies = [
 
 [[package]]
 name = "common-procedure"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
+ "api",
  "async-stream",
  "async-trait",
  "backon",
  "common-base",
  "common-error",
+ "common-event-recorder",
  "common-macro",
  "common-runtime",
  "common-telemetry",
@@ -2655,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -2665,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "api",
  "async-trait",
@@ -2691,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "arc-swap",
  "common-error",
@@ -2712,7 +2715,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "clap 4.5.19",
@@ -2742,14 +2745,15 @@ dependencies = [
 
 [[package]]
 name = "common-session"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
+ "serde",
  "strum 0.27.1",
 ]
 
 [[package]]
 name = "common-sql"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "common-base",
  "common-datasource",
@@ -2768,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "backtrace",
  "common-error",
@@ -2796,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "client",
  "common-grpc",
@@ -2809,7 +2813,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "arrow 54.2.1",
  "chrono",
@@ -2827,7 +2831,7 @@ dependencies = [
 
 [[package]]
 name = "common-version"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "build-data",
  "cargo-manifest",
@@ -2838,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "common-wal"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "common-base",
  "common-error",
@@ -2861,7 +2865,7 @@ dependencies = [
 
 [[package]]
 name = "common-workload"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "api",
  "common-telemetry",
@@ -3860,7 +3864,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -3914,7 +3918,7 @@ dependencies = [
  "session",
  "snafu 0.8.5",
  "store-api",
- "substrait 0.16.0",
+ "substrait 0.17.0",
  "table",
  "tokio",
  "toml 0.8.19",
@@ -3924,7 +3928,7 @@ dependencies = [
 
 [[package]]
 name = "datatypes"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "arrow 54.2.1",
  "arrow-array 54.2.1",
@@ -4599,7 +4603,7 @@ checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "file-engine"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "api",
  "async-trait",
@@ -4736,7 +4740,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "flow"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "api",
  "arrow 54.2.1",
@@ -4803,7 +4807,7 @@ dependencies = [
  "sql",
  "store-api",
  "strum 0.27.1",
- "substrait 0.16.0",
+ "substrait 0.17.0",
  "table",
  "tokio",
  "tonic 0.12.3",
@@ -4858,7 +4862,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frontend"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -4919,7 +4923,7 @@ dependencies = [
  "sqlparser 0.54.0-greptime",
  "store-api",
  "strfmt",
- "substrait 0.16.0",
+ "substrait 0.17.0",
  "table",
  "tokio",
  "tokio-util",
@@ -6104,7 +6108,7 @@ dependencies = [
 
 [[package]]
 name = "index"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -6116,6 +6120,7 @@ dependencies = [
  "common-runtime",
  "common-telemetry",
  "common-test-util",
+ "criterion 0.4.0",
  "fastbloom",
  "fst",
  "futures",
@@ -6232,6 +6237,17 @@ dependencies = [
  "nom",
  "smallvec",
  "snafu 0.7.5",
+]
+
+[[package]]
+name = "inherent"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c38228f24186d9cc68c729accb4d413be9eaed6ad07ff79e0270d9e56f3de13"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -7018,7 +7034,7 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "log-query"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "common-error",
@@ -7030,7 +7046,7 @@ dependencies = [
 
 [[package]]
 name = "log-store"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7273,6 +7289,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
+name = "md5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
+
+[[package]]
 name = "measure_time"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7327,7 +7349,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "api",
  "async-trait",
@@ -7355,7 +7377,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "api",
  "async-trait",
@@ -7370,6 +7392,7 @@ dependencies = [
  "common-catalog",
  "common-config",
  "common-error",
+ "common-event-recorder",
  "common-greptimedb-telemetry",
  "common-grpc",
  "common-macro",
@@ -7452,7 +7475,7 @@ dependencies = [
 
 [[package]]
 name = "metric-engine"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -7477,6 +7500,7 @@ dependencies = [
  "lazy_static",
  "mito-codec",
  "mito2",
+ "moka",
  "mur3",
  "object-store",
  "prometheus",
@@ -7544,7 +7568,7 @@ dependencies = [
 
 [[package]]
 name = "mito-codec"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "api",
  "bytes",
@@ -7567,7 +7591,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -8320,7 +8344,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -8332,7 +8356,7 @@ dependencies = [
  "futures",
  "humantime-serde",
  "lazy_static",
- "md5",
+ "md5 0.7.0",
  "moka",
  "opendal",
  "prometheus",
@@ -8656,7 +8680,7 @@ dependencies = [
 
 [[package]]
 name = "operator"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -8712,7 +8736,7 @@ dependencies = [
  "sql",
  "sqlparser 0.54.0-greptime",
  "store-api",
- "substrait 0.16.0",
+ "substrait 0.17.0",
  "table",
  "tokio",
  "tokio-util",
@@ -8971,7 +8995,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "api",
  "async-trait",
@@ -9165,8 +9189,9 @@ dependencies = [
 
 [[package]]
 name = "pgwire"
-version = "0.30.2"
-source = "git+https://github.com/sunng87/pgwire?rev=127573d997228cfb70c7699881c568eae8131270#127573d997228cfb70c7699881c568eae8131270"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "017b8b74f9e8c7aff0087d4ef2b91676a5509e8928100d6a3510fd472210feb5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -9175,7 +9200,7 @@ dependencies = [
  "futures",
  "hex",
  "lazy-regex",
- "md5",
+ "md5 0.8.0",
  "postgres-types",
  "rand 0.9.0",
  "ring",
@@ -9298,7 +9323,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeline"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -9442,7 +9467,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "auth",
  "clap 4.5.19",
@@ -9755,7 +9780,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -10038,7 +10063,7 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-compression 0.4.13",
  "async-trait",
@@ -10080,7 +10105,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -10146,7 +10171,7 @@ dependencies = [
  "sqlparser 0.54.0-greptime",
  "statrs",
  "store-api",
- "substrait 0.16.0",
+ "substrait 0.17.0",
  "table",
  "tokio",
  "tokio-stream",
@@ -11258,6 +11283,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "sea-query"
+version = "0.32.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5d1c518eaf5eda38e5773f902b26ab6d5e9e9e2bb2349ca6c64cf96f80448c"
+dependencies = [
+ "inherent",
+ "sea-query-derive",
+]
+
+[[package]]
+name = "sea-query-derive"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bae0cbad6ab996955664982739354128c58d16e126114fe88c2a493642502aab"
+dependencies = [
+ "darling 0.20.10",
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11475,7 +11524,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -11599,7 +11648,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -11939,7 +11988,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "api",
  "chrono",
@@ -11996,7 +12045,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "clap 4.5.19",
@@ -12296,7 +12345,7 @@ dependencies = [
 
 [[package]]
 name = "stat"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "nix 0.30.1",
 ]
@@ -12322,7 +12371,7 @@ dependencies = [
 
 [[package]]
 name = "store-api"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -12485,7 +12534,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -12686,7 +12735,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "api",
  "async-trait",
@@ -12955,7 +13004,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "tests-fuzz"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "arbitrary",
  "async-trait",
@@ -12999,7 +13048,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -13017,6 +13066,7 @@ dependencies = [
  "common-catalog",
  "common-config",
  "common-error",
+ "common-event-recorder",
  "common-grpc",
  "common-meta",
  "common-procedure",
@@ -13059,6 +13109,7 @@ dependencies = [
  "rand 0.9.0",
  "rstest",
  "rstest_reuse",
+ "sea-query",
  "serde_json",
  "servers",
  "session",
@@ -13067,7 +13118,7 @@ dependencies = [
  "sql",
  "sqlx",
  "store-api",
- "substrait 0.16.0",
+ "substrait 0.17.0",
  "table",
  "tempfile",
  "time",
@@ -13077,6 +13128,7 @@ dependencies = [
  "tonic 0.12.3",
  "tower 0.5.2",
  "url",
+ "urlencoding",
  "uuid",
  "yaml-rust",
  "zstd 0.13.2",

--- a/config/config.md
+++ b/config/config.md
@@ -592,7 +592,7 @@
 | `flow.batching_mode.experimental_max_filter_num_per_query` | Integer | `20` | Maximum number of filters allowed in a single query |
 | `flow.batching_mode.experimental_time_window_merge_threshold` | Integer | `3` | Time window merge distance |
 | `flow.batching_mode.read_preference` | String | `Leader` | Read preference of the Frontend client. |
-| `flow.batching_mode.experimental_truncate_duration` | String | `10min` | Experimental: A duration to truncate the time window of repetitive data to improve performance |
+| `flow.batching_mode.experimental_truncate_duration` | String | `1h` | Experimental: A duration to truncate the time window of repetitive data to improve performance |
 | `grpc` | -- | -- | The gRPC server options. |
 | `grpc.bind_addr` | String | `127.0.0.1:6800` | The address to bind the gRPC server. |
 | `grpc.server_addr` | String | `127.0.0.1:6800` | The address advertised to the metasrv,<br/>and used for connections from outside the host |

--- a/config/config.md
+++ b/config/config.md
@@ -592,6 +592,7 @@
 | `flow.batching_mode.experimental_max_filter_num_per_query` | Integer | `20` | Maximum number of filters allowed in a single query |
 | `flow.batching_mode.experimental_time_window_merge_threshold` | Integer | `3` | Time window merge distance |
 | `flow.batching_mode.read_preference` | String | `Leader` | Read preference of the Frontend client. |
+| `flow.batching_mode.experimental_truncate_duration` | String | `10min` | Experimental: A duration to truncate the time window of repetitive data to improve performance |
 | `grpc` | -- | -- | The gRPC server options. |
 | `grpc.bind_addr` | String | `127.0.0.1:6800` | The address to bind the gRPC server. |
 | `grpc.server_addr` | String | `127.0.0.1:6800` | The address advertised to the metasrv,<br/>and used for connections from outside the host |

--- a/config/flownode.example.toml
+++ b/config/flownode.example.toml
@@ -32,6 +32,8 @@ node_id = 14
 #+experimental_time_window_merge_threshold=3
 ## Read preference of the Frontend client.
 #+read_preference="Leader"
+## Experimental: A duration to truncate the time window of repetitive data to improve performance
+#+experimental_truncate_duration="10min"
 
 ## The gRPC server options.
 [grpc]

--- a/config/flownode.example.toml
+++ b/config/flownode.example.toml
@@ -33,7 +33,7 @@ node_id = 14
 ## Read preference of the Frontend client.
 #+read_preference="Leader"
 ## Experimental: A duration to truncate the time window of repetitive data to improve performance
-#+experimental_truncate_duration="10min"
+#+experimental_truncate_duration="1h"
 
 ## The gRPC server options.
 [grpc]

--- a/src/flow/src/batching_mode.rs
+++ b/src/flow/src/batching_mode.rs
@@ -57,6 +57,9 @@ pub struct BatchingModeOptions {
     pub experimental_time_window_merge_threshold: usize,
     /// Read preference of the Frontend client.
     pub read_preference: ReadPreference,
+    /// Experimental: A duration to truncate the time window of repetitive data to improve performance
+    #[serde(with = "humantime_serde")]
+    pub experimental_truncate_duration: Duration,
 }
 
 impl Default for BatchingModeOptions {
@@ -72,6 +75,7 @@ impl Default for BatchingModeOptions {
             experimental_max_filter_num_per_query: 20,
             experimental_time_window_merge_threshold: 3,
             read_preference: Default::default(),
+            experimental_truncate_duration: Duration::from_secs(600),
         }
     }
 }

--- a/src/flow/src/batching_mode.rs
+++ b/src/flow/src/batching_mode.rs
@@ -75,7 +75,7 @@ impl Default for BatchingModeOptions {
             experimental_max_filter_num_per_query: 20,
             experimental_time_window_merge_threshold: 3,
             read_preference: Default::default(),
-            experimental_truncate_duration: Duration::from_secs(600),
+            experimental_truncate_duration: Duration::from_secs(3600),
         }
     }
 }

--- a/src/flow/src/batching_mode/state.rs
+++ b/src/flow/src/batching_mode/state.rs
@@ -41,9 +41,12 @@ pub struct TaskState {
     /// Query context
     pub(crate) query_ctx: QueryContextRef,
     /// last query complete time
-    last_update_time: Instant,
+    pub(crate) last_update_time: Instant,
     /// last time query duration
-    last_query_duration: Duration,
+    pub(crate) last_query_duration: Duration,
+    /// last truncate time
+    /// if `None`, means no truncate happened yet
+    pub(crate) last_truncate_time: Option<Instant>,
     /// Dirty Time windows need to be updated
     /// mapping of `start -> end` and non-overlapping
     pub(crate) dirty_time_windows: DirtyTimeWindows,
@@ -59,6 +62,7 @@ impl TaskState {
             query_ctx,
             last_update_time: Instant::now(),
             last_query_duration: Duration::from_secs(0),
+            last_truncate_time: None,
             dirty_time_windows: Default::default(),
             exec_state: ExecState::Idle,
             shutdown_rx,

--- a/src/flow/src/batching_mode/task.rs
+++ b/src/flow/src/batching_mode/task.rs
@@ -61,7 +61,7 @@ use crate::error::{
 use crate::metrics::{
     METRIC_FLOW_BATCHING_ENGINE_ERROR_CNT, METRIC_FLOW_BATCHING_ENGINE_QUERY_TIME,
     METRIC_FLOW_BATCHING_ENGINE_SLOW_QUERY, METRIC_FLOW_BATCHING_ENGINE_START_QUERY_CNT,
-    METRIC_FLOW_ROWS,
+    METRIC_FLOW_BATCHING_ENGINE_TRUNCATE_CNT, METRIC_FLOW_ROWS,
 };
 use crate::{Error, FlowId};
 
@@ -521,6 +521,9 @@ impl BatchingTask {
                     if filter.total_window_length() > filter.window_size
                         && !filter.time_ranges.is_empty()
                     {
+                        METRIC_FLOW_BATCHING_ENGINE_TRUNCATE_CNT
+                            .with_label_values(&[&flow_id_str])
+                            .inc();
                         if let Err(err) = self
                             .truncate_sink_table_with_ranges(
                                 filter.time_ranges.clone(),

--- a/src/flow/src/batching_mode/task.rs
+++ b/src/flow/src/batching_mode/task.rs
@@ -373,7 +373,7 @@ impl BatchingTask {
             && !filter.time_ranges.is_empty()
         {
             METRIC_FLOW_BATCHING_ENGINE_TRUNCATE_CNT
-                .with_label_values(&[&flow_id_str])
+                .with_label_values(&[flow_id_str])
                 .inc();
             debug!(
                 "Flow id = {:?} will truncate sink table {} with time ranges: {:?}",

--- a/src/flow/src/batching_mode/task.rs
+++ b/src/flow/src/batching_mode/task.rs
@@ -368,6 +368,25 @@ impl BatchingTask {
         frontend_client: &Arc<FrontendClient>,
         flow_id_str: &str,
     ) -> Result<u32, Error> {
+        if let Some(last_trunc_time) = self.state.read().unwrap().last_truncate_time {
+            // if last truncate time is not None, then we have already truncated before
+            // so no need to truncate again
+            if last_trunc_time.elapsed() < self.config.batch_opts.experimental_truncate_duration {
+                debug!(
+                    "Flow id = {:?} skip truncate since last truncate time is {:?} and elapsed time is less than experimental_truncate_duration",
+                    self.config.flow_id, last_trunc_time.elapsed()
+                );
+                return Ok(0);
+            } else {
+                // update last truncate time to now
+                self.state.write().unwrap().last_truncate_time = Some(Instant::now());
+            }
+        } else {
+            // if last truncate time is None, then we have never truncated before
+            // so we can proceed with truncation
+            self.state.write().unwrap().last_truncate_time = Some(Instant::now());
+        }
+
         // Heuristic: trigger truncate if the total time range to process is larger
         // than a single window size, indicating a significant catch-up operation is happening.
         if let Some(filter) = &info.filter

--- a/src/flow/src/batching_mode/task.rs
+++ b/src/flow/src/batching_mode/task.rs
@@ -518,7 +518,9 @@ impl BatchingTask {
 
             if let Some(info) = &new_query {
                 if let Some(filter) = &info.filter {
-                    if filter.total_window_length() > filter.window_size {
+                    if filter.total_window_length() > filter.window_size
+                        && !filter.time_ranges.is_empty()
+                    {
                         if let Err(err) = self
                             .truncate_sink_table_with_ranges(
                                 filter.time_ranges.clone(),

--- a/src/flow/src/metrics.rs
+++ b/src/flow/src/metrics.rs
@@ -87,6 +87,13 @@ lazy_static! {
             &["flow_id"],
         )
         .unwrap();
+    pub static ref METRIC_FLOW_BATCHING_ENGINE_TRUNCATE_CNT: IntCounterVec =
+        register_int_counter_vec!(
+            "greptime_flow_batching_truncate_count",
+            "flow batching engine truncate action count per flow id",
+            &["flow_id"],
+        )
+        .unwrap();
     pub static ref METRIC_FLOW_RUN_INTERVAL_MS: IntGauge =
         register_int_gauge!("greptime_flow_run_interval_ms", "flow run interval in ms").unwrap();
     pub static ref METRIC_FLOW_ROWS: IntCounterVec = register_int_counter_vec!(

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -1316,7 +1316,7 @@ experimental_frontend_activity_timeout = "1m"
 experimental_max_filter_num_per_query = 20
 experimental_time_window_merge_threshold = 3
 read_preference = "Leader"
-experimental_truncate_duration = "10m"
+experimental_truncate_duration = "1h"
 
 [logging]
 max_log_files = 720

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -1316,6 +1316,7 @@ experimental_frontend_activity_timeout = "1m"
 experimental_max_filter_num_per_query = 20
 experimental_time_window_merge_threshold = 3
 read_preference = "Leader"
+experimental_truncate_duration = "10m"
 
 [logging]
 max_log_files = 720

--- a/tests/cases/standalone/common/flow/flow_truncate.result
+++ b/tests/cases/standalone/common/flow/flow_truncate.result
@@ -1,0 +1,105 @@
+CREATE TABLE monitor (host STRING, ts TIMESTAMP, cpu DOUBLE DEFAULT 0, memory DOUBLE, TIME INDEX (ts), PRIMARY KEY(host));
+
+Affected Rows: 0
+
+CREATE TABLE avg_1m_monitor (time_window TIMESTAMP, host STRING, cpu DOUBLE, memory DOUBLE, TIME INDEX (time_window), PRIMARY KEY(host));
+
+Affected Rows: 0
+
+CREATE FLOW avg_1m_flow SINK TO avg_1m_monitor AS
+SELECT date_bin('1 minute', ts) AS time_window, host, avg(cpu) AS cpu, avg(memory) AS memory FROM monitor
+GROUP BY time_window, host;
+
+Affected Rows: 0
+
+INSERT INTO monitor(ts, host, cpu, memory) VALUES
+("2021-07-01 00:00:00.200", 'host1', 66.6, 1024),
+("2021-07-01 00:00:01.200", 'host1', 66.6, 1024),
+("2021-07-01 00:00:02.200", 'host1', 66.6, 1024),
+("2021-07-01 00:00:03.200", 'host1', 77.7, 2048),
+("2021-07-01 00:00:04.200", 'host1', 77.7, 2048),
+("2021-07-01 00:00:05.200", 'host1', 77.7, 2048),
+("2021-07-01 00:00:06.200", 'host1', 88.8, 4096),
+("2021-07-01 00:00:07.200", 'host1', 88.8, 4096),
+("2021-07-01 00:00:08.200", 'host1', 88.8, 4096);
+
+Affected Rows: 9
+
+-- shouldn't truncate as window size is equal to total window length
+-- SQLNESS REPLACE (ADMIN\sFLUSH_FLOW\('\w+'\)\s+\|\n\+-+\+\n\|\s+)[0-9]+\s+\| $1 FLOW_FLUSHED  |
+ADMIN FLUSH_FLOW('avg_1m_flow');
+
++---------------------------------+
+| ADMIN FLUSH_FLOW('avg_1m_flow') |
++---------------------------------+
+|  FLOW_FLUSHED  |
++---------------------------------+
+
+ADMIN FLUSH_TABLE('avg_1m_monitor');
+
++-------------------------------------+
+| ADMIN FLUSH_TABLE('avg_1m_monitor') |
++-------------------------------------+
+| 0                                   |
++-------------------------------------+
+
+SELECT * FROM avg_1m_monitor ORDER BY time_window, host;
+
++---------------------+-------+-------------------+--------------------+
+| time_window         | host  | cpu               | memory             |
++---------------------+-------+-------------------+--------------------+
+| 2021-07-01T00:00:00 | host1 | 77.69999999999999 | 2389.3333333333335 |
++---------------------+-------+-------------------+--------------------+
+
+INSERT INTO monitor(ts, host, cpu, memory) VALUES
+("2021-07-01 00:00:59.200", 'host1', 6.6, 224),
+("2021-07-01 00:01:01.200", 'host1', 6.6, 224),
+("2021-07-01 00:01:02.200", 'host1', 6.6, 224),
+("2021-07-01 00:01:03.200", 'host1', 7.7, 248),
+("2021-07-01 00:01:04.200", 'host1', 7.7, 248),
+("2021-07-01 00:01:05.200", 'host1', 7.7, 248),
+("2021-07-01 00:01:06.200", 'host1', 8.8, 296),
+("2021-07-01 00:01:07.200", 'host1', 8.8, 296),
+("2021-07-01 00:01:08.200", 'host1', 8.8, 296);
+
+Affected Rows: 9
+
+-- should truncate the old data before execute
+-- SQLNESS REPLACE (ADMIN\sFLUSH_FLOW\('\w+'\)\s+\|\n\+-+\+\n\|\s+)[0-9]+\s+\| $1 FLOW_FLUSHED  |
+ADMIN FLUSH_FLOW('avg_1m_flow');
+
++---------------------------------+
+| ADMIN FLUSH_FLOW('avg_1m_flow') |
++---------------------------------+
+|  FLOW_FLUSHED  |
++---------------------------------+
+
+ADMIN FLUSH_TABLE('avg_1m_monitor');
+
++-------------------------------------+
+| ADMIN FLUSH_TABLE('avg_1m_monitor') |
++-------------------------------------+
+| 0                                   |
++-------------------------------------+
+
+SELECT * FROM avg_1m_monitor ORDER BY time_window, host;
+
++---------------------+-------+-------------------+--------+
+| time_window         | host  | cpu               | memory |
++---------------------+-------+-------------------+--------+
+| 2021-07-01T00:00:00 | host1 | 70.58999999999999 | 2172.8 |
+| 2021-07-01T00:01:00 | host1 | 7.837499999999999 | 260.0  |
++---------------------+-------+-------------------+--------+
+
+DROP FLOW avg_1m_flow;
+
+Affected Rows: 0
+
+DROP TABLE avg_1m_monitor;
+
+Affected Rows: 0
+
+DROP TABLE monitor;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/flow/flow_truncate.sql
+++ b/tests/cases/standalone/common/flow/flow_truncate.sql
@@ -1,0 +1,49 @@
+CREATE TABLE monitor (host STRING, ts TIMESTAMP, cpu DOUBLE DEFAULT 0, memory DOUBLE, TIME INDEX (ts), PRIMARY KEY(host));
+
+CREATE TABLE avg_1m_monitor (time_window TIMESTAMP, host STRING, cpu DOUBLE, memory DOUBLE, TIME INDEX (time_window), PRIMARY KEY(host));
+
+CREATE FLOW avg_1m_flow SINK TO avg_1m_monitor AS
+SELECT date_bin('1 minute', ts) AS time_window, host, avg(cpu) AS cpu, avg(memory) AS memory FROM monitor
+GROUP BY time_window, host;
+
+INSERT INTO monitor(ts, host, cpu, memory) VALUES
+("2021-07-01 00:00:00.200", 'host1', 66.6, 1024),
+("2021-07-01 00:00:01.200", 'host1', 66.6, 1024),
+("2021-07-01 00:00:02.200", 'host1', 66.6, 1024),
+("2021-07-01 00:00:03.200", 'host1', 77.7, 2048),
+("2021-07-01 00:00:04.200", 'host1', 77.7, 2048),
+("2021-07-01 00:00:05.200", 'host1', 77.7, 2048),
+("2021-07-01 00:00:06.200", 'host1', 88.8, 4096),
+("2021-07-01 00:00:07.200", 'host1', 88.8, 4096),
+("2021-07-01 00:00:08.200", 'host1', 88.8, 4096);
+
+-- shouldn't truncate as window size is equal to total window length
+-- SQLNESS REPLACE (ADMIN\sFLUSH_FLOW\('\w+'\)\s+\|\n\+-+\+\n\|\s+)[0-9]+\s+\| $1 FLOW_FLUSHED  |
+ADMIN FLUSH_FLOW('avg_1m_flow');
+
+ADMIN FLUSH_TABLE('avg_1m_monitor');
+
+SELECT * FROM avg_1m_monitor ORDER BY time_window, host;
+
+INSERT INTO monitor(ts, host, cpu, memory) VALUES
+("2021-07-01 00:00:59.200", 'host1', 6.6, 224),
+("2021-07-01 00:01:01.200", 'host1', 6.6, 224),
+("2021-07-01 00:01:02.200", 'host1', 6.6, 224),
+("2021-07-01 00:01:03.200", 'host1', 7.7, 248),
+("2021-07-01 00:01:04.200", 'host1', 7.7, 248),
+("2021-07-01 00:01:05.200", 'host1', 7.7, 248),
+("2021-07-01 00:01:06.200", 'host1', 8.8, 296),
+("2021-07-01 00:01:07.200", 'host1', 8.8, 296),
+("2021-07-01 00:01:08.200", 'host1', 8.8, 296);
+
+-- should truncate the old data before execute
+-- SQLNESS REPLACE (ADMIN\sFLUSH_FLOW\('\w+'\)\s+\|\n\+-+\+\n\|\s+)[0-9]+\s+\| $1 FLOW_FLUSHED  |
+ADMIN FLUSH_FLOW('avg_1m_flow');
+
+ADMIN FLUSH_TABLE('avg_1m_monitor');
+
+SELECT * FROM avg_1m_monitor ORDER BY time_window, host;
+
+DROP FLOW avg_1m_flow;
+DROP TABLE avg_1m_monitor;
+DROP TABLE monitor;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

as title, truncate table before sending flow's query

~TODO: add rate limit for truncate operation~
rate limit impl-ed
should help with improve query performance of massively repeatedly updating table

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
