### PR TITLE
fix: load with latest

### DIFF
--- a/src/pipeline/src/error.rs
+++ b/src/pipeline/src/error.rs
@@ -609,10 +609,14 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Multiple pipelines with different schemas found, but none under current schema. Please replicate one of them or delete until only one schema left. schemas: {}",
-        schemas
+        "Multiple pipelines with different schemas found, but none under current schema. Please replicate one of them or delete until only one schema left. name: {}, current_schema: {}, schemas: {}",
+        name,
+        current_schema,
+        schemas,
     ))]
     MultiPipelineWithDiffSchema {
+        name: String,
+        current_schema: String,
         schemas: String,
         #[snafu(implicit)]
         location: Location,

--- a/src/pipeline/src/manager/pipeline_cache.rs
+++ b/src/pipeline/src/manager/pipeline_cache.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use common_telemetry::debug;
 use datatypes::timestamp::TimestampNanosecond;
 use moka::sync::Cache;
 
@@ -45,12 +46,17 @@ impl PipelineCache {
             pipelines: Cache::builder()
                 .max_capacity(PIPELINES_CACHE_SIZE)
                 .time_to_live(PIPELINES_CACHE_TTL)
+                .name("pipelines")
                 .build(),
             original_pipelines: Cache::builder()
                 .max_capacity(PIPELINES_CACHE_SIZE)
                 .time_to_live(PIPELINES_CACHE_TTL)
+                .name("original_pipelines")
                 .build(),
-            failover_cache: Cache::builder().max_capacity(PIPELINES_CACHE_SIZE).build(),
+            failover_cache: Cache::builder()
+                .max_capacity(PIPELINES_CACHE_SIZE)
+                .name("failover_cache")
+                .build(),
         }
     }
 
@@ -174,13 +180,13 @@ fn get_cache_generic<T: Clone + Send + Sync + 'static>(
     version: PipelineVersion,
 ) -> Result<Option<T>> {
     // lets try empty schema first
-    let k = generate_pipeline_cache_key(EMPTY_SCHEMA_NAME, name, version);
-    if let Some(value) = cache.get(&k) {
+    let emp_key = generate_pipeline_cache_key(EMPTY_SCHEMA_NAME, name, version);
+    if let Some(value) = cache.get(&emp_key) {
         return Ok(Some(value));
     }
     // use input schema
-    let k = generate_pipeline_cache_key(schema, name, version);
-    if let Some(value) = cache.get(&k) {
+    let schema_k = generate_pipeline_cache_key(schema, name, version);
+    if let Some(value) = cache.get(&schema_k) {
         return Ok(Some(value));
     }
 
@@ -194,13 +200,24 @@ fn get_cache_generic<T: Clone + Send + Sync + 'static>(
     match ks.len() {
         0 => Ok(None),
         1 => Ok(Some(ks.remove(0).1)),
-        _ => MultiPipelineWithDiffSchemaSnafu {
-            schemas: ks
-                .iter()
-                .filter_map(|(k, _)| k.split_once('/').map(|k| k.0))
-                .collect::<Vec<_>>()
-                .join(","),
+        _ => {
+            debug!(
+                "caches keys: {:?}, emp key: {:?}, schema key: {:?}, suffix key: {:?}",
+                cache.iter().map(|e| e.0).collect::<Vec<_>>(),
+                emp_key,
+                schema_k,
+                suffix_key
+            );
+            MultiPipelineWithDiffSchemaSnafu {
+                name: name.to_string(),
+                current_schema: schema.to_string(),
+                schemas: ks
+                    .iter()
+                    .filter_map(|(k, _)| k.split_once('/').map(|k| k.0))
+                    .collect::<Vec<_>>()
+                    .join(","),
+            }
+            .fail()?
         }
-        .fail()?,
     }
 }

--- a/src/pipeline/src/manager/table.rs
+++ b/src/pipeline/src/manager/table.rs
@@ -269,8 +269,13 @@ impl PipelineTable {
         let pipeline = self.get_pipeline_str(schema, name, version).await?;
         let compiled_pipeline = Arc::new(Self::compile_pipeline(&pipeline.0)?);
 
-        self.cache
-            .insert_pipeline_cache(schema, name, version, compiled_pipeline.clone(), false);
+        self.cache.insert_pipeline_cache(
+            schema,
+            name,
+            version,
+            compiled_pipeline.clone(),
+            version.is_none(),
+        );
         Ok(compiled_pipeline)
     }
 
@@ -280,14 +285,17 @@ impl PipelineTable {
         &self,
         schema: &str,
         name: &str,
-        version: PipelineVersion,
+        input_version: PipelineVersion,
     ) -> Result<(String, TimestampNanosecond)> {
-        if let Some(pipeline) = self.cache.get_pipeline_str_cache(schema, name, version)? {
+        if let Some(pipeline) = self
+            .cache
+            .get_pipeline_str_cache(schema, name, input_version)?
+        {
             return Ok(pipeline);
         }
 
         let mut pipeline_vec;
-        match self.find_pipeline(name, version).await {
+        match self.find_pipeline(name, input_version).await {
             Ok(p) => {
                 METRIC_PIPELINE_TABLE_FIND_COUNT
                     .with_label_values(&["true"])
@@ -304,8 +312,14 @@ impl PipelineTable {
                             .inc();
                         return self
                             .cache
-                            .get_failover_cache(schema, name, version)?
-                            .ok_or(PipelineNotFoundSnafu { name, version }.build());
+                            .get_failover_cache(schema, name, input_version)?
+                            .ok_or(
+                                PipelineNotFoundSnafu {
+                                    name,
+                                    version: input_version,
+                                }
+                                .build(),
+                            );
                     }
                     _ => {
                         // if other error, we should return it
@@ -316,7 +330,10 @@ impl PipelineTable {
         };
         ensure!(
             !pipeline_vec.is_empty(),
-            PipelineNotFoundSnafu { name, version }
+            PipelineNotFoundSnafu {
+                name,
+                version: input_version
+            }
         );
 
         // if the result is exact one, use it
@@ -328,7 +345,7 @@ impl PipelineTable {
                 name,
                 Some(version),
                 p.clone(),
-                false,
+                input_version.is_none(),
             );
             return Ok(p);
         }
@@ -344,13 +361,21 @@ impl PipelineTable {
         // throw an error
         let (pipeline_content, found_schema, version) =
             pipeline.context(MultiPipelineWithDiffSchemaSnafu {
+                name: name.to_string(),
+                current_schema: schema.to_string(),
                 schemas: pipeline_vec.iter().map(|v| v.1.clone()).join(","),
             })?;
 
         let v = *version;
         let p = (pipeline_content.clone(), v);
-        self.cache
-            .insert_pipeline_str_cache(found_schema, name, Some(v), p.clone(), false);
+
+        self.cache.insert_pipeline_str_cache(
+            found_schema,
+            name,
+            Some(v),
+            p.clone(),
+            input_version.is_none(),
+        );
         Ok(p)
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR adds the check whether loading pipeline into the cache should also write the `latest` cache entry.
Currently it doesn't. However, If the request doesn't carry the version (in most cases), the pipeline queried from the database is actually the `latest` one, so it should be put into the `latest` entry.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
