### PR TITLE
refactor: make `Function` trait a simple shim of DataFusion UDF

### DIFF
--- a/src/common/function/src/aggrs/aggr_wrapper/tests.rs
+++ b/src/common/function/src/aggrs/aggr_wrapper/tests.rs
@@ -925,7 +925,7 @@ async fn test_udaf_correct_eval_result() {
                 let percent = ScalarValue::Float64(Some(0.5)).to_array().unwrap();
                 let percent = ColumnarValue::Array(percent);
                 let state = ColumnarValue::Array(arr);
-                let udd_calc = UddSketchCalcFunction;
+                let udd_calc = UddSketchCalcFunction::default();
                 let res = udd_calc
                     .invoke_with_args(ScalarFunctionArgs {
                         args: vec![percent, state],
@@ -965,7 +965,7 @@ async fn test_udaf_correct_eval_result() {
             expected_fn: Some(|arr| {
                 let number_rows = arr.len();
                 let state = ColumnarValue::Array(arr);
-                let hll_calc = HllCalcFunction;
+                let hll_calc = HllCalcFunction::default();
                 let res = hll_calc
                     .invoke_with_args(ScalarFunctionArgs {
                         args: vec![state],

--- a/src/common/function/src/function.rs
+++ b/src/common/function/src/function.rs
@@ -17,18 +17,13 @@ use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
-use common_error::ext::{BoxedError, PlainError};
-use common_error::status_code::StatusCode;
-use common_query::error::{ExecuteSnafu, Result};
 use datafusion::arrow::datatypes::DataType;
 use datafusion::logical_expr::ColumnarValue;
 use datafusion_common::DataFusionError;
 use datafusion_common::arrow::array::ArrayRef;
 use datafusion_common::config::{ConfigEntry, ConfigExtension, ExtensionOptions};
 use datafusion_expr::{ScalarFunctionArgs, Signature};
-use datatypes::vectors::VectorRef;
 use session::context::{QueryContextBuilder, QueryContextRef};
-use snafu::ResultExt;
 
 use crate::state::FunctionState;
 
@@ -108,31 +103,15 @@ pub trait Function: fmt::Display + Sync + Send {
     fn name(&self) -> &str;
 
     /// The returned data type of function execution.
-    fn return_type(&self, input_types: &[DataType]) -> Result<DataType>;
+    fn return_type(&self, input_types: &[DataType]) -> datafusion_common::Result<DataType>;
 
     /// The signature of function.
-    fn signature(&self) -> Signature;
+    fn signature(&self) -> &Signature;
 
     fn invoke_with_args(
         &self,
         args: ScalarFunctionArgs,
-    ) -> datafusion_common::Result<ColumnarValue> {
-        // TODO(LFC): Remove default implementation once all UDFs have implemented this function.
-        let _ = args;
-        Err(datafusion_common::DataFusionError::NotImplemented(
-            "invoke_with_args".to_string(),
-        ))
-    }
-
-    /// Evaluate the function, e.g. run/execute the function.
-    /// TODO(LFC): Remove `eval` when all UDFs are rewritten to `invoke_with_args`
-    fn eval(&self, _: &FunctionContext, _: &[VectorRef]) -> Result<VectorRef> {
-        Err(BoxedError::new(PlainError::new(
-            "unsupported".to_string(),
-            StatusCode::Unsupported,
-        )))
-        .context(ExecuteSnafu)
-    }
+    ) -> datafusion_common::Result<ColumnarValue>;
 
     fn aliases(&self) -> &[String] {
         &[]

--- a/src/common/function/src/function_factory.rs
+++ b/src/common/function/src/function_factory.rs
@@ -52,9 +52,7 @@ impl From<ScalarUDF> for ScalarFunctionFactory {
 impl From<FunctionRef> for ScalarFunctionFactory {
     fn from(func: FunctionRef) -> Self {
         let name = func.name().to_string();
-        let func = Arc::new(move |ctx: FunctionContext| {
-            create_udf(func.clone(), ctx.query_ctx, ctx.state)
-        });
+        let func = Arc::new(move |_| create_udf(func.clone()));
         Self {
             name,
             factory: func,

--- a/src/common/function/src/function_registry.rs
+++ b/src/common/function/src/function_registry.rs
@@ -190,7 +190,7 @@ mod tests {
 
         assert!(registry.get_function("test_and").is_none());
         assert!(registry.scalar_functions().is_empty());
-        registry.register_scalar(TestAndFunction);
+        registry.register_scalar(TestAndFunction::default());
         let _ = registry.get_function("test_and").unwrap();
         assert_eq!(1, registry.scalar_functions().len());
     }

--- a/src/common/function/src/scalars/date.rs
+++ b/src/common/function/src/scalars/date.rs
@@ -26,8 +26,8 @@ pub(crate) struct DateFunction;
 
 impl DateFunction {
     pub fn register(registry: &FunctionRegistry) {
-        registry.register_scalar(DateAddFunction);
-        registry.register_scalar(DateSubFunction);
-        registry.register_scalar(DateFormatFunction);
+        registry.register_scalar(DateAddFunction::default());
+        registry.register_scalar(DateSubFunction::default());
+        registry.register_scalar(DateFormatFunction::default());
     }
 }

--- a/src/common/function/src/scalars/date/date_sub.rs
+++ b/src/common/function/src/scalars/date/date_sub.rs
@@ -14,7 +14,7 @@
 
 use std::fmt;
 
-use common_query::error::{ArrowComputeSnafu, Result};
+use common_query::error::ArrowComputeSnafu;
 use datafusion::logical_expr::ColumnarValue;
 use datafusion_expr::{ScalarFunctionArgs, Signature};
 use datatypes::arrow::compute::kernels::numeric;
@@ -27,35 +27,43 @@ use crate::helper;
 /// A function subtracts an interval value to Timestamp, Date, and return the result.
 /// The implementation of datetime type is based on Date64 which is incorrect so this function
 /// doesn't support the datetime type.
-#[derive(Clone, Debug, Default)]
-pub struct DateSubFunction;
+#[derive(Clone, Debug)]
+pub(crate) struct DateSubFunction {
+    signature: Signature,
+}
 
-const NAME: &str = "date_sub";
+impl Default for DateSubFunction {
+    fn default() -> Self {
+        Self {
+            signature: helper::one_of_sigs2(
+                vec![
+                    DataType::Date32,
+                    DataType::Timestamp(TimeUnit::Second, None),
+                    DataType::Timestamp(TimeUnit::Millisecond, None),
+                    DataType::Timestamp(TimeUnit::Microsecond, None),
+                    DataType::Timestamp(TimeUnit::Nanosecond, None),
+                ],
+                vec![
+                    DataType::Interval(IntervalUnit::MonthDayNano),
+                    DataType::Interval(IntervalUnit::YearMonth),
+                    DataType::Interval(IntervalUnit::DayTime),
+                ],
+            ),
+        }
+    }
+}
 
 impl Function for DateSubFunction {
     fn name(&self) -> &str {
-        NAME
+        "date_sub"
     }
 
-    fn return_type(&self, input_types: &[DataType]) -> Result<DataType> {
+    fn return_type(&self, input_types: &[DataType]) -> datafusion_common::Result<DataType> {
         Ok(input_types[0].clone())
     }
 
-    fn signature(&self) -> Signature {
-        helper::one_of_sigs2(
-            vec![
-                DataType::Date32,
-                DataType::Timestamp(TimeUnit::Second, None),
-                DataType::Timestamp(TimeUnit::Millisecond, None),
-                DataType::Timestamp(TimeUnit::Microsecond, None),
-                DataType::Timestamp(TimeUnit::Nanosecond, None),
-            ],
-            vec![
-                DataType::Interval(IntervalUnit::MonthDayNano),
-                DataType::Interval(IntervalUnit::YearMonth),
-                DataType::Interval(IntervalUnit::DayTime),
-            ],
-        )
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(
@@ -92,7 +100,7 @@ mod tests {
 
     #[test]
     fn test_date_sub_misc() {
-        let f = DateSubFunction;
+        let f = DateSubFunction::default();
         assert_eq!("date_sub", f.name());
         assert_eq!(
             DataType::Timestamp(TimeUnit::Microsecond, None),
@@ -121,7 +129,7 @@ mod tests {
 
     #[test]
     fn test_timestamp_date_sub() {
-        let f = DateSubFunction;
+        let f = DateSubFunction::default();
 
         let times = vec![Some(123), None, Some(42), None];
         // Intervals in milliseconds
@@ -170,7 +178,7 @@ mod tests {
 
     #[test]
     fn test_date_date_sub() {
-        let f = DateSubFunction;
+        let f = DateSubFunction::default();
         let days_per_month = 30;
 
         let dates = vec![

--- a/src/common/function/src/scalars/expression.rs
+++ b/src/common/function/src/scalars/expression.rs
@@ -28,6 +28,6 @@ pub(crate) struct ExpressionFunction;
 
 impl ExpressionFunction {
     pub fn register(registry: &FunctionRegistry) {
-        registry.register_scalar(IsNullFunction);
+        registry.register_scalar(IsNullFunction::default());
     }
 }

--- a/src/common/function/src/scalars/geo.rs
+++ b/src/common/function/src/scalars/geo.rs
@@ -27,57 +27,57 @@ pub(crate) struct GeoFunctions;
 impl GeoFunctions {
     pub fn register(registry: &FunctionRegistry) {
         // geohash
-        registry.register_scalar(geohash::GeohashFunction);
-        registry.register_scalar(geohash::GeohashNeighboursFunction);
+        registry.register_scalar(geohash::GeohashFunction::default());
+        registry.register_scalar(geohash::GeohashNeighboursFunction::default());
 
         // h3 index
-        registry.register_scalar(h3::H3LatLngToCell);
-        registry.register_scalar(h3::H3LatLngToCellString);
+        registry.register_scalar(h3::H3LatLngToCell::default());
+        registry.register_scalar(h3::H3LatLngToCellString::default());
 
         // h3 index inspection
-        registry.register_scalar(h3::H3CellBase);
-        registry.register_scalar(h3::H3CellIsPentagon);
-        registry.register_scalar(h3::H3StringToCell);
-        registry.register_scalar(h3::H3CellToString);
-        registry.register_scalar(h3::H3CellCenterLatLng);
-        registry.register_scalar(h3::H3CellResolution);
+        registry.register_scalar(h3::H3CellBase::default());
+        registry.register_scalar(h3::H3CellIsPentagon::default());
+        registry.register_scalar(h3::H3StringToCell::default());
+        registry.register_scalar(h3::H3CellToString::default());
+        registry.register_scalar(h3::H3CellCenterLatLng::default());
+        registry.register_scalar(h3::H3CellResolution::default());
 
         // h3 hierarchical grid
-        registry.register_scalar(h3::H3CellCenterChild);
-        registry.register_scalar(h3::H3CellParent);
-        registry.register_scalar(h3::H3CellToChildren);
-        registry.register_scalar(h3::H3CellToChildrenSize);
-        registry.register_scalar(h3::H3CellToChildPos);
-        registry.register_scalar(h3::H3ChildPosToCell);
-        registry.register_scalar(h3::H3CellContains);
+        registry.register_scalar(h3::H3CellCenterChild::default());
+        registry.register_scalar(h3::H3CellParent::default());
+        registry.register_scalar(h3::H3CellToChildren::default());
+        registry.register_scalar(h3::H3CellToChildrenSize::default());
+        registry.register_scalar(h3::H3CellToChildPos::default());
+        registry.register_scalar(h3::H3ChildPosToCell::default());
+        registry.register_scalar(h3::H3CellContains::default());
 
         // h3 grid traversal
-        registry.register_scalar(h3::H3GridDisk);
-        registry.register_scalar(h3::H3GridDiskDistances);
-        registry.register_scalar(h3::H3GridDistance);
-        registry.register_scalar(h3::H3GridPathCells);
+        registry.register_scalar(h3::H3GridDisk::default());
+        registry.register_scalar(h3::H3GridDiskDistances::default());
+        registry.register_scalar(h3::H3GridDistance::default());
+        registry.register_scalar(h3::H3GridPathCells::default());
 
         // h3 measurement
-        registry.register_scalar(h3::H3CellDistanceSphereKm);
-        registry.register_scalar(h3::H3CellDistanceEuclideanDegree);
+        registry.register_scalar(h3::H3CellDistanceSphereKm::default());
+        registry.register_scalar(h3::H3CellDistanceEuclideanDegree::default());
 
         // s2
-        registry.register_scalar(s2::S2LatLngToCell);
-        registry.register_scalar(s2::S2CellLevel);
-        registry.register_scalar(s2::S2CellToToken);
-        registry.register_scalar(s2::S2CellParent);
+        registry.register_scalar(s2::S2LatLngToCell::default());
+        registry.register_scalar(s2::S2CellLevel::default());
+        registry.register_scalar(s2::S2CellToToken::default());
+        registry.register_scalar(s2::S2CellParent::default());
 
         // spatial data type
-        registry.register_scalar(wkt::LatLngToPointWkt);
+        registry.register_scalar(wkt::LatLngToPointWkt::default());
 
         // spatial relation
-        registry.register_scalar(relation::STContains);
-        registry.register_scalar(relation::STWithin);
-        registry.register_scalar(relation::STIntersects);
+        registry.register_scalar(relation::STContains::default());
+        registry.register_scalar(relation::STWithin::default());
+        registry.register_scalar(relation::STIntersects::default());
 
         // spatial measure
-        registry.register_scalar(measure::STDistance);
-        registry.register_scalar(measure::STDistanceSphere);
-        registry.register_scalar(measure::STArea);
+        registry.register_scalar(measure::STDistance::default());
+        registry.register_scalar(measure::STDistanceSphere::default());
+        registry.register_scalar(measure::STArea::default());
     }
 }

--- a/src/common/function/src/scalars/geo/geohash.rs
+++ b/src/common/function/src/scalars/geo/geohash.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 
 use common_error::ext::{BoxedError, PlainError};
 use common_error::status_code::StatusCode;
-use common_query::error::{self, Result};
+use common_query::error;
 use datafusion::arrow::array::{Array, AsArray, ListBuilder, StringViewBuilder};
 use datafusion::arrow::datatypes::{DataType, Field, Float64Type, UInt8Type};
 use datafusion::logical_expr::ColumnarValue;
@@ -40,23 +40,13 @@ fn ensure_resolution_usize(v: u8) -> datafusion_common::Result<usize> {
 }
 
 /// Function that return geohash string for a given geospatial coordinate.
-#[derive(Clone, Debug, Default)]
-pub struct GeohashFunction;
-
-impl GeohashFunction {
-    const NAME: &'static str = "geohash";
+#[derive(Clone, Debug)]
+pub(crate) struct GeohashFunction {
+    signature: Signature,
 }
 
-impl Function for GeohashFunction {
-    fn name(&self) -> &str {
-        Self::NAME
-    }
-
-    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
-        Ok(DataType::Utf8)
-    }
-
-    fn signature(&self) -> Signature {
+impl Default for GeohashFunction {
+    fn default() -> Self {
         let mut signatures = Vec::new();
         for coord_type in &[DataType::Float32, DataType::Float64] {
             for resolution_type in INTEGERS {
@@ -70,7 +60,27 @@ impl Function for GeohashFunction {
                 ]));
             }
         }
-        Signature::one_of(signatures, Volatility::Stable)
+        Self {
+            signature: Signature::one_of(signatures, Volatility::Stable),
+        }
+    }
+}
+
+impl GeohashFunction {
+    const NAME: &'static str = "geohash";
+}
+
+impl Function for GeohashFunction {
+    fn name(&self) -> &str {
+        Self::NAME
+    }
+
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
+        Ok(DataType::Utf8)
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(
@@ -127,27 +137,13 @@ impl fmt::Display for GeohashFunction {
 }
 
 /// Function that return geohash string for a given geospatial coordinate.
-#[derive(Clone, Debug, Default)]
-pub struct GeohashNeighboursFunction;
-
-impl GeohashNeighboursFunction {
-    const NAME: &'static str = "geohash_neighbours";
+#[derive(Clone, Debug)]
+pub(crate) struct GeohashNeighboursFunction {
+    signature: Signature,
 }
 
-impl Function for GeohashNeighboursFunction {
-    fn name(&self) -> &str {
-        GeohashNeighboursFunction::NAME
-    }
-
-    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
-        Ok(DataType::List(Arc::new(Field::new(
-            "item",
-            DataType::Utf8View,
-            false,
-        ))))
-    }
-
-    fn signature(&self) -> Signature {
+impl Default for GeohashNeighboursFunction {
+    fn default() -> Self {
         let mut signatures = Vec::new();
         for coord_type in &[DataType::Float32, DataType::Float64] {
             for resolution_type in INTEGERS {
@@ -161,7 +157,31 @@ impl Function for GeohashNeighboursFunction {
                 ]));
             }
         }
-        Signature::one_of(signatures, Volatility::Stable)
+        Self {
+            signature: Signature::one_of(signatures, Volatility::Stable),
+        }
+    }
+}
+
+impl GeohashNeighboursFunction {
+    const NAME: &'static str = "geohash_neighbours";
+}
+
+impl Function for GeohashNeighboursFunction {
+    fn name(&self) -> &str {
+        GeohashNeighboursFunction::NAME
+    }
+
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
+        Ok(DataType::List(Arc::new(Field::new(
+            "item",
+            DataType::Utf8View,
+            false,
+        ))))
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(

--- a/src/common/function/src/scalars/geo/measure.rs
+++ b/src/common/function/src/scalars/geo/measure.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use common_error::ext::{BoxedError, PlainError};
 use common_error::status_code::StatusCode;
-use common_query::error::{self, Result};
+use common_query::error;
 use datafusion_common::arrow::array::{Array, AsArray, Float64Builder};
 use datafusion_common::arrow::compute;
 use datafusion_common::arrow::datatypes::DataType;
@@ -31,21 +31,31 @@ use crate::function::{Function, extract_args};
 use crate::scalars::geo::wkt::parse_wkt;
 
 /// Return WGS84(SRID: 4326) euclidean distance between two geometry object, in degree
-#[derive(Clone, Debug, Default, Display)]
+#[derive(Clone, Debug, Display)]
 #[display("{}", self.name())]
-pub struct STDistance;
+pub(crate) struct STDistance {
+    signature: Signature,
+}
+
+impl Default for STDistance {
+    fn default() -> Self {
+        Self {
+            signature: Signature::string(2, Volatility::Stable),
+        }
+    }
+}
 
 impl Function for STDistance {
     fn name(&self) -> &str {
         "st_distance"
     }
 
-    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
         Ok(DataType::Float64)
     }
 
-    fn signature(&self) -> Signature {
-        Signature::string(2, Volatility::Stable)
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(
@@ -84,21 +94,31 @@ impl Function for STDistance {
 }
 
 /// Return great circle distance between two geometry object, in meters
-#[derive(Clone, Debug, Default, Display)]
+#[derive(Clone, Debug, Display)]
 #[display("{}", self.name())]
-pub struct STDistanceSphere;
+pub(crate) struct STDistanceSphere {
+    signature: Signature,
+}
+
+impl Default for STDistanceSphere {
+    fn default() -> Self {
+        Self {
+            signature: Signature::string(2, Volatility::Stable),
+        }
+    }
+}
 
 impl Function for STDistanceSphere {
     fn name(&self) -> &str {
         "st_distance_sphere_m"
     }
 
-    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
         Ok(DataType::Float64)
     }
 
-    fn signature(&self) -> Signature {
-        Signature::string(2, Volatility::Stable)
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(
@@ -147,21 +167,31 @@ impl Function for STDistanceSphere {
 }
 
 /// Return area of given geometry object
-#[derive(Clone, Debug, Default, Display)]
+#[derive(Clone, Debug, Display)]
 #[display("{}", self.name())]
-pub struct STArea;
+pub(crate) struct STArea {
+    signature: Signature,
+}
+
+impl Default for STArea {
+    fn default() -> Self {
+        Self {
+            signature: Signature::string(1, Volatility::Stable),
+        }
+    }
+}
 
 impl Function for STArea {
     fn name(&self) -> &str {
         "st_area"
     }
 
-    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
         Ok(DataType::Float64)
     }
 
-    fn signature(&self) -> Signature {
-        Signature::string(1, Volatility::Stable)
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(

--- a/src/common/function/src/scalars/ip.rs
+++ b/src/common/function/src/scalars/ip.rs
@@ -30,14 +30,14 @@ impl IpFunctions {
     pub fn register(registry: &FunctionRegistry) {
         // Register IPv4 functions
         registry.register_scalar(Ipv4NumToString::default());
-        registry.register_scalar(Ipv4StringToNum);
-        registry.register_scalar(Ipv4ToCidr);
-        registry.register_scalar(Ipv4InRange);
+        registry.register_scalar(Ipv4StringToNum::default());
+        registry.register_scalar(Ipv4ToCidr::default());
+        registry.register_scalar(Ipv4InRange::default());
 
         // Register IPv6 functions
-        registry.register_scalar(Ipv6NumToString);
-        registry.register_scalar(Ipv6StringToNum);
-        registry.register_scalar(Ipv6ToCidr);
-        registry.register_scalar(Ipv6InRange);
+        registry.register_scalar(Ipv6NumToString::default());
+        registry.register_scalar(Ipv6StringToNum::default());
+        registry.register_scalar(Ipv6ToCidr::default());
+        registry.register_scalar(Ipv6InRange::default());
     }
 }

--- a/src/common/function/src/scalars/ip/range.rs
+++ b/src/common/function/src/scalars/ip/range.rs
@@ -36,21 +36,31 @@ use crate::function::{Function, extract_args};
 /// - ipv4_in_range('192.168.1.5', '192.168.1.0/24') -> true
 /// - ipv4_in_range('192.168.2.1', '192.168.1.0/24') -> false
 /// - ipv4_in_range('10.0.0.1', '10.0.0.0/8') -> true
-#[derive(Clone, Debug, Default, Display)]
+#[derive(Clone, Debug, Display)]
 #[display("{}", self.name())]
-pub struct Ipv4InRange;
+pub(crate) struct Ipv4InRange {
+    signature: Signature,
+}
+
+impl Default for Ipv4InRange {
+    fn default() -> Self {
+        Self {
+            signature: Signature::string(2, Volatility::Immutable),
+        }
+    }
+}
 
 impl Function for Ipv4InRange {
     fn name(&self) -> &str {
         "ipv4_in_range"
     }
 
-    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
         Ok(DataType::Boolean)
     }
 
-    fn signature(&self) -> Signature {
-        Signature::string(2, Volatility::Immutable)
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(
@@ -114,21 +124,31 @@ impl Function for Ipv4InRange {
 /// - ipv6_in_range('2001:db8:1::', '2001:db8::/32') -> true
 /// - ipv6_in_range('2001:db9::1', '2001:db8::/32') -> false
 /// - ipv6_in_range('::1', '::1/128') -> true
-#[derive(Clone, Debug, Default, Display)]
+#[derive(Clone, Debug, Display)]
 #[display("{}", self.name())]
-pub struct Ipv6InRange;
+pub(crate) struct Ipv6InRange {
+    signature: Signature,
+}
+
+impl Default for Ipv6InRange {
+    fn default() -> Self {
+        Self {
+            signature: Signature::string(2, Volatility::Immutable),
+        }
+    }
+}
 
 impl Function for Ipv6InRange {
     fn name(&self) -> &str {
         "ipv6_in_range"
     }
 
-    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
         Ok(DataType::Boolean)
     }
 
-    fn signature(&self) -> Signature {
-        Signature::string(2, Volatility::Immutable)
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(
@@ -313,7 +333,7 @@ mod tests {
 
     #[test]
     fn test_ipv4_in_range() {
-        let func = Ipv4InRange;
+        let func = Ipv4InRange::default();
 
         // Test IPs
         let ip_values = vec![
@@ -357,7 +377,7 @@ mod tests {
 
     #[test]
     fn test_ipv6_in_range() {
-        let func = Ipv6InRange;
+        let func = Ipv6InRange::default();
 
         // Test IPs
         let ip_values = vec![
@@ -401,8 +421,8 @@ mod tests {
 
     #[test]
     fn test_invalid_inputs() {
-        let ipv4_func = Ipv4InRange;
-        let ipv6_func = Ipv6InRange;
+        let ipv4_func = Ipv4InRange::default();
+        let ipv6_func = Ipv6InRange::default();
 
         // Invalid IPv4 address
         let invalid_ip_values = vec!["not-an-ip", "192.168.1.300"];
@@ -448,7 +468,7 @@ mod tests {
 
     #[test]
     fn test_edge_cases() {
-        let ipv4_func = Ipv4InRange;
+        let ipv4_func = Ipv4InRange::default();
 
         // Edge cases like prefix length 0 (matches everything) and 32 (exact match)
         let ip_values = vec!["8.8.8.8", "192.168.1.1", "192.168.1.1"];

--- a/src/common/function/src/scalars/json.rs
+++ b/src/common/function/src/scalars/json.rs
@@ -32,23 +32,23 @@ pub(crate) struct JsonFunction;
 
 impl JsonFunction {
     pub fn register(registry: &FunctionRegistry) {
-        registry.register_scalar(JsonToStringFunction);
-        registry.register_scalar(ParseJsonFunction);
+        registry.register_scalar(JsonToStringFunction::default());
+        registry.register_scalar(ParseJsonFunction::default());
 
-        registry.register_scalar(JsonGetInt);
-        registry.register_scalar(JsonGetFloat);
-        registry.register_scalar(JsonGetString);
-        registry.register_scalar(JsonGetBool);
+        registry.register_scalar(JsonGetInt::default());
+        registry.register_scalar(JsonGetFloat::default());
+        registry.register_scalar(JsonGetString::default());
+        registry.register_scalar(JsonGetBool::default());
 
-        registry.register_scalar(JsonIsNull);
-        registry.register_scalar(JsonIsInt);
-        registry.register_scalar(JsonIsFloat);
-        registry.register_scalar(JsonIsString);
-        registry.register_scalar(JsonIsBool);
-        registry.register_scalar(JsonIsArray);
-        registry.register_scalar(JsonIsObject);
+        registry.register_scalar(JsonIsNull::default());
+        registry.register_scalar(JsonIsInt::default());
+        registry.register_scalar(JsonIsFloat::default());
+        registry.register_scalar(JsonIsString::default());
+        registry.register_scalar(JsonIsBool::default());
+        registry.register_scalar(JsonIsArray::default());
+        registry.register_scalar(JsonIsObject::default());
 
-        registry.register_scalar(json_path_exists::JsonPathExistsFunction);
-        registry.register_scalar(json_path_match::JsonPathMatchFunction);
+        registry.register_scalar(json_path_exists::JsonPathExistsFunction::default());
+        registry.register_scalar(json_path_match::JsonPathMatchFunction::default());
     }
 }

--- a/src/common/function/src/scalars/json/json_path_exists.rs
+++ b/src/common/function/src/scalars/json/json_path_exists.rs
@@ -16,7 +16,6 @@ use std::fmt::{self, Display};
 use std::sync::Arc;
 
 use arrow::compute;
-use common_query::error::Result;
 use datafusion_common::DataFusionError;
 use datafusion_common::arrow::array::{Array, AsArray, BooleanBuilder};
 use datafusion_common::arrow::datatypes::DataType;
@@ -26,8 +25,22 @@ use crate::function::{Function, extract_args};
 use crate::helper;
 
 /// Check if the given JSON data contains the given JSON path.
-#[derive(Clone, Debug, Default)]
-pub struct JsonPathExistsFunction;
+#[derive(Clone, Debug)]
+pub(crate) struct JsonPathExistsFunction {
+    signature: Signature,
+}
+
+impl Default for JsonPathExistsFunction {
+    fn default() -> Self {
+        Self {
+            // TODO(LFC): Use a more clear type here instead of "Binary" for Json input, once we have a "Json" type.
+            signature: helper::one_of_sigs2(
+                vec![DataType::Binary, DataType::BinaryView, DataType::Null],
+                vec![DataType::Utf8, DataType::Utf8View, DataType::Null],
+            ),
+        }
+    }
+}
 
 const NAME: &str = "json_path_exists";
 
@@ -36,16 +49,12 @@ impl Function for JsonPathExistsFunction {
         NAME
     }
 
-    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
         Ok(DataType::Boolean)
     }
 
-    fn signature(&self) -> Signature {
-        // TODO(LFC): Use a more clear type here instead of "Binary" for Json input, once we have a "Json" type.
-        helper::one_of_sigs2(
-            vec![DataType::Binary, DataType::BinaryView, DataType::Null],
-            vec![DataType::Utf8, DataType::Utf8View, DataType::Null],
-        )
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(
@@ -110,7 +119,7 @@ mod tests {
 
     #[test]
     fn test_json_path_exists_function() {
-        let json_path_exists = JsonPathExistsFunction;
+        let json_path_exists = JsonPathExistsFunction::default();
 
         assert_eq!("json_path_exists", json_path_exists.name());
         assert_eq!(

--- a/src/common/function/src/scalars/json/parse_json.rs
+++ b/src/common/function/src/scalars/json/parse_json.rs
@@ -15,7 +15,6 @@
 use std::fmt::{self, Display};
 use std::sync::Arc;
 
-use common_query::error::Result;
 use datafusion_common::DataFusionError;
 use datafusion_common::arrow::array::{Array, AsArray, BinaryViewBuilder};
 use datafusion_common::arrow::compute;
@@ -25,8 +24,18 @@ use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, Signature, Volatility};
 use crate::function::{Function, extract_args};
 
 /// Parses the `String` into `JSONB`.
-#[derive(Clone, Debug, Default)]
-pub struct ParseJsonFunction;
+#[derive(Clone, Debug)]
+pub(crate) struct ParseJsonFunction {
+    signature: Signature,
+}
+
+impl Default for ParseJsonFunction {
+    fn default() -> Self {
+        Self {
+            signature: Signature::string(1, Volatility::Immutable),
+        }
+    }
+}
 
 const NAME: &str = "parse_json";
 
@@ -35,12 +44,12 @@ impl Function for ParseJsonFunction {
         NAME
     }
 
-    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
         Ok(DataType::BinaryView)
     }
 
-    fn signature(&self) -> Signature {
-        Signature::string(1, Volatility::Immutable)
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(
@@ -87,7 +96,7 @@ mod tests {
 
     #[test]
     fn test_get_by_path_function() {
-        let parse_json = ParseJsonFunction;
+        let parse_json = ParseJsonFunction::default();
 
         assert_eq!("parse_json", parse_json.name());
         assert_eq!(

--- a/src/common/function/src/scalars/matches.rs
+++ b/src/common/function/src/scalars/matches.rs
@@ -35,12 +35,22 @@ use crate::function_registry::FunctionRegistry;
 /// `matches` for full text search.
 ///
 /// Usage: matches(`<col>`, `<pattern>`) -> boolean
-#[derive(Clone, Debug, Default)]
-pub struct MatchesFunction;
+#[derive(Clone, Debug)]
+pub struct MatchesFunction {
+    signature: Signature,
+}
 
 impl MatchesFunction {
     pub fn register(registry: &FunctionRegistry) {
-        registry.register_scalar(MatchesFunction);
+        registry.register_scalar(MatchesFunction::default());
+    }
+}
+
+impl Default for MatchesFunction {
+    fn default() -> Self {
+        Self {
+            signature: Signature::string(2, Volatility::Immutable),
+        }
     }
 }
 
@@ -55,12 +65,12 @@ impl Function for MatchesFunction {
         "matches"
     }
 
-    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
         Ok(DataType::Boolean)
     }
 
-    fn signature(&self) -> Signature {
-        Signature::string(2, Volatility::Immutable)
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     // TODO: read case-sensitive config
@@ -1382,7 +1392,7 @@ mod test {
             ),
         ];
 
-        let f = MatchesFunction;
+        let f = MatchesFunction::default();
         for (pattern, expected) in cases {
             let args = ScalarFunctionArgs {
                 args: vec![

--- a/src/common/function/src/scalars/matches_term.rs
+++ b/src/common/function/src/scalars/matches_term.rs
@@ -15,7 +15,6 @@
 use std::fmt;
 use std::sync::Arc;
 
-use common_query::error::Result;
 use datafusion_common::arrow::array::{Array, AsArray, BooleanArray, BooleanBuilder};
 use datafusion_common::arrow::compute;
 use datafusion_common::arrow::datatypes::DataType;
@@ -72,11 +71,21 @@ use crate::function_registry::FunctionRegistry;
 /// -- Text: "Cat" => true
 /// -- Text: "cat" => false
 /// ```
-pub struct MatchesTermFunction;
+pub struct MatchesTermFunction {
+    signature: Signature,
+}
 
 impl MatchesTermFunction {
     pub fn register(registry: &FunctionRegistry) {
-        registry.register_scalar(MatchesTermFunction);
+        registry.register_scalar(MatchesTermFunction::default());
+    }
+}
+
+impl Default for MatchesTermFunction {
+    fn default() -> Self {
+        Self {
+            signature: Signature::string(2, Volatility::Immutable),
+        }
     }
 }
 
@@ -91,12 +100,12 @@ impl Function for MatchesTermFunction {
         "matches_term"
     }
 
-    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
         Ok(DataType::Boolean)
     }
 
-    fn signature(&self) -> Signature {
-        Signature::string(2, Volatility::Immutable)
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(

--- a/src/common/function/src/scalars/math/clamp.rs
+++ b/src/common/function/src/scalars/math/clamp.rs
@@ -15,7 +15,6 @@
 use std::fmt::{self, Display};
 use std::sync::Arc;
 
-use common_query::error::Result;
 use datafusion::arrow::array::{Array, ArrayRef, AsArray, PrimitiveArray};
 use datafusion::arrow::datatypes::DataType as ArrowDataType;
 use datafusion::logical_expr::{ColumnarValue, Volatility};
@@ -25,8 +24,19 @@ use datafusion_expr::{ScalarFunctionArgs, Signature};
 
 use crate::function::Function;
 
-#[derive(Clone, Debug, Default)]
-pub struct ClampFunction;
+#[derive(Clone, Debug)]
+pub struct ClampFunction {
+    signature: Signature,
+}
+
+impl Default for ClampFunction {
+    fn default() -> Self {
+        Self {
+            // input, min, max
+            signature: Signature::uniform(3, NUMERICS.to_vec(), Volatility::Immutable),
+        }
+    }
+}
 
 const CLAMP_NAME: &str = "clamp";
 
@@ -35,14 +45,16 @@ impl Function for ClampFunction {
         CLAMP_NAME
     }
 
-    fn return_type(&self, input_types: &[ArrowDataType]) -> Result<ArrowDataType> {
+    fn return_type(
+        &self,
+        input_types: &[ArrowDataType],
+    ) -> datafusion_common::Result<ArrowDataType> {
         // Type check is done by `signature`
         Ok(input_types[0].clone())
     }
 
-    fn signature(&self) -> Signature {
-        // input, min, max
-        Signature::uniform(3, NUMERICS.to_vec(), Volatility::Immutable)
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(
@@ -211,8 +223,19 @@ fn clamp_impl(
     }
 }
 
-#[derive(Clone, Debug, Default)]
-pub struct ClampMinFunction;
+#[derive(Clone, Debug)]
+pub struct ClampMinFunction {
+    signature: Signature,
+}
+
+impl Default for ClampMinFunction {
+    fn default() -> Self {
+        Self {
+            // input, min
+            signature: Signature::uniform(2, NUMERICS.to_vec(), Volatility::Immutable),
+        }
+    }
+}
 
 const CLAMP_MIN_NAME: &str = "clamp_min";
 
@@ -221,13 +244,15 @@ impl Function for ClampMinFunction {
         CLAMP_MIN_NAME
     }
 
-    fn return_type(&self, input_types: &[ArrowDataType]) -> Result<ArrowDataType> {
+    fn return_type(
+        &self,
+        input_types: &[ArrowDataType],
+    ) -> datafusion_common::Result<ArrowDataType> {
         Ok(input_types[0].clone())
     }
 
-    fn signature(&self) -> Signature {
-        // input, min
-        Signature::uniform(2, NUMERICS.to_vec(), Volatility::Immutable)
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(
@@ -252,8 +277,19 @@ impl Display for ClampMinFunction {
     }
 }
 
-#[derive(Clone, Debug, Default)]
-pub struct ClampMaxFunction;
+#[derive(Clone, Debug)]
+pub struct ClampMaxFunction {
+    signature: Signature,
+}
+
+impl Default for ClampMaxFunction {
+    fn default() -> Self {
+        Self {
+            // input, max
+            signature: Signature::uniform(2, NUMERICS.to_vec(), Volatility::Immutable),
+        }
+    }
+}
 
 const CLAMP_MAX_NAME: &str = "clamp_max";
 
@@ -262,13 +298,15 @@ impl Function for ClampMaxFunction {
         CLAMP_MAX_NAME
     }
 
-    fn return_type(&self, input_types: &[ArrowDataType]) -> Result<ArrowDataType> {
+    fn return_type(
+        &self,
+        input_types: &[ArrowDataType],
+    ) -> datafusion_common::Result<ArrowDataType> {
         Ok(input_types[0].clone())
     }
 
-    fn signature(&self) -> Signature {
-        // input, max
-        Signature::uniform(2, NUMERICS.to_vec(), Volatility::Immutable)
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(
@@ -361,7 +399,7 @@ mod test {
             ),
         ];
 
-        let func = ClampFunction;
+        let func = ClampFunction::default();
         for (in_data, min, max, expected) in inputs {
             let number_rows = in_data.len();
             let args = vec![
@@ -404,7 +442,7 @@ mod test {
             ),
         ];
 
-        let func = ClampFunction;
+        let func = ClampFunction::default();
         for (in_data, min, max, expected) in inputs {
             let number_rows = in_data.len();
             let args = vec![
@@ -447,7 +485,7 @@ mod test {
             ),
         ];
 
-        let func = ClampFunction;
+        let func = ClampFunction::default();
         for (in_data, min, max, expected) in inputs {
             let number_rows = in_data.len();
             let args = vec![
@@ -467,7 +505,7 @@ mod test {
         let min = 10.0;
         let max = -1.0;
 
-        let func = ClampFunction;
+        let func = ClampFunction::default();
         let number_rows = input.len();
         let args = vec![
             ColumnarValue::Array(Arc::new(Float64Array::from(input))),
@@ -484,7 +522,7 @@ mod test {
         let min = -1i64;
         let max = 10u64;
 
-        let func = ClampFunction;
+        let func = ClampFunction::default();
         let number_rows = input.len();
         let args = vec![
             ColumnarValue::Array(Arc::new(Float64Array::from(input))),
@@ -501,7 +539,7 @@ mod test {
         let min = -10.0;
         let max = 1.0;
 
-        let func = ClampFunction;
+        let func = ClampFunction::default();
         let number_rows = input.len();
         let args = vec![
             ColumnarValue::Array(Arc::new(Float64Array::from(input))),
@@ -517,7 +555,7 @@ mod test {
         let input = vec![Some(-3.0), Some(-2.0), Some(-1.0), Some(0.0), Some(1.0)];
         let min = -10.0;
 
-        let func = ClampFunction;
+        let func = ClampFunction::default();
         let number_rows = input.len();
         let args = vec![
             ColumnarValue::Array(Arc::new(Float64Array::from(input))),
@@ -531,7 +569,7 @@ mod test {
     fn clamp_on_string() {
         let input = vec![Some("foo"), Some("foo"), Some("foo"), Some("foo")];
 
-        let func = ClampFunction;
+        let func = ClampFunction::default();
         let number_rows = input.len();
         let args = vec![
             ColumnarValue::Array(Arc::new(StringArray::from(input))),
@@ -557,7 +595,7 @@ mod test {
             ),
         ];
 
-        let func = ClampMinFunction;
+        let func = ClampMinFunction::default();
         for (in_data, min, expected) in inputs {
             let number_rows = in_data.len();
             let args = vec![
@@ -585,7 +623,7 @@ mod test {
             ),
         ];
 
-        let func = ClampMaxFunction;
+        let func = ClampMaxFunction::default();
         for (in_data, max, expected) in inputs {
             let number_rows = in_data.len();
             let args = vec![
@@ -606,7 +644,7 @@ mod test {
             vec![Some(-1.0), Some(-1.0), Some(-1.0), Some(0.0), Some(1.0)],
         )];
 
-        let func = ClampMinFunction;
+        let func = ClampMinFunction::default();
         for (in_data, min, expected) in inputs {
             let number_rows = in_data.len();
             let args = vec![
@@ -627,7 +665,7 @@ mod test {
             vec![Some(-3.0), Some(-2.0), Some(-1.0), Some(0.0), Some(0.0)],
         )];
 
-        let func = ClampMaxFunction;
+        let func = ClampMaxFunction::default();
         for (in_data, max, expected) in inputs {
             let number_rows = in_data.len();
             let args = vec![
@@ -645,7 +683,7 @@ mod test {
         let input = vec![Some(-3.0), Some(-2.0), Some(-1.0), Some(0.0), Some(1.0)];
         let min = -1i64;
 
-        let func = ClampMinFunction;
+        let func = ClampMinFunction::default();
         let number_rows = input.len();
         let args = vec![
             ColumnarValue::Array(Arc::new(Float64Array::from(input))),
@@ -660,7 +698,7 @@ mod test {
         let input = vec![Some(-3.0), Some(-2.0), Some(-1.0), Some(0.0), Some(1.0)];
         let max = 1i64;
 
-        let func = ClampMaxFunction;
+        let func = ClampMaxFunction::default();
         let number_rows = input.len();
         let args = vec![
             ColumnarValue::Array(Arc::new(Float64Array::from(input))),

--- a/src/common/function/src/scalars/math/modulo.rs
+++ b/src/common/function/src/scalars/math/modulo.rs
@@ -15,7 +15,6 @@
 use std::fmt;
 use std::fmt::Display;
 
-use common_query::error::Result;
 use datafusion_common::arrow::compute;
 use datafusion_common::arrow::compute::kernels::numeric;
 use datafusion_common::arrow::datatypes::DataType;
@@ -27,8 +26,18 @@ use crate::function::{Function, extract_args};
 const NAME: &str = "mod";
 
 /// The function to find remainders
-#[derive(Clone, Debug, Default)]
-pub struct ModuloFunction;
+#[derive(Clone, Debug)]
+pub(crate) struct ModuloFunction {
+    signature: Signature,
+}
+
+impl Default for ModuloFunction {
+    fn default() -> Self {
+        Self {
+            signature: Signature::uniform(2, NUMERICS.to_vec(), Volatility::Immutable),
+        }
+    }
+}
 
 impl Display for ModuloFunction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -41,7 +50,7 @@ impl Function for ModuloFunction {
         NAME
     }
 
-    fn return_type(&self, input_types: &[DataType]) -> Result<DataType> {
+    fn return_type(&self, input_types: &[DataType]) -> datafusion_common::Result<DataType> {
         if input_types.iter().all(DataType::is_signed_integer) {
             Ok(DataType::Int64)
         } else if input_types.iter().all(DataType::is_unsigned_integer) {
@@ -51,8 +60,8 @@ impl Function for ModuloFunction {
         }
     }
 
-    fn signature(&self) -> Signature {
-        Signature::uniform(2, NUMERICS.to_vec(), Volatility::Immutable)
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(
@@ -89,7 +98,7 @@ mod tests {
     use super::*;
     #[test]
     fn test_mod_function_signed() {
-        let function = ModuloFunction;
+        let function = ModuloFunction::default();
         assert_eq!("mod", function.name());
         assert_eq!(
             DataType::Int64,
@@ -125,7 +134,7 @@ mod tests {
 
     #[test]
     fn test_mod_function_unsigned() {
-        let function = ModuloFunction;
+        let function = ModuloFunction::default();
         assert_eq!("mod", function.name());
         assert_eq!(
             DataType::UInt64,
@@ -161,7 +170,7 @@ mod tests {
 
     #[test]
     fn test_mod_function_float() {
-        let function = ModuloFunction;
+        let function = ModuloFunction::default();
         assert_eq!("mod", function.name());
         assert_eq!(
             DataType::Float64,
@@ -197,7 +206,7 @@ mod tests {
 
     #[test]
     fn test_mod_function_errors() {
-        let function = ModuloFunction;
+        let function = ModuloFunction::default();
         assert_eq!("mod", function.name());
         let nums = vec![27];
         let divs = vec![0];

--- a/src/common/function/src/scalars/test.rs
+++ b/src/common/function/src/scalars/test.rs
@@ -14,7 +14,6 @@
 
 use std::fmt;
 
-use common_query::error::Result;
 use datafusion::logical_expr::ColumnarValue;
 use datafusion_expr::{ScalarFunctionArgs, Signature, Volatility};
 use datatypes::arrow::datatypes::DataType;
@@ -23,23 +22,33 @@ use datatypes::vectors::{Helper, Vector};
 use crate::function::{Function, extract_args};
 use crate::scalars::expression::{EvalContext, scalar_binary_op};
 
-#[derive(Clone, Default)]
-pub(crate) struct TestAndFunction;
+#[derive(Clone)]
+pub(crate) struct TestAndFunction {
+    signature: Signature,
+}
+
+impl Default for TestAndFunction {
+    fn default() -> Self {
+        Self {
+            signature: Signature::exact(
+                vec![DataType::Boolean, DataType::Boolean],
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
 
 impl Function for TestAndFunction {
     fn name(&self) -> &str {
         "test_and"
     }
 
-    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
         Ok(DataType::Boolean)
     }
 
-    fn signature(&self) -> Signature {
-        Signature::exact(
-            vec![DataType::Boolean, DataType::Boolean],
-            Volatility::Immutable,
-        )
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(

--- a/src/common/function/src/scalars/timestamp.rs
+++ b/src/common/function/src/scalars/timestamp.rs
@@ -22,6 +22,6 @@ pub(crate) struct TimestampFunction;
 
 impl TimestampFunction {
     pub fn register(registry: &FunctionRegistry) {
-        registry.register_scalar(ToUnixtimeFunction);
+        registry.register_scalar(ToUnixtimeFunction::default());
     }
 }

--- a/src/common/function/src/scalars/vector.rs
+++ b/src/common/function/src/scalars/vector.rs
@@ -41,29 +41,29 @@ pub(crate) struct VectorFunction;
 impl VectorFunction {
     pub fn register(registry: &FunctionRegistry) {
         // conversion
-        registry.register_scalar(convert::ParseVectorFunction);
-        registry.register_scalar(convert::VectorToStringFunction);
+        registry.register_scalar(convert::ParseVectorFunction::default());
+        registry.register_scalar(convert::VectorToStringFunction::default());
 
         // distance
-        registry.register_scalar(distance::CosDistanceFunction);
-        registry.register_scalar(distance::DotProductFunction);
-        registry.register_scalar(distance::L2SqDistanceFunction);
+        registry.register_scalar(distance::CosDistanceFunction::default());
+        registry.register_scalar(distance::DotProductFunction::default());
+        registry.register_scalar(distance::L2SqDistanceFunction::default());
 
         // scalar calculation
-        registry.register_scalar(scalar_add::ScalarAddFunction);
-        registry.register_scalar(scalar_mul::ScalarMulFunction);
+        registry.register_scalar(scalar_add::ScalarAddFunction::default());
+        registry.register_scalar(scalar_mul::ScalarMulFunction::default());
 
         // vector calculation
-        registry.register_scalar(vector_add::VectorAddFunction);
-        registry.register_scalar(vector_sub::VectorSubFunction);
-        registry.register_scalar(vector_mul::VectorMulFunction);
-        registry.register_scalar(vector_div::VectorDivFunction);
-        registry.register_scalar(vector_norm::VectorNormFunction);
-        registry.register_scalar(vector_dim::VectorDimFunction);
-        registry.register_scalar(vector_kth_elem::VectorKthElemFunction);
-        registry.register_scalar(vector_subvector::VectorSubvectorFunction);
-        registry.register_scalar(elem_sum::ElemSumFunction);
-        registry.register_scalar(elem_product::ElemProductFunction);
+        registry.register_scalar(vector_add::VectorAddFunction::default());
+        registry.register_scalar(vector_sub::VectorSubFunction::default());
+        registry.register_scalar(vector_mul::VectorMulFunction::default());
+        registry.register_scalar(vector_div::VectorDivFunction::default());
+        registry.register_scalar(vector_norm::VectorNormFunction::default());
+        registry.register_scalar(vector_dim::VectorDimFunction::default());
+        registry.register_scalar(vector_kth_elem::VectorKthElemFunction::default());
+        registry.register_scalar(vector_subvector::VectorSubvectorFunction::default());
+        registry.register_scalar(elem_sum::ElemSumFunction::default());
+        registry.register_scalar(elem_product::ElemProductFunction::default());
     }
 }
 
@@ -218,3 +218,44 @@ where
         Ok(ColumnarValue::Array(results))
     }
 }
+
+macro_rules! define_args_of_two_vector_literals_udf {
+    ($(#[$attr:meta])* $name: ident) => {
+        $(#[$attr])*
+        #[derive(Debug, Clone)]
+        pub(crate) struct $name {
+            signature: datafusion_expr::Signature,
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                use arrow::datatypes::DataType;
+
+                Self {
+                    signature: crate::helper::one_of_sigs2(
+                        vec![
+                            DataType::Utf8,
+                            DataType::Utf8View,
+                            DataType::Binary,
+                            DataType::BinaryView,
+                        ],
+                        vec![
+                            DataType::Utf8,
+                            DataType::Utf8View,
+                            DataType::Binary,
+                            DataType::BinaryView,
+                        ],
+                    ),
+                }
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", self.name().to_ascii_uppercase())
+            }
+        }
+    };
+}
+
+pub(crate) use define_args_of_two_vector_literals_udf;

--- a/src/common/function/src/scalars/vector/convert/parse_vector.rs
+++ b/src/common/function/src/scalars/vector/convert/parse_vector.rs
@@ -15,7 +15,7 @@
 use std::fmt::Display;
 use std::sync::Arc;
 
-use common_query::error::{InvalidVectorStringSnafu, Result};
+use common_query::error::InvalidVectorStringSnafu;
 use datafusion_common::arrow::array::{Array, AsArray, BinaryViewBuilder};
 use datafusion_common::arrow::compute;
 use datafusion_common::arrow::datatypes::DataType;
@@ -27,20 +27,30 @@ use crate::function::{Function, extract_args};
 
 const NAME: &str = "parse_vec";
 
-#[derive(Debug, Clone, Default)]
-pub struct ParseVectorFunction;
+#[derive(Debug, Clone)]
+pub struct ParseVectorFunction {
+    signature: Signature,
+}
+
+impl Default for ParseVectorFunction {
+    fn default() -> Self {
+        Self {
+            signature: Signature::string(1, Volatility::Immutable),
+        }
+    }
+}
 
 impl Function for ParseVectorFunction {
     fn name(&self) -> &str {
         NAME
     }
 
-    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
         Ok(DataType::BinaryView)
     }
 
-    fn signature(&self) -> Signature {
-        Signature::string(1, Volatility::Immutable)
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(
@@ -87,7 +97,7 @@ mod tests {
 
     #[test]
     fn test_parse_vector() {
-        let func = ParseVectorFunction;
+        let func = ParseVectorFunction::default();
 
         let arg0 = Arc::new(StringViewArray::from_iter([
             Some("[1.0,2.0,3.0]".to_string()),
@@ -132,7 +142,7 @@ mod tests {
 
     #[test]
     fn test_parse_vector_error() {
-        let func = ParseVectorFunction;
+        let func = ParseVectorFunction::default();
 
         let inputs = [
             StringViewArray::from_iter([

--- a/src/common/function/src/scalars/vector/distance.rs
+++ b/src/common/function/src/scalars/vector/distance.rs
@@ -19,7 +19,6 @@ mod l2sq;
 use std::borrow::Cow;
 use std::fmt::Display;
 
-use common_query::error::Result;
 use datafusion::logical_expr::ColumnarValue;
 use datafusion_common::ScalarValue;
 use datafusion_expr::{ScalarFunctionArgs, Signature};
@@ -32,33 +31,43 @@ macro_rules! define_distance_function {
     ($StructName:ident, $display_name:expr, $similarity_method:path) => {
         /// A function calculates the distance between two vectors.
 
-        #[derive(Debug, Clone, Default)]
-        pub struct $StructName;
+        #[derive(Debug, Clone)]
+        pub(crate) struct $StructName {
+            signature: Signature,
+        }
+
+        impl Default for $StructName {
+            fn default() -> Self {
+                Self {
+                    signature: helper::one_of_sigs2(
+                        vec![
+                            DataType::Utf8,
+                            DataType::Utf8View,
+                            DataType::Binary,
+                            DataType::BinaryView,
+                        ],
+                        vec![
+                            DataType::Utf8,
+                            DataType::Utf8View,
+                            DataType::Binary,
+                            DataType::BinaryView,
+                        ],
+                    ),
+                }
+            }
+        }
 
         impl Function for $StructName {
             fn name(&self) -> &str {
                 $display_name
             }
 
-            fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+            fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
                 Ok(DataType::Float32)
             }
 
-            fn signature(&self) -> Signature {
-                helper::one_of_sigs2(
-                    vec![
-                        DataType::Utf8,
-                        DataType::Utf8View,
-                        DataType::Binary,
-                        DataType::BinaryView,
-                    ],
-                    vec![
-                        DataType::Utf8,
-                        DataType::Utf8View,
-                        DataType::Binary,
-                        DataType::BinaryView,
-                    ],
-                )
+            fn signature(&self) -> &Signature {
+                &self.signature
             }
 
             fn invoke_with_args(
@@ -134,9 +143,9 @@ mod tests {
     #[test]
     fn test_distance_string_string() {
         let funcs = [
-            Box::new(CosDistanceFunction {}) as Box<dyn Function>,
-            Box::new(L2SqDistanceFunction {}) as Box<dyn Function>,
-            Box::new(DotProductFunction {}) as Box<dyn Function>,
+            Box::new(CosDistanceFunction::default()) as Box<dyn Function>,
+            Box::new(L2SqDistanceFunction::default()) as Box<dyn Function>,
+            Box::new(DotProductFunction::default()) as Box<dyn Function>,
         ];
 
         for func in funcs {
@@ -174,9 +183,9 @@ mod tests {
     #[test]
     fn test_distance_binary_binary() {
         let funcs = [
-            Box::new(CosDistanceFunction {}) as Box<dyn Function>,
-            Box::new(L2SqDistanceFunction {}) as Box<dyn Function>,
-            Box::new(DotProductFunction {}) as Box<dyn Function>,
+            Box::new(CosDistanceFunction::default()) as Box<dyn Function>,
+            Box::new(L2SqDistanceFunction::default()) as Box<dyn Function>,
+            Box::new(DotProductFunction::default()) as Box<dyn Function>,
         ];
 
         for func in funcs {
@@ -215,9 +224,9 @@ mod tests {
     #[test]
     fn test_distance_string_binary() {
         let funcs = [
-            Box::new(CosDistanceFunction {}) as Box<dyn Function>,
-            Box::new(L2SqDistanceFunction {}) as Box<dyn Function>,
-            Box::new(DotProductFunction {}) as Box<dyn Function>,
+            Box::new(CosDistanceFunction::default()) as Box<dyn Function>,
+            Box::new(L2SqDistanceFunction::default()) as Box<dyn Function>,
+            Box::new(DotProductFunction::default()) as Box<dyn Function>,
         ];
 
         for func in funcs {
@@ -256,9 +265,9 @@ mod tests {
     #[test]
     fn test_invalid_vector_length() {
         let funcs = [
-            Box::new(CosDistanceFunction {}) as Box<dyn Function>,
-            Box::new(L2SqDistanceFunction {}) as Box<dyn Function>,
-            Box::new(DotProductFunction {}) as Box<dyn Function>,
+            Box::new(CosDistanceFunction::default()) as Box<dyn Function>,
+            Box::new(L2SqDistanceFunction::default()) as Box<dyn Function>,
+            Box::new(DotProductFunction::default()) as Box<dyn Function>,
         ];
 
         for func in funcs {

--- a/src/common/function/src/scalars/vector/elem_sum.rs
+++ b/src/common/function/src/scalars/vector/elem_sum.rs
@@ -14,7 +14,6 @@
 
 use std::fmt::Display;
 
-use common_query::error::Result;
 use datafusion::arrow::datatypes::DataType;
 use datafusion::logical_expr::ColumnarValue;
 use datafusion_common::ScalarValue;
@@ -27,27 +26,37 @@ use crate::scalars::vector::{VectorCalculator, impl_conv};
 
 const NAME: &str = "vec_elem_sum";
 
-#[derive(Debug, Clone, Default)]
-pub struct ElemSumFunction;
+#[derive(Debug, Clone)]
+pub(crate) struct ElemSumFunction {
+    signature: Signature,
+}
+
+impl Default for ElemSumFunction {
+    fn default() -> Self {
+        Self {
+            signature: Signature::one_of(
+                vec![
+                    TypeSignature::Uniform(1, STRINGS.to_vec()),
+                    TypeSignature::Uniform(1, BINARYS.to_vec()),
+                    TypeSignature::Uniform(1, vec![DataType::BinaryView]),
+                ],
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
 
 impl Function for ElemSumFunction {
     fn name(&self) -> &str {
         NAME
     }
 
-    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
         Ok(DataType::Float32)
     }
 
-    fn signature(&self) -> Signature {
-        Signature::one_of(
-            vec![
-                TypeSignature::Uniform(1, STRINGS.to_vec()),
-                TypeSignature::Uniform(1, BINARYS.to_vec()),
-                TypeSignature::Uniform(1, vec![DataType::BinaryView]),
-            ],
-            Volatility::Immutable,
-        )
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(
@@ -88,7 +97,7 @@ mod tests {
 
     #[test]
     fn test_elem_sum() {
-        let func = ElemSumFunction;
+        let func = ElemSumFunction::default();
 
         let input = Arc::new(StringViewArray::from(vec![
             Some("[1.0,2.0,3.0]".to_string()),

--- a/src/common/function/src/scalars/vector/scalar_add.rs
+++ b/src/common/function/src/scalars/vector/scalar_add.rs
@@ -14,7 +14,6 @@
 
 use std::fmt::Display;
 
-use common_query::error::Result;
 use datafusion::arrow::datatypes::DataType;
 use datafusion::logical_expr::ColumnarValue;
 use datafusion_common::ScalarValue;
@@ -50,23 +49,38 @@ const NAME: &str = "vec_scalar_add";
 /// | [0,1,2] |
 /// +---------+
 /// ```
-#[derive(Debug, Clone, Default)]
-pub struct ScalarAddFunction;
+#[derive(Debug, Clone)]
+pub(crate) struct ScalarAddFunction {
+    signature: Signature,
+}
+
+impl Default for ScalarAddFunction {
+    fn default() -> Self {
+        Self {
+            signature: helper::one_of_sigs2(
+                vec![DataType::Float64],
+                vec![
+                    DataType::Utf8,
+                    DataType::Utf8View,
+                    DataType::Binary,
+                    DataType::BinaryView,
+                ],
+            ),
+        }
+    }
+}
 
 impl Function for ScalarAddFunction {
     fn name(&self) -> &str {
         NAME
     }
 
-    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
         Ok(DataType::BinaryView)
     }
 
-    fn signature(&self) -> Signature {
-        helper::one_of_sigs2(
-            vec![DataType::Float64],
-            vec![DataType::Utf8, DataType::Binary, DataType::BinaryView],
-        )
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(
@@ -110,7 +124,7 @@ mod tests {
 
     #[test]
     fn test_scalar_add() {
-        let func = ScalarAddFunction;
+        let func = ScalarAddFunction::default();
 
         let input0 = Arc::new(Float64Array::from(vec![
             Some(1.0),

--- a/src/common/function/src/scalars/vector/scalar_mul.rs
+++ b/src/common/function/src/scalars/vector/scalar_mul.rs
@@ -14,7 +14,6 @@
 
 use std::fmt::Display;
 
-use common_query::error::Result;
 use datafusion::arrow::datatypes::DataType;
 use datafusion::logical_expr::ColumnarValue;
 use datafusion_common::ScalarValue;
@@ -50,28 +49,38 @@ const NAME: &str = "vec_scalar_mul";
 /// | [1,2,3] |
 /// +---------+
 /// ```
-#[derive(Debug, Clone, Default)]
-pub struct ScalarMulFunction;
+#[derive(Debug, Clone)]
+pub(crate) struct ScalarMulFunction {
+    signature: Signature,
+}
+
+impl Default for ScalarMulFunction {
+    fn default() -> Self {
+        Self {
+            signature: helper::one_of_sigs2(
+                vec![DataType::Float64],
+                vec![
+                    DataType::Utf8,
+                    DataType::Utf8View,
+                    DataType::Binary,
+                    DataType::BinaryView,
+                ],
+            ),
+        }
+    }
+}
 
 impl Function for ScalarMulFunction {
     fn name(&self) -> &str {
         NAME
     }
 
-    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
         Ok(DataType::BinaryView)
     }
 
-    fn signature(&self) -> Signature {
-        helper::one_of_sigs2(
-            vec![DataType::Float64],
-            vec![
-                DataType::Utf8,
-                DataType::Utf8View,
-                DataType::Binary,
-                DataType::BinaryView,
-            ],
-        )
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(
@@ -115,7 +124,7 @@ mod tests {
 
     #[test]
     fn test_scalar_mul() {
-        let func = ScalarMulFunction;
+        let func = ScalarMulFunction::default();
 
         let input0 = Arc::new(Float64Array::from(vec![
             Some(2.0),

--- a/src/common/function/src/scalars/vector/vector_add.rs
+++ b/src/common/function/src/scalars/vector/vector_add.rs
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 use std::borrow::Cow;
-use std::fmt::Display;
 
-use common_query::error::Result;
 use datafusion::arrow::datatypes::DataType;
 use datafusion::logical_expr::ColumnarValue;
 use datafusion_common::{DataFusionError, ScalarValue};
@@ -23,12 +21,12 @@ use datafusion_expr::{ScalarFunctionArgs, Signature};
 use nalgebra::DVectorView;
 
 use crate::function::Function;
-use crate::helper;
-use crate::scalars::vector::VectorCalculator;
 use crate::scalars::vector::impl_conv::veclit_to_binlit;
+use crate::scalars::vector::{VectorCalculator, define_args_of_two_vector_literals_udf};
 
 const NAME: &str = "vec_add";
 
+define_args_of_two_vector_literals_udf!(
 /// Adds corresponding elements of two vectors, returns a vector.
 ///
 /// # Example
@@ -42,23 +40,20 @@ const NAME: &str = "vec_add";
 /// | [2,3]                                                         |
 /// +---------------------------------------------------------------+
 ///
-#[derive(Debug, Clone, Default)]
-pub struct VectorAddFunction;
+
+VectorAddFunction);
 
 impl Function for VectorAddFunction {
     fn name(&self) -> &str {
         NAME
     }
 
-    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
         Ok(DataType::BinaryView)
     }
 
-    fn signature(&self) -> Signature {
-        helper::one_of_sigs2(
-            vec![DataType::Utf8, DataType::Binary, DataType::BinaryView],
-            vec![DataType::Utf8, DataType::Binary, DataType::BinaryView],
-        )
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(
@@ -94,12 +89,6 @@ impl Function for VectorAddFunction {
     }
 }
 
-impl Display for VectorAddFunction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", NAME.to_ascii_uppercase())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -112,7 +101,7 @@ mod tests {
 
     #[test]
     fn test_sub() {
-        let func = VectorAddFunction;
+        let func = VectorAddFunction::default();
 
         let input0 = Arc::new(StringViewArray::from(vec![
             Some("[1.0,2.0,3.0]".to_string()),
@@ -155,7 +144,7 @@ mod tests {
 
     #[test]
     fn test_sub_error() {
-        let func = VectorAddFunction;
+        let func = VectorAddFunction::default();
 
         let input0 = Arc::new(StringViewArray::from(vec![
             Some("[1.0,2.0,3.0]".to_string()),

--- a/src/common/function/src/scalars/vector/vector_div.rs
+++ b/src/common/function/src/scalars/vector/vector_div.rs
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 use std::borrow::Cow;
-use std::fmt::Display;
 
-use common_query::error::Result;
 use datafusion::arrow::datatypes::DataType;
 use datafusion::logical_expr::ColumnarValue;
 use datafusion_common::{DataFusionError, ScalarValue};
@@ -23,12 +21,12 @@ use datafusion_expr::{ScalarFunctionArgs, Signature};
 use nalgebra::DVectorView;
 
 use crate::function::Function;
-use crate::helper;
-use crate::scalars::vector::VectorCalculator;
 use crate::scalars::vector::impl_conv::veclit_to_binlit;
+use crate::scalars::vector::{VectorCalculator, define_args_of_two_vector_literals_udf};
 
 const NAME: &str = "vec_div";
 
+define_args_of_two_vector_literals_udf!(
 /// Divides corresponding elements of two vectors.
 ///
 /// # Example
@@ -43,23 +41,20 @@ const NAME: &str = "vec_div";
 /// +---------+
 ///
 /// ```
-#[derive(Debug, Clone, Default)]
-pub struct VectorDivFunction;
+
+VectorDivFunction);
 
 impl Function for VectorDivFunction {
     fn name(&self) -> &str {
         NAME
     }
 
-    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
         Ok(DataType::BinaryView)
     }
 
-    fn signature(&self) -> Signature {
-        helper::one_of_sigs2(
-            vec![DataType::Utf8, DataType::Binary, DataType::BinaryView],
-            vec![DataType::Utf8, DataType::Binary, DataType::BinaryView],
-        )
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(
@@ -95,12 +90,6 @@ impl Function for VectorDivFunction {
     }
 }
 
-impl Display for VectorDivFunction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", NAME.to_ascii_uppercase())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -113,7 +102,7 @@ mod tests {
 
     #[test]
     fn test_vector_mul() {
-        let func = VectorDivFunction;
+        let func = VectorDivFunction::default();
 
         let vec0 = vec![1.0, 2.0, 3.0];
         let vec1 = vec![1.0, 1.0];

--- a/src/common/function/src/scalars/vector/vector_kth_elem.rs
+++ b/src/common/function/src/scalars/vector/vector_kth_elem.rs
@@ -14,7 +14,6 @@
 
 use std::fmt::Display;
 
-use common_query::error::Result;
 use datafusion::logical_expr::ColumnarValue;
 use datafusion_common::{DataFusionError, ScalarValue};
 use datafusion_expr::{ScalarFunctionArgs, Signature};
@@ -43,23 +42,33 @@ const NAME: &str = "vec_kth_elem";
 /// ```
 ///
 
-#[derive(Debug, Clone, Default)]
-pub struct VectorKthElemFunction;
+#[derive(Debug, Clone)]
+pub(crate) struct VectorKthElemFunction {
+    signature: Signature,
+}
+
+impl Default for VectorKthElemFunction {
+    fn default() -> Self {
+        Self {
+            signature: helper::one_of_sigs2(
+                vec![DataType::Utf8, DataType::Binary],
+                vec![DataType::Int64],
+            ),
+        }
+    }
+}
 
 impl Function for VectorKthElemFunction {
     fn name(&self) -> &str {
         NAME
     }
 
-    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
         Ok(DataType::Float32)
     }
 
-    fn signature(&self) -> Signature {
-        helper::one_of_sigs2(
-            vec![DataType::Utf8, DataType::Binary],
-            vec![DataType::Int64],
-        )
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(
@@ -122,7 +131,7 @@ mod tests {
 
     #[test]
     fn test_vec_kth_elem() {
-        let func = VectorKthElemFunction;
+        let func = VectorKthElemFunction::default();
 
         let input0: ArrayRef = Arc::new(StringViewArray::from(vec![
             Some("[1.0,2.0,3.0]".to_string()),

--- a/src/common/function/src/scalars/vector/vector_mul.rs
+++ b/src/common/function/src/scalars/vector/vector_mul.rs
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 use std::borrow::Cow;
-use std::fmt::Display;
 
-use common_query::error::Result;
 use datafusion::arrow::datatypes::DataType;
 use datafusion::logical_expr::ColumnarValue;
 use datafusion_common::{DataFusionError, ScalarValue};
@@ -23,12 +21,12 @@ use datafusion_expr::{ScalarFunctionArgs, Signature};
 use nalgebra::DVectorView;
 
 use crate::function::Function;
-use crate::helper;
-use crate::scalars::vector::VectorCalculator;
 use crate::scalars::vector::impl_conv::veclit_to_binlit;
+use crate::scalars::vector::{VectorCalculator, define_args_of_two_vector_literals_udf};
 
 const NAME: &str = "vec_mul";
 
+define_args_of_two_vector_literals_udf!(
 /// Multiplies corresponding elements of two vectors.
 ///
 /// # Example
@@ -43,23 +41,19 @@ const NAME: &str = "vec_mul";
 /// +---------+
 ///
 /// ```
-#[derive(Debug, Clone, Default)]
-pub struct VectorMulFunction;
+VectorMulFunction);
 
 impl Function for VectorMulFunction {
     fn name(&self) -> &str {
         NAME
     }
 
-    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
         Ok(DataType::BinaryView)
     }
 
-    fn signature(&self) -> Signature {
-        helper::one_of_sigs2(
-            vec![DataType::Utf8, DataType::Binary, DataType::BinaryView],
-            vec![DataType::Utf8, DataType::Binary, DataType::BinaryView],
-        )
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(
@@ -95,12 +89,6 @@ impl Function for VectorMulFunction {
     }
 }
 
-impl Display for VectorMulFunction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", NAME.to_ascii_uppercase())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -113,7 +101,7 @@ mod tests {
 
     #[test]
     fn test_vector_mul() {
-        let func = VectorMulFunction;
+        let func = VectorMulFunction::default();
 
         let vec0 = vec![1.0, 2.0, 3.0];
         let vec1 = vec![1.0, 1.0];

--- a/src/common/function/src/scalars/vector/vector_sub.rs
+++ b/src/common/function/src/scalars/vector/vector_sub.rs
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 use std::borrow::Cow;
-use std::fmt::Display;
 
-use common_query::error::Result;
 use datafusion::arrow::datatypes::DataType;
 use datafusion::logical_expr::ColumnarValue;
 use datafusion_common::{DataFusionError, ScalarValue};
@@ -23,12 +21,12 @@ use datafusion_expr::{ScalarFunctionArgs, Signature};
 use nalgebra::DVectorView;
 
 use crate::function::Function;
-use crate::helper;
-use crate::scalars::vector::VectorCalculator;
 use crate::scalars::vector::impl_conv::veclit_to_binlit;
+use crate::scalars::vector::{VectorCalculator, define_args_of_two_vector_literals_udf};
 
 const NAME: &str = "vec_sub";
 
+define_args_of_two_vector_literals_udf!(
 /// Subtracts corresponding elements of two vectors, returns a vector.
 ///
 /// # Example
@@ -42,23 +40,19 @@ const NAME: &str = "vec_sub";
 /// | [0,-1]                                                        |
 /// +---------------------------------------------------------------+
 ///
-#[derive(Debug, Clone, Default)]
-pub struct VectorSubFunction;
+VectorSubFunction);
 
 impl Function for VectorSubFunction {
     fn name(&self) -> &str {
         NAME
     }
 
-    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
         Ok(DataType::BinaryView)
     }
 
-    fn signature(&self) -> Signature {
-        helper::one_of_sigs2(
-            vec![DataType::Utf8, DataType::Binary, DataType::BinaryView],
-            vec![DataType::Utf8, DataType::Binary, DataType::BinaryView],
-        )
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(
@@ -94,12 +88,6 @@ impl Function for VectorSubFunction {
     }
 }
 
-impl Display for VectorSubFunction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", NAME.to_ascii_uppercase())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -112,7 +100,7 @@ mod tests {
 
     #[test]
     fn test_sub() {
-        let func = VectorSubFunction;
+        let func = VectorSubFunction::default();
 
         let input0: ArrayRef = Arc::new(StringViewArray::from(vec![
             Some("[1.0,2.0,3.0]".to_string()),
@@ -155,7 +143,7 @@ mod tests {
 
     #[test]
     fn test_sub_error() {
-        let func = VectorSubFunction;
+        let func = VectorSubFunction::default();
 
         let input0: ArrayRef = Arc::new(StringViewArray::from(vec![
             Some("[1.0,2.0,3.0]".to_string()),

--- a/src/common/function/src/system.rs
+++ b/src/common/function/src/system.rs
@@ -34,14 +34,35 @@ pub(crate) struct SystemFunction;
 
 impl SystemFunction {
     pub fn register(registry: &FunctionRegistry) {
-        registry.register_scalar(BuildFunction);
-        registry.register_scalar(VersionFunction);
-        registry.register_scalar(DatabaseFunction);
-        registry.register_scalar(ReadPreferenceFunction);
-        registry.register_scalar(PgBackendPidFunction);
-        registry.register_scalar(ConnectionIdFunction);
-        registry.register_scalar(TimezoneFunction);
+        registry.register_scalar(BuildFunction::default());
+        registry.register_scalar(VersionFunction::default());
+        registry.register_scalar(DatabaseFunction::default());
+        registry.register_scalar(ReadPreferenceFunction::default());
+        registry.register_scalar(PgBackendPidFunction::default());
+        registry.register_scalar(ConnectionIdFunction::default());
+        registry.register_scalar(TimezoneFunction::default());
         registry.register(ProcedureStateFunction::factory());
         PGCatalogFunction::register(registry);
     }
 }
+
+macro_rules! define_nullary_udf {
+    ($(#[$attr:meta])* $name: ident) => {
+        $(#[$attr])*
+        #[derive(Clone, Debug, derive_more::Display)]
+        #[display("{}", self.name())]
+        pub(crate) struct $name {
+            signature: datafusion_expr::Signature,
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self {
+                    signature: datafusion_expr::Signature::nullary(Volatility::Immutable),
+                }
+            }
+        }
+    };
+}
+
+pub(crate) use define_nullary_udf;

--- a/src/common/function/src/system/build.rs
+++ b/src/common/function/src/system/build.rs
@@ -12,38 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt;
 use std::sync::Arc;
 
-use common_query::error::Result;
 use datafusion::arrow::array::StringViewArray;
 use datafusion::arrow::datatypes::DataType;
 use datafusion::logical_expr::ColumnarValue;
 use datafusion_expr::{ScalarFunctionArgs, Signature, Volatility};
 
 use crate::function::Function;
+use crate::system::define_nullary_udf;
 
+define_nullary_udf!(
 /// Generates build information
-#[derive(Clone, Debug, Default)]
-pub struct BuildFunction;
-
-impl fmt::Display for BuildFunction {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "BUILD")
-    }
-}
+BuildFunction);
 
 impl Function for BuildFunction {
     fn name(&self) -> &str {
         "build"
     }
 
-    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
         Ok(DataType::Utf8View)
     }
 
-    fn signature(&self) -> Signature {
-        Signature::nullary(Volatility::Immutable)
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(&self, _: ScalarFunctionArgs) -> datafusion_common::Result<ColumnarValue> {
@@ -65,10 +58,9 @@ mod tests {
     use super::*;
     #[test]
     fn test_build_function() {
-        let build = BuildFunction;
+        let build = BuildFunction::default();
         assert_eq!("build", build.name());
         assert_eq!(DataType::Utf8View, build.return_type(&[]).unwrap());
-        assert_eq!(build.signature(), Signature::nullary(Volatility::Immutable));
         let build_info = common_version::build_info().to_string();
         let actual = build
             .invoke_with_args(ScalarFunctionArgs {

--- a/src/common/function/src/system/pg_catalog/version.rs
+++ b/src/common/function/src/system/pg_catalog/version.rs
@@ -14,15 +14,24 @@
 
 use std::fmt;
 
-use common_query::error::Result;
 use datafusion::arrow::datatypes::DataType;
 use datafusion_common::ScalarValue;
 use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, Signature, Volatility};
 
 use crate::function::Function;
 
-#[derive(Clone, Debug, Default)]
-pub(crate) struct PGVersionFunction;
+#[derive(Clone, Debug)]
+pub(crate) struct PGVersionFunction {
+    signature: Signature,
+}
+
+impl Default for PGVersionFunction {
+    fn default() -> Self {
+        Self {
+            signature: Signature::exact(vec![], Volatility::Immutable),
+        }
+    }
+}
 
 impl fmt::Display for PGVersionFunction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -35,12 +44,12 @@ impl Function for PGVersionFunction {
         "pg_catalog.version"
     }
 
-    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
         Ok(DataType::Utf8View)
     }
 
-    fn signature(&self) -> Signature {
-        Signature::exact(vec![], Volatility::Immutable)
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(&self, _: ScalarFunctionArgs) -> datafusion_common::Result<ColumnarValue> {

--- a/src/common/function/src/system/timezone.rs
+++ b/src/common/function/src/system/timezone.rs
@@ -12,18 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt::{self};
-
-use common_query::error::Result;
 use datafusion::arrow::datatypes::DataType;
 use datafusion_common::ScalarValue;
 use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, Signature, Volatility};
 
 use crate::function::{Function, find_function_context};
+use crate::system::define_nullary_udf;
 
+define_nullary_udf!(
 /// A function to return current session timezone.
-#[derive(Clone, Debug, Default)]
-pub struct TimezoneFunction;
+TimezoneFunction);
 
 const NAME: &str = "timezone";
 
@@ -32,12 +30,12 @@ impl Function for TimezoneFunction {
         NAME
     }
 
-    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
         Ok(DataType::Utf8View)
     }
 
-    fn signature(&self) -> Signature {
-        Signature::nullary(Volatility::Immutable)
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(
@@ -48,12 +46,6 @@ impl Function for TimezoneFunction {
         let tz = func_ctx.query_ctx.timezone().to_string();
 
         Ok(ColumnarValue::Scalar(ScalarValue::Utf8View(Some(tz))))
-    }
-}
-
-impl fmt::Display for TimezoneFunction {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "TIMEZONE")
     }
 }
 
@@ -70,10 +62,9 @@ mod tests {
 
     #[test]
     fn test_build_function() {
-        let build = TimezoneFunction;
+        let build = TimezoneFunction::default();
         assert_eq!("timezone", build.name());
         assert_eq!(DataType::Utf8View, build.return_type(&[]).unwrap());
-        assert_eq!(build.signature(), Signature::nullary(Volatility::Immutable));
 
         let query_ctx = QueryContextBuilder::default().build().into();
 

--- a/src/common/function/src/system/version.rs
+++ b/src/common/function/src/system/version.rs
@@ -12,36 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt;
-
-use common_query::error::Result;
 use datafusion::arrow::datatypes::DataType;
 use datafusion_common::ScalarValue;
 use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, Signature, Volatility};
 use session::context::Channel;
 
 use crate::function::{Function, find_function_context};
+use crate::system::define_nullary_udf;
 
-#[derive(Clone, Debug, Default)]
-pub(crate) struct VersionFunction;
-
-impl fmt::Display for VersionFunction {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "VERSION")
-    }
-}
+define_nullary_udf!(VersionFunction);
 
 impl Function for VersionFunction {
     fn name(&self) -> &str {
         "version"
     }
 
-    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
         Ok(DataType::Utf8View)
     }
 
-    fn signature(&self) -> Signature {
-        Signature::nullary(Volatility::Immutable)
+    fn signature(&self) -> &Signature {
+        &self.signature
     }
 
     fn invoke_with_args(

--- a/src/mito2/src/sst/index/fulltext_index/applier/builder.rs
+++ b/src/mito2/src/sst/index/fulltext_index/applier/builder.rs
@@ -320,14 +320,14 @@ mod tests {
 
     fn matches_func() -> Arc<ScalarUDF> {
         Arc::new(
-            ScalarFunctionFactory::from(Arc::new(MatchesFunction) as FunctionRef)
+            ScalarFunctionFactory::from(Arc::new(MatchesFunction::default()) as FunctionRef)
                 .provide(Default::default()),
         )
     }
 
     fn matches_term_func() -> Arc<ScalarUDF> {
         Arc::new(
-            ScalarFunctionFactory::from(Arc::new(MatchesTermFunction) as FunctionRef)
+            ScalarFunctionFactory::from(Arc::new(MatchesTermFunction::default()) as FunctionRef)
                 .provide(Default::default()),
         )
     }

--- a/src/query/src/optimizer/constant_term.rs
+++ b/src/query/src/optimizer/constant_term.rs
@@ -240,7 +240,6 @@ mod tests {
     use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
     use common_function::scalars::matches_term::MatchesTermFunction;
     use common_function::scalars::udf::create_udf;
-    use common_function::state::FunctionState;
     use datafusion::datasource::memory::MemorySourceConfig;
     use datafusion::datasource::source::DataSourceExec;
     use datafusion::physical_optimizer::PhysicalOptimizerRule;
@@ -328,11 +327,7 @@ mod tests {
     }
 
     fn matches_term_udf() -> Arc<ScalarUDF> {
-        Arc::new(create_udf(
-            Arc::new(MatchesTermFunction),
-            QueryContext::arc(),
-            Arc::new(FunctionState::default()),
-        ))
+        Arc::new(create_udf(Arc::new(MatchesTermFunction::default())))
     }
 
     #[test]

--- a/src/query/src/optimizer/transcribe_atat.rs
+++ b/src/query/src/optimizer/transcribe_atat.rs
@@ -16,14 +16,12 @@ use std::sync::Arc;
 
 use common_function::scalars::matches_term::MatchesTermFunction;
 use common_function::scalars::udf::create_udf;
-use common_function::state::FunctionState;
 use datafusion::config::ConfigOptions;
 use datafusion_common::Result;
 use datafusion_common::tree_node::{Transformed, TreeNode, TreeNodeRewriter};
 use datafusion_expr::expr::ScalarFunction;
 use datafusion_expr::{Expr, LogicalPlan};
 use datafusion_optimizer::analyzer::AnalyzerRule;
-use session::context::QueryContext;
 
 use crate::plan::ExtractExpr;
 
@@ -88,11 +86,7 @@ impl TreeNodeRewriter for TranscribeAtatRewriter {
             && matches!(binary_expr.op, datafusion_expr::Operator::AtAt)
         {
             self.transcribed = true;
-            let scalar_udf = create_udf(
-                Arc::new(MatchesTermFunction),
-                QueryContext::arc(),
-                Arc::new(FunctionState::default()),
-            );
+            let scalar_udf = create_udf(Arc::new(MatchesTermFunction::default()));
             let exprs = vec![
                 binary_expr.left.as_ref().clone(),
                 binary_expr.right.as_ref().clone(),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

I was thinking of removing `Function` trait completely, but decide to keep it for future use maybe. At last, the UDFs are of greptimedb. However, to keep things simple, the `Function` trait is kept aligned with DataFusion's `ScalaUDFImpl`.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
