### PR TITLE
feat: Implements last-non-null dedup strategy for flat format

### DIFF
--- a/src/mito2/src/read/flat_dedup.rs
+++ b/src/mito2/src/read/flat_dedup.rs
@@ -386,10 +386,7 @@ impl FlatLastNonNull {
             return Ok((batch, contains_delete));
         }
 
-        let mut is_field = vec![false; batch.num_columns()];
-        // Iterates fields, skips internal columns.
-        is_field[field_column_start..batch.num_columns() - FIXED_POS_COLUMN_NUM].fill(true);
-
+        let field_column_end = batch.num_columns() - FIXED_POS_COLUMN_NUM;
         let take_options = Some(TakeOptions {
             check_bounds: false,
         });
@@ -400,7 +397,7 @@ impl FlatLastNonNull {
             .iter()
             .enumerate()
             .map(|(col_idx, column)| {
-                if is_field[col_idx] {
+                if col_idx >= field_column_start && col_idx < field_column_end {
                     let field_indices = Self::compute_field_indices(
                         &ranges,
                         column,

--- a/src/mito2/src/read/flat_dedup.rs
+++ b/src/mito2/src/read/flat_dedup.rs
@@ -388,9 +388,7 @@ impl FlatLastNonNull {
 
         let mut is_field = vec![false; batch.num_columns()];
         // Iterates fields, skips internal columns.
-        for idx in num_pk_columns..batch.num_columns() - FIXED_POS_COLUMN_NUM {
-            is_field[idx] = true;
-        }
+        is_field[num_pk_columns..batch.num_columns() - FIXED_POS_COLUMN_NUM].fill(true);
 
         let take_options = Some(TakeOptions {
             check_bounds: false,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/6505

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

Follow-up of https://github.com/GreptimeTeam/greptimedb/pull/6695

Implements the `FlatLastNonNull` strategy for flat format.

The difference between this strategy and `FlatLastRow` is that `FlatLastNonNull` takes the latest non null value for each field.

However, it has to handle deletion specially to avoid a deleted row overriding the latest row's field. It tracks whether the duplicated rows of the last key contain a deletion. If they have, then we should not include non-null fields from the next batch.

It ports all tests from the old dedup strategy.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
