### PR TITLE
chore: no logging when init table_flow cache if empty

### DIFF
--- a/src/common/meta/src/cache/flow/table_flownode.rs
+++ b/src/common/meta/src/cache/flow/table_flownode.rs
@@ -91,10 +91,12 @@ fn init_factory(table_flow_manager: TableFlowManagerRef) -> Initializer<TableId,
                 .map(Arc::new)
                 .map(Some)
                 .inspect(|set| {
-                    info!(
-                        "Initialized table_flownode cache for table_id: {}, set: {:?}",
-                        table_id, set
-                    );
+                    if set.as_ref().map(|s| !s.is_empty()).unwrap_or(false) {
+                        info!(
+                            "Initialized table_flownode cache for table_id: {}, set: {:?}",
+                            table_id, set
+                        );
+                    };
                 })
         })
     })


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

as title, no logging when init table_flow cache unless not empty

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
