### PR TITLE
fix: ignore reserved column IDs and prevent panic on chunk_size is zero

### DIFF
--- a/src/meta-srv/src/region/flush_trigger.rs
+++ b/src/meta-srv/src/region/flush_trigger.rs
@@ -225,10 +225,6 @@ impl RegionFlushTrigger {
         region_ids: &[RegionId],
         leader_regions: &HashMap<RegionId, LeaderRegion>,
     ) -> Result<()> {
-        if region_ids.is_empty() {
-            return Ok(());
-        }
-
         let regions = region_ids
             .iter()
             .flat_map(|region_id| match leader_regions.get(region_id) {
@@ -247,6 +243,11 @@ impl RegionFlushTrigger {
                 None => None,
             })
             .collect::<Vec<_>>();
+
+        // The`chunks` will panic if chunks_size is zero, so we return early if there are no regions to persist.
+        if regions.is_empty() {
+            return Ok(());
+        }
 
         let max_txn_ops = self.table_metadata_manager.kv_backend().max_txn_ops();
         let batch_size = max_txn_ops.min(regions.len());


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR contains two bug fixes:
- Ignore Reserved Column IDs: Modified `build_table_meta_from_column_metadatas` to filter out reserved column IDs when calculating the next column ID
- Fix Panic on Empty Regions: Moved the empty check in `RegionFlushTrigger::persist_leader_regions` to prevent panic when chunks() is called on an empty list

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
