### PR TITLE
feat(pipeline): generate create table sql from pipeline config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11572,6 +11572,7 @@ dependencies = [
  "openmetrics-parser",
  "opensrv-mysql",
  "opentelemetry-proto",
+ "operator",
  "otel-arrow-rust",
  "parking_lot 0.12.4",
  "permutation",

--- a/src/operator/src/expr_helper.rs
+++ b/src/operator/src/expr_helper.rs
@@ -241,27 +241,13 @@ pub fn create_to_expr(
     Ok(expr)
 }
 
-/// Convert [`CreateTableExpr`] gRPC request back to `CreateTable` statement.
-///
-/// This function performs the reverse conversion of [`create_to_expr`], taking a gRPC
-/// `CreateTableExpr` and converting it back to a SQL AST `CreateTable` statement.
+/// Convert gRPC's [`CreateTableExpr`] back to `CreateTable` statement.
+/// You can use `create_table_expr_by_column_schemas` to create a `CreateTableExpr` from column schemas.
 ///
 /// # Parameters
 ///
 /// * `expr` - The `CreateTableExpr` to convert
-/// * `quote_style` - Optional quote style for identifiers (defaults to `"`)
-///
-/// # Returns
-///
-/// Returns a `CreateTable` SQL AST node that represents the same table structure
-/// as the input `CreateTableExpr`.
-///
-/// # Note
-///
-/// The conversion may not be 100% identical to the original SQL due to:
-/// - Quote style differences
-/// - Table option normalization (e.g., "3days" -> "3d")
-/// - Primary key representation (always as constraints, not inline)
+/// * `quote_style` - Optional quote style for identifiers (defaults to MySQL style ` backtick)
 pub fn expr_to_create(expr: &CreateTableExpr, quote_style: Option<char>) -> Result<CreateTable> {
     let quote_style = quote_style.unwrap_or('`');
 

--- a/src/pipeline/src/etl.rs
+++ b/src/pipeline/src/etl.rs
@@ -342,6 +342,12 @@ impl Pipeline {
             TransformerMode::AutoTransform(_, _) => None,
         }
     }
+
+    pub fn is_variant_table_name(&self) -> bool {
+        // even if the pipeline doesn't have dispatcher or table_suffix,
+        // it can still be a variant because of VRL processor and hint
+        self.dispatcher.is_some() || self.tablesuffix.is_some()
+    }
 }
 
 pub(crate) fn find_key_index(intermediate_keys: &[String], key: &str, kind: &str) -> Result<usize> {

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -86,6 +86,7 @@ socket2 = "0.5"
 # 2. Use ring, instead of aws-lc-rs in https://github.com/databendlabs/opensrv/pull/72
 opensrv-mysql = { git = "https://github.com/datafuselabs/opensrv", rev = "a1fb4da215c8693c7e4f62be249a01b7fec52997" }
 opentelemetry-proto.workspace = true
+operator.workspace = true
 otel-arrow-rust.workspace = true
 parking_lot.workspace = true
 pgwire = { version = "0.32.1", default-features = false, features = ["server-api-ring"] }

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -1028,6 +1028,10 @@ impl HttpServer {
                 routing::get(event::query_pipeline),
             )
             .route(
+                "/pipelines/{pipeline_name}/create_table",
+                routing::get(event::query_pipeline_create_table),
+            )
+            .route(
                 "/pipelines/{pipeline_name}",
                 routing::post(event::add_pipeline),
             )

--- a/src/servers/src/http/result/greptime_manage_resp.rs
+++ b/src/servers/src/http/result/greptime_manage_resp.rs
@@ -55,6 +55,13 @@ impl GreptimedbManageResponse {
         }
     }
 
