### PR TITLE
feat: only show prometheus logical tables for __name__ values query

### DIFF
--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -47,7 +47,7 @@ use serde_json::Value;
 use session::context::{QueryContext, QueryContextRef};
 use snafu::{Location, OptionExt, ResultExt};
 use store_api::metric_engine_consts::{
-    DATA_SCHEMA_TABLE_ID_COLUMN_NAME, DATA_SCHEMA_TSID_COLUMN_NAME, PHYSICAL_TABLE_METADATA_KEY,
+    DATA_SCHEMA_TABLE_ID_COLUMN_NAME, DATA_SCHEMA_TSID_COLUMN_NAME, LOGICAL_TABLE_METADATA_KEY,
 };
 
 pub use super::result::prometheus_resp::PrometheusJsonResponse;
@@ -1143,13 +1143,14 @@ async fn retrieve_table_names(
 
     while let Some(table) = tables_stream.next().await {
         let table = table.context(CatalogSnafu)?;
-        if table
+        if !table
             .table_info()
             .meta
             .options
             .extra_options
-            .contains_key(PHYSICAL_TABLE_METADATA_KEY)
+            .contains_key(LOGICAL_TABLE_METADATA_KEY)
         {
+            // skip non-prometheus (non-metricengine) tables for __name__ query
             continue;
         }
 

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -1109,9 +1109,7 @@ pub async fn test_prom_http_api(store_type: StorageType) {
             "demo_metrics",
             "demo_metrics_with_nanos",
             "logic_table",
-            "mito",
             "multi_labels",
-            "numbers"
         ]))
         .unwrap()
     );


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Previously we removes physical table for `__name__` values query, this patch further update the logical to retain logical tables only. 

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
