### PR TITLE
fix: unit test about trigger labels parse

### DIFF
--- a/src/sql/src/parsers/alter_parser/trigger.rs
+++ b/src/sql/src/parsers/alter_parser/trigger.rs
@@ -607,7 +607,7 @@ mod tests {
     fn test_parse_alter_trigger_labels() {
         // Passed case: SET LABELS.
         // Note: "ALTER TRIGGER" is matched.
-        let sql = r#"test_trigger SET LABELS (Key1='value1', 'KEY2'='value2')"#;
+        let sql = r#"test_trigger SET LABELS (Key1='value1', 'KEY2'='VALUE2')"#;
         let mut ctx = ParserContext::new(&GreptimeDbDialect {}, sql).unwrap();
         let stmt = ctx.parse_alter_trigger().unwrap();
         let Statement::AlterTrigger(alter) = stmt else {
@@ -616,8 +616,10 @@ mod tests {
         let Some(LabelOperations::ReplaceAll(labels)) = alter.operation.label_operations else {
             panic!("Expected ReplaceAll label operations");
         };
+
+        assert_eq!(labels.len(), 2);
         assert_eq!(labels.get("key1"), Some(&"value1".to_string()));
-        assert_eq!(labels.get("KEY2"), Some(&"value2".to_string()));
+        assert_eq!(labels.get("key2"), Some(&"VALUE2".to_string()));
 
         // Passed case: multiple ADD/DROP/MODIFY LABELS.
         let sql = r#"test_trigger ADD LABELS (key1='value1') MODIFY LABELS (key2='value2') DROP LABELS ('key3')"#;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

When executing unit tests
```bash
cargo nextest run --package sql --lib --features enterprise -- parsers::alter_parser::trigger::tests
```
I encountered an error
```text
    thread 'parsers::alter_parser::trigger::tests::test_parse_alter_trigger_labels' panicked at greptimedb/src/sql/src/parsers/alter_parser/trigger.rs:620:9:
    assertion `left == right` failed
      left: None
     right: Some("value2")
```
Because when parsing sql options, [this logic](https://github.com/GreptimeTeam/greptimedb/blob/f159fcf599bc17a7367ac524441604ec6d0a6973/src/sql/src/util.rs#L57) always lowercases the key.

This pr will fix it.

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
