### PR TITLE
fix(path): fix program lookup failure on Windows CI

### DIFF
--- a/tests/runner/src/env.rs
+++ b/tests/runner/src/env.rs
@@ -358,7 +358,7 @@ impl Env {
             "GreptimeDB binary is not available. Please pass in the path to the directory that contains the pre-built GreptimeDB binary. Or you may call `self.build_db()` beforehand.",
         );
 
-        let mut process = Command::new(program)
+        let mut process = Command::new(bins_dir.join(program))
             .current_dir(bins_dir.clone())
             .env("TZ", "UTC")
             .args(args)

--- a/tests/runner/src/env.rs
+++ b/tests/runner/src/env.rs
@@ -358,7 +358,9 @@ impl Env {
             "GreptimeDB binary is not available. Please pass in the path to the directory that contains the pre-built GreptimeDB binary. Or you may call `self.build_db()` beforehand.",
         );
 
-        let mut process = Command::new(bins_dir.join(program))
+        let abs_bins_dir = bins_dir.canonicalize().expect("Failed to canonicalize bins_dir");
+
+        let mut process = Command::new(abs_bins_dir.join(program))
             .current_dir(bins_dir.clone())
             .env("TZ", "UTC")
             .args(args)

--- a/tests/runner/src/env.rs
+++ b/tests/runner/src/env.rs
@@ -358,7 +358,9 @@ impl Env {
             "GreptimeDB binary is not available. Please pass in the path to the directory that contains the pre-built GreptimeDB binary. Or you may call `self.build_db()` beforehand.",
         );
 
-        let abs_bins_dir = bins_dir.canonicalize().expect("Failed to canonicalize bins_dir");
+        let abs_bins_dir = bins_dir
+            .canonicalize()
+            .expect("Failed to canonicalize bins_dir");
 
         let mut process = Command::new(abs_bins_dir.join(program))
             .current_dir(bins_dir.clone())

--- a/tests/runner/src/util.rs
+++ b/tests/runner/src/util.rs
@@ -27,10 +27,7 @@ use tokio_stream::StreamExt;
 /// Check port every 0.1 second.
 const PORT_CHECK_INTERVAL: Duration = Duration::from_millis(100);
 
-#[cfg(not(windows))]
-pub const PROGRAM: &str = "./greptime";
-#[cfg(windows)]
-pub const PROGRAM: &str = "greptime.exe";
+pub const PROGRAM: &str = "greptime";
 
 fn http_proxy() -> Option<String> {
     for proxy in ["http_proxy", "HTTP_PROXY", "all_proxy", "ALL_PROXY"] {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR fixed Nightly CI can't run in Windows operating system, I assume but can't make sure if rust edition was upgrade to 2024 cause this problem, because there not have enough document for it.

Seem like this is an old question of Rust, because document say:

> The search path to be used may be controlled by setting the PATH environment variable on the Command, but this has some implementation limitations on Windows (see issue #37519).

So I am thinking the best solution is using absolute path.

Relates to https://github.com/rust-lang/rust/issues/37519

Relates to https://github.com/GreptimeTeam/greptimedb/commit/c9377e7c5a59eb37fdfc1ef38cd48f611434c262

Nightly CI log link: 
	yesterday: https://github.com/GreptimeTeam/greptimedb/actions/runs/17566553580/job/49894591577
	today: https://github.com/GreptimeTeam/greptimedb/actions/runs/17597977802/job/49994354158

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
