### PR TITLE
chore: prefix debug_assertion only variables with underscore

### DIFF
--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -274,7 +274,7 @@ impl SeqScan {
                 stream_ctx.input.num_memtables(),
                 stream_ctx.input.num_files(),
             ));
-            let mapper = stream_ctx.input.mapper.as_primary_key().context(UnexpectedSnafu {
+            let _mapper = stream_ctx.input.mapper.as_primary_key().context(UnexpectedSnafu {
                 reason: "Unexpected format",
             })?;
             // Scans each part.
@@ -312,7 +312,7 @@ impl SeqScan {
                     #[cfg(debug_assertions)]
                     checker.ensure_part_range_batch(
                         "SeqScan",
-                        mapper.metadata().region_id,
+                        _mapper.metadata().region_id,
                         partition,
                         part_range,
                         &batch,

--- a/src/mito2/src/read/unordered_scan.rs
+++ b/src/mito2/src/read/unordered_scan.rs
@@ -227,7 +227,7 @@ impl UnorderedScan {
             for part_range in part_ranges {
                 let mut metrics = ScannerMetrics::default();
                 let mut fetch_start = Instant::now();
-                let mapper = &stream_ctx.input.mapper;
+                let _mapper = &stream_ctx.input.mapper;
                 #[cfg(debug_assertions)]
                 let mut checker = crate::read::BatchChecker::default()
                     .with_start(Some(part_range.start))
@@ -253,7 +253,7 @@ impl UnorderedScan {
                     #[cfg(debug_assertions)]
                     checker.ensure_part_range_batch(
                         "UnorderedScan",
-                        mapper.metadata().region_id,
+                        _mapper.metadata().region_id,
                         partition,
                         part_range,
                         &batch,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

from #6679

## What's changed and what's your intention?


`mapper` is only used in `#[debug_assertion]`, so ignore is to avoid lint warnings in non-debug profiles

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
