### PR TITLE
fix: obtain system time after fetching lease values

### DIFF
--- a/src/meta-srv/src/discovery.rs
+++ b/src/meta-srv/src/discovery.rs
@@ -26,6 +26,7 @@ use common_meta::distributed_time_constants::{
 use common_meta::error::Result;
 use common_meta::peer::{Peer, PeerDiscovery, PeerResolver};
 use common_meta::{DatanodeId, FlownodeId};
+use common_time::util::DefaultSystemTimer;
 use snafu::ResultExt;
 
 use crate::cluster::MetaPeerClient;
@@ -35,6 +36,7 @@ use crate::discovery::lease::{LeaseValueAccessor, LeaseValueType};
 impl PeerDiscovery for MetaPeerClient {
     async fn active_frontends(&self) -> Result<Vec<Peer>> {
         utils::alive_frontends(
+            &DefaultSystemTimer,
             self,
             Duration::from_millis(FRONTEND_HEARTBEAT_INTERVAL_MILLIS),
         )
@@ -47,20 +49,30 @@ impl PeerDiscovery for MetaPeerClient {
         &self,
         filter: Option<for<'a> fn(&'a NodeWorkloads) -> bool>,
     ) -> Result<Vec<Peer>> {
-        utils::alive_datanodes(self, Duration::from_secs(DATANODE_LEASE_SECS), filter)
-            .await
-            .map_err(BoxedError::new)
-            .context(common_meta::error::ExternalSnafu)
+        utils::alive_datanodes(
+            &DefaultSystemTimer,
+            self,
+            Duration::from_secs(DATANODE_LEASE_SECS),
+            filter,
+        )
+        .await
+        .map_err(BoxedError::new)
+        .context(common_meta::error::ExternalSnafu)
     }
 
     async fn active_flownodes(
         &self,
         filter: Option<for<'a> fn(&'a NodeWorkloads) -> bool>,
     ) -> Result<Vec<Peer>> {
-        utils::alive_flownodes(self, Duration::from_secs(FLOWNODE_LEASE_SECS), filter)
-            .await
-            .map_err(BoxedError::new)
-            .context(common_meta::error::ExternalSnafu)
+        utils::alive_flownodes(
+            &DefaultSystemTimer,
+            self,
+            Duration::from_secs(FLOWNODE_LEASE_SECS),
+            filter,
+        )
+        .await
+        .map_err(BoxedError::new)
+        .context(common_meta::error::ExternalSnafu)
     }
 }
 

--- a/src/meta-srv/src/discovery/lease.rs
+++ b/src/meta-srv/src/discovery/lease.rs
@@ -95,20 +95,22 @@ impl LeaseValueAccessor for MetaPeerClient {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicI64, Ordering};
     use std::time::Duration;
 
-    use api::v1::meta::DatanodeWorkloads;
     use api::v1::meta::heartbeat_request::NodeWorkloads;
+    use api::v1::meta::{DatanodeWorkloads, FlownodeWorkloads};
     use common_meta::cluster::{FrontendStatus, NodeInfo, NodeInfoKey, NodeStatus, Role};
     use common_meta::distributed_time_constants::FRONTEND_HEARTBEAT_INTERVAL_MILLIS;
     use common_meta::kv_backend::ResettableKvBackendRef;
     use common_meta::peer::{Peer, PeerDiscovery};
     use common_meta::rpc::store::PutRequest;
-    use common_time::util::current_time_millis;
+    use common_time::util::{DefaultSystemTimer, SystemTimer, current_time_millis};
     use common_workload::DatanodeWorkloadType;
 
     use crate::discovery::utils::{self, accept_ingest_workload};
