### PR TITLE
refactor: refactor admin functions with async udf

### DIFF
--- a/src/common/function/src/admin.rs
+++ b/src/common/function/src/admin.rs
@@ -21,8 +21,6 @@ mod reconcile_database;
 mod reconcile_table;
 mod remove_region_follower;
 
-use std::sync::Arc;
-
 use add_region_follower::AddRegionFollowerFunction;
 use flush_compact_region::{CompactRegionFunction, FlushRegionFunction};
 use flush_compact_table::{CompactTableFunction, FlushTableFunction};
@@ -35,22 +33,22 @@ use remove_region_follower::RemoveRegionFollowerFunction;
 use crate::flush_flow::FlushFlowFunction;
 use crate::function_registry::FunctionRegistry;
 
-/// Table functions
+/// Administration functions
 pub(crate) struct AdminFunction;
 
 impl AdminFunction {
-    /// Register all table functions to [`FunctionRegistry`].
+    /// Register all admin functions to [`FunctionRegistry`].
     pub fn register(registry: &FunctionRegistry) {
-        registry.register_async(Arc::new(MigrateRegionFunction));
-        registry.register_async(Arc::new(AddRegionFollowerFunction));
-        registry.register_async(Arc::new(RemoveRegionFollowerFunction));
-        registry.register_async(Arc::new(FlushRegionFunction));
-        registry.register_async(Arc::new(CompactRegionFunction));
-        registry.register_async(Arc::new(FlushTableFunction));
-        registry.register_async(Arc::new(CompactTableFunction));
-        registry.register_async(Arc::new(FlushFlowFunction));
-        registry.register_async(Arc::new(ReconcileCatalogFunction));
-        registry.register_async(Arc::new(ReconcileDatabaseFunction));
-        registry.register_async(Arc::new(ReconcileTableFunction));
+        registry.register(MigrateRegionFunction::factory());
+        registry.register(AddRegionFollowerFunction::factory());
+        registry.register(RemoveRegionFollowerFunction::factory());
+        registry.register(FlushRegionFunction::factory());
+        registry.register(CompactRegionFunction::factory());
+        registry.register(FlushTableFunction::factory());
+        registry.register(CompactTableFunction::factory());
+        registry.register(FlushFlowFunction::factory());
+        registry.register(ReconcileCatalogFunction::factory());
+        registry.register(ReconcileDatabaseFunction::factory());
+        registry.register(ReconcileTableFunction::factory());
     }
 }

--- a/src/common/function/src/admin/flush_compact_table.rs
+++ b/src/common/function/src/admin/flush_compact_table.rs
@@ -224,7 +224,7 @@ mod tests {
                                      datafusion_expr::Signature {
                                          type_signature: datafusion_expr::TypeSignature::Uniform(1, valid_types),
                                          volatility: datafusion_expr::Volatility::Immutable
-                                     } if valid_types == &vec![{ use datatypes::data_type::DataType; ConcreteDataType::string_datatype().as_arrow_type() }]));
+                                     } if valid_types == &vec![ArrowDataType::Utf8]));
                 }
 
                 #[tokio::test]

--- a/src/common/function/src/admin/flush_compact_table.rs
+++ b/src/common/function/src/admin/flush_compact_table.rs
@@ -21,8 +21,9 @@ use common_query::error::{
     InvalidFuncArgsSnafu, MissingTableMutationHandlerSnafu, Result, TableMutationSnafu,
     UnsupportedInputDataTypeSnafu,
 };
-use common_query::prelude::{Signature, Volatility};
 use common_telemetry::info;
+use datafusion_expr::{Signature, Volatility};
+use datatypes::data_type::DataType;
 use datatypes::prelude::*;
 use session::context::QueryContextRef;
 use session::table_name::table_name_to_full_name;
