### PR TITLE
fix: box Explain node in Statement to reduce stack size

### DIFF
--- a/src/sql/src/parsers/explain_parser.rs
+++ b/src/sql/src/parsers/explain_parser.rs
@@ -31,7 +31,9 @@ impl ParserContext<'_> {
                 actual: self.peek_token_as_string(),
             })?;
 
-        Ok(Statement::Explain(Explain::try_from(explain_statement)?))
+        Ok(Statement::Explain(Box::new(Explain::try_from(
+            explain_statement,
+        )?)))
     }
 }
 
@@ -118,6 +120,6 @@ mod tests {
         })
         .unwrap();
 
-        assert_eq!(stmts[0], Statement::Explain(explain))
+        assert_eq!(stmts[0], Statement::Explain(Box::new(explain)))
     }
 }

--- a/src/sql/src/statements/statement.rs
+++ b/src/sql/src/statements/statement.rs
@@ -124,7 +124,7 @@ pub enum Statement {
     // DESCRIBE TABLE
     DescribeTable(DescribeTable),
     // EXPLAIN QUERY
-    Explain(Explain),
+    Explain(Box<Explain>),
     // COPY
     Copy(Copy),
     // Telemetry Query Language


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Maybe related to https://github.com/GreptimeTeam/greptimedb/pull/6634

## What's changed and what's your intention?


I find https://github.com/GreptimeTeam/greptimedb/pull/6645 will stack overflowed on a totally unrelated place (range query test). And from the debugger, `stacker` chooses not to grow the stack size every time.

I suspect this is caused by some large enum or struct. And it turns out this is at least related. Before `Statement` is 1856 size, because of `Explain` which is the same size as well. After boxing it the `Statement`'s size shrinks to 384, and the overflow in #6645 is gone

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
