### PR TITLE
refactor: change plugin option type from `&[PluginOptions]` to `Option<&PluginOptions>` for understandability

### DIFF
--- a/src/cmd/src/datanode/builder.rs
+++ b/src/cmd/src/datanode/builder.rs
@@ -71,7 +71,7 @@ impl InstanceBuilder {
         maybe_activate_heap_profile(&dn_opts.memory);
         create_resource_limit_metrics(APP_NAME);
 
-        plugins::setup_datanode_plugins(plugins, &opts.plugins, dn_opts)
+        plugins::setup_datanode_plugins(plugins, opts.plugins.as_ref(), dn_opts)
             .await
             .context(StartDatanodeSnafu)?;
 

--- a/src/cmd/src/flownode.rs
+++ b/src/cmd/src/flownode.rs
@@ -291,7 +291,7 @@ impl StartCommand {
         opts.grpc.detect_server_addr();
 
         let mut plugins = Plugins::new();
-        plugins::setup_flownode_plugins(&mut plugins, &plugin_opts, &opts)
+        plugins::setup_flownode_plugins(&mut plugins, plugin_opts.as_ref(), &opts)
             .await
             .context(StartFlownodeSnafu)?;
 

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -293,7 +293,7 @@ impl StartCommand {
         let mut opts = opts.component;
         opts.grpc.detect_server_addr();
         let mut plugins = Plugins::new();
-        plugins::setup_frontend_plugins(&mut plugins, &plugin_opts, &opts)
+        plugins::setup_frontend_plugins(&mut plugins, plugin_opts.as_ref(), &opts)
             .await
             .context(error::StartFrontendSnafu)?;
 
@@ -526,7 +526,7 @@ mod tests {
         };
 
         let mut plugins = Plugins::new();
-        plugins::setup_frontend_plugins(&mut plugins, &[], &fe_opts)
+        plugins::setup_frontend_plugins(&mut plugins, None, &fe_opts)
             .await
             .unwrap();
 

--- a/src/cmd/src/metasrv.rs
+++ b/src/cmd/src/metasrv.rs
@@ -337,7 +337,7 @@ impl StartCommand {
         info!("Metasrv options: {:#?}", opts);
 
         let mut plugins = Plugins::new();
-        plugins::setup_metasrv_plugins(&mut plugins, &plugin_opts, &opts)
+        plugins::setup_metasrv_plugins(&mut plugins, plugin_opts.as_ref(), &opts)
             .await
             .context(StartMetaServerSnafu)?;
 

--- a/src/cmd/src/options.rs
+++ b/src/cmd/src/options.rs
@@ -42,7 +42,7 @@ pub struct GreptimeOptions<T> {
     /// The runtime options.
     pub runtime: RuntimeOptions,
     /// The plugin options.
-    pub plugins: Vec<PluginOptions>,
+    pub plugins: Option<PluginOptions>,
 
     /// The options of each component (like Datanode or Standalone) of GreptimeDB.
     #[serde(flatten)]

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -503,11 +503,11 @@ impl StartCommand {
         let fe_opts = opts.frontend_options();
         let dn_opts = opts.datanode_options();
 
-        plugins::setup_frontend_plugins(&mut plugins, &plugin_opts, &fe_opts)
+        plugins::setup_frontend_plugins(&mut plugins, plugin_opts.as_ref(), &fe_opts)
             .await
             .context(error::StartFrontendSnafu)?;
 
-        plugins::setup_datanode_plugins(&mut plugins, &plugin_opts, &dn_opts)
+        plugins::setup_datanode_plugins(&mut plugins, plugin_opts.as_ref(), &dn_opts)
             .await
             .context(error::StartDatanodeSnafu)?;
 
@@ -877,7 +877,7 @@ mod tests {
         };
 
         let mut plugins = Plugins::new();
-        plugins::setup_frontend_plugins(&mut plugins, &[], &fe_opts)
+        plugins::setup_frontend_plugins(&mut plugins, None, &fe_opts)
             .await
             .unwrap();
 

--- a/src/plugins/src/datanode.rs
+++ b/src/plugins/src/datanode.rs
@@ -22,7 +22,7 @@ use crate::options::PluginOptions;
 #[allow(unused_mut)]
 pub async fn setup_datanode_plugins(
     plugins: &mut Plugins,
-    plugin_options: &[PluginOptions],
+    plugin_options: Option<&PluginOptions>,
     dn_opts: &DatanodeOptions,
 ) -> Result<()> {
     Ok(())

--- a/src/plugins/src/flownode.rs
+++ b/src/plugins/src/flownode.rs
@@ -21,7 +21,7 @@ use crate::options::PluginOptions;
 #[allow(unused_mut)]
 pub async fn setup_flownode_plugins(
     _plugins: &mut Plugins,
-    _plugin_options: &[PluginOptions],
+    _plugin_options: Option<&PluginOptions>,
     _fn_opts: &FlownodeOptions,
 ) -> Result<()> {
     Ok(())

--- a/src/plugins/src/frontend.rs
+++ b/src/plugins/src/frontend.rs
@@ -23,7 +23,7 @@ use crate::options::PluginOptions;
 #[allow(unused_mut)]
 pub async fn setup_frontend_plugins(
     plugins: &mut Plugins,
-    _plugin_options: &[PluginOptions],
+    _plugin_options: Option<&PluginOptions>,
     fe_opts: &FrontendOptions,
 ) -> Result<()> {
     if let Some(user_provider) = fe_opts.user_provider.as_ref() {

--- a/src/plugins/src/meta_srv.rs
+++ b/src/plugins/src/meta_srv.rs
@@ -21,7 +21,7 @@ use crate::options::PluginOptions;
 #[allow(unused_variables)]
 pub async fn setup_metasrv_plugins(
     _plugins: &mut Plugins,
-    plugin_options: &[PluginOptions],
+    _plugin_options: Option<&PluginOptions>,
     metasrv_opts: &MetasrvOptions,
 ) -> Result<()> {
     Ok(())

--- a/src/plugins/src/options.rs
+++ b/src/plugins/src/options.rs
@@ -18,6 +18,6 @@ use serde::{Deserialize, Serialize};
 pub struct DummyOptions;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub enum PluginOptions {
-    Dummy(DummyOptions),
+pub struct PluginOptions {
+    pub dummy: DummyOptions,
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The original type `&[PluginOptions]` is not accurate for describing the actual plugin configurations. In most scenarios, there is only one element for `[PluginOptions]`. Moreover, it's not easy to use environment variables to set up plugins.

After using `Option<&PluginOptions>`, the configs will look like:

```
...
[plugins]
[plugins.foo]
name = "foo"
[plugins.bar]
name = "bar"
...
```

For one plugin, it can design its own configs. Therefore, the `PluginOptions` will look like:

```rust
#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
pub struct PluginOptions {
    pub PluginFoo: Option<PluginFooOptions>,
    pub PluginBar: Option<PluginBarOptions>,
}
```

It will be simpler to write the setup code, for example:

```rust
pub async fn setup_datanode_plugins(
    plugins: &mut Plugins,
    plugin_options: Option<&PluginOptions>,
    dn_opts: &DatanodeOptions,
) -> Result<()> {
    if let Some(PluginFoo) = plugin_options.PluginFoo {
        // initialization of PluginFoo.
    }
}
```

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
