### PR TITLE
fix: deregister failure detectors on rollback and improve timeout handling

### DIFF
--- a/src/meta-srv/src/procedure/region_migration.rs
+++ b/src/meta-srv/src/procedure/region_migration.rs
@@ -685,6 +685,9 @@ impl RegionMigrationProcedure {
                     .with_context(|_| error::RetryLaterWithSourceSnafu {
                         reason: format!("Failed to update the table route during the rollback downgraded leader region: {region_id}"),
                     })?;
+            self.context
+                .deregister_failure_detectors_for_candidate_region()
+                .await;
         }
 
         self.context.register_failure_detectors().await;

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -401,6 +401,7 @@ impl RegionOpener {
         config: &MitoConfig,
         wal: &Wal<S>,
     ) -> Result<Option<MitoRegionRef>> {
+        let now = Instant::now();
         let region_options = self.options.as_ref().unwrap().clone();
 
         let region_manifest_options = Self::manifest_options(
@@ -492,8 +493,12 @@ impl RegionOpener {
                 .unwrap_or_default()
                 .max(flushed_entry_id);
             info!(
-                "Start replaying memtable at replay_from_entry_id: {} for region {}, manifest version: {}, flushed entry id: {}",
-                replay_from_entry_id, region_id, manifest.manifest_version, flushed_entry_id
+                "Start replaying memtable at replay_from_entry_id: {} for region {}, manifest version: {}, flushed entry id: {}, elapsed: {:?}",
+                replay_from_entry_id,
+                region_id,
+                manifest.manifest_version,
+                flushed_entry_id,
+                now.elapsed()
             );
             replay_memtable(
                 &provider,
@@ -515,8 +520,11 @@ impl RegionOpener {
             }
         } else {
             info!(
-                "Skip the WAL replay for region: {}, manifest version: {}, flushed_entry_id: {}",
-                region_id, manifest.manifest_version, flushed_entry_id
+                "Skip the WAL replay for region: {}, manifest version: {}, flushed_entry_id: {}, elapsed: {:?}",
+                region_id,
+                manifest.manifest_version,
+                flushed_entry_id,
+                now.elapsed()
             );
 
             0

--- a/src/mito2/src/worker/handle_open.rs
+++ b/src/mito2/src/worker/handle_open.rs
@@ -15,6 +15,7 @@
 //! Handling open request.
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use common_telemetry::info;
 use object_store::util::join_path;
@@ -119,6 +120,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             }
         };
 
+        let now = Instant::now();
         let regions = self.regions.clone();
         let wal = self.wal.clone();
         let config = self.config.clone();
@@ -129,7 +131,12 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         common_runtime::spawn_global(async move {
             match opener.open(&config, &wal).await {
                 Ok(region) => {
-                    info!("Region {} is opened, worker: {}", region_id, worker_id);
+                    info!(
+                        "Region {} is opened, worker: {}, elapsed: {:?}",
+                        region_id,
+                        worker_id,
+                        now.elapsed()
+                    );
                     region_count.inc();
 
                     // Insert the Region into the RegionMap.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR
- Deregister failure detectors for candidate region during rollback
- Use dynamic timeout for opening candidate regions based on operation timeout (half of remaining time with a minimum threshold) instead of fixed timeout
- Add elapsed time tracking to region open operations for better observability


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