+    pub fn from_sql(sql: SqlOutput, execution_time_ms: u64) -> Self {
+        GreptimedbManageResponse {
+            manage_result: ManageResult::Sql { sql },
+            execution_time_ms,
+        }
+    }
+
     pub fn with_execution_time(mut self, execution_time: u64) -> Self {
         self.execution_time_ms = execution_time;
         self
@@ -69,8 +76,7 @@ impl GreptimedbManageResponse {
 #[serde(untagged)]
 pub enum ManageResult {
     Pipelines { pipelines: Vec<PipelineOutput> },
-    // todo(shuiyisong): refactor scripts api
-    Scripts(),
+    Sql { sql: SqlOutput },
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -79,6 +85,13 @@ pub struct PipelineOutput {
     version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pipeline: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SqlOutput {
+    pub(crate) sql: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) message: Option<String>,
 }
 
 impl IntoResponse for GreptimedbManageResponse {

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -124,6 +124,7 @@ macro_rules! http_tests {
                 test_pipeline_2,
                 test_pipeline_skip_error,
                 test_pipeline_filter,
+                test_pipeline_create_table,
 
                 test_otlp_metrics_new,
                 test_otlp_traces_v0,
@@ -2502,6 +2503,98 @@ transform:
         "[[\"Jane\",1716668197328000000]]",
     )
     .await;
+
+    guard.remove_all().await;
+}
+
+pub async fn test_pipeline_create_table(store_type: StorageType) {
+    common_telemetry::init_default_ut_logging();
+    let (app, mut guard) =
+        setup_test_http_app_with_frontend(store_type, "test_pipeline_create_table").await;
+
+    // handshake
+    let client = TestClient::new(app).await;
+
+    let pipeline_body = r#"
+processors:
+- dissect:
+    fields:
+      - message
+    patterns:
+      - '%{ip_address} - %{username} [%{timestamp}] "%{http_method} %{request_line} %{protocol}" %{status_code} %{response_size}'
+    ignore_missing: true
+- date:
+    fields:
+      - timestamp
+    formats:
+      - "%d/%b/%Y:%H:%M:%S %z"
+
+transform:
+  - fields:
+      - timestamp
+    type: time
+    index: timestamp
+  - fields:
+      - ip_address
+    type: string
+    index: skipping
+  - fields:
+      - username
+    type: string
+    tag: true
+  - fields:
+      - http_method
+    type: string
+    index: inverted
+  - fields:
+      - request_line
+    type: string
+    index: fulltext
+  - fields:
+      - protocol
+    type: string
+  - fields:
+      - status_code
+    type: int32
+    index: inverted
+    tag: true
+  - fields:
+      - response_size
+    type: int64
+    on_failure: default
+    default: 0
+  - fields:
+      - message
+    type: string
+"#;
+
+    // 1. create pipeline
+    let res = client
+        .post("/v1/events/pipelines/test")
+        .header("Content-Type", "application/x-yaml")
+        .body(pipeline_body)
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let res = client
+        .get("/v1/pipelines/test/create_table?table=logs1")
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+    let resp: serde_json::Value = res.json().await;
+    let sql = resp
+        .get("sql")
+        .unwrap()
+        .get("sql")
+        .unwrap()
+        .as_str()
+        .unwrap();
+
+    assert_eq!(
+        "CREATE TABLE IF NOT EXISTS `logs1` (\n  `timestamp` TIMESTAMP(9) NOT NULL,\n  `ip_address` STRING NULL SKIPPING INDEX WITH(false_positive_rate = '0.01', granularity = '10240', type = 'BLOOM'),\n  `username` STRING NULL,\n  `http_method` STRING NULL INVERTED INDEX,\n  `request_line` STRING NULL FULLTEXT INDEX WITH(analyzer = 'English', backend = 'bloom', case_sensitive = 'false', false_positive_rate = '0.01', granularity = '10240'),\n  `protocol` STRING NULL,\n  `status_code` INT NULL INVERTED INDEX,\n  `response_size` BIGINT NULL,\n  `message` STRING NULL,\n  TIME INDEX (`timestamp`),\n  PRIMARY KEY (`username`, `status_code`)\n)\nENGINE=mito\nWITH(\n  append_mode = 'true'\n)",
+        sql
+    );
 
     guard.remove_all().await;
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR adds
1. `expr_to_create`: create `CreateTable` using `CreateTableExpr`, which is the opposite of `create_to_expr`
2. `/v1/pipelines/{pipeline_name}/create_table`: generate create table SQL from pipeline's transform config


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
