### PR TITLE
feat(meta-srv): add repartition procedure skeleton

### DIFF
--- a/src/meta-srv/src/procedure/repartition.rs
+++ b/src/meta-srv/src/procedure/repartition.rs
@@ -12,8 +12,63 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod allocate_region;
+pub mod collect;
+pub mod deallocate_region;
+pub mod dispatch;
 pub mod group;
 pub mod plan;
+pub mod repartition_end;
+pub mod repartition_start;
+
+use std::any::Any;
+use std::fmt::Debug;
+
+use common_meta::cache_invalidator::CacheInvalidatorRef;
+use common_meta::key::TableMetadataManagerRef;
+use common_procedure::{Context as ProcedureContext, Status};
+use serde::{Deserialize, Serialize};
+use store_api::storage::TableId;
+
+use crate::error::Result;
+use crate::procedure::repartition::plan::RepartitionPlanEntry;
+use crate::service::mailbox::MailboxRef;
 
 #[cfg(test)]
 pub mod test_util;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PersistentContext {
+    pub catalog_name: String,
+    pub schema_name: String,
+    pub table_name: String,
+    pub table_id: TableId,
+    pub plans: Vec<RepartitionPlanEntry>,
+}
+
+pub struct Context {
+    pub persistent_ctx: PersistentContext,
+    pub table_metadata_manager: TableMetadataManagerRef,
+    pub mailbox: MailboxRef,
+    pub server_addr: String,
+    pub cache_invalidator: CacheInvalidatorRef,
+}
+
+#[async_trait::async_trait]
+#[typetag::serde(tag = "repartition_state")]
+pub(crate) trait State: Sync + Send + Debug {
+    fn name(&self) -> &'static str {
+        let type_name = std::any::type_name::<Self>();
+        // short name
+        type_name.split("::").last().unwrap_or(type_name)
+    }
+
+    /// Yields the next [State] and [Status].
+    async fn next(
+        &mut self,
+        ctx: &mut Context,
+        procedure_ctx: &ProcedureContext,
+    ) -> Result<(Box<dyn State>, Status)>;
+
+    fn as_any(&self) -> &dyn Any;
+}

