### PR TITLE
fix: unlimit `trace_id` query in jaeger API

### DIFF
--- a/src/frontend/src/instance/jaeger.rs
+++ b/src/frontend/src/instance/jaeger.rs
@@ -155,13 +155,6 @@ impl JaegerQueryHandler for Instance {
             filters.push(col(TIMESTAMP_COLUMN).lt_eq(lit_timestamp_nano(end_time)));
         }
 
-        let limit = if start_time.is_some() && end_time.is_some() {
-            // allow unlimited limit if time range is specified
-            limit
-        } else {
-            limit.or(Some(DEFAULT_LIMIT))
-        };
-
         Ok(query_trace_table(
             ctx,
             self.catalog_manager(),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

As the title suggests. The Grafana jaeger plugin doesn't actually give timestamp parameters when invoking the `/<trace_id>` query. So we need to remove the limit by default to return all the span results.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
