### PR TITLE
feat: put sqlness into a separated dir

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,7 +2,7 @@
 linker = "aarch64-linux-gnu-gcc"
 
 [alias]
-sqlness = "run --bin sqlness-runner --"
+sqlness = "run --bin sqlness-runner --target-dir target/sqlness --"
 
 [unstable.git]
 shallow_index = true


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

sqlness always recompiles. `ring`'s build script might be the reason. sqlness and greptimedb share the same ring but overlap each other's compile results: `dependency on `build_script_build` is newer than we are 1757023792.664006568s > 1757023474.770973656s`. put sqlness into another dir seems to work for me

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
