### PR TITLE
fix: only skips auto convert when encoding is sparse

### DIFF
--- a/src/mito2/src/sst/parquet/flat_format.rs
+++ b/src/mito2/src/sst/parquet/flat_format.rs
@@ -379,6 +379,12 @@ impl ParquetPrimaryKeyToFlat {
         column_ids: impl Iterator<Item = ColumnId>,
         skip_auto_convert: bool,
     ) -> ParquetPrimaryKeyToFlat {
+        assert!(if skip_auto_convert {
+            metadata.primary_key_encoding == PrimaryKeyEncoding::Sparse
+        } else {
+            true
+        });
+
         let column_ids: Vec<_> = column_ids.collect();
 
         // Creates a map to lookup index based on the new format.

--- a/src/mito2/src/sst/parquet/format.rs
+++ b/src/mito2/src/sst/parquet/format.rs
@@ -1740,7 +1740,7 @@ mod tests {
             .collect();
         let format = FlatReadFormat::new(
             metadata.clone(),
-            column_ids.into_iter(),
+            column_ids.clone().into_iter(),
             None,
             "test",
             false,
@@ -1797,7 +1797,7 @@ mod tests {
         let record_batch = RecordBatch::try_new(old_schema, columns).unwrap();
 
         // Test conversion with sparse encoding
-        let result = format.convert_batch(record_batch, None).unwrap();
+        let result = format.convert_batch(record_batch.clone(), None).unwrap();
 
         // Construct expected RecordBatch in flat format with decoded primary key columns
         let tag0_array = Arc::new(DictionaryArray::new(
@@ -1826,5 +1826,12 @@ mod tests {
 
         // Compare the actual result with the expected record batch
         assert_eq!(expected_record_batch, result);
+
+        let format =
+            FlatReadFormat::new(metadata.clone(), column_ids.into_iter(), None, "test", true)
+                .unwrap();
+        // Test conversion with sparse encoding and skip convert.
+        let result = format.convert_batch(record_batch.clone(), None).unwrap();
+        assert_eq!(record_batch, result);
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/6078

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

The skip_auto_convert flag should only take effect when the encoding is sparse.

Otherwise, we will have an incorrect schema during compaction when the encoding is dense.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
