### PR TITLE
refactor: refine error status code mappings

### DIFF
--- a/src/common/procedure/src/error.rs
+++ b/src/common/procedure/src/error.rs
@@ -260,21 +260,20 @@ impl ErrorExt for Error {
             | Error::PutPoison { source, .. }
             | Error::DeletePoison { source, .. }
             | Error::GetPoison { source, .. }
-            | Error::CheckStatus { source, .. } => source.status_code(),
+            | Error::CheckStatus { source, .. }
+            | Error::RetryLater { source, .. } => source.status_code(),
 
             Error::ToJson { .. }
             | Error::DeleteState { .. }
             | Error::FromJson { .. }
-            | Error::WaitWatcher { .. }
-            | Error::RetryLater { .. }
-            | Error::RollbackProcedureRecovered { .. }
-            | Error::TooManyRunningProcedures { .. }
-            | Error::PoisonKeyNotDefined { .. } => StatusCode::Internal,
+            | Error::WaitWatcher { .. } => StatusCode::Internal,
 
             Error::RetryTimesExceeded { .. }
             | Error::RollbackTimesExceeded { .. }
             | Error::ManagerNotStart { .. }
-            | Error::ManagerPasued { .. } => StatusCode::IllegalState,
+            | Error::ManagerPasued { .. }
+            | Error::TooManyRunningProcedures { .. }
+            | Error::RollbackProcedureRecovered { .. } => StatusCode::IllegalState,
 
             Error::RollbackNotSupported { .. } => StatusCode::Unsupported,
             Error::LoaderConflict { .. } | Error::DuplicateProcedure { .. } => {
@@ -283,7 +282,8 @@ impl ErrorExt for Error {
             Error::ProcedurePanic { .. }
             | Error::ParseSegmentKey { .. }
             | Error::Unexpected { .. }
-            | &Error::ProcedureNotFound { .. } => StatusCode::Unexpected,
+            | &Error::ProcedureNotFound { .. }
+            | Error::PoisonKeyNotDefined { .. } => StatusCode::Unexpected,
             Error::ProcedureExec { source, .. } => source.status_code(),
             Error::StartRemoveOutdatedMetaTask { source, .. }
             | Error::StopRemoveOutdatedMetaTask { source, .. } => source.status_code(),

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -958,30 +958,30 @@ impl ErrorExt for Error {
             | Error::BatchGet { .. }
             | Error::Range { .. }
             | Error::ResponseHeaderNotFound { .. }
-            | Error::IsNotLeader { .. }
             | Error::InvalidHttpBody { .. }
             | Error::ExceededRetryLimit { .. }
             | Error::SendShutdownSignal { .. }
-            | Error::PusherNotFound { .. }
             | Error::PushMessage { .. }
             | Error::MailboxClosed { .. }
-            | Error::MailboxTimeout { .. }
             | Error::MailboxReceiver { .. }
-            | Error::MailboxChannelClosed { .. }
-            | Error::RetryLater { .. }
-            | Error::RetryLaterWithSource { .. }
             | Error::StartGrpc { .. }
             | Error::PublishMessage { .. }
             | Error::Join { .. }
-            | Error::PeerUnavailable { .. }
-            | Error::ExceededDeadline { .. }
             | Error::ChooseItems { .. }
             | Error::FlowStateHandler { .. }
             | Error::BuildWalOptionsAllocator { .. }
             | Error::BuildPartitionClient { .. }
-            | Error::BuildKafkaClient { .. }
-            | Error::DeleteRecords { .. }
-            | Error::PruneTaskAlreadyRunning { .. } => StatusCode::Internal,
+            | Error::BuildKafkaClient { .. } => StatusCode::Internal,
+
+            Error::DeleteRecords { .. }
+            | Error::PeerUnavailable { .. }
+            | Error::PusherNotFound { .. } => StatusCode::Unexpected,
+            Error::MailboxTimeout { .. } | Error::ExceededDeadline { .. } => StatusCode::Cancelled,
+            Error::PruneTaskAlreadyRunning { .. }
+            | Error::RetryLater { .. }
+            | Error::MailboxChannelClosed { .. }
+            | Error::IsNotLeader { .. } => StatusCode::IllegalState,
+            Error::RetryLaterWithSource { source, .. } => source.status_code(),
 
             Error::Unsupported { .. } => StatusCode::Unsupported,
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR adjusts the error mappings to ensure that errors with incorrect or overly generic status codes are surfaced with more informative messages. This improves observability and enhances the user experience during debugging.

Previously, `error.output_msg()` would suppress `Internal` and `Unknown` error by default, resulting in vague error messages like:
```
{"status":"Failed","error":"Internal error: 1003"}
```
This often confused users when running sql such as `admin procedure_state('id')`.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
