### PR TITLE
fix: cache estimate methods

### DIFF
--- a/src/mito2/src/cache/index/bloom_filter_index.rs
+++ b/src/mito2/src/cache/index/bloom_filter_index.rs
@@ -208,6 +208,7 @@ mod test {
 
         let base = file_id.as_bytes().len()
             + std::mem::size_of::<ColumnId>()
+            + std::mem::size_of::<Tag>()
             + std::mem::size_of::<BloomFilterMeta>();
         let expected_dynamic = meta.segment_loc_indices.len() * std::mem::size_of::<u64>()
             + meta.bloom_filter_locs.len() * std::mem::size_of::<BloomFilterLoc>();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Two cases that the value size is not estimated correctly

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
