### PR TITLE
feat(mito): list SSTs from manifest and storage

### DIFF
--- a/src/metric-engine/src/engine.rs
+++ b/src/metric-engine/src/engine.rs
@@ -378,26 +378,6 @@ impl RegionEngine for MetricEngine {
     fn as_any(&self) -> &dyn Any {
         self
     }
-
-    async fn all_ssts_from_manifest(
-        &self,
-    ) -> Result<Vec<store_api::sst_entry::ManifestSstEntry>, BoxedError> {
-        let mut entries = self.inner.mito.all_ssts_from_manifest().await?;
-        for entry in &mut entries {
-            entry.engine = METRIC_ENGINE_NAME.to_string();
-        }
-        Ok(entries)
-    }
-
-    async fn all_ssts_from_storage(
-        &self,
-    ) -> Result<Vec<store_api::sst_entry::StorageSstEntry>, BoxedError> {
-        let mut entries = self.inner.mito.all_ssts_from_storage().await?;
-        for entry in &mut entries {
-            entry.engine = METRIC_ENGINE_NAME.to_string();
-        }
-        Ok(entries)
-    }
 }
 
 impl MetricEngine {

--- a/src/metric-engine/src/engine.rs
+++ b/src/metric-engine/src/engine.rs
@@ -378,6 +378,26 @@ impl RegionEngine for MetricEngine {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
+    async fn all_ssts_from_manifest(
+        &self,
+    ) -> Result<Vec<store_api::sst_entry::ManifestSstEntry>, BoxedError> {
+        let mut entries = self.inner.mito.all_ssts_from_manifest().await?;
+        for entry in &mut entries {
+            entry.engine = METRIC_ENGINE_NAME.to_string();
+        }
+        Ok(entries)
+    }
+
+    async fn all_ssts_from_storage(
+        &self,
+    ) -> Result<Vec<store_api::sst_entry::StorageSstEntry>, BoxedError> {
+        let mut entries = self.inner.mito.all_ssts_from_storage().await?;
+        for entry in &mut entries {
+            entry.engine = METRIC_ENGINE_NAME.to_string();
+        }
+        Ok(entries)
+    }
 }
 
 impl MetricEngine {
@@ -487,7 +507,7 @@ mod test {
     use mito2::sst::location::region_dir_from_table_dir;
     use store_api::metric_engine_consts::PHYSICAL_TABLE_METADATA_KEY;
     use store_api::region_request::{
-        PathType, RegionCloseRequest, RegionFlushRequest, RegionOpenRequest,
+        PathType, RegionCloseRequest, RegionFlushRequest, RegionOpenRequest, RegionRequest,
     };
 
     use super::*;

--- a/src/metric-engine/src/engine/flush.rs
+++ b/src/metric-engine/src/engine/flush.rs
@@ -50,3 +50,111 @@ impl MetricEngineInner {
             .map(|response| response.affected_rows)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use api::v1::Rows;
+    use itertools::Itertools as _;
+    use store_api::region_request::RegionPutRequest;
+
+    use super::*;
+    use crate::test_util::{build_rows, row_schema_with_tags, TestEnv};
+
+    #[tokio::test]
+    async fn test_list_ssts_after_write_and_flush_metric() {
+        let env = TestEnv::new().await;
+        let engine = env.metric();
+
+        let phy_to_logi = vec![
+            (
+                RegionId::new(11, 1),
+                vec![RegionId::new(1111, 11), RegionId::new(1111, 12)],
+            ),
+            (RegionId::new(11, 2), vec![RegionId::new(1111, 2)]),
+            (RegionId::new(22, 42), vec![RegionId::new(2222, 42)]),
+        ];
+
+        for (phy_region_id, logi_region_ids) in &phy_to_logi {
+            env.create_physical_region(*phy_region_id, &TestEnv::default_table_dir())
+                .await;
+            for logi_region_id in logi_region_ids {
+                env.create_logical_region(*phy_region_id, *logi_region_id)
+                    .await;
+            }
+        }
+
+        // write to logical regions
+        for (_, logi_region_ids) in &phy_to_logi {
+            for logi_region_id in logi_region_ids {
+                let schema = row_schema_with_tags(&["job"]);
+                let rows = build_rows(1, 10);
+                let request = RegionRequest::Put(RegionPutRequest {
+                    rows: Rows { schema, rows },
+                    hint: None,
+                });
+                engine
+                    .handle_request(*logi_region_id, request)
+                    .await
+                    .unwrap();
+            }
+        }
+
+        for (phy_region_id, _) in &phy_to_logi {
+            engine
+                .handle_request(
+                    *phy_region_id,
+                    RegionRequest::Flush(RegionFlushRequest {
+                        row_group_size: None,
+                    }),
+                )
+                .await
+                .unwrap();
+        }
+
+        // list from manifest
+        let mut manifest_entries = engine.all_ssts_from_manifest().await.unwrap();
+        let debug_format = manifest_entries
+            .iter_mut()
+            .map(|e| {
+                e.file_path = e.file_path.replace(&e.file_id, "<file_id>");
+                e.file_id = "<file_id>".to_string();
+                format!("\n{:?}", e)
+            })
+            .sorted()
+            .collect::<Vec<_>>()
+            .join("");
+        assert_eq!(
+            debug_format,
+            r#"
+ManifestSstEntry { engine: "metric", table_dir: "test_metric_region/", region_id: 47244640257(11, 1), table_id: 11, region_number: 1, region_group: 0, region_sequence: 1, file_id: "<file_id>", level: 0, file_path: "test_metric_region/11_0000000001/data/<file_id>.parquet", file_size: 3157, num_rows: 10, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 9::Millisecond, sequence: Some(20) }
+ManifestSstEntry { engine: "metric", table_dir: "test_metric_region/", region_id: 47244640258(11, 2), table_id: 11, region_number: 2, region_group: 0, region_sequence: 2, file_id: "<file_id>", level: 0, file_path: "test_metric_region/11_0000000002/data/<file_id>.parquet", file_size: 3157, num_rows: 10, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 9::Millisecond, sequence: Some(10) }
+ManifestSstEntry { engine: "metric", table_dir: "test_metric_region/", region_id: 47261417473(11, 16777217), table_id: 11, region_number: 16777217, region_group: 1, region_sequence: 1, file_id: "<file_id>", level: 0, file_path: "test_metric_region/11_0000000001/metadata/<file_id>.parquet", file_size: 3201, num_rows: 8, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 0::Millisecond, sequence: Some(8) }
+ManifestSstEntry { engine: "metric", table_dir: "test_metric_region/", region_id: 47261417474(11, 16777218), table_id: 11, region_number: 16777218, region_group: 1, region_sequence: 2, file_id: "<file_id>", level: 0, file_path: "test_metric_region/11_0000000002/metadata/<file_id>.parquet", file_size: 3185, num_rows: 4, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 0::Millisecond, sequence: Some(4) }
+ManifestSstEntry { engine: "metric", table_dir: "test_metric_region/", region_id: 94489280554(22, 42), table_id: 22, region_number: 42, region_group: 0, region_sequence: 42, file_id: "<file_id>", level: 0, file_path: "test_metric_region/22_0000000042/data/<file_id>.parquet", file_size: 3157, num_rows: 10, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 9::Millisecond, sequence: Some(10) }
+ManifestSstEntry { engine: "metric", table_dir: "test_metric_region/", region_id: 94506057770(22, 16777258), table_id: 22, region_number: 16777258, region_group: 1, region_sequence: 42, file_id: "<file_id>", level: 0, file_path: "test_metric_region/22_0000000042/metadata/<file_id>.parquet", file_size: 3185, num_rows: 4, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 0::Millisecond, sequence: Some(4) }"#
+        );
+
+        // list from storage
+        let mut storage_entries = engine.all_ssts_from_storage().await.unwrap();
+        let debug_format = storage_entries
+            .iter_mut()
+            .map(|e| {
+                let i = e.file_path.rfind('/').unwrap();
+                e.file_path.replace_range(i.., "/<file_id>.parquet");
+                format!("\n{:?}", e)
+            })
+            .sorted()
+            .collect::<Vec<_>>()
+            .join("");
+        assert_eq!(
+            debug_format,
+            r#"
+StorageSstEntry { engine: "metric", file_path: "test_metric_region/11_0000000001/data/<file_id>.parquet", file_size: None, last_modified_ms: None }
+StorageSstEntry { engine: "metric", file_path: "test_metric_region/11_0000000001/metadata/<file_id>.parquet", file_size: None, last_modified_ms: None }
+StorageSstEntry { engine: "metric", file_path: "test_metric_region/11_0000000002/data/<file_id>.parquet", file_size: None, last_modified_ms: None }
+StorageSstEntry { engine: "metric", file_path: "test_metric_region/11_0000000002/metadata/<file_id>.parquet", file_size: None, last_modified_ms: None }
+StorageSstEntry { engine: "metric", file_path: "test_metric_region/22_0000000042/data/<file_id>.parquet", file_size: None, last_modified_ms: None }
+StorageSstEntry { engine: "metric", file_path: "test_metric_region/22_0000000042/metadata/<file_id>.parquet", file_size: None, last_modified_ms: None }"#
+        );
+    }
+}

--- a/src/metric-engine/src/engine/flush.rs
+++ b/src/metric-engine/src/engine/flush.rs
@@ -101,18 +101,13 @@ mod tests {
 
         for (phy_region_id, _) in &phy_to_logi {
             engine
-                .handle_request(
-                    *phy_region_id,
-                    RegionRequest::Flush(RegionFlushRequest {
-                        row_group_size: None,
-                    }),
-                )
+                .handle_request(*phy_region_id, RegionRequest::Flush(Default::default()))
                 .await
                 .unwrap();
         }
 
         // list from manifest
-        let mut manifest_entries = engine.all_ssts_from_manifest().await.unwrap();
+        let mut manifest_entries = env.mito().all_ssts_from_manifest();
         let debug_format = manifest_entries
             .iter_mut()
             .map(|e| {
@@ -126,16 +121,16 @@ mod tests {
         assert_eq!(
             debug_format,
             r#"
-ManifestSstEntry { engine: "metric", table_dir: "test_metric_region/", region_id: 47244640257(11, 1), table_id: 11, region_number: 1, region_group: 0, region_sequence: 1, file_id: "<file_id>", level: 0, file_path: "test_metric_region/11_0000000001/data/<file_id>.parquet", file_size: 3157, num_rows: 10, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 9::Millisecond, sequence: Some(20) }
-ManifestSstEntry { engine: "metric", table_dir: "test_metric_region/", region_id: 47244640258(11, 2), table_id: 11, region_number: 2, region_group: 0, region_sequence: 2, file_id: "<file_id>", level: 0, file_path: "test_metric_region/11_0000000002/data/<file_id>.parquet", file_size: 3157, num_rows: 10, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 9::Millisecond, sequence: Some(10) }
-ManifestSstEntry { engine: "metric", table_dir: "test_metric_region/", region_id: 47261417473(11, 16777217), table_id: 11, region_number: 16777217, region_group: 1, region_sequence: 1, file_id: "<file_id>", level: 0, file_path: "test_metric_region/11_0000000001/metadata/<file_id>.parquet", file_size: 3201, num_rows: 8, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 0::Millisecond, sequence: Some(8) }
-ManifestSstEntry { engine: "metric", table_dir: "test_metric_region/", region_id: 47261417474(11, 16777218), table_id: 11, region_number: 16777218, region_group: 1, region_sequence: 2, file_id: "<file_id>", level: 0, file_path: "test_metric_region/11_0000000002/metadata/<file_id>.parquet", file_size: 3185, num_rows: 4, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 0::Millisecond, sequence: Some(4) }
-ManifestSstEntry { engine: "metric", table_dir: "test_metric_region/", region_id: 94489280554(22, 42), table_id: 22, region_number: 42, region_group: 0, region_sequence: 42, file_id: "<file_id>", level: 0, file_path: "test_metric_region/22_0000000042/data/<file_id>.parquet", file_size: 3157, num_rows: 10, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 9::Millisecond, sequence: Some(10) }
-ManifestSstEntry { engine: "metric", table_dir: "test_metric_region/", region_id: 94506057770(22, 16777258), table_id: 22, region_number: 16777258, region_group: 1, region_sequence: 42, file_id: "<file_id>", level: 0, file_path: "test_metric_region/22_0000000042/metadata/<file_id>.parquet", file_size: 3185, num_rows: 4, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 0::Millisecond, sequence: Some(4) }"#
+ManifestSstEntry { table_dir: "test_metric_region/", region_id: 47244640257(11, 1), table_id: 11, region_number: 1, region_group: 0, region_sequence: 1, file_id: "<file_id>", level: 0, file_path: "test_metric_region/11_0000000001/data/<file_id>.parquet", file_size: 3157, num_rows: 10, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 9::Millisecond, sequence: Some(20) }
+ManifestSstEntry { table_dir: "test_metric_region/", region_id: 47244640258(11, 2), table_id: 11, region_number: 2, region_group: 0, region_sequence: 2, file_id: "<file_id>", level: 0, file_path: "test_metric_region/11_0000000002/data/<file_id>.parquet", file_size: 3157, num_rows: 10, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 9::Millisecond, sequence: Some(10) }
+ManifestSstEntry { table_dir: "test_metric_region/", region_id: 47261417473(11, 16777217), table_id: 11, region_number: 16777217, region_group: 1, region_sequence: 1, file_id: "<file_id>", level: 0, file_path: "test_metric_region/11_0000000001/metadata/<file_id>.parquet", file_size: 3201, num_rows: 8, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 0::Millisecond, sequence: Some(8) }
+ManifestSstEntry { table_dir: "test_metric_region/", region_id: 47261417474(11, 16777218), table_id: 11, region_number: 16777218, region_group: 1, region_sequence: 2, file_id: "<file_id>", level: 0, file_path: "test_metric_region/11_0000000002/metadata/<file_id>.parquet", file_size: 3185, num_rows: 4, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 0::Millisecond, sequence: Some(4) }
+ManifestSstEntry { table_dir: "test_metric_region/", region_id: 94489280554(22, 42), table_id: 22, region_number: 42, region_group: 0, region_sequence: 42, file_id: "<file_id>", level: 0, file_path: "test_metric_region/22_0000000042/data/<file_id>.parquet", file_size: 3157, num_rows: 10, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 9::Millisecond, sequence: Some(10) }
+ManifestSstEntry { table_dir: "test_metric_region/", region_id: 94506057770(22, 16777258), table_id: 22, region_number: 16777258, region_group: 1, region_sequence: 42, file_id: "<file_id>", level: 0, file_path: "test_metric_region/22_0000000042/metadata/<file_id>.parquet", file_size: 3185, num_rows: 4, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 0::Millisecond, sequence: Some(4) }"#
         );
 
         // list from storage
-        let mut storage_entries = engine.all_ssts_from_storage().await.unwrap();
+        let mut storage_entries = env.mito().all_ssts_from_storage().await.unwrap();
         let debug_format = storage_entries
             .iter_mut()
             .map(|e| {
@@ -149,12 +144,12 @@ ManifestSstEntry { engine: "metric", table_dir: "test_metric_region/", region_id
         assert_eq!(
             debug_format,
             r#"
-StorageSstEntry { engine: "metric", file_path: "test_metric_region/11_0000000001/data/<file_id>.parquet", file_size: None, last_modified_ms: None }
-StorageSstEntry { engine: "metric", file_path: "test_metric_region/11_0000000001/metadata/<file_id>.parquet", file_size: None, last_modified_ms: None }
-StorageSstEntry { engine: "metric", file_path: "test_metric_region/11_0000000002/data/<file_id>.parquet", file_size: None, last_modified_ms: None }
-StorageSstEntry { engine: "metric", file_path: "test_metric_region/11_0000000002/metadata/<file_id>.parquet", file_size: None, last_modified_ms: None }
-StorageSstEntry { engine: "metric", file_path: "test_metric_region/22_0000000042/data/<file_id>.parquet", file_size: None, last_modified_ms: None }
-StorageSstEntry { engine: "metric", file_path: "test_metric_region/22_0000000042/metadata/<file_id>.parquet", file_size: None, last_modified_ms: None }"#
+StorageSstEntry { file_path: "test_metric_region/11_0000000001/data/<file_id>.parquet", file_size: None, last_modified_ms: None }
+StorageSstEntry { file_path: "test_metric_region/11_0000000001/metadata/<file_id>.parquet", file_size: None, last_modified_ms: None }
+StorageSstEntry { file_path: "test_metric_region/11_0000000002/data/<file_id>.parquet", file_size: None, last_modified_ms: None }
+StorageSstEntry { file_path: "test_metric_region/11_0000000002/metadata/<file_id>.parquet", file_size: None, last_modified_ms: None }
+StorageSstEntry { file_path: "test_metric_region/22_0000000042/data/<file_id>.parquet", file_size: None, last_modified_ms: None }
+StorageSstEntry { file_path: "test_metric_region/22_0000000042/metadata/<file_id>.parquet", file_size: None, last_modified_ms: None }"#
         );
     }
 }

--- a/src/metric-engine/src/engine/flush.rs
+++ b/src/metric-engine/src/engine/flush.rs
@@ -113,6 +113,9 @@ mod tests {
             .all_ssts_from_manifest()
             .map(|mut e| {
                 e.file_path = e.file_path.replace(&e.file_id, "<file_id>");
+                e.index_file_path = e
+                    .index_file_path
+                    .map(|path| path.replace(&e.file_id, "<file_id>"));
                 e.file_id = "<file_id>".to_string();
                 format!("\n{:?}", e)
             })
@@ -122,12 +125,12 @@ mod tests {
         assert_eq!(
             debug_format,
             r#"
-ManifestSstEntry { table_dir: "test_metric_region/", region_id: 47244640257(11, 1), table_id: 11, region_number: 1, region_group: 0, region_sequence: 1, file_id: "<file_id>", level: 0, file_path: "test_metric_region/11_0000000001/data/<file_id>.parquet", file_size: 3157, num_rows: 10, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 9::Millisecond, sequence: Some(20) }
-ManifestSstEntry { table_dir: "test_metric_region/", region_id: 47244640258(11, 2), table_id: 11, region_number: 2, region_group: 0, region_sequence: 2, file_id: "<file_id>", level: 0, file_path: "test_metric_region/11_0000000002/data/<file_id>.parquet", file_size: 3157, num_rows: 10, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 9::Millisecond, sequence: Some(10) }
-ManifestSstEntry { table_dir: "test_metric_region/", region_id: 47261417473(11, 16777217), table_id: 11, region_number: 16777217, region_group: 1, region_sequence: 1, file_id: "<file_id>", level: 0, file_path: "test_metric_region/11_0000000001/metadata/<file_id>.parquet", file_size: 3201, num_rows: 8, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 0::Millisecond, sequence: Some(8) }
-ManifestSstEntry { table_dir: "test_metric_region/", region_id: 47261417474(11, 16777218), table_id: 11, region_number: 16777218, region_group: 1, region_sequence: 2, file_id: "<file_id>", level: 0, file_path: "test_metric_region/11_0000000002/metadata/<file_id>.parquet", file_size: 3185, num_rows: 4, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 0::Millisecond, sequence: Some(4) }
-ManifestSstEntry { table_dir: "test_metric_region/", region_id: 94489280554(22, 42), table_id: 22, region_number: 42, region_group: 0, region_sequence: 42, file_id: "<file_id>", level: 0, file_path: "test_metric_region/22_0000000042/data/<file_id>.parquet", file_size: 3157, num_rows: 10, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 9::Millisecond, sequence: Some(10) }
-ManifestSstEntry { table_dir: "test_metric_region/", region_id: 94506057770(22, 16777258), table_id: 22, region_number: 16777258, region_group: 1, region_sequence: 42, file_id: "<file_id>", level: 0, file_path: "test_metric_region/22_0000000042/metadata/<file_id>.parquet", file_size: 3185, num_rows: 4, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 0::Millisecond, sequence: Some(4) }"#
+ManifestSstEntry { table_dir: "test_metric_region/", region_id: 47244640257(11, 1), table_id: 11, region_number: 1, region_group: 0, region_sequence: 1, file_id: "<file_id>", level: 0, file_path: "test_metric_region/11_0000000001/data/<file_id>.parquet", file_size: 3157, index_file_path: Some("test_metric_region/11_0000000001/data/index/<file_id>.puffin"), index_file_size: Some(235), num_rows: 10, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 9::Millisecond, sequence: Some(20) }
+ManifestSstEntry { table_dir: "test_metric_region/", region_id: 47244640258(11, 2), table_id: 11, region_number: 2, region_group: 0, region_sequence: 2, file_id: "<file_id>", level: 0, file_path: "test_metric_region/11_0000000002/data/<file_id>.parquet", file_size: 3157, index_file_path: Some("test_metric_region/11_0000000002/data/index/<file_id>.puffin"), index_file_size: Some(235), num_rows: 10, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 9::Millisecond, sequence: Some(10) }
+ManifestSstEntry { table_dir: "test_metric_region/", region_id: 47261417473(11, 16777217), table_id: 11, region_number: 16777217, region_group: 1, region_sequence: 1, file_id: "<file_id>", level: 0, file_path: "test_metric_region/11_0000000001/metadata/<file_id>.parquet", file_size: 3201, index_file_path: None, index_file_size: None, num_rows: 8, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 0::Millisecond, sequence: Some(8) }
+ManifestSstEntry { table_dir: "test_metric_region/", region_id: 47261417474(11, 16777218), table_id: 11, region_number: 16777218, region_group: 1, region_sequence: 2, file_id: "<file_id>", level: 0, file_path: "test_metric_region/11_0000000002/metadata/<file_id>.parquet", file_size: 3185, index_file_path: None, index_file_size: None, num_rows: 4, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 0::Millisecond, sequence: Some(4) }
+ManifestSstEntry { table_dir: "test_metric_region/", region_id: 94489280554(22, 42), table_id: 22, region_number: 42, region_group: 0, region_sequence: 42, file_id: "<file_id>", level: 0, file_path: "test_metric_region/22_0000000042/data/<file_id>.parquet", file_size: 3157, index_file_path: Some("test_metric_region/22_0000000042/data/index/<file_id>.puffin"), index_file_size: Some(235), num_rows: 10, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 9::Millisecond, sequence: Some(10) }
+ManifestSstEntry { table_dir: "test_metric_region/", region_id: 94506057770(22, 16777258), table_id: 22, region_number: 16777258, region_group: 1, region_sequence: 42, file_id: "<file_id>", level: 0, file_path: "test_metric_region/22_0000000042/metadata/<file_id>.parquet", file_size: 3185, index_file_path: None, index_file_size: None, num_rows: 4, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 0::Millisecond, sequence: Some(4) }"#
         );
 
         // list from storage
@@ -140,7 +143,7 @@ ManifestSstEntry { table_dir: "test_metric_region/", region_id: 94506057770(22, 
             .into_iter()
             .map(|mut e| {
                 let i = e.file_path.rfind('/').unwrap();
-                e.file_path.replace_range(i.., "/<file_id>.parquet");
+                e.file_path.replace_range(i..(i + 37), "/<file_id>");
                 format!("\n{:?}", e)
             })
             .sorted()
@@ -150,10 +153,13 @@ ManifestSstEntry { table_dir: "test_metric_region/", region_id: 94506057770(22, 
             debug_format,
             r#"
 StorageSstEntry { file_path: "test_metric_region/11_0000000001/data/<file_id>.parquet", file_size: None, last_modified_ms: None }
+StorageSstEntry { file_path: "test_metric_region/11_0000000001/data/index/<file_id>.puffin", file_size: None, last_modified_ms: None }
 StorageSstEntry { file_path: "test_metric_region/11_0000000001/metadata/<file_id>.parquet", file_size: None, last_modified_ms: None }
 StorageSstEntry { file_path: "test_metric_region/11_0000000002/data/<file_id>.parquet", file_size: None, last_modified_ms: None }
+StorageSstEntry { file_path: "test_metric_region/11_0000000002/data/index/<file_id>.puffin", file_size: None, last_modified_ms: None }
 StorageSstEntry { file_path: "test_metric_region/11_0000000002/metadata/<file_id>.parquet", file_size: None, last_modified_ms: None }
 StorageSstEntry { file_path: "test_metric_region/22_0000000042/data/<file_id>.parquet", file_size: None, last_modified_ms: None }
+StorageSstEntry { file_path: "test_metric_region/22_0000000042/data/index/<file_id>.puffin", file_size: None, last_modified_ms: None }
 StorageSstEntry { file_path: "test_metric_region/22_0000000042/metadata/<file_id>.parquet", file_size: None, last_modified_ms: None }"#
         );
     }

--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -15,8 +15,9 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use async_stream::try_stream;
 use common_time::Timestamp;
-use futures::TryStreamExt;
+use futures::{Stream, TryStreamExt};
 use object_store::services::Fs;
 use object_store::util::{join_dir, with_instrument_layers};
 use object_store::{ErrorKind, ObjectStore, ATOMIC_WRITE_DIR, OLD_ATOMIC_WRITE_DIR};
@@ -305,47 +306,43 @@ impl AccessLayer {
     }
 
     /// Lists the SST entries from the storage layer in the table directory.
-    pub async fn storage_sst_entries(&self) -> Result<Vec<StorageSstEntry>> {
-        let mut lister = self
-            .object_store
-            .lister_with(self.table_dir.as_str())
-            .recursive(true)
-            .await
-            .context(OpenDalSnafu)?;
+    pub fn storage_sst_entries(&self) -> impl Stream<Item = Result<StorageSstEntry>> {
+        let object_store = self.object_store.clone();
+        let table_dir = self.table_dir.clone();
 
-        let mut entries = Vec::new();
-        while let Some(entry) = lister.try_next().await.context(OpenDalSnafu)? {
-            let metadata = entry.metadata();
-            if metadata.is_dir() {
-                continue;
+        try_stream! {
+            let mut lister = object_store
+                .lister_with(table_dir.as_str())
+                .recursive(true)
+                .await
+                .context(OpenDalSnafu)?;
+
+            while let Some(entry) = lister.try_next().await.context(OpenDalSnafu)? {
+                let metadata = entry.metadata();
+                if metadata.is_dir() {
+                    continue;
+                }
+
+                let path = entry.path();
+                if !path.ends_with(".parquet") {
+                    continue;
+                }
+
+                let file_size = metadata.content_length();
+                let file_size = if file_size == 0 { None } else { Some(file_size) };
+                let last_modified_ms = metadata
+                    .last_modified()
+                    .map(|ts| Timestamp::new_millisecond(ts.timestamp_millis()));
+
+                let entry = StorageSstEntry {
+                    file_path: path.to_string(),
+                    file_size,
+                    last_modified_ms,
+                };
+
+                yield entry;
             }
-
-            let file_path = entry.path();
-            if !file_path.ends_with(".parquet") {
-                continue;
-            }
-
-            let file_size = metadata.content_length();
-            let file_size = if file_size == 0 {
-                None
-            } else {
-                Some(file_size)
-            };
-
-            let last_modified_ms = metadata
-                .last_modified()
-                .map(|ts| Timestamp::new_millisecond(ts.timestamp_millis()));
-
-            let entry = StorageSstEntry {
-                file_path: file_path.to_string(),
-                file_size,
-                last_modified_ms,
-            };
-
-            entries.push(entry);
         }
-
-        Ok(entries)
     }
 }
 

--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -31,7 +31,6 @@ use crate::cache::file_cache::{FileCacheRef, FileType, IndexKey};
 use crate::cache::write_cache::SstUploadRequest;
 use crate::cache::CacheManagerRef;
 use crate::config::{BloomFilterConfig, FulltextIndexConfig, InvertedIndexConfig};
-use crate::engine::MITO_ENGINE_NAME;
 use crate::error::{CleanDirSnafu, DeleteIndexSnafu, DeleteSstSnafu, OpenDalSnafu, Result};
 use crate::metrics::{COMPACTION_STAGE_ELAPSED, FLUSH_ELAPSED};
 use crate::read::Source;
@@ -338,7 +337,6 @@ impl AccessLayer {
                 .map(|ts| Timestamp::new_millisecond(ts.timestamp_millis()));
 
             let entry = StorageSstEntry {
-                engine: MITO_ENGINE_NAME.to_string(),
                 file_path: file_path.to_string(),
                 file_size,
                 last_modified_ms,

--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -324,7 +324,7 @@ impl AccessLayer {
                 }
 
                 let path = entry.path();
-                if !path.ends_with(".parquet") {
+                if !path.ends_with(".parquet") && !path.ends_with(".puffin") {
                     continue;
                 }
 

--- a/src/mito2/src/engine/basic_test.rs
+++ b/src/mito2/src/engine/basic_test.rs
@@ -768,7 +768,7 @@ async fn test_list_ssts() {
     }
 
     // list from manifest
-    let mut manifest_entries = engine.all_ssts_from_manifest().await.unwrap();
+    let mut manifest_entries = engine.all_ssts_from_manifest();
     let debug_format = manifest_entries
         .iter_mut()
         .map(|e| {
@@ -782,9 +782,9 @@ async fn test_list_ssts() {
     assert_eq!(
         debug_format,
         r#"
-ManifestSstEntry { engine: "mito", table_dir: "test/", region_id: 47244640257(11, 1), table_id: 11, region_number: 1, region_group: 0, region_sequence: 1, file_id: "<file_id>", level: 0, file_path: "test/11_0000000001/<file_id>.parquet", file_size: 2483, num_rows: 10, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 9000::Millisecond, sequence: Some(10) }
-ManifestSstEntry { engine: "mito", table_dir: "test/", region_id: 47244640258(11, 2), table_id: 11, region_number: 2, region_group: 0, region_sequence: 2, file_id: "<file_id>", level: 0, file_path: "test/11_0000000002/<file_id>.parquet", file_size: 2483, num_rows: 10, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 9000::Millisecond, sequence: Some(10) }
-ManifestSstEntry { engine: "mito", table_dir: "test/", region_id: 94489280554(22, 42), table_id: 22, region_number: 42, region_group: 0, region_sequence: 42, file_id: "<file_id>", level: 0, file_path: "test/22_0000000042/<file_id>.parquet", file_size: 2483, num_rows: 10, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 9000::Millisecond, sequence: Some(10) }"#
+ManifestSstEntry { table_dir: "test/", region_id: 47244640257(11, 1), table_id: 11, region_number: 1, region_group: 0, region_sequence: 1, file_id: "<file_id>", level: 0, file_path: "test/11_0000000001/<file_id>.parquet", file_size: 2483, num_rows: 10, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 9000::Millisecond, sequence: Some(10) }
+ManifestSstEntry { table_dir: "test/", region_id: 47244640258(11, 2), table_id: 11, region_number: 2, region_group: 0, region_sequence: 2, file_id: "<file_id>", level: 0, file_path: "test/11_0000000002/<file_id>.parquet", file_size: 2483, num_rows: 10, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 9000::Millisecond, sequence: Some(10) }
+ManifestSstEntry { table_dir: "test/", region_id: 94489280554(22, 42), table_id: 22, region_number: 42, region_group: 0, region_sequence: 42, file_id: "<file_id>", level: 0, file_path: "test/22_0000000042/<file_id>.parquet", file_size: 2483, num_rows: 10, num_row_groups: 1, min_ts: 0::Millisecond, max_ts: 9000::Millisecond, sequence: Some(10) }"#
     );
 
     // list from storage
@@ -802,8 +802,8 @@ ManifestSstEntry { engine: "mito", table_dir: "test/", region_id: 94489280554(22
     assert_eq!(
         debug_format,
         r#"
-StorageSstEntry { engine: "mito", file_path: "test/11_0000000001/<file_id>.parquet", file_size: None, last_modified_ms: None }
-StorageSstEntry { engine: "mito", file_path: "test/11_0000000002/<file_id>.parquet", file_size: None, last_modified_ms: None }
-StorageSstEntry { engine: "mito", file_path: "test/22_0000000042/<file_id>.parquet", file_size: None, last_modified_ms: None }"#
+StorageSstEntry { file_path: "test/11_0000000001/<file_id>.parquet", file_size: None, last_modified_ms: None }
+StorageSstEntry { file_path: "test/11_0000000002/<file_id>.parquet", file_size: None, last_modified_ms: None }
+StorageSstEntry { file_path: "test/22_0000000042/<file_id>.parquet", file_size: None, last_modified_ms: None }"#
     );
 }

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -37,7 +37,6 @@ use store_api::storage::{RegionId, SequenceNumber};
 use store_api::ManifestVersion;
 
 use crate::access_layer::AccessLayerRef;
-use crate::engine::MITO_ENGINE_NAME;
 use crate::error::{
     FlushableRegionStateSnafu, RegionNotFoundSnafu, RegionStateSnafu, RegionTruncatedSnafu, Result,
     UpdateManifestSnafu,
@@ -514,7 +513,6 @@ impl MitoRegion {
                     let meta = file.meta_ref();
                     let region_id = meta.region_id;
                     ManifestSstEntry {
-                        engine: MITO_ENGINE_NAME.to_string(),
                         table_dir: table_dir.to_string(),
                         region_id,
                         table_id: region_id.table_id(),

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -277,11 +277,10 @@ impl WorkerGroup {
         &self.workers[index]
     }
 
-    pub(crate) fn all_regions(&self) -> Vec<MitoRegionRef> {
+    pub(crate) fn all_regions(&self) -> impl Iterator<Item = MitoRegionRef> + use<'_> {
         self.workers
             .iter()
             .flat_map(|worker| worker.regions.list_regions())
-            .collect()
     }
 }
 

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -276,6 +276,13 @@ impl WorkerGroup {
 
         &self.workers[index]
     }
+
+    pub(crate) fn all_regions(&self) -> Vec<MitoRegionRef> {
+        self.workers
+            .iter()
+            .flat_map(|worker| worker.regions.list_regions())
+            .collect()
+    }
 }
 
 // Tests methods.

--- a/src/store-api/src/lib.rs
+++ b/src/store-api/src/lib.rs
@@ -27,6 +27,7 @@ pub mod mito_engine_options;
 pub mod path_utils;
 pub mod region_engine;
 pub mod region_request;
+pub mod sst_entry;
 pub mod storage;
 
 pub type ManifestVersion = u64;

--- a/src/store-api/src/region_engine.rs
+++ b/src/store-api/src/region_engine.rs
@@ -37,6 +37,7 @@ use crate::metadata::RegionMetadataRef;
 use crate::region_request::{
     BatchRegionDdlRequest, RegionOpenRequest, RegionRequest, RegionSequencesRequest,
 };
+use crate::sst_entry::{ManifestSstEntry, StorageSstEntry};
 use crate::storage::{RegionId, ScanRequest, SequenceNumber};
 
 /// The settable region role state.
@@ -806,6 +807,16 @@ pub trait RegionEngine: Send + Sync {
     ///
     /// Returns the `None` if the region is not found.
     fn role(&self, region_id: RegionId) -> Option<RegionRole>;
+
+    /// Lists all SSTs from the manifest of all regions in the engine.
+    async fn all_ssts_from_manifest(&self) -> Result<Vec<ManifestSstEntry>, BoxedError> {
+        Ok(vec![])
+    }
+
+    /// Lists all SSTs from the storage layer of all regions in the engine.
+    async fn all_ssts_from_storage(&self) -> Result<Vec<StorageSstEntry>, BoxedError> {
+        Ok(vec![])
+    }
 
     fn as_any(&self) -> &dyn Any;
 }

--- a/src/store-api/src/region_engine.rs
+++ b/src/store-api/src/region_engine.rs
@@ -37,7 +37,6 @@ use crate::metadata::RegionMetadataRef;
 use crate::region_request::{
     BatchRegionDdlRequest, RegionOpenRequest, RegionRequest, RegionSequencesRequest,
 };
-use crate::sst_entry::{ManifestSstEntry, StorageSstEntry};
 use crate::storage::{RegionId, ScanRequest, SequenceNumber};
 
 /// The settable region role state.
@@ -807,16 +806,6 @@ pub trait RegionEngine: Send + Sync {
     ///
     /// Returns the `None` if the region is not found.
     fn role(&self, region_id: RegionId) -> Option<RegionRole>;
-
-    /// Lists all SSTs from the manifest of all regions in the engine.
-    async fn all_ssts_from_manifest(&self) -> Result<Vec<ManifestSstEntry>, BoxedError> {
-        Ok(vec![])
-    }
-
-    /// Lists all SSTs from the storage layer of all regions in the engine.
-    async fn all_ssts_from_storage(&self) -> Result<Vec<StorageSstEntry>, BoxedError> {
-        Ok(vec![])
-    }
 
     fn as_any(&self) -> &dyn Any;
 }

--- a/src/store-api/src/sst_entry.rs
+++ b/src/store-api/src/sst_entry.rs
@@ -20,8 +20,6 @@ use crate::storage::{RegionGroup, RegionId, RegionNumber, RegionSeq, TableId};
 /// An entry describing a SST file known by the engine's manifest.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ManifestSstEntry {
-    /// Engine label, e.g., "mito", "metric".
-    pub engine: String,
     /// The table directory this file belongs to.
     pub table_dir: String,
     /// The region id this file belongs to.
@@ -57,8 +55,6 @@ pub struct ManifestSstEntry {
 /// An entry describing a SST file listed from storage layer directly.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct StorageSstEntry {
-    /// Engine label, e.g., "mito", "metric".
-    pub engine: String,
     /// Full path of the SST file in object store.
     pub file_path: String,
     /// File size in bytes.

--- a/src/store-api/src/sst_entry.rs
+++ b/src/store-api/src/sst_entry.rs
@@ -40,6 +40,10 @@ pub struct ManifestSstEntry {
     pub file_path: String,
     /// File size in bytes.
     pub file_size: u64,
+    /// Full path of the index file in object store.
+    pub index_file_path: Option<String>,
+    /// File size of the index file in object store.
+    pub index_file_size: Option<u64>,
     /// Number of rows in the SST.
     pub num_rows: u64,
     /// Number of row groups in the SST.

--- a/src/store-api/src/sst_entry.rs
+++ b/src/store-api/src/sst_entry.rs
@@ -1,0 +1,68 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_time::Timestamp;
+use serde::{Deserialize, Serialize};
+
+use crate::storage::{RegionGroup, RegionId, RegionNumber, RegionSeq, TableId};
+
+/// An entry describing a SST file known by the engine's manifest.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ManifestSstEntry {
+    /// Engine label, e.g., "mito", "metric".
+    pub engine: String,
+    /// The table directory this file belongs to.
+    pub table_dir: String,
+    /// The region id this file belongs to.
+    pub region_id: RegionId,
+    /// The table id this file belongs to.
+    pub table_id: TableId,
+    /// The region number this file belongs to.
+    pub region_number: RegionNumber,
+    /// The region group this file belongs to.
+    pub region_group: RegionGroup,
+    /// The region sequence this file belongs to.
+    pub region_sequence: RegionSeq,
+    /// Engine-specific file identifier (string form).
+    pub file_id: String,
+    /// SST level.
+    pub level: u8,
+    /// Full path of the SST file in object store.
+    pub file_path: String,
+    /// File size in bytes.
+    pub file_size: u64,
+    /// Number of rows in the SST.
+    pub num_rows: u64,
+    /// Number of row groups in the SST.
+    pub num_row_groups: u64,
+    /// Min timestamp.
+    pub min_ts: Timestamp,
+    /// Max timestamp.
+    pub max_ts: Timestamp,
+    /// The sequence number associated with this file.
+    pub sequence: Option<u64>,
+}
+
+/// An entry describing a SST file listed from storage layer directly.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StorageSstEntry {
+    /// Engine label, e.g., "mito", "metric".
+    pub engine: String,
+    /// Full path of the SST file in object store.
+    pub file_path: String,
+    /// File size in bytes.
+    pub file_size: Option<u64>,
+    /// Last modified time in milliseconds since epoch, if available from storage.
+    pub last_modified_ms: Option<Timestamp>,
+}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

* Add `sst_entry::{ManifestSstEntry, StorageSstEntry}`
* Implement `all_ssts_from_manifest` and `all_ssts_from_storage` for mito engine

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