--- a/src/meta-srv/src/procedure/repartition/allocate_region.rs
+++ b/src/meta-srv/src/procedure/repartition/allocate_region.rs
@@ -1,0 +1,67 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+
+use common_procedure::{Context as ProcedureContext, Status};
+use serde::{Deserialize, Serialize};
+
+use crate::error::Result;
+use crate::procedure::repartition::dispatch::Dispatch;
+use crate::procedure::repartition::plan::{AllocationPlanEntry, RepartitionPlanEntry};
+use crate::procedure::repartition::{Context, State};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AllocateRegion {
+    plan_entries: Vec<AllocationPlanEntry>,
+}
+
+impl AllocateRegion {
+    pub fn new(plan_entries: Vec<AllocationPlanEntry>) -> Self {
+        Self { plan_entries }
+    }
+}
+
+#[async_trait::async_trait]
+#[typetag::serde]
+impl State for AllocateRegion {
+    async fn next(
+        &mut self,
+        ctx: &mut Context,
+        _procedure_ctx: &ProcedureContext,
+    ) -> Result<(Box<dyn State>, Status)> {
+        let region_to_allocate = self
+            .plan_entries
+            .iter()
+            .map(|p| p.regions_to_allocate)
+            .sum::<usize>();
+
+        if region_to_allocate == 0 {
+            let repartition_plan_entries = self
+                .plan_entries
+                .iter()
+                .map(RepartitionPlanEntry::from_allocation_plan_entry)
+                .collect::<Vec<_>>();
+            ctx.persistent_ctx.plans = repartition_plan_entries;
+            return Ok((Box::new(Dispatch), Status::executing(true)));
+        }
+
+        // TODO(weny): allocate regions.
+        todo!()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/src/meta-srv/src/procedure/repartition/collect.rs
+++ b/src/meta-srv/src/procedure/repartition/collect.rs
@@ -1,0 +1,106 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+
+use common_procedure::{Context as ProcedureContext, ProcedureId, Status, watcher};
+use common_telemetry::error;
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+
+use crate::error::{RepartitionSubprocedureStateReceiverSnafu, Result};
+use crate::procedure::repartition::deallocate_region::DeallocateRegion;
+use crate::procedure::repartition::group::GroupId;
+use crate::procedure::repartition::{Context, State};
+
+/// Metadata for tracking a dispatched sub-procedure.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub struct ProcedureMeta {
+    /// The index of the plan entry in the parent procedure's plan list.
+    pub plan_index: usize,
+    /// The group id of the repartition group.
+    pub group_id: GroupId,
+    /// The procedure id of the sub-procedure.
+    pub procedure_id: ProcedureId,
+}
+
+/// State for collecting results from dispatched sub-procedures.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Collect {
+    /// Sub-procedures that are currently in-flight.
+    pub inflight_procedures: Vec<ProcedureMeta>,
+    /// Sub-procedures that have completed successfully.
+    pub succeeded_procedures: Vec<ProcedureMeta>,
+    /// Sub-procedures that have failed.
+    pub failed_procedures: Vec<ProcedureMeta>,
+    /// Sub-procedures whose state could not be determined.
+    pub unknown_procedures: Vec<ProcedureMeta>,
+}
+
+impl Collect {
+    pub fn new(inflight_procedures: Vec<ProcedureMeta>) -> Self {
+        Self {
+            inflight_procedures,
+            succeeded_procedures: Vec::new(),
+            failed_procedures: Vec::new(),
+            unknown_procedures: Vec::new(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+#[typetag::serde]
+impl State for Collect {
+    async fn next(
+        &mut self,
+        _ctx: &mut Context,
+        procedure_ctx: &ProcedureContext,
+    ) -> Result<(Box<dyn State>, Status)> {
+        for procedure_meta in self.inflight_procedures.iter() {
+            let procedure_id = procedure_meta.procedure_id;
+            let group_id = procedure_meta.group_id;
+            let Some(mut receiver) = procedure_ctx
+                .provider
+                .procedure_state_receiver(procedure_id)
+                .await
+                .context(RepartitionSubprocedureStateReceiverSnafu { procedure_id })?
+            else {
+                error!(
+                    "failed to get procedure state receiver, procedure_id: {}, group_id: {}",
+                    procedure_id, group_id
+                );
+                self.unknown_procedures.push(*procedure_meta);
+                continue;
+            };
+
+            match watcher::wait(&mut receiver).await {
+                Ok(_) => self.succeeded_procedures.push(*procedure_meta),
+                Err(e) => {
+                    error!(e; "failed to wait for repartition subprocedure, procedure_id: {}, group_id: {}", procedure_id, group_id);
+                    self.failed_procedures.push(*procedure_meta);
+                }
+            }
+        }
+
+        if !self.failed_procedures.is_empty() || !self.unknown_procedures.is_empty() {
+            // TODO(weny): retry the failed or unknown procedures.
+        }
+
+        Ok((Box::new(DeallocateRegion), Status::executing(true)))
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/src/meta-srv/src/procedure/repartition/deallocate_region.rs
+++ b/src/meta-srv/src/procedure/repartition/deallocate_region.rs
@@ -1,0 +1,52 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+
+use common_procedure::{Context as ProcedureContext, Status};
+use serde::{Deserialize, Serialize};
+
+use crate::error::Result;
+use crate::procedure::repartition::repartition_end::RepartitionEnd;
+use crate::procedure::repartition::{Context, State};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeallocateRegion;
+
+#[async_trait::async_trait]
+#[typetag::serde]
+impl State for DeallocateRegion {
+    async fn next(
+        &mut self,
+        ctx: &mut Context,
+        _procedure_ctx: &ProcedureContext,
+    ) -> Result<(Box<dyn State>, Status)> {
+        let region_to_deallocate = ctx
+            .persistent_ctx
+            .plans
+            .iter()
+            .map(|p| p.pending_deallocate_region_ids.len())
+            .sum::<usize>();
+        if region_to_deallocate == 0 {
+            return Ok((Box::new(RepartitionEnd), Status::done()));
+        }
+
+        // TODO(weny): deallocate regions.
+        todo!()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/src/meta-srv/src/procedure/repartition/dispatch.rs
+++ b/src/meta-srv/src/procedure/repartition/dispatch.rs
@@ -1,0 +1,66 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+
+use common_procedure::{Context as ProcedureContext, ProcedureWithId, Status};
+use serde::{Deserialize, Serialize};
+
+use crate::error::Result;
+use crate::procedure::repartition::collect::{Collect, ProcedureMeta};
+use crate::procedure::repartition::group::RepartitionGroupProcedure;
+use crate::procedure::repartition::{self, Context, State};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Dispatch;
+
+#[async_trait::async_trait]
+#[typetag::serde]
+impl State for Dispatch {
+    async fn next(
+        &mut self,
+        ctx: &mut Context,
+        _procedure_ctx: &ProcedureContext,
+    ) -> Result<(Box<dyn State>, Status)> {
+        let table_id = ctx.persistent_ctx.table_id;
+        let mut procedures = Vec::with_capacity(ctx.persistent_ctx.plans.len());
+        let mut procedure_metas = Vec::with_capacity(ctx.persistent_ctx.plans.len());
+        for (plan_index, plan) in ctx.persistent_ctx.plans.iter().enumerate() {
+            let persistent_ctx = repartition::group::PersistentContext::new(
+                plan.group_id,
+                table_id,
+                plan.source_regions.clone(),
+                plan.target_regions.clone(),
+            );
+
+            let group_procedure = RepartitionGroupProcedure::new(persistent_ctx, ctx);
+            let procedure = ProcedureWithId::with_random_id(Box::new(group_procedure));
+            procedure_metas.push(ProcedureMeta {
+                plan_index,
+                group_id: plan.group_id,
+                procedure_id: procedure.id,
+            });
+            procedures.push(procedure);
+        }
+
+        Ok((
+            Box::new(Collect::new(procedure_metas)),
+            Status::suspended(procedures, true),
+        ))
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/src/meta-srv/src/procedure/repartition/repartition_end.rs
+++ b/src/meta-srv/src/procedure/repartition/repartition_end.rs
@@ -1,0 +1,40 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+
+use common_procedure::{Context as ProcedureContext, Status};
+use serde::{Deserialize, Serialize};
+
+use crate::error::Result;
+use crate::procedure::repartition::{Context, State};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RepartitionEnd;
+
+#[async_trait::async_trait]
+#[typetag::serde]
+impl State for RepartitionEnd {
+    async fn next(
+        &mut self,
+        _ctx: &mut Context,
+        _procedure_ctx: &ProcedureContext,
+    ) -> Result<(Box<dyn State>, Status)> {
+        Ok((Box::new(RepartitionEnd), Status::done()))
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/src/meta-srv/src/procedure/repartition/repartition_start.rs
+++ b/src/meta-srv/src/procedure/repartition/repartition_start.rs
@@ -1,0 +1,172 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+
+use common_meta::key::table_route::PhysicalTableRouteValue;
+use common_procedure::{Context as ProcedureContext, Status};
+use partition::expr::PartitionExpr;
+use partition::subtask::{self, RepartitionSubtask};
+use serde::{Deserialize, Serialize};
+use snafu::{OptionExt, ResultExt};
+use uuid::Uuid;
+
+use crate::error::{self, Result};
+use crate::procedure::repartition::allocate_region::AllocateRegion;
+use crate::procedure::repartition::plan::{AllocationPlanEntry, RegionDescriptor};
+use crate::procedure::repartition::repartition_end::RepartitionEnd;
+use crate::procedure::repartition::{Context, State};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RepartitionStart {
+    from_exprs: Vec<PartitionExpr>,
+    to_exprs: Vec<PartitionExpr>,
+}
+
+impl RepartitionStart {
+    pub fn new(from_exprs: Vec<PartitionExpr>, to_exprs: Vec<PartitionExpr>) -> Self {
+        Self {
+            from_exprs,
+            to_exprs,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+#[typetag::serde]
+impl State for RepartitionStart {
+    async fn next(
+        &mut self,
+        ctx: &mut Context,
+        _: &ProcedureContext,
+    ) -> Result<(Box<dyn State>, Status)> {
+        let (_, table_route) = ctx
+            .table_metadata_manager
+            .table_route_manager()
+            .get_physical_table_route(ctx.persistent_ctx.table_id)
+            .await
+            .context(error::TableMetadataManagerSnafu)?;
+
+        let plans = Self::build_plan(&table_route, &self.from_exprs, &self.to_exprs)?;
+
+        if plans.is_empty() {
+            return Ok((Box::new(RepartitionEnd), Status::done()));
+        }
+
+        Ok((
+            Box::new(AllocateRegion::new(plans)),
+            Status::executing(false),
+        ))
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+impl RepartitionStart {
+    #[allow(dead_code)]
+    fn build_plan(
+        physical_route: &PhysicalTableRouteValue,
+        from_exprs: &[PartitionExpr],
+        to_exprs: &[PartitionExpr],
+    ) -> Result<Vec<AllocationPlanEntry>> {
+        let subtasks = subtask::create_subtasks(from_exprs, to_exprs)
+            .context(error::RepartitionCreateSubtasksSnafu)?;
+        if subtasks.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let src_descriptors = Self::source_region_descriptors(from_exprs, physical_route)?;
+        Ok(Self::build_plan_entries(
+            subtasks,
+            &src_descriptors,
+            to_exprs,
+        ))
+    }
+
+    #[allow(dead_code)]
+    fn build_plan_entries(
+        subtasks: Vec<RepartitionSubtask>,
+        source_index: &[RegionDescriptor],
+        target_exprs: &[PartitionExpr],
+    ) -> Vec<AllocationPlanEntry> {
+        subtasks
+            .into_iter()
+            .map(|subtask| {
+                let group_id = Uuid::new_v4();
+                let source_regions = subtask
+                    .from_expr_indices
+                    .iter()
+                    .map(|&idx| source_index[idx].clone())
+                    .collect::<Vec<_>>();
+
+                let target_partition_exprs = subtask
+                    .to_expr_indices
+                    .iter()
+                    .map(|&idx| target_exprs[idx].clone())
+                    .collect::<Vec<_>>();
+                let regions_to_allocate = target_partition_exprs
+                    .len()
+                    .saturating_sub(source_regions.len());
+                let regions_to_deallocate = source_regions
+                    .len()
+                    .saturating_sub(target_partition_exprs.len());
+                AllocationPlanEntry {
+                    group_id,
+                    source_regions,
+                    target_partition_exprs,
+                    regions_to_allocate,
+                    regions_to_deallocate,
+                }
+            })
+            .collect::<Vec<_>>()
+    }
+
+    fn source_region_descriptors(
+        from_exprs: &[PartitionExpr],
+        physical_route: &PhysicalTableRouteValue,
+    ) -> Result<Vec<RegionDescriptor>> {
+        let existing_regions = physical_route
+            .region_routes
+            .iter()
+            .map(|route| (route.region.id, route.region.partition_expr()))
+            .collect::<Vec<_>>();
+
+        let descriptors = from_exprs
+            .iter()
+            .map(|expr| {
+                let expr_json = expr
+                    .as_json_str()
+                    .context(error::SerializePartitionExprSnafu)?;
+
+                let matched_region_id = existing_regions
+                    .iter()
+                    .find_map(|(region_id, existing_expr)| {
+                        (existing_expr == &expr_json).then_some(*region_id)
+                    })
+                    .with_context(|| error::RepartitionSourceExprMismatchSnafu {
+                        expr: expr_json,
+                    })?;
+
+                Ok(RegionDescriptor {
+                    region_id: matched_region_id,
+                    partition_expr: expr.clone(),
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(descriptors)
+    }
+}

--- a/src/partition/src/subtask.rs
+++ b/src/partition/src/subtask.rs
@@ -303,4 +303,43 @@ mod tests {
         let subtasks = create_subtasks(&from, &to).unwrap();
         assert!(subtasks.is_empty());
     }
+
+    #[test]
+    fn test_three_components() {
+        // Left: A:[0,10), B:[20,30), C:[40,50)
+        let from = vec![
+            col("x")
+                .gt_eq(Value::Int64(0))
+                .and(col("x").lt(Value::Int64(10))),
+            col("x")
+                .gt_eq(Value::Int64(20))
+                .and(col("x").lt(Value::Int64(30))),
+            col("x")
+                .gt_eq(Value::Int64(40))
+                .and(col("x").lt(Value::Int64(50))),
+        ];
+        // Right: A:[0,10), B:[20,30), C:[40,60)
+        let to = vec![
+            col("x")
+                .gt_eq(Value::Int64(0))
+                .and(col("x").lt(Value::Int64(10))),
+            col("x")
+                .gt_eq(Value::Int64(20))
+                .and(col("x").lt(Value::Int64(30))),
+            col("x")
+                .gt_eq(Value::Int64(40))
+                .and(col("x").lt(Value::Int64(60))),
+        ];
+        let subtasks = create_subtasks(&from, &to).unwrap();
+        assert_eq!(subtasks.len(), 3);
+        assert_eq!(subtasks[0].from_expr_indices, vec![0]);
+        assert_eq!(subtasks[0].to_expr_indices, vec![0]);
+        assert_eq!(subtasks[0].transition_map, vec![vec![0]]);
+        assert_eq!(subtasks[1].from_expr_indices, vec![1]);
+        assert_eq!(subtasks[1].to_expr_indices, vec![1]);
+        assert_eq!(subtasks[1].transition_map, vec![vec![1]]);
+        assert_eq!(subtasks[2].from_expr_indices, vec![2]);
+        assert_eq!(subtasks[2].to_expr_indices, vec![2]);
+        assert_eq!(subtasks[2].transition_map, vec![vec![2]]);
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#6558 

## What's changed and what's your intention?

This PR adds the skeleton for the repartition procedure in meta-srv. The basic state machine and data structures are in place, with some implementation details to be completed in follow-up PRs.

## Changes

### Repartition Procedure States

Added the state machine skeleton with the following states:

- **RepartitionStart**: Builds the repartition plan from partition expressions
- **AllocateRegion**: Placeholder for region allocation logic
- **DispatchGroup**: Dispatches sub-procedures for each repartition group
- **CollectGroup**: Collects results from dispatched group sub-procedures
- **DeallocateRegion**: Placeholder for region deallocation logic
- **RepartitionEnd**: Final state

### Data Structures

- `AllocationPlanEntry`: Plan entry for the region allocation phase
- `RepartitionPlanEntry`: Plan entry for the dispatch phase
- `RepartitionGroupProcedure`: Sub-procedure for handling group-level repartitioning

### Error Types

- `RepartitionCreateSubtasks`
- `RepartitionSourceExprMismatch`
- `RepartitionSubprocedureStateReceiver`

## TODOs

The following will be implemented in follow-up PRs:

- Region allocation logic in `AllocateRegion`
- Region deallocation logic in `DeallocateRegion`
- `RepartitionGroupProcedure` execute/rollback/dump/lock_key implementation

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
