### PR TITLE
fix: using anonymous s3 access when ak and sk is not provided

### DIFF
--- a/src/object-store/src/config.rs
+++ b/src/object-store/src/config.rs
@@ -134,7 +134,7 @@ impl From<&S3Connection> for S3 {
                 .secret_access_key(connection.secret_access_key.expose_secret());
         } else {
             warn!("No access key id or secret access key provided, using anonymous access");
-            builder = builder.allow_anonymous();
+            builder = builder.allow_anonymous().disable_ec2_metadata();
         }
 
         if let Some(endpoint) = &connection.endpoint {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

If ak and sk is not provided for s3, we have to set `allow_anonymous` and `disable_ec2_metadata` to disable loading credential.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
