### PR TITLE
chore(mito): nit remove extra hashset in gc workers

### DIFF
--- a/src/mito2/src/gc.rs
+++ b/src/mito2/src/gc.rs
@@ -540,7 +540,7 @@ impl LocalGcWorker {
     fn filter_deletable_files(
         &self,
         entries: Vec<Entry>,
-        in_use_filenames: &HashSet<&FileId>,
+        in_use_filenames: &HashSet<FileId>,
         may_linger_filenames: &HashSet<&FileId>,
         eligible_for_removal: &HashSet<&FileId>,
         unknown_file_may_linger_until: chrono::DateTime<chrono::Utc>,
@@ -641,9 +641,6 @@ impl LocalGcWorker {
             .flatten()
             .collect::<HashSet<_>>();
 
-        // in use filenames, include sst and index files
-        let in_use_filenames = in_used.iter().collect::<HashSet<_>>();
-
         // When full_file_listing is false, skip expensive list operations and only delete
         // files that are tracked in recently_removed_files
         if !self.full_file_listing {
@@ -653,7 +650,7 @@ impl LocalGcWorker {
             // 3. Have passed the lingering time
             let files_to_delete: Vec<FileId> = eligible_for_removal
                 .iter()
-                .filter(|file_id| !in_use_filenames.contains(*file_id))
+                .filter(|file_id| !in_used.contains(*file_id))
                 .map(|&f| *f)
                 .collect();
 
@@ -672,7 +669,7 @@ impl LocalGcWorker {
         let (all_unused_files_ready_for_delete, all_in_exist_linger_files) = self
             .filter_deletable_files(
                 all_entries,
-                &in_use_filenames,
+                in_used,
                 &may_linger_filenames,
                 &eligible_for_removal,
                 unknown_file_may_linger_until,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?



Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
 i felt like the iter and collect into another hashset is not necessary as we can use the original `in_used` set
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
