### PR TITLE
feat: support alter database compaction options

### DIFF
--- a/src/common/meta/src/rpc/ddl.rs
+++ b/src/common/meta/src/rpc/ddl.rs
@@ -47,6 +47,7 @@ use serde_with::{DefaultOnNull, serde_as};
 use session::context::{QueryContextBuilder, QueryContextRef};
 use snafu::{OptionExt, ResultExt};
 use table::metadata::{RawTableInfo, TableId};
+use table::requests::validate_database_option;
 use table::table_name::TableName;
 use table::table_reference::TableReference;
 
@@ -1059,14 +1060,21 @@ impl TryFrom<PbOption> for SetDatabaseOption {
     type Error = error::Error;
 
     fn try_from(PbOption { key, value }: PbOption) -> Result<Self> {
-        match key.to_ascii_lowercase().as_str() {
+        let key_lower = key.to_ascii_lowercase();
+        match key_lower.as_str() {
             TTL_KEY => {
                 let ttl = DatabaseTimeToLive::from_humantime_or_str(&value)
                     .map_err(|_| InvalidSetDatabaseOptionSnafu { key, value }.build())?;
 
                 Ok(SetDatabaseOption::Ttl(ttl))
             }
-            _ => InvalidSetDatabaseOptionSnafu { key, value }.fail(),
+            _ => {
+                if validate_database_option(&key_lower) {
+                    Ok(SetDatabaseOption::Other(key_lower, value))
+                } else {
+                    InvalidSetDatabaseOptionSnafu { key, value }.fail()
+                }
+            }
         }
     }
 }
@@ -1074,20 +1082,29 @@ impl TryFrom<PbOption> for SetDatabaseOption {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum SetDatabaseOption {
     Ttl(DatabaseTimeToLive),
+    Other(String, String),
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum UnsetDatabaseOption {
     Ttl,
+    Other(String),
 }
 
 impl TryFrom<&str> for UnsetDatabaseOption {
     type Error = error::Error;
 
     fn try_from(key: &str) -> Result<Self> {
-        match key.to_ascii_lowercase().as_str() {
+        let key_lower = key.to_ascii_lowercase();
+        match key_lower.as_str() {
             TTL_KEY => Ok(UnsetDatabaseOption::Ttl),
-            _ => InvalidUnsetDatabaseOptionSnafu { key }.fail(),
+            _ => {
+                if validate_database_option(&key_lower) {
+                    Ok(UnsetDatabaseOption::Other(key_lower))
+                } else {
+                    InvalidUnsetDatabaseOptionSnafu { key }.fail()
+                }
+            }
         }
     }
 }

--- a/tests/cases/standalone/common/alter/alter_database.result
+++ b/tests/cases/standalone/common/alter/alter_database.result
@@ -104,6 +104,216 @@ SHOW CREATE DATABASE alter_database;
 | alter_database | CREATE DATABASE IF NOT EXISTS alter_database |
 +----------------+----------------------------------------------+
 
+ALTER DATABASE alter_database SET 'compaction.type'='twcs';
+
+Affected Rows: 0
+
+SHOW CREATE DATABASE alter_database;
+
++----------------+----------------------------------------------+
+| Database       | Create Database                              |
++----------------+----------------------------------------------+
+| alter_database | CREATE DATABASE IF NOT EXISTS alter_database |
+|                | WITH(                                        |
+|                |   'compaction.type' = 'twcs'                 |
+|                | )                                            |
++----------------+----------------------------------------------+
+
+ALTER DATABASE alter_database SET 'compaction.twcs.time_window'='2h';
+
+Affected Rows: 0
+
+SHOW CREATE DATABASE alter_database;
+
++----------------+----------------------------------------------+
+| Database       | Create Database                              |
++----------------+----------------------------------------------+
+| alter_database | CREATE DATABASE IF NOT EXISTS alter_database |
+|                | WITH(                                        |
+|                |   'compaction.twcs.time_window' = '2h',      |
+|                |   'compaction.type' = 'twcs'                 |
+|                | )                                            |
++----------------+----------------------------------------------+
+
+ALTER DATABASE alter_database SET 'compaction.twcs.trigger_file_num'='8';
+
+Affected Rows: 0
+
+ALTER DATABASE alter_database SET 'compaction.twcs.max_output_file_size'='512MB';
+
+Affected Rows: 0
+
+SHOW CREATE DATABASE alter_database;
+
++----------------+-----------------------------------------------------+
+| Database       | Create Database                                     |
++----------------+-----------------------------------------------------+
+| alter_database | CREATE DATABASE IF NOT EXISTS alter_database        |
+|                | WITH(                                               |
+|                |   'compaction.twcs.max_output_file_size' = '512MB', |
+|                |   'compaction.twcs.time_window' = '2h',             |
+|                |   'compaction.twcs.trigger_file_num' = '8',         |
+|                |   'compaction.type' = 'twcs'                        |
+|                | )                                                   |
++----------------+-----------------------------------------------------+
+
+ALTER DATABASE alter_database SET 'compaction.twcs.time_window'='1d';
+
+Affected Rows: 0
+
+SHOW CREATE DATABASE alter_database;
+
++----------------+-----------------------------------------------------+
+| Database       | Create Database                                     |
++----------------+-----------------------------------------------------+
+| alter_database | CREATE DATABASE IF NOT EXISTS alter_database        |
+|                | WITH(                                               |
+|                |   'compaction.twcs.max_output_file_size' = '512MB', |
+|                |   'compaction.twcs.time_window' = '1d',             |
+|                |   'compaction.twcs.trigger_file_num' = '8',         |
+|                |   'compaction.type' = 'twcs'                        |
+|                | )                                                   |
++----------------+-----------------------------------------------------+
+
+-- SQLNESS ARG restart=true
+SHOW CREATE DATABASE alter_database;
+
++----------------+-----------------------------------------------------+
+| Database       | Create Database                                     |
++----------------+-----------------------------------------------------+
+| alter_database | CREATE DATABASE IF NOT EXISTS alter_database        |
+|                | WITH(                                               |
+|                |   'compaction.twcs.max_output_file_size' = '512MB', |
+|                |   'compaction.twcs.time_window' = '1d',             |
+|                |   'compaction.twcs.trigger_file_num' = '8',         |
+|                |   'compaction.type' = 'twcs'                        |
+|                | )                                                   |
++----------------+-----------------------------------------------------+
+
+ALTER DATABASE alter_database UNSET 'compaction.twcs.trigger_file_num';
+
+Affected Rows: 0
+
+SHOW CREATE DATABASE alter_database;
+
++----------------+-----------------------------------------------------+
+| Database       | Create Database                                     |
++----------------+-----------------------------------------------------+
+| alter_database | CREATE DATABASE IF NOT EXISTS alter_database        |
+|                | WITH(                                               |
+|                |   'compaction.twcs.max_output_file_size' = '512MB', |
+|                |   'compaction.twcs.time_window' = '1d',             |
+|                |   'compaction.type' = 'twcs'                        |
+|                | )                                                   |
++----------------+-----------------------------------------------------+
+
+ALTER DATABASE alter_database UNSET 'compaction.twcs.time_window';
+
+Affected Rows: 0
+
+SHOW CREATE DATABASE alter_database;
+
++----------------+-----------------------------------------------------+
+| Database       | Create Database                                     |
++----------------+-----------------------------------------------------+
+| alter_database | CREATE DATABASE IF NOT EXISTS alter_database        |
+|                | WITH(                                               |
+|                |   'compaction.twcs.max_output_file_size' = '512MB', |
+|                |   'compaction.type' = 'twcs'                        |
+|                | )                                                   |
++----------------+-----------------------------------------------------+
+
+ALTER DATABASE alter_database SET 'compaction.twcs.fallback_to_local'='true';
+
+Affected Rows: 0
+
+SHOW CREATE DATABASE alter_database;
+
++----------------+-----------------------------------------------------+
+| Database       | Create Database                                     |
++----------------+-----------------------------------------------------+
+| alter_database | CREATE DATABASE IF NOT EXISTS alter_database        |
+|                | WITH(                                               |
+|                |   'compaction.twcs.fallback_to_local' = 'true',     |
+|                |   'compaction.twcs.max_output_file_size' = '512MB', |
+|                |   'compaction.type' = 'twcs'                        |
+|                | )                                                   |
++----------------+-----------------------------------------------------+
+
+ALTER DATABASE alter_database UNSET 'compaction.type';
+
+Affected Rows: 0
+
+ALTER DATABASE alter_database UNSET 'compaction.twcs.max_output_file_size';
+
+Affected Rows: 0
+
+ALTER DATABASE alter_database UNSET 'compaction.twcs.fallback_to_local';
+
+Affected Rows: 0
+
+SHOW CREATE DATABASE alter_database;
+
++----------------+----------------------------------------------+
+| Database       | Create Database                              |
++----------------+----------------------------------------------+
+| alter_database | CREATE DATABASE IF NOT EXISTS alter_database |
++----------------+----------------------------------------------+
+
+-- SQLNESS ARG restart=true
+SHOW CREATE DATABASE alter_database;
+
++----------------+----------------------------------------------+
+| Database       | Create Database                              |
++----------------+----------------------------------------------+
+| alter_database | CREATE DATABASE IF NOT EXISTS alter_database |
++----------------+----------------------------------------------+
+
+ALTER DATABASE alter_database SET 'invalid.compaction.option'='value';
+
+Error: 1004(InvalidArguments), Invalid set database option, key: invalid.compaction.option, value: value
+
+ALTER DATABASE alter_database SET 'ttl'='1h';
+
+Affected Rows: 0
+
+ALTER DATABASE alter_database SET 'compaction.type'='twcs';
+
+Affected Rows: 0
+
+ALTER DATABASE alter_database SET 'compaction.twcs.time_window'='30m';
+
+Affected Rows: 0
+
+SHOW CREATE DATABASE alter_database;
+
++----------------+----------------------------------------------+
+| Database       | Create Database                              |
++----------------+----------------------------------------------+
+| alter_database | CREATE DATABASE IF NOT EXISTS alter_database |
+|                | WITH(                                        |
+|                |   'compaction.twcs.time_window' = '30m',     |
+|                |   'compaction.type' = 'twcs',                |
+|                |   ttl = '1h'                                 |
+|                | )                                            |
++----------------+----------------------------------------------+
+
+ALTER DATABASE alter_database UNSET 'ttl';
+
+Affected Rows: 0
+
+SHOW CREATE DATABASE alter_database;
+
++----------------+----------------------------------------------+
+| Database       | Create Database                              |
++----------------+----------------------------------------------+
+| alter_database | CREATE DATABASE IF NOT EXISTS alter_database |
+|                | WITH(                                        |
+|                |   'compaction.twcs.time_window' = '30m',     |
+|                |   'compaction.type' = 'twcs'                 |
+|                | )                                            |
++----------------+----------------------------------------------+
+
 DROP DATABASE alter_database;
 
 Affected Rows: 0

--- a/tests/cases/standalone/common/alter/alter_database.sql
+++ b/tests/cases/standalone/common/alter/alter_database.sql
@@ -32,5 +32,63 @@ SHOW CREATE DATABASE alter_database;
 -- SQLNESS ARG restart=true
 SHOW CREATE DATABASE alter_database;
 
+ALTER DATABASE alter_database SET 'compaction.type'='twcs';
+
+SHOW CREATE DATABASE alter_database;
+
+ALTER DATABASE alter_database SET 'compaction.twcs.time_window'='2h';
+
+SHOW CREATE DATABASE alter_database;
+
+ALTER DATABASE alter_database SET 'compaction.twcs.trigger_file_num'='8';
+
+ALTER DATABASE alter_database SET 'compaction.twcs.max_output_file_size'='512MB';
+
+SHOW CREATE DATABASE alter_database;
+
+ALTER DATABASE alter_database SET 'compaction.twcs.time_window'='1d';
+
+SHOW CREATE DATABASE alter_database;
+
+-- SQLNESS ARG restart=true
+SHOW CREATE DATABASE alter_database;
+
+ALTER DATABASE alter_database UNSET 'compaction.twcs.trigger_file_num';
+
+SHOW CREATE DATABASE alter_database;
+
+ALTER DATABASE alter_database UNSET 'compaction.twcs.time_window';
+
+SHOW CREATE DATABASE alter_database;
+
+ALTER DATABASE alter_database SET 'compaction.twcs.fallback_to_local'='true';
+
+SHOW CREATE DATABASE alter_database;
+
+ALTER DATABASE alter_database UNSET 'compaction.type';
+
+ALTER DATABASE alter_database UNSET 'compaction.twcs.max_output_file_size';
+
+ALTER DATABASE alter_database UNSET 'compaction.twcs.fallback_to_local';
+
+SHOW CREATE DATABASE alter_database;
+
+-- SQLNESS ARG restart=true
+SHOW CREATE DATABASE alter_database;
+
+ALTER DATABASE alter_database SET 'invalid.compaction.option'='value';
+
+ALTER DATABASE alter_database SET 'ttl'='1h';
+
+ALTER DATABASE alter_database SET 'compaction.type'='twcs';
+
+ALTER DATABASE alter_database SET 'compaction.twcs.time_window'='30m';
+
+SHOW CREATE DATABASE alter_database;
+
+ALTER DATABASE alter_database UNSET 'ttl';
+
+SHOW CREATE DATABASE alter_database;
+
 DROP DATABASE alter_database;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

close #5050 

## What's changed and what's your intention?

- Add `Other` variant to `SetDatabaseOption` and `UnsetDatabaseOption`
- Update `TryFrom` implementations to validate options using `VALID_DB_OPT_KEYS`
- Add test for compaction options
<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
