### PR TITLE
feat: enable zstd for bulk memtable encoded parts

### DIFF
--- a/src/mito2/src/memtable/bulk/part.rs
+++ b/src/mito2/src/memtable/bulk/part.rs
@@ -45,6 +45,7 @@ use mito_codec::row_converter::{
     DensePrimaryKeyCodec, PrimaryKeyCodec, PrimaryKeyCodecExt, build_primary_key_codec,
 };
 use parquet::arrow::ArrowWriter;
+use parquet::basic::{Compression, ZstdLevel};
 use parquet::data_type::AsBytes;
 use parquet::file::metadata::ParquetMetaData;
 use parquet::file::properties::WriterProperties;
@@ -635,6 +636,7 @@ impl BulkPartEncoder {
                 .set_key_value_metadata(Some(vec![key_value_meta]))
                 .set_write_batch_size(row_group_size)
                 .set_max_row_group_size(row_group_size)
+                .set_compression(Compression::ZSTD(ZstdLevel::default()))
                 .set_column_index_truncate_length(None)
                 .set_statistics_truncate_length(None)
                 .build(),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/6505

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

Enable zstd for encoded parts in bulk memtable.

This can reduce the memory usage and part size flushed to the storage.

Before
<img width="2224" height="526" alt="image" src="https://github.com/user-attachments/assets/338359db-be4e-4770-9131-4da29891b415" />

After
<img width="4500" height="2142" alt="image" src="https://github.com/user-attachments/assets/ff9d0a64-56df-4c2c-85b7-61139c1f7b82" />


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
