### PR TITLE
fix: correct unicode representation for jsonb_to_string

### DIFF
--- a/src/common/function/src/scalars/json/json_to_string.rs
+++ b/src/common/function/src/scalars/json/json_to_string.rs
@@ -19,6 +19,7 @@ use datafusion_common::DataFusionError;
 use datafusion_common::arrow::array::{Array, AsArray, StringViewBuilder};
 use datafusion_common::arrow::datatypes::DataType;
 use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, Signature, Volatility};
+use datatypes::types::jsonb_to_string;
 
 use crate::function::{Function, extract_args};
 
@@ -74,7 +75,7 @@ impl Function for JsonToStringFunction {
         for i in 0..size {
             let json = jsons.is_valid(i).then(|| jsons.value(i));
             let result = json
-                .map(|json| jsonb::from_slice(json).map(|x| x.to_string()))
+                .map(jsonb_to_string)
                 .transpose()
                 .map_err(|e| DataFusionError::Execution(format!("invalid json binary: {e}")))?;
 

--- a/src/datatypes/src/types/json_type.rs
+++ b/src/datatypes/src/types/json_type.rs
@@ -405,18 +405,12 @@ pub fn jsonb_to_string(val: &[u8]) -> Result<String> {
 /// Converts a json type value to serde_json::Value
 pub fn jsonb_to_serde_json(val: &[u8]) -> Result<serde_json::Value> {
     let json_string = jsonb_to_string(val)?;
-    let normalized = fix_unicode_point(&json_string)?;
-    serde_json::Value::from_str(&normalized).context(DeserializeSnafu { json: normalized })
+    serde_json::Value::from_str(&json_string).context(DeserializeSnafu { json: json_string })
 }
 
 /// Normalizes a JSON string by converting Rust-style Unicode escape sequences to JSON-compatible format.
 ///
-/// This function is intended to be used on JSON strings produced from the internal
-/// JSONB representation (e.g. via [`jsonb_to_string`]). It first calls
-/// `serde_json::Value::from_str` to check if the string is valid. If that succeeds,
-/// the original string is returned as-is.
-///
-/// If the initial parse fails, the input is scanned for Rust-style Unicode code
+/// The input is scanned for Rust-style Unicode code
 /// point escapes of the form `\\u{H...}` (a backslash, `u`, an opening brace,
 /// followed by 1–6 hexadecimal digits, and a closing brace). Each such escape is
 /// converted into JSON-compatible UTF‑16 escape sequences:
@@ -427,8 +421,7 @@ pub fn jsonb_to_serde_json(val: &[u8]) -> Result<serde_json::Value> {
 ///   the code point is encoded as a UTF‑16 surrogate pair and emitted as two consecutive
 ///   `\\uXXXX` sequences (as JSON format required).
 ///
-/// After this normalization, the function returns the normalized string, or a
-/// `DeserializeSnafu` error if the parse failed for reasons other than invalid escape sequences.
+/// After this normalization, the function returns the normalized string
 fn fix_unicode_point(json: &str) -> Result<String> {
     static UNICODE_CODE_POINT_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
         // Match literal "\u{...}" sequences, capturing 1–6 (code point range) hex digits

--- a/tests/cases/standalone/common/types/json/json.result
+++ b/tests/cases/standalone/common/types/json/json.result
@@ -37,22 +37,23 @@ INSERT INTO jsons VALUES('[null]', 0),
             }
         ]
     }
-}}', 11);
+}}', 11),
+('{"a":"abc\u2028tom"}', 12);
 
-Affected Rows: 12
+Affected Rows: 13
 
