### PR TITLE
fix: truncate manifest action compat

### DIFF
--- a/src/mito2/src/manifest/action.rs
+++ b/src/mito2/src/manifest/action.rs
@@ -62,59 +62,16 @@ pub struct RegionRemove {
     pub region_id: RegionId,
 }
 
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct RegionTruncate {
     pub region_id: RegionId,
+    #[serde(flatten)]
     pub kind: TruncateKind,
-}
-
-impl<'de> Deserialize<'de> for RegionTruncate {
-    /// manual deserialization to support backward compatibility
-    /// first try deser to v2, failing that, try v1
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-        pub struct RegionTruncateV1 {
-            pub region_id: RegionId,
-            /// Last WAL entry id of truncated data.
-            pub truncated_entry_id: EntryId,
-            // Last sequence number of truncated data.
-            pub truncated_sequence: SequenceNumber,
-        }
-
-        #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-        pub struct RegionTruncateV2 {
-            pub region_id: RegionId,
-            pub kind: TruncateKind,
-        }
-
-        // had to first make it a cloneable value to be able to deserialize twice
-        let cloneable_value = serde_json::Value::deserialize(deserializer)?;
-
-        let res = RegionTruncateV2::deserialize(cloneable_value.clone());
-        if let Ok(v2) = res {
-            Ok(RegionTruncate {
-                region_id: v2.region_id,
-                kind: v2.kind,
-            })
-        } else {
-            let v1 = RegionTruncateV1::deserialize(cloneable_value.clone())
-                .map_err(serde::de::Error::custom)?;
-            Ok(RegionTruncate {
-                region_id: v1.region_id,
-                kind: TruncateKind::All {
-                    truncated_entry_id: v1.truncated_entry_id,
-                    truncated_sequence: v1.truncated_sequence,
-                },
-            })
-        }
-    }
 }
 
 /// The kind of truncate operation.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(untagged)]
 pub enum TruncateKind {
     /// Truncate all data in the region, marked by all data before the given entry id&sequence.
     All {
@@ -303,6 +260,8 @@ impl RegionMetaActionList {
 #[cfg(test)]
 mod tests {
 
+    use common_time::Timestamp;
+
     use super::*;
 
     // These tests are used to ensure backward compatibility of manifest files.
@@ -485,22 +444,43 @@ mod tests {
 
         // Test deserializing RegionTruncate from new schema
         let region_truncate_v2_json = r#"{
+    "region_id": 4402341478400,
+    "files_to_remove": [
+        {
             "region_id": 4402341478400,
-            "kind": {
-                "All": {
-                    "truncated_entry_id": 10,
-                    "truncated_sequence": 20
+            "file_id": "4b220a70-2b03-4641-9687-b65d94641208",
+            "time_range": [
+                {
+                    "value": 1451609210000,
+                    "unit": "Millisecond"
+                },
+                {
+                    "value": 1451609520000,
+                    "unit": "Millisecond"
                 }
-            }
-        }"#;
+            ],
+            "level": 1,
+            "file_size": 100
+        }
+    ]
+}"#;
 
         let truncate_v2: RegionTruncate = serde_json::from_str(region_truncate_v2_json).unwrap();
         assert_eq!(truncate_v2.region_id, 4402341478400);
         assert_eq!(
             truncate_v2.kind,
-            TruncateKind::All {
-                truncated_entry_id: 10,
-                truncated_sequence: 20,
+            TruncateKind::Partial {
+                files_to_remove: vec![FileMeta {
+                    region_id: RegionId::from_u64(4402341478400),
+                    file_id: FileId::parse_str("4b220a70-2b03-4641-9687-b65d94641208").unwrap(),
+                    time_range: (
+                        Timestamp::new_millisecond(1451609210000),
+                        Timestamp::new_millisecond(1451609520000)
+                    ),
+                    level: 1,
+                    file_size: 100,
+                    ..Default::default()
+                }]
             }
         );
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

##6602

## What's changed and what's your intention?

as title, previous pr failed to notice this incompatibility with region truncate action in manifest files, so if you truncate a table in old version, then immediately upgrade to new version, db wouldn't understand the manifest action files(luckily it didn't break manifest checkpoint files), ~so this fix make sure region truncate deser now first try v2(latest version) of itself, then try v1(old version) and convert it to v2~, added `#[serde(flatten)]` and `#[serde(untagged)]` instead

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
