### PR TITLE
chore: rename the default ts column name to `greptime_timestamp` for influxdb line protocol

### DIFF
--- a/src/servers/src/influxdb.rs
+++ b/src/servers/src/influxdb.rs
@@ -25,7 +25,6 @@ use crate::row_writer::{self, MultiTableData};
 
 const INFLUXDB_API_PATH_NAME: &str = "influxdb";
 const INFLUXDB_API_V2_PATH_NAME: &str = "influxdb/api/v2";
-// const INFLUXDB_TIMESTAMP_COLUMN_NAME: &str = "ts";
 const DEFAULT_TIME_PRECISION: Precision = Precision::Nanosecond;
 
 #[inline]
@@ -194,7 +193,7 @@ monitor2,host=host4 cpu=66.3,memory=1029 1663840496400340003";
                         }
                     }
                 }
-                "ts" => {
+                "greptime_timestamp" => {
                     assert_eq!(
                         ColumnDataType::TimestampNanosecond as i32,
                         column_schema.datatype
@@ -269,7 +268,7 @@ monitor2,host=host4 cpu=66.3,memory=1029 1663840496400340003";
                         }
                     }
                 }
-                "ts" => {
+                "greptime_timestamp" => {
                     assert_eq!(
                         ColumnDataType::TimestampNanosecond as i32,
                         column_schema.datatype

--- a/tests-integration/src/influxdb.rs
+++ b/tests-integration/src/influxdb.rs
@@ -42,7 +42,7 @@ monitor1,host=host2 memory=1027";
 
         let mut output = instance
             .do_query(
-                "SELECT ts, host, cpu, memory FROM monitor1 ORDER BY ts",
+                "SELECT greptime_timestamp, host, cpu, memory FROM monitor1 ORDER BY greptime_timestamp",
                 QueryContext::arc(),
             )
             .await;
@@ -74,7 +74,7 @@ monitor1,host=host2 memory=1027 1663840496400340001";
 
         let mut output = instance
             .do_query(
-                "SELECT ts, host, cpu, memory FROM monitor1 ORDER BY ts",
+                "SELECT greptime_timestamp, host, cpu, memory FROM monitor1 ORDER BY greptime_timestamp",
                 QueryContext::arc(),
             )
             .await;
@@ -87,7 +87,7 @@ monitor1,host=host2 memory=1027 1663840496400340001";
             recordbatches.pretty_print().unwrap(),
             "\
 +-------------------------------+-------+------+--------+
-| ts                            | host  | cpu  | memory |
+| greptime_timestamp            | host  | cpu  | memory |
 +-------------------------------+-------+------+--------+
 | 2022-09-22T09:54:56.100023100 | host1 | 66.6 | 1024.0 |
 | 2022-09-22T09:54:56.400340001 | host2 |      | 1027.0 |
@@ -105,7 +105,7 @@ monitor1,host=host2 cpu=32 1663840496400340001";
 
         let mut output = instance
             .do_query(
-                "SELECT ts, host, cpu, memory FROM monitor1 ORDER BY ts",
+                "SELECT greptime_timestamp, host, cpu, memory FROM monitor1 ORDER BY greptime_timestamp",
                 QueryContext::arc(),
             )
             .await;
@@ -118,7 +118,7 @@ monitor1,host=host2 cpu=32 1663840496400340001";
             recordbatches.pretty_print().unwrap(),
             "\
 +-------------------------------+-------+------+--------+
-| ts                            | host  | cpu  | memory |
+| greptime_timestamp            | host  | cpu  | memory |
 +-------------------------------+-------+------+--------+
 | 2022-09-22T09:54:56.100023100 | host1 | 66.6 | 1024.0 |
 | 2022-09-22T09:54:56.400340001 | host2 | 32.0 | 1027.0 |

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -6448,7 +6448,7 @@ pub async fn test_influxdb_write(store_type: StorageType) {
     validate_data(
         "test_influxdb_write",
         &client,
-        "select * from test_alter order by ts;",
+        "select * from test_alter order by greptime_timestamp;",
         expected,
     )
     .await;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

As the title suggests. 
This is **NOT** a breaking change. For existing users, the handler will use the existing table's ts columns name.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
