### PR TITLE
perf: avoid boundary checks on accessing array items

### DIFF
--- a/src/common/function/src/aggrs/count_hash.rs
+++ b/src/common/function/src/aggrs/count_hash.rs
@@ -453,8 +453,8 @@ impl Accumulator for CountHashAccumulator {
                 );
             };
             let hash_array = inner_array.as_any().downcast_ref::<UInt64Array>().unwrap();
-            for i in 0..hash_array.len() {
-                self.values.insert(hash_array.value(i));
+            for &hash in hash_array.values().iter().take(hash_array.len()) {
+                self.values.insert(hash);
             }
         }
         Ok(())

--- a/src/common/function/src/aggrs/geo/encoding.rs
+++ b/src/common/function/src/aggrs/geo/encoding.rs
@@ -152,9 +152,9 @@ impl DfAccumulator for JsonEncodePathAccumulator {
         let lng_array = lng_array.as_primitive::<Float64Type>();
 
         let mut coords = Vec::with_capacity(len);
-        for i in 0..len {
-            let lng = lng_array.value(i);
-            let lat = lat_array.value(i);
+        let lng_values = lng_array.values();
+        let lat_values = lat_array.values();
+        for (&lng, &lat) in lng_values.iter().zip(lat_values.iter()).take(len) {
             coords.push(vec![lng, lat]);
         }
 

--- a/src/common/function/src/scalars/primary_key.rs
+++ b/src/common/function/src/scalars/primary_key.rs
@@ -208,9 +208,9 @@ fn decode_dictionary(
 
     let mut rows = Vec::with_capacity(number_rows);
     let keys = dict.keys();
-    for i in 0..number_rows {
-        let dict_index = keys.value(i) as usize;
-        rows.push(decoded_values[dict_index].clone());
+    let dict_indices = keys.values();
+    for &dict_index in dict_indices[..number_rows].iter() {
+        rows.push(decoded_values[dict_index as usize].clone());
     }
 
     Ok(rows)

--- a/src/mito2/src/sst/index.rs
+++ b/src/mito2/src/sst/index.rs
@@ -1174,9 +1174,8 @@ pub(crate) fn decode_primary_keys_with_counts(
     let mut result: Vec<(CompositeValues, usize)> = Vec::new();
     let mut prev_key: Option<u32> = None;
 
-    for i in 0..keys.len() {
-        let current_key = keys.value(i);
-
+    let pk_indices = keys.values();
+    for &current_key in pk_indices.iter().take(keys.len()) {
         // Checks if current key is the same as previous key
         if let Some(prev) = prev_key
             && prev == current_key

--- a/src/mito2/src/sst/parquet/flat_format.rs
+++ b/src/mito2/src/sst/parquet/flat_format.rs
@@ -563,9 +563,8 @@ pub(crate) fn decode_primary_keys(
 
     // The parquet reader may read the whole dictionary page into the dictionary values, so
     // we may decode many primary keys not in this batch if we decode the values array directly.
-    for i in 0..keys.len() {
-        let current_key = keys.value(i);
-
+    let pk_indices = keys.values();
+    for &current_key in pk_indices.iter().take(keys.len()) {
         // Check if current key is the same as previous key
         if let Some(prev) = prev_key
             && prev == current_key


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Some micro optimizations. Not benched.

`.value(i)` will have boundary checks on every call, replace it with `.values()` flavor can omit them.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
