### PR TITLE
fix: correctly set extension range source index

### DIFF
--- a/src/api/src/v1.rs
+++ b/src/api/src/v1.rs
@@ -14,6 +14,8 @@
 
 pub mod column_def;
 
+pub mod helper;
+
 pub mod meta {
     pub use greptime_proto::v1::meta::*;
 }

--- a/src/api/src/v1/helper.rs
+++ b/src/api/src/v1/helper.rs
@@ -1,0 +1,65 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use greptime_proto::v1::value::ValueData;
+use greptime_proto::v1::{ColumnDataType, ColumnSchema, Row, SemanticType, Value};
+
+/// Create a time index [ColumnSchema] with column's name and datatype.
+/// Other fields are left default.
+/// Useful when you just want to create a simple [ColumnSchema] without providing much struct fields.
+pub fn time_index_column_schema(name: &str, datatype: ColumnDataType) -> ColumnSchema {
+    ColumnSchema {
+        column_name: name.to_string(),
+        datatype: datatype as i32,
+        semantic_type: SemanticType::Timestamp as i32,
+        ..Default::default()
+    }
+}
+
+/// Create a tag [ColumnSchema] with column's name and datatype.
+/// Other fields are left default.
+/// Useful when you just want to create a simple [ColumnSchema] without providing much struct fields.
+pub fn tag_column_schema(name: &str, datatype: ColumnDataType) -> ColumnSchema {
+    ColumnSchema {
+        column_name: name.to_string(),
+        datatype: datatype as i32,
+        semantic_type: SemanticType::Tag as i32,
+        ..Default::default()
+    }
+}
+
+/// Create a field [ColumnSchema] with column's name and datatype.
+/// Other fields are left default.
+/// Useful when you just want to create a simple [ColumnSchema] without providing much struct fields.
+pub fn field_column_schema(name: &str, datatype: ColumnDataType) -> ColumnSchema {
+    ColumnSchema {
+        column_name: name.to_string(),
+        datatype: datatype as i32,
+        semantic_type: SemanticType::Field as i32,
+        ..Default::default()
+    }
+}
+
+/// Create a [Row] from [ValueData]s.
+/// Useful when you don't want to write much verbose codes.
+pub fn row(values: Vec<ValueData>) -> Row {
+    Row {
+        values: values
+            .into_iter()
+            .map(|x| Value {
+                value_data: Some(x),
+            })
+            .collect::<Vec<_>>(),
+    }
+}

--- a/src/common/event-recorder/src/recorder.rs
+++ b/src/common/event-recorder/src/recorder.rs
@@ -19,6 +19,7 @@ use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use api::v1::column_data_type_extension::TypeExt;
+use api::v1::helper::{tag_column_schema, time_index_column_schema};
 use api::v1::value::ValueData;
 use api::v1::{
     ColumnDataType, ColumnDataTypeExtension, ColumnSchema, JsonTypeExtension, Row,
@@ -143,12 +144,7 @@ pub fn build_row_inserts_request(events: &[Box<dyn Event>]) -> Result<RowInsertR
         // We already validated the events, so it's safe to get the first event to build the schema for the RowInsertRequest.
         let event = &events[0];
         let mut schema = vec![
-            ColumnSchema {
-                column_name: EVENTS_TABLE_TYPE_COLUMN_NAME.to_string(),
-                datatype: ColumnDataType::String.into(),
-                semantic_type: SemanticType::Tag.into(),
-                ..Default::default()
-            },
+            tag_column_schema(EVENTS_TABLE_TYPE_COLUMN_NAME, ColumnDataType::String),
             ColumnSchema {
                 column_name: EVENTS_TABLE_PAYLOAD_COLUMN_NAME.to_string(),
                 datatype: ColumnDataType::Binary as i32,
@@ -158,12 +154,10 @@ pub fn build_row_inserts_request(events: &[Box<dyn Event>]) -> Result<RowInsertR
                 }),
                 ..Default::default()
             },
