### PR TITLE
chore: add a standalone flag in plugins during startup

### DIFF
--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -42,6 +42,7 @@ use common_meta::region_keeper::MemoryRegionKeeper;
 use common_meta::region_registry::LeaderRegionRegistry;
 use common_meta::sequence::{Sequence, SequenceBuilder};
 use common_meta::wal_provider::{WalProviderRef, build_wal_provider};
+use common_options::plugin_options::StandaloneFlag;
 use common_procedure::ProcedureManagerRef;
 use common_query::prelude::set_default_prefix;
 use common_telemetry::info;
@@ -369,6 +370,7 @@ impl StartCommand {
         creator: InstanceCreator,
     ) -> Result<(Instance, InstanceCreatorResult)> {
         let mut plugins = Plugins::new();
+        plugins.insert(StandaloneFlag);
         set_default_prefix(opts.default_column_prefix.as_deref())
             .map_err(BoxedError::new)
             .context(error::BuildCliSnafu)?;

--- a/src/common/options/src/plugin_options.rs
+++ b/src/common/options/src/plugin_options.rs
@@ -27,3 +27,9 @@ pub type PluginOptionsSerializerRef = Arc<dyn PluginOptionsSerializer>;
 pub trait PluginOptionsDeserializer<T: DeserializeOwned>: Send + Sync {
     fn deserialize(&self, payload: &str) -> Result<T, serde_json::Error>;
 }
+
+/// A flag for stating the standalone mode in the plugins.
+///
+/// The standalone build and start process calls `setup_frontend_plugins` and `setup_datanode_plugins`,
+/// so we add a flag to the plugins to indicate that the plugins are running in the standalone mode.
+pub struct StandaloneFlag;

--- a/src/common/options/src/plugin_options.rs
+++ b/src/common/options/src/plugin_options.rs
@@ -32,4 +32,5 @@ pub trait PluginOptionsDeserializer<T: DeserializeOwned>: Send + Sync {
 ///
 /// The standalone build and start process calls `setup_frontend_plugins` and `setup_datanode_plugins`,
 /// so we add a flag to the plugins to indicate that the plugins are running in the standalone mode.
+#[derive(Clone, Copy, Debug)]
 pub struct StandaloneFlag;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Now the standalone calls `setup_frontend_plugins` and `setup_datanode_plugins` during build.
Within the `setup_frontend_plugins`, we have no ways to identify whether the caller is standalone or frontend.

This PR adds a flag to be inserted into the plugins before calling the functions, stating the identity of the caller, which is the standalone mode.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
