### PR TITLE
fix: missing flamegraph feature in pprof dependency

### DIFF
--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -71,7 +71,6 @@ nu-ansi-term = "0.46"
 object-store.workspace = true
 parquet = { workspace = true, features = ["object_store"] }
 plugins.workspace = true
-pprof = "0.14.0"
 prometheus.workspace = true
 prost.workspace = true
 query.workspace = true
@@ -92,6 +91,11 @@ tokio.workspace = true
 toml.workspace = true
 tonic.workspace = true
 tracing-appender.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+pprof = { version = "0.14", features = [
+    "flamegraph",
+] }
 
 [target.'cfg(not(windows))'.dependencies]
 tikv-jemallocator = "0.6"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR fix compilation error caused by missing flamegraph feature in pprof dependency.
```
error[E0599]: no method named `flamegraph` found for struct `pprof::Report` in the current scope
   --> src/cmd/src/datanode/objbench.rs:276:44
    |
276 |                     if let Err(e) = report.flamegraph(&mut flamegraph_data) {
    |                                            ^^^^^^^^^^ method not found in `pprof::Report`

For more information about this error, try `rustc --explain E0599`.
```

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
