### PR TITLE
fix: incorrect timestamp resolution in information_schema.partitions table

### DIFF
--- a/src/catalog/src/system_schema/information_schema/partitions.rs
+++ b/src/catalog/src/system_schema/information_schema/partitions.rs
@@ -332,7 +332,7 @@ impl InformationSchemaPartitionsBuilder {
             let expression = partition.partition_expr.as_ref().map(|e| e.to_string());
             self.partition_expressions.push(expression.as_deref());
             self.create_times.push(Some(TimestampMicrosecond::from(
-                table_info.meta.created_on.timestamp_millis(),
+                table_info.meta.created_on.timestamp_micros(),
             )));
             self.partition_ids.push(Some(partition.id.as_u64()));
         }


### PR DESCRIPTION

I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


Before

<img width="1501" height="270" alt="image" src="https://github.com/user-attachments/assets/1bdf2d67-7993-4c91-a99a-a9127a0c5ffb" />

After

<img width="1499" height="282" alt="image" src="https://github.com/user-attachments/assets/05e48820-434e-4bdb-86f1-5d74de27bdc8" />


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
