### PR TITLE
ci: upgrade GCC in centos dev-builder for cxx crate compatibility

### DIFF
--- a/docker/dev-builder/centos/Dockerfile
+++ b/docker/dev-builder/centos/Dockerfile
@@ -14,6 +14,22 @@ RUN yum install -y epel-release  \
     centos-release-scl  \
     which
 
+# Fix SCL repo URLs (also EOL, need to use vault.centos.org)
+# Install devtoolset-11 for GCC 11 (required for cxx crate which needs full C++11 support)
+# CentOS 7's default GCC 4.8 lacks std::is_trivially_* type traits
+RUN sed -i \
+        -e 's/mirror.centos.org/vault.centos.org/g' \
+        -e 's/^#.*baseurl=http/baseurl=http/g' \
+        -e 's/^mirrorlist=http/#mirrorlist=http/g' \
+        /etc/yum.repos.d/CentOS-SCLo-*.repo && \
+    yum install -y devtoolset-11-gcc devtoolset-11-gcc-c++ devtoolset-11-binutils && \
+    yum clean all
+
+# Set compiler environment variables for cc-rs/cxx crates
+ENV CC=/opt/rh/devtoolset-11/root/usr/bin/gcc
+ENV CXX=/opt/rh/devtoolset-11/root/usr/bin/g++
+ENV PATH=/opt/rh/devtoolset-11/root/usr/bin:$PATH
+
 # Install protoc
 ARG PROTOBUF_VERSION=29.3
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Fix ci failure https://github.com/GreptimeTeam/greptimedb/actions/runs/20292242704/job/58279106197

## What's changed and what's your intention?

Install devtoolset-11 to provide GCC 11 which has full C++11 support.
  
CentOS 7's default GCC 4.8 lacks std::is_trivially_* type traits, which are required by cxx crate (dependency of usearch for vector index).

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
