### PR TITLE
test: only set ttl to forever in fuzz alter test

### DIFF
--- a/tests-fuzz/src/generator/alter_expr.rs
+++ b/tests-fuzz/src/generator/alter_expr.rs
@@ -219,16 +219,9 @@ impl<R: Rng> Generator<AlterTableExpr, R> for AlterExprSetTableOptionsGenerator<
             .iter()
             .map(|idx| match all_options[*idx] {
                 AlterTableOption::Ttl(_) => {
-                    let ttl_type = rng.random_range(0..3);
-                    match ttl_type {
-                        0 => {
-                            let duration: u32 = rng.random();
-                            AlterTableOption::Ttl(Ttl::Duration((duration as i64).into()))
-                        }
-                        1 => AlterTableOption::Ttl(Ttl::Instant),
-                        2 => AlterTableOption::Ttl(Ttl::Forever),
-                        _ => unreachable!(),
-                    }
+                    // The database purges expired files in background so it's hard to check
+                    // non-forever TTL.
+                    AlterTableOption::Ttl(Ttl::Forever)
                 }
                 AlterTableOption::TwcsTimeWindow(_) => {
                     let time_window: u32 = rng.random();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

Fix fuzz alter test that may query expired data and assert it.

Case 1, setting ttl to `instant`.
```
2025-11-07T03:15:24.694884Z  INFO fuzz_alter_table: Insert Into table: INSERT INTO `quiA` (`VEliT`,aut,`REm`,`eA`,esse,`QUiBusDam`,`VOLupTATUM`,`rErum`,`SAePE`, qui) VALUES (42,42,42,true,42,true,42,42,true, "1970-01-01 00:00:00+0000");, result: MySqlQueryResult { rows_affected: 1, last_insert_id: 0 }
2025-11-07T03:15:24.695690Z DEBUG sqlx_mysql::connection::tls: not performing TLS upgrade: unsupported by server
2025-11-07T03:15:24.704428Z  INFO fuzz_alter_table: Alter table: ALTER TABLE `quiA` RENAME `eT`;, result: MySqlQueryResult { rows_affected: 0, last_insert_id: 0 }
2025-11-07T03:15:24.832090Z  INFO fuzz_alter_table: Select from table: SELECT * FROM `eT`, result: MySqlQueryResult { rows_affected: 0, last_insert_id: 0 }
2025-11-07T03:15:24.838092Z  INFO fuzz_alter_table: Alter table: ALTER TABLE `eT` SET 'compaction.twcs.max_output_file_size' = '7049.4PiB', 'ttl' = '1246219161ms';, result: MySqlQueryResult { rows_affected: 0, last_insert_id: 0 }
2025-11-07T03:15:24.879850Z  INFO fuzz_alter_table: Select from table: SELECT * FROM `eT`, result: MySqlQueryResult { rows_affected: 0, last_insert_id: 0 }
2025-11-07T03:15:24.884017Z  INFO fuzz_alter_table: Alter table: ALTER TABLE `eT` RENAME et;, result: MySqlQueryResult { rows_affected: 0, last_insert_id: 0 }
2025-11-07T03:15:24.920662Z  INFO fuzz_alter_table: Select from table: SELECT * FROM et, result: MySqlQueryResult { rows_affected: 0, last_insert_id: 0 }
2025-11-07T03:15:24.924803Z  INFO fuzz_alter_table: Alter table: ALTER TABLE et SET 'ttl' = 'instant';, result: MySqlQueryResult { rows_affected: 0, last_insert_id: 0 }
2025-11-07T03:15:24.961162Z  INFO fuzz_alter_table: Select from table: SELECT * FROM et, result: MySqlQueryResult { rows_affected: 0, last_insert_id: 0 }
2025-11-07T03:15:25.039789Z  INFO fuzz_alter_table: Alter table: ALTER TABLE et MODIFY COLUMN `SAePE` BIGINT;, result: MySqlQueryResult { rows_affected: 0, last_insert_id: 0 }
```

Case 2, the default value of timestamp is expired.
```
2025-11-07T04:04:09.305892Z  INFO fuzz_alter_table: Insert Into table: INSERT INTO a (`euM`,`DOLOReM`,`MAIOREs`,et,`veLIT`,`repellenduS`,`DisTinCtIo`,`QUia`,`neqUe`,`ASPErNAtUR`,nisi,`aliaS`, `DUcIMuS`) VALUES (42,42,42,42,42,42,42,42,42,42,42,42, "1970-01-01 00:00:00+0000");, result: MySqlQueryResult { rows_affected: 1, last_insert_id: 0 }
2025-11-07T04:04:09.306555Z DEBUG sqlx_mysql::connection::tls: not performing TLS upgrade: unsupported by server
2025-11-07T04:04:09.310436Z  INFO fuzz_alter_table: Alter table: ALTER TABLE a UNSET 'compaction.twcs.max_output_file_size';, result: MySqlQueryResult { rows_affected: 0, last_insert_id: 0 }
2025-11-07T04:04:09.348058Z  INFO fuzz_alter_table: Select from table: SELECT * FROM a, result: MySqlQueryResult { rows_affected: 0, last_insert_id: 0 }
2025-11-07T04:04:09.351842Z  INFO fuzz_alter_table: Alter table: ALTER TABLE a SET 'ttl' = '3938410060ms', 'compaction.twcs.max_output_file_size' = '247.6PiB', 'compaction.twcs.time_window' = '223958756ms';, result: MySqlQueryResult { rows_affected: 0, last_insert_id: 0 }
2025-11-07T04:04:09.387781Z  INFO fuzz_alter_table: Select from table: SELECT * FROM a, result: MySqlQueryResult { rows_affected: 0, last_insert_id: 0 }
2025-11-07T04:04:09.391379Z  INFO fuzz_alter_table: Alter table: ALTER TABLE a SET 'compaction.twcs.max_output_file_size' = '7545.9PiB';, result: MySqlQueryResult { rows_affected: 0, last_insert_id: 0 }
2025-11-07T04:04:09.420810Z  INFO fuzz_alter_table: Select from table: SELECT * FROM a, result: MySqlQueryResult { rows_affected: 0, last_insert_id: 0 }
2025-11-07T04:04:09.450231Z  INFO fuzz_alter_table: Alter table: ALTER TABLE a ADD COLUMN minus DOUBLE NULL;, result: MySqlQueryResult { rows_affected: 0, last_insert_id: 0 }
```

This PR only sets TTL to forever to avoid the fragile TTL check.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
