### PR TITLE
chore: impl cast from primitives to PathType

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12393,6 +12393,7 @@ dependencies = [
  "futures",
  "humantime",
  "lazy_static",
+ "num_enum 0.7.3",
  "prometheus",
  "prost 0.13.5",
  "serde",

--- a/src/store-api/Cargo.toml
+++ b/src/store-api/Cargo.toml
@@ -26,6 +26,7 @@ derive_builder.workspace = true
 futures.workspace = true
 humantime.workspace = true
 lazy_static.workspace = true
+num_enum = "0.7"
 prometheus.workspace = true
 prost.workspace = true
 serde.workspace = true

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -36,6 +36,7 @@ use common_recordbatch::DfRecordBatch;
 use common_time::{TimeToLive, Timestamp};
 use datatypes::prelude::ConcreteDataType;
 use datatypes::schema::{FulltextOptions, SkippingIndexOptions};
+use num_enum::TryFromPrimitive;
 use serde::{Deserialize, Serialize};
 use snafu::{ensure, OptionExt, ResultExt};
 use strum::{AsRefStr, IntoStaticStr};
@@ -56,7 +57,8 @@ use crate::path_utils::table_dir;
 use crate::storage::{ColumnId, RegionId, ScanRequest};
 
 /// The type of path to generate.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, TryFromPrimitive)]
+#[repr(u8)]
 pub enum PathType {
     /// A bare path - the original path of an engine.
     ///
@@ -1957,5 +1959,24 @@ mod tests {
             column_metadatas: column_metadatas_with_new_field_column,
         };
         kind.validate(&metadata).unwrap();
+    }
+
+    #[test]
+    fn test_cast_path_type_to_primitive() {
+        assert_eq!(PathType::Bare as u8, 0);
+        assert_eq!(PathType::Data as u8, 1);
+        assert_eq!(PathType::Metadata as u8, 2);
+        assert_eq!(
+            PathType::try_from(PathType::Bare as u8).unwrap(),
+            PathType::Bare
+        );
+        assert_eq!(
+            PathType::try_from(PathType::Data as u8).unwrap(),
+            PathType::Data
+        );
+        assert_eq!(
+            PathType::try_from(PathType::Metadata as u8).unwrap(),
+            PathType::Metadata
+        );
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
 ### Add `num_enum` for Enum Conversion and Update `PathType`

 - **Added `num_enum` Dependency**: Updated `Cargo.lock` and `Cargo.toml` to include `num_enum` for enum conversion functionality.
   - Files: `Cargo.lock`, `src/store-api/Cargo.toml`

 - **Enhanced `PathType` Enum**: Implemented `TryFromPrimitive` for `PathType` to enable conversion from primitive types.
   - Files: `src/store-api/src/region_request.rs`

 - **Added Unit Tests**: Introduced tests to verify the conversion of `PathType` enum to and from primitive types.
   - Files: `src/store-api/src/region_request.rs`

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
