### PR TITLE
perf(metric-engine)!: tsid generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2912,7 +2912,7 @@ dependencies = [
  "cast",
  "ciborium",
  "clap 3.2.25",
- "criterion-plot",
+ "criterion-plot 0.5.0",
  "futures",
  "itertools 0.10.5",
  "lazy_static",
@@ -2939,7 +2939,7 @@ dependencies = [
  "cast",
  "ciborium",
  "clap 4.5.40",
- "criterion-plot",
+ "criterion-plot 0.5.0",
  "is-terminal",
  "itertools 0.10.5",
  "num-traits",
@@ -2956,6 +2956,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap 4.5.40",
+ "criterion-plot 0.6.0",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
 name = "criterion-plot"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2963,6 +2986,16 @@ checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools 0.10.5",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -7433,6 +7466,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.22.1",
+ "bytes",
  "common-base",
  "common-error",
  "common-macro",
@@ -7443,9 +7477,11 @@ dependencies = [
  "common-telemetry",
  "common-test-util",
  "common-time",
+ "criterion 0.7.0",
  "datafusion",
  "datatypes",
  "futures-util",
+ "fxhash",
  "humantime-serde",
  "itertools 0.14.0",
  "lazy_static",
@@ -7455,6 +7491,7 @@ dependencies = [
  "mur3",
  "object-store",
  "prometheus",
+ "prost 0.13.5",
  "serde",
  "serde_json",
  "smallvec",

--- a/src/metric-engine/Cargo.toml
+++ b/src/metric-engine/Cargo.toml
@@ -7,12 +7,17 @@ license.workspace = true
 [lints]
 workspace = true
 
+[features]
+default = []
+testing = []
+
 [dependencies]
 api.workspace = true
 aquamarine.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
 base64.workspace = true
+bytes.workspace = true
 common-base.workspace = true
 common-error.workspace = true
 common-macro.workspace = true
@@ -24,13 +29,13 @@ common-time.workspace = true
 datafusion.workspace = true
 datatypes.workspace = true
 futures-util.workspace = true
+fxhash = "0.2"
 humantime-serde.workspace = true
 itertools.workspace = true
 lazy_static = "1.4"
 mito-codec.workspace = true
 mito2.workspace = true
 moka.workspace = true
-mur3 = "0.1"
 object-store.workspace = true
 prometheus.workspace = true
 serde.workspace = true
@@ -44,4 +49,12 @@ tracing.workspace = true
 [dev-dependencies]
 common-meta = { workspace = true, features = ["testing"] }
 common-test-util.workspace = true
+criterion = "0.7"
 mito2 = { workspace = true, features = ["test"] }
+mur3 = "0.1"
+prost.workspace = true
+
+[[bench]]
+name = "bench_tsid_generator"
+harness = false
+required-features = ["testing"]

--- a/src/metric-engine/benches/bench_tsid_generator.rs
+++ b/src/metric-engine/benches/bench_tsid_generator.rs
@@ -1,0 +1,107 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::hint::black_box;
+
+use api::prom_store::remote::WriteRequest;
+use bytes::Bytes;
+use criterion::{criterion_group, criterion_main, Criterion};
+use metric_engine::row_modifier::{FxHashTsidGenerator, TsidGenerator};
+use prost::Message;
+
+type Mur3HashGenerator = TsidGenerator<mur3::Hasher128>;
+
+const TSID_HASH_SEED: u32 = 846793005;
+
+#[allow(clippy::type_complexity)]
+fn prepare_labels() -> (Vec<(String, String)>, Vec<(Bytes, Bytes)>) {
+    let mut d = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    d.push("..");
+    d.push("servers");
+    d.push("benches");
+    d.push("write_request.pb.data");
+    let data = std::fs::read(d).unwrap();
+    let request = WriteRequest::decode(&*data).unwrap();
+    let bytes_labels = request
+        .timeseries
+        .iter()
+        .flat_map(|t| {
+            t.labels.iter().map(|c| {
+                (
+                    Bytes::copy_from_slice(c.name.as_bytes()),
+                    Bytes::copy_from_slice(c.value.as_bytes()),
+                )
+            })
+        })
+        .collect::<Vec<_>>();
+    let string_labels = request
+        .timeseries
+        .into_iter()
+        .flat_map(|t| t.labels.into_iter().map(|c| (c.name, c.value)))
+        .collect::<Vec<_>>();
+
+    (string_labels, bytes_labels)
+}
+
+fn encode_ts_id(c: &mut Criterion) {
+    let (strings, bytes) = prepare_labels();
+
+    let mut group = c.benchmark_group("encode_ts_id");
+    group.bench_function("mur3-string", |b| {
+        b.iter(|| {
+            let mut generator =
+                Mur3HashGenerator::with_hasher(mur3::Hasher128::with_seed(TSID_HASH_SEED));
+            for (k, v) in &strings {
+                generator.write_label(k, v);
+            }
+            black_box(generator.finish());
+        });
+    });
+
+    group.bench_function("mur3-bytes", |b| {
+        b.iter(|| {
+            let mut generator =
+                Mur3HashGenerator::with_hasher(mur3::Hasher128::with_seed(TSID_HASH_SEED));
+            for (k, v) in &bytes {
+                generator.write_label_bytes(k, v);
+            }
+            black_box(generator.finish());
+        });
+    });
+
+    group.bench_function("fxhash-string", |b| {
+        b.iter(|| {
+            let mut generator = FxHashTsidGenerator::default();
+            for (k, v) in &strings {
+                generator.write_label(k, v);
+            }
+            black_box(generator.finish());
+        });
+    });
+
+    group.bench_function("fxhash-bytes", |b| {
+        b.iter(|| {
+            let mut generator = FxHashTsidGenerator::default();
+            for (k, v) in &bytes {
+                generator.write_label_bytes(k, v);
+            }
+            black_box(generator.finish());
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, encode_ts_id);
+criterion_main!(benches);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Optimize `TsidGenerator` by replacing murmur hash with fxhash to achieve 2x performance boost in typical prometheus remote write cases.

## Security Concerns

fxhash is vulnerable to deliberately constructed collision keys which may cause outage in DoS cases. But for Prometheus remote write cases the input comes from intranet. For observability cloud services we should be able to customize hash algorithms which is left open to discussions.

## Compatiblity

This will change the time-series ordering because the tsid value for the same label values combination is changed, so this is a breaking change.


## Benchmarks

```
$ cargo bench -p metric-engine -F testing --bench bench_tsid_generator

encode_ts_id/mur3-string
                        time:   [93.603 µs 93.952 µs 94.349 µs]
                        change: [+0.8519% +1.3230% +1.7482%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)

encode_ts_id/mur3-bytes time:   [94.322 µs 94.983 µs 95.766 µs]
                        change: [+3.7723% +4.2515% +4.7567%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 16 outliers among 100 measurements (16.00%)

encode_ts_id/fxhash-string
                        time:   [42.574 µs 42.597 µs 42.626 µs]
                        change: [+0.0728% +0.1195% +0.1669%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)

encode_ts_id/fxhash-bytes
                        time:   [42.765 µs 42.801 µs 42.847 µs]
                        change: [−0.0912% −0.0219% +0.0477%] (p = 0.55 > 0.05)
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
```

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
