### PR TITLE
feat(log-query): support binary op, scalar fn & is_true/is_false

### DIFF
--- a/src/log-query/src/log_query.rs
+++ b/src/log-query/src/log_query.rs
@@ -326,14 +326,15 @@ pub enum ContentFilter {
         inclusive: bool,
     },
     In(Vec<String>),
-    // TODO(ruihang): arithmetic operations
+    IsTrue,
+    IsFalse,
 
     // Compound filters
-    Compound(Vec<ContentFilter>, BinaryOperator),
+    Compound(Vec<ContentFilter>, ConjunctionOperator),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum BinaryOperator {
+pub enum ConjunctionOperator {
     And,
     Or,
 }

--- a/src/log-query/src/log_query.rs
+++ b/src/log-query/src/log_query.rs
@@ -82,7 +82,7 @@ pub enum LogExpr {
     },
     BinaryOp {
         left: Box<LogExpr>,
-        op: String,
+        op: BinaryOperator,
         right: Box<LogExpr>,
     },
     Alias {
@@ -335,6 +335,29 @@ pub enum ContentFilter {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ConjunctionOperator {
+    And,
+    Or,
+}
+
+/// Binary operators for LogExpr::BinaryOp.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum BinaryOperator {
+    // Comparison operators
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+
+    // Arithmetic operators
+    Plus,
+    Minus,
+    Multiply,
+    Divide,
+    Modulo,
+
+    // Logical operators
     And,
     Or,
 }


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


New supported:
- `LogQuery::ScalarFunction`
- `LogQuery::BinaryOp`
- `ColumnFilter::IsTrue` and `ColumnFilter::IsFalse`

Changed:
- Rename `BinaryOperator` to `ConjunctionOperator`

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
