### PR TITLE
fix: promql range function has incorrect timestamps

### DIFF
--- a/src/promql/src/extension_plan/range_manipulate.rs
+++ b/src/promql/src/extension_plan/range_manipulate.rs
@@ -606,13 +606,11 @@ impl RangeManipulateStream {
         // shorten the range to calculate
         let first_ts = ts_column.value(0);
         // Preserve the query's alignment pattern when optimizing start time
-        let query_offset = self.start % self.interval;
-        let candidate_start =
-            ((first_ts - query_offset) / self.interval) * self.interval + query_offset;
-        let first_ts_aligned = if candidate_start < first_ts {
-            candidate_start + self.interval
+        let remainder = (first_ts - self.start).rem_euclid(self.interval);
+        let first_ts_aligned = if remainder == 0 {
+            first_ts
         } else {
-            candidate_start
+            first_ts + (self.interval - remainder)
         };
         let last_ts = ts_column.value(ts_column.len() - 1);
         let last_ts_aligned = ((last_ts + self.range) / self.interval) * self.interval;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


The optimization implemented in #5849 may generate incorrect start timestamp alignment. E.g.,

<img width="1001" height="226" alt="image" src="https://github.com/user-attachments/assets/44ee4081-f0f0-4631-895b-27bd1673e39b" />


<img width="686" height="438" alt="image" src="https://github.com/user-attachments/assets/ab223d1e-09fd-4dc7-b092-7f1a6a2e2c20" />

after this fix:

<img width="1001" height="246" alt="image" src="https://github.com/user-attachments/assets/6145c280-3186-45e4-9ebb-c7c13bd01b5d" />



## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
