### PR TITLE
fix: match promql column reference in case sensitive way

### DIFF
--- a/src/query/src/promql/planner.rs
+++ b/src/query/src/promql/planner.rs
@@ -1223,12 +1223,13 @@ impl PromPlanner {
                 let mut exprs = Vec::with_capacity(labels.labels.len());
                 for label in &labels.labels {
                     // nonexistence label will be ignored
-                    if let Ok(field) = input_schema.field_with_unqualified_name(label) {
-                        exprs.push(DfExpr::Column(Column::from(field.name())));
+                    if let Some(column_name) = Self::find_case_sensitive_column(input_schema, label)
+                    {
+                        exprs.push(DfExpr::Column(Column::from_name(column_name.clone())));
 
                         if update_ctx {
                             // update the tag columns in context
-                            self.ctx.tag_columns.push(label.clone());
+                            self.ctx.tag_columns.push(column_name);
                         }
                     }
                 }
@@ -1291,13 +1292,12 @@ impl PromPlanner {
                 continue;
             }
 
-            let col = if table_schema
-                .field_with_unqualified_name(&matcher.name)
-                .is_err()
-            {
-                DfExpr::Literal(ScalarValue::Utf8(Some(String::new())), None).alias(matcher.name)
+            let column_name = Self::find_case_sensitive_column(table_schema, matcher.name.as_str());
+            let col = if let Some(column_name) = column_name {
+                DfExpr::Column(Column::from_name(column_name))
             } else {
-                DfExpr::Column(Column::from_name(matcher.name))
+                DfExpr::Literal(ScalarValue::Utf8(Some(String::new())), None)
+                    .alias(matcher.name.clone())
             };
             let lit = DfExpr::Literal(ScalarValue::Utf8(Some(matcher.value)), None);
             let expr = match matcher.op {
@@ -1352,6 +1352,14 @@ impl PromPlanner {
         }
 
         Ok(exprs)
+    }
+
+    fn find_case_sensitive_column(schema: &DFSchemaRef, column: &str) -> Option<String> {
+        schema
+            .fields()
+            .iter()
+            .find(|field| field.name() == column)
+            .map(|field| field.name().clone())
     }
 
     fn table_ref(&self) -> Result<TableReference> {

--- a/tests/cases/standalone/common/tql/case_sensitive.result
+++ b/tests/cases/standalone/common/tql/case_sensitive.result
@@ -81,3 +81,50 @@ drop schema "AnotherSchema";
 
 Affected Rows: 0
 
+create table metric (ts timestamp(3) time index, `AbCdE` string primary key, val double);
+
+Affected Rows: 0
+
+insert into metric values
+    (0, 'host1', 1),
+    (5000, 'host1', 2),
+    (10000, 'host1', 3),
+    (0, 'host2', 4),
+    (5000, 'host2', 5),
+    (10000, 'host2', 6);
+
+Affected Rows: 6
+
+-- which is actually group by nothing (invalid label name)
+tql eval (0,10,'5s') sum by (abcde) (metric);
+
++---------------------+-----------------+
+| ts                  | sum(metric.val) |
++---------------------+-----------------+
+| 1970-01-01T00:00:00 | 5.0             |
+| 1970-01-01T00:00:05 | 7.0             |
+| 1970-01-01T00:00:10 | 9.0             |
++---------------------+-----------------+
+
+tql eval (0,10,'5s') sum by (AbCdE) (metric);
+
++-------+---------------------+-----------------+
+| AbCdE | ts                  | sum(metric.val) |
++-------+---------------------+-----------------+
+| host1 | 1970-01-01T00:00:00 | 1.0             |
+| host1 | 1970-01-01T00:00:05 | 2.0             |
+| host1 | 1970-01-01T00:00:10 | 3.0             |
+| host2 | 1970-01-01T00:00:00 | 4.0             |
+| host2 | 1970-01-01T00:00:05 | 5.0             |
+| host2 | 1970-01-01T00:00:10 | 6.0             |
++-------+---------------------+-----------------+
+
+-- not allowed by the parser
+tql eval (0,10,'5s') sum by (`AbCdE`) (metric);
+
+Error: 2000(InvalidSyntax), invalid promql query
+
+drop table metric;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/tql/case_sensitive.sql
+++ b/tests/cases/standalone/common/tql/case_sensitive.sql
@@ -39,3 +39,23 @@ drop table "MemAvailable";
 drop table "AnotherSchema"."MemTotal";
 
 drop schema "AnotherSchema";
+
+create table metric (ts timestamp(3) time index, `AbCdE` string primary key, val double);
+
+insert into metric values
+    (0, 'host1', 1),
+    (5000, 'host1', 2),
+    (10000, 'host1', 3),
+    (0, 'host2', 4),
+    (5000, 'host2', 5),
+    (10000, 'host2', 6);
+
+-- which is actually group by nothing (invalid label name)
+tql eval (0,10,'5s') sum by (abcde) (metric);
+
+tql eval (0,10,'5s') sum by (AbCdE) (metric);
+
+-- not allowed by the parser
+tql eval (0,10,'5s') sum by (`AbCdE`) (metric);
+
+drop table metric;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Haven't figured out why this behavior changed. But I added a sqlness case for it.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
