### PR TITLE
chore: update leader HTTP API

### DIFF
--- a/src/meta-srv/src/service/admin/leader.rs
+++ b/src/meta-srv/src/service/admin/leader.rs
@@ -39,15 +39,15 @@ pub(crate) struct LeaderInfo {
 
 impl LeaderHandler {
     async fn get_leader_info(&self) -> Result<LeaderInfo> {
-        if let Some(election) = &self.election {
-            return Ok(LeaderInfo {
-                leader_addr: Some(election.leader().await.context(error::KvBackendSnafu)?.0),
-                is_leader: election.is_leader(),
-            });
-        }
+        let (leader_addr, is_leader) = if let Some(election) = &self.election {
+            (Some(election.leader().await.context(error::KvBackendSnafu)?.0), election.is_leader())
+        } else {
+            (None, false)
+        };
+
         Ok(LeaderInfo {
-            leader_addr: None,
-            is_leader: false,
+            leader_addr,
+            is_leader,
         })
     }
 }

--- a/src/meta-srv/src/service/admin/leader.rs
+++ b/src/meta-srv/src/service/admin/leader.rs
@@ -14,8 +14,10 @@
 
 use std::collections::HashMap;
 
+use axum::Json;
 use axum::extract::State;
 use axum::response::{IntoResponse, Response};
+use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use tonic::codegen::http;
 
@@ -29,6 +31,12 @@ pub struct LeaderHandler {
     pub election: Option<ElectionRef>,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct LeaderResponse {
+    leader_addr: Option<String>,
+    is_leader: bool,
+}
+
 impl LeaderHandler {
     async fn get_leader(&self) -> Result<Option<String>> {
         if let Some(election) = &self.election {
@@ -37,16 +45,31 @@ impl LeaderHandler {
         }
         Ok(None)
     }
+
+    async fn get_leader_response(&self) -> Result<LeaderResponse> {
+        if let Some(election) = &self.election {
+            let leader_addr = election.leader().await?.0;
+            let is_leader = election.is_leader();
+            return Ok(LeaderResponse {
+                leader_addr: Some(leader_addr),
+                is_leader,
+            });
+        }
+        Ok(LeaderResponse {
+            leader_addr: None,
+            is_leader: false,
+        })
+    }
 }
 
 /// Get the leader handler.
 #[axum_macros::debug_handler]
 pub(crate) async fn get(State(handler): State<LeaderHandler>) -> Response {
     handler
-        .get_leader()
+        .get_leader_response()
         .await
+        .map(Json)
         .map_err(ErrorHandler::new)
-        .map(|leader| leader.unwrap_or("election info is None".to_string()))
         .into_response()
 }
 

--- a/src/meta-srv/src/service/admin/leader.rs
+++ b/src/meta-srv/src/service/admin/leader.rs
@@ -40,7 +40,10 @@ pub(crate) struct LeaderInfo {
 impl LeaderHandler {
     async fn get_leader_info(&self) -> Result<LeaderInfo> {
         let (leader_addr, is_leader) = if let Some(election) = &self.election {
-            (Some(election.leader().await.context(error::KvBackendSnafu)?.0), election.is_leader())
+            (
+                Some(election.leader().await.context(error::KvBackendSnafu)?.0),
+                election.is_leader(),
+            )
         } else {
             (None, false)
         };

--- a/src/meta-srv/src/service/admin/leader.rs
+++ b/src/meta-srv/src/service/admin/leader.rs
@@ -32,30 +32,20 @@ pub struct LeaderHandler {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub(crate) struct LeaderResponse {
-    leader_addr: Option<String>,
-    is_leader: bool,
+pub(crate) struct LeaderInfo {
+    pub leader_addr: Option<String>,
+    pub is_leader: bool,
 }
 
 impl LeaderHandler {
-    async fn get_leader(&self) -> Result<Option<String>> {
+    async fn get_leader_info(&self) -> Result<LeaderInfo> {
         if let Some(election) = &self.election {
-            let leader_addr = election.leader().await.context(error::KvBackendSnafu)?.0;
-            return Ok(Some(leader_addr));
-        }
-        Ok(None)
-    }
-
-    async fn get_leader_response(&self) -> Result<LeaderResponse> {
-        if let Some(election) = &self.election {
-            let leader_addr = election.leader().await?.0;
-            let is_leader = election.is_leader();
-            return Ok(LeaderResponse {
-                leader_addr: Some(leader_addr),
-                is_leader,
+            return Ok(LeaderInfo {
+                leader_addr: Some(election.leader().await.context(error::KvBackendSnafu)?.0),
+                is_leader: election.is_leader(),
             });
         }
-        Ok(LeaderResponse {
+        Ok(LeaderInfo {
             leader_addr: None,
             is_leader: false,
         })
@@ -66,7 +56,7 @@ impl LeaderHandler {
 #[axum_macros::debug_handler]
 pub(crate) async fn get(State(handler): State<LeaderHandler>) -> Response {
     handler
-        .get_leader_response()
+        .get_leader_info()
         .await
         .map(Json)
         .map_err(ErrorHandler::new)
@@ -81,7 +71,7 @@ impl HttpHandler for LeaderHandler {
         _: http::Method,
         _: &HashMap<String, String>,
     ) -> Result<http::Response<String>> {
-        if let Some(leader_addr) = self.get_leader().await? {
+        if let Some(leader_addr) = self.get_leader_info().await?.leader_addr {
             return http::Response::builder()
                 .status(http::StatusCode::OK)
                 .body(leader_addr)


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Update the response format of the `/admin/leader` HTTP API on the meta-srv.

Before:
```
❯ curl localhost:3100/admin/leader
127.0.0.1:3002
```

After:
```
❯ curl localhost:3100/admin/leader | jq
{
  "leader_addr": "127.0.0.1:3002",
  "is_leader": true
} 
```

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
