### PR TITLE
fix: add delays in reconcile tests for async cache invalidation

### DIFF
--- a/src/frontend/src/heartbeat.rs
+++ b/src/frontend/src/heartbeat.rs
@@ -104,6 +104,9 @@ impl HeartbeatTask {
                 match resp_stream.message().await {
                     Ok(Some(resp)) => {
                         debug!("Receiving heartbeat response: {:?}", resp);
+                        if let Some(message) = &resp.mailbox_message {
+                            info!("Received mailbox message: {message:?}");
+                        }
                         let ctx = HeartbeatResponseHandlerContext::new(mailbox.clone(), resp);
                         if let Err(e) = capture_self.handle_response(ctx).await {
                             error!(e; "Error while handling heartbeat response");

--- a/tests-integration/src/tests/reconcile_table.rs
+++ b/tests-integration/src/tests/reconcile_table.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::time::Duration;
+
 use client::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, OutputData};
 use common_meta::reconciliation::ResolveStrategy;
 use common_meta::reconciliation::manager::ReconciliationManagerRef;
@@ -165,6 +167,8 @@ async fn test_reconcile_dropped_column() {
         "grpc_latencies",
     )
     .await;
+    // Try best effort to wait for the cache to be invalidated.
+    tokio::time::sleep(Duration::from_secs(1)).await;
 
     // Now we should able to query table again.
     let output = execute_sql(&frontend, "SELECT * FROM grpc_latencies ORDER BY host").await;
@@ -268,6 +272,8 @@ async fn test_reconcile_added_column() {
         "grpc_latencies",
     )
     .await;
+    // Try best effort to wait for the cache to be invalidated.
+    tokio::time::sleep(Duration::from_secs(1)).await;
 
     // Now the column cloud_provider is available.
     let output = execute_sql(&frontend, "SELECT * FROM grpc_latencies ORDER BY host").await;
@@ -342,6 +348,8 @@ async fn test_reconcile_modify_column_type() {
         "grpc_latencies",
     )
     .await;
+    // Try best effort to wait for the cache to be invalidated.
+    tokio::time::sleep(Duration::from_secs(1)).await;
 
     // Now we can query the table again.
     let output = execute_sql(&frontend, "SELECT * FROM grpc_latencies ORDER BY host").await;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
close #7040

## What's changed and what's your intention?

This PR addresses race conditions in tests caused by asynchronous cache invalidation. Add 1-second sleep delays to allow cache invalidation to complete before asserting query results. Also add logging for mailbox messages in heartbeat responses to improve observability.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
