### PR TITLE
fix: postgres show statement describe and timestamp text parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9195,9 +9195,9 @@ dependencies = [
 
 [[package]]
 name = "pgwire"
-version = "0.36.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5cc59678d0c10c73a552d465ce9156995189d1c678f2784dc817fe8623487f5"
+checksum = "d331bb0eef5bc83a221c0a85b1f205bccf094d4f72a26ae1d68a1b1c535123b7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -87,7 +87,7 @@ operator.workspace = true
 otel-arrow-rust.workspace = true
 parking_lot.workspace = true
 pg_interval = "0.4"
-pgwire = { version = "0.36", default-features = false, features = [
+pgwire = { version = "0.36.1", default-features = false, features = [
     "server-api-ring",
     "pg-ext-types",
 ] }

--- a/src/servers/src/lib.rs
+++ b/src/servers/src/lib.rs
@@ -56,7 +56,7 @@ pub mod server;
 pub mod tls;
 
 /// Cached SQL and logical plan for database interfaces
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct SqlPlan {
     query: String,
     // Store the parsed statement to determine if it is a query and whether to track it.

--- a/src/servers/src/postgres/fixtures.rs
+++ b/src/servers/src/postgres/fixtures.rs
@@ -22,7 +22,7 @@ use pgwire::api::results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse
 use pgwire::error::PgWireResult;
 use pgwire::messages::data::DataRow;
 use regex::Regex;
-use session::context::QueryContextRef;
+use session::context::{QueryContext, QueryContextRef};
 
 fn build_string_data_rows(
     schema: Arc<Vec<FieldInfo>>,
@@ -60,11 +60,7 @@ static ABORT_TRANSACTION_PATTERN: Lazy<Regex> =
 
 /// Test if given query statement matches the patterns
 pub(crate) fn matches(query: &str) -> bool {
-    START_TRANSACTION_PATTERN.is_match(query)
-        || COMMIT_TRANSACTION_PATTERN.is_match(query)
-        || ABORT_TRANSACTION_PATTERN.is_match(query)
-        || SHOW_PATTERN.captures(query).is_some()
-        || SET_TRANSACTION_PATTERN.is_match(query)
+    process(query, QueryContext::arc()).is_some()
 }
 
 fn set_transaction_warning(query_ctx: QueryContextRef) {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This patch includes additional text encoding parse and describe support:

- show statement has to be described manually due to lack of query engine support at this stage. we might look into this in future, but it's a low-priority. These show statements are not postgres-native, and users can still use `psql` to run them.
- timestamp text encoding has been fixed in upstream pgwire 0.36.1 or https://github.com/sunng87/pgwire/pull/353 specifically. 

This branch passes https://github.com/GreptimeTeam/greptimedb-tests

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