-INSERT INTO jsons VALUES(parse_json('[null]'), 12),
-(parse_json('[true]'), 13),
-(parse_json('[false]'), 14),
-(parse_json('[0]'), 15),
-(parse_json('["foo"]'), 16),
-(parse_json('[]'), 17),
-(parse_json('{}'), 18),
-(parse_json('[0,1]'), 19),
-(parse_json('{"foo":"bar"}'), 20),
-(parse_json('{"a":null,"foo":"bar"}'), 21),
-(parse_json('[-1]'), 22),
-(parse_json('[-2147483648]'), 23),
+INSERT INTO jsons VALUES(parse_json('[null]'), 1000),
+(parse_json('[true]'), 1001),
+(parse_json('[false]'), 1002),
+(parse_json('[0]'), 1003),
+(parse_json('["foo"]'), 1004),
+(parse_json('[]'), 1005),
+(parse_json('{}'), 1006),
+(parse_json('[0,1]'), 1007),
+(parse_json('{"foo":"bar"}'), 1008),
+(parse_json('{"a":null,"foo":"bar"}'), 1009),
+(parse_json('[-1]'), 1010),
+(parse_json('[-2147483648]'), 1011),
 (parse_json('{"entities": {
             "description": {
                 "urls": [
@@ -76,9 +77,10 @@ INSERT INTO jsons VALUES(parse_json('[null]'), 12),
                     }
                 ]
             }
-        }}'), 24);
+        }}'), 1012),
+(parse_json('{"a":"abc\u2028tom"}'), 1013);
 
-Affected Rows: 13
+Affected Rows: 14
 
 SELECT json_to_string(j), t FROM jsons;
 
@@ -97,25 +99,27 @@ SELECT json_to_string(j), t FROM jsons;
 | {"a":null,"foo":"bar"}                                                                                                                                                                                                                                                                                                    | 1970-01-01T00:00:00.009 |
 | [-1]                                                                                                                                                                                                                                                                                                                      | 1970-01-01T00:00:00.010 |
 | {"entities":{"description":{"urls":[{"display_url":"pixiv.net/member.php?id=…","expanded_url":"http://www.pixiv.net/member.php?id=4776","indices":[58,80],"url":"http://t.co/QMLJeFmfMT"},{"display_url":"ask.fm/KATANA77","expanded_url":"http://ask.fm/KATANA77","indices":[95,117],"url":"http://t.co/LU8T7vmU3h"}]}}} | 1970-01-01T00:00:00.011 |
-| [null]                                                                                                                                                                                                                                                                                                                    | 1970-01-01T00:00:00.012 |
-| [true]                                                                                                                                                                                                                                                                                                                    | 1970-01-01T00:00:00.013 |
-| [false]                                                                                                                                                                                                                                                                                                                   | 1970-01-01T00:00:00.014 |
-| [0]                                                                                                                                                                                                                                                                                                                       | 1970-01-01T00:00:00.015 |
-| ["foo"]                                                                                                                                                                                                                                                                                                                   | 1970-01-01T00:00:00.016 |
-| []                                                                                                                                                                                                                                                                                                                        | 1970-01-01T00:00:00.017 |
-| {}                                                                                                                                                                                                                                                                                                                        | 1970-01-01T00:00:00.018 |
-| [0,1]                                                                                                                                                                                                                                                                                                                     | 1970-01-01T00:00:00.019 |
-| {"foo":"bar"}                                                                                                                                                                                                                                                                                                             | 1970-01-01T00:00:00.020 |
-| {"a":null,"foo":"bar"}                                                                                                                                                                                                                                                                                                    | 1970-01-01T00:00:00.021 |
-| [-1]                                                                                                                                                                                                                                                                                                                      | 1970-01-01T00:00:00.022 |
-| [-2147483648]                                                                                                                                                                                                                                                                                                             | 1970-01-01T00:00:00.023 |
-| {"entities":{"description":{"urls":[{"display_url":"pixiv.net/member.php?id=…","expanded_url":"http://www.pixiv.net/member.php?id=4776","indices":[58,80],"url":"http://t.co/QMLJeFmfMT"},{"display_url":"ask.fm/KATANA77","expanded_url":"http://ask.fm/KATANA77","indices":[95,117],"url":"http://t.co/LU8T7vmU3h"}]}}} | 1970-01-01T00:00:00.024 |
+| {"a":"abc\u2028tom"}                                                                                                                                                                                                                                                                                                      | 1970-01-01T00:00:00.012 |
+| [null]                                                                                                                                                                                                                                                                                                                    | 1970-01-01T00:00:01     |
+| [true]                                                                                                                                                                                                                                                                                                                    | 1970-01-01T00:00:01.001 |
+| [false]                                                                                                                                                                                                                                                                                                                   | 1970-01-01T00:00:01.002 |
+| [0]                                                                                                                                                                                                                                                                                                                       | 1970-01-01T00:00:01.003 |
+| ["foo"]                                                                                                                                                                                                                                                                                                                   | 1970-01-01T00:00:01.004 |
+| []                                                                                                                                                                                                                                                                                                                        | 1970-01-01T00:00:01.005 |
+| {}                                                                                                                                                                                                                                                                                                                        | 1970-01-01T00:00:01.006 |
+| [0,1]                                                                                                                                                                                                                                                                                                                     | 1970-01-01T00:00:01.007 |
+| {"foo":"bar"}                                                                                                                                                                                                                                                                                                             | 1970-01-01T00:00:01.008 |
+| {"a":null,"foo":"bar"}                                                                                                                                                                                                                                                                                                    | 1970-01-01T00:00:01.009 |
+| [-1]                                                                                                                                                                                                                                                                                                                      | 1970-01-01T00:00:01.010 |
+| [-2147483648]                                                                                                                                                                                                                                                                                                             | 1970-01-01T00:00:01.011 |
+| {"entities":{"description":{"urls":[{"display_url":"pixiv.net/member.php?id=…","expanded_url":"http://www.pixiv.net/member.php?id=4776","indices":[58,80],"url":"http://t.co/QMLJeFmfMT"},{"display_url":"ask.fm/KATANA77","expanded_url":"http://ask.fm/KATANA77","indices":[95,117],"url":"http://t.co/LU8T7vmU3h"}]}}} | 1970-01-01T00:00:01.012 |
+| {"a":"abc\u2028tom"}                                                                                                                                                                                                                                                                                                      | 1970-01-01T00:00:01.013 |
 +---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------+
 
 --Insert invalid json strings--
 DELETE FROM jsons;
 