-            ColumnSchema {
-                column_name: EVENTS_TABLE_TIMESTAMP_COLUMN_NAME.to_string(),
-                datatype: ColumnDataType::TimestampNanosecond.into(),
-                semantic_type: SemanticType::Timestamp.into(),
-                ..Default::default()
-            },
+            time_index_column_schema(
+                EVENTS_TABLE_TIMESTAMP_COLUMN_NAME,
+                ColumnDataType::TimestampNanosecond,
+            ),
         ];
         schema.extend(event.extra_schema());
 

--- a/src/metric-engine/src/metadata_region.rs
+++ b/src/metric-engine/src/metadata_region.rs
@@ -17,8 +17,9 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::Duration;
 
+use api::v1::helper::row;
 use api::v1::value::ValueData;
-use api::v1::{ColumnDataType, ColumnSchema, Row, Rows, SemanticType, Value};
+use api::v1::{ColumnDataType, ColumnSchema, Rows, SemanticType};
 use async_stream::try_stream;
 use base64::engine::general_purpose::STANDARD_NO_PAD;
 use base64::Engine;
@@ -497,18 +498,12 @@ impl MetadataRegion {
             schema: cols,
             rows: kv
                 .into_iter()
-                .map(|(key, value)| Row {
-                    values: vec![
-                        Value {
-                            value_data: Some(ValueData::TimestampMillisecondValue(0)),
-                        },
-                        Value {
-                            value_data: Some(ValueData::StringValue(key)),
-                        },
-                        Value {
-                            value_data: Some(ValueData::StringValue(value)),
-                        },
-                    ],
+                .map(|(key, value)| {
+                    row(vec![
+                        ValueData::TimestampMillisecondValue(0),
+                        ValueData::StringValue(key),
+                        ValueData::StringValue(value),
+                    ])
                 })
                 .collect(),
         };
@@ -533,15 +528,11 @@ impl MetadataRegion {
         ];
         let rows = keys
             .iter()
-            .map(|key| Row {
-                values: vec![
-                    Value {
-                        value_data: Some(ValueData::TimestampMillisecondValue(0)),
-                    },
-                    Value {
-                        value_data: Some(ValueData::StringValue(key.to_string())),
-                    },
-                ],
+            .map(|key| {
+                row(vec![
+                    ValueData::TimestampMillisecondValue(0),
+                    ValueData::StringValue(key.to_string()),
+                ])
             })
             .collect();
         let rows = Rows { schema: cols, rows };

--- a/src/mito2/src/engine/basic_test.rs
+++ b/src/mito2/src/engine/basic_test.rs
@@ -16,6 +16,7 @@
 
 use std::collections::HashMap;
 
+use api::v1::helper::row;
 use api::v1::value::ValueData;
 use api::v1::{Rows, SemanticType};
 use common_base::readable_size::ReadableSize;
@@ -231,24 +232,14 @@ async fn test_different_order() {
 
     // Now the schema is field_1, tag_1, ts, tag_0, field_0
     let rows = (0..3)
-        .map(|i| api::v1::Row {
-            values: vec![
-                api::v1::Value {
-                    value_data: Some(ValueData::F64Value((i + 10) as f64)),
-                },
-                api::v1::Value {
-                    value_data: Some(ValueData::StringValue(format!("b{i}"))),
-                },
-                api::v1::Value {
-                    value_data: Some(ValueData::TimestampMillisecondValue(i as i64 * 1000)),
-                },
-                api::v1::Value {
-                    value_data: Some(ValueData::StringValue(format!("a{i}"))),
-                },
-                api::v1::Value {
-                    value_data: Some(ValueData::F64Value(i as f64)),
-                },
-            ],
+        .map(|i| {
+            row(vec![
+                ValueData::F64Value((i + 10) as f64),
+                ValueData::StringValue(format!("b{i}")),
+                ValueData::TimestampMillisecondValue(i as i64 * 1000),
+                ValueData::StringValue(format!("a{i}")),
+                ValueData::F64Value(i as f64),
+            ])
         })
         .collect();
     let rows = Rows {
@@ -293,24 +284,14 @@ async fn test_different_order_and_type() {
 
     // Now the schema is tag_0, tag_1, field_1, field_0, ts
     let rows = (0..3)
-        .map(|i| api::v1::Row {
-            values: vec![
-                api::v1::Value {
-                    value_data: Some(ValueData::StringValue(format!("a{i}"))),
-                },
-                api::v1::Value {
-                    value_data: Some(ValueData::StringValue(format!("b{i}"))),
-                },
-                api::v1::Value {
-                    value_data: Some(ValueData::StringValue((i + 10).to_string())),
-                },
-                api::v1::Value {
-                    value_data: Some(ValueData::F64Value(i as f64)),
-                },
-                api::v1::Value {
-                    value_data: Some(ValueData::TimestampMillisecondValue(i as i64 * 1000)),
-                },
-            ],
+        .map(|i| {
+            row(vec![
+                ValueData::StringValue(format!("a{i}")),
+                ValueData::StringValue(format!("b{i}")),
+                ValueData::StringValue((i + 10).to_string()),
+                ValueData::F64Value(i as f64),
+                ValueData::TimestampMillisecondValue(i as i64 * 1000),
+            ])
         })
         .collect();
     let rows = Rows {
@@ -516,18 +497,12 @@ async fn test_absent_and_invalid_columns() {
     // Input tag_0, field_1 (invalid type string), ts
     column_schemas.remove(1);
     let rows = (0..3)
-        .map(|i| api::v1::Row {
-            values: vec![
-                api::v1::Value {
-                    value_data: Some(ValueData::StringValue(format!("a{i}"))),
-                },
-                api::v1::Value {
-                    value_data: Some(ValueData::StringValue(i.to_string())),
-                },
-                api::v1::Value {
-                    value_data: Some(ValueData::TimestampMillisecondValue(i as i64 * 1000)),
-                },
-            ],
+        .map(|i| {
+            row(vec![
+                ValueData::StringValue(format!("a{i}")),
+                ValueData::StringValue(i.to_string()),
+                ValueData::TimestampMillisecondValue(i as i64 * 1000),
+            ])
         })
         .collect();
     let rows = Rows {

--- a/src/mito2/src/extension.rs
+++ b/src/mito2/src/extension.rs
@@ -1,11 +1,11 @@
-use std::fmt::Display;
+use std::fmt::Debug;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use common_error::ext::BoxedError;
 use common_time::range::TimestampRange;
 use common_time::Timestamp;
-use store_api::storage::ScanRequest;
+use store_api::storage::{ScanRequest, SequenceNumber};
 
 use crate::error::Result;
 use crate::read::range::RowGroupIndex;
@@ -20,7 +20,7 @@ pub type InclusiveTimeRange = (Timestamp, Timestamp);
 /// memtable range and sst file range, but resides on the outside.
 /// It can be scanned side by side as other ranges to produce the final result, so it's very useful
 /// to extend the source of data in GreptimeDB.
-pub trait ExtensionRange: Display + Send + Sync {
+pub trait ExtensionRange: Debug + Send + Sync {
     /// The number of rows in this range.
     fn num_rows(&self) -> u64;
 
@@ -56,9 +56,11 @@ pub trait ExtensionRangeProvider: Send + Sync {
     /// Find the extension ranges by the timestamp filter and the [`ScanRequest`].
     async fn find_extension_ranges(
         &self,
+        flushed_sequence: SequenceNumber,
         timestamp_range: TimestampRange,
         request: &ScanRequest,
     ) -> Result<Vec<BoxedExtensionRange>> {
+        let _ = flushed_sequence;
         let _ = timestamp_range;
         let _ = request;
         Ok(vec![])

--- a/src/mito2/src/memtable/simple_bulk_memtable.rs
+++ b/src/mito2/src/memtable/simple_bulk_memtable.rs
@@ -393,8 +393,9 @@ impl Iterator for Iter {
 mod tests {
     use std::sync::Arc;
 
+    use api::v1::helper::row;
     use api::v1::value::ValueData;
-    use api::v1::{Mutation, OpType, Row, Rows, SemanticType};
+    use api::v1::{Mutation, OpType, Rows, SemanticType};
     use common_recordbatch::DfRecordBatch;
     use common_time::Timestamp;
     use datatypes::arrow::array::{ArrayRef, Float64Array, RecordBatch, TimestampMillisecondArray};
@@ -458,18 +459,12 @@ mod tests {
 
         let rows: Vec<_> = row_values
             .iter()
-            .map(|(ts, f1, f2)| Row {
-                values: vec![
-                    api::v1::Value {
-                        value_data: Some(ValueData::TimestampMillisecondValue(*ts)),
-                    },
-                    api::v1::Value {
-                        value_data: Some(ValueData::F64Value(*f1)),
-                    },
-                    api::v1::Value {
-                        value_data: Some(ValueData::StringValue(f2.clone())),
-                    },
-                ],
+            .map(|(ts, f1, f2)| {
+                row(vec![
+                    ValueData::TimestampMillisecondValue(*ts),
+                    ValueData::F64Value(*f1),
+                    ValueData::StringValue(f2.clone()),
+                ])
             })
             .collect();
         let mutation = Mutation {

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -1264,8 +1264,9 @@ mod tests {
     use std::collections::{HashMap, HashSet};
 
     use api::helper::ColumnDataTypeWrapper;
+    use api::v1::helper::row;
     use api::v1::value::ValueData;
-    use api::v1::{Mutation, Row, Rows, SemanticType};
+    use api::v1::{Mutation, Rows, SemanticType};
     use common_time::Timestamp;
     use datatypes::prelude::{ConcreteDataType, ScalarVector};
     use datatypes::schema::ColumnSchema;
@@ -1507,24 +1508,14 @@ mod tests {
             .collect();
 
         let rows = (0..len)
-            .map(|i| Row {
-                values: vec![
-                    api::v1::Value {
-                        value_data: Some(ValueData::StringValue(k0.clone())),
-                    },
-                    api::v1::Value {
-                        value_data: Some(ValueData::I64Value(k1)),
-                    },
-                    api::v1::Value {
-                        value_data: Some(ValueData::TimestampMillisecondValue(i as i64)),
-                    },
-                    api::v1::Value {
-                        value_data: Some(ValueData::I64Value(i as i64)),
-                    },
-                    api::v1::Value {
-                        value_data: Some(ValueData::F64Value(i as f64)),
-                    },
-                ],
+            .map(|i| {
+                row(vec![
+                    ValueData::StringValue(k0.clone()),
+                    ValueData::I64Value(k1),
+                    ValueData::TimestampMillisecondValue(i as i64),
+                    ValueData::I64Value(i as i64),
+                    ValueData::F64Value(i as f64),
+                ])
             })
             .collect();
         let mutation = api::v1::Mutation {
@@ -1578,30 +1569,13 @@ mod tests {
                             sequence: j as u64,
                             rows: Some(Rows {
                                 schema: column_schemas.clone(),
-                                rows: vec![Row {
-                                    values: vec![
-                                        api::v1::Value {
-                                            value_data: Some(ValueData::StringValue(format!(
-                                                "{}",
-                                                j
-                                            ))),
-                                        },
-                                        api::v1::Value {
-                                            value_data: Some(ValueData::I64Value(j as i64)),
-                                        },
-                                        api::v1::Value {
-                                            value_data: Some(ValueData::TimestampMillisecondValue(
-                                                j as i64,
-                                            )),
-                                        },
-                                        api::v1::Value {
-                                            value_data: Some(ValueData::I64Value(j as i64)),
-                                        },
-                                        api::v1::Value {
-                                            value_data: Some(ValueData::F64Value(j as f64)),
-                                        },
-                                    ],
-                                }],
+                                rows: vec![row(vec![
+                                    ValueData::StringValue(format!("{}", j)),
+                                    ValueData::I64Value(j as i64),
+                                    ValueData::TimestampMillisecondValue(j as i64),
+                                    ValueData::I64Value(j as i64),
+                                    ValueData::F64Value(j as f64),
+                                ])],
                             }),
                             write_hint: None,
                         },

--- a/src/mito2/src/read/range.rs
+++ b/src/mito2/src/read/range.rs
@@ -98,7 +98,7 @@ impl RangeMeta {
         Self::push_seq_file_ranges(input.memtables.len(), &input.files, &mut ranges);
 
         #[cfg(feature = "enterprise")]
-        Self::push_extension_ranges(input.extension_ranges(), &mut ranges);
+        Self::push_extension_ranges(input, &mut ranges);
 
         let ranges = group_ranges_for_seq_scan(ranges);
         if compaction || input.distribution == Some(TimeSeriesDistribution::PerSeries) {
@@ -120,7 +120,7 @@ impl RangeMeta {
         );
 
         #[cfg(feature = "enterprise")]
-        Self::push_extension_ranges(input.extension_ranges(), &mut ranges);
+        Self::push_extension_ranges(input, &mut ranges);
 
         ranges
     }
@@ -320,12 +320,9 @@ impl RangeMeta {
     }
 
     #[cfg(feature = "enterprise")]
-    fn push_extension_ranges(
-        ranges: &[crate::extension::BoxedExtensionRange],
-        metas: &mut Vec<RangeMeta>,
-    ) {
-        for range in ranges.iter() {
-            let index = metas.len();
+    fn push_extension_ranges(input: &ScanInput, metas: &mut Vec<RangeMeta>) {
+        for (i, range) in input.extension_ranges().iter().enumerate() {
+            let index = input.num_memtables() + input.num_files() + i;
             metas.push(RangeMeta {
                 time_range: range.time_range(),
                 indices: smallvec![SourceIndex {

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -476,8 +476,9 @@ impl ScanRegion {
         #[cfg(feature = "enterprise")]
         let input = if let Some(provider) = self.extension_range_provider {
             let ranges = provider
-                .find_extension_ranges(time_range, &self.request)
+                .find_extension_ranges(self.version.flushed_sequence, time_range, &self.request)
                 .await?;
+            debug!("Find extension ranges: {ranges:?}");
             input.with_extension_ranges(ranges)
         } else {
             input
@@ -1101,7 +1102,7 @@ impl StreamContext {
             num_file_ranges,
         )?;
         if num_other_ranges > 0 {
-            write!(f, r#"", other_ranges":{}"#, num_other_ranges)?;
+            write!(f, r#", "other_ranges":{}"#, num_other_ranges)?;
         }
         write!(f, "}}")?;
 
@@ -1156,7 +1157,7 @@ impl StreamContext {
                 let mut delimiter = "";
                 write!(f, ", extension_ranges: [")?;
                 for range in self.input.extension_ranges() {
-                    write!(f, "{}{}", delimiter, range)?;
+                    write!(f, "{}{:?}", delimiter, range)?;
                     delimiter = ", ";
                 }
                 write!(f, "]")?;

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -29,6 +29,7 @@ use std::sync::Arc;
 use api::greptime_proto::v1;
 use api::helper::ColumnDataTypeWrapper;
 use api::v1::column_def::options_from_column_schema;
+use api::v1::helper::row;
 use api::v1::value::ValueData;
 use api::v1::{OpType, Row, Rows, SemanticType};
 use common_base::readable_size::ReadableSize;
@@ -940,18 +941,12 @@ pub fn column_metadata_to_column_schema(metadata: &ColumnMetadata) -> api::v1::C
 /// `start`, `end` are in second resolution.
 pub fn build_rows(start: usize, end: usize) -> Vec<Row> {
     (start..end)
-        .map(|i| api::v1::Row {
-            values: vec![
-                api::v1::Value {
-                    value_data: Some(ValueData::StringValue(i.to_string())),
-                },
-                api::v1::Value {
-                    value_data: Some(ValueData::F64Value(i as f64)),
-                },
-                api::v1::Value {
-                    value_data: Some(ValueData::TimestampMillisecondValue(i as i64 * 1000)),
-                },
-            ],
+        .map(|i| {
+            row(vec![
+                ValueData::StringValue(i.to_string()),
+                ValueData::F64Value(i as f64),
+                ValueData::TimestampMillisecondValue(i as i64 * 1000),
+            ])
         })
         .collect()
 }
@@ -1025,18 +1020,12 @@ pub async fn put_rows(engine: &MitoEngine, region_id: RegionId, rows: Rows) {
 pub fn build_rows_for_key(key: &str, start: usize, end: usize, value_start: usize) -> Vec<Row> {
     (start..end)
         .enumerate()
-        .map(|(idx, ts)| api::v1::Row {
-            values: vec![
-                api::v1::Value {
-                    value_data: Some(ValueData::StringValue(key.to_string())),
-                },
-                api::v1::Value {
-                    value_data: Some(ValueData::F64Value((value_start + idx) as f64)),
-                },
-                api::v1::Value {
-                    value_data: Some(ValueData::TimestampMillisecondValue(ts as i64 * 1000)),
-                },
-            ],
+        .map(|(idx, ts)| {
+            row(vec![
+                ValueData::StringValue(key.to_string()),
+                ValueData::F64Value((value_start + idx) as f64),
+                ValueData::TimestampMillisecondValue(ts as i64 * 1000),
+            ])
         })
         .collect()
 }
@@ -1044,15 +1033,11 @@ pub fn build_rows_for_key(key: &str, start: usize, end: usize, value_start: usiz
 /// Build rows to delete for specific `key`.
 pub fn build_delete_rows_for_key(key: &str, start: usize, end: usize) -> Vec<Row> {
     (start..end)
-        .map(|ts| api::v1::Row {
-            values: vec![
-                api::v1::Value {
-                    value_data: Some(ValueData::StringValue(key.to_string())),
-                },
-                api::v1::Value {
-                    value_data: Some(ValueData::TimestampMillisecondValue(ts as i64 * 1000)),
-                },
-            ],
+        .map(|ts| {
+            row(vec![
+                ValueData::StringValue(key.to_string()),
+                ValueData::TimestampMillisecondValue(ts as i64 * 1000),
+            ])
         })
         .collect()
 }

--- a/src/mito2/src/test_util/version_util.rs
+++ b/src/mito2/src/test_util/version_util.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 use std::num::NonZeroU64;
 use std::sync::Arc;
 
+use api::v1::helper::{tag_column_schema, time_index_column_schema};
 use api::v1::value::ValueData;
 use api::v1::{self, ColumnDataType, Mutation, OpType, Row, Rows, SemanticType};
 use common_time::Timestamp;
@@ -148,18 +149,8 @@ pub(crate) fn write_rows_to_version(
         rows.push(Row { values });
     }
     let schema = vec![
-        v1::ColumnSchema {
-            column_name: "ts".to_string(),
-            datatype: ColumnDataType::TimestampMillisecond as i32,
-            semantic_type: SemanticType::Timestamp as i32,
-            ..Default::default()
-        },
-        v1::ColumnSchema {
-            column_name: "tag_0".to_string(),
-            datatype: ColumnDataType::String as i32,
-            semantic_type: SemanticType::Tag as i32,
-            ..Default::default()
-        },
+        time_index_column_schema("ts", ColumnDataType::TimestampMillisecond),
+        tag_column_schema("tag_0", ColumnDataType::String),
     ];
     let rows = Rows { rows, schema };
     let mutation = Mutation {

--- a/src/mito2/src/wal.rs
+++ b/src/mito2/src/wal.rs
@@ -221,9 +221,10 @@ impl<S: LogStore> WalWriter<S> {
 
 #[cfg(test)]
 mod tests {
+    use api::v1::helper::{tag_column_schema, time_index_column_schema};
     use api::v1::{
-        bulk_wal_entry, value, ArrowIpc, BulkWalEntry, ColumnDataType, ColumnSchema, Mutation,
-        OpType, Row, Rows, SemanticType, Value,
+        bulk_wal_entry, value, ArrowIpc, BulkWalEntry, ColumnDataType, Mutation, OpType, Row, Rows,
+        Value,
     };
     use common_recordbatch::DfRecordBatch;
     use common_test_util::flight::encode_to_flight_data;
@@ -281,18 +282,8 @@ mod tests {
             })
             .collect();
         let schema = vec![
-            ColumnSchema {
-                column_name: "tag".to_string(),
-                datatype: ColumnDataType::String as i32,
-                semantic_type: SemanticType::Tag as i32,
-                ..Default::default()
-            },
-            ColumnSchema {
-                column_name: "ts".to_string(),
-                datatype: ColumnDataType::TimestampMillisecond as i32,
-                semantic_type: SemanticType::Timestamp as i32,
-                ..Default::default()
-            },
+            tag_column_schema("tag", ColumnDataType::String),
+            time_index_column_schema("ts", ColumnDataType::TimestampMillisecond),
         ];
 
         Mutation {

--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -1164,7 +1164,8 @@ impl FlowMirrorTask {
 mod tests {
     use std::sync::Arc;
 
-    use api::v1::{ColumnSchema as GrpcColumnSchema, RowInsertRequest, Rows, SemanticType, Value};
+    use api::v1::helper::{field_column_schema, time_index_column_schema};
+    use api::v1::{RowInsertRequest, Rows, Value};
     use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
     use common_meta::cache::new_table_flownode_set_cache;
     use common_meta::ddl::test_util::datanode_handler::NaiveDatanodeHandler;
@@ -1235,18 +1236,8 @@ mod tests {
             table_name: "test_table".to_string(),
             rows: Some(Rows {
                 schema: vec![
-                    GrpcColumnSchema {
-                        column_name: "ts_wrong".to_string(),
-                        datatype: api::v1::ColumnDataType::TimestampMillisecond as i32,
-                        semantic_type: SemanticType::Timestamp as i32,
-                        ..Default::default()
-                    },
-                    GrpcColumnSchema {
-                        column_name: "field_wrong".to_string(),
-                        datatype: api::v1::ColumnDataType::Float64 as i32,
-                        semantic_type: SemanticType::Field as i32,
-                        ..Default::default()
-                    },
+                    time_index_column_schema("ts_wrong", ColumnDataType::TimestampMillisecond),
+                    field_column_schema("field_wrong", ColumnDataType::Float64),
                 ],
                 rows: vec![api::v1::Row {
                     values: vec![Value::default(), Value::default()],

--- a/src/operator/src/req_convert/delete/table_to_region.rs
+++ b/src/operator/src/req_convert/delete/table_to_region.rs
@@ -53,9 +53,10 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
 
+    use api::v1::helper::tag_column_schema;
     use api::v1::region::DeleteRequest as RegionDeleteRequest;
     use api::v1::value::ValueData;
-    use api::v1::{ColumnDataType, ColumnSchema, Row, SemanticType, Value};
+    use api::v1::{ColumnDataType, Row, Value};
     use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
     use datatypes::vectors::{Int32Vector, VectorRef};
     use store_api::storage::RegionId;
@@ -132,12 +133,7 @@ mod tests {
         RegionDeleteRequest {
             region_id,
             rows: Some(Rows {
-                schema: vec![ColumnSchema {
-                    column_name: "a".to_string(),
-                    datatype: ColumnDataType::Int32 as i32,
-                    semantic_type: SemanticType::Tag as i32,
-                    ..Default::default()
-                }],
+                schema: vec![tag_column_schema("a", ColumnDataType::Int32)],
                 rows: rows
                     .into_iter()
                     .map(|v| Row {

--- a/src/operator/src/req_convert/insert/table_to_region.rs
+++ b/src/operator/src/req_convert/insert/table_to_region.rs
@@ -69,9 +69,10 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
 
+    use api::v1::helper::tag_column_schema;
     use api::v1::region::InsertRequest as RegionInsertRequest;
     use api::v1::value::ValueData;
-    use api::v1::{ColumnDataType, ColumnSchema, Row, SemanticType, Value};
+    use api::v1::{ColumnDataType, Row, Value};
     use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
     use datatypes::vectors::{Int32Vector, VectorRef};
     use store_api::storage::RegionId;
@@ -149,12 +150,7 @@ mod tests {
         RegionInsertRequest {
             region_id,
             rows: Some(Rows {
-                schema: vec![ColumnSchema {
-                    column_name: "a".to_string(),
-                    datatype: ColumnDataType::Int32 as i32,
-                    semantic_type: SemanticType::Tag as i32,
-                    ..Default::default()
-                }],
+                schema: vec![tag_column_schema("a", ColumnDataType::Int32)],
                 rows: rows
                     .into_iter()
                     .map(|v| Row {

--- a/src/partition/src/splitter.rs
+++ b/src/partition/src/splitter.rs
@@ -134,8 +134,9 @@ mod tests {
     use std::any::Any;
     use std::sync::Arc;
 
+    use api::v1::helper::{field_column_schema, tag_column_schema};
     use api::v1::value::ValueData;
-    use api::v1::{ColumnDataType, SemanticType};
+    use api::v1::ColumnDataType;
     use serde::{Deserialize, Serialize};
 
     use super::*;
@@ -144,24 +145,9 @@ mod tests {
 
     fn mock_rows() -> Rows {
         let schema = vec![
-            ColumnSchema {
-                column_name: "id".to_string(),
-                datatype: ColumnDataType::String as i32,
-                semantic_type: SemanticType::Tag as i32,
-                ..Default::default()
-            },
-            ColumnSchema {
-                column_name: "name".to_string(),
-                datatype: ColumnDataType::String as i32,
-                semantic_type: SemanticType::Tag as i32,
-                ..Default::default()
-            },
-            ColumnSchema {
-                column_name: "age".to_string(),
-                datatype: ColumnDataType::Uint32 as i32,
-                semantic_type: SemanticType::Field as i32,
-                ..Default::default()
-            },
+            tag_column_schema("id", ColumnDataType::String),
+            tag_column_schema("name", ColumnDataType::String),
+            field_column_schema("age", ColumnDataType::Uint32),
         ];
         let rows = vec![
             Row {

--- a/src/servers/src/pipeline.rs
+++ b/src/servers/src/pipeline.rs
@@ -17,7 +17,8 @@ use std::sync::Arc;
 
 use ahash::{HashMap, HashMapExt};
 use api::greptime_proto;
-use api::v1::{ColumnDataType, ColumnSchema, RowInsertRequest, Rows, SemanticType};
+use api::v1::helper::time_index_column_schema;
+use api::v1::{ColumnDataType, RowInsertRequest, Rows};
 use common_time::timestamp::TimeUnit;
 use pipeline::{
     identity_pipeline, unwrap_or_continue_if_err, ContextReq, DispatchedTo, Pipeline,
@@ -133,13 +134,9 @@ async fn run_custom_pipeline(
             };
 
             let mut schema_info = SchemaInfo::default();
-            schema_info.schema.push(ColumnSchema {
-                column_name: ts_name.clone(),
-                datatype: timeunit.into(),
-                semantic_type: SemanticType::Timestamp as i32,
-                datatype_extension: None,
-                options: None,
-            });
+            schema_info
+                .schema
+                .push(time_index_column_schema(ts_name, timeunit));
 
             schema_info
         }

--- a/src/servers/src/row_writer.rs
+++ b/src/servers/src/row_writer.rs
@@ -15,6 +15,7 @@
 use std::collections::HashMap;
 
 use api::v1::column_data_type_extension::TypeExt;
+use api::v1::helper::time_index_column_schema;
 use api::v1::value::ValueData;
 use api::v1::{
     ColumnDataType, ColumnDataTypeExtension, ColumnSchema, JsonTypeExtension, Row,
@@ -399,12 +400,7 @@ fn write_ts_to(
         one_row[*index].value_data = Some(ts);
     } else {
         let index = schema.len();
-        schema.push(ColumnSchema {
-            column_name: name.clone(),
-            datatype: datatype as i32,
-            semantic_type: SemanticType::Timestamp as i32,
-            ..Default::default()
-        });
+        schema.push(time_index_column_schema(&name, datatype));
         column_indexes.insert(name, index);
         one_row.push(ts.into())
     }


### PR DESCRIPTION
refactor: extract the common codes of creating proto ColumnSchema and Row to helper functions

fix: explicitly set the follower max sequence when finding extension ranges to avoid potential concurrency hazard

I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

the extension range source index in the StreamContext was not correctly set to the extension ranges array index in the ScanInput, which caused out of bound error during scanning

also refactor some codes

also eliminate a potential concurrency hazard in finding follower max sequence

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
