### PR TITLE
feat: add an flag to enable the experimental flat format

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -151,6 +151,7 @@
 | `region_engine.mito.max_concurrent_scan_files` | Integer | `384` | Maximum number of SST files to scan concurrently. |
 | `region_engine.mito.allow_stale_entries` | Bool | `false` | Whether to allow stale WAL entries read during replay. |
 | `region_engine.mito.min_compaction_interval` | String | `0m` | Minimum time interval between two compactions.<br/>To align with the old behavior, the default value is 0 (no restrictions). |
+| `region_engine.mito.enable_experimental_flat_format` | Bool | `false` | Whether to enable experimental flat format. |
 | `region_engine.mito.index` | -- | -- | The options for index in Mito engine. |
 | `region_engine.mito.index.aux_path` | String | `""` | Auxiliary directory path for the index in filesystem, used to store intermediate files for<br/>creating the index and staging files for searching the index, defaults to `{data_home}/index_intermediate`.<br/>The default name for this directory is `index_intermediate` for backward compatibility.<br/><br/>This path contains two subdirectories:<br/>- `__intm`: for storing intermediate files used during creating index.<br/>- `staging`: for storing staging files used during searching index. |
 | `region_engine.mito.index.staging_size` | String | `2GB` | The max capacity of the staging directory. |
@@ -543,6 +544,7 @@
 | `region_engine.mito.max_concurrent_scan_files` | Integer | `384` | Maximum number of SST files to scan concurrently. |
 | `region_engine.mito.allow_stale_entries` | Bool | `false` | Whether to allow stale WAL entries read during replay. |
 | `region_engine.mito.min_compaction_interval` | String | `0m` | Minimum time interval between two compactions.<br/>To align with the old behavior, the default value is 0 (no restrictions). |
+| `region_engine.mito.enable_experimental_flat_format` | Bool | `false` | Whether to enable experimental flat format. |
 | `region_engine.mito.index` | -- | -- | The options for index in Mito engine. |
 | `region_engine.mito.index.aux_path` | String | `""` | Auxiliary directory path for the index in filesystem, used to store intermediate files for<br/>creating the index and staging files for searching the index, defaults to `{data_home}/index_intermediate`.<br/>The default name for this directory is `index_intermediate` for backward compatibility.<br/><br/>This path contains two subdirectories:<br/>- `__intm`: for storing intermediate files used during creating index.<br/>- `staging`: for storing staging files used during searching index. |
 | `region_engine.mito.index.staging_size` | String | `2GB` | The max capacity of the staging directory. |

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -497,6 +497,9 @@ allow_stale_entries = false
 ## To align with the old behavior, the default value is 0 (no restrictions).
 min_compaction_interval = "0m"
 
+## Whether to enable experimental flat format.
+enable_experimental_flat_format = false
+
 ## The options for index in Mito engine.
 [region_engine.mito.index]
 

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -576,6 +576,9 @@ allow_stale_entries = false
 ## To align with the old behavior, the default value is 0 (no restrictions).
 min_compaction_interval = "0m"
 
+## Whether to enable experimental flat format.
+enable_experimental_flat_format = false
+
 ## The options for index in Mito engine.
 [region_engine.mito.index]
 

--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -68,6 +68,7 @@ pub struct Metrics {
     pub(crate) update_index: Duration,
     pub(crate) upload_parquet: Duration,
     pub(crate) upload_puffin: Duration,
+    pub(crate) compact_memtable: Duration,
 }
 
 impl Metrics {
@@ -79,6 +80,7 @@ impl Metrics {
             update_index: Default::default(),
             upload_parquet: Default::default(),
             upload_puffin: Default::default(),
+            compact_memtable: Default::default(),
         }
     }
 
@@ -89,6 +91,7 @@ impl Metrics {
         self.update_index += other.update_index;
         self.upload_parquet += other.upload_parquet;
         self.upload_puffin += other.upload_puffin;
+        self.compact_memtable += other.compact_memtable;
         self
     }
 
