### PR TITLE
feat: count underscore in English tokenizer and improve performance

### DIFF
--- a/src/index/Cargo.toml
+++ b/src/index/Cargo.toml
@@ -42,7 +42,12 @@ uuid.workspace = true
 
 [dev-dependencies]
 common-test-util.workspace = true
+criterion = "0.4"
 rand.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
+
+[[bench]]
+name = "tokenizer_bench"
+harness = false

--- a/src/index/benches/tokenizer_bench.rs
+++ b/src/index/benches/tokenizer_bench.rs
@@ -1,0 +1,66 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use index::fulltext_index::tokenizer::{EnglishTokenizer, Tokenizer};
+
+fn bench_english_tokenizer(c: &mut Criterion) {
+    let tokenizer = EnglishTokenizer;
+
+    let texts = vec![
+        ("short", "Hello, world! This is a test."),
+        ("medium", "The quick brown fox jumps over the lazy dog. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."),
+        ("long", "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt."),
+        ("mixed_chars", "Hello123 world!!! This-is_a.test@example.com with various: punctuation; and [brackets] {curly} (parentheses) & symbols* + numbers456."),
+        ("numbers_heavy", "test123 456test test789 abc123def 999888777 hello42world 123 456 789 mix1ng l3tt3rs 4nd numb3rs"),
+        ("punctuation_heavy", "Hello!!! World??? This...is...a...test... With lots of!!! punctuation??? marks!!! And... ellipses???"),
+        ("postgres log", "2025-08-01 21:09:28.928 UTC [27] LOG:  checkpoint complete: wrote 0 buffers (0.0%); 0 WAL file(s) added, 0 removed, 0 recycled; write=0.001 s, sync=0.001 s, total=0.003 s; sync files=0, longest=0.000 s, average=0.000 s; distance=0 kB, estimate=5 kB; lsn=0/1992868, redo lsn=0/1992868"),
+        ("many_short_words", "a b c d e f g h i j k l m n o p q r s t u v w x y z"),
+        ("with_unicode", "这是，一个测试。🈶一些 Unicøde 字符比如 café and naïve words."),
+    ];
+
+    let mut group = c.benchmark_group("english_tokenizer");
+
+    for (size, text) in texts {
+        group.bench_with_input(BenchmarkId::new("tokenize", size), &text, |b, text| {
+            b.iter(|| tokenizer.tokenize(text))
+        });
+    }
+
+    group.finish();
+
+    // Benchmark with repeated tokenization to simulate real-world usage
+    let mut repeat_group = c.benchmark_group("english_tokenizer_repeated");
+
+    let sample_text = "The quick brown fox jumps over the lazy dog. This sentence contains most letters of the alphabet.";
+
+    for repeat_count in [10, 100, 1000] {
+        repeat_group.bench_with_input(
+            BenchmarkId::new("repeated_tokenize", repeat_count),
+            &repeat_count,
+            |b, &repeat_count| {
+                b.iter(|| {
+                    for _ in 0..repeat_count {
+                        tokenizer.tokenize(sample_text);
+                    }
+                })
+            },
+        );
+    }
+
+    repeat_group.finish();
+}
+
+criterion_group!(benches, bench_english_tokenizer);
+criterion_main!(benches);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

- don't separate on '_'
- performance improvement
- benchmark

Benchmark compare with previous implementation:
```
english_tokenizer/tokenize/short
                        time:   [36.693 ns 36.861 ns 37.038 ns]
                        change: [-32.648% -32.371% -32.079%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
english_tokenizer/tokenize/medium
                        time:   [153.71 ns 154.05 ns 154.40 ns]
                        change: [-38.949% -38.758% -38.523%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe
english_tokenizer/tokenize/long
                        time:   [416.41 ns 418.59 ns 420.88 ns]
                        change: [-54.355% -54.151% -53.955%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) low mild
english_tokenizer/tokenize/mixed_chars
                        time:   [96.234 ns 96.810 ns 97.442 ns]
                        change: [-53.532% -53.339% -53.141%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
english_tokenizer/tokenize/numbers_heavy
                        time:   [101.51 ns 101.93 ns 102.41 ns]
                        change: [-34.777% -34.591% -34.387%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  2 (2.00%) high mild
  11 (11.00%) high severe
english_tokenizer/tokenize/punctuation_heavy
                        time:   [102.37 ns 102.73 ns 103.12 ns]
                        change: [-44.286% -44.103% -43.901%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
english_tokenizer/tokenize/postgres log
                        time:   [190.18 ns 190.94 ns 191.73 ns]
                        change: [-53.639% -53.528% -53.421%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) low mild
  5 (5.00%) high mild
  4 (4.00%) high severe
english_tokenizer/tokenize/many_short_words
                        time:   [126.79 ns 127.11 ns 127.38 ns]
                        change: [-23.708% -23.345% -22.893%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
english_tokenizer/tokenize/with_unicode
                        time:   [61.698 ns 62.185 ns 62.698 ns]
                        change: [-73.410% -73.244% -73.082%] (p = 0.00 < 0.05)
                        Performance has improved.

english_tokenizer_repeated/repeated_tokenize/10
                        time:   [1.1401 µs 1.1422 µs 1.1445 µs]
                        change: [-37.271% -37.083% -36.902%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
english_tokenizer_repeated/repeated_tokenize/100
                        time:   [11.318 µs 11.349 µs 11.383 µs]
                        change: [-35.162% -34.549% -33.968%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
english_tokenizer_repeated/repeated_tokenize/1000
                        time:   [99.466 µs 99.905 µs 100.36 µs]
                        change: [-37.585% -37.377% -37.148%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
```

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
