### PR TITLE
chore: add server-side error logging to improve observability in gRPC

### DIFF
--- a/src/common/error/src/status_code.rs
+++ b/src/common/error/src/status_code.rs
@@ -290,6 +290,8 @@ macro_rules! define_into_tonic_status {
                 use tonic::metadata::MetadataMap;
                 use $crate::GREPTIME_DB_HEADER_ERROR_CODE;
 
+                common_telemetry::error!(err; "Failed to handle request");
+
                 let mut headers = HeaderMap::<HeaderValue>::with_capacity(2);
 
                 // If either of the status_code or error msg cannot convert to valid HTTP header value


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Internal errors are by design discarded on the server side when converting to gRPC status responses. This results in clients only seeing generic "internal error" messages without specific details about what went wrong, making debugging and troubleshooting difficult.

This PR adds error logging in the `define_into_tonic_status` macro to capture detailed error information on the server side before the error details are stripped for the client response.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
