### PR TITLE
refactor: make json value use json type

### DIFF
--- a/src/api/src/helper.rs
+++ b/src/api/src/helper.rs
@@ -406,7 +406,9 @@ impl TryFrom<ConcreteDataType> for ColumnDataTypeWrapper {
                             type_ext: Some(TypeExt::JsonType(JsonTypeExtension::JsonBinary.into())),
                         }),
                         JsonFormat::Native(inner) => {
-                            let inner_type = ColumnDataTypeWrapper::try_from(*inner.clone())?;
+                            let inner_type = ColumnDataTypeWrapper::try_from(
+                                ConcreteDataType::from(inner.as_ref()),
+                            )?;
                             Some(ColumnDataTypeExtension {
                                 type_ext: Some(TypeExt::JsonNativeType(Box::new(
                                     JsonNativeTypeExtension {
@@ -1627,6 +1629,20 @@ mod tests {
                             type_ext: Some(TypeExt::StructType(StructTypeExtension {
                                 fields: vec![
                                     v1::StructField {
+                                        name: "address".to_string(),
+                                        datatype: ColumnDataTypeWrapper::string_datatype()
+                                            .datatype()
+                                            .into(),
+                                        datatype_extension: None
+                                    },
+                                    v1::StructField {
+                                        name: "age".to_string(),
+                                        datatype: ColumnDataTypeWrapper::int64_datatype()
+                                            .datatype()
+                                            .into(),
+                                        datatype_extension: None
+                                    },
+                                    v1::StructField {
                                         name: "id".to_string(),
                                         datatype: ColumnDataTypeWrapper::int64_datatype()
                                             .datatype()
@@ -1640,20 +1656,6 @@ mod tests {
                                             .into(),
                                         datatype_extension: None
                                     },
-                                    v1::StructField {
-                                        name: "age".to_string(),
-                                        datatype: ColumnDataTypeWrapper::int32_datatype()
-                                            .datatype()
-                                            .into(),
-                                        datatype_extension: None
-                                    },
-                                    v1::StructField {
-                                        name: "address".to_string(),
-                                        datatype: ColumnDataTypeWrapper::string_datatype()
-                                            .datatype()
-                                            .into(),
-                                        datatype_extension: None
-                                    }
                                 ]
                             }))
                         }))

--- a/src/datatypes/src/data_type.rs
+++ b/src/datatypes/src/data_type.rs
@@ -33,8 +33,8 @@ use crate::types::{
     BinaryType, BooleanType, DateType, Decimal128Type, DictionaryType, DurationMicrosecondType,
     DurationMillisecondType, DurationNanosecondType, DurationSecondType, DurationType, Float32Type,
     Float64Type, Int8Type, Int16Type, Int32Type, Int64Type, IntervalDayTimeType,
-    IntervalMonthDayNanoType, IntervalType, IntervalYearMonthType, JsonFormat, JsonType, ListType,
-    NullType, StringType, StructType, TimeMillisecondType, TimeType, TimestampMicrosecondType,
+    IntervalMonthDayNanoType, IntervalType, IntervalYearMonthType, JsonType, ListType, NullType,
+    StringType, StructType, TimeMillisecondType, TimeType, TimestampMicrosecondType,
     TimestampMillisecondType, TimestampNanosecondType, TimestampSecondType, TimestampType,
     UInt8Type, UInt16Type, UInt32Type, UInt64Type, VectorType,
 };
@@ -677,7 +677,7 @@ impl ConcreteDataType {
     }
 
     pub fn json_native_datatype(inner_type: ConcreteDataType) -> ConcreteDataType {
-        ConcreteDataType::Json(JsonType::new(JsonFormat::Native(Box::new(inner_type))))
+        ConcreteDataType::Json(JsonType::new_native((&inner_type).into()))
     }
 }
 

--- a/src/datatypes/src/types/json_type.rs
+++ b/src/datatypes/src/types/json_type.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
+use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -38,11 +39,127 @@ pub const JSON_TYPE_NAME: &str = "Json";
 const JSON_PLAIN_FIELD_NAME: &str = "__plain__";
 const JSON_PLAIN_FIELD_METADATA_KEY: &str = "is_plain_json";
 
+pub type JsonObjectType = BTreeMap<String, JsonNativeType>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum JsonNumberType {
+    U64,
+    I64,
+    F64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum JsonNativeType {
+    Null,
+    Bool,
+    Number(JsonNumberType),
+    String,
+    Array(Box<JsonNativeType>),
+    Object(JsonObjectType),
+}
+
+impl JsonNativeType {
+    pub fn u64() -> Self {
+        Self::Number(JsonNumberType::U64)
+    }
+
+    pub fn i64() -> Self {
+        Self::Number(JsonNumberType::I64)
+    }
+
+    pub fn f64() -> Self {
+        Self::Number(JsonNumberType::F64)
+    }
+}
+
+impl From<&JsonNativeType> for ConcreteDataType {
+    fn from(value: &JsonNativeType) -> Self {
+        match value {
+            JsonNativeType::Null => ConcreteDataType::null_datatype(),
+            JsonNativeType::Bool => ConcreteDataType::boolean_datatype(),
+            JsonNativeType::Number(JsonNumberType::U64) => ConcreteDataType::uint64_datatype(),
+            JsonNativeType::Number(JsonNumberType::I64) => ConcreteDataType::int64_datatype(),
+            JsonNativeType::Number(JsonNumberType::F64) => ConcreteDataType::float64_datatype(),
+            JsonNativeType::String => ConcreteDataType::string_datatype(),
+            JsonNativeType::Array(item_type) => {
+                ConcreteDataType::List(ListType::new(Arc::new(item_type.as_ref().into())))
+            }
+            JsonNativeType::Object(object) => {
+                let fields = object
+                    .iter()
+                    .map(|(type_name, field_type)| {
+                        StructField::new(type_name.clone(), field_type.into(), true)
+                    })
+                    .collect();
+                ConcreteDataType::Struct(StructType::new(Arc::new(fields)))
+            }
+        }
+    }
+}
+
+impl From<&ConcreteDataType> for JsonNativeType {
+    fn from(value: &ConcreteDataType) -> Self {
+        match value {
+            ConcreteDataType::Null(_) => JsonNativeType::Null,
+            ConcreteDataType::Boolean(_) => JsonNativeType::Bool,
+            ConcreteDataType::UInt64(_)
+            | ConcreteDataType::UInt32(_)
+            | ConcreteDataType::UInt16(_)
+            | ConcreteDataType::UInt8(_) => JsonNativeType::u64(),
+            ConcreteDataType::Int64(_)
+            | ConcreteDataType::Int32(_)
+            | ConcreteDataType::Int16(_)
+            | ConcreteDataType::Int8(_) => JsonNativeType::i64(),
+            ConcreteDataType::Float64(_) | ConcreteDataType::Float32(_) => JsonNativeType::f64(),
+            ConcreteDataType::String(_) => JsonNativeType::String,
+            ConcreteDataType::List(list_type) => {
+                JsonNativeType::Array(Box::new(list_type.item_type().into()))
+            }
+            ConcreteDataType::Struct(struct_type) => JsonNativeType::Object(
+                struct_type
+                    .fields()
+                    .iter()
+                    .map(|field| (field.name().to_string(), field.data_type().into()))
+                    .collect(),
+            ),
+            ConcreteDataType::Json(json_type) => json_type.native_type().clone(),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Display for JsonNativeType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            JsonNativeType::Null => write!(f, "Null"),
+            JsonNativeType::Bool => write!(f, "Bool"),
+            JsonNativeType::Number(t) => {
+                write!(f, "Number({t:?})")
+            }
+            JsonNativeType::String => write!(f, "String"),
+            JsonNativeType::Array(item_type) => {
+                write!(f, "Array[{}]", item_type)
+            }
+            JsonNativeType::Object(object) => {
+                write!(
+                    f,
+                    "Object{{{}}}",
+                    object
+                        .iter()
+                        .map(|(k, v)| format!(r#""{k}": {v}"#))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, Default)]
 pub enum JsonFormat {
     #[default]
     Jsonb,
-    Native(Box<ConcreteDataType>),
+    Native(Box<JsonNativeType>),
 }
 
 /// JsonType is a data type for JSON data. It is stored as binary data of jsonb format.
@@ -57,22 +174,22 @@ impl JsonType {
         Self { format }
     }
 
-    pub(crate) fn new_native(native: ConcreteDataType) -> Self {
+    pub(crate) fn new_native(native: JsonNativeType) -> Self {
         Self {
             format: JsonFormat::Native(Box::new(native)),
         }
     }
 
-    pub(crate) fn native_type(&self) -> ConcreteDataType {
+    pub(crate) fn native_type(&self) -> &JsonNativeType {
         match &self.format {
-            JsonFormat::Jsonb => ConcreteDataType::binary_datatype(),
-            JsonFormat::Native(x) => x.as_ref().clone(),
+            JsonFormat::Jsonb => &JsonNativeType::String,
+            JsonFormat::Native(x) => x.as_ref(),
         }
     }
 
     pub(crate) fn empty() -> Self {
         Self {
-            format: JsonFormat::Native(Box::new(ConcreteDataType::null_datatype())),
+            format: JsonFormat::Native(Box::new(JsonNativeType::Null)),
         }
     }
 
@@ -83,26 +200,11 @@ impl JsonType {
     pub(crate) fn as_struct_type(&self) -> StructType {
         match &self.format {
             JsonFormat::Jsonb => StructType::default(),
-            JsonFormat::Native(inner) => match inner.as_ref() {
+            JsonFormat::Native(inner) => match ConcreteDataType::from(inner.as_ref()) {
                 ConcreteDataType::Struct(t) => t.clone(),
-                x => plain_json_struct_type(x.clone()),
+                x => plain_json_struct_type(x),
             },
         }
-    }
-
-    /// Check if this json type is the special "plain" one.
-    /// See [JsonType::as_struct_type].
-    #[expect(unused)]
-    pub(crate) fn is_plain_json(&self) -> bool {
-        let JsonFormat::Native(box ConcreteDataType::Struct(t)) = &self.format else {
-            return true;
-        };
-        let fields = t.fields();
-        let Some((single, [])) = fields.split_first() else {
-            return false;
-        };
-        single.name() == JSON_PLAIN_FIELD_NAME
-            && single.metadata(JSON_PLAIN_FIELD_METADATA_KEY) == Some("true")
     }
 
     /// Try to merge this json type with others, error on datatype conflict.
@@ -140,17 +242,11 @@ pub(crate) fn plain_json_struct_type(item_type: ConcreteDataType) -> StructType 
     StructType::new(Arc::new(vec![field]))
 }
 
-fn is_mergeable(this: &ConcreteDataType, that: &ConcreteDataType) -> bool {
-    fn is_mergeable_struct(this: &StructType, that: &StructType) -> bool {
-        let this_fields = this.fields();
-        let this_fields = this_fields
-            .iter()
-            .map(|x| (x.name(), x))
-            .collect::<HashMap<_, _>>();
-
-        for that_field in that.fields().iter() {
-            if let Some(this_field) = this_fields.get(that_field.name())
-                && !is_mergeable(this_field.data_type(), that_field.data_type())
+fn is_mergeable(this: &JsonNativeType, that: &JsonNativeType) -> bool {
+    fn is_mergeable_object(this: &JsonObjectType, that: &JsonObjectType) -> bool {
+        for (type_name, that_type) in that {
+            if let Some(this_type) = this.get(type_name)
+                && !is_mergeable(this_type, that_type)
             {
                 return false;
             }
@@ -160,64 +256,46 @@ fn is_mergeable(this: &ConcreteDataType, that: &ConcreteDataType) -> bool {
 
     match (this, that) {
         (this, that) if this == that => true,
-        (ConcreteDataType::List(this), ConcreteDataType::List(that)) => {
-            is_mergeable(this.item_type(), that.item_type())
+        (JsonNativeType::Array(this), JsonNativeType::Array(that)) => {
+            is_mergeable(this.as_ref(), that.as_ref())
         }
-        (ConcreteDataType::Struct(this), ConcreteDataType::Struct(that)) => {
-            is_mergeable_struct(this, that)
+        (JsonNativeType::Object(this), JsonNativeType::Object(that)) => {
+            is_mergeable_object(this, that)
         }
-        (ConcreteDataType::Null(_), _) | (_, ConcreteDataType::Null(_)) => true,
+        (JsonNativeType::Null, _) | (_, JsonNativeType::Null) => true,
         _ => false,
     }
 }
 
-fn merge(this: &ConcreteDataType, that: &ConcreteDataType) -> Result<ConcreteDataType> {
+fn merge(this: &JsonNativeType, that: &JsonNativeType) -> Result<JsonNativeType> {
+    fn merge_object(this: &JsonObjectType, that: &JsonObjectType) -> Result<JsonObjectType> {
+        let mut this = this.clone();
+        // merge "that" into "this" directly:
+        for (type_name, that_type) in that {
+            if let Some(this_type) = this.get_mut(type_name) {
+                let merged_type = merge(this_type, that_type)?;
+                *this_type = merged_type;
+            } else {
+                this.insert(type_name.clone(), that_type.clone());
+            }
+        }
+        Ok(this)
+    }
+
     match (this, that) {
         (this, that) if this == that => Ok(this.clone()),
-        (ConcreteDataType::List(this), ConcreteDataType::List(that)) => {
-            merge_list(this, that).map(ConcreteDataType::List)
+        (JsonNativeType::Array(this), JsonNativeType::Array(that)) => {
+            merge(this.as_ref(), that.as_ref()).map(|x| JsonNativeType::Array(Box::new(x)))
         }
-        (ConcreteDataType::Struct(this), ConcreteDataType::Struct(that)) => {
-            merge_struct(this, that).map(ConcreteDataType::Struct)
+        (JsonNativeType::Object(this), JsonNativeType::Object(that)) => {
+            merge_object(this, that).map(JsonNativeType::Object)
         }
-        (ConcreteDataType::Null(_), x) | (x, ConcreteDataType::Null(_)) => Ok(x.clone()),
+        (JsonNativeType::Null, x) | (x, JsonNativeType::Null) => Ok(x.clone()),
         _ => MergeJsonDatatypeSnafu {
             reason: format!("datatypes have conflict, this: {this}, that: {that}"),
         }
         .fail(),
     }
-}
-
-fn merge_list(this: &ListType, that: &ListType) -> Result<ListType> {
-    let merged = merge(this.item_type(), that.item_type())?;
-    Ok(ListType::new(Arc::new(merged)))
-}
-
-fn merge_struct(this: &StructType, that: &StructType) -> Result<StructType> {
-    let this = Arc::unwrap_or_clone(this.fields());
-    let that = Arc::unwrap_or_clone(that.fields());
-
-    let mut this: BTreeMap<String, StructField> = this
-        .into_iter()
-        .map(|x| (x.name().to_string(), x))
-        .collect();
-    // merge "that" into "this" directly:
-    for that_field in that {
-        let field_name = that_field.name().to_string();
-        if let Some(this_field) = this.get(&field_name) {
-            let merged_field = StructField::new(
-                field_name.clone(),
-                merge(this_field.data_type(), that_field.data_type())?,
-                true, // the value in json object must be always nullable
-            );
-            this.insert(field_name, merged_field);
-        } else {
-            this.insert(field_name, that_field);
-        }
-    }
-
-    let fields = this.into_values().collect::<Vec<_>>();
-    Ok(StructType::new(Arc::new(fields)))
 }
 
 impl DataType for JsonType {
@@ -319,9 +397,7 @@ mod tests {
             Ok(())
         }
 
-        let json_type = &mut JsonType::new(JsonFormat::Native(Box::new(
-            ConcreteDataType::null_datatype(),
-        )));
+        let json_type = &mut JsonType::new_native(JsonNativeType::Null);
 
         // can merge with json object:
         let json = r#"{
@@ -329,16 +405,15 @@ mod tests {
             "list": [1, 2, 3],
             "object": {"a": 1}
         }"#;
-        let expected =
-            r#"Json<Struct<"hello": String, "list": List<Int64>, "object": Struct<"a": Int64>>>"#;
+        let expected = r#"Json<Object{"hello": String, "list": Array[Number(I64)], "object": Object{"a": Number(I64)}}>"#;
         test(json, json_type, Ok(expected))?;
 
         // cannot merge with other non-object json values:
         let jsons = [r#""s""#, "1", "[1]"];
         let expects = [
-            r#"Failed to merge JSON datatype: datatypes have conflict, this: Struct<"hello": String, "list": List<Int64>, "object": Struct<"a": Int64>>, that: String"#,
-            r#"Failed to merge JSON datatype: datatypes have conflict, this: Struct<"hello": String, "list": List<Int64>, "object": Struct<"a": Int64>>, that: Int64"#,
-            r#"Failed to merge JSON datatype: datatypes have conflict, this: Struct<"hello": String, "list": List<Int64>, "object": Struct<"a": Int64>>, that: List<Int64>"#,
+            r#"Failed to merge JSON datatype: datatypes have conflict, this: Object{"hello": String, "list": Array[Number(I64)], "object": Object{"a": Number(I64)}}, that: String"#,
+            r#"Failed to merge JSON datatype: datatypes have conflict, this: Object{"hello": String, "list": Array[Number(I64)], "object": Object{"a": Number(I64)}}, that: Number(I64)"#,
+            r#"Failed to merge JSON datatype: datatypes have conflict, this: Object{"hello": String, "list": Array[Number(I64)], "object": Object{"a": Number(I64)}}, that: Array[Number(I64)]"#,
         ];
         for (json, expect) in jsons.into_iter().zip(expects.into_iter()) {
             test(json, json_type, Err(expect))?;
@@ -350,8 +425,7 @@ mod tests {
             "float": 0.123,
             "no": 42
         }"#;
-        let expected =
-            r#"Failed to merge JSON datatype: datatypes have conflict, this: String, that: Int64"#;
+        let expected = r#"Failed to merge JSON datatype: datatypes have conflict, this: String, that: Number(I64)"#;
         test(json, json_type, Err(expected))?;
 
         // can merge with another json object:
@@ -360,7 +434,7 @@ mod tests {
             "float": 0.123,
             "int": 42
         }"#;
-        let expected = r#"Json<Struct<"float": Float64, "hello": String, "int": Int64, "list": List<Int64>, "object": Struct<"a": Int64>>>"#;
+        let expected = r#"Json<Object{"float": Number(F64), "hello": String, "int": Number(I64), "list": Array[Number(I64)], "object": Object{"a": Number(I64)}}>"#;
         test(json, json_type, Ok(expected))?;
 
         // can merge with some complex nested json object:
@@ -370,7 +444,7 @@ mod tests {
             "float": 0.456,
             "int": 0
         }"#;
-        let expected = r#"Json<Struct<"float": Float64, "hello": String, "int": Int64, "list": List<Int64>, "object": Struct<"a": Int64, "foo": String, "l": List<String>, "o": Struct<"key": String>>>>"#;
+        let expected = r#"Json<Object{"float": Number(F64), "hello": String, "int": Number(I64), "list": Array[Number(I64)], "object": Object{"a": Number(I64), "foo": String, "l": Array[String], "o": Object{"key": String}}}>"#;
         test(json, json_type, Ok(expected))?;
 
         Ok(())

--- a/src/datatypes/src/types/struct_type.rs
+++ b/src/datatypes/src/types/struct_type.rs
@@ -151,6 +151,7 @@ impl StructField {
         self.metadata.insert(key.to_string(), value.to_string());
     }
 
+    #[expect(unused)]
     pub(crate) fn metadata(&self, key: &str) -> Option<&str> {
         self.metadata.get(key).map(String::as_str)
     }

--- a/src/datatypes/src/vectors/json/builder.rs
+++ b/src/datatypes/src/vectors/json/builder.rs
@@ -320,10 +320,10 @@ mod tests {
             Ok(()),
             Ok(()),
             Err(
-                "Failed to merge JSON datatype: datatypes have conflict, this: Int64, that: String",
+                "Failed to merge JSON datatype: datatypes have conflict, this: Number(I64), that: String",
             ),
             Err(
-                "Failed to merge JSON datatype: datatypes have conflict, this: Int64, that: List<Boolean>",
+                "Failed to merge JSON datatype: datatypes have conflict, this: Number(I64), that: Array[Bool]",
             ),
         ];
         let mut builder = JsonVectorBuilder::with_capacity(1);
@@ -395,12 +395,12 @@ mod tests {
         // test children builders:
         assert_eq!(builder.builders.len(), 6);
         let expect_types = [
-            r#"Json<Struct<"list": List<Int64>, "s": String>>"#,
-            r#"Json<Struct<"float": Float64, "s": String>>"#,
-            r#"Json<Struct<"float": Float64, "int": Int64>>"#,
-            r#"Json<Struct<"int": Int64, "object": Struct<"hello": String, "timestamp": Int64>>>"#,
-            r#"Json<Struct<"nested": Struct<"a": Struct<"b": Struct<"b": Struct<"a": String>>>>, "object": Struct<"timestamp": Int64>>>"#,
-            r#"Json<Struct<"nested": Struct<"a": Struct<"b": Struct<"a": Struct<"b": String>>>>, "object": Struct<"timestamp": Int64>>>"#,
+            r#"Json<Object{"list": Array[Number(I64)], "s": String}>"#,
+            r#"Json<Object{"float": Number(F64), "s": String}>"#,
+            r#"Json<Object{"float": Number(F64), "int": Number(I64)}>"#,
+            r#"Json<Object{"int": Number(I64), "object": Object{"hello": String, "timestamp": Number(I64)}}>"#,
+            r#"Json<Object{"nested": Object{"a": Object{"b": Object{"b": Object{"a": String}}}}, "object": Object{"timestamp": Number(I64)}}>"#,
+            r#"Json<Object{"nested": Object{"a": Object{"b": Object{"a": Object{"b": String}}}}, "object": Object{"timestamp": Number(I64)}}>"#,
         ];
         let expect_vectors = [
             r#"
@@ -455,7 +455,7 @@ mod tests {
         }
 
         // test final merged json type:
-        let expected = r#"Json<Struct<"float": Float64, "int": Int64, "list": List<Int64>, "nested": Struct<"a": Struct<"b": Struct<"a": Struct<"b": String>, "b": Struct<"a": String>>>>, "object": Struct<"hello": String, "timestamp": Int64>, "s": String>>"#;
+        let expected = r#"Json<Object{"float": Number(F64), "int": Number(I64), "list": Array[Number(I64)], "nested": Object{"a": Object{"b": Object{"a": Object{"b": String}, "b": Object{"a": String}}}}, "object": Object{"hello": String, "timestamp": Number(I64)}, "s": String}>"#;
         assert_eq!(builder.data_type().to_string(), expected);
 
         // test final produced vector:


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

instead of being backed by `ConcreteDataType` directly, which makes json value verbose to operate its type

also the new json type is precisely corresponding to the json value, making codes lesser error-prone

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
