### PR TITLE
refactor!: add a `opentelemetry_traces_operations` table to aggregate `(service_name, span_name, span_kind)` to improve query performance

### DIFF
--- a/src/common/catalog/src/consts.rs
+++ b/src/common/catalog/src/consts.rs
@@ -150,4 +150,9 @@ pub const TRACE_TABLE_NAME_SESSION_KEY: &str = "trace_table_name";
 pub fn trace_services_table_name(trace_table_name: &str) -> String {
     format!("{}_services", trace_table_name)
 }
+
+/// Generate the trace operations table name from the trace table name by adding `_operations` suffix.
+pub fn trace_operations_table_name(trace_table_name: &str) -> String {
+    format!("{}_operations", trace_table_name)
+}
 // ---- End of special table and fields ----

--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -29,7 +29,8 @@ use catalog::CatalogManagerRef;
 use client::{OutputData, OutputMeta};
 use common_catalog::consts::{
     PARENT_SPAN_ID_COLUMN, SERVICE_NAME_COLUMN, TRACE_ID_COLUMN, TRACE_TABLE_NAME,
-    TRACE_TABLE_NAME_SESSION_KEY, default_engine, trace_services_table_name,
+    TRACE_TABLE_NAME_SESSION_KEY, default_engine, trace_operations_table_name,
+    trace_services_table_name,
 };
 use common_grpc_expr::util::ColumnExpr;
 use common_meta::cache::TableFlownodeSetCacheRef;
