### PR TITLE
build(ci): respect skip test flag in nightly build ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,7 +213,7 @@ jobs:
 
   run-multi-lang-tests:
     name: Run Multi-language SDK Tests
-    if: ${{ env.DISABLE_RUN_TESTS == 'false' && (inputs.build_linux_artifacts || github.event_name == 'push' || github.event_name == 'schedule') }}
+    if: ${{ !(inputs.skip_test || vars.DEFAULT_SKIP_TEST == 'true') && (inputs.build_linux_artifacts || github.event_name == 'push' || github.event_name == 'schedule') }}
     needs: [
       allocate-runners,
       build-linux-amd64-artifacts,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


Failed case: https://github.com/GreptimeTeam/greptimedb/actions/runs/21436682130/job/61734881809

This patch only fixes the bug that "skip test" flag is not honored, but that failure itself still need to be fixed

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