-Affected Rows: 25
+Affected Rows: 27
 
 INSERT INTO jsons VALUES(parse_json('{"a":1, "b":2, "c":3'), 4);
 

--- a/tests/cases/standalone/common/types/json/json.sql
+++ b/tests/cases/standalone/common/types/json/json.sql
@@ -35,20 +35,21 @@ INSERT INTO jsons VALUES('[null]', 0),
             }
         ]
     }
-}}', 11);
+}}', 11),
+('{"a":"abc\u2028tom"}', 12);
 
-INSERT INTO jsons VALUES(parse_json('[null]'), 12),
-(parse_json('[true]'), 13),
-(parse_json('[false]'), 14),
-(parse_json('[0]'), 15),
-(parse_json('["foo"]'), 16),
-(parse_json('[]'), 17),
-(parse_json('{}'), 18),
-(parse_json('[0,1]'), 19),
-(parse_json('{"foo":"bar"}'), 20),
-(parse_json('{"a":null,"foo":"bar"}'), 21),
-(parse_json('[-1]'), 22),
-(parse_json('[-2147483648]'), 23),
+INSERT INTO jsons VALUES(parse_json('[null]'), 1000),
+(parse_json('[true]'), 1001),
+(parse_json('[false]'), 1002),
+(parse_json('[0]'), 1003),
+(parse_json('["foo"]'), 1004),
+(parse_json('[]'), 1005),
+(parse_json('{}'), 1006),
+(parse_json('[0,1]'), 1007),
+(parse_json('{"foo":"bar"}'), 1008),
+(parse_json('{"a":null,"foo":"bar"}'), 1009),
+(parse_json('[-1]'), 1010),
+(parse_json('[-2147483648]'), 1011),
 (parse_json('{"entities": {
             "description": {
                 "urls": [
@@ -72,7 +73,8 @@ INSERT INTO jsons VALUES(parse_json('[null]'), 12),
                     }
                 ]
             }
-        }}'), 24);
+        }}'), 1012),
+(parse_json('{"a":"abc\u2028tom"}'), 1013);
 
 SELECT json_to_string(j), t FROM jsons;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Fixes #7808

## What's changed and what's your intention?

Correct unicode representation for json string. 

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