@@ -110,6 +113,11 @@ impl Metrics {
                 FLUSH_ELAPSED
                     .with_label_values(&["upload_puffin"])
                     .observe(self.upload_puffin.as_secs_f64());
+                if !self.compact_memtable.is_zero() {
+                    FLUSH_ELAPSED
+                        .with_label_values(&["compact_memtable"])
+                        .observe(self.upload_puffin.as_secs_f64());
+                }
             }
             WriteType::Compaction => {
                 COMPACTION_STAGE_ELAPSED

--- a/src/mito2/src/compaction/compactor.rs
+++ b/src/mito2/src/compaction/compactor.rs
@@ -335,8 +335,6 @@ impl Compactor for DefaultCompactor {
             let region_id = compaction_region.region_id;
             let cache_manager = compaction_region.cache_manager.clone();
             let storage = compaction_region.region_options.storage.clone();
-            // TODO: Set flat_format from mito config
-            let flat_format = false;
             let index_options = compaction_region
                 .current_version
                 .options
@@ -344,6 +342,9 @@ impl Compactor for DefaultCompactor {
                 .clone();
             let append_mode = compaction_region.current_version.options.append_mode;
             let merge_mode = compaction_region.current_version.options.merge_mode();
+            let flat_format = compaction_region
+                .engine_config
+                .enable_experimental_flat_format;
             let inverted_index_config = compaction_region.engine_config.inverted_index.clone();
             let fulltext_index_config = compaction_region.engine_config.fulltext_index.clone();
             let bloom_filter_index_config =

--- a/src/mito2/src/config.rs
+++ b/src/mito2/src/config.rs
@@ -141,6 +141,10 @@ pub struct MitoConfig {
     /// To align with the old behavior, the default value is 0 (no restrictions).
     #[serde(with = "humantime_serde")]
     pub min_compaction_interval: Duration,
+
+    /// Whether to enable experimental flat format.
+    /// When enabled, forces using BulkMemtable and BulkMemtableBuilder.
+    pub enable_experimental_flat_format: bool,
 }
 
 impl Default for MitoConfig {
@@ -177,6 +181,7 @@ impl Default for MitoConfig {
             bloom_filter_index: BloomFilterConfig::default(),
             memtable: MemtableConfig::default(),
             min_compaction_interval: Duration::from_secs(0),
+            enable_experimental_flat_format: false,
         };
 
         // Adjust buffer and cache size according to system memory if we can.

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -685,8 +685,7 @@ impl EngineInner {
         .with_ignore_fulltext_index(self.config.fulltext_index.apply_on_query.disabled())
         .with_ignore_bloom_filter(self.config.bloom_filter_index.apply_on_query.disabled())
         .with_start_time(query_start)
-        // TODO(yingwen): Enable it after flat format is supported.
-        .with_flat_format(false);
+        .with_flat_format(self.config.enable_experimental_flat_format);
 
         #[cfg(feature = "enterprise")]
         let scan_region = self.maybe_fill_extension_range_provider(scan_region, region);

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -444,6 +444,7 @@ impl RegionFlushTask {
                 common_telemetry::error!(e; "Failed to compact memtable before flush");
             }
             let compact_cost = compact_start.elapsed();
+            flush_metrics.compact_memtable += compact_cost;
 
             let mem_ranges = mem.ranges(None, PredicateGroup::default(), None)?;
             let num_mem_ranges = mem_ranges.ranges.len();

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -33,6 +33,7 @@ use store_api::storage::{ColumnId, SequenceNumber};
 use crate::config::MitoConfig;
 use crate::error::{Result, UnsupportedOperationSnafu};
 use crate::flush::WriteBufferManagerRef;
+use crate::memtable::bulk::BulkMemtableBuilder;
 use crate::memtable::partition_tree::{PartitionTreeConfig, PartitionTreeMemtableBuilder};
 use crate::memtable::time_series::TimeSeriesMemtableBuilder;
 use crate::metrics::WRITE_BUFFER_BYTES;
@@ -344,6 +345,18 @@ impl MemtableBuilderProvider {
         dedup: bool,
         merge_mode: MergeMode,
     ) -> MemtableBuilderRef {
+        if self.config.enable_experimental_flat_format {
+            common_telemetry::info!(
+                "Overriding memtable config, use BulkMemtable under flat format"
+            );
+
+            return Arc::new(BulkMemtableBuilder::new(
+                self.write_buffer_manager.clone(),
+                !dedup, // append_mode: true if not dedup, false if dedup
+                merge_mode,
+            ));
+        }
+
         match options {
             Some(MemtableOptions::TimeSeries) => Arc::new(TimeSeriesMemtableBuilder::new(
                 self.write_buffer_manager.clone(),
@@ -367,6 +380,14 @@ impl MemtableBuilderProvider {
     }
 
     fn default_memtable_builder(&self, dedup: bool, merge_mode: MergeMode) -> MemtableBuilderRef {
+        if self.config.enable_experimental_flat_format {
+            return Arc::new(BulkMemtableBuilder::new(
+                self.write_buffer_manager.clone(),
+                !dedup, // append_mode: true if not dedup, false if dedup
+                merge_mode,
+            ));
+        }
+
         match &self.config.memtable {
             MemtableConfig::PartitionTree(config) => {
                 let mut config = config.clone();

--- a/src/mito2/src/read/projection.rs
+++ b/src/mito2/src/read/projection.rs
@@ -749,7 +749,8 @@ mod tests {
         assert_eq!(
             [
                 (1, ConcreteDataType::int64_datatype()),
-                (4, ConcreteDataType::int64_datatype())
+                (4, ConcreteDataType::int64_datatype()),
+                (0, ConcreteDataType::timestamp_millisecond_datatype())
             ],
             mapper.as_flat().unwrap().batch_schema()
         );

--- a/src/mito2/src/sst/parquet/format.rs
+++ b/src/mito2/src/sst/parquet/format.rs
@@ -732,6 +732,8 @@ pub(crate) struct FormatProjection {
     pub(crate) projection_indices: Vec<usize>,
     /// Column id to their index in the projected schema (
     /// the schema after projection).
+    ///
+    /// It doesn't contain time index column if it is not present in the projection.
     pub(crate) column_id_to_projected_index: HashMap<ColumnId, usize>,
 }
 

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -1443,6 +1443,7 @@ parallel_scan_channel_size = 32
 max_concurrent_scan_files = 384
 allow_stale_entries = false
 min_compaction_interval = "0s"
+enable_experimental_flat_format = false
 
 [region_engine.mito.index]
 aux_path = ""


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/6078

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

This PR bridges the flat format to the mito engine and adds a flag `enable_experimental_flat_format` to enable this format. Note that once enabled, we MUST not disable the flat format because the old format can't read files with the flat format.

It fixes an issue that the `FlatProjectionMapper` may not add the time index to the `batch_schema` and `input_arrow_schema`.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
