### PR TITLE
fix: incorrect column statistics of promql plans

### DIFF
--- a/src/promql/src/extension_plan/histogram_fold.rs
+++ b/src/promql/src/extension_plan/histogram_fold.rs
@@ -25,7 +25,7 @@ use datafusion::arrow::compute::{SortOptions, concat_batches};
 use datafusion::arrow::datatypes::{DataType, Float64Type, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::stats::Precision;
-use datafusion::common::{ColumnStatistics, DFSchema, DFSchemaRef, Statistics};
+use datafusion::common::{DFSchema, DFSchemaRef, Statistics};
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::execution::TaskContext;
 use datafusion::logical_expr::{LogicalPlan, UserDefinedLogicalNodeCore};
@@ -554,11 +554,7 @@ impl ExecutionPlan for HistogramFoldExec {
         Ok(Statistics {
             num_rows: Precision::Absent,
             total_byte_size: Precision::Absent,
-            column_statistics: vec![
-                ColumnStatistics::new_unknown();
-                // plus one more for the removed column by function `convert_schema`
-                self.schema().flattened_fields().len() + 1
-            ],
+            column_statistics: Statistics::unknown_column(&self.schema()),
         })
     }
 

--- a/src/promql/src/extension_plan/instant_manipulate.rs
+++ b/src/promql/src/extension_plan/instant_manipulate.rs
@@ -22,7 +22,7 @@ use datafusion::arrow::array::{Array, Float64Array, TimestampMillisecondArray, U
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::stats::Precision;
-use datafusion::common::{ColumnStatistics, DFSchema, DFSchemaRef};
+use datafusion::common::{DFSchema, DFSchemaRef};
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::execution::context::TaskContext;
 use datafusion::logical_expr::{EmptyRelation, Expr, LogicalPlan, UserDefinedLogicalNodeCore};
@@ -388,10 +388,7 @@ impl ExecutionPlan for InstantManipulateExec {
             num_rows: Precision::Inexact(estimated_row_num.floor() as _),
             total_byte_size: estimated_total_bytes,
             // TODO(ruihang): support this column statistics
-            column_statistics: vec![
-                ColumnStatistics::new_unknown();
-                self.schema().flattened_fields().len()
-            ],
+            column_statistics: Statistics::unknown_column(&self.schema()),
         })
     }
 

