### PR TITLE
fix: part sort share same topk dyn filter&early stop use dyn filter

### DIFF
--- a/src/query/src/part_sort.rs
+++ b/src/query/src/part_sort.rs
@@ -1157,7 +1157,7 @@ mod test {
 
         // The TopK result buffer is empty, so we cannot determine early-stop.
         // Ensure this path returns `Ok(false)` (and, importantly, does not panic).
-        assert!(!stream.can_stop_early().unwrap());
+        assert!(!stream.can_stop_early(&schema).unwrap());
     }
 
     #[ignore = "hard to gen expected data correctly here, TODO(discord9): fix it later"]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

as title, previously it construct a new one without sort column as it's child, which could cause bug, ~but before part sort's stop early optimization `sort_top_buffer` is called only once so bug is hidden, but after early stop optimization `sort_top_buffer` might got called multiple times hence cause problem~ and also dyn filter need to be shared to properly prune stuff
- make sure dyn filter is shared among `PartSortExec`/`PartSortStream`/`TopK`
- Also due to the intereface of `TopK`, had to refactor to using dyn filter to determine early stop as it's the most clear way, in term of correctness, `TopK` also use this dyn filter to filter before `insert_batch` so the result should be correct since the logic of filtering is the same

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
