### PR TITLE
refactor(mito2): make MemtableStats fields public

### DIFF
--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -136,18 +136,18 @@ impl RangesOptions {
 #[derive(Debug, Default, Clone)]
 pub struct MemtableStats {
     /// The estimated bytes allocated by this memtable from heap.
-    estimated_bytes: usize,
+    pub estimated_bytes: usize,
     /// The inclusive time range that this memtable contains. It is None if
     /// and only if the memtable is empty.
-    time_range: Option<(Timestamp, Timestamp)>,
+    pub time_range: Option<(Timestamp, Timestamp)>,
     /// Total rows in memtable
     pub num_rows: usize,
     /// Total number of ranges in the memtable.
     pub num_ranges: usize,
     /// The maximum sequence number in the memtable.
-    max_sequence: SequenceNumber,
+    pub max_sequence: SequenceNumber,
     /// Number of estimated timeseries in memtable.
-    series_count: usize,
+    pub series_count: usize,
 }
 
 impl MemtableStats {


### PR DESCRIPTION

I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
Change visibility of estimated_bytes, time_range, max_sequence, and series_count fields from private to public for external access.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
