### PR TITLE
fix: http and tql should return the same value for nuknown

### DIFF
--- a/src/servers/src/http/result/prometheus_resp.rs
+++ b/src/servers/src/http/result/prometheus_resp.rs
@@ -185,6 +185,14 @@ impl PrometheusJsonResponse {
         metric_name: Option<String>,
         result_type: ValueType,
     ) -> Result<PrometheusResponse> {
+        // Return empty result if no batches
+        if batches.iter().next().is_none() {
+            return Ok(PrometheusResponse::PromData(PromData {
+                result_type: result_type.to_string(),
+                ..Default::default()
+            }));
+        }
+
         // infer semantic type of each column from schema.
         // TODO(ruihang): wish there is a better way to do this.
         let mut timestamp_column_index = None;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

#6717 

also fix these on http


histogram_quantile(-0.5, rate(demo_api_request_duration_seconds_bucket[1m]))
histogram_quantile(0.1, rate(demo_api_request_duration_seconds_bucket[1m]))
histogram_quantile(0.5, rate(demo_api_request_duration_seconds_bucket[1m]))
histogram_quantile(0.75, rate(demo_api_request_duration_seconds_bucket[1m]))
histogram_quantile(0.95, rate(demo_api_request_duration_seconds_bucket[1m]))
histogram_quantile(0.90, rate(demo_api_request_duration_seconds_bucket[1m]))
histogram_quantile(0.99, rate(demo_api_request_duration_seconds_bucket[1m]))
histogram_quantile(1, rate(demo_api_request_duration_seconds_bucket[1m]))
histogram_quantile(1.5, rate(demo_api_request_duration_seconds_bucket[1m]))
histogram_quantile(0.9, nonexistent_metric)
histogram_quantile(0.9, demo_memory_usage_bytes)

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
