### PR TITLE
fix: partition tree's dict size metrics mismatch

### DIFF
--- a/src/mito2/src/memtable/partition_tree/dict.rs
+++ b/src/mito2/src/memtable/partition_tree/dict.rs
@@ -100,10 +100,10 @@ impl KeyDictBuilder {
 
         // Since we store the key twice so the bytes usage doubled.
         metrics.key_bytes += full_primary_key.len() * 2 + sparse_key_len;
-        self.key_bytes_in_index += full_primary_key.len();
+        self.key_bytes_in_index += full_primary_key.len() + sparse_key_len;
 
         // Adds key size of index to the metrics.
-        MEMTABLE_DICT_BYTES.add((full_primary_key.len() + sparse_key_len) as i64);
+        MEMTABLE_DICT_BYTES.add(self.key_bytes_in_index as i64);
 
         pk_index
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


`sparse_key_len` is not subtracted on drop

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
