### PR TITLE
fix: correct jemalloc metrics

### DIFF
--- a/src/servers/src/metrics/jemalloc.rs
+++ b/src/servers/src/metrics/jemalloc.rs
@@ -71,8 +71,8 @@ impl JemallocCollector {
         let _ = self.epoch.advance().context(UpdateJemallocMetricsSnafu)?;
         let allocated = self.allocated.read().context(UpdateJemallocMetricsSnafu)?;
         let resident = self.resident.read().context(UpdateJemallocMetricsSnafu)?;
-        SYS_JEMALLOC_RESIDEN.set(allocated as i64);
-        SYS_JEMALLOC_ALLOCATED.set(resident as i64);
+        SYS_JEMALLOC_ALLOCATED.set(allocated as i64);
+        SYS_JEMALLOC_RESIDEN.set(resident as i64);
         Ok(())
     }
 }


### PR DESCRIPTION

I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

This pr mainly fix metrics about jemalloc, mainly swap the allocated and resident metrics in the set calls which ensure each metric receives its corresponding value.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
