### PR TITLE
ci: remove redundant directory level when uploading artifacts to S3

### DIFF
--- a/.github/scripts/upload-artifacts-to-s3.sh
+++ b/.github/scripts/upload-artifacts-to-s3.sh
@@ -33,7 +33,7 @@ function upload_artifacts() {
   #    └── greptime-darwin-amd64-v0.2.0.tar.gz
   find "$ARTIFACTS_DIR" -type f \( -name "*.tar.gz" -o -name "*.sha256sum" \) | while IFS= read -r file; do
     filename=$(basename "$file")
-    TARGET_URL="$PROXY_URL/$RELEASE_DIRS/$VERSION/$filename"
+    TARGET_URL="$PROXY_URL/$RELEASE_DIRS/$VERSION"
 
     curl -X PUT \
       -u "$PROXY_USERNAME:$PROXY_PASSWORD" \
@@ -49,7 +49,7 @@ function update_version_info() {
     if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
       echo "Updating latest-version.txt"
       echo "$VERSION" > latest-version.txt
-      TARGET_URL="$PROXY_URL/$RELEASE_DIRS/latest-version.txt"
+      TARGET_URL="$PROXY_URL/$RELEASE_DIRS"
 
       curl -X PUT \
         -u "$PROXY_USERNAME:$PROXY_PASSWORD" \
@@ -62,7 +62,7 @@ function update_version_info() {
       echo "Updating latest-nightly-version.txt"
       echo "$VERSION" > latest-nightly-version.txt
 
-      TARGET_URL="$PROXY_URL/$RELEASE_DIRS/latest-nightly-version.txt"
+      TARGET_URL="$PROXY_URL/$RELEASE_DIRS"
       curl -X PUT \
         -u "$PROXY_USERNAME:$PROXY_PASSWORD" \
         -F "file=@latest-nightly-version.txt" \


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

https://github.com/GreptimeTeam/greptimedb/pull/7800

## What's changed and what's your intention?
Modify the directory where artifacts are stored in AWS S3.


Now directory level:
```
  # releases/greptimedb
  # ├── latest-version.txt/
  # ├    ├──latest-version.txt
  # ├── latest-nightly-version.txt/
  # ├    ├──latest-nightly-version.txt
  # ├── v0.1.0
  # │   ├── greptime-darwin-amd64-v0.1.0.sha256sum/
  # ├        ├──greptime-darwin-amd64-v0.1.0.sha256sum
  # │   └── greptime-darwin-amd64-v0.1.0.tar.gz
  # ├        ├──greptime-darwin-amd64-v0.1.0.tar.gz
```


New change to:
```
  # releases/greptimedb
  # ├── latest-version.txt
  # ├── latest-nightly-version.txt
  # ├── v0.1.0
  # │   ├── greptime-darwin-amd64-v0.1.0.sha256sum
  # │   └── greptime-darwin-amd64-v0.1.0.tar.gz
```

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
