### PR TITLE
chore: add default value to sparse_primary_key_encoding config item

### DIFF
--- a/src/metric-engine/src/config.rs
+++ b/src/metric-engine/src/config.rs
@@ -17,13 +17,14 @@ use std::time::Duration;
 use common_telemetry::warn;
 use serde::{Deserialize, Serialize};
 
-/// The default flush interval of the metadata region.  
+/// The default flush interval of the metadata region.
 pub(crate) const DEFAULT_FLUSH_METADATA_REGION_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Configuration for the metric engine.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EngineConfig {
     /// Whether to use sparse primary key encoding.
+    #[serde(default = "EngineConfig::default_sparse_primary_key_encoding")]
     pub sparse_primary_key_encoding: bool,
     /// The flush interval of the metadata region.
     #[serde(
@@ -37,7 +38,7 @@ impl Default for EngineConfig {
     fn default() -> Self {
         Self {
             flush_metadata_region_interval: DEFAULT_FLUSH_METADATA_REGION_INTERVAL,
-            sparse_primary_key_encoding: true,
+            sparse_primary_key_encoding: Self::default_sparse_primary_key_encoding(),
         }
     }
 }
@@ -45,6 +46,10 @@ impl Default for EngineConfig {
 impl EngineConfig {
     fn default_flush_metadata_region_interval() -> Duration {
         DEFAULT_FLUSH_METADATA_REGION_INTERVAL
+    }
+
+    fn default_sparse_primary_key_encoding() -> bool {
+        true
     }
 
     /// Sanitizes the configuration.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR introduces a default value (true) for the sparse-primary-key-encoding configuration option. And also preserves backward compatibility with existing configuration files

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
