### PR TITLE
chore: impl default for SlowQueriesRecordType and LogFormat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2785,6 +2785,7 @@ version = "0.17.0"
 dependencies = [
  "backtrace",
  "common-error",
+ "common-macro",
  "common-version",
  "console-subscriber",
  "greptime-proto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2305,6 +2305,7 @@ dependencies = [
  "rand 0.9.0",
  "regex",
  "serde",
+ "serde_json",
  "snafu 0.8.5",
  "strum 0.27.1",
  "tokio",

--- a/src/common/datasource/Cargo.toml
+++ b/src/common/datasource/Cargo.toml
@@ -49,4 +49,5 @@ url = "2.3"
 [dev-dependencies]
 common-telemetry.workspace = true
 common-test-util.workspace = true
+serde_json.workspace = true
 uuid.workspace = true

--- a/src/common/datasource/src/compression.rs
+++ b/src/common/datasource/src/compression.rs
@@ -19,6 +19,7 @@ use std::str::FromStr;
 use async_compression::tokio::bufread::{BzDecoder, GzipDecoder, XzDecoder, ZstdDecoder};
 use async_compression::tokio::write;
 use bytes::Bytes;
+use common_macro::DeserializeWithEmptyDefault;
 use datafusion::datasource::file_format::file_compression_type::FileCompressionType;
 use futures::Stream;
 use serde::Serialize;
@@ -28,7 +29,18 @@ use tokio_util::io::{ReaderStream, StreamReader};
 
 use crate::error::{self, Error, Result};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EnumIter, Serialize, Default)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    EnumIter,
