### PR TITLE
chore: unset tz env in test

### DIFF
--- a/src/common/time/src/timezone.rs
+++ b/src/common/time/src/timezone.rs
@@ -173,6 +173,9 @@ mod tests {
 
     #[test]
     fn test_from_tz_string() {
+        unsafe {
+            std::env::remove_var("TZ");
+        }
         assert_eq!(
             Timezone::Named(Tz::UTC),
             Timezone::from_tz_string("SYSTEM").unwrap()


### PR DESCRIPTION
 ### Commit Message

I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Updated `timezone.rs` to include removal of the `TZ` environment variable in the `test_from_tz_string` function to avoid test failure when `TZ` env is set.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
