### PR TITLE
refactor: remove duplicated valueref to json

### DIFF
--- a/src/datatypes/src/error.rs
+++ b/src/datatypes/src/error.rs
@@ -238,6 +238,12 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display("Failed to process JSONB value"))]
+    InvalidJsonb {
+        error: jsonb::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 impl ErrorExt for Error {
@@ -257,6 +263,7 @@ impl ErrorExt for Error {
             | InvalidTimestampPrecision { .. }
             | InvalidPrecisionOrScale { .. }
             | InvalidJson { .. }
+            | InvalidJsonb { .. }
             | InvalidVector { .. }
             | InvalidFulltextOption { .. }
             | InvalidSkippingIndexOption { .. } => StatusCode::InvalidArguments,

--- a/src/datatypes/src/types.rs
+++ b/src/datatypes/src/types.rs
@@ -44,7 +44,8 @@ pub use interval_type::{
     IntervalDayTimeType, IntervalMonthDayNanoType, IntervalType, IntervalYearMonthType,
 };
 pub use json_type::{
-    JSON_TYPE_NAME, JsonType, json_type_value_to_string, parse_string_to_json_type_value,
+    JSON_TYPE_NAME, JsonType, json_type_value_to_serde_json, json_type_value_to_string,
+    parse_string_to_json_type_value,
 };
 pub use list_type::ListType;
 pub use null_type::NullType;

--- a/src/datatypes/src/value.rs
+++ b/src/datatypes/src/value.rs
@@ -38,7 +38,6 @@ use snafu::{ResultExt, ensure};
 
 use crate::error::{self, ConvertArrowArrayToScalarsSnafu, Error, Result, TryFromValueSnafu};
 use crate::prelude::*;
-use crate::schema::ColumnSchema;
 use crate::type_id::LogicalTypeId;
 use crate::types::{IntervalType, ListType};
 use crate::vectors::ListVector;
@@ -1301,53 +1300,6 @@ impl<'a> From<Option<ListValueRef<'a>>> for ValueRef<'a> {
             None => ValueRef::Null,
         }
     }
-}
-
-/// transform a [ValueRef] to a [serde_json::Value].
-/// The json type will be handled specially
-pub fn transform_value_ref_to_json_value<'a>(
-    value: ValueRef<'a>,
-    schema: &'a ColumnSchema,
-) -> serde_json::Result<serde_json::Value> {
-    let json_value = match value {
-        ValueRef::Null => serde_json::Value::Null,
-        ValueRef::Boolean(v) => serde_json::Value::Bool(v),
-        ValueRef::UInt8(v) => serde_json::Value::from(v),
-        ValueRef::UInt16(v) => serde_json::Value::from(v),
-        ValueRef::UInt32(v) => serde_json::Value::from(v),
-        ValueRef::UInt64(v) => serde_json::Value::from(v),
-        ValueRef::Int8(v) => serde_json::Value::from(v),
-        ValueRef::Int16(v) => serde_json::Value::from(v),
-        ValueRef::Int32(v) => serde_json::Value::from(v),
-        ValueRef::Int64(v) => serde_json::Value::from(v),
-        ValueRef::Float32(v) => serde_json::Value::from(v.0),
-        ValueRef::Float64(v) => serde_json::Value::from(v.0),
-        ValueRef::String(bytes) => serde_json::Value::String(bytes.to_string()),
-        ValueRef::Binary(bytes) => {
-            if let ConcreteDataType::Json(_) = schema.data_type {
-                match jsonb::from_slice(bytes) {
-                    Ok(json) => json.into(),
-                    Err(e) => {
-                        error!(e; "Failed to parse jsonb");
-                        serde_json::Value::Null
-                    }
-                }
-            } else {
-                serde_json::to_value(bytes)?
-            }
-        }
-        ValueRef::Date(v) => serde_json::Value::Number(v.val().into()),
-        ValueRef::List(v) => serde_json::to_value(v)?,
-        ValueRef::Timestamp(v) => serde_json::to_value(v.value())?,
-        ValueRef::Time(v) => serde_json::to_value(v.value())?,
-        ValueRef::IntervalYearMonth(v) => serde_json::Value::from(v),
-        ValueRef::IntervalDayTime(v) => serde_json::Value::from(v),
-        ValueRef::IntervalMonthDayNano(v) => serde_json::Value::from(v),
-        ValueRef::Duration(v) => serde_json::to_value(v.value())?,
-        ValueRef::Decimal128(v) => serde_json::to_value(v.to_string())?,
-    };
-
-    Ok(json_value)
 }
 
 /// Reference to a [ListValue].


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This patch follows how we serialize data for mysql/postgres and removes duplicated implementation of valueref to json in datatypes.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
