### PR TITLE
perf: Reduce fulltext bloom load time

### DIFF
--- a/src/index/src/fulltext_index/create/bloom_filter.rs
+++ b/src/index/src/fulltext_index/create/bloom_filter.rs
@@ -89,8 +89,12 @@ impl FulltextIndexCreator for BloomFilterFulltextIndexCreator {
         &mut self,
         puffin_writer: &mut (impl PuffinWriter + Send),
         blob_key: &str,
-        put_options: PutOptions,
+        mut put_options: PutOptions,
     ) -> Result<u64> {
+        // Compressing the bloom filter doesn't reduce the size but hurts read performance.
+        // Always disable compression here.
+        put_options.compression = None;
+
         let creator = self.inner.as_mut().context(AbortedSnafu)?;
 
         let (tx, rx) = tokio::io::duplex(PIPE_BUFFER_SIZE_FOR_SENDING_BLOB);

--- a/src/mito2/src/cache/index/bloom_filter_index.rs
+++ b/src/mito2/src/cache/index/bloom_filter_index.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 use api::v1::index::BloomFilterMeta;
 use async_trait::async_trait;
 use bytes::Bytes;
-use futures::future::try_join_all;
 use index::bloom_filter::error::Result;
 use index::bloom_filter::reader::BloomFilterReader;
 use store_api::storage::ColumnId;
@@ -120,21 +119,24 @@ impl<R: BloomFilterReader + Send> BloomFilterReader for CachedBloomFilterIndexBl
     }
 
     async fn read_vec(&self, ranges: &[Range<u64>]) -> Result<Vec<Bytes>> {
-        let fetch = ranges.iter().map(|range| {
+        let mut pages = Vec::with_capacity(ranges.len());
+        for range in ranges {
             let inner = &self.inner;
-            self.cache.get_or_load(
-                (self.file_id, self.column_id, self.tag),
-                self.blob_size,
-                range.start,
-                (range.end - range.start) as u32,
-                move |ranges| async move { inner.read_vec(&ranges).await },
-            )
-        });
-        Ok(try_join_all(fetch)
-            .await?
-            .into_iter()
-            .map(Bytes::from)
-            .collect::<Vec<_>>())
+            let page = self
+                .cache
+                .get_or_load(
+                    (self.file_id, self.column_id, self.tag),
+                    self.blob_size,
+                    range.start,
+                    (range.end - range.start) as u32,
+                    move |ranges| async move { inner.read_vec(&ranges).await },
+                )
+                .await?;
+
+            pages.push(Bytes::from(page));
+        }
+
+        Ok(pages)
     }
 
     /// Reads the meta information of the bloom filter.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

This PR improves the first load time on bloom fulltext index.

Before this PR, fulltext index always enabled compression. When using bloom backend, compression doesn't reduce the size of the puffin blob a lot, but introduces extra time to decompress the blob to the staging directory.
```
Init blob to stager, type: greptime-fulltext-index-bloom-0, blob size: 14763795, after size: 14927141, cost: 187.463416ms
```

It removes `try_join_all` from cached blob readers. This can reduce duplicated IO and load time for bloom blobs.
When reading multiple bloom filter ranges, `get_or_load()` usually fetches the same underlying page to merge IO.
If the blob reader uses `try_join_all` to fetch pages concurrently, it will fetch the same page multiple times from the puffin file.

This can lead to worse performance when the `granularity` is small:
```
INFO mito2::cache::index::bloom_filter_index: bloom filter read vec from cache, ranges: 400
INFO mito2::cache::index: Cache miss range: [0..65536]
INFO mito2::cache::index: Cache miss range: [0..65536]
INFO mito2::cache::index: Cache miss range: [0..65536]
INFO mito2::cache::index: Cache miss range: [0..65536]
INFO mito2::cache::index: Cache miss range: [0..65536]
INFO mito2::cache::index: Cache miss range: [0..65536]
INFO mito2::cache::index: Cache miss range: [0..65536]
......
```

Removing this can reduce about 50% of the first load time with the default granularity.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
