### PR TITLE
chore: return 404 if trace not found

### DIFF
--- a/src/servers/src/http/jaeger.rs
+++ b/src/servers/src/http/jaeger.rs
@@ -493,6 +493,10 @@ pub async fn handle_get_trace(
 
     match covert_to_records(output).await {
         Ok(Some(records)) => match traces_from_records(records) {
+            Ok(traces) if traces.is_empty() => (
+                HttpStatusCode::NOT_FOUND,
+                axum::Json(JaegerAPIResponse::trace_not_found()),
+            ),
             Ok(traces) => (
                 HttpStatusCode::OK,
                 axum::Json(JaegerAPIResponse {

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -6575,6 +6575,30 @@ pub async fn test_jaeger_query_api_for_trace_v1(store_type: StorageType) {
     let expected: Value = serde_json::from_str(expected).unwrap();
     assert_eq!(resp, expected);
 
+    // Test `/api/traces/{trace_id}` API for non-existent trace.
+    let res = client
+        .get("/v1/jaeger/api/traces/0000000000000000000000000000dead")
+        .header("x-greptime-trace-table-name", trace_table_name)
+        .send()
+        .await;
+    assert_eq!(StatusCode::NOT_FOUND, res.status());
+    let expected = r#"{
+  "data": null,
+  "total": 0,
+  "limit": 0,
+  "offset": 0,
+  "errors": [
+    {
+      "code": 404,
+      "msg": "trace not found"
+    }
+  ]
+}
+"#;
+    let resp: Value = serde_json::from_str(&res.text().await).unwrap();
+    let expected: Value = serde_json::from_str(expected).unwrap();
+    assert_eq!(resp, expected);
+
     // Test `/api/traces` API.
     let res = client
         .get("/v1/jaeger/api/traces?service=test-jaeger-query-api&operation=access-mysql&start=1738726754492421&end=1738726754642422&tags=%7B%22operation.type%22%3A%22access-mysql%22%7D")


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

In current implementation, if query by trace id hits no trace, the database returns an empty result.
However, in the official Jaeger implementation, it returns 404.

This PR checks the return vector from the query by trace id API. If the vector is empty, it returns 404 now.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
