### PR TITLE
fix: correct signature of current_schemas function

### DIFF
--- a/tests/cases/standalone/common/system/pg_catalog.result
+++ b/tests/cases/standalone/common/system/pg_catalog.result
@@ -13,15 +13,15 @@ SELECT session_user is not null;
 | t                          |
 +----------------------------+
 
--- session_user and current_schema
+-- current_schema
 -- SQLNESS PROTOCOL POSTGRES
-select current_schema();
+select current_schema(), current_schemas(true), current_schemas(false), version(), current_database();
 
-+------------------+
-| current_schema() |
-+------------------+
-| public           |
-+------------------+
++------------------+---------------------------------------------------------+---------------------------------+------------------------------+--------------------+
+| current_schema() | current_schemas(Boolean(true))                          | current_schemas(Boolean(false)) | version                      | current_database() |
++------------------+---------------------------------------------------------+---------------------------------+------------------------------+--------------------+
+| public           | {public,information_schema,pg_catalog,greptime_private} | {public}                        | 16.3-greptimedb-1.0.0-beta.1 | greptime           |
++------------------+---------------------------------------------------------+---------------------------------+------------------------------+--------------------+
 
 -- search_path for pg using schema for now FIXME when support real search_path
 -- SQLNESS PROTOCOL POSTGRES

--- a/tests/cases/standalone/common/system/pg_catalog.sql
+++ b/tests/cases/standalone/common/system/pg_catalog.sql
@@ -5,9 +5,9 @@ create database pg_catalog;
 -- SQLNESS PROTOCOL POSTGRES
 SELECT session_user is not null;
 
--- session_user and current_schema
+-- current_schema
 -- SQLNESS PROTOCOL POSTGRES
-select current_schema();
+select current_schema(), current_schemas(true), current_schemas(false), version(), current_database();
 
 -- search_path for pg using schema for now FIXME when support real search_path
 -- SQLNESS PROTOCOL POSTGRES


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Resolve signature issue of pg_catalog function `current_schemas`. This is a little weird for its inconsistent behavior between greptimedb and datafusion-postgres.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
