### PR TITLE
fix: correct impl Clear for &[u8]

### DIFF
--- a/src/servers/src/repeated_field.rs
+++ b/src/servers/src/repeated_field.rs
@@ -32,7 +32,7 @@ use std::{fmt, slice, vec};
 
 use bytes::Bytes;
 
-const NULL_BYTES: &'static [u8] = &[];
+const NULL_BYTES: &[u8] = &[];
 
 /// anything that can be cleared
 pub trait Clear {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Corrects the implementation of `Clear` for `&[u8]` to avoid data corruption.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
