### PR TITLE
refactor: remove duplication coverage and code from window sort tests

### DIFF
--- a/src/query/src/window_sort.rs
+++ b/src/query/src/window_sort.rs
@@ -1490,6 +1490,7 @@ mod test {
         }
     }
 
+    #[allow(clippy::type_complexity)]
     fn run_compute_working_ranges_test(
         testcases: Vec<(
             BTreeMap<(Timestamp, Timestamp), Vec<usize>>,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

 1. Eliminated Duplication Code

  Created test helper module (lines 1262-1294):
  - `default_sort_opts(descending)` - Reusable SortOptions builder
  - `ts_field(unit) `- Timestamp field creator
  - `ts_column()` - Column creator
  - `partition_range(start, end, num_rows, id)` - Simplified PartitionRange constructor
  - `ts_array(values)` - Array creation helper

  Simplified TestStream API:
  - Removed redundant parameters from constructor
  - Added `new_simple()` convenience method for common cases
  - Reduced from 6 parameters to 5 (removed Column parameter)

  2. Consolidated Duplicate Coverage

  `test_cmp_with_opts` (lines 2208-2289):
  - Reduced from 10 test cases to 7
  - Removed 3 redundant None/None → Equal cases
  - Added comments explaining why one case is sufficient

  `test_compute_working_ranges` (lines 1492-1914):
  - Merged two tests (`test_compute_working_ranges` and `test_compute_working_ranges_rev`)
  - Created shared helper function `run_compute_working_ranges_test()`
  - Renamed to `test_compute_working_ranges_descending` and `test_compute_working_ranges_ascending`
  - Eliminated duplicate test logic

  3. Fixed Scattered Cases

  Split large test_window_sort_stream into 5 focused test functions:

  1. `test_window_sort_empty_and_minimal` (4 cases) - Empty inputs and boundary cases
  2. `test_window_sort_overlapping` (3 cases) - Range overlap scenarios
  3. `test_window_sort_with_fetch` (2 cases) - Limit/fetch behavior
  4. `test_window_sort_descending` (1 case) - Descending sort order
  5. `test_window_sort_complex` (3 cases) - Complex multi-range scenarios

![disclosure](https://img.shields.io/badge/by-claude_code_opus_4.5-blue)

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