@@ -618,8 +619,10 @@ impl Inserter {
                 // note that auto create table shouldn't be ttl instant table
                 // for it's a very unexpected behavior and should be set by user explicitly
                 for mut create_table in create_tables {
-                    if create_table.table_name == trace_services_table_name(trace_table_name) {
-                        // Disable append mode for trace services table since it requires upsert behavior.
+                    if create_table.table_name == trace_services_table_name(trace_table_name)
+                        || create_table.table_name == trace_operations_table_name(trace_table_name)
+                    {
+                        // Disable append mode for auxiliary tables (services/operations) since they require upsert behavior.
                         create_table
                             .table_options
                             .insert(APPEND_MODE_KEY.to_string(), "false".to_string());

--- a/src/servers/src/otlp/trace/v0.rs
+++ b/src/servers/src/otlp/trace/v0.rs
@@ -16,7 +16,7 @@ use std::collections::HashSet;
 
 use api::v1::value::ValueData;
 use api::v1::{ColumnDataType, RowInsertRequests};
-use common_catalog::consts::trace_services_table_name;
+use common_catalog::consts::{trace_operations_table_name, trace_services_table_name};
 use common_grpc::precision::Precision;
 use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
 use pipeline::{GreptimePipelineParams, PipelineWay};
@@ -35,6 +35,9 @@ use crate::row_writer::{self, MultiTableData, TableData};
 
 const APPROXIMATE_COLUMN_COUNT: usize = 24;
 
+// Use a timestamp(2100-01-01 00:00:00) as large as possible.
+const MAX_TIMESTAMP: i64 = 4102444800000000000;
+
 /// Convert SpanTraces to GreptimeDB row insert requests.
 /// Returns `InsertRequests` and total number of rows to ingest
 pub fn v0_to_grpc_insert_requests(
@@ -49,22 +52,39 @@ pub fn v0_to_grpc_insert_requests(
     let mut multi_table_writer = MultiTableData::default();
     let mut trace_writer = TableData::new(APPROXIMATE_COLUMN_COUNT, spans.len());
     let mut trace_services_writer = TableData::new(APPROXIMATE_COLUMN_COUNT, 1);
+    let mut trace_operations_writer = TableData::new(APPROXIMATE_COLUMN_COUNT, 1);
 
     let mut services = HashSet::new();
+    let mut operations = HashSet::new();
     for span in spans {
         if let Some(service_name) = &span.service_name {
             // Only insert the service name if it's not already in the set.
             if !services.contains(service_name) {
                 services.insert(service_name.clone());
             }
+
+            // Collect operations (service_name + span_name + span_kind).
+            let operation = (
+                service_name.clone(),
+                span.span_name.clone(),
+                span.span_kind.clone(),
+            );
+            if !operations.contains(&operation) {
+                operations.insert(operation);
+            }
         }
         write_span_to_row(&mut trace_writer, span)?;
     }
     write_trace_services_to_row(&mut trace_services_writer, services)?;
+    write_trace_operations_to_row(&mut trace_operations_writer, operations)?;
 
     multi_table_writer.add_table_data(
         trace_services_table_name(&table_name),
         trace_services_writer,
+    );
+    multi_table_writer.add_table_data(
+        trace_operations_table_name(&table_name),
+        trace_operations_writer,
     );
     multi_table_writer.add_table_data(table_name, trace_writer);
 
@@ -161,7 +181,7 @@ fn write_trace_services_to_row(writer: &mut TableData, services: HashSet<String>
         row_writer::write_ts_to_nanos(
             writer,
             TIMESTAMP_COLUMN,
-            Some(4102444800000000000), // Use a timestamp(2100-01-01 00:00:00) as large as possible.
+            Some(MAX_TIMESTAMP),
             Precision::Nanosecond,
             &mut row,
         )?;
@@ -173,6 +193,38 @@ fn write_trace_services_to_row(writer: &mut TableData, services: HashSet<String>
                 SERVICE_NAME_COLUMN,
                 Some(service_name),
             )),
+            &mut row,
+        )?;
+        writer.add_row(row);
+    }
+
+    Ok(())
+}
+
+fn write_trace_operations_to_row(
+    writer: &mut TableData,
+    operations: HashSet<(String, String, String)>,
+) -> Result<()> {
+    for (service_name, span_name, span_kind) in operations {
+        let mut row = writer.alloc_one_row();
+        // Write the timestamp as 0.
+        row_writer::write_ts_to_nanos(
+            writer,
+            TIMESTAMP_COLUMN,
+            Some(MAX_TIMESTAMP),
+            Precision::Nanosecond,
+            &mut row,
+        )?;
+
+        // Write the `service_name`, `span_name`, and `span_kind` columns.
+        row_writer::write_fields(
+            writer,
+            vec![
+                make_string_column_data(SERVICE_NAME_COLUMN, Some(service_name)),
+                make_string_column_data(SPAN_NAME_COLUMN, Some(span_name)),
+                make_string_column_data(SPAN_KIND_COLUMN, Some(span_kind)),
+            ]
+            .into_iter(),
             &mut row,
         )?;
         writer.add_row(row);

--- a/src/servers/src/otlp/trace/v1.rs
+++ b/src/servers/src/otlp/trace/v1.rs
@@ -16,7 +16,7 @@ use std::collections::HashSet;
 
 use api::v1::value::ValueData;
 use api::v1::{ColumnDataType, RowInsertRequests, Value};
-use common_catalog::consts::trace_services_table_name;
+use common_catalog::consts::{trace_operations_table_name, trace_services_table_name};
 use common_grpc::precision::Precision;
 use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
 use opentelemetry_proto::tonic::common::v1::any_value::Value as OtlpValue;
@@ -36,6 +36,9 @@ use crate::query_handler::PipelineHandlerRef;
 use crate::row_writer::{self, MultiTableData, TableData};
 
 const APPROXIMATE_COLUMN_COUNT: usize = 30;
+
+// Use a timestamp(2100-01-01 00:00:00) as large as possible.
+const MAX_TIMESTAMP: i64 = 4102444800000000000;
 
 /// Convert SpanTraces to GreptimeDB row insert requests.
 /// Returns `InsertRequests` and total number of rows to ingest
@@ -60,22 +63,39 @@ pub fn v1_to_grpc_insert_requests(
     let mut multi_table_writer = MultiTableData::default();
     let mut trace_writer = TableData::new(APPROXIMATE_COLUMN_COUNT, spans.len());
     let mut trace_services_writer = TableData::new(APPROXIMATE_COLUMN_COUNT, 1);
+    let mut trace_operations_writer = TableData::new(APPROXIMATE_COLUMN_COUNT, 1);
 
     let mut services = HashSet::new();
+    let mut operations = HashSet::new();
     for span in spans {
         if let Some(service_name) = &span.service_name {
             // Only insert the service name if it's not already in the set.
             if !services.contains(service_name) {
                 services.insert(service_name.clone());
             }
+
+            // Only insert the operation if it's not already in the set.
+            let operation = (
+                service_name.clone(),
+                span.span_name.clone(),
+                span.span_kind.clone(),
+            );
+            if !operations.contains(&operation) {
+                operations.insert(operation);
+            }
         }
         write_span_to_row(&mut trace_writer, span)?;
     }
     write_trace_services_to_row(&mut trace_services_writer, services)?;
+    write_trace_operations_to_row(&mut trace_operations_writer, operations)?;
 
     multi_table_writer.add_table_data(
         trace_services_table_name(&table_name),
         trace_services_writer,
+    );
+    multi_table_writer.add_table_data(
+        trace_operations_table_name(&table_name),
+        trace_operations_writer,
     );
     multi_table_writer.add_table_data(table_name, trace_writer);
 
@@ -160,7 +180,7 @@ fn write_trace_services_to_row(writer: &mut TableData, services: HashSet<String>
         row_writer::write_ts_to_nanos(
             writer,
             TIMESTAMP_COLUMN,
-            Some(4102444800000000000), // Use a timestamp(2100-01-01 00:00:00) as large as possible.
+            Some(MAX_TIMESTAMP),
             Precision::Nanosecond,
             &mut row,
         )?;
@@ -169,6 +189,38 @@ fn write_trace_services_to_row(writer: &mut TableData, services: HashSet<String>
         row_writer::write_tags(
             writer,
             std::iter::once((SERVICE_NAME_COLUMN.to_string(), service_name)),
+            &mut row,
+        )?;
+        writer.add_row(row);
+    }
+
+    Ok(())
+}
+
+fn write_trace_operations_to_row(
+    writer: &mut TableData,
+    operations: HashSet<(String, String, String)>,
+) -> Result<()> {
+    for (service_name, span_name, span_kind) in operations {
+        let mut row = writer.alloc_one_row();
+        // Write the timestamp as 0.
+        row_writer::write_ts_to_nanos(
+            writer,
+            TIMESTAMP_COLUMN,
+            Some(MAX_TIMESTAMP),
+            Precision::Nanosecond,
+            &mut row,
+        )?;
+
+        // Write the `service_name`, `span_name`, and `span_kind` columns as tags.
+        row_writer::write_tags(
+            writer,
+            vec![
+                (SERVICE_NAME_COLUMN.to_string(), service_name),
+                (SPAN_NAME_COLUMN.to_string(), span_name),
+                (SPAN_KIND_COLUMN.to_string(), span_kind),
+            ]
+            .into_iter(),
             &mut row,
         )?;
         writer.add_row(row);

--- a/src/servers/src/query_handler.rs
+++ b/src/servers/src/query_handler.rs
@@ -198,8 +198,6 @@ pub trait JaegerQueryHandler {
         ctx: QueryContextRef,
         service_name: &str,
         span_kind: Option<&str>,
-        start_time: Option<i64>,
-        end_time: Option<i64>,
     ) -> Result<Output>;
 
     /// Retrieves a trace by its unique identifier.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

1. Add a `opentelemetry_traces_operations` table to aggregate `(service_name, span_name, span_kind)` to improve query performance for Jaeger API `/operations`;

2. Breaking Changes: Remove `JAEGER_TIME_RANGE_FOR_OPERATIONS_HEADER` header. It's not necessary to add a time range filter when we create `opentelemetry_traces_operations` table.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