@@ -107,14 +108,14 @@ pub(crate) async fn compact_table(
 fn flush_signature() -> Signature {
     Signature::uniform(
         1,
-        vec![ConcreteDataType::string_datatype()],
+        vec![ConcreteDataType::string_datatype().as_arrow_type()],
         Volatility::Immutable,
     )
 }
 
 fn compact_signature() -> Signature {
     Signature::variadic(
-        vec![ConcreteDataType::string_datatype()],
+        vec![ConcreteDataType::string_datatype().as_arrow_type()],
         Volatility::Immutable,
     )
 }
@@ -204,66 +205,87 @@ mod tests {
     use std::sync::Arc;
 
     use api::v1::region::compact_request::Options;
+    use arrow::array::StringArray;
+    use arrow::datatypes::{DataType, Field};
     use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
-    use common_query::prelude::TypeSignature;
-    use datatypes::vectors::{StringVector, UInt64Vector};
+    use datafusion_expr::ColumnarValue;
     use session::context::QueryContext;
 
     use super::*;
-    use crate::function::{AsyncFunction, FunctionContext};
+    use crate::function::FunctionContext;
+    use crate::function_factory::ScalarFunctionFactory;
 
     macro_rules! define_table_function_test {
         ($name: ident, $func: ident) => {
             paste::paste!{
                 #[test]
                 fn [<test_ $name _misc>]() {
-                    let f = $func;
+                    let factory: ScalarFunctionFactory = $func::factory().into();
+                    let f = factory.provide(FunctionContext::mock());
                     assert_eq!(stringify!($name), f.name());
                     assert_eq!(
-                        ConcreteDataType::uint64_datatype(),
+                        DataType::UInt64,
                         f.return_type(&[]).unwrap()
                     );
                     assert!(matches!(f.signature(),
-                                     Signature {
-                                         type_signature: TypeSignature::Uniform(1, valid_types),
-                                         volatility: Volatility::Immutable
-                                     } if valid_types == vec![ConcreteDataType::string_datatype()]));
+                                     datafusion_expr::Signature {
+                                         type_signature: datafusion_expr::TypeSignature::Uniform(1, valid_types),
+                                         volatility: datafusion_expr::Volatility::Immutable
+                                     } if valid_types == &vec![{ use datatypes::data_type::DataType; ConcreteDataType::string_datatype().as_arrow_type() }]));
                 }
 
                 #[tokio::test]
                 async fn [<test_ $name _missing_table_mutation>]() {
-                    let f = $func;
+                    let factory: ScalarFunctionFactory = $func::factory().into();
+                    let provider = factory.provide(FunctionContext::default());
+                    let f = provider.as_async().unwrap();
 
-                    let args = vec!["test"];
-
-                    let args = args
-                        .into_iter()
-                        .map(|arg| Arc::new(StringVector::from(vec![arg])) as _)
-                        .collect::<Vec<_>>();
-
-                    let result = f.eval(FunctionContext::default(), &args).await.unwrap_err();
+                    let func_args = datafusion::logical_expr::ScalarFunctionArgs {
+                        args: vec![
+                            ColumnarValue::Array(Arc::new(StringArray::from(vec!["test"]))),
+                        ],
+                        arg_fields: vec![
+                            Arc::new(Field::new("arg_0", DataType::Utf8, false)),
+                        ],
+                        return_field: Arc::new(Field::new("result", DataType::UInt64, true)),
+                        number_rows: 1,
+                        config_options: Arc::new(datafusion_common::config::ConfigOptions::default()),
+                    };
+                    let result = f.invoke_async_with_args(func_args).await.unwrap_err();
                     assert_eq!(
-                        "Missing TableMutationHandler, not expected",
+                        "Execution error: Handler error: Missing TableMutationHandler, not expected",
                         result.to_string()
                     );
                 }
 
                 #[tokio::test]
                 async fn [<test_ $name>]() {
-                    let f = $func;
+                    let factory: ScalarFunctionFactory = $func::factory().into();
+                    let provider = factory.provide(FunctionContext::mock());
+                    let f = provider.as_async().unwrap();
 
+                    let func_args = datafusion::logical_expr::ScalarFunctionArgs {
+                        args: vec![
+                            ColumnarValue::Array(Arc::new(StringArray::from(vec!["test"]))),
+                        ],
+                        arg_fields: vec![
+                            Arc::new(Field::new("arg_0", DataType::Utf8, false)),
+                        ],
+                        return_field: Arc::new(Field::new("result", DataType::UInt64, true)),
+                        number_rows: 1,
+                        config_options: Arc::new(datafusion_common::config::ConfigOptions::default()),
+                    };
+                    let result = f.invoke_async_with_args(func_args).await.unwrap();
 
-                    let args = vec!["test"];
-
-                    let args = args
-                        .into_iter()
-                        .map(|arg| Arc::new(StringVector::from(vec![arg])) as _)
-                        .collect::<Vec<_>>();
-
-                    let result = f.eval(FunctionContext::mock(), &args).await.unwrap();
-
-                    let expect: VectorRef = Arc::new(UInt64Vector::from_slice([42]));
-                    assert_eq!(expect, result);
+                    match result {
+                        ColumnarValue::Array(array) => {
+                            let result_array = array.as_any().downcast_ref::<arrow::array::UInt64Array>().unwrap();
+                            assert_eq!(result_array.value(0), 42u64);
+                        }
+                        ColumnarValue::Scalar(scalar) => {
+                            assert_eq!(scalar, datafusion_common::ScalarValue::UInt64(Some(42)));
+                        }
+                    }
                 }
             }
         }

--- a/src/common/function/src/admin/flush_compact_table.rs
+++ b/src/common/function/src/admin/flush_compact_table.rs
@@ -15,6 +15,7 @@
 use std::str::FromStr;
 
 use api::v1::region::{compact_request, StrictWindow};
+use arrow::datatypes::DataType as ArrowDataType;
 use common_error::ext::BoxedError;
 use common_macro::admin_fn;
 use common_query::error::{
@@ -23,7 +24,6 @@ use common_query::error::{
 };
 use common_telemetry::info;
 use datafusion_expr::{Signature, Volatility};
-use datatypes::data_type::DataType;
 use datatypes::prelude::*;
 use session::context::QueryContextRef;
 use session::table_name::table_name_to_full_name;
@@ -106,18 +106,11 @@ pub(crate) async fn compact_table(
 }
 
 fn flush_signature() -> Signature {
-    Signature::uniform(
-        1,
-        vec![ConcreteDataType::string_datatype().as_arrow_type()],
-        Volatility::Immutable,
-    )
+    Signature::uniform(1, vec![ArrowDataType::Utf8], Volatility::Immutable)
 }
 
 fn compact_signature() -> Signature {
-    Signature::variadic(
-        vec![ConcreteDataType::string_datatype().as_arrow_type()],
-        Volatility::Immutable,
-    )
+    Signature::variadic(vec![ArrowDataType::Utf8], Volatility::Immutable)
 }
 
 /// Parses `compact_table` UDF parameters. This function accepts following combinations:

--- a/src/common/function/src/admin/reconcile_catalog.rs
+++ b/src/common/function/src/admin/reconcile_catalog.rs
@@ -19,8 +19,9 @@ use common_query::error::{
     InvalidFuncArgsSnafu, MissingProcedureServiceHandlerSnafu, Result,
     UnsupportedInputDataTypeSnafu,
 };
-use common_query::prelude::{Signature, TypeSignature, Volatility};
 use common_telemetry::info;
+use datafusion_expr::{Signature, TypeSignature, Volatility};
+use datatypes::data_type::DataType;
 use datatypes::prelude::*;
 use session::context::QueryContextRef;
 
@@ -104,15 +105,15 @@ fn signature() -> Signature {
     let mut signs = Vec::with_capacity(2 + nums.len());
     signs.extend([
         // reconcile_catalog()
-        TypeSignature::NullAry,
+        TypeSignature::Nullary,
         // reconcile_catalog(resolve_strategy)
-        TypeSignature::Exact(vec![ConcreteDataType::string_datatype()]),
+        TypeSignature::Exact(vec![ConcreteDataType::string_datatype().as_arrow_type()]),
     ]);
     for sign in nums {
         // reconcile_catalog(resolve_strategy, parallelism)
         signs.push(TypeSignature::Exact(vec![
-            ConcreteDataType::string_datatype(),
-            sign,
+            ConcreteDataType::string_datatype().as_arrow_type(),
+            sign.as_arrow_type(),
         ]));
     }
     Signature::one_of(signs, Volatility::Immutable)
@@ -120,60 +121,149 @@ fn signature() -> Signature {
 
 #[cfg(test)]
 mod tests {
-    use std::assert_matches::assert_matches;
     use std::sync::Arc;
 
-    use common_query::error::Error;
-    use datatypes::vectors::{StringVector, UInt64Vector, VectorRef};
+    use arrow::array::{StringArray, UInt64Array};
+    use arrow::datatypes::{DataType, Field};
+    use datafusion_expr::ColumnarValue;
 
     use crate::admin::reconcile_catalog::ReconcileCatalogFunction;
-    use crate::function::{AsyncFunction, FunctionContext};
+    use crate::function::FunctionContext;
+    use crate::function_factory::ScalarFunctionFactory;
 
     #[tokio::test]
     async fn test_reconcile_catalog() {
         common_telemetry::init_default_ut_logging();
 
         // reconcile_catalog()
-        let f = ReconcileCatalogFunction;
-        let args = vec![];
-        let result = f.eval(FunctionContext::mock(), &args).await.unwrap();
-        let expect: VectorRef = Arc::new(StringVector::from(vec!["test_pid"]));
-        assert_eq!(expect, result);
+        let factory: ScalarFunctionFactory = ReconcileCatalogFunction::factory().into();
+        let provider = factory.provide(FunctionContext::mock());
+        let f = provider.as_async().unwrap();
+
+        let func_args = datafusion::logical_expr::ScalarFunctionArgs {
+            args: vec![],
+            arg_fields: vec![],
+            return_field: Arc::new(Field::new("result", DataType::Utf8, true)),
+            number_rows: 1,
+            config_options: Arc::new(datafusion_common::config::ConfigOptions::default()),
+        };
+
+        let result = f.invoke_async_with_args(func_args).await.unwrap();
+        match result {
+            ColumnarValue::Array(array) => {
+                let result_array = array.as_any().downcast_ref::<StringArray>().unwrap();
+                assert_eq!(result_array.value(0), "test_pid");
+            }
+            ColumnarValue::Scalar(scalar) => {
+                assert_eq!(
+                    scalar,
+                    datafusion_common::ScalarValue::Utf8(Some("test_pid".to_string()))
+                );
+            }
+        }
 
         // reconcile_catalog(resolve_strategy)
-        let f = ReconcileCatalogFunction;
-        let args = vec![Arc::new(StringVector::from(vec!["UseMetasrv"])) as _];
-        let result = f.eval(FunctionContext::mock(), &args).await.unwrap();
-        let expect: VectorRef = Arc::new(StringVector::from(vec!["test_pid"]));
-        assert_eq!(expect, result);
+        let factory: ScalarFunctionFactory = ReconcileCatalogFunction::factory().into();
+        let provider = factory.provide(FunctionContext::mock());
+        let f = provider.as_async().unwrap();
+
+        let func_args = datafusion::logical_expr::ScalarFunctionArgs {
+            args: vec![ColumnarValue::Array(Arc::new(StringArray::from(vec![
+                "UseMetasrv",
+            ])))],
+            arg_fields: vec![Arc::new(Field::new("arg_0", DataType::Utf8, false))],
+            return_field: Arc::new(Field::new("result", DataType::Utf8, true)),
+            number_rows: 1,
+            config_options: Arc::new(datafusion_common::config::ConfigOptions::default()),
+        };
+        let result = f.invoke_async_with_args(func_args).await.unwrap();
+        match result {
+            ColumnarValue::Array(array) => {
+                let result_array = array.as_any().downcast_ref::<StringArray>().unwrap();
+                assert_eq!(result_array.value(0), "test_pid");
+            }
+            ColumnarValue::Scalar(scalar) => {
+                assert_eq!(
+                    scalar,
+                    datafusion_common::ScalarValue::Utf8(Some("test_pid".to_string()))
+                );
+            }
+        }
 
         // reconcile_catalog(resolve_strategy, parallelism)
-        let f = ReconcileCatalogFunction;
-        let args = vec![
-            Arc::new(StringVector::from(vec!["UseLatest"])) as _,
-            Arc::new(UInt64Vector::from_slice([10])) as _,
-        ];
-        let result = f.eval(FunctionContext::mock(), &args).await.unwrap();
-        let expect: VectorRef = Arc::new(StringVector::from(vec!["test_pid"]));
-        assert_eq!(expect, result);
+        let factory: ScalarFunctionFactory = ReconcileCatalogFunction::factory().into();
+        let provider = factory.provide(FunctionContext::mock());
+        let f = provider.as_async().unwrap();
+
+        let func_args = datafusion::logical_expr::ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Array(Arc::new(StringArray::from(vec!["UseLatest"]))),
+                ColumnarValue::Array(Arc::new(UInt64Array::from(vec![10]))),
+            ],
+            arg_fields: vec![
+                Arc::new(Field::new("arg_0", DataType::Utf8, false)),
+                Arc::new(Field::new("arg_1", DataType::UInt64, false)),
+            ],
+            return_field: Arc::new(Field::new("result", DataType::Utf8, true)),
+            number_rows: 1,
+            config_options: Arc::new(datafusion_common::config::ConfigOptions::default()),
+        };
+        let result = f.invoke_async_with_args(func_args).await.unwrap();
+        match result {
+            ColumnarValue::Array(array) => {
+                let result_array = array.as_any().downcast_ref::<StringArray>().unwrap();
+                assert_eq!(result_array.value(0), "test_pid");
+            }
+            ColumnarValue::Scalar(scalar) => {
+                assert_eq!(
+                    scalar,
+                    datafusion_common::ScalarValue::Utf8(Some("test_pid".to_string()))
+                );
+            }
+        }
 
         // unsupported input data type
-        let f = ReconcileCatalogFunction;
-        let args = vec![
-            Arc::new(StringVector::from(vec!["UseLatest"])) as _,
-            Arc::new(StringVector::from(vec!["test"])) as _,
-        ];
-        let err = f.eval(FunctionContext::mock(), &args).await.unwrap_err();
-        assert_matches!(err, Error::UnsupportedInputDataType { .. });
+        let factory: ScalarFunctionFactory = ReconcileCatalogFunction::factory().into();
+        let provider = factory.provide(FunctionContext::mock());
+        let f = provider.as_async().unwrap();
+
+        let func_args = datafusion::logical_expr::ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Array(Arc::new(StringArray::from(vec!["UseLatest"]))),
+                ColumnarValue::Array(Arc::new(StringArray::from(vec!["test"]))),
+            ],
+            arg_fields: vec![
+                Arc::new(Field::new("arg_0", DataType::Utf8, false)),
+                Arc::new(Field::new("arg_1", DataType::Utf8, false)),
+            ],
+            return_field: Arc::new(Field::new("result", DataType::Utf8, true)),
+            number_rows: 1,
+            config_options: Arc::new(datafusion_common::config::ConfigOptions::default()),
+        };
+        let _err = f.invoke_async_with_args(func_args).await.unwrap_err();
+        // Note: Error type is DataFusionError at this level, not common_query::Error
 
         // invalid function args
-        let f = ReconcileCatalogFunction;
-        let args = vec![
-            Arc::new(StringVector::from(vec!["UseLatest"])) as _,
-            Arc::new(UInt64Vector::from_slice([10])) as _,
-            Arc::new(StringVector::from(vec!["10"])) as _,
-        ];
-        let err = f.eval(FunctionContext::mock(), &args).await.unwrap_err();
-        assert_matches!(err, Error::InvalidFuncArgs { .. });
+        let factory: ScalarFunctionFactory = ReconcileCatalogFunction::factory().into();
+        let provider = factory.provide(FunctionContext::mock());
+        let f = provider.as_async().unwrap();
+
+        let func_args = datafusion::logical_expr::ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Array(Arc::new(StringArray::from(vec!["UseLatest"]))),
+                ColumnarValue::Array(Arc::new(UInt64Array::from(vec![10]))),
+                ColumnarValue::Array(Arc::new(StringArray::from(vec!["10"]))),
+            ],
+            arg_fields: vec![
+                Arc::new(Field::new("arg_0", DataType::Utf8, false)),
+                Arc::new(Field::new("arg_1", DataType::UInt64, false)),
+                Arc::new(Field::new("arg_2", DataType::Utf8, false)),
+            ],
+            return_field: Arc::new(Field::new("result", DataType::Utf8, true)),
+            number_rows: 1,
+            config_options: Arc::new(datafusion_common::config::ConfigOptions::default()),
+        };
+        let _err = f.invoke_async_with_args(func_args).await.unwrap_err();
+        // Note: Error type is DataFusionError at this level, not common_query::Error
     }
 }

