### PR TITLE
fix: allow ipv4_num_to_string to accept Int32/Int64/UInt64 inputs

### DIFF
--- a/src/common/function/src/scalars/ip/ipv4.rs
+++ b/src/common/function/src/scalars/ip/ipv4.rs
@@ -44,7 +44,12 @@ impl Default for Ipv4NumToString {
     fn default() -> Self {
         Self {
             signature: Signature::new(
-                TypeSignature::Exact(vec![DataType::UInt32]),
+                TypeSignature::OneOf(vec![
+                    TypeSignature::Exact(vec![DataType::UInt32]),
+                    TypeSignature::Exact(vec![DataType::Int32]),
+                    TypeSignature::Exact(vec![DataType::Int64]),
+                    TypeSignature::Exact(vec![DataType::UInt64]),
+                ]),
                 Volatility::Immutable,
             ),
             aliases: ["inet_ntoa".to_string()],
@@ -70,6 +75,7 @@ impl Function for Ipv4NumToString {
         args: ScalarFunctionArgs,
     ) -> datafusion_common::Result<ColumnarValue> {
         let [arg0] = extract_args(self.name(), &args)?;
+        let arg0 = compute::cast(&arg0, &DataType::UInt32)?;
         let uint_vec = arg0.as_primitive::<UInt32Type>();
 
         let size = uint_vec.len();
@@ -171,7 +177,7 @@ mod tests {
     use std::sync::Arc;
 
     use arrow_schema::Field;
-    use datafusion_common::arrow::array::{StringViewArray, UInt32Array};
+    use datafusion_common::arrow::array::{Int32Array, Int64Array, StringViewArray, UInt32Array};
 
     use super::*;
 
@@ -198,6 +204,52 @@ mod tests {
         assert_eq!(result.value(1), "192.168.0.1");
         assert_eq!(result.value(2), "0.0.0.0");
         assert_eq!(result.value(3), "255.255.255.255");
+    }
+
+    #[test]
+    fn test_ipv4_num_to_string_int32() {
+        let func = Ipv4NumToString::default();
+
+        // 167772161 (0x0A000001) = "10.0.0.1" fits in Int32
+        let values = vec![167772161i32, 0i32];
+        let input = ColumnarValue::Array(Arc::new(Int32Array::from(values)));
+
+        let args = ScalarFunctionArgs {
+            args: vec![input],
+            arg_fields: vec![],
+            number_rows: 2,
+            return_field: Arc::new(Field::new("x", DataType::Utf8View, false)),
+            config_options: Arc::new(Default::default()),
+        };
+        let result = func.invoke_with_args(args).unwrap();
+        let result = result.to_array(2).unwrap();
+        let result = result.as_string_view();
+
+        assert_eq!(result.value(0), "10.0.0.1");
+        assert_eq!(result.value(1), "0.0.0.0");
+    }
+
+    #[test]
+    fn test_ipv4_num_to_string_int64() {
+        let func = Ipv4NumToString::default();
+
+        // 3232235521 (0xC0A80001) = "192.168.0.1" — too large for Int32, fits in Int64
+        let values = vec![3232235521i64, 167772161i64];
+        let input = ColumnarValue::Array(Arc::new(Int64Array::from(values)));
+
+        let args = ScalarFunctionArgs {
+            args: vec![input],
+            arg_fields: vec![],
+            number_rows: 2,
+            return_field: Arc::new(Field::new("x", DataType::Utf8View, false)),
+            config_options: Arc::new(Default::default()),
+        };
+        let result = func.invoke_with_args(args).unwrap();
+        let result = result.to_array(2).unwrap();
+        let result = result.as_string_view();
+
+        assert_eq!(result.value(0), "192.168.0.1");
+        assert_eq!(result.value(1), "10.0.0.1");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #7977

I ran into this when trying to use `ipv4_num_to_string(3232235521)` directly — SQL integer literals default to `Int64`, but the function only accepted `UInt32`, so it would fail with a coercion error.

The fix expands the accepted types from just `UInt32` to also include `Int32`, `Int64`, and `UInt64`, and adds a `compute::cast` to `UInt32` at the start of `invoke_with_args` (the same pattern used by other functions in this module like `ipv4_string_to_num`). Tests for `Int32` and `Int64` inputs are included.

## Changes

- `TypeSignature::Exact([UInt32])` → `TypeSignature::OneOf([UInt32, Int32, Int64, UInt64])`
- Add `compute::cast(&arg0, &DataType::UInt32)?` before processing
- Add unit tests `test_ipv4_num_to_string_int32` and `test_ipv4_num_to_string_int64`