### PR TITLE
fix: send get file ref to all regions

### DIFF
--- a/src/common/meta/src/key/table_repart.rs
+++ b/src/common/meta/src/key/table_repart.rs
@@ -15,6 +15,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt::Display;
 
+use common_telemetry::debug;
 use futures::TryStreamExt;
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt as _, ResultExt, ensure};
@@ -356,8 +357,8 @@ impl TableRepartManager {
             return Ok(());
         }
 
-        if let Some(current) = current {
-            let (txn, _) = self.build_update_txn(table_id, &current, new_value)?;
+        if let Some(current) = &current {
+            let (txn, _) = self.build_update_txn(table_id, current, new_value)?;
             let result = self.kv_backend.txn(txn).await?;
 
             ensure!(
@@ -384,6 +385,10 @@ impl TableRepartManager {
             );
         }
 
+        debug!(
+            "Upserted repartition value for table {}: current: {:?}, new: {:?}",
+            table_id, current, new_value
+        );
         Ok(())
     }
 

--- a/src/mito2/src/gc.rs
+++ b/src/mito2/src/gc.rs
@@ -441,8 +441,8 @@ impl LocalGcWorker {
 
         let unused_file_cnt = deletable_files.len();
 
-        debug!(
-            "gc: for region{}{region_id}: In manifest files: {}, Tmp ref file cnt: {}, recently removed files: {}, Unused files to delete: {}",
+        info!(
+            "gc: for region{}{region_id}: In manifest file cnt: {}, Tmp ref file cnt: {}, recently removed files: {}, Unused files to delete: {:?}",
             if region.is_none() {
                 "(region dropped)"
             } else {
@@ -451,7 +451,7 @@ impl LocalGcWorker {
             current_files.map(|c| c.len()).unwrap_or(0),
             tmp_ref_files.len(),
             removed_file_cnt,
-            deletable_files.len()
+            &deletable_files,
         );
 
         debug!(


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

send get file ref request to all regions just in case, because the alternative is to maintain a super complex repartition mapping

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
