### PR TITLE
feat: align influxdb line timestamp with table time index

### DIFF
--- a/src/frontend/src/instance/influxdb.rs
+++ b/src/frontend/src/instance/influxdb.rs
@@ -164,7 +164,7 @@ fn align_time_unit(value: &ValueData, target: TimeUnit) -> servers::error::Resul
         ValueData::TimestampNanosecondValue(x) => Timestamp::new_nanosecond(*x),
         _ => {
             return UnexpectedResultSnafu {
-                reason: format!("Timestamp value '{:?} is not of timestamp type!", value),
+                reason: format!("Timestamp value '{:?}' is not of timestamp type!", value),
             }
             .fail();
         }

--- a/tests-integration/src/influxdb.rs
+++ b/tests-integration/src/influxdb.rs
@@ -147,10 +147,13 @@ monitor,host=127.0.0.2 cpu=0.2,memory=2.0 1719460800002";
         };
         instance.exec(request, QueryContext::arc()).await.unwrap();
 
-        // Insert some influxdb lines with implicit millisecond precision.
+        // Insert some influxdb lines without precision.
+        // According to the specification (both v1 and v2), if precision is not set, it is default
+        // to "nanosecond". The lines here will be converted to insert requests as usual and then
+        // be aligned to millisecond time unit.
         let lines = r"
-monitor,host=127.0.0.1 cpu=0.3,memory=3.0 1719460800003
-monitor,host=127.0.0.2 cpu=0.4,memory=4.0 1719460800004";
+monitor,host=127.0.0.1 cpu=0.3,memory=3.0 1719460800003000000
+monitor,host=127.0.0.2 cpu=0.4,memory=4.0 1719460800004000000";
         let request = InfluxdbRequest {
             precision: None,
             lines: lines.to_string(),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Sometimes the table is created before any influxdb lines were put, or the lines timestamp precision could change. Anyway, we should align the input to the table's schema.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
