### PR TITLE
fix: skip placeholder when partition columns

### DIFF
--- a/src/query/src/dist_plan/analyzer.rs
+++ b/src/query/src/dist_plan/analyzer.rs
@@ -52,6 +52,9 @@ mod utils;
 
 pub(crate) use utils::AliasMapping;
 
+/// Placeholder for other physical partition columns that are not in logical table
+const OTHER_PHY_PART_COL_PLACEHOLDER: &str = "__OTHER_PHYSICAL_PART_COLS_PLACEHOLDER__";
+
 #[derive(Debug, Clone)]
 pub struct DistPlannerOptions {
     pub allow_query_fallback: bool,
@@ -530,12 +533,16 @@ impl PlanRewriter {
                     // as subset of phy part cols can still be used for certain optimization, and it works as if
                     // those columns are always null
                     // This helps with distinguishing between non-partitioned table and partitioned table with all phy part cols not in logical table
-                    partition_cols.push("__OTHER_PHYSICAL_PART_COLS_PLACEHOLDER__".to_string());
+                    partition_cols.push(OTHER_PHY_PART_COL_PLACEHOLDER.to_string());
                 }
                 self.partition_cols = Some(
                             partition_cols
                                 .into_iter()
                                 .map(|c| {
+                                    if c == OTHER_PHY_PART_COL_PLACEHOLDER {
+                                        // for placeholder, just return a empty alias
+                                        return Ok((c.clone(), BTreeSet::new()));
+                                    }
                                     let index =
                                         plan.schema().index_of_column_by_name(None, &c).ok_or_else(|| {
                                             datafusion_common::DataFusionError::Internal(

--- a/src/query/src/dist_plan/analyzer/fallback.rs
+++ b/src/query/src/dist_plan/analyzer/fallback.rs
@@ -28,7 +28,7 @@ use table::metadata::TableType;
 use table::table::adapter::DfTableProviderAdapter;
 
 use crate::dist_plan::MergeScanLogicalPlan;
-use crate::dist_plan::analyzer::AliasMapping;
+use crate::dist_plan::analyzer::{AliasMapping, OTHER_PHY_PART_COL_PLACEHOLDER};
 
 /// FallbackPlanRewriter is a plan rewriter that will only push down table scan node
 /// This is used when `PlanRewriter` produce errors when trying to rewrite the plan
@@ -70,6 +70,10 @@ impl TreeNodeRewriter for FallbackPlanRewriter {
                         Some(partition_cols
                                 .into_iter()
                                 .map(|c| {
+                                    if c == OTHER_PHY_PART_COL_PLACEHOLDER {
+                                        // for placeholder, just return a empty alias
+                                        return Ok((c.clone(), BTreeSet::new()));
+                                    }
                                     let index =
                                         plan.schema().index_of_column_by_name(None, &c).ok_or_else(|| {
                                             datafusion_common::DataFusionError::Internal(

--- a/tests/cases/standalone/common/create/metric_engine_partition.result
+++ b/tests/cases/standalone/common/create/metric_engine_partition.result
@@ -386,6 +386,35 @@ select ts, count(*) from logical_table_4 GROUP BY ts ORDER BY ts;
 |_|_|
 +-+-+
 
+select * from logical_table_4;
+
++-----------------------+-----+------+-------------------+---------------------+
+| another_partition_key | cpu | host | one_partition_key | ts                  |
++-----------------------+-----+------+-------------------+---------------------+
+|                       | 1.0 |      |                   | 2023-01-01T00:00:00 |
+|                       | 2.0 |      |                   | 2023-01-01T00:00:01 |
+|                       | 3.0 |      |                   | 2023-01-01T00:00:02 |
++-----------------------+-----+------+-------------------+---------------------+
+
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE (RepartitionExec:.*) RepartitionExec: REDACTED
+EXPLAIN select * from logical_table_4;
+
++-+-+
+| plan_type_| plan_|
++-+-+
+| logical_plan_| MergeScan [is_placeholder=false, remote_input=[_|
+|_| Projection: logical_table_4.another_partition_key, logical_table_4.cpu, logical_table_4.host, logical_table_4.one_partition_key, logical_table_4.ts |
+|_|_TableScan: logical_table_4_|
+|_| ]]_|
+| physical_plan | CooperativeExec_|
+|_|_MergeScanExec: REDACTED
+|_|_|
++-+-+
+
 drop table logical_table_2;
 
 Affected Rows: 0

--- a/tests/cases/standalone/common/create/metric_engine_partition.sql
+++ b/tests/cases/standalone/common/create/metric_engine_partition.sql
@@ -140,6 +140,15 @@ select ts, count(*) from logical_table_4 GROUP BY ts ORDER BY ts;
 EXPLAIN 
 select ts, count(*) from logical_table_4 GROUP BY ts ORDER BY ts;
 
+select * from logical_table_4;
+
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE (RepartitionExec:.*) RepartitionExec: REDACTED
+EXPLAIN select * from logical_table_4;
+
 drop table logical_table_2;
 
 drop table logical_table_3;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

as title, empty alias for placeholder column, so that old metrics table wouldn't error when query

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
