### PR TITLE
fix: fix SQL table identifier quoting for election

### DIFF
--- a/src/common/meta/src/kv_backend/rds/mysql.rs
+++ b/src/common/meta/src/kv_backend/rds/mysql.rs
@@ -613,7 +613,7 @@ mod tests {
     #[tokio::test]
     async fn test_mysql_put() {
         maybe_skip_mysql_integration_test!();
-        let kv_backend = build_mysql_kv_backend("put_test").await.unwrap();
+        let kv_backend = build_mysql_kv_backend("put-test").await.unwrap();
         let prefix = b"put/";
         prepare_kv_with_prefix(&kv_backend, prefix.to_vec()).await;
         test_kv_put_with_prefix(&kv_backend, prefix.to_vec()).await;
@@ -623,7 +623,7 @@ mod tests {
     #[tokio::test]
     async fn test_mysql_range() {
         maybe_skip_mysql_integration_test!();
-        let kv_backend = build_mysql_kv_backend("range_test").await.unwrap();
+        let kv_backend = build_mysql_kv_backend("range-test").await.unwrap();
         let prefix = b"range/";
         prepare_kv_with_prefix(&kv_backend, prefix.to_vec()).await;
         test_kv_range_with_prefix(&kv_backend, prefix.to_vec()).await;
@@ -633,7 +633,7 @@ mod tests {
     #[tokio::test]
     async fn test_mysql_range_2() {
         maybe_skip_mysql_integration_test!();
-        let kv_backend = build_mysql_kv_backend("range2_test").await.unwrap();
+        let kv_backend = build_mysql_kv_backend("range2-test").await.unwrap();
         let prefix = b"range2/";
         test_kv_range_2_with_prefix(&kv_backend, prefix.to_vec()).await;
         unprepare_kv(&kv_backend, prefix).await;
@@ -642,7 +642,7 @@ mod tests {
     #[tokio::test]
     async fn test_mysql_all_range() {
         maybe_skip_mysql_integration_test!();
-        let kv_backend = build_mysql_kv_backend("simple_range_test").await.unwrap();
+        let kv_backend = build_mysql_kv_backend("simple_range-test").await.unwrap();
         let prefix = b"";
         prepare_kv_with_prefix(&kv_backend, prefix.to_vec()).await;
         test_simple_kv_range(&kv_backend).await;
@@ -652,7 +652,7 @@ mod tests {
     #[tokio::test]
     async fn test_mysql_batch_get() {
         maybe_skip_mysql_integration_test!();
-        let kv_backend = build_mysql_kv_backend("batch_get_test").await.unwrap();
+        let kv_backend = build_mysql_kv_backend("batch_get-test").await.unwrap();
         let prefix = b"batch_get/";
         prepare_kv_with_prefix(&kv_backend, prefix.to_vec()).await;
         test_kv_batch_get_with_prefix(&kv_backend, prefix.to_vec()).await;
@@ -662,7 +662,7 @@ mod tests {
     #[tokio::test]
     async fn test_mysql_batch_delete() {
         maybe_skip_mysql_integration_test!();
-        let kv_backend = build_mysql_kv_backend("batch_delete_test").await.unwrap();
+        let kv_backend = build_mysql_kv_backend("batch_delete-test").await.unwrap();
         let prefix = b"batch_delete/";
         prepare_kv_with_prefix(&kv_backend, prefix.to_vec()).await;
         test_kv_delete_range_with_prefix(&kv_backend, prefix.to_vec()).await;
@@ -672,7 +672,7 @@ mod tests {
     #[tokio::test]
     async fn test_mysql_batch_delete_with_prefix() {
         maybe_skip_mysql_integration_test!();
-        let kv_backend = build_mysql_kv_backend("batch_delete_with_prefix_test")
+        let kv_backend = build_mysql_kv_backend("batch_delete_with_prefix-test")
             .await
             .unwrap();
         let prefix = b"batch_delete/";
@@ -684,7 +684,7 @@ mod tests {
     #[tokio::test]
     async fn test_mysql_delete_range() {
         maybe_skip_mysql_integration_test!();
-        let kv_backend = build_mysql_kv_backend("delete_range_test").await.unwrap();
+        let kv_backend = build_mysql_kv_backend("delete_range-test").await.unwrap();
         let prefix = b"delete_range/";
         prepare_kv_with_prefix(&kv_backend, prefix.to_vec()).await;
         test_kv_delete_range_with_prefix(&kv_backend, prefix.to_vec()).await;
@@ -694,7 +694,7 @@ mod tests {
     #[tokio::test]
     async fn test_mysql_compare_and_put() {
         maybe_skip_mysql_integration_test!();
-        let kv_backend = build_mysql_kv_backend("compare_and_put_test")
+        let kv_backend = build_mysql_kv_backend("compare_and_put-test")
             .await
             .unwrap();
         let prefix = b"compare_and_put/";
@@ -705,7 +705,7 @@ mod tests {
     #[tokio::test]
     async fn test_mysql_txn() {
         maybe_skip_mysql_integration_test!();
-        let kv_backend = build_mysql_kv_backend("txn_test").await.unwrap();
+        let kv_backend = build_mysql_kv_backend("txn-test").await.unwrap();
         test_txn_one_compare_op(&kv_backend).await;
         text_txn_multi_compare_op(&kv_backend).await;
         test_txn_compare_equal(&kv_backend).await;

--- a/src/common/meta/src/kv_backend/rds/postgres.rs
+++ b/src/common/meta/src/kv_backend/rds/postgres.rs
@@ -1105,7 +1105,7 @@ mod tests {
     #[tokio::test]
     async fn test_pg_put() {
         maybe_skip_postgres_integration_test!();
-        let kv_backend = build_pg_kv_backend("put_test").await.unwrap();
+        let kv_backend = build_pg_kv_backend("put-test").await.unwrap();
         let prefix = b"put/";
         prepare_kv_with_prefix(&kv_backend, prefix.to_vec()).await;
         test_kv_put_with_prefix(&kv_backend, prefix.to_vec()).await;
@@ -1115,7 +1115,7 @@ mod tests {
     #[tokio::test]
     async fn test_pg_range() {
         maybe_skip_postgres_integration_test!();
-        let kv_backend = build_pg_kv_backend("range_test").await.unwrap();
+        let kv_backend = build_pg_kv_backend("range-test").await.unwrap();
         let prefix = b"range/";
         prepare_kv_with_prefix(&kv_backend, prefix.to_vec()).await;
         test_kv_range_with_prefix(&kv_backend, prefix.to_vec()).await;
@@ -1125,7 +1125,7 @@ mod tests {
     #[tokio::test]
     async fn test_pg_range_2() {
         maybe_skip_postgres_integration_test!();
-        let kv_backend = build_pg_kv_backend("range2_test").await.unwrap();
+        let kv_backend = build_pg_kv_backend("range2-test").await.unwrap();
         let prefix = b"range2/";
         test_kv_range_2_with_prefix(&kv_backend, prefix.to_vec()).await;
         unprepare_kv(&kv_backend, prefix).await;
@@ -1134,7 +1134,7 @@ mod tests {
     #[tokio::test]
     async fn test_pg_all_range() {
         maybe_skip_postgres_integration_test!();
-        let kv_backend = build_pg_kv_backend("simple_range_test").await.unwrap();
+        let kv_backend = build_pg_kv_backend("simple_range-test").await.unwrap();
         let prefix = b"";
         prepare_kv_with_prefix(&kv_backend, prefix.to_vec()).await;
         test_simple_kv_range(&kv_backend).await;
@@ -1144,7 +1144,7 @@ mod tests {
     #[tokio::test]
     async fn test_pg_batch_get() {
         maybe_skip_postgres_integration_test!();
-        let kv_backend = build_pg_kv_backend("batch_get_test").await.unwrap();
+        let kv_backend = build_pg_kv_backend("batch_get-test").await.unwrap();
         let prefix = b"batch_get/";
         prepare_kv_with_prefix(&kv_backend, prefix.to_vec()).await;
         test_kv_batch_get_with_prefix(&kv_backend, prefix.to_vec()).await;
@@ -1154,7 +1154,7 @@ mod tests {
     #[tokio::test]
     async fn test_pg_batch_delete() {
         maybe_skip_postgres_integration_test!();
-        let kv_backend = build_pg_kv_backend("batch_delete_test").await.unwrap();
+        let kv_backend = build_pg_kv_backend("batch_delete-test").await.unwrap();
         let prefix = b"batch_delete/";
         prepare_kv_with_prefix(&kv_backend, prefix.to_vec()).await;
         test_kv_delete_range_with_prefix(&kv_backend, prefix.to_vec()).await;
@@ -1164,7 +1164,7 @@ mod tests {
     #[tokio::test]
     async fn test_pg_batch_delete_with_prefix() {
         maybe_skip_postgres_integration_test!();
-        let kv_backend = build_pg_kv_backend("batch_delete_with_prefix_test")
+        let kv_backend = build_pg_kv_backend("batch_delete_with_prefix-test")
             .await
             .unwrap();
         let prefix = b"batch_delete/";
@@ -1176,7 +1176,7 @@ mod tests {
     #[tokio::test]
     async fn test_pg_delete_range() {
         maybe_skip_postgres_integration_test!();
-        let kv_backend = build_pg_kv_backend("delete_range_test").await.unwrap();
+        let kv_backend = build_pg_kv_backend("delete_range-test").await.unwrap();
         let prefix = b"delete_range/";
         prepare_kv_with_prefix(&kv_backend, prefix.to_vec()).await;
         test_kv_delete_range_with_prefix(&kv_backend, prefix.to_vec()).await;
@@ -1186,7 +1186,7 @@ mod tests {
     #[tokio::test]
     async fn test_pg_compare_and_put() {
         maybe_skip_postgres_integration_test!();
-        let kv_backend = build_pg_kv_backend("compare_and_put_test").await.unwrap();
+        let kv_backend = build_pg_kv_backend("compare_and_put-test").await.unwrap();
         let prefix = b"compare_and_put/";
         let kv_backend = Arc::new(kv_backend);
         test_kv_compare_and_put_with_prefix(kv_backend.clone(), prefix.to_vec()).await;
@@ -1195,7 +1195,7 @@ mod tests {
     #[tokio::test]
     async fn test_pg_txn() {
         maybe_skip_postgres_integration_test!();
-        let kv_backend = build_pg_kv_backend("txn_test").await.unwrap();
+        let kv_backend = build_pg_kv_backend("txn-test").await.unwrap();
         test_txn_one_compare_op(&kv_backend).await;
         text_txn_multi_compare_op(&kv_backend).await;
         test_txn_compare_equal(&kv_backend).await;

--- a/src/meta-srv/src/election/rds/mysql.rs
+++ b/src/meta-srv/src/election/rds/mysql.rs
@@ -149,7 +149,7 @@ impl<'a> ElectionSqlFactory<'a> {
     }
 
     fn delete_value_sql(&self) -> String {
-        format!("DELETE FROM {} WHERE k = ?;", self.table_name)
+        format!("DELETE FROM `{}` WHERE k = ?;", self.table_name)
     }
 }
 
@@ -1014,7 +1014,7 @@ mod tests {
             execution_timeout,
             Duration::from_secs(1),
             wait_timeout,
-            table_name.unwrap_or("default_greptime_metakv_election"),
+            table_name.unwrap_or("default_greptime_metakv-election"),
         );
         client.maybe_init_client().await?;
         if table_name.is_some() {
@@ -1025,7 +1025,7 @@ mod tests {
 
     async fn drop_table(client: &Mutex<ElectionMysqlClient>, table_name: &str) {
         let mut client = client.lock().await;
-        let sql = format!("DROP TABLE IF EXISTS {};", table_name);
+        let sql = format!("DROP TABLE IF EXISTS `{}`;", table_name);
         client.execute(sqlx::query(&sql), &sql).await.unwrap();
     }
 
@@ -1036,7 +1036,7 @@ mod tests {
         let value = "test_value".to_string();
 
         let uuid = uuid::Uuid::new_v4().to_string();
-        let table_name = "test_mysql_crud_greptime_metakv";
+        let table_name = "test_mysql_crud_greptime-metakv";
         let candidate_lease_ttl = Duration::from_secs(10);
         let meta_lease_ttl = Duration::from_secs(2);
 
@@ -1050,7 +1050,7 @@ mod tests {
             let mut a = client.lock().await;
             let txn = a.transaction().await.unwrap();
             let mut executor = Executor::Txn(txn);
-            let raw_query = format!("SELECT * FROM {} FOR UPDATE;", table_name);
+            let raw_query = format!("SELECT * FROM `{}` FOR UPDATE;", table_name);
             let query = sqlx::query(&raw_query);
             let _ = executor.query(query, &raw_query).await.unwrap();
         }
@@ -1186,7 +1186,7 @@ mod tests {
         let meta_lease_ttl = Duration::from_secs(2);
         let idle_session_timeout = Duration::from_secs(0);
         let uuid = uuid::Uuid::new_v4().to_string();
-        let table_name = "test_candidate_registration_greptime_metakv";
+        let table_name = "test_candidate_registration_greptime-metakv";
         let mut handles = vec![];
         let client = create_mysql_client(Some(table_name), execution_timeout, idle_session_timeout)
             .await
@@ -1256,7 +1256,7 @@ mod tests {
         let mut client = election.client.lock().await;
         let txn = client.transaction().await.unwrap();
         let mut executor = Executor::Txn(txn);
-        let raw_query = format!("SELECT * FROM {} FOR UPDATE;", table_name);
+        let raw_query = format!("SELECT * FROM `{}` FOR UPDATE;", table_name);
         let query = sqlx::query(&raw_query);
         let _ = executor.query(query, &raw_query).await.unwrap();
         election.elected(executor, expected_lease).await
@@ -1280,7 +1280,7 @@ mod tests {
         let execution_timeout = Duration::from_secs(10);
         let idle_session_timeout = Duration::from_secs(0);
         let uuid = uuid::Uuid::new_v4().to_string();
-        let table_name = "test_elected_failed_greptime_metakv";
+        let table_name = "test_elected_failed_greptime-metakv";
         let client = create_mysql_client(Some(table_name), execution_timeout, idle_session_timeout)
             .await
             .unwrap();
@@ -1313,7 +1313,7 @@ mod tests {
         maybe_skip_mysql_integration_test!();
         let leader_value = "test_leader".to_string();
         let uuid = uuid::Uuid::new_v4().to_string();
-        let table_name = "test_reelection_greptime_metakv";
+        let table_name = "test_reelection_greptime-metakv";
         let candidate_lease_ttl = Duration::from_secs(5);
         let meta_lease_ttl = Duration::from_secs(5);
         let execution_timeout = Duration::from_secs(10);
@@ -1381,7 +1381,7 @@ mod tests {
         let execution_timeout = Duration::from_secs(10);
         let idle_session_timeout = Duration::from_secs(0);
         let uuid = uuid::Uuid::new_v4().to_string();
-        let table_name = "test_elected_and_step_down_greptime_metakv";
+        let table_name = "test_elected_and_step_down_greptime-metakv";
         let client = create_mysql_client(Some(table_name), execution_timeout, idle_session_timeout)
             .await
             .unwrap();
@@ -1470,7 +1470,7 @@ mod tests {
         maybe_skip_mysql_integration_test!();
         let leader_value = "test_leader".to_string();
         let uuid = uuid::Uuid::new_v4().to_string();
-        let table_name = "test_leader_action_greptime_metakv";
+        let table_name = "test_leader_action_greptime-metakv";
         let candidate_lease_ttl = Duration::from_secs(5);
         let meta_lease_ttl = Duration::from_secs(2);
         let execution_timeout = Duration::from_secs(10);
@@ -1657,7 +1657,7 @@ mod tests {
         common_telemetry::init_default_ut_logging();
         let leader_value = "test_leader".to_string();
         let uuid = uuid::Uuid::new_v4().to_string();
-        let table_name = "test_reset_campaign_greptime_metakv";
+        let table_name = "test_reset_campaign_greptime-metakv";
         let candidate_lease_ttl = Duration::from_secs(5);
         let meta_lease_ttl = Duration::from_secs(2);
         let execution_timeout = Duration::from_secs(10);
@@ -1695,7 +1695,7 @@ mod tests {
         let execution_timeout = Duration::from_secs(10);
         let idle_session_timeout = Duration::from_secs(0);
         let uuid = uuid::Uuid::new_v4().to_string();
-        let table_name = "test_follower_action_greptime_metakv";
+        let table_name = "test_follower_action_greptime-metakv";
 
         let follower_client =
             create_mysql_client(Some(table_name), execution_timeout, idle_session_timeout)


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#7532

## What's changed and what's your intention?

Fix SQL identifier quoting for election to handle table names with special characters (e.g., hyphens).

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
