### PR TITLE
feat: support prefiltering any columns in flat format

### DIFF
--- a/src/mito2/src/memtable/bulk/context.rs
+++ b/src/mito2/src/memtable/bulk/context.rs
@@ -27,16 +27,10 @@ use table::predicate::Predicate;
 use crate::error::Result;
 use crate::sst::parquet::file_range::{PreFilterMode, RangeBase};
 use crate::sst::parquet::flat_format::FlatReadFormat;
-use crate::sst::parquet::prefilter::{CachedPrimaryKeyFilter, is_usable_primary_key_filter};
-use crate::sst::parquet::reader::SimpleFilterContext;
+use crate::sst::parquet::prefilter::{CachedPrimaryKeyFilter, build_bulk_filter_plan};
 use crate::sst::parquet::stats::RowGroupPruningStats;
 
 pub(crate) type BulkIterContextRef = Arc<BulkIterContext>;
-
-struct BulkFilterPlan {
-    remaining_simple_filters: Vec<SimpleFilterContext>,
-    pk_filters: Option<Arc<Vec<SimpleFilterEvaluator>>>,
-}
 
 pub struct BulkIterContext {
     pub(crate) base: RangeBase,
@@ -97,8 +91,7 @@ impl BulkIterContext {
             .map(|pred| pred.dyn_filters().as_ref().clone())
             .unwrap_or_default();
 
-        let filter_plan =
-            Self::build_filter_plan(&region_metadata, &read_format, predicate.as_ref());
+        let filter_plan = build_bulk_filter_plan(&read_format, predicate.as_ref());
 
         Ok(Self {
             base: RangeBase {
@@ -147,50 +140,6 @@ impl BulkIterContext {
         }
     }
 
-    fn build_filter_plan(
-        region_metadata: &RegionMetadataRef,
-        read_format: &FlatReadFormat,
-        predicate: Option<&Predicate>,
-    ) -> BulkFilterPlan {
-        let simple_filters: Vec<SimpleFilterContext> = predicate
-            .into_iter()
-            .flat_map(|predicate| {
-                predicate
-                    .exprs()
-                    .iter()
-                    .filter_map(|expr| SimpleFilterContext::new_opt(region_metadata, None, expr))
-            })
-            .collect();
-
-        let metadata = read_format.metadata();
-        if read_format.batch_has_raw_pk_columns() || metadata.primary_key.is_empty() {
-            return BulkFilterPlan {
-                remaining_simple_filters: simple_filters,
-                pk_filters: None,
-            };
-        }
-
-        let mut remaining_simple_filters = Vec::new();
-        let mut pk_filters = Vec::new();
-
-        for filter_ctx in simple_filters {
-            let pk_filter = filter_ctx.filter().as_filter().and_then(|filter| {
-                is_usable_primary_key_filter(metadata, None, filter).then(|| filter.clone())
-            });
-
-            if let Some(pk_filter) = pk_filter {
-                pk_filters.push(pk_filter);
-            } else {
-                remaining_simple_filters.push(filter_ctx);
-            }
-        }
-
-        BulkFilterPlan {
-            remaining_simple_filters,
-            pk_filters: (!pk_filters.is_empty()).then_some(Arc::new(pk_filters)),
-        }
-    }
-
     /// Builds a fresh PK filter for a new iterator. Returns `None` if PK
     /// prefiltering is not applicable.
     pub(crate) fn build_pk_filter(&self) -> Option<CachedPrimaryKeyFilter> {
@@ -216,96 +165,5 @@ impl BulkIterContext {
     /// Returns the region id.
     pub(crate) fn region_id(&self) -> store_api::storage::RegionId {
         self.base.read_format.metadata().region_id
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::sync::Arc;
-
-    use datafusion_expr::{col, lit};
-    use store_api::codec::PrimaryKeyEncoding;
-
-    use super::*;
-    use crate::test_util::sst_util::{sst_region_metadata, sst_region_metadata_with_encoding};
-
-    #[test]
-    fn test_build_filter_plan_splits_pk_prefiltered_simple_filters_on_legacy_path() {
-        let metadata: RegionMetadataRef = Arc::new(sst_region_metadata_with_encoding(
-            PrimaryKeyEncoding::Sparse,
-        ));
-        let read_format = FlatReadFormat::new(
-            metadata.clone(),
-            metadata.column_metadatas.iter().map(|c| c.column_id),
-            None,
-            "memtable",
-            false,
-        )
-        .unwrap();
-        assert!(!read_format.batch_has_raw_pk_columns());
-        let predicate = Predicate::new(vec![
-            col("tag_0").eq(lit("a")),
-            col("field_0").gt(lit(1_u64)),
-        ]);
-
-        let plan = BulkIterContext::build_filter_plan(&metadata, &read_format, Some(&predicate));
-
-        assert!(plan.pk_filters.is_some());
-        assert_eq!(plan.pk_filters.as_ref().unwrap().len(), 1);
-        assert_eq!(plan.remaining_simple_filters.len(), 1);
-        let remaining_filter = plan.remaining_simple_filters[0]
-            .filter()
-            .as_filter()
-            .unwrap();
-        assert_eq!(remaining_filter.column_name(), "field_0");
-    }
-
-    #[test]
-    fn test_build_filter_plan_keeps_tag_filters_in_range_base_without_pk_prefilter_support() {
-        let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
-        let read_format = FlatReadFormat::new(
-            metadata.clone(),
-            metadata.column_metadatas.iter().map(|c| c.column_id),
-            None,
-            "memtable",
-            true,
-        )
-        .unwrap();
-        assert!(read_format.batch_has_raw_pk_columns());
-        let predicate = Predicate::new(vec![col("tag_0").eq(lit("a"))]);
-
-        let plan = BulkIterContext::build_filter_plan(&metadata, &read_format, Some(&predicate));
-
-        assert!(plan.pk_filters.is_none());
-        assert_eq!(plan.remaining_simple_filters.len(), 1);
-        let remaining_filter = plan.remaining_simple_filters[0]
-            .filter()
-            .as_filter()
-            .unwrap();
-        assert_eq!(remaining_filter.column_name(), "tag_0");
-    }
-
-    #[test]
-    fn test_build_filter_plan_keeps_non_pk_filters_in_range_base() {
-        let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
-        let read_format = FlatReadFormat::new(
-            metadata.clone(),
-            metadata.column_metadatas.iter().map(|c| c.column_id),
-            None,
-            "memtable",
-            true,
-        )
-        .unwrap();
-        let predicate = Predicate::new(vec![col("field_0").gt(lit(1_u64))]);
-
-        let plan = BulkIterContext::build_filter_plan(&metadata, &read_format, Some(&predicate));
-
-        assert!(plan.pk_filters.is_none());
-        assert_eq!(plan.remaining_simple_filters.len(), 1);
-        let remaining_filter = plan.remaining_simple_filters[0]
-            .filter()
-            .as_filter()
-            .unwrap();
-        assert_eq!(remaining_filter.column_name(), "field_0");
     }
 }

--- a/src/mito2/src/memtable/bulk/context.rs
+++ b/src/mito2/src/memtable/bulk/context.rs
@@ -33,6 +33,11 @@ use crate::sst::parquet::stats::RowGroupPruningStats;
 
 pub(crate) type BulkIterContextRef = Arc<BulkIterContext>;
 
+struct BulkFilterPlan {
+    remaining_simple_filters: Vec<SimpleFilterContext>,
+    pk_filters: Option<Arc<Vec<SimpleFilterEvaluator>>>,
+}
+
 pub struct BulkIterContext {
     pub(crate) base: RangeBase,
     pub(crate) predicate: Option<Predicate>,
@@ -66,17 +71,6 @@ impl BulkIterContext {
     ) -> Result<Self> {
         let codec = build_primary_key_codec(&region_metadata);
 
-        let simple_filters: Vec<SimpleFilterContext> = predicate
-            .as_ref()
-            .iter()
-            .flat_map(|predicate| {
-                predicate
-                    .exprs()
-                    .iter()
-                    .filter_map(|expr| SimpleFilterContext::new_opt(&region_metadata, None, expr))
-            })
-            .collect();
-
         let read_format = if let Some(column_ids) = projection {
             FlatReadFormat::new(
                 region_metadata.clone(),
@@ -103,12 +97,12 @@ impl BulkIterContext {
             .map(|pred| pred.dyn_filters().as_ref().clone())
             .unwrap_or_default();
 
-        // Pre-extract PK filters if applicable.
-        let pk_filters = Self::extract_pk_filters(&read_format, &simple_filters);
+        let filter_plan =
+            Self::build_filter_plan(&region_metadata, &read_format, predicate.as_ref());
 
         Ok(Self {
             base: RangeBase {
-                filters: simple_filters,
+                filters: filter_plan.remaining_simple_filters,
                 dyn_filters,
                 read_format,
                 prune_schema: region_metadata.schema.clone(),
@@ -121,7 +115,7 @@ impl BulkIterContext {
                 partition_filter: None,
             },
             predicate,
-            pk_filters,
+            pk_filters: filter_plan.pk_filters,
         })
     }
 
@@ -153,31 +147,48 @@ impl BulkIterContext {
         }
     }
 
-    /// Extracts PK filters if flat format with dictionary-encoded PKs is used.
-    fn extract_pk_filters(
+    fn build_filter_plan(
+        region_metadata: &RegionMetadataRef,
         read_format: &FlatReadFormat,
-        filters: &[SimpleFilterContext],
-    ) -> Option<Arc<Vec<SimpleFilterEvaluator>>> {
-        if read_format.batch_has_raw_pk_columns() {
-            return None;
-        }
-        let metadata = read_format.metadata();
-        if metadata.primary_key.is_empty() {
-            return None;
-        }
-
-        let pk_filters: Vec<_> = filters
-            .iter()
-            .filter_map(|filter_ctx| {
-                let filter = filter_ctx.filter().as_filter()?;
-                is_usable_primary_key_filter(metadata, None, filter).then(|| filter.clone())
+        predicate: Option<&Predicate>,
+    ) -> BulkFilterPlan {
+        let simple_filters: Vec<SimpleFilterContext> = predicate
+            .into_iter()
+            .flat_map(|predicate| {
+                predicate
+                    .exprs()
+                    .iter()
+                    .filter_map(|expr| SimpleFilterContext::new_opt(region_metadata, None, expr))
             })
             .collect();
-        if pk_filters.is_empty() {
-            return None;
+
+        let metadata = read_format.metadata();
+        if read_format.batch_has_raw_pk_columns() || metadata.primary_key.is_empty() {
+            return BulkFilterPlan {
+                remaining_simple_filters: simple_filters,
+                pk_filters: None,
+            };
         }
 
-        Some(Arc::new(pk_filters))
+        let mut remaining_simple_filters = Vec::new();
+        let mut pk_filters = Vec::new();
+
+        for filter_ctx in simple_filters {
+            let pk_filter = filter_ctx.filter().as_filter().and_then(|filter| {
+                is_usable_primary_key_filter(metadata, None, filter).then(|| filter.clone())
+            });
+
+            if let Some(pk_filter) = pk_filter {
+                pk_filters.push(pk_filter);
+            } else {
+                remaining_simple_filters.push(filter_ctx);
+            }
+        }
+
+        BulkFilterPlan {
+            remaining_simple_filters,
+            pk_filters: (!pk_filters.is_empty()).then_some(Arc::new(pk_filters)),
+        }
     }
 
     /// Builds a fresh PK filter for a new iterator. Returns `None` if PK
@@ -205,5 +216,96 @@ impl BulkIterContext {
     /// Returns the region id.
     pub(crate) fn region_id(&self) -> store_api::storage::RegionId {
         self.base.read_format.metadata().region_id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use datafusion_expr::{col, lit};
+    use store_api::codec::PrimaryKeyEncoding;
+
+    use super::*;
+    use crate::test_util::sst_util::{sst_region_metadata, sst_region_metadata_with_encoding};
+
+    #[test]
+    fn test_build_filter_plan_splits_pk_prefiltered_simple_filters_on_legacy_path() {
+        let metadata: RegionMetadataRef = Arc::new(sst_region_metadata_with_encoding(
+            PrimaryKeyEncoding::Sparse,
+        ));
+        let read_format = FlatReadFormat::new(
+            metadata.clone(),
+            metadata.column_metadatas.iter().map(|c| c.column_id),
+            None,
+            "memtable",
+            false,
+        )
+        .unwrap();
+        assert!(!read_format.batch_has_raw_pk_columns());
+        let predicate = Predicate::new(vec![
+            col("tag_0").eq(lit("a")),
+            col("field_0").gt(lit(1_u64)),
+        ]);
+
+        let plan = BulkIterContext::build_filter_plan(&metadata, &read_format, Some(&predicate));
+
+        assert!(plan.pk_filters.is_some());
+        assert_eq!(plan.pk_filters.as_ref().unwrap().len(), 1);
+        assert_eq!(plan.remaining_simple_filters.len(), 1);
+        let remaining_filter = plan.remaining_simple_filters[0]
+            .filter()
+            .as_filter()
+            .unwrap();
+        assert_eq!(remaining_filter.column_name(), "field_0");
+    }
+
+    #[test]
+    fn test_build_filter_plan_keeps_tag_filters_in_range_base_without_pk_prefilter_support() {
+        let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
+        let read_format = FlatReadFormat::new(
+            metadata.clone(),
+            metadata.column_metadatas.iter().map(|c| c.column_id),
+            None,
+            "memtable",
+            true,
+        )
+        .unwrap();
+        assert!(read_format.batch_has_raw_pk_columns());
+        let predicate = Predicate::new(vec![col("tag_0").eq(lit("a"))]);
+
+        let plan = BulkIterContext::build_filter_plan(&metadata, &read_format, Some(&predicate));
+
+        assert!(plan.pk_filters.is_none());
+        assert_eq!(plan.remaining_simple_filters.len(), 1);
+        let remaining_filter = plan.remaining_simple_filters[0]
+            .filter()
+            .as_filter()
+            .unwrap();
+        assert_eq!(remaining_filter.column_name(), "tag_0");
+    }
+
+    #[test]
+    fn test_build_filter_plan_keeps_non_pk_filters_in_range_base() {
+        let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
+        let read_format = FlatReadFormat::new(
+            metadata.clone(),
+            metadata.column_metadatas.iter().map(|c| c.column_id),
+            None,
+            "memtable",
+            true,
+        )
+        .unwrap();
+        let predicate = Predicate::new(vec![col("field_0").gt(lit(1_u64))]);
+
+        let plan = BulkIterContext::build_filter_plan(&metadata, &read_format, Some(&predicate));
+
+        assert!(plan.pk_filters.is_none());
+        assert_eq!(plan.remaining_simple_filters.len(), 1);
+        let remaining_filter = plan.remaining_simple_filters[0]
+            .filter()
+            .as_filter()
+            .unwrap();
+        assert_eq!(remaining_filter.column_name(), "field_0");
     }
 }

--- a/src/mito2/src/memtable/bulk/context.rs
+++ b/src/mito2/src/memtable/bulk/context.rs
@@ -109,6 +109,7 @@ impl BulkIterContext {
         Ok(Self {
             base: RangeBase {
                 filters: simple_filters,
+                physical_filters: vec![],
                 dyn_filters,
                 read_format,
                 prune_schema: region_metadata.schema.clone(),

--- a/src/mito2/src/memtable/bulk/context.rs
+++ b/src/mito2/src/memtable/bulk/context.rs
@@ -27,7 +27,7 @@ use table::predicate::Predicate;
 use crate::error::Result;
 use crate::sst::parquet::file_range::{PreFilterMode, RangeBase};
 use crate::sst::parquet::flat_format::FlatReadFormat;
-use crate::sst::parquet::prefilter::CachedPrimaryKeyFilter;
+use crate::sst::parquet::prefilter::{CachedPrimaryKeyFilter, is_usable_primary_key_filter};
 use crate::sst::parquet::reader::SimpleFilterContext;
 use crate::sst::parquet::stats::RowGroupPruningStats;
 
@@ -168,7 +168,10 @@ impl BulkIterContext {
 
         let pk_filters: Vec<_> = filters
             .iter()
-            .filter_map(|f| f.primary_key_prefilter())
+            .filter_map(|filter_ctx| {
+                let filter = filter_ctx.filter().as_filter()?;
+                is_usable_primary_key_filter(metadata, None, filter).then(|| filter.clone())
+            })
             .collect();
         if pk_filters.is_empty() {
             return None;

--- a/src/mito2/src/memtable/bulk/context.rs
+++ b/src/mito2/src/memtable/bulk/context.rs
@@ -109,7 +109,6 @@ impl BulkIterContext {
         Ok(Self {
             base: RangeBase {
                 filters: simple_filters,
-                physical_filters: vec![],
                 dyn_filters,
                 read_format,
                 prune_schema: region_metadata.schema.clone(),

--- a/src/mito2/src/memtable/bulk/part_reader.rs
+++ b/src/mito2/src/memtable/bulk/part_reader.rs
@@ -380,7 +380,6 @@ fn apply_combined_filters(
     metrics: &mut MemScanMetricsData,
 ) -> error::Result<Option<RecordBatch>> {
     // Apply PK prefilter on raw batch before convert_batch to reduce conversion overhead.
-    let has_pk_prefilter = pk_filter.is_some();
     let record_batch = if let Some(pk_filter) = pk_filter {
         let rows_before = record_batch.num_rows();
         let prefilter_start = Instant::now();
@@ -413,7 +412,6 @@ fn apply_combined_filters(
         let predicate_mask = context.base.compute_filter_mask_flat(
             &record_batch,
             skip_fields,
-            has_pk_prefilter,
             &mut tag_decode_state,
         )?;
         // If predicate filters out the entire batch, return None early

--- a/src/mito2/src/sst/parquet/file_range.rs
+++ b/src/mito2/src/sst/parquet/file_range.rs
@@ -297,6 +297,7 @@ impl FileRangeContext {
 
     /// Filters the input RecordBatch by the pushed down predicate and returns RecordBatch.
     /// If a partition expr filter is configured, it is also applied.
+    /// Physical filter exprs are not evaluated here; they are only applied during prefiltering.
     pub(crate) fn precise_filter_flat(
         &self,
         input: RecordBatch,
@@ -369,8 +370,6 @@ pub(crate) struct PartitionFilterContext {
 pub(crate) struct RangeBase {
     /// Filters pushed down.
     pub(crate) filters: Vec<SimpleFilterContext>,
-    /// Physical filters pushed down.
-    pub(crate) physical_filters: Vec<PhysicalFilterContext>,
     /// Dynamic filter physical exprs.
     pub(crate) dyn_filters: Vec<Arc<DynamicFilterPhysicalExpr>>,
     /// Helper to read the SST.
@@ -416,13 +415,13 @@ impl RangeBase {
         &self,
         input: RecordBatch,
         skip_fields: bool,
-        skip_prefiltered_filters: bool,
+        has_prefilter: bool,
     ) -> Result<Option<RecordBatch>> {
         let mut tag_decode_state = TagDecodeState::new();
         let mask = self.compute_filter_mask_flat(
             &input,
             skip_fields,
-            skip_prefiltered_filters,
+            has_prefilter,
             &mut tag_decode_state,
         )?;
 
@@ -459,6 +458,7 @@ impl RangeBase {
 
     /// Computes the filter mask for the input RecordBatch based on pushed down predicates.
     /// If a partition expr filter is configured, it is applied later in `precise_filter_flat` but **NOT** in this function.
+    /// Physical filter exprs are excluded here and only apply during prefiltering.
     ///
     /// Returns `None` if the entire batch is filtered out, otherwise returns the boolean mask.
     ///
@@ -469,7 +469,7 @@ impl RangeBase {
         &self,
         input: &RecordBatch,
         skip_fields: bool,
-        skip_prefiltered_filters: bool,
+        has_prefilter: bool,
         tag_decode_state: &mut TagDecodeState,
     ) -> Result<Option<BooleanBuffer>> {
         let mut mask = BooleanBuffer::new_set(input.num_rows());
@@ -491,13 +491,9 @@ impl RangeBase {
                 continue;
             }
 
-            // Flat parquet PK prefiltering already applied these tag predicates while refining
-            // row selection, so skip them here to avoid decoding/evaluating the same condition twice.
-            if should_skip_simple_filter_after_prefilter(
-                skip_prefiltered_filters,
-                skip_fields,
-                filter_ctx,
-            ) {
+            // Skip simple filters only when parquet prefilter already evaluated the same
+            // condition while refining row selection.
+            if should_skip_simple_filter_after_prefilter(has_prefilter, filter_ctx) {
                 continue;
             }
 
@@ -530,61 +526,6 @@ impl RangeBase {
                 mask = mask.bitand(&result);
             }
             // Non-tag column not found in projection.
-        }
-
-        for filter_ctx in &self.physical_filters {
-            let filter = match filter_ctx.filter() {
-                MaybePhysicalFilter::Filter(filter) => filter,
-                MaybePhysicalFilter::Matched => continue,
-                MaybePhysicalFilter::Pruned => return Ok(None),
-            };
-
-            if skip_fields && filter_ctx.semantic_type() == SemanticType::Field {
-                continue;
-            }
-
-            if should_skip_physical_filter_after_prefilter(
-                skip_prefiltered_filters,
-                skip_fields,
-                filter_ctx,
-            ) {
-                continue;
-            }
-
-            let column =
-                if let Some((idx, _)) = input.schema().column_with_name(filter_ctx.column_name()) {
-                    Some(input.column(idx).clone())
-                } else if filter_ctx.semantic_type() == SemanticType::Tag {
-                    self.maybe_decode_tag_column(
-                        metadata,
-                        filter_ctx.column_id(),
-                        input,
-                        tag_decode_state,
-                    )?
-                } else {
-                    None
-                };
-
-            let Some(column) = column else {
-                continue;
-            };
-
-            let record_batch = RecordBatch::try_new(filter_ctx.schema().clone(), vec![column])
-                .context(NewRecordBatchSnafu)?;
-            let evaluated = filter
-                .evaluate(&record_batch)
-                .context(EvalPartitionFilterSnafu)?;
-            let array = evaluated
-                .into_array(record_batch.num_rows())
-                .context(EvalPartitionFilterSnafu)?;
-            let boolean_array =
-                array
-                    .as_any()
-                    .downcast_ref::<BooleanArray>()
-                    .context(UnexpectedSnafu {
-                        reason: "Failed to downcast physical filter result to BooleanArray",
-                    })?;
-            mask = mask.bitand(boolean_array.values());
         }
 
         Ok(Some(mask))
@@ -728,33 +669,14 @@ impl RangeBase {
 }
 
 fn should_skip_simple_filter_after_prefilter(
-    skip_prefiltered_filters: bool,
-    skip_fields: bool,
+    has_prefilter: bool,
     filter_ctx: &SimpleFilterContext,
 ) -> bool {
-    if !skip_prefiltered_filters {
+    if !has_prefilter {
         return false;
     }
 
-    match filter_ctx.semantic_type() {
-        SemanticType::Field => !skip_fields,
-        SemanticType::Tag | SemanticType::Timestamp => true,
-    }
-}
-
-fn should_skip_physical_filter_after_prefilter(
-    skip_prefiltered_filters: bool,
-    skip_fields: bool,
-    filter_ctx: &PhysicalFilterContext,
-) -> bool {
-    if !skip_prefiltered_filters {
-        return false;
-    }
-
-    match filter_ctx.semantic_type() {
-        SemanticType::Field => !skip_fields,
-        SemanticType::Tag | SemanticType::Timestamp => true,
-    }
+    filter_ctx.usable_prefilter()
 }
 
 #[cfg(test)]
@@ -767,10 +689,7 @@ mod tests {
     use crate::sst::parquet::flat_format::FlatReadFormat;
     use crate::test_util::sst_util::{new_record_batch_with_custom_sequence, sst_region_metadata};
 
-    fn new_test_range_base(
-        filters: Vec<SimpleFilterContext>,
-        physical_filters: Vec<PhysicalFilterContext>,
-    ) -> RangeBase {
+    fn new_test_range_base(filters: Vec<SimpleFilterContext>) -> RangeBase {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
         let read_format = FlatReadFormat::new(
             metadata.clone(),
@@ -783,7 +702,6 @@ mod tests {
 
         RangeBase {
             filters,
-            physical_filters,
             dyn_filters: vec![],
             read_format,
             expected_metadata: None,
@@ -799,11 +717,12 @@ mod tests {
     #[test]
     fn test_compute_filter_mask_flat_skips_prefiltered_pk_filters() {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
-        let filters = vec![
+        let mut filters = vec![
             SimpleFilterContext::new_opt(&metadata, None, &col("tag_0").eq(lit("a"))).unwrap(),
             SimpleFilterContext::new_opt(&metadata, None, &col("field_0").gt(lit(1_u64))).unwrap(),
         ];
-        let base = new_test_range_base(filters, vec![]);
+        filters[0].set_usable_prefilter(true);
+        let base = new_test_range_base(filters);
         let batch = new_record_batch_with_custom_sequence(&["b", "x"], 0, 4, 1);
 
         let mask_without_skip = base
@@ -816,11 +735,11 @@ mod tests {
             .compute_filter_mask_flat(&batch, false, true, &mut TagDecodeState::new())
             .unwrap()
             .unwrap();
-        assert_eq!(mask_with_skip.count_set_bits(), 4);
+        assert_eq!(mask_with_skip.count_set_bits(), 2);
     }
 
     #[test]
-    fn test_compute_filter_mask_flat_skips_prefiltered_physical_filters() {
+    fn test_compute_filter_mask_flat_does_not_postfilter_physical_filters() {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
         let read_format = ReadFormat::new_flat(
             metadata.clone(),
@@ -830,23 +749,21 @@ mod tests {
             true,
         )
         .unwrap();
-        let physical_filters = vec![
-            PhysicalFilterContext::new_opt(
-                &metadata,
-                None,
-                &read_format,
-                &((col("field_0") + lit(1_u64)).gt(lit(2_u64))),
-            )
-            .unwrap(),
-        ];
-        let base = new_test_range_base(vec![], physical_filters);
+        let physical_filter = crate::sst::parquet::reader::PhysicalFilterContext::new_opt(
+            &metadata,
+            None,
+            &read_format,
+            &((col("field_0") + lit(1_u64)).gt(lit(2_u64))),
+        );
+        assert!(physical_filter.is_some());
+        let base = new_test_range_base(vec![]);
         let batch = new_record_batch_with_custom_sequence(&["b", "x"], 0, 4, 1);
 
         let mask_without_skip = base
             .compute_filter_mask_flat(&batch, false, false, &mut TagDecodeState::new())
             .unwrap()
             .unwrap();
-        assert_eq!(mask_without_skip.count_set_bits(), 2);
+        assert_eq!(mask_without_skip.count_set_bits(), 4);
 
         let mask_with_skip = base
             .compute_filter_mask_flat(&batch, false, true, &mut TagDecodeState::new())

--- a/src/mito2/src/sst/parquet/file_range.rs
+++ b/src/mito2/src/sst/parquet/file_range.rs
@@ -172,6 +172,7 @@ impl FileRange {
                 self.row_group_idx,
                 self.row_selection.clone(),
                 fetch_metrics,
+                skip_fields,
             ))
             .await?;
 
@@ -324,6 +325,7 @@ impl FileRangeContext {
         row_group_idx: usize,
         row_selection: Option<RowSelection>,
         fetch_metrics: Option<&'a ParquetFetchMetrics>,
+        skip_fields: bool,
     ) -> RowGroupBuildContext<'a> {
         RowGroupBuildContext {
             filters: &self.base.filters,
@@ -331,6 +333,7 @@ impl FileRangeContext {
             row_group_idx,
             row_selection,
             fetch_metrics,
+            skip_fields,
         }
     }
 
@@ -342,7 +345,7 @@ impl FileRangeContext {
 }
 
 /// Mode to pre-filter columns in a range.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PreFilterMode {
     /// Filters all columns.
     All,

--- a/src/mito2/src/sst/parquet/file_range.rs
+++ b/src/mito2/src/sst/parquet/file_range.rs
@@ -50,8 +50,8 @@ use crate::sst::parquet::flat_format::{
     DecodedPrimaryKeys, FlatReadFormat, decode_primary_keys, time_index_column_index,
 };
 use crate::sst::parquet::reader::{
-    FlatRowGroupReader, MaybeFilter, RowGroupBuildContext, RowGroupReaderBuilder,
-    SimpleFilterContext,
+    FlatRowGroupReader, MaybeFilter, PhysicalFilterContext, RowGroupBuildContext,
+    RowGroupReaderBuilder, SimpleFilterContext,
 };
 use crate::sst::parquet::row_group::ParquetFetchMetrics;
 use crate::sst::parquet::stats::RowGroupPruningStats;
@@ -327,6 +327,7 @@ impl FileRangeContext {
     ) -> RowGroupBuildContext<'a> {
         RowGroupBuildContext {
             filters: &self.base.filters,
+            physical_filters: &self.base.physical_filters,
             row_group_idx,
             row_selection,
             fetch_metrics,
@@ -367,6 +368,8 @@ pub(crate) struct PartitionFilterContext {
 pub(crate) struct RangeBase {
     /// Filters pushed down.
     pub(crate) filters: Vec<SimpleFilterContext>,
+    /// Physical filters pushed down.
+    pub(crate) physical_filters: Vec<PhysicalFilterContext>,
     /// Dynamic filter physical exprs.
     pub(crate) dyn_filters: Vec<Arc<DynamicFilterPhysicalExpr>>,
     /// Helper to read the SST.
@@ -687,6 +690,7 @@ mod tests {
 
         RangeBase {
             filters,
+            physical_filters: vec![],
             dyn_filters: vec![],
             read_format,
             expected_metadata: None,

--- a/src/mito2/src/sst/parquet/file_range.rs
+++ b/src/mito2/src/sst/parquet/file_range.rs
@@ -753,7 +753,7 @@ mod tests {
             &metadata,
             None,
             &read_format,
-            &((col("field_0") + lit(1_u64)).gt(lit(2_u64))),
+            &col("field_0").in_list(vec![lit(1_u64), lit(2_u64)], false),
         );
         assert!(physical_filter.is_some());
         let base = new_test_range_base(vec![]);

--- a/src/mito2/src/sst/parquet/file_range.rs
+++ b/src/mito2/src/sst/parquet/file_range.rs
@@ -328,8 +328,6 @@ impl FileRangeContext {
         skip_fields: bool,
     ) -> RowGroupBuildContext<'a> {
         RowGroupBuildContext {
-            filters: &self.base.filters,
-            physical_filters: &self.base.physical_filters,
             row_group_idx,
             row_selection,
             fetch_metrics,

--- a/src/mito2/src/sst/parquet/file_range.rs
+++ b/src/mito2/src/sst/parquet/file_range.rs
@@ -769,7 +769,10 @@ mod tests {
     use crate::sst::parquet::flat_format::FlatReadFormat;
     use crate::test_util::sst_util::{new_record_batch_with_custom_sequence, sst_region_metadata};
 
-    fn new_test_range_base(filters: Vec<SimpleFilterContext>) -> RangeBase {
+    fn new_test_range_base(
+        filters: Vec<SimpleFilterContext>,
+        physical_filters: Vec<PhysicalFilterContext>,
+    ) -> RangeBase {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
         let read_format = FlatReadFormat::new(
             metadata.clone(),
@@ -782,7 +785,7 @@ mod tests {
 
         RangeBase {
             filters,
-            physical_filters: vec![],
+            physical_filters,
             dyn_filters: vec![],
             read_format,
             expected_metadata: None,
@@ -802,7 +805,7 @@ mod tests {
             SimpleFilterContext::new_opt(&metadata, None, &col("tag_0").eq(lit("a"))).unwrap(),
             SimpleFilterContext::new_opt(&metadata, None, &col("field_0").gt(lit(1_u64))).unwrap(),
         ];
-        let base = new_test_range_base(filters);
+        let base = new_test_range_base(filters, vec![]);
         let batch = new_record_batch_with_custom_sequence(&["b", "x"], 0, 4, 1);
 
         let mask_without_skip = base
@@ -815,6 +818,42 @@ mod tests {
             .compute_filter_mask_flat(&batch, false, true, &mut TagDecodeState::new())
             .unwrap()
             .unwrap();
-        assert_eq!(mask_with_skip.count_set_bits(), 2);
+        assert_eq!(mask_with_skip.count_set_bits(), 4);
+    }
+
+    #[test]
+    fn test_compute_filter_mask_flat_skips_prefiltered_physical_filters() {
+        let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
+        let read_format = ReadFormat::new_flat(
+            metadata.clone(),
+            metadata.column_metadatas.iter().map(|c| c.column_id),
+            None,
+            "test",
+            true,
+        )
+        .unwrap();
+        let physical_filters = vec![
+            PhysicalFilterContext::new_opt(
+                &metadata,
+                None,
+                &read_format,
+                &((col("field_0") + lit(1_u64)).gt(lit(2_u64))),
+            )
+            .unwrap(),
+        ];
+        let base = new_test_range_base(vec![], physical_filters);
+        let batch = new_record_batch_with_custom_sequence(&["b", "x"], 0, 4, 1);
+
+        let mask_without_skip = base
+            .compute_filter_mask_flat(&batch, false, false, &mut TagDecodeState::new())
+            .unwrap()
+            .unwrap();
+        assert_eq!(mask_without_skip.count_set_bits(), 2);
+
+        let mask_with_skip = base
+            .compute_filter_mask_flat(&batch, false, true, &mut TagDecodeState::new())
+            .unwrap()
+            .unwrap();
+        assert_eq!(mask_with_skip.count_set_bits(), 4);
     }
 }

--- a/src/mito2/src/sst/parquet/file_range.rs
+++ b/src/mito2/src/sst/parquet/file_range.rs
@@ -50,8 +50,8 @@ use crate::sst::parquet::flat_format::{
     DecodedPrimaryKeys, FlatReadFormat, decode_primary_keys, time_index_column_index,
 };
 use crate::sst::parquet::reader::{
-    FlatRowGroupReader, MaybeFilter, PhysicalFilterContext, RowGroupBuildContext,
-    RowGroupReaderBuilder, SimpleFilterContext,
+    FlatRowGroupReader, MaybeFilter, MaybePhysicalFilter, PhysicalFilterContext,
+    RowGroupBuildContext, RowGroupReaderBuilder, SimpleFilterContext,
 };
 use crate::sst::parquet::row_group::ParquetFetchMetrics;
 use crate::sst::parquet::stats::RowGroupPruningStats;
@@ -199,7 +199,7 @@ impl FileRange {
                 FlatRowGroupReader::new(self.context.clone(), parquet_reader);
             // Flat PK prefilter makes the input stream predicate-dependent, so cached
             // selector results are not reusable across queries with different filters.
-            let cache_strategy = if self.context.reader_builder.has_flat_primary_key_prefilter() {
+            let cache_strategy = if self.context.reader_builder.has_predicate_prefilter() {
                 CacheStrategy::Disabled
             } else {
                 self.context.reader_builder.cache_strategy().clone()
@@ -305,7 +305,7 @@ impl FileRangeContext {
         self.base.precise_filter_flat(
             input,
             skip_fields,
-            self.reader_builder.has_flat_primary_key_prefilter(),
+            self.reader_builder.has_predicate_prefilter(),
         )
     }
 
@@ -418,13 +418,13 @@ impl RangeBase {
         &self,
         input: RecordBatch,
         skip_fields: bool,
-        skip_prefiltered_pk_filters: bool,
+        skip_prefiltered_filters: bool,
     ) -> Result<Option<RecordBatch>> {
         let mut tag_decode_state = TagDecodeState::new();
         let mask = self.compute_filter_mask_flat(
             &input,
             skip_fields,
-            skip_prefiltered_pk_filters,
+            skip_prefiltered_filters,
             &mut tag_decode_state,
         )?;
 
@@ -471,7 +471,7 @@ impl RangeBase {
         &self,
         input: &RecordBatch,
         skip_fields: bool,
-        skip_prefiltered_pk_filters: bool,
+        skip_prefiltered_filters: bool,
         tag_decode_state: &mut TagDecodeState,
     ) -> Result<Option<BooleanBuffer>> {
         let mut mask = BooleanBuffer::new_set(input.num_rows());
@@ -495,7 +495,11 @@ impl RangeBase {
 
             // Flat parquet PK prefiltering already applied these tag predicates while refining
             // row selection, so skip them here to avoid decoding/evaluating the same condition twice.
-            if skip_prefiltered_pk_filters && filter_ctx.usable_primary_key_filter() {
+            if should_skip_simple_filter_after_prefilter(
+                skip_prefiltered_filters,
+                skip_fields,
+                filter_ctx,
+            ) {
                 continue;
             }
 
@@ -528,6 +532,61 @@ impl RangeBase {
                 mask = mask.bitand(&result);
             }
             // Non-tag column not found in projection.
+        }
+
+        for filter_ctx in &self.physical_filters {
+            let filter = match filter_ctx.filter() {
+                MaybePhysicalFilter::Filter(filter) => filter,
+                MaybePhysicalFilter::Matched => continue,
+                MaybePhysicalFilter::Pruned => return Ok(None),
+            };
+
+            if skip_fields && filter_ctx.semantic_type() == SemanticType::Field {
+                continue;
+            }
+
+            if should_skip_physical_filter_after_prefilter(
+                skip_prefiltered_filters,
+                skip_fields,
+                filter_ctx,
+            ) {
+                continue;
+            }
+
+            let column =
+                if let Some((idx, _)) = input.schema().column_with_name(filter_ctx.column_name()) {
+                    Some(input.column(idx).clone())
+                } else if filter_ctx.semantic_type() == SemanticType::Tag {
+                    self.maybe_decode_tag_column(
+                        metadata,
+                        filter_ctx.column_id(),
+                        input,
+                        tag_decode_state,
+                    )?
+                } else {
+                    None
+                };
+
+            let Some(column) = column else {
+                continue;
+            };
+
+            let record_batch = RecordBatch::try_new(filter_ctx.schema().clone(), vec![column])
+                .context(NewRecordBatchSnafu)?;
+            let evaluated = filter
+                .evaluate(&record_batch)
+                .context(EvalPartitionFilterSnafu)?;
+            let array = evaluated
+                .into_array(record_batch.num_rows())
+                .context(EvalPartitionFilterSnafu)?;
+            let boolean_array =
+                array
+                    .as_any()
+                    .downcast_ref::<BooleanArray>()
+                    .context(UnexpectedSnafu {
+                        reason: "Failed to downcast physical filter result to BooleanArray",
+                    })?;
+            mask = mask.bitand(boolean_array.values());
         }
 
         Ok(Some(mask))
@@ -667,6 +726,36 @@ impl RangeBase {
         }
 
         RecordBatch::try_new(arrow_schema.clone(), columns).context(NewRecordBatchSnafu)
+    }
+}
+
+fn should_skip_simple_filter_after_prefilter(
+    skip_prefiltered_filters: bool,
+    skip_fields: bool,
+    filter_ctx: &SimpleFilterContext,
+) -> bool {
+    if !skip_prefiltered_filters {
+        return false;
+    }
+
+    match filter_ctx.semantic_type() {
+        SemanticType::Field => !skip_fields,
+        SemanticType::Tag | SemanticType::Timestamp => true,
+    }
+}
+
+fn should_skip_physical_filter_after_prefilter(
+    skip_prefiltered_filters: bool,
+    skip_fields: bool,
+    filter_ctx: &PhysicalFilterContext,
+) -> bool {
+    if !skip_prefiltered_filters {
+        return false;
+    }
+
+    match filter_ctx.semantic_type() {
+        SemanticType::Field => !skip_fields,
+        SemanticType::Tag | SemanticType::Timestamp => true,
     }
 }
 

--- a/src/mito2/src/sst/parquet/file_range.rs
+++ b/src/mito2/src/sst/parquet/file_range.rs
@@ -172,7 +172,6 @@ impl FileRange {
                 self.row_group_idx,
                 self.row_selection.clone(),
                 fetch_metrics,
-                skip_fields,
             ))
             .await?;
 
@@ -325,11 +324,9 @@ impl FileRangeContext {
         row_group_idx: usize,
         row_selection: Option<RowSelection>,
         fetch_metrics: Option<&'a ParquetFetchMetrics>,
-        skip_fields: bool,
     ) -> RowGroupBuildContext<'a> {
         RowGroupBuildContext {
             filters: &self.base.filters,
-            skip_fields,
             row_group_idx,
             row_selection,
             fetch_metrics,

--- a/src/mito2/src/sst/parquet/file_range.rs
+++ b/src/mito2/src/sst/parquet/file_range.rs
@@ -50,8 +50,8 @@ use crate::sst::parquet::flat_format::{
     DecodedPrimaryKeys, FlatReadFormat, decode_primary_keys, time_index_column_index,
 };
 use crate::sst::parquet::reader::{
-    FlatRowGroupReader, MaybeFilter, MaybePhysicalFilter, PhysicalFilterContext,
-    RowGroupBuildContext, RowGroupReaderBuilder, SimpleFilterContext,
+    FlatRowGroupReader, MaybeFilter, RowGroupBuildContext, RowGroupReaderBuilder,
+    SimpleFilterContext,
 };
 use crate::sst::parquet::row_group::ParquetFetchMetrics;
 use crate::sst::parquet::stats::RowGroupPruningStats;
@@ -172,7 +172,6 @@ impl FileRange {
                 self.row_group_idx,
                 self.row_selection.clone(),
                 fetch_metrics,
-                skip_fields,
             ))
             .await?;
 
@@ -322,13 +321,11 @@ impl FileRangeContext {
         row_group_idx: usize,
         row_selection: Option<RowSelection>,
         fetch_metrics: Option<&'a ParquetFetchMetrics>,
-        skip_fields: bool,
     ) -> RowGroupBuildContext<'a> {
         RowGroupBuildContext {
             row_group_idx,
             row_selection,
             fetch_metrics,
-            skip_fields,
         }
     }
 
@@ -706,7 +703,7 @@ mod tests {
     #[test]
     fn test_compute_filter_mask_flat_does_not_postfilter_physical_filters() {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
-        let read_format = ReadFormat::new_flat(
+        let read_format = FlatReadFormat::new(
             metadata.clone(),
             metadata.column_metadatas.iter().map(|c| c.column_id),
             None,

--- a/src/mito2/src/sst/parquet/file_range.rs
+++ b/src/mito2/src/sst/parquet/file_range.rs
@@ -303,11 +303,7 @@ impl FileRangeContext {
         input: RecordBatch,
         skip_fields: bool,
     ) -> Result<Option<RecordBatch>> {
-        self.base.precise_filter_flat(
-            input,
-            skip_fields,
-            self.reader_builder.has_predicate_prefilter(),
-        )
+        self.base.precise_filter_flat(input, skip_fields)
     }
 
     pub(crate) fn pre_filter_mode(&self) -> PreFilterMode {
@@ -415,15 +411,9 @@ impl RangeBase {
         &self,
         input: RecordBatch,
         skip_fields: bool,
-        has_prefilter: bool,
     ) -> Result<Option<RecordBatch>> {
         let mut tag_decode_state = TagDecodeState::new();
-        let mask = self.compute_filter_mask_flat(
-            &input,
-            skip_fields,
-            has_prefilter,
-            &mut tag_decode_state,
-        )?;
+        let mask = self.compute_filter_mask_flat(&input, skip_fields, &mut tag_decode_state)?;
 
         // If mask is None, the entire batch is filtered out
         let Some(mut mask) = mask else {
@@ -469,7 +459,6 @@ impl RangeBase {
         &self,
         input: &RecordBatch,
         skip_fields: bool,
-        has_prefilter: bool,
         tag_decode_state: &mut TagDecodeState,
     ) -> Result<Option<BooleanBuffer>> {
         let mut mask = BooleanBuffer::new_set(input.num_rows());
@@ -488,12 +477,6 @@ impl RangeBase {
 
             // Skip field filters if skip_fields is true
             if skip_fields && filter_ctx.semantic_type() == SemanticType::Field {
-                continue;
-            }
-
-            // Skip simple filters only when parquet prefilter already evaluated the same
-            // condition while refining row selection.
-            if should_skip_simple_filter_after_prefilter(has_prefilter, filter_ctx) {
                 continue;
             }
 
@@ -668,17 +651,6 @@ impl RangeBase {
     }
 }
 
-fn should_skip_simple_filter_after_prefilter(
-    has_prefilter: bool,
-    filter_ctx: &SimpleFilterContext,
-) -> bool {
-    if !has_prefilter {
-        return false;
-    }
-
-    filter_ctx.usable_prefilter()
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -715,27 +687,20 @@ mod tests {
     }
 
     #[test]
-    fn test_compute_filter_mask_flat_skips_prefiltered_pk_filters() {
+    fn test_compute_filter_mask_flat_applies_remaining_simple_filters() {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
-        let mut filters = vec![
+        let filters = vec![
             SimpleFilterContext::new_opt(&metadata, None, &col("tag_0").eq(lit("a"))).unwrap(),
             SimpleFilterContext::new_opt(&metadata, None, &col("field_0").gt(lit(1_u64))).unwrap(),
         ];
-        filters[0].set_usable_prefilter(true);
         let base = new_test_range_base(filters);
         let batch = new_record_batch_with_custom_sequence(&["b", "x"], 0, 4, 1);
 
-        let mask_without_skip = base
-            .compute_filter_mask_flat(&batch, false, false, &mut TagDecodeState::new())
+        let mask = base
+            .compute_filter_mask_flat(&batch, false, &mut TagDecodeState::new())
             .unwrap()
             .unwrap();
-        assert_eq!(mask_without_skip.count_set_bits(), 0);
-
-        let mask_with_skip = base
-            .compute_filter_mask_flat(&batch, false, true, &mut TagDecodeState::new())
-            .unwrap()
-            .unwrap();
-        assert_eq!(mask_with_skip.count_set_bits(), 2);
+        assert_eq!(mask.count_set_bits(), 0);
     }
 
     #[test]
@@ -759,16 +724,10 @@ mod tests {
         let base = new_test_range_base(vec![]);
         let batch = new_record_batch_with_custom_sequence(&["b", "x"], 0, 4, 1);
 
-        let mask_without_skip = base
-            .compute_filter_mask_flat(&batch, false, false, &mut TagDecodeState::new())
+        let mask = base
+            .compute_filter_mask_flat(&batch, false, &mut TagDecodeState::new())
             .unwrap()
             .unwrap();
-        assert_eq!(mask_without_skip.count_set_bits(), 4);
-
-        let mask_with_skip = base
-            .compute_filter_mask_flat(&batch, false, true, &mut TagDecodeState::new())
-            .unwrap()
-            .unwrap();
-        assert_eq!(mask_with_skip.count_set_bits(), 4);
+        assert_eq!(mask.count_set_bits(), 4);
     }
 }

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -18,13 +18,13 @@
 //! (the prefilter phase), applying filters to compute a refined row selection,
 //! then reading the remaining columns with the refined selection.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::ops::{BitAnd, Range};
 use std::sync::Arc;
 
 use api::v1::SemanticType;
 use common_recordbatch::filter::SimpleFilterEvaluator;
-use datatypes::arrow::array::{ArrayRef, BinaryArray, BooleanArray, BooleanBufferBuilder};
+use datatypes::arrow::array::{BinaryArray, BooleanArray, BooleanBufferBuilder};
 use datatypes::arrow::buffer::BooleanBuffer;
 use datatypes::arrow::record_batch::RecordBatch;
 use futures::StreamExt;
@@ -33,24 +33,19 @@ use parquet::arrow::ProjectionMask;
 use parquet::arrow::arrow_reader::RowSelection;
 use parquet::schema::types::SchemaDescriptor;
 use snafu::{OptionExt, ResultExt};
-use store_api::codec::PrimaryKeyEncoding;
 use store_api::metadata::{RegionMetadata, RegionMetadataRef};
-use store_api::storage::ColumnId;
 use store_api::storage::consts::PRIMARY_KEY_COLUMN_NAME;
 
 use crate::error::{
     ComputeArrowSnafu, DecodeSnafu, EvalPartitionFilterSnafu, NewRecordBatchSnafu,
     ReadParquetSnafu, RecordBatchSnafu, Result, UnexpectedSnafu,
 };
-use crate::sst::parquet::flat_format::{
-    DecodedPrimaryKeys, FlatReadFormat, decode_primary_keys, primary_key_column_index,
-};
+use crate::sst::parquet::flat_format::{FlatReadFormat, primary_key_column_index};
 use crate::sst::parquet::format::PrimaryKeyArray;
 use crate::sst::parquet::reader::{
     MaybeFilter, MaybePhysicalFilter, PhysicalFilterContext, RowGroupBuildContext,
     RowGroupReaderBuilder, SimpleFilterContext,
 };
-use crate::sst::parquet::row_selection::row_selection_from_row_ranges_exact;
 
 pub(crate) fn matching_row_ranges_by_primary_key(
     input: &RecordBatch,
@@ -229,33 +224,16 @@ impl PrimaryKeyFilter for CachedPrimaryKeyFilter {
     }
 }
 
-enum PrefilterVariant {
-    /// Primary-key prefiltering for primary-key-format data.
-    PrimaryKey {
-        /// PK filter instance.
-        pk_filter: Box<dyn PrimaryKeyFilter>,
-        /// Index of the PK column within the prefilter projection batch.
-        /// This is 0 when we project only the PK column.
-        pk_column_index: usize,
-    },
-    /// General prefiltering for mixed simple and physical filters.
-    General {
-        filters: Vec<SimpleFilterContext>,
-        physical_filters: Vec<PhysicalFilterContext>,
-        codec: Arc<dyn PrimaryKeyCodec>,
-        metadata: RegionMetadataRef,
-    },
-}
-
 /// Context for prefiltering a row group.
-///
-/// Currently supports primary key (PK) filtering only.
-/// Will be extended with simple column filters and physical filters in the future.
 pub(crate) struct PrefilterContext {
     /// Projection mask for reading prefilter columns.
     projection: ProjectionMask,
-    /// Filter execution strategy for this prefilter context.
-    variant: PrefilterVariant,
+    /// Optional PK filter for legacy primary-key-format parquet.
+    pk_filter: Option<Box<dyn PrimaryKeyFilter>>,
+    /// Simple filters that can be evaluated directly from the prefilter batch.
+    filters: Vec<SimpleFilterContext>,
+    /// Physical filters that can be evaluated directly from the prefilter batch.
+    physical_filters: Vec<PhysicalFilterContext>,
 }
 
 /// Pre-built state for constructing [PrefilterContext] per row group.
@@ -265,22 +243,11 @@ pub(crate) struct PrefilterContext {
 /// is created via [PrefilterContextBuilder::build()] for each row group.
 pub(crate) struct PrefilterContextBuilder {
     projection: ProjectionMask,
-    variant: PrefilterBuilderVariant,
-}
-
-enum PrefilterBuilderVariant {
-    PrimaryKey {
-        pk_column_index: usize,
-        codec: Arc<dyn PrimaryKeyCodec>,
-        metadata: RegionMetadataRef,
-        pk_filters: Arc<Vec<SimpleFilterEvaluator>>,
-    },
-    General {
-        filters: Vec<SimpleFilterContext>,
-        physical_filters: Vec<PhysicalFilterContext>,
-        codec: Arc<dyn PrimaryKeyCodec>,
-        metadata: RegionMetadataRef,
-    },
+    pk_filters: Option<Arc<Vec<SimpleFilterEvaluator>>>,
+    filters: Vec<SimpleFilterContext>,
+    physical_filters: Vec<PhysicalFilterContext>,
+    codec: Arc<dyn PrimaryKeyCodec>,
+    metadata: RegionMetadataRef,
 }
 
 impl PrefilterContextBuilder {
@@ -300,36 +267,37 @@ impl PrefilterContextBuilder {
         field_prefilter_enabled: bool,
     ) -> Option<Self> {
         let metadata = read_format.metadata();
-        let always_prefilter_pk = primary_key_filters
-            .filter(|filters| !filters.is_empty())
-            .is_some_and(|_| {
-                !metadata.primary_key.is_empty() && !read_format.batch_has_raw_pk_columns()
-            });
+        let use_raw_tag_columns = read_format.batch_has_raw_pk_columns();
+        let pk_filters = (!use_raw_tag_columns)
+            .then(|| {
+                primary_key_filters
+                    .filter(|filters| !filters.is_empty())
+                    .cloned()
+            })
+            .flatten();
 
         let mut prefilter_column_names = HashSet::new();
-        let mut general_filters = Vec::new();
-        let mut general_physical_filters = Vec::new();
+        let mut prefilter_filters = Vec::new();
+        let mut prefilter_physical_filters = Vec::new();
 
         for filter_ctx in filters {
             if !field_prefilter_enabled && filter_ctx.semantic_type() == SemanticType::Field {
                 continue;
             }
 
-            general_filters.push(filter_ctx.clone());
-
             let filter = match filter_ctx.filter() {
                 MaybeFilter::Filter(filter) => filter,
                 MaybeFilter::Matched | MaybeFilter::Pruned => continue,
             };
 
-            prefilter_column_names.insert(filter.column_name().to_string());
-
-            if filter_ctx.semantic_type() == SemanticType::Tag
-                && read_format
-                    .arrow_schema()
-                    .column_with_name(filter.column_name())
-                    .is_none()
+            if read_format
+                .arrow_schema()
+                .column_with_name(filter.column_name())
+                .is_some()
             {
+                prefilter_column_names.insert(filter.column_name().to_string());
+                prefilter_filters.push(filter_ctx.clone());
+            } else if filter_ctx.usable_primary_key_filter() && pk_filters.is_some() {
                 prefilter_column_names.insert(PRIMARY_KEY_COLUMN_NAME.to_string());
             }
         }
@@ -339,21 +307,17 @@ impl PrefilterContextBuilder {
                 continue;
             }
 
-            general_physical_filters.push(filter_ctx.clone());
-
             if !matches!(filter_ctx.filter(), MaybePhysicalFilter::Filter(_)) {
                 continue;
             }
 
-            prefilter_column_names.insert(filter_ctx.column_name().to_string());
-
-            if filter_ctx.semantic_type() == SemanticType::Tag
-                && read_format
-                    .arrow_schema()
-                    .column_with_name(filter_ctx.column_name())
-                    .is_none()
+            if read_format
+                .arrow_schema()
+                .column_with_name(filter_ctx.column_name())
+                .is_some()
             {
-                prefilter_column_names.insert(PRIMARY_KEY_COLUMN_NAME.to_string());
+                prefilter_column_names.insert(filter_ctx.column_name().to_string());
+                prefilter_physical_filters.push(filter_ctx.clone());
             }
         }
 
@@ -363,76 +327,37 @@ impl PrefilterContextBuilder {
             parquet_schema,
         );
 
-        if always_prefilter_pk
-            && general_physical_filters.is_empty()
-            && !general_filters.is_empty()
-            && general_filters
-                .iter()
-                .all(SimpleFilterContext::usable_primary_key_filter)
-            && prefilter_count == 1
-        {
-            let pk_column_index = 0;
-            return Some(Self {
-                projection,
-                variant: PrefilterBuilderVariant::PrimaryKey {
-                    pk_column_index,
-                    codec: Arc::clone(codec),
-                    metadata: metadata.clone(),
-                    pk_filters: Arc::clone(primary_key_filters?),
-                },
-            });
-        }
-
         if prefilter_count == 0 {
             return None;
         }
 
-        if !always_prefilter_pk && prefilter_count >= read_format.projection_indices().len() {
+        if pk_filters.is_none() && prefilter_count >= read_format.projection_indices().len() {
             return None;
         }
 
         Some(Self {
             projection,
-            variant: PrefilterBuilderVariant::General {
-                filters: general_filters,
-                physical_filters: general_physical_filters,
-                codec: Arc::clone(codec),
-                metadata: metadata.clone(),
-            },
+            pk_filters,
+            filters: prefilter_filters,
+            physical_filters: prefilter_physical_filters,
+            codec: Arc::clone(codec),
+            metadata: metadata.clone(),
         })
     }
 
     /// Builds a [PrefilterContext] for a specific row group.
     pub(crate) fn build(&self) -> PrefilterContext {
-        let variant = match &self.variant {
-            PrefilterBuilderVariant::PrimaryKey {
-                pk_column_index,
-                codec,
-                metadata,
-                pk_filters,
-            } => {
-                let pk_filter = codec.primary_key_filter(metadata, Arc::clone(pk_filters), false);
-                let pk_filter = Box::new(CachedPrimaryKeyFilter::new(pk_filter));
-                PrefilterVariant::PrimaryKey {
-                    pk_filter,
-                    pk_column_index: *pk_column_index,
-                }
-            }
-            PrefilterBuilderVariant::General {
-                filters,
-                physical_filters,
-                codec,
-                metadata,
-            } => PrefilterVariant::General {
-                filters: filters.clone(),
-                physical_filters: physical_filters.clone(),
-                codec: Arc::clone(codec),
-                metadata: metadata.clone(),
-            },
-        };
+        let pk_filter = self.pk_filters.as_ref().map(|pk_filters| {
+            let pk_filter =
+                self.codec
+                    .primary_key_filter(&self.metadata, Arc::clone(pk_filters), false);
+            Box::new(CachedPrimaryKeyFilter::new(pk_filter)) as Box<dyn PrimaryKeyFilter>
+        });
         PrefilterContext {
             projection: self.projection.clone(),
-            variant,
+            pk_filter,
+            filters: self.filters.clone(),
+            physical_filters: self.physical_filters.clone(),
         }
     }
 }
@@ -454,121 +379,15 @@ pub(crate) async fn execute_prefilter(
     reader_builder: &RowGroupReaderBuilder,
     build_ctx: &RowGroupBuildContext<'_>,
 ) -> Result<PrefilterResult> {
-    match &mut prefilter_ctx.variant {
-        PrefilterVariant::PrimaryKey {
-            pk_filter,
-            pk_column_index,
-        } => {
-            execute_primary_key_prefilter(
-                prefilter_ctx.projection.clone(),
-                *pk_column_index,
-                pk_filter.as_mut(),
-                reader_builder,
-                build_ctx,
-            )
-            .await
-        }
-        PrefilterVariant::General {
-            filters,
-            physical_filters,
-            codec,
-            metadata,
-        } => {
-            execute_general_prefilter(
-                prefilter_ctx.projection.clone(),
-                filters,
-                physical_filters,
-                codec.as_ref(),
-                metadata,
-                reader_builder,
-                build_ctx,
-            )
-            .await
-        }
-    }
-}
-
-async fn execute_primary_key_prefilter(
-    projection: ProjectionMask,
-    pk_column_index: usize,
-    pk_filter: &mut dyn PrimaryKeyFilter,
-    reader_builder: &RowGroupReaderBuilder,
-    build_ctx: &RowGroupBuildContext<'_>,
-) -> Result<PrefilterResult> {
-    // Reads PK column only.
-    let mut pk_stream = reader_builder
-        .build_with_projection(
-            build_ctx.row_group_idx,
-            build_ctx.row_selection.clone(),
-            projection,
-            build_ctx.fetch_metrics,
-        )
-        .await?;
-
-    // Applies PK filter to each batch and collect matching row ranges.
-    let mut matched_row_ranges: Vec<Range<usize>> = Vec::new();
-    let mut row_offset = 0;
-    let mut rows_before_filter = 0usize;
-
-    while let Some(batch_result) = pk_stream.next().await {
-        let batch = batch_result.context(ReadParquetSnafu {
-            path: reader_builder.file_path(),
-        })?;
-        let batch_num_rows = batch.num_rows();
-        if batch_num_rows == 0 {
-            continue;
-        }
-        rows_before_filter += batch_num_rows;
-
-        let ranges = matching_row_ranges_by_primary_key(&batch, pk_column_index, pk_filter)?;
-        matched_row_ranges.extend(
-            ranges
-                .into_iter()
-                .map(|range| (range.start + row_offset)..(range.end + row_offset)),
-        );
-        row_offset += batch_num_rows;
-    }
-
-    // Converts matched ranges to RowSelection.
-    let rows_selected: usize = matched_row_ranges.iter().map(|r| r.end - r.start).sum();
-    let filtered_rows = rows_before_filter.saturating_sub(rows_selected);
-
-    let refined_selection = if rows_selected == 0 {
-        RowSelection::from(vec![])
-    } else {
-        // Build the prefilter selection relative to the yielded rows
-        // (not total_rows), since matched_row_ranges are offsets within
-        // the rows actually read from the stream.
-        let prefilter_selection =
-            row_selection_from_row_ranges_exact(matched_row_ranges.into_iter(), rows_before_filter);
-
-        // Use and_then to apply prefilter selection within the context
-        // of the original selection, since prefilter offsets are relative
-        // to the original selection's selected rows.
-        match &build_ctx.row_selection {
-            Some(original) => original.and_then(&prefilter_selection),
-            None => prefilter_selection,
-        }
-    };
-
-    Ok(PrefilterResult {
-        refined_selection,
-        filtered_rows,
-    })
-}
-
-struct TagDecodeState {
-    decoded_pks: Option<DecodedPrimaryKeys>,
-    decoded_tag_cache: HashMap<ColumnId, ArrayRef>,
-}
-
-impl TagDecodeState {
-    fn new() -> Self {
-        Self {
-            decoded_pks: None,
-            decoded_tag_cache: HashMap::new(),
-        }
-    }
+    execute_general_prefilter(
+        prefilter_ctx.projection.clone(),
+        &mut prefilter_ctx.pk_filter,
+        &prefilter_ctx.filters,
+        &prefilter_ctx.physical_filters,
+        reader_builder,
+        build_ctx,
+    )
+    .await
 }
 
 fn compute_projection_mask(
@@ -591,10 +410,9 @@ fn compute_projection_mask(
 
 async fn execute_general_prefilter(
     projection: ProjectionMask,
+    pk_filter: &mut Option<Box<dyn PrimaryKeyFilter>>,
     filters: &[SimpleFilterContext],
     physical_filters: &[PhysicalFilterContext],
-    codec: &dyn PrimaryKeyCodec,
-    metadata: &RegionMetadataRef,
     reader_builder: &RowGroupReaderBuilder,
     build_ctx: &RowGroupBuildContext<'_>,
 ) -> Result<PrefilterResult> {
@@ -621,11 +439,16 @@ async fn execute_general_prefilter(
         }
         rows_before_filter += num_rows;
 
-        let batch_mask =
-            match apply_filters_to_batch(&batch, filters, physical_filters, metadata, codec)? {
-                Some(mask) => mask,
-                None => BooleanBuffer::new_unset(num_rows),
-            };
+        let batch_mask = match apply_filters_to_batch(
+            &batch,
+            pk_filter,
+            filters,
+            physical_filters,
+            reader_builder.file_path(),
+        )? {
+            Some(mask) => mask,
+            None => BooleanBuffer::new_unset(num_rows),
+        };
         rows_selected += batch_mask.count_set_bits();
         filter_arrays.push(BooleanArray::from(batch_mask));
     }
@@ -649,13 +472,29 @@ async fn execute_general_prefilter(
 
 fn apply_filters_to_batch(
     batch: &RecordBatch,
+    pk_filter: &mut Option<Box<dyn PrimaryKeyFilter>>,
     filters: &[SimpleFilterContext],
     physical_filters: &[PhysicalFilterContext],
-    metadata: &RegionMetadataRef,
-    codec: &dyn PrimaryKeyCodec,
+    file_path: &str,
 ) -> Result<Option<BooleanBuffer>> {
     let mut mask = BooleanBuffer::new_set(batch.num_rows());
-    let mut tag_decode_state = TagDecodeState::new();
+
+    if let Some(pk_filter) = pk_filter.as_mut() {
+        // Prefilter reads a reduced projection. For PK prefilter, the encoded
+        // primary key column is always appended as the last projected column,
+        // while `__sequence` and `__op_type` are not read.
+        let pk_column_index = batch.num_columns() - 1;
+        let matched_row_ranges =
+            matching_row_ranges_by_primary_key(batch, pk_column_index, pk_filter.as_mut())?;
+        let mut builder = BooleanBufferBuilder::new(batch.num_rows());
+        builder.append_n(batch.num_rows(), false);
+        for range in matched_row_ranges {
+            for row in range {
+                builder.set_bit(row, true);
+            }
+        }
+        mask = mask.bitand(&builder.finish());
+    }
 
     for filter_ctx in filters {
         let filter = match filter_ctx.filter() {
@@ -664,23 +503,18 @@ fn apply_filters_to_batch(
             MaybeFilter::Pruned => return Ok(None),
         };
 
-        let column = if let Some((idx, _)) = batch.schema().column_with_name(filter.column_name()) {
-            Some(batch.column(idx).clone())
-        } else if filter_ctx.semantic_type() == SemanticType::Tag {
-            maybe_decode_tag_column(
-                metadata,
-                filter_ctx.column_id(),
-                batch,
-                &mut tag_decode_state,
-                codec,
-            )?
-        } else {
-            None
-        };
-
-        let Some(column) = column else {
-            continue;
-        };
+        let (idx, _) = batch
+            .schema()
+            .column_with_name(filter.column_name())
+            .context(UnexpectedSnafu {
+                reason: format!(
+                    "Prefilter column '{}' (id {}) not found in batch for file {}",
+                    filter.column_name(),
+                    filter_ctx.column_id(),
+                    file_path
+                ),
+            })?;
+        let column = batch.column(idx).clone();
         let result = filter.evaluate_array(&column).context(RecordBatchSnafu)?;
         mask = mask.bitand(&result);
     }
@@ -692,24 +526,18 @@ fn apply_filters_to_batch(
             MaybePhysicalFilter::Pruned => return Ok(None),
         };
 
-        let column =
-            if let Some((idx, _)) = batch.schema().column_with_name(filter_ctx.column_name()) {
-                Some(batch.column(idx).clone())
-            } else if filter_ctx.semantic_type() == SemanticType::Tag {
-                maybe_decode_tag_column(
-                    metadata,
+        let (idx, _) = batch
+            .schema()
+            .column_with_name(filter_ctx.column_name())
+            .context(UnexpectedSnafu {
+                reason: format!(
+                    "Prefilter physical column '{}' (id {}) not found in batch for file {}",
+                    filter_ctx.column_name(),
                     filter_ctx.column_id(),
-                    batch,
-                    &mut tag_decode_state,
-                    codec,
-                )?
-            } else {
-                None
-            };
-
-        let Some(column) = column else {
-            continue;
-        };
+                    file_path
+                ),
+            })?;
+        let column = batch.column(idx).clone();
 
         let record_batch = RecordBatch::try_new(filter_ctx.schema().clone(), vec![column])
             .context(NewRecordBatchSnafu)?;
@@ -736,49 +564,6 @@ fn apply_filters_to_batch(
     }
 }
 
-fn maybe_decode_tag_column(
-    metadata: &RegionMetadataRef,
-    column_id: ColumnId,
-    input: &RecordBatch,
-    tag_decode_state: &mut TagDecodeState,
-    codec: &dyn PrimaryKeyCodec,
-) -> Result<Option<ArrayRef>> {
-    let Some(pk_index) = metadata.primary_key_index(column_id) else {
-        return Ok(None);
-    };
-
-    if let Some(cached_column) = tag_decode_state.decoded_tag_cache.get(&column_id) {
-        return Ok(Some(cached_column.clone()));
-    }
-
-    if tag_decode_state.decoded_pks.is_none() {
-        tag_decode_state.decoded_pks = Some(decode_primary_keys(codec, input)?);
-    }
-
-    let pk_index = if codec.encoding() == PrimaryKeyEncoding::Sparse {
-        None
-    } else {
-        Some(pk_index)
-    };
-    let Some(column_index) = metadata.column_index_by_id(column_id) else {
-        return Ok(None);
-    };
-    let Some(decoded) = tag_decode_state.decoded_pks.as_ref() else {
-        return Ok(None);
-    };
-
-    let column_metadata = &metadata.column_metadatas[column_index];
-    let tag_column = decoded.get_tag_column(
-        column_id,
-        pk_index,
-        &column_metadata.column_schema.data_type,
-    )?;
-    tag_decode_state
-        .decoded_tag_cache
-        .insert(column_id, tag_column.clone());
-    Ok(Some(tag_column))
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -798,7 +583,8 @@ mod tests {
     use crate::sst::internal_fields;
     use crate::sst::parquet::flat_format::{FlatReadFormat, primary_key_column_index};
     use crate::test_util::sst_util::{
-        new_primary_key, sst_region_metadata, sst_region_metadata_with_encoding,
+        new_primary_key, new_record_batch_with_custom_sequence, sst_region_metadata,
+        sst_region_metadata_with_encoding,
     };
 
     #[test]
@@ -884,7 +670,7 @@ mod tests {
 
     fn new_physical_filter_contexts(
         metadata: &RegionMetadataRef,
-        read_format: &ReadFormat,
+        read_format: &FlatReadFormat,
         exprs: &[datafusion_expr::Expr],
     ) -> Vec<PhysicalFilterContext> {
         exprs
@@ -893,7 +679,7 @@ mod tests {
             .collect()
     }
 
-    fn parquet_schema(read_format: &ReadFormat) -> SchemaDescriptor {
+    fn parquet_schema(read_format: &FlatReadFormat) -> SchemaDescriptor {
         ArrowSchemaConverter::new()
             .convert(read_format.arrow_schema())
             .unwrap()
@@ -945,6 +731,53 @@ mod tests {
                 pk_array,
                 Arc::new(UInt64Array::from(vec![1; primary_keys.len()])),
                 Arc::new(UInt8Array::from(vec![1; primary_keys.len()])),
+            ],
+        )
+        .unwrap()
+    }
+
+    fn new_prefilter_batch(primary_keys: &[&[u8]], field_values: &[u64]) -> RecordBatch {
+        assert_eq!(primary_keys.len(), field_values.len());
+
+        let metadata = Arc::new(sst_region_metadata());
+        let arrow_schema = metadata.schema.arrow_schema();
+        let field_column = arrow_schema
+            .field(arrow_schema.index_of("field_0").unwrap())
+            .clone();
+        let time_index_column = arrow_schema
+            .field(arrow_schema.index_of("ts").unwrap())
+            .clone();
+        let schema = Arc::new(Schema::new(vec![
+            field_column,
+            time_index_column,
+            internal_fields()[0].as_ref().clone(),
+        ]));
+
+        let mut dict_values = Vec::new();
+        let mut keys = Vec::with_capacity(primary_keys.len());
+        for pk in primary_keys {
+            let key = dict_values
+                .iter()
+                .position(|existing: &&[u8]| existing == pk)
+                .unwrap_or_else(|| {
+                    dict_values.push(*pk);
+                    dict_values.len() - 1
+                });
+            keys.push(key as u32);
+        }
+        let pk_array: ArrayRef = Arc::new(DictionaryArray::<UInt32Type>::new(
+            UInt32Array::from(keys),
+            Arc::new(BinaryArray::from_iter_values(dict_values.iter().copied())),
+        ));
+
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(UInt64Array::from(field_values.to_vec())),
+                Arc::new(TimestampMillisecondArray::from_iter_values(
+                    0..primary_keys.len() as i64,
+                )),
+                pk_array,
             ],
         )
         .unwrap()
@@ -1017,7 +850,7 @@ mod tests {
     fn test_prefilter_builder_restricts_field_filters_to_append_mode() {
         let metadata: RegionMetadataRef =
             Arc::new(sst_region_metadata_with_encoding(PrimaryKeyEncoding::Dense));
-        let read_format = ReadFormat::new_flat(
+        let read_format = FlatReadFormat::new(
             metadata.clone(),
             metadata.column_metadatas.iter().map(|c| c.column_id),
             None,
@@ -1053,13 +886,69 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_filters_to_batch_decodes_tag_columns() {
+    fn test_apply_filters_to_batch_uses_flat_tag_columns_directly() {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
-        let codec = build_primary_key_codec(metadata.as_ref());
         let filters = new_simple_filter_contexts(&metadata, &[col("tag_0").eq(lit("a"))]);
+        let batch = new_record_batch_with_custom_sequence(&["a", "x"], 0, 4, 1);
+
+        let mut no_pk_filter = None;
+        let mask = apply_filters_to_batch(&batch, &mut no_pk_filter, &filters, &[], "test")
+            .unwrap()
+            .unwrap();
+        assert_eq!(mask.count_set_bits(), 4);
+    }
+
+    #[test]
+    fn test_apply_filters_to_batch_errors_on_missing_selected_column() {
+        let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
+        let filters = new_simple_filter_contexts(&metadata, &[col("tag_0").eq(lit("a"))]);
+        let pk = new_primary_key(&["a", "x"]);
+        let batch = new_raw_batch(&[pk.as_slice()], &[10]);
+
+        let mut no_pk_filter = None;
+        let err =
+            apply_filters_to_batch(&batch, &mut no_pk_filter, &filters, &[], "test").unwrap_err();
+        let err = err.to_string();
+        assert!(err.contains("Prefilter column"));
+        assert!(err.contains("tag_0"));
+    }
+
+    #[test]
+    fn test_apply_filters_to_batch_evaluates_physical_filters() {
+        let metadata: RegionMetadataRef =
+            Arc::new(sst_region_metadata_with_encoding(PrimaryKeyEncoding::Dense));
+        let read_format = FlatReadFormat::new(
+            metadata.clone(),
+            metadata.column_metadatas.iter().map(|c| c.column_id),
+            None,
+            "test",
+            false,
+        )
+        .unwrap();
+        let expr = (col("field_0") + lit(1_u64)).gt(lit(11_u64));
+        let physical_filters = new_physical_filter_contexts(&metadata, &read_format, &[expr]);
+        let pk = new_primary_key(&["a", "x"]);
+        let batch = new_raw_batch(&[pk.as_slice(), pk.as_slice(), pk.as_slice()], &[9, 10, 11]);
+
+        let mut no_pk_filter = None;
+        let mask =
+            apply_filters_to_batch(&batch, &mut no_pk_filter, &[], &physical_filters, "test")
+                .unwrap()
+                .unwrap();
+        assert_eq!(mask.count_set_bits(), 1);
+    }
+
+    #[test]
+    fn test_apply_filters_to_batch_uses_last_projected_column_for_pk_prefilter() {
+        let metadata = Arc::new(sst_region_metadata());
+        let filters = Arc::new(new_test_filters(&[col("tag_0").eq(lit("a"))]));
+        let mut pk_filter = Some(Box::new(CachedPrimaryKeyFilter::new(
+            build_primary_key_codec(metadata.as_ref())
+                .primary_key_filter(&metadata, filters, false),
+        )) as Box<dyn PrimaryKeyFilter>);
         let pk_a = new_primary_key(&["a", "x"]);
         let pk_b = new_primary_key(&["b", "x"]);
-        let batch = new_raw_batch(
+        let batch = new_prefilter_batch(
             &[
                 pk_a.as_slice(),
                 pk_a.as_slice(),
@@ -1069,34 +958,10 @@ mod tests {
             &[10, 11, 12, 13],
         );
 
-        let mask = apply_filters_to_batch(&batch, &filters, &[], &metadata, codec.as_ref())
+        let mask = apply_filters_to_batch(&batch, &mut pk_filter, &[], &[], "test")
             .unwrap()
             .unwrap();
+
         assert_eq!(mask.count_set_bits(), 2);
-    }
-
-    #[test]
-    fn test_apply_filters_to_batch_evaluates_physical_filters() {
-        let metadata: RegionMetadataRef =
-            Arc::new(sst_region_metadata_with_encoding(PrimaryKeyEncoding::Dense));
-        let read_format = ReadFormat::new_flat(
-            metadata.clone(),
-            metadata.column_metadatas.iter().map(|c| c.column_id),
-            None,
-            "test",
-            false,
-        )
-        .unwrap();
-        let codec = build_primary_key_codec(metadata.as_ref());
-        let expr = (col("field_0") + lit(1_u64)).gt(lit(11_u64));
-        let physical_filters = new_physical_filter_contexts(&metadata, &read_format, &[expr]);
-        let pk = new_primary_key(&["a", "x"]);
-        let batch = new_raw_batch(&[pk.as_slice(), pk.as_slice(), pk.as_slice()], &[9, 10, 11]);
-
-        let mask =
-            apply_filters_to_batch(&batch, &[], &physical_filters, &metadata, codec.as_ref())
-                .unwrap()
-                .unwrap();
-        assert_eq!(mask.count_set_bits(), 1);
     }
 }

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -368,22 +368,6 @@ pub(crate) struct PrefilterResult {
 ///
 /// Reads only the prefilter columns (currently the PK dictionary column),
 /// applies filters, and returns a refined [RowSelection].
-pub(crate) async fn execute_prefilter(
-    prefilter_ctx: &mut PrefilterContext,
-    reader_builder: &RowGroupReaderBuilder,
-    build_ctx: &RowGroupBuildContext<'_>,
-) -> Result<PrefilterResult> {
-    execute_general_prefilter(
-        prefilter_ctx.projection.clone(),
-        &mut prefilter_ctx.pk_filter,
-        &prefilter_ctx.filters,
-        &prefilter_ctx.physical_filters,
-        reader_builder,
-        build_ctx,
-    )
-    .await
-}
-
 fn compute_projection_mask(
     column_names: &HashSet<String>,
     arrow_schema: &datatypes::arrow::datatypes::SchemaRef,
@@ -402,11 +386,8 @@ fn compute_projection_mask(
     )
 }
 
-async fn execute_general_prefilter(
-    projection: ProjectionMask,
-    pk_filter: &mut Option<Box<dyn PrimaryKeyFilter>>,
-    filters: &[SimpleFilterContext],
-    physical_filters: &[PhysicalFilterContext],
+pub(crate) async fn execute_prefilter(
+    prefilter_ctx: &mut PrefilterContext,
     reader_builder: &RowGroupReaderBuilder,
     build_ctx: &RowGroupBuildContext<'_>,
 ) -> Result<PrefilterResult> {
@@ -414,7 +395,7 @@ async fn execute_general_prefilter(
         .build_with_projection(
             build_ctx.row_group_idx,
             build_ctx.row_selection.clone(),
-            projection,
+            prefilter_ctx.projection.clone(),
             build_ctx.fetch_metrics,
         )
         .await?;
@@ -435,9 +416,9 @@ async fn execute_general_prefilter(
 
         let batch_mask = match apply_filters_to_batch(
             &batch,
-            pk_filter,
-            filters,
-            physical_filters,
+            &mut prefilter_ctx.pk_filter,
+            &prefilter_ctx.filters,
+            &prefilter_ctx.physical_filters,
             reader_builder.file_path(),
         )? {
             Some(mask) => mask,

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -902,7 +902,7 @@ mod tests {
             false,
         )
         .unwrap();
-        let expr = (col("field_0") + lit(1_u64)).gt(lit(11_u64));
+        let expr = col("field_0").in_list(vec![lit(11_u64)], false);
         let physical_filters = new_physical_filter_contexts(&metadata, &read_format, &[expr]);
         let pk = new_primary_key(&["a", "x"]);
         let batch = new_raw_batch(&[pk.as_slice(), pk.as_slice(), pk.as_slice()], &[9, 10, 11]);

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -791,6 +791,7 @@ mod tests {
     };
     use datatypes::arrow::datatypes::{Schema, UInt32Type};
     use mito_codec::row_converter::{PrimaryKeyFilter, build_primary_key_codec};
+    use parquet::arrow::ArrowSchemaConverter;
     use store_api::codec::PrimaryKeyEncoding;
 
     use super::*;
@@ -869,6 +870,33 @@ mod tests {
             .iter()
             .filter_map(SimpleFilterEvaluator::try_new)
             .collect()
+    }
+
+    fn new_simple_filter_contexts(
+        metadata: &RegionMetadataRef,
+        exprs: &[datafusion_expr::Expr],
+    ) -> Vec<SimpleFilterContext> {
+        exprs
+            .iter()
+            .filter_map(|expr| SimpleFilterContext::new_opt(metadata, None, expr))
+            .collect()
+    }
+
+    fn new_physical_filter_contexts(
+        metadata: &RegionMetadataRef,
+        read_format: &ReadFormat,
+        exprs: &[datafusion_expr::Expr],
+    ) -> Vec<PhysicalFilterContext> {
+        exprs
+            .iter()
+            .filter_map(|expr| PhysicalFilterContext::new_opt(metadata, None, read_format, expr))
+            .collect()
+    }
+
+    fn parquet_schema(read_format: &ReadFormat) -> SchemaDescriptor {
+        ArrowSchemaConverter::new()
+            .convert(read_format.arrow_schema())
+            .unwrap()
     }
 
     fn new_raw_batch(primary_keys: &[&[u8]], field_values: &[u64]) -> RecordBatch {
@@ -983,5 +1011,92 @@ mod tests {
 
         assert_eq!(filtered.num_rows(), 4);
         assert_eq!(field_values(&filtered), vec![10, 11, 14, 15]);
+    }
+
+    #[test]
+    fn test_prefilter_builder_restricts_field_filters_to_append_mode() {
+        let metadata: RegionMetadataRef =
+            Arc::new(sst_region_metadata_with_encoding(PrimaryKeyEncoding::Dense));
+        let read_format = ReadFormat::new_flat(
+            metadata.clone(),
+            metadata.column_metadatas.iter().map(|c| c.column_id),
+            None,
+            "test",
+            false,
+        )
+        .unwrap();
+        let codec = build_primary_key_codec(metadata.as_ref());
+        let filters = new_simple_filter_contexts(&metadata, &[col("field_0").gt(lit(1_u64))]);
+        let parquet_schema = parquet_schema(&read_format);
+
+        let builder = PrefilterContextBuilder::new(
+            &read_format,
+            &codec,
+            None,
+            &filters,
+            &[],
+            &parquet_schema,
+            false,
+        );
+        assert!(builder.is_none());
+
+        let builder = PrefilterContextBuilder::new(
+            &read_format,
+            &codec,
+            None,
+            &filters,
+            &[],
+            &parquet_schema,
+            true,
+        );
+        assert!(builder.is_some());
+    }
+
+    #[test]
+    fn test_apply_filters_to_batch_decodes_tag_columns() {
+        let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
+        let codec = build_primary_key_codec(metadata.as_ref());
+        let filters = new_simple_filter_contexts(&metadata, &[col("tag_0").eq(lit("a"))]);
+        let pk_a = new_primary_key(&["a", "x"]);
+        let pk_b = new_primary_key(&["b", "x"]);
+        let batch = new_raw_batch(
+            &[
+                pk_a.as_slice(),
+                pk_a.as_slice(),
+                pk_b.as_slice(),
+                pk_b.as_slice(),
+            ],
+            &[10, 11, 12, 13],
+        );
+
+        let mask = apply_filters_to_batch(&batch, &filters, &[], &metadata, codec.as_ref())
+            .unwrap()
+            .unwrap();
+        assert_eq!(mask.count_set_bits(), 2);
+    }
+
+    #[test]
+    fn test_apply_filters_to_batch_evaluates_physical_filters() {
+        let metadata: RegionMetadataRef =
+            Arc::new(sst_region_metadata_with_encoding(PrimaryKeyEncoding::Dense));
+        let read_format = ReadFormat::new_flat(
+            metadata.clone(),
+            metadata.column_metadatas.iter().map(|c| c.column_id),
+            None,
+            "test",
+            false,
+        )
+        .unwrap();
+        let codec = build_primary_key_codec(metadata.as_ref());
+        let expr = (col("field_0") + lit(1_u64)).gt(lit(11_u64));
+        let physical_filters = new_physical_filter_contexts(&metadata, &read_format, &[expr]);
+        let pk = new_primary_key(&["a", "x"]);
+        let batch = new_raw_batch(&[pk.as_slice(), pk.as_slice(), pk.as_slice()], &[9, 10, 11]);
+
+        let mask =
+            apply_filters_to_batch(&batch, &[], &physical_filters, &metadata, codec.as_ref())
+                .unwrap()
+                .unwrap();
+        assert_eq!(mask.count_set_bits(), 1);
     }
 }

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -42,7 +42,7 @@ use crate::error::{
     ReadParquetSnafu, RecordBatchSnafu, Result, UnexpectedSnafu,
 };
 use crate::sst::parquet::file_range::PreFilterMode;
-use crate::sst::parquet::flat_format::{FlatReadFormat, primary_key_column_index};
+use crate::sst::parquet::flat_format::FlatReadFormat;
 use crate::sst::parquet::format::PrimaryKeyArray;
 use crate::sst::parquet::reader::{
     MaybeFilter, PhysicalFilterContext, RowGroupBuildContext, RowGroupReaderBuilder,

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -916,6 +916,13 @@ mod tests {
             .to_vec()
     }
 
+    fn remaining_simple_filter_columns(filters: &[SimpleFilterContext]) -> Vec<&str> {
+        filters
+            .iter()
+            .map(|filter_ctx| filter_ctx.filter().as_filter().unwrap().column_name())
+            .collect()
+    }
+
     #[test]
     fn test_prefilter_primary_key_drops_single_dictionary_batch() {
         let metadata = Arc::new(sst_region_metadata());
@@ -996,71 +1003,72 @@ mod tests {
     }
 
     #[test]
-    fn test_build_bulk_filter_plan_splits_pk_prefiltered_simple_filters_on_legacy_path() {
+    fn test_build_bulk_filter_plan_classifies_filters_across_read_paths() {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata_with_encoding(
             PrimaryKeyEncoding::Sparse,
         ));
-        let read_format =
-            FlatReadFormat::new(metadata.clone(), metadata.column_metadatas.iter().map(|c| c.column_id), None, "memtable", false).unwrap();
-        assert!(!read_format.batch_has_raw_pk_columns());
-        let predicate = Predicate::new(vec![
-            col("tag_0").eq(lit("a")),
-            col("field_0").gt(lit(1_u64)),
-        ]);
+        let legacy_read_format = FlatReadFormat::new(
+            metadata.clone(),
+            metadata.column_metadatas.iter().map(|c| c.column_id),
+            None,
+            "memtable",
+            false,
+        )
+        .unwrap();
+        assert!(!legacy_read_format.batch_has_raw_pk_columns());
 
-        let plan = build_bulk_filter_plan(&read_format, Some(&predicate));
+        let plan = build_bulk_filter_plan(
+            &legacy_read_format,
+            Some(&Predicate::new(vec![
+                col("tag_0").eq(lit("a")),
+                col("field_0").gt(lit(1_u64)),
+            ])),
+        );
+        assert_eq!(
+            plan.pk_filters.as_ref().map(|filters| filters.len()),
+            Some(1)
+        );
+        assert_eq!(
+            remaining_simple_filter_columns(&plan.remaining_simple_filters),
+            vec!["field_0"]
+        );
 
-        assert!(plan.pk_filters.is_some());
-        assert_eq!(plan.pk_filters.as_ref().unwrap().len(), 1);
-        assert_eq!(plan.remaining_simple_filters.len(), 1);
-        let remaining_filter = plan.remaining_simple_filters[0]
-            .filter()
-            .as_filter()
-            .unwrap();
-        assert_eq!(remaining_filter.column_name(), "field_0");
+        let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
+        let raw_pk_read_format = FlatReadFormat::new(
+            metadata.clone(),
+            metadata.column_metadatas.iter().map(|c| c.column_id),
+            None,
+            "memtable",
+            true,
+        )
+        .unwrap();
+        assert!(raw_pk_read_format.batch_has_raw_pk_columns());
+
+        let tag_only_plan = build_bulk_filter_plan(
+            &raw_pk_read_format,
+            Some(&Predicate::new(vec![col("tag_0").eq(lit("a"))])),
+        );
+        assert!(tag_only_plan.pk_filters.is_none());
+        assert_eq!(
+            remaining_simple_filter_columns(&tag_only_plan.remaining_simple_filters),
+            vec!["tag_0"]
+        );
+
+        let field_only_plan = build_bulk_filter_plan(
+            &raw_pk_read_format,
+            Some(&Predicate::new(vec![col("field_0").gt(lit(1_u64))])),
+        );
+        assert!(field_only_plan.pk_filters.is_none());
+        assert_eq!(
+            remaining_simple_filter_columns(&field_only_plan.remaining_simple_filters),
+            vec!["field_0"]
+        );
     }
 
     #[test]
-    fn test_build_bulk_filter_plan_keeps_tag_filters_without_pk_prefilter_support() {
+    fn test_build_reader_filter_plan_classifies_filters_for_prefilter_modes() {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
-        let read_format =
-            FlatReadFormat::new(metadata.clone(), metadata.column_metadatas.iter().map(|c| c.column_id), None, "memtable", true).unwrap();
-        assert!(read_format.batch_has_raw_pk_columns());
-        let predicate = Predicate::new(vec![col("tag_0").eq(lit("a"))]);
-
-        let plan = build_bulk_filter_plan(&read_format, Some(&predicate));
-
-        assert!(plan.pk_filters.is_none());
-        assert_eq!(plan.remaining_simple_filters.len(), 1);
-        let remaining_filter = plan.remaining_simple_filters[0]
-            .filter()
-            .as_filter()
-            .unwrap();
-        assert_eq!(remaining_filter.column_name(), "tag_0");
-    }
-
-    #[test]
-    fn test_build_bulk_filter_plan_keeps_non_pk_filters_in_range_base() {
-        let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
-        let read_format =
-            FlatReadFormat::new(metadata.clone(), metadata.column_metadatas.iter().map(|c| c.column_id), None, "memtable", true).unwrap();
-        let predicate = Predicate::new(vec![col("field_0").gt(lit(1_u64))]);
-
-        let plan = build_bulk_filter_plan(&read_format, Some(&predicate));
-
-        assert!(plan.pk_filters.is_none());
-        assert_eq!(plan.remaining_simple_filters.len(), 1);
-        let remaining_filter = plan.remaining_simple_filters[0]
-            .filter()
-            .as_filter()
-            .unwrap();
-        assert_eq!(remaining_filter.column_name(), "field_0");
-    }
-
-    #[test]
-    fn test_build_reader_filter_plan_keeps_field_filters_for_prune_reader_in_skip_fields_mode() {
-        let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
-        let read_format = FlatReadFormat::new(
+        let full_read_format = FlatReadFormat::new(
             metadata.clone(),
             metadata.column_metadatas.iter().map(|c| c.column_id),
             None,
@@ -1068,37 +1076,29 @@ mod tests {
             true,
         )
         .unwrap();
-        let parquet_schema = parquet_schema(&read_format);
+        let full_parquet_schema = parquet_schema(&full_read_format);
         let codec = build_primary_key_codec(metadata.as_ref());
-        let predicate = Predicate::new(vec![
-            col("tag_0").eq(lit("a")),
-            col("field_0").gt(lit(1_u64)),
-        ]);
 
-        let plan = build_reader_filter_plan(
-            Some(&predicate),
+        let skip_fields_plan = build_reader_filter_plan(
+            Some(&Predicate::new(vec![
+                col("tag_0").eq(lit("a")),
+                col("field_0").gt(lit(1_u64)),
+            ])),
             None,
             PreFilterMode::SkipFields,
-            &read_format,
-            &parquet_schema,
+            &full_read_format,
+            &full_parquet_schema,
             &codec,
         );
+        assert!(skip_fields_plan.prefilter_builder.is_some());
+        assert_eq!(
+            remaining_simple_filter_columns(&skip_fields_plan.remaining_simple_filters),
+            vec!["field_0"]
+        );
 
-        assert!(plan.prefilter_builder.is_some());
-        assert_eq!(plan.remaining_simple_filters.len(), 1);
-        let remaining_filter = plan.remaining_simple_filters[0]
-            .filter()
-            .as_filter()
-            .unwrap();
-        assert_eq!(remaining_filter.column_name(), "field_0");
-    }
-
-    #[test]
-    fn test_build_reader_filter_plan_uses_pk_prefilter_for_unprojected_tag_filters() {
-        let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
         let field_0 = metadata.column_by_name("field_0").unwrap().column_id;
         let ts = metadata.time_index_column().column_id;
-        let read_format = FlatReadFormat::new(
+        let projected_read_format = FlatReadFormat::new(
             metadata.clone(),
             [field_0, ts].into_iter(),
             None,
@@ -1106,21 +1106,17 @@ mod tests {
             true,
         )
         .unwrap();
-        let parquet_schema = parquet_schema(&read_format);
-        let codec = build_primary_key_codec(metadata.as_ref());
-        let predicate = Predicate::new(vec![col("tag_0").eq(lit("a"))]);
-
-        let plan = build_reader_filter_plan(
-            Some(&predicate),
+        let projected_parquet_schema = parquet_schema(&projected_read_format);
+        let pk_prefilter_plan = build_reader_filter_plan(
+            Some(&Predicate::new(vec![col("tag_0").eq(lit("a"))])),
             None,
             PreFilterMode::All,
-            &read_format,
-            &parquet_schema,
+            &projected_read_format,
+            &projected_parquet_schema,
             &codec,
         );
-
-        assert!(plan.prefilter_builder.is_some());
-        assert!(plan.remaining_simple_filters.is_empty());
+        assert!(pk_prefilter_plan.prefilter_builder.is_some());
+        assert!(pk_prefilter_plan.remaining_simple_filters.is_empty());
     }
 
     #[test]

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -216,18 +216,26 @@ impl PrimaryKeyFilter for CachedPrimaryKeyFilter {
     }
 }
 
+enum PrefilterVariant {
+    /// Primary-key prefiltering for primary-key-format data.
+    PrimaryKey {
+        /// PK filter instance.
+        pk_filter: Box<dyn PrimaryKeyFilter>,
+        /// Index of the PK column within the prefilter projection batch.
+        /// This is 0 when we project only the PK column.
+        pk_column_index: usize,
+    },
+}
+
 /// Context for prefiltering a row group.
 ///
 /// Currently supports primary key (PK) filtering only.
 /// Will be extended with simple column filters and physical filters in the future.
 pub(crate) struct PrefilterContext {
-    /// PK filter instance.
-    pk_filter: Box<dyn PrimaryKeyFilter>,
-    /// Projection mask for reading only the PK column.
-    pk_projection: ProjectionMask,
-    /// Index of the PK column within the prefilter projection batch.
-    /// This is 0 when we project only the PK column.
-    pk_column_index: usize,
+    /// Projection mask for reading prefilter columns.
+    projection: ProjectionMask,
+    /// Filter execution strategy for this prefilter context.
+    variant: PrefilterVariant,
 }
 
 /// Pre-built state for constructing [PrefilterContext] per row group.
@@ -236,7 +244,7 @@ pub(crate) struct PrefilterContext {
 /// are computed once. A fresh [PrefilterContext] with its own mutable PK filter
 /// is created via [PrefilterContextBuilder::build()] for each row group.
 pub(crate) struct PrefilterContextBuilder {
-    pk_projection: ProjectionMask,
+    projection: ProjectionMask,
     pk_column_index: usize,
     codec: Arc<dyn PrimaryKeyCodec>,
     metadata: RegionMetadataRef,
@@ -274,13 +282,13 @@ impl PrefilterContextBuilder {
         // Compute PK-only projection mask.
         let num_parquet_columns = parquet_schema.num_columns();
         let pk_index = primary_key_column_index(num_parquet_columns);
-        let pk_projection = ProjectionMask::roots(parquet_schema, [pk_index]);
+        let projection = ProjectionMask::roots(parquet_schema, [pk_index]);
 
         // The PK column is the only column in the projection, so its index is 0.
         let pk_column_index = 0;
 
         Some(Self {
-            pk_projection,
+            projection,
             pk_column_index,
             codec: Arc::clone(codec),
             metadata: metadata.clone(),
@@ -297,9 +305,11 @@ impl PrefilterContextBuilder {
                 .primary_key_filter(&self.metadata, Arc::clone(&self.pk_filters), false);
         let pk_filter = Box::new(CachedPrimaryKeyFilter::new(pk_filter));
         PrefilterContext {
-            pk_filter,
-            pk_projection: self.pk_projection.clone(),
-            pk_column_index: self.pk_column_index,
+            projection: self.projection.clone(),
+            variant: PrefilterVariant::PrimaryKey {
+                pk_filter,
+                pk_column_index: self.pk_column_index,
+            },
         }
     }
 }
@@ -321,12 +331,36 @@ pub(crate) async fn execute_prefilter(
     reader_builder: &RowGroupReaderBuilder,
     build_ctx: &RowGroupBuildContext<'_>,
 ) -> Result<PrefilterResult> {
+    match &mut prefilter_ctx.variant {
+        PrefilterVariant::PrimaryKey {
+            pk_filter,
+            pk_column_index,
+        } => {
+            execute_primary_key_prefilter(
+                prefilter_ctx.projection.clone(),
+                *pk_column_index,
+                pk_filter.as_mut(),
+                reader_builder,
+                build_ctx,
+            )
+            .await
+        }
+    }
+}
+
+async fn execute_primary_key_prefilter(
+    projection: ProjectionMask,
+    pk_column_index: usize,
+    pk_filter: &mut dyn PrimaryKeyFilter,
+    reader_builder: &RowGroupReaderBuilder,
+    build_ctx: &RowGroupBuildContext<'_>,
+) -> Result<PrefilterResult> {
     // Reads PK column only.
     let mut pk_stream = reader_builder
         .build_with_projection(
             build_ctx.row_group_idx,
             build_ctx.row_selection.clone(),
-            prefilter_ctx.pk_projection.clone(),
+            projection,
             build_ctx.fetch_metrics,
         )
         .await?;
@@ -346,11 +380,7 @@ pub(crate) async fn execute_prefilter(
         }
         rows_before_filter += batch_num_rows;
 
-        let ranges = matching_row_ranges_by_primary_key(
-            &batch,
-            prefilter_ctx.pk_column_index,
-            prefilter_ctx.pk_filter.as_mut(),
-        )?;
+        let ranges = matching_row_ranges_by_primary_key(&batch, pk_column_index, pk_filter)?;
         matched_row_ranges.extend(
             ranges
                 .into_iter()

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -255,64 +255,37 @@ impl PrefilterContextBuilder {
     /// Creates a builder if prefiltering is applicable.
     ///
     /// Returns `None` if:
-    /// - No primary key filters are available
-    /// - The read format doesn't use flat layout with dictionary-encoded PKs
-    /// - The primary key is empty
+    /// - The read format doesn't use flat layout
+    /// - No prefilter columns are selected
+    /// - Prefilter would read the full projection without any PK filter
     pub(crate) fn new(
         read_format: &FlatReadFormat,
         codec: &Arc<dyn PrimaryKeyCodec>,
-        primary_key_filters: Option<&Arc<Vec<SimpleFilterEvaluator>>>,
-        filters: &[SimpleFilterContext],
-        physical_filters: &[PhysicalFilterContext],
+        primary_key_filters: Option<Arc<Vec<SimpleFilterEvaluator>>>,
+        filters: Vec<SimpleFilterContext>,
+        physical_filters: Vec<PhysicalFilterContext>,
         parquet_schema: &SchemaDescriptor,
-        field_prefilter_enabled: bool,
     ) -> Option<Self> {
         let metadata = read_format.metadata();
         let use_raw_tag_columns = read_format.batch_has_raw_pk_columns();
         let pk_filters = (!use_raw_tag_columns)
-            .then(|| {
-                primary_key_filters
-                    .filter(|filters| !filters.is_empty())
-                    .cloned()
-            })
-            .flatten();
+            .then_some(primary_key_filters)
+            .flatten()
+            .filter(|filters| !filters.is_empty());
 
         let mut prefilter_column_names = HashSet::new();
-        let mut prefilter_filters = Vec::new();
-        let mut prefilter_physical_filters = Vec::new();
-
-        for filter_ctx in filters {
-            let filter = match filter_ctx.filter() {
-                MaybeFilter::Filter(filter) => filter,
-                MaybeFilter::Matched | MaybeFilter::Pruned => continue,
-            };
-
-            if filter_ctx.usable_prefilter()
-                && read_format
-                    .arrow_schema()
-                    .column_with_name(filter.column_name())
-                    .is_some()
-            {
+        for filter_ctx in &filters {
+            if let MaybeFilter::Filter(filter) = filter_ctx.filter() {
                 prefilter_column_names.insert(filter.column_name().to_string());
-                prefilter_filters.push(filter_ctx.clone());
-            } else if filter_ctx.usable_primary_key_filter() && pk_filters.is_some() {
-                prefilter_column_names.insert(PRIMARY_KEY_COLUMN_NAME.to_string());
             }
         }
 
-        for filter_ctx in physical_filters {
-            if !field_prefilter_enabled && filter_ctx.semantic_type() == SemanticType::Field {
-                continue;
-            }
+        if pk_filters.is_some() {
+            prefilter_column_names.insert(PRIMARY_KEY_COLUMN_NAME.to_string());
+        }
 
-            if read_format
-                .arrow_schema()
-                .column_with_name(filter_ctx.column_name())
-                .is_some()
-            {
-                prefilter_column_names.insert(filter_ctx.column_name().to_string());
-                prefilter_physical_filters.push(filter_ctx.clone());
-            }
+        for filter_ctx in &physical_filters {
+            prefilter_column_names.insert(filter_ctx.column_name().to_string());
         }
 
         let (projection, prefilter_count) = compute_projection_mask(
@@ -332,8 +305,8 @@ impl PrefilterContextBuilder {
         Some(Self {
             projection,
             pk_filters,
-            filters: prefilter_filters,
-            physical_filters: prefilter_physical_filters,
+            filters,
+            physical_filters,
             codec: Arc::clone(codec),
             metadata: metadata.clone(),
         })
@@ -635,11 +608,7 @@ mod tests {
     ) -> Vec<SimpleFilterContext> {
         exprs
             .iter()
-            .filter_map(|expr| {
-                let mut filter = SimpleFilterContext::new_opt(metadata, None, expr)?;
-                filter.set_usable_prefilter(true);
-                Some(filter)
-            })
+            .filter_map(|expr| SimpleFilterContext::new_opt(metadata, None, expr))
             .collect()
     }
 
@@ -822,7 +791,7 @@ mod tests {
     }
 
     #[test]
-    fn test_prefilter_builder_restricts_field_filters_to_append_mode() {
+    fn test_prefilter_builder_returns_none_without_selected_filters() {
         let metadata: RegionMetadataRef =
             Arc::new(sst_region_metadata_with_encoding(PrimaryKeyEncoding::Dense));
         let read_format = FlatReadFormat::new(
@@ -834,32 +803,17 @@ mod tests {
         )
         .unwrap();
         let codec = build_primary_key_codec(metadata.as_ref());
-        let mut filters = new_simple_filter_contexts(&metadata, &[col("field_0").gt(lit(1_u64))]);
-        filters[0].set_usable_prefilter(false);
         let parquet_schema = parquet_schema(&read_format);
 
         let builder = PrefilterContextBuilder::new(
             &read_format,
             &codec,
             None,
-            &filters,
-            &[],
+            Vec::new(),
+            Vec::new(),
             &parquet_schema,
-            false,
         );
         assert!(builder.is_none());
-
-        filters[0].set_usable_prefilter(true);
-        let builder = PrefilterContextBuilder::new(
-            &read_format,
-            &codec,
-            None,
-            &filters,
-            &[],
-            &parquet_schema,
-            true,
-        );
-        assert!(builder.is_some());
     }
 
     #[test]

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -35,11 +35,13 @@ use parquet::schema::types::SchemaDescriptor;
 use snafu::{OptionExt, ResultExt};
 use store_api::metadata::{RegionMetadata, RegionMetadataRef};
 use store_api::storage::consts::PRIMARY_KEY_COLUMN_NAME;
+use table::predicate::Predicate;
 
 use crate::error::{
     ComputeArrowSnafu, DecodeSnafu, EvalPartitionFilterSnafu, NewRecordBatchSnafu,
     ReadParquetSnafu, RecordBatchSnafu, Result, UnexpectedSnafu,
 };
+use crate::sst::parquet::file_range::PreFilterMode;
 use crate::sst::parquet::flat_format::{FlatReadFormat, primary_key_column_index};
 use crate::sst::parquet::format::PrimaryKeyArray;
 use crate::sst::parquet::reader::{
@@ -221,6 +223,156 @@ impl PrimaryKeyFilter for CachedPrimaryKeyFilter {
         self.last_primary_key.extend_from_slice(pk);
         self.last_match = Some(matched);
         Ok(matched)
+    }
+}
+
+pub(crate) struct BulkFilterPlan {
+    pub(crate) remaining_simple_filters: Vec<SimpleFilterContext>,
+    pub(crate) pk_filters: Option<Arc<Vec<SimpleFilterEvaluator>>>,
+}
+
+pub(crate) struct ReaderFilterPlan {
+    pub(crate) remaining_simple_filters: Vec<SimpleFilterContext>,
+    pub(crate) prefilter_builder: Option<PrefilterContextBuilder>,
+}
+
+pub(crate) fn build_bulk_filter_plan(
+    read_format: &FlatReadFormat,
+    predicate: Option<&Predicate>,
+) -> BulkFilterPlan {
+    let metadata = read_format.metadata();
+    let simple_filters: Vec<SimpleFilterContext> = predicate
+        .into_iter()
+        .flat_map(|predicate| {
+            predicate
+                .exprs()
+                .iter()
+                .filter_map(|expr| SimpleFilterContext::new_opt(metadata, None, expr))
+        })
+        .collect();
+
+    if read_format.batch_has_raw_pk_columns() || metadata.primary_key.is_empty() {
+        return BulkFilterPlan {
+            remaining_simple_filters: simple_filters,
+            pk_filters: None,
+        };
+    }
+
+    let mut remaining_simple_filters = Vec::new();
+    let mut pk_filters = Vec::new();
+
+    for filter_ctx in simple_filters {
+        let pk_filter = filter_ctx.filter().as_filter().and_then(|filter| {
+            is_usable_primary_key_filter(metadata, None, filter).then(|| filter.clone())
+        });
+
+        if let Some(pk_filter) = pk_filter {
+            pk_filters.push(pk_filter);
+        } else {
+            remaining_simple_filters.push(filter_ctx);
+        }
+    }
+
+    BulkFilterPlan {
+        remaining_simple_filters,
+        pk_filters: (!pk_filters.is_empty()).then_some(Arc::new(pk_filters)),
+    }
+}
+
+pub(crate) fn build_reader_filter_plan(
+    predicate: Option<&Predicate>,
+    expected_metadata: Option<&RegionMetadata>,
+    pre_filter_mode: PreFilterMode,
+    read_format: &FlatReadFormat,
+    parquet_schema: &SchemaDescriptor,
+    codec: &Arc<dyn PrimaryKeyCodec>,
+) -> ReaderFilterPlan {
+    let Some(predicate) = predicate else {
+        return ReaderFilterPlan {
+            remaining_simple_filters: Vec::new(),
+            prefilter_builder: None,
+        };
+    };
+
+    let metadata = read_format.metadata();
+    let mut simple_filters = Vec::new();
+    let mut prefilter_simple_filters = Vec::new();
+    let mut remaining_simple_filters = Vec::new();
+    let mut prefilter_physical_filters = Vec::new();
+    let mut primary_key_filters = Vec::new();
+
+    let field_prefilter_enabled = pre_filter_mode == PreFilterMode::All;
+    let supports_pk_prefilter = !read_format.batch_has_raw_pk_columns();
+
+    for expr in predicate.exprs() {
+        if let Some(filter) = SimpleFilterContext::new_opt(metadata, expected_metadata, expr) {
+            simple_filters.push(filter);
+            continue;
+        }
+
+        if let Some(filter) =
+            PhysicalFilterContext::new_opt(metadata, expected_metadata, read_format, expr)
+        {
+            let usable_prefilter = (field_prefilter_enabled
+                || filter.semantic_type() != SemanticType::Field)
+                && read_format
+                    .arrow_schema()
+                    .column_with_name(filter.column_name())
+                    .is_some();
+            if usable_prefilter {
+                prefilter_physical_filters.push(filter);
+            }
+        }
+    }
+
+    for filter_ctx in simple_filters.iter().cloned() {
+        let Some(filter) = filter_ctx.filter().as_filter() else {
+            remaining_simple_filters.push(filter_ctx);
+            continue;
+        };
+
+        let direct_prefilter = (field_prefilter_enabled
+            || filter_ctx.semantic_type() != SemanticType::Field)
+            && read_format
+                .arrow_schema()
+                .column_with_name(filter.column_name())
+                .is_some();
+        if direct_prefilter {
+            prefilter_simple_filters.push(filter_ctx);
+            continue;
+        }
+
+        let pk_prefilter = supports_pk_prefilter
+            && is_usable_primary_key_filter(metadata, expected_metadata, filter);
+        if pk_prefilter {
+            primary_key_filters.push(filter.clone());
+            prefilter_simple_filters.push(filter_ctx);
+        } else {
+            remaining_simple_filters.push(filter_ctx);
+        }
+    }
+
+    let primary_key_filters =
+        (!primary_key_filters.is_empty()).then_some(Arc::new(primary_key_filters));
+    let prefilter_builder = PrefilterContextBuilder::new(
+        read_format,
+        codec,
+        primary_key_filters,
+        prefilter_simple_filters,
+        prefilter_physical_filters,
+        parquet_schema,
+    );
+
+    if prefilter_builder.is_some() {
+        ReaderFilterPlan {
+            remaining_simple_filters,
+            prefilter_builder,
+        }
+    } else {
+        ReaderFilterPlan {
+            remaining_simple_filters: simple_filters,
+            prefilter_builder: None,
+        }
     }
 }
 
@@ -814,6 +966,134 @@ mod tests {
             &parquet_schema,
         );
         assert!(builder.is_none());
+    }
+
+    #[test]
+    fn test_build_bulk_filter_plan_splits_pk_prefiltered_simple_filters_on_legacy_path() {
+        let metadata: RegionMetadataRef = Arc::new(sst_region_metadata_with_encoding(
+            PrimaryKeyEncoding::Sparse,
+        ));
+        let read_format =
+            FlatReadFormat::new(metadata.clone(), metadata.column_metadatas.iter().map(|c| c.column_id), None, "memtable", false).unwrap();
+        assert!(!read_format.batch_has_raw_pk_columns());
+        let predicate = Predicate::new(vec![
+            col("tag_0").eq(lit("a")),
+            col("field_0").gt(lit(1_u64)),
+        ]);
+
+        let plan = build_bulk_filter_plan(&read_format, Some(&predicate));
+
+        assert!(plan.pk_filters.is_some());
+        assert_eq!(plan.pk_filters.as_ref().unwrap().len(), 1);
+        assert_eq!(plan.remaining_simple_filters.len(), 1);
+        let remaining_filter = plan.remaining_simple_filters[0]
+            .filter()
+            .as_filter()
+            .unwrap();
+        assert_eq!(remaining_filter.column_name(), "field_0");
+    }
+
+    #[test]
+    fn test_build_bulk_filter_plan_keeps_tag_filters_without_pk_prefilter_support() {
+        let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
+        let read_format =
+            FlatReadFormat::new(metadata.clone(), metadata.column_metadatas.iter().map(|c| c.column_id), None, "memtable", true).unwrap();
+        assert!(read_format.batch_has_raw_pk_columns());
+        let predicate = Predicate::new(vec![col("tag_0").eq(lit("a"))]);
+
+        let plan = build_bulk_filter_plan(&read_format, Some(&predicate));
+
+        assert!(plan.pk_filters.is_none());
+        assert_eq!(plan.remaining_simple_filters.len(), 1);
+        let remaining_filter = plan.remaining_simple_filters[0]
+            .filter()
+            .as_filter()
+            .unwrap();
+        assert_eq!(remaining_filter.column_name(), "tag_0");
+    }
+
+    #[test]
+    fn test_build_bulk_filter_plan_keeps_non_pk_filters_in_range_base() {
+        let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
+        let read_format =
+            FlatReadFormat::new(metadata.clone(), metadata.column_metadatas.iter().map(|c| c.column_id), None, "memtable", true).unwrap();
+        let predicate = Predicate::new(vec![col("field_0").gt(lit(1_u64))]);
+
+        let plan = build_bulk_filter_plan(&read_format, Some(&predicate));
+
+        assert!(plan.pk_filters.is_none());
+        assert_eq!(plan.remaining_simple_filters.len(), 1);
+        let remaining_filter = plan.remaining_simple_filters[0]
+            .filter()
+            .as_filter()
+            .unwrap();
+        assert_eq!(remaining_filter.column_name(), "field_0");
+    }
+
+    #[test]
+    fn test_build_reader_filter_plan_keeps_field_filters_for_prune_reader_in_skip_fields_mode() {
+        let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
+        let read_format = FlatReadFormat::new(
+            metadata.clone(),
+            metadata.column_metadatas.iter().map(|c| c.column_id),
+            None,
+            "test",
+            true,
+        )
+        .unwrap();
+        let parquet_schema = parquet_schema(&read_format);
+        let codec = build_primary_key_codec(metadata.as_ref());
+        let predicate = Predicate::new(vec![
+            col("tag_0").eq(lit("a")),
+            col("field_0").gt(lit(1_u64)),
+        ]);
+
+        let plan = build_reader_filter_plan(
+            Some(&predicate),
+            None,
+            PreFilterMode::SkipFields,
+            &read_format,
+            &parquet_schema,
+            &codec,
+        );
+
+        assert!(plan.prefilter_builder.is_some());
+        assert_eq!(plan.remaining_simple_filters.len(), 1);
+        let remaining_filter = plan.remaining_simple_filters[0]
+            .filter()
+            .as_filter()
+            .unwrap();
+        assert_eq!(remaining_filter.column_name(), "field_0");
+    }
+
+    #[test]
+    fn test_build_reader_filter_plan_uses_pk_prefilter_for_unprojected_tag_filters() {
+        let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
+        let field_0 = metadata.column_by_name("field_0").unwrap().column_id;
+        let ts = metadata.time_index_column().column_id;
+        let read_format = FlatReadFormat::new(
+            metadata.clone(),
+            [field_0, ts].into_iter(),
+            None,
+            "test",
+            true,
+        )
+        .unwrap();
+        let parquet_schema = parquet_schema(&read_format);
+        let codec = build_primary_key_codec(metadata.as_ref());
+        let predicate = Predicate::new(vec![col("tag_0").eq(lit("a"))]);
+
+        let plan = build_reader_filter_plan(
+            Some(&predicate),
+            None,
+            PreFilterMode::All,
+            &read_format,
+            &parquet_schema,
+            &codec,
+        );
+
+        assert!(plan.prefilter_builder.is_some());
+        assert!(plan.remaining_simple_filters.is_empty());
     }
 
     #[test]

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -18,12 +18,14 @@
 //! (the prefilter phase), applying filters to compute a refined row selection,
 //! then reading the remaining columns with the refined selection.
 
-use std::ops::Range;
+use std::collections::{HashMap, HashSet};
+use std::ops::{BitAnd, Range};
 use std::sync::Arc;
 
 use api::v1::SemanticType;
 use common_recordbatch::filter::SimpleFilterEvaluator;
-use datatypes::arrow::array::{BinaryArray, BooleanArray, BooleanBufferBuilder};
+use datatypes::arrow::array::{ArrayRef, BinaryArray, BooleanArray, BooleanBufferBuilder};
+use datatypes::arrow::buffer::BooleanBuffer;
 use datatypes::arrow::record_batch::RecordBatch;
 use futures::StreamExt;
 use mito_codec::row_converter::{PrimaryKeyCodec, PrimaryKeyFilter};
@@ -31,12 +33,23 @@ use parquet::arrow::ProjectionMask;
 use parquet::arrow::arrow_reader::RowSelection;
 use parquet::schema::types::SchemaDescriptor;
 use snafu::{OptionExt, ResultExt};
+use store_api::codec::PrimaryKeyEncoding;
 use store_api::metadata::{RegionMetadata, RegionMetadataRef};
+use store_api::storage::ColumnId;
+use store_api::storage::consts::PRIMARY_KEY_COLUMN_NAME;
 
-use crate::error::{ComputeArrowSnafu, DecodeSnafu, ReadParquetSnafu, Result, UnexpectedSnafu};
-use crate::sst::parquet::flat_format::{FlatReadFormat, primary_key_column_index};
+use crate::error::{
+    ComputeArrowSnafu, DecodeSnafu, EvalPartitionFilterSnafu, NewRecordBatchSnafu,
+    ReadParquetSnafu, RecordBatchSnafu, Result, UnexpectedSnafu,
+};
+use crate::sst::parquet::flat_format::{
+    DecodedPrimaryKeys, FlatReadFormat, decode_primary_keys, primary_key_column_index,
+};
 use crate::sst::parquet::format::PrimaryKeyArray;
-use crate::sst::parquet::reader::{RowGroupBuildContext, RowGroupReaderBuilder};
+use crate::sst::parquet::reader::{
+    MaybeFilter, MaybePhysicalFilter, PhysicalFilterContext, RowGroupBuildContext,
+    RowGroupReaderBuilder, SimpleFilterContext,
+};
 use crate::sst::parquet::row_selection::row_selection_from_row_ranges_exact;
 
 pub(crate) fn matching_row_ranges_by_primary_key(
@@ -225,6 +238,13 @@ enum PrefilterVariant {
         /// This is 0 when we project only the PK column.
         pk_column_index: usize,
     },
+    /// General prefiltering for mixed simple and physical filters.
+    General {
+        filters: Vec<SimpleFilterContext>,
+        physical_filters: Vec<PhysicalFilterContext>,
+        codec: Arc<dyn PrimaryKeyCodec>,
+        metadata: RegionMetadataRef,
+    },
 }
 
 /// Context for prefiltering a row group.
@@ -245,10 +265,22 @@ pub(crate) struct PrefilterContext {
 /// is created via [PrefilterContextBuilder::build()] for each row group.
 pub(crate) struct PrefilterContextBuilder {
     projection: ProjectionMask,
-    pk_column_index: usize,
-    codec: Arc<dyn PrimaryKeyCodec>,
-    metadata: RegionMetadataRef,
-    pk_filters: Arc<Vec<SimpleFilterEvaluator>>,
+    variant: PrefilterBuilderVariant,
+}
+
+enum PrefilterBuilderVariant {
+    PrimaryKey {
+        pk_column_index: usize,
+        codec: Arc<dyn PrimaryKeyCodec>,
+        metadata: RegionMetadataRef,
+        pk_filters: Arc<Vec<SimpleFilterEvaluator>>,
+    },
+    General {
+        filters: Vec<SimpleFilterContext>,
+        physical_filters: Vec<PhysicalFilterContext>,
+        codec: Arc<dyn PrimaryKeyCodec>,
+        metadata: RegionMetadataRef,
+    },
 }
 
 impl PrefilterContextBuilder {
@@ -262,54 +294,146 @@ impl PrefilterContextBuilder {
         read_format: &FlatReadFormat,
         codec: &Arc<dyn PrimaryKeyCodec>,
         primary_key_filters: Option<&Arc<Vec<SimpleFilterEvaluator>>>,
+        filters: &[SimpleFilterContext],
+        physical_filters: &[PhysicalFilterContext],
         parquet_schema: &SchemaDescriptor,
+        field_prefilter_enabled: bool,
     ) -> Option<Self> {
-        let pk_filters = primary_key_filters?;
-        if pk_filters.is_empty() {
-            return None;
-        }
-
         let metadata = read_format.metadata();
-        if metadata.primary_key.is_empty() {
+        let always_prefilter_pk = primary_key_filters
+            .filter(|filters| !filters.is_empty())
+            .is_some_and(|_| {
+                !metadata.primary_key.is_empty() && !read_format.batch_has_raw_pk_columns()
+            });
+
+        let mut prefilter_column_names = HashSet::new();
+        let mut general_filters = Vec::new();
+        let mut general_physical_filters = Vec::new();
+
+        for filter_ctx in filters {
+            if !field_prefilter_enabled && filter_ctx.semantic_type() == SemanticType::Field {
+                continue;
+            }
+
+            general_filters.push(filter_ctx.clone());
+
+            let filter = match filter_ctx.filter() {
+                MaybeFilter::Filter(filter) => filter,
+                MaybeFilter::Matched | MaybeFilter::Pruned => continue,
+            };
+
+            prefilter_column_names.insert(filter.column_name().to_string());
+
+            if filter_ctx.semantic_type() == SemanticType::Tag
+                && read_format
+                    .arrow_schema()
+                    .column_with_name(filter.column_name())
+                    .is_none()
+            {
+                prefilter_column_names.insert(PRIMARY_KEY_COLUMN_NAME.to_string());
+            }
+        }
+
+        for filter_ctx in physical_filters {
+            if !field_prefilter_enabled && filter_ctx.semantic_type() == SemanticType::Field {
+                continue;
+            }
+
+            general_physical_filters.push(filter_ctx.clone());
+
+            if !matches!(filter_ctx.filter(), MaybePhysicalFilter::Filter(_)) {
+                continue;
+            }
+
+            prefilter_column_names.insert(filter_ctx.column_name().to_string());
+
+            if filter_ctx.semantic_type() == SemanticType::Tag
+                && read_format
+                    .arrow_schema()
+                    .column_with_name(filter_ctx.column_name())
+                    .is_none()
+            {
+                prefilter_column_names.insert(PRIMARY_KEY_COLUMN_NAME.to_string());
+            }
+        }
+
+        let (projection, prefilter_count) = compute_projection_mask(
+            &prefilter_column_names,
+            read_format.arrow_schema(),
+            parquet_schema,
+        );
+
+        if always_prefilter_pk
+            && general_physical_filters.is_empty()
+            && !general_filters.is_empty()
+            && general_filters
+                .iter()
+                .all(SimpleFilterContext::usable_primary_key_filter)
+            && prefilter_count == 1
+        {
+            let num_parquet_columns = parquet_schema.num_columns();
+            let pk_column_index = 0;
+            return Some(Self {
+                projection,
+                variant: PrefilterBuilderVariant::PrimaryKey {
+                    pk_column_index,
+                    codec: Arc::clone(codec),
+                    metadata: metadata.clone(),
+                    pk_filters: Arc::clone(primary_key_filters?),
+                },
+            });
+        }
+
+        if prefilter_count == 0 {
             return None;
         }
 
-        // Only perform PK prefiltering for primary-key-to-flat conversion path.
-        if read_format.batch_has_raw_pk_columns() {
+        if !always_prefilter_pk && prefilter_count >= read_format.projection_indices().len() {
             return None;
         }
-
-        // Compute PK-only projection mask.
-        let num_parquet_columns = parquet_schema.num_columns();
-        let pk_index = primary_key_column_index(num_parquet_columns);
-        let projection = ProjectionMask::roots(parquet_schema, [pk_index]);
-
-        // The PK column is the only column in the projection, so its index is 0.
-        let pk_column_index = 0;
 
         Some(Self {
             projection,
-            pk_column_index,
-            codec: Arc::clone(codec),
-            metadata: metadata.clone(),
-            pk_filters: Arc::clone(pk_filters),
+            variant: PrefilterBuilderVariant::General {
+                filters: general_filters,
+                physical_filters: general_physical_filters,
+                codec: Arc::clone(codec),
+                metadata: metadata.clone(),
+            },
         })
     }
 
     /// Builds a [PrefilterContext] for a specific row group.
     pub(crate) fn build(&self) -> PrefilterContext {
-        // Parquet PK prefilter always supports the partition column. Only
-        // PartitionTreeMemtable skips it after partition pruning.
-        let pk_filter =
-            self.codec
-                .primary_key_filter(&self.metadata, Arc::clone(&self.pk_filters), false);
-        let pk_filter = Box::new(CachedPrimaryKeyFilter::new(pk_filter));
+        let variant = match &self.variant {
+            PrefilterBuilderVariant::PrimaryKey {
+                pk_column_index,
+                codec,
+                metadata,
+                pk_filters,
+            } => {
+                let pk_filter = codec.primary_key_filter(metadata, Arc::clone(pk_filters), false);
+                let pk_filter = Box::new(CachedPrimaryKeyFilter::new(pk_filter));
+                PrefilterVariant::PrimaryKey {
+                    pk_filter,
+                    pk_column_index: *pk_column_index,
+                }
+            }
+            PrefilterBuilderVariant::General {
+                filters,
+                physical_filters,
+                codec,
+                metadata,
+            } => PrefilterVariant::General {
+                filters: filters.clone(),
+                physical_filters: physical_filters.clone(),
+                codec: Arc::clone(codec),
+                metadata: metadata.clone(),
+            },
+        };
         PrefilterContext {
             projection: self.projection.clone(),
-            variant: PrefilterVariant::PrimaryKey {
-                pk_filter,
-                pk_column_index: self.pk_column_index,
-            },
+            variant,
         }
     }
 }
@@ -340,6 +464,23 @@ pub(crate) async fn execute_prefilter(
                 prefilter_ctx.projection.clone(),
                 *pk_column_index,
                 pk_filter.as_mut(),
+                reader_builder,
+                build_ctx,
+            )
+            .await
+        }
+        PrefilterVariant::General {
+            filters,
+            physical_filters,
+            codec,
+            metadata,
+        } => {
+            execute_general_prefilter(
+                prefilter_ctx.projection.clone(),
+                filters,
+                physical_filters,
+                codec.as_ref(),
+                metadata,
                 reader_builder,
                 build_ctx,
             )
@@ -417,6 +558,228 @@ async fn execute_primary_key_prefilter(
     })
 }
 
+struct TagDecodeState {
+    decoded_pks: Option<DecodedPrimaryKeys>,
+    decoded_tag_cache: HashMap<ColumnId, ArrayRef>,
+}
+
+impl TagDecodeState {
+    fn new() -> Self {
+        Self {
+            decoded_pks: None,
+            decoded_tag_cache: HashMap::new(),
+        }
+    }
+}
+
+fn compute_projection_mask(
+    column_names: &HashSet<String>,
+    arrow_schema: &datatypes::arrow::datatypes::SchemaRef,
+    parquet_schema: &SchemaDescriptor,
+) -> (ProjectionMask, usize) {
+    let mut projection_indices: Vec<usize> = column_names
+        .iter()
+        .filter_map(|name| arrow_schema.column_with_name(name).map(|(index, _)| index))
+        .collect();
+    projection_indices.sort_unstable();
+    projection_indices.dedup();
+    let count = projection_indices.len();
+    (
+        ProjectionMask::roots(parquet_schema, projection_indices.iter().copied()),
+        count,
+    )
+}
+
+async fn execute_general_prefilter(
+    projection: ProjectionMask,
+    filters: &[SimpleFilterContext],
+    physical_filters: &[PhysicalFilterContext],
+    codec: &dyn PrimaryKeyCodec,
+    metadata: &RegionMetadataRef,
+    reader_builder: &RowGroupReaderBuilder,
+    build_ctx: &RowGroupBuildContext<'_>,
+) -> Result<PrefilterResult> {
+    let mut stream = reader_builder
+        .build_with_projection(
+            build_ctx.row_group_idx,
+            build_ctx.row_selection.clone(),
+            projection,
+            build_ctx.fetch_metrics,
+        )
+        .await?;
+
+    let mut filter_arrays = Vec::new();
+    let mut rows_before_filter = 0usize;
+    let mut rows_selected = 0usize;
+
+    while let Some(batch_result) = stream.next().await {
+        let batch = batch_result.context(ReadParquetSnafu {
+            path: reader_builder.file_path(),
+        })?;
+        let num_rows = batch.num_rows();
+        if num_rows == 0 {
+            continue;
+        }
+        rows_before_filter += num_rows;
+
+        let batch_mask =
+            match apply_filters_to_batch(&batch, filters, physical_filters, metadata, codec)? {
+                Some(mask) => mask,
+                None => BooleanBuffer::new_unset(num_rows),
+            };
+        rows_selected += batch_mask.count_set_bits();
+        filter_arrays.push(BooleanArray::from(batch_mask));
+    }
+
+    let filtered_rows = rows_before_filter.saturating_sub(rows_selected);
+    let refined_selection = if filter_arrays.is_empty() || rows_selected == 0 {
+        RowSelection::from(vec![])
+    } else {
+        let prefilter_selection = RowSelection::from_filters(&filter_arrays);
+        match &build_ctx.row_selection {
+            Some(original) => original.and_then(&prefilter_selection),
+            None => prefilter_selection,
+        }
+    };
+
+    Ok(PrefilterResult {
+        refined_selection,
+        filtered_rows,
+    })
+}
+
+fn apply_filters_to_batch(
+    batch: &RecordBatch,
+    filters: &[SimpleFilterContext],
+    physical_filters: &[PhysicalFilterContext],
+    metadata: &RegionMetadataRef,
+    codec: &dyn PrimaryKeyCodec,
+) -> Result<Option<BooleanBuffer>> {
+    let mut mask = BooleanBuffer::new_set(batch.num_rows());
+    let mut tag_decode_state = TagDecodeState::new();
+
+    for filter_ctx in filters {
+        let filter = match filter_ctx.filter() {
+            MaybeFilter::Filter(filter) => filter,
+            MaybeFilter::Matched => continue,
+            MaybeFilter::Pruned => return Ok(None),
+        };
+
+        let column = if let Some((idx, _)) = batch.schema().column_with_name(filter.column_name()) {
+            Some(batch.column(idx).clone())
+        } else if filter_ctx.semantic_type() == SemanticType::Tag {
+            maybe_decode_tag_column(
+                metadata,
+                filter_ctx.column_id(),
+                batch,
+                &mut tag_decode_state,
+                codec,
+            )?
+        } else {
+            None
+        };
+
+        let Some(column) = column else {
+            continue;
+        };
+        let result = filter.evaluate_array(&column).context(RecordBatchSnafu)?;
+        mask = mask.bitand(&result);
+    }
+
+    for filter_ctx in physical_filters {
+        let filter = match filter_ctx.filter() {
+            MaybePhysicalFilter::Filter(filter) => filter,
+            MaybePhysicalFilter::Matched => continue,
+            MaybePhysicalFilter::Pruned => return Ok(None),
+        };
+
+        let column =
+            if let Some((idx, _)) = batch.schema().column_with_name(filter_ctx.column_name()) {
+                Some(batch.column(idx).clone())
+            } else if filter_ctx.semantic_type() == SemanticType::Tag {
+                maybe_decode_tag_column(
+                    metadata,
+                    filter_ctx.column_id(),
+                    batch,
+                    &mut tag_decode_state,
+                    codec,
+                )?
+            } else {
+                None
+            };
+
+        let Some(column) = column else {
+            continue;
+        };
+
+        let record_batch = RecordBatch::try_new(filter_ctx.schema().clone(), vec![column])
+            .context(NewRecordBatchSnafu)?;
+        let evaluated = filter
+            .evaluate(&record_batch)
+            .context(EvalPartitionFilterSnafu)?;
+        let array = evaluated
+            .into_array(record_batch.num_rows())
+            .context(EvalPartitionFilterSnafu)?;
+        let boolean_array =
+            array
+                .as_any()
+                .downcast_ref::<BooleanArray>()
+                .context(UnexpectedSnafu {
+                    reason: "Failed to downcast physical filter result to BooleanArray",
+                })?;
+        mask = mask.bitand(boolean_array.values());
+    }
+
+    if mask.count_set_bits() == 0 {
+        Ok(None)
+    } else {
+        Ok(Some(mask))
+    }
+}
+
+fn maybe_decode_tag_column(
+    metadata: &RegionMetadataRef,
+    column_id: ColumnId,
+    input: &RecordBatch,
+    tag_decode_state: &mut TagDecodeState,
+    codec: &dyn PrimaryKeyCodec,
+) -> Result<Option<ArrayRef>> {
+    let Some(pk_index) = metadata.primary_key_index(column_id) else {
+        return Ok(None);
+    };
+
+    if let Some(cached_column) = tag_decode_state.decoded_tag_cache.get(&column_id) {
+        return Ok(Some(cached_column.clone()));
+    }
+
+    if tag_decode_state.decoded_pks.is_none() {
+        tag_decode_state.decoded_pks = Some(decode_primary_keys(codec, input)?);
+    }
+
+    let pk_index = if codec.encoding() == PrimaryKeyEncoding::Sparse {
+        None
+    } else {
+        Some(pk_index)
+    };
+    let Some(column_index) = metadata.column_index_by_id(column_id) else {
+        return Ok(None);
+    };
+    let Some(decoded) = tag_decode_state.decoded_pks.as_ref() else {
+        return Ok(None);
+    };
+
+    let column_metadata = &metadata.column_metadatas[column_index];
+    let tag_column = decoded.get_tag_column(
+        column_id,
+        pk_index,
+        &column_metadata.column_schema.data_type,
+    )?;
+    tag_decode_state
+        .decoded_tag_cache
+        .insert(column_id, tag_column.clone());
+    Ok(Some(tag_column))
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -433,7 +796,7 @@ mod tests {
 
     use super::*;
     use crate::sst::internal_fields;
-    use crate::sst::parquet::flat_format::FlatReadFormat;
+    use crate::sst::parquet::flat_format::{FlatReadFormat, primary_key_column_index};
     use crate::test_util::sst_util::{
         new_primary_key, sst_region_metadata, sst_region_metadata_with_encoding,
     };

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 
 use api::v1::SemanticType;
 use common_recordbatch::filter::SimpleFilterEvaluator;
-use datatypes::arrow::array::{BinaryArray, BooleanArray, BooleanBufferBuilder};
+use datatypes::arrow::array::{Array, BinaryArray, BooleanArray, BooleanBufferBuilder};
 use datatypes::arrow::buffer::BooleanBuffer;
 use datatypes::arrow::record_batch::RecordBatch;
 use futures::StreamExt;
@@ -665,7 +665,13 @@ fn apply_filters_to_batch(
                 .context(UnexpectedSnafu {
                     reason: "Failed to downcast physical filter result to BooleanArray",
                 })?;
-        mask = mask.bitand(boolean_array.values());
+        // Treat null results as false (filtered out); value bits are not guaranteed
+        // to be false for invalid entries.
+        let mut result = boolean_array.values().clone();
+        if let Some(nulls) = boolean_array.nulls() {
+            result = result.bitand(nulls.inner());
+        }
+        mask = mask.bitand(&result);
     }
 
     if mask.count_set_bits() == 0 {

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -371,7 +371,6 @@ impl PrefilterContextBuilder {
                 .all(SimpleFilterContext::usable_primary_key_filter)
             && prefilter_count == 1
         {
-            let num_parquet_columns = parquet_schema.num_columns();
             let pk_column_index = 0;
             return Some(Self {
                 projection,

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -152,48 +152,6 @@ pub(crate) fn prefilter_flat_batch_by_primary_key(
     }
 }
 
-/// Returns whether a filter can be applied by parquet primary-key prefiltering.
-///
-/// Unlike `PartitionTreeMemtable`, parquet prefilter always supports predicates
-/// on the partition column.
-pub(crate) fn is_usable_primary_key_filter(
-    sst_metadata: &RegionMetadataRef,
-    expected_metadata: Option<&RegionMetadata>,
-    filter: &SimpleFilterEvaluator,
-) -> bool {
-    let sst_column = match expected_metadata {
-        Some(expected_metadata) => {
-            let Some(expected_column) = expected_metadata.column_by_name(filter.column_name())
-            else {
-                return false;
-            };
-            let Some(sst_column) = sst_metadata.column_by_id(expected_column.column_id) else {
-                return false;
-            };
-
-            if sst_column.column_schema.name != expected_column.column_schema.name
-                || sst_column.semantic_type != expected_column.semantic_type
-                || sst_column.column_schema.data_type != expected_column.column_schema.data_type
-            {
-                return false;
-            }
-
-            sst_column
-        }
-        None => {
-            let Some(sst_column) = sst_metadata.column_by_name(filter.column_name()) else {
-                return false;
-            };
-            sst_column
-        }
-    };
-
-    sst_column.semantic_type == SemanticType::Tag
-        && sst_metadata
-            .primary_key_index(sst_column.column_id)
-            .is_some()
-}
-
 pub(crate) struct CachedPrimaryKeyFilter {
     inner: Box<dyn PrimaryKeyFilter>,
     last_primary_key: Vec<u8>,
@@ -270,7 +228,7 @@ pub(crate) fn build_bulk_filter_plan(
         // Split tag predicates that can be evaluated against the encoded PK
         // from filters that still need normal row-wise evaluation later.
         let pk_filter = filter_ctx.filter().as_filter().and_then(|filter| {
-            is_usable_primary_key_filter(metadata, None, filter).then(|| filter.clone())
+            (filter_ctx.semantic_type() == SemanticType::Tag).then(|| filter.clone())
         });
 
         if let Some(pk_filter) = pk_filter {
@@ -302,88 +260,88 @@ pub(crate) fn build_reader_filter_plan(
     };
 
     let metadata = read_format.metadata();
-    let mut simple_filters = Vec::new();
     let mut prefilter_simple_filters = Vec::new();
     let mut remaining_simple_filters = Vec::new();
     let mut prefilter_physical_filters = Vec::new();
     let mut primary_key_filters = Vec::new();
+    let mut pk_filter_contexts = Vec::new();
 
     // `SkipFields` keeps field predicates in the normal read path to avoid a
     // second read of projected field columns, while tags/timestamp can still
     // participate in prefiltering.
     let field_prefilter_enabled = pre_filter_mode == PreFilterMode::All;
-    // PK prefilter requires the encoded primary key column to remain available
-    // in the flat-format batch.
-    let supports_pk_prefilter = !read_format.batch_has_raw_pk_columns();
+    // When true, tag columns are encoded in the primary key column and are NOT
+    // stored as separate parquet columns. Tag predicates must go through PK
+    // decoding rather than direct column reads.
+    let need_pk_prefilter = !read_format.batch_has_raw_pk_columns();
+
+    // Whether a column can be read directly from parquet for prefiltering,
+    // based on its semantic type and the current mode/format.
+    let can_direct_prefilter = |semantic_type: SemanticType| -> bool {
+        match semantic_type {
+            SemanticType::Tag => !need_pk_prefilter,
+            SemanticType::Field => field_prefilter_enabled,
+            SemanticType::Timestamp => true,
+        }
+    };
 
     for expr in predicate.exprs() {
         // Prefer cheap simple filters first. They also preserve `Matched` /
         // `Pruned` states for columns that only exist in expected metadata.
-        if let Some(filter) = SimpleFilterContext::new_opt(metadata, expected_metadata, expr) {
-            simple_filters.push(filter);
+        if let Some(filter_ctx) = SimpleFilterContext::new_opt(metadata, expected_metadata, expr) {
+            // `Matched` and `Pruned` come from expected-metadata compatibility
+            // and must stay in the main filter list so later phases keep that
+            // outcome.
+            let Some(filter) = filter_ctx.filter().as_filter() else {
+                remaining_simple_filters.push(filter_ctx);
+                continue;
+            };
+
+            // If the column is stored as a separate parquet column and is already projected in the main read,
+            // we can evaluate the simple filter directly during prefilter.
+            let direct_prefilter = can_direct_prefilter(filter_ctx.semantic_type());
+            if direct_prefilter {
+                assert!(
+                    read_format
+                        .arrow_schema()
+                        .column_with_name(filter.column_name())
+                        .is_some(),
+                    "Column '{}' is not present in the arrow schema {:?}",
+                    filter.column_name(),
+                    read_format.arrow_schema(),
+                );
+                prefilter_simple_filters.push(filter_ctx);
+                continue;
+            }
+
+            // Otherwise try to filter through encoded-PK matching.
+            if need_pk_prefilter && filter_ctx.semantic_type() == SemanticType::Tag {
+                primary_key_filters.push(filter.clone());
+                pk_filter_contexts.push(filter_ctx);
+            } else {
+                remaining_simple_filters.push(filter_ctx);
+            }
             continue;
         }
 
+        // `PhysicalFilterContext::new_opt` returns `None` when the column is
+        // not in the projected arrow schema, so no extra `column_with_name`
+        // check is needed here.
         if let Some(filter) =
             PhysicalFilterContext::new_opt(metadata, expected_metadata, read_format, expr)
+            && can_direct_prefilter(filter.semantic_type())
         {
-            // Physical filters are only worth running in prefilter if the
-            // needed column is available in the reduced projection and the
-            // mode allows this column class.
-            let usable_prefilter = (field_prefilter_enabled
-                || filter.semantic_type() != SemanticType::Field)
-                && read_format
-                    .arrow_schema()
-                    .column_with_name(filter.column_name())
-                    .is_some();
-            if usable_prefilter {
-                prefilter_physical_filters.push(filter);
-            }
+            prefilter_physical_filters.push(filter);
         }
     }
 
-    for filter_ctx in simple_filters.iter().cloned() {
-        // `Matched` and `Pruned` come from expected-metadata compatibility and
-        // must stay in the main filter list so later phases keep that outcome.
-        let Some(filter) = filter_ctx.filter().as_filter() else {
-            remaining_simple_filters.push(filter_ctx);
-            continue;
-        };
-
-        // If the column is already projected in the main read, we can evaluate
-        // the simple filter directly during prefilter without falling back to
-        // PK decoding.
-        let direct_prefilter = (field_prefilter_enabled
-            || filter_ctx.semantic_type() != SemanticType::Field)
-            && read_format
-                .arrow_schema()
-                .column_with_name(filter.column_name())
-                .is_some();
-        if direct_prefilter {
-            prefilter_simple_filters.push(filter_ctx);
-            continue;
-        }
-
-        // Otherwise try to recover tag predicates through encoded-PK matching.
-        // These filters are still added to the prefilter phase so they can
-        // contribute to the refined row selection there.
-        let pk_prefilter = supports_pk_prefilter
-            && is_usable_primary_key_filter(metadata, expected_metadata, filter);
-        if pk_prefilter {
-            primary_key_filters.push(filter.clone());
-            prefilter_simple_filters.push(filter_ctx);
-        } else {
-            remaining_simple_filters.push(filter_ctx);
-        }
-    }
-
-    let primary_key_filters =
+    let pk_filter_exprs =
         (!primary_key_filters.is_empty()).then_some(Arc::new(primary_key_filters));
     let prefilter_builder = PrefilterContextBuilder::new(
         read_format,
         codec,
-        primary_key_filters,
-        prefilter_simple_filters,
+        pk_filter_exprs,
+        prefilter_simple_filters.clone(),
         prefilter_physical_filters,
         parquet_schema,
     );
@@ -396,8 +354,10 @@ pub(crate) fn build_reader_filter_plan(
     } else {
         // If prefilter setup is not worthwhile, keep the original simple
         // filters on the normal path so behavior is unchanged.
+        remaining_simple_filters.extend(prefilter_simple_filters);
+        remaining_simple_filters.extend(pk_filter_contexts);
         ReaderFilterPlan {
-            remaining_simple_filters: simple_filters,
+            remaining_simple_filters,
             prefilter_builder: None,
         }
     }
@@ -483,7 +443,9 @@ impl PrefilterContextBuilder {
             return None;
         }
 
-        if !should_use_prefilter(prefilter_count, remaining_count, total_count) {
+        if pk_filters.is_none()
+            && !should_use_prefilter(prefilter_count, remaining_count, total_count)
+        {
             return None;
         }
 
@@ -735,38 +697,6 @@ mod tests {
         new_primary_key, new_record_batch_with_custom_sequence, sst_region_metadata,
         sst_region_metadata_with_encoding,
     };
-
-    #[test]
-    fn test_is_usable_primary_key_filter_skips_legacy_primary_key_batches() {
-        let metadata = Arc::new(sst_region_metadata_with_encoding(
-            PrimaryKeyEncoding::Sparse,
-        ));
-        let read_format = FlatReadFormat::new(
-            metadata.clone(),
-            metadata.column_metadatas.iter().map(|c| c.column_id),
-            None,
-            "test",
-            true,
-        )
-        .unwrap();
-        assert!(!read_format.batch_has_raw_pk_columns());
-
-        let filter = SimpleFilterEvaluator::try_new(&col("tag_0").eq(lit("b"))).unwrap();
-        assert!(is_usable_primary_key_filter(&metadata, None, &filter));
-    }
-
-    #[test]
-    fn test_is_usable_primary_key_filter_supports_partition_column_by_default() {
-        let metadata = Arc::new(sst_region_metadata_with_encoding(
-            PrimaryKeyEncoding::Sparse,
-        ));
-        let filter = SimpleFilterEvaluator::try_new(
-            &col(store_api::metric_engine_consts::DATA_SCHEMA_TABLE_ID_COLUMN_NAME).eq(lit(1_u32)),
-        )
-        .unwrap();
-
-        assert!(is_usable_primary_key_filter(&metadata, None, &filter));
-    }
 
     struct CountingPrimaryKeyFilter {
         hits: Arc<AtomicUsize>,

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -43,8 +43,8 @@ use crate::error::{
 use crate::sst::parquet::flat_format::{FlatReadFormat, primary_key_column_index};
 use crate::sst::parquet::format::PrimaryKeyArray;
 use crate::sst::parquet::reader::{
-    MaybeFilter, MaybePhysicalFilter, PhysicalFilterContext, RowGroupBuildContext,
-    RowGroupReaderBuilder, SimpleFilterContext,
+    MaybeFilter, PhysicalFilterContext, RowGroupBuildContext, RowGroupReaderBuilder,
+    SimpleFilterContext,
 };
 
 pub(crate) fn matching_row_ranges_by_primary_key(
@@ -233,6 +233,7 @@ pub(crate) struct PrefilterContext {
     /// Simple filters that can be evaluated directly from the prefilter batch.
     filters: Vec<SimpleFilterContext>,
     /// Physical filters that can be evaluated directly from the prefilter batch.
+    /// Physical expressions are only applied in the prefilter phase.
     physical_filters: Vec<PhysicalFilterContext>,
 }
 
@@ -281,19 +282,16 @@ impl PrefilterContextBuilder {
         let mut prefilter_physical_filters = Vec::new();
 
         for filter_ctx in filters {
-            if !field_prefilter_enabled && filter_ctx.semantic_type() == SemanticType::Field {
-                continue;
-            }
-
             let filter = match filter_ctx.filter() {
                 MaybeFilter::Filter(filter) => filter,
                 MaybeFilter::Matched | MaybeFilter::Pruned => continue,
             };
 
-            if read_format
-                .arrow_schema()
-                .column_with_name(filter.column_name())
-                .is_some()
+            if filter_ctx.usable_prefilter()
+                && read_format
+                    .arrow_schema()
+                    .column_with_name(filter.column_name())
+                    .is_some()
             {
                 prefilter_column_names.insert(filter.column_name().to_string());
                 prefilter_filters.push(filter_ctx.clone());
@@ -304,10 +302,6 @@ impl PrefilterContextBuilder {
 
         for filter_ctx in physical_filters {
             if !field_prefilter_enabled && filter_ctx.semantic_type() == SemanticType::Field {
-                continue;
-            }
-
-            if !matches!(filter_ctx.filter(), MaybePhysicalFilter::Filter(_)) {
                 continue;
             }
 
@@ -520,11 +514,7 @@ fn apply_filters_to_batch(
     }
 
     for filter_ctx in physical_filters {
-        let filter = match filter_ctx.filter() {
-            MaybePhysicalFilter::Filter(filter) => filter,
-            MaybePhysicalFilter::Matched => continue,
-            MaybePhysicalFilter::Pruned => return Ok(None),
-        };
+        let filter = filter_ctx.filter();
 
         let (idx, _) = batch
             .schema()
@@ -664,7 +654,11 @@ mod tests {
     ) -> Vec<SimpleFilterContext> {
         exprs
             .iter()
-            .filter_map(|expr| SimpleFilterContext::new_opt(metadata, None, expr))
+            .filter_map(|expr| {
+                let mut filter = SimpleFilterContext::new_opt(metadata, None, expr)?;
+                filter.set_usable_prefilter(true);
+                Some(filter)
+            })
             .collect()
     }
 
@@ -859,7 +853,8 @@ mod tests {
         )
         .unwrap();
         let codec = build_primary_key_codec(metadata.as_ref());
-        let filters = new_simple_filter_contexts(&metadata, &[col("field_0").gt(lit(1_u64))]);
+        let mut filters = new_simple_filter_contexts(&metadata, &[col("field_0").gt(lit(1_u64))]);
+        filters[0].set_usable_prefilter(false);
         let parquet_schema = parquet_schema(&read_format);
 
         let builder = PrefilterContextBuilder::new(
@@ -873,6 +868,7 @@ mod tests {
         );
         assert!(builder.is_none());
 
+        filters[0].set_usable_prefilter(true);
         let builder = PrefilterContextBuilder::new(
             &read_format,
             &codec,

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -481,7 +481,7 @@ fn apply_filters_to_batch(
         let (idx, _) = batch
             .schema()
             .column_with_name(filter.column_name())
-            .context(UnexpectedSnafu {
+            .with_context(|| UnexpectedSnafu {
                 reason: format!(
                     "Prefilter column '{}' (id {}) not found in batch for file {}",
                     filter.column_name(),
@@ -500,7 +500,7 @@ fn apply_filters_to_batch(
         let (idx, _) = batch
             .schema()
             .column_with_name(filter_ctx.column_name())
-            .context(UnexpectedSnafu {
+            .with_context(|| UnexpectedSnafu {
                 reason: format!(
                     "Prefilter physical column '{}' (id {}) not found in batch for file {}",
                     filter_ctx.column_name(),

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -241,6 +241,8 @@ pub(crate) fn build_bulk_filter_plan(
     predicate: Option<&Predicate>,
 ) -> BulkFilterPlan {
     let metadata = read_format.metadata();
+    // Bulk memtable only needs simple binary filters here. Any filter that
+    // cannot be reduced to a SimpleFilterContext stays out of this fast path.
     let simple_filters: Vec<SimpleFilterContext> = predicate
         .into_iter()
         .flat_map(|predicate| {
@@ -251,6 +253,9 @@ pub(crate) fn build_bulk_filter_plan(
         })
         .collect();
 
+    // PK prefilter only works when flat batches still carry the encoded PK
+    // column. If tags have already been expanded to raw columns, the iterator
+    // can apply those filters directly and there is nothing to extract here.
     if read_format.batch_has_raw_pk_columns() || metadata.primary_key.is_empty() {
         return BulkFilterPlan {
             remaining_simple_filters: simple_filters,
@@ -262,6 +267,8 @@ pub(crate) fn build_bulk_filter_plan(
     let mut pk_filters = Vec::new();
 
     for filter_ctx in simple_filters {
+        // Split tag predicates that can be evaluated against the encoded PK
+        // from filters that still need normal row-wise evaluation later.
         let pk_filter = filter_ctx.filter().as_filter().and_then(|filter| {
             is_usable_primary_key_filter(metadata, None, filter).then(|| filter.clone())
         });
@@ -301,10 +308,17 @@ pub(crate) fn build_reader_filter_plan(
     let mut prefilter_physical_filters = Vec::new();
     let mut primary_key_filters = Vec::new();
 
+    // `SkipFields` keeps field predicates in the normal read path to avoid a
+    // second read of projected field columns, while tags/timestamp can still
+    // participate in prefiltering.
     let field_prefilter_enabled = pre_filter_mode == PreFilterMode::All;
+    // PK prefilter requires the encoded primary key column to remain available
+    // in the flat-format batch.
     let supports_pk_prefilter = !read_format.batch_has_raw_pk_columns();
 
     for expr in predicate.exprs() {
+        // Prefer cheap simple filters first. They also preserve `Matched` /
+        // `Pruned` states for columns that only exist in expected metadata.
         if let Some(filter) = SimpleFilterContext::new_opt(metadata, expected_metadata, expr) {
             simple_filters.push(filter);
             continue;
@@ -313,6 +327,9 @@ pub(crate) fn build_reader_filter_plan(
         if let Some(filter) =
             PhysicalFilterContext::new_opt(metadata, expected_metadata, read_format, expr)
         {
+            // Physical filters are only worth running in prefilter if the
+            // needed column is available in the reduced projection and the
+            // mode allows this column class.
             let usable_prefilter = (field_prefilter_enabled
                 || filter.semantic_type() != SemanticType::Field)
                 && read_format
@@ -326,11 +343,16 @@ pub(crate) fn build_reader_filter_plan(
     }
 
     for filter_ctx in simple_filters.iter().cloned() {
+        // `Matched` and `Pruned` come from expected-metadata compatibility and
+        // must stay in the main filter list so later phases keep that outcome.
         let Some(filter) = filter_ctx.filter().as_filter() else {
             remaining_simple_filters.push(filter_ctx);
             continue;
         };
 
+        // If the column is already projected in the main read, we can evaluate
+        // the simple filter directly during prefilter without falling back to
+        // PK decoding.
         let direct_prefilter = (field_prefilter_enabled
             || filter_ctx.semantic_type() != SemanticType::Field)
             && read_format
@@ -342,6 +364,9 @@ pub(crate) fn build_reader_filter_plan(
             continue;
         }
 
+        // Otherwise try to recover tag predicates through encoded-PK matching.
+        // These filters are still added to the prefilter phase so they can
+        // contribute to the refined row selection there.
         let pk_prefilter = supports_pk_prefilter
             && is_usable_primary_key_filter(metadata, expected_metadata, filter);
         if pk_prefilter {
@@ -369,6 +394,8 @@ pub(crate) fn build_reader_filter_plan(
             prefilter_builder,
         }
     } else {
+        // If prefilter setup is not worthwhile, keep the original simple
+        // filters on the normal path so behavior is unchanged.
         ReaderFilterPlan {
             remaining_simple_filters: simple_filters,
             prefilter_builder: None,

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -477,7 +477,13 @@ impl PrefilterContextBuilder {
             return None;
         }
 
-        if pk_filters.is_none() && prefilter_count >= read_format.projection_indices().len() {
+        let total_count = read_format.projection_indices().len();
+        let remaining_count = total_count.saturating_sub(prefilter_count);
+        if pk_filters.is_none() && prefilter_count >= total_count {
+            return None;
+        }
+
+        if !should_use_prefilter(prefilter_count, remaining_count, total_count) {
             return None;
         }
 
@@ -508,6 +514,9 @@ impl PrefilterContextBuilder {
     }
 }
 
+const PREFILTER_COLUMN_RATIO_THRESHOLD: f64 = 0.5;
+const PREFILTER_MIN_REMAINING_COLUMNS: usize = 2;
+
 /// Result of prefiltering a row group.
 pub(crate) struct PrefilterResult {
     /// Refined row selection after prefiltering.
@@ -536,6 +545,23 @@ fn compute_projection_mask(
         ProjectionMask::roots(parquet_schema, projection_indices.iter().copied()),
         count,
     )
+}
+
+fn should_use_prefilter(
+    prefilter_count: usize,
+    remaining_count: usize,
+    total_count: usize,
+) -> bool {
+    if remaining_count == 0 {
+        return false;
+    }
+
+    if remaining_count < PREFILTER_MIN_REMAINING_COLUMNS {
+        return false;
+    }
+
+    let ratio = prefilter_count as f64 / total_count as f64;
+    ratio <= PREFILTER_COLUMN_RATIO_THRESHOLD
 }
 
 pub(crate) async fn execute_prefilter(
@@ -1000,6 +1026,15 @@ mod tests {
             &parquet_schema,
         );
         assert!(builder.is_none());
+    }
+
+    #[test]
+    fn test_should_use_prefilter() {
+        assert!(should_use_prefilter(1, 5, 6));
+        assert!(!should_use_prefilter(1, 0, 1));
+        assert!(!should_use_prefilter(1, 1, 2));
+        assert!(!should_use_prefilter(4, 3, 7));
+        assert!(should_use_prefilter(3, 3, 6));
     }
 
     #[test]

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -184,13 +184,35 @@ impl PrimaryKeyFilter for CachedPrimaryKeyFilter {
     }
 }
 
+/// How the bulk-memtable read should apply each predicate.
+///
+/// Unlike the parquet reader, the bulk path has no prefilter pass; predicates
+/// either run row-wise inside the iterator or are pushed down to encoded-PK
+/// matching when the batch still carries the primary-key column.
 pub(crate) struct BulkFilterPlan {
+    /// Simple filters the iterator still has to evaluate row-wise on each batch.
     pub(crate) remaining_simple_filters: Vec<SimpleFilterContext>,
+    /// Tag predicates lowered to encoded-PK filters. `None` when the batch
+    /// already exposes raw tag columns or there are no tag predicates.
     pub(crate) pk_filters: Option<Arc<Vec<SimpleFilterEvaluator>>>,
 }
 
+/// How the parquet reader should apply each predicate.
+///
+/// The reader runs in two phases. Predicates routed into `prefilter_builder`
+/// execute on a reduced column set first to compute a refined row selection;
+/// `remaining_simple_filters` execute alongside the full projection on the
+/// normal read path. The contract for what is precise vs best-effort is
+/// documented on [`build_reader_filter_plan`].
 pub(crate) struct ReaderFilterPlan {
+    /// Simple filters that must run on the normal read path: predicates with
+    /// `Matched` / `Pruned` outcomes (which carry expected-metadata
+    /// compatibility decisions later phases rely on), and predicates whose
+    /// column cannot be read directly during the prefilter pass.
     pub(crate) remaining_simple_filters: Vec<SimpleFilterContext>,
+    /// Pre-built state for the prefilter pass, or `None` when prefiltering is
+    /// not worthwhile (no prefilter columns selected, or the prefilter
+    /// projection would cover nearly the full read).
     pub(crate) prefilter_builder: Option<PrefilterContextBuilder>,
 }
 
@@ -244,6 +266,20 @@ pub(crate) fn build_bulk_filter_plan(
     }
 }
 
+/// Splits a query [`Predicate`] into a [`ReaderFilterPlan`]: predicates that can run
+/// during the prefilter pass (on a reduced projection, to compute a refined row
+/// selection) versus predicates that must run on the normal read path (alongside the
+/// full projection).
+///
+/// The prefilter pass is *best-effort pruning*: a physical-filter predicate is silently
+/// dropped when [`PhysicalFilterContext::new_opt`] returns `None` (column not in the
+/// projected arrow schema). This is safe because the DataFusion `FilterExec` above the
+/// reader always re-applies the original predicate, so the prefilter pass is purely a
+/// pruning hint.
+///
+/// Tag and timestamp predicates that lower to [`SimpleFilterEvaluator`] are an
+/// exception — the engine enforces them precisely, so the prefilter pass is the only
+/// place they execute. They are never silently dropped.
 pub(crate) fn build_reader_filter_plan(
     predicate: Option<&Predicate>,
     expected_metadata: Option<&RegionMetadata>,
@@ -324,9 +360,10 @@ pub(crate) fn build_reader_filter_plan(
             continue;
         }
 
-        // `PhysicalFilterContext::new_opt` returns `None` when the column is
-        // not in the projected arrow schema, so no extra `column_with_name`
-        // check is needed here.
+        // Best-effort physical-filter prefilter (see fn-level doc): `new_opt`
+        // returning `None` means the column is not in the projected arrow
+        // schema, and dropping the predicate is safe because the upper
+        // `FilterExec` re-applies it.
         if let Some(filter) =
             PhysicalFilterContext::new_opt(metadata, expected_metadata, read_format, expr)
             && can_direct_prefilter(filter.semantic_type())

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -28,7 +28,7 @@ use common_telemetry::{error, tracing, warn};
 use datafusion::physical_plan::PhysicalExpr;
 use datafusion_expr::Expr;
 use datafusion_expr::utils::expr_to_columns;
-use datatypes::arrow::array::{Array as _, ArrayRef, BooleanArray};
+use datatypes::arrow::array::ArrayRef;
 use datatypes::arrow::datatypes::{Field, Schema as ArrowSchema, SchemaRef};
 use datatypes::arrow::record_batch::RecordBatch;
 use datatypes::data_type::ConcreteDataType;
@@ -455,12 +455,23 @@ impl ParquetReaderBuilder {
         let (filters, physical_filters) = if let Some(predicate) = &self.predicate {
             let mut simple_filters = Vec::new();
             let mut physical_filters = Vec::new();
+            let field_prefilter_enabled = self.pre_filter_mode == PreFilterMode::All;
             for expr in predicate.exprs() {
-                if let Some(filter) = SimpleFilterContext::new_opt(
+                if let Some(mut filter) = SimpleFilterContext::new_opt(
                     &region_meta,
                     self.expected_metadata.as_deref(),
                     expr,
                 ) {
+                    let prefilter_uses_column = filter.filter().as_filter().is_some_and(|filter| {
+                        read_format
+                            .arrow_schema()
+                            .column_with_name(filter.column_name())
+                            .is_some()
+                    });
+                    let usable_prefilter = (field_prefilter_enabled
+                        || filter.semantic_type() != SemanticType::Field)
+                        && (prefilter_uses_column || filter.usable_primary_key_filter());
+                    filter.set_usable_prefilter(usable_prefilter);
                     simple_filters.push(filter);
                     continue;
                 }
@@ -525,7 +536,6 @@ impl ParquetReaderBuilder {
             reader_builder,
             RangeBase {
                 filters,
-                physical_filters,
                 dyn_filters,
                 read_format,
                 expected_metadata: self.expected_metadata.clone(),
@@ -1813,6 +1823,16 @@ pub(crate) enum MaybeFilter {
     Pruned,
 }
 
+impl MaybeFilter {
+    /// Returns the inner filter when it is available.
+    pub(crate) fn as_filter(&self) -> Option<&SimpleFilterEvaluator> {
+        match self {
+            MaybeFilter::Filter(filter) => Some(filter),
+            MaybeFilter::Matched | MaybeFilter::Pruned => None,
+        }
+    }
+}
+
 #[derive(Clone)]
 /// Context to evaluate the column filter for a parquet file.
 pub(crate) struct SimpleFilterContext {
@@ -1822,6 +1842,10 @@ pub(crate) struct SimpleFilterContext {
     column_id: ColumnId,
     /// Semantic type of the column.
     semantic_type: SemanticType,
+    /// The data type of the column.
+    data_type: ConcreteDataType,
+    /// Whether this filter can be applied by parquet prefiltering in the current read path.
+    usable_prefilter: bool,
     /// Whether this filter can be applied by flat parquet primary-key prefiltering.
     usable_primary_key_filter: bool,
 }
@@ -1878,6 +1902,8 @@ impl SimpleFilterContext {
             filter: maybe_filter,
             column_id: column_metadata.column_id,
             semantic_type: column_metadata.semantic_type,
+            data_type: column_metadata.column_schema.data_type.clone(),
+            usable_prefilter: false,
             usable_primary_key_filter,
         })
     }
@@ -1895,6 +1921,21 @@ impl SimpleFilterContext {
     /// Returns the semantic type of the column.
     pub(crate) fn semantic_type(&self) -> SemanticType {
         self.semantic_type
+    }
+
+    /// Returns the data type of the column.
+    pub(crate) fn data_type(&self) -> &ConcreteDataType {
+        &self.data_type
+    }
+
+    /// Returns whether this filter can be applied by parquet prefiltering.
+    pub(crate) fn usable_prefilter(&self) -> bool {
+        self.usable_prefilter
+    }
+
+    /// Updates whether this filter can be applied by parquet prefiltering.
+    pub(crate) fn set_usable_prefilter(&mut self, usable_prefilter: bool) {
+        self.usable_prefilter = usable_prefilter;
     }
 
     /// Returns whether this filter is eligible for flat parquet PK prefiltering.
@@ -1916,21 +1957,10 @@ impl SimpleFilterContext {
 }
 
 #[derive(Clone)]
-/// The physical filter to evaluate or the prune result of the default value.
-pub(crate) enum MaybePhysicalFilter {
-    /// The filter to evaluate.
-    Filter(Arc<dyn PhysicalExpr>),
-    /// The filter matches the default value.
-    Matched,
-    /// The filter is pruned.
-    Pruned,
-}
-
-#[derive(Clone)]
 /// Context to evaluate a physical expression for a parquet file.
 pub(crate) struct PhysicalFilterContext {
     /// Filter to evaluate.
-    filter: MaybePhysicalFilter,
+    filter: Arc<dyn PhysicalExpr>,
     /// Id of the column to evaluate.
     column_id: ColumnId,
     /// Name of the column to evaluate.
@@ -1953,15 +1983,18 @@ impl PhysicalFilterContext {
         expr: &Expr,
     ) -> Option<Self> {
         let column_name = Self::single_column_name(expr)?;
-        let (column_metadata, column_in_sst) = match expected_meta {
+        let column_metadata = match expected_meta {
             Some(meta) => {
                 let column = meta.column_by_name(&column_name)?;
-                let column_in_sst = sst_meta.column_by_id(column.column_id).is_some();
-                (column, column_in_sst)
+                let sst_column = sst_meta.column_by_id(column.column_id)?;
+                if sst_column.column_schema.name != column_name {
+                    return None;
+                }
+                column
             }
             None => {
                 let column = sst_meta.column_by_name(&column_name)?;
-                (column, true)
+                column
             }
         };
 
@@ -1984,43 +2017,14 @@ impl PhysicalFilterContext {
                 }
             };
         let schema = Arc::new(ArrowSchema::new(vec![field]));
-        let physical_expr = Predicate::new(vec![expr.clone()])
-            .to_physical_exprs(&schema)
+        let physical_expr = Predicate::to_physical_expr(expr, &schema)
             .inspect_err(|e| {
                 error!("Unable to build physical filter for {expr}, schema: {schema:?}, err: {e}");
             })
-            .ok()?
-            .into_iter()
-            .next()?;
-
-        let filter = if column_in_sst {
-            MaybePhysicalFilter::Filter(physical_expr)
-        } else {
-            let default_value = column_metadata
-                .column_schema
-                .create_default()
-                .ok()
-                .flatten()?;
-            let scalar_value = default_value
-                .try_to_scalar_value(&column_metadata.column_schema.data_type)
-                .ok()?;
-            let array = scalar_value.to_array_of_size(1).ok()?;
-            let record_batch = RecordBatch::try_new(schema.clone(), vec![array]).ok()?;
-            let evaluated = physical_expr.evaluate(&record_batch).ok()?;
-            let array = evaluated.into_array(record_batch.num_rows()).ok()?;
-            let boolean_array = array.as_any().downcast_ref::<BooleanArray>()?;
-            if boolean_array.is_null(0) {
-                return None;
-            }
-            if boolean_array.value(0) {
-                MaybePhysicalFilter::Matched
-            } else {
-                MaybePhysicalFilter::Pruned
-            }
-        };
+            .ok()?;
 
         Some(Self {
-            filter,
+            filter: physical_expr,
             column_id: column_metadata.column_id,
             column_name,
             semantic_type: column_metadata.semantic_type,
@@ -2040,7 +2044,7 @@ impl PhysicalFilterContext {
     }
 
     /// Returns the filter to evaluate.
-    pub(crate) fn filter(&self) -> &MaybePhysicalFilter {
+    pub(crate) fn filter(&self) -> &Arc<dyn PhysicalExpr> {
         &self.filter
     }
 
@@ -2414,5 +2418,28 @@ mod tests {
         .unwrap();
         assert!(!mismatched_ctx.usable_primary_key_filter());
         assert!(mismatched_ctx.primary_key_prefilter().is_none());
+    }
+
+    #[test]
+    fn test_physical_filter_context_skips_renamed_column() {
+        let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
+        let expected_metadata = expected_metadata_with_reused_tag_name(metadata.as_ref());
+        let read_format = ReadFormat::new_flat(
+            metadata.clone(),
+            metadata.column_metadatas.iter().map(|c| c.column_id),
+            None,
+            "test",
+            true,
+        )
+        .unwrap();
+
+        let ctx = PhysicalFilterContext::new_opt(
+            &metadata,
+            Some(expected_metadata.as_ref()),
+            &read_format,
+            &col("tag_0").eq(lit("a")),
+        );
+
+        assert!(ctx.is_none());
     }
 }

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -1673,12 +1673,6 @@ pub(crate) struct RowGroupReaderBuilder {
 /// Context passed to [RowGroupReaderBuilder::build()] carrying all information
 /// needed for prefiltering decisions.
 pub(crate) struct RowGroupBuildContext<'a> {
-    /// Simple filters pushed down. Used by prefilter on other columns.
-    #[allow(dead_code)]
-    pub(crate) filters: &'a [SimpleFilterContext],
-    /// Physical filters pushed down. Used by prefilter on other columns.
-    #[allow(dead_code)]
-    pub(crate) physical_filters: &'a [PhysicalFilterContext],
     /// Index of the row group to read.
     pub(crate) row_group_idx: usize,
     /// Row selection for the row group. `None` means all rows.
@@ -1922,7 +1916,6 @@ impl SimpleFilterContext {
 }
 
 #[derive(Clone)]
-#[allow(dead_code)]
 /// The physical filter to evaluate or the prune result of the default value.
 pub(crate) enum MaybePhysicalFilter {
     /// The filter to evaluate.
@@ -1934,7 +1927,6 @@ pub(crate) enum MaybePhysicalFilter {
 }
 
 #[derive(Clone)]
-#[allow(dead_code)]
 /// Context to evaluate a physical expression for a parquet file.
 pub(crate) struct PhysicalFilterContext {
     /// Filter to evaluate.
@@ -1949,7 +1941,6 @@ pub(crate) struct PhysicalFilterContext {
     schema: SchemaRef,
 }
 
-#[allow(dead_code)]
 impl PhysicalFilterContext {
     /// Creates a context for the `expr`.
     ///
@@ -1958,7 +1949,7 @@ impl PhysicalFilterContext {
     pub(crate) fn new_opt(
         sst_meta: &RegionMetadataRef,
         expected_meta: Option<&RegionMetadata>,
-        read_format: &ReadFormat,
+        read_format: &FlatReadFormat,
         expr: &Expr,
     ) -> Option<Self> {
         let column_name = Self::single_column_name(expr)?;

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -24,10 +24,12 @@ use std::time::{Duration, Instant};
 
 use api::v1::SemanticType;
 use common_recordbatch::filter::SimpleFilterEvaluator;
-use common_telemetry::{tracing, warn};
+use common_telemetry::{error, tracing, warn};
+use datafusion::physical_plan::PhysicalExpr;
 use datafusion_expr::Expr;
-use datatypes::arrow::array::ArrayRef;
-use datatypes::arrow::datatypes::{Field, SchemaRef};
+use datafusion_expr::utils::expr_to_columns;
+use datatypes::arrow::array::{Array as _, ArrayRef, BooleanArray};
+use datatypes::arrow::datatypes::{Field, Schema as ArrowSchema, SchemaRef};
 use datatypes::arrow::record_batch::RecordBatch;
 use datatypes::data_type::ConcreteDataType;
 use datatypes::prelude::DataType;
@@ -450,20 +452,30 @@ impl ParquetReaderBuilder {
             ArrowReaderMetadata::try_new(parquet_meta.clone(), arrow_reader_options)
                 .context(ReadDataPartSnafu)?;
 
-        let filters = if let Some(predicate) = &self.predicate {
-            predicate
-                .exprs()
-                .iter()
-                .filter_map(|expr| {
-                    SimpleFilterContext::new_opt(
-                        &region_meta,
-                        self.expected_metadata.as_deref(),
-                        expr,
-                    )
-                })
-                .collect::<Vec<_>>()
+        let (filters, physical_filters) = if let Some(predicate) = &self.predicate {
+            let mut simple_filters = Vec::new();
+            let mut physical_filters = Vec::new();
+            for expr in predicate.exprs() {
+                if let Some(filter) = SimpleFilterContext::new_opt(
+                    &region_meta,
+                    self.expected_metadata.as_deref(),
+                    expr,
+                ) {
+                    simple_filters.push(filter);
+                    continue;
+                }
+                if let Some(filter) = PhysicalFilterContext::new_opt(
+                    &region_meta,
+                    self.expected_metadata.as_deref(),
+                    &read_format,
+                    expr,
+                ) {
+                    physical_filters.push(filter);
+                }
+            }
+            (simple_filters, physical_filters)
         } else {
-            vec![]
+            (vec![], vec![])
         };
 
         let dyn_filters = if let Some(predicate) = &self.predicate {
@@ -510,6 +522,7 @@ impl ParquetReaderBuilder {
             reader_builder,
             RangeBase {
                 filters,
+                physical_filters,
                 dyn_filters,
                 read_format,
                 expected_metadata: self.expected_metadata.clone(),
@@ -1660,6 +1673,9 @@ pub(crate) struct RowGroupBuildContext<'a> {
     /// Simple filters pushed down. Used by prefilter on other columns.
     #[allow(dead_code)]
     pub(crate) filters: &'a [SimpleFilterContext],
+    /// Physical filters pushed down. Used by prefilter on other columns.
+    #[allow(dead_code)]
+    pub(crate) physical_filters: &'a [PhysicalFilterContext],
     /// Index of the row group to read.
     pub(crate) row_group_idx: usize,
     /// Row selection for the row group. `None` means all rows.
@@ -1897,6 +1913,157 @@ impl SimpleFilterContext {
             MaybeFilter::Filter(filter) => Some(filter.clone()),
             MaybeFilter::Matched | MaybeFilter::Pruned => None,
         }
+    }
+}
+
+#[allow(dead_code)]
+/// The physical filter to evaluate or the prune result of the default value.
+pub(crate) enum MaybePhysicalFilter {
+    /// The filter to evaluate.
+    Filter(Arc<dyn PhysicalExpr>),
+    /// The filter matches the default value.
+    Matched,
+    /// The filter is pruned.
+    Pruned,
+}
+
+#[allow(dead_code)]
+/// Context to evaluate a physical expression for a parquet file.
+pub(crate) struct PhysicalFilterContext {
+    /// Filter to evaluate.
+    filter: MaybePhysicalFilter,
+    /// Id of the column to evaluate.
+    column_id: ColumnId,
+    /// Name of the column to evaluate.
+    column_name: String,
+    /// Semantic type of the column.
+    semantic_type: SemanticType,
+    /// Schema containing only the referenced column.
+    schema: SchemaRef,
+}
+
+#[allow(dead_code)]
+impl PhysicalFilterContext {
+    /// Creates a context for the `expr`.
+    ///
+    /// Returns None if the expression doesn't reference exactly one column or the
+    /// column to filter doesn't exist in the SST metadata or the expected metadata.
+    pub(crate) fn new_opt(
+        sst_meta: &RegionMetadataRef,
+        expected_meta: Option<&RegionMetadata>,
+        read_format: &ReadFormat,
+        expr: &Expr,
+    ) -> Option<Self> {
+        let column_name = Self::single_column_name(expr)?;
+        let (column_metadata, column_in_sst) = match expected_meta {
+            Some(meta) => {
+                let column = meta.column_by_name(&column_name)?;
+                let column_in_sst = sst_meta.column_by_id(column.column_id).is_some();
+                (column, column_in_sst)
+            }
+            None => {
+                let column = sst_meta.column_by_name(&column_name)?;
+                (column, true)
+            }
+        };
+
+        let field =
+            if let Some((_, field)) = read_format.arrow_schema().column_with_name(&column_name) {
+                field.clone()
+            } else {
+                let field = Field::try_from(&column_metadata.column_schema).ok()?;
+                if column_metadata.semantic_type == SemanticType::Tag
+                    && column_metadata.column_schema.data_type.is_string()
+                {
+                    tag_maybe_to_dictionary_field(
+                        &column_metadata.column_schema.data_type,
+                        &Arc::new(field),
+                    )
+                    .as_ref()
+                    .clone()
+                } else {
+                    field
+                }
+            };
+        let schema = Arc::new(ArrowSchema::new(vec![field]));
+        let physical_expr = Predicate::new(vec![expr.clone()])
+            .to_physical_exprs(&schema)
+            .inspect_err(|e| {
+                error!("Unable to build physical filter for {expr}, schema: {schema:?}, err: {e}");
+            })
+            .ok()?
+            .into_iter()
+            .next()?;
+
+        let filter = if column_in_sst {
+            MaybePhysicalFilter::Filter(physical_expr)
+        } else {
+            let default_value = column_metadata
+                .column_schema
+                .create_default()
+                .ok()
+                .flatten()?;
+            let scalar_value = default_value
+                .try_to_scalar_value(&column_metadata.column_schema.data_type)
+                .ok()?;
+            let array = scalar_value.to_array_of_size(1).ok()?;
+            let record_batch = RecordBatch::try_new(schema.clone(), vec![array]).ok()?;
+            let evaluated = physical_expr.evaluate(&record_batch).ok()?;
+            let array = evaluated.into_array(record_batch.num_rows()).ok()?;
+            let boolean_array = array.as_any().downcast_ref::<BooleanArray>()?;
+            if boolean_array.is_null(0) {
+                return None;
+            }
+            if boolean_array.value(0) {
+                MaybePhysicalFilter::Matched
+            } else {
+                MaybePhysicalFilter::Pruned
+            }
+        };
+
+        Some(Self {
+            filter,
+            column_id: column_metadata.column_id,
+            column_name,
+            semantic_type: column_metadata.semantic_type,
+            schema,
+        })
+    }
+
+    fn single_column_name(expr: &Expr) -> Option<String> {
+        let mut columns = HashSet::new();
+        if expr_to_columns(expr, &mut columns).is_err() {
+            return None;
+        }
+        if columns.len() != 1 {
+            return None;
+        }
+        columns.iter().next().map(|column| column.name.clone())
+    }
+
+    /// Returns the filter to evaluate.
+    pub(crate) fn filter(&self) -> &MaybePhysicalFilter {
+        &self.filter
+    }
+
+    /// Returns the column id.
+    pub(crate) fn column_id(&self) -> ColumnId {
+        self.column_id
+    }
+
+    /// Returns the column name.
+    pub(crate) fn column_name(&self) -> &str {
+        &self.column_name
+    }
+
+    /// Returns the semantic type of the column.
+    pub(crate) fn semantic_type(&self) -> SemanticType {
+        self.semantic_type
+    }
+
+    /// Returns the schema containing only the referenced column.
+    pub(crate) fn schema(&self) -> &SchemaRef {
+        &self.schema
     }
 }
 

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -1706,7 +1706,7 @@ impl RowGroupReaderBuilder {
         &self.cache_strategy
     }
 
-    pub(crate) fn has_flat_primary_key_prefilter(&self) -> bool {
+    pub(crate) fn has_predicate_prefilter(&self) -> bool {
         self.prefilter_builder.is_some()
     }
 

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -34,13 +34,12 @@ use datatypes::arrow::record_batch::RecordBatch;
 use datatypes::data_type::ConcreteDataType;
 use datatypes::prelude::DataType;
 use futures::StreamExt;
-use mito_codec::row_converter::{PrimaryKeyCodec, build_primary_key_codec};
+use mito_codec::row_converter::build_primary_key_codec;
 use object_store::ObjectStore;
 use parquet::arrow::ProjectionMask;
 use parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions, RowSelection};
 use parquet::arrow::async_reader::{ParquetRecordBatchStream, ParquetRecordBatchStreamBuilder};
 use parquet::file::metadata::{PageIndexPolicy, ParquetMetaData};
-use parquet::schema::types::SchemaDescriptor;
 use partition::expr::PartitionExpr;
 use snafu::ResultExt;
 use store_api::codec::PrimaryKeyEncoding;
@@ -82,7 +81,7 @@ use crate::sst::parquet::flat_format::FlatReadFormat;
 use crate::sst::parquet::format::need_override_sequence;
 use crate::sst::parquet::metadata::MetadataLoader;
 use crate::sst::parquet::prefilter::{
-    PrefilterContextBuilder, execute_prefilter, is_usable_primary_key_filter,
+    PrefilterContextBuilder, build_reader_filter_plan, execute_prefilter,
 };
 use crate::sst::parquet::read_columns::{
     ParquetReadColumns, ProjectionMaskPlan, build_projection_plan,
@@ -96,11 +95,6 @@ const INDEX_TYPE_FULLTEXT: &str = "fulltext";
 const INDEX_TYPE_INVERTED: &str = "inverted";
 const INDEX_TYPE_BLOOM: &str = "bloom filter";
 const INDEX_TYPE_VECTOR: &str = "vector";
-
-struct ReaderFilterPlan {
-    remaining_simple_filters: Vec<SimpleFilterContext>,
-    prefilter_builder: Option<PrefilterContextBuilder>,
-}
 
 macro_rules! handle_index_error {
     ($err:expr, $file_handle:expr, $index_type:expr) => {
@@ -466,8 +460,10 @@ impl ParquetReaderBuilder {
 
         let codec = build_primary_key_codec(read_format.metadata());
 
-        let filter_plan = self.build_filter_plan(
-            &region_meta,
+        let filter_plan = build_reader_filter_plan(
+            self.predicate.as_ref(),
+            self.expected_metadata.as_deref(),
+            self.pre_filter_mode,
             &read_format,
             parquet_meta.file_metadata().schema_descr(),
             &codec,
@@ -508,112 +504,6 @@ impl ParquetReaderBuilder {
         metrics.build_cost += start.elapsed();
 
         Ok(Some((context, selection)))
-    }
-
-    fn build_filter_plan(
-        &self,
-        region_meta: &RegionMetadataRef,
-        read_format: &ReadFormat,
-        parquet_schema: &SchemaDescriptor,
-        codec: &Arc<dyn PrimaryKeyCodec>,
-    ) -> ReaderFilterPlan {
-        let Some(predicate) = &self.predicate else {
-            return ReaderFilterPlan {
-                remaining_simple_filters: Vec::new(),
-                prefilter_builder: None,
-            };
-        };
-
-        let mut simple_filters = Vec::new();
-        let mut prefilter_simple_filters = Vec::new();
-        let mut remaining_simple_filters = Vec::new();
-        let mut prefilter_physical_filters = Vec::new();
-        let mut primary_key_filters = Vec::new();
-
-        let field_prefilter_enabled = self.pre_filter_mode == PreFilterMode::All;
-        let supports_pk_prefilter = read_format
-            .as_flat()
-            .is_some_and(|flat_format| !flat_format.batch_has_raw_pk_columns());
-
-        for expr in predicate.exprs() {
-            if let Some(filter) =
-                SimpleFilterContext::new_opt(region_meta, self.expected_metadata.as_deref(), expr)
-            {
-                simple_filters.push(filter);
-                continue;
-            }
-
-            if let Some(filter) = PhysicalFilterContext::new_opt(
-                region_meta,
-                self.expected_metadata.as_deref(),
-                read_format,
-                expr,
-            ) {
-                let usable_prefilter = (field_prefilter_enabled
-                    || filter.semantic_type() != SemanticType::Field)
-                    && read_format
-                        .arrow_schema()
-                        .column_with_name(filter.column_name())
-                        .is_some();
-                if usable_prefilter {
-                    prefilter_physical_filters.push(filter);
-                }
-            }
-        }
-
-        for filter_ctx in simple_filters.iter().cloned() {
-            let Some(filter) = filter_ctx.filter().as_filter() else {
-                remaining_simple_filters.push(filter_ctx);
-                continue;
-            };
-
-            let direct_prefilter = (field_prefilter_enabled
-                || filter_ctx.semantic_type() != SemanticType::Field)
-                && read_format
-                    .arrow_schema()
-                    .column_with_name(filter.column_name())
-                    .is_some();
-            if direct_prefilter {
-                prefilter_simple_filters.push(filter_ctx);
-                continue;
-            }
-
-            let pk_prefilter = supports_pk_prefilter
-                && is_usable_primary_key_filter(
-                    region_meta,
-                    self.expected_metadata.as_deref(),
-                    filter,
-                );
-            if pk_prefilter {
-                primary_key_filters.push(filter.clone());
-                prefilter_simple_filters.push(filter_ctx);
-            } else {
-                remaining_simple_filters.push(filter_ctx);
-            }
-        }
-
-        let primary_key_filters =
-            (!primary_key_filters.is_empty()).then_some(Arc::new(primary_key_filters));
-        let prefilter_builder = PrefilterContextBuilder::new(
-            read_format,
-            codec,
-            primary_key_filters,
-            prefilter_simple_filters,
-            prefilter_physical_filters,
-            parquet_schema,
-        );
-
-        if prefilter_builder.is_some() {
-            ReaderFilterPlan {
-                remaining_simple_filters,
-                prefilter_builder,
-            }
-        } else {
-            ReaderFilterPlan {
-                remaining_simple_filters: simple_filters,
-                prefilter_builder: None,
-            }
-        }
     }
 
     fn is_same_region_partition(
@@ -2426,85 +2316,6 @@ mod tests {
             .primary_key(vec![10, 1]);
 
         Arc::new(builder.build().unwrap())
-    }
-
-    fn new_test_parquet_reader_builder(
-        predicate: Predicate,
-        pre_filter_mode: PreFilterMode,
-    ) -> ParquetReaderBuilder {
-        let object_store = ObjectStore::new(Memory::default()).unwrap().finish();
-        let file_handle = sst_file_handle(0, 1);
-
-        ParquetReaderBuilder::new(
-            "test_table".to_string(),
-            PathType::Bare,
-            file_handle,
-            object_store,
-        )
-        .predicate(Some(predicate))
-        .pre_filter_mode(pre_filter_mode)
-    }
-
-    #[test]
-    fn test_build_filter_plan_keeps_field_filters_for_prune_reader_in_skip_fields_mode() {
-        let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
-        let read_format = ReadFormat::new_flat(
-            metadata.clone(),
-            metadata.column_metadatas.iter().map(|c| c.column_id),
-            None,
-            "test",
-            true,
-        )
-        .unwrap();
-        let parquet_schema = parquet::arrow::ArrowSchemaConverter::new()
-            .convert(read_format.arrow_schema())
-            .unwrap();
-        let codec = build_primary_key_codec(metadata.as_ref());
-        let builder = new_test_parquet_reader_builder(
-            Predicate::new(vec![
-                col("tag_0").eq(lit("a")),
-                col("field_0").gt(lit(1_u64)),
-            ]),
-            PreFilterMode::SkipFields,
-        );
-
-        let plan = builder.build_filter_plan(&metadata, &read_format, &parquet_schema, &codec);
-
-        assert!(plan.prefilter_builder.is_some());
-        assert_eq!(plan.remaining_simple_filters.len(), 1);
-        let remaining_filter = plan.remaining_simple_filters[0]
-            .filter()
-            .as_filter()
-            .unwrap();
-        assert_eq!(remaining_filter.column_name(), "field_0");
-    }
-
-    #[test]
-    fn test_build_filter_plan_uses_pk_prefilter_for_unprojected_tag_filters() {
-        let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
-        let field_0 = metadata.column_by_name("field_0").unwrap().column_id;
-        let ts = metadata.time_index_column().column_id;
-        let read_format = ReadFormat::new_flat(
-            metadata.clone(),
-            [field_0, ts].into_iter(),
-            None,
-            "test",
-            true,
-        )
-        .unwrap();
-        let parquet_schema = parquet::arrow::ArrowSchemaConverter::new()
-            .convert(read_format.arrow_schema())
-            .unwrap();
-        let codec = build_primary_key_codec(metadata.as_ref());
-        let builder = new_test_parquet_reader_builder(
-            Predicate::new(vec![col("tag_0").eq(lit("a"))]),
-            PreFilterMode::All,
-        );
-
-        let plan = builder.build_filter_plan(&metadata, &read_format, &parquet_schema, &codec);
-
-        assert!(plan.prefilter_builder.is_some());
-        assert!(plan.remaining_simple_filters.is_empty());
     }
 
     #[test]

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -1869,8 +1869,8 @@ impl SimpleFilterContext {
     }
 }
 
-#[derive(Clone)]
 /// Context to evaluate a physical expression for a parquet file.
+#[derive(Clone)]
 pub(crate) struct PhysicalFilterContext {
     /// Filter to evaluate.
     filter: Arc<dyn PhysicalExpr>,
@@ -1903,14 +1903,13 @@ impl PhysicalFilterContext {
             Some(meta) => {
                 let column = meta.column_by_name(&column_name)?;
                 let sst_column = sst_meta.column_by_id(column.column_id)?;
+                // Physical expr requires the column name to match the SST column name.
                 if sst_column.column_schema.name != column_name {
                     return None;
                 }
                 column
             }
-            None => {
-                sst_meta.column_by_name(&column_name)?
-            }
+            None => sst_meta.column_by_name(&column_name)?,
         };
 
         // The column must be present in the projected arrow schema for the
@@ -1920,7 +1919,7 @@ impl PhysicalFilterContext {
         let schema = Arc::new(ArrowSchema::new(vec![field]));
         let physical_expr = Predicate::to_physical_expr(expr, &schema)
             .inspect_err(|e| {
-                error!("Unable to build physical filter for {expr}, schema: {schema:?}, err: {e}");
+                error!(e; "Unable to build physical filter for {expr}, schema: {schema:?}");
             })
             .ok()?;
 
@@ -1936,8 +1935,7 @@ impl PhysicalFilterContext {
     /// Returns true if the expression is a variant we want to evaluate as a
     /// physical prefilter. Binary exprs are intentionally excluded because
     /// [`SimpleFilterEvaluator`] already handles them.
-    // TODO: extend to a small allowlist of cheap scalar functions
-    // (e.g. `lower`, `length`, date truncations) when we have a use case.
+    // TODO(yingwen): extend more expressions if necessary. For example, allow some cheap scalar functions (e.g. `lower`, `length`, date truncations)
     fn is_prefilter_candidate(expr: &Expr) -> bool {
         matches!(
             expr,

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -1795,8 +1795,6 @@ pub(crate) struct SimpleFilterContext {
     column_id: ColumnId,
     /// Semantic type of the column.
     semantic_type: SemanticType,
-    /// The data type of the column.
-    data_type: ConcreteDataType,
 }
 
 impl SimpleFilterContext {
@@ -1844,7 +1842,6 @@ impl SimpleFilterContext {
             filter: maybe_filter,
             column_id: column_metadata.column_id,
             semantic_type: column_metadata.semantic_type,
-            data_type: column_metadata.column_schema.data_type.clone(),
         })
     }
 
@@ -1861,11 +1858,6 @@ impl SimpleFilterContext {
     /// Returns the semantic type of the column.
     pub(crate) fn semantic_type(&self) -> SemanticType {
         self.semantic_type
-    }
-
-    /// Returns the data type of the column.
-    pub(crate) fn data_type(&self) -> &ConcreteDataType {
-        &self.data_type
     }
 }
 

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -1982,6 +1982,9 @@ impl PhysicalFilterContext {
         read_format: &FlatReadFormat,
         expr: &Expr,
     ) -> Option<Self> {
+        if !Self::is_prefilter_candidate(expr) {
+            return None;
+        }
         let column_name = Self::single_column_name(expr)?;
         let column_metadata = match expected_meta {
             Some(meta) => {
@@ -2030,6 +2033,18 @@ impl PhysicalFilterContext {
             semantic_type: column_metadata.semantic_type,
             schema,
         })
+    }
+
+    /// Returns true if the expression is a variant we want to evaluate as a
+    /// physical prefilter. Binary exprs are intentionally excluded because
+    /// [`SimpleFilterEvaluator`] already handles them.
+    // TODO: extend to a small allowlist of cheap scalar functions
+    // (e.g. `lower`, `length`, date truncations) when we have a use case.
+    fn is_prefilter_candidate(expr: &Expr) -> bool {
+        matches!(
+            expr,
+            Expr::InList(_) | Expr::IsNull(_) | Expr::IsNotNull(_) | Expr::Between(_)
+        )
     }
 
     fn single_column_name(expr: &Expr) -> Option<String> {
@@ -2437,9 +2452,46 @@ mod tests {
             &metadata,
             Some(expected_metadata.as_ref()),
             &read_format,
-            &col("tag_0").eq(lit("a")),
+            &col("tag_0").in_list(vec![lit("a"), lit("b")], false),
         );
 
         assert!(ctx.is_none());
+    }
+
+    #[test]
+    fn test_physical_filter_context_only_accepts_prefilter_candidates() {
+        let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
+        let read_format = ReadFormat::new_flat(
+            metadata.clone(),
+            metadata.column_metadatas.iter().map(|c| c.column_id),
+            None,
+            "test",
+            true,
+        )
+        .unwrap();
+
+        // InList is on the allowlist — should build a context.
+        let in_list = col("tag_0").in_list(vec![lit("a"), lit("b")], false);
+        assert!(PhysicalFilterContext::new_opt(&metadata, None, &read_format, &in_list).is_some());
+
+        // NOT IN uses the same variant with `negated: true` — also accepted.
+        let not_in = col("tag_0").in_list(vec![lit("a"), lit("b")], true);
+        assert!(PhysicalFilterContext::new_opt(&metadata, None, &read_format, &not_in).is_some());
+
+        // IS NULL / IS NOT NULL are accepted.
+        let is_null = col("tag_0").is_null();
+        assert!(PhysicalFilterContext::new_opt(&metadata, None, &read_format, &is_null).is_some());
+        let is_not_null = col("tag_0").is_not_null();
+        assert!(
+            PhysicalFilterContext::new_opt(&metadata, None, &read_format, &is_not_null).is_some()
+        );
+
+        // BETWEEN is accepted.
+        let between = col("field_0").between(lit(1_u64), lit(10_u64));
+        assert!(PhysicalFilterContext::new_opt(&metadata, None, &read_format, &between).is_some());
+
+        // Binary expr is handled by SimpleFilterEvaluator — rejected here.
+        let binary = col("tag_0").eq(lit("a"));
+        assert!(PhysicalFilterContext::new_opt(&metadata, None, &read_format, &binary).is_none());
     }
 }

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -48,7 +48,6 @@ use store_api::region_request::PathType;
 use store_api::storage::{ColumnId, FileId};
 use table::predicate::Predicate;
 
-use self::stream::{ParquetErrorAdapter, ProjectedRecordBatchStream};
 use crate::cache::index::result_cache::PredicateKey;
 use crate::cache::{CacheStrategy, CachedSstMeta};
 #[cfg(feature = "vector_index")]
@@ -86,6 +85,7 @@ use crate::sst::parquet::prefilter::{
 use crate::sst::parquet::read_columns::{
     ParquetReadColumns, ProjectionMaskPlan, build_projection_plan,
 };
+use crate::sst::parquet::reader::stream::{ParquetErrorAdapter, ProjectedRecordBatchStream};
 use crate::sst::parquet::row_group::ParquetFetchMetrics;
 use crate::sst::parquet::row_selection::RowGroupSelection;
 use crate::sst::parquet::stats::RowGroupPruningStats;

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -1660,9 +1660,6 @@ pub(crate) struct RowGroupBuildContext<'a> {
     /// Simple filters pushed down. Used by prefilter on other columns.
     #[allow(dead_code)]
     pub(crate) filters: &'a [SimpleFilterContext],
-    /// Whether to skip field filters. Used by prefilter on other columns.
-    #[allow(dead_code)]
-    pub(crate) skip_fields: bool,
     /// Index of the row group to read.
     pub(crate) row_group_idx: usize,
     /// Row selection for the row group. `None` means all rows.
@@ -1956,7 +1953,6 @@ impl ParquetReader {
                     row_group_idx,
                     Some(row_selection),
                     Some(&self.fetch_metrics),
-                    skip_fields,
                 ))
                 .await?;
             self.reader = Some(FlatPruneReader::new_with_row_group_reader(
@@ -1987,7 +1983,6 @@ impl ParquetReader {
                     row_group_idx,
                     Some(row_selection),
                     Some(&fetch_metrics),
-                    skip_fields,
                 ))
                 .await?;
             Some(FlatPruneReader::new_with_row_group_reader(

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -1672,6 +1672,19 @@ impl RowGroupReaderBuilder {
     /// If prefiltering is applicable (based on `build_ctx`), this performs a two-phase read:
     /// 1. Reads only the prefilter columns (e.g. PK column), applies filters to get a refined row selection
     /// 2. Reads the full projection with the refined row selection
+    ///
+    /// The prefilter pass is *best-effort pruning*, not the precise filter for the query.
+    /// Predicates that cannot be lowered to prefilter columns (column not projected,
+    /// expression not supported, etc.) are silently skipped. Correctness rests on the
+    /// DataFusion `FilterExec` above this reader, which always re-applies the original
+    /// predicate. Tag and timestamp predicates that flow through [`SimpleFilterEvaluator`]
+    /// are an exception — the engine enforces them precisely, so the prefilter pass is the
+    /// only place they execute. See [`build_reader_filter_plan`] for the bucketing rules.
+    ///
+    /// When the prefilter result selects no rows, the second read still issues but
+    /// parquet-rs short-circuits before any column-chunk IO: the row-group state machine
+    /// jumps to `Finished` once it sees `num_rows_selected() == 0`, so no fast path is
+    /// added here.
     pub(crate) async fn build(
         &self,
         build_ctx: RowGroupBuildContext<'_>,

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -1909,29 +1909,14 @@ impl PhysicalFilterContext {
                 column
             }
             None => {
-                let column = sst_meta.column_by_name(&column_name)?;
-                column
+                sst_meta.column_by_name(&column_name)?
             }
         };
 
-        let field =
-            if let Some((_, field)) = read_format.arrow_schema().column_with_name(&column_name) {
-                field.clone()
-            } else {
-                let field = Field::try_from(&column_metadata.column_schema).ok()?;
-                if column_metadata.semantic_type == SemanticType::Tag
-                    && column_metadata.column_schema.data_type.is_string()
-                {
-                    tag_maybe_to_dictionary_field(
-                        &column_metadata.column_schema.data_type,
-                        &Arc::new(field),
-                    )
-                    .as_ref()
-                    .clone()
-                } else {
-                    field
-                }
-            };
+        // The column must be present in the projected arrow schema for the
+        // prefilter to be able to read it.
+        let (_, field) = read_format.arrow_schema().column_with_name(&column_name)?;
+        let field = field.clone();
         let schema = Arc::new(ArrowSchema::new(vec![field]));
         let physical_expr = Predicate::to_physical_expr(expr, &schema)
             .inspect_err(|e| {

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -499,7 +499,10 @@ impl ParquetReaderBuilder {
             &read_format,
             &codec,
             primary_key_filters.as_ref(),
+            &filters,
+            &physical_filters,
             parquet_meta.file_metadata().schema_descr(),
+            self.pre_filter_mode == PreFilterMode::All,
         );
 
         let output_schema = read_format.output_arrow_schema()?;
@@ -1805,6 +1808,7 @@ impl RowGroupReaderBuilder {
     }
 }
 
+#[derive(Clone)]
 /// The filter to evaluate or the prune result of the default value.
 pub(crate) enum MaybeFilter {
     /// The filter to evaluate.
@@ -1815,6 +1819,7 @@ pub(crate) enum MaybeFilter {
     Pruned,
 }
 
+#[derive(Clone)]
 /// Context to evaluate the column filter for a parquet file.
 pub(crate) struct SimpleFilterContext {
     /// Filter to evaluate.
@@ -1916,6 +1921,7 @@ impl SimpleFilterContext {
     }
 }
 
+#[derive(Clone)]
 #[allow(dead_code)]
 /// The physical filter to evaluate or the prune result of the default value.
 pub(crate) enum MaybePhysicalFilter {
@@ -1927,6 +1933,7 @@ pub(crate) enum MaybePhysicalFilter {
     Pruned,
 }
 
+#[derive(Clone)]
 #[allow(dead_code)]
 /// Context to evaluate a physical expression for a parquet file.
 pub(crate) struct PhysicalFilterContext {

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -34,12 +34,13 @@ use datatypes::arrow::record_batch::RecordBatch;
 use datatypes::data_type::ConcreteDataType;
 use datatypes::prelude::DataType;
 use futures::StreamExt;
-use mito_codec::row_converter::build_primary_key_codec;
+use mito_codec::row_converter::{PrimaryKeyCodec, build_primary_key_codec};
 use object_store::ObjectStore;
 use parquet::arrow::ProjectionMask;
 use parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions, RowSelection};
 use parquet::arrow::async_reader::{ParquetRecordBatchStream, ParquetRecordBatchStreamBuilder};
 use parquet::file::metadata::{PageIndexPolicy, ParquetMetaData};
+use parquet::schema::types::SchemaDescriptor;
 use partition::expr::PartitionExpr;
 use snafu::ResultExt;
 use store_api::codec::PrimaryKeyEncoding;
@@ -95,6 +96,11 @@ const INDEX_TYPE_FULLTEXT: &str = "fulltext";
 const INDEX_TYPE_INVERTED: &str = "inverted";
 const INDEX_TYPE_BLOOM: &str = "bloom filter";
 const INDEX_TYPE_VECTOR: &str = "vector";
+
+struct ReaderFilterPlan {
+    remaining_simple_filters: Vec<SimpleFilterContext>,
+    prefilter_builder: Option<PrefilterContextBuilder>,
+}
 
 macro_rules! handle_index_error {
     ($err:expr, $file_handle:expr, $index_type:expr) => {
@@ -452,43 +458,6 @@ impl ParquetReaderBuilder {
             ArrowReaderMetadata::try_new(parquet_meta.clone(), arrow_reader_options)
                 .context(ReadDataPartSnafu)?;
 
-        let (filters, physical_filters) = if let Some(predicate) = &self.predicate {
-            let mut simple_filters = Vec::new();
-            let mut physical_filters = Vec::new();
-            let field_prefilter_enabled = self.pre_filter_mode == PreFilterMode::All;
-            for expr in predicate.exprs() {
-                if let Some(mut filter) = SimpleFilterContext::new_opt(
-                    &region_meta,
-                    self.expected_metadata.as_deref(),
-                    expr,
-                ) {
-                    let prefilter_uses_column = filter.filter().as_filter().is_some_and(|filter| {
-                        read_format
-                            .arrow_schema()
-                            .column_with_name(filter.column_name())
-                            .is_some()
-                    });
-                    let usable_prefilter = (field_prefilter_enabled
-                        || filter.semantic_type() != SemanticType::Field)
-                        && (prefilter_uses_column || filter.usable_primary_key_filter());
-                    filter.set_usable_prefilter(usable_prefilter);
-                    simple_filters.push(filter);
-                    continue;
-                }
-                if let Some(filter) = PhysicalFilterContext::new_opt(
-                    &region_meta,
-                    self.expected_metadata.as_deref(),
-                    &read_format,
-                    expr,
-                ) {
-                    physical_filters.push(filter);
-                }
-            }
-            (simple_filters, physical_filters)
-        } else {
-            (vec![], vec![])
-        };
-
         let dyn_filters = if let Some(predicate) = &self.predicate {
             predicate.dyn_filters().as_ref().clone()
         } else {
@@ -497,23 +466,11 @@ impl ParquetReaderBuilder {
 
         let codec = build_primary_key_codec(read_format.metadata());
 
-        // Extract primary key filters from precomputed filter contexts for prefiltering.
-        let primary_key_filters = {
-            let pk_filters = filters
-                .iter()
-                .filter_map(SimpleFilterContext::primary_key_prefilter)
-                .collect::<Vec<_>>();
-            (!pk_filters.is_empty()).then_some(Arc::new(pk_filters))
-        };
-
-        let prefilter_builder = PrefilterContextBuilder::new(
+        let filter_plan = self.build_filter_plan(
+            &region_meta,
             &read_format,
-            &codec,
-            primary_key_filters.as_ref(),
-            &filters,
-            &physical_filters,
             parquet_meta.file_metadata().schema_descr(),
-            self.pre_filter_mode == PreFilterMode::All,
+            &codec,
         );
 
         let output_schema = read_format.output_arrow_schema()?;
@@ -527,7 +484,7 @@ impl ParquetReaderBuilder {
             object_store: self.object_store.clone(),
             projection: projection_plan,
             cache_strategy: self.cache_strategy.clone(),
-            prefilter_builder,
+            prefilter_builder: filter_plan.prefilter_builder,
         };
 
         let partition_filter = self.build_partition_filter(&read_format, &prune_schema)?;
@@ -535,7 +492,7 @@ impl ParquetReaderBuilder {
         let context = FileRangeContext::new(
             reader_builder,
             RangeBase {
-                filters,
+                filters: filter_plan.remaining_simple_filters,
                 dyn_filters,
                 read_format,
                 expected_metadata: self.expected_metadata.clone(),
@@ -551,6 +508,112 @@ impl ParquetReaderBuilder {
         metrics.build_cost += start.elapsed();
 
         Ok(Some((context, selection)))
+    }
+
+    fn build_filter_plan(
+        &self,
+        region_meta: &RegionMetadataRef,
+        read_format: &ReadFormat,
+        parquet_schema: &SchemaDescriptor,
+        codec: &Arc<dyn PrimaryKeyCodec>,
+    ) -> ReaderFilterPlan {
+        let Some(predicate) = &self.predicate else {
+            return ReaderFilterPlan {
+                remaining_simple_filters: Vec::new(),
+                prefilter_builder: None,
+            };
+        };
+
+        let mut simple_filters = Vec::new();
+        let mut prefilter_simple_filters = Vec::new();
+        let mut remaining_simple_filters = Vec::new();
+        let mut prefilter_physical_filters = Vec::new();
+        let mut primary_key_filters = Vec::new();
+
+        let field_prefilter_enabled = self.pre_filter_mode == PreFilterMode::All;
+        let supports_pk_prefilter = read_format
+            .as_flat()
+            .is_some_and(|flat_format| !flat_format.batch_has_raw_pk_columns());
+
+        for expr in predicate.exprs() {
+            if let Some(filter) =
+                SimpleFilterContext::new_opt(region_meta, self.expected_metadata.as_deref(), expr)
+            {
+                simple_filters.push(filter);
+                continue;
+            }
+
+            if let Some(filter) = PhysicalFilterContext::new_opt(
+                region_meta,
+                self.expected_metadata.as_deref(),
+                read_format,
+                expr,
+            ) {
+                let usable_prefilter = (field_prefilter_enabled
+                    || filter.semantic_type() != SemanticType::Field)
+                    && read_format
+                        .arrow_schema()
+                        .column_with_name(filter.column_name())
+                        .is_some();
+                if usable_prefilter {
+                    prefilter_physical_filters.push(filter);
+                }
+            }
+        }
+
+        for filter_ctx in simple_filters.iter().cloned() {
+            let Some(filter) = filter_ctx.filter().as_filter() else {
+                remaining_simple_filters.push(filter_ctx);
+                continue;
+            };
+
+            let direct_prefilter = (field_prefilter_enabled
+                || filter_ctx.semantic_type() != SemanticType::Field)
+                && read_format
+                    .arrow_schema()
+                    .column_with_name(filter.column_name())
+                    .is_some();
+            if direct_prefilter {
+                prefilter_simple_filters.push(filter_ctx);
+                continue;
+            }
+
+            let pk_prefilter = supports_pk_prefilter
+                && is_usable_primary_key_filter(
+                    region_meta,
+                    self.expected_metadata.as_deref(),
+                    filter,
+                );
+            if pk_prefilter {
+                primary_key_filters.push(filter.clone());
+                prefilter_simple_filters.push(filter_ctx);
+            } else {
+                remaining_simple_filters.push(filter_ctx);
+            }
+        }
+
+        let primary_key_filters =
+            (!primary_key_filters.is_empty()).then_some(Arc::new(primary_key_filters));
+        let prefilter_builder = PrefilterContextBuilder::new(
+            read_format,
+            codec,
+            primary_key_filters,
+            prefilter_simple_filters,
+            prefilter_physical_filters,
+            parquet_schema,
+        );
+
+        if prefilter_builder.is_some() {
+            ReaderFilterPlan {
+                remaining_simple_filters,
+                prefilter_builder,
+            }
+        } else {
+            ReaderFilterPlan {
+                remaining_simple_filters: simple_filters,
+                prefilter_builder: None,
+            }
+        }
     }
 
     fn is_same_region_partition(
@@ -1844,10 +1907,6 @@ pub(crate) struct SimpleFilterContext {
     semantic_type: SemanticType,
     /// The data type of the column.
     data_type: ConcreteDataType,
-    /// Whether this filter can be applied by parquet prefiltering in the current read path.
-    usable_prefilter: bool,
-    /// Whether this filter can be applied by flat parquet primary-key prefiltering.
-    usable_primary_key_filter: bool,
 }
 
 impl SimpleFilterContext {
@@ -1861,10 +1920,6 @@ impl SimpleFilterContext {
         expr: &Expr,
     ) -> Option<Self> {
         let filter = SimpleFilterEvaluator::try_new(expr)?;
-        // Parquet PK prefilter always supports the partition column. Only
-        // PartitionTreeMemtable skips it after partition pruning.
-        let usable_primary_key_filter =
-            is_usable_primary_key_filter(sst_meta, expected_meta, &filter);
         let (column_metadata, maybe_filter) = match expected_meta {
             Some(meta) => {
                 // Gets the column metadata from the expected metadata.
@@ -1895,16 +1950,11 @@ impl SimpleFilterContext {
             }
         };
 
-        let usable_primary_key_filter =
-            matches!(maybe_filter, MaybeFilter::Filter(_)) && usable_primary_key_filter;
-
         Some(Self {
             filter: maybe_filter,
             column_id: column_metadata.column_id,
             semantic_type: column_metadata.semantic_type,
             data_type: column_metadata.column_schema.data_type.clone(),
-            usable_prefilter: false,
-            usable_primary_key_filter,
         })
     }
 
@@ -1926,33 +1976,6 @@ impl SimpleFilterContext {
     /// Returns the data type of the column.
     pub(crate) fn data_type(&self) -> &ConcreteDataType {
         &self.data_type
-    }
-
-    /// Returns whether this filter can be applied by parquet prefiltering.
-    pub(crate) fn usable_prefilter(&self) -> bool {
-        self.usable_prefilter
-    }
-
-    /// Updates whether this filter can be applied by parquet prefiltering.
-    pub(crate) fn set_usable_prefilter(&mut self, usable_prefilter: bool) {
-        self.usable_prefilter = usable_prefilter;
-    }
-
-    /// Returns whether this filter is eligible for flat parquet PK prefiltering.
-    pub(crate) fn usable_primary_key_filter(&self) -> bool {
-        self.usable_primary_key_filter
-    }
-
-    /// Returns the filter evaluator when it is eligible for PK prefiltering.
-    pub(crate) fn primary_key_prefilter(&self) -> Option<SimpleFilterEvaluator> {
-        if !self.usable_primary_key_filter {
-            return None;
-        }
-
-        match &self.filter {
-            MaybeFilter::Filter(filter) => Some(filter.clone()),
-            MaybeFilter::Matched | MaybeFilter::Pruned => None,
-        }
     }
 }
 
@@ -2405,34 +2428,99 @@ mod tests {
         Arc::new(builder.build().unwrap())
     }
 
-    #[test]
-    fn test_simple_filter_context_marks_usable_primary_key_filter() {
-        let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
-        let ctx =
-            SimpleFilterContext::new_opt(&metadata, None, &col("tag_0").eq(lit("a"))).unwrap();
+    fn new_test_parquet_reader_builder(
+        predicate: Predicate,
+        pre_filter_mode: PreFilterMode,
+    ) -> ParquetReaderBuilder {
+        let object_store = ObjectStore::new(Memory::default()).unwrap().finish();
+        let file_handle = sst_file_handle(0, 1);
 
-        assert!(ctx.usable_primary_key_filter());
-        assert!(ctx.primary_key_prefilter().is_some());
+        ParquetReaderBuilder::new(
+            "test_table".to_string(),
+            PathType::Bare,
+            file_handle,
+            object_store,
+        )
+        .predicate(Some(predicate))
+        .pre_filter_mode(pre_filter_mode)
     }
 
     #[test]
-    fn test_simple_filter_context_skips_non_usable_primary_key_filter() {
+    fn test_build_filter_plan_keeps_field_filters_for_prune_reader_in_skip_fields_mode() {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
+        let read_format = ReadFormat::new_flat(
+            metadata.clone(),
+            metadata.column_metadatas.iter().map(|c| c.column_id),
+            None,
+            "test",
+            true,
+        )
+        .unwrap();
+        let parquet_schema = parquet::arrow::ArrowSchemaConverter::new()
+            .convert(read_format.arrow_schema())
+            .unwrap();
+        let codec = build_primary_key_codec(metadata.as_ref());
+        let builder = new_test_parquet_reader_builder(
+            Predicate::new(vec![
+                col("tag_0").eq(lit("a")),
+                col("field_0").gt(lit(1_u64)),
+            ]),
+            PreFilterMode::SkipFields,
+        );
 
-        let field_ctx =
-            SimpleFilterContext::new_opt(&metadata, None, &col("field_0").eq(lit(1_u64))).unwrap();
-        assert!(!field_ctx.usable_primary_key_filter());
-        assert!(field_ctx.primary_key_prefilter().is_none());
+        let plan = builder.build_filter_plan(&metadata, &read_format, &parquet_schema, &codec);
 
+        assert!(plan.prefilter_builder.is_some());
+        assert_eq!(plan.remaining_simple_filters.len(), 1);
+        let remaining_filter = plan.remaining_simple_filters[0]
+            .filter()
+            .as_filter()
+            .unwrap();
+        assert_eq!(remaining_filter.column_name(), "field_0");
+    }
+
+    #[test]
+    fn test_build_filter_plan_uses_pk_prefilter_for_unprojected_tag_filters() {
+        let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
+        let field_0 = metadata.column_by_name("field_0").unwrap().column_id;
+        let ts = metadata.time_index_column().column_id;
+        let read_format = ReadFormat::new_flat(
+            metadata.clone(),
+            [field_0, ts].into_iter(),
+            None,
+            "test",
+            true,
+        )
+        .unwrap();
+        let parquet_schema = parquet::arrow::ArrowSchemaConverter::new()
+            .convert(read_format.arrow_schema())
+            .unwrap();
+        let codec = build_primary_key_codec(metadata.as_ref());
+        let builder = new_test_parquet_reader_builder(
+            Predicate::new(vec![col("tag_0").eq(lit("a"))]),
+            PreFilterMode::All,
+        );
+
+        let plan = builder.build_filter_plan(&metadata, &read_format, &parquet_schema, &codec);
+
+        assert!(plan.prefilter_builder.is_some());
+        assert!(plan.remaining_simple_filters.is_empty());
+    }
+
+    #[test]
+    fn test_simple_filter_context_uses_default_value_for_mismatched_expected_metadata() {
+        let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
         let expected_metadata = expected_metadata_with_reused_tag_name(metadata.as_ref());
-        let mismatched_ctx = SimpleFilterContext::new_opt(
+        let ctx = SimpleFilterContext::new_opt(
             &metadata,
             Some(expected_metadata.as_ref()),
             &col("tag_0").eq(lit("a")),
         )
         .unwrap();
-        assert!(!mismatched_ctx.usable_primary_key_filter());
-        assert!(mismatched_ctx.primary_key_prefilter().is_none());
+        assert!(matches!(
+            ctx.filter(),
+            MaybeFilter::Matched | MaybeFilter::Pruned
+        ));
     }
 
     #[test]

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -2321,7 +2321,7 @@ mod tests {
     fn test_physical_filter_context_skips_renamed_column() {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
         let expected_metadata = expected_metadata_with_reused_tag_name(metadata.as_ref());
-        let read_format = ReadFormat::new_flat(
+        let read_format = FlatReadFormat::new(
             metadata.clone(),
             metadata.column_metadatas.iter().map(|c| c.column_id),
             None,
@@ -2343,7 +2343,7 @@ mod tests {
     #[test]
     fn test_physical_filter_context_only_accepts_prefilter_candidates() {
         let metadata: RegionMetadataRef = Arc::new(sst_region_metadata());
-        let read_format = ReadFormat::new_flat(
+        let read_format = FlatReadFormat::new(
             metadata.clone(),
             metadata.column_metadatas.iter().map(|c| c.column_id),
             None,

--- a/src/mito2/src/sst/parquet/row_selection.rs
+++ b/src/mito2/src/sst/parquet/row_selection.rs
@@ -567,26 +567,6 @@ pub(crate) fn row_selection_from_row_ranges(
     RowSelection::from(selectors)
 }
 
-/// Like [`row_selection_from_row_ranges`] but guarantees the resulting selection
-/// covers exactly `total_row_count` rows by appending a trailing skip if needed.
-///
-/// Required when the result is used as the inner operand of [`RowSelection::and_then`], because
-/// `and_then` expects the inner selection to account for every row selected by the outer one.
-pub(crate) fn row_selection_from_row_ranges_exact(
-    row_ranges: impl Iterator<Item = Range<usize>>,
-    total_row_count: usize,
-) -> RowSelection {
-    let (mut selectors, last_processed_end) =
-        build_selectors_from_row_ranges(row_ranges, total_row_count);
-    if last_processed_end < total_row_count {
-        // Preserve the full logical length of the selection even when the final rows are all
-        // filtered out. Without this trailing skip, `and_then` sees an undersized inner
-        // selection and panics.
-        add_or_merge_selector(&mut selectors, total_row_count - last_processed_end, true);
-    }
-    RowSelection::from(selectors)
-}
-
 fn build_selectors_from_row_ranges(
     row_ranges: impl Iterator<Item = Range<usize>>,
     total_row_count: usize,
@@ -737,56 +717,6 @@ mod tests {
         let selection = row_selection_from_row_ranges(ranges.into_iter(), 5);
         let expected = RowSelection::from(vec![RowSelector::skip(1), RowSelector::select(4)]);
         assert_eq!(selection, expected);
-    }
-
-    #[test]
-    fn test_exact_single_range_with_trailing_skip() {
-        let selection = row_selection_from_row_ranges_exact(Some(0..3).into_iter(), 6);
-        let expected = RowSelection::from(vec![RowSelector::select(3), RowSelector::skip(3)]);
-        assert_eq!(selection, expected);
-        assert_eq!(selection.row_count(), 3);
-    }
-
-    #[test]
-    fn test_exact_non_contiguous_ranges() {
-        let ranges = [1..3, 5..8];
-        let selection = row_selection_from_row_ranges_exact(ranges.iter().cloned(), 10);
-        let expected = RowSelection::from(vec![
-            RowSelector::skip(1),
-            RowSelector::select(2),
-            RowSelector::skip(2),
-            RowSelector::select(3),
-            RowSelector::skip(2),
-        ]);
-        assert_eq!(selection, expected);
-        assert_eq!(selection.row_count(), 5);
-    }
-
-    #[test]
-    fn test_exact_empty_ranges() {
-        let selection = row_selection_from_row_ranges_exact([].iter().cloned(), 10);
-        let expected = RowSelection::from(vec![RowSelector::skip(10)]);
-        assert_eq!(selection, expected);
-        assert_eq!(selection.row_count(), 0);
-    }
-
-    #[test]
-    fn test_exact_range_covers_all_rows() {
-        let selection = row_selection_from_row_ranges_exact(Some(0..10).into_iter(), 10);
-        let expected = RowSelection::from(vec![RowSelector::select(10)]);
-        assert_eq!(selection, expected);
-        assert_eq!(selection.row_count(), 10);
-    }
-
-    #[test]
-    fn test_exact_compatible_with_and_then() {
-        // Outer selects rows 0..6 out of 10.
-        let outer = RowSelection::from(vec![RowSelector::select(6), RowSelector::skip(4)]);
-        // Inner: within those 6 rows, select only rows 0..3.
-        let inner = row_selection_from_row_ranges_exact(Some(0..3).into_iter(), 6);
-        let result = outer.and_then(&inner);
-        let expected = RowSelection::from(vec![RowSelector::select(3), RowSelector::skip(7)]);
-        assert_eq!(result, expected);
     }
 
     #[test]

--- a/src/table/src/predicate.rs
+++ b/src/table/src/predicate.rs
@@ -120,11 +120,11 @@ impl Predicate {
             .context(error::DatafusionSnafu)
     }
 
-    /// Builds physical exprs according to provided schema.
-    pub fn to_physical_exprs(
-        &self,
+    /// Builds a single physical expr according to provided schema.
+    pub fn to_physical_expr(
+        expr: &Expr,
         schema: &arrow::datatypes::SchemaRef,
-    ) -> error::Result<Vec<Arc<dyn PhysicalExpr>>> {
+    ) -> error::Result<Arc<dyn PhysicalExpr>> {
         let df_schema = schema
             .clone()
             .to_dfschema_ref()
@@ -135,12 +135,21 @@ impl Predicate {
         // registering variables.
         let execution_props = &ExecutionProps::new();
 
+        create_physical_expr(expr, df_schema.as_ref(), execution_props)
+            .context(error::DatafusionSnafu)
+    }
+
+    /// Builds physical exprs according to provided schema.
+    pub fn to_physical_exprs(
+        &self,
+        schema: &arrow::datatypes::SchemaRef,
+    ) -> error::Result<Vec<Arc<dyn PhysicalExpr>>> {
         let dyn_filters = self.dyn_filter_phy_exprs()?;
 
         Ok(self
             .exprs
             .iter()
-            .filter_map(|expr| create_physical_expr(expr, df_schema.as_ref(), execution_props).ok())
+            .filter_map(|expr| Self::to_physical_expr(expr, schema).ok())
             .chain(dyn_filters)
             .collect::<Vec<_>>())
     }
@@ -730,5 +739,8 @@ mod tests {
 
         let predicates = predicate.to_physical_exprs(&schema).unwrap();
         assert!(!predicates.is_empty());
+
+        let physical_expr = Predicate::to_physical_expr(&col("host").eq(lit("host_a")), &schema);
+        assert!(physical_expr.is_ok());
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Previously, parquet prefiltering only supported primary key (PK) columns — tag predicates were evaluated by decoding the encoded primary key column to compute a refined row selection before reading the remaining columns.

This PR generalizes prefiltering to support **all column types** (tags, fields, and timestamps), not just primary keys. Key changes:

**New filter planning layer** (`prefilter.rs`):
- Introduces `build_reader_filter_plan()` and `build_bulk_filter_plan()` that categorize predicates into three groups:
  - **PK filters**: tag predicates evaluated via encoded primary key decoding (existing path)
  - **Simple prefilters**: tag/field/timestamp predicates on columns directly readable from parquet
  - **Physical prefilters**: more complex expressions (`IN`, `IS NULL`, `IS NOT NULL`, `BETWEEN`) compiled to physical exprs for single-column evaluation
- A `PreFilterMode` (`All` vs `SkipFields`) controls whether field column predicates participate in prefiltering
- Prefiltering is enabled only when the estimated selectivity meets a configurable threshold

**Unified prefilter execution** (`prefilter.rs`):
- `PrefilterContext` now holds a unified projection covering PK + simple + physical filter columns
- `execute_prefilter()` reads the projected columns once, then applies all three filter types to produce a combined `BooleanBuffer` row mask
- Filters already applied during prefiltering are removed from the post-read filter list to avoid redundant evaluation

**Refactored reader/filter path** (`reader.rs`, `file_range.rs`):
- `SimpleFilterContext` no longer tracks `usable_primary_key_filter`; filter routing is handled by the plan builder
- New `PhysicalFilterContext` wraps a `PhysicalExpr` for single-column prefilter evaluation
- `RowGroupBuildContext` is simplified — prefilter-related fields (`filters`, `skip_fields`) are removed
- `precise_filter_flat()` no longer needs to skip prefiltered PK filters since they're excluded from the remaining filter list

**Other changes**:
- Extracts `Predicate::to_physical_expr()` as a public method for building a single physical expr
- Adds tests covering generalized prefilter behavior and verifying physical filters are not re-evaluated post-filter


**Performance**
4.5x faster in TSBS cpu-max-all-8 query.

<details>
<summary>Before</summary>

```
Run complete after 100 queries with 1 workers (Overall query rate 5.51 queries/sec):
Influx max of all CPU metrics, random    8 hosts, random 8h0m0s by 1h:
min:   128.09ms, med:   182.73ms, mean:   181.21ms, max:  239.89ms, stddev:    29.43ms, sum:  18.1sec, count: 100
all queries                                                          :
min:   128.09ms, med:   182.73ms, mean:   181.21ms, max:  239.89ms, stddev:    29.43ms, sum:  18.1sec, count: 100
wall clock time: 18.143011sec
```

</details>

<details>
<summary>After</summary>

```
Run complete after 100 queries with 1 workers (Overall query rate 25.21 queries/sec):
Influx max of all CPU metrics, random    8 hosts, random 8h0m0s by 1h:
min:    26.60ms, med:    39.41ms, mean:    39.60ms, max:   55.67ms, stddev:     5.73ms, sum:   4.0sec, count: 100
all queries                                                          :
min:    26.60ms, med:    39.41ms, mean:    39.60ms, max:   55.67ms, stddev:     5.73ms, sum:   4.0sec, count: 100
wall clock time: 3.973266sec
```

</details>


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.