### PR TITLE
fix(index): intersect bitmaps before early exit in predicates applier

### DIFF
--- a/src/index/src/inverted_index/search/index_apply/predicates_apply.rs
+++ b/src/index/src/inverted_index/search/index_apply/predicates_apply.rs
@@ -94,7 +94,7 @@ impl IndexApplier for PredicatesIndexApplier {
             .collect::<Vec<_>>();
 
         let mut mapper = ParallelFstValuesMapper::new(reader);
-        let mut bm_vec = mapper.map_values_vec(&value_and_meta_vec, metrics).await?;
+        let bm_vec = mapper.map_values_vec(&value_and_meta_vec, metrics).await?;
 
         let mut iter = bm_vec.into_iter();
         let mut bitmap = iter.next().unwrap(); // SAFETY: `fst_ranges` is not empty


### PR DESCRIPTION
## Summary

When merging multiple segment bitmaps in `PredicatesIndexApplier`, the loop bailed out on an empty next bitmap **without** intersecting it into the accumulator. Intersecting with an empty bitmap must clear the result; skipping that step left stale bits set.

## Change

- Always `intersect` the next bitmap into the accumulator, then check `count_ones()` for an early exit.