### PR TITLE
feat: support nested projection in mito2 read path

### DIFF
--- a/src/common/recordbatch/src/error.rs
+++ b/src/common/recordbatch/src/error.rs
@@ -81,6 +81,14 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display("Failed to cast column"))]
+    CastColumn {
+        #[snafu(source)]
+        error: datafusion::error::DataFusionError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Fail to format record batch"))]
     Format {
         #[snafu(source)]
@@ -210,6 +218,7 @@ impl ErrorExt for Error {
             | Error::ToArrowScalar { .. }
             | Error::ProjectArrowRecordBatch { .. }
             | Error::PhysicalExpr { .. }
+            | Error::CastColumn { .. }
             | Error::RecordBatchSliceIndexOverflow { .. }
             | Error::AlignJsonArray { .. } => StatusCode::Internal,
 

--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -57,6 +57,7 @@ use crate::read::Batch;
 use crate::read::range_cache::{RangeScanCacheKey, RangeScanCacheValue};
 use crate::sst::file::{RegionFileId, RegionIndexId};
 use crate::sst::parquet::PARQUET_METADATA_KEY;
+use crate::sst::parquet::read_columns::ParquetReadColumns;
 use crate::sst::parquet::reader::MetadataCacheMetrics;
 
 /// Metrics type key for sst meta.
@@ -1223,24 +1224,27 @@ pub enum SelectorResult {
 pub struct SelectorResultValue {
     /// Batches of rows selected by the selector.
     pub result: SelectorResult,
-    /// Projection of rows.
-    pub projection: Vec<usize>,
+    /// The read columns of rows.
+    pub read_cols: ParquetReadColumns,
 }
 
 impl SelectorResultValue {
     /// Creates a new selector result value with primary key format.
-    pub fn new(result: Vec<Batch>, projection: Vec<usize>) -> SelectorResultValue {
+    pub fn new(result: Vec<Batch>, read_cols: ParquetReadColumns) -> SelectorResultValue {
         SelectorResultValue {
             result: SelectorResult::PrimaryKey(result),
-            projection,
+            read_cols,
         }
     }
 
     /// Creates a new selector result value with flat format.
-    pub fn new_flat(result: Vec<RecordBatch>, projection: Vec<usize>) -> SelectorResultValue {
+    pub fn new_flat(
+        result: Vec<RecordBatch>,
+        read_cols: ParquetReadColumns,
+    ) -> SelectorResultValue {
         SelectorResultValue {
             result: SelectorResult::Flat(result),
-            projection,
+            read_cols,
         }
     }
 
@@ -1442,7 +1446,10 @@ mod tests {
             selector: TimeSeriesRowSelector::LastRow,
         };
         assert!(cache.get_selector_result(&key).is_none());
-        let result = Arc::new(SelectorResultValue::new(Vec::new(), Vec::new()));
+        let result = Arc::new(SelectorResultValue::new(
+            Vec::new(),
+            ParquetReadColumns::from_deduped(Vec::new()),
+        ));
         cache.put_selector_result(key, result);
         assert!(cache.get_selector_result(&key).is_some());
     }
@@ -1459,7 +1466,7 @@ mod tests {
             region_id: RegionId::new(1, 1),
             row_groups: vec![(FileId::random(), 0)],
             scan: ScanRequestFingerprintBuilder {
-                read_column_ids: vec![],
+                read_columns: vec![].into(),
                 read_column_types: vec![],
                 filters: vec!["tag_0 = 1".to_string()],
                 time_filters: vec![],

--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -1293,6 +1293,7 @@ mod tests {
     use crate::read::range_cache::{
         RangeScanCacheKey, RangeScanCacheValue, ScanRequestFingerprintBuilder,
     };
+    use crate::read::read_columns::ReadColumns;
     use crate::sst::parquet::row_selection::RowGroupSelection;
 
     #[tokio::test]
@@ -1466,7 +1467,7 @@ mod tests {
             region_id: RegionId::new(1, 1),
             row_groups: vec![(FileId::random(), 0)],
             scan: ScanRequestFingerprintBuilder {
-                read_columns: vec![].into(),
+                read_columns: ReadColumns::from_deduped_column_ids(std::iter::empty()),
                 read_column_types: vec![],
                 filters: vec!["tag_0 = 1".to_string()],
                 time_filters: vec![],

--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -1250,7 +1250,6 @@ mod tests {
     use crate::read::range_cache::{
         RangeScanCacheKey, RangeScanCacheValue, ScanRequestFingerprintBuilder,
     };
-    use crate::read::read_columns::ReadColumns;
     use crate::sst::parquet::row_selection::RowGroupSelection;
 
     #[tokio::test]
@@ -1406,7 +1405,7 @@ mod tests {
         assert!(cache.get_selector_result(&key).is_none());
         let result = Arc::new(SelectorResultValue::new(
             Vec::new(),
-            ParquetReadColumns::new(Vec::new()),
+            ParquetReadColumns::from_deduped(Vec::new()),
         ));
         cache.put_selector_result(key, result);
         assert!(cache.get_selector_result(&key).is_some());
@@ -1424,7 +1423,7 @@ mod tests {
             region_id: RegionId::new(1, 1),
             row_groups: vec![(FileId::random(), 0)],
             scan: ScanRequestFingerprintBuilder {
-                read_columns: ReadColumns::from_column_ids(std::iter::empty()),
+                read_columns: vec![].into(),
                 read_column_types: vec![],
                 filters: vec!["tag_0 = 1".to_string()],
                 time_filters: vec![],

--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -57,6 +57,7 @@ use crate::read::Batch;
 use crate::read::range_cache::{RangeScanCacheKey, RangeScanCacheValue};
 use crate::sst::file::{RegionFileId, RegionIndexId};
 use crate::sst::parquet::PARQUET_METADATA_KEY;
+use crate::sst::parquet::read_columns::ParquetReadColumns;
 use crate::sst::parquet::reader::MetadataCacheMetrics;
 
 /// Metrics type key for sst meta.
@@ -1180,24 +1181,27 @@ pub enum SelectorResult {
 pub struct SelectorResultValue {
     /// Batches of rows selected by the selector.
     pub result: SelectorResult,
-    /// Projection of rows.
-    pub projection: Vec<usize>,
+    /// The read columns of rows.
+    pub read_cols: ParquetReadColumns,
 }
 
 impl SelectorResultValue {
     /// Creates a new selector result value with primary key format.
-    pub fn new(result: Vec<Batch>, projection: Vec<usize>) -> SelectorResultValue {
+    pub fn new(result: Vec<Batch>, read_cols: ParquetReadColumns) -> SelectorResultValue {
         SelectorResultValue {
             result: SelectorResult::PrimaryKey(result),
-            projection,
+            read_cols,
         }
     }
 
     /// Creates a new selector result value with flat format.
-    pub fn new_flat(result: Vec<RecordBatch>, projection: Vec<usize>) -> SelectorResultValue {
+    pub fn new_flat(
+        result: Vec<RecordBatch>,
+        read_cols: ParquetReadColumns,
+    ) -> SelectorResultValue {
         SelectorResultValue {
             result: SelectorResult::Flat(result),
-            projection,
+            read_cols,
         }
     }
 
@@ -1246,6 +1250,7 @@ mod tests {
     use crate::read::range_cache::{
         RangeScanCacheKey, RangeScanCacheValue, ScanRequestFingerprintBuilder,
     };
+    use crate::read::read_columns::ReadColumns;
     use crate::sst::parquet::row_selection::RowGroupSelection;
 
     #[tokio::test]
@@ -1399,7 +1404,10 @@ mod tests {
             selector: TimeSeriesRowSelector::LastRow,
         };
         assert!(cache.get_selector_result(&key).is_none());
-        let result = Arc::new(SelectorResultValue::new(Vec::new(), Vec::new()));
+        let result = Arc::new(SelectorResultValue::new(
+            Vec::new(),
+            ParquetReadColumns::new(Vec::new()),
+        ));
         cache.put_selector_result(key, result);
         assert!(cache.get_selector_result(&key).is_some());
     }
@@ -1416,7 +1424,7 @@ mod tests {
             region_id: RegionId::new(1, 1),
             row_groups: vec![(FileId::random(), 0)],
             scan: ScanRequestFingerprintBuilder {
-                read_column_ids: vec![],
+                read_columns: ReadColumns::from_column_ids(std::iter::empty()),
                 read_column_types: vec![],
                 filters: vec!["tag_0 = 1".to_string()],
                 time_filters: vec![],

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -1240,6 +1240,14 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+
+    #[snafu(display("Failed to cast column"))]
+    CastColumn {
+        #[snafu(source)]
+        error: datafusion::error::DataFusionError,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -1329,6 +1337,7 @@ impl ErrorExt for Error {
             | ReadDataPart { .. }
             | BuildEntry { .. }
             | Metadata { .. }
+            | CastColumn { .. }
             | MitoManifestInfo { .. } => StatusCode::Internal,
 
             FetchManifests { source, .. } => source.status_code(),

--- a/src/mito2/src/memtable/bulk/context.rs
+++ b/src/mito2/src/memtable/bulk/context.rs
@@ -77,7 +77,7 @@ impl BulkIterContext {
         };
         let read_format = FlatReadFormat::new(
             region_metadata.clone(),
-            &read_cols,
+            read_cols,
             None,
             "memtable",
             skip_auto_convert,

--- a/src/mito2/src/memtable/bulk/context.rs
+++ b/src/mito2/src/memtable/bulk/context.rs
@@ -25,6 +25,7 @@ use store_api::storage::ColumnId;
 use table::predicate::Predicate;
 
 use crate::error::Result;
+use crate::read::read_columns::ReadColumns;
 use crate::sst::parquet::file_range::{PreFilterMode, RangeBase};
 use crate::sst::parquet::flat_format::FlatReadFormat;
 use crate::sst::parquet::prefilter::{CachedPrimaryKeyFilter, build_bulk_filter_plan};
@@ -65,26 +66,22 @@ impl BulkIterContext {
     ) -> Result<Self> {
         let codec = build_primary_key_codec(&region_metadata);
 
-        let read_format = if let Some(column_ids) = projection {
-            FlatReadFormat::new(
-                region_metadata.clone(),
-                column_ids.iter().copied(),
-                None,
-                "memtable",
-                skip_auto_convert,
-            )?
+        let read_cols: ReadColumns = if let Some(col_ids) = projection {
+            col_ids.iter().copied().into()
         } else {
-            FlatReadFormat::new(
-                region_metadata.clone(),
-                region_metadata
-                    .column_metadatas
-                    .iter()
-                    .map(|col| col.column_id),
-                None,
-                "memtable",
-                skip_auto_convert,
-            )?
+            region_metadata
+                .column_metadatas
+                .iter()
+                .map(|col| col.column_id)
+                .into()
         };
+        let read_format = FlatReadFormat::new(
+            region_metadata.clone(),
+            &read_cols,
+            None,
+            "memtable",
+            skip_auto_convert,
+        )?;
 
         let dyn_filters = predicate
             .as_ref()

--- a/src/mito2/src/memtable/bulk/context.rs
+++ b/src/mito2/src/memtable/bulk/context.rs
@@ -66,14 +66,15 @@ impl BulkIterContext {
     ) -> Result<Self> {
         let codec = build_primary_key_codec(&region_metadata);
 
-        let read_cols: ReadColumns = if let Some(col_ids) = projection {
-            col_ids.iter().copied().into()
+        let read_cols = if let Some(col_ids) = projection {
+            ReadColumns::from_deduped_column_ids(col_ids.iter().copied())
         } else {
-            region_metadata
-                .column_metadatas
-                .iter()
-                .map(|col| col.column_id)
-                .into()
+            ReadColumns::from_deduped_column_ids(
+                region_metadata
+                    .column_metadatas
+                    .iter()
+                    .map(|col| col.column_id),
+            )
         };
         let read_format = FlatReadFormat::new(
             region_metadata.clone(),

--- a/src/mito2/src/memtable/bulk/context.rs
+++ b/src/mito2/src/memtable/bulk/context.rs
@@ -25,6 +25,7 @@ use store_api::storage::ColumnId;
 use table::predicate::Predicate;
 
 use crate::error::Result;
+use crate::read::read_columns::ReadColumns;
 use crate::sst::parquet::file_range::{PreFilterMode, RangeBase};
 use crate::sst::parquet::format::ReadFormat;
 use crate::sst::parquet::prefilter::CachedPrimaryKeyFilter;
@@ -79,7 +80,7 @@ impl BulkIterContext {
 
         let read_format = ReadFormat::new(
             region_metadata.clone(),
-            projection,
+            projection.map(|cols| ReadColumns::from_column_ids(cols.iter().copied())),
             true,
             None,
             "memtable",

--- a/src/mito2/src/memtable/bulk/context.rs
+++ b/src/mito2/src/memtable/bulk/context.rs
@@ -78,9 +78,10 @@ impl BulkIterContext {
             })
             .collect();
 
+        let projection = projection.map(|cols| ReadColumns::from_column_ids(cols.iter().copied()));
         let read_format = ReadFormat::new(
             region_metadata.clone(),
-            projection.map(|cols| ReadColumns::from_column_ids(cols.iter().copied())),
+            projection.as_ref(),
             true,
             None,
             "memtable",

--- a/src/mito2/src/memtable/bulk/part_reader.rs
+++ b/src/mito2/src/memtable/bulk/part_reader.rs
@@ -64,7 +64,7 @@ impl EncodedBulkPartIter {
         let data = encoded_part.data().clone();
         let series_count = encoded_part.metadata().num_series as usize;
 
-        // TODO(fys): Support applying nested paths when computing the projection mask.
+        // TODO(fys): Nested projection pushdown to the memtable layer is not supported yet.
         let root_indices = context
             .read_format()
             .parquet_read_columns()

--- a/src/mito2/src/memtable/bulk/part_reader.rs
+++ b/src/mito2/src/memtable/bulk/part_reader.rs
@@ -64,10 +64,13 @@ impl EncodedBulkPartIter {
         let data = encoded_part.data().clone();
         let series_count = encoded_part.metadata().num_series as usize;
 
-        let projection_mask = ProjectionMask::roots(
-            parquet_meta.file_metadata().schema_descr(),
-            context.read_format().projection_indices().iter().copied(),
-        );
+        // TODO(fys): Support applying nested paths when computing the projection mask.
+        let root_indices = context
+            .read_format()
+            .parquet_read_columns()
+            .root_indices_iter();
+        let projection_mask =
+            ProjectionMask::roots(parquet_meta.file_metadata().schema_descr(), root_indices);
         let builder =
             MemtableRowGroupReaderBuilder::try_new(&context, projection_mask, parquet_meta, data)?;
 
@@ -276,7 +279,11 @@ impl BulkPartBatchIter {
 
     /// Applies projection to the RecordBatch if needed.
     fn apply_projection(&self, record_batch: RecordBatch) -> error::Result<RecordBatch> {
-        let projection_indices = self.context.read_format().projection_indices();
+        let projection_indices = self
+            .context
+            .read_format()
+            .parquet_read_columns()
+            .root_indices();
         if projection_indices.len() == record_batch.num_columns() {
             return Ok(record_batch);
         }

--- a/src/mito2/src/memtable/bulk/part_reader.rs
+++ b/src/mito2/src/memtable/bulk/part_reader.rs
@@ -68,7 +68,7 @@ impl EncodedBulkPartIter {
 
         let projection_mask = ProjectionMask::roots(
             parquet_meta.file_metadata().schema_descr(),
-            context.read_format().projection_indices().iter().copied(),
+            context.read_format().projection_indices_iter(),
         );
         let builder =
             MemtableRowGroupReaderBuilder::try_new(&context, projection_mask, parquet_meta, data)?;
@@ -280,13 +280,17 @@ impl BulkPartBatchIter {
 
     /// Applies projection to the RecordBatch if needed.
     fn apply_projection(&self, record_batch: RecordBatch) -> error::Result<RecordBatch> {
-        let projection_indices = self.context.read_format().projection_indices();
+        let projection_indices: Vec<_> = self
+            .context
+            .read_format()
+            .projection_indices_iter()
+            .collect();
         if projection_indices.len() == record_batch.num_columns() {
             return Ok(record_batch);
         }
 
         record_batch
-            .project(projection_indices)
+            .project(&projection_indices)
             .context(ComputeArrowSnafu)
     }
 

--- a/src/mito2/src/read.rs
+++ b/src/mito2/src/read.rs
@@ -29,6 +29,7 @@ pub mod range;
 pub mod range_cache;
 #[cfg(not(feature = "test"))]
 pub(crate) mod range_cache;
+pub mod read_columns;
 pub mod scan_region;
 pub mod scan_util;
 pub(crate) mod seq_scan;

--- a/src/mito2/src/read/batch_adapter.rs
+++ b/src/mito2/src/read/batch_adapter.rs
@@ -681,7 +681,7 @@ mod tests {
             BatchToRecordBatchAdapter::new(iter, metadata.clone(), codec, &read_column_ids);
         let rb = adapter.into_iter().next().unwrap().unwrap();
 
-        let mapper = FlatProjectionMapper::new(&metadata, [0, 3].into_iter()).unwrap();
+        let mapper = FlatProjectionMapper::new(&metadata, [0, 3]).unwrap();
         assert_eq!(rb.schema(), mapper.input_arrow_schema(false));
         // tag_0 + field_1 + ts + 3 internal columns.
         assert_eq!(6, rb.num_columns());

--- a/src/mito2/src/read/compat.rs
+++ b/src/mito2/src/read/compat.rs
@@ -602,6 +602,7 @@ mod tests {
 
     use super::*;
     use crate::read::flat_projection::FlatProjectionMapper;
+    use crate::read::read_columns::ReadColumns;
     use crate::sst::parquet::flat_format::FlatReadFormat;
     use crate::sst::{FlatSchemaOptions, to_flat_sst_arrow_schema};
 
@@ -704,14 +705,9 @@ mod tests {
         ));
 
         let mapper = FlatProjectionMapper::all(&expected_metadata).unwrap();
-        let read_format = FlatReadFormat::new(
-            actual_metadata.clone(),
-            [0, 1, 2, 3].into_iter(),
-            None,
-            "test",
-            false,
-        )
-        .unwrap();
+        let read_cols = ReadColumns::from_deduped_column_ids([0, 1, 2, 3]);
+        let read_format =
+            FlatReadFormat::new(actual_metadata.clone(), &read_cols, None, "test", false).unwrap();
         let format_projection = read_format.format_projection();
 
         let compat_batch =
@@ -792,21 +788,15 @@ mod tests {
             &[1],
         ));
 
-        // Output projection: tag_1, field_2. Read also includes field_3.
         let mapper = FlatProjectionMapper::new_with_read_columns(
             &expected_metadata,
             vec![1, 2],
             vec![1, 2, 3],
         )
         .unwrap();
-        let read_format = FlatReadFormat::new(
-            actual_metadata.clone(),
-            [1, 2, 3].into_iter(),
-            None,
-            "test",
-            false,
-        )
-        .unwrap();
+        let read_cols = ReadColumns::from_deduped_column_ids([1, 2, 3]);
+        let read_format =
+            FlatReadFormat::new(actual_metadata.clone(), &read_cols, None, "test", false).unwrap();
         let format_projection = read_format.format_projection();
 
         let compat_batch =
@@ -890,14 +880,9 @@ mod tests {
         let expected_metadata = Arc::new(expected_metadata);
 
         let mapper = FlatProjectionMapper::all(&expected_metadata).unwrap();
-        let read_format = FlatReadFormat::new(
-            actual_metadata.clone(),
-            [0, 1, 2, 3].into_iter(),
-            None,
-            "test",
-            false,
-        )
-        .unwrap();
+        let read_cols = ReadColumns::from_deduped_column_ids([0, 1, 2, 3]);
+        let read_format =
+            FlatReadFormat::new(actual_metadata.clone(), &read_cols, None, "test", false).unwrap();
         let format_projection = read_format.format_projection();
 
         let compat_batch =
@@ -984,14 +969,9 @@ mod tests {
         let expected_metadata = Arc::new(expected_metadata);
 
         let mapper = FlatProjectionMapper::all(&expected_metadata).unwrap();
-        let read_format = FlatReadFormat::new(
-            actual_metadata.clone(),
-            [0, 2, 3].into_iter(),
-            None,
-            "test",
-            true,
-        )
-        .unwrap();
+        let read_cols = ReadColumns::from_deduped_column_ids([0, 2, 3]);
+        let read_format =
+            FlatReadFormat::new(actual_metadata.clone(), &read_cols, None, "test", true).unwrap();
         let format_projection = read_format.format_projection();
 
         let compat_batch =

--- a/src/mito2/src/read/compat.rs
+++ b/src/mito2/src/read/compat.rs
@@ -602,7 +602,6 @@ mod tests {
 
     use super::*;
     use crate::read::flat_projection::FlatProjectionMapper;
-    use crate::read::read_columns::ReadColumns;
     use crate::sst::parquet::flat_format::FlatReadFormat;
     use crate::sst::{FlatSchemaOptions, to_flat_sst_arrow_schema};
 
@@ -705,9 +704,9 @@ mod tests {
         ));
 
         let mapper = FlatProjectionMapper::all(&expected_metadata).unwrap();
-        let read_cols = ReadColumns::from_deduped_column_ids([0, 1, 2, 3]);
         let read_format =
-            FlatReadFormat::new(actual_metadata.clone(), &read_cols, None, "test", false).unwrap();
+            FlatReadFormat::new(actual_metadata.clone(), [0, 1, 2, 3], None, "test", false)
+                .unwrap();
         let format_projection = read_format.format_projection();
 
         let compat_batch =
@@ -794,9 +793,8 @@ mod tests {
             vec![1, 2, 3],
         )
         .unwrap();
-        let read_cols = ReadColumns::from_deduped_column_ids([1, 2, 3]);
         let read_format =
-            FlatReadFormat::new(actual_metadata.clone(), &read_cols, None, "test", false).unwrap();
+            FlatReadFormat::new(actual_metadata.clone(), [1, 2, 3], None, "test", false).unwrap();
         let format_projection = read_format.format_projection();
 
         let compat_batch =
@@ -880,9 +878,9 @@ mod tests {
         let expected_metadata = Arc::new(expected_metadata);
 
         let mapper = FlatProjectionMapper::all(&expected_metadata).unwrap();
-        let read_cols = ReadColumns::from_deduped_column_ids([0, 1, 2, 3]);
         let read_format =
-            FlatReadFormat::new(actual_metadata.clone(), &read_cols, None, "test", false).unwrap();
+            FlatReadFormat::new(actual_metadata.clone(), [0, 1, 2, 3], None, "test", false)
+                .unwrap();
         let format_projection = read_format.format_projection();
 
         let compat_batch =
@@ -969,9 +967,8 @@ mod tests {
         let expected_metadata = Arc::new(expected_metadata);
 
         let mapper = FlatProjectionMapper::all(&expected_metadata).unwrap();
-        let read_cols = ReadColumns::from_deduped_column_ids([0, 2, 3]);
         let read_format =
-            FlatReadFormat::new(actual_metadata.clone(), &read_cols, None, "test", true).unwrap();
+            FlatReadFormat::new(actual_metadata.clone(), [0, 2, 3], None, "test", true).unwrap();
         let format_projection = read_format.format_projection();
 
         let compat_batch =

--- a/src/mito2/src/read/compat.rs
+++ b/src/mito2/src/read/compat.rs
@@ -602,6 +602,7 @@ mod tests {
 
     use super::*;
     use crate::read::flat_projection::FlatProjectionMapper;
+    use crate::read::read_columns::ReadColumns;
     use crate::sst::parquet::flat_format::FlatReadFormat;
     use crate::sst::{FlatSchemaOptions, to_flat_sst_arrow_schema};
 
@@ -704,9 +705,14 @@ mod tests {
         ));
 
         let mapper = FlatProjectionMapper::all(&expected_metadata).unwrap();
-        let read_format =
-            FlatReadFormat::new(actual_metadata.clone(), [0, 1, 2, 3], None, "test", false)
-                .unwrap();
+        let read_format = FlatReadFormat::new(
+            actual_metadata.clone(),
+            ReadColumns::from_deduped_column_ids([0, 1, 2, 3]),
+            None,
+            "test",
+            false,
+        )
+        .unwrap();
         let format_projection = read_format.format_projection();
 
         let compat_batch =
@@ -790,11 +796,17 @@ mod tests {
         let mapper = FlatProjectionMapper::new_with_read_columns(
             &expected_metadata,
             vec![1, 2],
-            vec![1, 2, 3],
+            ReadColumns::from_deduped_column_ids([1, 2, 3]),
         )
         .unwrap();
-        let read_format =
-            FlatReadFormat::new(actual_metadata.clone(), [1, 2, 3], None, "test", false).unwrap();
+        let read_format = FlatReadFormat::new(
+            actual_metadata.clone(),
+            ReadColumns::from_deduped_column_ids([1, 2, 3]),
+            None,
+            "test",
+            false,
+        )
+        .unwrap();
         let format_projection = read_format.format_projection();
 
         let compat_batch =
@@ -878,9 +890,14 @@ mod tests {
         let expected_metadata = Arc::new(expected_metadata);
 
         let mapper = FlatProjectionMapper::all(&expected_metadata).unwrap();
-        let read_format =
-            FlatReadFormat::new(actual_metadata.clone(), [0, 1, 2, 3], None, "test", false)
-                .unwrap();
+        let read_format = FlatReadFormat::new(
+            actual_metadata.clone(),
+            ReadColumns::from_deduped_column_ids([0, 1, 2, 3]),
+            None,
+            "test",
+            false,
+        )
+        .unwrap();
         let format_projection = read_format.format_projection();
 
         let compat_batch =
@@ -967,8 +984,14 @@ mod tests {
         let expected_metadata = Arc::new(expected_metadata);
 
         let mapper = FlatProjectionMapper::all(&expected_metadata).unwrap();
-        let read_format =
-            FlatReadFormat::new(actual_metadata.clone(), [0, 2, 3], None, "test", true).unwrap();
+        let read_format = FlatReadFormat::new(
+            actual_metadata.clone(),
+            ReadColumns::from_deduped_column_ids([0, 2, 3]),
+            None,
+            "test",
+            true,
+        )
+        .unwrap();
         let format_projection = read_format.format_projection();
 
         let compat_batch =

--- a/src/mito2/src/read/compat.rs
+++ b/src/mito2/src/read/compat.rs
@@ -1217,7 +1217,7 @@ mod tests {
         let mapper = FlatProjectionMapper::all(&expected_metadata).unwrap();
         let read_cols = ReadColumns::from_column_ids([0, 1, 2, 3]);
         let read_format =
-            FlatReadFormat::new(actual_metadata.clone(), read_cols, None, "test", false).unwrap();
+            FlatReadFormat::new(actual_metadata.clone(), &read_cols, None, "test", false).unwrap();
         let format_projection = read_format.format_projection();
 
         let compat_batch =
@@ -1306,7 +1306,7 @@ mod tests {
         .unwrap();
         let read_cols = ReadColumns::from_column_ids([1, 2, 3]);
         let read_format =
-            FlatReadFormat::new(actual_metadata.clone(), read_cols, None, "test", false).unwrap();
+            FlatReadFormat::new(actual_metadata.clone(), &read_cols, None, "test", false).unwrap();
         let format_projection = read_format.format_projection();
 
         let compat_batch =
@@ -1392,7 +1392,7 @@ mod tests {
         let mapper = FlatProjectionMapper::all(&expected_metadata).unwrap();
         let read_cols = ReadColumns::from_column_ids([0, 1, 2, 3]);
         let read_format =
-            FlatReadFormat::new(actual_metadata.clone(), read_cols, None, "test", false).unwrap();
+            FlatReadFormat::new(actual_metadata.clone(), &read_cols, None, "test", false).unwrap();
         let format_projection = read_format.format_projection();
 
         let compat_batch =
@@ -1481,7 +1481,7 @@ mod tests {
         let mapper = FlatProjectionMapper::all(&expected_metadata).unwrap();
         let read_cols = ReadColumns::from_column_ids([0, 2, 3]);
         let read_format =
-            FlatReadFormat::new(actual_metadata.clone(), read_cols, None, "test", true).unwrap();
+            FlatReadFormat::new(actual_metadata.clone(), &read_cols, None, "test", true).unwrap();
         let format_projection = read_format.format_projection();
 
         let compat_batch =

--- a/src/mito2/src/read/compat.rs
+++ b/src/mito2/src/read/compat.rs
@@ -986,11 +986,11 @@ mod tests {
     };
     use store_api::codec::PrimaryKeyEncoding;
     use store_api::metadata::{ColumnMetadata, RegionMetadataBuilder};
-    use store_api::storage::{ProjectionInput, RegionId};
+    use store_api::storage::RegionId;
 
     use super::*;
     use crate::read::flat_projection::FlatProjectionMapper;
-    use crate::read::read_columns::{ReadColumns, read_columns_from_projection};
+    use crate::read::read_columns::ReadColumns;
     use crate::sst::parquet::flat_format::FlatReadFormat;
     use crate::sst::{FlatSchemaOptions, to_flat_sst_arrow_schema};
 
@@ -1298,12 +1298,9 @@ mod tests {
             &[1],
         ));
 
-        let projection_input = ProjectionInput::new(vec![1, 2]);
-        let output_cols =
-            read_columns_from_projection(&projection_input, &expected_metadata).unwrap();
         let mapper = FlatProjectionMapper::new_with_read_columns(
             &expected_metadata,
-            output_cols,
+            vec![1, 2],
             vec![1, 2, 3],
         )
         .unwrap();

--- a/src/mito2/src/read/compat.rs
+++ b/src/mito2/src/read/compat.rs
@@ -606,7 +606,7 @@ fn may_compat_fields(
     actual: &RegionMetadata,
 ) -> Result<Option<CompatFields>> {
     let expect_fields = mapper.batch_fields();
-    let actual_fields = Batch::projected_fields(actual, mapper.column_ids());
+    let actual_fields = Batch::projected_fields(actual, &mapper.read_columns().column_ids());
     if expect_fields == actual_fields {
         return Ok(None);
     }
@@ -986,10 +986,11 @@ mod tests {
     };
     use store_api::codec::PrimaryKeyEncoding;
     use store_api::metadata::{ColumnMetadata, RegionMetadataBuilder};
-    use store_api::storage::RegionId;
+    use store_api::storage::{ProjectionInput, RegionId};
 
     use super::*;
     use crate::read::flat_projection::FlatProjectionMapper;
+    use crate::read::read_columns::{ReadColumns, read_columns_from_projection};
     use crate::sst::parquet::flat_format::FlatReadFormat;
     use crate::sst::{FlatSchemaOptions, to_flat_sst_arrow_schema};
 
@@ -1214,14 +1215,9 @@ mod tests {
         ));
 
         let mapper = FlatProjectionMapper::all(&expected_metadata).unwrap();
-        let read_format = FlatReadFormat::new(
-            actual_metadata.clone(),
-            [0, 1, 2, 3].into_iter(),
-            None,
-            "test",
-            false,
-        )
-        .unwrap();
+        let read_cols = ReadColumns::from_column_ids([0, 1, 2, 3]);
+        let read_format =
+            FlatReadFormat::new(actual_metadata.clone(), read_cols, None, "test", false).unwrap();
         let format_projection = read_format.format_projection();
 
         let compat_batch =
@@ -1302,21 +1298,18 @@ mod tests {
             &[1],
         ));
 
-        // Output projection: tag_1, field_2. Read also includes field_3.
+        let projection_input = ProjectionInput::new(vec![1, 2]);
+        let output_cols =
+            read_columns_from_projection(&projection_input, &expected_metadata).unwrap();
         let mapper = FlatProjectionMapper::new_with_read_columns(
             &expected_metadata,
-            vec![1, 2],
+            output_cols,
             vec![1, 2, 3],
         )
         .unwrap();
-        let read_format = FlatReadFormat::new(
-            actual_metadata.clone(),
-            [1, 2, 3].into_iter(),
-            None,
-            "test",
-            false,
-        )
-        .unwrap();
+        let read_cols = ReadColumns::from_column_ids([1, 2, 3]);
+        let read_format =
+            FlatReadFormat::new(actual_metadata.clone(), read_cols, None, "test", false).unwrap();
         let format_projection = read_format.format_projection();
 
         let compat_batch =
@@ -1400,14 +1393,9 @@ mod tests {
         let expected_metadata = Arc::new(expected_metadata);
 
         let mapper = FlatProjectionMapper::all(&expected_metadata).unwrap();
-        let read_format = FlatReadFormat::new(
-            actual_metadata.clone(),
-            [0, 1, 2, 3].into_iter(),
-            None,
-            "test",
-            false,
-        )
-        .unwrap();
+        let read_cols = ReadColumns::from_column_ids([0, 1, 2, 3]);
+        let read_format =
+            FlatReadFormat::new(actual_metadata.clone(), read_cols, None, "test", false).unwrap();
         let format_projection = read_format.format_projection();
 
         let compat_batch =
@@ -1494,14 +1482,9 @@ mod tests {
         let expected_metadata = Arc::new(expected_metadata);
 
         let mapper = FlatProjectionMapper::all(&expected_metadata).unwrap();
-        let read_format = FlatReadFormat::new(
-            actual_metadata.clone(),
-            [0, 2, 3].into_iter(),
-            None,
-            "test",
-            true,
-        )
-        .unwrap();
+        let read_cols = ReadColumns::from_column_ids([0, 2, 3]);
+        let read_format =
+            FlatReadFormat::new(actual_metadata.clone(), read_cols, None, "test", true).unwrap();
         let format_projection = read_format.format_projection();
 
         let compat_batch =

--- a/src/mito2/src/read/flat_projection.rs
+++ b/src/mito2/src/read/flat_projection.rs
@@ -33,6 +33,7 @@ use store_api::storage::ColumnId;
 use crate::cache::CacheStrategy;
 use crate::error::{InvalidRequestSnafu, RecordBatchSnafu, Result};
 use crate::read::projection::{read_column_ids_from_projection, repeated_vector_with_cache};
+use crate::read::read_columns::ReadColumns;
 use crate::sst::parquet::flat_format::sst_column_id_indices;
 use crate::sst::parquet::format::FormatProjection;
 use crate::sst::{
@@ -48,11 +49,11 @@ pub struct FlatProjectionMapper {
     metadata: RegionMetadataRef,
     /// Schema for converted [RecordBatch] to return.
     output_schema: SchemaRef,
-    /// Ids of columns to read from memtables and SSTs.
+    /// The columns to read from memtables and SSTs.
     /// The mapper won't deduplicate the column ids.
     ///
     /// Note that this doesn't contain the `__table_id` and `__tsid`.
-    read_column_ids: Vec<ColumnId>,
+    read_cols: ReadColumns,
     /// Ids and DataTypes of columns of the expected batch.
     /// We can use this to check if the batch is compatible with the expected schema.
     ///
@@ -73,9 +74,9 @@ impl FlatProjectionMapper {
     /// empty `RecordBatch` and only use its row count in this query.
     pub fn new(
         metadata: &RegionMetadataRef,
-        projection: impl Iterator<Item = usize>,
+        projection: impl IntoIterator<Item = usize>,
     ) -> Result<Self> {
-        let projection: Vec<_> = projection.collect();
+        let projection: Vec<_> = projection.into_iter().collect();
         let read_column_ids = read_column_ids_from_projection(metadata, &projection)?;
         Self::new_with_read_columns(metadata, projection, read_column_ids)
     }
@@ -84,39 +85,38 @@ impl FlatProjectionMapper {
     pub fn new_with_read_columns(
         metadata: &RegionMetadataRef,
         projection: Vec<usize>,
-        read_column_ids: Vec<ColumnId>,
+        read_cols: impl Into<ReadColumns>,
     ) -> Result<Self> {
+        let projection: Vec<_> = projection.into_iter().collect();
+        let read_cols = read_cols.into();
         // If the original projection is empty.
         let is_empty_projection = projection.is_empty();
 
         // Output column schemas for the projection.
-        let mut column_schemas = Vec::with_capacity(projection.len());
+        let mut col_schemas = Vec::with_capacity(projection.len());
         // Column ids of the output projection without deduplication.
-        let mut output_column_ids = Vec::with_capacity(projection.len());
+        let mut output_col_ids = Vec::with_capacity(projection.len());
         for idx in &projection {
-            // For each projection index, we get the column id for projection.
-            let column =
-                metadata
-                    .column_metadatas
-                    .get(*idx)
-                    .with_context(|| InvalidRequestSnafu {
-                        region_id: metadata.region_id,
-                        reason: format!("projection index {} is out of bound", idx),
-                    })?;
-
-            output_column_ids.push(column.column_id);
-            // Safety: idx is valid.
-            column_schemas.push(metadata.schema.column_schemas()[*idx].clone());
+            let col = metadata
+                .column_metadatas
+                .get(*idx)
+                .with_context(|| InvalidRequestSnafu {
+                    region_id: metadata.region_id,
+                    reason: format!("projection index {} is out of bound", idx),
+                })?;
+            output_col_ids.push(col.column_id);
+            col_schemas.push(col.column_schema.clone());
         }
 
         // Creates a map to lookup index.
         let id_to_index = sst_column_id_indices(metadata);
+
         // TODO(yingwen): Support different flat schema options.
         let format_projection = FormatProjection::compute_format_projection(
             &id_to_index,
             // All columns with internal columns.
             metadata.column_metadatas.len() + 3,
-            read_column_ids.iter().copied(),
+            &read_cols,
         );
 
         let batch_schema = flat_projected_columns(metadata, &format_projection);
@@ -129,13 +129,13 @@ impl FlatProjectionMapper {
             Arc::new(Schema::new(vec![]))
         } else {
             // Safety: Columns come from existing schema.
-            Arc::new(Schema::new(column_schemas))
+            Arc::new(Schema::new(col_schemas))
         };
 
         let batch_indices = if is_empty_projection {
             vec![]
         } else {
-            output_column_ids
+            output_col_ids
                 .iter()
                 .map(|id| {
                     // Safety: The map is computed from the read projection.
@@ -163,7 +163,7 @@ impl FlatProjectionMapper {
         Ok(FlatProjectionMapper {
             metadata: metadata.clone(),
             output_schema,
-            read_column_ids,
+            read_cols,
             batch_schema,
             is_empty_projection,
             batch_indices,
@@ -180,11 +180,9 @@ impl FlatProjectionMapper {
     pub(crate) fn metadata(&self) -> &RegionMetadataRef {
         &self.metadata
     }
-
-    /// Returns ids of projected columns that we need to read
-    /// from memtables and SSTs.
-    pub(crate) fn column_ids(&self) -> &[ColumnId] {
-        &self.read_column_ids
+    /// Returns projected columns that we need to read from memtables and SSTs.
+    pub(crate) fn read_columns(&self) -> &ReadColumns {
+        &self.read_cols
     }
 
     /// Returns the field column start index in output batch.
@@ -435,15 +433,13 @@ impl CompactionProjectionMapper {
             .chain([metadata.time_index_column_pos()])
             .collect::<Vec<_>>();
 
-        let mapper = FlatProjectionMapper::new_with_read_columns(
-            metadata,
-            projection,
-            metadata
-                .column_metadatas
-                .iter()
-                .map(|col| col.column_id)
-                .collect(),
-        )?;
+        let read_col_ids: Vec<_> = metadata
+            .column_metadatas
+            .iter()
+            .map(|col| col.column_id)
+            .collect();
+        let mapper =
+            FlatProjectionMapper::new_with_read_columns(metadata, projection, read_col_ids)?;
         let assembler = DfBatchAssembler::new(mapper.output_schema());
 
         Ok(Self { mapper, assembler })

--- a/src/mito2/src/read/flat_projection.rs
+++ b/src/mito2/src/read/flat_projection.rs
@@ -116,7 +116,7 @@ impl FlatProjectionMapper {
             &id_to_index,
             // All columns with internal columns.
             metadata.column_metadatas.len() + 3,
-            &read_cols,
+            read_cols.clone(),
         );
 
         let batch_schema = flat_projected_columns(metadata, &format_projection);

--- a/src/mito2/src/read/flat_projection.rs
+++ b/src/mito2/src/read/flat_projection.rs
@@ -87,7 +87,6 @@ impl FlatProjectionMapper {
         projection: Vec<usize>,
         read_cols: impl Into<ReadColumns>,
     ) -> Result<Self> {
-        let projection: Vec<_> = projection.into_iter().collect();
         let read_cols = read_cols.into();
         // If the original projection is empty.
         let is_empty_projection = projection.is_empty();

--- a/src/mito2/src/read/flat_projection.rs
+++ b/src/mito2/src/read/flat_projection.rs
@@ -433,11 +433,7 @@ impl CompactionProjectionMapper {
             .chain([metadata.time_index_column_pos()])
             .collect::<Vec<_>>();
 
-        let read_col_ids: Vec<_> = metadata
-            .column_metadatas
-            .iter()
-            .map(|col| col.column_id)
-            .collect();
+        let read_col_ids = metadata.column_metadatas.iter().map(|col| col.column_id);
         let mapper =
             FlatProjectionMapper::new_with_read_columns(metadata, projection, read_col_ids)?;
         let assembler = DfBatchAssembler::new(mapper.output_schema());

--- a/src/mito2/src/read/flat_projection.rs
+++ b/src/mito2/src/read/flat_projection.rs
@@ -78,16 +78,16 @@ impl FlatProjectionMapper {
     ) -> Result<Self> {
         let projection: Vec<_> = projection.into_iter().collect();
         let read_column_ids = read_column_ids_from_projection(metadata, &projection)?;
-        Self::new_with_read_columns(metadata, projection, read_column_ids)
+        let read_cols = ReadColumns::from_deduped_column_ids(read_column_ids);
+        Self::new_with_read_columns(metadata, projection, read_cols)
     }
 
     /// Returns a new mapper with output projection and explicit read columns.
     pub fn new_with_read_columns(
         metadata: &RegionMetadataRef,
         projection: Vec<usize>,
-        read_cols: impl Into<ReadColumns>,
+        read_cols: ReadColumns,
     ) -> Result<Self> {
-        let read_cols = read_cols.into();
         // If the original projection is empty.
         let is_empty_projection = projection.is_empty();
 
@@ -433,8 +433,8 @@ impl CompactionProjectionMapper {
             .collect::<Vec<_>>();
 
         let read_col_ids = metadata.column_metadatas.iter().map(|col| col.column_id);
-        let mapper =
-            FlatProjectionMapper::new_with_read_columns(metadata, projection, read_col_ids)?;
+        let read_cols = ReadColumns::from_deduped_column_ids(read_col_ids);
+        let mapper = FlatProjectionMapper::new_with_read_columns(metadata, projection, read_cols)?;
         let assembler = DfBatchAssembler::new(mapper.output_schema());
 
         Ok(Self { mapper, assembler })

--- a/src/mito2/src/read/flat_projection.rs
+++ b/src/mito2/src/read/flat_projection.rs
@@ -30,12 +30,12 @@ use datatypes::value::Value;
 use datatypes::vectors::Helper;
 use snafu::{OptionExt, ResultExt};
 use store_api::metadata::{RegionMetadata, RegionMetadataRef};
-use store_api::storage::{ColumnId, ProjectionInput};
+use store_api::storage::ColumnId;
 
 use crate::cache::CacheStrategy;
 use crate::error::{InvalidRequestSnafu, RecordBatchSnafu, Result};
 use crate::read::projection::{read_column_ids_from_projection, repeated_vector_with_cache};
-use crate::read::read_columns::{ReadColumns, read_columns_from_projection};
+use crate::read::read_columns::ReadColumns;
 use crate::sst::parquet::flat_format::sst_column_id_indices;
 use crate::sst::parquet::format::FormatProjection;
 use crate::sst::{
@@ -70,49 +70,40 @@ pub struct FlatProjectionMapper {
 }
 
 impl FlatProjectionMapper {
-    /// Returns a new mapper with projection.
+    /// Builds a mapper from a user projection.
     /// If `projection` is empty, it outputs [RecordBatch] without any column but only a row count.
     /// `SELECT COUNT(*) FROM table` is an example that uses an empty projection. DataFusion accepts
     /// empty `RecordBatch` and only use its row count in this query.
     pub fn new(
         metadata: &RegionMetadataRef,
-        projection: impl Iterator<Item = usize>,
+        projection: impl IntoIterator<Item = usize>,
     ) -> Result<Self> {
-        let projection: Vec<_> = projection.collect();
+        let projection: Vec<_> = projection.into_iter().collect();
         let read_column_ids = read_column_ids_from_projection(metadata, &projection)?;
-        let output_cols = if projection.is_empty() {
-            ReadColumns::default()
-        } else {
-            let projection_input = ProjectionInput::new(projection);
-            read_columns_from_projection(&projection_input, metadata)?
-        };
-        Self::new_with_read_columns(metadata, output_cols, read_column_ids)
+        Self::new_with_read_columns(metadata, projection, read_column_ids)
     }
 
-    /// Returns a new mapper with output projection and explicit read columns.
+    /// Builds a mapper from a user projection and explicit read columns.
     pub fn new_with_read_columns(
         metadata: &RegionMetadataRef,
-        output_cols: impl Into<ReadColumns>,
+        projection: impl IntoIterator<Item = usize>,
         read_cols: impl Into<ReadColumns>,
     ) -> Result<Self> {
-        let output_cols = output_cols.into();
+        let projection: Vec<_> = projection.into_iter().collect();
         let read_cols = read_cols.into();
         // If the original projection is empty.
-        let is_empty_projection = output_cols.is_empty();
+        let is_empty_projection = projection.is_empty();
 
-        let mut col_schemas = Vec::with_capacity(output_cols.columns().len());
-        for read_col in output_cols.columns() {
-            let col_id = read_col.column_id();
+        let mut col_schemas = Vec::with_capacity(projection.len());
+        for idx in &projection {
             let col = metadata
-                .column_by_id(col_id)
+                .column_metadatas
+                .get(*idx)
                 .with_context(|| InvalidRequestSnafu {
                     region_id: metadata.region_id,
-                    reason: format!("col id {} is invalid", col_id),
+                    reason: format!("projection index {} is out of bound", idx),
                 })?;
-            // TODO(fys): try use col.nested path to prune the column schema
-            // if it is a nested field.
-            let col_schema = col.column_schema.clone();
-            col_schemas.push(col_schema);
+            col_schemas.push(col.column_schema.clone());
         }
 
         // Creates a map to lookup index.
@@ -142,9 +133,16 @@ impl FlatProjectionMapper {
         let batch_indices = if is_empty_projection {
             vec![]
         } else {
-            output_cols
-                .column_ids_iter()
-                .map(|id| {
+            projection
+                .iter()
+                .map(|idx| {
+                    let column = metadata.column_metadatas.get(*idx).with_context(|| {
+                        InvalidRequestSnafu {
+                            region_id: metadata.region_id,
+                            reason: format!("projection index {} is out of bound", idx),
+                        }
+                    })?;
+                    let id = column.column_id;
                     // Safety: The map is computed from the read projection.
                     format_projection
                         .column_id_to_projected_index
@@ -473,10 +471,8 @@ impl CompactionProjectionMapper {
             .iter()
             .map(|col| col.column_id)
             .collect();
-        let output_cols =
-            read_columns_from_projection(&ProjectionInput::new(projection), metadata)?;
         let mapper =
-            FlatProjectionMapper::new_with_read_columns(metadata, output_cols, read_column_ids)?;
+            FlatProjectionMapper::new_with_read_columns(metadata, projection, read_column_ids)?;
         let assembler = DfBatchAssembler::new(mapper.output_schema());
 
         Ok(Self { mapper, assembler })

--- a/src/mito2/src/read/flat_projection.rs
+++ b/src/mito2/src/read/flat_projection.rs
@@ -94,7 +94,10 @@ impl FlatProjectionMapper {
         // If the original projection is empty.
         let is_empty_projection = projection.is_empty();
 
+        // Output column schemas for the projection.
         let mut col_schemas = Vec::with_capacity(projection.len());
+        // Column ids of the output projection without deduplication.
+        let mut output_column_ids = Vec::with_capacity(projection.len());
         for idx in &projection {
             let col = metadata
                 .column_metadatas
@@ -103,6 +106,7 @@ impl FlatProjectionMapper {
                     region_id: metadata.region_id,
                     reason: format!("projection index {} is out of bound", idx),
                 })?;
+            output_column_ids.push(col.column_id);
             col_schemas.push(col.column_schema.clone());
         }
 
@@ -133,24 +137,17 @@ impl FlatProjectionMapper {
         let batch_indices = if is_empty_projection {
             vec![]
         } else {
-            projection
+            output_column_ids
                 .iter()
-                .map(|idx| {
-                    let column = metadata.column_metadatas.get(*idx).with_context(|| {
-                        InvalidRequestSnafu {
-                            region_id: metadata.region_id,
-                            reason: format!("projection index {} is out of bound", idx),
-                        }
-                    })?;
-                    let id = column.column_id;
+                .map(|id| {
                     // Safety: The map is computed from the read projection.
                     format_projection
                         .column_id_to_projected_index
-                        .get(&id)
+                        .get(id)
                         .copied()
                         .with_context(|| {
                             let name = metadata
-                                .column_by_id(id)
+                                .column_by_id(*id)
                                 .map(|column| column.column_schema.name.clone())
                                 .unwrap_or_else(|| id.to_string());
                             InvalidRequestSnafu {
@@ -185,7 +182,7 @@ impl FlatProjectionMapper {
     pub(crate) fn metadata(&self) -> &RegionMetadataRef {
         &self.metadata
     }
-
+    /// Returns projected columns that we need to read from memtables and SSTs.
     pub(crate) fn read_columns(&self) -> &ReadColumns {
         &self.read_cols
     }

--- a/src/mito2/src/read/flat_projection.rs
+++ b/src/mito2/src/read/flat_projection.rs
@@ -18,7 +18,9 @@ use std::sync::Arc;
 
 use api::v1::SemanticType;
 use common_error::ext::BoxedError;
-use common_recordbatch::error::{ArrowComputeSnafu, ExternalSnafu, NewDfRecordBatchSnafu};
+use common_recordbatch::error::{
+    ArrowComputeSnafu, CastColumnSnafu, ExternalSnafu, NewDfRecordBatchSnafu,
+};
 use common_recordbatch::{DfRecordBatch, RecordBatch};
 use datafusion_common::cast_column;
 use datatypes::arrow::array::Array;
@@ -289,28 +291,22 @@ impl FlatProjectionMapper {
                         .context(ArrowComputeSnafu)?;
                     array = casted;
                 }
-            }
-            // TODO(fys): remove this after we fix the schema mismatch issue.
-            else {
-                let target_schema = self.output_schema.arrow_schema();
-                if target_schema.field(output_idx).data_type()
-                    != batch.schema().field(*index).data_type()
-                {
-                    common_telemetry::info!(
-                        "Casting column {} from type {} to {} since the batch schema doesn't match the output schema",
-                        self.output_schema.column_schemas()[output_idx].name,
-                        batch.schema().field(*index).data_type(),
-                        target_schema.field(output_idx).data_type()
-                    );
-                    let source_col = batch.column(*index).clone();
+            } else {
+                // ProjectionMapper still builds the output schema based on
+                // root-level projection indices and does not yet prune struct
+                // fields according to nested paths. Meanwhile, the SST read
+                // path already respects nested paths, so the input struct column
+                // here may be narrower than what the output schema expects.
+                // We need to cast it back to the output schema to keep downstream
+                // batch construction type-consistent.
+                let output_schema = self.output_schema.arrow_schema();
+                let target_datatype = output_schema.field(output_idx).data_type();
+                let is_struct = matches!(target_datatype, ArrowDataType::Struct(..));
+                if is_struct && target_datatype != batch.schema().field(*index).data_type() {
+                    let source_col = batch.column(*index);
                     let target_field = self.output_schema.arrow_schema().field(output_idx);
-                    array =
-                        cast_column(&source_col, target_field, &CastOptions::default()).unwrap();
-                } else {
-                    common_telemetry::info!(
-                        "Skip casting column {} since the batch schema matches the output schema",
-                        self.output_schema.column_schemas()[output_idx].name
-                    );
+                    array = cast_column(source_col, target_field, &CastOptions::default())
+                        .context(CastColumnSnafu)?;
                 }
             }
             arrays.push(array);

--- a/src/mito2/src/read/flat_projection.rs
+++ b/src/mito2/src/read/flat_projection.rs
@@ -260,6 +260,7 @@ impl FlatProjectionMapper {
         }
         // Construct output record batch directly from Arrow arrays to avoid
         // Arrow -> Vector -> Arrow roundtrips in the hot path.
+        let output_arrow_schema = self.output_schema.arrow_schema();
         let mut arrays = Vec::with_capacity(self.output_schema.num_columns());
         for (output_idx, index) in self.batch_indices.iter().enumerate() {
             let mut array = batch.column(*index).clone();
@@ -299,12 +300,11 @@ impl FlatProjectionMapper {
                 // here may be narrower than what the output schema expects.
                 // We need to cast it back to the output schema to keep downstream
                 // batch construction type-consistent.
-                let output_schema = self.output_schema.arrow_schema();
-                let target_datatype = output_schema.field(output_idx).data_type();
+                let target_field = output_arrow_schema.field(output_idx);
+                let target_datatype = target_field.data_type();
                 let is_struct = matches!(target_datatype, ArrowDataType::Struct(..));
                 if is_struct && target_datatype != batch.schema().field(*index).data_type() {
                     let source_col = batch.column(*index);
-                    let target_field = self.output_schema.arrow_schema().field(output_idx);
                     array = cast_column(source_col, target_field, &CastOptions::default())
                         .context(CastColumnSnafu)?;
                 }
@@ -312,9 +312,8 @@ impl FlatProjectionMapper {
             arrays.push(array);
         }
 
-        let df_record_batch =
-            DfRecordBatch::try_new(self.output_schema.arrow_schema().clone(), arrays)
-                .context(NewDfRecordBatchSnafu)?;
+        let df_record_batch = DfRecordBatch::try_new(output_arrow_schema.clone(), arrays)
+            .context(NewDfRecordBatchSnafu)?;
         Ok(RecordBatch::from_df_record_batch(
             self.output_schema.clone(),
             df_record_batch,

--- a/src/mito2/src/read/flat_projection.rs
+++ b/src/mito2/src/read/flat_projection.rs
@@ -80,8 +80,12 @@ impl FlatProjectionMapper {
     ) -> Result<Self> {
         let projection: Vec<_> = projection.collect();
         let read_column_ids = read_column_ids_from_projection(metadata, &projection)?;
-        let projection_input = ProjectionInput::new(projection);
-        let output_cols = read_columns_from_projection(&projection_input, metadata)?;
+        let output_cols = if projection.is_empty() {
+            ReadColumns::default()
+        } else {
+            let projection_input = ProjectionInput::new(projection);
+            read_columns_from_projection(&projection_input, metadata)?
+        };
         Self::new_with_read_columns(metadata, output_cols, read_column_ids)
     }
 

--- a/src/mito2/src/read/flat_projection.rs
+++ b/src/mito2/src/read/flat_projection.rs
@@ -20,19 +20,22 @@ use api::v1::SemanticType;
 use common_error::ext::BoxedError;
 use common_recordbatch::error::{ArrowComputeSnafu, ExternalSnafu, NewDfRecordBatchSnafu};
 use common_recordbatch::{DfRecordBatch, RecordBatch};
+use datafusion_common::cast_column;
 use datatypes::arrow::array::Array;
 use datatypes::arrow::datatypes::{DataType as ArrowDataType, Field};
+use datatypes::compute::CastOptions;
 use datatypes::prelude::{ConcreteDataType, DataType};
 use datatypes::schema::{Schema, SchemaRef};
 use datatypes::value::Value;
 use datatypes::vectors::Helper;
 use snafu::{OptionExt, ResultExt};
 use store_api::metadata::{RegionMetadata, RegionMetadataRef};
-use store_api::storage::ColumnId;
+use store_api::storage::{ColumnId, ProjectionInput};
 
 use crate::cache::CacheStrategy;
 use crate::error::{InvalidRequestSnafu, RecordBatchSnafu, Result};
 use crate::read::projection::{read_column_ids_from_projection, repeated_vector_with_cache};
+use crate::read::read_columns::{ReadColumns, read_columns_from_projection};
 use crate::sst::parquet::flat_format::sst_column_id_indices;
 use crate::sst::parquet::format::FormatProjection;
 use crate::sst::{
@@ -48,11 +51,11 @@ pub struct FlatProjectionMapper {
     metadata: RegionMetadataRef,
     /// Schema for converted [RecordBatch] to return.
     output_schema: SchemaRef,
-    /// Ids of columns to read from memtables and SSTs.
+    /// The columns to read from memtables and SSTs.
     /// The mapper won't deduplicate the column ids.
     ///
     /// Note that this doesn't contain the `__table_id` and `__tsid`.
-    read_column_ids: Vec<ColumnId>,
+    read_cols: ReadColumns,
     /// Ids and DataTypes of columns of the expected batch.
     /// We can use this to check if the batch is compatible with the expected schema.
     ///
@@ -77,46 +80,46 @@ impl FlatProjectionMapper {
     ) -> Result<Self> {
         let projection: Vec<_> = projection.collect();
         let read_column_ids = read_column_ids_from_projection(metadata, &projection)?;
-        Self::new_with_read_columns(metadata, projection, read_column_ids)
+        let projection_input = ProjectionInput::new(projection);
+        let output_cols = read_columns_from_projection(&projection_input, metadata)?;
+        Self::new_with_read_columns(metadata, output_cols, read_column_ids)
     }
 
     /// Returns a new mapper with output projection and explicit read columns.
     pub fn new_with_read_columns(
         metadata: &RegionMetadataRef,
-        projection: Vec<usize>,
-        read_column_ids: Vec<ColumnId>,
+        output_cols: impl Into<ReadColumns>,
+        read_cols: impl Into<ReadColumns>,
     ) -> Result<Self> {
+        let output_cols = output_cols.into();
+        let read_cols = read_cols.into();
         // If the original projection is empty.
-        let is_empty_projection = projection.is_empty();
+        let is_empty_projection = output_cols.is_empty();
 
-        // Output column schemas for the projection.
-        let mut column_schemas = Vec::with_capacity(projection.len());
-        // Column ids of the output projection without deduplication.
-        let mut output_column_ids = Vec::with_capacity(projection.len());
-        for idx in &projection {
-            // For each projection index, we get the column id for projection.
-            let column =
-                metadata
-                    .column_metadatas
-                    .get(*idx)
-                    .with_context(|| InvalidRequestSnafu {
-                        region_id: metadata.region_id,
-                        reason: format!("projection index {} is out of bound", idx),
-                    })?;
-
-            output_column_ids.push(column.column_id);
-            // Safety: idx is valid.
-            column_schemas.push(metadata.schema.column_schemas()[*idx].clone());
+        let mut col_schemas = Vec::with_capacity(output_cols.columns().len());
+        for read_col in output_cols.columns() {
+            let col_id = read_col.column_id();
+            let col = metadata
+                .column_by_id(col_id)
+                .with_context(|| InvalidRequestSnafu {
+                    region_id: metadata.region_id,
+                    reason: format!("col id {} is invalid", col_id),
+                })?;
+            // TODO(fys): try use col.nested path to prune the column schema
+            // if it is a nested field.
+            let col_schema = col.column_schema.clone();
+            col_schemas.push(col_schema);
         }
 
         // Creates a map to lookup index.
         let id_to_index = sst_column_id_indices(metadata);
+
         // TODO(yingwen): Support different flat schema options.
         let format_projection = FormatProjection::compute_format_projection(
             &id_to_index,
             // All columns with internal columns.
             metadata.column_metadatas.len() + 3,
-            read_column_ids.iter().copied(),
+            &read_cols,
         );
 
         let batch_schema = flat_projected_columns(metadata, &format_projection);
@@ -129,23 +132,23 @@ impl FlatProjectionMapper {
             Arc::new(Schema::new(vec![]))
         } else {
             // Safety: Columns come from existing schema.
-            Arc::new(Schema::new(column_schemas))
+            Arc::new(Schema::new(col_schemas))
         };
 
         let batch_indices = if is_empty_projection {
             vec![]
         } else {
-            output_column_ids
-                .iter()
+            output_cols
+                .column_ids_iter()
                 .map(|id| {
                     // Safety: The map is computed from the read projection.
                     format_projection
                         .column_id_to_projected_index
-                        .get(id)
+                        .get(&id)
                         .copied()
                         .with_context(|| {
                             let name = metadata
-                                .column_by_id(*id)
+                                .column_by_id(id)
                                 .map(|column| column.column_schema.name.clone())
                                 .unwrap_or_else(|| id.to_string());
                             InvalidRequestSnafu {
@@ -163,7 +166,7 @@ impl FlatProjectionMapper {
         Ok(FlatProjectionMapper {
             metadata: metadata.clone(),
             output_schema,
-            read_column_ids,
+            read_cols,
             batch_schema,
             is_empty_projection,
             batch_indices,
@@ -181,10 +184,8 @@ impl FlatProjectionMapper {
         &self.metadata
     }
 
-    /// Returns ids of projected columns that we need to read
-    /// from memtables and SSTs.
-    pub(crate) fn column_ids(&self) -> &[ColumnId] {
-        &self.read_column_ids
+    pub(crate) fn read_columns(&self) -> &ReadColumns {
+        &self.read_cols
     }
 
     /// Returns the field column start index in output batch.
@@ -288,6 +289,29 @@ impl FlatProjectionMapper {
                     let casted = datatypes::arrow::compute::cast(&array, value_type)
                         .context(ArrowComputeSnafu)?;
                     array = casted;
+                }
+            }
+            // TODO(fys): remove this after we fix the schema mismatch issue.
+            else {
+                let target_schema = self.output_schema.arrow_schema();
+                if target_schema.field(output_idx).data_type()
+                    != batch.schema().field(*index).data_type()
+                {
+                    common_telemetry::info!(
+                        "Casting column {} from type {} to {} since the batch schema doesn't match the output schema",
+                        self.output_schema.column_schemas()[output_idx].name,
+                        batch.schema().field(*index).data_type(),
+                        target_schema.field(output_idx).data_type()
+                    );
+                    let source_col = batch.column(*index).clone();
+                    let target_field = self.output_schema.arrow_schema().field(output_idx);
+                    array =
+                        cast_column(&source_col, target_field, &CastOptions::default()).unwrap();
+                } else {
+                    common_telemetry::info!(
+                        "Skip casting column {} since the batch schema matches the output schema",
+                        self.output_schema.column_schemas()[output_idx].name
+                    );
                 }
             }
             arrays.push(array);
@@ -440,15 +464,15 @@ impl CompactionProjectionMapper {
             .chain([metadata.time_index_column_pos()])
             .collect::<Vec<_>>();
 
-        let mapper = FlatProjectionMapper::new_with_read_columns(
-            metadata,
-            projection,
-            metadata
-                .column_metadatas
-                .iter()
-                .map(|col| col.column_id)
-                .collect(),
-        )?;
+        let read_column_ids: Vec<_> = metadata
+            .column_metadatas
+            .iter()
+            .map(|col| col.column_id)
+            .collect();
+        let output_cols =
+            read_columns_from_projection(&ProjectionInput::new(projection), metadata)?;
+        let mapper =
+            FlatProjectionMapper::new_with_read_columns(metadata, output_cols, read_column_ids)?;
         let assembler = DfBatchAssembler::new(mapper.output_schema());
 
         Ok(Self { mapper, assembler })

--- a/src/mito2/src/read/last_row.rs
+++ b/src/mito2/src/read/last_row.rs
@@ -34,6 +34,7 @@ use crate::read::{Batch, BatchReader, BoxedBatchReader, BoxedRecordBatchStream};
 use crate::sst::parquet::DEFAULT_READ_BATCH_SIZE;
 use crate::sst::parquet::flat_format::{primary_key_column_index, time_index_column_index};
 use crate::sst::parquet::format::{PrimaryKeyArray, primary_key_offsets};
+use crate::sst::parquet::read_columns::ParquetReadColumns;
 use crate::sst::parquet::reader::FlatRowGroupReader;
 
 /// Reader to keep the last row for each time series.
@@ -134,7 +135,7 @@ impl FlatRowGroupLastRowCachedReader {
         file_id: FileId,
         row_group_idx: usize,
         cache_strategy: CacheStrategy,
-        projection: &[usize],
+        read_cols: &ParquetReadColumns,
         reader: FlatRowGroupReader,
     ) -> Self {
         let key = SelectorResultKey {
@@ -145,14 +146,14 @@ impl FlatRowGroupLastRowCachedReader {
 
         if let Some(value) = cache_strategy.get_selector_result(&key) {
             let is_flat = matches!(&value.result, SelectorResult::Flat(_));
-            let schema_matches = value.projection == projection;
+            let schema_matches = value.read_cols == *read_cols;
             if is_flat && schema_matches {
                 Self::new_hit(value)
             } else {
-                Self::new_miss(key, projection, reader, cache_strategy)
+                Self::new_miss(key, read_cols, reader, cache_strategy)
             }
         } else {
-            Self::new_miss(key, projection, reader, cache_strategy)
+            Self::new_miss(key, read_cols, reader, cache_strategy)
         }
     }
 
@@ -171,14 +172,14 @@ impl FlatRowGroupLastRowCachedReader {
 
     fn new_miss(
         key: SelectorResultKey,
-        projection: &[usize],
+        read_cols: &ParquetReadColumns,
         reader: FlatRowGroupReader,
         cache_strategy: CacheStrategy,
     ) -> Self {
         selector_result_cache_miss();
         Self::Miss(FlatRowGroupLastRowReader::new(
             key,
-            projection.to_vec(),
+            read_cols.clone(),
             reader,
             cache_strategy,
         ))
@@ -257,7 +258,7 @@ pub(crate) struct FlatRowGroupLastRowReader {
     selector: FlatLastTimestampSelector,
     yielded_batches: Vec<RecordBatch>,
     cache_strategy: CacheStrategy,
-    projection: Vec<usize>,
+    read_cols: ParquetReadColumns,
     /// Accumulates small selector-output batches before concatenating.
     pending: BatchBuffer,
 }
@@ -265,7 +266,7 @@ pub(crate) struct FlatRowGroupLastRowReader {
 impl FlatRowGroupLastRowReader {
     fn new(
         key: SelectorResultKey,
-        projection: Vec<usize>,
+        read_cols: ParquetReadColumns,
         reader: FlatRowGroupReader,
         cache_strategy: CacheStrategy,
     ) -> Self {
@@ -275,7 +276,7 @@ impl FlatRowGroupLastRowReader {
             selector: FlatLastTimestampSelector::default(),
             yielded_batches: vec![],
             cache_strategy,
-            projection,
+            read_cols,
             pending: BatchBuffer::new(),
         }
     }
@@ -323,7 +324,7 @@ impl FlatRowGroupLastRowReader {
         let batches = std::mem::take(&mut self.yielded_batches);
         let value = Arc::new(SelectorResultValue::new_flat(
             batches,
-            self.projection.clone(),
+            self.read_cols.clone(),
         ));
         self.cache_strategy.put_selector_result(self.key, value);
     }

--- a/src/mito2/src/read/last_row.rs
+++ b/src/mito2/src/read/last_row.rs
@@ -35,6 +35,7 @@ use crate::read::{Batch, BatchReader, BoxedBatchReader, BoxedRecordBatchStream};
 use crate::sst::parquet::DEFAULT_READ_BATCH_SIZE;
 use crate::sst::parquet::flat_format::{primary_key_column_index, time_index_column_index};
 use crate::sst::parquet::format::{PrimaryKeyArray, primary_key_offsets};
+use crate::sst::parquet::read_columns::ParquetReadColumns;
 use crate::sst::parquet::reader::{FlatRowGroupReader, ReaderMetrics, RowGroupReader};
 
 /// Reader to keep the last row for each time series.
@@ -108,7 +109,7 @@ impl RowGroupLastRowCachedReader {
         if let Some(value) = cache_strategy.get_selector_result(&key) {
             let is_primary_key = matches!(&value.result, SelectorResult::PrimaryKey(_));
             let schema_matches =
-                value.projection == row_group_reader.read_format().projection_indices();
+                value.read_cols == *row_group_reader.read_format().parquet_read_columns();
             if is_primary_key && schema_matches {
                 // Format and schema match, use cache batches.
                 Self::new_hit(value)
@@ -235,7 +236,7 @@ impl RowGroupLastRowReader {
         }
         let value = Arc::new(SelectorResultValue::new(
             std::mem::take(&mut self.yielded_batches),
-            self.reader.read_format().projection_indices().to_vec(),
+            self.reader.read_format().parquet_read_columns().clone(),
         ));
         self.cache_strategy.put_selector_result(self.key, value);
     }
@@ -312,7 +313,7 @@ impl FlatRowGroupLastRowCachedReader {
         file_id: FileId,
         row_group_idx: usize,
         cache_strategy: CacheStrategy,
-        projection: &[usize],
+        read_cols: &ParquetReadColumns,
         reader: FlatRowGroupReader,
     ) -> Self {
         let key = SelectorResultKey {
@@ -323,14 +324,14 @@ impl FlatRowGroupLastRowCachedReader {
 
         if let Some(value) = cache_strategy.get_selector_result(&key) {
             let is_flat = matches!(&value.result, SelectorResult::Flat(_));
-            let schema_matches = value.projection == projection;
+            let schema_matches = value.read_cols == *read_cols;
             if is_flat && schema_matches {
                 Self::new_hit(value)
             } else {
-                Self::new_miss(key, projection, reader, cache_strategy)
+                Self::new_miss(key, read_cols, reader, cache_strategy)
             }
         } else {
-            Self::new_miss(key, projection, reader, cache_strategy)
+            Self::new_miss(key, read_cols, reader, cache_strategy)
         }
     }
 
@@ -349,14 +350,14 @@ impl FlatRowGroupLastRowCachedReader {
 
     fn new_miss(
         key: SelectorResultKey,
-        projection: &[usize],
+        read_cols: &ParquetReadColumns,
         reader: FlatRowGroupReader,
         cache_strategy: CacheStrategy,
     ) -> Self {
         selector_result_cache_miss();
         Self::Miss(FlatRowGroupLastRowReader::new(
             key,
-            projection.to_vec(),
+            read_cols.clone(),
             reader,
             cache_strategy,
         ))
@@ -435,7 +436,7 @@ pub(crate) struct FlatRowGroupLastRowReader {
     selector: FlatLastTimestampSelector,
     yielded_batches: Vec<RecordBatch>,
     cache_strategy: CacheStrategy,
-    projection: Vec<usize>,
+    read_cols: ParquetReadColumns,
     /// Accumulates small selector-output batches before concatenating.
     pending: BatchBuffer,
 }
@@ -443,7 +444,7 @@ pub(crate) struct FlatRowGroupLastRowReader {
 impl FlatRowGroupLastRowReader {
     fn new(
         key: SelectorResultKey,
-        projection: Vec<usize>,
+        read_cols: ParquetReadColumns,
         reader: FlatRowGroupReader,
         cache_strategy: CacheStrategy,
     ) -> Self {
@@ -453,7 +454,7 @@ impl FlatRowGroupLastRowReader {
             selector: FlatLastTimestampSelector::default(),
             yielded_batches: vec![],
             cache_strategy,
-            projection,
+            read_cols,
             pending: BatchBuffer::new(),
         }
     }
@@ -501,7 +502,7 @@ impl FlatRowGroupLastRowReader {
         let batches = std::mem::take(&mut self.yielded_batches);
         let value = Arc::new(SelectorResultValue::new_flat(
             batches,
-            self.projection.clone(),
+            self.read_cols.clone(),
         ));
         self.cache_strategy.put_selector_result(self.key, value);
     }

--- a/src/mito2/src/read/projection.rs
+++ b/src/mito2/src/read/projection.rs
@@ -221,7 +221,10 @@ mod tests {
         );
         let cache = CacheStrategy::Disabled;
         let mapper = FlatProjectionMapper::all(&metadata).unwrap();
-        assert_eq!([0, 1, 2, 3, 4], mapper.column_ids());
+        assert_eq!(
+            &[0, 1, 2, 3, 4],
+            mapper.read_columns().column_ids().as_slice()
+        );
         assert_eq!(
             [
                 (1, ConcreteDataType::int64_datatype()),
@@ -255,8 +258,8 @@ mod tests {
                 .build(),
         );
         let cache = CacheStrategy::Disabled;
-        let mapper = FlatProjectionMapper::new(&metadata, [4, 1].into_iter()).unwrap();
-        assert_eq!([4, 1], mapper.column_ids());
+        let mapper = FlatProjectionMapper::new(&metadata, [4, 1]).unwrap();
+        assert_eq!(&[4, 1], mapper.read_columns().column_ids().as_slice());
         assert_eq!(
             [
                 (1, ConcreteDataType::int64_datatype()),
@@ -291,7 +294,7 @@ mod tests {
         let mapper =
             FlatProjectionMapper::new_with_read_columns(&metadata, vec![4, 1], vec![4, 1, 3])
                 .unwrap();
-        assert_eq!([4, 1, 3], mapper.column_ids());
+        assert_eq!(&[4, 1, 3], mapper.read_columns().column_ids().as_slice());
 
         let batch = new_flat_batch(None, &[(1, 1)], &[(3, 3), (4, 4)], 3);
         let record_batch = mapper.convert(&batch, &cache).unwrap();
@@ -315,8 +318,8 @@ mod tests {
                 .build(),
         );
         let cache = CacheStrategy::Disabled;
-        let mapper = FlatProjectionMapper::new(&metadata, [].into_iter()).unwrap();
-        assert_eq!([0], mapper.column_ids());
+        let mapper = FlatProjectionMapper::new(&metadata, []).unwrap();
+        assert_eq!(&[0], mapper.read_columns().column_ids().as_slice());
         assert!(mapper.output_schema().is_empty());
         assert_eq!(
             [(0, ConcreteDataType::timestamp_millisecond_datatype())],

--- a/src/mito2/src/read/projection.rs
+++ b/src/mito2/src/read/projection.rs
@@ -108,6 +108,7 @@ mod tests {
 
     use super::*;
     use crate::read::flat_projection::FlatProjectionMapper;
+    use crate::read::read_columns::ReadColumns;
 
     fn print_record_batch(record_batch: RecordBatch) -> String {
         pretty::pretty_format_batches(&[record_batch.into_df_record_batch()])
@@ -291,9 +292,12 @@ mod tests {
                 .build(),
         );
         let cache = CacheStrategy::Disabled;
-        let mapper =
-            FlatProjectionMapper::new_with_read_columns(&metadata, vec![4, 1], vec![4, 1, 3])
-                .unwrap();
+        let mapper = FlatProjectionMapper::new_with_read_columns(
+            &metadata,
+            vec![4, 1],
+            ReadColumns::from_deduped_column_ids([4, 1, 3]),
+        )
+        .unwrap();
         assert_eq!(&[4, 1, 3], mapper.read_columns().column_ids().as_slice());
 
         let batch = new_flat_batch(None, &[(1, 1)], &[(3, 3), (4, 4)], 3);

--- a/src/mito2/src/read/projection.rs
+++ b/src/mito2/src/read/projection.rs
@@ -35,7 +35,7 @@ use crate::cache::CacheStrategy;
 use crate::error::{InvalidRequestSnafu, Result};
 use crate::read::Batch;
 use crate::read::flat_projection::FlatProjectionMapper;
-use crate::read::read_columns::{ReadColumns, build_read_columns};
+use crate::read::read_columns::ReadColumns;
 
 /// Only cache vector when its length `<=` this value.
 pub(crate) const MAX_VECTOR_LENGTH_TO_CACHE: usize = 16384;
@@ -196,8 +196,7 @@ impl PrimaryKeyProjectionMapper {
         }
 
         let codec = build_primary_key_codec(metadata);
-        let read_cols =
-            build_read_columns(metadata, &projection_input.nested_paths, &read_column_ids)?;
+        let read_cols = ReadColumns::from_column_ids(read_column_ids.iter().copied());
         // If projection is empty, we don't output any column.
         let output_schema = if is_empty_projection {
             Arc::new(Schema::new(vec![]))

--- a/src/mito2/src/read/projection.rs
+++ b/src/mito2/src/read/projection.rs
@@ -29,12 +29,13 @@ use datatypes::vectors::VectorRef;
 use mito_codec::row_converter::{CompositeValues, PrimaryKeyCodec, build_primary_key_codec};
 use snafu::{OptionExt, ResultExt};
 use store_api::metadata::RegionMetadataRef;
-use store_api::storage::ColumnId;
+use store_api::storage::{ColumnId, ProjectionInput};
 
 use crate::cache::CacheStrategy;
 use crate::error::{InvalidRequestSnafu, Result};
 use crate::read::Batch;
 use crate::read::flat_projection::FlatProjectionMapper;
+use crate::read::read_columns::{ReadColumns, build_read_columns};
 
 /// Only cache vector when its length `<=` this value.
 pub(crate) const MAX_VECTOR_LENGTH_TO_CACHE: usize = 16384;
@@ -61,12 +62,11 @@ impl ProjectionMapper {
     /// Returns a new mapper with output projection and explicit read columns.
     pub fn new_with_read_columns(
         metadata: &RegionMetadataRef,
-        projection: impl Iterator<Item = usize>,
-        read_column_ids: Vec<ColumnId>,
+        output_cols: impl Into<ReadColumns>,
+        read_cols: impl Into<ReadColumns>,
     ) -> Result<Self> {
-        let projection: Vec<_> = projection.collect();
         Ok(ProjectionMapper::Flat(
-            FlatProjectionMapper::new_with_read_columns(metadata, projection, read_column_ids)?,
+            FlatProjectionMapper::new_with_read_columns(metadata, output_cols, read_cols)?,
         ))
     }
 
@@ -91,12 +91,10 @@ impl ProjectionMapper {
         }
     }
 
-    /// Returns ids of projected columns that we need to read
-    /// from memtables and SSTs.
-    pub(crate) fn column_ids(&self) -> &[ColumnId] {
+    pub(crate) fn read_columns(&self) -> &ReadColumns {
         match self {
-            ProjectionMapper::PrimaryKey(m) => m.column_ids(),
-            ProjectionMapper::Flat(m) => m.column_ids(),
+            ProjectionMapper::PrimaryKey(m) => m.read_columns(),
+            ProjectionMapper::Flat(m) => m.read_columns(),
         }
     }
 
@@ -148,7 +146,7 @@ pub struct PrimaryKeyProjectionMapper {
     /// Schema for converted [RecordBatch].
     output_schema: SchemaRef,
     /// Ids of columns to read from memtables and SSTs.
-    read_column_ids: Vec<ColumnId>,
+    read_cols: ReadColumns,
     /// Ids and DataTypes of field columns in the read [Batch].
     batch_fields: Vec<(ColumnId, ConcreteDataType)>,
     /// `true` If the original projection is empty.
@@ -167,15 +165,17 @@ impl PrimaryKeyProjectionMapper {
     ) -> Result<PrimaryKeyProjectionMapper> {
         let projection: Vec<_> = projection.collect();
         let read_column_ids = read_column_ids_from_projection(metadata, &projection)?;
-        Self::new_with_read_columns(metadata, projection, read_column_ids)
+        let projection_input = ProjectionInput::new(projection);
+        Self::new_with_read_columns(metadata, projection_input, read_column_ids)
     }
 
     /// Returns a new mapper with output projection and explicit read columns.
     pub fn new_with_read_columns(
         metadata: &RegionMetadataRef,
-        projection: Vec<usize>,
+        projection_input: ProjectionInput,
         read_column_ids: Vec<ColumnId>,
     ) -> Result<PrimaryKeyProjectionMapper> {
+        let projection = projection_input.projection;
         // If the original projection is empty.
         let is_empty_projection = projection.is_empty();
 
@@ -196,6 +196,8 @@ impl PrimaryKeyProjectionMapper {
         }
 
         let codec = build_primary_key_codec(metadata);
+        let read_cols =
+            build_read_columns(metadata, &projection_input.nested_paths, &read_column_ids)?;
         // If projection is empty, we don't output any column.
         let output_schema = if is_empty_projection {
             Arc::new(Schema::new(vec![]))
@@ -254,7 +256,7 @@ impl PrimaryKeyProjectionMapper {
             has_tags,
             codec,
             output_schema,
-            read_column_ids,
+            read_cols,
             batch_fields,
             is_empty_projection,
         })
@@ -277,8 +279,12 @@ impl PrimaryKeyProjectionMapper {
 
     /// Returns ids of projected columns that we need to read
     /// from memtables and SSTs.
-    pub(crate) fn column_ids(&self) -> &[ColumnId] {
-        &self.read_column_ids
+    pub(crate) fn column_ids_iter(&self) -> impl Iterator<Item = ColumnId> + '_ {
+        self.read_cols.column_ids_iter()
+    }
+
+    pub(crate) fn read_columns(&self) -> &ReadColumns {
+        &self.read_cols
     }
 
     /// Returns ids of fields in [Batch]es the mapper expects to convert.
@@ -459,6 +465,7 @@ mod tests {
     };
 
     use super::*;
+    use crate::read::read_columns::read_columns_from_projection;
 
     fn print_record_batch(record_batch: RecordBatch) -> String {
         pretty::pretty_format_batches(&[record_batch.into_df_record_batch()])
@@ -582,7 +589,7 @@ mod tests {
         );
         let cache = CacheStrategy::Disabled;
         let mapper = ProjectionMapper::all(&metadata).unwrap();
-        assert_eq!([0, 1, 2, 3, 4], mapper.column_ids());
+        assert_eq!(vec![0, 1, 2, 3, 4], mapper.read_columns().column_ids());
         assert_eq!(
             [
                 (1, ConcreteDataType::int64_datatype()),
@@ -618,7 +625,7 @@ mod tests {
         let cache = CacheStrategy::Disabled;
         // Columns v1, k0
         let mapper = ProjectionMapper::new(&metadata, [4, 1].into_iter()).unwrap();
-        assert_eq!([4, 1], mapper.column_ids());
+        assert_eq!(vec![4, 1], mapper.read_columns().column_ids());
         assert_eq!(
             [
                 (1, ConcreteDataType::int64_datatype()),
@@ -651,10 +658,11 @@ mod tests {
         );
         let cache = CacheStrategy::Disabled;
         // Output columns v1, k0. Read also includes v0.
+        let projection_input = ProjectionInput::new(vec![4, 1]);
+        let output_cols = read_columns_from_projection(&projection_input, &metadata).unwrap();
         let mapper =
-            ProjectionMapper::new_with_read_columns(&metadata, [4, 1].into_iter(), vec![4, 1, 3])
-                .unwrap();
-        assert_eq!([4, 1, 3], mapper.column_ids());
+            ProjectionMapper::new_with_read_columns(&metadata, output_cols, vec![4, 1, 3]).unwrap();
+        assert_eq!(vec![4, 1, 3], mapper.read_columns().column_ids());
 
         let batch = new_flat_batch(None, &[(1, 1)], &[(3, 3), (4, 4)], 3);
         let record_batch = mapper.as_flat().unwrap().convert(&batch, &cache).unwrap();
@@ -680,7 +688,7 @@ mod tests {
         let cache = CacheStrategy::Disabled;
         // Empty projection
         let mapper = ProjectionMapper::new(&metadata, [].into_iter()).unwrap();
-        assert_eq!([0], mapper.column_ids()); // Should still read the time index column
+        assert_eq!(vec![0], mapper.read_columns().column_ids()); // Should still read the time index column
         assert!(mapper.output_schema().is_empty());
         let flat_mapper = mapper.as_flat().unwrap();
         assert_eq!(

--- a/src/mito2/src/read/projection.rs
+++ b/src/mito2/src/read/projection.rs
@@ -622,7 +622,7 @@ mod tests {
         );
         let cache = CacheStrategy::Disabled;
         // Columns v1, k0
-        let mapper = ProjectionMapper::new(&metadata, [4, 1].into_iter()).unwrap();
+        let mapper = ProjectionMapper::new(&metadata, [4, 1]).unwrap();
         assert_eq!(vec![4, 1], mapper.read_columns().column_ids());
         assert_eq!(
             [
@@ -683,7 +683,7 @@ mod tests {
         );
         let cache = CacheStrategy::Disabled;
         // Empty projection
-        let mapper = ProjectionMapper::new(&metadata, [].into_iter()).unwrap();
+        let mapper = ProjectionMapper::new(&metadata, []).unwrap();
         assert_eq!(vec![0], mapper.read_columns().column_ids()); // Should still read the time index column
         assert!(mapper.output_schema().is_empty());
         let flat_mapper = mapper.as_flat().unwrap();

--- a/src/mito2/src/read/projection.rs
+++ b/src/mito2/src/read/projection.rs
@@ -49,24 +49,24 @@ pub enum ProjectionMapper {
 }
 
 impl ProjectionMapper {
-    /// Returns a new mapper with projection.
+    /// Builds a mapper from a user projection.
     pub fn new(
         metadata: &RegionMetadataRef,
-        projection: impl Iterator<Item = usize> + Clone,
+        projection: impl IntoIterator<Item = usize>,
     ) -> Result<Self> {
         Ok(ProjectionMapper::Flat(FlatProjectionMapper::new(
             metadata, projection,
         )?))
     }
 
-    /// Returns a new mapper with output projection and explicit read columns.
+    /// Builds a mapper from a user projection and explicit read columns.
     pub fn new_with_read_columns(
         metadata: &RegionMetadataRef,
-        output_cols: impl Into<ReadColumns>,
+        projection: impl IntoIterator<Item = usize>,
         read_cols: impl Into<ReadColumns>,
     ) -> Result<Self> {
         Ok(ProjectionMapper::Flat(
-            FlatProjectionMapper::new_with_read_columns(metadata, output_cols, read_cols)?,
+            FlatProjectionMapper::new_with_read_columns(metadata, projection, read_cols)?,
         ))
     }
 
@@ -465,8 +465,6 @@ mod tests {
     };
 
     use super::*;
-    use crate::read::read_columns::read_columns_from_projection;
-
     fn print_record_batch(record_batch: RecordBatch) -> String {
         pretty::pretty_format_batches(&[record_batch.into_df_record_batch()])
             .unwrap()
@@ -658,10 +656,8 @@ mod tests {
         );
         let cache = CacheStrategy::Disabled;
         // Output columns v1, k0. Read also includes v0.
-        let projection_input = ProjectionInput::new(vec![4, 1]);
-        let output_cols = read_columns_from_projection(&projection_input, &metadata).unwrap();
         let mapper =
-            ProjectionMapper::new_with_read_columns(&metadata, output_cols, vec![4, 1, 3]).unwrap();
+            ProjectionMapper::new_with_read_columns(&metadata, vec![4, 1], vec![4, 1, 3]).unwrap();
         assert_eq!(vec![4, 1, 3], mapper.read_columns().column_ids());
 
         let batch = new_flat_batch(None, &[(1, 1)], &[(3, 3), (4, 4)], 3);

--- a/src/mito2/src/read/range_cache.rs
+++ b/src/mito2/src/read/range_cache.rs
@@ -26,12 +26,13 @@ use datatypes::prelude::ConcreteDataType;
 use futures::TryStreamExt;
 use snafu::ResultExt;
 use store_api::region_engine::PartitionRange;
-use store_api::storage::{ColumnId, FileId, RegionId, TimeSeriesRowSelector};
+use store_api::storage::{FileId, RegionId, TimeSeriesRowSelector};
 use tokio::sync::{mpsc, oneshot};
 
 use crate::cache::CacheStrategy;
 use crate::error::{ComputeArrowSnafu, Result};
 use crate::read::BoxedRecordBatchStream;
+use crate::read::read_columns::ReadColumns;
 use crate::read::scan_region::StreamContext;
 use crate::read::scan_util::PartitionMetrics;
 use crate::region::options::MergeMode;
@@ -63,7 +64,7 @@ pub(crate) struct ScanRequestFingerprint {
 
 #[derive(Debug)]
 pub(crate) struct ScanRequestFingerprintBuilder {
-    pub(crate) read_column_ids: Vec<ColumnId>,
+    pub(crate) read_columns: ReadColumns,
     pub(crate) read_column_types: Vec<Option<ConcreteDataType>>,
     pub(crate) filters: Vec<String>,
     pub(crate) time_filters: Vec<String>,
@@ -77,7 +78,7 @@ pub(crate) struct ScanRequestFingerprintBuilder {
 impl ScanRequestFingerprintBuilder {
     pub(crate) fn build(self) -> ScanRequestFingerprint {
         let Self {
-            read_column_ids,
+            read_columns,
             read_column_types,
             filters,
             time_filters,
@@ -90,7 +91,7 @@ impl ScanRequestFingerprintBuilder {
 
         ScanRequestFingerprint {
             inner: Arc::new(SharedScanRequestFingerprint {
-                read_column_ids,
+                read_columns,
                 read_column_types,
                 filters,
             }),
@@ -107,8 +108,8 @@ impl ScanRequestFingerprintBuilder {
 /// Non-copiable struct of the fingerprint.
 #[derive(Debug, PartialEq, Eq, Hash)]
 struct SharedScanRequestFingerprint {
-    /// Column ids of the projection.
-    read_column_ids: Vec<ColumnId>,
+    /// Logical columns of the projection.
+    read_columns: ReadColumns,
     /// Column types of the projection.
     /// We keep this to ensure we won't reuse the fingerprint after a schema change.
     read_column_types: Vec<Option<ConcreteDataType>>,
@@ -118,8 +119,8 @@ struct SharedScanRequestFingerprint {
 
 impl ScanRequestFingerprint {
     #[cfg(test)]
-    pub(crate) fn read_column_ids(&self) -> &[ColumnId] {
-        &self.inner.read_column_ids
+    pub(crate) fn read_columns(&self) -> &ReadColumns {
+        &self.inner.read_columns
     }
 
     #[cfg(test)]
@@ -154,7 +155,7 @@ impl ScanRequestFingerprint {
 
     pub(crate) fn estimated_size(&self) -> usize {
         mem::size_of::<SharedScanRequestFingerprint>()
-            + self.inner.read_column_ids.capacity() * mem::size_of::<ColumnId>()
+            + self.inner.read_columns.estimated_size()
             + self.inner.read_column_types.capacity() * mem::size_of::<Option<ConcreteDataType>>()
             + self.inner.filters.capacity() * mem::size_of::<String>()
             + self
@@ -591,7 +592,7 @@ pub fn bench_cache_flat_range_stream(
     let cache_strategy = CacheStrategy::EnableAll(cache_manager);
 
     let fingerprint = ScanRequestFingerprintBuilder {
-        read_column_ids: vec![],
+        read_columns: ReadColumns::from_deduped_column_ids(std::iter::empty()),
         read_column_types: vec![],
         filters: vec![],
         time_filters: vec![],
@@ -654,8 +655,9 @@ mod tests {
         filter_deleted: bool,
         partition_expr_version: u64,
     ) -> ScanRequestFingerprint {
+        let read_columns = ReadColumns::from_deduped_column_ids([1, 2]);
         ScanRequestFingerprintBuilder {
-            read_column_ids: vec![1, 2],
+            read_columns,
             read_column_types: vec![None, None],
             filters,
             time_filters,
@@ -704,7 +706,7 @@ mod tests {
     ) -> (StreamContext, PartitionRange) {
         let env = SchedulerEnv::new().await;
         let metadata = Arc::new(metadata_with_primary_key(vec![0, 1], false));
-        let mapper = FlatProjectionMapper::new(&metadata, [0, 2, 3].into_iter()).unwrap();
+        let mapper = FlatProjectionMapper::new(&metadata, [0, 2, 3]).unwrap();
         let predicate = PredicateGroup::new(metadata.as_ref(), &filters).unwrap();
         let file_id = FileId::random();
         let file = sst_file_handle_with_file_id(
@@ -848,7 +850,7 @@ mod tests {
 
         let reset = fingerprint.without_time_filters();
 
-        assert_eq!(reset.read_column_ids(), fingerprint.read_column_ids());
+        assert_eq!(reset.read_columns(), fingerprint.read_columns());
         assert_eq!(reset.read_column_types(), fingerprint.read_column_types());
         assert_eq!(reset.filters(), fingerprint.filters());
         assert!(reset.time_filters().is_empty());

--- a/src/mito2/src/read/range_cache.rs
+++ b/src/mito2/src/read/range_cache.rs
@@ -692,7 +692,7 @@ mod tests {
     ) -> (StreamContext, PartitionRange) {
         let env = SchedulerEnv::new().await;
         let metadata = Arc::new(metadata_with_primary_key(vec![0, 1], false));
-        let mapper = ProjectionMapper::new(&metadata, [0, 2, 3].into_iter()).unwrap();
+        let mapper = ProjectionMapper::new(&metadata, [0, 2, 3]).unwrap();
         let predicate = PredicateGroup::new(metadata.as_ref(), &filters).unwrap();
         let file_id = FileId::random();
         let file = sst_file_handle_with_file_id(

--- a/src/mito2/src/read/range_cache.rs
+++ b/src/mito2/src/read/range_cache.rs
@@ -821,7 +821,7 @@ mod tests {
     #[test]
     fn normalizes_and_clears_time_filters() {
         let normalized = ScanRequestFingerprintBuilder {
-            read_columns: ReadColumns::from_column_ids(vec![1, 2]),
+            read_columns: ReadColumns::from_column_ids([1, 2]),
             read_column_types: vec![None, None],
             filters: vec!["k0 = 'foo'".to_string()],
             time_filters: vec![],
@@ -836,7 +836,7 @@ mod tests {
         assert!(normalized.time_filters().is_empty());
 
         let fingerprint = ScanRequestFingerprintBuilder {
-            read_columns: ReadColumns::from_column_ids(vec![1, 2]),
+            read_columns: ReadColumns::from_column_ids([1, 2]),
             read_column_types: vec![None, None],
             filters: vec!["k0 = 'foo'".to_string()],
             time_filters: vec!["ts >= 1000".to_string()],

--- a/src/mito2/src/read/range_cache.rs
+++ b/src/mito2/src/read/range_cache.rs
@@ -26,12 +26,13 @@ use datatypes::prelude::ConcreteDataType;
 use futures::TryStreamExt;
 use snafu::ResultExt;
 use store_api::region_engine::PartitionRange;
-use store_api::storage::{ColumnId, FileId, RegionId, TimeSeriesRowSelector};
+use store_api::storage::{FileId, RegionId, TimeSeriesRowSelector};
 use tokio::sync::{mpsc, oneshot};
 
 use crate::cache::CacheStrategy;
 use crate::error::{ComputeArrowSnafu, Result, UnexpectedSnafu};
 use crate::read::BoxedRecordBatchStream;
+use crate::read::read_columns::ReadColumns;
 use crate::read::scan_region::StreamContext;
 use crate::read::scan_util::PartitionMetrics;
 use crate::region::options::MergeMode;
@@ -64,7 +65,7 @@ pub(crate) struct ScanRequestFingerprint {
 
 #[derive(Debug)]
 pub(crate) struct ScanRequestFingerprintBuilder {
-    pub(crate) read_column_ids: Vec<ColumnId>,
+    pub(crate) read_columns: ReadColumns,
     pub(crate) read_column_types: Vec<Option<ConcreteDataType>>,
     pub(crate) filters: Vec<String>,
     pub(crate) time_filters: Vec<String>,
@@ -78,7 +79,7 @@ pub(crate) struct ScanRequestFingerprintBuilder {
 impl ScanRequestFingerprintBuilder {
     pub(crate) fn build(self) -> ScanRequestFingerprint {
         let Self {
-            read_column_ids,
+            read_columns,
             read_column_types,
             filters,
             time_filters,
@@ -91,7 +92,7 @@ impl ScanRequestFingerprintBuilder {
 
         ScanRequestFingerprint {
             inner: Arc::new(SharedScanRequestFingerprint {
-                read_column_ids,
+                read_columns,
                 read_column_types,
                 filters,
             }),
@@ -108,8 +109,8 @@ impl ScanRequestFingerprintBuilder {
 /// Non-copiable struct of the fingerprint.
 #[derive(Debug, PartialEq, Eq, Hash)]
 struct SharedScanRequestFingerprint {
-    /// Column ids of the projection.
-    read_column_ids: Vec<ColumnId>,
+    /// Logical columns of the projection.
+    read_columns: ReadColumns,
     /// Column types of the projection.
     /// We keep this to ensure we won't reuse the fingerprint after a schema change.
     read_column_types: Vec<Option<ConcreteDataType>>,
@@ -119,8 +120,8 @@ struct SharedScanRequestFingerprint {
 
 impl ScanRequestFingerprint {
     #[cfg(test)]
-    pub(crate) fn read_column_ids(&self) -> &[ColumnId] {
-        &self.inner.read_column_ids
+    pub(crate) fn read_columns(&self) -> &ReadColumns {
+        &self.inner.read_columns
     }
 
     #[cfg(test)]
@@ -155,7 +156,7 @@ impl ScanRequestFingerprint {
 
     pub(crate) fn estimated_size(&self) -> usize {
         mem::size_of::<SharedScanRequestFingerprint>()
-            + self.inner.read_column_ids.capacity() * mem::size_of::<ColumnId>()
+            + mem::size_of_val(self.inner.read_columns.columns())
             + self.inner.read_column_types.capacity() * mem::size_of::<Option<ConcreteDataType>>()
             + self.inner.filters.capacity() * mem::size_of::<String>()
             + self
@@ -590,7 +591,7 @@ pub fn bench_cache_flat_range_stream(
     let cache_strategy = CacheStrategy::EnableAll(cache_manager);
 
     let fingerprint = ScanRequestFingerprintBuilder {
-        read_column_ids: vec![],
+        read_columns: ReadColumns::from_column_ids(std::iter::empty()),
         read_column_types: vec![],
         filters: vec![],
         time_filters: vec![],
@@ -652,7 +653,7 @@ mod tests {
             region_id,
             row_groups: vec![],
             scan: ScanRequestFingerprintBuilder {
-                read_column_ids: vec![],
+                read_columns: ReadColumns::from_column_ids(std::iter::empty()),
                 read_column_types: vec![],
                 filters: vec![],
                 time_filters: vec![],
@@ -820,7 +821,7 @@ mod tests {
     #[test]
     fn normalizes_and_clears_time_filters() {
         let normalized = ScanRequestFingerprintBuilder {
-            read_column_ids: vec![1, 2],
+            read_columns: ReadColumns::from_column_ids(vec![1, 2]),
             read_column_types: vec![None, None],
             filters: vec!["k0 = 'foo'".to_string()],
             time_filters: vec![],
@@ -835,7 +836,7 @@ mod tests {
         assert!(normalized.time_filters().is_empty());
 
         let fingerprint = ScanRequestFingerprintBuilder {
-            read_column_ids: vec![1, 2],
+            read_columns: ReadColumns::from_column_ids(vec![1, 2]),
             read_column_types: vec![None, None],
             filters: vec!["k0 = 'foo'".to_string()],
             time_filters: vec!["ts >= 1000".to_string()],
@@ -849,7 +850,7 @@ mod tests {
 
         let reset = fingerprint.without_time_filters();
 
-        assert_eq!(reset.read_column_ids(), fingerprint.read_column_ids());
+        assert_eq!(reset.read_columns(), fingerprint.read_columns());
         assert_eq!(reset.read_column_types(), fingerprint.read_column_types());
         assert_eq!(reset.filters(), fingerprint.filters());
         assert!(reset.time_filters().is_empty());

--- a/src/mito2/src/read/range_cache.rs
+++ b/src/mito2/src/read/range_cache.rs
@@ -156,7 +156,7 @@ impl ScanRequestFingerprint {
 
     pub(crate) fn estimated_size(&self) -> usize {
         mem::size_of::<SharedScanRequestFingerprint>()
-            + mem::size_of_val(self.inner.read_columns.columns())
+            + self.inner.read_columns.estimated_size()
             + self.inner.read_column_types.capacity() * mem::size_of::<Option<ConcreteDataType>>()
             + self.inner.filters.capacity() * mem::size_of::<String>()
             + self

--- a/src/mito2/src/read/read_columns.rs
+++ b/src/mito2/src/read/read_columns.rs
@@ -62,7 +62,7 @@ use crate::read::scan_region::PredicateGroup;
 /// If `nested_paths` is empty, the whole column will be read.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
 pub struct ReadColumns {
-    cols: Vec<ReadColumn>,
+    pub cols: Vec<ReadColumn>,
 }
 
 impl ReadColumns {
@@ -82,7 +82,7 @@ impl ReadColumns {
     }
 
     pub fn column_ids_iter(&self) -> impl Iterator<Item = ColumnId> + '_ {
-        self.cols.iter().map(|column| column.column_id())
+        self.cols.iter().map(|column| column.column_id)
     }
 
     pub fn column_ids(&self) -> Vec<ColumnId> {
@@ -114,10 +114,10 @@ where
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ReadColumn {
-    column_id: ColumnId,
+    pub column_id: ColumnId,
     /// Nested field paths under this column.
     /// Empty means reading the whole column.
-    nested_paths: Vec<NestedPath>,
+    pub nested_paths: Vec<NestedPath>,
 }
 
 impl ReadColumn {
@@ -126,10 +126,6 @@ impl ReadColumn {
             column_id,
             nested_paths,
         }
-    }
-
-    pub fn column_id(&self) -> ColumnId {
-        self.column_id
     }
 
     pub fn nested_paths(&self) -> &[NestedPath] {

--- a/src/mito2/src/read/read_columns.rs
+++ b/src/mito2/src/read/read_columns.rs
@@ -106,6 +106,15 @@ impl ReadColumns {
     }
 }
 
+impl<I> From<I> for ReadColumns
+where
+    I: IntoIterator<Item = ColumnId>,
+{
+    fn from(col_ids: I) -> Self {
+        ReadColumns::from_deduped_column_ids(col_ids)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ReadColumn {
     column_id: ColumnId,

--- a/src/mito2/src/read/read_columns.rs
+++ b/src/mito2/src/read/read_columns.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO(fys): remove this once the module is used
-#![allow(dead_code)]
-
 use std::collections::{BTreeMap, HashSet};
 use std::mem;
 

--- a/src/mito2/src/read/read_columns.rs
+++ b/src/mito2/src/read/read_columns.rs
@@ -103,15 +103,6 @@ impl ReadColumns {
     }
 }
 
-impl<I> From<I> for ReadColumns
-where
-    I: IntoIterator<Item = ColumnId>,
-{
-    fn from(col_ids: I) -> Self {
-        ReadColumns::from_deduped_column_ids(col_ids)
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ReadColumn {
     pub column_id: ColumnId,

--- a/src/mito2/src/read/read_columns.rs
+++ b/src/mito2/src/read/read_columns.rs
@@ -96,7 +96,7 @@ impl ReadColumns {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ReadColumn {
     column_id: ColumnId,
-    /// Nested filed paths under this column.
+    /// Nested field paths under this column.
     /// Empty means reading the whole column.
     nested_paths: Vec<NestedPath>,
 }

--- a/src/mito2/src/read/read_columns.rs
+++ b/src/mito2/src/read/read_columns.rs
@@ -1,0 +1,559 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::{BTreeMap, HashSet};
+
+use datafusion_common::HashMap;
+use datafusion_expr::utils::expr_to_columns;
+use snafu::OptionExt;
+use store_api::metadata::RegionMetadataRef;
+use store_api::storage::{ColumnId, NestedPath, ProjectionInput};
+
+use crate::error::{InvalidRequestSnafu, Result};
+use crate::read::scan_region::PredicateGroup;
+
+/// Logical columns to read from a region.
+///
+/// Read columns describe which logical columns and nested fields should be read
+/// from storage. Each read column is identified by its [`ColumnId`],
+/// which represents the root column in the storage schema.
+///
+/// Nested fields under the column are specified by [`NestedPath`] entries.
+/// Each path includes the root column name as its first element.
+///
+/// For example, assume column id `9` corresponds to a root column named `j`
+/// with nested fields:
+///
+/// ```text
+/// j
+/// ├── a
+/// └── b
+///     └── c
+/// ```
+///
+/// The following SQL:
+///
+/// SELECT j.a, j.b.c FROM t
+///
+/// may produce read columns like:
+///
+/// ```text
+/// ReadColumn {
+///     column_id: 9,
+///     nested_paths: [
+///         ["j", "a"],
+///         ["j", "b", "c"],
+///     ]
+/// }
+/// ```
+///
+/// If `nested_paths` is empty, the whole column will be read.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+pub struct ReadColumns {
+    cols: Vec<ReadColumn>,
+}
+
+impl ReadColumns {
+    pub fn from_column_ids<I>(column_ids: I) -> Self
+    where
+        I: IntoIterator<Item = u32>,
+    {
+        let cols = column_ids
+            .into_iter()
+            .map(|col_id| ReadColumn::new(col_id, vec![]))
+            .collect();
+        ReadColumns { cols }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.cols.is_empty()
+    }
+
+    pub fn column_ids_iter(&self) -> impl Iterator<Item = ColumnId> + '_ {
+        self.cols.iter().map(|column| column.column_id())
+    }
+
+    pub fn column_ids(&self) -> Vec<ColumnId> {
+        self.column_ids_iter().collect()
+    }
+
+    pub fn columns(&self) -> &[ReadColumn] {
+        &self.cols
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ReadColumn {
+    column_id: ColumnId,
+    /// Nested filed paths under this column.
+    /// Empty means reading the whole column.
+    nested_paths: Vec<NestedPath>,
+}
+
+impl ReadColumn {
+    pub fn new(column_id: ColumnId, nested_paths: Vec<NestedPath>) -> Self {
+        Self {
+            column_id,
+            nested_paths,
+        }
+    }
+
+    pub fn column_id(&self) -> ColumnId {
+        self.column_id
+    }
+
+    pub fn nested_paths(&self) -> &[NestedPath] {
+        &self.nested_paths
+    }
+}
+
+impl From<Vec<ColumnId>> for ReadColumns {
+    fn from(col_ids: Vec<ColumnId>) -> Self {
+        ReadColumns::from_column_ids(col_ids)
+    }
+}
+
+/// Builds the final read columns.
+///
+/// `read_column_ids` determines which root columns to read and in what order.
+/// Nested paths are attached to matching columns by column name.
+pub fn build_read_columns(
+    metadata: &RegionMetadataRef,
+    nested_paths: &[NestedPath],
+    read_col_ids: &[ColumnId],
+) -> Result<ReadColumns> {
+    let mut paths_by_col: HashMap<String, Vec<NestedPath>> = HashMap::new();
+    for path in nested_paths {
+        let Some((root_name, _)) = path.split_first() else {
+            continue;
+        };
+        paths_by_col
+            .entry(root_name.clone())
+            .or_default()
+            .push(path.clone());
+    }
+
+    let mut cols = Vec::with_capacity(read_col_ids.len());
+    for col_id in read_col_ids {
+        let column_id = *col_id;
+
+        let col = metadata
+            .column_by_id(column_id)
+            .with_context(|| InvalidRequestSnafu {
+                region_id: metadata.region_id,
+                reason: format!("read column id {} does not exist in metadata", column_id),
+            })?;
+
+        let nested_paths = paths_by_col
+            .get(&col.column_schema.name)
+            .cloned()
+            .unwrap_or_default();
+
+        cols.push(ReadColumn {
+            column_id,
+            nested_paths,
+        });
+    }
+
+    Ok(ReadColumns { cols })
+}
+
+pub fn merge_read_cols(a: ReadColumns, b: ReadColumns) -> ReadColumns {
+    let mut merged = BTreeMap::<u32, Vec<NestedPath>>::new();
+
+    for col in a.cols.into_iter().chain(b.cols) {
+        if let Some(nested_paths) = merged.get_mut(&col.column_id) {
+            if nested_paths.is_empty() || col.nested_paths.is_empty() {
+                *nested_paths = vec![];
+            } else {
+                merge_nested_paths(nested_paths, col.nested_paths);
+            }
+            continue;
+        }
+
+        merged.insert(col.column_id, normalize_nested_paths(col.nested_paths));
+    }
+
+    ReadColumns {
+        cols: merged
+            .into_iter()
+            .map(|(column_id, nested_paths)| ReadColumn {
+                column_id,
+                nested_paths,
+            })
+            .collect(),
+    }
+}
+
+fn normalize_nested_paths(nested_paths: Vec<NestedPath>) -> Vec<NestedPath> {
+    let mut normalized = Vec::with_capacity(nested_paths.len());
+    merge_nested_paths(&mut normalized, nested_paths);
+    normalized
+}
+
+fn merge_nested_paths(merged: &mut Vec<NestedPath>, incoming: Vec<NestedPath>) {
+    for path in incoming {
+        if merged
+            .iter()
+            .any(|existing| path.starts_with(existing.as_slice()))
+        {
+            continue;
+        }
+
+        merged.retain(|existing| !existing.starts_with(path.as_slice()));
+        merged.push(path);
+    }
+}
+
+/// Build [`ReadColumns`] from [`ProjectionInput`].
+///
+/// Note: If `projection.projection` is empty, this function still reads the
+/// time index column so the scan can preserve row counts for empty-output
+/// queries such as `SELECT COUNT(*)`.
+pub fn read_columns_from_projection(
+    projection: &ProjectionInput,
+    metadata: &RegionMetadataRef,
+) -> Result<ReadColumns> {
+    let root_indices = if projection.projection.is_empty() {
+        vec![metadata.time_index_column_pos()]
+    } else {
+        projection.projection.clone()
+    };
+
+    let col_ids = root_indices
+        .iter()
+        .map(|idx| {
+            metadata
+                .column_metadatas
+                .get(*idx)
+                .with_context(|| InvalidRequestSnafu {
+                    region_id: metadata.region_id,
+                    reason: format!("projection index {} is out of bound", idx),
+                })
+                .map(|col| col.column_id)
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut paths_by_col: HashMap<String, Vec<NestedPath>> = HashMap::new();
+    for path in &projection.nested_paths {
+        let Some((root_name, _)) = path.split_first() else {
+            continue;
+        };
+        paths_by_col
+            .entry(root_name.clone())
+            .or_default()
+            .push(path.clone());
+    }
+
+    let mut cols = Vec::with_capacity(col_ids.len());
+    for column_id in col_ids {
+        let col = metadata
+            .column_by_id(column_id)
+            .with_context(|| InvalidRequestSnafu {
+                region_id: metadata.region_id,
+                reason: format!("read column id {} does not exist in metadata", column_id),
+            })?;
+
+        let nested_paths = paths_by_col
+            .get(&col.column_schema.name)
+            .cloned()
+            .unwrap_or_default();
+
+        cols.push(ReadColumn {
+            column_id,
+            nested_paths,
+        });
+    }
+
+    Ok(ReadColumns { cols })
+}
+
+/// Build [`ReadColumns`] from [`PredicateGroup`].
+pub fn read_columns_from_predicate(
+    predicate: &PredicateGroup,
+    metadata: &RegionMetadataRef,
+) -> ReadColumns {
+    let mut root_names = HashSet::new();
+    let mut columns = HashSet::new();
+
+    if let Some(p) = predicate.predicate_without_region() {
+        for expr in p.exprs() {
+            columns.clear();
+            if expr_to_columns(expr, &mut columns).is_err() {
+                continue;
+            }
+            root_names.extend(columns.iter().map(|column| column.name.clone()));
+        }
+    }
+
+    if let Some(expr) = predicate.region_partition_expr() {
+        expr.collect_column_names(&mut root_names);
+    }
+
+    // TODO(fys): Parse nested paths from predicate expressions and attach them
+    // to read columns instead of always reading the whole root column.
+    let cols = metadata
+        .column_metadatas
+        .iter()
+        .filter(|column| root_names.contains(column.column_schema.name.as_str()))
+        .map(|column| ReadColumn::new(column.column_id, vec![]))
+        .collect();
+
+    ReadColumns { cols }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use api::v1::SemanticType;
+    use datafusion_expr::{col, lit};
+    use datatypes::prelude::ConcreteDataType;
+    use datatypes::schema::ColumnSchema;
+    use store_api::metadata::{ColumnMetadata, RegionMetadataBuilder};
+    use store_api::storage::RegionId;
+
+    use super::*;
+
+    #[test]
+    fn test_read_columns_from_empty_projection() {
+        let metadata = new_test_metadata();
+
+        let read_columns =
+            read_columns_from_projection(&ProjectionInput::default(), &metadata).unwrap();
+
+        let expected = ReadColumns {
+            cols: vec![ReadColumn::new(2, vec![])],
+        };
+        assert_eq!(expected, read_columns);
+
+        let projection_input =
+            ProjectionInput::new(vec![]).with_nested_paths(vec![vec!["1".to_string()]]);
+        let read_columns = read_columns_from_projection(&projection_input, &metadata).unwrap();
+
+        let expected = ReadColumns {
+            cols: vec![ReadColumn::new(2, vec![])],
+        };
+        assert_eq!(expected, read_columns);
+    }
+
+    #[test]
+    fn test_read_columns_from_projection_with_nested_paths() {
+        let metadata = new_test_metadata();
+        let projection = ProjectionInput::new(vec![1, 0]).with_nested_paths(vec![
+            nested_path(&["field_0", "a"]),
+            nested_path(&["field_0", "b", "c"]),
+        ]);
+
+        let read_columns = read_columns_from_projection(&projection, &metadata).unwrap();
+
+        let expected = ReadColumns {
+            cols: vec![
+                ReadColumn::new(
+                    3,
+                    vec![
+                        nested_path(&["field_0", "a"]),
+                        nested_path(&["field_0", "b", "c"]),
+                    ],
+                ),
+                ReadColumn::new(0, vec![]),
+            ],
+        };
+        assert_eq!(expected, read_columns,);
+    }
+
+    #[test]
+    fn test_read_columns_from_projection_out_of_bound() {
+        let metadata = new_test_metadata();
+        let projection = ProjectionInput::new(vec![3]);
+
+        let err = read_columns_from_projection(&projection, &metadata).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("projection index 3 is out of bound")
+        );
+    }
+
+    #[test]
+    fn test_read_columns_from_predicate_reads_root_columns_only() {
+        let metadata = new_test_metadata();
+        let predicate = PredicateGroup::new(
+            metadata.as_ref(),
+            &[col("field_0").gt(lit(1)), col("tag_0").eq(lit("a"))],
+        )
+        .unwrap();
+
+        let read_columns = read_columns_from_predicate(&predicate, &metadata);
+
+        let expected = ReadColumns {
+            cols: vec![ReadColumn::new(0, vec![]), ReadColumn::new(3, vec![])],
+        };
+        assert_eq!(expected, read_columns);
+    }
+
+    #[test]
+    fn test_read_columns_from_predicate_empty() {
+        let metadata = new_test_metadata();
+        let predicate = PredicateGroup::new(metadata.as_ref(), &[]).unwrap();
+
+        let read_columns = read_columns_from_predicate(&predicate, &metadata);
+
+        assert!(read_columns.is_empty());
+    }
+
+    #[test]
+    fn test_merge_read_cols_with_only_root() {
+        let a = ReadColumns {
+            cols: vec![ReadColumn::new(3, vec![]), ReadColumn::new(1, vec![])],
+        };
+        let b = ReadColumns {
+            cols: vec![ReadColumn::new(2, vec![])],
+        };
+
+        let merged = merge_read_cols(a, b);
+
+        assert_eq!(
+            merged,
+            ReadColumns {
+                cols: vec![
+                    ReadColumn::new(1, vec![]),
+                    ReadColumn::new(2, vec![]),
+                    ReadColumn::new(3, vec![]),
+                ],
+            }
+        );
+    }
+
+    #[test]
+    fn test_merge_read_cols_with_nested_paths() {
+        let a = ReadColumns {
+            cols: vec![ReadColumn::new(1, vec![nested_path(&["j", "a"])])],
+        };
+        let b = ReadColumns {
+            cols: vec![ReadColumn::new(
+                1,
+                vec![nested_path(&["j", "b"]), nested_path(&["j", "c"])],
+            )],
+        };
+
+        let merged = merge_read_cols(a, b);
+
+        assert_eq!(
+            merged,
+            ReadColumns {
+                cols: vec![ReadColumn::new(
+                    1,
+                    vec![
+                        nested_path(&["j", "a"]),
+                        nested_path(&["j", "b"]),
+                        nested_path(&["j", "c"]),
+                    ],
+                )],
+            }
+        );
+    }
+
+    #[test]
+    fn test_merge_read_cols_with_column_override() {
+        let a = ReadColumns {
+            cols: vec![
+                ReadColumn::new(1, vec![nested_path(&["j", "a"])]),
+                ReadColumn::new(2, vec![nested_path(&["k", "b"])]),
+            ],
+        };
+        let b = ReadColumns {
+            cols: vec![
+                ReadColumn::new(1, vec![]),
+                ReadColumn::new(2, vec![nested_path(&["k", "b", "c"])]),
+            ],
+        };
+
+        let merged = merge_read_cols(a, b);
+
+        assert_eq!(
+            merged,
+            ReadColumns {
+                cols: vec![
+                    ReadColumn::new(1, vec![]),
+                    ReadColumn::new(2, vec![nested_path(&["k", "b"])])
+                ],
+            }
+        );
+    }
+
+    #[test]
+    fn test_merge_read_cols_dedups_redundant_nested_paths() {
+        let a = ReadColumns {
+            cols: vec![ReadColumn::new(
+                1,
+                vec![
+                    nested_path(&["j", "a", "b"]),
+                    nested_path(&["j", "a"]),
+                    nested_path(&["j", "a", "b", "c"]),
+                ],
+            )],
+        };
+        let b = ReadColumns {
+            cols: vec![ReadColumn::new(1, vec![nested_path(&["j", "a"])])],
+        };
+
+        let merged = merge_read_cols(a, b);
+
+        assert_eq!(
+            merged,
+            ReadColumns {
+                cols: vec![ReadColumn::new(1, vec![nested_path(&["j", "a"])])],
+            }
+        );
+    }
+
+    fn new_test_metadata() -> RegionMetadataRef {
+        let mut builder = RegionMetadataBuilder::new(RegionId::new(1, 1));
+        builder
+            .push_column_metadata(ColumnMetadata {
+                column_schema: ColumnSchema::new(
+                    "tag_0".to_string(),
+                    ConcreteDataType::string_datatype(),
+                    true,
+                ),
+                semantic_type: SemanticType::Tag,
+                column_id: 0,
+            })
+            .push_column_metadata(ColumnMetadata {
+                column_schema: ColumnSchema::new(
+                    "field_0".to_string(),
+                    ConcreteDataType::string_datatype(),
+                    true,
+                ),
+                semantic_type: SemanticType::Field,
+                column_id: 3,
+            })
+            .push_column_metadata(ColumnMetadata {
+                column_schema: ColumnSchema::new(
+                    "ts".to_string(),
+                    ConcreteDataType::timestamp_millisecond_datatype(),
+                    false,
+                ),
+                semantic_type: SemanticType::Timestamp,
+                column_id: 2,
+            });
+        builder.primary_key(vec![0]);
+        Arc::new(builder.build().unwrap())
+    }
+
+    fn nested_path(parts: &[&str]) -> NestedPath {
+        parts.iter().map(|part| (*part).to_string()).collect()
+    }
+}

--- a/src/mito2/src/read/read_columns.rs
+++ b/src/mito2/src/read/read_columns.rs
@@ -124,51 +124,6 @@ impl From<Vec<ColumnId>> for ReadColumns {
     }
 }
 
-/// Builds the final read columns.
-///
-/// `read_column_ids` determines which root columns to read and in what order.
-/// Nested paths are attached to matching columns by column name.
-pub fn build_read_columns(
-    metadata: &RegionMetadataRef,
-    nested_paths: &[NestedPath],
-    read_col_ids: &[ColumnId],
-) -> Result<ReadColumns> {
-    let mut paths_by_col: HashMap<String, Vec<NestedPath>> = HashMap::new();
-    for path in nested_paths {
-        let Some((root_name, _)) = path.split_first() else {
-            continue;
-        };
-        paths_by_col
-            .entry(root_name.clone())
-            .or_default()
-            .push(path.clone());
-    }
-
-    let mut cols = Vec::with_capacity(read_col_ids.len());
-    for col_id in read_col_ids {
-        let column_id = *col_id;
-
-        let col = metadata
-            .column_by_id(column_id)
-            .with_context(|| InvalidRequestSnafu {
-                region_id: metadata.region_id,
-                reason: format!("read column id {} does not exist in metadata", column_id),
-            })?;
-
-        let nested_paths = paths_by_col
-            .get(&col.column_schema.name)
-            .cloned()
-            .unwrap_or_default();
-
-        cols.push(ReadColumn {
-            column_id,
-            nested_paths,
-        });
-    }
-
-    Ok(ReadColumns { cols })
-}
-
 pub fn merge_read_cols(a: ReadColumns, b: ReadColumns) -> ReadColumns {
     let mut merged = BTreeMap::<u32, Vec<NestedPath>>::new();
 

--- a/src/mito2/src/read/read_columns.rs
+++ b/src/mito2/src/read/read_columns.rs
@@ -124,7 +124,7 @@ impl From<Vec<ColumnId>> for ReadColumns {
     }
 }
 
-pub fn merge_read_cols(a: ReadColumns, b: ReadColumns) -> ReadColumns {
+pub fn merge(a: ReadColumns, b: ReadColumns) -> ReadColumns {
     let mut merged = BTreeMap::<u32, Vec<NestedPath>>::new();
 
     for col in a.cols.into_iter().chain(b.cols) {
@@ -377,7 +377,7 @@ mod tests {
             cols: vec![ReadColumn::new(2, vec![])],
         };
 
-        let merged = merge_read_cols(a, b);
+        let merged = merge(a, b);
 
         assert_eq!(
             merged,
@@ -403,7 +403,7 @@ mod tests {
             )],
         };
 
-        let merged = merge_read_cols(a, b);
+        let merged = merge(a, b);
 
         assert_eq!(
             merged,
@@ -435,7 +435,7 @@ mod tests {
             ],
         };
 
-        let merged = merge_read_cols(a, b);
+        let merged = merge(a, b);
 
         assert_eq!(
             merged,
@@ -464,7 +464,7 @@ mod tests {
             cols: vec![ReadColumn::new(1, vec![nested_path(&["j", "a"])])],
         };
 
-        let merged = merge_read_cols(a, b);
+        let merged = merge(a, b);
 
         assert_eq!(
             merged,

--- a/src/mito2/src/read/read_columns.rs
+++ b/src/mito2/src/read/read_columns.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::{BTreeMap, HashSet};
+use std::mem;
 
 use datafusion_common::HashMap;
 use datafusion_expr::utils::expr_to_columns;
@@ -91,6 +92,15 @@ impl ReadColumns {
     pub fn columns(&self) -> &[ReadColumn] {
         &self.cols
     }
+
+    pub fn estimated_size(&self) -> usize {
+        self.cols.capacity() * mem::size_of::<ReadColumn>()
+            + self
+                .cols
+                .iter()
+                .map(ReadColumn::estimated_size)
+                .sum::<usize>()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -115,6 +125,18 @@ impl ReadColumn {
 
     pub fn nested_paths(&self) -> &[NestedPath] {
         &self.nested_paths
+    }
+
+    pub fn estimated_size(&self) -> usize {
+        self.nested_paths.capacity() * mem::size_of::<NestedPath>()
+            + self
+                .nested_paths
+                .iter()
+                .map(|path| {
+                    path.capacity() * mem::size_of::<String>()
+                        + path.iter().map(|node| node.capacity()).sum::<usize>()
+                })
+                .sum::<usize>()
     }
 }
 

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -34,11 +34,11 @@ use datafusion_expr::utils::expr_to_columns;
 use futures::StreamExt;
 use partition::expr::PartitionExpr;
 use smallvec::SmallVec;
-use snafu::{OptionExt as _, ResultExt};
+use snafu::ResultExt;
 use store_api::metadata::{RegionMetadata, RegionMetadataRef};
 use store_api::region_engine::{PartitionRange, RegionScannerRef};
 use store_api::storage::{
-    ColumnId, RegionId, ScanRequest, SequenceNumber, SequenceRange, TimeSeriesDistribution,
+    RegionId, ScanRequest, SequenceNumber, SequenceRange, TimeSeriesDistribution,
     TimeSeriesRowSelector,
 };
 use table::predicate::{Predicate, build_time_range_predicate, extract_time_range_from_expr};
@@ -48,7 +48,7 @@ use tokio_stream::wrappers::ReceiverStream;
 use crate::access_layer::AccessLayerRef;
 use crate::cache::CacheStrategy;
 use crate::config::DEFAULT_MAX_CONCURRENT_SCAN_FILES;
-use crate::error::{InvalidPartitionExprSnafu, InvalidRequestSnafu, Result};
+use crate::error::{InvalidPartitionExprSnafu, Result};
 #[cfg(feature = "enterprise")]
 use crate::extension::{BoxedExtensionRange, BoxedExtensionRangeProvider};
 use crate::memtable::{MemtableRange, RangesOptions};
@@ -57,6 +57,9 @@ use crate::read::compat::{self, FlatCompatBatch};
 use crate::read::flat_projection::FlatProjectionMapper;
 use crate::read::range::{FileRangeBuilder, MemRangeBuilder, RangeMeta, RowGroupIndex};
 use crate::read::range_cache::ScanRequestFingerprint;
+use crate::read::read_columns::{
+    ReadColumns, merge, read_columns_from_predicate, read_columns_from_projection,
+};
 use crate::read::seq_scan::SeqScan;
 use crate::read::series_scan::SeriesScan;
 use crate::read::stream::ScanBatchStream;
@@ -399,23 +402,33 @@ impl ScanRegion {
         let time_range = self.build_time_range_predicate();
         let predicate = PredicateGroup::new(&self.version.metadata, &self.request.filters)?;
 
-        let read_column_ids = match self.request.projection_indices() {
-            Some(p) => self.build_read_column_ids(p, &predicate)?,
-            None => self
-                .version
-                .metadata
-                .column_metadatas
-                .iter()
-                .map(|col| col.column_id)
-                .collect(),
+        let read_cols = match &self.request.projection_input {
+            Some(p) => {
+                // Read columns include the pushed-down projection and columns
+                // resolved from the pushed-down predicate.
+                let metadata = &self.version.metadata;
+                let from_projection = read_columns_from_projection(p.clone(), metadata)?;
+                let from_predicate = read_columns_from_predicate(&predicate, metadata);
+                merge(from_projection, from_predicate)
+            }
+            None => {
+                let read_col_ids = self
+                    .version
+                    .metadata
+                    .column_metadatas
+                    .iter()
+                    .map(|col| col.column_id);
+                ReadColumns::from_deduped_column_ids(read_col_ids)
+            }
         };
+        let read_col_ids = read_cols.column_ids();
 
         // The mapper always computes projected column ids as the schema of SSTs may change.
         let mapper = match self.request.projection_indices() {
             Some(p) => FlatProjectionMapper::new_with_read_columns(
                 &self.version.metadata,
                 p.to_vec(),
-                read_column_ids.clone(),
+                read_cols,
             )?,
             None => FlatProjectionMapper::all(&self.version.metadata)?,
         };
@@ -464,7 +477,7 @@ impl ScanRegion {
                 continue;
             }
             let ranges_in_memtable = m.ranges(
-                Some(read_column_ids.as_slice()),
+                Some(&read_col_ids),
                 RangesOptions::default()
                     .with_predicate(predicate.clone())
                     .with_sequence(SequenceRange::new(
@@ -571,72 +584,6 @@ impl ScanRegion {
             .expect("Time index must have timestamp-compatible type")
             .unit();
         build_time_range_predicate(&time_index.column_schema.name, unit, &self.request.filters)
-    }
-
-    /// Return all columns id to read according to the projection and filters.
-    fn build_read_column_ids(
-        &self,
-        projection: &[usize],
-        predicate: &PredicateGroup,
-    ) -> Result<Vec<ColumnId>> {
-        let metadata = &self.version.metadata;
-        // use Vec for read_column_ids to keep the order of columns.
-        let mut read_column_ids = Vec::new();
-        let mut seen = HashSet::new();
-
-        for idx in projection {
-            let column =
-                metadata
-                    .column_metadatas
-                    .get(*idx)
-                    .with_context(|| InvalidRequestSnafu {
-                        region_id: metadata.region_id,
-                        reason: format!("projection index {} is out of bound", idx),
-                    })?;
-            seen.insert(column.column_id);
-            // keep the projection order
-            read_column_ids.push(column.column_id);
-        }
-
-        if projection.is_empty() {
-            let time_index = metadata.time_index_column().column_id;
-            if seen.insert(time_index) {
-                read_column_ids.push(time_index);
-            }
-        }
-
-        let mut extra_names = HashSet::new();
-        let mut columns = HashSet::new();
-
-        for expr in &self.request.filters {
-            columns.clear();
-            if expr_to_columns(expr, &mut columns).is_err() {
-                continue;
-            }
-            extra_names.extend(columns.iter().map(|column| column.name.clone()));
-        }
-
-        if let Some(expr) = predicate.region_partition_expr() {
-            expr.collect_column_names(&mut extra_names);
-        }
-
-        if !extra_names.is_empty() {
-            for column in &metadata.column_metadatas {
-                if extra_names.contains(column.column_schema.name.as_str())
-                    && !seen.contains(&column.column_id)
-                {
-                    read_column_ids.push(column.column_id);
-                }
-                extra_names.remove(column.column_schema.name.as_str());
-            }
-            if !extra_names.is_empty() {
-                warn!(
-                    "Some columns in filters are not found in region {}: {:?}",
-                    metadata.region_id, extra_names
-                );
-            }
-        }
-        Ok(read_column_ids)
     }
 
     /// Partitions filters into two groups: non-field filters and field filters.
@@ -797,10 +744,10 @@ pub struct ScanInput {
     access_layer: AccessLayerRef,
     /// Maps projected Batches to RecordBatches.
     pub(crate) mapper: Arc<FlatProjectionMapper>,
-    /// Column ids to read from memtables and SSTs.
+    /// The columns to read from memtables and SSTs.
     /// Notice this is different from the columns in `mapper` which are projected columns.
     /// But this read columns might also include non-projected columns needed for filtering.
-    pub(crate) read_column_ids: Vec<ColumnId>,
+    pub(crate) read_cols: ReadColumns,
     /// Time range filter for time index.
     pub(crate) time_range: Option<TimestampRange>,
     /// Predicate to push down.
@@ -855,7 +802,7 @@ impl ScanInput {
     pub(crate) fn new(access_layer: AccessLayerRef, mapper: FlatProjectionMapper) -> ScanInput {
         ScanInput {
             access_layer,
-            read_column_ids: mapper.column_ids().to_vec(),
+            read_cols: mapper.read_columns().clone(),
             mapper: Arc::new(mapper),
             time_range: None,
             predicate: PredicateGroup::default(),
@@ -1102,14 +1049,14 @@ impl ScanInput {
         let decode_pk_values = !self.compaction
             && self
                 .mapper
-                .column_ids()
-                .iter()
-                .any(|column_id| self.mapper.metadata().primary_key.contains(column_id));
+                .read_columns()
+                .column_ids_iter()
+                .any(|column_id| self.mapper.metadata().primary_key.contains(&column_id));
         let reader = self
             .access_layer
             .read_sst(file.clone())
             .predicate(predicate)
-            .projection(Some(self.read_column_ids.clone()))
+            .projection(Some(self.read_cols.clone()))
             .cache(self.cache_strategy.clone())
             .inverted_index_appliers(self.inverted_index_appliers.clone())
             .bloom_filter_index_appliers(self.bloom_filter_index_appliers.clone())
@@ -1408,19 +1355,18 @@ pub(crate) fn build_scan_fingerprint(input: &ScanInput) -> Option<ScanRequestFin
     // Ensure the filters are sorted for consistent fingerprinting.
     filters.sort_unstable();
     time_filters.sort_unstable();
-
+    let read_columns = input.read_cols.clone();
     Some(
         crate::read::range_cache::ScanRequestFingerprintBuilder {
-            read_column_ids: input.read_column_ids.clone(),
-            read_column_types: input
-                .read_column_ids
-                .iter()
+            read_column_types: read_columns
+                .column_ids_iter()
                 .map(|id| {
                     metadata
-                        .column_by_id(*id)
+                        .column_by_id(id)
                         .map(|col| col.column_schema.data_type.clone())
                 })
                 .collect(),
+            read_columns,
             filters,
             time_filters,
             series_row_selector: input.series_row_selector,
@@ -1797,31 +1743,17 @@ mod tests {
     use datatypes::value::Value;
     use partition::expr::col as partition_col;
     use store_api::metadata::RegionMetadataBuilder;
-    use store_api::storage::{
-        ProjectionInput, ScanRequest, TimeSeriesDistribution, TimeSeriesRowSelector,
-    };
+    use store_api::storage::{TimeSeriesDistribution, TimeSeriesRowSelector};
 
     use super::*;
     use crate::cache::CacheManager;
-    use crate::memtable::time_partition::TimePartitions;
     use crate::read::range_cache::ScanRequestFingerprintBuilder;
-    use crate::region::version::VersionBuilder;
-    use crate::test_util::memtable_util::{EmptyMemtableBuilder, metadata_with_primary_key};
+    use crate::test_util::memtable_util::metadata_with_primary_key;
     use crate::test_util::scheduler_util::SchedulerEnv;
-
-    fn new_version(metadata: RegionMetadataRef) -> VersionRef {
-        let mutable = Arc::new(TimePartitions::new(
-            metadata.clone(),
-            Arc::new(EmptyMemtableBuilder::default()),
-            0,
-            None,
-        ));
-        Arc::new(VersionBuilder::new(metadata, mutable).build())
-    }
 
     async fn new_scan_input(metadata: RegionMetadataRef, filters: Vec<Expr>) -> ScanInput {
         let env = SchedulerEnv::new().await;
-        let mapper = FlatProjectionMapper::new(&metadata, [0, 2, 3].into_iter()).unwrap();
+        let mapper = FlatProjectionMapper::new(&metadata, [0, 2, 3]).unwrap();
         let predicate = PredicateGroup::new(metadata.as_ref(), &filters).unwrap();
         let file = FileHandle::new(
             crate::sst::file::FileMeta::default(),
@@ -1836,86 +1768,6 @@ mod tests {
                     .build(),
             )))
             .with_files(vec![file])
-    }
-
-    #[tokio::test]
-    async fn test_build_read_column_ids_includes_filters() {
-        let metadata = Arc::new(metadata_with_primary_key(vec![0, 1], false));
-        let version = new_version(metadata.clone());
-        let env = SchedulerEnv::new().await;
-        let request = ScanRequest {
-            projection_input: Some(vec![4].into()),
-            filters: vec![
-                col("v0").gt(lit(1)),
-                col("ts").gt(lit(0)),
-                col("k0").eq(lit("foo")),
-            ],
-            ..Default::default()
-        };
-        let scan_region = ScanRegion::new(
-            version,
-            env.access_layer.clone(),
-            request,
-            CacheStrategy::Disabled,
-        );
-        let predicate =
-            PredicateGroup::new(metadata.as_ref(), &scan_region.request.filters).unwrap();
-        let projection = &scan_region.request.projection_indices().unwrap();
-        let read_ids = scan_region
-            .build_read_column_ids(projection, &predicate)
-            .unwrap();
-        assert_eq!(vec![4, 0, 2, 3], read_ids);
-    }
-
-    #[tokio::test]
-    async fn test_build_read_column_ids_empty_projection() {
-        let metadata = Arc::new(metadata_with_primary_key(vec![0, 1], false));
-        let version = new_version(metadata.clone());
-        let env = SchedulerEnv::new().await;
-        let request = ScanRequest {
-            projection_input: Some(ProjectionInput::default()),
-            ..Default::default()
-        };
-        let scan_region = ScanRegion::new(
-            version,
-            env.access_layer.clone(),
-            request,
-            CacheStrategy::Disabled,
-        );
-        let predicate =
-            PredicateGroup::new(metadata.as_ref(), &scan_region.request.filters).unwrap();
-        let projection = &scan_region.request.projection_indices().unwrap();
-        let read_ids = scan_region
-            .build_read_column_ids(projection, &predicate)
-            .unwrap();
-        // Empty projection should still read the time index column (id 2 in this test schema).
-        assert_eq!(vec![2], read_ids);
-    }
-
-    #[tokio::test]
-    async fn test_build_read_column_ids_keeps_projection_order() {
-        let metadata = Arc::new(metadata_with_primary_key(vec![0, 1], false));
-        let version = new_version(metadata.clone());
-        let env = SchedulerEnv::new().await;
-        let request = ScanRequest {
-            projection_input: Some(vec![4, 1].into()),
-            filters: vec![col("v0").gt(lit(1))],
-            ..Default::default()
-        };
-        let scan_region = ScanRegion::new(
-            version,
-            env.access_layer.clone(),
-            request,
-            CacheStrategy::Disabled,
-        );
-        let predicate =
-            PredicateGroup::new(metadata.as_ref(), &scan_region.request.filters).unwrap();
-        let projection = &scan_region.request.projection_indices().unwrap();
-        let read_ids = scan_region
-            .build_read_column_ids(projection, &predicate)
-            .unwrap();
-        // Projection order preserved, extra columns appended in schema order.
-        assert_eq!(vec![4, 1, 3], read_ids);
     }
 
     /// Helper to create a timestamp millisecond literal.
@@ -1943,7 +1795,7 @@ mod tests {
         let fingerprint = build_scan_fingerprint(&input).unwrap();
 
         let expected = ScanRequestFingerprintBuilder {
-            read_column_ids: input.read_column_ids.clone(),
+            read_columns: input.read_cols,
             read_column_types: vec![
                 metadata
                     .column_by_id(0)
@@ -2019,7 +1871,7 @@ mod tests {
         let fingerprint = build_scan_fingerprint(&input).unwrap();
 
         let expected = ScanRequestFingerprintBuilder {
-            read_column_ids: input.read_column_ids.clone(),
+            read_columns: input.read_cols,
             read_column_types: vec![
                 metadata
                     .column_by_id(0)

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -405,7 +405,7 @@ impl ScanRegion {
         let read_cols = match &self.request.projection_input {
             Some(p) => {
                 // Read columns include the pushed-down projection and columns
-                // resolved from the pushed-down predicate.
+                // resolved from the predicate.
                 let metadata = &self.version.metadata;
                 let from_projection = read_columns_from_projection(p.clone(), metadata)?;
                 let from_predicate = read_columns_from_predicate(&predicate, metadata);

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -393,7 +393,7 @@ impl ScanRegion {
         let time_range = self.build_time_range_predicate();
         let predicate = PredicateGroup::new(&self.version.metadata, &self.request.filters)?;
 
-        let (output_cols, read_cols) = match &self.request.projection_input {
+        let read_cols = match &self.request.projection_input {
             Some(p) => {
                 // 1. build read columns from projection input.
                 // 2. build read columns from predicate.
@@ -406,8 +406,7 @@ impl ScanRegion {
                 let metadata = &self.version.metadata;
                 let output_cols = read_columns_from_projection(p, metadata)?;
                 let from_predicate = read_columns_from_predicate(&predicate, metadata);
-                let read_cols = merge_read_cols(output_cols.clone(), from_predicate);
-                (output_cols, read_cols)
+                merge_read_cols(output_cols, from_predicate)
             }
             None => {
                 let read_col_ids: Vec<_> = self
@@ -418,16 +417,16 @@ impl ScanRegion {
                     .map(|col| col.column_id)
                     .collect();
                 let output_cols = ReadColumns::from_column_ids(read_col_ids);
-                (output_cols.clone(), output_cols)
+                output_cols
             }
         };
         let read_column_ids = read_cols.column_ids();
 
         // The mapper always computes projected column ids as the schema of SSTs may change.
         let mapper = match self.request.projection_indices() {
-            Some(_projection_input) => ProjectionMapper::new_with_read_columns(
+            Some(projection) => ProjectionMapper::new_with_read_columns(
                 &self.version.metadata,
-                output_cols,
+                projection.iter().copied(),
                 read_cols,
             )?,
             None => ProjectionMapper::all(&self.version.metadata)?,

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -57,7 +57,7 @@ use crate::read::projection::ProjectionMapper;
 use crate::read::range::{FileRangeBuilder, MemRangeBuilder, RangeMeta, RowGroupIndex};
 use crate::read::range_cache::ScanRequestFingerprint;
 use crate::read::read_columns::{
-    ReadColumns, merge_read_cols, read_columns_from_predicate, read_columns_from_projection,
+    ReadColumns, merge, read_columns_from_predicate, read_columns_from_projection,
 };
 use crate::read::seq_scan::SeqScan;
 use crate::read::series_scan::SeriesScan;
@@ -401,7 +401,7 @@ impl ScanRegion {
                 let metadata = &self.version.metadata;
                 let from_projection = read_columns_from_projection(p, metadata)?;
                 let from_predicate = read_columns_from_predicate(&predicate, metadata);
-                merge_read_cols(from_projection, from_predicate)
+                merge(from_projection, from_predicate)
             }
             None => {
                 let read_col_ids = self
@@ -1326,8 +1326,7 @@ pub(crate) fn build_scan_fingerprint(input: &ScanInput) -> Option<ScanRequestFin
     Some(
         crate::read::range_cache::ScanRequestFingerprintBuilder {
             read_column_types: read_columns
-                .column_ids()
-                .iter()
+                .column_ids_iter()
                 .map(|id| {
                     metadata
                         .column_by_id(*id)

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -1329,7 +1329,7 @@ pub(crate) fn build_scan_fingerprint(input: &ScanInput) -> Option<ScanRequestFin
                 .column_ids_iter()
                 .map(|id| {
                     metadata
-                        .column_by_id(*id)
+                        .column_by_id(id)
                         .map(|col| col.column_schema.data_type.clone())
                 })
                 .collect(),

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -398,35 +398,28 @@ impl ScanRegion {
                 // 1. build read columns from projection input.
                 // 2. build read columns from predicate.
                 // 3. merge final read columns for read sst logically.
-                //
-                // Note: we can modify the nested_paths in the projection input via
-                // try-swapping with projection or other techniques to reduce I/O when
-                // reading from the underlying SSTs. This also affects the schema of the
-                // data passed to DataFusion.
                 let metadata = &self.version.metadata;
-                let output_cols = read_columns_from_projection(p, metadata)?;
+                let from_projection = read_columns_from_projection(p, metadata)?;
                 let from_predicate = read_columns_from_predicate(&predicate, metadata);
-                merge_read_cols(output_cols, from_predicate)
+                merge_read_cols(from_projection, from_predicate)
             }
             None => {
-                let read_col_ids: Vec<_> = self
+                let read_col_ids = self
                     .version
                     .metadata
                     .column_metadatas
                     .iter()
-                    .map(|col| col.column_id)
-                    .collect();
-                let output_cols = ReadColumns::from_column_ids(read_col_ids);
-                output_cols
+                    .map(|col| col.column_id);
+                ReadColumns::from_column_ids(read_col_ids)
             }
         };
         let read_column_ids = read_cols.column_ids();
 
         // The mapper always computes projected column ids as the schema of SSTs may change.
         let mapper = match self.request.projection_indices() {
-            Some(projection) => ProjectionMapper::new_with_read_columns(
+            Some(p) => ProjectionMapper::new_with_read_columns(
                 &self.version.metadata,
-                projection.iter().copied(),
+                p.iter().copied(),
                 read_cols,
             )?,
             None => ProjectionMapper::all(&self.version.metadata)?,
@@ -476,7 +469,7 @@ impl ScanRegion {
                 continue;
             }
             let ranges_in_memtable = m.ranges(
-                Some(read_column_ids.as_slice()),
+                Some(&read_column_ids),
                 RangesOptions::default()
                     .with_predicate(predicate.clone())
                     .with_sequence(SequenceRange::new(
@@ -1763,7 +1756,7 @@ mod tests {
         let fingerprint = build_scan_fingerprint(&input).unwrap();
 
         let expected = ScanRequestFingerprintBuilder {
-            read_columns: input.read_cols.clone(),
+            read_columns: input.read_cols,
             read_column_types: vec![
                 metadata
                     .column_by_id(0)
@@ -1839,7 +1832,7 @@ mod tests {
         let fingerprint = build_scan_fingerprint(&input).unwrap();
 
         let expected = ScanRequestFingerprintBuilder {
-            read_columns: input.read_cols.clone(),
+            read_columns: input.read_cols,
             read_column_types: vec![
                 metadata
                     .column_by_id(0)

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -34,11 +34,11 @@ use datafusion_expr::utils::expr_to_columns;
 use futures::StreamExt;
 use partition::expr::PartitionExpr;
 use smallvec::SmallVec;
-use snafu::{OptionExt as _, ResultExt};
+use snafu::ResultExt;
 use store_api::metadata::{RegionMetadata, RegionMetadataRef};
 use store_api::region_engine::{PartitionRange, RegionScannerRef};
 use store_api::storage::{
-    ColumnId, RegionId, ScanRequest, SequenceRange, TimeSeriesDistribution, TimeSeriesRowSelector,
+    RegionId, ScanRequest, SequenceRange, TimeSeriesDistribution, TimeSeriesRowSelector,
 };
 use table::predicate::{Predicate, build_time_range_predicate, extract_time_range_from_expr};
 use tokio::sync::{Semaphore, mpsc};
@@ -47,7 +47,7 @@ use tokio_stream::wrappers::ReceiverStream;
 use crate::access_layer::AccessLayerRef;
 use crate::cache::CacheStrategy;
 use crate::config::DEFAULT_MAX_CONCURRENT_SCAN_FILES;
-use crate::error::{InvalidPartitionExprSnafu, InvalidRequestSnafu, Result};
+use crate::error::{InvalidPartitionExprSnafu, Result};
 #[cfg(feature = "enterprise")]
 use crate::extension::{BoxedExtensionRange, BoxedExtensionRangeProvider};
 use crate::memtable::{MemtableRange, RangesOptions};
@@ -56,6 +56,9 @@ use crate::read::compat::{self, CompatBatch, FlatCompatBatch, PrimaryKeyCompatBa
 use crate::read::projection::ProjectionMapper;
 use crate::read::range::{FileRangeBuilder, MemRangeBuilder, RangeMeta, RowGroupIndex};
 use crate::read::range_cache::ScanRequestFingerprint;
+use crate::read::read_columns::{
+    ReadColumns, merge_read_cols, read_columns_from_predicate, read_columns_from_projection,
+};
 use crate::read::seq_scan::SeqScan;
 use crate::read::series_scan::SeriesScan;
 use crate::read::stream::ScanBatchStream;
@@ -390,23 +393,42 @@ impl ScanRegion {
         let time_range = self.build_time_range_predicate();
         let predicate = PredicateGroup::new(&self.version.metadata, &self.request.filters)?;
 
-        let read_column_ids = match self.request.projection_indices() {
-            Some(p) => self.build_read_column_ids(p, &predicate)?,
-            None => self
-                .version
-                .metadata
-                .column_metadatas
-                .iter()
-                .map(|col| col.column_id)
-                .collect(),
+        let (output_cols, read_cols) = match &self.request.projection_input {
+            Some(p) => {
+                // 1. build read columns from projection input.
+                // 2. build read columns from predicate.
+                // 3. merge final read columns for read sst logically.
+                //
+                // Note: we can modify the nested_paths in the projection input via
+                // try-swapping with projection or other techniques to reduce I/O when
+                // reading from the underlying SSTs. This also affects the schema of the
+                // data passed to DataFusion.
+                let metadata = &self.version.metadata;
+                let output_cols = read_columns_from_projection(p, metadata)?;
+                let from_predicate = read_columns_from_predicate(&predicate, metadata);
+                let read_cols = merge_read_cols(output_cols.clone(), from_predicate);
+                (output_cols, read_cols)
+            }
+            None => {
+                let read_col_ids: Vec<_> = self
+                    .version
+                    .metadata
+                    .column_metadatas
+                    .iter()
+                    .map(|col| col.column_id)
+                    .collect();
+                let output_cols = ReadColumns::from_column_ids(read_col_ids);
+                (output_cols.clone(), output_cols)
+            }
         };
+        let read_column_ids = read_cols.column_ids();
 
         // The mapper always computes projected column ids as the schema of SSTs may change.
         let mapper = match self.request.projection_indices() {
-            Some(p) => ProjectionMapper::new_with_read_columns(
+            Some(_projection_input) => ProjectionMapper::new_with_read_columns(
                 &self.version.metadata,
-                p.iter().copied(),
-                read_column_ids.clone(),
+                output_cols,
+                read_cols,
             )?,
             None => ProjectionMapper::all(&self.version.metadata)?,
         };
@@ -556,72 +578,6 @@ impl ScanRegion {
             .expect("Time index must have timestamp-compatible type")
             .unit();
         build_time_range_predicate(&time_index.column_schema.name, unit, &self.request.filters)
-    }
-
-    /// Return all columns id to read according to the projection and filters.
-    fn build_read_column_ids(
-        &self,
-        projection: &[usize],
-        predicate: &PredicateGroup,
-    ) -> Result<Vec<ColumnId>> {
-        let metadata = &self.version.metadata;
-        // use Vec for read_column_ids to keep the order of columns.
-        let mut read_column_ids = Vec::new();
-        let mut seen = HashSet::new();
-
-        for idx in projection {
-            let column =
-                metadata
-                    .column_metadatas
-                    .get(*idx)
-                    .with_context(|| InvalidRequestSnafu {
-                        region_id: metadata.region_id,
-                        reason: format!("projection index {} is out of bound", idx),
-                    })?;
-            seen.insert(column.column_id);
-            // keep the projection order
-            read_column_ids.push(column.column_id);
-        }
-
-        if projection.is_empty() {
-            let time_index = metadata.time_index_column().column_id;
-            if seen.insert(time_index) {
-                read_column_ids.push(time_index);
-            }
-        }
-
-        let mut extra_names = HashSet::new();
-        let mut columns = HashSet::new();
-
-        for expr in &self.request.filters {
-            columns.clear();
-            if expr_to_columns(expr, &mut columns).is_err() {
-                continue;
-            }
-            extra_names.extend(columns.iter().map(|column| column.name.clone()));
-        }
-
-        if let Some(expr) = predicate.region_partition_expr() {
-            expr.collect_column_names(&mut extra_names);
-        }
-
-        if !extra_names.is_empty() {
-            for column in &metadata.column_metadatas {
-                if extra_names.contains(column.column_schema.name.as_str())
-                    && !seen.contains(&column.column_id)
-                {
-                    read_column_ids.push(column.column_id);
-                }
-                extra_names.remove(column.column_schema.name.as_str());
-            }
-            if !extra_names.is_empty() {
-                warn!(
-                    "Some columns in filters are not found in region {}: {:?}",
-                    metadata.region_id, extra_names
-                );
-            }
-        }
-        Ok(read_column_ids)
     }
 
     /// Partitions filters into two groups: non-field filters and field filters.
@@ -782,10 +738,10 @@ pub struct ScanInput {
     access_layer: AccessLayerRef,
     /// Maps projected Batches to RecordBatches.
     pub(crate) mapper: Arc<ProjectionMapper>,
-    /// Column ids to read from memtables and SSTs.
+    /// The columns to read from memtables and SSTs.
     /// Notice this is different from the columns in `mapper` which are projected columns.
     /// But this read columns might also include non-projected columns needed for filtering.
-    pub(crate) read_column_ids: Vec<ColumnId>,
+    pub(crate) read_cols: ReadColumns,
     /// Time range filter for time index.
     pub(crate) time_range: Option<TimestampRange>,
     /// Predicate to push down.
@@ -838,7 +794,7 @@ impl ScanInput {
     pub(crate) fn new(access_layer: AccessLayerRef, mapper: ProjectionMapper) -> ScanInput {
         ScanInput {
             access_layer,
-            read_column_ids: mapper.column_ids().to_vec(),
+            read_cols: mapper.read_columns().clone(),
             mapper: Arc::new(mapper),
             time_range: None,
             predicate: PredicateGroup::default(),
@@ -1077,7 +1033,7 @@ impl ScanInput {
             .access_layer
             .read_sst(file.clone())
             .predicate(predicate)
-            .projection(Some(self.read_column_ids.clone()))
+            .projection(Some(self.read_cols.clone()))
             .cache(self.cache_strategy.clone())
             .inverted_index_appliers(self.inverted_index_appliers.clone())
             .bloom_filter_index_appliers(self.bloom_filter_index_appliers.clone())
@@ -1374,12 +1330,11 @@ pub(crate) fn build_scan_fingerprint(input: &ScanInput) -> Option<ScanRequestFin
     // Ensure the filters are sorted for consistent fingerprinting.
     filters.sort_unstable();
     time_filters.sort_unstable();
-
+    let read_columns = input.read_cols.clone();
     Some(
         crate::read::range_cache::ScanRequestFingerprintBuilder {
-            read_column_ids: input.read_column_ids.clone(),
-            read_column_types: input
-                .read_column_ids
+            read_column_types: read_columns
+                .column_ids()
                 .iter()
                 .map(|id| {
                     metadata
@@ -1387,6 +1342,7 @@ pub(crate) fn build_scan_fingerprint(input: &ScanInput) -> Option<ScanRequestFin
                         .map(|col| col.column_schema.data_type.clone())
                 })
                 .collect(),
+            read_columns,
             filters,
             time_filters,
             series_row_selector: input.series_row_selector,
@@ -1756,27 +1712,13 @@ mod tests {
     use datatypes::value::Value;
     use partition::expr::col as partition_col;
     use store_api::metadata::RegionMetadataBuilder;
-    use store_api::storage::{
-        ProjectionInput, ScanRequest, TimeSeriesDistribution, TimeSeriesRowSelector,
-    };
+    use store_api::storage::{TimeSeriesDistribution, TimeSeriesRowSelector};
 
     use super::*;
     use crate::cache::CacheManager;
-    use crate::memtable::time_partition::TimePartitions;
     use crate::read::range_cache::ScanRequestFingerprintBuilder;
-    use crate::region::version::VersionBuilder;
-    use crate::test_util::memtable_util::{EmptyMemtableBuilder, metadata_with_primary_key};
+    use crate::test_util::memtable_util::metadata_with_primary_key;
     use crate::test_util::scheduler_util::SchedulerEnv;
-
-    fn new_version(metadata: RegionMetadataRef) -> VersionRef {
-        let mutable = Arc::new(TimePartitions::new(
-            metadata.clone(),
-            Arc::new(EmptyMemtableBuilder::default()),
-            0,
-            None,
-        ));
-        Arc::new(VersionBuilder::new(metadata, mutable).build())
-    }
 
     async fn new_scan_input(metadata: RegionMetadataRef, filters: Vec<Expr>) -> ScanInput {
         let env = SchedulerEnv::new().await;
@@ -1795,86 +1737,6 @@ mod tests {
                     .build(),
             )))
             .with_files(vec![file])
-    }
-
-    #[tokio::test]
-    async fn test_build_read_column_ids_includes_filters() {
-        let metadata = Arc::new(metadata_with_primary_key(vec![0, 1], false));
-        let version = new_version(metadata.clone());
-        let env = SchedulerEnv::new().await;
-        let request = ScanRequest {
-            projection_input: Some(vec![4].into()),
-            filters: vec![
-                col("v0").gt(lit(1)),
-                col("ts").gt(lit(0)),
-                col("k0").eq(lit("foo")),
-            ],
-            ..Default::default()
-        };
-        let scan_region = ScanRegion::new(
-            version,
-            env.access_layer.clone(),
-            request,
-            CacheStrategy::Disabled,
-        );
-        let predicate =
-            PredicateGroup::new(metadata.as_ref(), &scan_region.request.filters).unwrap();
-        let projection = &scan_region.request.projection_indices().unwrap();
-        let read_ids = scan_region
-            .build_read_column_ids(projection, &predicate)
-            .unwrap();
-        assert_eq!(vec![4, 0, 2, 3], read_ids);
-    }
-
-    #[tokio::test]
-    async fn test_build_read_column_ids_empty_projection() {
-        let metadata = Arc::new(metadata_with_primary_key(vec![0, 1], false));
-        let version = new_version(metadata.clone());
-        let env = SchedulerEnv::new().await;
-        let request = ScanRequest {
-            projection_input: Some(ProjectionInput::default()),
-            ..Default::default()
-        };
-        let scan_region = ScanRegion::new(
-            version,
-            env.access_layer.clone(),
-            request,
-            CacheStrategy::Disabled,
-        );
-        let predicate =
-            PredicateGroup::new(metadata.as_ref(), &scan_region.request.filters).unwrap();
-        let projection = &scan_region.request.projection_indices().unwrap();
-        let read_ids = scan_region
-            .build_read_column_ids(projection, &predicate)
-            .unwrap();
-        // Empty projection should still read the time index column (id 2 in this test schema).
-        assert_eq!(vec![2], read_ids);
-    }
-
-    #[tokio::test]
-    async fn test_build_read_column_ids_keeps_projection_order() {
-        let metadata = Arc::new(metadata_with_primary_key(vec![0, 1], false));
-        let version = new_version(metadata.clone());
-        let env = SchedulerEnv::new().await;
-        let request = ScanRequest {
-            projection_input: Some(vec![4, 1].into()),
-            filters: vec![col("v0").gt(lit(1))],
-            ..Default::default()
-        };
-        let scan_region = ScanRegion::new(
-            version,
-            env.access_layer.clone(),
-            request,
-            CacheStrategy::Disabled,
-        );
-        let predicate =
-            PredicateGroup::new(metadata.as_ref(), &scan_region.request.filters).unwrap();
-        let projection = &scan_region.request.projection_indices().unwrap();
-        let read_ids = scan_region
-            .build_read_column_ids(projection, &predicate)
-            .unwrap();
-        // Projection order preserved, extra columns appended in schema order.
-        assert_eq!(vec![4, 1, 3], read_ids);
     }
 
     /// Helper to create a timestamp millisecond literal.
@@ -1902,7 +1764,7 @@ mod tests {
         let fingerprint = build_scan_fingerprint(&input).unwrap();
 
         let expected = ScanRequestFingerprintBuilder {
-            read_column_ids: input.read_column_ids.clone(),
+            read_columns: input.read_cols.clone(),
             read_column_types: vec![
                 metadata
                     .column_by_id(0)
@@ -1978,7 +1840,7 @@ mod tests {
         let fingerprint = build_scan_fingerprint(&input).unwrap();
 
         let expected = ScanRequestFingerprintBuilder {
-            read_column_ids: input.read_column_ids.clone(),
+            read_columns: input.read_cols.clone(),
             read_column_types: vec![
                 metadata
                     .column_by_id(0)

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -1714,7 +1714,7 @@ mod tests {
 
     async fn new_scan_input(metadata: RegionMetadataRef, filters: Vec<Expr>) -> ScanInput {
         let env = SchedulerEnv::new().await;
-        let mapper = ProjectionMapper::new(&metadata, [0, 2, 3].into_iter()).unwrap();
+        let mapper = ProjectionMapper::new(&metadata, [0, 2, 3]).unwrap();
         let predicate = PredicateGroup::new(metadata.as_ref(), &filters).unwrap();
         let file = FileHandle::new(
             crate::sst::file::FileMeta::default(),

--- a/src/mito2/src/read/scan_util.rs
+++ b/src/mito2/src/read/scan_util.rs
@@ -1368,7 +1368,7 @@ mod split_tests {
     async fn new_stream_context_with_files(files: Vec<FileHandle>) -> StreamContext {
         let env = SchedulerEnv::new().await;
         let metadata = Arc::new(metadata_with_primary_key(vec![0, 1], false));
-        let mapper = FlatProjectionMapper::new(&metadata, [0, 2, 3].into_iter()).unwrap();
+        let mapper = FlatProjectionMapper::new(&metadata, [0, 2, 3]).unwrap();
         let input = ScanInput::new(env.access_layer.clone(), mapper).with_files(files);
 
         StreamContext {
@@ -1745,7 +1745,7 @@ mod tests {
     ) -> Arc<StreamContext> {
         let env = SchedulerEnv::new().await;
         let metadata = metadata_for_test();
-        let mapper = FlatProjectionMapper::new(&metadata, [0, 2, 3].into_iter()).unwrap();
+        let mapper = FlatProjectionMapper::new(&metadata, [0, 2, 3]).unwrap();
         let input = ScanInput::new(env.access_layer.clone(), mapper)
             .with_cache(CacheStrategy::Disabled)
             .with_memtables(memtables)

--- a/src/mito2/src/read/scan_util.rs
+++ b/src/mito2/src/read/scan_util.rs
@@ -1369,7 +1369,7 @@ mod split_tests {
     async fn new_stream_context_with_files(files: Vec<FileHandle>) -> StreamContext {
         let env = SchedulerEnv::new().await;
         let metadata = Arc::new(metadata_with_primary_key(vec![0, 1], false));
-        let mapper = ProjectionMapper::new(&metadata, [0, 2, 3].into_iter()).unwrap();
+        let mapper = ProjectionMapper::new(&metadata, [0, 2, 3]).unwrap();
         let input = ScanInput::new(env.access_layer.clone(), mapper).with_files(files);
 
         StreamContext {
@@ -1741,7 +1741,7 @@ mod tests {
     ) -> Arc<StreamContext> {
         let env = SchedulerEnv::new().await;
         let metadata = metadata_for_test();
-        let mapper = ProjectionMapper::new(&metadata, [0, 2, 3].into_iter()).unwrap();
+        let mapper = ProjectionMapper::new(&metadata, [0, 2, 3]).unwrap();
         let input = ScanInput::new(env.access_layer.clone(), mapper)
             .with_cache(CacheStrategy::Disabled)
             .with_memtables(memtables)

--- a/src/mito2/src/sst/parquet/file_range.rs
+++ b/src/mito2/src/sst/parquet/file_range.rs
@@ -207,7 +207,7 @@ impl FileRange {
                 self.file_handle().file_id().file_id(),
                 self.row_group_idx,
                 cache_strategy,
-                self.context.read_format().projection_indices(),
+                self.context.read_format().parquet_read_columns(),
                 flat_row_group_reader,
             );
             FlatPruneReader::new_with_last_row_reader(self.context.clone(), reader, skip_fields)
@@ -655,19 +655,18 @@ mod tests {
     use datafusion_expr::{col, lit};
 
     use super::*;
+    use crate::read::read_columns::ReadColumns;
     use crate::sst::parquet::flat_format::FlatReadFormat;
     use crate::test_util::sst_util::{new_record_batch_with_custom_sequence, sst_region_metadata};
 
     fn new_test_range_base(filters: Vec<SimpleFilterContext>) -> RangeBase {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
-        let read_format = FlatReadFormat::new(
-            metadata.clone(),
+
+        let read_cols = ReadColumns::from_deduped_column_ids(
             metadata.column_metadatas.iter().map(|c| c.column_id),
-            None,
-            "test",
-            true,
-        )
-        .unwrap();
+        );
+        let read_format =
+            FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", true).unwrap();
 
         RangeBase {
             filters,
@@ -703,14 +702,11 @@ mod tests {
     #[test]
     fn test_compute_filter_mask_flat_does_not_postfilter_physical_filters() {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
-        let read_format = FlatReadFormat::new(
-            metadata.clone(),
+        let read_cols = ReadColumns::from_deduped_column_ids(
             metadata.column_metadatas.iter().map(|c| c.column_id),
-            None,
-            "test",
-            true,
-        )
-        .unwrap();
+        );
+        let read_format =
+            FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", true).unwrap();
         let physical_filter = crate::sst::parquet::reader::PhysicalFilterContext::new_opt(
             &metadata,
             None,

--- a/src/mito2/src/sst/parquet/file_range.rs
+++ b/src/mito2/src/sst/parquet/file_range.rs
@@ -655,18 +655,20 @@ mod tests {
     use datafusion_expr::{col, lit};
 
     use super::*;
-    use crate::read::read_columns::ReadColumns;
     use crate::sst::parquet::flat_format::FlatReadFormat;
     use crate::test_util::sst_util::{new_record_batch_with_custom_sequence, sst_region_metadata};
 
     fn new_test_range_base(filters: Vec<SimpleFilterContext>) -> RangeBase {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
 
-        let read_cols = ReadColumns::from_deduped_column_ids(
+        let read_format = FlatReadFormat::new(
+            metadata.clone(),
             metadata.column_metadatas.iter().map(|c| c.column_id),
-        );
-        let read_format =
-            FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", true).unwrap();
+            None,
+            "test",
+            true,
+        )
+        .unwrap();
 
         RangeBase {
             filters,
@@ -702,11 +704,14 @@ mod tests {
     #[test]
     fn test_compute_filter_mask_flat_does_not_postfilter_physical_filters() {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
-        let read_cols = ReadColumns::from_deduped_column_ids(
+        let read_format = FlatReadFormat::new(
+            metadata.clone(),
             metadata.column_metadatas.iter().map(|c| c.column_id),
-        );
-        let read_format =
-            FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", true).unwrap();
+            None,
+            "test",
+            true,
+        )
+        .unwrap();
         let physical_filter = crate::sst::parquet::reader::PhysicalFilterContext::new_opt(
             &metadata,
             None,

--- a/src/mito2/src/sst/parquet/file_range.rs
+++ b/src/mito2/src/sst/parquet/file_range.rs
@@ -655,6 +655,7 @@ mod tests {
     use datafusion_expr::{col, lit};
 
     use super::*;
+    use crate::read::read_columns::ReadColumns;
     use crate::sst::parquet::flat_format::FlatReadFormat;
     use crate::test_util::sst_util::{new_record_batch_with_custom_sequence, sst_region_metadata};
 
@@ -663,7 +664,9 @@ mod tests {
 
         let read_format = FlatReadFormat::new(
             metadata.clone(),
-            metadata.column_metadatas.iter().map(|c| c.column_id),
+            ReadColumns::from_deduped_column_ids(
+                metadata.column_metadatas.iter().map(|c| c.column_id),
+            ),
             None,
             "test",
             true,
@@ -706,7 +709,9 @@ mod tests {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
         let read_format = FlatReadFormat::new(
             metadata.clone(),
-            metadata.column_metadatas.iter().map(|c| c.column_id),
+            ReadColumns::from_deduped_column_ids(
+                metadata.column_metadatas.iter().map(|c| c.column_id),
+            ),
             None,
             "test",
             true,

--- a/src/mito2/src/sst/parquet/file_range.rs
+++ b/src/mito2/src/sst/parquet/file_range.rs
@@ -275,7 +275,7 @@ impl FileRange {
                 self.file_handle().file_id().file_id(),
                 self.row_group_idx,
                 cache_strategy,
-                self.context.read_format().projection_indices(),
+                self.context.read_format().parquet_read_columns(),
                 flat_row_group_reader,
             );
             FlatPruneReader::new_with_last_row_reader(self.context.clone(), reader, skip_fields)
@@ -957,19 +957,16 @@ mod tests {
     use datafusion_expr::{col, lit};
 
     use super::*;
+    use crate::read::read_columns::ReadColumns;
     use crate::sst::parquet::format::ReadFormat;
     use crate::test_util::sst_util::{new_record_batch_with_custom_sequence, sst_region_metadata};
 
     fn new_test_range_base(filters: Vec<SimpleFilterContext>) -> RangeBase {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
-        let read_format = ReadFormat::new_flat(
-            metadata.clone(),
-            metadata.column_metadatas.iter().map(|c| c.column_id),
-            None,
-            "test",
-            true,
-        )
-        .unwrap();
+        let read_cols =
+            ReadColumns::from_column_ids(metadata.column_metadatas.iter().map(|c| c.column_id));
+        let read_format =
+            ReadFormat::new_flat(metadata.clone(), read_cols, None, "test", true).unwrap();
 
         RangeBase {
             filters,

--- a/src/mito2/src/sst/parquet/file_range.rs
+++ b/src/mito2/src/sst/parquet/file_range.rs
@@ -966,7 +966,7 @@ mod tests {
         let read_cols =
             ReadColumns::from_column_ids(metadata.column_metadatas.iter().map(|c| c.column_id));
         let read_format =
-            ReadFormat::new_flat(metadata.clone(), read_cols, None, "test", true).unwrap();
+            ReadFormat::new_flat(metadata.clone(), &read_cols, None, "test", true).unwrap();
 
         RangeBase {
             filters,

--- a/src/mito2/src/sst/parquet/flat_format.rs
+++ b/src/mito2/src/sst/parquet/flat_format.rs
@@ -788,8 +788,9 @@ impl FlatConvertFormat {
 impl FlatReadFormat {
     /// Creates a helper with existing `metadata` and all columns.
     pub fn new_with_all_columns(metadata: RegionMetadataRef) -> FlatReadFormat {
-        let read_cols =
-            ReadColumns::from_deduped_column_ids(metadata.column_metadatas.iter().map(|c| c.column_id));
+        let read_cols = ReadColumns::from_deduped_column_ids(
+            metadata.column_metadatas.iter().map(|c| c.column_id),
+        );
         Self::new(Arc::clone(&metadata), &read_cols, None, "test", false).unwrap()
     }
 }

--- a/src/mito2/src/sst/parquet/flat_format.rs
+++ b/src/mito2/src/sst/parquet/flat_format.rs
@@ -51,10 +51,12 @@ use crate::error::{
     ComputeArrowSnafu, DecodeSnafu, InvalidParquetSnafu, InvalidRecordBatchSnafu,
     NewRecordBatchSnafu, Result,
 };
+use crate::read::read_columns::ReadColumns;
 use crate::sst::parquet::format::{
     FIXED_POS_COLUMN_NUM, FormatProjection, INTERNAL_COLUMN_NUM, PrimaryKeyArray,
     PrimaryKeyReadFormat, StatValues, column_null_counts, column_values,
 };
+use crate::sst::parquet::read_columns::ParquetReadColumns;
 use crate::sst::{
     FlatSchemaOptions, flat_sst_arrow_schema_column_num, tag_maybe_to_dictionary_field,
     to_flat_sst_arrow_schema,
@@ -162,7 +164,7 @@ impl FlatReadFormat {
     /// If `skip_auto_convert` is true, skips auto conversion of format when the encoding is sparse encoding.
     pub fn new(
         metadata: RegionMetadataRef,
-        column_ids: impl Iterator<Item = ColumnId>,
+        read_cols: &ReadColumns,
         num_columns: Option<usize>,
         file_path: &str,
         skip_auto_convert: bool,
@@ -178,16 +180,16 @@ impl FlatReadFormat {
                 // Only skip auto convert when the primary key encoding is sparse.
                 ParquetAdapter::PrimaryKeyToFlat(ParquetPrimaryKeyToFlat::new(
                     metadata,
-                    column_ids,
+                    read_cols,
                     skip_auto_convert,
                 ))
             } else {
                 ParquetAdapter::PrimaryKeyToFlat(ParquetPrimaryKeyToFlat::new(
-                    metadata, column_ids, false,
+                    metadata, read_cols, false,
                 ))
             }
         } else {
-            ParquetAdapter::Flat(ParquetFlat::new(metadata, column_ids))
+            ParquetAdapter::Flat(ParquetFlat::new(metadata, read_cols))
         };
 
         Ok(FlatReadFormat {
@@ -258,9 +260,10 @@ impl FlatReadFormat {
 
     /// Gets the projected output schema produced by parquet reading.
     pub(crate) fn output_arrow_schema(&self) -> Result<SchemaRef> {
+        let projection = self.parquet_read_columns().root_indices();
         let schema = self
             .arrow_schema()
-            .project(self.projection_indices())
+            .project(projection)
             .context(ComputeArrowSnafu)?;
         Ok(Arc::new(schema))
     }
@@ -273,11 +276,11 @@ impl FlatReadFormat {
         }
     }
 
-    /// Gets sorted projection indices to read from the SST file.
-    pub(crate) fn projection_indices(&self) -> &[usize] {
+    /// Get the sorted read columns to read from the sst file.
+    pub(crate) fn parquet_read_columns(&self) -> &ParquetReadColumns {
         match &self.parquet_adapter {
-            ParquetAdapter::Flat(p) => &p.format_projection.projection_indices,
-            ParquetAdapter::PrimaryKeyToFlat(p) => p.format.projection_indices(),
+            ParquetAdapter::Flat(p) => &p.format_projection.parquet_read_cols,
+            ParquetAdapter::PrimaryKeyToFlat(p) => p.format.parquet_read_columns(),
         }
     }
 
@@ -413,7 +416,7 @@ impl ParquetPrimaryKeyToFlat {
     /// Creates a helper with existing `metadata` and `column_ids` to read.
     fn new(
         metadata: RegionMetadataRef,
-        column_ids: impl Iterator<Item = ColumnId>,
+        read_cols: &ReadColumns,
         skip_auto_convert: bool,
     ) -> ParquetPrimaryKeyToFlat {
         assert!(if skip_auto_convert {
@@ -422,20 +425,18 @@ impl ParquetPrimaryKeyToFlat {
             true
         });
 
-        let column_ids: Vec<_> = column_ids.collect();
-
         // Creates a map to lookup index based on the new format.
         let id_to_index = sst_column_id_indices(&metadata);
         let sst_column_num =
             flat_sst_arrow_schema_column_num(&metadata, &FlatSchemaOptions::default());
 
         let codec = build_primary_key_codec(&metadata);
-        let format = PrimaryKeyReadFormat::new(metadata.clone(), column_ids.iter().copied());
+        let format = PrimaryKeyReadFormat::new(metadata.clone(), read_cols);
         let (convert_format, format_projection) = if skip_auto_convert {
             (
                 None,
                 FormatProjection {
-                    projection_indices: format.projection_indices().to_vec(),
+                    parquet_read_cols: format.parquet_read_columns().clone(),
                     column_id_to_projected_index: format.field_id_to_projected_index().clone(),
                 },
             )
@@ -444,7 +445,7 @@ impl ParquetPrimaryKeyToFlat {
             let format_projection = FormatProjection::compute_format_projection(
                 &id_to_index,
                 sst_column_num,
-                column_ids.iter().copied(),
+                read_cols,
             );
             (
                 FlatConvertFormat::new(Arc::clone(&metadata), &format_projection, codec),
@@ -482,14 +483,14 @@ struct ParquetFlat {
 
 impl ParquetFlat {
     /// Creates a helper with existing `metadata` and `column_ids` to read.
-    fn new(metadata: RegionMetadataRef, column_ids: impl Iterator<Item = ColumnId>) -> ParquetFlat {
+    fn new(metadata: RegionMetadataRef, read_cols: &ReadColumns) -> ParquetFlat {
         // Creates a map to lookup index.
         let id_to_index = sst_column_id_indices(&metadata);
         let arrow_schema = to_flat_sst_arrow_schema(&metadata, &FlatSchemaOptions::default());
         let sst_column_num =
             flat_sst_arrow_schema_column_num(&metadata, &FlatSchemaOptions::default());
         let format_projection =
-            FormatProjection::compute_format_projection(&id_to_index, sst_column_num, column_ids);
+            FormatProjection::compute_format_projection(&id_to_index, sst_column_num, read_cols);
 
         Self {
             metadata,
@@ -787,14 +788,9 @@ impl FlatConvertFormat {
 impl FlatReadFormat {
     /// Creates a helper with existing `metadata` and all columns.
     pub fn new_with_all_columns(metadata: RegionMetadataRef) -> FlatReadFormat {
-        Self::new(
-            Arc::clone(&metadata),
-            metadata.column_metadatas.iter().map(|c| c.column_id),
-            None,
-            "test",
-            false,
-        )
-        .unwrap()
+        let read_cols =
+            ReadColumns::from_deduped_column_ids(metadata.column_metadatas.iter().map(|c| c.column_id));
+        Self::new(Arc::clone(&metadata), &read_cols, None, "test", false).unwrap()
     }
 }
 
@@ -810,6 +806,7 @@ mod tests {
     use store_api::storage::RegionId;
 
     use super::{FlatReadFormat, field_column_start};
+    use crate::read::read_columns::ReadColumns;
     use crate::sst::{
         FlatSchemaOptions, flat_sst_arrow_schema_column_num, to_flat_sst_arrow_schema,
     };
@@ -890,19 +887,15 @@ mod tests {
     #[test]
     fn test_output_arrow_schema_uses_projection() {
         let metadata = Arc::new(build_metadata(1, 2, PrimaryKeyEncoding::Dense));
-        let read_format = FlatReadFormat::new(
-            metadata.clone(),
-            [0_u32, 2_u32].into_iter(),
-            None,
-            "test",
-            false,
-        )
-        .unwrap();
+        let read_cols = ReadColumns::from_deduped_column_ids([0_u32, 2_u32]);
+        let read_format =
+            FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", false).unwrap();
 
         let output_schema = read_format.output_arrow_schema().unwrap();
+        let projection = read_format.parquet_read_columns().root_indices();
         let expected = Arc::new(
             to_flat_sst_arrow_schema(&metadata, &FlatSchemaOptions::default())
-                .project(read_format.projection_indices())
+                .project(projection)
                 .unwrap(),
         );
 

--- a/src/mito2/src/sst/parquet/flat_format.rs
+++ b/src/mito2/src/sst/parquet/flat_format.rs
@@ -164,11 +164,12 @@ impl FlatReadFormat {
     /// If `skip_auto_convert` is true, skips auto conversion of format when the encoding is sparse encoding.
     pub fn new(
         metadata: RegionMetadataRef,
-        read_cols: &ReadColumns,
+        read_cols: impl Into<ReadColumns>,
         num_columns: Option<usize>,
         file_path: &str,
         skip_auto_convert: bool,
     ) -> Result<FlatReadFormat> {
+        let read_cols = read_cols.into();
         let is_legacy = match num_columns {
             Some(num) => Self::is_legacy_format(&metadata, num, file_path)?,
             None => metadata.primary_key_encoding == PrimaryKeyEncoding::Sparse,
@@ -416,9 +417,10 @@ impl ParquetPrimaryKeyToFlat {
     /// Creates a helper with existing `metadata` and `column_ids` to read.
     fn new(
         metadata: RegionMetadataRef,
-        read_cols: &ReadColumns,
+        read_cols: impl Into<ReadColumns>,
         skip_auto_convert: bool,
     ) -> ParquetPrimaryKeyToFlat {
+        let read_cols = read_cols.into();
         assert!(if skip_auto_convert {
             metadata.primary_key_encoding == PrimaryKeyEncoding::Sparse
         } else {
@@ -431,7 +433,7 @@ impl ParquetPrimaryKeyToFlat {
             flat_sst_arrow_schema_column_num(&metadata, &FlatSchemaOptions::default());
 
         let codec = build_primary_key_codec(&metadata);
-        let format = PrimaryKeyReadFormat::new(metadata.clone(), read_cols);
+        let format = PrimaryKeyReadFormat::new(metadata.clone(), read_cols.clone());
         let (convert_format, format_projection) = if skip_auto_convert {
             (
                 None,
@@ -445,7 +447,7 @@ impl ParquetPrimaryKeyToFlat {
             let format_projection = FormatProjection::compute_format_projection(
                 &id_to_index,
                 sst_column_num,
-                read_cols,
+                read_cols.clone(),
             );
             (
                 FlatConvertFormat::new(Arc::clone(&metadata), &format_projection, codec),
@@ -483,7 +485,8 @@ struct ParquetFlat {
 
 impl ParquetFlat {
     /// Creates a helper with existing `metadata` and `column_ids` to read.
-    fn new(metadata: RegionMetadataRef, read_cols: &ReadColumns) -> ParquetFlat {
+    fn new(metadata: RegionMetadataRef, read_cols: impl Into<ReadColumns>) -> ParquetFlat {
+        let read_cols = read_cols.into();
         // Creates a map to lookup index.
         let id_to_index = sst_column_id_indices(&metadata);
         let arrow_schema = to_flat_sst_arrow_schema(&metadata, &FlatSchemaOptions::default());
@@ -788,10 +791,14 @@ impl FlatConvertFormat {
 impl FlatReadFormat {
     /// Creates a helper with existing `metadata` and all columns.
     pub fn new_with_all_columns(metadata: RegionMetadataRef) -> FlatReadFormat {
-        let read_cols = ReadColumns::from_deduped_column_ids(
+        Self::new(
+            Arc::clone(&metadata),
             metadata.column_metadatas.iter().map(|c| c.column_id),
-        );
-        Self::new(Arc::clone(&metadata), &read_cols, None, "test", false).unwrap()
+            None,
+            "test",
+            false,
+        )
+        .unwrap()
     }
 }
 
@@ -807,7 +814,6 @@ mod tests {
     use store_api::storage::RegionId;
 
     use super::{FlatReadFormat, field_column_start};
-    use crate::read::read_columns::ReadColumns;
     use crate::sst::{
         FlatSchemaOptions, flat_sst_arrow_schema_column_num, to_flat_sst_arrow_schema,
     };
@@ -888,9 +894,8 @@ mod tests {
     #[test]
     fn test_output_arrow_schema_uses_projection() {
         let metadata = Arc::new(build_metadata(1, 2, PrimaryKeyEncoding::Dense));
-        let read_cols = ReadColumns::from_deduped_column_ids([0_u32, 2_u32]);
         let read_format =
-            FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", false).unwrap();
+            FlatReadFormat::new(metadata.clone(), [0_u32, 2_u32], None, "test", false).unwrap();
 
         let output_schema = read_format.output_arrow_schema().unwrap();
         let projection = read_format.parquet_read_columns().root_indices();

--- a/src/mito2/src/sst/parquet/flat_format.rs
+++ b/src/mito2/src/sst/parquet/flat_format.rs
@@ -169,7 +169,6 @@ impl FlatReadFormat {
         file_path: &str,
         skip_auto_convert: bool,
     ) -> Result<FlatReadFormat> {
-        let read_cols = read_cols.into();
         let is_legacy = match num_columns {
             Some(num) => Self::is_legacy_format(&metadata, num, file_path)?,
             None => metadata.primary_key_encoding == PrimaryKeyEncoding::Sparse,

--- a/src/mito2/src/sst/parquet/flat_format.rs
+++ b/src/mito2/src/sst/parquet/flat_format.rs
@@ -164,7 +164,7 @@ impl FlatReadFormat {
     /// If `skip_auto_convert` is true, skips auto conversion of format when the encoding is sparse encoding.
     pub fn new(
         metadata: RegionMetadataRef,
-        read_cols: impl Into<ReadColumns>,
+        read_cols: ReadColumns,
         num_columns: Option<usize>,
         file_path: &str,
         skip_auto_convert: bool,
@@ -416,10 +416,9 @@ impl ParquetPrimaryKeyToFlat {
     /// Creates a helper with existing `metadata` and `column_ids` to read.
     fn new(
         metadata: RegionMetadataRef,
-        read_cols: impl Into<ReadColumns>,
+        read_cols: ReadColumns,
         skip_auto_convert: bool,
     ) -> ParquetPrimaryKeyToFlat {
-        let read_cols = read_cols.into();
         assert!(if skip_auto_convert {
             metadata.primary_key_encoding == PrimaryKeyEncoding::Sparse
         } else {
@@ -484,8 +483,7 @@ struct ParquetFlat {
 
 impl ParquetFlat {
     /// Creates a helper with existing `metadata` and `column_ids` to read.
-    fn new(metadata: RegionMetadataRef, read_cols: impl Into<ReadColumns>) -> ParquetFlat {
-        let read_cols = read_cols.into();
+    fn new(metadata: RegionMetadataRef, read_cols: ReadColumns) -> ParquetFlat {
         // Creates a map to lookup index.
         let id_to_index = sst_column_id_indices(&metadata);
         let arrow_schema = to_flat_sst_arrow_schema(&metadata, &FlatSchemaOptions::default());
@@ -792,7 +790,9 @@ impl FlatReadFormat {
     pub fn new_with_all_columns(metadata: RegionMetadataRef) -> FlatReadFormat {
         Self::new(
             Arc::clone(&metadata),
-            metadata.column_metadatas.iter().map(|c| c.column_id),
+            ReadColumns::from_deduped_column_ids(
+                metadata.column_metadatas.iter().map(|c| c.column_id),
+            ),
             None,
             "test",
             false,
@@ -813,6 +813,7 @@ mod tests {
     use store_api::storage::RegionId;
 
     use super::{FlatReadFormat, field_column_start};
+    use crate::read::read_columns::ReadColumns;
     use crate::sst::{
         FlatSchemaOptions, flat_sst_arrow_schema_column_num, to_flat_sst_arrow_schema,
     };
@@ -893,8 +894,14 @@ mod tests {
     #[test]
     fn test_output_arrow_schema_uses_projection() {
         let metadata = Arc::new(build_metadata(1, 2, PrimaryKeyEncoding::Dense));
-        let read_format =
-            FlatReadFormat::new(metadata.clone(), [0_u32, 2_u32], None, "test", false).unwrap();
+        let read_format = FlatReadFormat::new(
+            metadata.clone(),
+            ReadColumns::from_deduped_column_ids([0_u32, 2_u32]),
+            None,
+            "test",
+            false,
+        )
+        .unwrap();
 
         let output_schema = read_format.output_arrow_schema().unwrap();
         let projection = read_format.parquet_read_columns().root_indices();

--- a/src/mito2/src/sst/parquet/flat_format.rs
+++ b/src/mito2/src/sst/parquet/flat_format.rs
@@ -479,7 +479,7 @@ impl ParquetFlat {
         let sst_column_num =
             flat_sst_arrow_schema_column_num(&metadata, &FlatSchemaOptions::default());
         let format_projection =
-            FormatProjection::compute_format_projection(&id_to_index, sst_column_num, &read_cols);
+            FormatProjection::compute_format_projection(&id_to_index, sst_column_num, read_cols);
 
         Self {
             metadata,

--- a/src/mito2/src/sst/parquet/flat_format.rs
+++ b/src/mito2/src/sst/parquet/flat_format.rs
@@ -51,10 +51,12 @@ use crate::error::{
     ComputeArrowSnafu, DecodeSnafu, InvalidParquetSnafu, InvalidRecordBatchSnafu,
     NewRecordBatchSnafu, Result,
 };
+use crate::read::read_columns::ReadColumns;
 use crate::sst::parquet::format::{
     FIXED_POS_COLUMN_NUM, FormatProjection, INTERNAL_COLUMN_NUM, PrimaryKeyArray,
     PrimaryKeyReadFormat, ReadFormat, StatValues,
 };
+use crate::sst::parquet::read_columns::ParquetReadColumns;
 use crate::sst::{
     FlatSchemaOptions, flat_sst_arrow_schema_column_num, tag_maybe_to_dictionary_field,
     to_flat_sst_arrow_schema,
@@ -161,7 +163,7 @@ impl FlatReadFormat {
     /// If `skip_auto_convert` is true, skips auto conversion of format when the encoding is sparse encoding.
     pub fn new(
         metadata: RegionMetadataRef,
-        column_ids: impl Iterator<Item = ColumnId>,
+        read_cols: ReadColumns,
         num_columns: Option<usize>,
         file_path: &str,
         skip_auto_convert: bool,
@@ -177,16 +179,16 @@ impl FlatReadFormat {
                 // Only skip auto convert when the primary key encoding is sparse.
                 ParquetAdapter::PrimaryKeyToFlat(ParquetPrimaryKeyToFlat::new(
                     metadata,
-                    column_ids,
+                    read_cols,
                     skip_auto_convert,
                 ))
             } else {
                 ParquetAdapter::PrimaryKeyToFlat(ParquetPrimaryKeyToFlat::new(
-                    metadata, column_ids, false,
+                    metadata, read_cols, false,
                 ))
             }
         } else {
-            ParquetAdapter::Flat(ParquetFlat::new(metadata, column_ids))
+            ParquetAdapter::Flat(ParquetFlat::new(metadata, read_cols))
         };
 
         Ok(FlatReadFormat {
@@ -263,11 +265,11 @@ impl FlatReadFormat {
         }
     }
 
-    /// Gets sorted projection indices to read from the SST file.
-    pub(crate) fn projection_indices(&self) -> &[usize] {
+    /// Get the sorted read columns to read from the sst file.
+    pub(crate) fn parquet_read_columns(&self) -> &ParquetReadColumns {
         match &self.parquet_adapter {
-            ParquetAdapter::Flat(p) => &p.format_projection.projection_indices,
-            ParquetAdapter::PrimaryKeyToFlat(p) => p.format.projection_indices(),
+            ParquetAdapter::Flat(p) => &p.format_projection.parquet_read_cols,
+            ParquetAdapter::PrimaryKeyToFlat(p) => p.format.parquet_read_columns(),
         }
     }
 
@@ -403,7 +405,7 @@ impl ParquetPrimaryKeyToFlat {
     /// Creates a helper with existing `metadata` and `column_ids` to read.
     fn new(
         metadata: RegionMetadataRef,
-        column_ids: impl Iterator<Item = ColumnId>,
+        read_cols: ReadColumns,
         skip_auto_convert: bool,
     ) -> ParquetPrimaryKeyToFlat {
         assert!(if skip_auto_convert {
@@ -412,20 +414,18 @@ impl ParquetPrimaryKeyToFlat {
             true
         });
 
-        let column_ids: Vec<_> = column_ids.collect();
-
         // Creates a map to lookup index based on the new format.
         let id_to_index = sst_column_id_indices(&metadata);
         let sst_column_num =
             flat_sst_arrow_schema_column_num(&metadata, &FlatSchemaOptions::default());
 
         let codec = build_primary_key_codec(&metadata);
-        let format = PrimaryKeyReadFormat::new(metadata.clone(), column_ids.iter().copied());
+        let format = PrimaryKeyReadFormat::new(metadata.clone(), read_cols.clone());
         let (convert_format, format_projection) = if skip_auto_convert {
             (
                 None,
                 FormatProjection {
-                    projection_indices: format.projection_indices().to_vec(),
+                    parquet_read_cols: format.parquet_read_columns().clone(),
                     column_id_to_projected_index: format.field_id_to_projected_index().clone(),
                 },
             )
@@ -434,7 +434,7 @@ impl ParquetPrimaryKeyToFlat {
             let format_projection = FormatProjection::compute_format_projection(
                 &id_to_index,
                 sst_column_num,
-                column_ids.iter().copied(),
+                &read_cols,
             );
             (
                 FlatConvertFormat::new(Arc::clone(&metadata), &format_projection, codec),
@@ -472,14 +472,14 @@ struct ParquetFlat {
 
 impl ParquetFlat {
     /// Creates a helper with existing `metadata` and `column_ids` to read.
-    fn new(metadata: RegionMetadataRef, column_ids: impl Iterator<Item = ColumnId>) -> ParquetFlat {
+    fn new(metadata: RegionMetadataRef, read_cols: ReadColumns) -> ParquetFlat {
         // Creates a map to lookup index.
         let id_to_index = sst_column_id_indices(&metadata);
         let arrow_schema = to_flat_sst_arrow_schema(&metadata, &FlatSchemaOptions::default());
         let sst_column_num =
             flat_sst_arrow_schema_column_num(&metadata, &FlatSchemaOptions::default());
         let format_projection =
-            FormatProjection::compute_format_projection(&id_to_index, sst_column_num, column_ids);
+            FormatProjection::compute_format_projection(&id_to_index, sst_column_num, &read_cols);
 
         Self {
             metadata,
@@ -777,14 +777,9 @@ impl FlatConvertFormat {
 impl FlatReadFormat {
     /// Creates a helper with existing `metadata` and all columns.
     pub fn new_with_all_columns(metadata: RegionMetadataRef) -> FlatReadFormat {
-        Self::new(
-            Arc::clone(&metadata),
-            metadata.column_metadatas.iter().map(|c| c.column_id),
-            None,
-            "test",
-            false,
-        )
-        .unwrap()
+        let read_cols =
+            ReadColumns::from_column_ids(metadata.column_metadatas.iter().map(|c| c.column_id));
+        Self::new(Arc::clone(&metadata), read_cols, None, "test", false).unwrap()
     }
 }
 

--- a/src/mito2/src/sst/parquet/flat_format.rs
+++ b/src/mito2/src/sst/parquet/flat_format.rs
@@ -163,7 +163,7 @@ impl FlatReadFormat {
     /// If `skip_auto_convert` is true, skips auto conversion of format when the encoding is sparse encoding.
     pub fn new(
         metadata: RegionMetadataRef,
-        read_cols: ReadColumns,
+        read_cols: &ReadColumns,
         num_columns: Option<usize>,
         file_path: &str,
         skip_auto_convert: bool,
@@ -405,7 +405,7 @@ impl ParquetPrimaryKeyToFlat {
     /// Creates a helper with existing `metadata` and `column_ids` to read.
     fn new(
         metadata: RegionMetadataRef,
-        read_cols: ReadColumns,
+        read_cols: &ReadColumns,
         skip_auto_convert: bool,
     ) -> ParquetPrimaryKeyToFlat {
         assert!(if skip_auto_convert {
@@ -420,7 +420,7 @@ impl ParquetPrimaryKeyToFlat {
             flat_sst_arrow_schema_column_num(&metadata, &FlatSchemaOptions::default());
 
         let codec = build_primary_key_codec(&metadata);
-        let format = PrimaryKeyReadFormat::new(metadata.clone(), read_cols.clone());
+        let format = PrimaryKeyReadFormat::new(metadata.clone(), read_cols);
         let (convert_format, format_projection) = if skip_auto_convert {
             (
                 None,
@@ -434,7 +434,7 @@ impl ParquetPrimaryKeyToFlat {
             let format_projection = FormatProjection::compute_format_projection(
                 &id_to_index,
                 sst_column_num,
-                &read_cols,
+                read_cols,
             );
             (
                 FlatConvertFormat::new(Arc::clone(&metadata), &format_projection, codec),
@@ -472,7 +472,7 @@ struct ParquetFlat {
 
 impl ParquetFlat {
     /// Creates a helper with existing `metadata` and `column_ids` to read.
-    fn new(metadata: RegionMetadataRef, read_cols: ReadColumns) -> ParquetFlat {
+    fn new(metadata: RegionMetadataRef, read_cols: &ReadColumns) -> ParquetFlat {
         // Creates a map to lookup index.
         let id_to_index = sst_column_id_indices(&metadata);
         let arrow_schema = to_flat_sst_arrow_schema(&metadata, &FlatSchemaOptions::default());
@@ -779,7 +779,7 @@ impl FlatReadFormat {
     pub fn new_with_all_columns(metadata: RegionMetadataRef) -> FlatReadFormat {
         let read_cols =
             ReadColumns::from_column_ids(metadata.column_metadatas.iter().map(|c| c.column_id));
-        Self::new(Arc::clone(&metadata), read_cols, None, "test", false).unwrap()
+        Self::new(Arc::clone(&metadata), &read_cols, None, "test", false).unwrap()
     }
 }
 

--- a/src/mito2/src/sst/parquet/format.rs
+++ b/src/mito2/src/sst/parquet/format.rs
@@ -694,8 +694,9 @@ impl StatValues {
 impl PrimaryKeyReadFormat {
     /// Creates a helper with existing `metadata` and all columns.
     pub fn new_with_all_columns(metadata: RegionMetadataRef) -> PrimaryKeyReadFormat {
-        let read_cols =
-            ReadColumns::from_deduped_column_ids(metadata.column_metadatas.iter().map(|c| c.column_id));
+        let read_cols = ReadColumns::from_deduped_column_ids(
+            metadata.column_metadatas.iter().map(|c| c.column_id),
+        );
         Self::new(Arc::clone(&metadata), &read_cols)
     }
 }
@@ -1070,8 +1071,9 @@ mod tests {
     #[test]
     fn test_convert_record_batch_with_override_sequence() {
         let metadata = build_test_region_metadata();
-        let read_cols =
-            ReadColumns::from_deduped_column_ids(metadata.column_metadatas.iter().map(|c| c.column_id));
+        let read_cols = ReadColumns::from_deduped_column_ids(
+            metadata.column_metadatas.iter().map(|c| c.column_id),
+        );
         let read_format = PrimaryKeyReadFormat::new(metadata, &read_cols);
 
         let columns: Vec<ArrayRef> = vec![

--- a/src/mito2/src/sst/parquet/format.rs
+++ b/src/mito2/src/sst/parquet/format.rs
@@ -621,7 +621,7 @@ impl FormatProjection {
             Self::merge_or_push_parquet_column(&mut parquet_read_cols, index_of_sst, nested_paths);
 
             if !column_id_to_projected_index.contains_key(&col_id) {
-                let projected_index = column_id_to_projected_index.len();
+                let projected_index = parquet_read_cols.len() - 1;
                 column_id_to_projected_index.insert(col_id, projected_index);
             }
         }

--- a/src/mito2/src/sst/parquet/format.rs
+++ b/src/mito2/src/sst/parquet/format.rs
@@ -620,10 +620,9 @@ impl FormatProjection {
         for (col_id, index_of_sst, nested_paths) in projected_columns {
             Self::merge_or_push_parquet_column(&mut parquet_read_cols, index_of_sst, nested_paths);
 
-            if !column_id_to_projected_index.contains_key(&col_id) {
-                let projected_index = parquet_read_cols.len() - 1;
-                column_id_to_projected_index.insert(col_id, projected_index);
-            }
+            column_id_to_projected_index
+                .entry(col_id)
+                .or_insert_with(|| parquet_read_cols.len() - 1);
         }
 
         Self::append_fixed_root_columns(&mut parquet_read_cols, sst_column_num);

--- a/src/mito2/src/sst/parquet/format.rs
+++ b/src/mito2/src/sst/parquet/format.rs
@@ -224,7 +224,11 @@ pub struct PrimaryKeyReadFormat {
 
 impl PrimaryKeyReadFormat {
     /// Creates a helper with existing `metadata` and `column_ids` to read.
-    pub fn new(metadata: RegionMetadataRef, read_cols: &ReadColumns) -> PrimaryKeyReadFormat {
+    pub fn new(
+        metadata: RegionMetadataRef,
+        read_cols: impl Into<ReadColumns>,
+    ) -> PrimaryKeyReadFormat {
+        let read_cols = read_cols.into();
         let field_id_to_index: HashMap<_, _> = metadata
             .field_columns()
             .enumerate()
@@ -594,19 +598,16 @@ impl FormatProjection {
     pub(crate) fn compute_format_projection(
         id_to_index: &HashMap<ColumnId, usize>,
         sst_column_num: usize,
-        cols: &ReadColumns,
+        cols: ReadColumns,
     ) -> Self {
         let mut projected_columns: Vec<_> = cols
-            .columns()
-            .iter()
+            .cols
+            .into_iter()
             .filter_map(|col| {
                 id_to_index
-                    .get(&col.column_id())
+                    .get(&col.column_id)
                     .copied()
-                    .map(|index_of_sst| {
-                        let nested_paths = col.nested_paths().to_vec();
-                        (col.column_id(), index_of_sst, nested_paths)
-                    })
+                    .map(|index_of_sst| (col.column_id, index_of_sst, col.nested_paths))
             })
             .collect();
         projected_columns.sort_unstable_by_key(|(_, index, _)| *index);
@@ -694,10 +695,10 @@ impl StatValues {
 impl PrimaryKeyReadFormat {
     /// Creates a helper with existing `metadata` and all columns.
     pub fn new_with_all_columns(metadata: RegionMetadataRef) -> PrimaryKeyReadFormat {
-        let read_cols = ReadColumns::from_deduped_column_ids(
+        Self::new(
+            Arc::clone(&metadata),
             metadata.column_metadatas.iter().map(|c| c.column_id),
-        );
-        Self::new(Arc::clone(&metadata), &read_cols)
+        )
     }
 }
 
@@ -952,29 +953,25 @@ mod tests {
     fn test_projection_indices() {
         let metadata = build_test_region_metadata();
         // Only read tag1
-        let read_format =
-            PrimaryKeyReadFormat::new(metadata.clone(), &ReadColumns::from_deduped_column_ids([3]));
+        let read_format = PrimaryKeyReadFormat::new(metadata.clone(), [3]);
         assert_eq!(
             &[2, 3, 4, 5],
             read_format.parquet_read_columns().root_indices()
         );
         // Only read field1
-        let read_format =
-            PrimaryKeyReadFormat::new(metadata.clone(), &ReadColumns::from_deduped_column_ids([4]));
+        let read_format = PrimaryKeyReadFormat::new(metadata.clone(), [4]);
         assert_eq!(
             &[0, 2, 3, 4, 5],
             read_format.parquet_read_columns().root_indices()
         );
         // Only read ts
-        let read_format =
-            PrimaryKeyReadFormat::new(metadata.clone(), &ReadColumns::from_deduped_column_ids([5]));
+        let read_format = PrimaryKeyReadFormat::new(metadata.clone(), [5]);
         assert_eq!(
             &[2, 3, 4, 5],
             read_format.parquet_read_columns().root_indices()
         );
         // Read field0, tag0, ts
-        let read_format =
-            PrimaryKeyReadFormat::new(metadata, &ReadColumns::from_deduped_column_ids([2, 1, 5]));
+        let read_format = PrimaryKeyReadFormat::new(metadata, [2, 1, 5]);
         assert_eq!(
             &[1, 2, 3, 4, 5],
             read_format.parquet_read_columns().root_indices()
@@ -1024,8 +1021,7 @@ mod tests {
             .iter()
             .map(|col| col.column_id)
             .collect();
-        let read_cols = ReadColumns::from_deduped_column_ids(column_ids);
-        let read_format = PrimaryKeyReadFormat::new(metadata, &read_cols);
+        let read_format = PrimaryKeyReadFormat::new(metadata, column_ids);
         assert_eq!(arrow_schema, *read_format.arrow_schema());
 
         let record_batch = RecordBatch::new_empty(arrow_schema);
@@ -1044,8 +1040,7 @@ mod tests {
             .iter()
             .map(|col| col.column_id)
             .collect();
-        let read_cols = ReadColumns::from_deduped_column_ids(column_ids);
-        let read_format = PrimaryKeyReadFormat::new(metadata, &read_cols);
+        let read_format = PrimaryKeyReadFormat::new(metadata, column_ids);
 
         let columns: Vec<ArrayRef> = vec![
             Arc::new(Int64Array::from(vec![1, 1, 10, 10])), // field1
@@ -1071,10 +1066,10 @@ mod tests {
     #[test]
     fn test_convert_record_batch_with_override_sequence() {
         let metadata = build_test_region_metadata();
-        let read_cols = ReadColumns::from_deduped_column_ids(
+        let read_format = PrimaryKeyReadFormat::new(
+            metadata.clone(),
             metadata.column_metadatas.iter().map(|c| c.column_id),
         );
-        let read_format = PrimaryKeyReadFormat::new(metadata, &read_cols);
 
         let columns: Vec<ArrayRef> = vec![
             Arc::new(Int64Array::from(vec![1, 1, 10, 10])), // field1
@@ -1200,35 +1195,28 @@ mod tests {
         // The projection includes all "fixed position" columns: ts(4), __primary_key(5), __sequence(6), __op_type(7)
 
         // Only read tag1 (column_id=3, index=1) + fixed columns
-        let read_cols = ReadColumns::from_deduped_column_ids([3]);
-        let read_format =
-            FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", false).unwrap();
+        let read_format = FlatReadFormat::new(metadata.clone(), [3], None, "test", false).unwrap();
         assert_eq!(
             &[1, 4, 5, 6, 7],
             read_format.parquet_read_columns().root_indices()
         );
 
         // Only read field1 (column_id=4, index=2) + fixed columns
-        let read_cols = ReadColumns::from_deduped_column_ids([4]);
-        let read_format =
-            FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", false).unwrap();
+        let read_format = FlatReadFormat::new(metadata.clone(), [4], None, "test", false).unwrap();
         assert_eq!(
             &[2, 4, 5, 6, 7],
             read_format.parquet_read_columns().root_indices()
         );
 
         // Only read ts (column_id=5, index=4) + fixed columns (ts is already included in fixed)
-        let read_cols = ReadColumns::from_deduped_column_ids([5]);
-        let read_format =
-            FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", false).unwrap();
+        let read_format = FlatReadFormat::new(metadata.clone(), [5], None, "test", false).unwrap();
         assert_eq!(
             &[4, 5, 6, 7],
             read_format.parquet_read_columns().root_indices()
         );
 
         // Read field0(column_id=2, index=3), tag0(column_id=1, index=0), ts(column_id=5, index=4) + fixed columns
-        let read_cols = ReadColumns::from_deduped_column_ids([2, 1, 5]);
-        let read_format = FlatReadFormat::new(metadata, &read_cols, None, "test", false).unwrap();
+        let read_format = FlatReadFormat::new(metadata, [2, 1, 5], None, "test", false).unwrap();
         assert_eq!(
             &[0, 3, 4, 5, 6, 7],
             read_format.parquet_read_columns().root_indices()
@@ -1238,10 +1226,9 @@ mod tests {
     #[test]
     fn test_flat_read_format_convert_batch() {
         let metadata = build_test_region_metadata();
-        let read_cols = ReadColumns::from_deduped_column_ids(std::iter::once(1));
         let mut format = FlatReadFormat::new(
             metadata,
-            &read_cols, // Just read tag0
+            std::iter::once(1), // Just read tag0
             Some(8),
             "test",
             false,
@@ -1456,9 +1443,8 @@ mod tests {
             .iter()
             .map(|c| c.column_id)
             .collect();
-        let read_cols = ReadColumns::from_deduped_column_ids(column_ids);
         let format =
-            FlatReadFormat::new(metadata.clone(), &read_cols, Some(6), "test", false).unwrap();
+            FlatReadFormat::new(metadata.clone(), column_ids, Some(6), "test", false).unwrap();
 
         let num_rows = 4;
         let original_sequence = 100u64;
@@ -1533,9 +1519,8 @@ mod tests {
             .iter()
             .map(|c| c.column_id)
             .collect();
-        let read_cols = ReadColumns::from_deduped_column_ids(column_ids.clone());
         let format =
-            FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", false).unwrap();
+            FlatReadFormat::new(metadata.clone(), column_ids.clone(), None, "test", false).unwrap();
 
         let num_rows = 4;
         let original_sequence = 100u64;
@@ -1617,8 +1602,7 @@ mod tests {
         // Compare the actual result with the expected record batch
         assert_eq!(expected_record_batch, result);
 
-        let read_cols = ReadColumns::from_deduped_column_ids(column_ids);
-        let format = FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", true).unwrap();
+        let format = FlatReadFormat::new(metadata.clone(), column_ids, None, "test", true).unwrap();
         // Test conversion with sparse encoding and skip convert.
         let result = format.convert_batch(record_batch.clone(), None).unwrap();
         assert_eq!(record_batch, result);

--- a/src/mito2/src/sst/parquet/format.rs
+++ b/src/mito2/src/sst/parquet/format.rs
@@ -52,8 +52,10 @@ use store_api::storage::{ColumnId, SequenceNumber};
 use crate::error::{
     ConvertVectorSnafu, DecodeSnafu, InvalidRecordBatchSnafu, NewRecordBatchSnafu, Result,
 };
+use crate::read::read_columns::ReadColumns;
 use crate::read::{Batch, BatchBuilder, BatchColumn};
 use crate::sst::file::{FileMeta, FileTimeRange};
+use crate::sst::parquet::read_columns::{ParquetReadColumn, ParquetReadColumns};
 use crate::sst::to_sst_arrow_schema;
 
 /// Arrow array type for the primary key dictionary.
@@ -212,7 +214,7 @@ pub struct PrimaryKeyReadFormat {
     /// In SST schema, fields are stored in the front of the schema.
     field_id_to_index: HashMap<ColumnId, usize>,
     /// Indices of columns to read from the SST. It contains all internal columns.
-    projection_indices: Vec<usize>,
+    parquet_read_cols: ParquetReadColumns,
     /// Field column id to their index in the projected schema (
     /// the schema of [Batch]).
     field_id_to_projected_index: HashMap<ColumnId, usize>,
@@ -222,10 +224,7 @@ pub struct PrimaryKeyReadFormat {
 
 impl PrimaryKeyReadFormat {
     /// Creates a helper with existing `metadata` and `column_ids` to read.
-    pub fn new(
-        metadata: RegionMetadataRef,
-        column_ids: impl Iterator<Item = ColumnId>,
-    ) -> PrimaryKeyReadFormat {
+    pub fn new(metadata: RegionMetadataRef, read_cols: &ReadColumns) -> PrimaryKeyReadFormat {
         let field_id_to_index: HashMap<_, _> = metadata
             .field_columns()
             .enumerate()
@@ -236,14 +235,14 @@ impl PrimaryKeyReadFormat {
         let format_projection = FormatProjection::compute_format_projection(
             &field_id_to_index,
             arrow_schema.fields.len(),
-            column_ids,
+            read_cols,
         );
 
         PrimaryKeyReadFormat {
             metadata,
             arrow_schema,
             field_id_to_index,
-            projection_indices: format_projection.projection_indices,
+            parquet_read_cols: format_projection.parquet_read_cols,
             field_id_to_projected_index: format_projection.column_id_to_projected_index,
             primary_key_codec: None,
         }
@@ -262,9 +261,8 @@ impl PrimaryKeyReadFormat {
         &self.metadata
     }
 
-    /// Gets sorted projection indices to read.
-    pub(crate) fn projection_indices(&self) -> &[usize] {
-        &self.projection_indices
+    pub(crate) fn parquet_read_columns(&self) -> &ParquetReadColumns {
+        &self.parquet_read_cols
     }
 
     /// Gets the field id to projected index.
@@ -580,8 +578,8 @@ impl PrimaryKeyReadFormat {
 
 /// Helper to compute the projection for the SST.
 pub(crate) struct FormatProjection {
-    /// Indices of columns to read from the SST. It contains all internal columns.
-    pub(crate) projection_indices: Vec<usize>,
+    /// The columns to read from the SST. It contains all internal columns.
+    pub(crate) parquet_read_cols: ParquetReadColumns,
     /// Column id to their index in the projected schema (
     /// the schema after projection).
     ///
@@ -596,48 +594,75 @@ impl FormatProjection {
     pub(crate) fn compute_format_projection(
         id_to_index: &HashMap<ColumnId, usize>,
         sst_column_num: usize,
-        column_ids: impl Iterator<Item = ColumnId>,
+        cols: &ReadColumns,
     ) -> Self {
-        // Maps column id of a projected column to its index in SST.
-        // It also ignores columns not in the SST.
-        // [(column id, index in SST)]
-        let mut projected_schema: Vec<_> = column_ids
-            .filter_map(|column_id| {
+        let mut projected_columns: Vec<_> = cols
+            .columns()
+            .iter()
+            .filter_map(|col| {
                 id_to_index
-                    .get(&column_id)
+                    .get(&col.column_id())
                     .copied()
-                    .map(|index| (column_id, index))
+                    .map(|index_of_sst| {
+                        let nested_paths = col.nested_paths().to_vec();
+                        (col.column_id(), index_of_sst, nested_paths)
+                    })
             })
             .collect();
-        // Sorts columns by their indices in the SST. SST uses a bitmap for projection.
-        // This ensures the schema of `projected_schema` is the same as the batch returned from the SST.
-        projected_schema.sort_unstable_by_key(|x| x.1);
-        // Dedups the entries to avoid the case that `column_ids` has duplicated columns.
-        projected_schema.dedup_by_key(|x| x.1);
+        projected_columns.sort_unstable_by_key(|(_, index, _)| *index);
 
-        // Collects all projected indices.
-        // It contains the positions of all columns we need to read.
-        let mut projection_indices: Vec<_> = projected_schema
-            .iter()
-            .map(|(_column_id, index)| *index)
-            // We need to add all fixed position columns.
-            .chain(sst_column_num - FIXED_POS_COLUMN_NUM..sst_column_num)
-            .collect();
-        projection_indices.sort_unstable();
-        // Removes duplications.
-        projection_indices.dedup();
-
+        let mut parquet_read_cols: Vec<ParquetReadColumn> =
+            Vec::with_capacity(projected_columns.len() + FIXED_POS_COLUMN_NUM);
         // Creates a map from column id to the index of that column in the projected record batch.
-        let column_id_to_projected_index = projected_schema
-            .into_iter()
-            .map(|(column_id, _)| column_id)
-            .enumerate()
-            .map(|(index, column_id)| (column_id, index))
-            .collect();
+        let mut column_id_to_projected_index = HashMap::with_capacity(projected_columns.len());
+
+        for (col_id, index_of_sst, nested_paths) in projected_columns {
+            Self::merge_or_push_parquet_column(&mut parquet_read_cols, index_of_sst, nested_paths);
+
+            if !column_id_to_projected_index.contains_key(&col_id) {
+                let projected_index = column_id_to_projected_index.len();
+                column_id_to_projected_index.insert(col_id, projected_index);
+            }
+        }
+
+        Self::append_fixed_root_columns(&mut parquet_read_cols, sst_column_num);
 
         Self {
-            projection_indices,
+            parquet_read_cols: ParquetReadColumns::from_deduped(parquet_read_cols),
             column_id_to_projected_index,
+        }
+    }
+
+    fn merge_or_push_parquet_column(
+        parquet_read_cols: &mut Vec<ParquetReadColumn>,
+        index_of_sst: usize,
+        nested_paths: Vec<Vec<String>>,
+    ) {
+        // `projected_columns` is sorted by parquet root index, so repeated reads
+        // for the same root column are always adjacent.
+        if let Some(last_col) = parquet_read_cols.last_mut()
+            && last_col.root_index() == index_of_sst
+        {
+            last_col.merge_nested_paths(nested_paths);
+            return;
+        }
+
+        let parquet_col = ParquetReadColumn::new(index_of_sst).with_nested_paths(nested_paths);
+        parquet_read_cols.push(parquet_col);
+    }
+
+    fn append_fixed_root_columns(
+        parquet_read_cols: &mut Vec<ParquetReadColumn>,
+        sst_column_num: usize,
+    ) {
+        for index in sst_column_num - FIXED_POS_COLUMN_NUM..sst_column_num {
+            let needs_append = parquet_read_cols
+                .last()
+                .map(|col| col.root_index() != index)
+                .unwrap_or(true);
+            if needs_append {
+                parquet_read_cols.push(ParquetReadColumn::new(index));
+            }
         }
     }
 }
@@ -669,10 +694,9 @@ impl StatValues {
 impl PrimaryKeyReadFormat {
     /// Creates a helper with existing `metadata` and all columns.
     pub fn new_with_all_columns(metadata: RegionMetadataRef) -> PrimaryKeyReadFormat {
-        Self::new(
-            Arc::clone(&metadata),
-            metadata.column_metadatas.iter().map(|c| c.column_id),
-        )
+        let read_cols =
+            ReadColumns::from_deduped_column_ids(metadata.column_metadatas.iter().map(|c| c.column_id));
+        Self::new(Arc::clone(&metadata), &read_cols)
     }
 }
 
@@ -927,17 +951,33 @@ mod tests {
     fn test_projection_indices() {
         let metadata = build_test_region_metadata();
         // Only read tag1
-        let read_format = PrimaryKeyReadFormat::new(metadata.clone(), [3].iter().copied());
-        assert_eq!(&[2, 3, 4, 5], read_format.projection_indices());
+        let read_format =
+            PrimaryKeyReadFormat::new(metadata.clone(), &ReadColumns::from_deduped_column_ids([3]));
+        assert_eq!(
+            &[2, 3, 4, 5],
+            read_format.parquet_read_columns().root_indices()
+        );
         // Only read field1
-        let read_format = PrimaryKeyReadFormat::new(metadata.clone(), [4].iter().copied());
-        assert_eq!(&[0, 2, 3, 4, 5], read_format.projection_indices());
+        let read_format =
+            PrimaryKeyReadFormat::new(metadata.clone(), &ReadColumns::from_deduped_column_ids([4]));
+        assert_eq!(
+            &[0, 2, 3, 4, 5],
+            read_format.parquet_read_columns().root_indices()
+        );
         // Only read ts
-        let read_format = PrimaryKeyReadFormat::new(metadata.clone(), [5].iter().copied());
-        assert_eq!(&[2, 3, 4, 5], read_format.projection_indices());
+        let read_format =
+            PrimaryKeyReadFormat::new(metadata.clone(), &ReadColumns::from_deduped_column_ids([5]));
+        assert_eq!(
+            &[2, 3, 4, 5],
+            read_format.parquet_read_columns().root_indices()
+        );
         // Read field0, tag0, ts
-        let read_format = PrimaryKeyReadFormat::new(metadata, [2, 1, 5].iter().copied());
-        assert_eq!(&[1, 2, 3, 4, 5], read_format.projection_indices());
+        let read_format =
+            PrimaryKeyReadFormat::new(metadata, &ReadColumns::from_deduped_column_ids([2, 1, 5]));
+        assert_eq!(
+            &[1, 2, 3, 4, 5],
+            read_format.parquet_read_columns().root_indices()
+        );
     }
 
     #[test]
@@ -983,7 +1023,8 @@ mod tests {
             .iter()
             .map(|col| col.column_id)
             .collect();
-        let read_format = PrimaryKeyReadFormat::new(metadata, column_ids.iter().copied());
+        let read_cols = ReadColumns::from_deduped_column_ids(column_ids);
+        let read_format = PrimaryKeyReadFormat::new(metadata, &read_cols);
         assert_eq!(arrow_schema, *read_format.arrow_schema());
 
         let record_batch = RecordBatch::new_empty(arrow_schema);
@@ -1002,7 +1043,8 @@ mod tests {
             .iter()
             .map(|col| col.column_id)
             .collect();
-        let read_format = PrimaryKeyReadFormat::new(metadata, column_ids.iter().copied());
+        let read_cols = ReadColumns::from_deduped_column_ids(column_ids);
+        let read_format = PrimaryKeyReadFormat::new(metadata, &read_cols);
 
         let columns: Vec<ArrayRef> = vec![
             Arc::new(Int64Array::from(vec![1, 1, 10, 10])), // field1
@@ -1028,12 +1070,9 @@ mod tests {
     #[test]
     fn test_convert_record_batch_with_override_sequence() {
         let metadata = build_test_region_metadata();
-        let column_ids: Vec<_> = metadata
-            .column_metadatas
-            .iter()
-            .map(|col| col.column_id)
-            .collect();
-        let read_format = PrimaryKeyReadFormat::new(metadata, column_ids.iter().copied());
+        let read_cols =
+            ReadColumns::from_deduped_column_ids(metadata.column_metadatas.iter().map(|c| c.column_id));
+        let read_format = PrimaryKeyReadFormat::new(metadata, &read_cols);
 
         let columns: Vec<ArrayRef> = vec![
             Arc::new(Int64Array::from(vec![1, 1, 10, 10])), // field1
@@ -1159,35 +1198,48 @@ mod tests {
         // The projection includes all "fixed position" columns: ts(4), __primary_key(5), __sequence(6), __op_type(7)
 
         // Only read tag1 (column_id=3, index=1) + fixed columns
+        let read_cols = ReadColumns::from_deduped_column_ids([3]);
         let read_format =
-            FlatReadFormat::new(metadata.clone(), [3].iter().copied(), None, "test", false)
-                .unwrap();
-        assert_eq!(&[1, 4, 5, 6, 7], read_format.projection_indices());
+            FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", false).unwrap();
+        assert_eq!(
+            &[1, 4, 5, 6, 7],
+            read_format.parquet_read_columns().root_indices()
+        );
 
         // Only read field1 (column_id=4, index=2) + fixed columns
+        let read_cols = ReadColumns::from_deduped_column_ids([4]);
         let read_format =
-            FlatReadFormat::new(metadata.clone(), [4].iter().copied(), None, "test", false)
-                .unwrap();
-        assert_eq!(&[2, 4, 5, 6, 7], read_format.projection_indices());
+            FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", false).unwrap();
+        assert_eq!(
+            &[2, 4, 5, 6, 7],
+            read_format.parquet_read_columns().root_indices()
+        );
 
         // Only read ts (column_id=5, index=4) + fixed columns (ts is already included in fixed)
+        let read_cols = ReadColumns::from_deduped_column_ids([5]);
         let read_format =
-            FlatReadFormat::new(metadata.clone(), [5].iter().copied(), None, "test", false)
-                .unwrap();
-        assert_eq!(&[4, 5, 6, 7], read_format.projection_indices());
+            FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", false).unwrap();
+        assert_eq!(
+            &[4, 5, 6, 7],
+            read_format.parquet_read_columns().root_indices()
+        );
 
         // Read field0(column_id=2, index=3), tag0(column_id=1, index=0), ts(column_id=5, index=4) + fixed columns
-        let read_format =
-            FlatReadFormat::new(metadata, [2, 1, 5].iter().copied(), None, "test", false).unwrap();
-        assert_eq!(&[0, 3, 4, 5, 6, 7], read_format.projection_indices());
+        let read_cols = ReadColumns::from_deduped_column_ids([2, 1, 5]);
+        let read_format = FlatReadFormat::new(metadata, &read_cols, None, "test", false).unwrap();
+        assert_eq!(
+            &[0, 3, 4, 5, 6, 7],
+            read_format.parquet_read_columns().root_indices()
+        );
     }
 
     #[test]
     fn test_flat_read_format_convert_batch() {
         let metadata = build_test_region_metadata();
+        let read_cols = ReadColumns::from_deduped_column_ids(std::iter::once(1));
         let mut format = FlatReadFormat::new(
             metadata,
-            std::iter::once(1), // Just read tag0
+            &read_cols, // Just read tag0
             Some(8),
             "test",
             false,
@@ -1402,14 +1454,9 @@ mod tests {
             .iter()
             .map(|c| c.column_id)
             .collect();
-        let format = FlatReadFormat::new(
-            metadata.clone(),
-            column_ids.into_iter(),
-            Some(6),
-            "test",
-            false,
-        )
-        .unwrap();
+        let read_cols = ReadColumns::from_deduped_column_ids(column_ids);
+        let format =
+            FlatReadFormat::new(metadata.clone(), &read_cols, Some(6), "test", false).unwrap();
 
         let num_rows = 4;
         let original_sequence = 100u64;
@@ -1484,14 +1531,9 @@ mod tests {
             .iter()
             .map(|c| c.column_id)
             .collect();
-        let format = FlatReadFormat::new(
-            metadata.clone(),
-            column_ids.clone().into_iter(),
-            None,
-            "test",
-            false,
-        )
-        .unwrap();
+        let read_cols = ReadColumns::from_deduped_column_ids(column_ids.clone());
+        let format =
+            FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", false).unwrap();
 
         let num_rows = 4;
         let original_sequence = 100u64;
@@ -1573,9 +1615,8 @@ mod tests {
         // Compare the actual result with the expected record batch
         assert_eq!(expected_record_batch, result);
 
-        let format =
-            FlatReadFormat::new(metadata.clone(), column_ids.into_iter(), None, "test", true)
-                .unwrap();
+        let read_cols = ReadColumns::from_deduped_column_ids(column_ids);
+        let format = FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", true).unwrap();
         // Test conversion with sparse encoding and skip convert.
         let result = format.convert_batch(record_batch.clone(), None).unwrap();
         assert_eq!(record_batch, result);

--- a/src/mito2/src/sst/parquet/format.rs
+++ b/src/mito2/src/sst/parquet/format.rs
@@ -623,7 +623,10 @@ impl FormatProjection {
                 .or_insert_with(|| parquet_read_cols.len() - 1);
         }
 
-        Self::append_fixed_root_columns(&mut parquet_read_cols, sst_column_num);
+        // In SST schema, fixed-position columns are always in the tail:
+        // `time index, __primary_key, __sequence, __op_type`.
+        Self::append_time_index_if_needed(&mut parquet_read_cols, sst_column_num);
+        Self::append_fixed_internal_columns(&mut parquet_read_cols, sst_column_num);
 
         Self {
             parquet_read_cols: ParquetReadColumns::from_deduped(parquet_read_cols),
@@ -649,18 +652,31 @@ impl FormatProjection {
         parquet_read_cols.push(parquet_col);
     }
 
-    fn append_fixed_root_columns(
+    fn append_time_index_if_needed(
         parquet_read_cols: &mut Vec<ParquetReadColumn>,
         sst_column_num: usize,
     ) {
-        for index in sst_column_num - FIXED_POS_COLUMN_NUM..sst_column_num {
-            let needs_append = parquet_read_cols
-                .last()
-                .map(|col| col.root_index() != index)
-                .unwrap_or(true);
-            if needs_append {
-                parquet_read_cols.push(ParquetReadColumn::new(index));
-            }
+        let time_index = sst_column_num - FIXED_POS_COLUMN_NUM;
+        // Existing projected roots are already sorted by SST root index, and may
+        // already include the time index, so we compare against the last root to
+        // decide whether we still need to append `time index`.
+        let needs_time_index = parquet_read_cols
+            .last()
+            .map(|col| col.root_index() != time_index)
+            .unwrap_or(true);
+        if needs_time_index {
+            parquet_read_cols.push(ParquetReadColumn::new(time_index));
+        }
+    }
+
+    // Append internal columns in fixed order: `__primary_key`, `__sequence`,
+    // `__op_type`.
+    fn append_fixed_internal_columns(
+        parquet_read_cols: &mut Vec<ParquetReadColumn>,
+        sst_column_num: usize,
+    ) {
+        for index in sst_column_num - INTERNAL_COLUMN_NUM..sst_column_num {
+            parquet_read_cols.push(ParquetReadColumn::new(index));
         }
     }
 }

--- a/src/mito2/src/sst/parquet/format.rs
+++ b/src/mito2/src/sst/parquet/format.rs
@@ -224,11 +224,7 @@ pub struct PrimaryKeyReadFormat {
 
 impl PrimaryKeyReadFormat {
     /// Creates a helper with existing `metadata` and `column_ids` to read.
-    pub fn new(
-        metadata: RegionMetadataRef,
-        read_cols: impl Into<ReadColumns>,
-    ) -> PrimaryKeyReadFormat {
-        let read_cols = read_cols.into();
+    pub fn new(metadata: RegionMetadataRef, read_cols: ReadColumns) -> PrimaryKeyReadFormat {
         let field_id_to_index: HashMap<_, _> = metadata
             .field_columns()
             .enumerate()
@@ -610,6 +606,8 @@ impl FormatProjection {
                     .map(|index_of_sst| (col.column_id, index_of_sst, col.nested_paths))
             })
             .collect();
+        // Sorts columns by their indices in the SST. SST uses a bitmap for projection.
+        // This ensures the schema of `projected_columns` is the same as the batch returned from the SST.
         projected_columns.sort_unstable_by_key(|(_, index, _)| *index);
 
         let mut parquet_read_cols: Vec<ParquetReadColumn> =
@@ -696,7 +694,9 @@ impl PrimaryKeyReadFormat {
     pub fn new_with_all_columns(metadata: RegionMetadataRef) -> PrimaryKeyReadFormat {
         Self::new(
             Arc::clone(&metadata),
-            metadata.column_metadatas.iter().map(|c| c.column_id),
+            ReadColumns::from_deduped_column_ids(
+                metadata.column_metadatas.iter().map(|c| c.column_id),
+            ),
         )
     }
 }
@@ -952,25 +952,29 @@ mod tests {
     fn test_projection_indices() {
         let metadata = build_test_region_metadata();
         // Only read tag1
-        let read_format = PrimaryKeyReadFormat::new(metadata.clone(), [3]);
+        let read_format =
+            PrimaryKeyReadFormat::new(metadata.clone(), ReadColumns::from_deduped_column_ids([3]));
         assert_eq!(
             &[2, 3, 4, 5],
             read_format.parquet_read_columns().root_indices()
         );
         // Only read field1
-        let read_format = PrimaryKeyReadFormat::new(metadata.clone(), [4]);
+        let read_format =
+            PrimaryKeyReadFormat::new(metadata.clone(), ReadColumns::from_deduped_column_ids([4]));
         assert_eq!(
             &[0, 2, 3, 4, 5],
             read_format.parquet_read_columns().root_indices()
         );
         // Only read ts
-        let read_format = PrimaryKeyReadFormat::new(metadata.clone(), [5]);
+        let read_format =
+            PrimaryKeyReadFormat::new(metadata.clone(), ReadColumns::from_deduped_column_ids([5]));
         assert_eq!(
             &[2, 3, 4, 5],
             read_format.parquet_read_columns().root_indices()
         );
         // Read field0, tag0, ts
-        let read_format = PrimaryKeyReadFormat::new(metadata, [2, 1, 5]);
+        let read_format =
+            PrimaryKeyReadFormat::new(metadata, ReadColumns::from_deduped_column_ids([2, 1, 5]));
         assert_eq!(
             &[1, 2, 3, 4, 5],
             read_format.parquet_read_columns().root_indices()
@@ -1020,7 +1024,8 @@ mod tests {
             .iter()
             .map(|col| col.column_id)
             .collect();
-        let read_format = PrimaryKeyReadFormat::new(metadata, column_ids);
+        let read_format =
+            PrimaryKeyReadFormat::new(metadata, ReadColumns::from_deduped_column_ids(column_ids));
         assert_eq!(arrow_schema, *read_format.arrow_schema());
 
         let record_batch = RecordBatch::new_empty(arrow_schema);
@@ -1039,7 +1044,8 @@ mod tests {
             .iter()
             .map(|col| col.column_id)
             .collect();
-        let read_format = PrimaryKeyReadFormat::new(metadata, column_ids);
+        let read_format =
+            PrimaryKeyReadFormat::new(metadata, ReadColumns::from_deduped_column_ids(column_ids));
 
         let columns: Vec<ArrayRef> = vec![
             Arc::new(Int64Array::from(vec![1, 1, 10, 10])), // field1
@@ -1067,7 +1073,9 @@ mod tests {
         let metadata = build_test_region_metadata();
         let read_format = PrimaryKeyReadFormat::new(
             metadata.clone(),
-            metadata.column_metadatas.iter().map(|c| c.column_id),
+            ReadColumns::from_deduped_column_ids(
+                metadata.column_metadatas.iter().map(|c| c.column_id),
+            ),
         );
 
         let columns: Vec<ArrayRef> = vec![
@@ -1194,28 +1202,56 @@ mod tests {
         // The projection includes all "fixed position" columns: ts(4), __primary_key(5), __sequence(6), __op_type(7)
 
         // Only read tag1 (column_id=3, index=1) + fixed columns
-        let read_format = FlatReadFormat::new(metadata.clone(), [3], None, "test", false).unwrap();
+        let read_format = FlatReadFormat::new(
+            metadata.clone(),
+            ReadColumns::from_deduped_column_ids([3]),
+            None,
+            "test",
+            false,
+        )
+        .unwrap();
         assert_eq!(
             &[1, 4, 5, 6, 7],
             read_format.parquet_read_columns().root_indices()
         );
 
         // Only read field1 (column_id=4, index=2) + fixed columns
-        let read_format = FlatReadFormat::new(metadata.clone(), [4], None, "test", false).unwrap();
+        let read_format = FlatReadFormat::new(
+            metadata.clone(),
+            ReadColumns::from_deduped_column_ids([4]),
+            None,
+            "test",
+            false,
+        )
+        .unwrap();
         assert_eq!(
             &[2, 4, 5, 6, 7],
             read_format.parquet_read_columns().root_indices()
         );
 
         // Only read ts (column_id=5, index=4) + fixed columns (ts is already included in fixed)
-        let read_format = FlatReadFormat::new(metadata.clone(), [5], None, "test", false).unwrap();
+        let read_format = FlatReadFormat::new(
+            metadata.clone(),
+            ReadColumns::from_deduped_column_ids([5]),
+            None,
+            "test",
+            false,
+        )
+        .unwrap();
         assert_eq!(
             &[4, 5, 6, 7],
             read_format.parquet_read_columns().root_indices()
         );
 
         // Read field0(column_id=2, index=3), tag0(column_id=1, index=0), ts(column_id=5, index=4) + fixed columns
-        let read_format = FlatReadFormat::new(metadata, [2, 1, 5], None, "test", false).unwrap();
+        let read_format = FlatReadFormat::new(
+            metadata,
+            ReadColumns::from_deduped_column_ids([2, 1, 5]),
+            None,
+            "test",
+            false,
+        )
+        .unwrap();
         assert_eq!(
             &[0, 3, 4, 5, 6, 7],
             read_format.parquet_read_columns().root_indices()
@@ -1227,7 +1263,7 @@ mod tests {
         let metadata = build_test_region_metadata();
         let mut format = FlatReadFormat::new(
             metadata,
-            std::iter::once(1), // Just read tag0
+            ReadColumns::from_deduped_column_ids(std::iter::once(1)), // Just read tag0
             Some(8),
             "test",
             false,
@@ -1442,8 +1478,14 @@ mod tests {
             .iter()
             .map(|c| c.column_id)
             .collect();
-        let format =
-            FlatReadFormat::new(metadata.clone(), column_ids, Some(6), "test", false).unwrap();
+        let format = FlatReadFormat::new(
+            metadata.clone(),
+            ReadColumns::from_deduped_column_ids(column_ids),
+            Some(6),
+            "test",
+            false,
+        )
+        .unwrap();
 
         let num_rows = 4;
         let original_sequence = 100u64;
@@ -1518,8 +1560,14 @@ mod tests {
             .iter()
             .map(|c| c.column_id)
             .collect();
-        let format =
-            FlatReadFormat::new(metadata.clone(), column_ids.clone(), None, "test", false).unwrap();
+        let format = FlatReadFormat::new(
+            metadata.clone(),
+            ReadColumns::from_deduped_column_ids(column_ids.clone()),
+            None,
+            "test",
+            false,
+        )
+        .unwrap();
 
         let num_rows = 4;
         let original_sequence = 100u64;
@@ -1601,7 +1649,14 @@ mod tests {
         // Compare the actual result with the expected record batch
         assert_eq!(expected_record_batch, result);
 
-        let format = FlatReadFormat::new(metadata.clone(), column_ids, None, "test", true).unwrap();
+        let format = FlatReadFormat::new(
+            metadata.clone(),
+            ReadColumns::from_deduped_column_ids(column_ids),
+            None,
+            "test",
+            true,
+        )
+        .unwrap();
         // Test conversion with sparse encoding and skip convert.
         let result = format.convert_batch(record_batch.clone(), None).unwrap();
         assert_eq!(record_batch, result);

--- a/src/mito2/src/sst/parquet/format.rs
+++ b/src/mito2/src/sst/parquet/format.rs
@@ -138,7 +138,7 @@ pub enum ReadFormat {
 impl ReadFormat {
     /// Creates a helper to read the primary key format.
     pub fn new_primary_key(metadata: RegionMetadataRef, read_cols: &ReadColumns) -> Self {
-        ReadFormat::PrimaryKey(PrimaryKeyReadFormat::new(metadata, &read_cols))
+        ReadFormat::PrimaryKey(PrimaryKeyReadFormat::new(metadata, read_cols))
     }
 
     /// Creates a helper to read the flat format.
@@ -430,7 +430,7 @@ impl PrimaryKeyReadFormat {
         let format_projection = FormatProjection::compute_format_projection(
             &field_id_to_index,
             arrow_schema.fields.len(),
-            &read_cols,
+            read_cols,
         );
 
         PrimaryKeyReadFormat {

--- a/src/mito2/src/sst/parquet/format.rs
+++ b/src/mito2/src/sst/parquet/format.rs
@@ -137,14 +137,14 @@ pub enum ReadFormat {
 
 impl ReadFormat {
     /// Creates a helper to read the primary key format.
-    pub fn new_primary_key(metadata: RegionMetadataRef, read_cols: ReadColumns) -> Self {
-        ReadFormat::PrimaryKey(PrimaryKeyReadFormat::new(metadata, read_cols))
+    pub fn new_primary_key(metadata: RegionMetadataRef, read_cols: &ReadColumns) -> Self {
+        ReadFormat::PrimaryKey(PrimaryKeyReadFormat::new(metadata, &read_cols))
     }
 
     /// Creates a helper to read the flat format.
     pub fn new_flat(
         metadata: RegionMetadataRef,
-        read_cols: ReadColumns,
+        read_cols: &ReadColumns,
         num_columns: Option<usize>,
         file_path: &str,
         skip_auto_convert: bool,
@@ -161,7 +161,7 @@ impl ReadFormat {
     /// Creates a new read format.
     pub fn new(
         region_metadata: RegionMetadataRef,
-        projection: Option<ReadColumns>,
+        projection: Option<&ReadColumns>,
         flat_format: bool,
         num_columns: Option<usize>,
         file_path: &str,
@@ -186,7 +186,7 @@ impl ReadFormat {
                 );
                 ReadFormat::new_flat(
                     region_metadata.clone(),
-                    read_cols,
+                    &read_cols,
                     num_columns,
                     file_path,
                     skip_auto_convert,
@@ -204,7 +204,7 @@ impl ReadFormat {
             );
             Ok(ReadFormat::new_primary_key(
                 region_metadata.clone(),
-                read_cols,
+                &read_cols,
             ))
         }
     }
@@ -242,7 +242,7 @@ impl ReadFormat {
         }
     }
 
-    /// Gets sorted projection indices to read.
+    /// Gets sorted projection root indices to read.
     pub(crate) fn projection_indices_iter(&self) -> impl Iterator<Item = usize> + '_ {
         self.parquet_read_columns()
             .columns()
@@ -419,7 +419,7 @@ pub struct PrimaryKeyReadFormat {
 
 impl PrimaryKeyReadFormat {
     /// Creates a helper with existing `metadata` and `column_ids` to read.
-    pub fn new(metadata: RegionMetadataRef, read_cols: ReadColumns) -> PrimaryKeyReadFormat {
+    pub fn new(metadata: RegionMetadataRef, read_cols: &ReadColumns) -> PrimaryKeyReadFormat {
         let field_id_to_index: HashMap<_, _> = metadata
             .field_columns()
             .enumerate()
@@ -810,9 +810,9 @@ impl FormatProjection {
     pub(crate) fn compute_format_projection(
         id_to_index: &HashMap<ColumnId, usize>,
         sst_column_num: usize,
-        column_ids: &ReadColumns,
+        cols: &ReadColumns,
     ) -> Self {
-        let projected_columns = Self::collect_projected_columns(id_to_index, column_ids);
+        let projected_columns = Self::collect_projected_columns(id_to_index, cols);
 
         let mut parquet_read_cols: Vec<ParquetReadColumn> =
             Vec::with_capacity(projected_columns.len() + FIXED_POS_COLUMN_NUM);
@@ -933,7 +933,7 @@ impl PrimaryKeyReadFormat {
     pub fn new_with_all_columns(metadata: RegionMetadataRef) -> PrimaryKeyReadFormat {
         let read_cols =
             ReadColumns::from_column_ids(metadata.column_metadatas.iter().map(|c| c.column_id));
-        Self::new(Arc::clone(&metadata), read_cols)
+        Self::new(Arc::clone(&metadata), &read_cols)
     }
 }
 
@@ -1187,7 +1187,7 @@ mod tests {
         let metadata = build_test_region_metadata();
         // Only read tag1
         let read_cols = ReadColumns::from_column_ids([3]);
-        let read_format = ReadFormat::new_primary_key(metadata.clone(), read_cols);
+        let read_format = ReadFormat::new_primary_key(metadata.clone(), &read_cols);
         assert_eq!(
             &[2, 3, 4, 5],
             read_format
@@ -1197,7 +1197,7 @@ mod tests {
         );
         // Only read field1
         let read_cols = ReadColumns::from_column_ids([4]);
-        let read_format = ReadFormat::new_primary_key(metadata.clone(), read_cols);
+        let read_format = ReadFormat::new_primary_key(metadata.clone(), &read_cols);
         assert_eq!(
             &[0, 2, 3, 4, 5],
             read_format
@@ -1207,7 +1207,7 @@ mod tests {
         );
         // Only read ts
         let read_cols = ReadColumns::from_column_ids([5]);
-        let read_format = ReadFormat::new_primary_key(metadata.clone(), read_cols);
+        let read_format = ReadFormat::new_primary_key(metadata.clone(), &read_cols);
         assert_eq!(
             &[2, 3, 4, 5],
             read_format
@@ -1217,7 +1217,7 @@ mod tests {
         );
         // Read field0, tag0, ts
         let read_cols = ReadColumns::from_column_ids([2, 1, 5]);
-        let read_format = ReadFormat::new_primary_key(metadata, read_cols);
+        let read_format = ReadFormat::new_primary_key(metadata, &read_cols);
         assert_eq!(
             &[1, 2, 3, 4, 5],
             read_format
@@ -1270,8 +1270,8 @@ mod tests {
             .iter()
             .map(|col| col.column_id)
             .collect();
-        let read_cols = ReadColumns::from_column_ids(column_ids.iter().copied());
-        let read_format = PrimaryKeyReadFormat::new(metadata, read_cols);
+        let read_cols = ReadColumns::from_column_ids(column_ids);
+        let read_format = PrimaryKeyReadFormat::new(metadata, &read_cols);
         assert_eq!(arrow_schema, *read_format.arrow_schema());
 
         let record_batch = RecordBatch::new_empty(arrow_schema);
@@ -1290,8 +1290,8 @@ mod tests {
             .iter()
             .map(|col| col.column_id)
             .collect();
-        let read_cols = ReadColumns::from_column_ids(column_ids.iter().copied());
-        let read_format = PrimaryKeyReadFormat::new(metadata, read_cols);
+        let read_cols = ReadColumns::from_column_ids(column_ids);
+        let read_format = PrimaryKeyReadFormat::new(metadata, &read_cols);
 
         let columns: Vec<ArrayRef> = vec![
             Arc::new(Int64Array::from(vec![1, 1, 10, 10])), // field1
@@ -1320,7 +1320,7 @@ mod tests {
         let read_cols =
             ReadColumns::from_column_ids(metadata.column_metadatas.iter().map(|c| c.column_id));
         let read_format =
-            ReadFormat::new(metadata, Some(read_cols), false, None, "test", false).unwrap();
+            ReadFormat::new(metadata, Some(&read_cols), false, None, "test", false).unwrap();
 
         let columns: Vec<ArrayRef> = vec![
             Arc::new(Int64Array::from(vec![1, 1, 10, 10])), // field1
@@ -1450,7 +1450,7 @@ mod tests {
         // Only read tag1 (column_id=3, index=1) + fixed columns
         let read_cols = ReadColumns::from_column_ids([3]);
         let read_format =
-            ReadFormat::new_flat(metadata.clone(), read_cols, None, "test", false).unwrap();
+            ReadFormat::new_flat(metadata.clone(), &read_cols, None, "test", false).unwrap();
         assert_eq!(
             &[1, 4, 5, 6, 7],
             read_format
@@ -1462,7 +1462,7 @@ mod tests {
         // Only read field1 (column_id=4, index=2) + fixed columns
         let read_cols = ReadColumns::from_column_ids([4]);
         let read_format =
-            ReadFormat::new_flat(metadata.clone(), read_cols, None, "test", false).unwrap();
+            ReadFormat::new_flat(metadata.clone(), &read_cols, None, "test", false).unwrap();
         assert_eq!(
             &[2, 4, 5, 6, 7],
             read_format
@@ -1474,7 +1474,7 @@ mod tests {
         // Only read ts (column_id=5, index=4) + fixed columns (ts is already included in fixed)
         let read_cols = ReadColumns::from_column_ids([5]);
         let read_format =
-            ReadFormat::new_flat(metadata.clone(), read_cols, None, "test", false).unwrap();
+            ReadFormat::new_flat(metadata.clone(), &read_cols, None, "test", false).unwrap();
         assert_eq!(
             &[4, 5, 6, 7],
             read_format
@@ -1485,7 +1485,7 @@ mod tests {
 
         // Read field0(column_id=2, index=3), tag0(column_id=1, index=0), ts(column_id=5, index=4) + fixed columns
         let read_cols = ReadColumns::from_column_ids([2, 1, 5]);
-        let read_format = ReadFormat::new_flat(metadata, read_cols, None, "test", false).unwrap();
+        let read_format = ReadFormat::new_flat(metadata, &read_cols, None, "test", false).unwrap();
         assert_eq!(
             &[0, 3, 4, 5, 6, 7],
             read_format
@@ -1501,7 +1501,7 @@ mod tests {
         let read_cols = ReadColumns::from_column_ids(std::iter::once(1));
         let mut format = FlatReadFormat::new(
             metadata,
-            read_cols, // Just read tag0
+            &read_cols, // Just read tag0
             Some(8),
             "test",
             false,
@@ -1718,7 +1718,7 @@ mod tests {
             .collect();
         let read_cols = ReadColumns::from_column_ids(column_ids);
         let format =
-            FlatReadFormat::new(metadata.clone(), read_cols, Some(6), "test", false).unwrap();
+            FlatReadFormat::new(metadata.clone(), &read_cols, Some(6), "test", false).unwrap();
 
         let num_rows = 4;
         let original_sequence = 100u64;
@@ -1794,7 +1794,8 @@ mod tests {
             .map(|c| c.column_id)
             .collect();
         let read_cols = ReadColumns::from_column_ids(column_ids.clone());
-        let format = FlatReadFormat::new(metadata.clone(), read_cols, None, "test", false).unwrap();
+        let format =
+            FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", false).unwrap();
 
         let num_rows = 4;
         let original_sequence = 100u64;
@@ -1877,7 +1878,7 @@ mod tests {
         assert_eq!(expected_record_batch, result);
 
         let read_cols = ReadColumns::from_column_ids(column_ids);
-        let format = FlatReadFormat::new(metadata.clone(), read_cols, None, "test", true).unwrap();
+        let format = FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", true).unwrap();
         // Test conversion with sparse encoding and skip convert.
         let result = format.convert_batch(record_batch.clone(), None).unwrap();
         assert_eq!(record_batch, result);

--- a/src/mito2/src/sst/parquet/format.rs
+++ b/src/mito2/src/sst/parquet/format.rs
@@ -53,9 +53,11 @@ use store_api::storage::{ColumnId, SequenceNumber};
 use crate::error::{
     ConvertVectorSnafu, DecodeSnafu, InvalidRecordBatchSnafu, NewRecordBatchSnafu, Result,
 };
+use crate::read::read_columns::ReadColumns;
 use crate::read::{Batch, BatchBuilder, BatchColumn};
 use crate::sst::file::{FileMeta, FileTimeRange};
 use crate::sst::parquet::flat_format::FlatReadFormat;
+use crate::sst::parquet::read_columns::{ParquetReadColumn, ParquetReadColumns};
 use crate::sst::to_sst_arrow_schema;
 
 /// Arrow array type for the primary key dictionary.
@@ -135,24 +137,21 @@ pub enum ReadFormat {
 
 impl ReadFormat {
     /// Creates a helper to read the primary key format.
-    pub fn new_primary_key(
-        metadata: RegionMetadataRef,
-        column_ids: impl Iterator<Item = ColumnId>,
-    ) -> Self {
-        ReadFormat::PrimaryKey(PrimaryKeyReadFormat::new(metadata, column_ids))
+    pub fn new_primary_key(metadata: RegionMetadataRef, read_cols: ReadColumns) -> Self {
+        ReadFormat::PrimaryKey(PrimaryKeyReadFormat::new(metadata, read_cols))
     }
 
     /// Creates a helper to read the flat format.
     pub fn new_flat(
         metadata: RegionMetadataRef,
-        column_ids: impl Iterator<Item = ColumnId>,
+        read_cols: ReadColumns,
         num_columns: Option<usize>,
         file_path: &str,
         skip_auto_convert: bool,
     ) -> Result<Self> {
         Ok(ReadFormat::Flat(FlatReadFormat::new(
             metadata,
-            column_ids,
+            read_cols,
             num_columns,
             file_path,
             skip_auto_convert,
@@ -162,47 +161,50 @@ impl ReadFormat {
     /// Creates a new read format.
     pub fn new(
         region_metadata: RegionMetadataRef,
-        projection: Option<&[ColumnId]>,
+        projection: Option<ReadColumns>,
         flat_format: bool,
         num_columns: Option<usize>,
         file_path: &str,
         skip_auto_convert: bool,
     ) -> Result<ReadFormat> {
         if flat_format {
-            if let Some(column_ids) = projection {
+            if let Some(read_cols) = projection {
                 ReadFormat::new_flat(
                     region_metadata,
-                    column_ids.iter().copied(),
+                    read_cols,
                     num_columns,
                     file_path,
                     skip_auto_convert,
                 )
             } else {
                 // No projection, lists all column ids to read.
-                ReadFormat::new_flat(
-                    region_metadata.clone(),
+                let read_cols = ReadColumns::from_column_ids(
                     region_metadata
                         .column_metadatas
                         .iter()
                         .map(|col| col.column_id),
+                );
+                ReadFormat::new_flat(
+                    region_metadata.clone(),
+                    read_cols,
                     num_columns,
                     file_path,
                     skip_auto_convert,
                 )
             }
-        } else if let Some(column_ids) = projection {
-            Ok(ReadFormat::new_primary_key(
-                region_metadata,
-                column_ids.iter().copied(),
-            ))
+        } else if let Some(read_cols) = projection {
+            Ok(ReadFormat::new_primary_key(region_metadata, read_cols))
         } else {
             // No projection, lists all column ids to read.
-            Ok(ReadFormat::new_primary_key(
-                region_metadata.clone(),
+            let read_cols = ReadColumns::from_column_ids(
                 region_metadata
                     .column_metadatas
                     .iter()
                     .map(|col| col.column_id),
+            );
+            Ok(ReadFormat::new_primary_key(
+                region_metadata.clone(),
+                read_cols,
             ))
         }
     }
@@ -241,10 +243,17 @@ impl ReadFormat {
     }
 
     /// Gets sorted projection indices to read.
-    pub(crate) fn projection_indices(&self) -> &[usize] {
+    pub(crate) fn projection_indices_iter(&self) -> impl Iterator<Item = usize> + '_ {
+        self.parquet_read_columns()
+            .columns()
+            .iter()
+            .map(|col| col.root_index())
+    }
+
+    pub(crate) fn parquet_read_columns(&self) -> &ParquetReadColumns {
         match self {
-            ReadFormat::PrimaryKey(format) => format.projection_indices(),
-            ReadFormat::Flat(format) => format.projection_indices(),
+            ReadFormat::PrimaryKey(format) => format.parquet_read_columns(),
+            ReadFormat::Flat(format) => format.parquet_read_columns(),
         }
     }
 
@@ -398,7 +407,7 @@ pub struct PrimaryKeyReadFormat {
     /// In SST schema, fields are stored in the front of the schema.
     field_id_to_index: HashMap<ColumnId, usize>,
     /// Indices of columns to read from the SST. It contains all internal columns.
-    projection_indices: Vec<usize>,
+    parquet_read_cols: ParquetReadColumns,
     /// Field column id to their index in the projected schema (
     /// the schema of [Batch]).
     field_id_to_projected_index: HashMap<ColumnId, usize>,
@@ -410,10 +419,7 @@ pub struct PrimaryKeyReadFormat {
 
 impl PrimaryKeyReadFormat {
     /// Creates a helper with existing `metadata` and `column_ids` to read.
-    pub fn new(
-        metadata: RegionMetadataRef,
-        column_ids: impl Iterator<Item = ColumnId>,
-    ) -> PrimaryKeyReadFormat {
+    pub fn new(metadata: RegionMetadataRef, read_cols: ReadColumns) -> PrimaryKeyReadFormat {
         let field_id_to_index: HashMap<_, _> = metadata
             .field_columns()
             .enumerate()
@@ -424,14 +430,14 @@ impl PrimaryKeyReadFormat {
         let format_projection = FormatProjection::compute_format_projection(
             &field_id_to_index,
             arrow_schema.fields.len(),
-            column_ids,
+            &read_cols,
         );
 
         PrimaryKeyReadFormat {
             metadata,
             arrow_schema,
             field_id_to_index,
-            projection_indices: format_projection.projection_indices,
+            parquet_read_cols: format_projection.parquet_read_cols,
             field_id_to_projected_index: format_projection.column_id_to_projected_index,
             override_sequence: None,
             primary_key_codec: None,
@@ -465,9 +471,8 @@ impl PrimaryKeyReadFormat {
         &self.metadata
     }
 
-    /// Gets sorted projection indices to read.
-    pub(crate) fn projection_indices(&self) -> &[usize] {
-        &self.projection_indices
+    pub(crate) fn parquet_read_columns(&self) -> &ParquetReadColumns {
+        &self.parquet_read_cols
     }
 
     /// Gets the field id to projected index.
@@ -789,8 +794,8 @@ impl PrimaryKeyReadFormat {
 
 /// Helper to compute the projection for the SST.
 pub(crate) struct FormatProjection {
-    /// Indices of columns to read from the SST. It contains all internal columns.
-    pub(crate) projection_indices: Vec<usize>,
+    /// The columns to read from the SST. It contains all internal columns.
+    pub(crate) parquet_read_cols: ParquetReadColumns,
     /// Column id to their index in the projected schema (
     /// the schema after projection).
     ///
@@ -805,48 +810,96 @@ impl FormatProjection {
     pub(crate) fn compute_format_projection(
         id_to_index: &HashMap<ColumnId, usize>,
         sst_column_num: usize,
-        column_ids: impl Iterator<Item = ColumnId>,
+        column_ids: &ReadColumns,
     ) -> Self {
-        // Maps column id of a projected column to its index in SST.
-        // It also ignores columns not in the SST.
-        // [(column id, index in SST)]
-        let mut projected_schema: Vec<_> = column_ids
-            .filter_map(|column_id| {
-                id_to_index
-                    .get(&column_id)
-                    .copied()
-                    .map(|index| (column_id, index))
-            })
-            .collect();
-        // Sorts columns by their indices in the SST. SST uses a bitmap for projection.
-        // This ensures the schema of `projected_schema` is the same as the batch returned from the SST.
-        projected_schema.sort_unstable_by_key(|x| x.1);
-        // Dedups the entries to avoid the case that `column_ids` has duplicated columns.
-        projected_schema.dedup_by_key(|x| x.1);
+        let projected_columns = Self::collect_projected_columns(id_to_index, column_ids);
 
-        // Collects all projected indices.
-        // It contains the positions of all columns we need to read.
-        let mut projection_indices: Vec<_> = projected_schema
-            .iter()
-            .map(|(_column_id, index)| *index)
-            // We need to add all fixed position columns.
-            .chain(sst_column_num - FIXED_POS_COLUMN_NUM..sst_column_num)
-            .collect();
-        projection_indices.sort_unstable();
-        // Removes duplications.
-        projection_indices.dedup();
+        let mut parquet_read_cols: Vec<ParquetReadColumn> =
+            Vec::with_capacity(projected_columns.len() + FIXED_POS_COLUMN_NUM);
+        let mut column_id_to_projected_index = HashMap::with_capacity(projected_columns.len());
 
-        // Creates a map from column id to the index of that column in the projected record batch.
-        let column_id_to_projected_index = projected_schema
-            .into_iter()
-            .map(|(column_id, _)| column_id)
-            .enumerate()
-            .map(|(index, column_id)| (column_id, index))
-            .collect();
+        for (column_id, index_of_sst, nested_paths) in projected_columns {
+            Self::merge_or_push_parquet_column(&mut parquet_read_cols, index_of_sst, nested_paths);
+            Self::insert_projected_index(&mut column_id_to_projected_index, column_id);
+        }
+
+        Self::append_fixed_root_columns(&mut parquet_read_cols, sst_column_num);
 
         Self {
-            projection_indices,
+            parquet_read_cols: ParquetReadColumns::new(parquet_read_cols),
             column_id_to_projected_index,
+        }
+    }
+
+    fn collect_projected_columns(
+        id_to_index: &HashMap<ColumnId, usize>,
+        column_ids: &ReadColumns,
+    ) -> Vec<(ColumnId, usize, Vec<Vec<String>>)> {
+        let mut projected_columns: Vec<_> = column_ids
+            .columns()
+            .iter()
+            .filter_map(|column| {
+                id_to_index
+                    .get(&column.column_id())
+                    .copied()
+                    .map(|index_of_sst| {
+                        let nested_paths = column.nested_paths().to_vec();
+                        (column.column_id(), index_of_sst, nested_paths)
+                    })
+            })
+            .collect();
+        projected_columns.sort_unstable_by_key(|(_, index, _)| *index);
+        projected_columns
+    }
+
+    fn insert_projected_index(
+        column_id_to_projected_index: &mut HashMap<ColumnId, usize>,
+        column_id: ColumnId,
+    ) {
+        if !column_id_to_projected_index.contains_key(&column_id) {
+            let projected_index = column_id_to_projected_index.len();
+            column_id_to_projected_index.insert(column_id, projected_index);
+        }
+    }
+
+    fn merge_or_push_parquet_column(
+        parquet_read_cols: &mut Vec<ParquetReadColumn>,
+        index: usize,
+        nested_paths: Vec<Vec<String>>,
+    ) {
+        if let Some(last_col) = parquet_read_cols.last_mut()
+            && last_col.root_index() == index
+        {
+            if last_col.nested_paths().is_empty() || nested_paths.is_empty() {
+                *last_col = ParquetReadColumn::new(index);
+            } else {
+                let mut merged_paths = last_col.nested_paths().to_vec();
+                merged_paths.extend(nested_paths);
+                *last_col = ParquetReadColumn::new(index).with_nested_paths(merged_paths);
+            }
+            return;
+        }
+
+        let parquet_col = if nested_paths.is_empty() {
+            ParquetReadColumn::new(index)
+        } else {
+            ParquetReadColumn::new(index).with_nested_paths(nested_paths)
+        };
+        parquet_read_cols.push(parquet_col);
+    }
+
+    fn append_fixed_root_columns(
+        parquet_read_cols: &mut Vec<ParquetReadColumn>,
+        sst_column_num: usize,
+    ) {
+        for index in sst_column_num - FIXED_POS_COLUMN_NUM..sst_column_num {
+            let needs_append = parquet_read_cols
+                .last()
+                .map(|col| col.root_index() != index)
+                .unwrap_or(true);
+            if needs_append {
+                parquet_read_cols.push(ParquetReadColumn::new(index));
+            }
         }
     }
 }
@@ -878,10 +931,9 @@ impl StatValues {
 impl PrimaryKeyReadFormat {
     /// Creates a helper with existing `metadata` and all columns.
     pub fn new_with_all_columns(metadata: RegionMetadataRef) -> PrimaryKeyReadFormat {
-        Self::new(
-            Arc::clone(&metadata),
-            metadata.column_metadatas.iter().map(|c| c.column_id),
-        )
+        let read_cols =
+            ReadColumns::from_column_ids(metadata.column_metadatas.iter().map(|c| c.column_id));
+        Self::new(Arc::clone(&metadata), read_cols)
     }
 }
 
@@ -1134,17 +1186,45 @@ mod tests {
     fn test_projection_indices() {
         let metadata = build_test_region_metadata();
         // Only read tag1
-        let read_format = ReadFormat::new_primary_key(metadata.clone(), [3].iter().copied());
-        assert_eq!(&[2, 3, 4, 5], read_format.projection_indices());
+        let read_cols = ReadColumns::from_column_ids([3]);
+        let read_format = ReadFormat::new_primary_key(metadata.clone(), read_cols);
+        assert_eq!(
+            &[2, 3, 4, 5],
+            read_format
+                .projection_indices_iter()
+                .collect::<Vec<_>>()
+                .as_slice()
+        );
         // Only read field1
-        let read_format = ReadFormat::new_primary_key(metadata.clone(), [4].iter().copied());
-        assert_eq!(&[0, 2, 3, 4, 5], read_format.projection_indices());
+        let read_cols = ReadColumns::from_column_ids([4]);
+        let read_format = ReadFormat::new_primary_key(metadata.clone(), read_cols);
+        assert_eq!(
+            &[0, 2, 3, 4, 5],
+            read_format
+                .projection_indices_iter()
+                .collect::<Vec<_>>()
+                .as_slice()
+        );
         // Only read ts
-        let read_format = ReadFormat::new_primary_key(metadata.clone(), [5].iter().copied());
-        assert_eq!(&[2, 3, 4, 5], read_format.projection_indices());
+        let read_cols = ReadColumns::from_column_ids([5]);
+        let read_format = ReadFormat::new_primary_key(metadata.clone(), read_cols);
+        assert_eq!(
+            &[2, 3, 4, 5],
+            read_format
+                .projection_indices_iter()
+                .collect::<Vec<_>>()
+                .as_slice()
+        );
         // Read field0, tag0, ts
-        let read_format = ReadFormat::new_primary_key(metadata, [2, 1, 5].iter().copied());
-        assert_eq!(&[1, 2, 3, 4, 5], read_format.projection_indices());
+        let read_cols = ReadColumns::from_column_ids([2, 1, 5]);
+        let read_format = ReadFormat::new_primary_key(metadata, read_cols);
+        assert_eq!(
+            &[1, 2, 3, 4, 5],
+            read_format
+                .projection_indices_iter()
+                .collect::<Vec<_>>()
+                .as_slice()
+        );
     }
 
     #[test]
@@ -1190,7 +1270,8 @@ mod tests {
             .iter()
             .map(|col| col.column_id)
             .collect();
-        let read_format = PrimaryKeyReadFormat::new(metadata, column_ids.iter().copied());
+        let read_cols = ReadColumns::from_column_ids(column_ids.iter().copied());
+        let read_format = PrimaryKeyReadFormat::new(metadata, read_cols);
         assert_eq!(arrow_schema, *read_format.arrow_schema());
 
         let record_batch = RecordBatch::new_empty(arrow_schema);
@@ -1209,7 +1290,8 @@ mod tests {
             .iter()
             .map(|col| col.column_id)
             .collect();
-        let read_format = PrimaryKeyReadFormat::new(metadata, column_ids.iter().copied());
+        let read_cols = ReadColumns::from_column_ids(column_ids.iter().copied());
+        let read_format = PrimaryKeyReadFormat::new(metadata, read_cols);
 
         let columns: Vec<ArrayRef> = vec![
             Arc::new(Int64Array::from(vec![1, 1, 10, 10])), // field1
@@ -1235,13 +1317,10 @@ mod tests {
     #[test]
     fn test_convert_record_batch_with_override_sequence() {
         let metadata = build_test_region_metadata();
-        let column_ids: Vec<_> = metadata
-            .column_metadatas
-            .iter()
-            .map(|col| col.column_id)
-            .collect();
+        let read_cols =
+            ReadColumns::from_column_ids(metadata.column_metadatas.iter().map(|c| c.column_id));
         let read_format =
-            ReadFormat::new(metadata, Some(&column_ids), false, None, "test", false).unwrap();
+            ReadFormat::new(metadata, Some(read_cols), false, None, "test", false).unwrap();
 
         let columns: Vec<ArrayRef> = vec![
             Arc::new(Int64Array::from(vec![1, 1, 10, 10])), // field1
@@ -1369,35 +1448,60 @@ mod tests {
         // The projection includes all "fixed position" columns: ts(4), __primary_key(5), __sequence(6), __op_type(7)
 
         // Only read tag1 (column_id=3, index=1) + fixed columns
+        let read_cols = ReadColumns::from_column_ids([3]);
         let read_format =
-            ReadFormat::new_flat(metadata.clone(), [3].iter().copied(), None, "test", false)
-                .unwrap();
-        assert_eq!(&[1, 4, 5, 6, 7], read_format.projection_indices());
+            ReadFormat::new_flat(metadata.clone(), read_cols, None, "test", false).unwrap();
+        assert_eq!(
+            &[1, 4, 5, 6, 7],
+            read_format
+                .projection_indices_iter()
+                .collect::<Vec<_>>()
+                .as_slice()
+        );
 
         // Only read field1 (column_id=4, index=2) + fixed columns
+        let read_cols = ReadColumns::from_column_ids([4]);
         let read_format =
-            ReadFormat::new_flat(metadata.clone(), [4].iter().copied(), None, "test", false)
-                .unwrap();
-        assert_eq!(&[2, 4, 5, 6, 7], read_format.projection_indices());
+            ReadFormat::new_flat(metadata.clone(), read_cols, None, "test", false).unwrap();
+        assert_eq!(
+            &[2, 4, 5, 6, 7],
+            read_format
+                .projection_indices_iter()
+                .collect::<Vec<_>>()
+                .as_slice()
+        );
 
         // Only read ts (column_id=5, index=4) + fixed columns (ts is already included in fixed)
+        let read_cols = ReadColumns::from_column_ids([5]);
         let read_format =
-            ReadFormat::new_flat(metadata.clone(), [5].iter().copied(), None, "test", false)
-                .unwrap();
-        assert_eq!(&[4, 5, 6, 7], read_format.projection_indices());
+            ReadFormat::new_flat(metadata.clone(), read_cols, None, "test", false).unwrap();
+        assert_eq!(
+            &[4, 5, 6, 7],
+            read_format
+                .projection_indices_iter()
+                .collect::<Vec<_>>()
+                .as_slice()
+        );
 
         // Read field0(column_id=2, index=3), tag0(column_id=1, index=0), ts(column_id=5, index=4) + fixed columns
-        let read_format =
-            ReadFormat::new_flat(metadata, [2, 1, 5].iter().copied(), None, "test", false).unwrap();
-        assert_eq!(&[0, 3, 4, 5, 6, 7], read_format.projection_indices());
+        let read_cols = ReadColumns::from_column_ids([2, 1, 5]);
+        let read_format = ReadFormat::new_flat(metadata, read_cols, None, "test", false).unwrap();
+        assert_eq!(
+            &[0, 3, 4, 5, 6, 7],
+            read_format
+                .projection_indices_iter()
+                .collect::<Vec<_>>()
+                .as_slice()
+        );
     }
 
     #[test]
     fn test_flat_read_format_convert_batch() {
         let metadata = build_test_region_metadata();
+        let read_cols = ReadColumns::from_column_ids(std::iter::once(1));
         let mut format = FlatReadFormat::new(
             metadata,
-            std::iter::once(1), // Just read tag0
+            read_cols, // Just read tag0
             Some(8),
             "test",
             false,
@@ -1612,14 +1716,9 @@ mod tests {
             .iter()
             .map(|c| c.column_id)
             .collect();
-        let format = FlatReadFormat::new(
-            metadata.clone(),
-            column_ids.into_iter(),
-            Some(6),
-            "test",
-            false,
-        )
-        .unwrap();
+        let read_cols = ReadColumns::from_column_ids(column_ids);
+        let format =
+            FlatReadFormat::new(metadata.clone(), read_cols, Some(6), "test", false).unwrap();
 
         let num_rows = 4;
         let original_sequence = 100u64;
@@ -1694,14 +1793,8 @@ mod tests {
             .iter()
             .map(|c| c.column_id)
             .collect();
-        let format = FlatReadFormat::new(
-            metadata.clone(),
-            column_ids.clone().into_iter(),
-            None,
-            "test",
-            false,
-        )
-        .unwrap();
+        let read_cols = ReadColumns::from_column_ids(column_ids.clone());
+        let format = FlatReadFormat::new(metadata.clone(), read_cols, None, "test", false).unwrap();
 
         let num_rows = 4;
         let original_sequence = 100u64;
@@ -1783,9 +1876,8 @@ mod tests {
         // Compare the actual result with the expected record batch
         assert_eq!(expected_record_batch, result);
 
-        let format =
-            FlatReadFormat::new(metadata.clone(), column_ids.into_iter(), None, "test", true)
-                .unwrap();
+        let read_cols = ReadColumns::from_column_ids(column_ids);
+        let format = FlatReadFormat::new(metadata.clone(), read_cols, None, "test", true).unwrap();
         // Test conversion with sparse encoding and skip convert.
         let result = format.convert_batch(record_batch.clone(), None).unwrap();
         assert_eq!(record_batch, result);

--- a/src/mito2/src/sst/parquet/format.rs
+++ b/src/mito2/src/sst/parquet/format.rs
@@ -812,15 +812,33 @@ impl FormatProjection {
         sst_column_num: usize,
         cols: &ReadColumns,
     ) -> Self {
-        let projected_columns = Self::collect_projected_columns(id_to_index, cols);
+        let mut projected_columns: Vec<_> = cols
+            .columns()
+            .iter()
+            .filter_map(|col| {
+                id_to_index
+                    .get(&col.column_id())
+                    .copied()
+                    .map(|index_of_sst| {
+                        let nested_paths = col.nested_paths().to_vec();
+                        (col.column_id(), index_of_sst, nested_paths)
+                    })
+            })
+            .collect();
+        projected_columns.sort_unstable_by_key(|(_, index, _)| *index);
 
         let mut parquet_read_cols: Vec<ParquetReadColumn> =
             Vec::with_capacity(projected_columns.len() + FIXED_POS_COLUMN_NUM);
+        // Creates a map from column id to the index of that column in the projected record batch.
         let mut column_id_to_projected_index = HashMap::with_capacity(projected_columns.len());
 
-        for (column_id, index_of_sst, nested_paths) in projected_columns {
+        for (col_id, index_of_sst, nested_paths) in projected_columns {
             Self::merge_or_push_parquet_column(&mut parquet_read_cols, index_of_sst, nested_paths);
-            Self::insert_projected_index(&mut column_id_to_projected_index, column_id);
+
+            if !column_id_to_projected_index.contains_key(&col_id) {
+                let projected_index = column_id_to_projected_index.len();
+                column_id_to_projected_index.insert(col_id, projected_index);
+            }
         }
 
         Self::append_fixed_root_columns(&mut parquet_read_cols, sst_column_num);
@@ -831,60 +849,21 @@ impl FormatProjection {
         }
     }
 
-    fn collect_projected_columns(
-        id_to_index: &HashMap<ColumnId, usize>,
-        column_ids: &ReadColumns,
-    ) -> Vec<(ColumnId, usize, Vec<Vec<String>>)> {
-        let mut projected_columns: Vec<_> = column_ids
-            .columns()
-            .iter()
-            .filter_map(|column| {
-                id_to_index
-                    .get(&column.column_id())
-                    .copied()
-                    .map(|index_of_sst| {
-                        let nested_paths = column.nested_paths().to_vec();
-                        (column.column_id(), index_of_sst, nested_paths)
-                    })
-            })
-            .collect();
-        projected_columns.sort_unstable_by_key(|(_, index, _)| *index);
-        projected_columns
-    }
-
-    fn insert_projected_index(
-        column_id_to_projected_index: &mut HashMap<ColumnId, usize>,
-        column_id: ColumnId,
-    ) {
-        if !column_id_to_projected_index.contains_key(&column_id) {
-            let projected_index = column_id_to_projected_index.len();
-            column_id_to_projected_index.insert(column_id, projected_index);
-        }
-    }
-
     fn merge_or_push_parquet_column(
         parquet_read_cols: &mut Vec<ParquetReadColumn>,
-        index: usize,
+        index_of_sst: usize,
         nested_paths: Vec<Vec<String>>,
     ) {
+        // `projected_columns` is sorted by parquet root index, so repeated reads
+        // for the same root column are always adjacent.
         if let Some(last_col) = parquet_read_cols.last_mut()
-            && last_col.root_index() == index
+            && last_col.root_index() == index_of_sst
         {
-            if last_col.nested_paths().is_empty() || nested_paths.is_empty() {
-                *last_col = ParquetReadColumn::new(index);
-            } else {
-                let mut merged_paths = last_col.nested_paths().to_vec();
-                merged_paths.extend(nested_paths);
-                *last_col = ParquetReadColumn::new(index).with_nested_paths(merged_paths);
-            }
+            last_col.merge_nested_paths(nested_paths);
             return;
         }
 
-        let parquet_col = if nested_paths.is_empty() {
-            ParquetReadColumn::new(index)
-        } else {
-            ParquetReadColumn::new(index).with_nested_paths(nested_paths)
-        };
+        let parquet_col = ParquetReadColumn::new(index_of_sst).with_nested_paths(nested_paths);
         parquet_read_cols.push(parquet_col);
     }
 

--- a/src/mito2/src/sst/parquet/format.rs
+++ b/src/mito2/src/sst/parquet/format.rs
@@ -826,7 +826,7 @@ impl FormatProjection {
         Self::append_fixed_root_columns(&mut parquet_read_cols, sst_column_num);
 
         Self {
-            parquet_read_cols: ParquetReadColumns::new(parquet_read_cols),
+            parquet_read_cols: ParquetReadColumns::from_deduped(parquet_read_cols),
             column_id_to_projected_index,
         }
     }

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -474,10 +474,7 @@ impl PrefilterContextBuilder {
             return None;
         }
 
-        let total_count = read_format
-            .parquet_read_columns()
-            .root_indices_iter()
-            .count();
+        let total_count = read_format.parquet_read_columns().root_indices().len();
         let remaining_count = total_count.saturating_sub(prefilter_count);
         if pk_filters.is_none() && prefilter_count >= total_count {
             return None;

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -474,7 +474,10 @@ impl PrefilterContextBuilder {
             return None;
         }
 
-        let total_count = read_format.projection_indices().len();
+        let total_count = read_format
+            .parquet_read_columns()
+            .root_indices_iter()
+            .count();
         let remaining_count = total_count.saturating_sub(prefilter_count);
         if pk_filters.is_none() && prefilter_count >= total_count {
             return None;
@@ -734,6 +737,7 @@ mod tests {
     use store_api::codec::PrimaryKeyEncoding;
 
     use super::*;
+    use crate::read::read_columns::ReadColumns;
     use crate::sst::internal_fields;
     use crate::sst::parquet::flat_format::{FlatReadFormat, primary_key_column_index};
     use crate::test_util::sst_util::{
@@ -979,14 +983,11 @@ mod tests {
     fn test_prefilter_builder_returns_none_without_selected_filters() {
         let metadata: RegionMetadataRef =
             Arc::new(sst_region_metadata_with_encoding(PrimaryKeyEncoding::Dense));
-        let read_format = FlatReadFormat::new(
-            metadata.clone(),
+        let read_cols = ReadColumns::from_deduped_column_ids(
             metadata.column_metadatas.iter().map(|c| c.column_id),
-            None,
-            "test",
-            false,
-        )
-        .unwrap();
+        );
+        let read_format =
+            FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", false).unwrap();
         let codec = build_primary_key_codec(metadata.as_ref());
         let parquet_schema = parquet_schema(&read_format);
 
@@ -1015,14 +1016,11 @@ mod tests {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata_with_encoding(
             PrimaryKeyEncoding::Sparse,
         ));
-        let legacy_read_format = FlatReadFormat::new(
-            metadata.clone(),
+        let read_cols = ReadColumns::from_deduped_column_ids(
             metadata.column_metadatas.iter().map(|c| c.column_id),
-            None,
-            "memtable",
-            false,
-        )
-        .unwrap();
+        );
+        let legacy_read_format =
+            FlatReadFormat::new(metadata.clone(), &read_cols, None, "memtable", false).unwrap();
         assert!(!legacy_read_format.batch_has_raw_pk_columns());
 
         let plan = build_bulk_filter_plan(
@@ -1042,14 +1040,11 @@ mod tests {
         );
 
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
-        let raw_pk_read_format = FlatReadFormat::new(
-            metadata.clone(),
+        let read_cols = ReadColumns::from_deduped_column_ids(
             metadata.column_metadatas.iter().map(|c| c.column_id),
-            None,
-            "memtable",
-            true,
-        )
-        .unwrap();
+        );
+        let raw_pk_read_format =
+            FlatReadFormat::new(metadata.clone(), &read_cols, None, "memtable", true).unwrap();
         assert!(raw_pk_read_format.batch_has_raw_pk_columns());
 
         let tag_only_plan = build_bulk_filter_plan(
@@ -1076,14 +1071,11 @@ mod tests {
     #[test]
     fn test_build_reader_filter_plan_classifies_filters_for_prefilter_modes() {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
-        let full_read_format = FlatReadFormat::new(
-            metadata.clone(),
+        let read_cols = ReadColumns::from_deduped_column_ids(
             metadata.column_metadatas.iter().map(|c| c.column_id),
-            None,
-            "test",
-            true,
-        )
-        .unwrap();
+        );
+        let full_read_format =
+            FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", true).unwrap();
         let full_parquet_schema = parquet_schema(&full_read_format);
         let codec = build_primary_key_codec(metadata.as_ref());
 
@@ -1106,14 +1098,9 @@ mod tests {
 
         let field_0 = metadata.column_by_name("field_0").unwrap().column_id;
         let ts = metadata.time_index_column().column_id;
-        let projected_read_format = FlatReadFormat::new(
-            metadata.clone(),
-            [field_0, ts].into_iter(),
-            None,
-            "test",
-            true,
-        )
-        .unwrap();
+        let read_cols = ReadColumns::from_deduped_column_ids([field_0, ts]);
+        let projected_read_format =
+            FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", true).unwrap();
         let projected_parquet_schema = parquet_schema(&projected_read_format);
         let pk_prefilter_plan = build_reader_filter_plan(
             Some(&Predicate::new(vec![col("tag_0").eq(lit("a"))])),
@@ -1159,14 +1146,11 @@ mod tests {
     fn test_apply_filters_to_batch_evaluates_physical_filters() {
         let metadata: RegionMetadataRef =
             Arc::new(sst_region_metadata_with_encoding(PrimaryKeyEncoding::Dense));
-        let read_format = FlatReadFormat::new(
-            metadata.clone(),
+        let read_cols = ReadColumns::from_deduped_column_ids(
             metadata.column_metadatas.iter().map(|c| c.column_id),
-            None,
-            "test",
-            false,
-        )
-        .unwrap();
+        );
+        let read_format =
+            FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", false).unwrap();
         let expr = col("field_0").in_list(vec![lit(11_u64)], false);
         let physical_filters = new_physical_filter_contexts(&metadata, &read_format, &[expr]);
         let pk = new_primary_key(&["a", "x"]);

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -734,7 +734,6 @@ mod tests {
     use store_api::codec::PrimaryKeyEncoding;
 
     use super::*;
-    use crate::read::read_columns::ReadColumns;
     use crate::sst::internal_fields;
     use crate::sst::parquet::flat_format::{FlatReadFormat, primary_key_column_index};
     use crate::test_util::sst_util::{
@@ -980,11 +979,14 @@ mod tests {
     fn test_prefilter_builder_returns_none_without_selected_filters() {
         let metadata: RegionMetadataRef =
             Arc::new(sst_region_metadata_with_encoding(PrimaryKeyEncoding::Dense));
-        let read_cols = ReadColumns::from_deduped_column_ids(
+        let read_format = FlatReadFormat::new(
+            metadata.clone(),
             metadata.column_metadatas.iter().map(|c| c.column_id),
-        );
-        let read_format =
-            FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", false).unwrap();
+            None,
+            "test",
+            false,
+        )
+        .unwrap();
         let codec = build_primary_key_codec(metadata.as_ref());
         let parquet_schema = parquet_schema(&read_format);
 
@@ -1013,11 +1015,14 @@ mod tests {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata_with_encoding(
             PrimaryKeyEncoding::Sparse,
         ));
-        let read_cols = ReadColumns::from_deduped_column_ids(
+        let legacy_read_format = FlatReadFormat::new(
+            metadata.clone(),
             metadata.column_metadatas.iter().map(|c| c.column_id),
-        );
-        let legacy_read_format =
-            FlatReadFormat::new(metadata.clone(), &read_cols, None, "memtable", false).unwrap();
+            None,
+            "memtable",
+            false,
+        )
+        .unwrap();
         assert!(!legacy_read_format.batch_has_raw_pk_columns());
 
         let plan = build_bulk_filter_plan(
@@ -1037,11 +1042,14 @@ mod tests {
         );
 
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
-        let read_cols = ReadColumns::from_deduped_column_ids(
+        let raw_pk_read_format = FlatReadFormat::new(
+            metadata.clone(),
             metadata.column_metadatas.iter().map(|c| c.column_id),
-        );
-        let raw_pk_read_format =
-            FlatReadFormat::new(metadata.clone(), &read_cols, None, "memtable", true).unwrap();
+            None,
+            "memtable",
+            true,
+        )
+        .unwrap();
         assert!(raw_pk_read_format.batch_has_raw_pk_columns());
 
         let tag_only_plan = build_bulk_filter_plan(
@@ -1068,11 +1076,14 @@ mod tests {
     #[test]
     fn test_build_reader_filter_plan_classifies_filters_for_prefilter_modes() {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
-        let read_cols = ReadColumns::from_deduped_column_ids(
+        let full_read_format = FlatReadFormat::new(
+            metadata.clone(),
             metadata.column_metadatas.iter().map(|c| c.column_id),
-        );
-        let full_read_format =
-            FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", true).unwrap();
+            None,
+            "test",
+            true,
+        )
+        .unwrap();
         let full_parquet_schema = parquet_schema(&full_read_format);
         let codec = build_primary_key_codec(metadata.as_ref());
 
@@ -1095,9 +1106,8 @@ mod tests {
 
         let field_0 = metadata.column_by_name("field_0").unwrap().column_id;
         let ts = metadata.time_index_column().column_id;
-        let read_cols = ReadColumns::from_deduped_column_ids([field_0, ts]);
         let projected_read_format =
-            FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", true).unwrap();
+            FlatReadFormat::new(metadata.clone(), [field_0, ts], None, "test", true).unwrap();
         let projected_parquet_schema = parquet_schema(&projected_read_format);
         let pk_prefilter_plan = build_reader_filter_plan(
             Some(&Predicate::new(vec![col("tag_0").eq(lit("a"))])),
@@ -1143,11 +1153,14 @@ mod tests {
     fn test_apply_filters_to_batch_evaluates_physical_filters() {
         let metadata: RegionMetadataRef =
             Arc::new(sst_region_metadata_with_encoding(PrimaryKeyEncoding::Dense));
-        let read_cols = ReadColumns::from_deduped_column_ids(
+        let read_format = FlatReadFormat::new(
+            metadata.clone(),
             metadata.column_metadatas.iter().map(|c| c.column_id),
-        );
-        let read_format =
-            FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", false).unwrap();
+            None,
+            "test",
+            false,
+        )
+        .unwrap();
         let expr = col("field_0").in_list(vec![lit(11_u64)], false);
         let physical_filters = new_physical_filter_contexts(&metadata, &read_format, &[expr]);
         let pk = new_primary_key(&["a", "x"]);

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -734,6 +734,7 @@ mod tests {
     use store_api::codec::PrimaryKeyEncoding;
 
     use super::*;
+    use crate::read::read_columns::ReadColumns;
     use crate::sst::internal_fields;
     use crate::sst::parquet::flat_format::{FlatReadFormat, primary_key_column_index};
     use crate::test_util::sst_util::{
@@ -981,7 +982,9 @@ mod tests {
             Arc::new(sst_region_metadata_with_encoding(PrimaryKeyEncoding::Dense));
         let read_format = FlatReadFormat::new(
             metadata.clone(),
-            metadata.column_metadatas.iter().map(|c| c.column_id),
+            ReadColumns::from_deduped_column_ids(
+                metadata.column_metadatas.iter().map(|c| c.column_id),
+            ),
             None,
             "test",
             false,
@@ -1017,7 +1020,9 @@ mod tests {
         ));
         let legacy_read_format = FlatReadFormat::new(
             metadata.clone(),
-            metadata.column_metadatas.iter().map(|c| c.column_id),
+            ReadColumns::from_deduped_column_ids(
+                metadata.column_metadatas.iter().map(|c| c.column_id),
+            ),
             None,
             "memtable",
             false,
@@ -1044,7 +1049,9 @@ mod tests {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
         let raw_pk_read_format = FlatReadFormat::new(
             metadata.clone(),
-            metadata.column_metadatas.iter().map(|c| c.column_id),
+            ReadColumns::from_deduped_column_ids(
+                metadata.column_metadatas.iter().map(|c| c.column_id),
+            ),
             None,
             "memtable",
             true,
@@ -1078,7 +1085,9 @@ mod tests {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
         let full_read_format = FlatReadFormat::new(
             metadata.clone(),
-            metadata.column_metadatas.iter().map(|c| c.column_id),
+            ReadColumns::from_deduped_column_ids(
+                metadata.column_metadatas.iter().map(|c| c.column_id),
+            ),
             None,
             "test",
             true,
@@ -1106,8 +1115,14 @@ mod tests {
 
         let field_0 = metadata.column_by_name("field_0").unwrap().column_id;
         let ts = metadata.time_index_column().column_id;
-        let projected_read_format =
-            FlatReadFormat::new(metadata.clone(), [field_0, ts], None, "test", true).unwrap();
+        let projected_read_format = FlatReadFormat::new(
+            metadata.clone(),
+            ReadColumns::from_deduped_column_ids([field_0, ts]),
+            None,
+            "test",
+            true,
+        )
+        .unwrap();
         let projected_parquet_schema = parquet_schema(&projected_read_format);
         let pk_prefilter_plan = build_reader_filter_plan(
             Some(&Predicate::new(vec![col("tag_0").eq(lit("a"))])),
@@ -1155,7 +1170,9 @@ mod tests {
             Arc::new(sst_region_metadata_with_encoding(PrimaryKeyEncoding::Dense));
         let read_format = FlatReadFormat::new(
             metadata.clone(),
-            metadata.column_metadatas.iter().map(|c| c.column_id),
+            ReadColumns::from_deduped_column_ids(
+                metadata.column_metadatas.iter().map(|c| c.column_id),
+            ),
             None,
             "test",
             false,

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -418,7 +418,7 @@ mod tests {
         let read_cols =
             ReadColumns::from_column_ids(metadata.column_metadatas.iter().map(|c| c.column_id));
         let read_format =
-            ReadFormat::new_flat(metadata.clone(), read_cols, None, "test", true).unwrap();
+            ReadFormat::new_flat(metadata.clone(), &read_cols, None, "test", true).unwrap();
         assert!(read_format.as_flat().is_some());
 
         let filter = SimpleFilterEvaluator::try_new(&col("tag_0").eq(lit("b"))).unwrap();

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -403,6 +403,7 @@ mod tests {
     use store_api::codec::PrimaryKeyEncoding;
 
     use super::*;
+    use crate::read::read_columns::ReadColumns;
     use crate::sst::internal_fields;
     use crate::sst::parquet::format::ReadFormat;
     use crate::test_util::sst_util::{
@@ -414,14 +415,10 @@ mod tests {
         let metadata = Arc::new(sst_region_metadata_with_encoding(
             PrimaryKeyEncoding::Sparse,
         ));
-        let read_format = ReadFormat::new_flat(
-            metadata.clone(),
-            metadata.column_metadatas.iter().map(|c| c.column_id),
-            None,
-            "test",
-            true,
-        )
-        .unwrap();
+        let read_cols =
+            ReadColumns::from_column_ids(metadata.column_metadatas.iter().map(|c| c.column_id));
+        let read_format =
+            ReadFormat::new_flat(metadata.clone(), read_cols, None, "test", true).unwrap();
         assert!(read_format.as_flat().is_some());
 
         let filter = SimpleFilterEvaluator::try_new(&col("tag_0").eq(lit("b"))).unwrap();

--- a/src/mito2/src/sst/parquet/read_columns.rs
+++ b/src/mito2/src/sst/parquet/read_columns.rs
@@ -23,21 +23,46 @@ pub type ParquetNestedPath = Vec<String>;
 /// The parquet columns to read.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParquetReadColumns {
+    /// Root parquet column indices in the same order as `cols`.
+    ///
+    /// Most readers need these indices as a borrowed slice for Arrow schema
+    /// projection or parquet root-column projection. Keeping them here avoids
+    /// repeatedly collecting `cols.iter().map(|col| col.root_index)`.
+    root_indices: Vec<usize>,
     cols: Vec<ParquetReadColumn>,
     has_nested: bool,
 }
 
 impl ParquetReadColumns {
+    /// Builds parquet read columns from deduplicated, normalized input.
+    ///
+    /// `cols` must not contain duplicate root indices, and nested paths must
+    /// already be merged. Empty `nested_paths` means reading the whole root column.
+    ///
+    /// This constructor does not validate or merge input.
+    pub fn from_deduped(cols: Vec<ParquetReadColumn>) -> Self {
+        let has_nested = cols.iter().any(|col| !col.nested_paths.is_empty());
+        let root_indices = cols.iter().map(|col| col.root_index).collect();
+        Self {
+            root_indices,
+            cols,
+            has_nested,
+        }
+    }
+
     /// Builds root-column projections from root indices that are already
     /// deduplicated.
     ///
     /// Note: this constructor does not check for duplicates.
     pub fn from_deduped_root_indices(root_indices: impl IntoIterator<Item = usize>) -> Self {
+        let root_indices = root_indices.into_iter().collect::<Vec<_>>();
         let cols = root_indices
-            .into_iter()
+            .iter()
+            .copied()
             .map(ParquetReadColumn::new)
             .collect();
         Self {
+            root_indices,
             cols,
             has_nested: false,
         }
@@ -52,7 +77,12 @@ impl ParquetReadColumns {
     }
 
     pub fn root_indices_iter(&self) -> impl Iterator<Item = usize> + '_ {
-        self.cols.iter().map(|col| col.root_index)
+        self.root_indices.iter().copied()
+    }
+
+    /// Returns root parquet column indices.
+    pub fn root_indices(&self) -> &[usize] {
+        &self.root_indices
     }
 }
 
@@ -92,6 +122,17 @@ impl ParquetReadColumn {
         Self {
             nested_paths,
             ..self
+        }
+    }
+
+    /// Merges additional nested paths into this root column.
+    pub fn merge_nested_paths(&mut self, nested_paths: Vec<ParquetNestedPath>) {
+        let reads_whole_root = self.nested_paths.is_empty() || nested_paths.is_empty();
+        if reads_whole_root {
+            // Empty nested paths means reading the whole root column.
+            self.nested_paths = vec![];
+        } else {
+            self.nested_paths.extend(nested_paths);
         }
     }
 
@@ -235,13 +276,10 @@ mod tests {
     fn test_reads_whole_root() {
         let parquet_schema_desc = build_test_nested_parquet_schema();
 
-        let projection = ParquetReadColumns {
-            cols: vec![ParquetReadColumn {
-                root_index: 0,
-                nested_paths: vec![],
-            }],
-            has_nested: false,
-        };
+        let projection = ParquetReadColumns::from_deduped(vec![ParquetReadColumn {
+            root_index: 0,
+            nested_paths: vec![],
+        }]);
 
         let (leaf_indices, matched_roots) =
             build_parquet_leaves_indices(&parquet_schema_desc, &projection);
@@ -253,19 +291,16 @@ mod tests {
     fn test_filters_nested_paths() {
         let parquet_schema_desc = build_test_nested_parquet_schema();
 
-        let projection = ParquetReadColumns {
-            cols: vec![
-                ParquetReadColumn {
-                    root_index: 0,
-                    nested_paths: vec![vec!["j".to_string(), "b".to_string()]],
-                },
-                ParquetReadColumn {
-                    root_index: 1,
-                    nested_paths: vec![],
-                },
-            ],
-            has_nested: true,
-        };
+        let projection = ParquetReadColumns::from_deduped(vec![
+            ParquetReadColumn {
+                root_index: 0,
+                nested_paths: vec![vec!["j".to_string(), "b".to_string()]],
+            },
+            ParquetReadColumn {
+                root_index: 1,
+                nested_paths: vec![],
+            },
+        ]);
 
         let (leaf_indices, matched_roots) =
             build_parquet_leaves_indices(&parquet_schema_desc, &projection);
@@ -277,13 +312,10 @@ mod tests {
     fn test_reads_middle_level_path() {
         let parquet_schema_desc = build_test_nested_parquet_schema();
 
-        let projection = ParquetReadColumns {
-            cols: vec![ParquetReadColumn {
-                root_index: 0,
-                nested_paths: vec![vec!["j".to_string(), "b".to_string()]],
-            }],
-            has_nested: true,
-        };
+        let projection = ParquetReadColumns::from_deduped(vec![ParquetReadColumn {
+            root_index: 0,
+            nested_paths: vec![vec!["j".to_string(), "b".to_string()]],
+        }]);
 
         let (leaf_indices, matched_roots) =
             build_parquet_leaves_indices(&parquet_schema_desc, &projection);
@@ -295,13 +327,10 @@ mod tests {
     fn test_reads_leaf_level_path() {
         let parquet_schema_desc = build_test_nested_parquet_schema();
 
-        let projection = ParquetReadColumns {
-            cols: vec![ParquetReadColumn {
-                root_index: 0,
-                nested_paths: vec![vec!["j".to_string(), "b".to_string(), "c".to_string()]],
-            }],
-            has_nested: true,
-        };
+        let projection = ParquetReadColumns::from_deduped(vec![ParquetReadColumn {
+            root_index: 0,
+            nested_paths: vec![vec!["j".to_string(), "b".to_string(), "c".to_string()]],
+        }]);
 
         let (leaf_indices, matched_roots) =
             build_parquet_leaves_indices(&parquet_schema_desc, &projection);
@@ -313,19 +342,16 @@ mod tests {
     fn test_build_projection_mask_with_unmatched_roots() {
         let parquet_schema_desc = build_test_nested_parquet_schema();
 
-        let projection = ParquetReadColumns {
-            cols: vec![
-                ParquetReadColumn {
-                    root_index: 0,
-                    nested_paths: vec![vec!["j".to_string(), "missing".to_string()]],
-                },
-                ParquetReadColumn {
-                    root_index: 1,
-                    nested_paths: vec![],
-                },
-            ],
-            has_nested: true,
-        };
+        let projection = ParquetReadColumns::from_deduped(vec![
+            ParquetReadColumn {
+                root_index: 0,
+                nested_paths: vec![vec!["j".to_string(), "missing".to_string()]],
+            },
+            ParquetReadColumn {
+                root_index: 1,
+                nested_paths: vec![],
+            },
+        ]);
 
         let plan = build_projection_plan(&projection, &parquet_schema_desc);
 
@@ -340,21 +366,44 @@ mod tests {
     fn test_merges_mixed_paths() {
         let parquet_schema_desc = build_test_nested_parquet_schema();
 
-        let projection = ParquetReadColumns {
-            cols: vec![ParquetReadColumn {
-                root_index: 0,
-                nested_paths: vec![
-                    vec!["j".to_string(), "a".to_string()],
-                    vec!["j".to_string(), "b".to_string(), "d".to_string()],
-                ],
-            }],
-            has_nested: true,
-        };
+        let projection = ParquetReadColumns::from_deduped(vec![ParquetReadColumn {
+            root_index: 0,
+            nested_paths: vec![
+                vec!["j".to_string(), "a".to_string()],
+                vec!["j".to_string(), "b".to_string(), "d".to_string()],
+            ],
+        }]);
 
         let (leaf_indices, matched_roots) =
             build_parquet_leaves_indices(&parquet_schema_desc, &projection);
         assert_eq!(vec![0, 2], leaf_indices);
         assert_eq!(HashSet::from([0]), matched_roots);
+    }
+
+    #[test]
+    fn test_merge_nested_paths_extends_paths() {
+        let mut col = ParquetReadColumn::new(0)
+            .with_nested_paths(vec![vec!["j".to_string(), "a".to_string()]]);
+
+        col.merge_nested_paths(vec![vec!["j".to_string(), "b".to_string()]]);
+
+        assert_eq!(
+            &[
+                vec!["j".to_string(), "a".to_string()],
+                vec!["j".to_string(), "b".to_string()],
+            ],
+            col.nested_paths()
+        );
+    }
+
+    #[test]
+    fn test_merge_nested_paths_with_whole_root() {
+        let mut col = ParquetReadColumn::new(0)
+            .with_nested_paths(vec![vec!["j".to_string(), "a".to_string()]]);
+
+        col.merge_nested_paths(vec![]);
+
+        assert!(col.nested_paths().is_empty());
     }
 
     // Test schema:

--- a/src/mito2/src/sst/parquet/read_columns.rs
+++ b/src/mito2/src/sst/parquet/read_columns.rs
@@ -28,6 +28,12 @@ pub struct ParquetReadColumns {
 }
 
 impl ParquetReadColumns {
+    /// Builds parquet read columns from deduplicated, normalized input.
+    ///
+    /// `cols` must not contain duplicate root indices, and nested paths must
+    /// already be merged. Empty `nested_paths` means reading the whole root column.
+    ///
+    /// This constructor does not validate or merge input.
     pub fn from_deduped(cols: Vec<ParquetReadColumn>) -> Self {
         let has_nested = cols.iter().any(|col| !col.nested_paths.is_empty());
         Self { cols, has_nested }

--- a/src/mito2/src/sst/parquet/read_columns.rs
+++ b/src/mito2/src/sst/parquet/read_columns.rs
@@ -106,6 +106,17 @@ impl ParquetReadColumn {
         }
     }
 
+    /// Merges additional nested paths into this root column.
+    pub fn merge_nested_paths(&mut self, nested_paths: Vec<ParquetNestedPath>) {
+        let reads_whole_root = self.nested_paths.is_empty() || nested_paths.is_empty();
+        if reads_whole_root {
+            // Empty nested paths means reading the whole root column.
+            self.nested_paths = vec![];
+        } else {
+            self.nested_paths.extend(nested_paths);
+        }
+    }
+
     pub fn root_index(&self) -> usize {
         self.root_index
     }
@@ -266,6 +277,32 @@ mod tests {
             vec![0, 2],
             build_parquet_leaves_indices(&parquet_schema_desc, &projection)
         );
+    }
+
+    #[test]
+    fn test_merge_nested_paths_extends_paths() {
+        let mut col = ParquetReadColumn::new(0)
+            .with_nested_paths(vec![vec!["j".to_string(), "a".to_string()]]);
+
+        col.merge_nested_paths(vec![vec!["j".to_string(), "b".to_string()]]);
+
+        assert_eq!(
+            &[
+                vec!["j".to_string(), "a".to_string()],
+                vec!["j".to_string(), "b".to_string()],
+            ],
+            col.nested_paths()
+        );
+    }
+
+    #[test]
+    fn test_merge_nested_paths_with_whole_root() {
+        let mut col = ParquetReadColumn::new(0)
+            .with_nested_paths(vec![vec!["j".to_string(), "a".to_string()]]);
+
+        col.merge_nested_paths(vec![]);
+
+        assert!(col.nested_paths().is_empty());
     }
 
     // Test schema:

--- a/src/mito2/src/sst/parquet/read_columns.rs
+++ b/src/mito2/src/sst/parquet/read_columns.rs
@@ -28,7 +28,7 @@ pub struct ParquetReadColumns {
 }
 
 impl ParquetReadColumns {
-    pub fn new(cols: Vec<ParquetReadColumn>) -> Self {
+    pub fn from_deduped(cols: Vec<ParquetReadColumn>) -> Self {
         let has_nested = cols.iter().any(|col| !col.nested_paths.is_empty());
         Self { cols, has_nested }
     }

--- a/src/mito2/src/sst/parquet/read_columns.rs
+++ b/src/mito2/src/sst/parquet/read_columns.rs
@@ -28,6 +28,11 @@ pub struct ParquetReadColumns {
 }
 
 impl ParquetReadColumns {
+    pub fn new(cols: Vec<ParquetReadColumn>) -> Self {
+        let has_nested = cols.iter().any(|col| !col.nested_paths.is_empty());
+        Self { cols, has_nested }
+    }
+
     /// Builds root-column projections from root indices that are already
     /// deduplicated.
     ///

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -48,6 +48,7 @@ use store_api::region_request::PathType;
 use store_api::storage::{ColumnId, FileId};
 use table::predicate::Predicate;
 
+use self::stream::{NestedSchemaAligner, ParquetErrorAdapter, ProjectedRecordBatchStream};
 use crate::cache::index::result_cache::PredicateKey;
 use crate::cache::{CacheStrategy, CachedSstMeta};
 #[cfg(feature = "vector_index")]
@@ -59,6 +60,7 @@ use crate::metrics::{
 };
 use crate::read::flat_projection::CompactionProjectionMapper;
 use crate::read::prune::FlatPruneReader;
+use crate::read::read_columns::ReadColumns;
 use crate::sst::file::FileHandle;
 use crate::sst::index::bloom_filter::applier::{
     BloomFilterIndexApplierRef, BloomFilterIndexApplyMetrics,
@@ -82,10 +84,7 @@ use crate::sst::parquet::metadata::MetadataLoader;
 use crate::sst::parquet::prefilter::{
     PrefilterContextBuilder, build_reader_filter_plan, execute_prefilter,
 };
-use crate::sst::parquet::read_columns::{
-    ParquetReadColumns, ProjectionMaskPlan, build_projection_plan,
-};
-use crate::sst::parquet::reader::stream::{ParquetErrorAdapter, ProjectedRecordBatchStream};
+use crate::sst::parquet::read_columns::{ProjectionMaskPlan, build_projection_plan};
 use crate::sst::parquet::row_group::ParquetFetchMetrics;
 use crate::sst::parquet::row_selection::RowGroupSelection;
 use crate::sst::parquet::stats::RowGroupPruningStats;
@@ -127,11 +126,11 @@ pub struct ParquetReaderBuilder {
     object_store: ObjectStore,
     /// Predicate to push down.
     predicate: Option<Predicate>,
-    /// Metadata of columns to read.
+    /// The columns to read.
     ///
     /// `None` reads all columns. Due to schema change, the projection
     /// can contain columns not in the parquet file.
-    projection: Option<Vec<ColumnId>>,
+    read_cols: Option<ReadColumns>,
     /// Strategy to cache SST data.
     cache_strategy: CacheStrategy,
     /// Index appliers.
@@ -171,7 +170,7 @@ impl ParquetReaderBuilder {
             file_handle,
             object_store,
             predicate: None,
-            projection: None,
+            read_cols: None,
             cache_strategy: CacheStrategy::Disabled,
             inverted_index_appliers: [None, None],
             bloom_filter_index_appliers: [None, None],
@@ -199,8 +198,8 @@ impl ParquetReaderBuilder {
     ///
     /// The reader only applies the projection to fields.
     #[must_use]
-    pub fn projection(mut self, projection: Option<Vec<ColumnId>>) -> ParquetReaderBuilder {
-        self.projection = projection;
+    pub fn projection(mut self, read_cols: Option<ReadColumns>) -> ParquetReaderBuilder {
+        self.read_cols = read_cols;
         self
     }
 
@@ -377,30 +376,25 @@ impl ParquetReaderBuilder {
             None
         };
 
-        let mut read_format = if let Some(column_ids) = &self.projection {
-            FlatReadFormat::new(
-                region_meta.clone(),
-                column_ids.iter().copied(),
-                Some(parquet_meta.file_metadata().schema_descr().num_columns()),
-                &file_path,
-                skip_auto_convert,
-            )?
+        let read_cols = if let Some(read_cols) = &self.read_cols {
+            read_cols.clone()
         } else {
-            // Lists all column ids to read, we always use the expected metadata if possible.
             let expected_meta = self.expected_metadata.as_ref().unwrap_or(&region_meta);
-            let column_ids: Vec<_> = expected_meta
-                .column_metadatas
-                .iter()
-                .map(|col| col.column_id)
-                .collect();
-            FlatReadFormat::new(
-                region_meta.clone(),
-                column_ids.iter().copied(),
-                Some(parquet_meta.file_metadata().schema_descr().num_columns()),
-                &file_path,
-                skip_auto_convert,
-            )?
+            // Lists all column ids to read, we always use the expected metadata if possible.
+            ReadColumns::from_deduped_column_ids(
+                expected_meta
+                    .column_metadatas
+                    .iter()
+                    .map(|col| col.column_id),
+            )
         };
+        let mut read_format = FlatReadFormat::new(
+            region_meta.clone(),
+            &read_cols,
+            Some(parquet_meta.file_metadata().schema_descr().num_columns()),
+            &file_path,
+            skip_auto_convert,
+        )?;
         if need_override_sequence(&parquet_meta) {
             read_format
                 .set_override_sequence(self.file_handle.meta_ref().sequence.map(|x| x.get()));
@@ -408,12 +402,8 @@ impl ParquetReaderBuilder {
 
         // Computes the projection mask.
         let parquet_schema_desc = parquet_meta.file_metadata().schema_descr();
-        let parquet_read_cols = ParquetReadColumns::from_deduped_root_indices(
-            read_format.projection_indices().iter().copied(),
-        );
-
-        let projection_plan = build_projection_plan(&parquet_read_cols, parquet_schema_desc);
-
+        let parquet_read_cols = read_format.parquet_read_columns();
+        let projection_plan = build_projection_plan(parquet_read_cols, parquet_schema_desc);
         let selection = self
             .row_groups_to_read(&read_format, &parquet_meta, &mut metrics.filter_metrics)
             .await;
@@ -1730,11 +1720,12 @@ impl RowGroupReaderBuilder {
         stream: ParquetRecordBatchStream<SstAsyncFileReader>,
     ) -> Result<ProjectedRecordBatchStream> {
         let stream = ParquetErrorAdapter::new(stream, self.file_path.clone());
-        ProjectedRecordBatchStream::new(
+        let stream = stream::MissingColFiller::new(
             stream,
             self.projection.projected_root_presence.clone(),
             self.output_schema.clone(),
-        )
+        )?;
+        Ok(NestedSchemaAligner::new(stream, self.output_schema.clone()))
     }
 
     /// Builds a [ParquetRecordBatchStream] with a custom projection mask.
@@ -2220,17 +2211,15 @@ mod tests {
         object_store.write(&file_path, parquet_bytes).await.unwrap();
 
         let region_metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
-        let read_format = FlatReadFormat::new(
-            region_metadata.clone(),
+        let read_cols = ReadColumns::from_deduped_column_ids(
             region_metadata
                 .column_metadatas
                 .iter()
                 .map(|column| column.column_id),
-            None,
-            &file_path,
-            false,
-        )
-        .unwrap();
+        );
+        let read_format =
+            FlatReadFormat::new(region_metadata.clone(), &read_cols, None, &file_path, false)
+                .unwrap();
 
         let mut cache_metrics = MetadataCacheMetrics::default();
         let loader = MetadataLoader::new(object_store.clone(), &file_path, file_size);
@@ -2326,14 +2315,11 @@ mod tests {
     fn test_physical_filter_context_skips_renamed_column() {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
         let expected_metadata = expected_metadata_with_reused_tag_name(metadata.as_ref());
-        let read_format = FlatReadFormat::new(
-            metadata.clone(),
+        let read_cols = ReadColumns::from_deduped_column_ids(
             metadata.column_metadatas.iter().map(|c| c.column_id),
-            None,
-            "test",
-            true,
-        )
-        .unwrap();
+        );
+        let read_format =
+            FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", true).unwrap();
 
         let ctx = PhysicalFilterContext::new_opt(
             &metadata,
@@ -2348,14 +2334,11 @@ mod tests {
     #[test]
     fn test_physical_filter_context_only_accepts_prefilter_candidates() {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
-        let read_format = FlatReadFormat::new(
-            metadata.clone(),
+        let read_cols = ReadColumns::from_deduped_column_ids(
             metadata.column_metadatas.iter().map(|c| c.column_id),
-            None,
-            "test",
-            true,
-        )
-        .unwrap();
+        );
+        let read_format =
+            FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", true).unwrap();
 
         // InList is on the allowlist — should build a context.
         let in_list = col("tag_0").in_list(vec![lit("a"), lit("b")], false);

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -390,7 +390,7 @@ impl ParquetReaderBuilder {
         };
         let mut read_format = FlatReadFormat::new(
             region_meta.clone(),
-            &read_cols,
+            read_cols,
             Some(parquet_meta.file_metadata().schema_descr().num_columns()),
             &file_path,
             skip_auto_convert,
@@ -2211,15 +2211,17 @@ mod tests {
         object_store.write(&file_path, parquet_bytes).await.unwrap();
 
         let region_metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
-        let read_cols = ReadColumns::from_deduped_column_ids(
+        let read_format = FlatReadFormat::new(
+            region_metadata.clone(),
             region_metadata
                 .column_metadatas
                 .iter()
                 .map(|column| column.column_id),
-        );
-        let read_format =
-            FlatReadFormat::new(region_metadata.clone(), &read_cols, None, &file_path, false)
-                .unwrap();
+            None,
+            &file_path,
+            false,
+        )
+        .unwrap();
 
         let mut cache_metrics = MetadataCacheMetrics::default();
         let loader = MetadataLoader::new(object_store.clone(), &file_path, file_size);
@@ -2315,11 +2317,14 @@ mod tests {
     fn test_physical_filter_context_skips_renamed_column() {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
         let expected_metadata = expected_metadata_with_reused_tag_name(metadata.as_ref());
-        let read_cols = ReadColumns::from_deduped_column_ids(
+        let read_format = FlatReadFormat::new(
+            metadata.clone(),
             metadata.column_metadatas.iter().map(|c| c.column_id),
-        );
-        let read_format =
-            FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", true).unwrap();
+            None,
+            "test",
+            true,
+        )
+        .unwrap();
 
         let ctx = PhysicalFilterContext::new_opt(
             &metadata,
@@ -2334,11 +2339,14 @@ mod tests {
     #[test]
     fn test_physical_filter_context_only_accepts_prefilter_candidates() {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
-        let read_cols = ReadColumns::from_deduped_column_ids(
+        let read_format = FlatReadFormat::new(
+            metadata.clone(),
             metadata.column_metadatas.iter().map(|c| c.column_id),
-        );
-        let read_format =
-            FlatReadFormat::new(metadata.clone(), &read_cols, None, "test", true).unwrap();
+            None,
+            "test",
+            true,
+        )
+        .unwrap();
 
         // InList is on the allowlist — should build a context.
         let in_list = col("tag_0").in_list(vec![lit("a"), lit("b")], false);

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -469,6 +469,7 @@ impl ParquetReaderBuilder {
             output_schema,
             object_store: self.object_store.clone(),
             projection: projection_plan,
+            has_nested_projection: parquet_read_cols.has_nested(),
             cache_strategy: self.cache_strategy.clone(),
             prefilter_builder: filter_plan.prefilter_builder,
         };
@@ -1617,6 +1618,8 @@ pub(crate) struct RowGroupReaderBuilder {
     object_store: ObjectStore,
     /// Projection mask.
     projection: ProjectionMaskPlan,
+    /// Whether projected read columns include nested paths.
+    has_nested_projection: bool,
     /// Cache.
     cache_strategy: CacheStrategy,
     /// Pre-built prefilter state. `None` if prefiltering is not applicable.
@@ -1720,12 +1723,16 @@ impl RowGroupReaderBuilder {
         stream: ParquetRecordBatchStream<SstAsyncFileReader>,
     ) -> Result<ProjectedRecordBatchStream> {
         let stream = ParquetErrorAdapter::new(stream, self.file_path.clone());
-        let stream = stream::MissingColFiller::new(
+        if !self.has_nested_projection {
+            return Ok(stream.boxed());
+        }
+
+        Ok(NestedSchemaAligner::new(
             stream,
             self.projection.projected_root_presence.clone(),
             self.output_schema.clone(),
-        )?;
-        Ok(NestedSchemaAligner::new(stream, self.output_schema.clone()))
+        )?
+        .boxed())
     }
 
     /// Builds a [ParquetRecordBatchStream] with a custom projection mask.
@@ -2213,10 +2220,12 @@ mod tests {
         let region_metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
         let read_format = FlatReadFormat::new(
             region_metadata.clone(),
-            region_metadata
-                .column_metadatas
-                .iter()
-                .map(|column| column.column_id),
+            ReadColumns::from_deduped_column_ids(
+                region_metadata
+                    .column_metadatas
+                    .iter()
+                    .map(|column| column.column_id),
+            ),
             None,
             &file_path,
             false,
@@ -2319,7 +2328,9 @@ mod tests {
         let expected_metadata = expected_metadata_with_reused_tag_name(metadata.as_ref());
         let read_format = FlatReadFormat::new(
             metadata.clone(),
-            metadata.column_metadatas.iter().map(|c| c.column_id),
+            ReadColumns::from_deduped_column_ids(
+                metadata.column_metadatas.iter().map(|c| c.column_id),
+            ),
             None,
             "test",
             true,
@@ -2341,7 +2352,9 @@ mod tests {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
         let read_format = FlatReadFormat::new(
             metadata.clone(),
-            metadata.column_metadatas.iter().map(|c| c.column_id),
+            ReadColumns::from_deduped_column_ids(
+                metadata.column_metadatas.iter().map(|c| c.column_id),
+            ),
             None,
             "test",
             true,

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -385,7 +385,7 @@ impl ParquetReaderBuilder {
         };
         let mut read_format = ReadFormat::new(
             region_meta.clone(),
-            Some(read_cols),
+            Some(&read_cols),
             true, // Always reads as flat format.
             Some(parquet_meta.file_metadata().schema_descr().num_columns()),
             &file_path,

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -55,6 +55,7 @@ use crate::metrics::{
 };
 use crate::read::flat_projection::CompactionProjectionMapper;
 use crate::read::prune::FlatPruneReader;
+use crate::read::read_columns::ReadColumns;
 use crate::read::{Batch, BatchReader};
 use crate::sst::file::FileHandle;
 use crate::sst::index::bloom_filter::applier::{
@@ -120,11 +121,11 @@ pub struct ParquetReaderBuilder {
     object_store: ObjectStore,
     /// Predicate to push down.
     predicate: Option<Predicate>,
-    /// Metadata of columns to read.
+    /// The columns to read.
     ///
     /// `None` reads all columns. Due to schema change, the projection
     /// can contain columns not in the parquet file.
-    projection: Option<Vec<ColumnId>>,
+    read_cols: Option<ReadColumns>,
     /// Strategy to cache SST data.
     cache_strategy: CacheStrategy,
     /// Index appliers.
@@ -164,7 +165,7 @@ impl ParquetReaderBuilder {
             file_handle,
             object_store,
             predicate: None,
-            projection: None,
+            read_cols: None,
             cache_strategy: CacheStrategy::Disabled,
             inverted_index_appliers: [None, None],
             bloom_filter_index_appliers: [None, None],
@@ -192,8 +193,8 @@ impl ParquetReaderBuilder {
     ///
     /// The reader only applies the projection to fields.
     #[must_use]
-    pub fn projection(mut self, projection: Option<Vec<ColumnId>>) -> ParquetReaderBuilder {
-        self.projection = projection;
+    pub fn projection(mut self, read_cols: Option<ReadColumns>) -> ParquetReaderBuilder {
+        self.read_cols = read_cols;
         self
     }
 
@@ -370,32 +371,26 @@ impl ParquetReaderBuilder {
             None
         };
 
-        let mut read_format = if let Some(column_ids) = &self.projection {
-            ReadFormat::new(
-                region_meta.clone(),
-                Some(column_ids),
-                true, // Always reads as flat format.
-                Some(parquet_meta.file_metadata().schema_descr().num_columns()),
-                &file_path,
-                skip_auto_convert,
-            )?
+        let expected_meta = self.expected_metadata.as_ref().unwrap_or(&region_meta);
+        let read_cols = if let Some(read_cols) = &self.read_cols {
+            read_cols.clone()
         } else {
             // Lists all column ids to read, we always use the expected metadata if possible.
-            let expected_meta = self.expected_metadata.as_ref().unwrap_or(&region_meta);
-            let column_ids: Vec<_> = expected_meta
-                .column_metadatas
-                .iter()
-                .map(|col| col.column_id)
-                .collect();
-            ReadFormat::new(
-                region_meta.clone(),
-                Some(&column_ids),
-                true, // Always reads as flat format.
-                Some(parquet_meta.file_metadata().schema_descr().num_columns()),
-                &file_path,
-                skip_auto_convert,
-            )?
+            ReadColumns::from_column_ids(
+                expected_meta
+                    .column_metadatas
+                    .iter()
+                    .map(|col| col.column_id),
+            )
         };
+        let mut read_format = ReadFormat::new(
+            region_meta.clone(),
+            Some(read_cols),
+            true, // Always reads as flat format.
+            Some(parquet_meta.file_metadata().schema_descr().num_columns()),
+            &file_path,
+            skip_auto_convert,
+        )?;
         if self.decode_primary_key_values {
             read_format.set_decode_primary_key_values(true);
         }
@@ -406,10 +401,8 @@ impl ParquetReaderBuilder {
 
         // Computes the projection mask.
         let parquet_schema_desc = parquet_meta.file_metadata().schema_descr();
-        let parquet_read_cols = ParquetReadColumns::from_deduped_root_indices(
-            read_format.projection_indices().iter().copied(),
-        );
-
+        let parquet_read_cols =
+            ParquetReadColumns::from_deduped_root_indices(read_format.projection_indices_iter());
         let projection_mask = build_projection_mask(&parquet_read_cols, parquet_schema_desc);
         let selection = self
             .row_groups_to_read(&read_format, &parquet_meta, &mut metrics.filter_metrics)

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -79,7 +79,7 @@ use crate::sst::parquet::metadata::MetadataLoader;
 use crate::sst::parquet::prefilter::{
     PrefilterContextBuilder, execute_prefilter, is_usable_primary_key_filter,
 };
-use crate::sst::parquet::read_columns::{ParquetReadColumns, build_projection_mask};
+use crate::sst::parquet::read_columns::build_projection_mask;
 use crate::sst::parquet::row_group::ParquetFetchMetrics;
 use crate::sst::parquet::row_selection::RowGroupSelection;
 use crate::sst::parquet::stats::RowGroupPruningStats;
@@ -401,8 +401,7 @@ impl ParquetReaderBuilder {
 
         // Computes the projection mask.
         let parquet_schema_desc = parquet_meta.file_metadata().schema_descr();
-        let parquet_read_cols =
-            ParquetReadColumns::from_deduped_root_indices(read_format.projection_indices_iter());
+        let parquet_read_cols = read_format.parquet_read_columns();
         let projection_mask = build_projection_mask(&parquet_read_cols, parquet_schema_desc);
         let selection = self
             .row_groups_to_read(&read_format, &parquet_meta, &mut metrics.filter_metrics)

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -402,7 +402,7 @@ impl ParquetReaderBuilder {
         // Computes the projection mask.
         let parquet_schema_desc = parquet_meta.file_metadata().schema_descr();
         let parquet_read_cols = read_format.parquet_read_columns();
-        let projection_mask = build_projection_mask(&parquet_read_cols, parquet_schema_desc);
+        let projection_mask = build_projection_mask(parquet_read_cols, parquet_schema_desc);
         let selection = self
             .row_groups_to_read(&read_format, &parquet_meta, &mut metrics.filter_metrics)
             .await;

--- a/src/mito2/src/sst/parquet/reader/stream.rs
+++ b/src/mito2/src/sst/parquet/reader/stream.rs
@@ -15,14 +15,18 @@
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use datatypes::arrow::array::new_null_array;
-use datatypes::arrow::datatypes::SchemaRef;
+use datafusion_common::cast_column;
+use datafusion_common::format::DEFAULT_CAST_OPTIONS;
+use datatypes::arrow::array::{ArrayRef, new_null_array};
+use datatypes::arrow::datatypes::{DataType, FieldRef, SchemaRef};
 use datatypes::arrow::record_batch::RecordBatch;
 use futures::Stream;
 use parquet::arrow::async_reader::ParquetRecordBatchStream;
 use snafu::{IntoError, ResultExt, ensure};
 
-use crate::error::{NewRecordBatchSnafu, ReadParquetSnafu, Result, UnexpectedSnafu};
+use crate::error::{
+    CastColumnSnafu, NewRecordBatchSnafu, ReadParquetSnafu, Result, UnexpectedSnafu,
+};
 use crate::sst::parquet::async_reader::SstAsyncFileReader;
 
 /// Wraps a parquet record batch stream and fills missing projected root columns.
@@ -45,7 +49,8 @@ pub struct MissingColFiller<S> {
     all_matched: bool,
 }
 
-pub(crate) type ProjectedRecordBatchStream = MissingColFiller<ParquetErrorAdapter>;
+pub(crate) type ProjectedRecordBatchStream =
+    NestedSchemaAligner<MissingColFiller<ParquetErrorAdapter>>;
 
 impl<S> MissingColFiller<S>
 where
@@ -146,6 +151,82 @@ fn fill_missing_cols(
     RecordBatch::try_new(output_schema.clone(), cols).context(NewRecordBatchSnafu)
 }
 
+/// Aligns nested arrays in projected batches to the expected output schema.
+///
+/// Parquet nested projection can return a root column whose nested fields are a
+/// subset of the expected logical schema. This wrapper normalizes those arrays
+/// so all projected batches share the same schema before entering upper readers.
+pub struct NestedSchemaAligner<S> {
+    inner: S,
+    output_schema: SchemaRef,
+}
+
+impl<S> NestedSchemaAligner<S>
+where
+    S: Stream<Item = Result<RecordBatch>>,
+{
+    pub fn new(inner: S, output_schema: SchemaRef) -> Self {
+        Self {
+            inner,
+            output_schema,
+        }
+    }
+}
+
+impl<S> Stream for NestedSchemaAligner<S>
+where
+    S: Stream<Item = Result<RecordBatch>> + Unpin,
+{
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+
+        match Pin::new(&mut this.inner).poll_next(cx) {
+            Poll::Ready(Some(Ok(rb))) => {
+                Poll::Ready(Some(align_batch_to_schema(rb, &this.output_schema)))
+            }
+            Poll::Ready(Some(Err(err))) => Poll::Ready(Some(Err(err))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+fn align_batch_to_schema(rb: RecordBatch, output_schema: &SchemaRef) -> Result<RecordBatch> {
+    ensure!(
+        rb.num_columns() == output_schema.fields().len(),
+        UnexpectedSnafu {
+            reason: format!(
+                "NestedSchemaAligner expected {} columns but got {}",
+                output_schema.fields().len(),
+                rb.num_columns()
+            ),
+        }
+    );
+
+    let columns = rb
+        .columns()
+        .iter()
+        .zip(output_schema.fields())
+        .map(|(array, field)| align_array_to_field(array, field))
+        .collect::<Result<Vec<_>>>()?;
+
+    RecordBatch::try_new(output_schema.clone(), columns).context(NewRecordBatchSnafu)
+}
+
+fn align_array_to_field(array: &ArrayRef, field: &FieldRef) -> Result<ArrayRef> {
+    if array.data_type() == field.data_type() {
+        return Ok(array.clone());
+    }
+
+    if !matches!(field.data_type(), DataType::Struct(_)) {
+        return Ok(array.clone());
+    }
+
+    cast_column(array, field.as_ref(), &DEFAULT_CAST_OPTIONS).context(CastColumnSnafu)
+}
+
 /// Maps parquet stream errors into mito errors before batches enter the filler.
 pub(crate) struct ParquetErrorAdapter {
     inner: ParquetRecordBatchStream<SstAsyncFileReader>,
@@ -181,7 +262,7 @@ impl Stream for ParquetErrorAdapter {
 mod tests {
     use std::sync::Arc;
 
-    use datatypes::arrow::array::{Array, ArrayRef, Int64Array, StringArray};
+    use datatypes::arrow::array::{Array, ArrayRef, Int64Array, StringArray, StructArray};
     use datatypes::arrow::datatypes::{DataType, Field, Fields, Schema};
     use futures::{StreamExt, stream};
 
@@ -298,6 +379,43 @@ mod tests {
             err.to_string()
                 .contains("expected 2 input columns but got 1")
         );
+    }
+
+    #[tokio::test]
+    async fn test_nested_schema_aligner_aligns_struct_field() {
+        let output_schema = schema([Field::new(
+            "nested",
+            DataType::Struct(Fields::from(vec![
+                Field::new("x", DataType::Int64, true),
+                Field::new("y", DataType::Utf8, true),
+            ])),
+            true,
+        )]);
+        let input = RecordBatch::try_new(
+            schema([Field::new(
+                "nested",
+                DataType::Struct(Fields::from(vec![Field::new("x", DataType::Int64, true)])),
+                true,
+            )]),
+            vec![Arc::new(StructArray::from(vec![(
+                Arc::new(Field::new("x", DataType::Int64, true)),
+                int_array([1, 2]),
+            )]))],
+        )
+        .unwrap();
+
+        let mut aligner =
+            NestedSchemaAligner::new(stream::iter([Ok(input)]), output_schema.clone());
+        let output = aligner.next().await.unwrap().unwrap();
+
+        assert_eq!(output_schema, output.schema());
+        let nested = output
+            .column(0)
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+        assert_eq!(2, nested.columns().len());
+        assert_eq!(2, nested.column(1).null_count());
     }
 
     fn schema(fields: impl IntoIterator<Item = Field>) -> SchemaRef {

--- a/src/mito2/src/sst/parquet/reader/stream.rs
+++ b/src/mito2/src/sst/parquet/reader/stream.rs
@@ -151,11 +151,12 @@ fn fill_missing_cols(
     RecordBatch::try_new(output_schema.clone(), cols).context(NewRecordBatchSnafu)
 }
 
-/// Aligns nested arrays in projected batches to the expected output schema.
+/// Aligns struct arrays in projected batches to the expected output schema.
 ///
-/// Parquet nested projection can return a root column whose nested fields are a
-/// subset of the expected logical schema. This wrapper normalizes those arrays
-/// so all projected batches share the same schema before entering upper readers.
+/// After nested-path filtering, returned struct arrays may contain only a
+/// subset of fields, so their schema can differ from the expected output
+/// schema. This stream aligns those struct arrays to keep projected batches
+/// schema-consistent before entering upper readers.
 pub struct NestedSchemaAligner<S> {
     inner: S,
     output_schema: SchemaRef,
@@ -209,13 +210,13 @@ fn align_batch_to_schema(rb: RecordBatch, output_schema: &SchemaRef) -> Result<R
         .columns()
         .iter()
         .zip(output_schema.fields())
-        .map(|(array, field)| align_array_to_field(array, field))
+        .map(|(array, field)| align_array(array, field))
         .collect::<Result<Vec<_>>>()?;
 
     RecordBatch::try_new(output_schema.clone(), columns).context(NewRecordBatchSnafu)
 }
 
-fn align_array_to_field(array: &ArrayRef, field: &FieldRef) -> Result<ArrayRef> {
+fn align_array(array: &ArrayRef, field: &FieldRef) -> Result<ArrayRef> {
     if array.data_type() == field.data_type() {
         return Ok(array.clone());
     }

--- a/src/mito2/src/sst/parquet/reader/stream.rs
+++ b/src/mito2/src/sst/parquet/reader/stream.rs
@@ -332,7 +332,10 @@ mod tests {
             Err(err) => err,
         };
 
-        assert!(err.to_string().contains("projected root matches len 2"));
+        assert!(
+            err.to_string()
+                .contains("projected root presence len 2 does not match output schema columns 1")
+        );
     }
 
     #[tokio::test]

--- a/src/mito2/src/sst/parquet/reader/stream.rs
+++ b/src/mito2/src/sst/parquet/reader/stream.rs
@@ -21,6 +21,7 @@ use datatypes::arrow::array::{ArrayRef, new_null_array};
 use datatypes::arrow::datatypes::{DataType, FieldRef, SchemaRef};
 use datatypes::arrow::record_batch::RecordBatch;
 use futures::Stream;
+use futures::stream::BoxStream;
 use parquet::arrow::async_reader::ParquetRecordBatchStream;
 use snafu::{IntoError, ResultExt, ensure};
 
@@ -29,66 +30,77 @@ use crate::error::{
 };
 use crate::sst::parquet::async_reader::SstAsyncFileReader;
 
-/// Wraps a parquet record batch stream and fills missing projected root columns.
+/// Aligns projected batches to the expected output schema for nested projections.
 ///
+/// Background
+/// ----------
 /// Nested projection may ask parquet to read leaves under a root column. If none
 /// of the requested leaves exists in the current parquet file, parquet decoding
-/// omits the whole root from the physical `RecordBatch`. The logical projection
-/// still contains that root, so this wrapper restores the output shape by
-/// inserting a root-level null array.
-pub struct MissingColFiller<S> {
-    /// Inner stream that yields record batches from parquet reader.
+/// omits the whole root from the physical [`RecordBatch`].
+///
+/// In addition, after nested-path filtering, returned struct arrays may contain
+/// only a subset of fields. The current output schema is not pruned by nested
+/// paths, so physical struct fields can be a subset of the expected struct
+/// fields, and their nested schema can differ from the expected output schema.
+///
+/// To keep projected batches schema-consistent before entering upper readers:
+/// - Root-column presence alignment restores missing projected root columns by
+///   inserting root-level null arrays.
+/// - Nested struct alignment aligns struct arrays to the expected nested field
+///   layout.
+pub struct NestedSchemaAligner<S> {
     inner: S,
     /// Output schema expected by the upper reader.
     output_schema: SchemaRef,
-    /// Whether each projected root exists in the physical batch returned by parquet.
-    projected_root_matches: Vec<bool>,
+    /// Whether each projected root exists in the physical batch returned by
+    /// parquet.
+    projected_root_presence: Vec<bool>,
     /// Number of columns expected from the physical batch returned by parquet.
     expected_input_col_num: usize,
-    /// Whether all projected roots are present and the stream can pass batches through.
-    all_matched: bool,
+    /// Whether all projected roots are present and the stream can pass batches
+    /// through.
+    all_roots_present: bool,
 }
 
-pub(crate) type ProjectedRecordBatchStream =
-    NestedSchemaAligner<MissingColFiller<ParquetErrorAdapter>>;
+pub(crate) type ProjectedRecordBatchStream = BoxStream<'static, Result<RecordBatch>>;
 
-impl<S> MissingColFiller<S>
+impl<S> NestedSchemaAligner<S>
 where
     S: Stream<Item = Result<RecordBatch>>,
 {
     pub fn new(
         inner: S,
-        projected_root_matches: Vec<bool>,
+        projected_root_presence: Vec<bool>,
         output_schema: SchemaRef,
-    ) -> Result<MissingColFiller<S>> {
+    ) -> Result<NestedSchemaAligner<S>> {
         ensure!(
-            projected_root_matches.len() == output_schema.fields().len(),
+            projected_root_presence.len() == output_schema.fields().len(),
             UnexpectedSnafu {
                 reason: format!(
-                    "MissingColFiller projected root matches len {} does not match output schema columns {}",
-                    projected_root_matches.len(),
+                    "NestedSchemaAligner projected root presence len {} does not match output schema columns {}",
+                    projected_root_presence.len(),
                     output_schema.fields().len()
                 ),
             }
         );
 
-        let expected_input_col_num = projected_root_matches
+        let expected_input_col_num = projected_root_presence
             .iter()
             .filter(|matched| **matched)
             .count();
-        let all_matched = projected_root_matches.iter().all(|&m| m);
+        let all_roots_present = projected_root_presence.iter().all(|&m| m);
 
-        Ok(MissingColFiller {
+        Ok(NestedSchemaAligner {
             inner,
             output_schema,
-            projected_root_matches,
+            projected_root_presence,
             expected_input_col_num,
-            all_matched,
+            all_roots_present,
         })
     }
 }
 
-impl<S> Stream for MissingColFiller<S>
+impl<S> Stream for NestedSchemaAligner<S>
 where
     S: Stream<Item = Result<RecordBatch>> + Unpin,
 {
@@ -99,18 +111,22 @@ where
 
         match Pin::new(&mut this.inner).poll_next(cx) {
             Poll::Ready(Some(Ok(rb))) => {
-                let output_schema = &this.output_schema;
-                let rb = if this.all_matched {
+                let rb = if this.all_roots_present {
                     rb
                 } else {
                     fill_missing_cols(
                         rb,
-                        output_schema,
-                        &this.projected_root_matches,
+                        &this.output_schema,
+                        &this.projected_root_presence,
                         this.expected_input_col_num,
                     )?
                 };
-                Poll::Ready(Some(Ok(rb)))
+
+                if rb.schema() == this.output_schema {
+                    Poll::Ready(Some(Ok(rb)))
+                } else {
+                    Poll::Ready(Some(align_batch_to_schema(rb, &this.output_schema)))
+                }
             }
             Poll::Ready(Some(Err(err))) => Poll::Ready(Some(Err(err))),
             Poll::Ready(None) => Poll::Ready(None),
@@ -129,7 +145,7 @@ fn fill_missing_cols(
         rb.columns().len() == expected_input_col_num,
         UnexpectedSnafu {
             reason: format!(
-                "MissingColFiller expected {} input columns but got {}",
+                "NestedSchemaAligner expected {} input columns but got {}",
                 expected_input_col_num,
                 rb.columns().len()
             ),
@@ -149,49 +165,6 @@ fn fill_missing_cols(
     }
 
     RecordBatch::try_new(output_schema.clone(), cols).context(NewRecordBatchSnafu)
-}
-
-/// Aligns struct arrays in projected batches to the expected output schema.
-///
-/// After nested-path filtering, returned struct arrays may contain only a
-/// subset of fields, so their schema can differ from the expected output
-/// schema. This stream aligns those struct arrays to keep projected batches
-/// schema-consistent before entering upper readers.
-pub struct NestedSchemaAligner<S> {
-    inner: S,
-    output_schema: SchemaRef,
-}
-
-impl<S> NestedSchemaAligner<S>
-where
-    S: Stream<Item = Result<RecordBatch>>,
-{
-    pub fn new(inner: S, output_schema: SchemaRef) -> Self {
-        Self {
-            inner,
-            output_schema,
-        }
-    }
-}
-
-impl<S> Stream for NestedSchemaAligner<S>
-where
-    S: Stream<Item = Result<RecordBatch>> + Unpin,
-{
-    type Item = Result<RecordBatch>;
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.get_mut();
-
-        match Pin::new(&mut this.inner).poll_next(cx) {
-            Poll::Ready(Some(Ok(rb))) => {
-                Poll::Ready(Some(align_batch_to_schema(rb, &this.output_schema)))
-            }
-            Poll::Ready(Some(Err(err))) => Poll::Ready(Some(Err(err))),
-            Poll::Ready(None) => Poll::Ready(None),
-            Poll::Pending => Poll::Pending,
-        }
-    }
 }
 
 fn align_batch_to_schema(rb: RecordBatch, output_schema: &SchemaRef) -> Result<RecordBatch> {
@@ -270,7 +243,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_filler_with_all_projected_roots_match() {
+    async fn test_aligner_with_all_projected_roots_match() {
         let output_schema = schema([
             Field::new("a", DataType::Int64, true),
             Field::new("b", DataType::Utf8, true),
@@ -282,16 +255,16 @@ mod tests {
         .unwrap();
         let stream = stream::iter([Ok(input.clone())]);
 
-        let mut filler =
-            MissingColFiller::new(stream, vec![true, true], output_schema.clone()).unwrap();
-        let output = filler.next().await.unwrap().unwrap();
+        let mut aligner =
+            NestedSchemaAligner::new(stream, vec![true, true], output_schema.clone()).unwrap();
+        let output = aligner.next().await.unwrap().unwrap();
 
         assert_eq!(input, output);
-        assert!(filler.next().await.is_none());
+        assert!(aligner.next().await.is_none());
     }
 
     #[tokio::test]
-    async fn test_filler_with_fills_null_root_columns() {
+    async fn test_aligner_with_fills_null_root_columns() {
         let input_schema = schema([Field::new("a", DataType::Int64, true)]);
         let output_schema = schema([
             Field::new("a", DataType::Int64, true),
@@ -301,9 +274,10 @@ mod tests {
         let input = RecordBatch::try_new(input_schema, vec![int_array([10, 20])]).unwrap();
         let stream = stream::iter([Ok(input)]);
 
-        let mut filler =
-            MissingColFiller::new(stream, vec![true, false, false], output_schema.clone()).unwrap();
-        let output = filler.next().await.unwrap().unwrap();
+        let mut aligner =
+            NestedSchemaAligner::new(stream, vec![true, false, false], output_schema.clone())
+                .unwrap();
+        let output = aligner.next().await.unwrap().unwrap();
 
         assert_eq!(output_schema, output.schema());
         assert_eq!(3, output.num_columns());
@@ -325,7 +299,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_filler_with_fills_missing_struct_root_column() {
+    async fn test_aligner_with_fills_missing_struct_root_column() {
         let input_schema = schema([Field::new("a", DataType::Int64, true)]);
         let struct_type = DataType::Struct(Fields::from(vec![
             Field::new("x", DataType::Int64, true),
@@ -338,9 +312,9 @@ mod tests {
         let input = RecordBatch::try_new(input_schema, vec![int_array([10, 20])]).unwrap();
         let stream = stream::iter([Ok(input)]);
 
-        let mut filler =
-            MissingColFiller::new(stream, vec![true, false], output_schema.clone()).unwrap();
-        let output = filler.next().await.unwrap().unwrap();
+        let mut aligner =
+            NestedSchemaAligner::new(stream, vec![true, false], output_schema.clone()).unwrap();
+        let output = aligner.next().await.unwrap().unwrap();
 
         assert_eq!(output_schema, output.schema());
         assert_eq!(2, output.num_columns());
@@ -349,12 +323,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_filler_with_reject_projection_len_mismatch() {
+    async fn test_aligner_reject_projection_len_mismatch() {
         let output_schema = schema([Field::new("a", DataType::Int64, true)]);
         let stream = stream::iter([]);
 
-        let err = match MissingColFiller::new(stream, vec![true, false], output_schema) {
-            Ok(_) => panic!("MissingColFiller should reject projection length mismatch"),
+        let err = match NestedSchemaAligner::new(stream, vec![true, false], output_schema) {
+            Ok(_) => panic!("NestedSchemaAligner should reject projection length mismatch"),
             Err(err) => err,
         };
 
@@ -362,7 +336,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_filler_reject_with_input_column_mismatch() {
+    async fn test_aligner_reject_with_input_column_mismatch() {
         let input_schema = schema([Field::new("a", DataType::Int64, true)]);
         let output_schema = schema([
             Field::new("a", DataType::Int64, true),
@@ -372,9 +346,9 @@ mod tests {
         let input = RecordBatch::try_new(input_schema, vec![int_array([1, 2])]).unwrap();
         let stream = stream::iter([Ok(input)]);
 
-        let mut filler =
-            MissingColFiller::new(stream, vec![true, true, false], output_schema).unwrap();
-        let err = filler.next().await.unwrap().unwrap_err();
+        let mut aligner =
+            NestedSchemaAligner::new(stream, vec![true, true, false], output_schema).unwrap();
+        let err = aligner.next().await.unwrap().unwrap_err();
 
         assert!(
             err.to_string()
@@ -406,7 +380,8 @@ mod tests {
         .unwrap();
 
         let mut aligner =
-            NestedSchemaAligner::new(stream::iter([Ok(input)]), output_schema.clone());
+            NestedSchemaAligner::new(stream::iter([Ok(input)]), vec![true], output_schema.clone())
+                .unwrap();
         let output = aligner.next().await.unwrap().unwrap();
 
         assert_eq!(output_schema, output.schema());

--- a/src/mito2/src/sst/parquet/reader/stream.rs
+++ b/src/mito2/src/sst/parquet/reader/stream.rs
@@ -60,6 +60,8 @@ pub struct NestedSchemaAligner<S> {
     /// Whether all projected roots are present and the stream can pass batches
     /// through.
     all_roots_present: bool,
+    /// The cache for whether incoming batches already match output schema.
+    is_schema_matched: Option<bool>,
 }
 
 pub(crate) type ProjectedRecordBatchStream = BoxStream<'static, Result<RecordBatch>>;
@@ -96,6 +98,7 @@ where
             projected_root_presence,
             expected_input_col_num,
             all_roots_present,
+            is_schema_matched: None,
         })
     }
 }
@@ -122,7 +125,15 @@ where
                     )?
                 };
 
-                if rb.schema() == this.output_schema {
+                if !this.all_roots_present {
+                    return Poll::Ready(Some(Ok(rb)));
+                }
+
+                let is_schema_matched = *this
+                    .is_schema_matched
+                    .get_or_insert_with(|| rb.schema() == this.output_schema);
+
+                if is_schema_matched {
                     Poll::Ready(Some(Ok(rb)))
                 } else {
                     Poll::Ready(Some(align_batch_to_schema(rb, &this.output_schema)))

--- a/src/mito2/src/sst/parquet/reader/stream.rs
+++ b/src/mito2/src/sst/parquet/reader/stream.rs
@@ -125,10 +125,6 @@ where
                     )?
                 };
 
-                if !this.all_roots_present {
-                    return Poll::Ready(Some(Ok(rb)));
-                }
-
                 let is_schema_matched = *this
                     .is_schema_matched
                     .get_or_insert_with(|| rb.schema() == this.output_schema);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR adds nested projection support in the Mito read path.

Previously, the scan path only propagated root column ids to memtables and SST readers. While this was sufficient for root-level projection, nested projection information was lost before reaching the Parquet reader, preventing precise pruning of nested leaf columns.

### The execution flow is as follows:

- Build `ReadColumns` from the pushed-down projection, including nested paths.
- Merge in columns referenced by pushed-down predicates, ensuring filter columns are still read even if they are not projected.
- Propagate `ReadColumns` through `ScanInput`, `FlatProjectionMapper`, `FlatReadFormat`, and `ParquetReaderBuilder`.
- Convert logical `ReadColumns` into `ParquetReadColumns` during format projection planning.
- Build the Parquet projection mask from `ParquetReadColumns`, enabling nested leaf projection pushdown.

### Limitations / Not covered in this PR:

- Nested-path projection is currently applied only to Parquet data pruning. The output schema is still not pruned accordingly, so after reading SST batches we must align struct arrays to the expected output schema. 
- Nested projection is not applied to memtables.
- For pushed-down predicates, only column ids are extracted; nested paths are not yet considered.

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
