### PR TITLE
fix: fix SeriesScan verbose mode mising metrics

### DIFF
--- a/src/mito2/src/read/series_scan.rs
+++ b/src/mito2/src/read/series_scan.rs
@@ -168,7 +168,7 @@ impl SeriesScan {
             }
         );
 
-        self.maybe_start_distributor(metrics_set, &self.metrics_list);
+        self.maybe_start_distributor(metrics_set, &self.metrics_list, ctx.explain_verbose);
 
         let mut receiver = self.take_receiver(partition)?;
         let stream = try_stream! {
@@ -214,6 +214,7 @@ impl SeriesScan {
         &self,
         metrics_set: &ExecutionPlanMetricsSet,
         metrics_list: &Arc<PartitionMetricsList>,
+        explain_verbose: bool,
     ) {
         let mut rx_list = self.receivers.lock().unwrap();
         if !rx_list.is_empty() {
@@ -229,6 +230,7 @@ impl SeriesScan {
             senders,
             metrics_set: metrics_set.clone(),
             metrics_list: metrics_list.clone(),
+            explain_verbose,
         };
         let region_id = distributor.stream_ctx.input.mapper.metadata().region_id;
         let span = tracing::info_span!("SeriesScan::distributor", region_id = %region_id);
@@ -430,6 +432,8 @@ struct SeriesDistributor {
     /// distributor.
     metrics_set: ExecutionPlanMetricsSet,
     metrics_list: Arc<PartitionMetricsList>,
+    /// Whether to use verbose logging and collect detailed metrics.
+    explain_verbose: bool,
 }
 
 impl SeriesDistributor {
@@ -470,7 +474,7 @@ impl SeriesDistributor {
 
         let part_metrics = new_partition_metrics(
             &self.stream_ctx,
-            false,
+            self.explain_verbose,
             &self.metrics_set,
             self.partitions.len(),
             &self.metrics_list,
@@ -576,7 +580,7 @@ impl SeriesDistributor {
 
         let part_metrics = new_partition_metrics(
             &self.stream_ctx,
-            false,
+            self.explain_verbose,
             &self.metrics_set,
             self.partitions.len(),
             &self.metrics_list,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

SeriesScan distributor should collect metrics according to the verbose flag.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
