### PR TITLE
feat: skip reading some internal columns

### DIFF
--- a/src/mito2/src/read/flat_projection.rs
+++ b/src/mito2/src/read/flat_projection.rs
@@ -30,7 +30,7 @@ use store_api::storage::ColumnId;
 
 use crate::error::{InvalidRequestSnafu, Result};
 use crate::sst::parquet::flat_format::sst_column_id_indices;
-use crate::sst::parquet::format::FormatProjection;
+use crate::sst::parquet::format::{FormatProjection, InternalProjection};
 use crate::sst::{
     FlatSchemaOptions, internal_fields, tag_maybe_to_dictionary_field, to_flat_sst_arrow_schema,
 };
@@ -108,6 +108,7 @@ impl FlatProjectionMapper {
             // All columns with internal columns.
             metadata.column_metadatas.len() + 3,
             column_ids.iter().copied(),
+            InternalProjection::default(),
         );
 
         let batch_schema = flat_projected_columns(metadata, &format_projection);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Skipped reading the dedup-only internal columns (`__op_type` and `__sequence`) for PK-only, append-mode scans that aren’t filtering deletes and synthesize them when absent.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
