### PR TITLE
fix: use configured kv_client in etcd multi-transaction operations

### DIFF
--- a/src/common/meta/src/kv_backend/etcd.rs
+++ b/src/common/meta/src/kv_backend/etcd.rs
@@ -100,7 +100,7 @@ impl EtcdStore {
                     .with_label_values(&["etcd", "txn"])
                     .start_timer();
                 let txn = Txn::new().and_then(part);
-                self.client.kv_client().txn(txn).await
+                self.kv_client().txn(txn).await
             })
             .collect::<Vec<_>>();
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)


## What's changed and what's your intention?

Fix etcd client usage to properly apply max decoding message size configuration in multi-transaction operations. Follow up of #6859

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
