### PR TITLE
feat: rename `region_statistics` to `region_statistics_history`

### DIFF
--- a/src/meta-srv/src/handler/persist_stats_handler.rs
+++ b/src/meta-srv/src/handler/persist_stats_handler.rs
@@ -41,7 +41,7 @@ pub struct PersistStatsHandler {
 }
 
 /// The name of the table to persist region stats.
-const META_REGION_STATS_TABLE_NAME: &str = "region_statistics";
+const META_REGION_STATS_HISTORY_TABLE_NAME: &str = "region_statistics_history";
 /// The default context to persist region stats.
 const DEFAULT_CONTEXT: InserterContext = InserterContext {
     catalog: DEFAULT_CATALOG_NAME,
@@ -207,7 +207,7 @@ impl PersistStatsHandler {
                 &DEFAULT_CONTEXT,
                 RowInsertRequests {
                     inserts: vec![RowInsertRequest {
-                        table_name: META_REGION_STATS_TABLE_NAME.to_string(),
+                        table_name: META_REGION_STATS_HISTORY_TABLE_NAME.to_string(),
                         rows: Some(Rows {
                             schema: PersistRegionStat::schema(),
                             rows,
@@ -532,7 +532,10 @@ mod tests {
             assert_eq!(requests.len(), 1);
             requests.pop().unwrap()
         };
-        assert_eq!(request.table_name, META_REGION_STATS_TABLE_NAME.to_string());
+        assert_eq!(
+            request.table_name,
+            META_REGION_STATS_HISTORY_TABLE_NAME.to_string()
+        );
         assert_eq!(request.rows.unwrap().rows, vec![expected_row]);
 
         // Check last persisted time


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#6721 
## What's changed and what's your intention?

rename `region_statistics` to `region_statistics_history`

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
