### PR TITLE
feat: functions and structs to scan flat format file and mem ranges

### DIFF
--- a/src/mito2/src/read/prune.rs
+++ b/src/mito2/src/read/prune.rs
@@ -19,6 +19,7 @@ use common_recordbatch::filter::SimpleFilterEvaluator;
 use common_time::Timestamp;
 use datatypes::arrow::array::BooleanArray;
 use datatypes::arrow::buffer::BooleanBuffer;
+use datatypes::arrow::record_batch::RecordBatch;
 use snafu::ResultExt;
 
 use crate::error::{RecordBatchSnafu, Result};
@@ -27,7 +28,7 @@ use crate::read::last_row::RowGroupLastRowCachedReader;
 use crate::read::{Batch, BatchReader};
 use crate::sst::file::FileTimeRange;
 use crate::sst::parquet::file_range::FileRangeContextRef;
-use crate::sst::parquet::reader::{ReaderMetrics, RowGroupReader};
+use crate::sst::parquet::reader::{FlatRowGroupReader, ReaderMetrics, RowGroupReader};
 
 pub enum Source {
     RowGroup(RowGroupReader),
@@ -235,6 +236,94 @@ impl Iterator for PruneTimeIterator {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.next_non_empty_batch().transpose()
+    }
+}
+
+pub enum FlatSource {
+    RowGroup(FlatRowGroupReader),
+}
+
+impl FlatSource {
+    fn next_batch(&mut self) -> Result<Option<RecordBatch>> {
+        match self {
+            FlatSource::RowGroup(r) => r.next_batch(),
+        }
+    }
+}
+
+/// A flat format reader that returns RecordBatch instead of Batch.
+pub struct FlatPruneReader {
+    /// Context for file ranges.
+    context: FileRangeContextRef,
+    source: FlatSource,
+    metrics: ReaderMetrics,
+}
+
+impl FlatPruneReader {
+    pub(crate) fn new_with_row_group_reader(
+        ctx: FileRangeContextRef,
+        reader: FlatRowGroupReader,
+    ) -> Self {
+        Self {
+            context: ctx,
+            source: FlatSource::RowGroup(reader),
+            metrics: Default::default(),
+        }
+    }
+
+    /// Merge metrics with the inner reader and return the merged metrics.
+    pub(crate) fn metrics(&self) -> ReaderMetrics {
+        // FlatRowGroupReader doesn't collect metrics, so just return our own
+        self.metrics.clone()
+    }
+
+    pub(crate) fn next_batch(&mut self) -> Result<Option<RecordBatch>> {
+        while let Some(record_batch) = {
+            let start = std::time::Instant::now();
+            let batch = self.source.next_batch()?;
+            self.metrics.scan_cost += start.elapsed();
+            batch
+        } {
+            // Update metrics for the received batch
+            self.metrics.num_rows += record_batch.num_rows();
+            self.metrics.num_batches += 1;
+
+            match self.prune_flat(record_batch)? {
+                Some(filtered_batch) => {
+                    return Ok(Some(filtered_batch));
+                }
+                None => {
+                    continue;
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Prunes batches by the pushed down predicate and returns RecordBatch.
+    fn prune_flat(&mut self, record_batch: RecordBatch) -> Result<Option<RecordBatch>> {
+        // fast path
+        if self.context.filters().is_empty() {
+            return Ok(Some(record_batch));
+        }
+
+        let num_rows_before_filter = record_batch.num_rows();
+        let Some(filtered_batch) = self.context.precise_filter_flat(record_batch)? else {
+            // the entire batch is filtered out
+            self.metrics.filter_metrics.rows_precise_filtered += num_rows_before_filter;
+            return Ok(None);
+        };
+
+        // update metric
+        let filtered_rows = num_rows_before_filter - filtered_batch.num_rows();
+        self.metrics.filter_metrics.rows_precise_filtered += filtered_rows;
+
+        if filtered_batch.num_rows() > 0 {
+            Ok(Some(filtered_batch))
+        } else {
+            Ok(None)
+        }
     }
 }
 

--- a/src/mito2/src/read/scan_util.rs
+++ b/src/mito2/src/read/scan_util.rs
@@ -35,7 +35,7 @@ use crate::metrics::{
 };
 use crate::read::range::{RangeBuilderList, RowGroupIndex};
 use crate::read::scan_region::StreamContext;
-use crate::read::{Batch, BoxedBatchStream, ScannerMetrics, Source};
+use crate::read::{Batch, BoxedBatchStream, BoxedRecordBatchStream, ScannerMetrics, Source};
 use crate::sst::file::FileTimeRange;
 use crate::sst::parquet::file_range::FileRange;
 use crate::sst::parquet::reader::{ReaderFilterMetrics, ReaderMetrics};
@@ -841,4 +841,20 @@ pub(crate) async fn maybe_scan_other_ranges(
         }
         .fail()
     }
+}
+
+#[allow(dead_code)]
+pub(crate) async fn maybe_scan_flat_other_ranges(
+    context: &Arc<StreamContext>,
+    index: RowGroupIndex,
+    metrics: &PartitionMetrics,
+) -> Result<BoxedRecordBatchStream> {
+    let _ = context;
+    let _ = index;
+    let _ = metrics;
+
+    crate::error::UnexpectedSnafu {
+        reason: "no other ranges scannable in flat format",
+    }
+    .fail()
 }

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -1372,7 +1372,7 @@ impl FlatRowGroupReader {
                     &self.override_sequence,
                 ) {
                     let converted =
-                        flat_format.convert_batch(&record_batch, Some(override_array))?;
+                        flat_format.convert_batch(record_batch, Some(override_array))?;
                     return Ok(Some(converted));
                 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
- https://github.com/GreptimeTeam/greptimedb/issues/6505
- https://github.com/GreptimeTeam/greptimedb/issues/6078

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

Adds some utilities for implementing scanners
- scan_flat_mem_ranges
- scan_flat_file_ranges

Adds the following method to the IterBuilder trait:
- is_record_batch
- build_record_batch_iter

Implements `FlatPruneReader` to filter record batches and `FlatRowGroupReader` to read and convert batches in a row group.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
