### PR TITLE
fix: preserve the order of primary key indices as defined in the original table info

### DIFF
--- a/src/common/meta/src/ddl/create_table/template.rs
+++ b/src/common/meta/src/ddl/create_table/template.rs
@@ -92,11 +92,6 @@ pub fn build_template_from_raw_table_info_for_physical_table(
         &table_info.meta.primary_key_indices,
         &name_to_ids,
     )?;
-    let primary_key_ids = column_metadatas
-        .iter()
-        .filter(|c| c.semantic_type == SemanticType::Tag)
-        .map(|c| c.column_id)
-        .collect::<Vec<_>>();
     let column_defs = column_metadatas
         .iter()
         .map(|c| {
@@ -114,13 +109,20 @@ pub fn build_template_from_raw_table_info_for_physical_table(
             Ok(region_column_def)
         })
         .collect::<Result<Vec<_>>>()?;
+    // Preserve the order of primary key indices as defined in the original table info.
+    let primary_key = table_info
+        .meta
+        .primary_key_indices
+        .iter()
+        .map(|idx| column_metadatas[*idx].column_id)
+        .collect();
 
     let options = HashMap::from(&table_info.meta.options);
     let template = CreateRequest {
         region_id: 0,
         engine: table_info.meta.engine.clone(),
         column_defs,
-        primary_key: primary_key_ids,
+        primary_key,
         path: String::new(),
         options,
         partition: None,
@@ -263,6 +265,7 @@ mod tests {
     use store_api::storage::{RegionId, RegionNumber};
 
     use super::*;
+    use crate::key::test_utils;
 
     #[test]
     fn test_build_one_sets_partition_expr_per_region() {
@@ -290,5 +293,15 @@ mod tests {
             &partition_exprs,
         );
         assert_eq!(r0.partition.as_ref().unwrap().expression, expr_a);
+    }
+
+    #[test]
+    fn test_build_template_for_physical_table_primary_key_matches_indices() {
+        let mut table_info = test_utils::new_test_table_info(42);
+        table_info.meta.primary_key_indices = vec![0, 2];
+        table_info.meta.column_ids = vec![10, 20, 30];
+
+        let template = build_template_from_raw_table_info_for_physical_table(&table_info).unwrap();
+        assert_eq!(template.primary_key, vec![10, 30]);
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
fix #7739
## What's changed and what's your intention?

This PR fixes an inconsistency bug in physical-table template generation: `CreateRequest.primary_key` must be derived from `table_info.meta.primary_key_indices` (schema indices), not inferred from tag columns / column IDs.

Before this fix, newly allocated regions could carry metadata whose primary key definition was inconsistent with existing regions. That inconsistency later broke projection mapping logic (projection mapper expects consistent schema-index-based primary key metadata across regions), causing runtime errors in related query/read paths.

The e2e tests will be covered in #7703

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
