### PR TITLE
fix: postgres timezone setting by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8675,6 +8675,7 @@ dependencies = [
  "futures",
  "futures-util",
  "humantime",
+ "itertools 0.14.0",
  "jsonb",
  "lazy_static",
  "meta-client",

--- a/src/operator/Cargo.toml
+++ b/src/operator/Cargo.toml
@@ -47,6 +47,7 @@ file-engine.workspace = true
 futures.workspace = true
 futures-util.workspace = true
 humantime.workspace = true
+itertools.workspace = true
 jsonb.workspace = true
 lazy_static.workspace = true
 meta-client.workspace = true

--- a/src/operator/src/statement.rs
+++ b/src/operator/src/statement.rs
@@ -46,12 +46,13 @@ use common_meta::key::{TableMetadataManager, TableMetadataManagerRef};
 use common_meta::kv_backend::KvBackendRef;
 use common_meta::procedure_executor::ProcedureExecutorRef;
 use common_query::Output;
-use common_telemetry::tracing;
+use common_telemetry::{debug, tracing};
 use common_time::Timestamp;
 use common_time::range::TimestampRange;
 use datafusion_expr::LogicalPlan;
 use datatypes::prelude::ConcreteDataType;
 use humantime::format_duration;
+use itertools::Itertools;
 use partition::manager::{PartitionRuleManager, PartitionRuleManagerRef};
 use query::QueryEngineRef;
 use query::parser::QueryStatement;
@@ -451,6 +452,13 @@ impl StatementExecutor {
 
     fn set_variables(&self, set_var: SetVariables, query_ctx: QueryContextRef) -> Result<Output> {
         let var_name = set_var.variable.to_string().to_uppercase();
+
+        debug!(
+            "Trying to set {}={} for session: {} ",
+            var_name,
+            set_var.value.iter().map(|e| e.to_string()).join(", "),
+            query_ctx.conn_info()
+        );
 
         match var_name.as_str() {
             "READ_PREFERENCE" => set_read_preference(set_var.value, query_ctx)?,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The postgres jdbc driver will send the timezone with startup message, and we should respect it.

The sample metadata:
```
 {"database": "java_tests", "user": "", "schema": "java_tests", "client_encoding": "UTF8", "catalog": "greptime", "TimeZone": "America/Los_Angeles", "DateStyle": "ISO"}
```

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
