### PR TITLE
feat: new HTTP API for formatting SQL

### DIFF
--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -1051,6 +1051,10 @@ impl HttpServer {
                 routing::get(handler::sql_parse).post(handler::sql_parse),
             )
             .route(
+                "/sql/format",
+                routing::get(handler::sql_format).post(handler::sql_format),
+            )
+            .route(
                 "/promql",
                 routing::get(handler::promql).post(handler::promql),
             )


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

New HTTP endpoint `sql/format?sql=` for formatting SQLs.

It would become prettier in the future https://docs.rs/sqlparser/0.58.0/sqlparser/index.html#pretty-printing

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
