### PR TITLE
refactor: load metadata using offical impl

### DIFF
--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -180,15 +180,6 @@ pub enum Error {
         error: ArrowError,
     },
 
-    #[snafu(display("Failed to load parquet metadata, path: {}", path))]
-    LoadParquetMetadata {
-        path: String,
-        #[snafu(source)]
-        error: parquet::errors::ParquetError,
-        #[snafu(implicit)]
-        location: Location,
-    },
-
     #[snafu(display("Failed to read parquet file, path: {}", path))]
     ReadParquet {
         path: String,
@@ -1184,9 +1175,7 @@ impl ErrorExt for Error {
 
         match self {
             DataTypeMismatch { source, .. } => source.status_code(),
-            OpenDal { .. } | ReadParquet { .. } | LoadParquetMetadata { .. } => {
-                StatusCode::StorageUnavailable
-            }
+            OpenDal { .. } | ReadParquet { .. } => StatusCode::StorageUnavailable,
             WriteWal { source, .. } | ReadWal { source, .. } | DeleteWal { source, .. } => {
                 source.status_code()
             }

--- a/src/mito2/src/sst/parquet/metadata.rs
+++ b/src/mito2/src/sst/parquet/metadata.rs
@@ -81,9 +81,7 @@ impl<'a> MetadataLoader<'a> {
             .await
             .map_err(|e| match unbox_external_error(e) {
                 Ok(os_err) => error::OpenDalSnafu {}.into_error(os_err),
-                Err(parquet_err) => {
-                    error::LoadParquetMetadataSnafu { path }.into_error(parquet_err)
-                }
+                Err(parquet_err) => error::ReadParquetSnafu { path }.into_error(parquet_err),
             })
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

as title, use offical loader for metadata

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