--- a/tests/cases/standalone/common/promql/stats_schema_mismatch_regression.result
+++ b/tests/cases/standalone/common/promql/stats_schema_mismatch_regression.result
@@ -1,0 +1,154 @@
+-- Regression tests for PromQL execution plans that return mismatched
+-- `Statistics::column_statistics` length.
+--
+-- DataFusion expects: `statistics.column_statistics.len() == schema.fields().len()`.
+-- If not, `FilterExec` may fail while building `ExprBoundaries` with:
+-- "Could not create `ExprBoundaries`: ... col_index has gone out of bounds ..."
+-- -----------------------------------------------------------------------------
+-- Case 1: HistogramFoldExec + topk(histogram_quantile(...)) on metric engine
+-- -----------------------------------------------------------------------------
+CREATE TABLE promql_stats_mismatch_physical (
+  ts TIMESTAMP(3) TIME INDEX,
+  val DOUBLE,
+) ENGINE = metric WITH ("physical_metric_table" = "");
+
+Affected Rows: 0
+
+CREATE TABLE promql_stats_mismatch_hist_bucket (
+  `cluster` STRING NULL,
+  le STRING NULL,
+  instance STRING NULL,
+  operation STRING NULL,
+  `type` STRING NULL,
+  ts TIMESTAMP(3) NOT NULL,
+  val DOUBLE NULL,
+  TIME INDEX (ts),
+  PRIMARY KEY(`cluster`, le, instance, operation, `type`),
+)
+ENGINE = metric
+WITH(
+  on_physical_table = 'promql_stats_mismatch_physical'
+);
+
+Affected Rows: 0
+
+-- Counter samples at t=0 and t=5m (300000ms). `rate(...[5m])` uses the delta in this window.
+INSERT INTO promql_stats_mismatch_hist_bucket (`cluster`, le, instance, operation, `type`, ts, val) VALUES
+  -- t = 0
+  ('cluster', '0.5',  'inst1', 'op', 't', 0, 0),
+  ('cluster', '1',    'inst1', 'op', 't', 0, 0),
+  ('cluster', '2',    'inst1', 'op', 't', 0, 0),
+  ('cluster', '+Inf', 'inst1', 'op', 't', 0, 0),
+  ('cluster', '0.5',  'inst2', 'op', 't', 0, 0),
+  ('cluster', '1',    'inst2', 'op', 't', 0, 0),
+  ('cluster', '2',    'inst2', 'op', 't', 0, 0),
+  ('cluster', '+Inf', 'inst2', 'op', 't', 0, 0),
+  ('cluster', '0.5',  'inst3', 'op', 't', 0, 0),
+  ('cluster', '1',    'inst3', 'op', 't', 0, 0),
+  ('cluster', '2',    'inst3', 'op', 't', 0, 0),
+  ('cluster', '+Inf', 'inst3', 'op', 't', 0, 0),
+  ('cluster', '0.5',  'inst4', 'op', 't', 0, 0),
+  ('cluster', '1',    'inst4', 'op', 't', 0, 0),
+  ('cluster', '2',    'inst4', 'op', 't', 0, 0),
+  ('cluster', '+Inf', 'inst4', 'op', 't', 0, 0),
+  ('cluster', '0.5',  'inst5', 'op', 't', 0, 0),
+  ('cluster', '1',    'inst5', 'op', 't', 0, 0),
+  ('cluster', '2',    'inst5', 'op', 't', 0, 0),
+  ('cluster', '+Inf', 'inst5', 'op', 't', 0, 0),
+  ('cluster', '0.5',  'inst6', 'op', 't', 0, 0),
+  ('cluster', '1',    'inst6', 'op', 't', 0, 0),
+  ('cluster', '2',    'inst6', 'op', 't', 0, 0),
+  ('cluster', '+Inf', 'inst6', 'op', 't', 0, 0),
+  -- t = 300000ms (5m)
+  ('cluster', '0.5',  'inst1', 'op', 't', 300000, 95),
+  ('cluster', '1',    'inst1', 'op', 't', 300000, 98),
+  ('cluster', '2',    'inst1', 'op', 't', 300000, 100),
+  ('cluster', '+Inf', 'inst1', 'op', 't', 300000, 100),
+  ('cluster', '0.5',  'inst2', 'op', 't', 300000, 50),
+  ('cluster', '1',    'inst2', 'op', 't', 300000, 95),
+  ('cluster', '2',    'inst2', 'op', 't', 300000, 100),
+  ('cluster', '+Inf', 'inst2', 'op', 't', 300000, 100),
+  ('cluster', '0.5',  'inst3', 'op', 't', 300000, 50),
+  ('cluster', '1',    'inst3', 'op', 't', 300000, 75),
+  ('cluster', '2',    'inst3', 'op', 't', 300000, 100),
+  ('cluster', '+Inf', 'inst3', 'op', 't', 300000, 100),
+  ('cluster', '0.5',  'inst4', 'op', 't', 300000, 50),
+  ('cluster', '1',    'inst4', 'op', 't', 300000, 80),
+  ('cluster', '2',    'inst4', 'op', 't', 300000, 97),
+  ('cluster', '+Inf', 'inst4', 'op', 't', 300000, 100),
+  ('cluster', '0.5',  'inst5', 'op', 't', 300000, 10),
+  ('cluster', '1',    'inst5', 'op', 't', 300000, 20),
+  ('cluster', '2',    'inst5', 'op', 't', 300000, 100),
+  ('cluster', '+Inf', 'inst5', 'op', 't', 300000, 100),
+  ('cluster', '0.5',  'inst6', 'op', 't', 300000, 0),
+  ('cluster', '1',    'inst6', 'op', 't', 300000, 0),
+  ('cluster', '2',    'inst6', 'op', 't', 300000, 100),
+  ('cluster', '+Inf', 'inst6', 'op', 't', 300000, 100);
+
+Affected Rows: 48
+
+-- This used to error due to HistogramFoldExec returning `column_statistics` with wrong length.
+TQL EVAL (300, 300, '300s')
+  topk(
+    5,
+    histogram_quantile(
+      0.95,
+      sum(rate(promql_stats_mismatch_hist_bucket{cluster="cluster"}[5m])) by (cluster, le, instance, operation, type)
+    )
+  ) AS q95;
+
++--------------------+---------+----------+-----------+------+---------------------+
+| q95                | cluster | instance | operation | type | ts                  |
++--------------------+---------+----------+-----------+------+---------------------+
+| 1.95               | cluster | inst6    | op        | t    | 1970-01-01T00:05:00 |
+| 1.9375             | cluster | inst5    | op        | t    | 1970-01-01T00:05:00 |
+| 1.882352941176471  | cluster | inst4    | op        | t    | 1970-01-01T00:05:00 |
+| 1.8000000000000003 | cluster | inst3    | op        | t    | 1970-01-01T00:05:00 |
+| 1.0                | cluster | inst2    | op        | t    | 1970-01-01T00:05:00 |
++--------------------+---------+----------+-----------+------+---------------------+
+
+DROP TABLE promql_stats_mismatch_hist_bucket;
+
+Affected Rows: 0
+
+DROP TABLE promql_stats_mismatch_physical;
+
+Affected Rows: 0
+
+-- -----------------------------------------------------------------------------
+-- Case 2: InstantManipulateExec stats mismatch with nested Arrow fields
+-- -----------------------------------------------------------------------------
+--
+-- Metric engine enforces float64 field + string tags, so it can't create a nested schema
+-- needed to reproduce the `flattened_fields().len()` vs `fields().len()` mismatch.
+-- Use a normal table with a structured JSON (Arrow Struct) field column instead.
+CREATE TABLE promql_instant_mismatch_nested (
+  ts TIMESTAMP(3) TIME INDEX,
+  k STRING PRIMARY KEY,
+  v JSON(format = "structured"),
+);
+
+Affected Rows: 0
+
+INSERT INTO promql_instant_mismatch_nested VALUES
+  (0, 'a', '{"x": 1}'),
+  (1000, 'a', '{"x": 2}');
+
+Affected Rows: 2
+
+-- This used to error due to InstantManipulateExec returning `column_statistics` sized by
+-- `schema.flattened_fields().len()` when the schema contains nested fields (Arrow Struct).
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (0, 1, '1s') promql_instant_mismatch_nested == promql_instant_mismatch_nested;
+
++---------------------+---+--------+---------------------+---+--------+
+| ts                  | k | v      | ts                  | k | v      |
++---------------------+---+--------+---------------------+---+--------+
+| 1970-01-01T00:00:00 | a | {x: 1} | 1970-01-01T00:00:00 | a | {x: 1} |
+| 1970-01-01T00:00:01 | a | {x: 2} | 1970-01-01T00:00:01 | a | {x: 2} |
++---------------------+---+--------+---------------------+---+--------+
+
+DROP TABLE promql_instant_mismatch_nested;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/promql/stats_schema_mismatch_regression.sql
+++ b/tests/cases/standalone/common/promql/stats_schema_mismatch_regression.sql
@@ -1,0 +1,122 @@
+-- Regression tests for PromQL execution plans that return mismatched
+-- `Statistics::column_statistics` length.
+--
+-- DataFusion expects: `statistics.column_statistics.len() == schema.fields().len()`.
+-- If not, `FilterExec` may fail while building `ExprBoundaries` with:
+-- "Could not create `ExprBoundaries`: ... col_index has gone out of bounds ..."
+
+-- -----------------------------------------------------------------------------
+-- Case 1: HistogramFoldExec + topk(histogram_quantile(...)) on metric engine
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE promql_stats_mismatch_physical (
+  ts TIMESTAMP(3) TIME INDEX,
+  val DOUBLE,
+) ENGINE = metric WITH ("physical_metric_table" = "");
+
+CREATE TABLE promql_stats_mismatch_hist_bucket (
+  `cluster` STRING NULL,
+  le STRING NULL,
+  instance STRING NULL,
+  operation STRING NULL,
+  `type` STRING NULL,
+  ts TIMESTAMP(3) NOT NULL,
+  val DOUBLE NULL,
+  TIME INDEX (ts),
+  PRIMARY KEY(`cluster`, le, instance, operation, `type`),
+)
+ENGINE = metric
+WITH(
+  on_physical_table = 'promql_stats_mismatch_physical'
+);
+
+-- Counter samples at t=0 and t=5m (300000ms). `rate(...[5m])` uses the delta in this window.
+INSERT INTO promql_stats_mismatch_hist_bucket (`cluster`, le, instance, operation, `type`, ts, val) VALUES
+  -- t = 0
+  ('cluster', '0.5',  'inst1', 'op', 't', 0, 0),
+  ('cluster', '1',    'inst1', 'op', 't', 0, 0),
+  ('cluster', '2',    'inst1', 'op', 't', 0, 0),
+  ('cluster', '+Inf', 'inst1', 'op', 't', 0, 0),
+  ('cluster', '0.5',  'inst2', 'op', 't', 0, 0),
+  ('cluster', '1',    'inst2', 'op', 't', 0, 0),
+  ('cluster', '2',    'inst2', 'op', 't', 0, 0),
+  ('cluster', '+Inf', 'inst2', 'op', 't', 0, 0),
+  ('cluster', '0.5',  'inst3', 'op', 't', 0, 0),
+  ('cluster', '1',    'inst3', 'op', 't', 0, 0),
+  ('cluster', '2',    'inst3', 'op', 't', 0, 0),
+  ('cluster', '+Inf', 'inst3', 'op', 't', 0, 0),
+  ('cluster', '0.5',  'inst4', 'op', 't', 0, 0),
+  ('cluster', '1',    'inst4', 'op', 't', 0, 0),
+  ('cluster', '2',    'inst4', 'op', 't', 0, 0),
+  ('cluster', '+Inf', 'inst4', 'op', 't', 0, 0),
+  ('cluster', '0.5',  'inst5', 'op', 't', 0, 0),
+  ('cluster', '1',    'inst5', 'op', 't', 0, 0),
+  ('cluster', '2',    'inst5', 'op', 't', 0, 0),
+  ('cluster', '+Inf', 'inst5', 'op', 't', 0, 0),
+  ('cluster', '0.5',  'inst6', 'op', 't', 0, 0),
+  ('cluster', '1',    'inst6', 'op', 't', 0, 0),
+  ('cluster', '2',    'inst6', 'op', 't', 0, 0),
+  ('cluster', '+Inf', 'inst6', 'op', 't', 0, 0),
+  -- t = 300000ms (5m)
+  ('cluster', '0.5',  'inst1', 'op', 't', 300000, 95),
+  ('cluster', '1',    'inst1', 'op', 't', 300000, 98),
+  ('cluster', '2',    'inst1', 'op', 't', 300000, 100),
+  ('cluster', '+Inf', 'inst1', 'op', 't', 300000, 100),
+  ('cluster', '0.5',  'inst2', 'op', 't', 300000, 50),
+  ('cluster', '1',    'inst2', 'op', 't', 300000, 95),
+  ('cluster', '2',    'inst2', 'op', 't', 300000, 100),
+  ('cluster', '+Inf', 'inst2', 'op', 't', 300000, 100),
+  ('cluster', '0.5',  'inst3', 'op', 't', 300000, 50),
+  ('cluster', '1',    'inst3', 'op', 't', 300000, 75),
+  ('cluster', '2',    'inst3', 'op', 't', 300000, 100),
+  ('cluster', '+Inf', 'inst3', 'op', 't', 300000, 100),
+  ('cluster', '0.5',  'inst4', 'op', 't', 300000, 50),
+  ('cluster', '1',    'inst4', 'op', 't', 300000, 80),
+  ('cluster', '2',    'inst4', 'op', 't', 300000, 97),
+  ('cluster', '+Inf', 'inst4', 'op', 't', 300000, 100),
+  ('cluster', '0.5',  'inst5', 'op', 't', 300000, 10),
+  ('cluster', '1',    'inst5', 'op', 't', 300000, 20),
+  ('cluster', '2',    'inst5', 'op', 't', 300000, 100),
+  ('cluster', '+Inf', 'inst5', 'op', 't', 300000, 100),
+  ('cluster', '0.5',  'inst6', 'op', 't', 300000, 0),
+  ('cluster', '1',    'inst6', 'op', 't', 300000, 0),
+  ('cluster', '2',    'inst6', 'op', 't', 300000, 100),
+  ('cluster', '+Inf', 'inst6', 'op', 't', 300000, 100);
+
+-- This used to error due to HistogramFoldExec returning `column_statistics` with wrong length.
+TQL EVAL (300, 300, '300s')
+  topk(
+    5,
+    histogram_quantile(
+      0.95,
+      sum(rate(promql_stats_mismatch_hist_bucket{cluster="cluster"}[5m])) by (cluster, le, instance, operation, type)
+    )
+  ) AS q95;
+
+DROP TABLE promql_stats_mismatch_hist_bucket;
+DROP TABLE promql_stats_mismatch_physical;
+
+-- -----------------------------------------------------------------------------
+-- Case 2: InstantManipulateExec stats mismatch with nested Arrow fields
+-- -----------------------------------------------------------------------------
+--
+-- Metric engine enforces float64 field + string tags, so it can't create a nested schema
+-- needed to reproduce the `flattened_fields().len()` vs `fields().len()` mismatch.
+-- Use a normal table with a structured JSON (Arrow Struct) field column instead.
+
+CREATE TABLE promql_instant_mismatch_nested (
+  ts TIMESTAMP(3) TIME INDEX,
+  k STRING PRIMARY KEY,
+  v JSON(format = "structured"),
+);
+
+INSERT INTO promql_instant_mismatch_nested VALUES
+  (0, 'a', '{"x": 1}'),
+  (1000, 'a', '{"x": 2}');
+
+-- This used to error due to InstantManipulateExec returning `column_statistics` sized by
+-- `schema.flattened_fields().len()` when the schema contains nested fields (Arrow Struct).
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (0, 1, '1s') promql_instant_mismatch_nested == promql_instant_mismatch_nested;
+
+DROP TABLE promql_instant_mismatch_nested;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

See the regression test `stats_schema_mismatch_regression.sql` for details.

`partition_statistics` describes the output of `HistogramFoldExec`, so its `column_statistics` must match with the output schema. The previous comment said about that extra `le` column is already removed in `convert_schema`.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
