### PR TITLE
fix: staging mode with proper region edit operations

### DIFF
--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -1012,14 +1012,14 @@ mod tests {
             .collect();
         // Assumes the flush job is finished.
         version_control.apply_edit(
-            RegionEdit {
+            Some(RegionEdit {
                 files_to_add: Vec::new(),
                 files_to_remove: Vec::new(),
                 timestamp_ms: None,
                 compaction_time_window: None,
                 flushed_entry_id: None,
                 flushed_sequence: None,
-            },
+            }),
             &[0],
             builder.file_purger(),
         );

--- a/src/mito2/src/test_util/version_util.rs
+++ b/src/mito2/src/test_util/version_util.rs
@@ -204,14 +204,14 @@ pub(crate) fn apply_edit(
         .collect();
 
     version_control.apply_edit(
-        RegionEdit {
+        Some(RegionEdit {
             files_to_add,
             files_to_remove: files_to_remove.to_vec(),
             timestamp_ms: None,
             compaction_time_window: None,
             flushed_entry_id: None,
             flushed_sequence: None,
-        },
+        }),
         &[],
         purger,
     );

--- a/src/mito2/src/worker/handle_compaction.rs
+++ b/src/mito2/src/worker/handle_compaction.rs
@@ -74,9 +74,11 @@ impl<S> RegionWorkerLoop<S> {
         };
         region.update_compaction_millis();
 
-        region
-            .version_control
-            .apply_edit(request.edit.clone(), &[], region.file_purger.clone());
+        region.version_control.apply_edit(
+            Some(request.edit.clone()),
+            &[],
+            region.file_purger.clone(),
+        );
 
         // compaction finished.
         request.on_success();

--- a/src/mito2/src/worker/handle_flush.rs
+++ b/src/mito2/src/worker/handle_flush.rs
@@ -215,9 +215,14 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                 "Skipping region metadata update for region {} in staging mode",
                 region_id
             );
+            region.version_control.apply_edit(
+                None,
+                &request.memtables_to_remove,
+                region.file_purger.clone(),
+            );
         } else {
             region.version_control.apply_edit(
-                request.edit.clone(),
+                Some(request.edit.clone()),
                 &request.memtables_to_remove,
                 region.file_purger.clone(),
             );

--- a/src/mito2/src/worker/handle_manifest.rs
+++ b/src/mito2/src/worker/handle_manifest.rs
@@ -262,9 +262,11 @@ impl<S> RegionWorkerLoop<S> {
 
         if edit_result.result.is_ok() {
             // Applies the edit to the region.
-            region
-                .version_control
-                .apply_edit(edit_result.edit, &[], region.file_purger.clone());
+            region.version_control.apply_edit(
+                Some(edit_result.edit),
+                &[],
+                region.file_purger.clone(),
+            );
         }
 
         // Sets the region as writable.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

- follow up of #6913
- part of #6558

## What's changed and what's your intention?


This patch fixes two things:
- in staging mode, a flush request should remove immutable memtables (those data in memtable, before flushing, is still visible)
- on exit staging mode, it should apply region edits to version control to make manifests visible to in-memory states

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
