### PR TITLE
fix(mito2): inclusive range overlap for compaction Ranged

### DIFF
--- a/src/mito2/src/compaction/run.rs
+++ b/src/mito2/src/compaction/run.rs
@@ -39,7 +39,7 @@ pub trait Ranged {
         let (lhs_start, lhs_end) = self.range();
         let (rhs_start, rhs_end) = other.range();
 
-        lhs_start.max(rhs_start) < lhs_end.min(rhs_end)
+        lhs_start.max(rhs_start) <= lhs_end.min(rhs_end)
     }
 }
 


### PR DESCRIPTION
## Summary

`Ranged::overlap` is documented as using **inclusive** bounds. For inclusive ranges, two ranges overlap iff `max(start) <= min(end)`. The previous strict `<` treated ranges that only meet at a shared boundary as non-overlapping.

## Change

- Use `<=` in the overlap predicate in `src/mito2/src/compaction/run.rs`.