### PR TITLE
fix: relax azblob validation requirements

### DIFF
--- a/src/cli/src/common/object_store.rs
+++ b/src/cli/src/common/object_store.rs
@@ -220,18 +220,8 @@ impl PrefixedAzblobConnection {
             name: "AzBlob",
             required: [
                 (&self.azblob_container, "container"),
-                (&self.azblob_root, "root"),
-                (&self.azblob_account_name, "account name"),
                 (&self.azblob_endpoint, "endpoint"),
-            ],
-            custom_validator: |missing: &mut Vec<&str>| {
-                // account_key is only required if sas_token is not provided
-                if self.azblob_sas_token.is_none()
-                    && self.azblob_account_key.is_empty()
-                {
-                    missing.push("account key (when sas_token is not provided)");
-                }
-            }
+            ]
         )
     }
 }

--- a/src/cli/src/data/export.rs
+++ b/src/cli/src/data/export.rs
@@ -1084,7 +1084,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_export_command_build_with_azblob_empty_account_name() {
-        // Test Azure Blob with empty account_name
+        // account_name is optional for Azure Blob validation
         let cmd = ExportCommand::parse_from([
             "export",
             "--addr",
@@ -1092,30 +1092,19 @@ mod tests {
             "--azblob",
             "--azblob-container",
             "test-container",
-            "--azblob-root",
-            "test-root",
             "--azblob-account-name",
             "", // Empty account name
-            "--azblob-account-key",
-            MOCK_AZBLOB_ACCOUNT_KEY_B64,
             "--azblob-endpoint",
             "https://account.blob.core.windows.net",
         ]);
 
         let result = cmd.build().await;
-        assert!(result.is_err());
-        if let Err(err) = result {
-            assert!(
-                err.to_string().contains("AzBlob account name must be set"),
-                "Actual error: {}",
-                err
-            );
-        }
+        assert!(result.is_ok(), "Empty account_name should succeed");
     }
 
     #[tokio::test]
     async fn test_export_command_build_with_azblob_missing_account_key() {
-        // Missing account key
+        // account_key is optional for Azure Blob validation
         let cmd = ExportCommand::parse_from([
             "export",
             "--addr",
@@ -1123,24 +1112,12 @@ mod tests {
             "--azblob",
             "--azblob-container",
             "test-container",
-            "--azblob-root",
-            "test-root",
-            "--azblob-account-name",
-            "test-account",
             "--azblob-endpoint",
             "https://account.blob.core.windows.net",
         ]);
 
         let result = cmd.build().await;
-        assert!(result.is_err());
-        if let Err(err) = result {
-            assert!(
-                err.to_string()
-                    .contains("AzBlob account key (when sas_token is not provided) must be set"),
-                "Actual error: {}",
-                err
-            );
-        }
+        assert!(result.is_ok(), "Missing account_key should succeed");
     }
 
     // ==================== Gap 3: Boundary cases ====================
@@ -1238,19 +1215,56 @@ mod tests {
             "--azblob",
             "--azblob-container",
             "test-container",
-            "--azblob-root",
-            "test-root",
-            "--azblob-account-name",
-            "test-account",
-            "--azblob-account-key",
-            MOCK_AZBLOB_ACCOUNT_KEY_B64,
             "--azblob-endpoint",
             "https://account.blob.core.windows.net",
-            // No sas_token
         ]);
 
         let result = cmd.build().await;
         assert!(result.is_ok(), "Minimal AzBlob config should succeed");
+    }
+
+    #[tokio::test]
+    async fn test_export_command_build_with_azblob_missing_endpoint() {
+        let cmd = ExportCommand::parse_from([
+            "export",
+            "--addr",
+            "127.0.0.1:4000",
+            "--azblob",
+            "--azblob-container",
+            "test-container",
+        ]);
+
+        let result = cmd.build().await;
+        assert!(result.is_err());
+        if let Err(err) = result {
+            assert!(
+                err.to_string().contains("AzBlob endpoint must be set"),
+                "Actual error: {}",
+                err
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_export_command_build_with_azblob_missing_container() {
+        let cmd = ExportCommand::parse_from([
+            "export",
+            "--addr",
+            "127.0.0.1:4000",
+            "--azblob",
+            "--azblob-endpoint",
+            "https://account.blob.core.windows.net",
+        ]);
+
+        let result = cmd.build().await;
+        assert!(result.is_err());
+        if let Err(err) = result {
+            assert!(
+                err.to_string().contains("AzBlob container must be set"),
+                "Actual error: {}",
+                err
+            );
+        }
     }
 
     #[tokio::test]
@@ -1287,7 +1301,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_export_command_build_with_azblob_only_sas_token() {
-        // Azure Blob with sas_token but no account_key - should succeed
+        // Azure Blob with sas_token but no credentials - should still succeed
         let cmd = ExportCommand::parse_from([
             "export",
             "--addr",
@@ -1295,15 +1309,10 @@ mod tests {
             "--azblob",
             "--azblob-container",
             "test-container",
-            "--azblob-root",
-            "test-root",
-            "--azblob-account-name",
-            "test-account",
             "--azblob-endpoint",
             "https://account.blob.core.windows.net",
             "--azblob-sas-token",
             "test-sas-token",
-            // No account_key
         ]);
 
         let result = cmd.build().await;
@@ -1324,10 +1333,6 @@ mod tests {
             "--azblob",
             "--azblob-container",
             "test-container",
-            "--azblob-root",
-            "test-root",
-            "--azblob-account-name",
-            "test-account",
             "--azblob-account-key",
             "", // Empty account_key is OK if sas_token is provided
             "--azblob-endpoint",


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR relaxes azblob validation requirements, allowing users to use IMDS with the operator CLI.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
