### PR TITLE
fix: wrap tql cte in a subquery alias

### DIFF
--- a/src/query/src/planner.rs
+++ b/src/query/src/planner.rs
@@ -282,6 +282,16 @@ impl DfLogicalPlanner {
                             .build()
                             .context(PlanSqlSnafu)?;
                     }
+
+                    // Wrap in SubqueryAlias to ensure proper table qualification for CTE
+                    logical_plan = LogicalPlan::SubqueryAlias(
+                        datafusion_expr::SubqueryAlias::try_new(
+                            Arc::new(logical_plan),
+                            cte.name.value.clone(),
+                        )
+                        .context(PlanSqlSnafu)?,
+                    );
+
                     planner_context.insert_cte(&cte.name.value, logical_plan);
                 }
                 CteContent::Sql(_) => {

--- a/tests/cases/standalone/common/tql/tql-cte.result
+++ b/tests/cases/standalone/common/tql/tql-cte.result
@@ -109,6 +109,22 @@ SELECT count(*) as host1_points FROM host_metrics;
 | 5            |
 +--------------+
 
+-- TQL CTE with column reference
+WITH host_metrics AS (
+    TQL EVAL (0, 40, '10s') labels{host="host1"}
+)
+SELECT host_metrics.ts, host_metrics.host FROM host_metrics;
+
++---------------------+-------+
+| ts                  | host  |
++---------------------+-------+
+| 1970-01-01T00:00:00 | host1 |
+| 1970-01-01T00:00:10 | host1 |
+| 1970-01-01T00:00:20 | host1 |
+| 1970-01-01T00:00:30 | host1 |
+| 1970-01-01T00:00:40 | host1 |
++---------------------+-------+
+
 -- Multiple TQL CTEs referencing different tables
 WITH 
     metric_data(ts, val) AS (TQL EVAL (0, 40, '10s') metric),

--- a/tests/cases/standalone/common/tql/tql-cte.sql
+++ b/tests/cases/standalone/common/tql/tql-cte.sql
@@ -56,6 +56,12 @@ WITH host_metrics AS (
 )
 SELECT count(*) as host1_points FROM host_metrics;
 
+-- TQL CTE with column reference
+WITH host_metrics AS (
+    TQL EVAL (0, 40, '10s') labels{host="host1"}
+)
+SELECT host_metrics.ts, host_metrics.host FROM host_metrics;
+
 -- Multiple TQL CTEs referencing different tables
 WITH 
     metric_data(ts, val) AS (TQL EVAL (0, 40, '10s') metric),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

- closes #6906

## What's changed and what's your intention?

wrap them in a subquery alias so they can be referenced using cte name

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
