### PR TITLE
fix: Allow overriding sequence when writing flat SSTs

### DIFF
--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -337,7 +337,9 @@ impl AccessLayer {
                         .await?
                 }
                 Either::Right(flat_source) => {
-                    writer.write_all_flat(flat_source, write_opts).await?
+                    writer
+                        .write_all_flat(flat_source, request.max_sequence, write_opts)
+                        .await?
                 }
             }
         };

--- a/src/mito2/src/cache/write_cache.rs
+++ b/src/mito2/src/cache/write_cache.rs
@@ -250,7 +250,11 @@ impl WriteCache {
                     .write_all(source, write_request.max_sequence, write_opts)
                     .await?
             }
-            either::Right(flat_source) => writer.write_all_flat(flat_source, write_opts).await?,
+            either::Right(flat_source) => {
+                writer
+                    .write_all_flat(flat_source, write_request.max_sequence, write_opts)
+                    .await?
+            }
         };
 
         // Upload sst file to remote object store.

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -1182,7 +1182,7 @@ mod tests {
         .await;
 
         writer
-            .write_all_flat(flat_source, write_opts)
+            .write_all_flat(flat_source, None, write_opts)
             .await
             .unwrap()
             .remove(0)
@@ -1293,7 +1293,7 @@ mod tests {
         .await;
 
         let info = writer
-            .write_all_flat(flat_source, &write_opts)
+            .write_all_flat(flat_source, None, &write_opts)
             .await
             .unwrap()
             .remove(0);

--- a/src/mito2/src/sst/parquet/writer.rs
+++ b/src/mito2/src/sst/parquet/writer.rs
@@ -321,9 +321,12 @@ where
     pub async fn write_all_flat(
         &mut self,
         source: FlatSource,
+        override_sequence: Option<SequenceNumber>,
         opts: &WriteOptions,
     ) -> Result<SstInfoArray> {
-        let res = self.write_all_flat_without_cleaning(source, opts).await;
+        let res = self
+            .write_all_flat_without_cleaning(source, override_sequence, opts)
+            .await;
         if res.is_err() {
             // Clean tmp files explicitly on failure.
             let file_id = self.current_file;
@@ -337,6 +340,7 @@ where
     async fn write_all_flat_without_cleaning(
         &mut self,
         mut source: FlatSource,
+        override_sequence: Option<SequenceNumber>,
         opts: &WriteOptions,
     ) -> Result<SstInfoArray> {
         let mut results = smallvec![];
@@ -344,7 +348,7 @@ where
             self.metadata.clone(),
             &FlatSchemaOptions::from_encoding(self.metadata.primary_key_encoding),
         )
-        .with_override_sequence(None);
+        .with_override_sequence(override_sequence);
         let mut stats = SourceStats::default();
 
         while let Some(record_batch) = self


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/7732

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

Override sequence when writing flat SSTs.

This isn't a critical issue because the bulk memtable has part-level sequence, so parts usually have the same sequence.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
