### PR TITLE
fix: Separate admin and normal function registries.

### DIFF
--- a/src/common/function/src/function_registry.rs
+++ b/src/common/function/src/function_registry.rs
@@ -147,9 +147,8 @@ pub static FUNCTION_REGISTRY: LazyLock<Arc<FunctionRegistry>> = LazyLock::new(||
     MatchesFunction::register(&function_registry);
     MatchesTermFunction::register(&function_registry);
 
-    // System and administration functions
+    // System functions
     SystemFunction::register(&function_registry);
-    AdminFunction::register(&function_registry);
 
     // Json related functions
     JsonFunction::register(&function_registry);
@@ -175,6 +174,15 @@ pub static FUNCTION_REGISTRY: LazyLock<Arc<FunctionRegistry>> = LazyLock::new(||
 
     // state function of supported aggregate functions
     StateMergeHelper::register(&function_registry);
+
+    Arc::new(function_registry)
+});
+
+pub static ADMIN_FUNCTION_REGISTRY: LazyLock<Arc<FunctionRegistry>> = LazyLock::new(|| {
+    let function_registry = FunctionRegistry::default();
+
+    // Administration functions
+    AdminFunction::register(&function_registry);
 
     Arc::new(function_registry)
 });


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
Fixes #7059 

## What's changed and what's your intention?
1. In my previous PR (https://github.com/GreptimeTeam/greptimedb/pull/7061), I added a check to determine whether a function is an admin function. However, that check did not cover all cases.
2. Introduced a new `ADMIN_FUNCTION_REGISTRY` that registers **only admin functions**. The `execute_admin_command()` function now checks this registry instead of `FUNCTION_REGISTRY`, ensuring a clear separation between normal and admin functions.
3. All changes from the previous PR have been reverted, since this new approach fully addresses the issue.

## Implementation Details
- Added `ADMIN_FUNCTION_REGISTRY` as a dedicated registry for admin functions.
- Updated `execute_admin_command()` to use the new registry.
- Removed previous logic that attempted to detect admin functions from the mixed `FUNCTION_REGISTRY` inside `execute_admin_command()` .


<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
