### PR TITLE
chore: bump sequence on region edit

### DIFF
--- a/src/datanode/src/tests.rs
+++ b/src/datanode/src/tests.rs
@@ -252,7 +252,7 @@ impl RegionEngine for MockRegionEngine {
         unimplemented!()
     }
 
-    async fn get_last_seq_num(&self, _: RegionId) -> Result<SequenceNumber, BoxedError> {
+    async fn get_committed_sequence(&self, _: RegionId) -> Result<SequenceNumber, BoxedError> {
         unimplemented!()
     }
 

--- a/src/datanode/src/tests.rs
+++ b/src/datanode/src/tests.rs
@@ -252,7 +252,7 @@ impl RegionEngine for MockRegionEngine {
         unimplemented!()
     }
 
-    async fn get_last_seq_num(&self, _: RegionId) -> Result<Option<SequenceNumber>, BoxedError> {
+    async fn get_last_seq_num(&self, _: RegionId) -> Result<SequenceNumber, BoxedError> {
         unimplemented!()
     }
 

--- a/src/file-engine/src/engine.rs
+++ b/src/file-engine/src/engine.rs
@@ -115,8 +115,8 @@ impl RegionEngine for FileRegionEngine {
         None
     }
 
-    async fn get_last_seq_num(&self, _: RegionId) -> Result<Option<SequenceNumber>, BoxedError> {
-        Ok(None)
+    async fn get_last_seq_num(&self, _: RegionId) -> Result<SequenceNumber, BoxedError> {
+        Ok(Default::default())
     }
 
     fn set_region_role(&self, region_id: RegionId, role: RegionRole) -> Result<(), BoxedError> {

--- a/src/file-engine/src/engine.rs
+++ b/src/file-engine/src/engine.rs
@@ -115,7 +115,7 @@ impl RegionEngine for FileRegionEngine {
         None
     }
 
-    async fn get_last_seq_num(&self, _: RegionId) -> Result<SequenceNumber, BoxedError> {
+    async fn get_committed_sequence(&self, _: RegionId) -> Result<SequenceNumber, BoxedError> {
         Ok(Default::default())
     }
 

--- a/src/metric-engine/src/engine.rs
+++ b/src/metric-engine/src/engine.rs
@@ -257,7 +257,10 @@ impl RegionEngine for MetricEngine {
         self.handle_query(region_id, request).await
     }
 
-    async fn get_last_seq_num(&self, region_id: RegionId) -> Result<SequenceNumber, BoxedError> {
+    async fn get_committed_sequence(
+        &self,
+        region_id: RegionId,
+    ) -> Result<SequenceNumber, BoxedError> {
         self.inner
             .get_last_seq_num(region_id)
             .await

--- a/src/metric-engine/src/engine.rs
+++ b/src/metric-engine/src/engine.rs
@@ -257,10 +257,7 @@ impl RegionEngine for MetricEngine {
         self.handle_query(region_id, request).await
     }
 
-    async fn get_last_seq_num(
-        &self,
-        region_id: RegionId,
-    ) -> Result<Option<SequenceNumber>, BoxedError> {
+    async fn get_last_seq_num(&self, region_id: RegionId) -> Result<SequenceNumber, BoxedError> {
         self.inner
             .get_last_seq_num(region_id)
             .await

--- a/src/metric-engine/src/engine/read.rs
+++ b/src/metric-engine/src/engine/read.rs
@@ -97,7 +97,7 @@ impl MetricEngineInner {
             utils::to_data_region_id(physical_region_id)
         };
         self.mito
-            .get_last_seq_num(region_id)
+            .get_committed_sequence(region_id)
             .await
             .context(MitoReadOperationSnafu)
     }

--- a/src/metric-engine/src/engine/read.rs
+++ b/src/metric-engine/src/engine/read.rs
@@ -89,7 +89,7 @@ impl MetricEngineInner {
         Ok(scanner)
     }
 
-    pub async fn get_last_seq_num(&self, region_id: RegionId) -> Result<Option<SequenceNumber>> {
+    pub async fn get_last_seq_num(&self, region_id: RegionId) -> Result<SequenceNumber> {
         let region_id = if self.is_physical_region(region_id) {
             region_id
         } else {

--- a/src/mito2/src/compaction/compactor.rs
+++ b/src/mito2/src/compaction/compactor.rs
@@ -475,6 +475,7 @@ impl Compactor for DefaultCompactor {
                 .map(|seconds| Duration::from_secs(seconds as u64)),
             flushed_entry_id: None,
             flushed_sequence: None,
+            committed_sequence: None,
         };
 
         let action_list = RegionMetaActionList::with_action(RegionMetaAction::Edit(edit.clone()));

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -658,10 +658,10 @@ impl EngineInner {
         receiver.await.context(RecvSnafu)?
     }
 
-    fn get_last_seq_num(&self, region_id: RegionId) -> Result<Option<SequenceNumber>> {
+    fn get_last_seq_num(&self, region_id: RegionId) -> Result<SequenceNumber> {
         // Reading a region doesn't need to go through the region worker thread.
-        let region = self.find_region(region_id)?;
-        Ok(Some(region.find_committed_sequence()))
+        self.find_region(region_id)
+            .map(|r| r.find_committed_sequence())
     }
 
     /// Handles the scan `request` and returns a [ScanRegion].
@@ -829,10 +829,7 @@ impl RegionEngine for MitoEngine {
             .map_err(BoxedError::new)
     }
 
-    async fn get_last_seq_num(
-        &self,
-        region_id: RegionId,
-    ) -> Result<Option<SequenceNumber>, BoxedError> {
+    async fn get_last_seq_num(&self, region_id: RegionId) -> Result<SequenceNumber, BoxedError> {
         self.inner
             .get_last_seq_num(region_id)
             .map_err(BoxedError::new)

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -465,6 +465,7 @@ fn is_valid_region_edit(edit: &RegionEdit) -> bool {
                 compaction_time_window: None,
                 flushed_entry_id: None,
                 flushed_sequence: None,
+                ..
             }
         )
 }
@@ -1015,6 +1016,7 @@ mod tests {
             compaction_time_window: None,
             flushed_entry_id: None,
             flushed_sequence: None,
+            committed_sequence: None,
         };
         assert!(is_valid_region_edit(&edit));
 
@@ -1026,6 +1028,7 @@ mod tests {
             compaction_time_window: None,
             flushed_entry_id: None,
             flushed_sequence: None,
+            committed_sequence: None,
         };
         assert!(!is_valid_region_edit(&edit));
 
@@ -1037,6 +1040,7 @@ mod tests {
             compaction_time_window: None,
             flushed_entry_id: None,
             flushed_sequence: None,
+            committed_sequence: None,
         };
         assert!(!is_valid_region_edit(&edit));
 
@@ -1048,6 +1052,7 @@ mod tests {
             compaction_time_window: Some(Duration::from_secs(1)),
             flushed_entry_id: None,
             flushed_sequence: None,
+            committed_sequence: None,
         };
         assert!(!is_valid_region_edit(&edit));
         let edit = RegionEdit {
@@ -1057,6 +1062,7 @@ mod tests {
             compaction_time_window: None,
             flushed_entry_id: Some(1),
             flushed_sequence: None,
+            committed_sequence: None,
         };
         assert!(!is_valid_region_edit(&edit));
         let edit = RegionEdit {
@@ -1066,6 +1072,7 @@ mod tests {
             compaction_time_window: None,
             flushed_entry_id: None,
             flushed_sequence: Some(1),
+            committed_sequence: None,
         };
         assert!(!is_valid_region_edit(&edit));
     }

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -23,6 +23,8 @@ mod basic_test;
 #[cfg(test)]
 mod batch_open_test;
 #[cfg(test)]
+mod bump_committed_sequence_test;
+#[cfg(test)]
 mod catchup_test;
 #[cfg(test)]
 mod close_test;

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -659,7 +659,8 @@ impl EngineInner {
         receiver.await.context(RecvSnafu)?
     }
 
-    fn get_last_seq_num(&self, region_id: RegionId) -> Result<SequenceNumber> {
+    /// Returns the sequence of latest committed data.
+    fn get_committed_sequence(&self, region_id: RegionId) -> Result<SequenceNumber> {
         // Reading a region doesn't need to go through the region worker thread.
         self.find_region(region_id)
             .map(|r| r.find_committed_sequence())
@@ -830,9 +831,12 @@ impl RegionEngine for MitoEngine {
             .map_err(BoxedError::new)
     }
 
-    async fn get_last_seq_num(&self, region_id: RegionId) -> Result<SequenceNumber, BoxedError> {
+    async fn get_committed_sequence(
+        &self,
+        region_id: RegionId,
+    ) -> Result<SequenceNumber, BoxedError> {
         self.inner
-            .get_last_seq_num(region_id)
+            .get_committed_sequence(region_id)
             .map_err(BoxedError::new)
     }
 

--- a/src/mito2/src/engine/bump_committed_sequence_test.rs
+++ b/src/mito2/src/engine/bump_committed_sequence_test.rs
@@ -1,0 +1,94 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use store_api::region_engine::RegionEngine;
+use store_api::region_request::{PathType, RegionOpenRequest, RegionRequest};
+use store_api::storage::RegionId;
+
+use crate::config::MitoConfig;
+use crate::manifest::action::RegionEdit;
+use crate::sst::file::FileMeta;
+use crate::test_util::{CreateRequestBuilder, TestEnv};
+
+#[tokio::test]
+async fn test_bump_committed_sequence() {
+    common_telemetry::init_default_ut_logging();
+    let mut env = TestEnv::new().await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new().build();
+
+    let table_dir = request.table_dir.clone();
+
+    env.get_schema_metadata_manager()
+        .register_region_table_info(
+            region_id.table_id(),
+            "test_table",
+            "test_catalog",
+            "test_schema",
+            None,
+            env.get_kv_backend(),
+        )
+        .await;
+
+    let _ = engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+    let region = engine.get_region(region_id).unwrap();
+    assert_eq!(region.version_control.current().committed_sequence, 0);
+    assert_eq!(region.version_control.current().version.flushed_sequence, 0);
+
+    engine
+        .edit_region(
+            region_id,
+            RegionEdit {
+                files_to_add: vec![FileMeta::default()],
+                files_to_remove: vec![],
+                timestamp_ms: None,
+                compaction_time_window: None,
+                flushed_entry_id: None,
+                flushed_sequence: None,
+                committed_sequence: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(region.version_control.current().version.flushed_sequence, 0);
+    assert_eq!(region.version_control.committed_sequence(), 1);
+
+    // Reopen region.
+    let engine = env.reopen_engine(engine, MitoConfig::default()).await;
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Open(RegionOpenRequest {
+                engine: String::new(),
+                table_dir,
+                path_type: PathType::Bare,
+                options: HashMap::default(),
+                skip_wal_replay: false,
+                checkpoint: None,
+            }),
+        )
+        .await
+        .unwrap();
+    let region = engine.get_region(region_id).unwrap();
+    assert_eq!(region.version_control.current().version.flushed_sequence, 0);
+    assert_eq!(region.version_control.committed_sequence(), 1);
+}

--- a/src/mito2/src/engine/edit_region_test.rs
+++ b/src/mito2/src/engine/edit_region_test.rs
@@ -96,6 +96,7 @@ async fn test_edit_region_schedule_compaction() {
         compaction_time_window: None,
         flushed_entry_id: None,
         flushed_sequence: None,
+        committed_sequence: None,
     };
     engine
         .edit_region(region.region_id, new_edit())
@@ -185,6 +186,7 @@ async fn test_edit_region_fill_cache() {
         compaction_time_window: None,
         flushed_entry_id: None,
         flushed_sequence: None,
+        committed_sequence: None,
     };
     engine.edit_region(region.region_id, edit).await.unwrap();
 
@@ -236,6 +238,7 @@ async fn test_edit_region_concurrently() {
                     compaction_time_window: None,
                     flushed_entry_id: None,
                     flushed_sequence: None,
+                    committed_sequence: None,
                 };
                 engine
                     .edit_region(self.region.region_id, edit)

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -462,6 +462,7 @@ impl RegionFlushTask {
             // The last entry has been flushed.
             flushed_entry_id: Some(version_data.last_entry_id),
             flushed_sequence: Some(version_data.committed_sequence),
+            committed_sequence: None,
         };
         info!("Applying {edit:?} to region {}", self.region_id);
 
@@ -1019,6 +1020,7 @@ mod tests {
                 compaction_time_window: None,
                 flushed_entry_id: None,
                 flushed_sequence: None,
+                committed_sequence: None,
             }),
             &[0],
             builder.file_purger(),

--- a/src/mito2/src/manifest/action.rs
+++ b/src/mito2/src/manifest/action.rs
@@ -120,6 +120,7 @@ pub struct RegionManifest {
     pub flushed_entry_id: EntryId,
     /// Last sequence of flushed data.
     pub flushed_sequence: SequenceNumber,
+    pub committed_sequence: Option<SequenceNumber>,
     /// Current manifest version.
     pub manifest_version: ManifestVersion,
     /// Last WAL entry id of truncated data.
@@ -139,6 +140,7 @@ impl PartialEq for RegionManifest {
             && self.manifest_version == other.manifest_version
             && self.truncated_entry_id == other.truncated_entry_id
             && self.compaction_time_window == other.compaction_time_window
+            && self.committed_sequence == other.committed_sequence
     }
 }
 
@@ -152,6 +154,7 @@ pub struct RegionManifestBuilder {
     manifest_version: ManifestVersion,
     truncated_entry_id: Option<EntryId>,
     compaction_time_window: Option<Duration>,
+    committed_sequence: Option<SequenceNumber>,
 }
 
 impl RegionManifestBuilder {
@@ -167,6 +170,7 @@ impl RegionManifestBuilder {
                 flushed_sequence: s.flushed_sequence,
                 truncated_entry_id: s.truncated_entry_id,
                 compaction_time_window: s.compaction_time_window,
+                committed_sequence: s.committed_sequence,
             }
         } else {
             Default::default()
@@ -199,6 +203,13 @@ impl RegionManifestBuilder {
         }
         if let Some(flushed_sequence) = edit.flushed_sequence {
             self.flushed_sequence = self.flushed_sequence.max(flushed_sequence);
+        }
+
+        if let Some(committed_sequence) = edit.committed_sequence {
+            self.committed_sequence = Some(
+                self.committed_sequence
+                    .map_or(committed_sequence, |exist| exist.max(committed_sequence)),
+            );
         }
         if let Some(window) = edit.compaction_time_window {
             self.compaction_time_window = Some(window);
@@ -254,6 +265,7 @@ impl RegionManifestBuilder {
             removed_files: self.removed_files,
             flushed_entry_id: self.flushed_entry_id,
             flushed_sequence: self.flushed_sequence,
+            committed_sequence: self.committed_sequence,
             manifest_version: self.manifest_version,
             truncated_entry_id: self.truncated_entry_id,
             compaction_time_window: self.compaction_time_window,
@@ -704,6 +716,7 @@ mod tests {
             files: HashMap::new(),
             flushed_entry_id: 0,
             flushed_sequence: 0,
+            committed_sequence: None,
             manifest_version: 0,
             truncated_entry_id: None,
             compaction_time_window: None,
@@ -813,6 +826,7 @@ mod tests {
                 removed_files: Default::default(),
                 flushed_entry_id: 0,
                 flushed_sequence: 0,
+                committed_sequence: None,
                 manifest_version: 0,
                 truncated_entry_id: None,
                 compaction_time_window: None,
@@ -825,6 +839,7 @@ mod tests {
             removed_files: Default::default(),
             flushed_entry_id: 0,
             flushed_sequence: 0,
+            committed_sequence: None,
             manifest_version: 0,
             truncated_entry_id: None,
             compaction_time_window: None,

--- a/src/mito2/src/manifest/action.rs
+++ b/src/mito2/src/manifest/action.rs
@@ -62,6 +62,7 @@ pub struct RegionEdit {
     pub compaction_time_window: Option<Duration>,
     pub flushed_entry_id: Option<EntryId>,
     pub flushed_sequence: Option<SequenceNumber>,
+    pub committed_sequence: Option<SequenceNumber>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -377,6 +378,7 @@ impl RegionMetaActionList {
             compaction_time_window: None,
             flushed_entry_id: None,
             flushed_sequence: None,
+            committed_sequence: None,
         };
 
         for action in self.actions {
@@ -390,6 +392,10 @@ impl RegionMetaActionList {
                 }
                 if let Some(seq) = region_edit.flushed_sequence {
                     edit.flushed_sequence = Some(edit.flushed_sequence.map_or(seq, |v| v.max(seq)));
+                }
+                if let Some(seq) = region_edit.committed_sequence {
+                    edit.committed_sequence =
+                        Some(edit.committed_sequence.map_or(seq, |v| v.max(seq)));
                 }
                 // Prefer the latest non-none time window
                 if region_edit.compaction_time_window.is_some() {
@@ -872,6 +878,7 @@ mod tests {
                 compaction_time_window: None,
                 flushed_entry_id: None,
                 flushed_sequence: None,
+                committed_sequence: None,
             },
             new_from_old
         );
@@ -884,6 +891,7 @@ mod tests {
             compaction_time_window: None,
             flushed_entry_id: None,
             flushed_sequence: None,
+            committed_sequence: None,
         };
 
         let new_json = serde_json::to_string(&new).unwrap();

--- a/src/mito2/src/manifest/manager.rs
+++ b/src/mito2/src/manifest/manager.rs
@@ -915,6 +915,6 @@ mod test {
 
         // get manifest size again
         let manifest_size = manager.manifest_usage();
-        assert_eq!(manifest_size, 1695);
+        assert_eq!(manifest_size, 1721);
     }
 }

--- a/src/mito2/src/manifest/manager.rs
+++ b/src/mito2/src/manifest/manager.rs
@@ -194,6 +194,7 @@ impl RegionManifestManager {
                 compaction_time_window: None,
                 flushed_entry_id: Some(flushed_entry_id),
                 flushed_sequence: None,
+                committed_sequence: None,
             }));
         }
 
@@ -886,6 +887,7 @@ mod test {
                         compaction_time_window: None,
                         flushed_entry_id: None,
                         flushed_sequence: None,
+                        committed_sequence: None,
                     })]),
                     RegionRoleState::Leader(RegionLeaderState::Writable),
                 )
@@ -913,6 +915,6 @@ mod test {
 
         // get manifest size again
         let manifest_size = manager.manifest_usage();
-        assert_eq!(manifest_size, 1669);
+        assert_eq!(manifest_size, 1695);
     }
 }

--- a/src/mito2/src/manifest/tests/checkpoint.rs
+++ b/src/mito2/src/manifest/tests/checkpoint.rs
@@ -77,6 +77,7 @@ fn nop_action() -> RegionMetaActionList {
         compaction_time_window: None,
         flushed_entry_id: None,
         flushed_sequence: None,
+        committed_sequence: None,
     })])
 }
 
@@ -276,6 +277,7 @@ async fn checkpoint_with_different_compression_types() {
             compaction_time_window: None,
             flushed_entry_id: None,
             flushed_sequence: None,
+            committed_sequence: None,
         })]);
         actions.push(action);
     }
@@ -340,6 +342,7 @@ fn generate_action_lists(num: usize) -> (Vec<FileId>, Vec<RegionMetaActionList>)
             compaction_time_window: None,
             flushed_entry_id: None,
             flushed_sequence: None,
+            committed_sequence: None,
         })]);
         actions.push(action);
     }

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -735,7 +735,6 @@ where
             None,
         );
         for mutation in entry.mutations {
-            info!("=== Replay mutation sequence: {}", mutation.sequence);
             rows_replayed += mutation
                 .rows
                 .as_ref()

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -473,16 +473,7 @@ impl RegionOpener {
             .build();
         let flushed_entry_id = version.flushed_entry_id;
         let version_control = Arc::new(VersionControl::new(version));
-        if let Some(committed_sequence) = manifest.committed_sequence {
-            debug!(
-                "Overriding committed sequence, region: {}, flushed_sequence: {}, committed_sequence: {} -> {}",
-                self.region_id,
-                version_control.current().version.flushed_sequence,
-                version_control.committed_sequence(),
-                committed_sequence
-            );
-            version_control.set_committed_sequence(committed_sequence);
-        }
+
         let topic_latest_entry_id = if !self.skip_wal_replay {
             let replay_from_entry_id = self
                 .replay_checkpoint
@@ -518,6 +509,21 @@ impl RegionOpener {
 
             0
         };
+
+        if let Some(committed_in_manifest) = manifest.committed_sequence {
+            let committed_after_replay = version_control.committed_sequence();
+            if committed_in_manifest > committed_after_replay {
+                info!(
+                    "Overriding committed sequence, region: {}, flushed_sequence: {}, committed_sequence: {} -> {}",
+                    self.region_id,
+                    version_control.current().version.flushed_sequence,
+                    version_control.committed_sequence(),
+                    committed_in_manifest
+                );
+                version_control.set_committed_sequence(committed_in_manifest);
+            }
+        }
+
         let now = self.time_provider.current_time_millis();
         let region = MitoRegion {
             region_id: self.region_id,
@@ -729,6 +735,7 @@ where
             None,
         );
         for mutation in entry.mutations {
+            info!("=== Replay mutation sequence: {}", mutation.sequence);
             rows_replayed += mutation
                 .rows
                 .as_ref()
@@ -739,14 +746,22 @@ where
                 mutation.rows,
                 mutation.write_hint,
                 OptionOutputTx::none(),
+                // We should respect the sequence in WAL during replay.
+                Some(mutation.sequence),
             );
         }
 
         for bulk_entry in entry.bulk_entries {
             let part = BulkPart::try_from(bulk_entry)?;
             rows_replayed += part.num_rows();
+            // During replay, we should adopt the sequence from WAL.
+            let bulk_sequence_from_wal = part.sequence;
             ensure!(
-                region_write_ctx.push_bulk(OptionOutputTx::none(), part),
+                region_write_ctx.push_bulk(
+                    OptionOutputTx::none(),
+                    part,
+                    Some(bulk_sequence_from_wal)
+                ),
                 RegionCorruptedSnafu {
                     region_id,
                     reason: "unable to replay memtable with bulk entries",

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -473,6 +473,16 @@ impl RegionOpener {
             .build();
         let flushed_entry_id = version.flushed_entry_id;
         let version_control = Arc::new(VersionControl::new(version));
+        if let Some(committed_sequence) = manifest.committed_sequence {
+            debug!(
+                "Overriding committed sequence, region: {}, flushed_sequence: {}, committed_sequence: {} -> {}",
+                self.region_id,
+                version_control.current().version.flushed_sequence,
+                version_control.committed_sequence(),
+                committed_sequence
+            );
+            version_control.set_committed_sequence(committed_sequence);
+        }
         let topic_latest_entry_id = if !self.skip_wal_replay {
             let replay_from_entry_id = self
                 .replay_checkpoint

--- a/src/mito2/src/region/version.rs
+++ b/src/mito2/src/region/version.rs
@@ -137,6 +137,7 @@ impl VersionControl {
     ) {
         let version = self.current().version;
         let builder = VersionBuilder::from_version(version);
+        let committed_sequence = edit.as_ref().and_then(|e| e.committed_sequence);
         let builder = if let Some(edit) = edit {
             builder.apply_edit(edit, purger)
         } else {
@@ -145,6 +146,11 @@ impl VersionControl {
         let new_version = Arc::new(builder.remove_memtables(memtables_to_remove).build());
 
         let mut version_data = self.data.write().unwrap();
+        version_data.committed_sequence = if let Some(committed_in_edit) = committed_sequence {
+            version_data.committed_sequence.max(committed_in_edit)
+        } else {
+            version_data.committed_sequence
+        };
         version_data.version = new_version;
     }
 

--- a/src/mito2/src/region/version.rs
+++ b/src/mito2/src/region/version.rs
@@ -71,6 +71,12 @@ impl VersionControl {
         self.data.read().unwrap().clone()
     }
 
+    /// Updates the `committed_sequence` of version.
+    pub(crate) fn set_committed_sequence(&self, seq: SequenceNumber) {
+        let mut data = self.data.write().unwrap();
+        data.committed_sequence = seq;
+    }
+
     /// Updates committed sequence and entry id.
     pub(crate) fn set_sequence_and_entry_id(&self, seq: SequenceNumber, entry_id: EntryId) {
         let mut data = self.data.write().unwrap();

--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -382,7 +382,7 @@ impl WriteRequest {
                 if column.column_schema.is_default_impure() {
                     UnexpectedSnafu {
                         reason: format!(
-                            "unexpected impure default value with region_id: {}, column: {}, default_value: {:?}", 
+                            "unexpected impure default value with region_id: {}, column: {}, default_value: {:?}",
                             self.region_id,
                             column.column_schema.name,
                             column.column_schema.default_constraint(),

--- a/src/mito2/src/test_util/version_util.rs
+++ b/src/mito2/src/test_util/version_util.rs
@@ -211,6 +211,7 @@ pub(crate) fn apply_edit(
             compaction_time_window: None,
             flushed_entry_id: None,
             flushed_sequence: None,
+            committed_sequence: None,
         }),
         &[],
         purger,

--- a/src/mito2/src/worker/handle_manifest.rs
+++ b/src/mito2/src/worker/handle_manifest.rs
@@ -207,8 +207,8 @@ impl<S> RegionWorkerLoop<S> {
             mut edit,
             tx: sender,
         } = request;
-        let file_sequence = region.version().flushed_sequence + 1;
-        edit.flushed_sequence = Some(file_sequence);
+        let file_sequence = region.version_control.committed_sequence() + 1;
+        edit.committed_sequence = Some(file_sequence);
 
         // For every file added through region edit, we should fill the file sequence
         for file in &mut edit.files_to_add {

--- a/src/mito2/src/worker/handle_manifest.rs
+++ b/src/mito2/src/worker/handle_manifest.rs
@@ -17,6 +17,7 @@
 //! It updates the manifest and applies the changes to the region in background.
 
 use std::collections::{HashMap, VecDeque};
+use std::num::NonZeroU64;
 use std::sync::Arc;
 
 use common_telemetry::{info, warn};
@@ -203,9 +204,16 @@ impl<S> RegionWorkerLoop<S> {
 
         let RegionEditRequest {
             region_id: _,
-            edit,
+            mut edit,
             tx: sender,
         } = request;
+        let file_sequence = region.version().flushed_sequence + 1;
+        edit.flushed_sequence = Some(file_sequence);
+
+        // For every file added through region edit, we should fill the file sequence
+        for file in &mut edit.files_to_add {
+            file.sequence = NonZeroU64::new(file_sequence);
+        }
 
         // Marks the region as editing.
         if let Err(e) = region.set_editing() {
@@ -229,6 +237,7 @@ impl<S> RegionWorkerLoop<S> {
                     result,
                 }),
             };
+
             // We don't set state back as the worker loop is already exited.
             if let Err(res) = request_sender
                 .send(WorkerRequestWithTime::new(notify))

--- a/src/mito2/src/worker/handle_write.rs
+++ b/src/mito2/src/worker/handle_write.rs
@@ -316,6 +316,7 @@ impl<S> RegionWorkerLoop<S> {
                 Some(sender_req.request.rows),
                 sender_req.request.hint,
                 sender_req.sender,
+                None,
             );
         }
     }
@@ -401,7 +402,7 @@ impl<S> RegionWorkerLoop<S> {
             }
 
             // Collect requests by region.
-            if !region_ctx.push_bulk(bulk_req.sender, bulk_req.request) {
+            if !region_ctx.push_bulk(bulk_req.sender, bulk_req.request, None) {
                 return;
             }
         }

--- a/src/query/src/optimizer/test_util.rs
+++ b/src/query/src/optimizer/test_util.rs
@@ -86,7 +86,10 @@ impl RegionEngine for MetaRegionEngine {
         None
     }
 
-    async fn get_last_seq_num(&self, _region_id: RegionId) -> Result<SequenceNumber, BoxedError> {
+    async fn get_committed_sequence(
+        &self,
+        _region_id: RegionId,
+    ) -> Result<SequenceNumber, BoxedError> {
         Ok(SequenceNumber::default())
     }
 

--- a/src/query/src/optimizer/test_util.rs
+++ b/src/query/src/optimizer/test_util.rs
@@ -86,11 +86,8 @@ impl RegionEngine for MetaRegionEngine {
         None
     }
 
-    async fn get_last_seq_num(
-        &self,
-        _region_id: RegionId,
-    ) -> Result<Option<SequenceNumber>, BoxedError> {
-        Ok(None)
+    async fn get_last_seq_num(&self, _region_id: RegionId) -> Result<SequenceNumber, BoxedError> {
+        Ok(SequenceNumber::default())
     }
 
     async fn stop(&self) -> Result<(), BoxedError> {

--- a/src/store-api/src/region_engine.rs
+++ b/src/store-api/src/region_engine.rs
@@ -747,10 +747,7 @@ pub trait RegionEngine: Send + Sync {
     ) -> Result<RegionResponse, BoxedError>;
 
     /// Returns the last sequence number of the region.
-    async fn get_last_seq_num(
-        &self,
-        region_id: RegionId,
-    ) -> Result<Option<SequenceNumber>, BoxedError>;
+    async fn get_last_seq_num(&self, region_id: RegionId) -> Result<SequenceNumber, BoxedError>;
 
     async fn get_region_sequences(
         &self,
@@ -759,7 +756,7 @@ pub trait RegionEngine: Send + Sync {
         let mut results = HashMap::with_capacity(seqs.region_ids.len());
 
         for region_id in seqs.region_ids {
-            let seq = self.get_last_seq_num(region_id).await?.unwrap_or_default();
+            let seq = self.get_last_seq_num(region_id).await?;
             results.insert(region_id.as_u64(), seq);
         }
 

--- a/src/store-api/src/region_engine.rs
+++ b/src/store-api/src/region_engine.rs
@@ -34,9 +34,7 @@ use tokio::sync::Semaphore;
 
 use crate::logstore::entry;
 use crate::metadata::RegionMetadataRef;
-use crate::region_request::{
-    BatchRegionDdlRequest, RegionOpenRequest, RegionRequest, RegionSequencesRequest,
-};
+use crate::region_request::{BatchRegionDdlRequest, RegionOpenRequest, RegionRequest};
 use crate::storage::{RegionId, ScanRequest, SequenceNumber};
 
 /// The settable region role state.
@@ -746,22 +744,11 @@ pub trait RegionEngine: Send + Sync {
         request: RegionRequest,
     ) -> Result<RegionResponse, BoxedError>;
 
-    /// Returns the last sequence number of the region.
-    async fn get_last_seq_num(&self, region_id: RegionId) -> Result<SequenceNumber, BoxedError>;
-
-    async fn get_region_sequences(
+    /// Returns the committed sequence (sequence of latest written data).
+    async fn get_committed_sequence(
         &self,
-        seqs: RegionSequencesRequest,
-    ) -> Result<HashMap<u64, u64>, BoxedError> {
-        let mut results = HashMap::with_capacity(seqs.region_ids.len());
-
-        for region_id in seqs.region_ids {
-            let seq = self.get_last_seq_num(region_id).await?;
-            results.insert(region_id.as_u64(), seq);
-        }
-
-        Ok(results)
-    }
+        region_id: RegionId,
+    ) -> Result<SequenceNumber, BoxedError>;
 
     /// Handles query and return a scanner that can be used to scan the region concurrently.
     async fn handle_query(

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -1377,12 +1377,6 @@ pub struct RegionCatchupRequest {
     pub checkpoint: Option<ReplayCheckpoint>,
 }
 
-/// Get sequences of regions by region ids.
-#[derive(Debug, Clone)]
-pub struct RegionSequencesRequest {
-    pub region_ids: Vec<RegionId>,
-}
-
 #[derive(Debug, Clone)]
 pub struct RegionBulkInsertsRequest {
     pub region_id: RegionId,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR allows region worker to bump the region sequence while handling region edit requests. That sequence will also be assigned to the files to add in the `RegionEdit` request so that each ingested SST files will have a overriding sequence number assigned by the region worker.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
