### PR TITLE
fix: cargo check -p common-meta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13517,7 +13517,6 @@ dependencies = [
  "meta-client",
  "meta-srv",
  "mito2",
- "moka",
  "mysql_async",
  "object-store",
  "opentelemetry-proto 0.31.0",

--- a/src/cache/Cargo.toml
+++ b/src/cache/Cargo.toml
@@ -9,6 +9,6 @@ catalog.workspace = true
 common-error.workspace = true
 common-macro.workspace = true
 common-meta.workspace = true
-moka.workspace = true
+moka = { workspace = true, features = ["future"] }
 partition.workspace = true
 snafu.workspace = true

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -72,7 +72,7 @@ meta-client.workspace = true
 meta-srv.workspace = true
 metric-engine.workspace = true
 mito2.workspace = true
-moka.workspace = true
+moka = { workspace = true, features = ["future"] }
 object-store.workspace = true
 parquet = { workspace = true, features = ["object_store"] }
 plugins.workspace = true

--- a/src/common/meta/Cargo.toml
+++ b/src/common/meta/Cargo.toml
@@ -59,7 +59,7 @@ hex.workspace = true
 humantime-serde.workspace = true
 itertools.workspace = true
 lazy_static.workspace = true
-moka.workspace = true
+moka = { workspace = true, features = ["future"] }
 object-store.workspace = true
 prometheus.workspace = true
 prost.workspace = true

--- a/src/metric-engine/Cargo.toml
+++ b/src/metric-engine/Cargo.toml
@@ -33,7 +33,7 @@ itertools.workspace = true
 lazy_static = "1.4"
 mito-codec.workspace = true
 mito2.workspace = true
-moka.workspace = true
+moka = { workspace = true, features = ["future"] }
 object-store.workspace = true
 prometheus.workspace = true
 serde.workspace = true

--- a/src/operator/Cargo.toml
+++ b/src/operator/Cargo.toml
@@ -53,7 +53,7 @@ lazy_static.workspace = true
 meta-client.workspace = true
 meter-core.workspace = true
 meter-macros.workspace = true
-moka.workspace = true
+moka = { workspace = true, features = ["future"] }
 object-store.workspace = true
 object_store_opendal.workspace = true
 partition.workspace = true

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -62,7 +62,6 @@ loki-proto.workspace = true
 meta-client.workspace = true
 meta-srv = { workspace = true, features = ["mock"] }
 mito2.workspace = true
-moka.workspace = true
 object-store.workspace = true
 operator = { workspace = true, features = ["testing"] }
 prost.workspace = true


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

I hit an error when running `cargo check -p common-meta`. The error:

```text
error: At least one of the crate features `sync` or `future` must be enabled for `moka` crate. Please update your dependencies in Cargo.toml
     --> /home/fys/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/moka-0.12.10/src/lib.rs:234:1
```

This happened because the workspace-level Cargo.toml only specified `moka = "0.12"` without any enabled features, while several crates depended on moka via `moka.workspace = true`. Those crates use `moka::future`, so building them without the future feature causes compilation to fail.

This change makes the affected crates explicitly enable the required future feature, and also removes the unused `moka` dependency from tests-integration.

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
