### PR TITLE
feat: add HTTP endpoint to control prof.gdump feature

### DIFF
--- a/docs/how-to/how-to-profile-memory.md
+++ b/docs/how-to/how-to-profile-memory.md
@@ -71,6 +71,15 @@ curl -X POST localhost:4000/debug/prof/mem/activate
 
 # Deactivate heap profiling
 curl -X POST localhost:4000/debug/prof/mem/deactivate
+
+# Activate gdump feature that dumps memory profiling data every time virtual memory usage exceeds previous maximum value.
+`curl -X POST localhost:4000/debug/prof/mem/gdump -d 'activate=true'`
+
+# Deactivate gdump.
+curl -X POST localhost:4000/debug/prof/mem/gdump -d 'activate=true'
+
+# Retrieve current gdump status.
+curl -X GET localhost:4000/debug/prof/mem/gdump
 ```
 
 ### Dump memory profiling data

--- a/src/common/mem-prof/src/jemalloc/error.rs
+++ b/src/common/mem-prof/src/jemalloc/error.rs
@@ -71,6 +71,18 @@ pub enum Error {
         #[snafu(source)]
         error: tikv_jemalloc_ctl::Error,
     },
+
+    #[snafu(display("Failed to read jemalloc gdump flag"))]
+    ReadGdump {
+        #[snafu(source)]
+        error: tikv_jemalloc_ctl::Error,
+    },
+
+    #[snafu(display("Failed to update jemalloc gdump flag"))]
+    UpdateGdump {
+        #[snafu(source)]
+        error: tikv_jemalloc_ctl::Error,
+    },
 }
 
 impl ErrorExt for Error {
@@ -84,6 +96,8 @@ impl ErrorExt for Error {
             Error::ActivateProf { .. } => StatusCode::Internal,
             Error::DeactivateProf { .. } => StatusCode::Internal,
             Error::ReadProfActive { .. } => StatusCode::Internal,
+            Error::ReadGdump { .. } => StatusCode::Internal,
+            Error::UpdateGdump { .. } => StatusCode::Internal,
         }
     }
 

--- a/src/common/mem-prof/src/lib.rs
+++ b/src/common/mem-prof/src/lib.rs
@@ -19,7 +19,7 @@ mod jemalloc;
 #[cfg(not(windows))]
 pub use jemalloc::{
     activate_heap_profile, deactivate_heap_profile, dump_flamegraph, dump_pprof, dump_profile,
-    is_heap_profile_active,
+    is_gdump_active, is_heap_profile_active, set_gdump_active,
 };
 
 #[cfg(windows)]
@@ -49,5 +49,15 @@ pub fn deactivate_heap_profile() -> error::Result<()> {
 
 #[cfg(windows)]
 pub fn is_heap_profile_active() -> error::Result<bool> {
+    error::ProfilingNotSupportedSnafu.fail()
+}
+
+#[cfg(windows)]
+pub fn is_gdump_active() -> error::Result<bool> {
+    error::ProfilingNotSupportedSnafu.fail()
+}
+
+#[cfg(windows)]
+pub fn set_gdump_active(_: bool) -> error::Result<()> {
     error::ProfilingNotSupportedSnafu.fail()
 }

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -899,6 +899,11 @@ impl HttpServer {
                             .route(
                                 "/mem/status",
                                 routing::get(mem_prof::heap_prof_status_handler),
+                            ) // jemalloc gdump flag status and toggle
+                            .route(
+                                "/mem/gdump",
+                                routing::get(mem_prof::gdump_status_handler)
+                                    .post(mem_prof::gdump_toggle_handler),
                             ),
                     ),
             ))


### PR DESCRIPTION

I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

[`prof.gdump`](https://jemalloc.net/jemalloc.3.html#prof.gdump) is a convenient features provided by jemalloc that dumps the memory profiling data every time the memory usage exceeds previous maximum value. This PR adds an HTTP endpoint to control the status of `prof.gdump`.

### Add Support for Jemalloc Gdump Flag

 - **`jemalloc.rs`**: Introduced `PROF_GDUMP` constant and added functions `set_gdump_active` and `is_gdump_active` to manage the gdump flag.
 - **`error.rs`**: Added error handling for reading and updating the jemalloc gdump flag with `ReadGdump` and `UpdateGdump` errors.
 - **`lib.rs`**: Exposed `is_gdump_active` and `set_gdump_active` functions for non-Windows platforms.
 - **`http.rs`**: Added HTTP routes for checking and toggling the jemalloc gdump flag status.
 - **`mem_prof.rs`**: Implemented handlers `gdump_toggle_handler` and `gdump_status_handler` for managing gdump flag via HTTP requests.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
