### PR TITLE
chore: add u64 for EqualValue and set expr is true when filter is empty

### DIFF
--- a/src/log-query/src/log_query.rs
+++ b/src/log-query/src/log_query.rs
@@ -368,7 +368,7 @@ impl From<f64> for EqualValue {
 
 impl From<u64> for EqualValue {
     fn from(value: u64) -> Self {
-        EqualValue::Uint(value)
+        EqualValue::UInt(value)
     }
 }
 

--- a/src/log-query/src/log_query.rs
+++ b/src/log-query/src/log_query.rs
@@ -336,6 +336,8 @@ pub enum EqualValue {
     Boolean(bool),
     /// Exact match with a number value.
     Int(i64),
+    /// Exact match with an unsigned integer value.
+    Uint(u64),
     /// Exact match with a float value.
     Float(f64),
 }
@@ -361,6 +363,12 @@ impl From<i64> for EqualValue {
 impl From<f64> for EqualValue {
     fn from(value: f64) -> Self {
         EqualValue::Float(value)
+    }
+}
+
+impl From<u64> for EqualValue {
+    fn from(value: u64) -> Self {
+        EqualValue::Uint(value)
     }
 }
 

--- a/src/log-query/src/log_query.rs
+++ b/src/log-query/src/log_query.rs
@@ -337,7 +337,7 @@ pub enum EqualValue {
     /// Exact match with a number value.
     Int(i64),
     /// Exact match with an unsigned integer value.
-    Uint(u64),
+    UInt(u64),
     /// Exact match with a float value.
     Float(f64),
 }

--- a/src/query/src/log_query/planner.rs
+++ b/src/query/src/log_query/planner.rs
@@ -201,7 +201,7 @@ impl LogQueryPlanner {
             .try_collect::<Vec<_>>()?;
 
         if filter_exprs.is_empty() {
-            return Ok(None);
+            return Ok(Some(col_expr.is_true()));
         }
 
         // Combine all filters with AND logic
@@ -475,6 +475,7 @@ impl LogQueryPlanner {
             EqualValue::Float(n) => lit(ScalarValue::Float64(Some(n))),
             EqualValue::Int(n) => lit(ScalarValue::Int64(Some(n))),
             EqualValue::Boolean(b) => lit(ScalarValue::Boolean(Some(b))),
+            EqualValue::Uint(n) => lit(ScalarValue::UInt64(Some(n))),
         }
     }
 

--- a/src/query/src/log_query/planner.rs
+++ b/src/query/src/log_query/planner.rs
@@ -475,7 +475,7 @@ impl LogQueryPlanner {
             EqualValue::Float(n) => lit(ScalarValue::Float64(Some(n))),
             EqualValue::Int(n) => lit(ScalarValue::Int64(Some(n))),
             EqualValue::Boolean(b) => lit(ScalarValue::Boolean(Some(b))),
-            EqualValue::Uint(n) => lit(ScalarValue::UInt64(Some(n))),
+            EqualValue::UInt(n) => lit(ScalarValue::UInt64(Some(n))),
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

* add u64 for EqualValue and set expr is true when filter is empty

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
