### PR TITLE
refactor: add stop methods for `LocalFilePurger` and `CompactionRegion`

### DIFF
--- a/src/mito2/src/compaction/compactor.rs
+++ b/src/mito2/src/compaction/compactor.rs
@@ -247,10 +247,10 @@ impl CompactionRegion {
         self.file_purger.clone()
     }
 
-    /// Stop the file purger of the compaction region.
-    pub async fn stop_file_purger(&self) -> Result<()> {
+    /// Stop the file purger scheduler of the compaction region.
+    pub async fn stop_purger_scheduler(&self) -> Result<()> {
         if let Some(file_purger) = &self.file_purger {
-            file_purger.stop().await
+            file_purger.stop_scheduler().await
         } else {
             Ok(())
         }

--- a/src/mito2/src/compaction/compactor.rs
+++ b/src/mito2/src/compaction/compactor.rs
@@ -242,8 +242,18 @@ pub async fn open_compaction_region(
 }
 
 impl CompactionRegion {
+    /// Get the file purger of the compaction region.
     pub fn file_purger(&self) -> Option<Arc<LocalFilePurger>> {
         self.file_purger.clone()
+    }
+
+    /// Stop the file purger of the compaction region.
+    pub async fn stop_file_purger(&self) -> Result<()> {
+        if let Some(file_purger) = &self.file_purger {
+            file_purger.stop().await
+        } else {
+            Ok(())
+        }
     }
 }
 

--- a/src/mito2/src/sst/file_purger.rs
+++ b/src/mito2/src/sst/file_purger.rs
@@ -79,7 +79,7 @@ impl LocalFilePurger {
     }
 
     /// Stop the scheduler of the file purger.
-    pub async fn stop(&self) -> Result<()> {
+    pub async fn stop_scheduler(&self) -> Result<()> {
         self.scheduler.stop(true).await
     }
 }

--- a/src/mito2/src/sst/file_purger.rs
+++ b/src/mito2/src/sst/file_purger.rs
@@ -20,6 +20,7 @@ use common_telemetry::{error, info};
 use crate::access_layer::AccessLayerRef;
 use crate::cache::file_cache::{FileType, IndexKey};
 use crate::cache::CacheManagerRef;
+use crate::error::Result;
 use crate::schedule::scheduler::SchedulerRef;
 use crate::sst::file::FileMeta;
 
@@ -75,6 +76,11 @@ impl LocalFilePurger {
             sst_layer,
             cache_manager,
         }
+    }
+
+    /// Stop the scheduler of the file purger.
+    pub async fn stop(&self) -> Result<()> {
+        self.scheduler.stop(true).await
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

1. Add `stop()` for `LocalFilePurger`;
2. Add `stop_file_purger()` for `CompactionRegion` by using `stop()` of `LocalFilePurger`

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
