### PR TITLE
fix: remove redundant error messages in admin functions

### DIFF
--- a/src/common/function/src/admin/flush_compact_region.rs
+++ b/src/common/function/src/admin/flush_compact_region.rs
@@ -128,7 +128,7 @@ mod tests {
                     };
                     let result = f.invoke_async_with_args(func_args).await.unwrap_err();
                     assert_eq!(
-                        "Execution error: Handler error: Missing TableMutationHandler, not expected",
+                        "Execution error: Missing TableMutationHandler, not expected",
                         result.to_string()
                     );
                 }

--- a/src/common/function/src/admin/flush_compact_table.rs
+++ b/src/common/function/src/admin/flush_compact_table.rs
@@ -355,7 +355,7 @@ mod tests {
                     };
                     let result = f.invoke_async_with_args(func_args).await.unwrap_err();
                     assert_eq!(
-                        "Execution error: Handler error: Missing TableMutationHandler, not expected",
+                        "Execution error: Missing TableMutationHandler, not expected",
                         result.to_string()
                     );
                 }

--- a/src/common/function/src/admin/migrate_region.rs
+++ b/src/common/function/src/admin/migrate_region.rs
@@ -173,7 +173,7 @@ mod tests {
         };
         let result = f.invoke_async_with_args(func_args).await.unwrap_err();
         assert_eq!(
-            "Execution error: Handler error: Missing ProcedureServiceHandler, not expected",
+            "Execution error: Missing ProcedureServiceHandler, not expected",
             result.to_string()
         );
     }

--- a/src/common/function/src/flush_flow.rs
+++ b/src/common/function/src/flush_flow.rs
@@ -149,7 +149,7 @@ mod test {
 
         let result = f.invoke_async_with_args(func_args).await.unwrap_err();
         assert_eq!(
-            "Execution error: Handler error: Missing FlowServiceHandler, not expected",
+            "Execution error: Missing FlowServiceHandler, not expected",
             result.to_string()
         );
     }

--- a/src/common/macro/src/admin_fn.rs
+++ b/src/common/macro/src/admin_fn.rs
@@ -316,14 +316,14 @@ fn build_struct(
                     .#handler
                     .as_ref()
                     .context(#snafu_type)
-                    .map_err(|e| datafusion_common::DataFusionError::Execution(format!("Handler error: {}", e.output_msg())))?;
+                    .map_err(|e| datafusion_common::DataFusionError::Execution(e.output_msg()))?;
 
                 let mut builder = store_api::storage::ConcreteDataType::#ret()
                     .create_mutable_vector(rows_num);
 
                 if columns_num == 0 {
                     let result = #fn_name(handler, query_ctx, &[]).await
-                        .map_err(|e| datafusion_common::DataFusionError::Execution(format!("Function execution error: {}", e.output_msg())))?;
+                        .map_err(|e| datafusion_common::DataFusionError::Execution(e.output_msg()))?;
 
                     builder.push_value_ref(&result.as_value_ref());
                 } else {
@@ -333,7 +333,7 @@ fn build_struct(
                             .collect();
 
                         let result = #fn_name(handler, query_ctx, &args).await
-                            .map_err(|e| datafusion_common::DataFusionError::Execution(format!("Function execution error: {}", e.output_msg())))?;
+                            .map_err(|e| datafusion_common::DataFusionError::Execution(e.output_msg()))?;
 
                         builder.push_value_ref(&result.as_value_ref());
                     }

--- a/src/operator/src/error.rs
+++ b/src/operator/src/error.rs
@@ -55,7 +55,7 @@ pub enum Error {
     #[snafu(display("Failed to build admin function args: {msg}"))]
     BuildAdminFunctionArgs { msg: String },
 
-    #[snafu(display("Failed to execute admin function: {msg}, error: {error}"))]
+    #[snafu(display("Failed to execute admin function {msg}"))]
     ExecuteAdminFunction {
         msg: String,
         #[snafu(source)]

--- a/src/operator/src/statement/admin.rs
+++ b/src/operator/src/statement/admin.rs
@@ -133,7 +133,7 @@ impl StatementExecutor {
             .invoke_async_with_args(func_args)
             .await
             .with_context(|_| ExecuteAdminFunctionSnafu {
-                msg: format!("Failed to execute admin function {}", fn_name),
+                msg: fn_name.to_string(),
             })?;
 
         // Convert result back to VectorRef

--- a/tests/cases/standalone/common/flow/flow_last_non_null.result
+++ b/tests/cases/standalone/common/flow/flow_last_non_null.result
@@ -185,7 +185,7 @@ Affected Rows: 2
 -- should return error
 ADMIN FLUSH_FLOW('find_approx_rate');
 
-Error: 1002(Unexpected), Failed to execute admin function: Failed to execute admin function flush_flow, error: Execution error: Function execution error: Internal error: 1003: Execution error: Function execution error: Internal error: 1003
+Error: 1002(Unexpected), Failed to execute admin function flush_flow: Execution error: Internal error: 1003
 
 DROP FLOW find_approx_rate;
 


### PR DESCRIPTION
Closes #7938

I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/7938

## What's changed and what's your intention?
The redundancy comes from three layers in the error wrapping chain
The error was wrapped three times with redundant context:
  - ExecuteAdminFunction display included {error} which output_msg() would append
   again → removed {error} from display
  - msg repeated "Failed to execute admin function" already in the display prefix
   → changed to just the function name
  - #[admin_fn] macro added unnecessary "Function execution error:" / "Handler
  error:" prefixes → pass output_msg() directly
  
Now：
<img width="778" height="128" alt="image" src="https://github.com/user-attachments/assets/5eaa3a76-f5ff-41e3-85e2-9d1917f65c8a" />


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
