### PR TITLE
fix: Install uv to avoid failure while creating databases

### DIFF
--- a/.github/workflows/run-multi-lang-tests.yml
+++ b/.github/workflows/run-multi-lang-tests.yml
@@ -88,6 +88,11 @@ jobs:
         with:
           python-version: '3.8'
 
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+
       - name: Setup Go 1.24
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Install `uv` since greptimedb-tests requires it to create databases.
https://github.com/GreptimeTeam/greptimedb-tests/blob/2051f92f31720b85666955179c97dd5763dd6e62/run_tests.sh#L107-L109

Otherwise CI may fail https://github.com/GreptimeTeam/greptimedb/actions/runs/22565778266/job/65365288930#step:15:156


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
