### PR TITLE
refactor!: update arrow-ipc output to stream format

### DIFF
--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -1684,8 +1684,8 @@ mod test {
 
                 HttpResponse::Arrow(resp) => {
                     let output = resp.data;
-                    let mut reader =
-                        StreamReader::try_new(Cursor::new(output), None).expect("Arrow reader error");
+                    let mut reader = StreamReader::try_new(Cursor::new(output), None)
+                        .expect("Arrow reader error");
                     let schema = reader.schema();
                     assert_eq!(schema.fields[0].name(), "numbers");
                     assert_eq!(schema.fields[0].data_type(), &DataType::UInt32);

--- a/src/servers/src/http/result/arrow_result.rs
+++ b/src/servers/src/http/result/arrow_result.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 
 use arrow::datatypes::Schema;
 use arrow_ipc::CompressionType;
-use arrow_ipc::writer::{StreamWriter, IpcWriteOptions};
+use arrow_ipc::writer::{IpcWriteOptions, StreamWriter};
 use axum::http::{HeaderValue, header};
 use axum::response::{IntoResponse, Response};
 use common_error::status_code::StatusCode;
@@ -200,8 +200,8 @@ mod test {
             match http_resp {
                 HttpResponse::Arrow(resp) => {
                     let output = resp.data;
-                    let mut reader =
-                        StreamReader::try_new(Cursor::new(output), None).expect("Arrow reader error");
+                    let mut reader = StreamReader::try_new(Cursor::new(output), None)
+                        .expect("Arrow reader error");
                     let schema = reader.schema();
                     assert_eq!(schema.fields[0].name(), "numbers");
                     assert_eq!(schema.fields[0].data_type(), &DataType::UInt32);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This is a breaking change about our http arrow output format. There are two types of arrow-ipc format, `file` and `stream`. 

I've read the `stream` mode is better for network transport: https://arrow.apache.org/docs/python/ipc.html#writing-and-reading-streams

This is a break change but I assume it's a minor change for a minor interface, it should be ok to include in 1.0 release.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