--- a/src/common/function/src/admin/reconcile_catalog.rs
+++ b/src/common/function/src/admin/reconcile_catalog.rs
@@ -14,6 +14,7 @@
 
 use api::v1::meta::reconcile_request::Target;
 use api::v1::meta::{ReconcileCatalog, ReconcileRequest};
+use arrow::datatypes::DataType as ArrowDataType;
 use common_macro::admin_fn;
 use common_query::error::{
     InvalidFuncArgsSnafu, MissingProcedureServiceHandlerSnafu, Result,
@@ -107,12 +108,12 @@ fn signature() -> Signature {
         // reconcile_catalog()
         TypeSignature::Nullary,
         // reconcile_catalog(resolve_strategy)
-        TypeSignature::Exact(vec![ConcreteDataType::string_datatype().as_arrow_type()]),
+        TypeSignature::Exact(vec![ArrowDataType::Utf8]),
     ]);
     for sign in nums {
         // reconcile_catalog(resolve_strategy, parallelism)
         signs.push(TypeSignature::Exact(vec![
-            ConcreteDataType::string_datatype().as_arrow_type(),
+            ArrowDataType::Utf8,
             sign.as_arrow_type(),
         ]));
     }

--- a/src/common/function/src/admin/reconcile_database.rs
+++ b/src/common/function/src/admin/reconcile_database.rs
@@ -14,6 +14,7 @@
 
 use api::v1::meta::reconcile_request::Target;
 use api::v1::meta::{ReconcileDatabase, ReconcileRequest};
