### PR TITLE
fix: fix build warnings

### DIFF
--- a/src/mito2/src/remap_manifest.rs
+++ b/src/mito2/src/remap_manifest.rs
@@ -22,7 +22,6 @@ use store_api::storage::RegionId;
 use crate::error;
 pub use crate::error::{Error, Result};
 use crate::manifest::action::{RegionManifest, RemovedFilesRecord};
-use crate::sst::file::FileMeta;
 
 /// Remaps file references from old region manifests to new region manifests.
 pub struct RemapManifest {
@@ -167,11 +166,13 @@ impl RemapManifest {
                 Entry::Vacant(e) => {
                     e.insert(file_meta_clone);
                 }
+                #[cfg(debug_assertions)]
                 Entry::Occupied(e) => {
                     // File already exists - verify it's the same physical file
-                    #[cfg(debug_assertions)]
                     Self::verify_file_consistency(e.get(), &file_meta_clone)?;
                 }
+                #[cfg(not(debug_assertions))]
+                Entry::Occupied(_) => {}
             }
         }
 
@@ -180,7 +181,10 @@ impl RemapManifest {
 
     /// Verifies that two file metadata entries are consistent.
     #[cfg(debug_assertions)]
-    fn verify_file_consistency(existing: &FileMeta, new: &FileMeta) -> Result<()> {
+    fn verify_file_consistency(
+        existing: &crate::sst::file::FileMeta,
+        new: &crate::sst::file::FileMeta,
+    ) -> Result<()> {
         // When the same file appears from multiple overlapping old regions,
         // verify they are actually the same physical file with identical metadata
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR fixes build warnings by removing unused imports and properly structuring conditional compilation attributes for debug/release builds.

<img width="2514" height="1312" alt="image (2)" src="https://github.com/user-attachments/assets/3efc39bf-02f7-4185-bf1a-cab1497c4e3a" />

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
