### PR TITLE
fix: follow promql rule for hanndling label of aggr

### DIFF
--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -857,10 +857,7 @@ fn collect_metric_names(expr: &PromqlExpr, metric_names: &mut HashSet<String>) {
             }
             collect_metric_names(expr, metric_names)
         }
-        PromqlExpr::Unary(UnaryExpr { .. }) => {
-            metric_names.clear();
-            return;
-        }
+        PromqlExpr::Unary(UnaryExpr { .. }) => metric_names.clear(),
         PromqlExpr::Binary(BinaryExpr { lhs, op, .. }) => {
             if matches!(
                 op.id(),
@@ -870,8 +867,7 @@ fn collect_metric_names(expr: &PromqlExpr, metric_names: &mut HashSet<String>) {
             ) {
                 collect_metric_names(lhs, metric_names)
             } else {
-                metric_names.clear();
-                return;
+                metric_names.clear()
             }
         }
         PromqlExpr::Paren(ParenExpr { expr }) => collect_metric_names(expr, metric_names),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


for a query like `sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{cluster="$cluster"}) by (namespace)`, it should not return `__name__` label in the result.

expect:

<img width="1280" height="466" alt="image" src="https://github.com/user-attachments/assets/da23367e-b9bc-4aa4-8d09-a8b7f1091ca0" />

actual:

<img width="1280" height="514" alt="image" src="https://github.com/user-attachments/assets/faa6d149-3788-4a46-9633-9a24eccf9f03" />


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
