### PR TITLE
fix: dynamic reload tracing layer loses trace id

### DIFF
--- a/src/common/telemetry/src/logging.rs
+++ b/src/common/telemetry/src/logging.rs
@@ -67,27 +67,18 @@ impl TraceReloadHandle {
         Self { inner }
     }
 
-    pub fn reload(&self, new_layer: Option<OtelTraceLayer>) -> Result<(), TraceReloadError> {
-        let mut guard = self.inner.write().map_err(|_| TraceReloadError)?;
+    pub fn reload(&self, new_layer: Option<OtelTraceLayer>) {
+        let mut guard = self.inner.write().unwrap();
         *guard = new_layer;
         drop(guard);
 
         callsite::rebuild_interest_cache();
-        Ok(())
     }
 }
 
-#[derive(Debug)]
-pub struct TraceReloadError;
-
-impl std::fmt::Display for TraceReloadError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "trace reload handle is poisoned")
-    }
-}
-
-impl std::error::Error for TraceReloadError {}
-
+/// A tracing layer that can be dynamically reloaded.
+///
+/// Mostly copied from [`tracing_subscriber::reload::Layer`].
 struct TraceLayer {
     inner: Arc<RwLock<Option<OtelTraceLayer>>>,
 }

--- a/src/servers/src/http/dyn_trace.rs
+++ b/src/servers/src/http/dyn_trace.rs
@@ -14,7 +14,7 @@
 
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use common_telemetry::{TRACE_RELOAD_HANDLE, error, get_or_init_tracer, info};
+use common_telemetry::{TRACE_RELOAD_HANDLE, get_or_init_tracer, info};
 
 use crate::error::{InvalidParameterSnafu, Result};
 
@@ -43,32 +43,12 @@ pub async fn dyn_trace_handler(enable_str: String) -> Result<impl IntoResponse> 
         };
 
         let trace_layer = tracing_opentelemetry::layer().with_tracer(tracer);
-        match trace_reload_handle.reload(Some(trace_layer)) {
-            Ok(_) => {
-                info!("trace enabled");
-                Ok((StatusCode::OK, "trace enabled".to_string()))
-            }
-            Err(e) => {
-                error!(e; "Failed to enable trace");
-                Ok((
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("failed to enable trace: {e}"),
-                ))
-            }
-        }
+        trace_reload_handle.reload(Some(trace_layer));
+        info!("trace enabled");
+        Ok((StatusCode::OK, "trace enabled".to_string()))
     } else {
-        match trace_reload_handle.reload(None) {
-            Ok(_) => {
-                info!("trace disabled");
-                Ok((StatusCode::OK, "trace disabled".to_string()))
-            }
-            Err(e) => {
-                error!(e; "Failed to disable trace");
-                Ok((
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("failed to disable trace: {e}"),
-                ))
-            }
-        }
+        trace_reload_handle.reload(None);
+        info!("trace disabled");
+        Ok((StatusCode::OK, "trace disabled".to_string()))
     }
 }


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


`tracing_subscriber::reload::Layer` prevents the trace layer from casting to the original item, which (I guess) will make the tracer not work as expected.

([source](https://docs.rs/tracing-subscriber/0.3.20/src/tracing_subscriber/reload.rs.html#187-204))

<img width="775" height="439" alt="image" src="https://github.com/user-attachments/assets/d6d9aa69-b8ac-49fe-a94e-bdd0f8463241" />

The proposed new wrapper is almost identical to the above one, but with a concrete inner type and can be downcast back. It also uses an `RwLock` as well as the above one.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