+    Serialize,
+    Default,
+    DeserializeWithEmptyDefault,
+)]
 #[serde(rename_all = "lowercase")]
 pub enum CompressionType {
     /// Gzip-ed file
@@ -43,15 +55,6 @@ pub enum CompressionType {
     #[default]
     Uncompressed,
 }
-
-common_macro::impl_deserialize_with_empty_default!(
-    CompressionType,
-    Gzip => "gzip",
-    Bzip2 => "bzip2",
-    Xz => "xz",
-    Zstd => "zstd",
-    Uncompressed => "uncompressed",
-);
 
 impl FromStr for CompressionType {
     type Err = Error;

--- a/src/common/datasource/src/compression.rs
+++ b/src/common/datasource/src/compression.rs
@@ -21,14 +21,14 @@ use async_compression::tokio::write;
 use bytes::Bytes;
 use datafusion::datasource::file_format::file_compression_type::FileCompressionType;
 use futures::Stream;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use strum::EnumIter;
 use tokio::io::{AsyncRead, AsyncWriteExt, BufReader};
 use tokio_util::io::{ReaderStream, StreamReader};
 
 use crate::error::{self, Error, Result};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EnumIter, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EnumIter, Serialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum CompressionType {
     /// Gzip-ed file
@@ -40,8 +40,18 @@ pub enum CompressionType {
     /// Zstd-ed file,
     Zstd,
     /// Uncompressed file
+    #[default]
     Uncompressed,
 }
+
+common_macro::impl_deserialize_with_empty_default!(
+    CompressionType,
+    Gzip => "gzip",
+    Bzip2 => "bzip2",
+    Xz => "xz",
+    Zstd => "zstd",
+    Uncompressed => "uncompressed",
+);
 
 impl FromStr for CompressionType {
     type Err = Error;

--- a/src/common/macro/src/lib.rs
+++ b/src/common/macro/src/lib.rs
@@ -16,6 +16,7 @@ mod admin_fn;
 mod aggr_func;
 mod print_caller;
 mod range_fn;
+mod serde_with_default;
 mod stack_trace_debug;
 mod utils;
 
@@ -185,4 +186,38 @@ pub fn derive_meta_builder(input: TokenStream) -> TokenStream {
     };
 
     gen.into()
+}
+
+/// Generates a custom `Deserialize` implementation for enums that treats empty strings as default values.
+///
+/// This macro is useful for configuration enums where an empty string should be treated as
+/// the default variant instead of causing a deserialization error.
+///
+/// # Example
+/// ```rust
+/// use common_macro::impl_deserialize_with_empty_default;
+/// use serde::{Serialize, Deserialize};
+///
+/// #[derive(Clone, Debug, Serialize, Default, PartialEq)]
+/// pub enum LogFormat {
+///     Json,
+///     #[default]
+///     Text,
+/// }
+///
+/// impl_deserialize_with_empty_default!(
+///     LogFormat,
+///     Json => "json",
+///     Text => "text",
+/// );
+/// ```
+///
+/// With this implementation:
+/// - `""` deserializes to `LogFormat::default()` (Text)
+/// - `"json"` deserializes to `LogFormat::Json`
+/// - `"text"` deserializes to `LogFormat::Text`
+/// - Any other string causes a deserialization error
+#[proc_macro]
+pub fn impl_deserialize_with_empty_default(input: TokenStream) -> TokenStream {
+    serde_with_default::impl_deserialize_with_empty_default(input)
 }

--- a/src/common/macro/src/serde_with_default.rs
+++ b/src/common/macro/src/serde_with_default.rs
@@ -13,62 +13,46 @@
 // limitations under the License.
 
 use proc_macro::TokenStream;
-use proc_macro2::Span;
 use quote::quote;
-use syn::parse::{Parse, ParseStream};
-use syn::{parse_macro_input, Error, Ident, LitStr, Result, Token};
+use syn::{parse_macro_input, Attribute, Data, DeriveInput, Error, Meta, Variant};
 
-struct DeserializeInput {
-    enum_name: Ident,
-    variants: Vec<(Ident, LitStr)>,
-}
+/// Implementation for the derive macro that automatically generates the deserialize implementation
+pub fn impl_deserialize_with_empty_default_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
 
-impl Parse for DeserializeInput {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let enum_name: Ident = input.parse()?;
-        input.parse::<Token![,]>()?;
+    let enum_name = &input.ident;
 
-        let mut variants = Vec::new();
-        while !input.is_empty() {
-            let variant: Ident = input.parse()?;
-            input.parse::<Token![=>]>()?;
-            let string_literal: LitStr = input.parse()?;
-            variants.push((variant, string_literal));
-
-            if input.peek(Token![,]) {
-                input.parse::<Token![,]>()?;
-            } else {
-                break;
-            }
-        }
-
-        if variants.is_empty() {
-            return Err(Error::new(
-                Span::call_site(),
-                "At least one variant must be specified",
-            ));
-        }
-
-        Ok(DeserializeInput {
+    let Data::Enum(data_enum) = &input.data else {
+        return Error::new_spanned(
             enum_name,
-            variants,
-        })
-    }
-}
+            "DeserializeWithEmptyDefault can only be used on enums",
+        )
+        .to_compile_error()
+        .into();
+    };
 
-pub fn impl_deserialize_with_empty_default(input: TokenStream) -> TokenStream {
-    let DeserializeInput {
-        enum_name,
-        variants,
-    } = parse_macro_input!(input as DeserializeInput);
+    // Extract container-level serde rename_all attribute
+    let rename_all = extract_rename_all(&input.attrs);
 
-    let variant_matches = variants.iter().map(|(variant, string_literal)| {
+    // Generate variant matches
+    let variant_matches = data_enum.variants.iter().map(|variant| {
+        let variant_ident = &variant.ident;
+        let variant_str = get_variant_string(variant, &rename_all);
+
         quote! {
-            #string_literal => Ok(#enum_name::#variant),
+            #variant_str => Ok(#enum_name::#variant_ident),
         }
     });
 
-    let variant_strings: Vec<_> = variants.iter().map(|(_, s)| s).collect();
+    // Generate variant strings for error message
+    let variant_strings: Vec<_> = data_enum
+        .variants
+        .iter()
+        .map(|variant| {
+            let variant_str = get_variant_string(variant, &rename_all);
+            quote! { #variant_str }
+        })
+        .collect();
 
     let expanded = quote! {
         impl<'de> serde::Deserialize<'de> for #enum_name {
@@ -90,4 +74,179 @@ pub fn impl_deserialize_with_empty_default(input: TokenStream) -> TokenStream {
     };
 
     TokenStream::from(expanded)
+}
+
+/// Extract the rename_all attribute from container attributes
+fn extract_rename_all(attrs: &[Attribute]) -> Option<String> {
+    for attr in attrs {
+        if attr.path().is_ident("serde") {
+            if let Meta::List(meta_list) = &attr.meta {
+                // Parse the meta list manually by looking for rename_all
+                let tokens_str = meta_list.tokens.to_string();
+                if let Some(start) = tokens_str.find("rename_all") {
+                    if let Some(eq_pos) = tokens_str[start..].find('=') {
+                        let after_eq = &tokens_str[start + eq_pos + 1..];
+                        if let Some(quote_start) = after_eq.find('"') {
+                            if let Some(quote_end) = after_eq[quote_start + 1..].find('"') {
+                                let value = &after_eq[quote_start + 1..quote_start + 1 + quote_end];
+                                return Some(value.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Get the string representation of a variant, considering serde rename attributes
+fn get_variant_string(variant: &Variant, rename_all: &Option<String>) -> String {
+    // Check for field-level rename attribute
+    for attr in &variant.attrs {
+        if attr.path().is_ident("serde") {
+            if let Meta::List(meta_list) = &attr.meta {
+                let tokens_str = meta_list.tokens.to_string();
+                if let Some(start) = tokens_str.find("rename") {
+                    // Make sure it's not "rename_all"
+                    if !tokens_str[start..].starts_with("rename_all") {
+                        if let Some(eq_pos) = tokens_str[start..].find('=') {
+                            let after_eq = &tokens_str[start + eq_pos + 1..];
+                            if let Some(quote_start) = after_eq.find('"') {
+                                if let Some(quote_end) = after_eq[quote_start + 1..].find('"') {
+                                    let value =
+                                        &after_eq[quote_start + 1..quote_start + 1 + quote_end];
+                                    return value.to_string();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Apply container-level rename_all if no field-level rename
+    let variant_name = variant.ident.to_string();
+    if let Some(rename_style) = rename_all {
+        apply_rename_style(&variant_name, rename_style)
+    } else {
+        variant_name
+    }
+}
+
+/// Apply the rename style to a variant name
+fn apply_rename_style(name: &str, style: &str) -> String {
+    match style {
+        "snake_case" => to_snake_case(name),
+        "kebab-case" => to_kebab_case(name),
+        "camelCase" => to_camel_case(name),
+        "PascalCase" => name.to_string(), // Already in PascalCase
+        "SCREAMING_SNAKE_CASE" => to_screaming_snake_case(name),
+        "lowercase" => name.to_lowercase(),
+        "UPPERCASE" => name.to_uppercase(),
+        _ => name.to_string(), // Unknown style, use as-is
+    }
+}
+
+/// Convert PascalCase to snake_case
+fn to_snake_case(name: &str) -> String {
+    let mut result = String::new();
+    let mut chars = name.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch.is_uppercase() && !result.is_empty() {
+            // Look ahead to see if next char is lowercase (camelCase pattern)
+            if let Some(&next_ch) = chars.peek() {
+                if next_ch.is_lowercase() || result.chars().last().is_some_and(|c| c.is_lowercase())
+                {
+                    result.push('_');
+                }
+            }
+        }
+        result.push(ch.to_lowercase().next().unwrap_or(ch));
+    }
+
+    result
+}
+
+/// Convert PascalCase to kebab-case
+fn to_kebab_case(name: &str) -> String {
+    to_snake_case(name).replace('_', "-")
+}
+
+/// Convert PascalCase to camelCase
+fn to_camel_case(name: &str) -> String {
+    let mut chars = name.chars();
+    if let Some(first) = chars.next() {
+        first.to_lowercase().collect::<String>() + &chars.collect::<String>()
+    } else {
+        String::new()
+    }
+}
+
+/// Convert PascalCase to SCREAMING_SNAKE_CASE
+fn to_screaming_snake_case(name: &str) -> String {
+    to_snake_case(name).to_uppercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_snake_case() {
+        assert_eq!(to_snake_case("Json"), "json");
+        assert_eq!(to_snake_case("Text"), "text");
+        assert_eq!(to_snake_case("LogFormat"), "log_format");
+        assert_eq!(to_snake_case("HTTPResponse"), "h_t_t_p_response");
+        assert_eq!(to_snake_case("XMLParser"), "x_m_l_parser");
+        assert_eq!(to_snake_case("SimpleCase"), "simple_case");
+        assert_eq!(to_snake_case("IOHandler"), "i_o_handler");
+        assert_eq!(to_snake_case("APIKey"), "a_p_i_key");
+        assert_eq!(to_snake_case("HTMLElement"), "h_t_m_l_element");
+    }
+
+    #[test]
+    fn test_to_kebab_case() {
+        assert_eq!(to_kebab_case("Json"), "json");
+        assert_eq!(to_kebab_case("LogFormat"), "log-format");
+        assert_eq!(to_kebab_case("SimpleCase"), "simple-case");
+    }
+
+    #[test]
+    fn test_to_camel_case() {
+        assert_eq!(to_camel_case("Json"), "json");
+        assert_eq!(to_camel_case("LogFormat"), "logFormat");
+        assert_eq!(to_camel_case("SimpleCase"), "simpleCase");
+    }
+
+    #[test]
+    fn test_to_screaming_snake_case() {
+        assert_eq!(to_screaming_snake_case("Json"), "JSON");
+        assert_eq!(to_screaming_snake_case("LogFormat"), "LOG_FORMAT");
+        assert_eq!(to_screaming_snake_case("SimpleCase"), "SIMPLE_CASE");
+    }
+
+    #[test]
+    fn test_apply_rename_style() {
+        assert_eq!(apply_rename_style("Json", "snake_case"), "json");
+        assert_eq!(apply_rename_style("LogFormat", "snake_case"), "log_format");
+        assert_eq!(apply_rename_style("Json", "kebab-case"), "json");
+        assert_eq!(apply_rename_style("LogFormat", "kebab-case"), "log-format");
+        assert_eq!(apply_rename_style("Json", "camelCase"), "json");
+        assert_eq!(apply_rename_style("LogFormat", "camelCase"), "logFormat");
+        assert_eq!(apply_rename_style("Json", "PascalCase"), "Json");
+        assert_eq!(apply_rename_style("LogFormat", "PascalCase"), "LogFormat");
+        assert_eq!(apply_rename_style("Json", "SCREAMING_SNAKE_CASE"), "JSON");
+        assert_eq!(
+            apply_rename_style("LogFormat", "SCREAMING_SNAKE_CASE"),
+            "LOG_FORMAT"
+        );
+        assert_eq!(apply_rename_style("Json", "lowercase"), "json");
+        assert_eq!(apply_rename_style("LogFormat", "lowercase"), "logformat");
+        assert_eq!(apply_rename_style("Json", "UPPERCASE"), "JSON");
+        assert_eq!(apply_rename_style("LogFormat", "UPPERCASE"), "LOGFORMAT");
+        assert_eq!(apply_rename_style("Json", "unknown"), "Json");
+    }
 }

--- a/src/common/macro/src/serde_with_default.rs
+++ b/src/common/macro/src/serde_with_default.rs
@@ -1,0 +1,93 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::quote;
+use syn::parse::{Parse, ParseStream};
+use syn::{parse_macro_input, Error, Ident, LitStr, Result, Token};
+
+struct DeserializeInput {
+    enum_name: Ident,
+    variants: Vec<(Ident, LitStr)>,
+}
+
+impl Parse for DeserializeInput {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let enum_name: Ident = input.parse()?;
+        input.parse::<Token![,]>()?;
+
+        let mut variants = Vec::new();
+        while !input.is_empty() {
+            let variant: Ident = input.parse()?;
+            input.parse::<Token![=>]>()?;
+            let string_literal: LitStr = input.parse()?;
+            variants.push((variant, string_literal));
+
+            if input.peek(Token![,]) {
+                input.parse::<Token![,]>()?;
+            } else {
+                break;
+            }
+        }
+
+        if variants.is_empty() {
+            return Err(Error::new(
+                Span::call_site(),
+                "At least one variant must be specified",
+            ));
+        }
+
+        Ok(DeserializeInput {
+            enum_name,
+            variants,
+        })
+    }
+}
+
+pub fn impl_deserialize_with_empty_default(input: TokenStream) -> TokenStream {
+    let DeserializeInput {
+        enum_name,
+        variants,
+    } = parse_macro_input!(input as DeserializeInput);
+
+    let variant_matches = variants.iter().map(|(variant, string_literal)| {
+        quote! {
+            #string_literal => Ok(#enum_name::#variant),
+        }
+    });
+
+    let variant_strings: Vec<_> = variants.iter().map(|(_, s)| s).collect();
+
+    let expanded = quote! {
+        impl<'de> serde::Deserialize<'de> for #enum_name {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                let s = String::deserialize(deserializer)?;
+                match s.as_str() {
+                    "" => Ok(#enum_name::default()),
+                    #(#variant_matches)*
+                    _ => Err(serde::de::Error::unknown_variant(
+                        &s,
+                        &[#(#variant_strings),*],
+                    )),
+                }
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}

--- a/src/common/telemetry/Cargo.toml
+++ b/src/common/telemetry/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [dependencies]
 backtrace = "0.3"
 common-error.workspace = true
+common-macro.workspace = true
 common-version.workspace = true
 console-subscriber = { version = "0.1", optional = true }
 greptime-proto.workspace = true

--- a/src/common/telemetry/src/logging.rs
+++ b/src/common/telemetry/src/logging.rs
@@ -126,19 +126,21 @@ impl Default for SlowQueryOptions {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Copy, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Copy, PartialEq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum SlowQueriesRecordType {
     /// Record the slow query in the system table.
+    #[default]
     SystemTable,
     /// Record the slow query in a specific logs file.
     Log,
 }
 
-#[derive(Clone, Debug, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum LogFormat {
     Json,
+    #[default]
     Text,
 }
 

--- a/src/common/telemetry/src/logging.rs
+++ b/src/common/telemetry/src/logging.rs
@@ -18,6 +18,7 @@ use std::io::IsTerminal;
 use std::sync::{Arc, Mutex, Once};
 use std::time::Duration;
 
+use common_macro::DeserializeWithEmptyDefault;
 use once_cell::sync::{Lazy, OnceCell};
 use opentelemetry::{global, KeyValue};
 use opentelemetry_otlp::{Protocol, SpanExporterBuilder, WithExportConfig};
@@ -83,7 +84,7 @@ pub struct LoggingOptions {
 }
 
 /// The protocol of OTLP export.
-#[derive(Clone, Debug, Serialize, PartialEq, Default)]
+#[derive(Clone, Debug, Serialize, PartialEq, Default, DeserializeWithEmptyDefault)]
 #[serde(rename_all = "snake_case")]
 pub enum OtlpExportProtocol {
     /// GRPC protocol.
@@ -93,12 +94,6 @@ pub enum OtlpExportProtocol {
     #[default]
     Http,
 }
-
-common_macro::impl_deserialize_with_empty_default!(
-    OtlpExportProtocol,
-    Grpc => "grpc",
-    Http => "http",
-);
 
 /// The options of slow query.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -135,7 +130,7 @@ impl Default for SlowQueryOptions {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Copy, PartialEq, Default)]
+#[derive(Clone, Debug, Serialize, Copy, PartialEq, Default, DeserializeWithEmptyDefault)]
 #[serde(rename_all = "snake_case")]
 pub enum SlowQueriesRecordType {
     /// Record the slow query in the system table.
@@ -145,25 +140,13 @@ pub enum SlowQueriesRecordType {
     Log,
 }
 
-common_macro::impl_deserialize_with_empty_default!(
-    SlowQueriesRecordType,
-    SystemTable => "system_table",
-    Log => "log",
-);
-
-#[derive(Clone, Debug, Copy, PartialEq, Eq, Serialize, Default)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Serialize, Default, DeserializeWithEmptyDefault)]
 #[serde(rename_all = "snake_case")]
 pub enum LogFormat {
     Json,
     #[default]
     Text,
 }
-
-common_macro::impl_deserialize_with_empty_default!(
-    LogFormat,
-    Json => "json",
-    Text => "text",
-);
 
 impl PartialEq for LoggingOptions {
     fn eq(&self, other: &Self) -> bool {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR implements default traits and custom deserialization for configuration enums to handle empty string values gracefully during deserialization. The changes allow configuration fields to use default values when empty strings are provided, improving the robustness of configuration parsing.

Key changes:

* Added Default trait implementations with `#[default]` attributes for `SlowQueriesRecordType`, `LogFormat`, `OtlpExportProtocol`, and `CompressionType` enums
* Creates a new procedural macro `DeserializeWithEmptyDefault` that generates custom `Deserialize` implementations treating empty strings as default values
* Added comprehensive tests to verify the deserialization behavior for all affected enums

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
