### PR TITLE
fix: fix panic and limit concurrency in flat format

### DIFF
--- a/src/mito2/src/read/compat.rs
+++ b/src/mito2/src/read/compat.rs
@@ -90,7 +90,6 @@ pub(crate) enum CompatBatch {
     /// Adapter for primary key format.
     PrimaryKey(PrimaryKeyCompatBatch),
     /// Adapter for flat format.
-    #[allow(dead_code)]
     Flat(FlatCompatBatch),
 }
 
@@ -104,7 +103,6 @@ impl CompatBatch {
     }
 
     /// Returns the inner flat batch adapter if this is a Flat format.
-    #[allow(dead_code)]
     pub(crate) fn as_flat(&self) -> Option<&FlatCompatBatch> {
         match self {
             CompatBatch::Flat(batch) => Some(batch),
@@ -186,7 +184,6 @@ pub(crate) fn has_same_columns_and_pk_encoding(
 }
 
 /// A helper struct to adapt schema of the batch to an expected schema.
-#[allow(dead_code)]
 pub(crate) struct FlatCompatBatch {
     /// Indices to convert actual fields to expect fields.
     index_or_defaults: Vec<IndexOrDefault>,
@@ -286,7 +283,6 @@ impl FlatCompatBatch {
     }
 
     /// Make columns of the `batch` compatible.
-    #[allow(dead_code)]
     pub(crate) fn compat(&self, batch: RecordBatch) -> Result<RecordBatch> {
         let len = batch.num_rows();
         let columns = self

--- a/src/mito2/src/read/compat.rs
+++ b/src/mito2/src/read/compat.rs
@@ -379,11 +379,13 @@ impl FlatCompatBatch {
         // Since this is for compaction, we always read all columns.
         let actual_schema: Vec<_> = actual
             .field_columns()
+            .chain([actual.time_index_column()])
             .map(|col| (col.column_id, col.column_schema.data_type.clone()))
             .collect();
         let expect_schema: Vec<_> = mapper
             .metadata()
             .field_columns()
+            .chain([mapper.metadata().time_index_column()])
             .map(|col| (col.column_id, col.column_schema.data_type.clone()))
             .collect();
 

--- a/src/mito2/src/read/compat.rs
+++ b/src/mito2/src/read/compat.rs
@@ -220,67 +220,6 @@ impl FlatCompatBatch {
             return FlatCompatBatch::try_new_compact_sparse(mapper, actual);
         }
 
-        // // Maps column id to the index and data type in the actual schema.
-        // let actual_schema_index: HashMap<_, _> = actual_schema
-        //     .iter()
-        //     .enumerate()
-        //     .map(|(idx, (column_id, data_type))| (*column_id, (idx, data_type)))
-        //     .collect();
-
-        // let mut index_or_defaults = Vec::with_capacity(expect_schema.len());
-        // let mut fields = Vec::with_capacity(expect_schema.len());
-        // for (column_id, expect_data_type) in expect_schema {
-        //     // Safety: expect_schema comes from the same mapper.
-        //     let column_index = mapper.metadata().column_index_by_id(*column_id).unwrap();
-        //     let expect_column = &mapper.metadata().column_metadatas[column_index];
-        //     let column_field = &mapper.metadata().schema.arrow_schema().fields()[column_index];
-        //     // For tag columns, we need to create a dictionary field.
-        //     if expect_column.semantic_type == SemanticType::Tag {
-        //         fields.push(tag_maybe_to_dictionary_field(
-        //             &expect_column.column_schema.data_type,
-        //             column_field,
-        //         ));
-        //     } else {
-        //         fields.push(column_field.clone());
-        //     };
-
-        //     if let Some((index, actual_data_type)) = actual_schema_index.get(column_id) {
-        //         let mut cast_type = None;
-
-        //         // Same column different type.
-        //         if expect_data_type != *actual_data_type {
-        //             cast_type = Some(expect_data_type.clone())
-        //         }
-        //         // Source has this column.
-        //         index_or_defaults.push(IndexOrDefault::Index {
-        //             pos: *index,
-        //             cast_type,
-        //         });
-        //     } else {
-        //         // Create a default vector with 1 element for that column.
-        //         let default_vector = expect_column
-        //             .column_schema
-        //             .create_default_vector(1)
-        //             .context(CreateDefaultSnafu {
-        //                 region_id: mapper.metadata().region_id,
-        //                 column: &expect_column.column_schema.name,
-        //             })?
-        //             .with_context(|| CompatReaderSnafu {
-        //                 region_id: mapper.metadata().region_id,
-        //                 reason: format!(
-        //                     "column {} does not have a default value to read",
-        //                     expect_column.column_schema.name
-        //                 ),
-        //             })?;
-        //         index_or_defaults.push(IndexOrDefault::DefaultValue {
-        //             column_id: expect_column.column_id,
-        //             default_vector,
-        //             semantic_type: expect_column.semantic_type,
-        //         });
-        //     };
-        // }
-        // fields.extend_from_slice(&internal_fields());
-
         let (index_or_defaults, fields) =
             Self::compute_index_and_fields(&actual_schema, expect_schema, &mapper.metadata())?;
 

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -961,6 +961,7 @@ impl ScanInput {
                     mapper,
                     flat_format.metadata(),
                     flat_format.format_projection(),
+                    self.compaction,
                 )?
                 .map(CompatBatch::Flat)
             } else {

--- a/src/mito2/src/sst/parquet/writer.rs
+++ b/src/mito2/src/sst/parquet/writer.rs
@@ -304,9 +304,11 @@ where
         opts: &WriteOptions,
     ) -> Result<SstInfoArray> {
         let mut results = smallvec![];
-        let flat_format =
-            FlatWriteFormat::new(self.metadata.clone(), &FlatSchemaOptions::default())
-                .with_override_sequence(None);
+        let flat_format = FlatWriteFormat::new(
+            self.metadata.clone(),
+            &FlatSchemaOptions::from_encoding(self.metadata.primary_key_encoding),
+        )
+        .with_override_sequence(None);
         let mut stats = SourceStats::default();
 
         while let Some(record_batch) = self

--- a/src/mito2/src/worker/handle_flush.rs
+++ b/src/mito2/src/worker/handle_flush.rs
@@ -119,6 +119,7 @@ impl<S> RegionWorkerLoop<S> {
             cache_manager: self.cache_manager.clone(),
             manifest_ctx: region.manifest_ctx.clone(),
             index_options: region.version().options.index_options.clone(),
+            flush_semaphore: self.flush_semaphore.clone(),
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
- https://github.com/GreptimeTeam/greptimedb/issues/6078

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

When the compaction job has to use FlatCompatBatch and the encoding is sparse, the schema of FlatCompatBatch still assumes the batch has decoded primary key arrays and causes schema mismatch.

This PR handles compaction and sparse encoding specially in FlatCompatBatch.

To avoid the flush job generating too many concurrent upload requests under the flat format, this PR also limits the parallelism of the spawned tasks by a global semaphore.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
