### PR TITLE
feat: flow inc query

### DIFF
--- a/src/client/src/database.rs
+++ b/src/client/src/database.rs
@@ -89,11 +89,23 @@ impl OutputMetrics {
     }
 
     pub fn region_watermark_map(&self) -> Option<std::collections::HashMap<u64, u64>> {
-        self.get()?.region_latest_sequences.map(|sequences| {
-            sequences
+        Some(
+            self.get()?
+                .region_watermarks
                 .into_iter()
-                .collect::<std::collections::HashMap<_, _>>()
-        })
+                .filter_map(|entry| entry.watermark.map(|seq| (entry.region_id, seq)))
+                .collect::<std::collections::HashMap<_, _>>(),
+        )
+    }
+
+    pub fn participating_regions(&self) -> Option<std::collections::BTreeSet<u64>> {
+        Some(
+            self.get()?
+                .region_watermarks
+                .into_iter()
+                .map(|entry| entry.region_id)
+                .collect::<std::collections::BTreeSet<_>>(),
+        )
     }
 }
 
@@ -115,6 +127,10 @@ impl OutputWithMetrics {
 
     pub fn region_watermark_map(&self) -> Option<std::collections::HashMap<u64, u64>> {
         self.metrics.region_watermark_map()
+    }
+
+    pub fn participating_regions(&self) -> Option<std::collections::BTreeSet<u64>> {
+        self.metrics.participating_regions()
     }
 
     pub fn into_output(self) -> Output {
@@ -874,7 +890,10 @@ mod tests {
             schema,
             batch: Some(batch),
             metrics: RecordBatchMetrics {
-                region_latest_sequences: Some(vec![(7, 42)]),
+                region_watermarks: vec![common_recordbatch::adapter::RegionWatermarkEntry {
+                    region_id: 7,
+                    watermark: Some(42),
+                }],
                 ..Default::default()
             },
             terminal_metrics_only: true,
@@ -892,6 +911,10 @@ mod tests {
 
         assert!(terminal_metrics.is_ready());
         assert_eq!(
+            terminal_metrics.participating_regions(),
+            Some(std::collections::BTreeSet::from([7_u64]))
+        );
+        assert_eq!(
             terminal_metrics.region_watermark_map(),
             Some(std::collections::HashMap::from([(7_u64, 42_u64)]))
         );
@@ -900,5 +923,20 @@ mod tests {
     #[test]
     fn test_parse_terminal_metrics_rejects_invalid_json() {
         assert!(parse_terminal_metrics("{not-json}").is_none());
+    }
+
+    #[test]
+    fn test_output_metrics_distinguishes_empty_region_watermarks_from_absence() {
+        let metrics = OutputMetrics::default();
+        metrics.update(Some(RecordBatchMetrics::default()));
+
+        assert_eq!(
+            metrics.participating_regions(),
+            Some(std::collections::BTreeSet::new())
+        );
+        assert_eq!(
+            metrics.region_watermark_map(),
+            Some(std::collections::HashMap::new())
+        );
     }
 }

--- a/src/client/src/database.rs
+++ b/src/client/src/database.rs
@@ -25,6 +25,7 @@ use api::v1::{
     AlterTableExpr, AuthHeader, Basic, CreateTableExpr, DdlRequest, GreptimeRequest,
     InsertRequests, QueryRequest, RequestHeader, RowInsertRequests,
 };
+use arc_swap::ArcSwapOption;
 use arrow_flight::{FlightData, Ticket};
 use async_stream::stream;
 use base64::Engine;
@@ -35,6 +36,7 @@ use common_error::ext::BoxedError;
 use common_grpc::flight::do_put::DoPutResponse;
 use common_grpc::flight::{FlightDecoder, FlightMessage};
 use common_query::Output;
+use common_recordbatch::adapter::RecordBatchMetrics;
 use common_recordbatch::error::ExternalSnafu;
 use common_recordbatch::{RecordBatch, RecordBatchStreamWrapper};
 use common_telemetry::tracing::Span;
@@ -424,24 +426,76 @@ impl Database {
                 .fail()
             }
             FlightMessage::Schema(schema) => {
+                let metrics = Arc::new(ArcSwapOption::from(None));
+                let metrics_ref = metrics.clone();
                 let schema = Arc::new(
                     datatypes::schema::Schema::try_from(schema)
                         .context(error::ConvertSchemaSnafu)?,
                 );
                 let schema_cloned = schema.clone();
                 let stream = Box::pin(stream!({
-                    while let Some(flight_message) = flight_message_stream.next().await {
-                        let flight_message = flight_message
-                            .map_err(BoxedError::new)
-                            .context(ExternalSnafu)?;
+                    let mut buffered_message: Option<FlightMessage> = None;
+                    let mut stream_ended = false;
+
+                    while !stream_ended {
+                        let flight_message_item = if let Some(msg) = buffered_message.take() {
+                            Some(Ok(msg))
+                        } else {
+                            flight_message_stream.next().await
+                        };
+
+                        let flight_message = match flight_message_item {
+                            Some(Ok(message)) => message,
+                            Some(Err(e)) => {
+                                yield Err(BoxedError::new(e)).context(ExternalSnafu);
+                                break;
+                            }
+                            None => break,
+                        };
+
                         match flight_message {
                             FlightMessage::RecordBatch(arrow_batch) => {
-                                yield Ok(RecordBatch::from_df_record_batch(
+                                let result_to_yield = RecordBatch::from_df_record_batch(
                                     schema_cloned.clone(),
                                     arrow_batch,
-                                ))
+                                );
+
+                                if let Some(next_flight_message_result) =
+                                    flight_message_stream.next().await
+                                {
+                                    match next_flight_message_result {
+                                        Ok(FlightMessage::Metrics(s)) => {
+                                            let m: Option<Arc<RecordBatchMetrics>> =
+                                                serde_json::from_str(&s).ok().map(Arc::new);
+                                            metrics_ref.swap(m);
+                                        }
+                                        Ok(FlightMessage::RecordBatch(rb)) => {
+                                            buffered_message = Some(FlightMessage::RecordBatch(rb));
+                                        }
+                                        Ok(_) => {
+                                            yield IllegalFlightMessagesSnafu {reason: "A RecordBatch message can only be succeeded by a Metrics message or another RecordBatch message"}
+                                                .fail()
+                                                .map_err(BoxedError::new)
+                                                .context(ExternalSnafu);
+                                            break;
+                                        }
+                                        Err(e) => {
+                                            yield Err(BoxedError::new(e)).context(ExternalSnafu);
+                                            break;
+                                        }
+                                    }
+                                } else {
+                                    stream_ended = true;
+                                }
+
+                                yield Ok(result_to_yield)
                             }
-                            FlightMessage::Metrics(_) => {}
+                            FlightMessage::Metrics(s) => {
+                                let m: Option<Arc<RecordBatchMetrics>> =
+                                    serde_json::from_str(&s).ok().map(Arc::new);
+                                metrics_ref.swap(m);
+                                break;
+                            }
                             FlightMessage::AffectedRows(_) | FlightMessage::Schema(_) => {
                                 yield IllegalFlightMessagesSnafu {reason: format!("A Schema message must be succeeded exclusively by a set of RecordBatch messages, flight_message: {:?}", flight_message)}
                                         .fail()
@@ -456,7 +510,7 @@ impl Database {
                     schema,
                     stream,
                     output_ordering: None,
-                    metrics: Default::default(),
+                    metrics,
                     span: Span::current(),
                 };
                 Ok(Output::new_with_stream(Box::pin(record_batch_stream)))

--- a/src/client/src/database.rs
+++ b/src/client/src/database.rs
@@ -15,6 +15,8 @@
 use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::task::{Context, Poll};
 
 use api::v1::auth_header::AuthScheme;
 use api::v1::ddl_request::Expr as DdlExpr;
@@ -38,7 +40,7 @@ use common_grpc::flight::{FlightDecoder, FlightMessage};
 use common_query::Output;
 use common_recordbatch::adapter::RecordBatchMetrics;
 use common_recordbatch::error::ExternalSnafu;
-use common_recordbatch::{RecordBatch, RecordBatchStreamWrapper};
+use common_recordbatch::{OrderOption, RecordBatch, RecordBatchStream, RecordBatchStreamWrapper};
 use common_telemetry::tracing::Span;
 use common_telemetry::tracing_context::W3cTrace;
 use common_telemetry::{error, warn};
@@ -58,6 +60,148 @@ use crate::{Client, Result, error, from_grpc_response};
 type FlightDataStream = Pin<Box<dyn Stream<Item = FlightData> + Send>>;
 
 type DoPutResponseStream = Pin<Box<dyn Stream<Item = Result<DoPutResponse>>>>;
+
+#[derive(Debug, Clone, Default)]
+pub struct OutputMetrics {
+    metrics: Arc<ArcSwapOption<RecordBatchMetrics>>,
+    ready: Arc<AtomicBool>,
+}
+
+impl OutputMetrics {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn update(&self, metrics: Option<RecordBatchMetrics>) {
+        self.metrics.swap(metrics.map(Arc::new));
+    }
+
+    pub fn mark_ready(&self) {
+        self.ready.store(true, Ordering::Release);
+    }
+
+    pub fn is_ready(&self) -> bool {
+        self.ready.load(Ordering::Acquire)
+    }
+
+    pub fn get(&self) -> Option<RecordBatchMetrics> {
+        self.metrics.load().as_ref().map(|m| m.as_ref().clone())
+    }
+
+    pub fn region_watermark_map(&self) -> Option<std::collections::HashMap<u64, u64>> {
+        self.get()?.region_latest_sequences.map(|sequences| {
+            sequences
+                .into_iter()
+                .collect::<std::collections::HashMap<_, _>>()
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct OutputWithMetrics {
+    pub output: Output,
+    pub metrics: OutputMetrics,
+}
+
+impl OutputWithMetrics {
+    pub fn from_output(output: Output) -> Self {
+        let terminal_metrics = OutputMetrics::new();
+        let output = attach_terminal_metrics(output, &terminal_metrics);
+        Self {
+            output,
+            metrics: terminal_metrics,
+        }
+    }
+
+    pub fn region_watermark_map(&self) -> Option<std::collections::HashMap<u64, u64>> {
+        self.metrics.region_watermark_map()
+    }
+
+    pub fn into_output(self) -> Output {
+        self.output
+    }
+}
+
+fn parse_terminal_metrics(metrics_json: &str) -> Option<Arc<RecordBatchMetrics>> {
+    serde_json::from_str(metrics_json).ok().map(Arc::new)
+}
+
+struct StreamWithMetrics {
+    stream: common_recordbatch::SendableRecordBatchStream,
+    metrics: OutputMetrics,
+}
+
+impl StreamWithMetrics {
+    fn new(stream: common_recordbatch::SendableRecordBatchStream, metrics: OutputMetrics) -> Self {
+        Self { stream, metrics }
+    }
+
+    fn sync_terminal_metrics(&self) {
+        self.metrics.update(self.stream.metrics());
+    }
+
+    fn mark_ready_if_terminated(&self) {
+        self.metrics.mark_ready();
+    }
+}
+
+impl RecordBatchStream for StreamWithMetrics {
+    fn name(&self) -> &str {
+        self.stream.name()
+    }
+
+    fn schema(&self) -> datatypes::schema::SchemaRef {
+        self.stream.schema()
+    }
+
+    fn output_ordering(&self) -> Option<&[OrderOption]> {
+        self.stream.output_ordering()
+    }
+
+    fn metrics(&self) -> Option<RecordBatchMetrics> {
+        self.sync_terminal_metrics();
+        self.metrics.get()
+    }
+}
+
+impl Stream for StreamWithMetrics {
+    type Item = common_recordbatch::error::Result<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let polled = Pin::new(&mut self.stream).poll_next(cx);
+        match &polled {
+            Poll::Ready(Some(_)) => self.sync_terminal_metrics(),
+            Poll::Ready(None) => {
+                self.sync_terminal_metrics();
+                self.mark_ready_if_terminated();
+            }
+            Poll::Pending => {}
+        }
+        polled
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.stream.size_hint()
+    }
+}
+
+fn attach_terminal_metrics(output: Output, terminal_metrics: &OutputMetrics) -> Output {
+    let Output { data, meta } = output;
+    let data = match data {
+        common_query::OutputData::Stream(stream) => {
+            terminal_metrics.update(stream.metrics());
+            common_query::OutputData::Stream(Box::pin(StreamWithMetrics::new(
+                stream,
+                terminal_metrics.clone(),
+            )))
+        }
+        other => {
+            terminal_metrics.mark_ready();
+            other
+        }
+    };
+    Output::new(data, meta)
+}
 
 #[derive(Clone, Debug, Default)]
 pub struct Database {
@@ -335,15 +479,46 @@ impl Database {
         let request = Request::Query(QueryRequest {
             query: Some(Query::Sql(sql.as_ref().to_string())),
         });
-        self.do_get(request, hints).await
+        self.do_get(request, hints)
+            .await
+            .map(OutputWithMetrics::into_output)
+    }
+
+    pub async fn sql_with_terminal_metrics<S>(
+        &self,
+        sql: S,
+        hints: &[(&str, &str)],
+    ) -> Result<OutputWithMetrics>
+    where
+        S: AsRef<str>,
+    {
+        self.query_with_terminal_metrics(
+            QueryRequest {
+                query: Some(Query::Sql(sql.as_ref().to_string())),
+            },
+            hints,
+        )
+        .await
     }
 
     /// Executes a logical plan directly without SQL parsing.
     pub async fn logical_plan(&self, logical_plan: Vec<u8>) -> Result<Output> {
-        let request = Request::Query(QueryRequest {
-            query: Some(Query::LogicalPlan(logical_plan)),
-        });
-        self.do_get(request, &[]).await
+        self.query_with_terminal_metrics(
+            QueryRequest {
+                query: Some(Query::LogicalPlan(logical_plan)),
+            },
+            &[],
+        )
+        .await
+        .map(OutputWithMetrics::into_output)
+    }
+
+    pub async fn query_with_terminal_metrics(
+        &self,
+        request: QueryRequest,
+        hints: &[(&str, &str)],
+    ) -> Result<OutputWithMetrics> {
+        self.do_get(Request::Query(request), hints).await
     }
 
     /// Creates a new table using the provided table expression.
@@ -351,7 +526,9 @@ impl Database {
         let request = Request::Ddl(DdlRequest {
             expr: Some(DdlExpr::CreateTable(expr)),
         });
-        self.do_get(request, &[]).await
+        self.do_get(request, &[])
+            .await
+            .map(OutputWithMetrics::into_output)
     }
 
     /// Alters an existing table using the provided alter expression.
@@ -359,10 +536,12 @@ impl Database {
         let request = Request::Ddl(DdlRequest {
             expr: Some(DdlExpr::AlterTable(expr)),
         });
-        self.do_get(request, &[]).await
+        self.do_get(request, &[])
+            .await
+            .map(OutputWithMetrics::into_output)
     }
 
-    async fn do_get(&self, request: Request, hints: &[(&str, &str)]) -> Result<Output> {
+    async fn do_get(&self, request: Request, hints: &[(&str, &str)]) -> Result<OutputWithMetrics> {
         let request = self.to_rpc_request(request);
         let request = Ticket {
             ticket: request.encode_to_vec().into(),
@@ -411,13 +590,35 @@ impl Database {
 
         match first_flight_message {
             FlightMessage::AffectedRows(rows) => {
-                ensure!(
-                    flight_message_stream.next().await.is_none(),
-                    IllegalFlightMessagesSnafu {
-                        reason: "Expect 'AffectedRows' Flight messages to be the one and the only!"
+                let terminal_metrics = OutputMetrics::new();
+                let next_message = flight_message_stream.next().await.transpose()?;
+                match next_message {
+                    None => terminal_metrics.mark_ready(),
+                    Some(FlightMessage::Metrics(s)) => {
+                        terminal_metrics.update(
+                            parse_terminal_metrics(&s).map(|metrics| metrics.as_ref().clone()),
+                        );
+                        terminal_metrics.mark_ready();
+                        ensure!(
+                            flight_message_stream.next().await.is_none(),
+                            IllegalFlightMessagesSnafu {
+                                reason: "Expect 'AffectedRows' Flight messages to be followed by at most one Metrics message"
+                            }
+                        );
                     }
-                );
-                Ok(Output::new_with_affected_rows(rows))
+                    Some(other) => {
+                        return IllegalFlightMessagesSnafu {
+                            reason: format!(
+                                "'AffectedRows' Flight message can only be followed by a Metrics message, got {other:?}"
+                            ),
+                        }
+                        .fail();
+                    }
+                }
+                Ok(OutputWithMetrics {
+                    output: Output::new_with_affected_rows(rows),
+                    metrics: terminal_metrics,
+                })
             }
             FlightMessage::RecordBatch(_) | FlightMessage::Metrics(_) => {
                 IllegalFlightMessagesSnafu {
@@ -465,8 +666,7 @@ impl Database {
                                 {
                                     match next_flight_message_result {
                                         Ok(FlightMessage::Metrics(s)) => {
-                                            let m: Option<Arc<RecordBatchMetrics>> =
-                                                serde_json::from_str(&s).ok().map(Arc::new);
+                                            let m = parse_terminal_metrics(&s);
                                             metrics_ref.swap(m);
                                         }
                                         Ok(FlightMessage::RecordBatch(rb)) => {
@@ -491,8 +691,7 @@ impl Database {
                                 yield Ok(result_to_yield)
                             }
                             FlightMessage::Metrics(s) => {
-                                let m: Option<Arc<RecordBatchMetrics>> =
-                                    serde_json::from_str(&s).ok().map(Arc::new);
+                                let m = parse_terminal_metrics(&s);
                                 metrics_ref.swap(m);
                                 break;
                             }
@@ -513,7 +712,9 @@ impl Database {
                     metrics,
                     span: Span::current(),
                 };
-                Ok(Output::new_with_stream(Box::pin(record_batch_stream)))
+                Ok(OutputWithMetrics::from_output(Output::new_with_stream(
+                    Box::pin(record_batch_stream),
+                )))
             }
         }
     }
@@ -567,14 +768,58 @@ struct FlightContext {
 #[cfg(test)]
 mod tests {
     use std::assert_matches::assert_matches;
+    use std::sync::Arc;
+    use std::task::{Context, Poll};
 
     use api::v1::auth_header::AuthScheme;
     use api::v1::{AuthHeader, Basic};
     use common_error::status_code::StatusCode;
+    use common_query::OutputData;
+    use common_recordbatch::{OrderOption, RecordBatch, RecordBatchStream};
+    use datatypes::prelude::{ConcreteDataType, VectorRef};
+    use datatypes::schema::{ColumnSchema, Schema};
+    use datatypes::vectors::Int32Vector;
+    use futures_util::StreamExt;
     use tonic::{Code, Status};
 
     use super::*;
     use crate::error::TonicSnafu;
+
+    struct MockMetricsStream {
+        schema: datatypes::schema::SchemaRef,
+        batch: Option<RecordBatch>,
+        metrics: RecordBatchMetrics,
+        terminal_metrics_only: bool,
+    }
+
+    impl Stream for MockMetricsStream {
+        type Item = common_recordbatch::error::Result<RecordBatch>;
+
+        fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            Poll::Ready(self.batch.take().map(Ok))
+        }
+    }
+
+    impl RecordBatchStream for MockMetricsStream {
+        fn name(&self) -> &str {
+            "MockMetricsStream"
+        }
+
+        fn schema(&self) -> datatypes::schema::SchemaRef {
+            self.schema.clone()
+        }
+
+        fn output_ordering(&self) -> Option<&[OrderOption]> {
+            None
+        }
+
+        fn metrics(&self) -> Option<RecordBatchMetrics> {
+            if self.terminal_metrics_only && self.batch.is_some() {
+                return None;
+            }
+            Some(self.metrics.clone())
+        }
+    }
 
     #[test]
     fn test_flight_ctx() {
@@ -611,5 +856,49 @@ mod tests {
         let actual: Error = status.into();
 
         assert_eq!(expected.to_string(), actual.to_string());
+    }
+
+    #[tokio::test]
+    async fn test_query_with_terminal_metrics_tracks_terminal_only_metrics() {
+        let schema = Arc::new(Schema::new(vec![ColumnSchema::new(
+            "v",
+            ConcreteDataType::int32_datatype(),
+            false,
+        )]));
+        let batch = RecordBatch::new(
+            schema.clone(),
+            vec![Arc::new(Int32Vector::from_slice([1, 2])) as VectorRef],
+        )
+        .unwrap();
+        let output = Output::new_with_stream(Box::pin(MockMetricsStream {
+            schema,
+            batch: Some(batch),
+            metrics: RecordBatchMetrics {
+                region_latest_sequences: Some(vec![(7, 42)]),
+                ..Default::default()
+            },
+            terminal_metrics_only: true,
+        }));
+
+        let result = OutputWithMetrics::from_output(output);
+        let terminal_metrics = result.metrics.clone();
+        assert!(!terminal_metrics.is_ready());
+        assert!(terminal_metrics.get().is_none());
+
+        let OutputData::Stream(mut stream) = result.output.data else {
+            panic!("expected stream output");
+        };
+        while stream.next().await.is_some() {}
+
+        assert!(terminal_metrics.is_ready());
+        assert_eq!(
+            terminal_metrics.region_watermark_map(),
+            Some(std::collections::HashMap::from([(7_u64, 42_u64)]))
+        );
+    }
+
+    #[test]
+    fn test_parse_terminal_metrics_rejects_invalid_json() {
+        assert!(parse_terminal_metrics("{not-json}").is_none());
     }
 }

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -34,7 +34,7 @@ pub use common_recordbatch::{RecordBatches, SendableRecordBatchStream};
 use snafu::OptionExt;
 
 pub use self::client::Client;
-pub use self::database::Database;
+pub use self::database::{Database, OutputMetrics, OutputWithMetrics};
 pub use self::error::{Error, Result};
 use crate::error::{IllegalDatabaseResponseSnafu, ServerSnafu};
 

--- a/src/common/meta/src/ddl/tests/create_flow.rs
+++ b/src/common/meta/src/ddl/tests/create_flow.rs
@@ -37,6 +37,8 @@ fn test_query_context() -> QueryContext {
         timezone: "UTC".to_string(),
         extensions: HashMap::new(),
         channel: 0,
+        snapshot_seqs: HashMap::new(),
+        sst_min_sequences: HashMap::new(),
     }
 }
 
@@ -251,6 +253,10 @@ fn test_create_flow_data_new_format_serialization() {
         catalog: "new_catalog".to_string(),
         schema: "new_schema".to_string(),
         timezone: "America/New_York".to_string(),
+        extensions: HashMap::new(),
+        channel: 0,
+        snapshot_seqs: HashMap::new(),
+        sst_min_sequences: HashMap::new(),
     };
 
     let data = CreateFlowData {
@@ -272,6 +278,9 @@ fn test_create_flow_data_new_format_serialization() {
     assert_eq!(deserialized.flow_context.catalog, "new_catalog");
     assert_eq!(deserialized.flow_context.schema, "new_schema");
     assert_eq!(deserialized.flow_context.timezone, "America/New_York");
+    assert_eq!(deserialized.flow_context.channel, 0);
+    assert_eq!(deserialized.flow_context.snapshot_seqs, HashMap::new());
+    assert_eq!(deserialized.flow_context.sst_min_sequences, HashMap::new());
 }
 
 #[test]
@@ -286,6 +295,8 @@ fn test_flow_query_context_conversion_from_query_context() {
         ]
         .into(),
         channel: 99,
+        snapshot_seqs: HashMap::from([(1, 10)]),
+        sst_min_sequences: HashMap::from([(1, 8)]),
     };
 
     let flow_context: FlowQueryContext = query_context.into();
@@ -293,6 +304,9 @@ fn test_flow_query_context_conversion_from_query_context() {
     assert_eq!(flow_context.catalog, "prod_catalog");
     assert_eq!(flow_context.schema, "public");
     assert_eq!(flow_context.timezone, "America/Los_Angeles");
+    assert_eq!(flow_context.channel, 99);
+    assert_eq!(flow_context.snapshot_seqs, HashMap::from([(1, 10)]));
+    assert_eq!(flow_context.sst_min_sequences, HashMap::from([(1, 8)]));
 }
 
 #[test]
@@ -301,6 +315,10 @@ fn test_flow_info_conversion_with_flow_context() {
         catalog: "info_catalog".to_string(),
         schema: "info_schema".to_string(),
         timezone: "Europe/Berlin".to_string(),
+        extensions: HashMap::new(),
+        channel: 0,
+        snapshot_seqs: HashMap::new(),
+        sst_min_sequences: HashMap::new(),
     };
 
     let data = CreateFlowData {
@@ -349,6 +367,10 @@ fn test_mixed_serialization_format_support() {
         catalog: "test".to_string(),
         schema: "test".to_string(),
         timezone: "UTC".to_string(),
+        extensions: HashMap::new(),
+        channel: 0,
+        snapshot_seqs: HashMap::new(),
+        sst_min_sequences: HashMap::new(),
     };
     assert_eq!(ctx_from_new, expected_new);
 }

--- a/src/common/meta/src/rpc/ddl.rs
+++ b/src/common/meta/src/rpc/ddl.rs
@@ -1432,6 +1432,10 @@ pub struct QueryContext {
     pub timezone: String,
     pub extensions: HashMap<String, String>,
     pub channel: u8,
+    #[serde(default)]
+    pub snapshot_seqs: HashMap<u64, u64>,
+    #[serde(default)]
+    pub sst_min_sequences: HashMap<u64, u64>,
 }
 
 impl QueryContext {
@@ -1459,6 +1463,14 @@ impl QueryContext {
     pub fn channel(&self) -> u8 {
         self.channel
     }
+
+    pub fn snapshot_seqs(&self) -> &HashMap<u64, u64> {
+        &self.snapshot_seqs
+    }
+
+    pub fn sst_min_sequences(&self) -> &HashMap<u64, u64> {
+        &self.sst_min_sequences
+    }
 }
 
 /// Lightweight query context for flow operations containing only essential fields.
@@ -1466,12 +1478,17 @@ impl QueryContext {
 /// for flow creation and execution.
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct FlowQueryContext {
-    /// Current catalog name - needed for flow metadata and recovery
     pub catalog: String,
-    /// Current schema name - needed for table resolution during flow execution
     pub schema: String,
-    /// Timezone for timestamp operations in the flow
     pub timezone: String,
+    #[serde(default)]
+    pub extensions: HashMap<String, String>,
+    #[serde(default)]
+    pub channel: u8,
+    #[serde(default)]
+    pub snapshot_seqs: HashMap<u64, u64>,
+    #[serde(default)]
+    pub sst_min_sequences: HashMap<u64, u64>,
 }
 
 impl<'de> Deserialize<'de> for FlowQueryContext {
@@ -1492,6 +1509,14 @@ impl<'de> Deserialize<'de> for FlowQueryContext {
             catalog: String,
             schema: String,
             timezone: String,
+            #[serde(default)]
+            extensions: HashMap<String, String>,
+            #[serde(default)]
+            channel: u8,
+            #[serde(default)]
+            snapshot_seqs: HashMap<u64, u64>,
+            #[serde(default)]
+            sst_min_sequences: HashMap<u64, u64>,
         }
 
         match ContextCompat::deserialize(deserializer)? {
@@ -1499,6 +1524,10 @@ impl<'de> Deserialize<'de> for FlowQueryContext {
                 catalog: helper.catalog,
                 schema: helper.schema,
                 timezone: helper.timezone,
+                extensions: helper.extensions,
+                channel: helper.channel,
+                snapshot_seqs: helper.snapshot_seqs,
+                sst_min_sequences: helper.sst_min_sequences,
             }),
             ContextCompat::Full(full_ctx) => Ok(full_ctx.into()),
         }
@@ -1507,12 +1536,21 @@ impl<'de> Deserialize<'de> for FlowQueryContext {
 
 impl From<PbQueryContext> for QueryContext {
     fn from(pb_ctx: PbQueryContext) -> Self {
+        let snapshot_sequences = pb_ctx.snapshot_seqs;
         Self {
             current_catalog: pb_ctx.current_catalog,
             current_schema: pb_ctx.current_schema,
             timezone: pb_ctx.timezone,
             extensions: pb_ctx.extensions,
             channel: pb_ctx.channel as u8,
+            snapshot_seqs: snapshot_sequences
+                .as_ref()
+                .map(|x| x.snapshot_seqs.clone())
+                .unwrap_or_default(),
+            sst_min_sequences: snapshot_sequences
+                .as_ref()
+                .map(|x| x.sst_min_sequences.clone())
+                .unwrap_or_default(),
         }
     }
 }
@@ -1525,6 +1563,8 @@ impl From<QueryContext> for PbQueryContext {
             timezone,
             extensions,
             channel,
+            snapshot_seqs,
+            sst_min_sequences,
         }: QueryContext,
     ) -> Self {
         PbQueryContext {
@@ -1533,7 +1573,10 @@ impl From<QueryContext> for PbQueryContext {
             timezone,
             extensions,
             channel: channel as u32,
-            snapshot_seqs: None,
+            snapshot_seqs: Some(api::v1::SnapshotSequences {
+                snapshot_seqs,
+                sst_min_sequences,
+            }),
             explain: None,
         }
     }
@@ -1545,6 +1588,10 @@ impl From<QueryContext> for FlowQueryContext {
             catalog: ctx.current_catalog,
             schema: ctx.current_schema,
             timezone: ctx.timezone,
+            extensions: ctx.extensions,
+            channel: ctx.channel,
+            snapshot_seqs: ctx.snapshot_seqs,
+            sst_min_sequences: ctx.sst_min_sequences,
         }
     }
 }
@@ -1555,8 +1602,10 @@ impl From<FlowQueryContext> for QueryContext {
             current_catalog: flow_ctx.catalog,
             current_schema: flow_ctx.schema,
             timezone: flow_ctx.timezone,
-            extensions: HashMap::new(),
-            channel: 0, // Use default channel for flows
+            extensions: flow_ctx.extensions,
+            channel: flow_ctx.channel,
+            snapshot_seqs: flow_ctx.snapshot_seqs,
+            sst_min_sequences: flow_ctx.sst_min_sequences,
         }
     }
 }
@@ -1720,6 +1769,8 @@ mod tests {
             timezone: "UTC".to_string(),
             extensions,
             channel: 5,
+            snapshot_seqs: HashMap::from([(10, 100)]),
+            sst_min_sequences: HashMap::from([(10, 90)]),
         };
 
         let flow_ctx: FlowQueryContext = query_ctx.into();
@@ -1727,6 +1778,9 @@ mod tests {
         assert_eq!(flow_ctx.catalog, "test_catalog");
         assert_eq!(flow_ctx.schema, "test_schema");
         assert_eq!(flow_ctx.timezone, "UTC");
+        assert_eq!(flow_ctx.channel, 5);
+        assert_eq!(flow_ctx.snapshot_seqs, HashMap::from([(10, 100)]));
+        assert_eq!(flow_ctx.sst_min_sequences, HashMap::from([(10, 90)]));
     }
 
     #[test]
@@ -1735,6 +1789,10 @@ mod tests {
             catalog: "prod_catalog".to_string(),
             schema: "public".to_string(),
             timezone: "America/New_York".to_string(),
+            extensions: HashMap::from([("k".to_string(), "v".to_string())]),
+            channel: 7,
+            snapshot_seqs: HashMap::from([(11, 111)]),
+            sst_min_sequences: HashMap::from([(11, 101)]),
         };
 
         let query_ctx: QueryContext = flow_ctx.clone().into();
@@ -1742,8 +1800,13 @@ mod tests {
         assert_eq!(query_ctx.current_catalog, "prod_catalog");
         assert_eq!(query_ctx.current_schema, "public");
         assert_eq!(query_ctx.timezone, "America/New_York");
-        assert!(query_ctx.extensions.is_empty());
-        assert_eq!(query_ctx.channel, 0);
+        assert_eq!(
+            query_ctx.extensions,
+            HashMap::from([("k".to_string(), "v".to_string())])
+        );
+        assert_eq!(query_ctx.channel, 7);
+        assert_eq!(query_ctx.snapshot_seqs, HashMap::from([(11, 111)]));
+        assert_eq!(query_ctx.sst_min_sequences, HashMap::from([(11, 101)]));
 
         // Test roundtrip conversion
         let flow_ctx_roundtrip: FlowQueryContext = query_ctx.into();
@@ -1756,6 +1819,10 @@ mod tests {
             catalog: "test_catalog".to_string(),
             schema: "test_schema".to_string(),
             timezone: "UTC".to_string(),
+            extensions: HashMap::new(),
+            channel: 0,
+            snapshot_seqs: HashMap::new(),
+            sst_min_sequences: HashMap::new(),
         };
 
         let serialized = serde_json::to_string(&flow_ctx).unwrap();
@@ -1776,6 +1843,10 @@ mod tests {
             catalog: "pb_catalog".to_string(),
             schema: "pb_schema".to_string(),
             timezone: "Asia/Tokyo".to_string(),
+            extensions: HashMap::from([("x".to_string(), "y".to_string())]),
+            channel: 6,
+            snapshot_seqs: HashMap::from([(3, 30)]),
+            sst_min_sequences: HashMap::from([(3, 21)]),
         };
 
         let pb_ctx: PbQueryContext = flow_ctx.into();
@@ -1783,9 +1854,44 @@ mod tests {
         assert_eq!(pb_ctx.current_catalog, "pb_catalog");
         assert_eq!(pb_ctx.current_schema, "pb_schema");
         assert_eq!(pb_ctx.timezone, "Asia/Tokyo");
-        assert!(pb_ctx.extensions.is_empty());
-        assert_eq!(pb_ctx.channel, 0);
-        assert!(pb_ctx.snapshot_seqs.is_none());
+        assert_eq!(
+            pb_ctx.extensions,
+            HashMap::from([("x".to_string(), "y".to_string())])
+        );
+        assert_eq!(pb_ctx.channel, 6);
+        assert_eq!(
+            pb_ctx.snapshot_seqs,
+            Some(api::v1::SnapshotSequences {
+                snapshot_seqs: HashMap::from([(3, 30)]),
+                sst_min_sequences: HashMap::from([(3, 21)]),
+            })
+        );
         assert!(pb_ctx.explain.is_none());
+    }
+
+    #[test]
+    fn test_pb_query_context_roundtrip_with_snapshot_sequences() {
+        let pb = PbQueryContext {
+            current_catalog: "c1".to_string(),
+            current_schema: "s1".to_string(),
+            timezone: "UTC".to_string(),
+            extensions: HashMap::from([("flow.return_region_seq".to_string(), "true".to_string())]),
+            channel: 3,
+            snapshot_seqs: Some(api::v1::SnapshotSequences {
+                snapshot_seqs: HashMap::from([(1, 100)]),
+                sst_min_sequences: HashMap::from([(1, 90)]),
+            }),
+            explain: None,
+        };
+
+        let query_ctx: QueryContext = pb.clone().into();
+        let pb_roundtrip: PbQueryContext = query_ctx.into();
+
+        assert_eq!(pb_roundtrip.current_catalog, pb.current_catalog);
+        assert_eq!(pb_roundtrip.current_schema, pb.current_schema);
+        assert_eq!(pb_roundtrip.timezone, pb.timezone);
+        assert_eq!(pb_roundtrip.extensions, pb.extensions);
+        assert_eq!(pb_roundtrip.channel, pb.channel);
+        assert_eq!(pb_roundtrip.snapshot_seqs, pb.snapshot_seqs);
     }
 }

--- a/src/common/recordbatch/src/adapter.rs
+++ b/src/common/recordbatch/src/adapter.rs
@@ -446,8 +446,15 @@ pub struct RecordBatchMetrics {
     // Detailed per-plan metrics
     /// An ordered list of plan metrics, from top to bottom in post-order.
     pub plan_metrics: Vec<PlanMetrics>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub region_watermarks: Vec<RegionWatermarkEntry>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RegionWatermarkEntry {
+    pub region_id: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub region_latest_sequences: Option<Vec<(u64, u64)>>,
+    pub watermark: Option<u64>,
 }
 
 /// Determines if a metric name represents a time measurement that should be formatted.

--- a/src/common/recordbatch/src/adapter.rs
+++ b/src/common/recordbatch/src/adapter.rs
@@ -446,6 +446,8 @@ pub struct RecordBatchMetrics {
     // Detailed per-plan metrics
     /// An ordered list of plan metrics, from top to bottom in post-order.
     pub plan_metrics: Vec<PlanMetrics>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub region_latest_sequences: Option<Vec<(u64, u64)>>,
 }
 
 /// Determines if a metric name represents a time measurement that should be formatted.

--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -19,7 +19,7 @@ use std::fmt::Debug;
 use std::ops::Deref;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use std::task::{Context, Poll};
 use std::time::Duration;
 
@@ -71,9 +71,9 @@ use store_api::metric_engine_consts::{
     FILE_ENGINE_NAME, LOGICAL_TABLE_METADATA_KEY, METRIC_ENGINE_NAME,
 };
 use store_api::region_engine::{
-    RegionEngineRef, RegionManifestInfo, RegionRole, RegionStatistic, RemapManifestsRequest,
-    RemapManifestsResponse, SetRegionRoleStateResponse, SettableRegionRoleState,
-    SyncRegionFromRequest,
+    RegionEngine, RegionEngineRef, RegionManifestInfo, RegionRole, RegionStatistic,
+    RemapManifestsRequest, RemapManifestsResponse, SetRegionRoleStateResponse,
+    SettableRegionRoleState, SyncRegionFromRequest,
 };
 use store_api::region_request::{
     AffectedRows, BatchRegionDdlRequest, RegionCatchupRequest, RegionCloseRequest,
@@ -224,7 +224,6 @@ impl RegionServer {
         self.inner.handle_request(region_id, request).await
     }
 
-    /// Returns a table provider for the region. Will set snapshot sequence if available in the context.
     async fn table_provider(
         &self,
         region_id: RegionId,
@@ -241,9 +240,21 @@ impl RegionServer {
             RegionNotReadySnafu { region_id }
         );
 
+        let engine = status.into_engine();
+        if let Some(ctx) = &ctx
+            && should_return_region_seq(ctx)
+            && ctx.get_snapshot(region_id.as_u64()).is_none()
+        {
+            let sampled_sequence = engine
+                .get_committed_sequence(region_id)
+                .await
+                .with_context(|_| HandleRegionRequestSnafu { region_id })?;
+            bind_snapshot_bound_region_seq(ctx, region_id, sampled_sequence);
+        }
+
         self.inner
             .table_provider_factory
-            .create(region_id, status.into_engine(), ctx)
+            .create(region_id, engine, ctx)
             .await
             .context(ExecuteLogicalPlanSnafu)
     }
@@ -261,20 +272,6 @@ impl RegionServer {
         };
 
         let region_id = RegionId::from_u64(request.region_id);
-        let should_return_region_seq = should_return_region_seq(&query_ctx);
-        let region_latest_seq = if should_return_region_seq {
-            let engine = self
-                .find_engine(region_id)?
-                .context(RegionNotFoundSnafu { region_id })?;
-            Some(
-                engine
-                    .get_committed_sequence(region_id)
-                    .await
-                    .with_context(|_| HandleRegionRequestSnafu { region_id })?,
-            )
-        } else {
-            None
-        };
         let catalog_list = Arc::new(NameAwareCatalogList::new(
             self.clone(),
             region_id,
@@ -305,13 +302,23 @@ impl RegionServer {
                     region_id,
                     plan,
                 },
-                query_ctx,
+                query_ctx.clone(),
             )
             .await?;
 
+        let region_latest_seq = if should_return_region_seq(&query_ctx) {
+            query_ctx.get_snapshot(region_id.as_u64())
+        } else {
+            None
+        };
+
         if let Some(seq) = region_latest_seq {
-            Ok(Box::pin(RegionWatermarkStream::new(stream, region_id, seq))
-                as SendableRecordBatchStream)
+            Ok(Box::pin(RegionWatermarkStream::new(
+                stream,
+                region_id,
+                seq,
+                self.find_engine(region_id)?,
+            )) as SendableRecordBatchStream)
         } else {
             Ok(stream)
         }
@@ -782,30 +789,95 @@ fn should_return_region_seq(query_ctx: &QueryContext) -> bool {
         || query_ctx.extension(FLOW_INCREMENTAL_AFTER_SEQS).is_some()
 }
 
+fn bind_snapshot_bound_region_seq(
+    query_ctx: &QueryContext,
+    region_id: RegionId,
+    sampled_sequence: u64,
+) -> u64 {
+    if let Some(snapshot_seq) = query_ctx.get_snapshot(region_id.as_u64()) {
+        snapshot_seq
+    } else {
+        query_ctx.set_snapshot(region_id.as_u64(), sampled_sequence);
+        sampled_sequence
+    }
+}
+
+/// Returns whether `snapshot_sequence` is a valid correctness watermark for this region,
+/// i.e. whether this query can safely treat it as the read upper bound.
+///
+/// For now this proof only covers memtable-side sequence information; SST-side proof
+/// can be added later if finer sequence metadata becomes available.
+fn can_prove_region_watermark_for_engine(
+    engine: &dyn RegionEngine,
+    region_id: RegionId,
+    snapshot_sequence: u64,
+) -> bool {
+    if let Some(mito_engine) = engine.as_any().downcast_ref::<MitoEngine>()
+        && let Some(region) = mito_engine.find_region(region_id)
+    {
+        return snapshot_sequence >= region.flushed_sequence();
+    }
+    true
+}
+
 struct RegionWatermarkStream {
     stream: SendableRecordBatchStream,
-    region_latest_sequence: (u64, u64),
+    region_id: u64,
+    snapshot_seq: u64,
+    proof_engine: Option<RegionEngineRef>,
     finished: AtomicBool,
+    proof_state: Mutex<Option<bool>>,
 }
 
 impl RegionWatermarkStream {
-    fn new(stream: SendableRecordBatchStream, region_id: RegionId, latest_sequence: u64) -> Self {
+    fn new(
+        stream: SendableRecordBatchStream,
+        region_id: RegionId,
+        latest_sequence: u64,
+        proof_engine: Option<RegionEngineRef>,
+    ) -> Self {
         Self {
             stream,
-            region_latest_sequence: (region_id.as_u64(), latest_sequence),
+            region_id: region_id.as_u64(),
+            snapshot_seq: latest_sequence,
+            proof_engine,
             finished: AtomicBool::new(false),
+            proof_state: Mutex::new(None),
         }
     }
 
+    fn compute_proof(&self) -> bool {
+        self.proof_engine
+            .as_ref()
+            .map(|engine| {
+                can_prove_region_watermark_for_engine(
+                    engine.as_ref(),
+                    RegionId::from_u64(self.region_id),
+                    self.snapshot_seq,
+                )
+            })
+            .unwrap_or(false)
+    }
+
+    fn proof_passed(&self) -> bool {
+        self.proof_state.lock().unwrap().unwrap_or(false)
+    }
+
     fn merged_metrics(&self, mut metrics: RecordBatchMetrics) -> RecordBatchMetrics {
+        // TODO(discord9): Move correctness-watermark proof into the mito scan
+        // path. The current stream-end proof is conservatively safe, but still
+        // allows false negatives if a late flush happens after the scan snapshot.
+        if !self.proof_passed() {
+            return metrics;
+        }
         let region_latest_sequences = metrics.region_latest_sequences.get_or_insert_with(Vec::new);
         if let Some((_, seq)) = region_latest_sequences
             .iter_mut()
-            .find(|(region_id, _)| *region_id == self.region_latest_sequence.0)
+            .find(|(region_id, _)| *region_id == self.region_id)
         {
-            *seq = self.region_latest_sequence.1;
+            *seq = self.snapshot_seq;
         } else {
-            region_latest_sequences.push(self.region_latest_sequence);
+            region_latest_sequences.push((self.region_id, self.snapshot_seq));
         }
         metrics
     }
@@ -840,6 +912,7 @@ impl Stream for RegionWatermarkStream {
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match Pin::new(&mut self.stream).poll_next(cx) {
             Poll::Ready(None) => {
+                *self.proof_state.lock().unwrap() = Some(self.compute_proof());
                 self.finished.store(true, Ordering::Relaxed);
                 Poll::Ready(None)
             }
@@ -851,16 +924,21 @@ impl Stream for RegionWatermarkStream {
 #[cfg(test)]
 mod watermark_tests {
     use std::collections::HashMap;
-    use std::sync::Arc;
+    use std::sync::{Arc, RwLock};
 
+    use api::v1::Rows;
     use common_recordbatch::{RecordBatch, RecordBatches};
     use datatypes::prelude::{ConcreteDataType, VectorRef};
     use datatypes::schema::{ColumnSchema, Schema};
     use datatypes::vectors::Int32Vector;
     use futures_util::StreamExt;
+    use mito2::config::MitoConfig;
+    use mito2::test_util::{self, CreateRequestBuilder, TestEnv};
     use session::context::QueryContextBuilder;
+    use store_api::region_request::RegionRequest;
 
     use super::*;
+    use crate::tests::MockRegionEngine;
 
     #[test]
     fn test_should_return_region_seq() {
@@ -884,6 +962,98 @@ mod watermark_tests {
         assert!(!should_return_region_seq(&ctx));
     }
 
+    #[test]
+    fn test_full_query_and_incremental_queries_require_region_seq() {
+        let ctx = QueryContextBuilder::default()
+            .extensions(HashMap::from([(
+                FLOW_INCREMENTAL_AFTER_SEQS.to_string(),
+                r#"{"1":10}"#.to_string(),
+            )]))
+            .build();
+        assert!(should_return_region_seq(&ctx));
+
+        let ctx = QueryContextBuilder::default()
+            .extensions(HashMap::from([(
+                FLOW_RETURN_REGION_SEQ.to_string(),
+                "true".to_string(),
+            )]))
+            .build();
+        assert!(should_return_region_seq(&ctx));
+
+        let ctx = QueryContextBuilder::default().build();
+        assert!(!should_return_region_seq(&ctx));
+    }
+
+    #[test]
+    fn test_bind_snapshot_bound_region_seq_reuses_existing_snapshot() {
+        let region_id = RegionId::new(42, 7);
+        let ctx = QueryContextBuilder::default()
+            .snapshot_seqs(Arc::new(RwLock::new(HashMap::from([(
+                region_id.as_u64(),
+                42_u64,
+            )]))))
+            .build();
+
+        let seq = bind_snapshot_bound_region_seq(&ctx, region_id, 99);
+
+        assert_eq!(seq, 42);
+        assert_eq!(ctx.get_snapshot(region_id.as_u64()), Some(42));
+    }
+
+    #[test]
+    fn test_bind_snapshot_bound_region_seq_sets_sampled_sequence() {
+        let region_id = RegionId::new(42, 7);
+        let ctx = QueryContextBuilder::default().build();
+
+        let seq = bind_snapshot_bound_region_seq(&ctx, region_id, 99);
+
+        assert_eq!(seq, 99);
+        assert_eq!(ctx.get_snapshot(region_id.as_u64()), Some(99));
+    }
+
+    #[test]
+    fn test_can_prove_region_watermark_for_non_mito_engine_defaults_true() {
+        let engine = MockRegionEngine::new(MITO_ENGINE_NAME).0;
+        assert!(can_prove_region_watermark_for_engine(
+            engine.as_ref(),
+            RegionId::new(1, 1),
+            42,
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_can_prove_region_watermark_for_mito_engine_when_snapshot_ge_flushed() {
+        let mut env = TestEnv::with_prefix(
+            "test_can_prove_region_watermark_for_mito_engine_when_snapshot_ge_flushed",
+        )
+        .await;
+        let engine = env.create_engine(MitoConfig::default()).await;
+
+        let region_id = RegionId::new(1, 1);
+        let request = CreateRequestBuilder::new().build();
+        let column_schemas = test_util::rows_schema(&request);
+        engine
+            .handle_request(region_id, RegionRequest::Create(request))
+            .await
+            .unwrap();
+
+        let rows = Rows {
+            schema: column_schemas,
+            rows: test_util::build_rows(0, 3),
+        };
+        test_util::put_rows(&engine, region_id, rows).await;
+        test_util::flush_region(&engine, region_id, None).await;
+
+        let region = engine.find_region(region_id).unwrap();
+        let snapshot_seq = region.flushed_sequence();
+
+        assert!(can_prove_region_watermark_for_engine(
+            &engine,
+            region_id,
+            snapshot_seq,
+        ));
+    }
+
     #[tokio::test]
     async fn test_region_watermark_stream_only_sets_terminal_metrics() {
         let schema = Arc::new(Schema::new(vec![ColumnSchema::new(
@@ -898,7 +1068,8 @@ mod watermark_tests {
             .as_stream();
 
         let region_id = RegionId::new(42, 7);
-        let wrapped = RegionWatermarkStream::new(stream, region_id, 99);
+        let proof_engine = Some(MockRegionEngine::new(MITO_ENGINE_NAME).0 as RegionEngineRef);
+        let wrapped = RegionWatermarkStream::new(stream, region_id, 99, proof_engine);
         let mut pinned = Box::pin(wrapped);
 
         assert!(pinned.as_ref().get_ref().metrics().is_none());
@@ -909,6 +1080,87 @@ mod watermark_tests {
             metrics.region_latest_sequences,
             Some(vec![(region_id.as_u64(), 99)])
         );
+    }
+
+    #[tokio::test]
+    async fn test_region_watermark_stream_without_proof_engine_omits_watermark() {
+        let schema = Arc::new(Schema::new(vec![ColumnSchema::new(
+            "v",
+            ConcreteDataType::int32_datatype(),
+            false,
+        )]));
+        let values: VectorRef = Arc::new(Int32Vector::from_slice([1, 2]));
+        let batch = RecordBatch::new(schema.clone(), vec![values]).unwrap();
+        let stream = RecordBatches::try_new(schema, vec![batch])
+            .unwrap()
+            .as_stream();
+
+        let region_id = RegionId::new(42, 7);
+        let wrapped = RegionWatermarkStream::new(stream, region_id, 99, None);
+        let mut pinned = Box::pin(wrapped);
+
+        while pinned.next().await.is_some() {}
+
+        let metrics = pinned.as_ref().get_ref().metrics().unwrap();
+        assert!(metrics.region_latest_sequences.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_region_watermark_stream_omits_watermark_after_late_flush() {
+        let mut env =
+            TestEnv::with_prefix("test_region_watermark_stream_omits_watermark_after_late_flush")
+                .await;
+        let engine = env.create_engine(MitoConfig::default()).await;
+
+        let region_id = RegionId::new(1, 1);
+        let request = CreateRequestBuilder::new().build();
+        let column_schemas = test_util::rows_schema(&request);
+        engine
+            .handle_request(region_id, RegionRequest::Create(request))
+            .await
+            .unwrap();
+
+        let initial_rows = Rows {
+            schema: column_schemas.clone(),
+            rows: test_util::build_rows(0, 3),
+        };
+        test_util::put_rows(&engine, region_id, initial_rows).await;
+        test_util::flush_region(&engine, region_id, None).await;
+
+        let snapshot_seq = engine.find_region(region_id).unwrap().flushed_sequence();
+
+        let schema = Arc::new(Schema::new(vec![ColumnSchema::new(
+            "v",
+            ConcreteDataType::int32_datatype(),
+            false,
+        )]));
+        let values: VectorRef = Arc::new(Int32Vector::from_slice([1, 2]));
+        let batch = RecordBatch::new(schema.clone(), vec![values]).unwrap();
+        let stream = RecordBatches::try_new(schema, vec![batch])
+            .unwrap()
+            .as_stream();
+
+        let wrapped = RegionWatermarkStream::new(
+            stream,
+            region_id,
+            snapshot_seq,
+            Some(Arc::new(engine.clone()) as RegionEngineRef),
+        );
+        let mut pinned = Box::pin(wrapped);
+
+        assert!(pinned.next().await.is_some());
+
+        let late_rows = Rows {
+            schema: column_schemas,
+            rows: test_util::build_rows(3, 5),
+        };
+        test_util::put_rows(&engine, region_id, late_rows).await;
+        test_util::flush_region(&engine, region_id, None).await;
+
+        assert!(pinned.next().await.is_none());
+
+        let metrics = pinned.as_ref().get_ref().metrics().unwrap();
+        assert!(metrics.region_latest_sequences.is_none());
     }
 }
 

--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -864,21 +864,29 @@ impl RegionWatermarkStream {
     }
 
     fn merged_metrics(&self, mut metrics: RecordBatchMetrics) -> RecordBatchMetrics {
+        let entry = if let Some(entry) = metrics
+            .region_watermarks
+            .iter_mut()
+            .find(|entry| entry.region_id == self.region_id)
+        {
+            entry
+        } else {
+            metrics
+                .region_watermarks
+                .push(common_recordbatch::adapter::RegionWatermarkEntry {
+                    region_id: self.region_id,
+                    watermark: None,
+                });
+            metrics.region_watermarks.last_mut().unwrap()
+        };
+
         // TODO(discord9): Move correctness-watermark proof into the mito scan
         // path. The current stream-end proof is conservatively safe, but still
         // allows false negatives if a late flush happens after the scan snapshot.
         if !self.proof_passed() {
             return metrics;
         }
-        let region_latest_sequences = metrics.region_latest_sequences.get_or_insert_with(Vec::new);
-        if let Some((_, seq)) = region_latest_sequences
-            .iter_mut()
-            .find(|(region_id, _)| *region_id == self.region_id)
-        {
-            *seq = self.snapshot_seq;
-        } else {
-            region_latest_sequences.push((self.region_id, self.snapshot_seq));
-        }
+        entry.watermark = Some(self.snapshot_seq);
         metrics
     }
 }
@@ -1077,8 +1085,11 @@ mod watermark_tests {
 
         let metrics = pinned.as_ref().get_ref().metrics().unwrap();
         assert_eq!(
-            metrics.region_latest_sequences,
-            Some(vec![(region_id.as_u64(), 99)])
+            metrics.region_watermarks,
+            vec![common_recordbatch::adapter::RegionWatermarkEntry {
+                region_id: region_id.as_u64(),
+                watermark: Some(99),
+            }]
         );
     }
 
@@ -1102,7 +1113,13 @@ mod watermark_tests {
         while pinned.next().await.is_some() {}
 
         let metrics = pinned.as_ref().get_ref().metrics().unwrap();
-        assert!(metrics.region_latest_sequences.is_none());
+        assert_eq!(
+            metrics.region_watermarks,
+            vec![common_recordbatch::adapter::RegionWatermarkEntry {
+                region_id: region_id.as_u64(),
+                watermark: None,
+            }]
+        );
     }
 
     #[tokio::test]
@@ -1160,7 +1177,13 @@ mod watermark_tests {
         assert!(pinned.next().await.is_none());
 
         let metrics = pinned.as_ref().get_ref().metrics().unwrap();
-        assert!(metrics.region_latest_sequences.is_none());
+        assert_eq!(
+            metrics.region_watermarks,
+            vec![common_recordbatch::adapter::RegionWatermarkEntry {
+                region_id: region_id.as_u64(),
+                watermark: None,
+            }]
+        );
     }
 }
 

--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -19,7 +19,7 @@ use std::fmt::Debug;
 use std::ops::Deref;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, RwLock};
 use std::task::{Context, Poll};
 use std::time::Duration;
 
@@ -71,9 +71,9 @@ use store_api::metric_engine_consts::{
     FILE_ENGINE_NAME, LOGICAL_TABLE_METADATA_KEY, METRIC_ENGINE_NAME,
 };
 use store_api::region_engine::{
-    RegionEngine, RegionEngineRef, RegionManifestInfo, RegionRole, RegionStatistic,
-    RemapManifestsRequest, RemapManifestsResponse, SetRegionRoleStateResponse,
-    SettableRegionRoleState, SyncRegionFromRequest,
+    RegionEngineRef, RegionManifestInfo, RegionRole, RegionStatistic, RemapManifestsRequest,
+    RemapManifestsResponse, SetRegionRoleStateResponse, SettableRegionRoleState,
+    SyncRegionFromRequest,
 };
 use store_api::region_request::{
     AffectedRows, BatchRegionDdlRequest, RegionCatchupRequest, RegionCloseRequest,
@@ -241,16 +241,6 @@ impl RegionServer {
         );
 
         let engine = status.into_engine();
-        if let Some(ctx) = &ctx
-            && should_return_region_seq(ctx)
-            && ctx.get_snapshot(region_id.as_u64()).is_none()
-        {
-            let sampled_sequence = engine
-                .get_committed_sequence(region_id)
-                .await
-                .with_context(|_| HandleRegionRequestSnafu { region_id })?;
-            bind_snapshot_bound_region_seq(ctx, region_id, sampled_sequence);
-        }
 
         self.inner
             .table_provider_factory
@@ -313,12 +303,8 @@ impl RegionServer {
         };
 
         if let Some(seq) = region_latest_seq {
-            Ok(Box::pin(RegionWatermarkStream::new(
-                stream,
-                region_id,
-                seq,
-                self.find_engine(region_id)?,
-            )) as SendableRecordBatchStream)
+            Ok(Box::pin(RegionWatermarkStream::new(stream, region_id, seq))
+                as SendableRecordBatchStream)
         } else {
             Ok(stream)
         }
@@ -789,78 +775,22 @@ fn should_return_region_seq(query_ctx: &QueryContext) -> bool {
         || query_ctx.extension(FLOW_INCREMENTAL_AFTER_SEQS).is_some()
 }
 
-fn bind_snapshot_bound_region_seq(
-    query_ctx: &QueryContext,
-    region_id: RegionId,
-    sampled_sequence: u64,
-) -> u64 {
-    if let Some(snapshot_seq) = query_ctx.get_snapshot(region_id.as_u64()) {
-        snapshot_seq
-    } else {
-        query_ctx.set_snapshot(region_id.as_u64(), sampled_sequence);
-        sampled_sequence
-    }
-}
-
-/// Returns whether `snapshot_sequence` is a valid correctness watermark for this region,
-/// i.e. whether this query can safely treat it as the read upper bound.
-///
-/// For now this proof only covers memtable-side sequence information; SST-side proof
-/// can be added later if finer sequence metadata becomes available.
-fn can_prove_region_watermark_for_engine(
-    engine: &dyn RegionEngine,
-    region_id: RegionId,
-    snapshot_sequence: u64,
-) -> bool {
-    if let Some(mito_engine) = engine.as_any().downcast_ref::<MitoEngine>()
-        && let Some(region) = mito_engine.find_region(region_id)
-    {
-        return snapshot_sequence >= region.flushed_sequence();
-    }
-    true
-}
-
+/// Wraps a region read stream so terminal metrics can carry the scan-open watermark.
 struct RegionWatermarkStream {
     stream: SendableRecordBatchStream,
     region_id: u64,
     snapshot_seq: u64,
-    proof_engine: Option<RegionEngineRef>,
     finished: AtomicBool,
-    proof_state: Mutex<Option<bool>>,
 }
 
 impl RegionWatermarkStream {
-    fn new(
-        stream: SendableRecordBatchStream,
-        region_id: RegionId,
-        latest_sequence: u64,
-        proof_engine: Option<RegionEngineRef>,
-    ) -> Self {
+    fn new(stream: SendableRecordBatchStream, region_id: RegionId, latest_sequence: u64) -> Self {
         Self {
             stream,
             region_id: region_id.as_u64(),
             snapshot_seq: latest_sequence,
-            proof_engine,
             finished: AtomicBool::new(false),
-            proof_state: Mutex::new(None),
         }
-    }
-
-    fn compute_proof(&self) -> bool {
-        self.proof_engine
-            .as_ref()
-            .map(|engine| {
-                can_prove_region_watermark_for_engine(
-                    engine.as_ref(),
-                    RegionId::from_u64(self.region_id),
-                    self.snapshot_seq,
-                )
-            })
-            .unwrap_or(false)
-    }
-
-    fn proof_passed(&self) -> bool {
-        self.proof_state.lock().unwrap().unwrap_or(false)
     }
 
     fn merged_metrics(&self, mut metrics: RecordBatchMetrics) -> RecordBatchMetrics {
@@ -880,12 +810,6 @@ impl RegionWatermarkStream {
             metrics.region_watermarks.last_mut().unwrap()
         };
 
-        // TODO(discord9): Move correctness-watermark proof into the mito scan
-        // path. The current stream-end proof is conservatively safe, but still
-        // allows false negatives if a late flush happens after the scan snapshot.
-        if !self.proof_passed() {
-            return metrics;
-        }
         entry.watermark = Some(self.snapshot_seq);
         metrics
     }
@@ -920,7 +844,6 @@ impl Stream for RegionWatermarkStream {
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match Pin::new(&mut self.stream).poll_next(cx) {
             Poll::Ready(None) => {
-                *self.proof_state.lock().unwrap() = Some(self.compute_proof());
                 self.finished.store(true, Ordering::Relaxed);
                 Poll::Ready(None)
             }
@@ -943,11 +866,24 @@ mod watermark_tests {
     use mito2::config::MitoConfig;
     use mito2::test_util::{self, CreateRequestBuilder, TestEnv};
     use session::context::QueryContextBuilder;
+    use store_api::region_engine::RegionEngine;
     use store_api::region_request::RegionRequest;
 
     use super::*;
-    use crate::tests::MockRegionEngine;
 
+    #[cfg(test)]
+    fn bind_snapshot_bound_region_seq(
+        query_ctx: &QueryContext,
+        region_id: RegionId,
+        sampled_sequence: u64,
+    ) -> u64 {
+        if let Some(snapshot_seq) = query_ctx.get_snapshot(region_id.as_u64()) {
+            snapshot_seq
+        } else {
+            query_ctx.set_snapshot(region_id.as_u64(), sampled_sequence);
+            sampled_sequence
+        }
+    }
     #[test]
     fn test_should_return_region_seq() {
         let ctx = QueryContextBuilder::default()
@@ -1019,49 +955,6 @@ mod watermark_tests {
         assert_eq!(ctx.get_snapshot(region_id.as_u64()), Some(99));
     }
 
-    #[test]
-    fn test_can_prove_region_watermark_for_non_mito_engine_defaults_true() {
-        let engine = MockRegionEngine::new(MITO_ENGINE_NAME).0;
-        assert!(can_prove_region_watermark_for_engine(
-            engine.as_ref(),
-            RegionId::new(1, 1),
-            42,
-        ));
-    }
-
-    #[tokio::test]
-    async fn test_can_prove_region_watermark_for_mito_engine_when_snapshot_ge_flushed() {
-        let mut env = TestEnv::with_prefix(
-            "test_can_prove_region_watermark_for_mito_engine_when_snapshot_ge_flushed",
-        )
-        .await;
-        let engine = env.create_engine(MitoConfig::default()).await;
-
-        let region_id = RegionId::new(1, 1);
-        let request = CreateRequestBuilder::new().build();
-        let column_schemas = test_util::rows_schema(&request);
-        engine
-            .handle_request(region_id, RegionRequest::Create(request))
-            .await
-            .unwrap();
-
-        let rows = Rows {
-            schema: column_schemas,
-            rows: test_util::build_rows(0, 3),
-        };
-        test_util::put_rows(&engine, region_id, rows).await;
-        test_util::flush_region(&engine, region_id, None).await;
-
-        let region = engine.find_region(region_id).unwrap();
-        let snapshot_seq = region.flushed_sequence();
-
-        assert!(can_prove_region_watermark_for_engine(
-            &engine,
-            region_id,
-            snapshot_seq,
-        ));
-    }
-
     #[tokio::test]
     async fn test_region_watermark_stream_only_sets_terminal_metrics() {
         let schema = Arc::new(Schema::new(vec![ColumnSchema::new(
@@ -1076,8 +969,7 @@ mod watermark_tests {
             .as_stream();
 
         let region_id = RegionId::new(42, 7);
-        let proof_engine = Some(MockRegionEngine::new(MITO_ENGINE_NAME).0 as RegionEngineRef);
-        let wrapped = RegionWatermarkStream::new(stream, region_id, 99, proof_engine);
+        let wrapped = RegionWatermarkStream::new(stream, region_id, 99);
         let mut pinned = Box::pin(wrapped);
 
         assert!(pinned.as_ref().get_ref().metrics().is_none());
@@ -1094,7 +986,7 @@ mod watermark_tests {
     }
 
     #[tokio::test]
-    async fn test_region_watermark_stream_without_proof_engine_omits_watermark() {
+    async fn test_region_watermark_stream_sets_watermark_from_snapshot() {
         let schema = Arc::new(Schema::new(vec![ColumnSchema::new(
             "v",
             ConcreteDataType::int32_datatype(),
@@ -1107,7 +999,7 @@ mod watermark_tests {
             .as_stream();
 
         let region_id = RegionId::new(42, 7);
-        let wrapped = RegionWatermarkStream::new(stream, region_id, 99, None);
+        let wrapped = RegionWatermarkStream::new(stream, region_id, 99);
         let mut pinned = Box::pin(wrapped);
 
         while pinned.next().await.is_some() {}
@@ -1117,15 +1009,15 @@ mod watermark_tests {
             metrics.region_watermarks,
             vec![common_recordbatch::adapter::RegionWatermarkEntry {
                 region_id: region_id.as_u64(),
-                watermark: None,
+                watermark: Some(99),
             }]
         );
     }
 
     #[tokio::test]
-    async fn test_region_watermark_stream_omits_watermark_after_late_flush() {
+    async fn test_region_watermark_stream_keeps_watermark_after_late_flush() {
         let mut env =
-            TestEnv::with_prefix("test_region_watermark_stream_omits_watermark_after_late_flush")
+            TestEnv::with_prefix("test_region_watermark_stream_keeps_watermark_after_late_flush")
                 .await;
         let engine = env.create_engine(MitoConfig::default()).await;
 
@@ -1157,12 +1049,7 @@ mod watermark_tests {
             .unwrap()
             .as_stream();
 
-        let wrapped = RegionWatermarkStream::new(
-            stream,
-            region_id,
-            snapshot_seq,
-            Some(Arc::new(engine.clone()) as RegionEngineRef),
-        );
+        let wrapped = RegionWatermarkStream::new(stream, region_id, snapshot_seq);
         let mut pinned = Box::pin(wrapped);
 
         assert!(pinned.next().await.is_some());
@@ -1181,7 +1068,7 @@ mod watermark_tests {
             metrics.region_watermarks,
             vec![common_recordbatch::adapter::RegionWatermarkEntry {
                 region_id: region_id.as_u64(),
-                watermark: None,
+                watermark: Some(snapshot_seq),
             }]
         );
     }

--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -17,8 +17,10 @@ mod catalog;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::ops::Deref;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use api::region::RegionResponse;
@@ -36,7 +38,8 @@ use common_error::status_code::StatusCode;
 use common_meta::datanode::TopicStatsReporter;
 use common_query::OutputData;
 use common_query::request::QueryRequest;
-use common_recordbatch::SendableRecordBatchStream;
+use common_recordbatch::adapter::RecordBatchMetrics;
+use common_recordbatch::{OrderOption, RecordBatch, RecordBatchStream, SendableRecordBatchStream};
 use common_runtime::Runtime;
 use common_telemetry::tracing::{self, info_span};
 use common_telemetry::tracing_context::{FutureExt, TracingContext};
@@ -45,6 +48,7 @@ use dashmap::DashMap;
 use datafusion::datasource::TableProvider;
 use datafusion_common::tree_node::TreeNode;
 use either::Either;
+use futures_util::Stream;
 use futures_util::future::try_join_all;
 use metric_engine::engine::MetricEngine;
 use mito2::engine::{MITO_ENGINE_NAME, MitoEngine};
@@ -53,6 +57,7 @@ use query::QueryEngineRef;
 pub use query::dummy_catalog::{
     DummyCatalogList, DummyTableProviderFactory, TableProviderFactoryRef,
 };
+use query::options::{FLOW_INCREMENTAL_AFTER_SEQS, FLOW_RETURN_REGION_SEQ};
 use serde_json;
 use servers::error::{
     self as servers_error, ExecuteGrpcRequestSnafu, Result as ServerResult, SuspendedSnafu,
@@ -256,6 +261,20 @@ impl RegionServer {
         };
 
         let region_id = RegionId::from_u64(request.region_id);
+        let should_return_region_seq = should_return_region_seq(&query_ctx);
+        let region_latest_seq = if should_return_region_seq {
+            let engine = self
+                .find_engine(region_id)?
+                .context(RegionNotFoundSnafu { region_id })?;
+            Some(
+                engine
+                    .get_committed_sequence(region_id)
+                    .await
+                    .with_context(|_| HandleRegionRequestSnafu { region_id })?,
+            )
+        } else {
+            None
+        };
         let catalog_list = Arc::new(NameAwareCatalogList::new(
             self.clone(),
             region_id,
@@ -278,7 +297,8 @@ impl RegionServer {
             .await
             .context(DecodeLogicalPlanSnafu)?;
 
-        self.inner
+        let stream = self
+            .inner
             .handle_read(
                 QueryRequest {
                     header: request.header,
@@ -287,7 +307,14 @@ impl RegionServer {
                 },
                 query_ctx,
             )
-            .await
+            .await?;
+
+        if let Some(seq) = region_latest_seq {
+            Ok(Box::pin(RegionWatermarkStream::new(stream, region_id, seq))
+                as SendableRecordBatchStream)
+        } else {
+            Ok(stream)
+        }
     }
 
     #[tracing::instrument(skip_all)]
@@ -745,6 +772,143 @@ impl RegionServer {
 
     pub(crate) fn suspend_state(&self) -> Arc<AtomicBool> {
         self.suspend.clone()
+    }
+}
+
+fn should_return_region_seq(query_ctx: &QueryContext) -> bool {
+    query_ctx
+        .extension(FLOW_RETURN_REGION_SEQ)
+        .is_some_and(|value| value.eq_ignore_ascii_case("true"))
+        || query_ctx.extension(FLOW_INCREMENTAL_AFTER_SEQS).is_some()
+}
+
+struct RegionWatermarkStream {
+    stream: SendableRecordBatchStream,
+    region_latest_sequence: (u64, u64),
+    finished: AtomicBool,
+}
+
+impl RegionWatermarkStream {
+    fn new(stream: SendableRecordBatchStream, region_id: RegionId, latest_sequence: u64) -> Self {
+        Self {
+            stream,
+            region_latest_sequence: (region_id.as_u64(), latest_sequence),
+            finished: AtomicBool::new(false),
+        }
+    }
+
+    fn merged_metrics(&self, mut metrics: RecordBatchMetrics) -> RecordBatchMetrics {
+        let region_latest_sequences = metrics.region_latest_sequences.get_or_insert_with(Vec::new);
+        if let Some((_, seq)) = region_latest_sequences
+            .iter_mut()
+            .find(|(region_id, _)| *region_id == self.region_latest_sequence.0)
+        {
+            *seq = self.region_latest_sequence.1;
+        } else {
+            region_latest_sequences.push(self.region_latest_sequence);
+        }
+        metrics
+    }
+}
+
+impl RecordBatchStream for RegionWatermarkStream {
+    fn name(&self) -> &str {
+        self.stream.name()
+    }
+
+    fn schema(&self) -> datatypes::schema::SchemaRef {
+        self.stream.schema()
+    }
+
+    fn output_ordering(&self) -> Option<&[OrderOption]> {
+        self.stream.output_ordering()
+    }
+
+    fn metrics(&self) -> Option<RecordBatchMetrics> {
+        let base = self.stream.metrics();
+        if !self.finished.load(Ordering::Relaxed) {
+            return base;
+        }
+
+        Some(self.merged_metrics(base.unwrap_or_default()))
+    }
+}
+
+impl Stream for RegionWatermarkStream {
+    type Item = common_recordbatch::error::Result<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match Pin::new(&mut self.stream).poll_next(cx) {
+            Poll::Ready(None) => {
+                self.finished.store(true, Ordering::Relaxed);
+                Poll::Ready(None)
+            }
+            other => other,
+        }
+    }
+}
+
+#[cfg(test)]
+mod watermark_tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use common_recordbatch::{RecordBatch, RecordBatches};
+    use datatypes::prelude::{ConcreteDataType, VectorRef};
+    use datatypes::schema::{ColumnSchema, Schema};
+    use datatypes::vectors::Int32Vector;
+    use futures_util::StreamExt;
+    use session::context::QueryContextBuilder;
+
+    use super::*;
+
+    #[test]
+    fn test_should_return_region_seq() {
+        let ctx = QueryContextBuilder::default()
+            .extensions(HashMap::from([(
+                FLOW_RETURN_REGION_SEQ.to_string(),
+                "true".to_string(),
+            )]))
+            .build();
+        assert!(should_return_region_seq(&ctx));
+
+        let ctx = QueryContextBuilder::default()
+            .extensions(HashMap::from([(
+                FLOW_INCREMENTAL_AFTER_SEQS.to_string(),
+                r#"{"1":10}"#.to_string(),
+            )]))
+            .build();
+        assert!(should_return_region_seq(&ctx));
+
+        let ctx = QueryContextBuilder::default().build();
+        assert!(!should_return_region_seq(&ctx));
+    }
+
+    #[tokio::test]
+    async fn test_region_watermark_stream_only_sets_terminal_metrics() {
+        let schema = Arc::new(Schema::new(vec![ColumnSchema::new(
+            "v",
+            ConcreteDataType::int32_datatype(),
+            false,
+        )]));
+        let values: VectorRef = Arc::new(Int32Vector::from_slice([1, 2]));
+        let batch = RecordBatch::new(schema.clone(), vec![values]).unwrap();
+        let stream = RecordBatches::try_new(schema, vec![batch])
+            .unwrap()
+            .as_stream();
+
+        let region_id = RegionId::new(42, 7);
+        let wrapped = RegionWatermarkStream::new(stream, region_id, 99);
+        let mut pinned = Box::pin(wrapped);
+
+        assert!(pinned.as_ref().get_ref().metrics().is_none());
+        while pinned.next().await.is_some() {}
+
+        let metrics = pinned.as_ref().get_ref().metrics().unwrap();
+        assert_eq!(
+            metrics.region_latest_sequences,
+            Some(vec![(region_id.as_u64(), 99)])
+        );
     }
 }
 

--- a/src/file-engine/src/engine.rs
+++ b/src/file-engine/src/engine.rs
@@ -94,7 +94,7 @@ impl RegionEngine for FileRegionEngine {
         let stream = self.handle_query(region_id, request).await?;
         let metadata = self.get_metadata(region_id).await?;
         // We don't support enabling append mode for file engine.
-        let scanner = Box::new(SinglePartitionScanner::new(stream, false, metadata));
+        let scanner = Box::new(SinglePartitionScanner::new(stream, false, metadata, None));
         Ok(scanner)
     }
 

--- a/src/flow/src/batching_mode/frontend_client.rs
+++ b/src/flow/src/batching_mode/frontend_client.rs
@@ -21,17 +21,18 @@ use std::time::SystemTime;
 use api::v1::greptime_request::Request;
 use api::v1::query_request::Query;
 use api::v1::{CreateTableExpr, QueryRequest};
-use client::{Client, Database};
+use client::{Client, Database, OutputWithMetrics};
 use common_error::ext::BoxedError;
 use common_grpc::channel_manager::{ChannelConfig, ChannelManager, load_client_tls_config};
 use common_meta::cluster::{NodeInfo, NodeInfoKey, Role};
 use common_meta::peer::Peer;
 use common_meta::rpc::store::RangeRequest;
-use common_query::Output;
+use common_query::{Output, OutputData};
 use common_telemetry::warn;
 use meta_client::client::MetaClient;
 use query::datafusion::QUERY_PARALLELISM_HINT;
-use query::options::QueryOptions;
+use query::metrics::terminal_recordbatch_metrics_from_plan;
+use query::options::{FlowQueryExtensions, QueryOptions};
 use rand::rng;
 use rand::seq::SliceRandom;
 use servers::query_handler::grpc::GrpcQueryHandler;
@@ -407,6 +408,79 @@ impl FrontendClient {
         }
     }
 
+    pub async fn query_with_terminal_metrics(
+        &self,
+        catalog: &str,
+        schema: &str,
+        request: QueryRequest,
+        extensions: &[(&str, &str)],
+    ) -> Result<OutputWithMetrics, Error> {
+        let flow_extensions = build_flow_extensions(extensions)?;
+        match self {
+            FrontendClient::Distributed {
+                query, batch_opts, ..
+            } => {
+                let query_parallelism = query.parallelism.to_string();
+                let mut hints = vec![
+                    (QUERY_PARALLELISM_HINT, query_parallelism.as_str()),
+                    (READ_PREFERENCE_HINT, batch_opts.read_preference.as_ref()),
+                ];
+                hints.extend_from_slice(extensions);
+                let db = self.get_random_active_frontend(catalog, schema).await?;
+                db.database
+                    .query_with_terminal_metrics(request, &hints)
+                    .await
+                    .map_err(BoxedError::new)
+                    .context(ExternalSnafu)
+            }
+            FrontendClient::Standalone {
+                database_client,
+                query,
+            } => {
+                let mut extensions_map = HashMap::from([(
+                    QUERY_PARALLELISM_HINT.to_string(),
+                    query.parallelism.to_string(),
+                )]);
+                for (key, value) in extensions {
+                    extensions_map.insert((*key).to_string(), (*value).to_string());
+                }
+                let ctx = QueryContextBuilder::default()
+                    .current_catalog(catalog.to_string())
+                    .current_schema(schema.to_string())
+                    .extensions(extensions_map)
+                    .build();
+                let ctx = Arc::new(ctx);
+                let database_client = {
+                    database_client
+                        .handler
+                        .lock()
+                        .map_err(|e| {
+                            UnexpectedSnafu {
+                                reason: format!("Failed to lock database client: {e}"),
+                            }
+                            .build()
+                        })?
+                        .as_ref()
+                        .context(UnexpectedSnafu {
+                            reason: "Standalone's frontend instance is not set",
+                        })?
+                        .upgrade()
+                        .context(UnexpectedSnafu {
+                            reason: "Failed to upgrade database client",
+                        })?
+                };
+                database_client
+                    .do_query(Request::Query(request), ctx)
+                    .await
+                    .map(|output| {
+                        wrap_standalone_output_with_terminal_metrics(output, &flow_extensions)
+                    })
+                    .map_err(BoxedError::new)
+                    .context(ExternalSnafu)
+            }
+        }
+    }
+
     /// Handle a request to frontend
     pub(crate) async fn handle(
         &self,
@@ -497,6 +571,39 @@ impl FrontendClient {
     }
 }
 
+fn build_flow_extensions(extensions: &[(&str, &str)]) -> Result<FlowQueryExtensions, Error> {
+    let flow_extensions = HashMap::from_iter(
+        extensions
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string())),
+    );
+    FlowQueryExtensions::from_extensions(&flow_extensions)
+        .map_err(BoxedError::new)
+        .context(ExternalSnafu)
+}
+
+fn wrap_standalone_output_with_terminal_metrics(
+    output: Output,
+    flow_extensions: &FlowQueryExtensions,
+) -> OutputWithMetrics {
+    let should_collect_region_watermark = flow_extensions.should_collect_region_watermark();
+    let terminal_metrics =
+        if should_collect_region_watermark && !matches!(&output.data, OutputData::Stream(_)) {
+            output
+                .meta
+                .plan
+                .clone()
+                .and_then(terminal_recordbatch_metrics_from_plan)
+        } else {
+            None
+        };
+    let result = OutputWithMetrics::from_output(output);
+    if let Some(metrics) = terminal_metrics {
+        result.metrics.update(Some(metrics));
+    }
+    result
+}
+
 /// Describe a peer of frontend
 #[derive(Debug, Default)]
 pub(crate) enum PeerDesc {
@@ -544,11 +651,19 @@ fn extract_u64_segment(message: &str, start: &str, end: &str) -> Option<u64> {
 
 #[cfg(test)]
 mod tests {
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
     use std::time::Duration;
 
     use common_error::ext::PlainError;
     use common_error::status_code::StatusCode;
-    use common_query::Output;
+    use common_query::{Output, OutputData};
+    use common_recordbatch::adapter::RecordBatchMetrics;
+    use common_recordbatch::{OrderOption, RecordBatch, RecordBatchStream};
+    use datatypes::prelude::{ConcreteDataType, VectorRef};
+    use datatypes::schema::{ColumnSchema, Schema};
+    use datatypes::vectors::Int32Vector;
+    use futures::StreamExt;
     use snafu::GenerateImplicitData;
     use tokio::time::timeout;
 
@@ -556,6 +671,55 @@ mod tests {
 
     #[derive(Debug)]
     struct NoopHandler;
+
+    struct MockMetricsStream {
+        schema: datatypes::schema::SchemaRef,
+        batch: Option<RecordBatch>,
+        metrics: RecordBatchMetrics,
+        terminal_metrics_only: bool,
+    }
+
+    impl futures::Stream for MockMetricsStream {
+        type Item = common_recordbatch::error::Result<RecordBatch>;
+
+        fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            Poll::Ready(self.batch.take().map(Ok))
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            (
+                usize::from(self.batch.is_some()),
+                Some(usize::from(self.batch.is_some())),
+            )
+        }
+    }
+
+    impl RecordBatchStream for MockMetricsStream {
+        fn name(&self) -> &str {
+            "MockMetricsStream"
+        }
+
+        fn schema(&self) -> datatypes::schema::SchemaRef {
+            self.schema.clone()
+        }
+
+        fn output_ordering(&self) -> Option<&[OrderOption]> {
+            None
+        }
+
+        fn metrics(&self) -> Option<RecordBatchMetrics> {
+            if self.terminal_metrics_only && self.batch.is_some() {
+                return None;
+            }
+            Some(self.metrics.clone())
+        }
+    }
+
+    #[derive(Debug)]
+    struct MetricsHandler;
+
+    #[derive(Debug)]
+    struct ExtensionAwareHandler;
 
     #[async_trait::async_trait]
     impl GrpcQueryHandlerWithBoxedError for NoopHandler {
@@ -565,6 +729,47 @@ mod tests {
             _ctx: QueryContextRef,
         ) -> std::result::Result<Output, BoxedError> {
             Ok(Output::new_with_affected_rows(0))
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl GrpcQueryHandlerWithBoxedError for MetricsHandler {
+        async fn do_query(
+            &self,
+            _query: Request,
+            _ctx: QueryContextRef,
+        ) -> std::result::Result<Output, BoxedError> {
+            let schema = Arc::new(Schema::new(vec![ColumnSchema::new(
+                "v",
+                ConcreteDataType::int32_datatype(),
+                false,
+            )]));
+            let batch = RecordBatch::new(
+                schema.clone(),
+                vec![Arc::new(Int32Vector::from_slice([1, 2])) as VectorRef],
+            )
+            .unwrap();
+            Ok(Output::new_with_stream(Box::pin(MockMetricsStream {
+                schema,
+                batch: Some(batch),
+                metrics: RecordBatchMetrics {
+                    region_latest_sequences: Some(vec![(42, 99)]),
+                    ..Default::default()
+                },
+                terminal_metrics_only: true,
+            })))
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl GrpcQueryHandlerWithBoxedError for ExtensionAwareHandler {
+        async fn do_query(
+            &self,
+            _query: Request,
+            ctx: QueryContextRef,
+        ) -> std::result::Result<Output, BoxedError> {
+            assert_eq!(ctx.extension("flow.return_region_seq"), Some("true"));
+            Ok(Output::new_with_affected_rows(1))
         }
     }
 
@@ -649,5 +854,82 @@ mod tests {
         let failure = FrontendClient::inspect_query_error(&err);
         assert!(!failure.is_stale_cursor());
         assert_eq!(failure.stale_cursor, None);
+    }
+
+    #[tokio::test]
+    async fn test_query_with_terminal_metrics_tracks_watermark_in_standalone_mode() {
+        let handler: Arc<dyn GrpcQueryHandlerWithBoxedError> = Arc::new(MetricsHandler);
+        let client =
+            FrontendClient::from_grpc_handler(Arc::downgrade(&handler), QueryOptions::default());
+
+        let result = client
+            .query_with_terminal_metrics(
+                "greptime",
+                "public",
+                QueryRequest {
+                    query: Some(Query::Sql("select 1".to_string())),
+                },
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let terminal_metrics = result.metrics.clone();
+        assert!(!result.metrics.is_ready());
+        assert!(terminal_metrics.get().is_none());
+
+        let OutputData::Stream(mut stream) = result.output.data else {
+            panic!("expected stream output");
+        };
+        while stream.next().await.is_some() {}
+
+        assert!(terminal_metrics.is_ready());
+        assert_eq!(
+            terminal_metrics.region_watermark_map(),
+            Some(HashMap::from([(42_u64, 99_u64)]))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_query_with_terminal_metrics_forwards_flow_extensions_in_standalone_mode() {
+        let handler: Arc<dyn GrpcQueryHandlerWithBoxedError> = Arc::new(ExtensionAwareHandler);
+        let client =
+            FrontendClient::from_grpc_handler(Arc::downgrade(&handler), QueryOptions::default());
+
+        let result = client
+            .query_with_terminal_metrics(
+                "greptime",
+                "public",
+                QueryRequest {
+                    query: Some(Query::Sql("insert into t select 1".to_string())),
+                },
+                &[("flow.return_region_seq", "true")],
+            )
+            .await
+            .unwrap();
+
+        assert!(result.metrics.is_ready());
+        assert!(result.region_watermark_map().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_query_with_terminal_metrics_rejects_invalid_flow_extensions() {
+        let handler: Arc<dyn GrpcQueryHandlerWithBoxedError> = Arc::new(NoopHandler);
+        let client =
+            FrontendClient::from_grpc_handler(Arc::downgrade(&handler), QueryOptions::default());
+
+        let err = client
+            .query_with_terminal_metrics(
+                "greptime",
+                "public",
+                QueryRequest {
+                    query: Some(Query::Sql("select 1".to_string())),
+                },
+                &[("flow.return_region_seq", "not-a-bool")],
+            )
+            .await
+            .unwrap_err();
+
+        assert!(format!("{err:?}").contains("Invalid value for flow.return_region_seq"));
     }
 }

--- a/src/flow/src/batching_mode/frontend_client.rs
+++ b/src/flow/src/batching_mode/frontend_client.rs
@@ -179,6 +179,27 @@ pub struct DatabaseWithPeer {
     pub peer: Peer,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct FlowQueryFailure {
+    pub stale_cursor: Option<FlowStaleCursorDetail>,
+}
+
+impl FlowQueryFailure {
+    pub fn is_stale_cursor(&self) -> bool {
+        self.stale_cursor.is_some()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct FlowStaleCursorDetail {
+    pub region_id: Option<String>,
+    pub given_seq: Option<u64>,
+    pub min_readable_seq: Option<u64>,
+}
+
+const STALE_CURSOR_TOKEN: &str = "STALE_CURSOR";
+const STALE_CURSOR_RETRY_HINT: &str = "FALLBACK_FULL_RECOMPUTE";
+
 impl DatabaseWithPeer {
     fn new(database: Database, peer: Peer) -> Self {
         Self { database, peer }
@@ -199,6 +220,13 @@ impl DatabaseWithPeer {
 }
 
 impl FrontendClient {
+    /// TODO(discord9): better way to detect stale cursor error instead of parsing the error message
+    pub fn inspect_query_error(err: &Error) -> FlowQueryFailure {
+        let debug = format!("{err:?}");
+        let stale_cursor = parse_stale_cursor_detail(&debug);
+        FlowQueryFailure { stale_cursor }
+    }
+
     /// scan for available frontend from metadata
     pub(crate) async fn scan_for_frontend(&self) -> Result<Vec<(NodeInfoKey, NodeInfo)>, Error> {
         let Self::Distributed { meta_client, .. } = self else {
@@ -491,11 +519,37 @@ impl std::fmt::Display for PeerDesc {
     }
 }
 
+fn parse_stale_cursor_detail(message: &str) -> Option<FlowStaleCursorDetail> {
+    if !message.contains(STALE_CURSOR_TOKEN) || !message.contains(STALE_CURSOR_RETRY_HINT) {
+        return None;
+    }
+
+    Some(FlowStaleCursorDetail {
+        region_id: extract_segment(message, "region: ", ", given_seq:"),
+        given_seq: extract_u64_segment(message, "given_seq: ", ", min_readable_seq:"),
+        min_readable_seq: extract_u64_segment(message, "min_readable_seq: ", ", retry_hint:"),
+    })
+}
+
+fn extract_segment(message: &str, start: &str, end: &str) -> Option<String> {
+    let start_idx = message.find(start)? + start.len();
+    let tail = &message[start_idx..];
+    let end_idx = tail.find(end)?;
+    Some(tail[..end_idx].trim().to_string())
+}
+
+fn extract_u64_segment(message: &str, start: &str, end: &str) -> Option<u64> {
+    extract_segment(message, start, end)?.parse().ok()
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
 
+    use common_error::ext::PlainError;
+    use common_error::status_code::StatusCode;
     use common_query::Output;
+    use snafu::GenerateImplicitData;
     use tokio::time::timeout;
 
     use super::*;
@@ -558,5 +612,42 @@ mod tests {
                 .await
                 .is_ok()
         );
+    }
+
+    #[test]
+    fn test_inspect_query_error_detects_stale_cursor() {
+        let err = Error::External {
+            source: BoxedError::new(PlainError::new(
+                "STALE_CURSOR: incremental query stale, region: 4398046511104(1024, 0), given_seq: 9, min_readable_seq: 18, retry_hint: FALLBACK_FULL_RECOMPUTE".to_string(),
+                StatusCode::EngineExecuteQuery,
+            )),
+            location: snafu::Location::generate(),
+        };
+
+        let failure = FrontendClient::inspect_query_error(&err);
+        assert!(failure.is_stale_cursor());
+        assert_eq!(
+            failure.stale_cursor,
+            Some(FlowStaleCursorDetail {
+                region_id: Some("4398046511104(1024, 0)".to_string()),
+                given_seq: Some(9),
+                min_readable_seq: Some(18),
+            })
+        );
+    }
+
+    #[test]
+    fn test_inspect_query_error_ignores_non_stale_error() {
+        let err = Error::External {
+            source: BoxedError::new(PlainError::new(
+                "ordinary query failure".to_string(),
+                StatusCode::EngineExecuteQuery,
+            )),
+            location: snafu::Location::generate(),
+        };
+
+        let failure = FrontendClient::inspect_query_error(&err);
+        assert!(!failure.is_stale_cursor());
+        assert_eq!(failure.stale_cursor, None);
     }
 }

--- a/src/flow/src/batching_mode/frontend_client.rs
+++ b/src/flow/src/batching_mode/frontend_client.rs
@@ -753,7 +753,10 @@ mod tests {
                 schema,
                 batch: Some(batch),
                 metrics: RecordBatchMetrics {
-                    region_latest_sequences: Some(vec![(42, 99)]),
+                    region_watermarks: vec![common_recordbatch::adapter::RegionWatermarkEntry {
+                        region_id: 42,
+                        watermark: Some(99),
+                    }],
                     ..Default::default()
                 },
                 terminal_metrics_only: true,

--- a/src/flow/src/batching_mode/state.rs
+++ b/src/flow/src/batching_mode/state.rs
@@ -14,7 +14,7 @@
 
 //! Batching mode task state, which changes frequently
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::time::Duration;
 
 use common_telemetry::debug;
@@ -49,6 +49,8 @@ pub struct TaskState {
     /// Dirty Time windows need to be updated
     /// mapping of `start -> end` and non-overlapping
     pub(crate) dirty_time_windows: DirtyTimeWindows,
+    checkpoint_mode: CheckpointMode,
+    checkpoints: BTreeMap<u64, u64>,
     exec_state: ExecState,
     /// Shutdown receiver
     pub(crate) shutdown_rx: oneshot::Receiver<()>,
@@ -63,6 +65,8 @@ impl TaskState {
             last_query_duration: Duration::from_secs(0),
             last_exec_time_millis: None,
             dirty_time_windows: Default::default(),
+            checkpoint_mode: CheckpointMode::FullSnapshot,
+            checkpoints: Default::default(),
             exec_state: ExecState::Idle,
             shutdown_rx,
             task_handle: None,
@@ -82,6 +86,78 @@ impl TaskState {
 
     pub fn last_execution_time_millis(&self) -> Option<i64> {
         self.last_exec_time_millis
+    }
+
+    pub fn checkpoint_mode(&self) -> CheckpointMode {
+        self.checkpoint_mode
+    }
+
+    pub fn checkpoints(&self) -> &BTreeMap<u64, u64> {
+        &self.checkpoints
+    }
+
+    pub fn mark_full_snapshot(&mut self) {
+        self.checkpoint_mode = CheckpointMode::FullSnapshot;
+    }
+
+    pub fn advance_checkpoints(&mut self, watermark_map: HashMap<u64, u64>) {
+        self.checkpoints = watermark_map.into_iter().collect();
+        self.checkpoint_mode = CheckpointMode::Incremental;
+    }
+
+    pub fn advance_incremental_checkpoints_with_participation(
+        &mut self,
+        participating_regions: &BTreeSet<u64>,
+        watermark_map: HashMap<u64, u64>,
+    ) {
+        for region_id in participating_regions {
+            if let Some(seq) = watermark_map.get(region_id) {
+                self.checkpoints.insert(*region_id, *seq);
+            }
+        }
+        self.checkpoint_mode = CheckpointMode::Incremental;
+    }
+
+    pub fn can_advance_incremental_checkpoints(&self, watermark_map: &HashMap<u64, u64>) -> bool {
+        !self.checkpoints.is_empty()
+            && self.checkpoints.len() == watermark_map.len()
+            && self.checkpoints.iter().all(|(region_id, checkpoint)| {
+                watermark_map
+                    .get(region_id)
+                    .is_some_and(|seq| seq >= checkpoint)
+            })
+    }
+
+    pub fn can_advance_full_snapshot_checkpoints(
+        &self,
+        participating_regions: &BTreeSet<u64>,
+        watermark_map: &HashMap<u64, u64>,
+    ) -> bool {
+        !participating_regions.is_empty()
+            && participating_regions.len() == watermark_map.len()
+            && participating_regions
+                .iter()
+                .all(|region_id| watermark_map.contains_key(region_id))
+    }
+
+    pub fn can_advance_incremental_checkpoints_with_participation(
+        &self,
+        participating_regions: &BTreeSet<u64>,
+        watermark_map: &HashMap<u64, u64>,
+    ) -> bool {
+        !self.checkpoints.is_empty()
+            && !participating_regions.is_empty()
+            && participating_regions.len() == watermark_map.len()
+            && participating_regions
+                .iter()
+                .all(|region_id| self.checkpoints.contains_key(region_id))
+            && participating_regions.iter().all(|region_id| {
+                let checkpoint = self.checkpoints.get(region_id);
+                watermark_map
+                    .get(region_id)
+                    .zip(checkpoint)
+                    .is_some_and(|(seq, checkpoint)| seq >= checkpoint)
+            })
     }
 
     /// Compute the next query delay based on the time window size or the last query duration.
@@ -559,6 +635,12 @@ enum ExecState {
     Executing,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CheckpointMode {
+    FullSnapshot,
+    Incremental,
+}
+
 /// Filter Expression's information
 #[derive(Debug, Clone)]
 pub struct FilterExprInfo {
@@ -600,6 +682,127 @@ mod test {
 
         state.after_query_exec(std::time::Duration::from_millis(1), true);
         assert!(state.last_execution_time_millis().is_some());
+    }
+
+    #[test]
+    fn test_task_state_checkpoint_mode_and_advancement() {
+        let query_ctx = QueryContext::arc();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let mut state = TaskState::new(query_ctx, rx);
+
+        assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
+        assert!(state.checkpoints().is_empty());
+
+        state.advance_checkpoints(HashMap::from([(1_u64, 10_u64), (2_u64, 20_u64)]));
+        assert_eq!(state.checkpoint_mode(), CheckpointMode::Incremental);
+        assert_eq!(
+            state.checkpoints(),
+            &BTreeMap::from([(1_u64, 10_u64), (2_u64, 20_u64)])
+        );
+
+        state.mark_full_snapshot();
+        assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
+        assert_eq!(
+            state.checkpoints(),
+            &BTreeMap::from([(1_u64, 10_u64), (2_u64, 20_u64)])
+        );
+    }
+
+    #[test]
+    fn test_incremental_checkpoint_advancement_requires_complete_map() {
+        let query_ctx = QueryContext::arc();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let mut state = TaskState::new(query_ctx, rx);
+        state.advance_checkpoints(HashMap::from([(1_u64, 10_u64), (2_u64, 20_u64)]));
+
+        assert!(!state.can_advance_incremental_checkpoints(&HashMap::from([(1_u64, 11_u64)])));
+        assert!(!state.can_advance_incremental_checkpoints(&HashMap::from([
+            (1_u64, 11_u64),
+            (2_u64, 19_u64),
+        ])));
+        assert!(state.can_advance_incremental_checkpoints(&HashMap::from([
+            (1_u64, 11_u64),
+            (2_u64, 20_u64),
+        ])));
+    }
+
+    #[test]
+    fn test_full_snapshot_checkpoint_advancement_requires_participating_regions() {
+        let query_ctx = QueryContext::arc();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let state = TaskState::new(query_ctx, rx);
+
+        assert!(!state.can_advance_full_snapshot_checkpoints(&BTreeSet::new(), &HashMap::new()));
+        assert!(!state.can_advance_full_snapshot_checkpoints(
+            &BTreeSet::from([1_u64, 2_u64]),
+            &HashMap::from([(1_u64, 10_u64)]),
+        ));
+        assert!(state.can_advance_full_snapshot_checkpoints(
+            &BTreeSet::from([1_u64, 2_u64]),
+            &HashMap::from([(1_u64, 10_u64), (2_u64, 20_u64)]),
+        ));
+    }
+
+    #[test]
+    fn test_incremental_checkpoint_advancement_requires_participation_alignment() {
+        let query_ctx = QueryContext::arc();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let mut state = TaskState::new(query_ctx, rx);
+        state.advance_checkpoints(HashMap::from([(1_u64, 10_u64), (2_u64, 20_u64)]));
+
+        assert!(
+            state.can_advance_incremental_checkpoints_with_participation(
+                &BTreeSet::from([1_u64]),
+                &HashMap::from([(1_u64, 11_u64)]),
+            )
+        );
+        assert!(
+            !state.can_advance_incremental_checkpoints_with_participation(
+                &BTreeSet::from([1_u64, 2_u64]),
+                &HashMap::from([(1_u64, 11_u64)]),
+            )
+        );
+        assert!(
+            !state.can_advance_incremental_checkpoints_with_participation(
+                &BTreeSet::from([3_u64]),
+                &HashMap::from([(3_u64, 11_u64)]),
+            )
+        );
+        assert!(
+            !state.can_advance_incremental_checkpoints_with_participation(
+                &BTreeSet::from([1_u64]),
+                &HashMap::from([(1_u64, 9_u64)]),
+            )
+        );
+        assert!(
+            state.can_advance_incremental_checkpoints_with_participation(
+                &BTreeSet::from([1_u64, 2_u64]),
+                &HashMap::from([(1_u64, 11_u64), (2_u64, 21_u64)]),
+            )
+        );
+    }
+
+    #[test]
+    fn test_incremental_checkpoint_advancement_merges_participating_subset() {
+        let query_ctx = QueryContext::arc();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let mut state = TaskState::new(query_ctx, rx);
+        state.advance_checkpoints(HashMap::from([
+            (1_u64, 10_u64),
+            (2_u64, 20_u64),
+            (3_u64, 30_u64),
+        ]));
+
+        state.advance_incremental_checkpoints_with_participation(
+            &BTreeSet::from([1_u64, 3_u64]),
+            HashMap::from([(1_u64, 12_u64), (3_u64, 35_u64)]),
+        );
+
+        assert_eq!(state.checkpoint_mode(), CheckpointMode::Incremental);
+        assert_eq!(
+            state.checkpoints(),
+            &BTreeMap::from([(1_u64, 12_u64), (2_u64, 20_u64), (3_u64, 35_u64)])
+        );
     }
 
     #[test]

--- a/src/flow/src/batching_mode/task.rs
+++ b/src/flow/src/batching_mode/task.rs
@@ -1170,6 +1170,7 @@ fn build_pk_from_aggr(plan: &LogicalPlan) -> Result<Option<TableDef>, Error> {
 }
 
 #[cfg(test)]
+#[allow(clippy::await_holding_lock)]
 mod test {
     use std::collections::BTreeMap;
     use std::sync::Arc;

--- a/src/flow/src/batching_mode/task.rs
+++ b/src/flow/src/batching_mode/task.rs
@@ -455,6 +455,44 @@ impl BatchingTask {
         Ok(Some((res, elapsed)))
     }
 
+    fn handle_flow_query_failure(&self, err: &Error, query: Option<&PlanInfo>) -> bool {
+        let failure = FrontendClient::inspect_query_error(err);
+        if failure.is_stale_cursor() {
+            warn!(
+                "Flow {} detected stale incremental query failure, switching to non-incremental recompute semantics for current query scope: {:?}",
+                self.config.flow_id, failure.stale_cursor
+            );
+
+            // notice that we only mark all as dirty if query itself has no time window filter.
+            if query.is_none_or(|query| query.filter.is_none())
+                && let Err(mark_err) = self.mark_all_windows_as_dirty()
+            {
+                warn!(
+                    "Flow {} failed to mark all windows dirty after stale incremental query without time-window scope: {}",
+                    self.config.flow_id, mark_err
+                );
+            }
+
+            true
+        } else {
+            false
+        }
+    }
+
+    fn restore_dirty_windows_after_failure(&self, query: &PlanInfo, is_stale_cursor: bool) {
+        if is_stale_cursor && query.filter.is_none() {
+            return;
+        }
+
+        self.state.write().unwrap().dirty_time_windows.add_windows(
+            query
+                .filter
+                .as_ref()
+                .map(|f| f.time_ranges.clone())
+                .unwrap_or_default(),
+        );
+    }
+
     /// start executing query in a loop, break when receive shutdown signal
     ///
     /// any error will be logged when executing query
@@ -558,6 +596,7 @@ impl BatchingTask {
                 }
                 // TODO(discord9): this error should have better place to go, but for now just print error, also more context is needed
                 Err(err) => {
+                    let is_stale_cursor = self.handle_flow_query_failure(&err, new_query.as_ref());
                     METRIC_FLOW_BATCHING_ENGINE_ERROR_CNT
                         .with_label_values(&[&flow_id_str])
                         .inc();
@@ -565,9 +604,7 @@ impl BatchingTask {
                         Some(query) => {
                             common_telemetry::error!(err; "Failed to execute query for flow={} with query: {}", self.config.flow_id, query.plan);
                             // Re-add dirty windows back since query failed
-                            self.state.write().unwrap().dirty_time_windows.add_windows(
-                                query.filter.map(|f| f.time_ranges).unwrap_or_default(),
-                            );
+                            self.restore_dirty_windows_after_failure(&query, is_stale_cursor);
                             // TODO(discord9): add some backoff here? half the query time window or what
                             // backoff meaning use smaller `max_window_cnt` for next query
 
@@ -979,8 +1016,11 @@ fn build_pk_from_aggr(plan: &LogicalPlan) -> Result<Option<TableDef>, Error> {
 #[cfg(test)]
 mod test {
     use api::v1::column_def::try_as_column_schema;
+    use common_error::ext::{BoxedError, PlainError};
+    use common_error::status_code::StatusCode;
     use pretty_assertions::assert_eq;
     use session::context::QueryContext;
+    use snafu::GenerateImplicitData;
 
     use super::*;
     use crate::test_utils::create_test_query_engine;
@@ -1105,5 +1145,127 @@ mod test {
             assert_eq!(tc.primary_keys, expr.primary_keys, "{:?}", tc.sql);
             assert_eq!(tc.time_index, expr.time_index, "{:?}", tc.sql);
         }
+    }
+
+    #[tokio::test]
+    async fn test_handle_flow_query_failure_marks_full_recompute_on_stale() {
+        let query_engine = create_test_query_engine();
+        let query_ctx = QueryContext::arc();
+        let plan = sql_to_df_plan(
+            query_ctx.clone(),
+            query_engine,
+            "SELECT number, ts FROM numbers_with_ts",
+            true,
+        )
+        .await
+        .unwrap();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let task = BatchingTask::try_new(TaskArgs {
+            flow_id: 42,
+            query: "SELECT number, ts FROM numbers_with_ts",
+            plan,
+            time_window_expr: None,
+            expire_after: None,
+            sink_table_name: [
+                "greptime".to_string(),
+                "public".to_string(),
+                "sink".to_string(),
+            ],
+            source_table_names: vec![[
+                "greptime".to_string(),
+                "public".to_string(),
+                "numbers_with_ts".to_string(),
+            ]],
+            query_ctx,
+            catalog_manager: create_test_query_engine()
+                .engine_state()
+                .catalog_manager()
+                .clone(),
+            shutdown_rx: rx,
+            batch_opts: Arc::new(BatchingModeOptions::default()),
+            flow_eval_interval: None,
+        })
+        .unwrap();
+
+        let err = Error::External {
+            source: BoxedError::new(PlainError::new(
+                "STALE_CURSOR: incremental query stale, region: 4398046511104(1024, 0), given_seq: 9, min_readable_seq: 18, retry_hint: FALLBACK_FULL_RECOMPUTE".to_string(),
+                StatusCode::EngineExecuteQuery,
+            )),
+            location: snafu::Location::generate(),
+        };
+
+        task.handle_flow_query_failure(&err, None);
+
+        let state = task.state.read().unwrap();
+        assert_eq!(state.dirty_time_windows.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_stale_failure_preserves_current_time_window_scope() {
+        let query_engine = create_test_query_engine();
+        let query_ctx = QueryContext::arc();
+        let plan = sql_to_df_plan(
+            query_ctx.clone(),
+            query_engine,
+            "SELECT number, ts FROM numbers_with_ts",
+            true,
+        )
+        .await
+        .unwrap();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let task = BatchingTask::try_new(TaskArgs {
+            flow_id: 43,
+            query: "SELECT number, ts FROM numbers_with_ts",
+            plan: plan.clone(),
+            time_window_expr: None,
+            expire_after: None,
+            sink_table_name: [
+                "greptime".to_string(),
+                "public".to_string(),
+                "sink".to_string(),
+            ],
+            source_table_names: vec![[
+                "greptime".to_string(),
+                "public".to_string(),
+                "numbers_with_ts".to_string(),
+            ]],
+            query_ctx,
+            catalog_manager: create_test_query_engine()
+                .engine_state()
+                .catalog_manager()
+                .clone(),
+            shutdown_rx: rx,
+            batch_opts: Arc::new(BatchingModeOptions::default()),
+            flow_eval_interval: None,
+        })
+        .unwrap();
+
+        let err = Error::External {
+            source: BoxedError::new(PlainError::new(
+                "STALE_CURSOR: incremental query stale, region: 4398046511104(1024, 0), given_seq: 9, min_readable_seq: 18, retry_hint: FALLBACK_FULL_RECOMPUTE".to_string(),
+                StatusCode::EngineExecuteQuery,
+            )),
+            location: snafu::Location::generate(),
+        };
+
+        let query = PlanInfo {
+            plan,
+            filter: Some(FilterExprInfo {
+                expr: datafusion_expr::lit(true),
+                col_name: "ts".to_string(),
+                time_ranges: vec![(Timestamp::new_second(0), Timestamp::new_second(1))],
+                window_size: chrono::Duration::seconds(1),
+            }),
+        };
+        let is_stale_cursor = task.handle_flow_query_failure(&err, Some(&query));
+        task.restore_dirty_windows_after_failure(&query, is_stale_cursor);
+
+        let state = task.state.read().unwrap();
+        assert_eq!(state.dirty_time_windows.len(), 1);
+        assert_eq!(
+            state.dirty_time_windows.window_size(),
+            std::time::Duration::from_secs(1)
+        );
     }
 }

--- a/src/flow/src/batching_mode/task.rs
+++ b/src/flow/src/batching_mode/task.rs
@@ -18,6 +18,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use api::v1::CreateTableExpr;
 use catalog::CatalogManagerRef;
+use client::OutputWithMetrics;
 use common_error::ext::BoxedError;
 use common_query::logical_plan::breakup_insert_plan;
 use common_telemetry::tracing::warn;
@@ -32,6 +33,10 @@ use datatypes::prelude::ConcreteDataType;
 use datatypes::schema::{ColumnSchema, Schema};
 use operator::expr_helper::column_schemas_to_defs;
 use query::QueryEngineRef;
+use query::options::{
+    FLOW_INCREMENTAL_AFTER_SEQS, FLOW_INCREMENTAL_MODE, FLOW_INCREMENTAL_MODE_MEMTABLE_ONLY,
+    FLOW_SINK_TABLE_ID,
+};
 use query::query_engine::DefaultSerializer;
 use session::context::QueryContextRef;
 use snafu::{OptionExt, ResultExt, ensure};
@@ -46,7 +51,7 @@ use tokio::time::Instant;
 use crate::adapter::{AUTO_CREATED_PLACEHOLDER_TS_COL, AUTO_CREATED_UPDATE_AT_TS_COL};
 use crate::batching_mode::BatchingModeOptions;
 use crate::batching_mode::frontend_client::FrontendClient;
-use crate::batching_mode::state::{FilterExprInfo, TaskState};
+use crate::batching_mode::state::{CheckpointMode, FilterExprInfo, TaskState};
 use crate::batching_mode::time_window::TimeWindowExpr;
 use crate::batching_mode::utils::{
     AddFilterRewriter, ColumnMatcherRewriter, FindGroupByFinalName, gen_plan_with_matching_schema,
@@ -378,81 +383,128 @@ impl BatchingTask {
             })?
             .data;
 
-        let mut peer_desc = None;
+        let extensions = self.build_flow_query_extensions().await?;
+        let extension_refs = extensions
+            .iter()
+            .map(|(key, value)| (*key, value.as_str()))
+            .collect::<Vec<_>>();
 
         let res = {
             let _timer = METRIC_FLOW_BATCHING_ENGINE_QUERY_TIME
                 .with_label_values(&[flow_id.to_string().as_str()])
                 .start_timer();
 
-            // hack and special handling the insert logical plan
             let req = if let Some((insert_to, insert_plan)) =
                 breakup_insert_plan(&plan, catalog, schema)
             {
                 let message = DFLogicalSubstraitConvertor {}
                     .encode(&insert_plan, DefaultSerializer)
                     .context(SubstraitEncodeLogicalPlanSnafu)?;
-                api::v1::greptime_request::Request::Query(api::v1::QueryRequest {
+                api::v1::QueryRequest {
                     query: Some(api::v1::query_request::Query::InsertIntoPlan(
                         api::v1::InsertIntoPlan {
                             table_name: Some(insert_to),
                             logical_plan: message.to_vec(),
                         },
                     )),
-                })
+                }
             } else {
                 let message = DFLogicalSubstraitConvertor {}
                     .encode(&plan, DefaultSerializer)
                     .context(SubstraitEncodeLogicalPlanSnafu)?;
 
-                api::v1::greptime_request::Request::Query(api::v1::QueryRequest {
+                api::v1::QueryRequest {
                     query: Some(api::v1::query_request::Query::LogicalPlan(message.to_vec())),
-                })
+                }
             };
 
             frontend_client
-                .handle(req, catalog, schema, &mut peer_desc)
+                .query_with_terminal_metrics(catalog, schema, req, &extension_refs)
                 .await
         };
 
         let elapsed = instant.elapsed();
-        if let Ok(affected_rows) = &res {
+        if let Ok(result) = &res {
+            let (affected_rows, _) = result.output.extract_rows_and_cost();
             debug!(
-                "Flow {flow_id} executed, affected_rows: {affected_rows:?}, elapsed: {:?}",
-                elapsed
+                "Flow {flow_id} executed, affected_rows: {affected_rows:?}, elapsed: {:?}, watermark: {:?}",
+                elapsed,
+                result.region_watermark_map()
             );
             METRIC_FLOW_ROWS
                 .with_label_values(&[format!("{}-out-batching", flow_id).as_str()])
-                .inc_by(*affected_rows as _);
+                .inc_by(affected_rows as _);
         } else if let Err(err) = &res {
             warn!(
-                "Failed to execute Flow {flow_id} on frontend {:?}, result: {err:?}, elapsed: {:?} with query: {}",
-                peer_desc, elapsed, &plan
+                "Failed to execute Flow {flow_id}, result: {err:?}, elapsed: {:?} with query: {}",
+                elapsed, &plan
             );
+            self.state.write().unwrap().after_query_exec(elapsed, false);
         }
 
         // record slow query
         if elapsed >= self.config.batch_opts.slow_query_threshold {
             warn!(
-                "Flow {flow_id} on frontend {:?} executed for {:?} before complete, query: {}",
-                peer_desc, elapsed, &plan
+                "Flow {flow_id} executed for {:?} before complete, query: {}",
+                elapsed, &plan
             );
             METRIC_FLOW_BATCHING_ENGINE_SLOW_QUERY
-                .with_label_values(&[
-                    flow_id.to_string().as_str(),
-                    &peer_desc.unwrap_or_default().to_string(),
-                ])
+                .with_label_values(&[flow_id.to_string().as_str(), "watermark-path"])
                 .observe(elapsed.as_secs_f64());
         }
 
-        self.state
-            .write()
-            .unwrap()
-            .after_query_exec(elapsed, res.is_ok());
-
         let res = res?;
+        let (affected_rows, _) = res.output.extract_rows_and_cost();
+        let affected_rows: u32 = affected_rows.try_into().map_err(|_| {
+            UnexpectedSnafu {
+                reason: format!("Failed to convert rows to u32: {}", affected_rows),
+            }
+            .build()
+        })?;
 
-        Ok(Some((res, elapsed)))
+        {
+            let mut state = self.state.write().unwrap();
+            Self::apply_query_result_to_state(&mut state, &res, elapsed);
+        }
+
+        Ok(Some((affected_rows, elapsed)))
+    }
+
+    fn apply_query_result_to_state(
+        state: &mut TaskState,
+        res: &OutputWithMetrics,
+        elapsed: Duration,
+    ) {
+        state.after_query_exec(elapsed, true);
+        if let (Some(participating_regions), Some(watermark_map)) =
+            (res.participating_regions(), res.region_watermark_map())
+        {
+            let checkpoint_mode = state.checkpoint_mode();
+            let can_advance = match checkpoint_mode {
+                CheckpointMode::FullSnapshot => state
+                    .can_advance_full_snapshot_checkpoints(&participating_regions, &watermark_map),
+                CheckpointMode::Incremental => state
+                    .can_advance_incremental_checkpoints_with_participation(
+                        &participating_regions,
+                        &watermark_map,
+                    ),
+            };
+
+            if can_advance {
+                match checkpoint_mode {
+                    CheckpointMode::FullSnapshot => state.advance_checkpoints(watermark_map),
+                    CheckpointMode::Incremental => state
+                        .advance_incremental_checkpoints_with_participation(
+                            &participating_regions,
+                            watermark_map,
+                        ),
+                }
+            } else {
+                state.mark_full_snapshot();
+            }
+        } else {
+            state.mark_full_snapshot();
+        }
     }
 
     fn handle_flow_query_failure(&self, err: &Error, query: Option<&PlanInfo>) -> bool {
@@ -462,6 +514,7 @@ impl BatchingTask {
                 "Flow {} detected stale incremental query failure, switching to non-incremental recompute semantics for current query scope: {:?}",
                 self.config.flow_id, failure.stale_cursor
             );
+            self.state.write().unwrap().mark_full_snapshot();
 
             // notice that we only mark all as dirty if query itself has no time window filter.
             if query.is_none_or(|query| query.filter.is_none())
@@ -491,6 +544,45 @@ impl BatchingTask {
                 .map(|f| f.time_ranges.clone())
                 .unwrap_or_default(),
         );
+    }
+
+    async fn build_flow_query_extensions(&self) -> Result<Vec<(&'static str, String)>, Error> {
+        let state = self.state.read().unwrap();
+        let mut extensions = vec![("flow.return_region_seq", "true".to_string())];
+
+        drop(state);
+        if let Some(table) = self
+            .config
+            .catalog_manager
+            .table(
+                &self.config.sink_table_name[0],
+                &self.config.sink_table_name[1],
+                &self.config.sink_table_name[2],
+                None,
+            )
+            .await
+            .map_err(BoxedError::new)
+            .context(ExternalSnafu)?
+        {
+            extensions.push((
+                FLOW_SINK_TABLE_ID,
+                table.table_info().table_id().to_string(),
+            ));
+        }
+
+        let state = self.state.read().unwrap();
+        if state.checkpoint_mode() == CheckpointMode::Incremental && !state.checkpoints().is_empty()
+        {
+            let checkpoints_json = serde_json::to_string(state.checkpoints())
+                .expect("checkpoint map should serialize");
+            extensions.push((
+                FLOW_INCREMENTAL_MODE,
+                FLOW_INCREMENTAL_MODE_MEMTABLE_ONLY.to_string(),
+            ));
+            extensions.push((FLOW_INCREMENTAL_AFTER_SEQS, checkpoints_json));
+        }
+
+        Ok(extensions)
     }
 
     /// start executing query in a loop, break when receive shutdown signal
@@ -1015,9 +1107,13 @@ fn build_pk_from_aggr(plan: &LogicalPlan) -> Result<Option<TableDef>, Error> {
 
 #[cfg(test)]
 mod test {
+    use std::collections::BTreeMap;
+
     use api::v1::column_def::try_as_column_schema;
     use common_error::ext::{BoxedError, PlainError};
     use common_error::status_code::StatusCode;
+    use common_query::Output;
+    use common_recordbatch::adapter::{RecordBatchMetrics, RegionWatermarkEntry};
     use pretty_assertions::assert_eq;
     use session::context::QueryContext;
     use snafu::GenerateImplicitData;
@@ -1266,6 +1362,329 @@ mod test {
         assert_eq!(
             state.dirty_time_windows.window_size(),
             std::time::Duration::from_secs(1)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_build_flow_query_extensions_switches_with_checkpoint_mode() {
+        let query_engine = create_test_query_engine();
+        let query_ctx = QueryContext::arc();
+        let plan = sql_to_df_plan(
+            query_ctx.clone(),
+            query_engine,
+            "SELECT number, ts FROM numbers_with_ts",
+            true,
+        )
+        .await
+        .unwrap();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let task = BatchingTask::try_new(TaskArgs {
+            flow_id: 44,
+            query: "SELECT number, ts FROM numbers_with_ts",
+            plan,
+            time_window_expr: None,
+            expire_after: None,
+            sink_table_name: [
+                "greptime".to_string(),
+                "public".to_string(),
+                "sink".to_string(),
+            ],
+            source_table_names: vec![[
+                "greptime".to_string(),
+                "public".to_string(),
+                "numbers_with_ts".to_string(),
+            ]],
+            query_ctx,
+            catalog_manager: create_test_query_engine()
+                .engine_state()
+                .catalog_manager()
+                .clone(),
+            shutdown_rx: rx,
+            batch_opts: Arc::new(BatchingModeOptions::default()),
+            flow_eval_interval: None,
+        })
+        .unwrap();
+
+        let extensions = task.build_flow_query_extensions().await.unwrap();
+        assert!(
+            extensions
+                .iter()
+                .any(|(k, v)| *k == "flow.return_region_seq" && v == "true")
+        );
+
+        task.state
+            .write()
+            .unwrap()
+            .advance_checkpoints(HashMap::from([(7_u64, 42_u64)]));
+        let extensions = task.build_flow_query_extensions().await.unwrap();
+        assert!(
+            extensions
+                .iter()
+                .any(|(k, v)| *k == "flow.return_region_seq" && v == "true")
+        );
+        assert!(
+            extensions
+                .iter()
+                .any(|(k, v)| *k == "flow.incremental_mode" && v == "memtable_only")
+        );
+        assert!(
+            extensions
+                .iter()
+                .any(|(k, v)| *k == "flow.incremental_after_seqs" && v == r#"{"7":42}"#)
+        );
+    }
+
+    fn watermark_result(entries: Vec<(u64, Option<u64>)>) -> OutputWithMetrics {
+        let result = OutputWithMetrics::from_output(Output::new_with_affected_rows(1));
+        result.metrics.update(Some(RecordBatchMetrics {
+            region_watermarks: entries
+                .into_iter()
+                .map(|(region_id, watermark)| RegionWatermarkEntry {
+                    region_id,
+                    watermark,
+                })
+                .collect(),
+            ..Default::default()
+        }));
+        result.metrics.mark_ready();
+        result
+    }
+
+    #[tokio::test]
+    async fn test_apply_query_result_to_state_advances_full_snapshot_to_incremental() {
+        let query_engine = create_test_query_engine();
+        let query_ctx = QueryContext::arc();
+        let plan = sql_to_df_plan(
+            query_ctx.clone(),
+            query_engine,
+            "SELECT number, ts FROM numbers_with_ts",
+            true,
+        )
+        .await
+        .unwrap();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let task = BatchingTask::try_new(TaskArgs {
+            flow_id: 45,
+            query: "SELECT number, ts FROM numbers_with_ts",
+            plan,
+            time_window_expr: None,
+            expire_after: None,
+            sink_table_name: [
+                "greptime".to_string(),
+                "public".to_string(),
+                "sink".to_string(),
+            ],
+            source_table_names: vec![[
+                "greptime".to_string(),
+                "public".to_string(),
+                "numbers_with_ts".to_string(),
+            ]],
+            query_ctx,
+            catalog_manager: create_test_query_engine()
+                .engine_state()
+                .catalog_manager()
+                .clone(),
+            shutdown_rx: rx,
+            batch_opts: Arc::new(BatchingModeOptions::default()),
+            flow_eval_interval: None,
+        })
+        .unwrap();
+
+        let result = watermark_result(vec![(1, Some(10)), (2, Some(20))]);
+        let mut state = task.state.write().unwrap();
+        BatchingTask::apply_query_result_to_state(&mut state, &result, Duration::from_millis(1));
+
+        assert_eq!(state.checkpoint_mode(), CheckpointMode::Incremental);
+        assert_eq!(
+            state.checkpoints(),
+            &BTreeMap::from([(1_u64, 10_u64), (2_u64, 20_u64)])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_apply_query_result_to_state_rejects_partial_incremental_watermark_map() {
+        let query_engine = create_test_query_engine();
+        let query_ctx = QueryContext::arc();
+        let plan = sql_to_df_plan(
+            query_ctx.clone(),
+            query_engine,
+            "SELECT number, ts FROM numbers_with_ts",
+            true,
+        )
+        .await
+        .unwrap();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let task = BatchingTask::try_new(TaskArgs {
+            flow_id: 46,
+            query: "SELECT number, ts FROM numbers_with_ts",
+            plan,
+            time_window_expr: None,
+            expire_after: None,
+            sink_table_name: [
+                "greptime".to_string(),
+                "public".to_string(),
+                "sink".to_string(),
+            ],
+            source_table_names: vec![[
+                "greptime".to_string(),
+                "public".to_string(),
+                "numbers_with_ts".to_string(),
+            ]],
+            query_ctx,
+            catalog_manager: create_test_query_engine()
+                .engine_state()
+                .catalog_manager()
+                .clone(),
+            shutdown_rx: rx,
+            batch_opts: Arc::new(BatchingModeOptions::default()),
+            flow_eval_interval: None,
+        })
+        .unwrap();
+
+        {
+            let mut state = task.state.write().unwrap();
+            state.advance_checkpoints(HashMap::from([(1_u64, 10_u64), (2_u64, 20_u64)]));
+        }
+
+        let result = watermark_result(vec![(1, Some(11)), (2, None)]);
+        let mut state = task.state.write().unwrap();
+        BatchingTask::apply_query_result_to_state(&mut state, &result, Duration::from_millis(1));
+
+        assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
+        assert_eq!(
+            state.checkpoints(),
+            &BTreeMap::from([(1_u64, 10_u64), (2_u64, 20_u64)])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_apply_query_result_to_state_accepts_pruned_incremental_subset_and_preserves_others()
+     {
+        let query_engine = create_test_query_engine();
+        let query_ctx = QueryContext::arc();
+        let plan = sql_to_df_plan(
+            query_ctx.clone(),
+            query_engine,
+            "SELECT number, ts FROM numbers_with_ts",
+            true,
+        )
+        .await
+        .unwrap();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let task = BatchingTask::try_new(TaskArgs {
+            flow_id: 48,
+            query: "SELECT number, ts FROM numbers_with_ts",
+            plan,
+            time_window_expr: None,
+            expire_after: None,
+            sink_table_name: [
+                "greptime".to_string(),
+                "public".to_string(),
+                "sink".to_string(),
+            ],
+            source_table_names: vec![[
+                "greptime".to_string(),
+                "public".to_string(),
+                "numbers_with_ts".to_string(),
+            ]],
+            query_ctx,
+            catalog_manager: create_test_query_engine()
+                .engine_state()
+                .catalog_manager()
+                .clone(),
+            shutdown_rx: rx,
+            batch_opts: Arc::new(BatchingModeOptions::default()),
+            flow_eval_interval: None,
+        })
+        .unwrap();
+
+        {
+            let mut state = task.state.write().unwrap();
+            state.advance_checkpoints(HashMap::from([
+                (1_u64, 10_u64),
+                (2_u64, 20_u64),
+                (3_u64, 30_u64),
+            ]));
+        }
+
+        let result = watermark_result(vec![(1, Some(12)), (3, Some(31))]);
+        let mut state = task.state.write().unwrap();
+        BatchingTask::apply_query_result_to_state(&mut state, &result, Duration::from_millis(1));
+
+        assert_eq!(state.checkpoint_mode(), CheckpointMode::Incremental);
+        assert_eq!(
+            state.checkpoints(),
+            &BTreeMap::from([(1_u64, 12_u64), (2_u64, 20_u64), (3_u64, 31_u64)])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stale_to_full_to_incremental_recovery_path() {
+        let query_engine = create_test_query_engine();
+        let query_ctx = QueryContext::arc();
+        let plan = sql_to_df_plan(
+            query_ctx.clone(),
+            query_engine,
+            "SELECT number, ts FROM numbers_with_ts",
+            true,
+        )
+        .await
+        .unwrap();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let task = BatchingTask::try_new(TaskArgs {
+            flow_id: 47,
+            query: "SELECT number, ts FROM numbers_with_ts",
+            plan: plan.clone(),
+            time_window_expr: None,
+            expire_after: None,
+            sink_table_name: [
+                "greptime".to_string(),
+                "public".to_string(),
+                "sink".to_string(),
+            ],
+            source_table_names: vec![[
+                "greptime".to_string(),
+                "public".to_string(),
+                "numbers_with_ts".to_string(),
+            ]],
+            query_ctx,
+            catalog_manager: create_test_query_engine()
+                .engine_state()
+                .catalog_manager()
+                .clone(),
+            shutdown_rx: rx,
+            batch_opts: Arc::new(BatchingModeOptions::default()),
+            flow_eval_interval: None,
+        })
+        .unwrap();
+
+        {
+            let mut state = task.state.write().unwrap();
+            state.advance_checkpoints(HashMap::from([(1_u64, 10_u64), (2_u64, 20_u64)]));
+            assert_eq!(state.checkpoint_mode(), CheckpointMode::Incremental);
+        }
+
+        let err = Error::External {
+            source: BoxedError::new(PlainError::new(
+                "STALE_CURSOR: incremental query stale, region: 4398046511104(1024, 0), given_seq: 9, min_readable_seq: 18, retry_hint: FALLBACK_FULL_RECOMPUTE".to_string(),
+                StatusCode::EngineExecuteQuery,
+            )),
+            location: snafu::Location::generate(),
+        };
+        assert!(task.handle_flow_query_failure(&err, None));
+        assert_eq!(
+            task.state.read().unwrap().checkpoint_mode(),
+            CheckpointMode::FullSnapshot
+        );
+
+        let result = watermark_result(vec![(1, Some(30)), (2, Some(40))]);
+        let mut state = task.state.write().unwrap();
+        BatchingTask::apply_query_result_to_state(&mut state, &result, Duration::from_millis(1));
+
+        assert_eq!(state.checkpoint_mode(), CheckpointMode::Incremental);
+        assert_eq!(
+            state.checkpoints(),
+            &BTreeMap::from([(1_u64, 30_u64), (2_u64, 40_u64)])
         );
     }
 }

--- a/src/flow/src/batching_mode/task.rs
+++ b/src/flow/src/batching_mode/task.rs
@@ -54,8 +54,9 @@ use crate::batching_mode::frontend_client::FrontendClient;
 use crate::batching_mode::state::{CheckpointMode, FilterExprInfo, TaskState};
 use crate::batching_mode::time_window::TimeWindowExpr;
 use crate::batching_mode::utils::{
-    AddFilterRewriter, ColumnMatcherRewriter, FindGroupByFinalName, gen_plan_with_matching_schema,
-    get_table_info_df_schema, sql_to_df_plan,
+    AddFilterRewriter, ColumnMatcherRewriter, FindGroupByFinalName,
+    analyze_poc_incremental_aggregate_plan, gen_plan_with_matching_schema,
+    get_table_info_df_schema, rewrite_poc_incremental_aggregate_with_sink_merge, sql_to_df_plan,
 };
 use crate::df_optimizer::apply_df_optimizer;
 use crate::error::{
@@ -141,6 +142,51 @@ pub struct PlanInfo {
 }
 
 impl BatchingTask {
+    async fn rewrite_incremental_sql_plan_if_needed(
+        &self,
+        plan: LogicalPlan,
+    ) -> Result<LogicalPlan, Error> {
+        if self.state.read().unwrap().checkpoint_mode() != CheckpointMode::Incremental {
+            return Ok(plan);
+        }
+        if self.config.query_type != QueryType::Sql {
+            return Ok(plan);
+        }
+
+        let Some(analysis) = analyze_poc_incremental_aggregate_plan(&plan)? else {
+            return Ok(plan);
+        };
+
+        if !analysis.unsupported_exprs.is_empty() {
+            return InvalidQuerySnafu {
+                reason: format!(
+                    "UNSUPPORTED_INCREMENTAL_AGG: query contains unsupported incremental aggregate expressions {:?}",
+                    analysis.unsupported_exprs
+                ),
+            }
+            .fail();
+        }
+
+        let (sink_table, _) = get_table_info_df_schema(
+            self.config.catalog_manager.clone(),
+            self.config.sink_table_name.clone(),
+        )
+        .await?;
+
+        let rewritten = rewrite_poc_incremental_aggregate_with_sink_merge(
+            &plan,
+            &analysis,
+            sink_table,
+            &self.config.sink_table_name,
+        )
+        .await?;
+        warn!(
+            "Flow {} rewrote incremental SQL aggregate query with POC sink merge",
+            self.config.flow_id,
+        );
+        Ok(rewritten)
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn try_new(
         TaskArgs {
@@ -779,15 +825,25 @@ impl BatchingTask {
                         return Ok(None);
                     }
 
-                    let plan = gen_plan_with_matching_schema(
+                    let plan = sql_to_df_plan(
+                        query_ctx.clone(),
+                        engine.clone(),
                         &self.config.query,
-                        query_ctx,
-                        engine,
-                        sink_table_schema.clone(),
-                        primary_key_indices,
-                        allow_partial,
+                        false,
                     )
                     .await?;
+                    let rewritten = self.rewrite_incremental_sql_plan_if_needed(plan).await?;
+                    let mut add_auto_column = ColumnMatcherRewriter::new(
+                        sink_table_schema.clone(),
+                        primary_key_indices.to_vec(),
+                        allow_partial,
+                    );
+                    let plan = rewritten
+                        .rewrite(&mut add_auto_column)
+                        .with_context(|_| DatafusionSnafu {
+                            context: "Failed to align rewritten plan with sink schema".to_string(),
+                        })?
+                        .data;
 
                     return Ok(Some(PlanInfo { plan, filter: None }));
                 }
@@ -878,12 +934,20 @@ impl BatchingTask {
 
         let plan =
             sql_to_df_plan(query_ctx.clone(), engine.clone(), &self.config.query, false).await?;
-        let rewrite = plan
+        let filtered = plan
             .clone()
             .rewrite(&mut add_filter)
-            .and_then(|p| p.data.rewrite(&mut add_auto_column))
             .with_context(|_| DatafusionSnafu {
                 context: format!("Failed to rewrite plan:\n {}\n", plan),
+            })?
+            .data;
+        let rewritten = self
+            .rewrite_incremental_sql_plan_if_needed(filtered)
+            .await?;
+        let rewrite = rewritten
+            .rewrite(&mut add_auto_column)
+            .with_context(|_| DatafusionSnafu {
+                context: "Failed to align rewritten plan with sink schema".to_string(),
             })?
             .data;
         // only apply optimize after complex rewrite is done
@@ -1108,18 +1172,105 @@ fn build_pk_from_aggr(plan: &LogicalPlan) -> Result<Option<TableDef>, Error> {
 #[cfg(test)]
 mod test {
     use std::collections::BTreeMap;
+    use std::sync::Arc;
 
     use api::v1::column_def::try_as_column_schema;
+    use catalog::RegisterTableRequest;
+    use catalog::memory::MemoryCatalogManager;
+    use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
     use common_error::ext::{BoxedError, PlainError};
     use common_error::status_code::StatusCode;
-    use common_query::Output;
+    use common_query::{Output, OutputData};
     use common_recordbatch::adapter::{RecordBatchMetrics, RegionWatermarkEntry};
+    use common_recordbatch::util;
+    use datatypes::arrow_array::{int_array_value_at_index, timestamp_array_value};
+    use datatypes::prelude::{ConcreteDataType, MutableVector, ScalarVectorBuilder};
+    use datatypes::schema::Schema;
+    use datatypes::timestamp::TimestampMillisecond;
+    use datatypes::vectors::{TimestampMillisecondVectorBuilder, VectorRef};
     use pretty_assertions::assert_eq;
     use session::context::QueryContext;
     use snafu::GenerateImplicitData;
+    use table::test_util::MemTable;
 
     use super::*;
     use crate::test_utils::create_test_query_engine;
+
+    fn register_test_table(
+        query_engine: &QueryEngineRef,
+        table_name: &str,
+        rows: &[(Option<u32>, i64)],
+    ) {
+        let schema = Arc::new(Schema::new(vec![
+            ColumnSchema::new("number", ConcreteDataType::uint32_datatype(), true),
+            ColumnSchema::new(
+                "ts",
+                ConcreteDataType::timestamp_millisecond_datatype(),
+                false,
+            )
+            .with_time_index(true),
+        ]));
+
+        let mut number_builder = datatypes::vectors::UInt32VectorBuilder::with_capacity(rows.len());
+        for (number, _) in rows {
+            number_builder.push(*number);
+        }
+        let numbers: VectorRef = number_builder.to_vector_cloned();
+        let mut ts_builder = TimestampMillisecondVectorBuilder::with_capacity(rows.len());
+        for (_, ts) in rows {
+            ts_builder.push(Some(TimestampMillisecond::new(*ts)));
+        }
+        let timestamps: VectorRef = ts_builder.to_vector_cloned();
+        let recordbatch =
+            common_recordbatch::RecordBatch::new(schema, vec![numbers, timestamps]).unwrap();
+        let table = MemTable::table(table_name, recordbatch);
+
+        let memory_catalog_manager = query_engine
+            .engine_state()
+            .catalog_manager()
+            .as_any()
+            .downcast_ref::<MemoryCatalogManager>()
+            .unwrap();
+        memory_catalog_manager
+            .register_table_sync(RegisterTableRequest {
+                catalog: DEFAULT_CATALOG_NAME.to_string(),
+                schema: DEFAULT_SCHEMA_NAME.to_string(),
+                table_name: table_name.to_string(),
+                table_id: 6000,
+                table,
+            })
+            .unwrap();
+    }
+
+    fn register_test_sink_table(
+        query_engine: &QueryEngineRef,
+        table_name: &str,
+        rows: &[(u32, i64)],
+    ) {
+        let rows = rows
+            .iter()
+            .map(|(number, ts)| (Some(*number), *ts))
+            .collect::<Vec<_>>();
+        register_test_table(query_engine, table_name, &rows);
+    }
+
+    fn extract_ts_number_rows(
+        batches: &[common_recordbatch::RecordBatch],
+    ) -> Vec<(i64, Option<i64>)> {
+        let mut rows = Vec::new();
+        for batch in batches {
+            let ts_col = batch.column_by_name("ts").unwrap();
+            let number_col = batch.column_by_name("number").unwrap();
+            for row_idx in 0..batch.num_rows() {
+                rows.push((
+                    timestamp_array_value(ts_col, row_idx).value(),
+                    int_array_value_at_index(number_col, row_idx),
+                ));
+            }
+        }
+        rows.sort_unstable();
+        rows
+    }
 
     #[tokio::test]
     async fn test_gen_create_table_sql() {
@@ -1686,5 +1837,540 @@ mod test {
             state.checkpoints(),
             &BTreeMap::from([(1_u64, 30_u64), (2_u64, 40_u64)])
         );
+    }
+
+    #[tokio::test]
+    async fn test_rewrite_incremental_sql_plan_for_supported_aggregate() {
+        let query_engine = create_test_query_engine();
+        let query_ctx = QueryContext::arc();
+        let sql = "SELECT max(number) AS number, ts FROM numbers_with_ts GROUP BY ts";
+        let plan = sql_to_df_plan(query_ctx.clone(), query_engine.clone(), sql, true)
+            .await
+            .unwrap();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let task = BatchingTask::try_new(TaskArgs {
+            flow_id: 49,
+            query: sql,
+            plan,
+            time_window_expr: None,
+            expire_after: None,
+            sink_table_name: [
+                "greptime".to_string(),
+                "public".to_string(),
+                "numbers_with_ts".to_string(),
+            ],
+            source_table_names: vec![[
+                "greptime".to_string(),
+                "public".to_string(),
+                "numbers_with_ts".to_string(),
+            ]],
+            query_ctx,
+            catalog_manager: create_test_query_engine()
+                .engine_state()
+                .catalog_manager()
+                .clone(),
+            shutdown_rx: rx,
+            batch_opts: Arc::new(BatchingModeOptions::default()),
+            flow_eval_interval: None,
+        })
+        .unwrap();
+
+        {
+            let mut state = task.state.write().unwrap();
+            state.advance_checkpoints(HashMap::from([(1_u64, 10_u64)]));
+        }
+
+        let raw_plan = sql_to_df_plan(
+            task.state.read().unwrap().query_ctx.clone(),
+            query_engine.clone(),
+            sql,
+            false,
+        )
+        .await
+        .unwrap();
+        let rewritten = task
+            .rewrite_incremental_sql_plan_if_needed(raw_plan)
+            .await
+            .unwrap();
+        let plan_text = format!("{}", rewritten.display_indent());
+        assert!(plan_text.contains("Left Join"));
+        assert!(!plan_text.contains("Union"));
+    }
+
+    #[tokio::test]
+    async fn test_rewrite_incremental_sql_plan_rejects_avg() {
+        let query_engine = create_test_query_engine();
+        let query_ctx = QueryContext::arc();
+        let sql = "SELECT avg(number) AS avg_num, ts FROM numbers_with_ts GROUP BY ts";
+        let plan = sql_to_df_plan(query_ctx.clone(), query_engine.clone(), sql, true)
+            .await
+            .unwrap();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let task = BatchingTask::try_new(TaskArgs {
+            flow_id: 50,
+            query: sql,
+            plan,
+            time_window_expr: None,
+            expire_after: None,
+            sink_table_name: [
+                "greptime".to_string(),
+                "public".to_string(),
+                "numbers_with_ts".to_string(),
+            ],
+            source_table_names: vec![[
+                "greptime".to_string(),
+                "public".to_string(),
+                "numbers_with_ts".to_string(),
+            ]],
+            query_ctx,
+            catalog_manager: create_test_query_engine()
+                .engine_state()
+                .catalog_manager()
+                .clone(),
+            shutdown_rx: rx,
+            batch_opts: Arc::new(BatchingModeOptions::default()),
+            flow_eval_interval: None,
+        })
+        .unwrap();
+
+        task.mark_all_windows_as_dirty().unwrap();
+        {
+            let mut state = task.state.write().unwrap();
+            state.advance_checkpoints(HashMap::from([(1_u64, 10_u64)]));
+        }
+
+        match task.gen_insert_plan(&query_engine, None).await {
+            Err(err) => assert!(format!("{err}").contains("UNSUPPORTED_INCREMENTAL_AGG")),
+            Ok(_) => panic!("expected UNSUPPORTED_INCREMENTAL_AGG error for avg query"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_rewrite_incremental_sql_plan_semantics_sum_only_new_and_both_sides() {
+        let query_engine = create_test_query_engine();
+        register_test_sink_table(&query_engine, "sink_semantic", &[(20, 2)]);
+
+        let query_ctx = QueryContext::arc();
+        let sql = "SELECT sum(number) AS number, ts FROM numbers_with_ts WHERE ts >= 2 AND ts <= 3 GROUP BY ts";
+        let plan = sql_to_df_plan(query_ctx.clone(), query_engine.clone(), sql, true)
+            .await
+            .unwrap();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let task = BatchingTask::try_new(TaskArgs {
+            flow_id: 51,
+            query: sql,
+            plan,
+            time_window_expr: None,
+            expire_after: None,
+            sink_table_name: [
+                "greptime".to_string(),
+                "public".to_string(),
+                "sink_semantic".to_string(),
+            ],
+            source_table_names: vec![[
+                "greptime".to_string(),
+                "public".to_string(),
+                "numbers_with_ts".to_string(),
+            ]],
+            query_ctx,
+            catalog_manager: query_engine.engine_state().catalog_manager().clone(),
+            shutdown_rx: rx,
+            batch_opts: Arc::new(BatchingModeOptions::default()),
+            flow_eval_interval: None,
+        })
+        .unwrap();
+
+        {
+            let mut state = task.state.write().unwrap();
+            state.advance_checkpoints(HashMap::from([(1_u64, 10_u64)]));
+        }
+
+        let raw_plan = sql_to_df_plan(
+            task.state.read().unwrap().query_ctx.clone(),
+            query_engine.clone(),
+            sql,
+            false,
+        )
+        .await
+        .unwrap();
+        let rewritten = task
+            .rewrite_incremental_sql_plan_if_needed(raw_plan)
+            .await
+            .unwrap();
+
+        let output = query_engine
+            .execute(rewritten, task.state.read().unwrap().query_ctx.clone())
+            .await
+            .unwrap();
+        let stream = match output.data {
+            OutputData::Stream(stream) => stream,
+            OutputData::RecordBatches(batches) => batches.as_stream(),
+            OutputData::AffectedRows(_) => panic!("expected query output"),
+        };
+        let batches = util::collect(stream).await.unwrap();
+
+        let rows = extract_ts_number_rows(&batches);
+        assert_eq!(rows, vec![(2, Some(22)), (3, Some(3))]);
+    }
+
+    #[tokio::test]
+    async fn test_rewrite_incremental_sql_plan_semantics_max_only_new_and_both_sides() {
+        let query_engine = create_test_query_engine();
+        register_test_sink_table(&query_engine, "sink_semantic_max", &[(20, 2)]);
+
+        let query_ctx = QueryContext::arc();
+        let sql = "SELECT max(number) AS number, ts FROM numbers_with_ts WHERE ts >= 2 AND ts <= 3 GROUP BY ts";
+        let plan = sql_to_df_plan(query_ctx.clone(), query_engine.clone(), sql, true)
+            .await
+            .unwrap();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let task = BatchingTask::try_new(TaskArgs {
+            flow_id: 52,
+            query: sql,
+            plan,
+            time_window_expr: None,
+            expire_after: None,
+            sink_table_name: [
+                "greptime".to_string(),
+                "public".to_string(),
+                "sink_semantic_max".to_string(),
+            ],
+            source_table_names: vec![[
+                "greptime".to_string(),
+                "public".to_string(),
+                "numbers_with_ts".to_string(),
+            ]],
+            query_ctx,
+            catalog_manager: query_engine.engine_state().catalog_manager().clone(),
+            shutdown_rx: rx,
+            batch_opts: Arc::new(BatchingModeOptions::default()),
+            flow_eval_interval: None,
+        })
+        .unwrap();
+
+        {
+            let mut state = task.state.write().unwrap();
+            state.advance_checkpoints(HashMap::from([(1_u64, 10_u64)]));
+        }
+
+        let raw_plan = sql_to_df_plan(
+            task.state.read().unwrap().query_ctx.clone(),
+            query_engine.clone(),
+            sql,
+            false,
+        )
+        .await
+        .unwrap();
+        let rewritten = task
+            .rewrite_incremental_sql_plan_if_needed(raw_plan)
+            .await
+            .unwrap();
+
+        let output = query_engine
+            .execute(rewritten, task.state.read().unwrap().query_ctx.clone())
+            .await
+            .unwrap();
+        let stream = match output.data {
+            OutputData::Stream(stream) => stream,
+            OutputData::RecordBatches(batches) => batches.as_stream(),
+            OutputData::AffectedRows(_) => panic!("expected query output"),
+        };
+        let batches = util::collect(stream).await.unwrap();
+
+        let rows = extract_ts_number_rows(&batches);
+        assert_eq!(rows, vec![(2, Some(20)), (3, Some(3))]);
+    }
+
+    #[tokio::test]
+    async fn test_rewrite_incremental_sql_plan_semantics_sum_nullable_delta_keeps_old_state() {
+        let query_engine = create_test_query_engine();
+        register_test_sink_table(&query_engine, "sink_semantic_sum_null", &[(20, 2)]);
+        register_test_table(
+            &query_engine,
+            "numbers_with_nullable_ts",
+            &[(None, 2), (Some(3), 3)],
+        );
+
+        let query_ctx = QueryContext::arc();
+        let sql = "SELECT sum(number) AS number, ts FROM numbers_with_nullable_ts GROUP BY ts";
+        let plan = sql_to_df_plan(query_ctx.clone(), query_engine.clone(), sql, true)
+            .await
+            .unwrap();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let task = BatchingTask::try_new(TaskArgs {
+            flow_id: 53,
+            query: sql,
+            plan,
+            time_window_expr: None,
+            expire_after: None,
+            sink_table_name: [
+                "greptime".to_string(),
+                "public".to_string(),
+                "sink_semantic_sum_null".to_string(),
+            ],
+            source_table_names: vec![[
+                "greptime".to_string(),
+                "public".to_string(),
+                "numbers_with_nullable_ts".to_string(),
+            ]],
+            query_ctx,
+            catalog_manager: query_engine.engine_state().catalog_manager().clone(),
+            shutdown_rx: rx,
+            batch_opts: Arc::new(BatchingModeOptions::default()),
+            flow_eval_interval: None,
+        })
+        .unwrap();
+
+        {
+            let mut state = task.state.write().unwrap();
+            state.advance_checkpoints(HashMap::from([(1_u64, 10_u64)]));
+        }
+
+        let raw_plan = sql_to_df_plan(
+            task.state.read().unwrap().query_ctx.clone(),
+            query_engine.clone(),
+            sql,
+            false,
+        )
+        .await
+        .unwrap();
+        let rewritten = task
+            .rewrite_incremental_sql_plan_if_needed(raw_plan)
+            .await
+            .unwrap();
+
+        let output = query_engine
+            .execute(rewritten, task.state.read().unwrap().query_ctx.clone())
+            .await
+            .unwrap();
+        let stream = match output.data {
+            OutputData::Stream(stream) => stream,
+            OutputData::RecordBatches(batches) => batches.as_stream(),
+            OutputData::AffectedRows(_) => panic!("expected query output"),
+        };
+        let batches = util::collect(stream).await.unwrap();
+
+        let rows = extract_ts_number_rows(&batches);
+        assert_eq!(rows, vec![(2, Some(20)), (3, Some(3))]);
+    }
+
+    #[tokio::test]
+    async fn test_rewrite_incremental_sql_plan_semantics_max_nullable_delta_keeps_old_state() {
+        let query_engine = create_test_query_engine();
+        register_test_sink_table(&query_engine, "sink_semantic_max_null", &[(20, 2)]);
+        register_test_table(
+            &query_engine,
+            "numbers_with_nullable_ts_max",
+            &[(None, 2), (Some(3), 3)],
+        );
+
+        let query_ctx = QueryContext::arc();
+        let sql = "SELECT max(number) AS number, ts FROM numbers_with_nullable_ts_max GROUP BY ts";
+        let plan = sql_to_df_plan(query_ctx.clone(), query_engine.clone(), sql, true)
+            .await
+            .unwrap();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let task = BatchingTask::try_new(TaskArgs {
+            flow_id: 54,
+            query: sql,
+            plan,
+            time_window_expr: None,
+            expire_after: None,
+            sink_table_name: [
+                "greptime".to_string(),
+                "public".to_string(),
+                "sink_semantic_max_null".to_string(),
+            ],
+            source_table_names: vec![[
+                "greptime".to_string(),
+                "public".to_string(),
+                "numbers_with_nullable_ts_max".to_string(),
+            ]],
+            query_ctx,
+            catalog_manager: query_engine.engine_state().catalog_manager().clone(),
+            shutdown_rx: rx,
+            batch_opts: Arc::new(BatchingModeOptions::default()),
+            flow_eval_interval: None,
+        })
+        .unwrap();
+
+        {
+            let mut state = task.state.write().unwrap();
+            state.advance_checkpoints(HashMap::from([(1_u64, 10_u64)]));
+        }
+
+        let raw_plan = sql_to_df_plan(
+            task.state.read().unwrap().query_ctx.clone(),
+            query_engine.clone(),
+            sql,
+            false,
+        )
+        .await
+        .unwrap();
+        let rewritten = task
+            .rewrite_incremental_sql_plan_if_needed(raw_plan)
+            .await
+            .unwrap();
+
+        let output = query_engine
+            .execute(rewritten, task.state.read().unwrap().query_ctx.clone())
+            .await
+            .unwrap();
+        let stream = match output.data {
+            OutputData::Stream(stream) => stream,
+            OutputData::RecordBatches(batches) => batches.as_stream(),
+            OutputData::AffectedRows(_) => panic!("expected query output"),
+        };
+        let batches = util::collect(stream).await.unwrap();
+
+        let rows = extract_ts_number_rows(&batches);
+        assert_eq!(rows, vec![(2, Some(20)), (3, Some(3))]);
+    }
+
+    #[tokio::test]
+    async fn test_rewrite_incremental_sql_plan_semantics_sum_sink_null_delta_nonnull_uses_delta() {
+        let query_engine = create_test_query_engine();
+        register_test_table(&query_engine, "sink_semantic_sum_sink_null", &[(None, 2)]);
+        register_test_table(
+            &query_engine,
+            "numbers_with_nullable_ts_sink_null",
+            &[(Some(7), 2), (Some(3), 3)],
+        );
+
+        let query_ctx = QueryContext::arc();
+        let sql =
+            "SELECT sum(number) AS number, ts FROM numbers_with_nullable_ts_sink_null GROUP BY ts";
+        let plan = sql_to_df_plan(query_ctx.clone(), query_engine.clone(), sql, true)
+            .await
+            .unwrap();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let task = BatchingTask::try_new(TaskArgs {
+            flow_id: 55,
+            query: sql,
+            plan,
+            time_window_expr: None,
+            expire_after: None,
+            sink_table_name: [
+                "greptime".to_string(),
+                "public".to_string(),
+                "sink_semantic_sum_sink_null".to_string(),
+            ],
+            source_table_names: vec![[
+                "greptime".to_string(),
+                "public".to_string(),
+                "numbers_with_nullable_ts_sink_null".to_string(),
+            ]],
+            query_ctx,
+            catalog_manager: query_engine.engine_state().catalog_manager().clone(),
+            shutdown_rx: rx,
+            batch_opts: Arc::new(BatchingModeOptions::default()),
+            flow_eval_interval: None,
+        })
+        .unwrap();
+
+        {
+            let mut state = task.state.write().unwrap();
+            state.advance_checkpoints(HashMap::from([(1_u64, 10_u64)]));
+        }
+
+        let raw_plan = sql_to_df_plan(
+            task.state.read().unwrap().query_ctx.clone(),
+            query_engine.clone(),
+            sql,
+            false,
+        )
+        .await
+        .unwrap();
+        let rewritten = task
+            .rewrite_incremental_sql_plan_if_needed(raw_plan)
+            .await
+            .unwrap();
+
+        let output = query_engine
+            .execute(rewritten, task.state.read().unwrap().query_ctx.clone())
+            .await
+            .unwrap();
+        let stream = match output.data {
+            OutputData::Stream(stream) => stream,
+            OutputData::RecordBatches(batches) => batches.as_stream(),
+            OutputData::AffectedRows(_) => panic!("expected query output"),
+        };
+        let batches = util::collect(stream).await.unwrap();
+
+        let rows = extract_ts_number_rows(&batches);
+        assert_eq!(rows, vec![(2, Some(7)), (3, Some(3))]);
+    }
+
+    #[tokio::test]
+    async fn test_rewrite_incremental_sql_plan_semantics_sum_double_null_stays_null() {
+        let query_engine = create_test_query_engine();
+        register_test_table(&query_engine, "sink_semantic_sum_double_null", &[(None, 2)]);
+        register_test_table(
+            &query_engine,
+            "numbers_with_nullable_ts_double_null",
+            &[(None, 2), (Some(3), 3)],
+        );
+
+        let query_ctx = QueryContext::arc();
+        let sql = "SELECT sum(number) AS number, ts FROM numbers_with_nullable_ts_double_null GROUP BY ts";
+        let plan = sql_to_df_plan(query_ctx.clone(), query_engine.clone(), sql, true)
+            .await
+            .unwrap();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let task = BatchingTask::try_new(TaskArgs {
+            flow_id: 56,
+            query: sql,
+            plan,
+            time_window_expr: None,
+            expire_after: None,
+            sink_table_name: [
+                "greptime".to_string(),
+                "public".to_string(),
+                "sink_semantic_sum_double_null".to_string(),
+            ],
+            source_table_names: vec![[
+                "greptime".to_string(),
+                "public".to_string(),
+                "numbers_with_nullable_ts_double_null".to_string(),
+            ]],
+            query_ctx,
+            catalog_manager: query_engine.engine_state().catalog_manager().clone(),
+            shutdown_rx: rx,
+            batch_opts: Arc::new(BatchingModeOptions::default()),
+            flow_eval_interval: None,
+        })
+        .unwrap();
+
+        {
+            let mut state = task.state.write().unwrap();
+            state.advance_checkpoints(HashMap::from([(1_u64, 10_u64)]));
+        }
+
+        let raw_plan = sql_to_df_plan(
+            task.state.read().unwrap().query_ctx.clone(),
+            query_engine.clone(),
+            sql,
+            false,
+        )
+        .await
+        .unwrap();
+        let rewritten = task
+            .rewrite_incremental_sql_plan_if_needed(raw_plan)
+            .await
+            .unwrap();
+
+        let output = query_engine
+            .execute(rewritten, task.state.read().unwrap().query_ctx.clone())
+            .await
+            .unwrap();
+        let stream = match output.data {
+            OutputData::Stream(stream) => stream,
+            OutputData::RecordBatches(batches) => batches.as_stream(),
+            OutputData::AffectedRows(_) => panic!("expected query output"),
+        };
+        let batches = util::collect(stream).await.unwrap();
+
+        let rows = extract_ts_number_rows(&batches);
+        assert_eq!(rows, vec![(2, None), (3, Some(3))]);
     }
 }

--- a/src/flow/src/batching_mode/utils.rs
+++ b/src/flow/src/batching_mode/utils.rs
@@ -19,15 +19,21 @@ use std::sync::Arc;
 
 use catalog::CatalogManagerRef;
 use common_error::ext::BoxedError;
+use common_function::aggrs::aggr_wrapper::get_aggr_func;
 use common_telemetry::debug;
+use datafusion::datasource::DefaultTableSource;
 use datafusion::error::Result as DfResult;
 use datafusion::logical_expr::Expr;
 use datafusion::sql::unparser::Unparser;
 use datafusion_common::tree_node::{
     Transformed, TreeNode as _, TreeNodeRecursion, TreeNodeRewriter, TreeNodeVisitor,
 };
-use datafusion_common::{DFSchema, DataFusionError, ScalarValue};
-use datafusion_expr::{Distinct, LogicalPlan, Projection};
+use datafusion_common::{DFSchema, DataFusionError, ScalarValue, TableReference};
+use datafusion_expr::logical_plan::TableScan;
+use datafusion_expr::{
+    Distinct, JoinType, LogicalPlan, LogicalPlanBuilder, Operator, Projection, and, binary_expr,
+    bitwise_and, bitwise_or, bitwise_xor, col, is_null, or, when,
+};
 use datatypes::schema::{ColumnSchema, SchemaRef};
 use query::QueryEngineRef;
 use query::parser::{DEFAULT_LOOKBACK_STRING, PromQuery, QueryLanguageParser, QueryStatement};
@@ -37,11 +43,303 @@ use sql::parser::{ParseOptions, ParserContext};
 use sql::statements::statement::Statement;
 use sql::statements::tql::Tql;
 use table::TableRef;
+use table::table::adapter::DfTableProviderAdapter;
 
 use crate::adapter::{AUTO_CREATED_PLACEHOLDER_TS_COL, AUTO_CREATED_UPDATE_AT_TS_COL};
 use crate::df_optimizer::apply_df_optimizer;
 use crate::error::{DatafusionSnafu, ExternalSnafu, InvalidQuerySnafu, TableNotFoundSnafu};
 use crate::{Error, TableName};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PocIncrementalMergeColumn {
+    pub output_name: String,
+    pub merge_function: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PocIncrementalAggregateAnalysis {
+    pub group_columns: Vec<String>,
+    pub merge_columns: Vec<PocIncrementalMergeColumn>,
+    pub unsupported_exprs: Vec<String>,
+}
+
+#[derive(Default)]
+struct LastAggregateExprFinder {
+    aggr_exprs: Option<Vec<Expr>>,
+}
+
+impl TreeNodeVisitor<'_> for LastAggregateExprFinder {
+    type Node = LogicalPlan;
+
+    fn f_down(&mut self, node: &Self::Node) -> datafusion_common::Result<TreeNodeRecursion> {
+        if let LogicalPlan::Aggregate(aggregate) = node {
+            self.aggr_exprs = Some(aggregate.aggr_expr.clone());
+        }
+        Ok(TreeNodeRecursion::Continue)
+    }
+}
+
+pub fn analyze_poc_incremental_aggregate_plan(
+    plan: &LogicalPlan,
+) -> Result<Option<PocIncrementalAggregateAnalysis>, Error> {
+    let mut group_finder = FindGroupByFinalName::default();
+    plan.visit(&mut group_finder)
+        .with_context(|_| DatafusionSnafu {
+            context: format!("Failed to inspect group-by columns from logical plan: {plan:?}"),
+        })?;
+
+    let mut aggregate_finder = LastAggregateExprFinder::default();
+    plan.visit(&mut aggregate_finder)
+        .with_context(|_| DatafusionSnafu {
+            context: format!("Failed to inspect aggregate expressions from logical plan: {plan:?}"),
+        })?;
+    let Some(aggr_exprs) = aggregate_finder.aggr_exprs else {
+        return Ok(None);
+    };
+
+    let mut output_aliases = HashMap::new();
+    if let LogicalPlan::Projection(projection) = plan {
+        for expr in &projection.expr {
+            match expr {
+                Expr::Alias(alias) => {
+                    if let Expr::Column(col) = alias.expr.as_ref() {
+                        output_aliases.insert(col.name.clone(), alias.name.clone());
+                    }
+                }
+                Expr::Column(col) => {
+                    output_aliases.insert(col.name.clone(), col.name.clone());
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let mut group_columns = group_finder
+        .get_group_expr_names()
+        .unwrap_or_default()
+        .into_iter()
+        .collect::<Vec<_>>();
+    group_columns.sort();
+
+    let mut merge_columns = Vec::with_capacity(aggr_exprs.len());
+    let mut unsupported_exprs = Vec::new();
+    for aggr_expr in aggr_exprs {
+        let Some(aggr_func) = get_aggr_func(&aggr_expr) else {
+            unsupported_exprs.push(aggr_expr.to_string());
+            continue;
+        };
+
+        let aggr_name = aggr_func.func.name().to_ascii_lowercase();
+        let merge_function = if aggr_func.params.distinct {
+            None
+        } else {
+            match aggr_name.as_str() {
+                "sum" => Some("sum"),
+                "count" => Some("sum"),
+                "min" => Some("min"),
+                "max" => Some("max"),
+                "bool_and" => Some("bool_and"),
+                "bool_or" => Some("bool_or"),
+                "bit_and" => Some("bit_and"),
+                "bit_or" => Some("bit_or"),
+                "bit_xor" => Some("bit_xor"),
+                _ => None,
+            }
+        };
+
+        let Some(merge_function) = merge_function else {
+            unsupported_exprs.push(aggr_expr.to_string());
+            continue;
+        };
+
+        let raw_name = aggr_expr.qualified_name().1;
+        let output_name = output_aliases.get(&raw_name).cloned().unwrap_or(raw_name);
+        merge_columns.push(PocIncrementalMergeColumn {
+            output_name,
+            merge_function: merge_function.to_string(),
+        });
+    }
+
+    Ok(Some(PocIncrementalAggregateAnalysis {
+        group_columns,
+        merge_columns,
+        unsupported_exprs,
+    }))
+}
+
+pub async fn rewrite_poc_incremental_aggregate_with_sink_merge(
+    delta_plan: &LogicalPlan,
+    analysis: &PocIncrementalAggregateAnalysis,
+    sink_table: TableRef,
+    sink_table_name: &TableName,
+) -> Result<LogicalPlan, Error> {
+    ensure!(
+        analysis.unsupported_exprs.is_empty(),
+        InvalidQuerySnafu {
+            reason: format!(
+                "UNSUPPORTED_INCREMENTAL_AGG: unsupported aggregate expressions {:?}",
+                analysis.unsupported_exprs
+            )
+        }
+    );
+
+    ensure!(
+        !analysis.merge_columns.is_empty(),
+        InvalidQuerySnafu {
+            reason:
+                "UNSUPPORTED_INCREMENTAL_AGG: aggregate query has no mergeable aggregate columns"
+                    .to_string()
+        }
+    );
+
+    let delta_alias = "__flow_delta";
+    let sink_alias = "__flow_sink";
+
+    let mut selected_columns = analysis.group_columns.clone();
+    selected_columns.extend(analysis.merge_columns.iter().map(|c| c.output_name.clone()));
+
+    let selected_exprs = selected_columns.iter().map(col).collect::<Vec<_>>();
+    let delta_selected = LogicalPlanBuilder::from(delta_plan.clone())
+        .project(selected_exprs.clone())
+        .with_context(|_| DatafusionSnafu {
+            context: "Failed to project delta plan for incremental sink merge".to_string(),
+        })?
+        .alias(delta_alias)
+        .with_context(|_| DatafusionSnafu {
+            context: "Failed to alias delta plan for incremental sink merge".to_string(),
+        })?
+        .build()
+        .with_context(|_| DatafusionSnafu {
+            context: "Failed to build projected delta plan for incremental sink merge".to_string(),
+        })?;
+
+    let table_provider = Arc::new(DfTableProviderAdapter::new(sink_table));
+    let table_source = Arc::new(DefaultTableSource::new(table_provider));
+    let sink_scan = LogicalPlan::TableScan(
+        TableScan::try_new(
+            TableReference::Full {
+                catalog: sink_table_name[0].clone().into(),
+                schema: sink_table_name[1].clone().into(),
+                table: sink_table_name[2].clone().into(),
+            },
+            table_source,
+            None,
+            vec![],
+            None,
+        )
+        .with_context(|_| DatafusionSnafu {
+            context: "Failed to build sink table scan for incremental sink merge".to_string(),
+        })?,
+    );
+
+    let sink_selected = LogicalPlanBuilder::from(sink_scan)
+        .project(selected_exprs)
+        .with_context(|_| DatafusionSnafu {
+            context: "Failed to project sink table scan for incremental sink merge".to_string(),
+        })?
+        .alias(sink_alias)
+        .with_context(|_| DatafusionSnafu {
+            context: "Failed to alias sink plan for incremental sink merge".to_string(),
+        })?
+        .build()
+        .with_context(|_| DatafusionSnafu {
+            context: "Failed to build projected sink plan for incremental sink merge".to_string(),
+        })?;
+
+    let join_keys = (
+        analysis
+            .group_columns
+            .iter()
+            .map(|c| datafusion_common::Column::from_qualified_name(format!("{delta_alias}.{c}")))
+            .collect::<Vec<_>>(),
+        analysis
+            .group_columns
+            .iter()
+            .map(|c| datafusion_common::Column::from_qualified_name(format!("{sink_alias}.{c}")))
+            .collect::<Vec<_>>(),
+    );
+
+    let joined = LogicalPlanBuilder::from(delta_selected)
+        .join(sink_selected, JoinType::Left, join_keys, None)
+        .with_context(|_| DatafusionSnafu {
+            context: "Failed to left join delta and sink plans for incremental sink merge"
+                .to_string(),
+        })?
+        .build()
+        .with_context(|_| DatafusionSnafu {
+            context: "Failed to build left join plan for incremental sink merge".to_string(),
+        })?;
+
+    let mut projection_exprs = analysis
+        .group_columns
+        .iter()
+        .map(|c| col(format!("{delta_alias}.{c}")).alias(c.clone()))
+        .collect::<Vec<_>>();
+    projection_exprs.extend(
+        analysis
+            .merge_columns
+            .iter()
+            .map(|merge_col| build_left_join_merge_expr(delta_alias, sink_alias, merge_col)),
+    );
+
+    LogicalPlanBuilder::from(joined)
+        .project(projection_exprs)
+        .with_context(|_| DatafusionSnafu {
+            context: "Failed to build projection merge plan for incremental sink merge".to_string(),
+        })?
+        .build()
+        .with_context(|_| DatafusionSnafu {
+            context: "Failed to finalize incremental aggregate sink merge plan".to_string(),
+        })
+}
+
+fn build_left_join_merge_expr(
+    delta_alias: &str,
+    sink_alias: &str,
+    merge_col: &PocIncrementalMergeColumn,
+) -> Expr {
+    let left = col(format!("{delta_alias}.{}", merge_col.output_name));
+    let right = col(format!("{sink_alias}.{}", merge_col.output_name));
+    let merged = match merge_col.merge_function.as_str() {
+        "sum" => when(is_null(left.clone()), right.clone())
+            .when(is_null(right.clone()), left.clone())
+            .otherwise(binary_expr(left.clone(), Operator::Plus, right.clone()))
+            .unwrap(),
+        "min" => when(is_null(right.clone()), left.clone())
+            .when(left.clone().lt_eq(right.clone()), left.clone())
+            .otherwise(right.clone())
+            .unwrap(),
+        "max" => when(is_null(right.clone()), left.clone())
+            .when(left.clone().gt_eq(right.clone()), left.clone())
+            .otherwise(right.clone())
+            .unwrap(),
+        "bool_and" => when(is_null(left.clone()), right.clone())
+            .when(is_null(right.clone()), left.clone())
+            .otherwise(and(left.clone(), right.clone()))
+            .unwrap(),
+        "bool_or" => when(is_null(left.clone()), right.clone())
+            .when(is_null(right.clone()), left.clone())
+            .otherwise(or(left.clone(), right.clone()))
+            .unwrap(),
+        "bit_and" => when(is_null(left.clone()), right.clone())
+            .when(is_null(right.clone()), left.clone())
+            .otherwise(bitwise_and(left.clone(), right.clone()))
+            .unwrap(),
+        "bit_or" => when(is_null(left.clone()), right.clone())
+            .when(is_null(right.clone()), left.clone())
+            .otherwise(bitwise_or(left.clone(), right.clone()))
+            .unwrap(),
+        "bit_xor" => when(is_null(left.clone()), right.clone())
+            .when(is_null(right.clone()), left.clone())
+            .otherwise(bitwise_xor(left.clone(), right.clone()))
+            .unwrap(),
+        other => Expr::Literal(
+            ScalarValue::Utf8(Some(format!("UNSUPPORTED_INCREMENTAL_AGG:{other}"))),
+            None,
+        ),
+    };
+    merged.alias(merge_col.output_name.clone())
+}
 
 pub async fn get_table_info_df_schema(
     catalog_mr: CatalogManagerRef,
@@ -905,6 +1203,76 @@ mod test {
                 group_by_exprs.get_group_expr_names().unwrap_or_default()
             );
         }
+    }
+
+    #[tokio::test]
+    async fn test_analyze_poc_incremental_aggregate_plan() {
+        let query_engine = create_test_query_engine();
+        let ctx = QueryContext::arc();
+        let sql = "SELECT max(number) AS number, ts FROM numbers_with_ts GROUP BY ts";
+        let plan = sql_to_df_plan(ctx, query_engine, sql, false).await.unwrap();
+
+        let analysis = analyze_poc_incremental_aggregate_plan(&plan)
+            .unwrap()
+            .unwrap();
+        assert!(analysis.unsupported_exprs.is_empty());
+        assert!(analysis.group_columns.contains(&"ts".to_string()));
+        assert_eq!(analysis.merge_columns.len(), 1);
+        assert_eq!(analysis.merge_columns[0].output_name, "number");
+        assert_eq!(analysis.merge_columns[0].merge_function, "max");
+    }
+
+    #[tokio::test]
+    async fn test_analyze_poc_incremental_aggregate_plan_rejects_avg() {
+        let query_engine = create_test_query_engine();
+        let ctx = QueryContext::arc();
+        let sql = "SELECT avg(number) AS avg_num, ts FROM numbers_with_ts GROUP BY ts";
+        let plan = sql_to_df_plan(ctx, query_engine, sql, false).await.unwrap();
+
+        let analysis = analyze_poc_incremental_aggregate_plan(&plan)
+            .unwrap()
+            .unwrap();
+        assert!(!analysis.unsupported_exprs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_rewrite_poc_incremental_aggregate_with_left_join() {
+        let query_engine = create_test_query_engine();
+        let ctx = QueryContext::arc();
+        let sql = "SELECT max(number) AS number, ts FROM numbers_with_ts GROUP BY ts";
+        let plan = sql_to_df_plan(ctx.clone(), query_engine.clone(), sql, false)
+            .await
+            .unwrap();
+        let analysis = analyze_poc_incremental_aggregate_plan(&plan)
+            .unwrap()
+            .unwrap();
+        let (sink_table, _) = get_table_info_df_schema(
+            query_engine.engine_state().catalog_manager().clone(),
+            [
+                "greptime".to_string(),
+                "public".to_string(),
+                "numbers_with_ts".to_string(),
+            ],
+        )
+        .await
+        .unwrap();
+
+        let rewritten = rewrite_poc_incremental_aggregate_with_sink_merge(
+            &plan,
+            &analysis,
+            sink_table,
+            &[
+                "greptime".to_string(),
+                "public".to_string(),
+                "numbers_with_ts".to_string(),
+            ],
+        )
+        .await
+        .unwrap();
+
+        let plan_text = format!("{}", rewritten.display_indent());
+        assert!(plan_text.contains("Left Join"));
+        assert!(!plan_text.contains("Union"));
     }
 
     #[tokio::test]

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -399,7 +399,7 @@ impl ErrorExt for Error {
 
             Error::PrometheusLabelValuesQueryPlan { source, .. } => source.status_code(),
 
-            Error::CollectRecordbatch { .. } => StatusCode::EngineExecuteQuery,
+            Error::CollectRecordbatch { source, .. } => source.status_code(),
 
             Error::SqlExecIntercepted { source, .. } => source.status_code(),
             Error::StartServer { source, .. } => source.status_code(),

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -31,6 +31,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, atomic};
 use std::time::{Duration, SystemTime};
 
+use arc_swap::ArcSwapOption;
 use async_stream::stream;
 use async_trait::async_trait;
 use auth::{PermissionChecker, PermissionCheckerRef, PermissionReq};
@@ -492,9 +493,12 @@ fn attach_timeout(output: Output, mut timeout: Duration) -> Result<Output> {
         OutputData::AffectedRows(_) | OutputData::RecordBatches(_) => output,
         OutputData::Stream(mut stream) => {
             let schema = stream.schema();
+            let metrics = Arc::new(ArcSwapOption::from(stream.metrics().map(Arc::new)));
+            let metrics_ref = metrics.clone();
             let s = Box::pin(stream! {
                 let mut start = tokio::time::Instant::now();
                 while let Some(item) = tokio::time::timeout(timeout, stream.next()).await.map_err(|_| StreamTimeoutSnafu.build())? {
+                    metrics_ref.swap(stream.metrics().map(Arc::new));
                     yield item;
 
                     let now = tokio::time::Instant::now();
@@ -505,12 +509,13 @@ fn attach_timeout(output: Output, mut timeout: Duration) -> Result<Output> {
                         StreamTimeoutSnafu.fail()?;
                     }
                 }
+                metrics_ref.swap(stream.metrics().map(Arc::new));
             }) as Pin<Box<dyn Stream<Item = _> + Send>>;
             let stream = RecordBatchStreamWrapper {
                 schema,
                 stream: s,
                 output_ordering: None,
-                metrics: Default::default(),
+                metrics,
                 span: Span::current(),
             };
             Output::new(OutputData::Stream(Box::pin(stream)), output.meta)
@@ -1131,12 +1136,22 @@ fn should_capture_statement(stmt: Option<&Statement>) -> bool {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::pin::Pin;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Arc, Barrier};
+    use std::task::{Context, Poll};
     use std::thread;
     use std::time::{Duration, Instant};
 
     use common_base::Plugins;
+    use common_query::{Output, OutputData};
+    use common_recordbatch::adapter::RecordBatchMetrics;
+    use common_recordbatch::{OrderOption, RecordBatch, RecordBatchStream};
+    use datatypes::data_type::ConcreteDataType;
+    use datatypes::prelude::VectorRef;
+    use datatypes::schema::{ColumnSchema, Schema, SchemaRef};
+    use datatypes::vectors::Int32Vector;
+    use futures::{Stream, StreamExt};
     use query::query_engine::options::QueryOptions;
     use session::context::QueryContext;
     use sql::dialect::GreptimeDbDialect;
@@ -1380,5 +1395,110 @@ mod tests {
             let result = check_permission(plugins.clone(), stmt, &query_ctx);
             assert_eq!(result.is_ok(), is_ok);
         }
+    }
+
+    struct MockMetricsStream {
+        schema: SchemaRef,
+        batch: Option<RecordBatch>,
+        metrics: RecordBatchMetrics,
+        terminal_metrics_only: bool,
+    }
+
+    impl Stream for MockMetricsStream {
+        type Item = common_recordbatch::error::Result<RecordBatch>;
+
+        fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            Poll::Ready(self.batch.take().map(Ok))
+        }
+    }
+
+    impl RecordBatchStream for MockMetricsStream {
+        fn schema(&self) -> SchemaRef {
+            self.schema.clone()
+        }
+
+        fn output_ordering(&self) -> Option<&[OrderOption]> {
+            None
+        }
+
+        fn metrics(&self) -> Option<RecordBatchMetrics> {
+            if self.terminal_metrics_only && self.batch.is_some() {
+                return None;
+            }
+            Some(self.metrics.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_attach_timeout_preserves_stream_metrics() {
+        let schema = Arc::new(Schema::new(vec![ColumnSchema::new(
+            "v",
+            ConcreteDataType::int32_datatype(),
+            false,
+        )]));
+        let batch = RecordBatch::new(
+            schema.clone(),
+            vec![Arc::new(Int32Vector::from_slice([1, 2])) as VectorRef],
+        )
+        .unwrap();
+        let expected_metrics = RecordBatchMetrics {
+            region_latest_sequences: Some(vec![(42, 99)]),
+            ..Default::default()
+        };
+        let output = Output::new_with_stream(Box::pin(MockMetricsStream {
+            schema,
+            batch: Some(batch),
+            metrics: expected_metrics.clone(),
+            terminal_metrics_only: false,
+        }));
+
+        let output = attach_timeout(output, Duration::from_secs(1)).unwrap();
+        let OutputData::Stream(mut stream) = output.data else {
+            panic!("expected stream output");
+        };
+        assert_eq!(
+            stream.metrics().and_then(|m| m.region_latest_sequences),
+            expected_metrics.region_latest_sequences.clone()
+        );
+        while stream.next().await.is_some() {}
+        assert_eq!(
+            stream.metrics().and_then(|m| m.region_latest_sequences),
+            expected_metrics.region_latest_sequences
+        );
+    }
+
+    #[tokio::test]
+    async fn test_attach_timeout_preserves_terminal_only_metrics() {
+        let schema = Arc::new(Schema::new(vec![ColumnSchema::new(
+            "v",
+            ConcreteDataType::int32_datatype(),
+            false,
+        )]));
+        let batch = RecordBatch::new(
+            schema.clone(),
+            vec![Arc::new(Int32Vector::from_slice([1, 2])) as VectorRef],
+        )
+        .unwrap();
+        let expected_metrics = RecordBatchMetrics {
+            region_latest_sequences: Some(vec![(7, 123)]),
+            ..Default::default()
+        };
+        let output = Output::new_with_stream(Box::pin(MockMetricsStream {
+            schema,
+            batch: Some(batch),
+            metrics: expected_metrics.clone(),
+            terminal_metrics_only: true,
+        }));
+
+        let output = attach_timeout(output, Duration::from_secs(1)).unwrap();
+        let OutputData::Stream(mut stream) = output.data else {
+            panic!("expected stream output");
+        };
+        assert!(stream.metrics().is_none());
+        while stream.next().await.is_some() {}
+        assert_eq!(
+            stream.metrics().and_then(|m| m.region_latest_sequences),
+            expected_metrics.region_latest_sequences
+        );
     }
 }

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -1145,7 +1145,7 @@ mod tests {
 
     use common_base::Plugins;
     use common_query::{Output, OutputData};
-    use common_recordbatch::adapter::RecordBatchMetrics;
+    use common_recordbatch::adapter::{RecordBatchMetrics, RegionWatermarkEntry};
     use common_recordbatch::{OrderOption, RecordBatch, RecordBatchStream};
     use datatypes::data_type::ConcreteDataType;
     use datatypes::prelude::VectorRef;
@@ -1442,7 +1442,10 @@ mod tests {
         )
         .unwrap();
         let expected_metrics = RecordBatchMetrics {
-            region_latest_sequences: Some(vec![(42, 99)]),
+            region_watermarks: vec![RegionWatermarkEntry {
+                region_id: 42,
+                watermark: Some(99),
+            }],
             ..Default::default()
         };
         let output = Output::new_with_stream(Box::pin(MockMetricsStream {
@@ -1457,13 +1460,13 @@ mod tests {
             panic!("expected stream output");
         };
         assert_eq!(
-            stream.metrics().and_then(|m| m.region_latest_sequences),
-            expected_metrics.region_latest_sequences.clone()
+            stream.metrics().map(|m| m.region_watermarks),
+            Some(expected_metrics.region_watermarks.clone())
         );
         while stream.next().await.is_some() {}
         assert_eq!(
-            stream.metrics().and_then(|m| m.region_latest_sequences),
-            expected_metrics.region_latest_sequences
+            stream.metrics().map(|m| m.region_watermarks),
+            Some(expected_metrics.region_watermarks)
         );
     }
 
@@ -1480,7 +1483,10 @@ mod tests {
         )
         .unwrap();
         let expected_metrics = RecordBatchMetrics {
-            region_latest_sequences: Some(vec![(7, 123)]),
+            region_watermarks: vec![RegionWatermarkEntry {
+                region_id: 7,
+                watermark: Some(123),
+            }],
             ..Default::default()
         };
         let output = Output::new_with_stream(Box::pin(MockMetricsStream {
@@ -1497,8 +1503,8 @@ mod tests {
         assert!(stream.metrics().is_none());
         while stream.next().await.is_some() {}
         assert_eq!(
-            stream.metrics().and_then(|m| m.region_latest_sequences),
-            expected_metrics.region_latest_sequences
+            stream.metrics().map(|m| m.region_watermarks),
+            Some(expected_metrics.region_watermarks)
         );
     }
 }

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -1012,11 +1012,16 @@ impl EngineInner {
 
     /// Handles the scan `request` and returns a [ScanRegion].
     #[tracing::instrument(skip_all, fields(region_id = %region_id))]
-    fn scan_region(&self, region_id: RegionId, request: ScanRequest) -> Result<ScanRegion> {
+    fn scan_region(&self, region_id: RegionId, mut request: ScanRequest) -> Result<ScanRegion> {
         let query_start = Instant::now();
         // Reading a region doesn't need to go through the region worker thread.
         let region = self.find_region(region_id)?;
-        let version = region.version();
+        let version_data = region.version_control.current();
+        let version = version_data.version;
+
+        if request.snapshot_on_scan && request.memtable_max_sequence.is_none() {
+            request.memtable_max_sequence = Some(version_data.committed_sequence);
+        }
 
         if let Some(given_seq) = request.memtable_min_sequence {
             let min_readable_seq = version.flushed_sequence;

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -129,8 +129,8 @@ use crate::cache::{CacheManagerRef, CacheStrategy};
 use crate::config::MitoConfig;
 use crate::engine::puffin_index::{IndexEntryContext, collect_index_entries_from_puffin};
 use crate::error::{
-    InvalidRequestSnafu, JoinSnafu, MitoManifestInfoSnafu, RecvSnafu, RegionNotFoundSnafu, Result,
-    SerdeJsonSnafu, SerializeColumnMetadataSnafu,
+    IncrementalQueryStaleSnafu, InvalidRequestSnafu, JoinSnafu, MitoManifestInfoSnafu, RecvSnafu,
+    RegionNotFoundSnafu, Result, SerdeJsonSnafu, SerializeColumnMetadataSnafu,
 };
 #[cfg(feature = "enterprise")]
 use crate::extension::BoxedExtensionRangeProviderFactory;
@@ -1017,6 +1017,19 @@ impl EngineInner {
         // Reading a region doesn't need to go through the region worker thread.
         let region = self.find_region(region_id)?;
         let version = region.version();
+
+        if let Some(given_seq) = request.memtable_min_sequence {
+            let min_readable_seq = version.flushed_sequence;
+            ensure!(
+                given_seq >= min_readable_seq,
+                IncrementalQueryStaleSnafu {
+                    region_id,
+                    given_seq,
+                    min_readable_seq,
+                }
+            );
+        }
+
         // Get cache.
         let cache_manager = self.workers.cache_manager();
 

--- a/src/mito2/src/engine/scan_test.rs
+++ b/src/mito2/src/engine/scan_test.rs
@@ -75,7 +75,7 @@ async fn test_incremental_query_stale_error() {
         }
         _ => panic!("unexpected err: {err}"),
     };
-    assert_eq!(StatusCode::InvalidArguments, err.status_code());
+    assert_eq!(StatusCode::RequestOutdated, err.status_code());
     let err_msg = err.to_string();
     assert!(err_msg.contains("STALE_CURSOR"));
     assert!(err_msg.contains(&region_id.to_string()));

--- a/src/mito2/src/engine/scan_test.rs
+++ b/src/mito2/src/engine/scan_test.rs
@@ -119,6 +119,56 @@ async fn test_scan_with_min_sst_sequence() {
     test_scan_with_min_sst_sequence_with_format(true).await;
 }
 
+#[tokio::test]
+async fn test_full_snapshot_upper_bound_does_not_constrain_sst_rows() {
+    let mut env =
+        TestEnv::with_prefix("test_full_snapshot_upper_bound_does_not_constrain_sst_rows").await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new().build();
+    let column_schemas = test_util::rows_schema(&request);
+
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    let first_rows = Rows {
+        schema: column_schemas.clone(),
+        rows: test_util::build_rows(0, 3),
+    };
+    test_util::put_rows(&engine, region_id, first_rows).await;
+    test_util::flush_region(&engine, region_id, None).await;
+
+    let snapshot_upper_bound = engine.get_committed_sequence(region_id).await.unwrap();
+
+    let second_rows = Rows {
+        schema: column_schemas,
+        rows: test_util::build_rows(3, 5),
+    };
+    test_util::put_rows(&engine, region_id, second_rows).await;
+    test_util::flush_region(&engine, region_id, None).await;
+
+    let scanner = engine
+        .scanner(
+            region_id,
+            ScanRequest {
+                memtable_max_sequence: Some(snapshot_upper_bound),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    let stream = scanner.scan().await.unwrap();
+    let batches = RecordBatches::try_collect(stream).await.unwrap();
+    let pretty = batches.pretty_print().unwrap();
+
+    assert!(pretty.contains("1970-01-01T00:00:03"));
+    assert!(pretty.contains("1970-01-01T00:00:04"));
+}
+
 async fn test_scan_with_min_sst_sequence_with_format(flat_format: bool) {
     let mut env = TestEnv::with_prefix("test_scan_with_min_sst_sequence").await;
     let engine = env

--- a/src/mito2/src/engine/scan_test.rs
+++ b/src/mito2/src/engine/scan_test.rs
@@ -23,9 +23,95 @@ use store_api::region_request::RegionRequest;
 use store_api::storage::{RegionId, ScanRequest, TimeSeriesDistribution};
 
 use crate::config::MitoConfig;
+use crate::error::Error;
 use crate::read::scan_region::Scanner;
 use crate::test_util;
 use crate::test_util::{CreateRequestBuilder, TestEnv};
+
+#[tokio::test]
+async fn test_incremental_query_stale_error() {
+    let mut env = TestEnv::with_prefix("test_incremental_query_stale_error").await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new().build();
+    let column_schemas = test_util::rows_schema(&request);
+
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    let rows = Rows {
+        schema: column_schemas.clone(),
+        rows: test_util::build_rows(0, 3),
+    };
+    test_util::put_rows(&engine, region_id, rows).await;
+    test_util::flush_region(&engine, region_id, None).await;
+
+    let err = engine
+        .scanner(
+            region_id,
+            ScanRequest {
+                memtable_min_sequence: Some(0),
+                ..Default::default()
+            },
+        )
+        .await
+        .err()
+        .expect("expect stale incremental error");
+
+    let min_readable_seq = match &err {
+        Error::IncrementalQueryStale {
+            region_id: err_region_id,
+            given_seq,
+            min_readable_seq,
+            ..
+        } => {
+            assert_eq!(*err_region_id, region_id);
+            assert_eq!(*given_seq, 0);
+            assert!(*min_readable_seq > 0);
+            *min_readable_seq
+        }
+        _ => panic!("unexpected err: {err}"),
+    };
+    assert_eq!(StatusCode::InvalidArguments, err.status_code());
+    let err_msg = err.to_string();
+    assert!(err_msg.contains("STALE_CURSOR"));
+    assert!(err_msg.contains(&region_id.to_string()));
+    assert!(err_msg.contains("given_seq: 0"));
+    assert!(err_msg.contains(&format!("min_readable_seq: {min_readable_seq}")));
+
+    let incremental_rows = Rows {
+        schema: column_schemas,
+        rows: test_util::build_rows(3, 5),
+    };
+    test_util::put_rows(&engine, region_id, incremental_rows).await;
+
+    let scanner = engine
+        .scanner(
+            region_id,
+            ScanRequest {
+                memtable_min_sequence: Some(min_readable_seq),
+                sst_min_sequence: Some(u64::MAX),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    let stream = scanner.scan().await.unwrap();
+    let batches = RecordBatches::try_collect(stream).await.unwrap();
+    assert_eq!(
+        batches.pretty_print().unwrap(),
+        "\
++-------+---------+---------------------+
+| tag_0 | field_0 | ts                  |
++-------+---------+---------------------+
+| 3     | 3.0     | 1970-01-01T00:00:03 |
+| 4     | 4.0     | 1970-01-01T00:00:04 |
++-------+---------+---------------------+"
+    );
+}
 
 #[tokio::test]
 async fn test_scan_with_min_sst_sequence() {

--- a/src/mito2/src/engine/scan_test.rs
+++ b/src/mito2/src/engine/scan_test.rs
@@ -169,6 +169,166 @@ async fn test_full_snapshot_upper_bound_does_not_constrain_sst_rows() {
     assert!(pretty.contains("1970-01-01T00:00:04"));
 }
 
+#[tokio::test]
+async fn test_snapshot_bound_query_binds_memtable_upper_bound_at_scan_open() {
+    let mut env =
+        TestEnv::with_prefix("test_snapshot_bound_query_binds_memtable_upper_bound_at_scan_open")
+            .await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new().build();
+    let column_schemas = test_util::rows_schema(&request);
+
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    let first_rows = Rows {
+        schema: column_schemas.clone(),
+        rows: test_util::build_rows(0, 3),
+    };
+    test_util::put_rows(&engine, region_id, first_rows).await;
+
+    let expected_snapshot = engine.get_committed_sequence(region_id).await.unwrap();
+    let scanner = engine
+        .scanner(
+            region_id,
+            ScanRequest {
+                snapshot_on_scan: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(scanner.snapshot_sequence(), Some(expected_snapshot));
+
+    let second_rows = Rows {
+        schema: column_schemas,
+        rows: test_util::build_rows(3, 5),
+    };
+    test_util::put_rows(&engine, region_id, second_rows).await;
+
+    let stream = scanner.scan().await.unwrap();
+    let batches = RecordBatches::try_collect(stream).await.unwrap();
+    assert_eq!(
+        batches.pretty_print().unwrap(),
+        "\
++-------+---------+---------------------+
+| tag_0 | field_0 | ts                  |
++-------+---------+---------------------+
+| 0     | 0.0     | 1970-01-01T00:00:00 |
+| 1     | 1.0     | 1970-01-01T00:00:01 |
+| 2     | 2.0     | 1970-01-01T00:00:02 |
++-------+---------+---------------------+"
+    );
+}
+
+#[tokio::test]
+async fn test_snapshot_bound_query_keeps_open_snapshot_after_late_flush() {
+    let mut env =
+        TestEnv::with_prefix("test_snapshot_bound_query_keeps_open_snapshot_after_late_flush")
+            .await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new().build();
+    let column_schemas = test_util::rows_schema(&request);
+
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    let first_rows = Rows {
+        schema: column_schemas.clone(),
+        rows: test_util::build_rows(0, 3),
+    };
+    test_util::put_rows(&engine, region_id, first_rows).await;
+
+    let expected_snapshot = engine.get_committed_sequence(region_id).await.unwrap();
+    let scanner = engine
+        .scanner(
+            region_id,
+            ScanRequest {
+                snapshot_on_scan: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(scanner.snapshot_sequence(), Some(expected_snapshot));
+
+    let second_rows = Rows {
+        schema: column_schemas,
+        rows: test_util::build_rows(3, 5),
+    };
+    test_util::put_rows(&engine, region_id, second_rows).await;
+    test_util::flush_region(&engine, region_id, None).await;
+
+    assert_eq!(scanner.snapshot_sequence(), Some(expected_snapshot));
+}
+
+#[tokio::test]
+async fn test_snapshot_bound_query_keeps_correct_result_after_late_flush() {
+    let mut env =
+        TestEnv::with_prefix("test_snapshot_bound_query_keeps_correct_result_after_late_flush")
+            .await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new().build();
+    let column_schemas = test_util::rows_schema(&request);
+
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    let first_rows = Rows {
+        schema: column_schemas.clone(),
+        rows: test_util::build_rows(0, 3),
+    };
+    test_util::put_rows(&engine, region_id, first_rows).await;
+
+    let expected_snapshot = engine.get_committed_sequence(region_id).await.unwrap();
+    let scanner = engine
+        .scanner(
+            region_id,
+            ScanRequest {
+                snapshot_on_scan: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(scanner.snapshot_sequence(), Some(expected_snapshot));
+
+    let second_rows = Rows {
+        schema: column_schemas,
+        rows: test_util::build_rows(3, 5),
+    };
+    test_util::put_rows(&engine, region_id, second_rows).await;
+    test_util::flush_region(&engine, region_id, None).await;
+
+    assert_eq!(scanner.snapshot_sequence(), Some(expected_snapshot));
+
+    let stream = scanner.scan().await.unwrap();
+    let batches = RecordBatches::try_collect(stream).await.unwrap();
+    assert_eq!(
+        batches.pretty_print().unwrap(),
+        "\
++-------+---------+---------------------+
+| tag_0 | field_0 | ts                  |
++-------+---------+---------------------+
+| 0     | 0.0     | 1970-01-01T00:00:00 |
+| 1     | 1.0     | 1970-01-01T00:00:01 |
+| 2     | 2.0     | 1970-01-01T00:00:02 |
++-------+---------+---------------------+"
+    );
+}
+
 async fn test_scan_with_min_sst_sequence_with_format(flat_format: bool) {
     let mut env = TestEnv::with_prefix("test_scan_with_min_sst_sequence").await;
     let engine = env

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -228,6 +228,20 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display(
+        "STALE_CURSOR: incremental query stale, region: {}, given_seq: {}, min_readable_seq: {}, retry_hint: FALLBACK_FULL_RECOMPUTE",
+        region_id,
+        given_seq,
+        min_readable_seq
+    ))]
+    IncrementalQueryStale {
+        region_id: RegionId,
+        given_seq: u64,
+        min_readable_seq: u64,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Old manifest missing for region {}", region_id))]
     MissingOldManifest {
         region_id: RegionId,
@@ -1286,6 +1300,7 @@ impl ErrorExt for Error {
             | InvalidScanIndex { .. }
             | InvalidMeta { .. }
             | InvalidRequest { .. }
+            | IncrementalQueryStale { .. }
             | PartitionExprVersionMismatch { .. }
             | FillDefault { .. }
             | ConvertColumnDataType { .. }

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -1300,7 +1300,6 @@ impl ErrorExt for Error {
             | InvalidScanIndex { .. }
             | InvalidMeta { .. }
             | InvalidRequest { .. }
-            | IncrementalQueryStale { .. }
             | PartitionExprVersionMismatch { .. }
             | FillDefault { .. }
             | ConvertColumnDataType { .. }
@@ -1318,6 +1317,8 @@ impl ErrorExt for Error {
             | MissingPartitionExpr { .. }
             | SerializePartitionExpr { .. }
             | InvalidSourceAndTargetRegion { .. } => StatusCode::InvalidArguments,
+
+            IncrementalQueryStale { .. } => StatusCode::RequestOutdated,
 
             RegionMetadataNotFound { .. }
             | Join { .. }

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -38,7 +38,8 @@ use snafu::{OptionExt as _, ResultExt};
 use store_api::metadata::{RegionMetadata, RegionMetadataRef};
 use store_api::region_engine::{PartitionRange, RegionScannerRef};
 use store_api::storage::{
-    ColumnId, RegionId, ScanRequest, SequenceRange, TimeSeriesDistribution, TimeSeriesRowSelector,
+    ColumnId, RegionId, ScanRequest, SequenceNumber, SequenceRange, TimeSeriesDistribution,
+    TimeSeriesRowSelector,
 };
 use table::predicate::{Predicate, build_time_range_predicate};
 use tokio::sync::{Semaphore, mpsc};
@@ -146,6 +147,14 @@ impl Scanner {
             Scanner::Seq(seq_scan) => seq_scan.input().index_ids(),
             Scanner::Unordered(unordered_scan) => unordered_scan.input().index_ids(),
             Scanner::Series(series_scan) => series_scan.input().index_ids(),
+        }
+    }
+
+    pub(crate) fn snapshot_sequence(&self) -> Option<SequenceNumber> {
+        match self {
+            Scanner::Seq(seq_scan) => seq_scan.input().snapshot_sequence,
+            Scanner::Unordered(unordered_scan) => unordered_scan.input().snapshot_sequence,
+            Scanner::Series(series_scan) => series_scan.input().snapshot_sequence,
         }
     }
 
@@ -551,6 +560,12 @@ impl ScanRegion {
             .with_merge_mode(self.version.options.merge_mode())
             .with_series_row_selector(self.request.series_row_selector)
             .with_distribution(self.request.distribution)
+            .with_snapshot_sequence(
+                self.request
+                    .snapshot_on_scan
+                    .then_some(self.request.memtable_max_sequence)
+                    .flatten(),
+            )
             .with_flat_format(flat_format);
         #[cfg(feature = "vector_index")]
         let input = input
@@ -856,6 +871,8 @@ pub struct ScanInput {
     pub(crate) distribution: Option<TimeSeriesDistribution>,
     /// Whether to use flat format.
     pub(crate) flat_format: bool,
+    /// Snapshot upper bound bound at scan open and propagated back to the caller.
+    pub(crate) snapshot_sequence: Option<SequenceNumber>,
     /// Whether this scan is for compaction.
     pub(crate) compaction: bool,
     #[cfg(feature = "enterprise")]
@@ -893,6 +910,7 @@ impl ScanInput {
             series_row_selector: None,
             distribution: None,
             flat_format: false,
+            snapshot_sequence: None,
             compaction: false,
             #[cfg(feature = "enterprise")]
             extension_ranges: Vec::new(),
@@ -1062,6 +1080,15 @@ impl ScanInput {
     #[must_use]
     pub(crate) fn with_flat_format(mut self, flat_format: bool) -> Self {
         self.flat_format = flat_format;
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn with_snapshot_sequence(
+        mut self,
+        snapshot_sequence: Option<SequenceNumber>,
+    ) -> Self {
+        self.snapshot_sequence = snapshot_sequence;
         self
     }
 

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -672,6 +672,10 @@ impl RegionScanner for SeqScan {
     fn set_logical_region(&mut self, logical_region: bool) {
         self.properties.set_logical_region(logical_region);
     }
+
+    fn snapshot_sequence(&self) -> Option<u64> {
+        self.stream_ctx.input.snapshot_sequence
+    }
 }
 
 impl DisplayAs for SeqScan {

--- a/src/mito2/src/read/series_scan.rs
+++ b/src/mito2/src/read/series_scan.rs
@@ -374,6 +374,10 @@ impl RegionScanner for SeriesScan {
     fn set_logical_region(&mut self, logical_region: bool) {
         self.properties.set_logical_region(logical_region);
     }
+
+    fn snapshot_sequence(&self) -> Option<u64> {
+        self.stream_ctx.input.snapshot_sequence
+    }
 }
 
 impl DisplayAs for SeriesScan {

--- a/src/mito2/src/read/unordered_scan.rs
+++ b/src/mito2/src/read/unordered_scan.rs
@@ -505,6 +505,10 @@ impl RegionScanner for UnorderedScan {
     fn set_logical_region(&mut self, logical_region: bool) {
         self.properties.set_logical_region(logical_region);
     }
+
+    fn snapshot_sequence(&self) -> Option<u64> {
+        self.stream_ctx.input.snapshot_sequence
+    }
 }
 
 impl DisplayAs for UnorderedScan {

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -318,6 +318,10 @@ impl MitoRegion {
         self.version_control.committed_sequence()
     }
 
+    pub fn flushed_sequence(&self) -> SequenceNumber {
+        self.version_control.current().version.flushed_sequence
+    }
+
     /// Returns whether the region is readonly.
     pub fn is_follower(&self) -> bool {
         self.manifest_ctx.state.load() == RegionRoleState::Follower

--- a/src/operator/src/utils.rs
+++ b/src/operator/src/utils.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::{Arc, RwLock};
+
 use common_time::Timezone;
 use session::context::{QueryContextBuilder, QueryContextRef};
 use snafu::ResultExt;
@@ -27,6 +29,8 @@ pub fn to_meta_query_context(
         timezone: query_context.timezone().to_string(),
         extensions: query_context.extensions(),
         channel: query_context.channel() as u8,
+        snapshot_seqs: query_context.snapshots(),
+        sst_min_sequences: query_context.sst_min_sequences(),
     }
 }
 
@@ -43,5 +47,41 @@ pub fn try_to_session_query_context(
         )
         .extensions(value.extensions)
         .channel((value.channel as u32).into())
+        .snapshot_seqs(Arc::new(RwLock::new(value.snapshot_seqs)))
+        .sst_min_sequences(Arc::new(RwLock::new(value.sst_min_sequences)))
         .build())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::{Arc, RwLock};
+
+    use common_time::Timezone;
+    use session::context::QueryContextBuilder;
+
+    use super::{to_meta_query_context, try_to_session_query_context};
+
+    #[test]
+    fn test_query_context_meta_roundtrip_with_sequences() {
+        let session_ctx = Arc::new(
+            QueryContextBuilder::default()
+                .current_catalog("c1".to_string())
+                .current_schema("s1".to_string())
+                .timezone(Timezone::from_tz_string("UTC").unwrap())
+                .set_extension("flow.return_region_seq".to_string(), "true".to_string())
+                .snapshot_seqs(Arc::new(RwLock::new(HashMap::from([(10, 100)]))))
+                .sst_min_sequences(Arc::new(RwLock::new(HashMap::from([(10, 90)]))))
+                .build(),
+        );
+
+        let meta_ctx = to_meta_query_context(session_ctx);
+        let roundtrip = try_to_session_query_context(meta_ctx).unwrap();
+
+        assert_eq!(roundtrip.current_catalog(), "c1");
+        assert_eq!(roundtrip.current_schema(), "s1");
+        assert_eq!(roundtrip.snapshots(), HashMap::from([(10, 100)]));
+        assert_eq!(roundtrip.sst_min_sequences(), HashMap::from([(10, 90)]));
+        assert_eq!(roundtrip.extension("flow.return_region_seq"), Some("true"));
+    }
 }

--- a/src/query/src/datafusion.rs
+++ b/src/query/src/datafusion.rs
@@ -132,7 +132,9 @@ impl DatafusionQueryEngine {
         let output = self
             .exec_query_plan((*dml.input).clone(), query_ctx.clone())
             .await?;
-        let mut stream = match output.data {
+        let common_query::Output { data, meta } = output;
+        let input_plan = meta.plan;
+        let mut stream = match data {
             OutputData::RecordBatches(batches) => batches.as_stream(),
             OutputData::Stream(stream) => stream,
             _ => unreachable!(),
@@ -168,7 +170,7 @@ impl DatafusionQueryEngine {
         }
         Ok(Output::new(
             OutputData::AffectedRows(affected_rows),
-            OutputMeta::new_with_cost(insert_cost),
+            OutputMeta::new(input_plan, insert_cost),
         ))
     }
 

--- a/src/query/src/datafusion.rs
+++ b/src/query/src/datafusion.rs
@@ -59,7 +59,8 @@ use crate::error::{
     TableNotFoundSnafu, TableReadOnlySnafu, UnsupportedExprSnafu,
 };
 use crate::executor::QueryExecutor;
-use crate::metrics::{OnDone, QUERY_STAGE_ELAPSED};
+use crate::metrics::{OnDone, QUERY_STAGE_ELAPSED, RegionWatermarkMetricsStream};
+use crate::options::FlowQueryExtensions;
 use crate::physical_wrapper::PhysicalPlanWrapperRef;
 use crate::planner::{DfLogicalPlanner, LogicalPlanner};
 use crate::query_engine::{DescribeResult, QueryEngineContext, QueryEngineState};
@@ -586,6 +587,11 @@ impl QueryExecutor for DatafusionQueryEngine {
         plan: &Arc<dyn ExecutionPlan>,
     ) -> Result<SendableRecordBatchStream> {
         let explain_verbose = ctx.query_ctx().explain_verbose();
+        let should_collect_region_watermark =
+            FlowQueryExtensions::from_extensions(&ctx.query_ctx().extensions())
+                .map(|extensions| extensions.should_collect_region_watermark())
+                .map_err(BoxedError::new)
+                .context(QueryExecutionSnafu)?;
         let output_partitions = plan.properties().output_partitioning().partition_count();
         if explain_verbose {
             common_telemetry::info!("Executing query plan, output_partitions: {output_partitions}");
@@ -621,7 +627,14 @@ impl QueryExecutor for DatafusionQueryEngine {
                         );
                     }
                 });
-                Ok(Box::pin(stream))
+                if should_collect_region_watermark {
+                    Ok(Box::pin(RegionWatermarkMetricsStream::new(
+                        Box::pin(stream),
+                        plan.clone(),
+                    )))
+                } else {
+                    Ok(Box::pin(stream))
+                }
             }
             _ => {
                 // merge into a single partition
@@ -650,7 +663,14 @@ impl QueryExecutor for DatafusionQueryEngine {
                         );
                     }
                 });
-                Ok(Box::pin(stream))
+                if should_collect_region_watermark {
+                    Ok(Box::pin(RegionWatermarkMetricsStream::new(
+                        Box::pin(stream),
+                        plan.clone(),
+                    )))
+                } else {
+                    Ok(Box::pin(stream))
+                }
             }
         }
     }

--- a/src/query/src/dist_plan/merge_scan.rs
+++ b/src/query/src/dist_plan/merge_scan.rs
@@ -415,6 +415,10 @@ impl MergeScanExec {
         )))
     }
 
+    pub fn regions(&self) -> &[RegionId] {
+        &self.regions
+    }
+
     pub fn try_with_new_distribution(&self, distribution: Distribution) -> Option<Self> {
         let Distribution::HashPartitioned(hash_exprs) = distribution else {
             // not applicable

--- a/src/query/src/dummy_catalog.rs
+++ b/src/query/src/dummy_catalog.rs
@@ -188,6 +188,12 @@ impl TableProvider for DummyTableProvider {
             .handle_query(self.region_id, request.clone())
             .await
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        if request.snapshot_on_scan
+            && let Some(query_ctx) = &self.query_ctx
+            && let Some(snapshot_sequence) = scanner.snapshot_sequence()
+        {
+            bind_snapshot_bound_region_seq(query_ctx, self.region_id, snapshot_sequence);
+        }
         let query_memory_permit = self.engine.register_query_memory_permit();
         let mut scan_exec = RegionScanExec::new(scanner, request, query_memory_permit)?;
         if let Some(query_ctx) = &self.query_ctx {
@@ -317,8 +323,8 @@ fn scan_request_from_query_context(
     query_ctx: &QueryContext,
 ) -> Result<ScanRequest> {
     let mut scan_request = ScanRequest {
-        memtable_max_sequence: query_ctx.get_snapshot(region_id.as_u64()),
         sst_min_sequence: query_ctx.sst_min_sequence(region_id.as_u64()),
+        snapshot_on_scan: query_requires_snapshot_bound(query_ctx),
         ..Default::default()
     };
 
@@ -336,6 +342,33 @@ fn scan_request_from_query_context(
     }
 
     Ok(scan_request)
+}
+
+fn query_requires_snapshot_bound(query_ctx: &QueryContext) -> bool {
+    FlowQueryExtensions::from_extensions(&query_ctx.extensions())
+        .map(|extensions| extensions.should_collect_region_watermark())
+        .unwrap_or(false)
+}
+
+fn bind_snapshot_bound_region_seq(
+    query_ctx: &QueryContext,
+    region_id: RegionId,
+    snapshot_sequence: u64,
+) -> u64 {
+    if let Some(existing) = query_ctx.get_snapshot(region_id.as_u64()) {
+        if existing != snapshot_sequence {
+            common_telemetry::warn!(
+                "conflicting snapshot sequence observed for region {} in a single query; keeping the first bound snapshot (existing={}, new={})",
+                region_id,
+                existing,
+                snapshot_sequence,
+            );
+        }
+        existing
+    } else {
+        query_ctx.set_snapshot(region_id.as_u64(), snapshot_sequence);
+        snapshot_sequence
+    }
 }
 
 #[async_trait]
@@ -471,7 +504,7 @@ impl CatalogManager for DummyCatalogManager {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::sync::RwLock;
+    use std::sync::{Arc, RwLock};
 
     use common_error::ext::ErrorExt;
     use common_error::status_code::StatusCode;
@@ -483,6 +516,48 @@ mod tests {
 
     fn test_region_id() -> RegionId {
         RegionId::new(1024, 1)
+    }
+
+    #[test]
+    fn test_scan_request_from_query_context_uses_snapshot_bound_intent() {
+        let region_id = test_region_id();
+        let query_ctx = QueryContextBuilder::default()
+            .extensions(HashMap::from([(
+                "flow.return_region_seq".to_string(),
+                "true".to_string(),
+            )]))
+            .snapshot_seqs(Arc::new(RwLock::new(HashMap::from([(
+                region_id.as_u64(),
+                42_u64,
+            )]))))
+            .sst_min_sequences(Arc::new(RwLock::new(HashMap::from([(
+                region_id.as_u64(),
+                7_u64,
+            )]))))
+            .build();
+
+        let request = scan_request_from_query_context(region_id, &query_ctx).unwrap();
+
+        assert!(request.snapshot_on_scan);
+        assert_eq!(request.memtable_max_sequence, None);
+        assert_eq!(request.sst_min_sequence, Some(7));
+    }
+
+    #[test]
+    fn test_scan_request_from_incremental_context_uses_snapshot_bound_intent() {
+        let region_id = test_region_id();
+        let query_ctx = QueryContextBuilder::default()
+            .extensions(HashMap::from([(
+                "flow.incremental_after_seqs".to_string(),
+                format!(r#"{{"{}":10}}"#, region_id.as_u64()),
+            )]))
+            .build();
+
+        let request = scan_request_from_query_context(region_id, &query_ctx).unwrap();
+
+        assert!(request.snapshot_on_scan);
+        assert_eq!(request.memtable_min_sequence, Some(10));
+        assert_eq!(request.memtable_max_sequence, None);
     }
 
     #[test]
@@ -500,9 +575,37 @@ mod tests {
             .build();
 
         let request = scan_request_from_query_context(region_id, &query_ctx).unwrap();
-        assert_eq!(request.memtable_max_sequence, Some(100));
+        assert_eq!(request.memtable_max_sequence, None);
         assert_eq!(request.sst_min_sequence, Some(90));
         assert_eq!(request.memtable_min_sequence, None);
+        assert!(!request.snapshot_on_scan);
+    }
+
+    #[test]
+    fn test_bind_snapshot_bound_region_seq_reuses_existing_snapshot() {
+        let region_id = test_region_id();
+        let query_ctx = QueryContextBuilder::default()
+            .snapshot_seqs(Arc::new(RwLock::new(HashMap::from([(
+                region_id.as_u64(),
+                42_u64,
+            )]))))
+            .build();
+
+        let seq = bind_snapshot_bound_region_seq(&query_ctx, region_id, 99);
+
+        assert_eq!(seq, 42);
+        assert_eq!(query_ctx.get_snapshot(region_id.as_u64()), Some(42));
+    }
+
+    #[test]
+    fn test_bind_snapshot_bound_region_seq_sets_snapshot_once() {
+        let region_id = test_region_id();
+        let query_ctx = QueryContextBuilder::default().build();
+
+        let seq = bind_snapshot_bound_region_seq(&query_ctx, region_id, 99);
+
+        assert_eq!(seq, 99);
+        assert_eq!(query_ctx.get_snapshot(region_id.as_u64()), Some(99));
     }
 
     #[test]

--- a/src/query/src/dummy_catalog.rs
+++ b/src/query/src/dummy_catalog.rs
@@ -43,6 +43,7 @@ use table::metadata::{TableId, TableInfoRef};
 use table::table::scan::RegionScanExec;
 
 use crate::error::{GetRegionMetadataSnafu, Result};
+use crate::options::FlowQueryExtensions;
 
 /// Resolve to the given region (specified by [RegionId]) unconditionally.
 #[derive(Clone, Debug)]
@@ -295,14 +296,11 @@ impl DummyTableProviderFactory {
                     region_id,
                 })?;
 
-        let scan_request = query_ctx
-            .as_ref()
-            .map(|ctx| ScanRequest {
-                memtable_max_sequence: ctx.get_snapshot(region_id.as_u64()),
-                sst_min_sequence: ctx.sst_min_sequence(region_id.as_u64()),
-                ..Default::default()
-            })
-            .unwrap_or_default();
+        let scan_request = if let Some(ctx) = query_ctx.as_ref() {
+            scan_request_from_query_context(region_id, ctx)?
+        } else {
+            ScanRequest::default()
+        };
 
         Ok(DummyTableProvider {
             region_id,
@@ -312,6 +310,32 @@ impl DummyTableProviderFactory {
             query_ctx,
         })
     }
+}
+
+fn scan_request_from_query_context(
+    region_id: RegionId,
+    query_ctx: &QueryContext,
+) -> Result<ScanRequest> {
+    let mut scan_request = ScanRequest {
+        memtable_max_sequence: query_ctx.get_snapshot(region_id.as_u64()),
+        sst_min_sequence: query_ctx.sst_min_sequence(region_id.as_u64()),
+        ..Default::default()
+    };
+
+    let flow_extensions = FlowQueryExtensions::from_extensions(&query_ctx.extensions())?;
+
+    let should_apply_incremental = flow_extensions.validate_for_scan(region_id)?;
+    if should_apply_incremental
+        && let Some(after_seq) = flow_extensions
+            .incremental_after_seqs
+            .as_ref()
+            .and_then(|seqs| seqs.get(&region_id.as_u64()))
+            .copied()
+    {
+        scan_request.memtable_min_sequence = Some(after_seq);
+    }
+
+    Ok(scan_request)
 }
 
 #[async_trait]
@@ -441,5 +465,137 @@ impl CatalogManager for DummyCatalogManager {
         _query_ctx: Option<&'a QueryContext>,
     ) -> BoxStream<'a, CatalogResult<TableRef>> {
         Box::pin(futures::stream::empty())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::RwLock;
+
+    use common_error::ext::ErrorExt;
+    use common_error::status_code::StatusCode;
+    use session::context::QueryContextBuilder;
+
+    use super::*;
+    use crate::error::Error;
+    use crate::options::{FLOW_INCREMENTAL_AFTER_SEQS, FLOW_INCREMENTAL_MODE, FLOW_SINK_TABLE_ID};
+
+    fn test_region_id() -> RegionId {
+        RegionId::new(1024, 1)
+    }
+
+    #[test]
+    fn test_scan_request_from_query_context_keeps_snapshot_fields() {
+        let region_id = test_region_id();
+        let query_ctx = QueryContextBuilder::default()
+            .snapshot_seqs(Arc::new(RwLock::new(HashMap::from([(
+                region_id.as_u64(),
+                100,
+            )]))))
+            .sst_min_sequences(Arc::new(RwLock::new(HashMap::from([(
+                region_id.as_u64(),
+                90,
+            )]))))
+            .build();
+
+        let request = scan_request_from_query_context(region_id, &query_ctx).unwrap();
+        assert_eq!(request.memtable_max_sequence, Some(100));
+        assert_eq!(request.sst_min_sequence, Some(90));
+        assert_eq!(request.memtable_min_sequence, None);
+    }
+
+    #[test]
+    fn test_scan_request_from_query_context_applies_incremental_after_seq_for_source_scan() {
+        let region_id = test_region_id();
+        let query_ctx = QueryContextBuilder::default()
+            .extensions(HashMap::from([
+                (
+                    FLOW_INCREMENTAL_MODE.to_string(),
+                    "memtable_only".to_string(),
+                ),
+                (
+                    FLOW_INCREMENTAL_AFTER_SEQS.to_string(),
+                    format!(r#"{{"{}":55}}"#, region_id.as_u64()),
+                ),
+            ]))
+            .build();
+
+        let request = scan_request_from_query_context(region_id, &query_ctx).unwrap();
+        assert_eq!(request.memtable_min_sequence, Some(55));
+    }
+
+    #[test]
+    fn test_scan_request_from_query_context_does_not_apply_incremental_for_sink_table() {
+        let region_id = test_region_id();
+        let query_ctx = QueryContextBuilder::default()
+            .extensions(HashMap::from([
+                (
+                    FLOW_INCREMENTAL_MODE.to_string(),
+                    "memtable_only".to_string(),
+                ),
+                (
+                    FLOW_INCREMENTAL_AFTER_SEQS.to_string(),
+                    format!(r#"{{"{}":55}}"#, region_id.as_u64()),
+                ),
+                (
+                    FLOW_SINK_TABLE_ID.to_string(),
+                    region_id.table_id().to_string(),
+                ),
+            ]))
+            .build();
+
+        let request = scan_request_from_query_context(region_id, &query_ctx).unwrap();
+        assert_eq!(request.memtable_min_sequence, None);
+    }
+
+    #[test]
+    fn test_scan_request_from_query_context_rejects_missing_memtable_only_region() {
+        let region_id = test_region_id();
+        let query_ctx = QueryContextBuilder::default()
+            .extensions(HashMap::from([
+                (
+                    FLOW_INCREMENTAL_MODE.to_string(),
+                    "memtable_only".to_string(),
+                ),
+                (
+                    FLOW_INCREMENTAL_AFTER_SEQS.to_string(),
+                    r#"{"9":55}"#.to_string(),
+                ),
+            ]))
+            .build();
+
+        let err = scan_request_from_query_context(region_id, &query_ctx).unwrap_err();
+        assert!(matches!(err, Error::InvalidQueryContextExtension { .. }));
+    }
+
+    #[test]
+    fn test_scan_request_from_query_context_rejects_invalid_incremental_json() {
+        let region_id = test_region_id();
+        let query_ctx = QueryContextBuilder::default()
+            .extensions(HashMap::from([(
+                FLOW_INCREMENTAL_AFTER_SEQS.to_string(),
+                "not-json".to_string(),
+            )]))
+            .build();
+
+        let err = scan_request_from_query_context(region_id, &query_ctx).unwrap_err();
+        assert!(matches!(err, Error::InvalidQueryContextExtension { .. }));
+        assert_eq!(err.status_code(), StatusCode::InvalidArguments);
+    }
+
+    #[test]
+    fn test_scan_request_from_query_context_rejects_invalid_sink_table_id() {
+        let region_id = test_region_id();
+        let query_ctx = QueryContextBuilder::default()
+            .extensions(HashMap::from([(
+                FLOW_SINK_TABLE_ID.to_string(),
+                "abc".to_string(),
+            )]))
+            .build();
+
+        let err = scan_request_from_query_context(region_id, &query_ctx).unwrap_err();
+        assert!(matches!(err, Error::InvalidQueryContextExtension { .. }));
+        assert_eq!(err.status_code(), StatusCode::InvalidArguments);
     }
 }

--- a/src/query/src/error.rs
+++ b/src/query/src/error.rs
@@ -368,6 +368,13 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display("Invalid query context extension: {}", reason))]
+    InvalidQueryContextExtension {
+        reason: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(transparent)]
     Datatypes {
         source: datatypes::error::Error,
@@ -399,7 +406,8 @@ impl ErrorExt for Error {
             | ColumnSchemaNoDefault { .. }
             | CteColumnSchemaMismatch { .. }
             | ConvertValue { .. }
-            | TryIntoDuration { .. } => StatusCode::InvalidArguments,
+            | TryIntoDuration { .. }
+            | InvalidQueryContextExtension { .. } => StatusCode::InvalidArguments,
 
             BuildBackend { .. } | ListObjects { .. } => StatusCode::StorageUnavailable,
 

--- a/src/query/src/metrics.rs
+++ b/src/query/src/metrics.rs
@@ -13,15 +13,19 @@
 // limitations under the License.
 
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use common_recordbatch::adapter::RecordBatchMetrics;
 use common_recordbatch::{OrderOption, RecordBatch, RecordBatchStream, SendableRecordBatchStream};
+use datafusion::physical_plan::ExecutionPlan;
 use datatypes::schema::SchemaRef;
 use futures::Stream;
 use futures_util::ready;
 use lazy_static::lazy_static;
 use prometheus::*;
+
+use crate::dist_plan::MergeScanExec;
 
 lazy_static! {
     /// Timer of different stages in query.
@@ -128,4 +132,73 @@ impl<F: FnOnce() + Unpin> Stream for OnDone<F> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.stream.size_hint()
     }
+}
+
+pub struct RegionWatermarkMetricsStream {
+    stream: SendableRecordBatchStream,
+    plan: Arc<dyn ExecutionPlan>,
+}
+
+impl RegionWatermarkMetricsStream {
+    pub fn new(stream: SendableRecordBatchStream, plan: Arc<dyn ExecutionPlan>) -> Self {
+        Self { stream, plan }
+    }
+}
+
+impl RecordBatchStream for RegionWatermarkMetricsStream {
+    fn name(&self) -> &str {
+        self.stream.name()
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.stream.schema()
+    }
+
+    fn output_ordering(&self) -> Option<&[OrderOption]> {
+        self.stream.output_ordering()
+    }
+
+    fn metrics(&self) -> Option<RecordBatchMetrics> {
+        let mut metrics = self.stream.metrics()?;
+        let region_latest_sequences = collect_region_latest_sequences(self.plan.clone());
+        if !region_latest_sequences.is_empty() {
+            metrics.region_latest_sequences = Some(region_latest_sequences);
+        }
+        Some(metrics)
+    }
+}
+
+impl Stream for RegionWatermarkMetricsStream {
+    type Item = common_recordbatch::error::Result<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.stream).poll_next(cx)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.stream.size_hint()
+    }
+}
+
+fn collect_region_latest_sequences(plan: Arc<dyn ExecutionPlan>) -> Vec<(u64, u64)> {
+    let mut merged = std::collections::HashMap::new();
+    let mut stack = vec![plan];
+
+    while let Some(plan) = stack.pop() {
+        if let Some(merge_scan) = plan.as_any().downcast_ref::<MergeScanExec>() {
+            for metrics in merge_scan.sub_stage_metrics() {
+                if let Some(region_latest_sequences) = metrics.region_latest_sequences {
+                    for (region_id, seq) in region_latest_sequences {
+                        merged.insert(region_id, seq);
+                    }
+                }
+            }
+        }
+
+        stack.extend(plan.children().into_iter().cloned());
+    }
+
+    let mut region_latest_sequences = merged.into_iter().collect::<Vec<_>>();
+    region_latest_sequences.sort_unstable_by_key(|(region_id, _)| *region_id);
+    region_latest_sequences
 }

--- a/src/query/src/metrics.rs
+++ b/src/query/src/metrics.rs
@@ -180,6 +180,20 @@ impl Stream for RegionWatermarkMetricsStream {
     }
 }
 
+pub fn terminal_recordbatch_metrics_from_plan(
+    plan: Arc<dyn ExecutionPlan>,
+) -> Option<RecordBatchMetrics> {
+    let region_latest_sequences = collect_region_latest_sequences(plan);
+    if region_latest_sequences.is_empty() {
+        None
+    } else {
+        Some(RecordBatchMetrics {
+            region_latest_sequences: Some(region_latest_sequences),
+            ..Default::default()
+        })
+    }
+}
+
 fn collect_region_latest_sequences(plan: Arc<dyn ExecutionPlan>) -> Vec<(u64, u64)> {
     let mut merged = std::collections::HashMap::new();
     let mut stack = vec![plan];

--- a/src/query/src/metrics.rs
+++ b/src/query/src/metrics.rs
@@ -211,6 +211,11 @@ fn collect_region_watermarks(plan: Arc<dyn ExecutionPlan>) -> Vec<RegionWatermar
 
     while let Some(plan) = stack.pop() {
         if let Some(merge_scan) = plan.as_any().downcast_ref::<MergeScanExec>() {
+            for region_id in merge_scan.regions() {
+                merged
+                    .entry(region_id.as_u64())
+                    .or_insert(MergeState::Unproved);
+            }
             for metrics in merge_scan.sub_stage_metrics() {
                 for entry in metrics.region_watermarks {
                     merged

--- a/src/query/src/metrics.rs
+++ b/src/query/src/metrics.rs
@@ -16,8 +16,9 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use common_recordbatch::adapter::RecordBatchMetrics;
+use common_recordbatch::adapter::{RecordBatchMetrics, RegionWatermarkEntry};
 use common_recordbatch::{OrderOption, RecordBatch, RecordBatchStream, SendableRecordBatchStream};
+use common_telemetry::warn;
 use datafusion::physical_plan::ExecutionPlan;
 use datatypes::schema::SchemaRef;
 use futures::Stream;
@@ -160,9 +161,9 @@ impl RecordBatchStream for RegionWatermarkMetricsStream {
 
     fn metrics(&self) -> Option<RecordBatchMetrics> {
         let mut metrics = self.stream.metrics()?;
-        let region_latest_sequences = collect_region_latest_sequences(self.plan.clone());
-        if !region_latest_sequences.is_empty() {
-            metrics.region_latest_sequences = Some(region_latest_sequences);
+        let region_watermarks = collect_region_watermarks(self.plan.clone());
+        if !region_watermarks.is_empty() {
+            metrics.region_watermarks = region_watermarks;
         }
         Some(metrics)
     }
@@ -183,28 +184,86 @@ impl Stream for RegionWatermarkMetricsStream {
 pub fn terminal_recordbatch_metrics_from_plan(
     plan: Arc<dyn ExecutionPlan>,
 ) -> Option<RecordBatchMetrics> {
-    let region_latest_sequences = collect_region_latest_sequences(plan);
-    if region_latest_sequences.is_empty() {
+    let region_watermarks = collect_region_watermarks(plan);
+    if region_watermarks.is_empty() {
         None
     } else {
         Some(RecordBatchMetrics {
-            region_latest_sequences: Some(region_latest_sequences),
+            region_watermarks,
             ..Default::default()
         })
     }
 }
 
-fn collect_region_latest_sequences(plan: Arc<dyn ExecutionPlan>) -> Vec<(u64, u64)> {
-    let mut merged = std::collections::HashMap::new();
+fn collect_region_watermarks(plan: Arc<dyn ExecutionPlan>) -> Vec<RegionWatermarkEntry> {
+    #[derive(Clone)]
+    enum MergeState {
+        Unproved,
+        Proved(u64),
+        Conflict {
+            region_id: u64,
+            watermarks: Vec<u64>,
+        },
+    }
+
+    let mut merged = std::collections::BTreeMap::<u64, MergeState>::new();
     let mut stack = vec![plan];
 
     while let Some(plan) = stack.pop() {
         if let Some(merge_scan) = plan.as_any().downcast_ref::<MergeScanExec>() {
             for metrics in merge_scan.sub_stage_metrics() {
-                if let Some(region_latest_sequences) = metrics.region_latest_sequences {
-                    for (region_id, seq) in region_latest_sequences {
-                        merged.insert(region_id, seq);
-                    }
+                for entry in metrics.region_watermarks {
+                    merged
+                        .entry(entry.region_id)
+                        .and_modify(|existing| {
+                            *existing = match (existing.clone(), entry.watermark) {
+                                (
+                                    MergeState::Conflict {
+                                        region_id,
+                                        mut watermarks,
+                                    },
+                                    Some(seq),
+                                ) => {
+                                    if !watermarks.contains(&seq) {
+                                        watermarks.push(seq);
+                                    }
+                                    MergeState::Conflict {
+                                        region_id,
+                                        watermarks,
+                                    }
+                                }
+                                (
+                                    MergeState::Conflict {
+                                        region_id,
+                                        watermarks,
+                                    },
+                                    None,
+                                ) => MergeState::Conflict {
+                                    region_id,
+                                    watermarks,
+                                },
+                                (MergeState::Unproved, None) => MergeState::Unproved,
+                                (MergeState::Unproved, Some(seq)) => MergeState::Proved(seq),
+                                (MergeState::Proved(existing_seq), None) => {
+                                    MergeState::Proved(existing_seq)
+                                }
+                                (MergeState::Proved(existing_seq), Some(seq))
+                                    if existing_seq == seq =>
+                                {
+                                    MergeState::Proved(existing_seq)
+                                }
+                                (MergeState::Proved(existing_seq), Some(seq)) => {
+                                    MergeState::Conflict {
+                                        region_id: entry.region_id,
+                                        watermarks: vec![existing_seq, seq],
+                                    }
+                                }
+                            }
+                        })
+                        .or_insert(match entry.watermark {
+                            Some(seq) => MergeState::Proved(seq),
+                            None => MergeState::Unproved,
+                        });
                 }
             }
         }
@@ -212,7 +271,24 @@ fn collect_region_latest_sequences(plan: Arc<dyn ExecutionPlan>) -> Vec<(u64, u6
         stack.extend(plan.children().into_iter().cloned());
     }
 
-    let mut region_latest_sequences = merged.into_iter().collect::<Vec<_>>();
-    region_latest_sequences.sort_unstable_by_key(|(region_id, _)| *region_id);
-    region_latest_sequences
+    merged
+        .into_iter()
+        .map(|(region_id, state)| RegionWatermarkEntry {
+            region_id,
+            watermark: match state {
+                MergeState::Unproved => None,
+                MergeState::Proved(seq) => Some(seq),
+                MergeState::Conflict {
+                    region_id,
+                    watermarks,
+                } => {
+                    warn!(
+                        "Conflicting proved watermarks for region {}: {:?}; degrading to unproved",
+                        region_id, watermarks
+                    );
+                    None
+                }
+            },
+        })
+        .collect()
 }

--- a/src/query/src/options.rs
+++ b/src/query/src/options.rs
@@ -12,8 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+
 use common_base::memory_limit::MemoryLimit;
 use serde::{Deserialize, Serialize};
+use table::metadata::TableId;
+
+pub const FLOW_INCREMENTAL_AFTER_SEQS: &str = "flow.incremental_after_seqs";
+pub const FLOW_INCREMENTAL_MODE: &str = "flow.incremental_mode";
+pub const FLOW_RETURN_REGION_SEQ: &str = "flow.return_region_seq";
+pub const FLOW_SINK_TABLE_ID: &str = "flow.sink_table_id";
+
+const FLOW_INCREMENTAL_MODE_MEMTABLE_ONLY: &str = "memtable_only";
 
 /// Query engine config
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -37,5 +47,273 @@ impl Default for QueryOptions {
             allow_query_fallback: false,
             memory_pool_size: MemoryLimit::default(),
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlowIncrementalMode {
+    MemtableOnly,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct FlowQueryExtensions {
+    pub incremental_after_seqs: Option<HashMap<u64, u64>>,
+    pub incremental_mode: Option<FlowIncrementalMode>,
+    pub return_region_seq: bool,
+    pub sink_table_id: Option<TableId>,
+}
+
+impl FlowQueryExtensions {
+    pub fn from_extensions(extensions: &HashMap<String, String>) -> Result<Self, String> {
+        let incremental_mode = extensions
+            .get(FLOW_INCREMENTAL_MODE)
+            .map(|value| match value.as_str() {
+                v if v.eq_ignore_ascii_case(FLOW_INCREMENTAL_MODE_MEMTABLE_ONLY) => {
+                    Ok(FlowIncrementalMode::MemtableOnly)
+                }
+                _ => Err(format!(
+                    "Invalid value for {}: {}",
+                    FLOW_INCREMENTAL_MODE, value
+                )),
+            })
+            .transpose()?;
+
+        let incremental_after_seqs = extensions
+            .get(FLOW_INCREMENTAL_AFTER_SEQS)
+            .map(|value| parse_incremental_after_seqs(value.as_str()))
+            .transpose()?;
+
+        let return_region_seq = extensions
+            .get(FLOW_RETURN_REGION_SEQ)
+            .map(|value| parse_bool(value.as_str()))
+            .transpose()?
+            .unwrap_or(false);
+
+        let sink_table_id = extensions
+            .get(FLOW_SINK_TABLE_ID)
+            .map(|value| {
+                value
+                    .parse::<TableId>()
+                    .map_err(|_| format!("Invalid value for {}: {}", FLOW_SINK_TABLE_ID, value))
+            })
+            .transpose()?;
+
+        if matches!(incremental_mode, Some(FlowIncrementalMode::MemtableOnly)) {
+            let after_seqs = incremental_after_seqs.as_ref().ok_or_else(|| {
+                format!(
+                    "{} is required when {}={}.",
+                    FLOW_INCREMENTAL_AFTER_SEQS,
+                    FLOW_INCREMENTAL_MODE,
+                    FLOW_INCREMENTAL_MODE_MEMTABLE_ONLY
+                )
+            })?;
+            if after_seqs.is_empty() {
+                return Err(format!(
+                    "{} must not be empty when {}={}.",
+                    FLOW_INCREMENTAL_AFTER_SEQS,
+                    FLOW_INCREMENTAL_MODE,
+                    FLOW_INCREMENTAL_MODE_MEMTABLE_ONLY
+                ));
+            }
+        }
+
+        Ok(Self {
+            incremental_after_seqs,
+            incremental_mode,
+            return_region_seq,
+            sink_table_id,
+        })
+    }
+
+    pub fn validate_for_scan(
+        &self,
+        source_region_ids: &[u64],
+        current_scan_table_id: Option<TableId>,
+    ) -> Result<bool, String> {
+        if self.sink_table_id.is_some() && self.sink_table_id == current_scan_table_id {
+            return Ok(false);
+        }
+
+        if matches!(
+            self.incremental_mode,
+            Some(FlowIncrementalMode::MemtableOnly)
+        ) {
+            let after_seqs = self.incremental_after_seqs.as_ref().ok_or_else(|| {
+                format!(
+                    "{} is required when {}=memtable_only.",
+                    FLOW_INCREMENTAL_AFTER_SEQS, FLOW_INCREMENTAL_MODE
+                )
+            })?;
+
+            for region_id in source_region_ids {
+                if !after_seqs.contains_key(region_id) {
+                    return Err(format!(
+                        "Missing region {} in {} when {}=memtable_only.",
+                        region_id, FLOW_INCREMENTAL_AFTER_SEQS, FLOW_INCREMENTAL_MODE
+                    ));
+                }
+            }
+        }
+
+        Ok(self.incremental_after_seqs.is_some())
+    }
+}
+
+fn parse_incremental_after_seqs(value: &str) -> Result<HashMap<u64, u64>, String> {
+    let raw = serde_json::from_str::<HashMap<String, u64>>(value).map_err(|e| {
+        format!(
+            "Invalid JSON for {}: {} ({})",
+            FLOW_INCREMENTAL_AFTER_SEQS, value, e
+        )
+    })?;
+
+    raw.into_iter()
+        .map(|(region_id, seq)| {
+            region_id
+                .parse::<u64>()
+                .map(|region_id| (region_id, seq))
+                .map_err(|_| {
+                    format!(
+                        "Invalid region id in {}: {}",
+                        FLOW_INCREMENTAL_AFTER_SEQS, region_id
+                    )
+                })
+        })
+        .collect()
+}
+
+fn parse_bool(value: &str) -> Result<bool, String> {
+    match value {
+        v if v.eq_ignore_ascii_case("true") => Ok(true),
+        v if v.eq_ignore_ascii_case("false") => Ok(false),
+        _ => Err(format!(
+            "Invalid value for {}: {}",
+            FLOW_RETURN_REGION_SEQ, value
+        )),
+    }
+}
+
+#[cfg(test)]
+mod flow_extension_tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_flow_extensions_default() {
+        let exts = HashMap::new();
+        let parsed = FlowQueryExtensions::from_extensions(&exts).unwrap();
+
+        assert_eq!(parsed.incremental_mode, None);
+        assert_eq!(parsed.incremental_after_seqs, None);
+        assert!(!parsed.return_region_seq);
+        assert_eq!(parsed.sink_table_id, None);
+    }
+
+    #[test]
+    fn test_parse_flow_extensions_memtable_only_success() {
+        let exts = HashMap::from([
+            (
+                FLOW_INCREMENTAL_MODE.to_string(),
+                FLOW_INCREMENTAL_MODE_MEMTABLE_ONLY.to_string(),
+            ),
+            (
+                FLOW_INCREMENTAL_AFTER_SEQS.to_string(),
+                r#"{"1":10,"2":20}"#.to_string(),
+            ),
+            (FLOW_RETURN_REGION_SEQ.to_string(), "true".to_string()),
+            (FLOW_SINK_TABLE_ID.to_string(), "1024".to_string()),
+        ]);
+
+        let parsed = FlowQueryExtensions::from_extensions(&exts).unwrap();
+        assert_eq!(
+            parsed.incremental_mode,
+            Some(FlowIncrementalMode::MemtableOnly)
+        );
+        assert_eq!(
+            parsed.incremental_after_seqs.unwrap(),
+            HashMap::from([(1, 10), (2, 20)])
+        );
+        assert!(parsed.return_region_seq);
+        assert_eq!(parsed.sink_table_id, Some(1024));
+    }
+
+    #[test]
+    fn test_parse_flow_extensions_mode_requires_after_seqs() {
+        let exts = HashMap::from([(
+            FLOW_INCREMENTAL_MODE.to_string(),
+            FLOW_INCREMENTAL_MODE_MEMTABLE_ONLY.to_string(),
+        )]);
+
+        let err = FlowQueryExtensions::from_extensions(&exts).unwrap_err();
+        assert!(err.contains(FLOW_INCREMENTAL_AFTER_SEQS));
+    }
+
+    #[test]
+    fn test_parse_flow_extensions_invalid_mode() {
+        let exts = HashMap::from([(FLOW_INCREMENTAL_MODE.to_string(), "foo".to_string())]);
+
+        let err = FlowQueryExtensions::from_extensions(&exts).unwrap_err();
+        assert!(err.contains(FLOW_INCREMENTAL_MODE));
+    }
+
+    #[test]
+    fn test_parse_flow_extensions_invalid_after_seqs_json() {
+        let exts = HashMap::from([
+            (
+                FLOW_INCREMENTAL_MODE.to_string(),
+                FLOW_INCREMENTAL_MODE_MEMTABLE_ONLY.to_string(),
+            ),
+            (
+                FLOW_INCREMENTAL_AFTER_SEQS.to_string(),
+                "not-json".to_string(),
+            ),
+        ]);
+
+        let err = FlowQueryExtensions::from_extensions(&exts).unwrap_err();
+        assert!(err.contains(FLOW_INCREMENTAL_AFTER_SEQS));
+    }
+
+    #[test]
+    fn test_parse_flow_extensions_invalid_sink_table_id() {
+        let exts = HashMap::from([(FLOW_SINK_TABLE_ID.to_string(), "x".to_string())]);
+
+        let err = FlowQueryExtensions::from_extensions(&exts).unwrap_err();
+        assert!(err.contains(FLOW_SINK_TABLE_ID));
+    }
+
+    #[test]
+    fn test_validate_for_scan_missing_source_region() {
+        let exts = HashMap::from([
+            (
+                FLOW_INCREMENTAL_MODE.to_string(),
+                FLOW_INCREMENTAL_MODE_MEMTABLE_ONLY.to_string(),
+            ),
+            (
+                FLOW_INCREMENTAL_AFTER_SEQS.to_string(),
+                r#"{"1":10}"#.to_string(),
+            ),
+        ]);
+
+        let parsed = FlowQueryExtensions::from_extensions(&exts).unwrap();
+        let err = parsed.validate_for_scan(&[1, 2], Some(100)).unwrap_err();
+        assert!(err.contains("Missing region 2"));
+    }
+
+    #[test]
+    fn test_validate_for_scan_sink_table_excluded() {
+        let exts = HashMap::from([
+            (
+                FLOW_INCREMENTAL_MODE.to_string(),
+                FLOW_INCREMENTAL_MODE_MEMTABLE_ONLY.to_string(),
+            ),
+            (
+                FLOW_INCREMENTAL_AFTER_SEQS.to_string(),
+                r#"{"1":10}"#.to_string(),
+            ),
+            (FLOW_SINK_TABLE_ID.to_string(), "1024".to_string()),
+        ]);
+
+        let parsed = FlowQueryExtensions::from_extensions(&exts).unwrap();
+        let apply_incremental = parsed.validate_for_scan(&[1, 2], Some(1024)).unwrap();
+        assert!(!apply_incremental);
     }
 }

--- a/src/query/src/options.rs
+++ b/src/query/src/options.rs
@@ -157,6 +157,10 @@ impl FlowQueryExtensions {
 
         Ok(self.incremental_after_seqs.is_some())
     }
+
+    pub fn should_collect_region_watermark(&self) -> bool {
+        self.return_region_seq || self.incremental_after_seqs.is_some()
+    }
 }
 
 fn parse_incremental_after_seqs(value: &str) -> Result<HashMap<u64, u64>> {
@@ -367,5 +371,29 @@ mod flow_extension_tests {
         let parsed = FlowQueryExtensions::from_extensions(&exts).unwrap();
         let apply_incremental = parsed.validate_for_scan(source_region_id).unwrap();
         assert!(!apply_incremental);
+    }
+
+    #[test]
+    fn test_should_collect_region_watermark_defaults_false() {
+        let parsed = FlowQueryExtensions::default();
+        assert!(!parsed.should_collect_region_watermark());
+    }
+
+    #[test]
+    fn test_should_collect_region_watermark_true_for_return_region_seq() {
+        let parsed = FlowQueryExtensions {
+            return_region_seq: true,
+            ..Default::default()
+        };
+        assert!(parsed.should_collect_region_watermark());
+    }
+
+    #[test]
+    fn test_should_collect_region_watermark_true_for_incremental_query() {
+        let parsed = FlowQueryExtensions {
+            incremental_after_seqs: Some(HashMap::from([(1, 10)])),
+            ..Default::default()
+        };
+        assert!(parsed.should_collect_region_watermark());
     }
 }

--- a/src/query/src/options.rs
+++ b/src/query/src/options.rs
@@ -16,7 +16,10 @@ use std::collections::HashMap;
 
 use common_base::memory_limit::MemoryLimit;
 use serde::{Deserialize, Serialize};
+use store_api::storage::RegionId;
 use table::metadata::TableId;
+
+use crate::error::{Error, InvalidQueryContextExtensionSnafu, Result};
 
 pub const FLOW_INCREMENTAL_AFTER_SEQS: &str = "flow.incremental_after_seqs";
 pub const FLOW_INCREMENTAL_MODE: &str = "flow.incremental_mode";
@@ -64,17 +67,17 @@ pub struct FlowQueryExtensions {
 }
 
 impl FlowQueryExtensions {
-    pub fn from_extensions(extensions: &HashMap<String, String>) -> Result<Self, String> {
+    pub fn from_extensions(extensions: &HashMap<String, String>) -> Result<Self> {
         let incremental_mode = extensions
             .get(FLOW_INCREMENTAL_MODE)
             .map(|value| match value.as_str() {
                 v if v.eq_ignore_ascii_case(FLOW_INCREMENTAL_MODE_MEMTABLE_ONLY) => {
                     Ok(FlowIncrementalMode::MemtableOnly)
                 }
-                _ => Err(format!(
+                _ => Err(invalid_query_context_extension(format!(
                     "Invalid value for {}: {}",
                     FLOW_INCREMENTAL_MODE, value
-                )),
+                ))),
             })
             .transpose()?;
 
@@ -92,28 +95,31 @@ impl FlowQueryExtensions {
         let sink_table_id = extensions
             .get(FLOW_SINK_TABLE_ID)
             .map(|value| {
-                value
-                    .parse::<TableId>()
-                    .map_err(|_| format!("Invalid value for {}: {}", FLOW_SINK_TABLE_ID, value))
+                value.parse::<TableId>().map_err(|_| {
+                    invalid_query_context_extension(format!(
+                        "Invalid value for {}: {}",
+                        FLOW_SINK_TABLE_ID, value
+                    ))
+                })
             })
             .transpose()?;
 
         if matches!(incremental_mode, Some(FlowIncrementalMode::MemtableOnly)) {
             let after_seqs = incremental_after_seqs.as_ref().ok_or_else(|| {
-                format!(
+                invalid_query_context_extension(format!(
                     "{} is required when {}={}.",
                     FLOW_INCREMENTAL_AFTER_SEQS,
                     FLOW_INCREMENTAL_MODE,
                     FLOW_INCREMENTAL_MODE_MEMTABLE_ONLY
-                )
+                ))
             })?;
             if after_seqs.is_empty() {
-                return Err(format!(
+                return Err(invalid_query_context_extension(format!(
                     "{} must not be empty when {}={}.",
                     FLOW_INCREMENTAL_AFTER_SEQS,
                     FLOW_INCREMENTAL_MODE,
                     FLOW_INCREMENTAL_MODE_MEMTABLE_ONLY
-                ));
+                )));
             }
         }
 
@@ -125,12 +131,8 @@ impl FlowQueryExtensions {
         })
     }
 
-    pub fn validate_for_scan(
-        &self,
-        source_region_ids: &[u64],
-        current_scan_table_id: Option<TableId>,
-    ) -> Result<bool, String> {
-        if self.sink_table_id.is_some() && self.sink_table_id == current_scan_table_id {
+    pub fn validate_for_scan(&self, source_region_id: RegionId) -> Result<bool> {
+        if self.sink_table_id.is_some() && self.sink_table_id == Some(source_region_id.table_id()) {
             return Ok(false);
         }
 
@@ -139,19 +141,17 @@ impl FlowQueryExtensions {
             Some(FlowIncrementalMode::MemtableOnly)
         ) {
             let after_seqs = self.incremental_after_seqs.as_ref().ok_or_else(|| {
-                format!(
+                invalid_query_context_extension(format!(
                     "{} is required when {}=memtable_only.",
                     FLOW_INCREMENTAL_AFTER_SEQS, FLOW_INCREMENTAL_MODE
-                )
+                ))
             })?;
 
-            for region_id in source_region_ids {
-                if !after_seqs.contains_key(region_id) {
-                    return Err(format!(
-                        "Missing region {} in {} when {}=memtable_only.",
-                        region_id, FLOW_INCREMENTAL_AFTER_SEQS, FLOW_INCREMENTAL_MODE
-                    ));
-                }
+            if !after_seqs.contains_key(&source_region_id.as_u64()) {
+                return Err(invalid_query_context_extension(format!(
+                    "Missing region {} in {} when {}=memtable_only.",
+                    source_region_id, FLOW_INCREMENTAL_AFTER_SEQS, FLOW_INCREMENTAL_MODE
+                )));
             }
         }
 
@@ -159,38 +159,62 @@ impl FlowQueryExtensions {
     }
 }
 
-fn parse_incremental_after_seqs(value: &str) -> Result<HashMap<u64, u64>, String> {
-    let raw = serde_json::from_str::<HashMap<String, u64>>(value).map_err(|e| {
-        format!(
+fn parse_incremental_after_seqs(value: &str) -> Result<HashMap<u64, u64>> {
+    let raw = serde_json::from_str::<HashMap<String, serde_json::Value>>(value).map_err(|e| {
+        invalid_query_context_extension(format!(
             "Invalid JSON for {}: {} ({})",
             FLOW_INCREMENTAL_AFTER_SEQS, value, e
-        )
+        ))
     })?;
 
     raw.into_iter()
-        .map(|(region_id, seq)| {
-            region_id
-                .parse::<u64>()
-                .map(|region_id| (region_id, seq))
-                .map_err(|_| {
-                    format!(
-                        "Invalid region id in {}: {}",
+        .map(|(region_id, raw_seq)| {
+            let region_id = region_id.parse::<u64>().map_err(|_| {
+                invalid_query_context_extension(format!(
+                    "Invalid region id in {}: {}",
+                    FLOW_INCREMENTAL_AFTER_SEQS, region_id
+                ))
+            })?;
+
+            let seq = match raw_seq {
+                serde_json::Value::Number(num) => num.as_u64().ok_or_else(|| {
+                    invalid_query_context_extension(format!(
+                        "Invalid sequence value in {} for region {}: {}",
+                        FLOW_INCREMENTAL_AFTER_SEQS, region_id, num
+                    ))
+                })?,
+                serde_json::Value::String(s) => s.parse::<u64>().map_err(|_| {
+                    invalid_query_context_extension(format!(
+                        "Invalid sequence string in {} for region {}: {}",
+                        FLOW_INCREMENTAL_AFTER_SEQS, region_id, s
+                    ))
+                })?,
+                _ => {
+                    return Err(invalid_query_context_extension(format!(
+                        "Invalid sequence value type in {} for region {}",
                         FLOW_INCREMENTAL_AFTER_SEQS, region_id
-                    )
-                })
+                    )));
+                }
+            };
+
+            Ok((region_id, seq))
         })
         .collect()
 }
 
-fn parse_bool(value: &str) -> Result<bool, String> {
+fn parse_bool(value: &str) -> Result<bool> {
     match value {
         v if v.eq_ignore_ascii_case("true") => Ok(true),
         v if v.eq_ignore_ascii_case("false") => Ok(false),
-        _ => Err(format!(
+        _ => Err(invalid_query_context_extension(format!(
             "Invalid value for {}: {}",
             FLOW_RETURN_REGION_SEQ, value
-        )),
+        ))),
     }
+}
+
+fn invalid_query_context_extension(reason: String) -> Error {
+    InvalidQueryContextExtensionSnafu { reason }.build()
 }
 
 #[cfg(test)]
@@ -244,7 +268,7 @@ mod flow_extension_tests {
         )]);
 
         let err = FlowQueryExtensions::from_extensions(&exts).unwrap_err();
-        assert!(err.contains(FLOW_INCREMENTAL_AFTER_SEQS));
+        assert!(format!("{err}").contains(FLOW_INCREMENTAL_AFTER_SEQS));
     }
 
     #[test]
@@ -252,7 +276,7 @@ mod flow_extension_tests {
         let exts = HashMap::from([(FLOW_INCREMENTAL_MODE.to_string(), "foo".to_string())]);
 
         let err = FlowQueryExtensions::from_extensions(&exts).unwrap_err();
-        assert!(err.contains(FLOW_INCREMENTAL_MODE));
+        assert!(format!("{err}").contains(FLOW_INCREMENTAL_MODE));
     }
 
     #[test]
@@ -269,7 +293,32 @@ mod flow_extension_tests {
         ]);
 
         let err = FlowQueryExtensions::from_extensions(&exts).unwrap_err();
-        assert!(err.contains(FLOW_INCREMENTAL_AFTER_SEQS));
+        assert!(format!("{err}").contains(FLOW_INCREMENTAL_AFTER_SEQS));
+    }
+
+    #[test]
+    fn test_parse_flow_extensions_after_seqs_string_values() {
+        let exts = HashMap::from([(
+            FLOW_INCREMENTAL_AFTER_SEQS.to_string(),
+            r#"{"1":"10","2":"20"}"#.to_string(),
+        )]);
+
+        let parsed = FlowQueryExtensions::from_extensions(&exts).unwrap();
+        assert_eq!(
+            parsed.incremental_after_seqs.unwrap(),
+            HashMap::from([(1, 10), (2, 20)])
+        );
+    }
+
+    #[test]
+    fn test_parse_flow_extensions_after_seqs_invalid_value_type() {
+        let exts = HashMap::from([(
+            FLOW_INCREMENTAL_AFTER_SEQS.to_string(),
+            r#"{"1":true}"#.to_string(),
+        )]);
+
+        let err = FlowQueryExtensions::from_extensions(&exts).unwrap_err();
+        assert!(format!("{err}").contains(FLOW_INCREMENTAL_AFTER_SEQS));
     }
 
     #[test]
@@ -277,11 +326,13 @@ mod flow_extension_tests {
         let exts = HashMap::from([(FLOW_SINK_TABLE_ID.to_string(), "x".to_string())]);
 
         let err = FlowQueryExtensions::from_extensions(&exts).unwrap_err();
-        assert!(err.contains(FLOW_SINK_TABLE_ID));
+        assert!(format!("{err}").contains(FLOW_SINK_TABLE_ID));
     }
 
     #[test]
     fn test_validate_for_scan_missing_source_region() {
+        let source_region_id = RegionId::new(100, 2);
+        let existing_region_id = RegionId::new(100, 1);
         let exts = HashMap::from([
             (
                 FLOW_INCREMENTAL_MODE.to_string(),
@@ -289,17 +340,18 @@ mod flow_extension_tests {
             ),
             (
                 FLOW_INCREMENTAL_AFTER_SEQS.to_string(),
-                r#"{"1":10}"#.to_string(),
+                format!(r#"{{"{}":10}}"#, existing_region_id.as_u64()),
             ),
         ]);
 
         let parsed = FlowQueryExtensions::from_extensions(&exts).unwrap();
-        let err = parsed.validate_for_scan(&[1, 2], Some(100)).unwrap_err();
-        assert!(err.contains("Missing region 2"));
+        let err = parsed.validate_for_scan(source_region_id).unwrap_err();
+        assert!(format!("{err}").contains("Missing region"));
     }
 
     #[test]
     fn test_validate_for_scan_sink_table_excluded() {
+        let source_region_id = RegionId::new(1024, 1);
         let exts = HashMap::from([
             (
                 FLOW_INCREMENTAL_MODE.to_string(),
@@ -307,13 +359,13 @@ mod flow_extension_tests {
             ),
             (
                 FLOW_INCREMENTAL_AFTER_SEQS.to_string(),
-                r#"{"1":10}"#.to_string(),
+                format!(r#"{{"{}":10}}"#, source_region_id.as_u64()),
             ),
             (FLOW_SINK_TABLE_ID.to_string(), "1024".to_string()),
         ]);
 
         let parsed = FlowQueryExtensions::from_extensions(&exts).unwrap();
-        let apply_incremental = parsed.validate_for_scan(&[1, 2], Some(1024)).unwrap();
+        let apply_incremental = parsed.validate_for_scan(source_region_id).unwrap();
         assert!(!apply_incremental);
     }
 }

--- a/src/query/src/options.rs
+++ b/src/query/src/options.rs
@@ -26,7 +26,7 @@ pub const FLOW_INCREMENTAL_MODE: &str = "flow.incremental_mode";
 pub const FLOW_RETURN_REGION_SEQ: &str = "flow.return_region_seq";
 pub const FLOW_SINK_TABLE_ID: &str = "flow.sink_table_id";
 
-const FLOW_INCREMENTAL_MODE_MEMTABLE_ONLY: &str = "memtable_only";
+pub const FLOW_INCREMENTAL_MODE_MEMTABLE_ONLY: &str = "memtable_only";
 
 /// Query engine config
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -703,7 +703,7 @@ impl ErrorExt for Error {
             #[cfg(not(windows))]
             UpdateJemallocMetrics { .. } => StatusCode::Internal,
 
-            CollectRecordbatch { .. } => StatusCode::EngineExecuteQuery,
+            CollectRecordbatch { source, .. } => source.status_code(),
 
             ExecuteQuery { source, .. }
             | ExecutePlan { source, .. }

--- a/src/servers/src/grpc/flight.rs
+++ b/src/servers/src/grpc/flight.rs
@@ -39,7 +39,9 @@ use datatypes::arrow::datatypes::SchemaRef;
 use futures::{Stream, future, ready};
 use futures_util::{StreamExt, TryStreamExt};
 use prost::Message;
-use session::context::{QueryContext, QueryContextRef};
+use query::metrics::terminal_recordbatch_metrics_from_plan;
+use query::options::FlowQueryExtensions;
+use session::context::{Channel, QueryContextRef};
 use snafu::{IntoError, ResultExt, ensure};
 use table::table_name::TableName;
 use tokio::sync::mpsc;
@@ -48,7 +50,9 @@ use tonic::{Request, Response, Status, Streaming};
 
 use crate::error::{InvalidParameterSnafu, Result, ToJsonSnafu};
 pub use crate::grpc::flight::stream::FlightRecordBatchStream;
-use crate::grpc::greptime_handler::{GreptimeRequestHandler, get_request_type};
+use crate::grpc::greptime_handler::{
+    GreptimeRequestHandler, create_query_context, get_request_type,
+};
 use crate::grpc::{FlightCompression, TonicResult, context_auth};
 use crate::request_memory_limiter::ServerMemoryLimiter;
 use crate::request_memory_metrics::RequestMemoryMetrics;
@@ -192,6 +196,10 @@ impl FlightCraft for GreptimeRequestHandler {
         let ticket = request.into_inner().ticket;
         let request =
             GreptimeRequest::decode(ticket.as_ref()).context(error::InvalidFlightTicketSnafu)?;
+        let query_ctx =
+            create_query_context(Channel::Grpc, request.header.as_ref(), hints.clone())?;
+        FlowQueryExtensions::from_extensions(&query_ctx.extensions())
+            .map_err(|e| Status::invalid_argument(e.to_string()))?;
 
         // The Grpc protocol pass query by Flight. It needs to be wrapped under a span, in order to record stream
         let span = info_span!(
@@ -206,7 +214,7 @@ impl FlightCraft for GreptimeRequestHandler {
                 output,
                 TracingContext::from_current_span(),
                 flight_compression,
-                QueryContext::arc(),
+                query_ctx,
             );
             Ok(Response::new(stream))
         }
@@ -539,12 +547,22 @@ fn to_flight_data_stream(
             Box::pin(stream) as _
         }
         OutputData::AffectedRows(rows) => {
-            let stream = tokio_stream::iter(
-                FlightEncoder::default()
-                    .encode(FlightMessage::AffectedRows(rows))
-                    .into_iter()
-                    .map(Ok),
-            );
+            let affected_rows = FlightEncoder::default().encode(FlightMessage::AffectedRows(rows));
+            let should_emit_terminal_metrics =
+                FlowQueryExtensions::from_extensions(&query_ctx.extensions())
+                    .expect("flow extensions must be validated before Flight serialization")
+                    .should_collect_region_watermark();
+            let terminal_metrics = should_emit_terminal_metrics
+                .then_some(output.meta.plan)
+                .flatten()
+                .and_then(terminal_recordbatch_metrics_from_plan)
+                .and_then(|metrics| serde_json::to_string(&metrics).ok())
+                .map(FlightMessage::Metrics)
+                .map(|message| FlightEncoder::default().encode(message))
+                .into_iter()
+                .flatten();
+            let stream =
+                tokio_stream::iter(affected_rows.into_iter().chain(terminal_metrics).map(Ok));
             Box::pin(stream) as _
         }
     }

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -433,6 +433,10 @@ impl QueryContext {
         self.snapshot_seqs.read().unwrap().clone()
     }
 
+    pub fn sst_min_sequences(&self) -> HashMap<u64, u64> {
+        self.sst_min_sequences.read().unwrap().clone()
+    }
+
     pub fn get_snapshot(&self, region_id: u64) -> Option<u64> {
         self.snapshot_seqs.read().unwrap().get(&region_id).cloned()
     }
@@ -669,6 +673,8 @@ impl ConfigurationVariables {
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashMap;
+
     use common_catalog::consts::DEFAULT_CATALOG_NAME;
 
     use super::*;
@@ -703,5 +709,31 @@ mod test {
 
         let context = QueryContext::with(DEFAULT_CATALOG_NAME, "test");
         assert_eq!("test", context.get_db_string());
+    }
+
+    #[test]
+    fn test_api_query_context_roundtrip_with_sequences() {
+        let api_ctx = api::v1::QueryContext {
+            current_catalog: "c1".to_string(),
+            current_schema: "s1".to_string(),
+            timezone: "UTC".to_string(),
+            extensions: HashMap::from([("flow.return_region_seq".to_string(), "true".to_string())]),
+            channel: Channel::Grpc as u32,
+            snapshot_seqs: Some(api::v1::SnapshotSequences {
+                snapshot_seqs: HashMap::from([(1, 100)]),
+                sst_min_sequences: HashMap::from([(1, 90)]),
+            }),
+            explain: None,
+        };
+
+        let session_ctx: QueryContext = api_ctx.clone().into();
+        let roundtrip_api: api::v1::QueryContext = session_ctx.into();
+
+        assert_eq!(roundtrip_api.current_catalog, api_ctx.current_catalog);
+        assert_eq!(roundtrip_api.current_schema, api_ctx.current_schema);
+        assert_eq!(roundtrip_api.timezone, api_ctx.timezone);
+        assert_eq!(roundtrip_api.extensions, api_ctx.extensions);
+        assert_eq!(roundtrip_api.channel, api_ctx.channel);
+        assert_eq!(roundtrip_api.snapshot_seqs, api_ctx.snapshot_seqs);
     }
 }

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -441,6 +441,13 @@ impl QueryContext {
         self.snapshot_seqs.read().unwrap().get(&region_id).cloned()
     }
 
+    pub fn set_snapshot(&self, region_id: u64, sequence: u64) {
+        self.snapshot_seqs
+            .write()
+            .unwrap()
+            .insert(region_id, sequence);
+    }
+
     /// Returns `true` if the session can cast strings to numbers in MySQL style.
     pub fn auto_string_to_numeric(&self) -> bool {
         matches!(self.channel, Channel::Mysql)

--- a/src/store-api/src/region_engine.rs
+++ b/src/store-api/src/region_engine.rs
@@ -462,6 +462,10 @@ pub trait RegionScanner: Debug + DisplayAs + Send {
 
     /// Sets whether the scanner is reading a logical region.
     fn set_logical_region(&mut self, logical_region: bool);
+
+    fn snapshot_sequence(&self) -> Option<SequenceNumber> {
+        None
+    }
 }
 
 pub type RegionScannerRef = Box<dyn RegionScanner>;
@@ -945,6 +949,7 @@ pub struct SinglePartitionScanner {
     schema: SchemaRef,
     properties: ScannerProperties,
     metadata: RegionMetadataRef,
+    snapshot_sequence: Option<SequenceNumber>,
 }
 
 impl SinglePartitionScanner {
@@ -953,6 +958,7 @@ impl SinglePartitionScanner {
         stream: SendableRecordBatchStream,
         append_mode: bool,
         metadata: RegionMetadataRef,
+        snapshot_sequence: Option<SequenceNumber>,
     ) -> Self {
         let schema = stream.schema();
         Self {
@@ -960,6 +966,7 @@ impl SinglePartitionScanner {
             schema,
             properties: ScannerProperties::default().with_append_mode(append_mode),
             metadata,
+            snapshot_sequence,
         }
     }
 }
@@ -1018,6 +1025,10 @@ impl RegionScanner for SinglePartitionScanner {
 
     fn set_logical_region(&mut self, logical_region: bool) {
         self.properties.set_logical_region(logical_region);
+    }
+
+    fn snapshot_sequence(&self) -> Option<SequenceNumber> {
+        self.snapshot_sequence
     }
 }
 

--- a/src/store-api/src/storage/requests.rs
+++ b/src/store-api/src/storage/requests.rs
@@ -112,6 +112,8 @@ pub struct ScanRequest {
     /// Optional constraint on the sequence number of the rows to read.
     /// If set, only rows with a sequence number **lesser or equal** to this value
     /// will be returned.
+    /// This is the effective memtable upper bound used by the scan, whether provided
+    /// explicitly or bound on scan open.
     pub memtable_max_sequence: Option<SequenceNumber>,
     /// Optional constraint on the minimal sequence number in the memtable.
     /// If set, only the memtables that contain sequences **greater than** this value will be scanned
@@ -119,6 +121,8 @@ pub struct ScanRequest {
     /// Optional constraint on the minimal sequence number in the SST files.
     /// If set, only the SST files that contain sequences greater than this value will be scanned.
     pub sst_min_sequence: Option<SequenceNumber>,
+    /// Whether to bind the effective snapshot upper bound when opening the scan.
+    pub snapshot_on_scan: bool,
     /// Optional hint for the distribution of time-series data.
     pub distribution: Option<TimeSeriesDistribution>,
     /// Optional hint for KNN vector search. When set, the scan should use
@@ -193,6 +197,14 @@ impl Display for ScanRequest {
                 "{}sst_min_sequence: {}",
                 delimiter.as_str(),
                 sst_min_sequence
+            )?;
+        }
+        if self.snapshot_on_scan {
+            write!(
+                f,
+                "{}snapshot_on_scan: {}",
+                delimiter.as_str(),
+                self.snapshot_on_scan
             )?;
         }
         if let Some(distribution) = &self.distribution {
@@ -277,6 +289,15 @@ mod tests {
         assert_eq!(
             request.to_string(),
             "ScanRequest { force_flat_format: true }"
+        );
+
+        let request = ScanRequest {
+            snapshot_on_scan: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            request.to_string(),
+            "ScanRequest { snapshot_on_scan: true }"
         );
     }
 }

--- a/src/table/src/table/scan.rs
+++ b/src/table/src/table/scan.rs
@@ -599,7 +599,12 @@ mod test {
             .primary_key(vec![1]);
         let region_metadata = Arc::new(builder.build().unwrap());
 
-        let scanner = Box::new(SinglePartitionScanner::new(stream, false, region_metadata));
+        let scanner = Box::new(SinglePartitionScanner::new(
+            stream,
+            false,
+            region_metadata,
+            None,
+        ));
         let plan = RegionScanExec::new(scanner, ScanRequest::default(), None).unwrap();
         let actual: SchemaRef = Arc::new(
             plan.properties

--- a/tests-integration/src/grpc/flight.rs
+++ b/tests-integration/src/grpc/flight.rs
@@ -16,6 +16,7 @@
 mod test {
     use std::net::SocketAddr;
     use std::sync::Arc;
+    use std::time::{Duration, Instant};
 
     use api::v1::auth_header::AuthScheme;
     use api::v1::{Basic, ColumnDataType, ColumnDef, CreateTableExpr, SemanticType};
@@ -30,11 +31,14 @@ mod test {
     use common_query::OutputData;
     use common_recordbatch::RecordBatch;
     use common_recordbatch::adapter::{RecordBatchMetrics, RegionWatermarkEntry};
+    use datatypes::arrow::array::Array;
+    use datatypes::arrow_array::StringArray;
     use datatypes::prelude::{ConcreteDataType, ScalarVector, VectorRef};
     use datatypes::schema::{ColumnSchema, Schema};
     use datatypes::vectors::{Int32Vector, StringVector, TimestampMillisecondVector};
     use futures_util::StreamExt;
     use itertools::Itertools;
+    use serde_json::Value;
     use servers::grpc::builder::GrpcServerBuilder;
     use servers::grpc::greptime_handler::GreptimeRequestHandler;
     use servers::grpc::{FlightCompression, GrpcServerConfig};
@@ -335,6 +339,707 @@ mod test {
         assert!(err_msg.contains("STALE_CURSOR"));
         assert!(err_msg.contains(&previous_watermark.0.to_string()));
         assert!(err_msg.contains(&previous_watermark.1.to_string()));
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    struct ManualIncrementalBenchmarkCase {
+        label: &'static str,
+        initial_hosts: usize,
+        initial_rows_per_host: usize,
+        delta_existing_hosts: usize,
+        delta_rows_per_host: usize,
+        include_new_delta_host: bool,
+        iterations: usize,
+    }
+
+    #[derive(Debug)]
+    struct QueryExecutionSummary {
+        pretty: String,
+        elapsed: Duration,
+        row_count: usize,
+        region_watermarks: Vec<RegionWatermarkEntry>,
+        region_watermark_map: Option<std::collections::HashMap<u64, u64>>,
+    }
+
+    #[derive(Debug)]
+    struct ExplainQuerySummary {
+        pretty: String,
+        row_count: usize,
+        plan_texts: Vec<String>,
+        json_nodes: Vec<ExplainNodeSummary>,
+    }
+
+    #[derive(Debug, Clone)]
+    struct ExplainNodeSummary {
+        name: String,
+        param: String,
+        output_rows: usize,
+        elapsed_compute: usize,
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "benchmark-style integration test for Task 4b"]
+    async fn test_standalone_flight_manual_incremental_join_benchmark() {
+        common_telemetry::init_default_ut_logging();
+
+        let (db, server) = setup_grpc_server(
+            StorageType::File,
+            "test_standalone_flight_manual_incremental_join_benchmark",
+        )
+        .await;
+        let addr = server.bind_addr().unwrap().to_string();
+
+        let client = Client::with_urls(vec![addr]);
+        let client = Database::new_with_dbname("greptime-public", client);
+
+        let cases = [
+            ManualIncrementalBenchmarkCase {
+                label: "small_delta_large_sink",
+                initial_hosts: 128,
+                initial_rows_per_host: 6,
+                delta_existing_hosts: 4,
+                delta_rows_per_host: 2,
+                include_new_delta_host: true,
+                iterations: 3,
+            },
+            ManualIncrementalBenchmarkCase {
+                label: "medium_delta_large_sink",
+                initial_hosts: 128,
+                initial_rows_per_host: 6,
+                delta_existing_hosts: 32,
+                delta_rows_per_host: 2,
+                include_new_delta_host: true,
+                iterations: 3,
+            },
+            ManualIncrementalBenchmarkCase {
+                label: "small_delta_small_sink",
+                initial_hosts: 16,
+                initial_rows_per_host: 6,
+                delta_existing_hosts: 4,
+                delta_rows_per_host: 2,
+                include_new_delta_host: true,
+                iterations: 3,
+            },
+            ManualIncrementalBenchmarkCase {
+                label: "tiny_delta_huge_sink",
+                initial_hosts: 1024,
+                initial_rows_per_host: 8,
+                delta_existing_hosts: 2,
+                delta_rows_per_host: 1,
+                include_new_delta_host: true,
+                iterations: 2,
+            },
+            ManualIncrementalBenchmarkCase {
+                label: "tiny_delta_src_heavy_sink_small",
+                initial_hosts: 16,
+                initial_rows_per_host: 1024,
+                delta_existing_hosts: 2,
+                delta_rows_per_host: 1,
+                include_new_delta_host: true,
+                iterations: 2,
+            },
+            ManualIncrementalBenchmarkCase {
+                label: "tiny_delta_src_huge_sink_mid",
+                initial_hosts: 128,
+                initial_rows_per_host: 512,
+                delta_existing_hosts: 2,
+                delta_rows_per_host: 1,
+                include_new_delta_host: true,
+                iterations: 2,
+            },
+            ManualIncrementalBenchmarkCase {
+                label: "tiny_delta_src_extreme_sink_mid",
+                initial_hosts: 256,
+                initial_rows_per_host: 1024,
+                delta_existing_hosts: 2,
+                delta_rows_per_host: 1,
+                include_new_delta_host: true,
+                iterations: 2,
+            },
+            ManualIncrementalBenchmarkCase {
+                label: "small_delta_src_ultra_sink_mid",
+                initial_hosts: 256,
+                initial_rows_per_host: 4096,
+                delta_existing_hosts: 20,
+                delta_rows_per_host: 100,
+                include_new_delta_host: true,
+                iterations: 2,
+            },
+        ];
+
+        for case in cases {
+            run_manual_incremental_join_benchmark_case(&db, &client, case).await;
+        }
+    }
+
+    async fn run_manual_incremental_join_benchmark_case(
+        db: &impl MockInstance,
+        client: &Database,
+        case: ManualIncrementalBenchmarkCase,
+    ) {
+        let source_table = format!("flow_bench_src_{}", case.label);
+        let sink_table = format!("flow_bench_sink_{}", case.label);
+
+        create_flow_bench_source_table(client, &source_table).await;
+        create_flow_bench_sink_table(client, &sink_table).await;
+
+        let initial_rows = make_source_rows(
+            &source_table,
+            0,
+            case.initial_hosts,
+            case.initial_rows_per_host,
+            1,
+        );
+        insert_source_rows(client, &source_table, &initial_rows).await;
+
+        let source_table_id = db
+            .frontend()
+            .catalog_manager()
+            .table("greptime", "public", &source_table, None)
+            .await
+            .unwrap()
+            .unwrap()
+            .table_info()
+            .table_id();
+        let previous_watermarks = std::collections::HashMap::from([(
+            RegionId::new(source_table_id, 0).as_u64(),
+            initial_rows.len() as u64,
+        )]);
+
+        execute_affected_rows_sql(
+            client,
+            &format!(
+                "insert into {sink_table} select host, cast(sum(v) as bigint), max(ts) from {source_table} group by host"
+            ),
+        )
+        .await;
+
+        let sink_table_id = db
+            .frontend()
+            .catalog_manager()
+            .table("greptime", "public", &sink_table, None)
+            .await
+            .unwrap()
+            .unwrap()
+            .table_info()
+            .table_id();
+
+        let delta_rows = make_delta_rows(
+            case,
+            (case.initial_hosts * case.initial_rows_per_host) as i64 + 1,
+        );
+        insert_source_rows(client, &source_table, &delta_rows).await;
+
+        let expected_summary =
+            execute_stream_query_with_hints(client, &full_aggregate_query(&source_table), &[])
+                .await;
+        let expected = expected_summary.pretty.clone();
+        let expected_row_count = expected_summary.row_count;
+        let changed_hosts = delta_rows
+            .iter()
+            .map(|(host, _, _)| host.clone())
+            .unique()
+            .collect_vec();
+        let expected_changed_summary = execute_stream_query_with_hints(
+            client,
+            &changed_rows_full_baseline_query(&source_table, &changed_hosts),
+            &[],
+        )
+        .await;
+        let expected_changed = expected_changed_summary.pretty.clone();
+        let expected_changed_row_count = expected_changed_summary.row_count;
+
+        let incremental_after_seqs = format_region_seq_map(&previous_watermarks);
+        let sink_table_id_str = sink_table_id.to_string();
+        let hint_pairs = [
+            ("flow.incremental_mode", "memtable_only".to_string()),
+            (
+                "flow.incremental_after_seqs",
+                incremental_after_seqs.clone(),
+            ),
+            ("flow.return_region_seq", "true".to_string()),
+            ("flow.sink_table_id", sink_table_id_str.clone()),
+        ];
+        let hints = hint_pairs
+            .iter()
+            .map(|(k, v)| (*k, v.as_str()))
+            .collect::<Vec<_>>();
+
+        let mut full_latencies = Vec::with_capacity(case.iterations);
+        let mut delta_only_left_join_latencies = Vec::with_capacity(case.iterations);
+
+        if matches!(
+            case.label,
+            "tiny_delta_src_extreme_sink_mid" | "small_delta_src_ultra_sink_mid"
+        ) {
+            let full_verbose = execute_explain_query_with_hints(
+                client,
+                &format!(
+                    "EXPLAIN ANALYZE VERBOSE {}",
+                    full_aggregate_query(&source_table)
+                ),
+                &[],
+            )
+            .await;
+            let delta_only_verbose = execute_explain_query_with_hints(
+                client,
+                &format!(
+                    "EXPLAIN ANALYZE VERBOSE {}",
+                    manual_delta_only_left_join_update_query(&source_table, &sink_table)
+                ),
+                &hints,
+            )
+            .await;
+            let full_json = execute_explain_query_with_hints(
+                client,
+                &format!(
+                    "EXPLAIN ANALYZE FORMAT JSON {}",
+                    full_aggregate_query(&source_table)
+                ),
+                &[],
+            )
+            .await;
+            let delta_only_json = execute_explain_query_with_hints(
+                client,
+                &format!(
+                    "EXPLAIN ANALYZE FORMAT JSON {}",
+                    manual_delta_only_left_join_update_query(&source_table, &sink_table)
+                ),
+                &hints,
+            )
+            .await;
+
+            assert!(
+                full_verbose.pretty.contains("AggregateExec")
+                    || full_verbose.pretty.contains("HashAggregateExec")
+            );
+            assert!(
+                delta_only_verbose.pretty.contains("HashJoinExec")
+                    || delta_only_verbose.pretty.contains("Left")
+            );
+            assert!(full_verbose.pretty.contains("SeqScan"));
+            assert!(delta_only_verbose.pretty.contains("SeqScan"));
+            assert!(full_json.pretty.contains("elapsed_compute"));
+            assert!(delta_only_json.pretty.contains("elapsed_compute"));
+            assert!(
+                full_json
+                    .json_nodes
+                    .iter()
+                    .any(|node| node.name == "AggregateExec"),
+                "expected full explain json to include AggregateExec nodes"
+            );
+            assert!(
+                full_json
+                    .json_nodes
+                    .iter()
+                    .any(|node| node.name == "SeqScan"),
+                "expected full explain json to include SeqScan nodes"
+            );
+            assert!(
+                delta_only_json
+                    .json_nodes
+                    .iter()
+                    .any(|node| node.name == "HashJoinExec"),
+                "expected delta-only explain json to include HashJoinExec nodes"
+            );
+            assert!(
+                delta_only_json
+                    .json_nodes
+                    .iter()
+                    .filter(|node| node.name == "SeqScan")
+                    .count()
+                    >= 2,
+                "expected delta-only explain json to include both source and sink SeqScan nodes"
+            );
+
+            common_telemetry::info!(
+                "FlowBench profile case={} full_verbose_rows={} delta_only_verbose_rows={} full_json_rows={} delta_only_json_rows={} full_json_plans={} delta_only_json_plans={}\nFULL_VERBOSE\n{}\nDELTA_ONLY_VERBOSE\n{}\nFULL_JSON\n{}\nDELTA_ONLY_JSON\n{}\nFULL_JSON_NODE_SUMMARY={:?}\nDELTA_ONLY_JSON_NODE_SUMMARY={:?}",
+                case.label,
+                full_verbose.row_count,
+                delta_only_verbose.row_count,
+                full_json.row_count,
+                delta_only_json.row_count,
+                full_json.plan_texts.len(),
+                delta_only_json.plan_texts.len(),
+                full_verbose.pretty,
+                delta_only_verbose.pretty,
+                full_json.pretty,
+                delta_only_json.pretty,
+                summarize_explain_nodes(&full_json.json_nodes),
+                summarize_explain_nodes(&delta_only_json.json_nodes),
+            );
+        }
+
+        for _ in 0..case.iterations {
+            let full_summary =
+                execute_stream_query_with_hints(client, &full_aggregate_query(&source_table), &[])
+                    .await;
+            let changed_rows_full_summary = execute_stream_query_with_hints(
+                client,
+                &changed_rows_full_baseline_query(&source_table, &changed_hosts),
+                &[],
+            )
+            .await;
+            let delta_only_left_join_summary = execute_stream_query_with_hints(
+                client,
+                &manual_delta_only_left_join_update_query(&source_table, &sink_table),
+                &hints,
+            )
+            .await;
+
+            assert_eq!(full_summary.pretty, expected);
+            assert_eq!(changed_rows_full_summary.pretty, expected_changed);
+            assert_eq!(delta_only_left_join_summary.pretty, expected_changed);
+            assert_eq!(
+                changed_rows_full_summary.row_count,
+                expected_changed_row_count
+            );
+            assert_eq!(
+                delta_only_left_join_summary.row_count,
+                expected_changed_row_count
+            );
+            assert!(
+                delta_only_left_join_summary
+                    .region_watermark_map
+                    .as_ref()
+                    .map(|watermarks| !watermarks.is_empty())
+                    .unwrap_or(false)
+                    || !delta_only_left_join_summary.region_watermarks.is_empty(),
+                "expected delta-only left-join incremental query to return region watermark metrics"
+            );
+
+            full_latencies.push(full_summary.elapsed);
+            delta_only_left_join_latencies.push(delta_only_left_join_summary.elapsed);
+        }
+
+        common_telemetry::info!(
+            "FlowBench case={} full_latencies_ms={:?} delta_only_left_join_latencies_ms={:?} expected_rows={} expected_changed_rows={}",
+            case.label,
+            full_latencies.iter().map(Duration::as_millis).collect_vec(),
+            delta_only_left_join_latencies
+                .iter()
+                .map(Duration::as_millis)
+                .collect_vec(),
+            expected_row_count,
+            expected_changed_row_count,
+        );
+
+        client
+            .sql(&format!("admin flush_table('{source_table}')"))
+            .await
+            .unwrap();
+
+        let output = client
+            .sql_with_hint(
+                &manual_delta_only_left_join_update_query(&source_table, &sink_table),
+                &hints,
+            )
+            .await
+            .unwrap();
+        let OutputData::Stream(mut stream) = output.data else {
+            panic!("expected stale delta-only benchmark query to return stream output");
+        };
+        let err = loop {
+            match stream.next().await {
+                Some(Err(err)) => break err,
+                Some(Ok(_)) => continue,
+                None => panic!("expected stale delta-only incremental benchmark query to fail"),
+            }
+        };
+        assert_eq!(err.status_code(), StatusCode::EngineExecuteQuery);
+        let err_msg = format!("{err:?}");
+        assert!(err_msg.contains("STALE_CURSOR"));
+    }
+
+    async fn execute_stream_query_with_hints(
+        client: &Database,
+        sql: &str,
+        hints: &[(&str, &str)],
+    ) -> QueryExecutionSummary {
+        let started = Instant::now();
+        let result = client.sql_with_terminal_metrics(sql, hints).await.unwrap();
+        let region_watermark_map = result.region_watermark_map();
+
+        let OutputData::Stream(mut stream) = result.output.data else {
+            panic!("expected stream output for benchmark query");
+        };
+
+        let schema = stream.schema();
+        let mut row_count = 0;
+        let mut rows = Vec::new();
+        while let Some(batch) = stream.next().await {
+            let batch = batch.unwrap();
+            row_count += batch.num_rows();
+            rows.push(batch);
+        }
+        let pretty = common_recordbatch::RecordBatches::try_new(schema, rows)
+            .unwrap()
+            .pretty_print()
+            .unwrap();
+        let elapsed = started.elapsed();
+        let region_watermarks = stream
+            .metrics()
+            .map(|metrics| metrics.region_watermarks)
+            .unwrap_or_default();
+        let region_watermark_map = region_watermark_map.or_else(|| {
+            let region_seq_pairs = region_watermarks
+                .iter()
+                .map(|entry| {
+                    entry
+                        .watermark
+                        .map(|watermark| (entry.region_id, watermark))
+                })
+                .collect::<Option<Vec<_>>>()?;
+            Some(std::collections::HashMap::from_iter(region_seq_pairs))
+        });
+
+        QueryExecutionSummary {
+            pretty,
+            elapsed,
+            row_count,
+            region_watermarks,
+            region_watermark_map,
+        }
+    }
+
+    async fn execute_explain_query_with_hints(
+        client: &Database,
+        sql: &str,
+        hints: &[(&str, &str)],
+    ) -> ExplainQuerySummary {
+        let output = client.sql_with_hint(sql, hints).await.unwrap();
+        let OutputData::Stream(mut stream) = output.data else {
+            panic!("expected stream output for explain query");
+        };
+
+        let schema = stream.schema();
+        let mut row_count = 0;
+        let mut rows = Vec::new();
+        while let Some(batch) = stream.next().await {
+            let batch = batch.unwrap();
+            row_count += batch.num_rows();
+            rows.push(batch);
+        }
+        let plan_texts = extract_explain_plan_texts(&rows);
+        let pretty = common_recordbatch::RecordBatches::try_new(schema, rows)
+            .unwrap()
+            .pretty_print()
+            .unwrap();
+        let json_nodes = plan_texts
+            .iter()
+            .filter_map(|plan| serde_json::from_str::<Value>(plan).ok())
+            .flat_map(|value| flatten_explain_json_nodes(&value))
+            .collect_vec();
+
+        ExplainQuerySummary {
+            pretty,
+            row_count,
+            plan_texts,
+            json_nodes,
+        }
+    }
+
+    fn extract_explain_plan_texts(rows: &[RecordBatch]) -> Vec<String> {
+        let mut plan_texts = Vec::new();
+        for batch in rows {
+            let Some(plan_column) = batch.columns().get(2) else {
+                continue;
+            };
+            let Some(plan_array) = plan_column.as_any().downcast_ref::<StringArray>() else {
+                continue;
+            };
+            for idx in 0..plan_array.len() {
+                if plan_array.is_valid(idx) {
+                    plan_texts.push(plan_array.value(idx).to_string());
+                }
+            }
+        }
+        plan_texts
+    }
+
+    fn flatten_explain_json_nodes(value: &Value) -> Vec<ExplainNodeSummary> {
+        let mut nodes = Vec::new();
+        flatten_explain_json_nodes_into(value, &mut nodes);
+        nodes
+    }
+
+    fn flatten_explain_json_nodes_into(value: &Value, nodes: &mut Vec<ExplainNodeSummary>) {
+        let name = value
+            .get("name")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let param = value
+            .get("param")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let output_rows = value
+            .get("output_rows")
+            .and_then(Value::as_u64)
+            .unwrap_or_default() as usize;
+        let elapsed_compute = value
+            .get("elapsed_compute")
+            .and_then(Value::as_u64)
+            .unwrap_or_default() as usize;
+
+        if !name.is_empty() {
+            nodes.push(ExplainNodeSummary {
+                name,
+                param,
+                output_rows,
+                elapsed_compute,
+            });
+        }
+
+        if let Some(children) = value.get("children").and_then(Value::as_array) {
+            for child in children {
+                flatten_explain_json_nodes_into(child, nodes);
+            }
+        }
+    }
+
+    fn summarize_explain_nodes(nodes: &[ExplainNodeSummary]) -> Vec<String> {
+        nodes
+            .iter()
+            .map(|node| {
+                format!(
+                    "{} rows={} elapsed_ns={} param={}",
+                    node.name, node.output_rows, node.elapsed_compute, node.param
+                )
+            })
+            .collect()
+    }
+
+    async fn execute_affected_rows_sql(client: &Database, sql: &str) {
+        let output = client.sql(sql).await.unwrap();
+        let OutputData::AffectedRows(_) = output.data else {
+            panic!("expected affected rows output for sql: {sql}");
+        };
+    }
+
+    async fn create_flow_bench_source_table(client: &Database, table_name: &str) {
+        execute_affected_rows_sql(
+            client,
+            &format!(
+                "create table {table_name}(host string, v bigint, ts timestamp time index, primary key(host))"
+            ),
+        )
+        .await;
+    }
+
+    async fn create_flow_bench_sink_table(client: &Database, table_name: &str) {
+        execute_affected_rows_sql(
+            client,
+            &format!(
+                "create table {table_name}(host string, total bigint, ts timestamp time index, primary key(host))"
+            ),
+        )
+        .await;
+    }
+
+    async fn insert_source_rows(client: &Database, table_name: &str, rows: &[(String, i64, i64)]) {
+        for chunk in &rows.iter().chunks(128) {
+            let values = chunk
+                .map(|(host, value, ts)| format!("('{host}', {value}, {ts})"))
+                .join(",");
+            execute_affected_rows_sql(
+                client,
+                &format!("insert into {table_name}(host, v, ts) values {values}"),
+            )
+            .await;
+        }
+    }
+
+    fn make_source_rows(
+        _table_name: &str,
+        ts_start: i64,
+        host_count: usize,
+        rows_per_host: usize,
+        value_bias: i64,
+    ) -> Vec<(String, i64, i64)> {
+        let mut rows = Vec::with_capacity(host_count * rows_per_host);
+        let mut ts = ts_start;
+        for host_idx in 0..host_count {
+            for row_idx in 0..rows_per_host {
+                ts += 1;
+                rows.push((
+                    format!("host_{host_idx:03}"),
+                    value_bias + host_idx as i64 + row_idx as i64,
+                    ts,
+                ));
+            }
+        }
+        rows
+    }
+
+    fn make_delta_rows(
+        case: ManualIncrementalBenchmarkCase,
+        ts_start: i64,
+    ) -> Vec<(String, i64, i64)> {
+        let mut rows = Vec::with_capacity(
+            case.delta_existing_hosts * case.delta_rows_per_host
+                + usize::from(case.include_new_delta_host) * case.delta_rows_per_host,
+        );
+        let mut ts = ts_start;
+
+        for host_idx in 0..case.delta_existing_hosts {
+            for row_idx in 0..case.delta_rows_per_host {
+                ts += 1;
+                rows.push((
+                    format!("host_{host_idx:03}"),
+                    1_000 + host_idx as i64 + row_idx as i64,
+                    ts,
+                ));
+            }
+        }
+
+        if case.include_new_delta_host {
+            for row_idx in 0..case.delta_rows_per_host {
+                ts += 1;
+                rows.push((
+                    format!("host_new_{}", case.label),
+                    2_000 + row_idx as i64,
+                    ts,
+                ));
+            }
+        }
+
+        rows
+    }
+
+    fn full_aggregate_query(source_table: &str) -> String {
+        format!(
+            "select host, cast(sum(v) as bigint) as total from {source_table} group by host order by host"
+        )
+    }
+
+    fn changed_rows_full_baseline_query(source_table: &str, changed_hosts: &[String]) -> String {
+        let host_list = changed_hosts
+            .iter()
+            .map(|host| format!("'{}'", host))
+            .join(",");
+        format!(
+            "select host, cast(sum(v) as bigint) as total from {source_table} where host in ({host_list}) group by host order by host"
+        )
+    }
+
+    fn manual_delta_only_left_join_update_query(source_table: &str, sink_table: &str) -> String {
+        format!(
+            "with delta as (select host, cast(sum(v) as bigint) as delta_total from {source_table} group by host) \
+             select d.host as host, cast(coalesce(s.total, 0) + d.delta_total as bigint) as total \
+             from delta d left join {sink_table} s on d.host = s.host \
+             order by host"
+        )
+    }
+
+    fn format_region_seq_map(region_seqs: &std::collections::HashMap<u64, u64>) -> String {
+        let mut entries = region_seqs
+            .iter()
+            .map(|(region_id, seq)| format!(r#""{region_id}":"{seq}""#))
+            .collect::<Vec<_>>();
+        entries.sort();
+        format!("{{{}}}", entries.join(","))
     }
 
     async fn test_put_record_batches(client: &Database, record_batches: Vec<RecordBatch>) {

--- a/tests-integration/src/grpc/flight.rs
+++ b/tests-integration/src/grpc/flight.rs
@@ -39,6 +39,7 @@ mod test {
     use servers::grpc::greptime_handler::GreptimeRequestHandler;
     use servers::grpc::{FlightCompression, GrpcServerConfig};
     use servers::server::Server;
+    use store_api::storage::RegionId;
 
     use crate::cluster::GreptimeDbClusterBuilder;
     use crate::grpc::query_and_expect;
@@ -154,10 +155,13 @@ mod test {
         while let Some(batch) = stream.next().await {
             batch.unwrap();
         }
-        assert!(
-            terminal_metrics
-                .region_watermark_map()
-                .is_some_and(|m| !m.is_empty())
+        let regions = db.list_all_regions().await;
+        assert_eq!(regions.len(), 1);
+        let (region_id, region) = regions.into_iter().next().unwrap();
+        let expected_watermark = (region_id.as_u64(), region.find_committed_sequence());
+        assert_eq!(
+            terminal_metrics.region_watermark_map(),
+            Some(std::collections::HashMap::from([expected_watermark]))
         );
 
         let output = client
@@ -175,17 +179,13 @@ mod test {
         }
         assert_eq!(row_count, 9);
 
-        let RecordBatchMetrics {
-            region_latest_sequences,
-            ..
-        } = stream.metrics().expect("expected terminal metrics");
-        let region_latest_sequences =
-            region_latest_sequences.expect("expected region watermark metrics");
-        assert_eq!(region_latest_sequences.len(), 1);
-        assert!(region_latest_sequences[0].0 > 0);
-        assert!(region_latest_sequences[0].1 > 0);
+        let metrics = stream.metrics().expect("expected terminal metrics");
+        let region_latest_sequences = metrics
+            .region_latest_sequences
+            .expect("expected region watermark metrics");
+        assert_eq!(region_latest_sequences, vec![expected_watermark]);
 
-        let previous_watermark = region_latest_sequences[0];
+        let previous_watermark = expected_watermark;
 
         create_table_named(&client, "bar").await;
         let result = client
@@ -222,7 +222,10 @@ mod test {
             panic!("expected affected rows output");
         };
         assert_eq!(affected_rows, 9);
-        assert!(result.region_watermark_map().is_some_and(|m| !m.is_empty()));
+        assert_eq!(
+            result.region_watermark_map(),
+            Some(std::collections::HashMap::from([previous_watermark]))
+        );
 
         let incremental_batches = create_record_batches(10);
         test_put_record_batches(&client, incremental_batches).await;
@@ -283,9 +286,16 @@ mod test {
             .expect("expected terminal incremental metrics");
         let region_latest_sequences =
             region_latest_sequences.expect("expected incremental region watermark metrics");
-        assert_eq!(region_latest_sequences.len(), 1);
-        assert_eq!(region_latest_sequences[0].0, previous_watermark.0);
-        assert!(region_latest_sequences[0].1 > previous_watermark.1);
+        let regions = db.list_all_regions().await;
+        let region = regions
+            .get(&RegionId::from_u64(previous_watermark.0))
+            .expect("expected source region to exist");
+        let expected_incremental_watermark =
+            (previous_watermark.0, region.find_committed_sequence());
+        assert_eq!(
+            region_latest_sequences,
+            vec![expected_incremental_watermark]
+        );
 
         client.sql("admin flush_table('foo')").await.unwrap();
 

--- a/tests-integration/src/grpc/flight.rs
+++ b/tests-integration/src/grpc/flight.rs
@@ -29,7 +29,7 @@ mod test {
     use common_grpc::flight::{FlightEncoder, FlightMessage};
     use common_query::OutputData;
     use common_recordbatch::RecordBatch;
-    use common_recordbatch::adapter::RecordBatchMetrics;
+    use common_recordbatch::adapter::{RecordBatchMetrics, RegionWatermarkEntry};
     use datatypes::prelude::{ConcreteDataType, ScalarVector, VectorRef};
     use datatypes::schema::{ColumnSchema, Schema};
     use datatypes::vectors::{Int32Vector, StringVector, TimestampMillisecondVector};
@@ -142,7 +142,7 @@ mod test {
             batch.unwrap();
         }
         let metrics = stream.metrics().expect("expected terminal metrics");
-        assert!(metrics.region_latest_sequences.is_none());
+        assert!(metrics.region_watermarks.is_empty());
 
         let result = client
             .sql_with_terminal_metrics(sql, &[("flow.return_region_seq", "true")])
@@ -180,10 +180,14 @@ mod test {
         assert_eq!(row_count, 9);
 
         let metrics = stream.metrics().expect("expected terminal metrics");
-        let region_latest_sequences = metrics
-            .region_latest_sequences
-            .expect("expected region watermark metrics");
-        assert_eq!(region_latest_sequences, vec![expected_watermark]);
+        let region_watermarks = metrics.region_watermarks;
+        assert_eq!(
+            region_watermarks,
+            vec![RegionWatermarkEntry {
+                region_id: expected_watermark.0,
+                watermark: Some(expected_watermark.1),
+            }]
+        );
 
         let previous_watermark = expected_watermark;
 
@@ -279,13 +283,10 @@ mod test {
         );
 
         let RecordBatchMetrics {
-            region_latest_sequences,
-            ..
+            region_watermarks, ..
         } = stream
             .metrics()
             .expect("expected terminal incremental metrics");
-        let region_latest_sequences =
-            region_latest_sequences.expect("expected incremental region watermark metrics");
         let regions = db.list_all_regions().await;
         let region = regions
             .get(&RegionId::from_u64(previous_watermark.0))
@@ -293,8 +294,11 @@ mod test {
         let expected_incremental_watermark =
             (previous_watermark.0, region.find_committed_sequence());
         assert_eq!(
-            region_latest_sequences,
-            vec![expected_incremental_watermark]
+            region_watermarks,
+            vec![RegionWatermarkEntry {
+                region_id: expected_incremental_watermark.0,
+                watermark: Some(expected_incremental_watermark.1),
+            }]
         );
 
         client.sql("admin flush_table('foo')").await.unwrap();

--- a/tests-integration/src/grpc/flight.rs
+++ b/tests-integration/src/grpc/flight.rs
@@ -23,10 +23,13 @@ mod test {
     use auth::user_provider_from_option;
     use client::{Client, Database};
     use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
+    use common_error::ext::ErrorExt;
+    use common_error::status_code::StatusCode;
     use common_grpc::flight::do_put::DoPutMetadata;
     use common_grpc::flight::{FlightEncoder, FlightMessage};
     use common_query::OutputData;
     use common_recordbatch::RecordBatch;
+    use common_recordbatch::adapter::RecordBatchMetrics;
     use datatypes::prelude::{ConcreteDataType, ScalarVector, VectorRef};
     use datatypes::schema::{ColumnSchema, Schema};
     use datatypes::vectors::{Int32Vector, StringVector, TimestampMillisecondVector};
@@ -129,6 +132,141 @@ mod test {
 | 1970-01-01T00:00:00.009 | -9 | s9 |
 +-------------------------+----+----+";
         query_and_expect(db.fe_instance().as_ref(), sql, expected).await;
+
+        let output = client.sql(sql).await.unwrap();
+        let OutputData::Stream(mut stream) = output.data else {
+            panic!("expected stream output");
+        };
+        while let Some(batch) = stream.next().await {
+            batch.unwrap();
+        }
+        let metrics = stream.metrics().expect("expected terminal metrics");
+        assert!(metrics.region_latest_sequences.is_none());
+
+        let output = client
+            .sql_with_hint(sql, &[("flow.return_region_seq", "true")])
+            .await
+            .unwrap();
+        let OutputData::Stream(mut stream) = output.data else {
+            panic!("expected stream output");
+        };
+
+        let mut row_count = 0;
+        while let Some(batch) = stream.next().await {
+            let batch = batch.unwrap();
+            row_count += batch.num_rows();
+        }
+        assert_eq!(row_count, 9);
+
+        let RecordBatchMetrics {
+            region_latest_sequences,
+            ..
+        } = stream.metrics().expect("expected terminal metrics");
+        let region_latest_sequences =
+            region_latest_sequences.expect("expected region watermark metrics");
+        assert_eq!(region_latest_sequences.len(), 1);
+        assert!(region_latest_sequences[0].0 > 0);
+        assert!(region_latest_sequences[0].1 > 0);
+
+        let previous_watermark = region_latest_sequences[0];
+
+        let incremental_batches = create_record_batches(10);
+        test_put_record_batches(&client, incremental_batches).await;
+
+        let output = client
+            .sql_with_hint(
+                sql,
+                &[
+                    ("flow.incremental_mode", "memtable_only"),
+                    (
+                        "flow.incremental_after_seqs",
+                        &format!(
+                            r#"{{"{}":"{}"}}"#,
+                            previous_watermark.0, previous_watermark.1
+                        ),
+                    ),
+                    ("flow.return_region_seq", "true"),
+                ],
+            )
+            .await
+            .unwrap();
+        let OutputData::Stream(mut stream) = output.data else {
+            panic!("expected stream output");
+        };
+
+        let schema = stream.schema();
+        let mut rows = Vec::new();
+        while let Some(batch) = stream.next().await {
+            rows.push(batch.unwrap());
+        }
+        let pretty = common_recordbatch::RecordBatches::try_new(schema, rows)
+            .unwrap()
+            .pretty_print()
+            .unwrap();
+        assert_eq!(
+            pretty,
+            "\
++-------------------------+-----+-----+
+| ts                      | a   | B   |
++-------------------------+-----+-----+
+| 1970-01-01T00:00:00.010 | -10 | s10 |
+| 1970-01-01T00:00:00.011 | -11 | s11 |
+| 1970-01-01T00:00:00.012 | -12 | s12 |
+| 1970-01-01T00:00:00.013 | -13 | s13 |
+| 1970-01-01T00:00:00.014 | -14 | s14 |
+| 1970-01-01T00:00:00.015 | -15 | s15 |
+| 1970-01-01T00:00:00.016 | -16 | s16 |
+| 1970-01-01T00:00:00.017 | -17 | s17 |
+| 1970-01-01T00:00:00.018 | -18 | s18 |
++-------------------------+-----+-----+"
+        );
+
+        let RecordBatchMetrics {
+            region_latest_sequences,
+            ..
+        } = stream
+            .metrics()
+            .expect("expected terminal incremental metrics");
+        let region_latest_sequences =
+            region_latest_sequences.expect("expected incremental region watermark metrics");
+        assert_eq!(region_latest_sequences.len(), 1);
+        assert_eq!(region_latest_sequences[0].0, previous_watermark.0);
+        assert!(region_latest_sequences[0].1 > previous_watermark.1);
+
+        client.sql("admin flush_table('foo')").await.unwrap();
+
+        let output = client
+            .sql_with_hint(
+                sql,
+                &[
+                    ("flow.incremental_mode", "memtable_only"),
+                    (
+                        "flow.incremental_after_seqs",
+                        &format!(
+                            r#"{{"{}":"{}"}}"#,
+                            previous_watermark.0, previous_watermark.1
+                        ),
+                    ),
+                    ("flow.return_region_seq", "true"),
+                ],
+            )
+            .await
+            .unwrap();
+        let OutputData::Stream(mut stream) = output.data else {
+            panic!("expected stream output");
+        };
+        let err = loop {
+            match stream.next().await {
+                Some(Err(err)) => break err,
+                Some(Ok(_)) => continue,
+                None => panic!("expected stale incremental query to fail while consuming stream"),
+            }
+        };
+        assert_eq!(err.status_code(), StatusCode::EngineExecuteQuery);
+        let err_msg = format!("{err:?}");
+        assert!(err_msg.contains("STALE_CURSOR"));
+        assert!(err_msg.contains(&previous_watermark.0.to_string()));
+        assert!(err_msg.contains(&previous_watermark.1.to_string()));
     }
 
     async fn test_put_record_batches(client: &Database, record_batches: Vec<RecordBatch>) {

--- a/tests-integration/src/grpc/flight.rs
+++ b/tests-integration/src/grpc/flight.rs
@@ -143,6 +143,23 @@ mod test {
         let metrics = stream.metrics().expect("expected terminal metrics");
         assert!(metrics.region_latest_sequences.is_none());
 
+        let result = client
+            .sql_with_terminal_metrics(sql, &[("flow.return_region_seq", "true")])
+            .await
+            .unwrap();
+        let terminal_metrics = result.metrics.clone();
+        let OutputData::Stream(mut stream) = result.output.data else {
+            panic!("expected stream output");
+        };
+        while let Some(batch) = stream.next().await {
+            batch.unwrap();
+        }
+        assert!(
+            terminal_metrics
+                .region_watermark_map()
+                .is_some_and(|m| !m.is_empty())
+        );
+
         let output = client
             .sql_with_hint(sql, &[("flow.return_region_seq", "true")])
             .await
@@ -169,6 +186,43 @@ mod test {
         assert!(region_latest_sequences[0].1 > 0);
 
         let previous_watermark = region_latest_sequences[0];
+
+        create_table_named(&client, "bar").await;
+        let result = client
+            .sql_with_terminal_metrics("insert into bar select ts, a, `B` from foo", &[])
+            .await
+            .unwrap();
+        let OutputData::AffectedRows(affected_rows) = result.output.data else {
+            panic!("expected affected rows output");
+        };
+        assert_eq!(affected_rows, 9);
+        assert!(result.metrics.is_ready());
+        assert!(result.region_watermark_map().is_none());
+
+        let err = client
+            .sql_with_terminal_metrics(
+                "insert into bar select ts, a, `B` from foo",
+                &[("flow.return_region_seq", "not-a-bool")],
+            )
+            .await
+            .unwrap_err();
+        let err_msg = format!("{err:?}");
+        assert!(err_msg.contains("Invalid value for flow.return_region_seq"));
+
+        client.sql("truncate table bar").await.unwrap();
+
+        let result = client
+            .sql_with_terminal_metrics(
+                "insert into bar select ts, a, `B` from foo",
+                &[("flow.return_region_seq", "true")],
+            )
+            .await
+            .unwrap();
+        let OutputData::AffectedRows(affected_rows) = result.output.data else {
+            panic!("expected affected rows output");
+        };
+        assert_eq!(affected_rows, 9);
+        assert!(result.region_watermark_map().is_some_and(|m| !m.is_empty()));
 
         let incremental_batches = create_record_batches(10);
         test_put_record_batches(&client, incremental_batches).await;
@@ -362,6 +416,10 @@ mod test {
     }
 
     async fn create_table(client: &Database) {
+        create_table_named(client, "foo").await;
+    }
+
+    async fn create_table_named(client: &Database, table_name: &str) {
         // create table foo (
         //   ts timestamp time index,
         //   a int primary key,
@@ -370,7 +428,7 @@ mod test {
         let output = client
             .create(CreateTableExpr {
                 schema_name: "public".to_string(),
-                table_name: "foo".to_string(),
+                table_name: table_name.to_string(),
                 column_defs: vec![
                     ColumnDef {
                         name: "ts".to_string(),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Summary

This PR adds a proof-of-concept for Flow incremental queries using a changed-rows-only incremental shape.

Instead of recomputing the full result from the full source input on every round, the POC aggregates only the delta window and joins it with sink state to emit only the rows that need to be updated in the sink.

## Why

The goal is to validate whether incremental queries can materially reduce Flow query cost before we invest further in end-to-end scheduling and batching work.

## Benchmark Result

The strongest result comes from a workload shaped like `src >> sink >> delta`:

- `small_delta_src_ultra_sink_mid`
  - full recompute: `707-716 ms`
  - changed-rows-only incremental (`delta-only left join update`): `124-126 ms`

This is roughly a 5.7x improvement in wall-clock latency.

## Profiling

For this workload, full recompute is dominated by scanning and aggregating the full source table, while the incremental path shifts the main cost to sink-side scan and join work.

That means the POC already demonstrates a meaningful win, and the next optimization target is clear: reduce sink-side read cost further.

## Caveats

- This is still a POC, not the final production shape.
- The gain is workload-dependent; the positive region is currently clearest when `src >> sink >> delta`.
- The current benchmark focuses on query-shape validation, not full end-to-end Flow scheduling behavior.

## Next Step

Continue optimizing the changed-rows-only incremental path, especially sink-side scan/repartition cost.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
