### PR TITLE
feat: report scanner metrics

### DIFF
--- a/src/mito2/src/read/scan_util.rs
+++ b/src/mito2/src/read/scan_util.rs
@@ -558,7 +558,6 @@ impl PartitionMetrics {
     /// Merges `build_reader_cost`.
     pub(crate) fn inc_build_reader_cost(&self, cost: Duration) {
         self.0.build_reader_cost.add_duration(cost);
-        self.record_elapsed_compute(cost);
 
         let mut metrics = self.0.metrics.lock().unwrap();
         metrics.build_reader_cost += cost;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

<img width="1369" height="345" alt="image" src="https://github.com/user-attachments/assets/1c932020-3a4d-43c7-8df2-e8b8c8790be4" />

`RegionScanExec's metrics is not maintained in other's way. Specifically, it doesn't have an `elapsed_compute` field. This patch reports an `elapsed_compute` number based on `ScannerMetrics`

<img width="620" height="432" alt="image" src="https://github.com/user-attachments/assets/28923343-c78b-4573-86fc-72c7e5660ebb" />


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
