### PR TITLE
fix: not step when aggr have order by/filter

### DIFF
--- a/src/common/function/src/aggrs/aggr_wrapper.rs
+++ b/src/common/function/src/aggrs/aggr_wrapper.rs
@@ -324,6 +324,17 @@ impl AggregateUDFImpl for StateWrapper {
             is_distinct: false,
         };
         let state_fields = self.inner.state_fields(state_fields_args)?;
+
+        let state_fields = state_fields
+            .into_iter()
+            .map(|f| {
+                let mut f = f.as_ref().clone();
+                // since state can be null when no input rows, so make all fields nullable
+                f.set_nullable(true);
+                Arc::new(f)
+            })
+            .collect::<Vec<_>>();
+
         let struct_field = DataType::Struct(state_fields.into());
         Ok(struct_field)
     }
@@ -388,6 +399,38 @@ impl Accumulator for StateAccum {
             .iter()
             .map(|s| s.to_array())
             .collect::<Result<Vec<_>, _>>()?;
+        let array_type = array
+            .iter()
+            .map(|a| a.data_type().clone())
+            .collect::<Vec<_>>();
+        let expected_type: Vec<_> = self
+            .state_fields
+            .iter()
+            .map(|f| f.data_type().clone())
+            .collect();
+        if array_type != expected_type {
+            debug!(
+                "State mismatch, expected: {}, got: {} for expected fields: {:?} and given array types: {:?}",
+                self.state_fields.len(),
+                array.len(),
+                self.state_fields,
+                array_type,
+            );
+            let guess_schema = array
+                .iter()
+                .enumerate()
+                .map(|(index, array)| {
+                    Field::new(
+                        format!("col_{index}[mismatch_state]").as_str(),
+                        array.data_type().clone(),
+                        true,
+                    )
+                })
+                .collect::<Fields>();
+            let arr = StructArray::try_new(guess_schema, array, None)?;
+
+            return Ok(ScalarValue::Struct(Arc::new(arr)));
+        }
         let struct_array = StructArray::try_new(self.state_fields.clone(), array, None)?;
         Ok(ScalarValue::Struct(Arc::new(struct_array)))
     }

--- a/src/query/src/dist_plan/commutativity.rs
+++ b/src/query/src/dist_plan/commutativity.rs
@@ -79,8 +79,11 @@ pub fn step_aggr_to_upper_aggr(
 pub fn is_all_aggr_exprs_steppable(aggr_exprs: &[Expr]) -> bool {
     aggr_exprs.iter().all(|expr| {
         if let Some(aggr_func) = get_aggr_func(expr) {
-            if aggr_func.params.distinct {
-                // Distinct aggregate functions are not steppable(yet).
+            if aggr_func.params.distinct
+                | !aggr_func.params.order_by.is_empty()
+                | aggr_func.params.filter.is_some()
+            {
+                // Distinct aggregate functions/order by/filter in aggr args are not steppable(yet).
                 return false;
             }
 

--- a/src/query/src/dist_plan/commutativity.rs
+++ b/src/query/src/dist_plan/commutativity.rs
@@ -80,8 +80,8 @@ pub fn is_all_aggr_exprs_steppable(aggr_exprs: &[Expr]) -> bool {
     aggr_exprs.iter().all(|expr| {
         if let Some(aggr_func) = get_aggr_func(expr) {
             if aggr_func.params.distinct
-                | !aggr_func.params.order_by.is_empty()
-                | aggr_func.params.filter.is_some()
+                || !aggr_func.params.order_by.is_empty()
+                || aggr_func.params.filter.is_some()
             {
                 // Distinct aggregate functions/order by/filter in aggr args are not steppable(yet).
                 return false;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

due to bad support in datafusion and substrait, aggr with order by/filter have some issues when using/serde-ing, so disable step aggr for those case for now until those issues get fixed&properly tested:
- disable step aggr for aggr func with order by/filter
- set state function's return type to all nullable for case when input is empty but need a state(which usually will be null)

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