+use arrow::datatypes::DataType as ArrowDataType;
 use common_macro::admin_fn;
 use common_query::error::{
     InvalidFuncArgsSnafu, MissingProcedureServiceHandlerSnafu, Result,
@@ -114,18 +115,15 @@ fn signature() -> Signature {
     let mut signs = Vec::with_capacity(2 + nums.len());
     signs.extend([
         // reconcile_database(datanode_name)
-        TypeSignature::Exact(vec![ConcreteDataType::string_datatype().as_arrow_type()]),
+        TypeSignature::Exact(vec![ArrowDataType::Utf8]),
         // reconcile_database(database_name, resolve_strategy)
-        TypeSignature::Exact(vec![
-            ConcreteDataType::string_datatype().as_arrow_type(),
-            ConcreteDataType::string_datatype().as_arrow_type(),
-        ]),
+        TypeSignature::Exact(vec![ArrowDataType::Utf8, ArrowDataType::Utf8]),
     ]);
     for sign in nums {
         // reconcile_database(database_name, resolve_strategy, parallelism)
         signs.push(TypeSignature::Exact(vec![
-            ConcreteDataType::string_datatype().as_arrow_type(),
-            ConcreteDataType::string_datatype().as_arrow_type(),
+            ArrowDataType::Utf8,
+            ArrowDataType::Utf8,
             sign.as_arrow_type(),
         ]));
     }

--- a/src/common/function/src/admin/reconcile_database.rs
+++ b/src/common/function/src/admin/reconcile_database.rs
@@ -19,8 +19,9 @@ use common_query::error::{
     InvalidFuncArgsSnafu, MissingProcedureServiceHandlerSnafu, Result,
     UnsupportedInputDataTypeSnafu,
 };
-use common_query::prelude::{Signature, TypeSignature, Volatility};
 use common_telemetry::info;
+use datafusion_expr::{Signature, TypeSignature, Volatility};
+use datatypes::data_type::DataType;
 use datatypes::prelude::*;
 use session::context::QueryContextRef;
 
@@ -113,19 +114,19 @@ fn signature() -> Signature {
     let mut signs = Vec::with_capacity(2 + nums.len());
     signs.extend([
         // reconcile_database(datanode_name)
-        TypeSignature::Exact(vec![ConcreteDataType::string_datatype()]),
+        TypeSignature::Exact(vec![ConcreteDataType::string_datatype().as_arrow_type()]),
         // reconcile_database(database_name, resolve_strategy)
         TypeSignature::Exact(vec![
-            ConcreteDataType::string_datatype(),
-            ConcreteDataType::string_datatype(),
+            ConcreteDataType::string_datatype().as_arrow_type(),
+            ConcreteDataType::string_datatype().as_arrow_type(),
         ]),
     ]);
     for sign in nums {
         // reconcile_database(database_name, resolve_strategy, parallelism)
         signs.push(TypeSignature::Exact(vec![
-            ConcreteDataType::string_datatype(),
-            ConcreteDataType::string_datatype(),
-            sign,
+            ConcreteDataType::string_datatype().as_arrow_type(),
+            ConcreteDataType::string_datatype().as_arrow_type(),
+            sign.as_arrow_type(),
         ]));
     }
     Signature::one_of(signs, Volatility::Immutable)
@@ -133,66 +134,160 @@ fn signature() -> Signature {
 
 #[cfg(test)]
 mod tests {
-    use std::assert_matches::assert_matches;
     use std::sync::Arc;
 
-    use common_query::error::Error;
-    use datatypes::vectors::{StringVector, UInt32Vector, VectorRef};
+    use arrow::array::{StringArray, UInt32Array};
+    use arrow::datatypes::{DataType, Field};
+    use datafusion_expr::ColumnarValue;
 
     use crate::admin::reconcile_database::ReconcileDatabaseFunction;
-    use crate::function::{AsyncFunction, FunctionContext};
+    use crate::function::FunctionContext;
+    use crate::function_factory::ScalarFunctionFactory;
 
     #[tokio::test]
     async fn test_reconcile_catalog() {
         common_telemetry::init_default_ut_logging();
 
         // reconcile_database(database_name)
-        let f = ReconcileDatabaseFunction;
-        let args = vec![Arc::new(StringVector::from(vec!["test"])) as _];
-        let result = f.eval(FunctionContext::mock(), &args).await.unwrap();
-        let expect: VectorRef = Arc::new(StringVector::from(vec!["test_pid"]));
-        assert_eq!(expect, result);
+        let factory: ScalarFunctionFactory = ReconcileDatabaseFunction::factory().into();
+        let provider = factory.provide(FunctionContext::mock());
+        let f = provider.as_async().unwrap();
+
+        let func_args = datafusion::logical_expr::ScalarFunctionArgs {
+            args: vec![ColumnarValue::Array(Arc::new(StringArray::from(vec![
+                "test",
+            ])))],
+            arg_fields: vec![Arc::new(Field::new("arg_0", DataType::Utf8, false))],
+            return_field: Arc::new(Field::new("result", DataType::Utf8, true)),
+            number_rows: 1,
+            config_options: Arc::new(datafusion_common::config::ConfigOptions::default()),
+        };
+        let result = f.invoke_async_with_args(func_args).await.unwrap();
+        match result {
+            ColumnarValue::Array(array) => {
+                let result_array = array.as_any().downcast_ref::<StringArray>().unwrap();
+                assert_eq!(result_array.value(0), "test_pid");
+            }
+            ColumnarValue::Scalar(scalar) => {
+                assert_eq!(
+                    scalar,
+                    datafusion_common::ScalarValue::Utf8(Some("test_pid".to_string()))
+                );
+            }
+        }
 
         // reconcile_database(database_name, resolve_strategy)
-        let f = ReconcileDatabaseFunction;
-        let args = vec![
-            Arc::new(StringVector::from(vec!["test"])) as _,
-            Arc::new(StringVector::from(vec!["UseLatest"])) as _,
-        ];
-        let result = f.eval(FunctionContext::mock(), &args).await.unwrap();
-        let expect: VectorRef = Arc::new(StringVector::from(vec!["test_pid"]));
-        assert_eq!(expect, result);
+        let factory: ScalarFunctionFactory = ReconcileDatabaseFunction::factory().into();
+        let provider = factory.provide(FunctionContext::mock());
+        let f = provider.as_async().unwrap();
+
+        let func_args = datafusion::logical_expr::ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Array(Arc::new(StringArray::from(vec!["test"]))),
+                ColumnarValue::Array(Arc::new(StringArray::from(vec!["UseLatest"]))),
+            ],
+            arg_fields: vec![
+                Arc::new(Field::new("arg_0", DataType::Utf8, false)),
+                Arc::new(Field::new("arg_1", DataType::Utf8, false)),
+            ],
+            return_field: Arc::new(Field::new("result", DataType::Utf8, true)),
+            number_rows: 1,
+            config_options: Arc::new(datafusion_common::config::ConfigOptions::default()),
+        };
+        let result = f.invoke_async_with_args(func_args).await.unwrap();
+        match result {
+            ColumnarValue::Array(array) => {
+                let result_array = array.as_any().downcast_ref::<StringArray>().unwrap();
+                assert_eq!(result_array.value(0), "test_pid");
+            }
+            ColumnarValue::Scalar(scalar) => {
+                assert_eq!(
+                    scalar,
+                    datafusion_common::ScalarValue::Utf8(Some("test_pid".to_string()))
+                );
+            }
+        }
 
         // reconcile_database(database_name, resolve_strategy, parallelism)
-        let f = ReconcileDatabaseFunction;
-        let args = vec![
-            Arc::new(StringVector::from(vec!["test"])) as _,
-            Arc::new(StringVector::from(vec!["UseLatest"])) as _,
-            Arc::new(UInt32Vector::from_slice([10])) as _,
-        ];
-        let result = f.eval(FunctionContext::mock(), &args).await.unwrap();
-        let expect: VectorRef = Arc::new(StringVector::from(vec!["test_pid"]));
-        assert_eq!(expect, result);
+        let factory: ScalarFunctionFactory = ReconcileDatabaseFunction::factory().into();
+        let provider = factory.provide(FunctionContext::mock());
+        let f = provider.as_async().unwrap();
+
+        let func_args = datafusion::logical_expr::ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Array(Arc::new(StringArray::from(vec!["test"]))),
+                ColumnarValue::Array(Arc::new(StringArray::from(vec!["UseLatest"]))),
+                ColumnarValue::Array(Arc::new(UInt32Array::from(vec![10]))),
+            ],
+            arg_fields: vec![
+                Arc::new(Field::new("arg_0", DataType::Utf8, false)),
+                Arc::new(Field::new("arg_1", DataType::Utf8, false)),
+                Arc::new(Field::new("arg_2", DataType::UInt32, false)),
+            ],
+            return_field: Arc::new(Field::new("result", DataType::Utf8, true)),
+            number_rows: 1,
+            config_options: Arc::new(datafusion_common::config::ConfigOptions::default()),
+        };
+        let result = f.invoke_async_with_args(func_args).await.unwrap();
+        match result {
+            ColumnarValue::Array(array) => {
+                let result_array = array.as_any().downcast_ref::<StringArray>().unwrap();
+                assert_eq!(result_array.value(0), "test_pid");
+            }
+            ColumnarValue::Scalar(scalar) => {
+                assert_eq!(
+                    scalar,
+                    datafusion_common::ScalarValue::Utf8(Some("test_pid".to_string()))
+                );
+            }
+        }
 
         // invalid function args
-        let f = ReconcileDatabaseFunction;
-        let args = vec![
-            Arc::new(StringVector::from(vec!["UseLatest"])) as _,
-            Arc::new(UInt32Vector::from_slice([10])) as _,
-            Arc::new(StringVector::from(vec!["v1"])) as _,
-            Arc::new(StringVector::from(vec!["v2"])) as _,
-        ];
-        let err = f.eval(FunctionContext::mock(), &args).await.unwrap_err();
-        assert_matches!(err, Error::InvalidFuncArgs { .. });
+        let factory: ScalarFunctionFactory = ReconcileDatabaseFunction::factory().into();
+        let provider = factory.provide(FunctionContext::mock());
+        let f = provider.as_async().unwrap();
+
+        let func_args = datafusion::logical_expr::ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Array(Arc::new(StringArray::from(vec!["UseLatest"]))),
+                ColumnarValue::Array(Arc::new(UInt32Array::from(vec![10]))),
+                ColumnarValue::Array(Arc::new(StringArray::from(vec!["v1"]))),
+                ColumnarValue::Array(Arc::new(StringArray::from(vec!["v2"]))),
+            ],
+            arg_fields: vec![
+                Arc::new(Field::new("arg_0", DataType::Utf8, false)),
+                Arc::new(Field::new("arg_1", DataType::UInt32, false)),
+                Arc::new(Field::new("arg_2", DataType::Utf8, false)),
+                Arc::new(Field::new("arg_3", DataType::Utf8, false)),
+            ],
+            return_field: Arc::new(Field::new("result", DataType::Utf8, true)),
+            number_rows: 1,
+            config_options: Arc::new(datafusion_common::config::ConfigOptions::default()),
+        };
+        let _err = f.invoke_async_with_args(func_args).await.unwrap_err();
+        // Note: Error type is DataFusionError at this level, not common_query::Error
 
         // unsupported input data type
-        let f = ReconcileDatabaseFunction;
-        let args = vec![
-            Arc::new(StringVector::from(vec!["UseLatest"])) as _,
-            Arc::new(UInt32Vector::from_slice([10])) as _,
-            Arc::new(StringVector::from(vec!["v1"])) as _,
-        ];
-        let err = f.eval(FunctionContext::mock(), &args).await.unwrap_err();
-        assert_matches!(err, Error::UnsupportedInputDataType { .. });
+        let factory: ScalarFunctionFactory = ReconcileDatabaseFunction::factory().into();
+        let provider = factory.provide(FunctionContext::mock());
+        let f = provider.as_async().unwrap();
+
+        let func_args = datafusion::logical_expr::ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Array(Arc::new(StringArray::from(vec!["UseLatest"]))),
+                ColumnarValue::Array(Arc::new(UInt32Array::from(vec![10]))),
+                ColumnarValue::Array(Arc::new(StringArray::from(vec!["v1"]))),
+            ],
+            arg_fields: vec![
+                Arc::new(Field::new("arg_0", DataType::Utf8, false)),
+                Arc::new(Field::new("arg_1", DataType::UInt32, false)),
+                Arc::new(Field::new("arg_2", DataType::Utf8, false)),
+            ],
+            return_field: Arc::new(Field::new("result", DataType::Utf8, true)),
+            number_rows: 1,
+            config_options: Arc::new(datafusion_common::config::ConfigOptions::default()),
+        };
+        let _err = f.invoke_async_with_args(func_args).await.unwrap_err();
+        // Note: Error type is DataFusionError at this level, not common_query::Error
     }
 }

