### PR TITLE
fix: support dictionary in regex match

### DIFF
--- a/src/common/recordbatch/src/filter.rs
+++ b/src/common/recordbatch/src/filter.rs
@@ -374,11 +374,12 @@ pub fn regexp_is_match_dictionary(
     let mut result = BooleanBufferBuilder::new(dict_array.len());
 
     if let Some(re) = regex {
+        let keys = dict_array.keys().values();
         for i in 0..dict_array.len() {
             if dict_array.is_null(i) {
                 result.append(false);
             } else {
-                let key = dict_array.key(i).unwrap();
+                let key = keys[i] as usize;
                 let string_value = string_values.value(key);
                 result.append(re.is_match(string_value));
             }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/6078

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

Supports dictionary array in regex_match

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
