### PR TITLE
ci: remove db driver test from release as well

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,18 +211,6 @@ jobs:
           image-namespace: ${{ vars.ECR_IMAGE_NAMESPACE }}
           large-page-size: true
 
-  run-multi-lang-tests:
-    name: Run Multi-language SDK Tests
-    if: ${{ inputs.build_linux_artifacts || github.event_name == 'push' || github.event_name == 'schedule' }}
-    needs: [
-      allocate-runners,
-      build-linux-amd64-artifacts,
-    ]
-    uses: ./.github/workflows/run-multi-lang-tests.yml
-    with:
-      artifact-name: greptime-linux-amd64-${{ needs.allocate-runners.outputs.version }}
-      artifact-is-tarball: true
-
   build-macos-artifacts:
     name: Build macOS artifacts
     strategy:
@@ -311,7 +299,6 @@ jobs:
       allocate-runners,
       build-linux-amd64-artifacts,
       build-linux-arm64-artifacts,
-      run-multi-lang-tests,
     ]
     runs-on: ubuntu-latest
     outputs:
@@ -392,8 +379,7 @@ jobs:
       (needs.build-linux-arm64-artifacts.result == 'success' || needs.build-linux-arm64-artifacts.result == 'skipped') &&
       (needs.build-macos-artifacts.result == 'success' || needs.build-macos-artifacts.result == 'skipped') &&
       (needs.build-windows-artifacts.result == 'success' || needs.build-windows-artifacts.result == 'skipped') &&
-      (needs.release-images-to-dockerhub.result == 'success' || needs.release-images-to-dockerhub.result == 'skipped') &&
-      (needs.run-multi-lang-tests.result == 'success' || needs.run-multi-lang-tests.result == 'skipped')
+      (needs.release-images-to-dockerhub.result == 'success' || needs.release-images-to-dockerhub.result == 'skipped')
     needs: [ # The job have to wait for all the artifacts are built.
       allocate-runners,
       build-linux-amd64-artifacts,
@@ -401,7 +387,6 @@ jobs:
       build-macos-artifacts,
       build-windows-artifacts,
       release-images-to-dockerhub,
-      run-multi-lang-tests,
     ]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

#7649 

## What's changed and what's your intention?

Remove `run-multi-lang-tests` from release process as well

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
