### PR TITLE
fix: count(1) instead of count(ts) when >1 inputs

### DIFF
--- a/src/query/src/optimizer/count_wildcard.rs
+++ b/src/query/src/optimizer/count_wildcard.rs
@@ -88,6 +88,10 @@ impl CountWildcardToTimeIndexRule {
         // check if the time index is a valid column as for current plan
         if let Some(col) = &col {
             let mut is_valid = false;
+            // if more than one input, we give up and just use `count(1)`
+            if plan.inputs().len() > 1 {
+                return None;
+            }
             for input in plan.inputs() {
                 if input.schema().has_column(col) {
                     is_valid = true;
@@ -165,6 +169,11 @@ impl TreeNodeVisitor<'_> for TimeIndexFinder {
                 .timestamp_column()
                 .map(|c| c.name.clone());
 
+            return Ok(TreeNodeRecursion::Stop);
+        }
+
+        if node.inputs().len() > 1 {
+            // if more than one input, we give up and just use `count(1)`
             return Ok(TreeNodeRecursion::Stop);
         }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

fallback to use `count(1)` instead of `count(ts)` for `count(*)` when multiple inputs are found

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