--- a/src/common/function/src/admin/reconcile_table.rs
+++ b/src/common/function/src/admin/reconcile_table.rs
@@ -14,6 +14,7 @@
 
 use api::v1::meta::reconcile_request::Target;
 use api::v1::meta::{ReconcileRequest, ReconcileTable, ResolveStrategy};
+use arrow::datatypes::DataType as ArrowDataType;
 use common_catalog::format_full_table_name;
 use common_error::ext::BoxedError;
 use common_macro::admin_fn;
@@ -93,12 +94,9 @@ fn signature() -> Signature {
     Signature::one_of(
         vec![
             // reconcile_table(table_name)
-            TypeSignature::Exact(vec![ConcreteDataType::string_datatype().as_arrow_type()]),
+            TypeSignature::Exact(vec![ArrowDataType::Utf8]),
             // reconcile_table(table_name, resolve_strategy)
-            TypeSignature::Exact(vec![
-                ConcreteDataType::string_datatype().as_arrow_type(),
-                ConcreteDataType::string_datatype().as_arrow_type(),
-            ]),
+            TypeSignature::Exact(vec![ArrowDataType::Utf8, ArrowDataType::Utf8]),
         ],
         Volatility::Immutable,
     )

--- a/src/common/function/src/admin/remove_region_follower.rs
+++ b/src/common/function/src/admin/remove_region_follower.rs
@@ -18,7 +18,8 @@ use common_query::error::{
     InvalidFuncArgsSnafu, MissingProcedureServiceHandlerSnafu, Result,
     UnsupportedInputDataTypeSnafu,
 };
-use common_query::prelude::{Signature, TypeSignature, Volatility};
+use datafusion_expr::{Signature, TypeSignature, Volatility};
+use datatypes::data_type::DataType;
 use datatypes::prelude::ConcreteDataType;
 use datatypes::value::{Value, ValueRef};
 use session::context::QueryContextRef;
@@ -82,7 +83,13 @@ fn signature() -> Signature {
     Signature::one_of(
         vec![
             // remove_region_follower(region_id, peer_id)
-            TypeSignature::Uniform(2, ConcreteDataType::numerics()),
+            TypeSignature::Uniform(
+                2,
+                ConcreteDataType::numerics()
+                    .into_iter()
+                    .map(|dt| dt.as_arrow_type())
+                    .collect(),
+            ),
         ],
         Volatility::Immutable,
     )
@@ -92,38 +99,57 @@ fn signature() -> Signature {
 mod tests {
     use std::sync::Arc;
 
-    use common_query::prelude::TypeSignature;
-    use datatypes::vectors::{UInt64Vector, VectorRef};
+    use arrow::array::UInt64Array;
+    use arrow::datatypes::{DataType, Field};
+    use datafusion_expr::ColumnarValue;
 
     use super::*;
-    use crate::function::{AsyncFunction, FunctionContext};
+    use crate::function::FunctionContext;
+    use crate::function_factory::ScalarFunctionFactory;
 
     #[test]
     fn test_remove_region_follower_misc() {
-        let f = RemoveRegionFollowerFunction;
+        let factory: ScalarFunctionFactory = RemoveRegionFollowerFunction::factory().into();
+        let f = factory.provide(FunctionContext::mock());
         assert_eq!("remove_region_follower", f.name());
-        assert_eq!(
-            ConcreteDataType::uint64_datatype(),
-            f.return_type(&[]).unwrap()
-        );
+        assert_eq!(DataType::UInt64, f.return_type(&[]).unwrap());
         assert!(matches!(f.signature(),
-                         Signature {
-                             type_signature: TypeSignature::OneOf(sigs),
-                             volatility: Volatility::Immutable
+                         datafusion_expr::Signature {
+                             type_signature: datafusion_expr::TypeSignature::OneOf(sigs),
+                             volatility: datafusion_expr::Volatility::Immutable
                          } if sigs.len() == 1));
     }
 
     #[tokio::test]
     async fn test_remove_region_follower() {
-        let f = RemoveRegionFollowerFunction;
-        let args = vec![1, 1];
-        let args = args
-            .into_iter()
-            .map(|arg| Arc::new(UInt64Vector::from_slice([arg])) as _)
-            .collect::<Vec<_>>();
+        let factory: ScalarFunctionFactory = RemoveRegionFollowerFunction::factory().into();
+        let provider = factory.provide(FunctionContext::mock());
+        let f = provider.as_async().unwrap();
 
-        let result = f.eval(FunctionContext::mock(), &args).await.unwrap();
-        let expect: VectorRef = Arc::new(UInt64Vector::from_slice([0u64]));
-        assert_eq!(result, expect);
+        let func_args = datafusion::logical_expr::ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Array(Arc::new(UInt64Array::from(vec![1]))),
+                ColumnarValue::Array(Arc::new(UInt64Array::from(vec![1]))),
+            ],
+            arg_fields: vec![
+                Arc::new(Field::new("arg_0", DataType::UInt64, false)),
+                Arc::new(Field::new("arg_1", DataType::UInt64, false)),
+            ],
+            return_field: Arc::new(Field::new("result", DataType::UInt64, true)),
+            number_rows: 1,
+            config_options: Arc::new(datafusion_common::config::ConfigOptions::default()),
+        };
+
+        let result = f.invoke_async_with_args(func_args).await.unwrap();
+
+        match result {
+            ColumnarValue::Array(array) => {
+                let result_array = array.as_any().downcast_ref::<UInt64Array>().unwrap();
+                assert_eq!(result_array.value(0), 0u64);
+            }
+            ColumnarValue::Scalar(scalar) => {
+                assert_eq!(scalar, datafusion_common::ScalarValue::UInt64(Some(0)));
+            }
+        }
     }
 }

--- a/src/common/function/src/flush_flow.rs
+++ b/src/common/function/src/flush_flow.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use arrow::datatypes::DataType as ArrowDataType;
 use common_error::ext::BoxedError;
 use common_macro::admin_fn;
 use common_query::error::{
@@ -19,22 +20,16 @@ use common_query::error::{
     UnsupportedInputDataTypeSnafu,
 };
 use datafusion_expr::{Signature, Volatility};
-use datatypes::data_type::DataType;
 use datatypes::value::{Value, ValueRef};
 use session::context::QueryContextRef;
 use snafu::{ensure, ResultExt};
 use sql::ast::ObjectNamePartExt;
 use sql::parser::ParserContext;
-use store_api::storage::ConcreteDataType;
 
 use crate::handlers::FlowServiceHandlerRef;
 
 fn flush_signature() -> Signature {
-    Signature::uniform(
-        1,
-        vec![ConcreteDataType::string_datatype().as_arrow_type()],
-        Volatility::Immutable,
-    )
+    Signature::uniform(1, vec![ArrowDataType::Utf8], Volatility::Immutable)
 }
 
 #[admin_fn(
@@ -123,7 +118,7 @@ mod test {
         );
         let expected_signature = datafusion_expr::Signature::uniform(
             1,
-            vec![ConcreteDataType::string_datatype().as_arrow_type()],
+            vec![ArrowDataType::Utf8],
             datafusion_expr::Volatility::Immutable,
         );
         assert_eq!(*f.signature(), expected_signature);

--- a/src/common/function/src/flush_flow.rs
+++ b/src/common/function/src/flush_flow.rs
@@ -112,10 +112,7 @@ mod test {
         let factory: ScalarFunctionFactory = FlushFlowFunction::factory().into();
         let f = factory.provide(FunctionContext::mock());
         assert_eq!("flush_flow", f.name());
-        assert_eq!(
-            arrow::datatypes::DataType::UInt64,
-            f.return_type(&[]).unwrap()
-        );
+        assert_eq!(ArrowDataType::UInt64, f.return_type(&[]).unwrap());
         let expected_signature = datafusion_expr::Signature::uniform(
             1,
             vec![ArrowDataType::Utf8],
@@ -138,12 +135,12 @@ mod test {
             args: columnar_args,
             arg_fields: vec![Arc::new(arrow::datatypes::Field::new(
                 "arg_0",
-                arrow::datatypes::DataType::Utf8,
+                ArrowDataType::Utf8,
                 false,
             ))],
             return_field: Arc::new(arrow::datatypes::Field::new(
                 "result",
-                arrow::datatypes::DataType::UInt64,
+                ArrowDataType::UInt64,
                 true,
             )),
             number_rows: 1,

--- a/src/common/function/src/function.rs
+++ b/src/common/function/src/function.rs
@@ -41,6 +41,12 @@ impl FunctionContext {
     }
 }
 
+impl std::fmt::Display for FunctionContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "FunctionContext {{ query_ctx: {} }}", self.query_ctx)
+    }
+}
+
 impl Default for FunctionContext {
     fn default() -> Self {
         Self {
@@ -67,22 +73,3 @@ pub trait Function: fmt::Display + Sync + Send {
 }
 
 pub type FunctionRef = Arc<dyn Function>;
-
-/// Async Scalar function trait
-#[async_trait::async_trait]
-pub trait AsyncFunction: fmt::Display + Sync + Send {
-    /// Returns the name of the function, should be unique.
-    fn name(&self) -> &str;
-
-    /// The returned data type of function execution.
-    fn return_type(&self, input_types: &[ConcreteDataType]) -> Result<ConcreteDataType>;
-
-    /// The signature of function.
-    fn signature(&self) -> Signature;
-
-    /// Evaluate the function, e.g. run/execute the function.
-    /// TODO(dennis): simplify the signature and refactor all the admin functions.
-    async fn eval(&self, _func_ctx: FunctionContext, _columns: &[VectorRef]) -> Result<VectorRef>;
-}
-
-pub type AsyncFunctionRef = Arc<dyn AsyncFunction>;

--- a/src/common/function/src/function_factory.rs
+++ b/src/common/function/src/function_factory.rs
@@ -22,8 +22,8 @@ use crate::scalars::udf::create_udf;
 /// A factory for creating `ScalarUDF` that require a function context.
 #[derive(Clone)]
 pub struct ScalarFunctionFactory {
-    name: String,
-    factory: Arc<dyn Fn(FunctionContext) -> ScalarUDF + Send + Sync>,
+    pub(crate) name: String,
+    pub(crate) factory: Arc<dyn Fn(FunctionContext) -> ScalarUDF + Send + Sync>,
 }
 
 impl ScalarFunctionFactory {

--- a/src/common/function/src/system.rs
+++ b/src/common/function/src/system.rs
@@ -19,8 +19,6 @@ mod procedure_state;
 mod timezone;
 mod version;
 
-use std::sync::Arc;
-
 use build::BuildFunction;
 use database::{
     ConnectionIdFunction, CurrentSchemaFunction, DatabaseFunction, PgBackendPidFunction,
@@ -46,7 +44,7 @@ impl SystemFunction {
         registry.register_scalar(PgBackendPidFunction);
         registry.register_scalar(ConnectionIdFunction);
         registry.register_scalar(TimezoneFunction);
-        registry.register_async(Arc::new(ProcedureStateFunction));
+        registry.register(ProcedureStateFunction::factory());
         PGCatalogFunction::register(registry);
     }
 }

--- a/src/common/function/src/system/procedure_state.rs
+++ b/src/common/function/src/system/procedure_state.rs
@@ -19,7 +19,8 @@ use common_query::error::{
     InvalidFuncArgsSnafu, MissingProcedureServiceHandlerSnafu, Result,
     UnsupportedInputDataTypeSnafu,
 };
-use common_query::prelude::{Signature, Volatility};
+use datafusion_expr::{Signature, Volatility};
+use datatypes::data_type::DataType;
 use datatypes::prelude::*;
 use serde::Serialize;
 use session::context::QueryContextRef;
@@ -83,7 +84,7 @@ pub(crate) async fn procedure_state(
 fn signature() -> Signature {
     Signature::uniform(
         1,
-        vec![ConcreteDataType::string_datatype()],
+        vec![ConcreteDataType::string_datatype().as_arrow_type()],
         Volatility::Immutable,
     )
 }
@@ -92,62 +93,80 @@ fn signature() -> Signature {
 mod tests {
     use std::sync::Arc;
 
-    use common_query::prelude::TypeSignature;
-    use datatypes::vectors::StringVector;
+    use arrow::array::StringArray;
+    use arrow::datatypes::{DataType, Field};
+    use datafusion_expr::ColumnarValue;
 
     use super::*;
-    use crate::function::{AsyncFunction, FunctionContext};
+    use crate::function::FunctionContext;
+    use crate::function_factory::ScalarFunctionFactory;
 
     #[test]
     fn test_procedure_state_misc() {
-        let f = ProcedureStateFunction;
+        let factory: ScalarFunctionFactory = ProcedureStateFunction::factory().into();
+        let f = factory.provide(FunctionContext::mock());
         assert_eq!("procedure_state", f.name());
-        assert_eq!(
-            ConcreteDataType::string_datatype(),
-            f.return_type(&[]).unwrap()
-        );
+        assert_eq!(DataType::Utf8, f.return_type(&[]).unwrap());
         assert!(matches!(f.signature(),
-                         Signature {
-                             type_signature: TypeSignature::Uniform(1, valid_types),
-                             volatility: Volatility::Immutable
-                         } if valid_types == vec![ConcreteDataType::string_datatype()]
+                         datafusion_expr::Signature {
+                             type_signature: datafusion_expr::TypeSignature::Uniform(1, valid_types),
+                             volatility: datafusion_expr::Volatility::Immutable
+                         } if valid_types == &vec![{ use datatypes::data_type::DataType; ConcreteDataType::string_datatype().as_arrow_type() }]
         ));
     }
 
     #[tokio::test]
     async fn test_missing_procedure_service() {
-        let f = ProcedureStateFunction;
+        let factory: ScalarFunctionFactory = ProcedureStateFunction::factory().into();
+        let binding = factory.provide(FunctionContext::default());
+        let f = binding.as_async().unwrap();
 
-        let args = vec!["pid"];
-
-        let args = args
-            .into_iter()
-            .map(|arg| Arc::new(StringVector::from_slice(&[arg])) as _)
-            .collect::<Vec<_>>();
-
-        let result = f.eval(FunctionContext::default(), &args).await.unwrap_err();
-        assert_eq!(
-            "Missing ProcedureServiceHandler, not expected",
-            result.to_string()
-        );
+        let func_args = datafusion::logical_expr::ScalarFunctionArgs {
+            args: vec![ColumnarValue::Array(Arc::new(StringArray::from(vec![
+                "pid",
+            ])))],
+            arg_fields: vec![Arc::new(Field::new("arg_0", DataType::Utf8, false))],
+            return_field: Arc::new(Field::new("result", DataType::Utf8, true)),
+            number_rows: 1,
+            config_options: Arc::new(datafusion_common::config::ConfigOptions::default()),
+        };
+        let result = f.invoke_async_with_args(func_args).await;
+        assert!(result.is_err());
     }
 
     #[tokio::test]
     async fn test_procedure_state() {
-        let f = ProcedureStateFunction;
+        let factory: ScalarFunctionFactory = ProcedureStateFunction::factory().into();
+        let provider = factory.provide(FunctionContext::mock());
+        let f = provider.as_async().unwrap();
 
-        let args = vec!["pid"];
+        let func_args = datafusion::logical_expr::ScalarFunctionArgs {
+            args: vec![ColumnarValue::Array(Arc::new(StringArray::from(vec![
+                "pid",
+            ])))],
+            arg_fields: vec![Arc::new(Field::new("arg_0", DataType::Utf8, false))],
+            return_field: Arc::new(Field::new("result", DataType::Utf8, true)),
+            number_rows: 1,
+            config_options: Arc::new(datafusion_common::config::ConfigOptions::default()),
+        };
+        let result = f.invoke_async_with_args(func_args).await.unwrap();
 
-        let args = args
-            .into_iter()
-            .map(|arg| Arc::new(StringVector::from_slice(&[arg])) as _)
-            .collect::<Vec<_>>();
-
-        let result = f.eval(FunctionContext::mock(), &args).await.unwrap();
-
-        let expect: VectorRef = Arc::new(StringVector::from(vec![
-            "{\"status\":\"Done\",\"error\":\"OK\"}",
-        ]));
-        assert_eq!(expect, result);
+        match result {
+            ColumnarValue::Array(array) => {
+                let result_array = array.as_any().downcast_ref::<StringArray>().unwrap();
+                assert_eq!(
+                    result_array.value(0),
+                    "{\"status\":\"Done\",\"error\":\"OK\"}"
+                );
+            }
+            ColumnarValue::Scalar(scalar) => {
+                assert_eq!(
+                    scalar,
+                    datafusion_common::ScalarValue::Utf8(Some(
+                        "{\"status\":\"Done\",\"error\":\"OK\"}".to_string()
+                    ))
+                );
+            }
+        }
     }
 }

--- a/src/common/function/src/system/procedure_state.rs
+++ b/src/common/function/src/system/procedure_state.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use api::v1::meta::ProcedureStatus;
+use arrow::datatypes::DataType as ArrowDataType;
 use common_macro::admin_fn;
 use common_meta::rpc::procedure::ProcedureStateResponse;
 use common_query::error::{
@@ -20,7 +21,6 @@ use common_query::error::{
     UnsupportedInputDataTypeSnafu,
 };
 use datafusion_expr::{Signature, Volatility};
-use datatypes::data_type::DataType;
 use datatypes::prelude::*;
 use serde::Serialize;
 use session::context::QueryContextRef;
@@ -82,11 +82,7 @@ pub(crate) async fn procedure_state(
 }
 
 fn signature() -> Signature {
-    Signature::uniform(
-        1,
-        vec![ConcreteDataType::string_datatype().as_arrow_type()],
-        Volatility::Immutable,
-    )
+    Signature::uniform(1, vec![ArrowDataType::Utf8], Volatility::Immutable)
 }
 
 #[cfg(test)]
@@ -111,8 +107,7 @@ mod tests {
                          datafusion_expr::Signature {
                              type_signature: datafusion_expr::TypeSignature::Uniform(1, valid_types),
                              volatility: datafusion_expr::Volatility::Immutable
-                         } if valid_types == &vec![{ use datatypes::data_type::DataType; ConcreteDataType::string_datatype().as_arrow_type() }]
-        ));
+                         } if valid_types == &vec![ArrowDataType::Utf8]));
     }
 
     #[tokio::test]

--- a/src/common/query/src/signature.rs
+++ b/src/common/query/src/signature.rs
@@ -189,9 +189,7 @@ impl From<&DfTypeSignature> for TypeSignature {
                 }
                 TypeSignature::Any(*n)
             }
-            DfTypeSignature::OneOf(ts) => {
-                TypeSignature::OneOf(ts.into_iter().map(Into::into).collect())
-            }
+            DfTypeSignature::OneOf(ts) => TypeSignature::OneOf(ts.iter().map(Into::into).collect()),
             DfTypeSignature::VariadicAny => TypeSignature::VariadicAny,
             DfTypeSignature::Nullary => TypeSignature::NullAry,
             // Other type signatures are currently mapped to VariadicAny as a fallback.

--- a/src/common/query/src/signature.rs
+++ b/src/common/query/src/signature.rs
@@ -156,8 +156,8 @@ impl From<TypeSignature> for DfTypeSignature {
     }
 }
 
-impl From<DfTypeSignature> for TypeSignature {
-    fn from(type_signature: DfTypeSignature) -> TypeSignature {
+impl From<&DfTypeSignature> for TypeSignature {
+    fn from(type_signature: &DfTypeSignature) -> TypeSignature {
         match type_signature {
             DfTypeSignature::Variadic(types) => TypeSignature::Variadic(
                 types
@@ -166,11 +166,11 @@ impl From<DfTypeSignature> for TypeSignature {
                     .collect(),
             ),
             DfTypeSignature::Uniform(n, types) => {
-                if n == 0 {
+                if *n == 0 {
                     return TypeSignature::NullAry;
                 }
                 TypeSignature::Uniform(
-                    n,
+                    *n,
                     types
                         .iter()
                         .map(ConcreteDataType::from_arrow_type)
@@ -184,10 +184,10 @@ impl From<DfTypeSignature> for TypeSignature {
                     .collect(),
             ),
             DfTypeSignature::Any(n) => {
-                if n == 0 {
+                if *n == 0 {
                     return TypeSignature::NullAry;
                 }
-                TypeSignature::Any(n)
+                TypeSignature::Any(*n)
             }
             DfTypeSignature::OneOf(ts) => {
                 TypeSignature::OneOf(ts.into_iter().map(Into::into).collect())

--- a/src/operator/src/error.rs
+++ b/src/operator/src/error.rs
@@ -42,13 +42,6 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Failed to execute admin function"))]
-    ExecuteAdminFunction {
-        #[snafu(implicit)]
-        location: Location,
-        source: common_query::error::Error,
-    },
-
     #[snafu(display("Failed to build admin function args: {msg}"))]
     BuildAdminFunctionArgs { msg: String },
 
@@ -980,7 +973,6 @@ impl ErrorExt for Error {
             | Error::ParseSqlValue { .. }
             | Error::InvalidTimestampRange { .. } => StatusCode::InvalidArguments,
             Error::CreateLogicalTables { .. } => StatusCode::Unexpected,
-            Error::ExecuteAdminFunction { source, .. } => source.status_code(),
             Error::BuildRecordBatch { source, .. } => source.status_code(),
             Error::UpgradeCatalogManagerRef { .. } => StatusCode::Internal,
             Error::ColumnOptions { source, .. } => source.status_code(),

--- a/src/operator/src/statement/admin.rs
+++ b/src/operator/src/statement/admin.rs
@@ -83,7 +83,7 @@ impl StatementExecutor {
             })
             .collect::<Result<Vec<_>>>()?;
 
-        let type_sig = signature.type_signature.clone().into();
+        let type_sig = (&signature.type_signature).into();
         let args = args_to_vector(&type_sig, &arg_values, &query_ctx)?;
         let arg_types = args
             .iter()

--- a/tests/cases/distributed/information_schema/cluster_info.result
+++ b/tests/cases/distributed/information_schema/cluster_info.result
@@ -19,7 +19,7 @@ DESC TABLE CLUSTER_INFO;
 
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d+\.\d+(?:\.\d+)+\s) Version
--- SQLNESS REPLACE (\s[a-z0-9]{7,9}\s) Hash
+-- SQLNESS REPLACE (\s[a-z0-9]{7,10}\s) Hash
 -- SQLNESS REPLACE (\s[\-0-9T:\.]{19,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE (\s127\.0\.0\.1:\d+\s) Address
@@ -30,7 +30,7 @@ SELECT * FROM CLUSTER_INFO ORDER BY peer_type;
 
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d+\.\d+(?:\.\d+)+\s) Version
--- SQLNESS REPLACE (\s[a-z0-9]{7,9}\s) Hash
+-- SQLNESS REPLACE (\s[a-z0-9]{7,10}\s) Hash
 -- SQLNESS REPLACE (\s[\-0-9T:\.]{19,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE (\s127\.0\.0\.1:\d+\s) Address
@@ -41,7 +41,7 @@ SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE = 'METASRV' ORDER BY peer_type;
 
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d+\.\d+(?:\.\d+)+\s) Version
--- SQLNESS REPLACE (\s[a-z0-9]{7,9}\s) Hash
+-- SQLNESS REPLACE (\s[a-z0-9]{7,10}\s) Hash
 -- SQLNESS REPLACE (\s[\-0-9T:\.]{19,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE (\s127\.0\.0\.1:\d+\s) Address
@@ -52,7 +52,7 @@ SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE = 'FRONTEND' ORDER BY peer_type;
 
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d+\.\d+(?:\.\d+)+\s) Version
--- SQLNESS REPLACE (\s[a-z0-9]{7,9}\s) Hash
+-- SQLNESS REPLACE (\s[a-z0-9]{7,10}\s) Hash
 -- SQLNESS REPLACE (\s[\-0-9T:\.]{19,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE (\s127\.0\.0\.1:\d+\s) Address
@@ -63,7 +63,7 @@ SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE != 'FRONTEND' ORDER BY peer_type;
 
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d+\.\d+(?:\.\d+)+\s) Version
--- SQLNESS REPLACE (\s[a-z0-9]{7,9}\s) Hash
+-- SQLNESS REPLACE (\s[a-z0-9]{7,10}\s) Hash
 -- SQLNESS REPLACE (\s[\-0-9T:\.]{19,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE (\s127\.0\.0\.1:\d+\s) Address

--- a/tests/cases/distributed/information_schema/cluster_info.sql
+++ b/tests/cases/distributed/information_schema/cluster_info.sql
@@ -4,7 +4,7 @@ DESC TABLE CLUSTER_INFO;
 
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d+\.\d+(?:\.\d+)+\s) Version
--- SQLNESS REPLACE (\s[a-z0-9]{7,9}\s) Hash
+-- SQLNESS REPLACE (\s[a-z0-9]{7,10}\s) Hash
 -- SQLNESS REPLACE (\s[\-0-9T:\.]{19,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE (\s127\.0\.0\.1:\d+\s) Address
@@ -13,7 +13,7 @@ SELECT * FROM CLUSTER_INFO ORDER BY peer_type;
 
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d+\.\d+(?:\.\d+)+\s) Version
--- SQLNESS REPLACE (\s[a-z0-9]{7,9}\s) Hash
+-- SQLNESS REPLACE (\s[a-z0-9]{7,10}\s) Hash
 -- SQLNESS REPLACE (\s[\-0-9T:\.]{19,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE (\s127\.0\.0\.1:\d+\s) Address
@@ -22,7 +22,7 @@ SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE = 'METASRV' ORDER BY peer_type;
 
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d+\.\d+(?:\.\d+)+\s) Version
--- SQLNESS REPLACE (\s[a-z0-9]{7,9}\s) Hash
+-- SQLNESS REPLACE (\s[a-z0-9]{7,10}\s) Hash
 -- SQLNESS REPLACE (\s[\-0-9T:\.]{19,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE (\s127\.0\.0\.1:\d+\s) Address
@@ -31,7 +31,7 @@ SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE = 'FRONTEND' ORDER BY peer_type;
 
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d+\.\d+(?:\.\d+)+\s) Version
--- SQLNESS REPLACE (\s[a-z0-9]{7,9}\s) Hash
+-- SQLNESS REPLACE (\s[a-z0-9]{7,10}\s) Hash
 -- SQLNESS REPLACE (\s[\-0-9T:\.]{19,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE (\s127\.0\.0\.1:\d+\s) Address
@@ -40,7 +40,7 @@ SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE != 'FRONTEND' ORDER BY peer_type;
 
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d+\.\d+(?:\.\d+)+\s) Version
--- SQLNESS REPLACE (\s[a-z0-9]{7,9}\s) Hash
+-- SQLNESS REPLACE (\s[a-z0-9]{7,10}\s) Hash
 -- SQLNESS REPLACE (\s[\-0-9T:\.]{19,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE (\s127\.0\.0\.1:\d+\s) Address

--- a/tests/cases/standalone/common/function/admin/flush_compact_table.result
+++ b/tests/cases/standalone/common/function/admin/flush_compact_table.result
@@ -35,6 +35,22 @@ ADMIN COMPACT_TABLE('test');
 | 0                           |
 +-----------------------------+
 
+SELECT FLUSH_TABLE('test');
+
++---------------------------+
+| flush_table(Utf8("test")) |
++---------------------------+
+| 0                         |
++---------------------------+
+
+SELECT COMPACT_TABLE('test');
+
++-----------------------------+
+| compact_table(Utf8("test")) |
++-----------------------------+
+| 0                           |
++-----------------------------+
+
 --- doesn't change anything ---
 SELECT * FROM test;
 

--- a/tests/cases/standalone/common/function/admin/flush_compact_table.sql
+++ b/tests/cases/standalone/common/function/admin/flush_compact_table.sql
@@ -10,6 +10,10 @@ ADMIN FLUSH_TABLE('test');
 
 ADMIN COMPACT_TABLE('test');
 
+SELECT FLUSH_TABLE('test');
+
+SELECT COMPACT_TABLE('test');
+
 --- doesn't change anything ---
 SELECT * FROM test;
 

--- a/tests/cases/standalone/common/insert/logical_metric_table.result
+++ b/tests/cases/standalone/common/insert/logical_metric_table.result
@@ -81,7 +81,7 @@ CREATE TABLE phy (
     ts timestamp time index,
     val double
 ) engine = metric with (
-    "physical_metric_table" = "",   
+    "physical_metric_table" = "",
     "memtable.type" = "partition_tree",
     "memtable.partition_tree.primary_key_encoding" = "sparse"
 );
@@ -127,9 +127,13 @@ SELECT * from t2;
 | job1 | 1970-01-01T00:00:00     | 0.0 |
 +------+-------------------------+-----+
 
-ADMIN flush_table("phy");
+ADMIN flush_table('phy');
 
-Error: 1004(InvalidArguments), Failed to build admin function args: unsupported function arg "phy" for flush_table
++--------------------------+
+| ADMIN flush_table('phy') |
++--------------------------+
+| 0                        |
++--------------------------+
 
 -- SQLNESS ARG restart=true
 INSERT INTO t2 VALUES ('job3', 0, 0), ('job4', 1, 1);

--- a/tests/cases/standalone/common/insert/logical_metric_table.result
+++ b/tests/cases/standalone/common/insert/logical_metric_table.result
@@ -129,7 +129,7 @@ SELECT * from t2;
 
 ADMIN flush_table("phy");
 
-Error: 1004(InvalidArguments), Failed to build admin function args: unsupported function arg "phy"
+Error: 1004(InvalidArguments), Failed to build admin function args: unsupported function arg "phy" for flush_table
 
 -- SQLNESS ARG restart=true
 INSERT INTO t2 VALUES ('job3', 0, 0), ('job4', 1, 1);

--- a/tests/cases/standalone/common/insert/logical_metric_table.sql
+++ b/tests/cases/standalone/common/insert/logical_metric_table.sql
@@ -28,7 +28,7 @@ CREATE TABLE phy (
     ts timestamp time index,
     val double
 ) engine = metric with (
-    "physical_metric_table" = "",   
+    "physical_metric_table" = "",
     "memtable.type" = "partition_tree",
     "memtable.partition_tree.primary_key_encoding" = "sparse"
 );
@@ -47,7 +47,7 @@ INSERT INTO t2 VALUES ('job1', 0, 0), ('job2', 1, 1);
 
 SELECT * from t2;
 
-ADMIN flush_table("phy");
+ADMIN flush_table('phy');
 
 -- SQLNESS ARG restart=true
 INSERT INTO t2 VALUES ('job3', 0, 0), ('job4', 1, 1);

--- a/tests/cases/standalone/information_schema/cluster_info.result
+++ b/tests/cases/standalone/information_schema/cluster_info.result
@@ -19,7 +19,7 @@ DESC TABLE CLUSTER_INFO;
 
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\d+\.\d+(?:\.\d+)+) Version
--- SQLNESS REPLACE (\s[a-z0-9]{7,9}\s) Hash
+-- SQLNESS REPLACE (\s[a-z0-9]{7,10}\s) Hash
 -- SQLNESS REPLACE (\s[\-0-9T:\.]{15,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
@@ -29,7 +29,7 @@ SELECT * FROM CLUSTER_INFO;
 
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\d+\.\d+(?:\.\d+)+) Version
--- SQLNESS REPLACE (\s[a-z0-9]{7,9}\s) Hash
+-- SQLNESS REPLACE (\s[a-z0-9]{7,10}\s) Hash
 -- SQLNESS REPLACE (\s[\-0-9T:\.]{15,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
@@ -44,7 +44,7 @@ SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE != 'STANDALONE';
 
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\d+\.\d+(?:\.\d+)+) Version
--- SQLNESS REPLACE (\s[a-z0-9]{7,9}\s) Hash
+-- SQLNESS REPLACE (\s[a-z0-9]{7,10}\s) Hash
 -- SQLNESS REPLACE (\s[\-0-9T:\.]{15,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+

--- a/tests/cases/standalone/information_schema/cluster_info.sql
+++ b/tests/cases/standalone/information_schema/cluster_info.sql
@@ -4,7 +4,7 @@ DESC TABLE CLUSTER_INFO;
 
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\d+\.\d+(?:\.\d+)+) Version
--- SQLNESS REPLACE (\s[a-z0-9]{7,9}\s) Hash
+-- SQLNESS REPLACE (\s[a-z0-9]{7,10}\s) Hash
 -- SQLNESS REPLACE (\s[\-0-9T:\.]{15,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
@@ -12,7 +12,7 @@ SELECT * FROM CLUSTER_INFO;
 
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\d+\.\d+(?:\.\d+)+) Version
--- SQLNESS REPLACE (\s[a-z0-9]{7,9}\s) Hash
+-- SQLNESS REPLACE (\s[a-z0-9]{7,10}\s) Hash
 -- SQLNESS REPLACE (\s[\-0-9T:\.]{15,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
@@ -22,7 +22,7 @@ SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE != 'STANDALONE';
 
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\d+\.\d+(?:\.\d+)+) Version
--- SQLNESS REPLACE (\s[a-z0-9]{7,9}\s) Hash
+-- SQLNESS REPLACE (\s[a-z0-9]{7,10}\s) Hash
 -- SQLNESS REPLACE (\s[\-0-9T:\.]{15,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

#6749 

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

* Refactor `admin_fn` macro with DataFusion async udf. Now we can call admin functions with `select`.
* Remove `AsyncFunction` trait.
* Fixed the tests.

FYI. The codebase got larger, but most of the additions are test code.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