-    use crate::key::{DatanodeLeaseKey, LeaseValue};
+    use crate::key::{DatanodeLeaseKey, FlownodeLeaseKey, LeaseValue};
     use crate::test_util::create_meta_peer_client;
 
     async fn put_lease_value(
@@ -126,17 +128,47 @@ mod tests {
             .unwrap();
     }
 
+    async fn put_flownode_lease_value(
+        kv_backend: &ResettableKvBackendRef,
+        key: FlownodeLeaseKey,
+        value: LeaseValue,
+    ) {
+        kv_backend
+            .put(PutRequest {
+                key: key.try_into().unwrap(),
+                value: value.try_into().unwrap(),
+                prev_kv: false,
+            })
+            .await
+            .unwrap();
+    }
+
+    struct MockTimer {
+        current: Arc<AtomicI64>,
+    }
+
+    impl SystemTimer for MockTimer {
+        fn current_time_millis(&self) -> i64 {
+            self.current.fetch_add(1, Ordering::Relaxed)
+        }
+
+        fn current_time_rfc3339(&self) -> String {
+            unimplemented!()
+        }
+    }
+
     #[tokio::test]
     async fn test_alive_datanodes() {
         let client = create_meta_peer_client();
         let in_memory = client.memory_backend();
         let lease_secs = 10;
+        let timer = DefaultSystemTimer;
 
         // put a stale lease value for node 1
         let key = DatanodeLeaseKey { node_id: 1 };
         let value = LeaseValue {
             // 20s ago
-            timestamp_millis: current_time_millis() - lease_secs * 2 * 1000,
+            timestamp_millis: timer.current_time_millis() - lease_secs * 2 * 1000,
             node_addr: "127.0.0.1:20201".to_string(),
             workloads: NodeWorkloads::Datanode(DatanodeWorkloads {
                 types: vec![DatanodeWorkloadType::Hybrid as i32],
@@ -147,7 +179,7 @@ mod tests {
         // put a fresh lease value for node 2
         let key = DatanodeLeaseKey { node_id: 2 };
         let value = LeaseValue {
-            timestamp_millis: current_time_millis(),
+            timestamp_millis: timer.current_time_millis(),
             node_addr: "127.0.0.1:20202".to_string(),
             workloads: NodeWorkloads::Datanode(DatanodeWorkloads {
                 types: vec![DatanodeWorkloadType::Hybrid as i32],
@@ -155,6 +187,37 @@ mod tests {
         };
         put_lease_value(&in_memory, key.clone(), value.clone()).await;
         let peers = utils::alive_datanodes(
+            &timer,
+            client.as_ref(),
+            Duration::from_secs(lease_secs as u64),
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers, vec![Peer::new(2, "127.0.0.1:20202".to_string())]);
+    }
+
+    #[tokio::test]
+    async fn test_alive_datanodes_with_timer() {
+        let client = create_meta_peer_client();
+        let in_memory = client.memory_backend();
+        let lease_secs = 10;
+        let timer = MockTimer {
+            current: Arc::new(AtomicI64::new(current_time_millis())),
+        };
+
+        let key = DatanodeLeaseKey { node_id: 2 };
+        let value = LeaseValue {
+            timestamp_millis: timer.current_time_millis(),
+            node_addr: "127.0.0.1:20202".to_string(),
+            workloads: NodeWorkloads::Datanode(DatanodeWorkloads {
+                types: vec![DatanodeWorkloadType::Hybrid as i32],
+            }),
+        };
+        put_lease_value(&in_memory, key.clone(), value.clone()).await;
+        let peers = utils::alive_datanodes(
+            &timer,
             client.as_ref(),
             Duration::from_secs(lease_secs as u64),
             None,
@@ -170,12 +233,13 @@ mod tests {
         let client = create_meta_peer_client();
         let in_memory = client.memory_backend();
         let lease_secs = 10;
+        let timer = DefaultSystemTimer;
 
         // put a lease value for node 1 without mode info
         let key = DatanodeLeaseKey { node_id: 1 };
         let value = LeaseValue {
             // 20s ago
-            timestamp_millis: current_time_millis() - 20 * 1000,
+            timestamp_millis: timer.current_time_millis() - 20 * 1000,
             node_addr: "127.0.0.1:20201".to_string(),
             workloads: NodeWorkloads::Datanode(DatanodeWorkloads {
                 types: vec![DatanodeWorkloadType::Hybrid as i32],
@@ -186,7 +250,7 @@ mod tests {
         // put a lease value for node 2 with mode info
         let key = DatanodeLeaseKey { node_id: 2 };
         let value = LeaseValue {
-            timestamp_millis: current_time_millis(),
+            timestamp_millis: timer.current_time_millis(),
             node_addr: "127.0.0.1:20202".to_string(),
             workloads: NodeWorkloads::Datanode(DatanodeWorkloads {
                 types: vec![DatanodeWorkloadType::Hybrid as i32],
@@ -197,7 +261,7 @@ mod tests {
         // put a lease value for node 3 with mode info
         let key = DatanodeLeaseKey { node_id: 3 };
         let value = LeaseValue {
-            timestamp_millis: current_time_millis(),
+            timestamp_millis: timer.current_time_millis(),
             node_addr: "127.0.0.1:20203".to_string(),
             workloads: NodeWorkloads::Datanode(DatanodeWorkloads {
                 types: vec![i32::MAX],
@@ -208,7 +272,7 @@ mod tests {
         // put a lease value for node 3 with mode info
         let key = DatanodeLeaseKey { node_id: 4 };
         let value = LeaseValue {
-            timestamp_millis: current_time_millis(),
+            timestamp_millis: timer.current_time_millis(),
             node_addr: "127.0.0.1:20204".to_string(),
             workloads: NodeWorkloads::Datanode(DatanodeWorkloads {
                 types: vec![i32::MAX],
@@ -217,6 +281,7 @@ mod tests {
         put_lease_value(&in_memory, key, value).await;
 
         let peers = utils::alive_datanodes(
+            &timer,
             client.as_ref(),
             Duration::from_secs(lease_secs),
             Some(accept_ingest_workload),
@@ -228,17 +293,83 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_alive_flownodes() {
+        let client = create_meta_peer_client();
+        let in_memory = client.memory_backend();
+        let lease_secs = 10;
+        let timer = DefaultSystemTimer;
+
+        // put a stale lease value for node 1
+        let key = FlownodeLeaseKey { node_id: 1 };
+        let value = LeaseValue {
+            // 20s ago
+            timestamp_millis: timer.current_time_millis() - lease_secs * 2 * 1000,
+            node_addr: "127.0.0.1:20201".to_string(),
+            workloads: NodeWorkloads::Flownode(FlownodeWorkloads { types: vec![] }),
+        };
+        put_flownode_lease_value(&in_memory, key, value).await;
+
+        // put a fresh lease value for node 2
+        let key = FlownodeLeaseKey { node_id: 2 };
+        let value = LeaseValue {
+            timestamp_millis: timer.current_time_millis(),
+            node_addr: "127.0.0.1:20202".to_string(),
+            workloads: NodeWorkloads::Flownode(FlownodeWorkloads { types: vec![] }),
+        };
+        put_flownode_lease_value(&in_memory, key.clone(), value.clone()).await;
+        let peers = utils::alive_flownodes(
+            &timer,
+            client.as_ref(),
+            Duration::from_secs(lease_secs as u64),
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers, vec![Peer::new(2, "127.0.0.1:20202".to_string())]);
+    }
+
+    #[tokio::test]
+    async fn test_alive_flownodes_with_timer() {
+        let client = create_meta_peer_client();
+        let in_memory = client.memory_backend();
+        let lease_secs = 10;
+        let timer = MockTimer {
+            current: Arc::new(AtomicI64::new(current_time_millis())),
+        };
+
+        let key = FlownodeLeaseKey { node_id: 2 };
+        let value = LeaseValue {
+            timestamp_millis: timer.current_time_millis(),
+            node_addr: "127.0.0.1:20202".to_string(),
+            workloads: NodeWorkloads::Flownode(FlownodeWorkloads { types: vec![] }),
+        };
+        put_flownode_lease_value(&in_memory, key.clone(), value.clone()).await;
+        let peers = utils::alive_flownodes(
+            &timer,
+            client.as_ref(),
+            Duration::from_secs(lease_secs as u64),
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers, vec![Peer::new(2, "127.0.0.1:20202".to_string())]);
+    }
+
+    #[tokio::test]
     async fn test_lookup_frontends() {
         let client = create_meta_peer_client();
         let in_memory = client.memory_backend();
         let lease_secs = 10;
+        let timer = DefaultSystemTimer;
 
         let active_frontend_node = NodeInfo {
             peer: Peer {
                 id: 0,
                 addr: "127.0.0.1:20201".to_string(),
             },
-            last_activity_ts: current_time_millis(),
+            last_activity_ts: timer.current_time_millis(),
             status: NodeStatus::Frontend(FrontendStatus {}),
             version: "1.0.0".to_string(),
             git_commit: "1234567890".to_string(),
@@ -266,7 +397,7 @@ mod tests {
                 id: 1,
                 addr: "127.0.0.1:20201".to_string(),
             },
-            last_activity_ts: current_time_millis() - 20 * 1000,
+            last_activity_ts: timer.current_time_millis() - 20 * 1000,
             status: NodeStatus::Frontend(FrontendStatus {}),
             version: "1.0.0".to_string(),
             git_commit: "1234567890".to_string(),
@@ -287,9 +418,52 @@ mod tests {
             .await
             .unwrap();
 
-        let peers = utils::alive_frontends(client.as_ref(), Duration::from_secs(lease_secs))
+        let peers =
+            utils::alive_frontends(&timer, client.as_ref(), Duration::from_secs(lease_secs))
+                .await
+                .unwrap();
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers[0].id, 0);
+    }
+
+    #[tokio::test]
+    async fn test_lookup_frontends_with_timer() {
+        let client = create_meta_peer_client();
+        let in_memory = client.memory_backend();
+        let lease_secs = 10;
+        let timer = MockTimer {
+            current: Arc::new(AtomicI64::new(current_time_millis())),
+        };
+
+        let active_frontend_node = NodeInfo {
+            peer: Peer {
+                id: 0,
+                addr: "127.0.0.1:20201".to_string(),
+            },
+            last_activity_ts: timer.current_time_millis(),
+            status: NodeStatus::Frontend(FrontendStatus {}),
+            version: "1.0.0".to_string(),
+            git_commit: "1234567890".to_string(),
+            start_time_ms: current_time_millis() as u64,
+            total_cpu_millicores: 0,
+            total_memory_bytes: 0,
+            cpu_usage_millicores: 0,
+            memory_usage_bytes: 0,
+            hostname: "test_hostname".to_string(),
+        };
+        let key_prefix = NodeInfoKey::key_prefix_with_role(Role::Frontend);
+        in_memory
+            .put(PutRequest {
+                key: format!("{}{}", key_prefix, "0").into(),
+                value: active_frontend_node.try_into().unwrap(),
+                prev_kv: false,
+            })
             .await
             .unwrap();
+        let peers =
+            utils::alive_frontends(&timer, client.as_ref(), Duration::from_secs(lease_secs))
+                .await
+                .unwrap();
         assert_eq!(peers.len(), 1);
         assert_eq!(peers[0].id, 0);
     }

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -49,6 +49,7 @@ use common_procedure::options::ProcedureConfig;
 use common_stat::ResourceStatRef;
 use common_telemetry::logging::{LoggingOptions, TracingOptions};
 use common_telemetry::{error, info, warn};
+use common_time::util::DefaultSystemTimer;
 use common_wal::config::MetasrvWalConfig;
 use serde::{Deserialize, Serialize};
 use servers::export_metrics::ExportMetricsOption;
@@ -735,6 +736,7 @@ impl Metasrv {
     /// A datanode is considered alive when it's still within the lease period.
     pub(crate) async fn lookup_datanode_peer(&self, peer_id: u64) -> Result<Option<Peer>> {
         discovery::utils::alive_datanode(
+            &DefaultSystemTimer,
             self.meta_peer_client.as_ref(),
             peer_id,
             Duration::from_secs(distributed_time_constants::DATANODE_LEASE_SECS),

--- a/tests-integration/src/cluster.rs
+++ b/tests-integration/src/cluster.rs
@@ -46,6 +46,7 @@ use common_runtime::Builder as RuntimeBuilder;
 use common_runtime::runtime::BuilderBuild;
 use common_stat::ResourceStatImpl;
 use common_test_util::temp_dir::create_temp_dir;
+use common_time::util::DefaultSystemTimer;
 use common_wal::config::{DatanodeWalConfig, MetasrvWalConfig};
 use datanode::config::DatanodeOptions;
 use datanode::datanode::{Datanode, DatanodeBuilder, ProcedureConfig};
@@ -319,6 +320,7 @@ impl GreptimeDbClusterBuilder {
     ) {
         for _ in 0..100 {
             let alive_datanodes = discovery::utils::alive_datanodes(
+                &DefaultSystemTimer,
                 meta_peer_client.as_ref(),
                 Duration::from_secs(u64::MAX),
                 None,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR fixes a bug in the `build_active_filter` function where the system time was acquired outside the closure, causing the filter to use a stale timestamp instead of the current time when evaluating items. This bug occasionally caused "The target peer is unavailable temporally" errors during region migration.

### Problem
The `build_active_filter` function had a critical timing bug:
1. The bug: The now timestamp was captured outside the closure when the filter was created
2. The issue: When `lookup_datanode_peer` uses this filter, it may list lease values from storage that have timestamps newer than the pre-captured now value
3. The consequence: The filter would incorrectly calculate elapsed time, treating active datanodes as inactive because their lease timestamps appeared to be "in the future" relative to the stale now

This race condition was particularly problematic in `lookup_datanode_peer`, where the time gap between filter creation and actual lease value listing could cause the system to incorrectly reject valid, active datanodes. In rare cases during manual region migration, this would manifest as "The target peer is unavailable temporally" errors even when the target datanode was fully operational.

### Changes
Refactored the filter interface:
- Changed `build_active_filter` signature to accept now as a parameter to the returned closure
- The filter now has signature `impl Fn(i64, &T) -> bool` instead of `impl Fn(&T) -> bool`
- This makes it explicit that callers must provide the timestamp at the point of filtering

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
