### PR TITLE
feat(copy): add DATE_FORMAT / DATETIME_FORMAT / TIMESTAMP_FORMAT supp…

### DIFF
--- a/src/common/datasource/src/file_format.rs
+++ b/src/common/datasource/src/file_format.rs
@@ -55,7 +55,11 @@ pub const FORMAT_HAS_HEADER: &str = "has_header";
 pub const FORMAT_TYPE: &str = "format";
 pub const FILE_PATTERN: &str = "pattern";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub const FORMAT_DATE: &str = "date_format";
+pub const FORMAT_DATETIME: &str = "datetime_format";
+pub const FORMAT_TIMESTAMP: &str = "timestamp_format";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Format {
     Csv(CsvFormat),
     Json(JsonFormat),

--- a/src/common/datasource/src/test_util.rs
+++ b/src/common/datasource/src/test_util.rs
@@ -27,7 +27,7 @@ use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
 use object_store::services::Fs;
 use object_store::ObjectStore;
 
-use crate::file_format::csv::stream_to_csv;
+use crate::file_format::csv::{stream_to_csv, CsvFormat};
 use crate::file_format::json::stream_to_json;
 use crate::test_util;
 
@@ -152,6 +152,7 @@ pub async fn setup_stream_to_csv_test(origin_path: &str, threshold: impl Fn(usiz
         Box::pin(stream),
         tmp_store.clone(),
         &output_path,
+        &CsvFormat::default(),
         threshold(size),
         8
     )

--- a/src/operator/src/statement/copy_table_from.rs
+++ b/src/operator/src/statement/copy_table_from.rs
@@ -386,7 +386,7 @@ impl StatementExecutor {
             }
             let path = entry.path();
             let file_metadata = self
-                .collect_metadata(&object_store, format, path.to_string())
+                .collect_metadata(&object_store, format.clone(), path.to_string())
                 .await?;
 
             let file_schema = file_metadata.schema();

--- a/src/operator/src/statement/copy_table_to.rs
+++ b/src/operator/src/statement/copy_table_to.rs
@@ -66,10 +66,11 @@ impl StatementExecutor {
             map_json_type_to_string_schema,
         ));
         match format {
-            Format::Csv(_) => stream_to_csv(
+            Format::Csv(format) => stream_to_csv(
                 Box::pin(DfRecordBatchStreamAdapter::new(stream)),
                 object_store,
                 path,
+                format,
                 threshold,
                 WRITE_CONCURRENCY,
             )
@@ -96,7 +97,10 @@ impl StatementExecutor {
                 .await
                 .context(error::WriteStreamToFileSnafu { path })
             }
-            _ => error::UnsupportedFormatSnafu { format: *format }.fail(),
+            _ => error::UnsupportedFormatSnafu {
+                format: format.clone(),
+            }
+            .fail(),
         }
     }
 


### PR DESCRIPTION
…ort for CSV (draft)

I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
- Issue: #6287 

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

**Summary (mandatory):**  
This PR introduces support for temporal formatting options (`DATE_FORMAT`, `DATETIME_FORMAT`, `TIMESTAMP_FORMAT`) in the `COPY TO` statement for CSV exports.  

**Details:**  
- Added parsing of the new `WITH` options into `CsvFormat`.
- Forwarded these options to the Arrow CSV writer, enabling custom formatting of date/datetime/timestamp columns during export.
- Currently implemented only for CSV. JSON and Parquet are untouched.  

**Limitations / Open Questions:**  
1. **Validation**: Chrono patterns need validation. Existing `to_date` / `to_char` functions already handle this; we may want to reuse that logic.  
2. **JSON format**: Arrow’s JSON writer does not currently support custom temporal formatting. Should we raise an error, ignore the option, or implement a fallback?  
3. **Datetime vs Timestamp**: The current design keeps both options (`DATETIME_FORMAT` and `TIMESTAMP_FORMAT`), but their distinction might need clarification (especially since Arrow internally treats datetime as timestamp).  



## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
