### PR TITLE
fix: time unit mismatch in `lookup_frontends` function

### DIFF
--- a/src/meta-srv/src/lease.rs
+++ b/src/meta-srv/src/lease.rs
@@ -17,6 +17,7 @@ use std::future::Future;
 use std::hash::Hash;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use std::time::Duration;
 
 use api::v1::meta::heartbeat_request::NodeWorkloads;
 use common_error::ext::BoxedError;
@@ -39,14 +40,14 @@ enum Value<'a> {
     NodeInfo(&'a NodeInfo),
 }
 
-fn build_lease_filter(lease_secs: u64) -> impl Fn(Value) -> bool {
+fn build_lease_filter(lease: Duration) -> impl Fn(Value) -> bool {
     move |value: Value| {
         let active_time = match value {
             Value::LeaseValue(lease_value) => lease_value.timestamp_millis,
             Value::NodeInfo(node_info) => node_info.last_activity_ts,
         };
 
-        ((time_util::current_time_millis() - active_time) as u64) < lease_secs.saturating_mul(1000)
+        ((time_util::current_time_millis() - active_time) as u64) < lease.as_millis() as u64
     }
 }
 
@@ -92,9 +93,9 @@ pub async fn find_datanode_lease_value(
 pub async fn lookup_datanode_peer(
     datanode_id: DatanodeId,
     meta_peer_client: &MetaPeerClientRef,
-    lease_secs: u64,
+    lease: Duration,
 ) -> Result<Option<Peer>> {
-    let lease_filter = build_lease_filter(lease_secs);
+    let lease_filter = build_lease_filter(lease);
     let lease_key = DatanodeLeaseKey {
         node_id: datanode_id,
     };
@@ -121,7 +122,7 @@ pub struct LeaseFilter<'a, K>
 where
     K: Eq + Hash + TryFrom<Vec<u8>, Error = Error> + 'a,
 {
-    lease_secs: u64,
+    lease: Duration,
     key_prefix: Vec<u8>,
     meta_peer_client: &'a MetaPeerClientRef,
     condition: Option<fn(&LeaseValue) -> bool>,
@@ -133,12 +134,12 @@ where
     K: Eq + Hash + TryFrom<Vec<u8>, Error = Error> + 'a,
 {
     pub fn new(
-        lease_secs: u64,
+        lease: Duration,
         key_prefix: Vec<u8>,
         meta_peer_client: &'a MetaPeerClientRef,
     ) -> Self {
         Self {
-            lease_secs,
+            lease,
             key_prefix,
             meta_peer_client,
             condition: None,
@@ -163,7 +164,7 @@ where
         let this = self.get_mut();
 
         if this.inner_future.is_none() {
-            let lease_filter = build_lease_filter(this.lease_secs);
+            let lease_filter = build_lease_filter(this.lease);
             let condition = this.condition;
             let key_prefix = std::mem::take(&mut this.key_prefix);
             let fut = filter(key_prefix, this.meta_peer_client, move |v| {
@@ -183,18 +184,18 @@ where
 /// Find all alive datanodes
 pub fn alive_datanodes(
     meta_peer_client: &MetaPeerClientRef,
-    lease_secs: u64,
+    lease: Duration,
 ) -> LeaseFilter<'_, DatanodeLeaseKey> {
-    LeaseFilter::new(lease_secs, DatanodeLeaseKey::prefix_key(), meta_peer_client)
+    LeaseFilter::new(lease, DatanodeLeaseKey::prefix_key(), meta_peer_client)
 }
 
 /// look up [`Peer`] given [`ClusterId`] and [`DatanodeId`], only return if it's alive under given `lease_secs`
 pub async fn lookup_flownode_peer(
     flownode_id: FlownodeId,
     meta_peer_client: &MetaPeerClientRef,
-    lease_secs: u64,
+    lease: Duration,
 ) -> Result<Option<Peer>> {
-    let lease_filter = build_lease_filter(lease_secs);
+    let lease_filter = build_lease_filter(lease);
     let lease_key = FlownodeLeaseKey {
         node_id: flownode_id,
     };
@@ -218,13 +219,13 @@ pub async fn lookup_flownode_peer(
 /// Lookup all alive frontends from the memory backend, only return if it's alive under given `lease_secs`.
 pub async fn lookup_frontends(
     meta_peer_client: &MetaPeerClientRef,
-    lease_secs: u64,
+    lease: Duration,
 ) -> Result<Vec<Peer>> {
     let range_request =
         RangeRequest::new().with_prefix(NodeInfoKey::key_prefix_with_role(ClusterRole::Frontend));
 
     let response = meta_peer_client.range(range_request).await?;
-    let lease_filter = build_lease_filter(lease_secs);
+    let lease_filter = build_lease_filter(lease);
 
     let mut peers = Vec::with_capacity(response.kvs.len());
     for kv in response.kvs {
@@ -241,7 +242,7 @@ pub async fn lookup_frontends(
 /// Find all alive flownodes
 pub fn alive_flownodes(
     meta_peer_client: &MetaPeerClientRef,
-    lease_secs: u64,
+    lease_secs: Duration,
 ) -> LeaseFilter<'_, FlownodeLeaseKey> {
     LeaseFilter::new(
         lease_secs,
@@ -294,14 +295,14 @@ impl MetaPeerLookupService {
 #[async_trait::async_trait]
 impl PeerLookupService for MetaPeerLookupService {
     async fn datanode(&self, id: DatanodeId) -> common_meta::error::Result<Option<Peer>> {
-        lookup_datanode_peer(id, &self.meta_peer_client, u64::MAX)
+        lookup_datanode_peer(id, &self.meta_peer_client, Duration::from_secs(u64::MAX))
             .await
             .map_err(BoxedError::new)
             .context(common_meta::error::ExternalSnafu)
     }
 
     async fn flownode(&self, id: FlownodeId) -> common_meta::error::Result<Option<Peer>> {
-        lookup_flownode_peer(id, &self.meta_peer_client, u64::MAX)
+        lookup_flownode_peer(id, &self.meta_peer_client, Duration::from_secs(u64::MAX))
             .await
             .map_err(BoxedError::new)
             .context(common_meta::error::ExternalSnafu)
@@ -312,7 +313,7 @@ impl PeerLookupService for MetaPeerLookupService {
         lookup_frontends(
             &self.meta_peer_client,
             // TODO(zyy17): How to get the heartbeat interval of the frontend if it uses a custom heartbeat interval?
-            FRONTEND_HEARTBEAT_INTERVAL_MILLIS,
+            Duration::from_millis(FRONTEND_HEARTBEAT_INTERVAL_MILLIS),
         )
         .await
         .map_err(BoxedError::new)
@@ -322,6 +323,8 @@ impl PeerLookupService for MetaPeerLookupService {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use api::v1::meta::heartbeat_request::NodeWorkloads;
     use api::v1::meta::DatanodeWorkloads;
     use common_meta::cluster::{FrontendStatus, NodeInfo, NodeInfoKey, NodeStatus};
@@ -380,7 +383,9 @@ mod tests {
             }),
         };
         put_lease_value(&in_memory, key.clone(), value.clone()).await;
-        let leases = alive_datanodes(&client, lease_secs as u64).await.unwrap();
+        let leases = alive_datanodes(&client, Duration::from_secs(lease_secs as u64))
+            .await
+            .unwrap();
         assert_eq!(leases.len(), 1);
         assert_eq!(leases.get(&key), Some(&value));
     }
@@ -436,7 +441,7 @@ mod tests {
         };
         put_lease_value(&in_memory, key, value).await;
 
-        let leases = alive_datanodes(&client, lease_secs as u64)
+        let leases = alive_datanodes(&client, Duration::from_secs(lease_secs))
             .with_condition(is_datanode_accept_ingest_workload)
             .await
             .unwrap();
@@ -494,7 +499,9 @@ mod tests {
             .await
             .unwrap();
 
-        let peers = lookup_frontends(&client, lease_secs as u64).await.unwrap();
+        let peers = lookup_frontends(&client, Duration::from_secs(lease_secs))
+            .await
+            .unwrap();
 
         assert_eq!(peers.len(), 1);
         assert_eq!(peers[0].id, 0);

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -688,7 +688,7 @@ impl Metasrv {
         lookup_datanode_peer(
             peer_id,
             &self.meta_peer_client,
-            distributed_time_constants::DATANODE_LEASE_SECS,
+            Duration::from_secs(distributed_time_constants::DATANODE_LEASE_SECS),
         )
         .await
     }

--- a/src/meta-srv/src/selector/lease_based.rs
+++ b/src/meta-srv/src/selector/lease_based.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::time::Duration;
 
 use common_meta::peer::Peer;
 
@@ -51,9 +52,12 @@ impl Selector for LeaseBasedSelector {
 
     async fn select(&self, ctx: &Self::Context, opts: SelectorOptions) -> Result<Self::Output> {
         // 1. get alive datanodes.
-        let lease_kvs = lease::alive_datanodes(&ctx.meta_peer_client, ctx.datanode_lease_secs)
-            .with_condition(lease::is_datanode_accept_ingest_workload)
-            .await?;
+        let lease_kvs = lease::alive_datanodes(
+            &ctx.meta_peer_client,
+            Duration::from_secs(ctx.datanode_lease_secs),
+        )
+        .with_condition(lease::is_datanode_accept_ingest_workload)
+        .await?;
 
         // 2. compute weight array, but the weight of each item is the same.
         let mut weight_array = lease_kvs

--- a/src/meta-srv/src/selector/load_based.rs
+++ b/src/meta-srv/src/selector/load_based.rs
@@ -14,6 +14,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::Duration;
 
 use common_meta::datanode::{DatanodeStatKey, DatanodeStatValue};
 use common_meta::key::TableMetadataManager;
@@ -66,9 +67,12 @@ where
 
     async fn select(&self, ctx: &Self::Context, opts: SelectorOptions) -> Result<Self::Output> {
         // 1. get alive datanodes.
-        let lease_kvs = lease::alive_datanodes(&ctx.meta_peer_client, ctx.datanode_lease_secs)
-            .with_condition(lease::is_datanode_accept_ingest_workload)
-            .await?;
+        let lease_kvs = lease::alive_datanodes(
+            &ctx.meta_peer_client,
+            Duration::from_secs(ctx.datanode_lease_secs),
+        )
+        .with_condition(lease::is_datanode_accept_ingest_workload)
+        .await?;
 
         // 2. get stat kvs and filter out expired datanodes.
         let stat_keys = lease_kvs.keys().map(|k| k.into()).collect();

--- a/src/meta-srv/src/selector/round_robin.rs
+++ b/src/meta-srv/src/selector/round_robin.rs
@@ -15,6 +15,7 @@
 use std::collections::HashSet;
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
+use std::time::Duration;
 
 use common_meta::peer::Peer;
 use snafu::ensure;
@@ -61,10 +62,12 @@ impl RoundRobinSelector {
         let mut peers = match self.select_target {
             SelectTarget::Datanode => {
                 // 1. get alive datanodes.
-                let lease_kvs =
-                    lease::alive_datanodes(&ctx.meta_peer_client, ctx.datanode_lease_secs)
-                        .with_condition(lease::is_datanode_accept_ingest_workload)
-                        .await?;
+                let lease_kvs = lease::alive_datanodes(
+                    &ctx.meta_peer_client,
+                    Duration::from_secs(ctx.datanode_lease_secs),
+                )
+                .with_condition(lease::is_datanode_accept_ingest_workload)
+                .await?;
 
                 let mut exclude_peer_ids = self
                     .node_excluder
@@ -82,8 +85,11 @@ impl RoundRobinSelector {
             }
             SelectTarget::Flownode => {
                 // 1. get alive flownodes.
-                let lease_kvs =
-                    lease::alive_flownodes(&ctx.meta_peer_client, ctx.flownode_lease_secs).await?;
+                let lease_kvs = lease::alive_flownodes(
+                    &ctx.meta_peer_client,
+                    Duration::from_secs(ctx.flownode_lease_secs),
+                )
+                .await?;
 
                 // 2. map into peers
                 lease_kvs

--- a/src/meta-srv/src/service/admin/node_lease.rs
+++ b/src/meta-srv/src/service/admin/node_lease.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
@@ -37,7 +38,8 @@ impl HttpHandler for NodeLeaseHandler {
         _: http::Method,
         _: &HashMap<String, String>,
     ) -> Result<http::Response<String>> {
-        let leases = lease::alive_datanodes(&self.meta_peer_client, u64::MAX).await?;
+        let leases =
+            lease::alive_datanodes(&self.meta_peer_client, Duration::from_secs(u64::MAX)).await?;
         let leases = leases
             .into_iter()
             .map(|(k, v)| HumanLease {

--- a/tests-integration/src/cluster.rs
+++ b/tests-integration/src/cluster.rs
@@ -316,10 +316,11 @@ impl GreptimeDbClusterBuilder {
         expected_datanodes: usize,
     ) {
         for _ in 0..100 {
-            let alive_datanodes = meta_srv::lease::alive_datanodes(meta_peer_client, u64::MAX)
-                .await
-                .unwrap()
-                .len();
+            let alive_datanodes =
+                meta_srv::lease::alive_datanodes(meta_peer_client, Duration::from_secs(u64::MAX))
+                    .await
+                    .unwrap()
+                    .len();
             if alive_datanodes == expected_datanodes {
                 return;
             }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR fixes a time unit mismatch bug in the `lookup_frontends` function. The function was accepting `lease_secs: u64` parameter (expecting seconds), but the caller was passing `FRONTEND_HEARTBEAT_INTERVAL_MILLIS`.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
