### PR TITLE
fix: unstable query sort results

### DIFF
--- a/tests/cases/standalone/common/setops/basic_setops.result
+++ b/tests/cases/standalone/common/setops/basic_setops.result
@@ -1,5 +1,5 @@
 -- Migrated from DuckDB test: test/sql/setops/test_setops.test
-SELECT 1 UNION ALL SELECT 2;
+SELECT 1 UNION ALL SELECT 2 ORDER BY 1;
 
 +----------+
 | Int64(1) |
@@ -8,7 +8,7 @@ SELECT 1 UNION ALL SELECT 2;
 | 2        |
 +----------+
 
-SELECT 1, 'a' UNION ALL SELECT 2, 'b';
+SELECT 1, 'a' UNION ALL SELECT 2, 'b' ORDER BY 1;
 
 +----------+-----------+
 | Int64(1) | Utf8("a") |

--- a/tests/cases/standalone/common/setops/basic_setops.sql
+++ b/tests/cases/standalone/common/setops/basic_setops.sql
@@ -1,8 +1,8 @@
 -- Migrated from DuckDB test: test/sql/setops/test_setops.test
 
-SELECT 1 UNION ALL SELECT 2;
+SELECT 1 UNION ALL SELECT 2 ORDER BY 1;
 
-SELECT 1, 'a' UNION ALL SELECT 2, 'b';
+SELECT 1, 'a' UNION ALL SELECT 2, 'b' ORDER BY 1;
 
 SELECT 1, 'a' UNION ALL SELECT 2, 'b' UNION ALL SELECT 3, 'c' ORDER BY 1;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

Fixed unstable query results in `basic_setops.sql`.



## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
