### PR TITLE
chore(breaking): change dispatch table name format

### DIFF
--- a/src/pipeline/src/etl.rs
+++ b/src/pipeline/src/etl.rs
@@ -218,7 +218,7 @@ impl From<&Rule> for DispatchedTo {
 impl DispatchedTo {
     /// Generate destination table name from input
     pub fn dispatched_to_table_name(&self, original: &str) -> String {
-        format!("{}_{}", &original, self.table_suffix)
+        [original, &self.table_suffix].concat()
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

* To unify table naming conventions, the table naming rules for pipeline dispatch have been modified.

**THIS PR IS A BREAKING CHANGE**

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
