### PR TITLE
refactor: optimize heartbeat channel and etcd client keepalive settings

### DIFF
--- a/src/common/meta/src/distributed_time_constants.rs
+++ b/src/common/meta/src/distributed_time_constants.rs
@@ -47,21 +47,16 @@ pub const META_KEEP_ALIVE_INTERVAL_SECS: u64 = META_LEASE_SECS / 2;
 pub const HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(META_KEEP_ALIVE_INTERVAL_SECS + 1);
 
 /// The keep-alive interval of the heartbeat channel.
-pub const HEARTBEAT_CHANNEL_KEEP_ALIVE_INTERVAL_SECS: Duration =
-    Duration::from_secs(META_KEEP_ALIVE_INTERVAL_SECS + 1);
+pub const HEARTBEAT_CHANNEL_KEEP_ALIVE_INTERVAL_SECS: Duration = Duration::from_secs(15);
 
 /// The keep-alive timeout of the heartbeat channel.
-pub const HEARTBEAT_CHANNEL_KEEP_ALIVE_TIMEOUT_SECS: Duration =
-    Duration::from_secs(META_KEEP_ALIVE_INTERVAL_SECS + 1);
+pub const HEARTBEAT_CHANNEL_KEEP_ALIVE_TIMEOUT_SECS: Duration = Duration::from_secs(5);
 
 /// The default options for the etcd client.
 pub fn default_etcd_client_options() -> ConnectOptions {
     ConnectOptions::new()
         .with_keep_alive_while_idle(true)
-        .with_keep_alive(
-            Duration::from_secs(META_KEEP_ALIVE_INTERVAL_SECS + 1),
-            Duration::from_secs(10),
-        )
+        .with_keep_alive(Duration::from_secs(15), Duration::from_secs(5))
         .with_connect_timeout(Duration::from_secs(10))
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR tunes the keepalive parameters to resolve unstable connections (e.g., transport is closing) caused by aggressive heartbeat intervals.
- Adjust heartbeat channel keepalive interval from 3s to 15s
- Reduce heartbeat channel keepalive timeout from to 5s
- Update etcd client keepalive settings to use consistent values (15s interval, 5s timeout)

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
