### PR TITLE
chore: make internal grpc optional

### DIFF
--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -50,7 +50,7 @@ pub struct FrontendOptions {
     pub grpc: GrpcOptions,
     /// The internal gRPC options for the frontend service.
     /// it provide the same service as the public gRPC service, just only for internal use.
-    pub internal_grpc: GrpcOptions,
+    pub internal_grpc: Option<GrpcOptions>,
     pub mysql: MysqlOptions,
     pub postgres: PostgresOptions,
     pub opentsdb: OpentsdbOptions,
@@ -80,7 +80,7 @@ impl Default for FrontendOptions {
             heartbeat: HeartbeatOptions::frontend_default(),
             http: HttpOptions::default(),
             grpc: GrpcOptions::default(),
-            internal_grpc: GrpcOptions::internal_default(),
+            internal_grpc: None,
             mysql: MysqlOptions::default(),
             postgres: PostgresOptions::default(),
             opentsdb: OpentsdbOptions::default(),

--- a/src/frontend/src/heartbeat.rs
+++ b/src/frontend/src/heartbeat.rs
@@ -56,10 +56,14 @@ impl HeartbeatTask {
         resp_handler_executor: HeartbeatResponseHandlerExecutorRef,
     ) -> Self {
         HeartbeatTask {
-            peer_addr: addrs::resolve_addr(
-                &opts.internal_grpc.bind_addr,
-                Some(&opts.internal_grpc.server_addr),
-            ),
+            // if internal grpc is configured, use its address as the peer address
+            // otherwise use the public grpc address, because peer address only promises to be reachable
+            // by other components, it doesn't matter whether it's internal or external
+            peer_addr: if let Some(internal) = &opts.internal_grpc {
+                addrs::resolve_addr(&internal.bind_addr, Some(&internal.server_addr))
+            } else {
+                addrs::resolve_addr(&opts.grpc.bind_addr, Some(&opts.grpc.server_addr))
+            },
             meta_client,
             report_interval: heartbeat_opts.interval.as_millis() as u64,
             retry_interval: heartbeat_opts.retry_interval.as_millis() as u64,

--- a/src/frontend/src/server.rs
+++ b/src/frontend/src/server.rs
@@ -218,11 +218,11 @@ where
             handlers.insert((Box::new(grpc_server), grpc_addr));
         }
 
-        if opts.meta_client.is_some() {
+        if let Some(internal_grpc) = &opts.internal_grpc {
             // Always init Internal GRPC server
-            let grpc_addr = parse_addr(&opts.internal_grpc.bind_addr)?;
+            let grpc_addr = parse_addr(&internal_grpc.bind_addr)?;
             let grpc_server = self.build_grpc_server(
-                &opts.grpc,
+                internal_grpc,
                 &opts.meta_client,
                 Some("INTERNAL_GRPC_SERVER".to_string()),
                 false,

--- a/tests-integration/src/cluster.rs
+++ b/tests-integration/src/cluster.rs
@@ -445,10 +445,7 @@ impl GreptimeDbClusterBuilder {
     }
 
     fn build_frontend_options(&self) -> FrontendOptions {
-        let mut fe_opts = FrontendOptions {
-            meta_client: Some(Default::default()),
-            ..Default::default()
-        };
+        let mut fe_opts = FrontendOptions::default();
 
         // Choose a random unused port between [14000, 24000] for local test to avoid conflicts.
         let port_range = 14000..=24000;
@@ -465,11 +462,6 @@ impl GreptimeDbClusterBuilder {
         let grpc_port = self.choose_random_unused_port(port_range.clone(), max_attempts, localhost);
         fe_opts.grpc.bind_addr = construct_addr(grpc_port);
         fe_opts.grpc.server_addr = construct_addr(grpc_port);
-
-        let internal_grpc_port =
-            self.choose_random_unused_port(port_range.clone(), max_attempts, localhost);
-        fe_opts.internal_grpc.bind_addr = construct_addr(internal_grpc_port);
-        fe_opts.internal_grpc.server_addr = construct_addr(internal_grpc_port);
 
         fe_opts.mysql.addr = construct_addr(self.choose_random_unused_port(
             port_range.clone(),

--- a/tests/conf/frontend-test.toml.template
+++ b/tests/conf/frontend-test.toml.template
@@ -1,7 +1,3 @@
 [grpc]
 bind_addr = "{grpc_addr}"
 server_addr = "{grpc_addr}"
-
-[internal_grpc]
-bind_addr = "{internal_grpc_addr}"
-server_addr = "{internal_grpc_addr}"

--- a/tests/runner/src/server_mode.rs
+++ b/tests/runner/src/server_mode.rs
@@ -60,7 +60,6 @@ pub enum ServerMode {
     Frontend {
         http_addr: String,
         rpc_bind_addr: String,
-        internal_rpc_bind_addr: String,
         mysql_addr: String,
         postgres_addr: String,
         metasrv_addr: String,
@@ -101,8 +100,6 @@ struct ConfigContext {
     metasrv_addr: String,
     // for frontend and standalone
     grpc_addr: String,
-    // for frontend in distributed mode
-    internal_grpc_addr: String,
     // for standalone
     mysql_addr: String,
     // for standalone
@@ -127,14 +124,12 @@ impl ServerMode {
     pub fn random_frontend(metasrv_port: u16) -> Self {
         let http_port = get_unique_random_port();
         let rpc_port = get_unique_random_port();
-        let internal_rpc_port = get_unique_random_port();
         let mysql_port = get_unique_random_port();
         let postgres_port = get_unique_random_port();
 
         ServerMode::Frontend {
             http_addr: format!("127.0.0.1:{http_port}"),
             rpc_bind_addr: format!("127.0.0.1:{rpc_port}"),
-            internal_rpc_bind_addr: format!("127.0.0.1:{internal_rpc_port}"),
             mysql_addr: format!("127.0.0.1:{mysql_port}"),
             postgres_addr: format!("127.0.0.1:{postgres_port}"),
             metasrv_addr: format!("127.0.0.1:{metasrv_port}"),
@@ -329,15 +324,6 @@ impl ServerMode {
             instance_id: id,
             metasrv_addr,
             grpc_addr,
-            internal_grpc_addr: if let ServerMode::Frontend {
-                internal_rpc_bind_addr,
-                ..
-            } = self
-            {
-                internal_rpc_bind_addr.clone()
-            } else {
-                String::new()
-            },
             mysql_addr,
             postgres_addr,
         };
@@ -395,7 +381,6 @@ impl ServerMode {
             ServerMode::Frontend {
                 http_addr,
                 rpc_bind_addr,
-                internal_rpc_bind_addr: _,
                 mysql_addr,
                 postgres_addr,
                 metasrv_addr,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

as title, so by default oss version wouldn't start a internal port

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
