### PR TITLE
chore: allow unlimited return if timerange is applied

### DIFF
--- a/src/servers/src/http/jaeger.rs
+++ b/src/servers/src/http/jaeger.rs
@@ -427,7 +427,13 @@ pub async fn handle_get_trace(
     let end_time_ns = query_params.end.map(|end_us| end_us * 1000);
 
     let output = match handler
-        .get_trace(query_ctx, &trace_id, start_time_ns, end_time_ns)
+        .get_trace(
+            query_ctx,
+            &trace_id,
+            start_time_ns,
+            end_time_ns,
+            query_params.limit,
+        )
         .await
     {
         Ok(output) => output,

--- a/src/servers/src/query_handler.rs
+++ b/src/servers/src/query_handler.rs
@@ -210,6 +210,7 @@ pub trait JaegerQueryHandler {
         trace_id: &str,
         start_time: Option<i64>,
         end_time: Option<i64>,
+        limit: Option<usize>,
     ) -> Result<Output>;
 
     /// Find traces by query params. It's used for `/api/traces` API.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

As the title suggests. For there are cases when one `trace_id` can relate to more than 2000 rows of spans.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
