### PR TITLE
feat: add index cache eviction support

### DIFF
--- a/src/mito2/src/cache/index/bloom_filter_index.rs
+++ b/src/mito2/src/cache/index/bloom_filter_index.rs
@@ -50,6 +50,11 @@ impl BloomFilterIndexCache {
             bloom_filter_index_content_weight,
         )
     }
+
+    /// Removes all cached entries for the given `file_id`.
+    pub fn invalidate_file(&self, file_id: FileId) {
+        self.invalidate_if(move |key| key.0 == file_id);
+    }
 }
 
 /// Calculates weight for bloom filter index metadata.

--- a/src/mito2/src/cache/index/inverted_index.rs
+++ b/src/mito2/src/cache/index/inverted_index.rs
@@ -44,6 +44,11 @@ impl InvertedIndexCache {
             inverted_index_content_weight,
         )
     }
+
+    /// Removes all cached entries for the given `file_id`.
+    pub fn invalidate_file(&self, file_id: FileId) {
+        self.invalidate_if(move |key| *key == file_id);
+    }
 }
 
 /// Calculates weight for inverted index metadata.

--- a/src/mito2/src/cache/index/result_cache.rs
+++ b/src/mito2/src/cache/index/result_cache.rs
@@ -63,6 +63,7 @@ impl IndexResultCache {
                     .with_label_values(&[INDEX_RESULT_TYPE, to_str(cause)])
                     .inc();
             })
+            .support_invalidation_closures()
             .build();
         Self { cache }
     }
@@ -96,6 +97,13 @@ impl IndexResultCache {
     /// Calculates the memory usage of a cache entry.
     fn index_result_cache_weight(k: &(PredicateKey, FileId), v: &Arc<RowGroupSelection>) -> u32 {
         k.0.mem_usage() as u32 + v.mem_usage() as u32
+    }
+
+    /// Removes cached results for the given file.
+    pub fn invalidate_file(&self, file_id: FileId) {
+        self.cache
+            .invalidate_entries_if(move |(_, cached_file_id), _| *cached_file_id == file_id)
+            .expect("cache should support invalidation closures");
     }
 }
 

--- a/src/puffin/src/puffin_manager/cache.rs
+++ b/src/puffin/src/puffin_manager/cache.rs
@@ -57,4 +57,9 @@ impl PuffinMetadataCache {
     pub fn put_metadata(&self, file_id: String, metadata: Arc<FileMetadata>) {
         self.cache.insert(file_id, metadata);
     }
+
+    /// Removes the metadata of the given file from the cache, if present.
+    pub fn remove(&self, file_id: &str) {
+        self.cache.invalidate(file_id);
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Add `CacheManager::evict_puffin_cache` to purge bloom, inverted, result, metadata, and write caches for a rebuilt puffin file.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
