### PR TITLE
fix: incorrect prefilter check

### DIFF
--- a/src/mito2/src/sst/parquet/flat_format.rs
+++ b/src/mito2/src/sst/parquet/flat_format.rs
@@ -282,10 +282,10 @@ impl FlatReadFormat {
         }
     }
 
-    /// Returns `true` if raw batches from parquet use the flat layout with a
-    /// dictionary-encoded `__primary_key` column (i.e., [`ParquetAdapter::Flat`]).
+    /// Returns `true` if raw batches from parquet use the flat layout and
+    /// stores primary key columns as raw columns.
     /// Returns `false` for the legacy primary-key-to-flat conversion path.
-    pub(crate) fn raw_batch_has_primary_key_dictionary(&self) -> bool {
+    pub(crate) fn batch_has_raw_pk_columns(&self) -> bool {
         matches!(&self.parquet_adapter, ParquetAdapter::Flat(_))
     }
 

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -217,9 +217,9 @@ impl PrefilterContextBuilder {
             return None;
         }
 
-        // Only flat format with dictionary-encoded PKs supports PK prefiltering.
+        // Only perform PK prefiltering for primary-key-to-flat conversion path.
         let flat_format = read_format.as_flat()?;
-        if !flat_format.raw_batch_has_primary_key_dictionary() {
+        if flat_format.batch_has_raw_pk_columns() {
             return None;
         }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
The comment on the method is a little misleading. We should use prefilter in primary-key-to-flat path.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
