### PR TITLE
feat: repartition grammar candy

### DIFF
--- a/src/sql/src/parsers/alter_parser.rs
+++ b/src/sql/src/parsers/alter_parser.rs
@@ -229,7 +229,7 @@ impl ParserContext<'_> {
         }
 
         self.parser
-            .expect_keyword(Keyword::TO)
+            .expect_keyword(Keyword::INTO)
             .context(error::SyntaxSnafu)?;
         let into_exprs = self.parse_repartition_expr_list()?;
 
@@ -977,7 +977,7 @@ ALTER TABLE t REPARTITION (
         let sql = r#"
 ALTER TABLE metrics SPLIT PARTITION (
   device_id < 100
-) TO (
+) INTO (
   device_id < 100 AND area < 'South',
   device_id < 100 AND area >= 'South'
 );"#;

--- a/tests/cases/standalone/common/alter/repartition.result
+++ b/tests/cases/standalone/common/alter/repartition.result
@@ -25,7 +25,7 @@ Error: 1001(Unsupported), Not supported: ALTER TABLE REPARTITION
 -- valid grammar, currently not implemented
 ALTER TABLE alter_repartition_table SPLIT PARTITION (
   device_id < 100
-) TO (
+) INTO (
   device_id < 100 AND area < 'South',
   device_id < 100 AND area >= 'South'
 );

--- a/tests/cases/standalone/common/alter/repartition.sql
+++ b/tests/cases/standalone/common/alter/repartition.sql
@@ -21,7 +21,7 @@ ALTER TABLE alter_repartition_table REPARTITION (
 -- valid grammar, currently not implemented
 ALTER TABLE alter_repartition_table SPLIT PARTITION (
   device_id < 100
-) TO (
+) INTO (
   device_id < 100 AND area < 'South',
   device_id < 100 AND area >= 'South'
 );


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


Wrap two grammar candies for `ALTER TABLE REPARTITION` grammar, for split and merge specifically.

```sql
ALTER TABLE <table> SPLIT PARTITION (<partition_expr>) TO (<partition_expr_list>);
ALTER TABLE <table> MERGE PARTITION (<partition_expr_list>);
```

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
