### PR TITLE
refactor: use `ConfiguratorRegistry`

### DIFF
--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -29,7 +29,7 @@ use common_meta::kv_backend::memory::MemoryKvBackend;
 use common_meta::kv_backend::{KvBackendRef, ResettableKvBackendRef};
 use common_telemetry::info;
 use either::Either;
-use servers::configurator::{GrpcRouterConfigurator, GrpcRouterConfiguratorListRef};
+use servers::configurator::ConfiguratorRegistryRef;
 use servers::http::{HttpServer, HttpServerBuilder};
 use servers::metrics_handler::MetricsHandler;
 use servers::server::Server;
@@ -132,13 +132,9 @@ impl MetasrvInstance {
 
         // Start gRPC server with admin services for backward compatibility
         let mut router = router(self.metasrv.clone());
-        if let Some(configurators) = self
-            .metasrv
-            .plugins()
-            .get::<GrpcRouterConfiguratorListRef<()>>()
-        {
-            router = configurators
-                .configure_grpc_router(router, ())
+        if let Some(registry) = self.metasrv.plugins().get::<ConfiguratorRegistryRef>() {
+            router = registry
+                .configure_grpc_router(router)
                 .await
                 .context(OtherSnafu)?;
         }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Both the HTTP and the gRPC configurator only uses one implementation: multiple implementation would overwrite each other.
This PR mainly add a list struct for holding multiple configurators to be used during startup.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
