### PR TITLE
fix(mito): allow region edit in writable state

### DIFF
--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -50,7 +50,6 @@ use crate::manifest::action::{RegionEdit, TruncateKind};
 use crate::memtable::MemtableId;
 use crate::memtable::bulk::part::BulkPart;
 use crate::metrics::COMPACTION_ELAPSED_TOTAL;
-use crate::region::RegionLeaderState;
 use crate::sst::file::FileMeta;
 use crate::sst::index::IndexBuildType;
 use crate::wal::EntryId;
@@ -970,8 +969,8 @@ pub(crate) struct RegionEditResult {
     pub(crate) edit: RegionEdit,
     /// Result from the manifest manager.
     pub(crate) result: Result<()>,
-    /// Expected region state while handling region edit result.
-    pub(crate) expected_region_state: RegionLeaderState,
+    /// Whether region state need to be set to Writable after handling this request.
+    pub(crate) update_region_state: bool,
 }
 
 #[derive(Debug)]

--- a/src/mito2/src/worker/handle_manifest.rs
+++ b/src/mito2/src/worker/handle_manifest.rs
@@ -249,7 +249,8 @@ impl<S> RegionWorkerLoop<S> {
                     sender,
                     edit,
                     result,
-                    expected_region_state: RegionLeaderState::Editing,
+                    // we always need to restore region state after region edit
+                    update_region_state: true,
                 }),
             };
 
@@ -293,8 +294,10 @@ impl<S> RegionWorkerLoop<S> {
             );
         }
 
-        // Sets the region as writable.
-        region.switch_state_to_writable(edit_result.expected_region_state);
+        if edit_result.update_region_state {
+            // Sets the region as writable.
+            region.switch_state_to_writable(RegionLeaderState::Editing);
+        }
 
         let _ = edit_result.sender.send(edit_result.result);
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/pull/7174

## What's changed and what's your intention?

Fix the annoying error message prompt while deleting expired ssts although it does not block file deleting.
 - Introduce a variable to hold the current region state for clarity in compaction task updates.
 - Add an expected_region_state field to RegionEditResult to manage region state expectations during manifest handling.
 
## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
