### PR TITLE
fix: correct test_index_build_type_compact

### DIFF
--- a/src/mito2/src/engine/listener.rs
+++ b/src/mito2/src/engine/listener.rs
@@ -75,10 +75,13 @@ pub trait EventListener: Send + Sync {
     async fn on_notify_region_change_result_begin(&self, _region_id: RegionId) {}
 
     /// Notifies the listener that the index build task is executed successfully.
-    async fn on_index_build_success(&self, _region_file_id: RegionFileId) {}
+    async fn on_index_build_finish(&self, _region_file_id: RegionFileId) {}
 
     /// Notifies the listener that the index build task is started.
     async fn on_index_build_begin(&self, _region_file_id: RegionFileId) {}
+
+    /// Notifies the listener that the index build task is aborted.
+    async fn on_index_build_abort(&self, _region_file_id: RegionFileId) {}
 }
 
 pub type EventListenerRef = Arc<dyn EventListener>;
@@ -309,45 +312,75 @@ impl EventListener for NotifyRegionChangeResultListener {
 
 #[derive(Default)]
 pub struct IndexBuildListener {
-    notify: Notify,
-    success_count: AtomicUsize,
-    start_count: AtomicUsize,
+    begin_count: AtomicUsize,
+    begin_notify: Notify,
+    finish_count: AtomicUsize,
+    finish_notify: Notify,
+    abort_count: AtomicUsize,
+    abort_notify: Notify,
+    // stop means finished or aborted
+    stop_notify: Notify,
 }
 
 impl IndexBuildListener {
     /// Wait until index build is done for `times` times.
     pub async fn wait_finish(&self, times: usize) {
-        while self.success_count.load(Ordering::Relaxed) < times {
-            self.notify.notified().await;
+        while self.finish_count.load(Ordering::Relaxed) < times {
+            self.finish_notify.notified().await;
+        }
+    }
+
+    /// Wait until index build is stopped for `times` times.
+    pub async fn wait_stop(&self, times: usize) {
+        while self.finish_count.load(Ordering::Relaxed) + self.abort_count.load(Ordering::Relaxed)
+            < times
+        {
+            self.stop_notify.notified().await;
+        }
+    }
+
+    /// Wait until index build is begun for `times` times.
+    pub async fn wait_begin(&self, times: usize) {
+        while self.begin_count.load(Ordering::Relaxed) < times {
+            self.begin_notify.notified().await;
         }
     }
 
     /// Clears the success count.
-    pub fn clear_success_count(&self) {
-        self.success_count.store(0, Ordering::Relaxed);
+    pub fn clear_finish_count(&self) {
+        self.finish_count.store(0, Ordering::Relaxed);
     }
 
     /// Returns the success count.
-    pub fn success_count(&self) -> usize {
-        self.success_count.load(Ordering::Relaxed)
+    pub fn finish_count(&self) -> usize {
+        self.finish_count.load(Ordering::Relaxed)
     }
 
     /// Returns the start count.
     pub fn begin_count(&self) -> usize {
-        self.start_count.load(Ordering::Relaxed)
+        self.begin_count.load(Ordering::Relaxed)
     }
 }
 
 #[async_trait]
 impl EventListener for IndexBuildListener {
-    async fn on_index_build_success(&self, region_file_id: RegionFileId) {
+    async fn on_index_build_finish(&self, region_file_id: RegionFileId) {
         info!("Region {} index build successfully", region_file_id);
-        self.success_count.fetch_add(1, Ordering::Relaxed);
-        self.notify.notify_one();
+        self.finish_count.fetch_add(1, Ordering::Relaxed);
+        self.finish_notify.notify_one();
+        self.stop_notify.notify_one();
     }
 
     async fn on_index_build_begin(&self, region_file_id: RegionFileId) {
         info!("Region {} index build begin", region_file_id);
-        self.start_count.fetch_add(1, Ordering::Relaxed);
+        self.begin_count.fetch_add(1, Ordering::Relaxed);
+        self.begin_notify.notify_one();
+    }
+
+    async fn on_index_build_abort(&self, region_file_id: RegionFileId) {
+        info!("Region {} index build aborted", region_file_id);
+        self.abort_count.fetch_add(1, Ordering::Relaxed);
+        self.abort_notify.notify_one();
+        self.stop_notify.notify_one();
     }
 }

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -1220,10 +1220,10 @@ impl WorkerListener {
         }
     }
 
-    pub(crate) async fn on_index_build_success(&self, _region_file_id: RegionFileId) {
+    pub(crate) async fn on_index_build_finish(&self, _region_file_id: RegionFileId) {
         #[cfg(any(test, feature = "test"))]
         if let Some(listener) = &self.listener {
-            listener.on_index_build_success(_region_file_id).await;
+            listener.on_index_build_finish(_region_file_id).await;
         }
     }
 
@@ -1231,6 +1231,13 @@ impl WorkerListener {
         #[cfg(any(test, feature = "test"))]
         if let Some(listener) = &self.listener {
             listener.on_index_build_begin(_region_file_id).await;
+        }
+    }
+
+    pub(crate) async fn on_index_build_abort(&self, _region_file_id: RegionFileId) {
+        #[cfg(any(test, feature = "test"))]
+        if let Some(listener) = &self.listener {
+            listener.on_index_build_abort(_region_file_id).await;
         }
     }
 }

--- a/src/mito2/src/worker/handle_rebuild_index.rs
+++ b/src/mito2/src/worker/handle_rebuild_index.rs
@@ -71,6 +71,7 @@ impl<S> RegionWorkerLoop<S> {
             file_meta: file.meta_ref().clone(),
             reason: build_type,
             access_layer: access_layer.clone(),
+            listener: self.listener.clone(),
             manifest_ctx: region.manifest_ctx.clone(),
             write_cache: self.cache_manager.write_cache().cloned(),
             file_purger: file.file_purger(),
@@ -172,9 +173,6 @@ impl<S> RegionWorkerLoop<S> {
             let _ = self
                 .index_build_scheduler
                 .schedule_build(&region.version_control, task);
-            self.listener
-                .on_index_build_begin(RegionFileId::new(region_id, file_handle.meta_ref().file_id))
-                .await;
         }
         // Wait for all index build tasks to finish and notify the caller.
         common_runtime::spawn_global(async move {
@@ -212,7 +210,7 @@ impl<S> RegionWorkerLoop<S> {
         );
         for file_meta in &request.edit.files_to_add {
             self.listener
-                .on_index_build_success(RegionFileId::new(region_id, file_meta.file_id))
+                .on_index_build_finish(RegionFileId::new(region_id, file_meta.file_id))
                 .await;
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

close #7133 

## What's changed and what's your intention?

Fix intermittent failures/hangs in test_index_build_type_compact.

### **Root cause analysis**:

In the original test, using `wait_finish(2)` to wait for task completion is incorrect, as tasks may have already finished before that point.

<img width="962" height="366" alt="d25b915c5c3b8306f6cc718ae31315a8" src="https://github.com/user-attachments/assets/612267e9-a5d8-4b7c-8dd0-acacc2caef7f" />

<img width="974" height="306" alt="422ec858300f73b165730a4f3d517c42" src="https://github.com/user-attachments/assets/2e55ec41-9919-42ab-bc22-f9d74180d89a" />

### Solution:
The correct approach is to wait for stop count (finish + abort) = total begin task count.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
