### PR TITLE
refactor(mito): remove `Compactor::compact` method

### DIFF
--- a/src/mito2/src/compaction/compactor.rs
+++ b/src/mito2/src/compaction/compactor.rs
@@ -16,7 +16,6 @@ use std::num::NonZero;
 use std::sync::Arc;
 use std::time::Duration;
 
-use api::v1::region::compact_request;
 use common_meta::key::SchemaMetadataManagerRef;
 use common_telemetry::{info, warn};
 use common_time::TimeToLive;
@@ -34,9 +33,10 @@ use crate::access_layer::{
     AccessLayer, AccessLayerRef, Metrics, OperationType, SstWriteRequest, WriteType,
 };
 use crate::cache::{CacheManager, CacheManagerRef};
-use crate::compaction::picker::{PickerOutput, new_picker};
+use crate::compaction::picker::PickerOutput;
 use crate::compaction::{CompactionOutput, CompactionSstReaderBuilder, find_dynamic_options};
 use crate::config::MitoConfig;
+use crate::error;
 use crate::error::{
     EmptyRegionDirSnafu, InvalidPartitionExprSnafu, ObjectStoreNotFoundSnafu, Result,
 };
@@ -55,7 +55,6 @@ use crate::sst::index::puffin_manager::PuffinManagerFactory;
 use crate::sst::location::region_dir_from_table_dir;
 use crate::sst::parquet::WriteOptions;
 use crate::sst::version::{SstVersion, SstVersionRef};
-use crate::{error, metrics};
 
 /// Region version for compaction that does not hold memtables.
 #[derive(Clone)]
@@ -290,13 +289,6 @@ pub trait Compactor: Send + Sync + 'static {
         compaction_region: &CompactionRegion,
         merge_output: MergeOutput,
     ) -> Result<RegionEdit>;
-
-    /// Execute compaction for a region.
-    async fn compact(
-        &self,
-        compaction_region: &CompactionRegion,
-        compact_request_options: compact_request::Options,
-    ) -> Result<()>;
 }
 
 /// Trait for merging a single compaction output into SST files.
@@ -587,50 +579,6 @@ where
             .await?;
 
         Ok(edit)
-    }
-
-    // The default implementation of compact combines the merge_ssts and update_manifest functions.
-    // Note: It's local compaction and only used for testing purpose.
-    async fn compact(
-        &self,
-        compaction_region: &CompactionRegion,
-        compact_request_options: compact_request::Options,
-    ) -> Result<()> {
-        let picker_output = {
-            let picker_output = new_picker(
-                &compact_request_options,
-                &compaction_region.region_options.compaction,
-                compaction_region.region_options.append_mode,
-                None,
-            )
-            .pick(compaction_region);
-
-            if let Some(picker_output) = picker_output {
-                picker_output
-            } else {
-                info!(
-                    "No files to compact for region_id: {}",
-                    compaction_region.region_id
-                );
-                return Ok(());
-            }
-        };
-
-        let merge_output = self.merge_ssts(compaction_region, picker_output).await?;
-        if merge_output.is_empty() {
-            info!(
-                "No files to compact for region_id: {}",
-                compaction_region.region_id
-            );
-            return Ok(());
-        }
-
-        metrics::COMPACTION_INPUT_BYTES.inc_by(merge_output.input_file_size() as f64);
-        metrics::COMPACTION_OUTPUT_BYTES.inc_by(merge_output.output_file_size() as f64);
-        self.update_manifest(compaction_region, merge_output)
-            .await?;
-
-        Ok(())
     }
 }
 


### PR DESCRIPTION

I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

**Removed `compact` Method**: Eliminated the `compact` method from the `Compactor` trait and its default implementation because it is not used in this repo and downstream repos. This change affects `compactor.rs`.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
