### PR TITLE
fix: cpu cores got wrongly calculated to 0

### DIFF
--- a/src/common/stat/src/resource.rs
+++ b/src/common/stat/src/resource.rs
@@ -58,8 +58,8 @@ pub fn get_total_memory_bytes() -> i64 {
     }
 }
 
-/// Get the total CPU cores. The result will be rounded to the nearest integer.
-/// For example, if the total CPU is 1.5 cores(1500 millicores), the result will be 2.
+/// Get the total CPU cores. The result will be rounded up to the next integer (ceiling).
+/// For example, if the total CPU is 1.1 cores (1100 millicores) or 1.5 cores (1500 millicores), the result will be 2.
 pub fn get_total_cpu_cores() -> usize {
     cpu_cores(get_total_cpu_millicores())
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

... which could cause panic on datanode startup:

```text
│ datanode thread 'main' (1) panicked at greptimedb/src/mito2/src/worker.rs:433:6:                                                                                                                                                                                                                                           │
│ datanode attempt to calculate the remainder with a divisor of zero                                                                                                                                                                                                                                                         │
│ datanode 2025-12-15T07:09:27.216136Z ERROR handle_batch_open_requests:handle_batch_open_requests: common_telemetry::panic_hook: panicked at greptimedb/src/mito2/src/worker.rs:433:6:
```

when pod cpu is only "100m"

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
