### PR TITLE
refactor: update valueref coerce function name based on its semantics

### DIFF
--- a/src/datatypes/src/value.rs
+++ b/src/datatypes/src/value.rs
@@ -1289,6 +1289,18 @@ macro_rules! impl_as_for_value_ref {
         match $value {
             ValueRef::Null => Ok(None),
             ValueRef::$Variant(v) => Ok(Some(v.clone())),
+            ValueRef::Json(v) => match v.as_ref() {
+                ValueRef::Null => Ok(None),
+                ValueRef::$Variant(v) => Ok(Some(v.clone())),
+                other => error::CastTypeSnafu {
+                    msg: format!(
+                        "Failed to cast value ref {:?} to {}",
+                        other,
+                        stringify!($Variant)
+                    ),
+                }
+                .fail(),
+            },
             other => error::CastTypeSnafu {
                 msg: format!(
                     "Failed to cast value ref {:?} to {}",
@@ -1314,56 +1326,57 @@ impl<'a> ValueRef<'a> {
     }
 
     /// Cast itself to binary slice.
-    pub fn as_binary(&self) -> Result<Option<&'a [u8]>> {
+    pub fn try_into_binary(&self) -> Result<Option<&'a [u8]>> {
         impl_as_for_value_ref!(self, Binary)
     }
 
     /// Cast itself to string slice.
-    pub fn as_string(&self) -> Result<Option<&'a str>> {
+    pub fn try_into_string(&self) -> Result<Option<&'a str>> {
         impl_as_for_value_ref!(self, String)
     }
 
     /// Cast itself to boolean.
-    pub fn as_boolean(&self) -> Result<Option<bool>> {
+    pub fn try_into_boolean(&self) -> Result<Option<bool>> {
         impl_as_for_value_ref!(self, Boolean)
     }
 
-    pub fn as_i8(&self) -> Result<Option<i8>> {
+    pub fn try_into_i8(&self) -> Result<Option<i8>> {
         impl_as_for_value_ref!(self, Int8)
     }
 
-    pub fn as_u8(&self) -> Result<Option<u8>> {
+    pub fn try_into_u8(&self) -> Result<Option<u8>> {
         impl_as_for_value_ref!(self, UInt8)
     }
 
-    pub fn as_i16(&self) -> Result<Option<i16>> {
+    pub fn try_into_i16(&self) -> Result<Option<i16>> {
         impl_as_for_value_ref!(self, Int16)
     }
 
-    pub fn as_u16(&self) -> Result<Option<u16>> {
+    pub fn try_into_u16(&self) -> Result<Option<u16>> {
         impl_as_for_value_ref!(self, UInt16)
     }
 
-    pub fn as_i32(&self) -> Result<Option<i32>> {
+    pub fn try_into_i32(&self) -> Result<Option<i32>> {
         impl_as_for_value_ref!(self, Int32)
     }
 
-    pub fn as_u32(&self) -> Result<Option<u32>> {
+    pub fn try_into_u32(&self) -> Result<Option<u32>> {
         impl_as_for_value_ref!(self, UInt32)
     }
 
-    pub fn as_i64(&self) -> Result<Option<i64>> {
+    pub fn try_into_i64(&self) -> Result<Option<i64>> {
         impl_as_for_value_ref!(self, Int64)
     }
 
-    pub fn as_u64(&self) -> Result<Option<u64>> {
+    pub fn try_into_u64(&self) -> Result<Option<u64>> {
         impl_as_for_value_ref!(self, UInt64)
     }
 
-    pub fn as_f32(&self) -> Result<Option<f32>> {
+    pub fn try_into_f32(&self) -> Result<Option<f32>> {
         match self {
             ValueRef::Null => Ok(None),
             ValueRef::Float32(f) => Ok(Some(f.0)),
+            ValueRef::Json(v) => v.try_into_f32(),
             other => error::CastTypeSnafu {
                 msg: format!("Failed to cast value ref {:?} to ValueRef::Float32", other,),
             }
@@ -1371,10 +1384,11 @@ impl<'a> ValueRef<'a> {
         }
     }
 
-    pub fn as_f64(&self) -> Result<Option<f64>> {
+    pub fn try_into_f64(&self) -> Result<Option<f64>> {
         match self {
             ValueRef::Null => Ok(None),
             ValueRef::Float64(f) => Ok(Some(f.0)),
+            ValueRef::Json(v) => v.try_into_f64(),
             other => error::CastTypeSnafu {
                 msg: format!("Failed to cast value ref {:?} to ValueRef::Float64", other,),
             }
@@ -1383,50 +1397,51 @@ impl<'a> ValueRef<'a> {
     }
 
     /// Cast itself to [Date].
-    pub fn as_date(&self) -> Result<Option<Date>> {
+    pub fn try_into_date(&self) -> Result<Option<Date>> {
         impl_as_for_value_ref!(self, Date)
     }
 
     /// Cast itself to [Timestamp].
-    pub fn as_timestamp(&self) -> Result<Option<Timestamp>> {
+    pub fn try_into_timestamp(&self) -> Result<Option<Timestamp>> {
         impl_as_for_value_ref!(self, Timestamp)
     }
 
     /// Cast itself to [Time].
-    pub fn as_time(&self) -> Result<Option<Time>> {
+    pub fn try_into_time(&self) -> Result<Option<Time>> {
         impl_as_for_value_ref!(self, Time)
     }
 
-    pub fn as_duration(&self) -> Result<Option<Duration>> {
+    pub fn try_into_duration(&self) -> Result<Option<Duration>> {
         impl_as_for_value_ref!(self, Duration)
     }
 
     /// Cast itself to [IntervalYearMonth].
-    pub fn as_interval_year_month(&self) -> Result<Option<IntervalYearMonth>> {
+    pub fn try_into_interval_year_month(&self) -> Result<Option<IntervalYearMonth>> {
         impl_as_for_value_ref!(self, IntervalYearMonth)
     }
 
     /// Cast itself to [IntervalDayTime].
-    pub fn as_interval_day_time(&self) -> Result<Option<IntervalDayTime>> {
+    pub fn try_into_interval_day_time(&self) -> Result<Option<IntervalDayTime>> {
         impl_as_for_value_ref!(self, IntervalDayTime)
     }
 
     /// Cast itself to [IntervalMonthDayNano].
-    pub fn as_interval_month_day_nano(&self) -> Result<Option<IntervalMonthDayNano>> {
+    pub fn try_into_interval_month_day_nano(&self) -> Result<Option<IntervalMonthDayNano>> {
         impl_as_for_value_ref!(self, IntervalMonthDayNano)
     }
 
     /// Cast itself to [ListValueRef].
-    pub fn as_list(&self) -> Result<Option<ListValueRef<'_>>> {
+    pub fn try_into_list(&self) -> Result<Option<ListValueRef<'_>>> {
         impl_as_for_value_ref!(self, List)
     }
 
-    pub fn as_struct(&self) -> Result<Option<StructValueRef<'_>>> {
+    /// Cast itself to [StructValueRef].
+    pub fn try_into_struct(&self) -> Result<Option<StructValueRef<'_>>> {
         impl_as_for_value_ref!(self, Struct)
     }
 
     /// Cast itself to [Decimal128].
-    pub fn as_decimal128(&self) -> Result<Option<Decimal128>> {
+    pub fn try_into_decimal128(&self) -> Result<Option<Decimal128>> {
         impl_as_for_value_ref!(self, Decimal128)
     }
 }
@@ -2512,11 +2527,11 @@ pub(crate) mod tests {
             };
         }
 
-        check_as_null!(as_binary);
-        check_as_null!(as_string);
-        check_as_null!(as_boolean);
-        check_as_null!(as_date);
-        check_as_null!(as_list);
+        check_as_null!(try_into_binary);
+        check_as_null!(try_into_string);
+        check_as_null!(try_into_boolean);
+        check_as_null!(try_into_list);
+        check_as_null!(try_into_struct);
 
         macro_rules! check_as_correct {
             ($data: expr, $Variant: ident, $method: ident) => {
@@ -2524,27 +2539,29 @@ pub(crate) mod tests {
             };
         }
 
-        check_as_correct!("hello", String, as_string);
-        check_as_correct!("hello".as_bytes(), Binary, as_binary);
-        check_as_correct!(true, Boolean, as_boolean);
-        check_as_correct!(Date::new(123), Date, as_date);
-        check_as_correct!(Time::new_second(12), Time, as_time);
-        check_as_correct!(Duration::new_second(12), Duration, as_duration);
+        check_as_correct!("hello", String, try_into_string);
+        check_as_correct!("hello".as_bytes(), Binary, try_into_binary);
+        check_as_correct!(true, Boolean, try_into_boolean);
+        check_as_correct!(Date::new(123), Date, try_into_date);
+        check_as_correct!(Time::new_second(12), Time, try_into_time);
+        check_as_correct!(Duration::new_second(12), Duration, try_into_duration);
 
         let list = build_list_value();
-        check_as_correct!(ListValueRef::Ref { val: &list }, List, as_list);
+        check_as_correct!(ListValueRef::Ref { val: &list }, List, try_into_list);
 
         let struct_value = build_struct_value();
-        check_as_correct!(StructValueRef::Ref(&struct_value), Struct, as_struct);
+        check_as_correct!(StructValueRef::Ref(&struct_value), Struct, try_into_struct);
 
         let wrong_value = ValueRef::Int32(12345);
-        assert!(wrong_value.as_binary().is_err());
-        assert!(wrong_value.as_string().is_err());
-        assert!(wrong_value.as_boolean().is_err());
-        assert!(wrong_value.as_date().is_err());
-        assert!(wrong_value.as_list().is_err());
-        assert!(wrong_value.as_time().is_err());
-        assert!(wrong_value.as_timestamp().is_err());
+        assert!(wrong_value.try_into_binary().is_err());
+        assert!(wrong_value.try_into_string().is_err());
+        assert!(wrong_value.try_into_boolean().is_err());
+        assert!(wrong_value.try_into_list().is_err());
+        assert!(wrong_value.try_into_struct().is_err());
+        assert!(wrong_value.try_into_date().is_err());
+        assert!(wrong_value.try_into_time().is_err());
+        assert!(wrong_value.try_into_timestamp().is_err());
+        assert!(wrong_value.try_into_duration().is_err());
     }
 
     #[test]

--- a/src/datatypes/src/vectors/binary.rs
+++ b/src/datatypes/src/vectors/binary.rs
@@ -242,7 +242,7 @@ impl MutableVector for BinaryVectorBuilder {
     }
 
     fn try_push_value_ref(&mut self, value: &ValueRef) -> Result<()> {
-        match value.as_binary()? {
+        match value.try_into_binary()? {
             Some(v) => self.mutable_array.append_value(v),
             None => self.mutable_array.append_null(),
         }
@@ -475,7 +475,7 @@ mod tests {
             .collect::<Vec<_>>();
         for i in 0..3 {
             assert_eq!(
-                json_vector.get_ref(i).as_binary().unwrap().unwrap(),
+                json_vector.get_ref(i).try_into_binary().unwrap().unwrap(),
                 jsonbs.get(i).unwrap().as_slice()
             );
         }
@@ -486,7 +486,7 @@ mod tests {
             .unwrap();
         for i in 0..3 {
             assert_eq!(
-                json_vector.get_ref(i).as_binary().unwrap().unwrap(),
+                json_vector.get_ref(i).try_into_binary().unwrap().unwrap(),
                 jsonbs.get(i).unwrap().as_slice()
             );
         }
@@ -551,8 +551,8 @@ mod tests {
         assert_eq!(converted.len(), expected.len());
         for i in 0..3 {
             assert_eq!(
-                converted.get_ref(i).as_binary().unwrap().unwrap(),
-                expected.get_ref(i).as_binary().unwrap().unwrap()
+                converted.get_ref(i).try_into_binary().unwrap().unwrap(),
+                expected.get_ref(i).try_into_binary().unwrap().unwrap()
             );
         }
     }

--- a/src/datatypes/src/vectors/boolean.rs
+++ b/src/datatypes/src/vectors/boolean.rs
@@ -180,7 +180,7 @@ impl MutableVector for BooleanVectorBuilder {
     }
 
     fn try_push_value_ref(&mut self, value: &ValueRef) -> Result<()> {
-        match value.as_boolean()? {
+        match value.try_into_boolean()? {
             Some(v) => self.mutable_array.append_value(v),
             None => self.mutable_array.append_null(),
         }

--- a/src/datatypes/src/vectors/decimal.rs
+++ b/src/datatypes/src/vectors/decimal.rs
@@ -315,7 +315,7 @@ impl MutableVector for Decimal128VectorBuilder {
     }
 
     fn try_push_value_ref(&mut self, value: &ValueRef) -> Result<()> {
-        let decimal_val = value.as_decimal128()?.map(|v| v.val());
+        let decimal_val = value.try_into_decimal128()?.map(|v| v.val());
         self.mutable_array.append_option(decimal_val);
         Ok(())
     }

--- a/src/datatypes/src/vectors/list.rs
+++ b/src/datatypes/src/vectors/list.rs
@@ -284,7 +284,7 @@ impl MutableVector for ListVectorBuilder {
     }
 
     fn try_push_value_ref(&mut self, value: &ValueRef) -> Result<()> {
-        if let Some(list_ref) = value.as_list()? {
+        if let Some(list_ref) = value.try_into_list()? {
             match list_ref {
                 ListValueRef::Indexed { vector, idx } => match vector.get(idx).as_list()? {
                     Some(list_value) => self.push_list_value(list_value)?,

--- a/src/datatypes/src/vectors/string.rs
+++ b/src/datatypes/src/vectors/string.rs
@@ -193,9 +193,8 @@ impl MutableVector for StringVectorBuilder {
     fn to_vector_cloned(&self) -> VectorRef {
         Arc::new(self.finish_cloned())
     }
-
     fn try_push_value_ref(&mut self, value: &ValueRef) -> Result<()> {
-        match value.as_string()? {
+        match value.try_into_string()? {
             Some(v) => self.mutable_array.append_value(v),
             None => self.mutable_array.append_null(),
         }

--- a/src/datatypes/src/vectors/struct_vector.rs
+++ b/src/datatypes/src/vectors/struct_vector.rs
@@ -351,7 +351,7 @@ impl MutableVector for StructVectorBuilder {
     }
 
     fn try_push_value_ref(&mut self, value: &ValueRef) -> Result<()> {
-        if let Some(struct_ref) = value.as_struct()? {
+        if let Some(struct_ref) = value.try_into_struct()? {
             match struct_ref {
                 StructValueRef::Indexed { vector, idx } => match vector.get(idx).as_struct()? {
                     Some(struct_value) => self.push_struct_value(struct_value)?,

--- a/src/metric-engine/src/metadata_region.rs
+++ b/src/metric-engine/src/metadata_region.rs
@@ -324,7 +324,7 @@ fn decode_record_batch_to_key_and_value(batch: RecordBatch) -> Vec<(String, Stri
         .flat_map(move |row_index| {
             let key = key_col
                 .get_ref(row_index)
-                .as_string()
+                .try_into_string()
                 .unwrap()
                 .map(|s| s.to_string());
 
@@ -333,7 +333,7 @@ fn decode_record_batch_to_key_and_value(batch: RecordBatch) -> Vec<(String, Stri
                     k,
                     val_col
                         .get_ref(row_index)
-                        .as_string()
+                        .try_into_string()
                         .unwrap()
                         .map(|s| s.to_string())
                         .unwrap_or_default(),
@@ -351,7 +351,7 @@ fn decode_record_batch_to_key(batch: RecordBatch) -> Vec<String> {
         .flat_map(move |row_index| {
             key_col
                 .get_ref(row_index)
-                .as_string()
+                .try_into_string()
                 .unwrap()
                 .map(|s| s.to_string())
         })
@@ -614,7 +614,7 @@ impl MetadataRegion {
         let val = first_batch
             .column(0)
             .get_ref(0)
-            .as_string()
+            .try_into_string()
             .unwrap()
             .map(|s| s.to_string());
 

--- a/src/mito-codec/src/index.rs
+++ b/src/mito-codec/src/index.rs
@@ -51,7 +51,7 @@ impl IndexValueCodec {
 
         if matches!(field.data_type(), ConcreteDataType::String(_)) {
             let value = value
-                .as_string()
+                .try_into_string()
                 .context(FieldTypeMismatchSnafu)?
                 .context(IndexEncodeNullSnafu)?;
             buffer.extend_from_slice(value.as_bytes());

--- a/src/mito-codec/src/key_values.rs
+++ b/src/mito-codec/src/key_values.rs
@@ -182,19 +182,19 @@ impl KeyValue<'_> {
             let Some(primary_key) = self.primary_keys().next() else {
                 return 0;
             };
-            let key = primary_key.as_binary().unwrap().unwrap();
+            let key = primary_key.try_into_binary().unwrap().unwrap();
 
             let mut deserializer = Deserializer::new(key);
             deserializer.advance(COLUMN_ID_ENCODE_SIZE);
             let field = SortField::new(ConcreteDataType::uint32_datatype());
             let table_id = field.deserialize(&mut deserializer).unwrap();
-            table_id.as_value_ref().as_u32().unwrap().unwrap()
+            table_id.as_value_ref().try_into_u32().unwrap().unwrap()
         } else {
             let Some(value) = self.primary_keys().next() else {
                 return 0;
             };
 
-            value.as_u32().unwrap().unwrap()
+            value.try_into_u32().unwrap().unwrap()
         }
     }
 

--- a/src/mito-codec/src/row_converter/dense.rs
+++ b/src/mito-codec/src/row_converter/dense.rs
@@ -124,7 +124,7 @@ impl SortField {
                     ConcreteDataType::$ty(_) => {
                         paste!{
                             value
-                            .[<as_ $f>]()
+                            .[<try_into_ $f>]()
                             .context(FieldTypeMismatchSnafu)?
                             .serialize($serializer)
                             .context(SerializeFieldSnafu)?;
@@ -132,26 +132,26 @@ impl SortField {
                     }
                 )*
                     ConcreteDataType::Timestamp(_) => {
-                        let timestamp = value.as_timestamp().context(FieldTypeMismatchSnafu)?;
+                        let timestamp = value.try_into_timestamp().context(FieldTypeMismatchSnafu)?;
                         timestamp
                             .map(|t|t.value())
                             .serialize($serializer)
                             .context(SerializeFieldSnafu)?;
                     }
                     ConcreteDataType::Interval(IntervalType::YearMonth(_)) => {
-                        let interval = value.as_interval_year_month().context(FieldTypeMismatchSnafu)?;
+                        let interval = value.try_into_interval_year_month().context(FieldTypeMismatchSnafu)?;
                         interval.map(|i| i.to_i32())
                             .serialize($serializer)
                             .context(SerializeFieldSnafu)?;
                     }
                     ConcreteDataType::Interval(IntervalType::DayTime(_)) => {
-                        let interval = value.as_interval_day_time().context(FieldTypeMismatchSnafu)?;
+                        let interval = value.try_into_interval_day_time().context(FieldTypeMismatchSnafu)?;
                         interval.map(|i| i.to_i64())
                             .serialize($serializer)
                             .context(SerializeFieldSnafu)?;
                     }
                     ConcreteDataType::Interval(IntervalType::MonthDayNano(_)) => {
-                        let interval = value.as_interval_month_day_nano().context(FieldTypeMismatchSnafu)?;
+                        let interval = value.try_into_interval_month_day_nano().context(FieldTypeMismatchSnafu)?;
                         interval.map(|i| i.to_i128())
                             .serialize($serializer)
                             .context(SerializeFieldSnafu)?;

--- a/src/mito2/src/memtable/builder.rs
+++ b/src/mito2/src/memtable/builder.rs
@@ -47,7 +47,7 @@ impl FieldBuilder {
     pub(crate) fn push(&mut self, value: ValueRef) -> datatypes::error::Result<()> {
         match self {
             FieldBuilder::String(b) => {
-                if let Some(s) = value.as_string()? {
+                if let Some(s) = value.try_into_string()? {
                     b.append(s);
                 } else {
                     b.append_null();

--- a/src/mito2/src/memtable/partition_tree.rs
+++ b/src/mito2/src/memtable/partition_tree.rs
@@ -428,7 +428,13 @@ mod tests {
 
         let expected_ts = kvs
             .iter()
-            .map(|kv| kv.timestamp().as_timestamp().unwrap().unwrap().value())
+            .map(|kv| {
+                kv.timestamp()
+                    .try_into_timestamp()
+                    .unwrap()
+                    .unwrap()
+                    .value()
+            })
             .collect::<Vec<_>>();
 
         let iter = memtable.iter(None, None, None).unwrap();

--- a/src/mito2/src/memtable/partition_tree/tree.rs
+++ b/src/mito2/src/memtable/partition_tree/tree.rs
@@ -151,7 +151,12 @@ impl PartitionTree {
         for kv in kvs.iter() {
             self.verify_primary_key_length(&kv)?;
             // Safety: timestamp of kv must be both present and a valid timestamp value.
-            let ts = kv.timestamp().as_timestamp().unwrap().unwrap().value();
+            let ts = kv
+                .timestamp()
+                .try_into_timestamp()
+                .unwrap()
+                .unwrap()
+                .value();
             metrics.min_ts = metrics.min_ts.min(ts);
             metrics.max_ts = metrics.max_ts.max(ts);
             metrics.value_bytes += kv.fields().map(|v| v.data_size()).sum::<usize>();
@@ -196,7 +201,12 @@ impl PartitionTree {
 
         self.verify_primary_key_length(&kv)?;
         // Safety: timestamp of kv must be both present and a valid timestamp value.
-        let ts = kv.timestamp().as_timestamp().unwrap().unwrap().value();
+        let ts = kv
+            .timestamp()
+            .try_into_timestamp()
+            .unwrap()
+            .unwrap()
+            .value();
         metrics.min_ts = metrics.min_ts.min(ts);
         metrics.max_ts = metrics.max_ts.max(ts);
         metrics.value_bytes += kv.fields().map(|v| v.data_size()).sum::<usize>();

--- a/src/mito2/src/memtable/simple_bulk_memtable.rs
+++ b/src/mito2/src/memtable/simple_bulk_memtable.rs
@@ -111,7 +111,12 @@ impl SimpleBulkMemtable {
         let size = series.push(ts, sequence, op_type, kv.fields());
         stats.value_bytes += size;
         // safety: timestamp of kv must be both present and a valid timestamp value.
-        let ts = kv.timestamp().as_timestamp().unwrap().unwrap().value();
+        let ts = kv
+            .timestamp()
+            .try_into_timestamp()
+            .unwrap()
+            .unwrap()
+            .value();
         stats.min_ts = stats.min_ts.min(ts);
         stats.max_ts = stats.max_ts.max(ts);
     }

--- a/src/mito2/src/memtable/time_partition.rs
+++ b/src/mito2/src/memtable/time_partition.rs
@@ -273,7 +273,7 @@ impl TimePartitions {
             let mut all_in_partition = true;
             for kv in kvs.iter() {
                 // Safety: We checked the schema in the write request.
-                let ts = kv.timestamp().as_timestamp().unwrap().unwrap();
+                let ts = kv.timestamp().try_into_timestamp().unwrap().unwrap();
                 if !part.contains_timestamp(ts) {
                     all_in_partition = false;
                     break;
@@ -634,7 +634,7 @@ impl TimePartitions {
         for kv in kvs.iter() {
             let mut part_found = false;
             // Safety: We used the timestamp before.
-            let ts = kv.timestamp().as_timestamp().unwrap().unwrap();
+            let ts = kv.timestamp().try_into_timestamp().unwrap().unwrap();
             for part in parts {
                 if part.contains_timestamp(ts) {
                     parts_to_write

--- a/src/mito2/src/sst/index/fulltext_index/creator.rs
+++ b/src/mito2/src/sst/index/fulltext_index/creator.rs
@@ -297,7 +297,7 @@ impl SingleCreator {
                 for i in 0..batch.num_rows() {
                     let data = data.get_ref(i);
                     let text = data
-                        .as_string()
+                        .try_into_string()
                         .context(DataTypeMismatchSnafu)?
                         .unwrap_or_default();
                     self.inner.push_text(text).await?;

--- a/src/promql/src/extension_plan/histogram_fold.rs
+++ b/src/promql/src/extension_plan/histogram_fold.rs
@@ -578,7 +578,7 @@ impl HistogramFoldStream {
                 let le_str_val = le_array.get(cursor + bias);
                 let le_str_val_ref = le_str_val.as_value_ref();
                 let le_str = le_str_val_ref
-                    .as_string()
+                    .try_into_string()
                     .unwrap()
                     .expect("le column should not be nullable");
                 let le = le_str.parse::<f64>().unwrap();
@@ -587,7 +587,7 @@ impl HistogramFoldStream {
                 let counter = field_array
                     .get(cursor + bias)
                     .as_value_ref()
-                    .as_f64()
+                    .try_into_f64()
                     .unwrap()
                     .expect("field column should not be nullable");
                 counters.push(counter);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

These functions are returning `Result` so it's better to rename them as `try_into_*`

This patch also added Json variant support for these coerce functions.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
