### PR TITLE
refactor: SQL and gRPC server handlers

### DIFF
--- a/docs/how-to/how-to-implement-sql-statement.md
+++ b/docs/how-to/how-to-implement-sql-statement.md
@@ -5,9 +5,11 @@ implemented `SqlQueryHandler`:
 
 ```rust
 impl SqlQueryHandler for Instance {
-    type Error = Error;
-
-    async fn do_query(&self, query: &str, query_ctx: QueryContextRef) -> Vec<Result<Output>> {
+    async fn do_query(
+        &self,
+        query: &str,
+        query_ctx: QueryContextRef,
+    ) -> Vec<servers::error::Result<Output>> {
         // ...
     }
 }

--- a/src/servers/src/query_handler/grpc.rs
+++ b/src/servers/src/query_handler/grpc.rs
@@ -18,96 +18,33 @@ use std::sync::Arc;
 use api::v1::greptime_request::Request;
 use async_trait::async_trait;
 use common_base::AffectedRows;
-use common_error::ext::{BoxedError, ErrorExt};
 use common_grpc::flight::do_put::DoPutResponse;
 use common_query::Output;
 use futures::Stream;
 use session::context::QueryContextRef;
-use snafu::ResultExt;
 use table::TableRef;
 
-use crate::error::{self, Result};
+use crate::error::Result;
 use crate::grpc::flight::{PutRecordBatchRequest, PutRecordBatchRequestStream};
 
-pub type GrpcQueryHandlerRef<E> = Arc<dyn GrpcQueryHandler<Error = E> + Send + Sync>;
-pub type ServerGrpcQueryHandlerRef = GrpcQueryHandlerRef<error::Error>;
+pub type ServerGrpcQueryHandlerRef = Arc<dyn GrpcQueryHandler + Send + Sync>;
 
 pub type RawRecordBatch = bytes::Bytes;
 
 #[async_trait]
 pub trait GrpcQueryHandler {
-    type Error: ErrorExt;
-
-    async fn do_query(
-        &self,
-        query: Request,
-        ctx: QueryContextRef,
-    ) -> std::result::Result<Output, Self::Error>;
+    async fn do_query(&self, query: Request, ctx: QueryContextRef) -> Result<Output>;
 
     async fn put_record_batch(
         &self,
         request: PutRecordBatchRequest,
         table_ref: &mut Option<TableRef>,
         ctx: QueryContextRef,
-    ) -> std::result::Result<AffectedRows, Self::Error>;
+    ) -> Result<AffectedRows>;
 
     fn handle_put_record_batch_stream(
         &self,
         stream: PutRecordBatchRequestStream,
         ctx: QueryContextRef,
-    ) -> Pin<Box<dyn Stream<Item = std::result::Result<DoPutResponse, Self::Error>> + Send>>;
-}
-
-pub struct ServerGrpcQueryHandlerAdapter<E>(GrpcQueryHandlerRef<E>);
-
-impl<E> ServerGrpcQueryHandlerAdapter<E> {
-    pub fn arc(handler: GrpcQueryHandlerRef<E>) -> Arc<Self> {
-        Arc::new(Self(handler))
-    }
-}
-
-#[async_trait]
-impl<E> GrpcQueryHandler for ServerGrpcQueryHandlerAdapter<E>
-where
-    E: ErrorExt + Send + Sync + 'static,
-{
-    type Error = error::Error;
-
-    async fn do_query(&self, query: Request, ctx: QueryContextRef) -> Result<Output> {
-        self.0
-            .do_query(query, ctx)
-            .await
-            .map_err(BoxedError::new)
-            .context(error::ExecuteGrpcQuerySnafu)
-    }
-
-    async fn put_record_batch(
-        &self,
-        request: PutRecordBatchRequest,
-        table_ref: &mut Option<TableRef>,
-        ctx: QueryContextRef,
-    ) -> Result<AffectedRows> {
-        self.0
-            .put_record_batch(request, table_ref, ctx)
-            .await
-            .map_err(BoxedError::new)
-            .context(error::ExecuteGrpcRequestSnafu)
-    }
-
-    fn handle_put_record_batch_stream(
-        &self,
-        stream: PutRecordBatchRequestStream,
-        ctx: QueryContextRef,
-    ) -> Pin<Box<dyn Stream<Item = Result<DoPutResponse>> + Send>> {
-        use futures_util::StreamExt;
-        Box::pin(
-            self.0
-                .handle_put_record_batch_stream(stream, ctx)
-                .map(|result| {
-                    result
-                        .map_err(|e| BoxedError::new(e))
-                        .context(error::ExecuteGrpcRequestSnafu)
-                }),
-        )
-    }
+    ) -> Pin<Box<dyn Stream<Item = Result<DoPutResponse>> + Send>>;
 }

--- a/src/servers/tests/http/influxdb_test.rs
+++ b/src/servers/tests/http/influxdb_test.rs
@@ -23,7 +23,7 @@ use common_test_util::ports;
 use datafusion_expr::LogicalPlan;
 use query::parser::PromQuery;
 use query::query_engine::DescribeResult;
-use servers::error::{Error, Result};
+use servers::error::Result;
 use servers::http::header::constants::GREPTIME_DB_HEADER_NAME;
 use servers::http::test_helpers::TestClient;
 use servers::http::{HttpOptions, HttpServerBuilder};
@@ -52,8 +52,6 @@ impl InfluxdbLineProtocolHandler for DummyInstance {
 
 #[async_trait]
 impl SqlQueryHandler for DummyInstance {
-    type Error = Error;
-
     async fn do_query(&self, _: &str, _: QueryContextRef) -> Vec<Result<Output>> {
         unimplemented!()
     }
@@ -63,15 +61,11 @@ impl SqlQueryHandler for DummyInstance {
         _stmt: Option<Statement>,
         _plan: LogicalPlan,
         _query_ctx: QueryContextRef,
-    ) -> std::result::Result<Output, Self::Error> {
+    ) -> Result<Output> {
         unimplemented!()
     }
 
-    async fn do_promql_query(
-        &self,
-        _: &PromQuery,
-        _: QueryContextRef,
-    ) -> Vec<std::result::Result<Output, Self::Error>> {
+    async fn do_promql_query(&self, _: &PromQuery, _: QueryContextRef) -> Vec<Result<Output>> {
         unimplemented!()
     }
 

--- a/src/servers/tests/http/opentsdb_test.rs
+++ b/src/servers/tests/http/opentsdb_test.rs
@@ -52,8 +52,6 @@ impl OpentsdbProtocolHandler for DummyInstance {
 
 #[async_trait]
 impl SqlQueryHandler for DummyInstance {
-    type Error = error::Error;
-
     async fn do_query(&self, _: &str, _: QueryContextRef) -> Vec<Result<Output>> {
         unimplemented!()
     }
@@ -63,15 +61,11 @@ impl SqlQueryHandler for DummyInstance {
         _stmt: Option<Statement>,
         _plan: LogicalPlan,
         _query_ctx: QueryContextRef,
-    ) -> std::result::Result<Output, Self::Error> {
+    ) -> Result<Output> {
         unimplemented!()
     }
 
-    async fn do_promql_query(
-        &self,
-        _: &PromQuery,
-        _: QueryContextRef,
-    ) -> Vec<std::result::Result<Output, Self::Error>> {
+    async fn do_promql_query(&self, _: &PromQuery, _: QueryContextRef) -> Vec<Result<Output>> {
         unimplemented!()
     }
 

--- a/src/servers/tests/http/prom_store_test.rs
+++ b/src/servers/tests/http/prom_store_test.rs
@@ -26,7 +26,7 @@ use datafusion_expr::LogicalPlan;
 use prost::Message;
 use query::parser::PromQuery;
 use query::query_engine::DescribeResult;
-use servers::error::{Error, Result};
+use servers::error::Result;
 use servers::http::header::{CONTENT_ENCODING_SNAPPY, CONTENT_TYPE_PROTOBUF};
 use servers::http::test_helpers::TestClient;
 use servers::http::{HttpOptions, HttpServerBuilder, PromValidationMode};
@@ -80,8 +80,6 @@ impl PromStoreProtocolHandler for DummyInstance {
 
 #[async_trait]
 impl SqlQueryHandler for DummyInstance {
-    type Error = Error;
-
     async fn do_query(&self, _: &str, _: QueryContextRef) -> Vec<Result<Output>> {
         unimplemented!()
     }
@@ -91,15 +89,11 @@ impl SqlQueryHandler for DummyInstance {
         _stmt: Option<Statement>,
         _plan: LogicalPlan,
         _query_ctx: QueryContextRef,
-    ) -> std::result::Result<Output, Self::Error> {
+    ) -> Result<Output> {
         unimplemented!()
     }
 
-    async fn do_promql_query(
-        &self,
-        _: &PromQuery,
-        _: QueryContextRef,
-    ) -> Vec<std::result::Result<Output, Self::Error>> {
+    async fn do_promql_query(&self, _: &PromQuery, _: QueryContextRef) -> Vec<Result<Output>> {
         unimplemented!()
     }
 

--- a/tests-integration/src/grpc/flight.rs
+++ b/tests-integration/src/grpc/flight.rs
@@ -35,7 +35,6 @@ mod test {
     use servers::grpc::builder::GrpcServerBuilder;
     use servers::grpc::greptime_handler::GreptimeRequestHandler;
     use servers::grpc::{FlightCompression, GrpcServerConfig};
-    use servers::query_handler::grpc::ServerGrpcQueryHandlerAdapter;
     use servers::server::Server;
 
     use crate::cluster::GreptimeDbClusterBuilder;
@@ -88,7 +87,7 @@ mod test {
 
         let runtime = common_runtime::global_runtime().clone();
         let greptime_request_handler = GreptimeRequestHandler::new(
-            ServerGrpcQueryHandlerAdapter::arc(db.frontend.instance.clone()),
+            db.frontend.instance.clone(),
             user_provider_from_option("static_user_provider:cmd:greptime_user=greptime_pwd").ok(),
             Some(runtime.clone()),
             FlightCompression::default(),

--- a/tests-integration/src/instance.rs
+++ b/tests-integration/src/instance.rs
@@ -23,13 +23,15 @@ mod tests {
     use client::OutputData;
     use common_base::Plugins;
     use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
+    use common_error::ext::ErrorExt;
+    use common_error::status_code::StatusCode;
     use common_meta::key::table_name::TableNameKey;
     use common_meta::rpc::router::region_distribution;
     use common_query::Output;
     use common_recordbatch::RecordBatches;
     use common_telemetry::debug;
     use datafusion_expr::LogicalPlan;
-    use frontend::error::{self, Error, Result};
+    use frontend::error::{Error, Result};
     use frontend::instance::Instance;
     use query::parser::QueryLanguageParser;
     use query::query_engine::DefaultSerializer;
@@ -443,7 +445,7 @@ mod tests {
             .await
             .remove(0)
         {
-            assert!(matches!(e, error::Error::NotSupported { .. }));
+            assert_eq!(e.status_code(), StatusCode::Unsupported);
         } else {
             unreachable!();
         }
@@ -453,7 +455,7 @@ mod tests {
             .await
             .remove(0)
         {
-            assert!(matches!(e, error::Error::NotSupported { .. }));
+            assert_eq!(e.status_code(), StatusCode::Unsupported);
         } else {
             unreachable!();
         }

--- a/tests-integration/src/tests/test_util.rs
+++ b/tests-integration/src/tests/test_util.rs
@@ -33,7 +33,6 @@ use common_wal::config::kafka::common::{KafkaConnectionConfig, KafkaTopicConfig}
 use common_wal::config::kafka::{DatanodeKafkaConfig, MetasrvKafkaConfig};
 use common_wal::config::{DatanodeWalConfig, MetasrvWalConfig};
 use datanode::datanode::Datanode;
-use frontend::error::Result;
 use frontend::instance::Instance;
 use futures::TryStreamExt;
 use meta_srv::metasrv::Metasrv;
@@ -439,7 +438,10 @@ pub fn find_testing_resource(path: &str) -> String {
     prepare_path(&p)
 }
 
-pub async fn try_execute_sql(instance: &Arc<Instance>, sql: &str) -> Result<Output> {
+pub async fn try_execute_sql(
+    instance: &Arc<Instance>,
+    sql: &str,
+) -> servers::error::Result<Output> {
     try_execute_sql_with(instance, sql, QueryContext::arc()).await
 }
 
@@ -447,7 +449,7 @@ pub async fn try_execute_sql_with(
     instance: &Arc<Instance>,
     sql: &str,
     query_ctx: QueryContextRef,
-) -> Result<Output> {
+) -> servers::error::Result<Output> {
     instance.do_query(sql, query_ctx).await.remove(0)
 }
 

--- a/tests-integration/tests/region_migration.rs
+++ b/tests-integration/tests/region_migration.rs
@@ -36,7 +36,6 @@ use common_wal::config::kafka::{DatanodeKafkaConfig, MetasrvKafkaConfig};
 use common_wal::config::{DatanodeWalConfig, MetasrvWalConfig};
 use datatypes::arrow::array::AsArray;
 use datatypes::arrow::datatypes::UInt64Type;
-use frontend::error::Result as FrontendResult;
 use frontend::instance::Instance;
 use futures::future::BoxFuture;
 use meta_srv::error;
@@ -52,6 +51,7 @@ use meta_srv::procedure::region_migration::{
 };
 use meta_srv::selector::{Selector, SelectorOptions};
 use sea_query::{Expr, Iden, Order, PostgresQueryBuilder, Query};
+use servers::error::Result as ServerResult;
 use servers::query_handler::sql::SqlQueryHandler;
 use session::context::{QueryContext, QueryContextRef};
 use store_api::storage::RegionId;
@@ -1258,7 +1258,7 @@ async fn query_procedure_by_sql(instance: &Arc<Instance>, pid: &str) -> String {
     column.value(0).to_string()
 }
 
-async fn insert_values(instance: &Arc<Instance>, ts: u64) -> Vec<FrontendResult<Output>> {
+async fn insert_values(instance: &Arc<Instance>, ts: u64) -> Vec<ServerResult<Output>> {
     let query_ctx = QueryContext::arc();
 
     let mut results = Vec::new();
@@ -1279,7 +1279,7 @@ async fn run_sql(
     instance: &Arc<Instance>,
     sql: &str,
     query_ctx: QueryContextRef,
-) -> FrontendResult<Output> {
+) -> ServerResult<Output> {
     info!("Run SQL: {sql}");
     instance.do_query(sql, query_ctx).await.remove(0)
 }

--- a/tests-integration/tests/repartition.rs
+++ b/tests-integration/tests/repartition.rs
@@ -23,11 +23,11 @@ use common_telemetry::info;
 use common_test_util::recordbatch::check_output_stream;
 use common_test_util::temp_dir::create_temp_dir;
 use common_wal::config::DatanodeWalConfig;
-use frontend::error::Result as FrontendResult;
 use frontend::instance::Instance;
 use meta_srv::gc::{self, BatchGcProcedure, GcSchedulerOptions, GcTickerRef};
 use meta_srv::metasrv::Metasrv;
 use mito2::gc::GcConfig;
+use servers::error::Result as ServerResult;
 use servers::query_handler::sql::SqlQueryHandler;
 use session::context::{QueryContext, QueryContextRef};
 use store_api::codec::PrimaryKeyEncoding;
@@ -867,7 +867,7 @@ async fn run_sql(
     instance: &Arc<Instance>,
     sql: &str,
     query_ctx: QueryContextRef,
-) -> FrontendResult<Output> {
+) -> ServerResult<Output> {
     info!("Run SQL: {sql}");
     instance.do_query(sql, query_ctx).await.remove(0)
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


Refactor `SqlQueryHandler` and `GrpcQueryHandler` to return `servers::error::Error` instead of associate type. Also remove `ServerSqlQueryHandlerAdapter` and `ServerGrpcQueryHandlerAdapter` correspondingly

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
