### PR TITLE
fix: clone the page before putting into the index cache

### DIFF
--- a/src/mito2/src/cache/index.rs
+++ b/src/mito2/src/cache/index.rs
@@ -21,7 +21,7 @@ use std::hash::Hash;
 use std::ops::Range;
 use std::sync::Arc;
 
-use bytes::{Bytes, BytesMut};
+use bytes::Bytes;
 use object_store::Buffer;
 
 use crate::metrics::{CACHE_BYTES, CACHE_HIT, CACHE_MISS};


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
- https://github.com/GreptimeTeam/greptimedb/issues/7198
- https://github.com/GreptimeTeam/greptimedb/issues/6779

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

Clone the pages from object store readers before putting into the IndexCache.

The pages from the reader may reference a large shared buffer and we can't get the actual buffer usage to compute the estimated cache size. This issue is similar to https://github.com/GreptimeTeam/greptimedb/issues/6779. The simplest way  to fix that is to cloning the page.

Since pages of index files are small, the cost should be acceptable.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
