### PR TITLE
ci: release only large page size binary for ARM platform

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,6 +209,7 @@ jobs:
           disable-run-tests: ${{ env.DISABLE_RUN_TESTS }}
           image-registry: ${{ vars.ECR_IMAGE_REGISTRY }}
           image-namespace: ${{ vars.ECR_IMAGE_NAMESPACE }}
+          large-page-size: true
 
   run-multi-lang-tests:
     name: Run Multi-language SDK Tests


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

close https://github.com/GreptimeTeam/greptimedb/issues/7572

example: https://github.com/GreptimeTeam/greptimedb/actions/runs/21247597723

## What's changed and what's your intention?

Make large page (page size = 64k) the default (and only) build artifact on ARM platform. 

As discussed offline, we generally believe that:

- building artifact with large page is a trend on ARM platform;
- large page binary can normally be ran in small page size (4k) OS, but not for the reverse case;
- it does more good than harm for a database product.

Hence this change.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
