### PR TITLE
feat: remote dyn filter basics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2139,7 +2139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5721,7 +5721,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=092ba1d01e2da676dca66cca7eebb55009da8ef8#092ba1d01e2da676dca66cca7eebb55009da8ef8"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=9423b6ae25e8e64b1c57ef2594a6a7698efb3c5a#9423b6ae25e8e64b1c57ef2594a6a7698efb3c5a"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",
@@ -6241,7 +6241,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -7330,7 +7330,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -10361,7 +10361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -10409,7 +10409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10422,7 +10422,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -15080,7 +15080,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2632,10 +2632,13 @@ dependencies = [
  "datafusion",
  "datafusion-common",
  "datafusion-expr",
+ "datafusion-proto",
  "datatypes",
  "futures-util",
  "once_cell",
+ "prost 0.14.1",
  "serde",
+ "serde_json",
  "snafu 0.8.6",
  "sqlparser",
  "sqlparser_derive 0.1.1",
@@ -4127,6 +4130,43 @@ dependencies = [
  "parking_lot 0.12.4",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "datafusion-proto"
+version = "52.1.0"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=02b82535e0160c4545667f36a03e1ff9d1d2e51f#02b82535e0160c4545667f36a03e1ff9d1d2e51f"
+dependencies = [
+ "arrow 57.3.0",
+ "chrono",
+ "datafusion-catalog",
+ "datafusion-catalog-listing",
+ "datafusion-common",
+ "datafusion-datasource",
+ "datafusion-datasource-arrow",
+ "datafusion-datasource-csv",
+ "datafusion-datasource-json",
+ "datafusion-datasource-parquet",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions-table",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-proto-common",
+ "object_store",
+ "prost 0.14.1",
+ "rand 0.9.1",
+]
+
+[[package]]
+name = "datafusion-proto-common"
+version = "52.1.0"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=02b82535e0160c4545667f36a03e1ff9d1d2e51f#02b82535e0160c4545667f36a03e1ff9d1d2e51f"
+dependencies = [
+ "arrow 57.3.0",
+ "datafusion-common",
+ "prost 0.14.1",
 ]
 
 [[package]]
@@ -12137,6 +12177,7 @@ dependencies = [
  "derive_more",
  "snafu 0.8.6",
  "sql",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4210,7 +4210,7 @@ dependencies = [
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-proto-common",
- "object_store",
+ "object_store 0.12.5",
  "prost 0.14.1",
  "rand 0.9.1",
 ]
@@ -5804,7 +5804,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=0de5437582920c8b30d6c34212f161db71d95c50#0de5437582920c8b30d6c34212f161db71d95c50"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=b8c9a206930fc4d88f8e2d5ec9a1265a7dd26a4d#b8c9a206930fc4d88f8e2d5ec9a1265a7dd26a4d"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",
@@ -6323,7 +6323,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -10786,7 +10786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -10806,8 +10806,8 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.14.0",
+ "heck 0.5.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -10855,7 +10855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10868,7 +10868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -13025,7 +13025,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1961e2ef424c1424204d3a5d6975f934f56b6d50ff5732382d84ebf460e147f7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2671,10 +2671,13 @@ dependencies = [
  "datafusion",
  "datafusion-common",
  "datafusion-expr",
+ "datafusion-proto",
  "datatypes",
  "futures-util",
  "once_cell",
+ "prost 0.14.1",
  "serde",
+ "serde_json",
  "snafu 0.8.6",
  "sqlparser",
  "sqlparser_derive 0.1.1",
@@ -4182,6 +4185,43 @@ dependencies = [
  "parking_lot 0.12.4",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "datafusion-proto"
+version = "52.1.0"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=02b82535e0160c4545667f36a03e1ff9d1d2e51f#02b82535e0160c4545667f36a03e1ff9d1d2e51f"
+dependencies = [
+ "arrow 57.3.0",
+ "chrono",
+ "datafusion-catalog",
+ "datafusion-catalog-listing",
+ "datafusion-common",
+ "datafusion-datasource",
+ "datafusion-datasource-arrow",
+ "datafusion-datasource-csv",
+ "datafusion-datasource-json",
+ "datafusion-datasource-parquet",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions-table",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-proto-common",
+ "object_store",
+ "prost 0.14.1",
+ "rand 0.9.1",
+]
+
+[[package]]
+name = "datafusion-proto-common"
+version = "52.1.0"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=02b82535e0160c4545667f36a03e1ff9d1d2e51f#02b82535e0160c4545667f36a03e1ff9d1d2e51f"
+dependencies = [
+ "arrow 57.3.0",
+ "datafusion-common",
+ "prost 0.14.1",
 ]
 
 [[package]]
@@ -12746,6 +12786,7 @@ dependencies = [
  "derive_more",
  "snafu 0.8.6",
  "sql",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2662,6 +2662,7 @@ version = "1.0.0"
 dependencies = [
  "api",
  "async-trait",
+ "base64 0.22.1",
  "bytes",
  "common-base",
  "common-error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5804,7 +5804,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=b8c9a206930fc4d88f8e2d5ec9a1265a7dd26a4d#b8c9a206930fc4d88f8e2d5ec9a1265a7dd26a4d"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=4cbc54accdd975ddbf84a473d254851f93a23431#4cbc54accdd975ddbf84a473d254851f93a23431"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",
@@ -6323,7 +6323,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -10807,7 +10807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -10855,7 +10855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10868,7 +10868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5804,7 +5804,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=4cbc54accdd975ddbf84a473d254851f93a23431#4cbc54accdd975ddbf84a473d254851f93a23431"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=dfd2a6d7d3d9c718cb159fcf9abae144b74fc503#dfd2a6d7d3d9c718cb159fcf9abae144b74fc503"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,7 @@ datafusion-orc = "0.7"
 datafusion-pg-catalog = "0.15.1"
 datafusion-physical-expr = "=52.1"
 datafusion-physical-plan = "=52.1"
+datafusion-proto = "=52.1"
 datafusion-sql = "=52.1"
 datafusion-substrait = "=52.1"
 deadpool = "0.12"
@@ -251,7 +252,7 @@ tracing-appender = "0.2"
 tracing-opentelemetry = "0.31.0"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "fmt"] }
 typetag = "0.2"
-uuid = { version = "1.17", features = ["serde", "v4", "fast-rng"] }
+uuid = { version = "1.17", features = ["serde", "v4", "v7", "fast-rng"] }
 vrl = "0.25"
 zstd = "0.13"
 # DO_NOT_REMOVE_THIS: END_OF_EXTERNAL_DEPENDENCIES
@@ -341,6 +342,7 @@ datafusion-optimizer = { git = "https://github.com/GreptimeTeam/datafusion.git",
 datafusion-physical-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "02b82535e0160c4545667f36a03e1ff9d1d2e51f" }
 datafusion-physical-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "02b82535e0160c4545667f36a03e1ff9d1d2e51f" }
 datafusion-physical-plan = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "02b82535e0160c4545667f36a03e1ff9d1d2e51f" }
+datafusion-proto = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "02b82535e0160c4545667f36a03e1ff9d1d2e51f" }
 datafusion-datasource = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "02b82535e0160c4545667f36a03e1ff9d1d2e51f" }
 datafusion-sql = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "02b82535e0160c4545667f36a03e1ff9d1d2e51f" }
 datafusion-substrait = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "02b82535e0160c4545667f36a03e1ff9d1d2e51f" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ etcd-client = { version = "0.17", features = [
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "092ba1d01e2da676dca66cca7eebb55009da8ef8" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "9423b6ae25e8e64b1c57ef2594a6a7698efb3c5a" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ fs2 = "0.4"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "4cbc54accdd975ddbf84a473d254851f93a23431" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "dfd2a6d7d3d9c718cb159fcf9abae144b74fc503" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ fs2 = "0.4"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "b8c9a206930fc4d88f8e2d5ec9a1265a7dd26a4d" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "4cbc54accdd975ddbf84a473d254851f93a23431" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ fs2 = "0.4"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "1b1812e839930f2037992d98657c0ff04fa5b2ee" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "b8c9a206930fc4d88f8e2d5ec9a1265a7dd26a4d" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ fs2 = "0.4"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "0de5437582920c8b30d6c34212f161db71d95c50" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "1b1812e839930f2037992d98657c0ff04fa5b2ee" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,7 @@ datafusion-orc = "0.7"
 datafusion-pg-catalog = "0.15.1"
 datafusion-physical-expr = "=52.1"
 datafusion-physical-plan = "=52.1"
+datafusion-proto = "=52.1"
 datafusion-sql = "=52.1"
 datafusion-substrait = "=52.1"
 datafusion_object_store = { package = "object_store", version = "0.12.5" }
@@ -258,7 +259,7 @@ tracing-appender = "0.2"
 tracing-opentelemetry = "0.31.0"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "fmt"] }
 typetag = "0.2"
-uuid = { version = "1.17", features = ["serde", "v4", "fast-rng"] }
+uuid = { version = "1.17", features = ["serde", "v4", "v7", "fast-rng"] }
 vrl = "0.25"
 zstd = "0.13"
 # DO_NOT_REMOVE_THIS: END_OF_EXTERNAL_DEPENDENCIES
@@ -349,6 +350,7 @@ datafusion-optimizer = { git = "https://github.com/GreptimeTeam/datafusion.git",
 datafusion-physical-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "02b82535e0160c4545667f36a03e1ff9d1d2e51f" }
 datafusion-physical-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "02b82535e0160c4545667f36a03e1ff9d1d2e51f" }
 datafusion-physical-plan = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "02b82535e0160c4545667f36a03e1ff9d1d2e51f" }
+datafusion-proto = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "02b82535e0160c4545667f36a03e1ff9d1d2e51f" }
 datafusion-datasource = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "02b82535e0160c4545667f36a03e1ff9d1d2e51f" }
 datafusion-sql = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "02b82535e0160c4545667f36a03e1ff9d1d2e51f" }
 datafusion-substrait = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "02b82535e0160c4545667f36a03e1ff9d1d2e51f" }

--- a/src/client/src/region.rs
+++ b/src/client/src/region.rs
@@ -16,7 +16,10 @@ use std::sync::Arc;
 
 use api::region::RegionResponse;
 use api::v1::ResponseHeader;
-use api::v1::region::RegionRequest;
+use api::v1::region::{
+    RegionRequest, RegionRequestHeader, RemoteDynFilterRequest, RemoteDynFilterUnregister,
+    RemoteDynFilterUpdate, region_request, remote_dyn_filter_request,
+};
 use arc_swap::ArcSwapOption;
 use arrow_flight::Ticket;
 use async_stream::stream;
@@ -284,6 +287,48 @@ impl RegionRequester {
     pub async fn handle(&self, request: RegionRequest) -> Result<RegionResponse> {
         self.handle_inner(request).await
     }
+
+    pub async fn handle_remote_dyn_filter_update(
+        &self,
+        query_id: impl Into<String>,
+        update: RemoteDynFilterUpdate,
+    ) -> Result<RegionResponse> {
+        self.handle_inner(build_remote_dyn_filter_request(
+            query_id.into(),
+            remote_dyn_filter_request::Action::Update(update),
+        ))
+        .await
+    }
+
+    pub async fn handle_remote_dyn_filter_unregister(
+        &self,
+        query_id: impl Into<String>,
+        unregister: RemoteDynFilterUnregister,
+    ) -> Result<RegionResponse> {
+        self.handle_inner(build_remote_dyn_filter_request(
+            query_id.into(),
+            remote_dyn_filter_request::Action::Unregister(unregister),
+        ))
+        .await
+    }
+}
+
+fn build_remote_dyn_filter_request(
+    query_id: String,
+    action: remote_dyn_filter_request::Action,
+) -> RegionRequest {
+    RegionRequest {
+        header: Some(RegionRequestHeader {
+            tracing_context: TracingContext::from_current_span().to_w3c(),
+            ..Default::default()
+        }),
+        body: Some(region_request::Body::RemoteDynFilter(
+            RemoteDynFilterRequest {
+                query_id,
+                action: Some(action),
+            },
+        )),
+    }
 }
 
 pub fn check_response_header(header: &Option<ResponseHeader>) -> Result<()> {
@@ -312,6 +357,7 @@ pub fn check_response_header(header: &Option<ResponseHeader>) -> Result<()> {
 #[cfg(test)]
 mod test {
     use api::v1::Status as PbStatus;
+    use api::v1::region::{RemoteDynFilterUpdate, region_request, remote_dyn_filter_request};
 
     use super::*;
     use crate::Error::{IllegalDatabaseResponse, Server};
@@ -360,5 +406,31 @@ mod test {
         };
         assert_eq!(code, StatusCode::Internal);
         assert_eq!(msg, "blabla");
+    }
+
+    #[test]
+    fn test_build_remote_dyn_filter_request_sets_header_and_body() {
+        let request = build_remote_dyn_filter_request(
+            "query-1".to_string(),
+            remote_dyn_filter_request::Action::Update(RemoteDynFilterUpdate {
+                filter_id: "filter-1".to_string(),
+                payload: vec![1, 2, 3],
+                generation: 7,
+                is_complete: false,
+            }),
+        );
+
+        request.header.expect("remote dyn filter header must exist");
+
+        let body = request.body.expect("remote dyn filter body must exist");
+        let region_request::Body::RemoteDynFilter(remote_request) = body else {
+            panic!("expected remote dyn filter request body");
+        };
+
+        assert_eq!(remote_request.query_id, "query-1");
+        assert!(matches!(
+            remote_request.action,
+            Some(remote_dyn_filter_request::Action::Update(_))
+        ));
     }
 }

--- a/src/common/meta/src/ddl/drop_table/executor.rs
+++ b/src/common/meta/src/ddl/drop_table/executor.rs
@@ -245,6 +245,7 @@ impl DropTableExecutor {
                         fast_path,
                         force,
                         partial_drop,
+                        soft_drop: false,
                     })),
                 };
                 let datanode = datanode.clone();

--- a/src/common/query/Cargo.toml
+++ b/src/common/query/Cargo.toml
@@ -22,8 +22,10 @@ common-time.workspace = true
 datafusion.workspace = true
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
+datafusion-proto.workspace = true
 datatypes.workspace = true
 once_cell.workspace = true
+prost.workspace = true
 serde.workspace = true
 snafu.workspace = true
 sqlparser.workspace = true
@@ -33,4 +35,5 @@ store-api.workspace = true
 [dev-dependencies]
 common-base.workspace = true
 futures-util.workspace = true
+serde_json.workspace = true
 tokio.workspace = true

--- a/src/common/query/Cargo.toml
+++ b/src/common/query/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 [dependencies]
 api.workspace = true
 async-trait.workspace = true
+base64.workspace = true
 bytes.workspace = true
 common-base.workspace = true
 common-error.workspace = true

--- a/src/common/query/src/request.rs
+++ b/src/common/query/src/request.rs
@@ -12,9 +12,161 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use api::v1::region::RegionRequestHeader;
+use datafusion::arrow::datatypes::Schema;
+use datafusion::execution::TaskContext;
+use datafusion::physical_expr::expressions::Column;
+use datafusion::physical_plan::PhysicalExpr;
+use datafusion::physical_plan::joins::HashTableLookupExpr;
+use datafusion_common::tree_node::{TreeNode, TreeNodeRecursion};
+use datafusion_common::{DataFusionError, Result as DataFusionResult};
 use datafusion_expr::LogicalPlan;
+use datafusion_proto::physical_plan::DefaultPhysicalExtensionCodec;
+use datafusion_proto::physical_plan::from_proto::parse_physical_expr;
+use datafusion_proto::physical_plan::to_proto::serialize_physical_expr;
+use datafusion_proto::protobuf::PhysicalExprNode;
+use prost::Message;
+use serde::{Deserialize, Serialize};
 use store_api::storage::RegionId;
+
+pub const DYN_FILTER_PROTOCOL_VERSION: u32 = 1;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(tag = "kind", content = "payload", rename_all = "snake_case")]
+pub enum DynFilterPayload {
+    Datafusion(Vec<u8>),
+}
+
+impl DynFilterPayload {
+    pub fn from_datafusion_expr(
+        expr: &Arc<dyn PhysicalExpr>,
+        max_payload_bytes: usize,
+    ) -> DataFusionResult<Self> {
+        validate_supported_payload_expr(expr)?;
+
+        let codec = DefaultPhysicalExtensionCodec {};
+        let proto = serialize_physical_expr(expr, &codec)?;
+        let mut bytes = Vec::new();
+        proto.encode(&mut bytes).map_err(|e| {
+            DataFusionError::Internal(format!("Failed to encode PhysicalExprNode: {e}"))
+        })?;
+
+        validate_payload_size(bytes.len(), max_payload_bytes)?;
+
+        Ok(Self::Datafusion(bytes))
+    }
+
+    pub fn decode_datafusion_expr(
+        &self,
+        task_ctx: &TaskContext,
+        input_schema: &Schema,
+        max_payload_bytes: usize,
+    ) -> DataFusionResult<Arc<dyn PhysicalExpr>> {
+        let Self::Datafusion(bytes) = self;
+        validate_payload_size(bytes.len(), max_payload_bytes)?;
+        let codec = DefaultPhysicalExtensionCodec {};
+        let proto = PhysicalExprNode::decode(bytes.as_slice()).map_err(|e| {
+            DataFusionError::Internal(format!("Failed to decode PhysicalExprNode: {e}"))
+        })?;
+
+        let expr = parse_physical_expr(&proto, task_ctx, input_schema, &codec)?;
+        validate_supported_payload_expr(&expr)?;
+        validate_decoded_payload_expr(&expr, input_schema)?;
+        Ok(expr)
+    }
+}
+
+fn validate_payload_size(
+    payload_size_bytes: usize,
+    max_payload_bytes: usize,
+) -> DataFusionResult<()> {
+    if payload_size_bytes > max_payload_bytes {
+        return Err(DataFusionError::Plan(format!(
+            "DynFilterPayload::Datafusion is {} bytes, which exceeds the configured limit of {} bytes",
+            payload_size_bytes, max_payload_bytes
+        )));
+    }
+
+    Ok(())
+}
+
+fn validate_supported_payload_expr(expr: &Arc<dyn PhysicalExpr>) -> DataFusionResult<()> {
+    expr.apply(|node| {
+        if node.as_any().is::<HashTableLookupExpr>() {
+            return Err(DataFusionError::Plan(
+                "HashTableLookupExpr cannot be encoded into DynFilterPayload::Datafusion"
+                    .to_string(),
+            ));
+        }
+
+        Ok(TreeNodeRecursion::Continue)
+    })?;
+
+    Ok(())
+}
+
+fn validate_decoded_payload_expr(
+    expr: &Arc<dyn PhysicalExpr>,
+    input_schema: &Schema,
+) -> DataFusionResult<()> {
+    expr.apply(|node| {
+        if let Some(column) = node.as_any().downcast_ref::<Column>() {
+            let Some(field) = input_schema.fields().get(column.index()) else {
+                return Err(DataFusionError::Plan(format!(
+                    "Decoded Column '{}' references out-of-bounds index {} for input schema of size {}",
+                    column.name(),
+                    column.index(),
+                    input_schema.fields().len()
+                )));
+            };
+
+            if field.name() != column.name() {
+                return Err(DataFusionError::Plan(format!(
+                    "Decoded Column name/index mismatch: payload has '{}' at index {}, but schema field is '{}'",
+                    column.name(),
+                    column.index(),
+                    field.name()
+                )));
+            }
+        }
+
+        Ok(TreeNodeRecursion::Continue)
+    })?;
+
+    Ok(())
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DynFilterUpdate {
+    pub protocol_version: u32,
+    pub query_id: String,
+    pub filter_id: String,
+    pub epoch: u64,
+    pub is_complete: bool,
+    pub payload: DynFilterPayload,
+}
+
+impl DynFilterUpdate {
+    pub fn new(
+        query_id: String,
+        filter_id: String,
+        epoch: u64,
+        is_complete: bool,
+        payload: DynFilterPayload,
+    ) -> Self {
+        Self {
+            protocol_version: DYN_FILTER_PROTOCOL_VERSION,
+            query_id,
+            filter_id,
+            epoch,
+            is_complete,
+            payload,
+        }
+    }
+}
 
 /// The query request to be handled by the RegionServer (Datanode).
 #[derive(Clone, Debug)]
@@ -27,4 +179,103 @@ pub struct QueryRequest {
 
     /// The form of the query: a logical plan.
     pub plan: LogicalPlan,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::physical_expr::expressions::Column;
+
+    use super::*;
+
+    #[test]
+    fn dyn_filter_update_sets_protocol_version() {
+        let update = DynFilterUpdate::new(
+            "query-1".to_string(),
+            "filter-1".to_string(),
+            3,
+            false,
+            DynFilterPayload::Datafusion(vec![1, 2, 3]),
+        );
+
+        assert_eq!(update.protocol_version, DYN_FILTER_PROTOCOL_VERSION);
+        assert!(!update.is_complete);
+        assert!(
+            matches!(update.payload, DynFilterPayload::Datafusion(ref bytes) if bytes == &vec![1, 2, 3])
+        );
+    }
+
+    #[test]
+    fn dyn_filter_update_json_round_trip_preserves_payload_shape() {
+        let update = DynFilterUpdate::new(
+            "query-2".to_string(),
+            "filter-9".to_string(),
+            9,
+            true,
+            DynFilterPayload::Datafusion(vec![9, 8, 7]),
+        );
+
+        let json = serde_json::to_string(&update).unwrap();
+        let decoded: DynFilterUpdate = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(decoded, update);
+        assert!(decoded.is_complete);
+        assert!(
+            matches!(decoded.payload, DynFilterPayload::Datafusion(ref bytes) if bytes == &vec![9, 8, 7])
+        );
+    }
+
+    #[test]
+    fn dyn_filter_payload_round_trips_physical_column_expr() {
+        let schema = Schema::new(vec![Field::new("host", DataType::Utf8, false)]);
+        let expr: Arc<dyn PhysicalExpr> =
+            Arc::new(Column::new_with_schema("host", &schema).unwrap());
+
+        let payload = DynFilterPayload::from_datafusion_expr(&expr, 1024).unwrap();
+        let decoded = payload
+            .decode_datafusion_expr(&TaskContext::default(), &schema, 1024)
+            .unwrap();
+
+        let original = expr.as_any().downcast_ref::<Column>().unwrap();
+        let decoded = decoded.as_any().downcast_ref::<Column>().unwrap();
+
+        assert_eq!(decoded.name(), original.name());
+        assert_eq!(decoded.index(), original.index());
+    }
+
+    #[test]
+    fn dyn_filter_payload_decode_rejects_invalid_bytes() {
+        let schema = Schema::new(vec![Field::new("host", DataType::Utf8, false)]);
+        let payload = DynFilterPayload::Datafusion(vec![1, 2, 3]);
+
+        let err = payload
+            .decode_datafusion_expr(&TaskContext::default(), &schema, 1024)
+            .unwrap_err();
+
+        assert!(matches!(err, DataFusionError::Internal(_)));
+    }
+
+    #[test]
+    fn dyn_filter_payload_decode_rejects_column_name_index_mismatch() {
+        let schema = Schema::new(vec![Field::new("host", DataType::Utf8, false)]);
+        let mismatched_expr: Arc<dyn PhysicalExpr> = Arc::new(Column::new("service", 0));
+
+        let payload = DynFilterPayload::from_datafusion_expr(&mismatched_expr, 1024).unwrap();
+        let err = payload
+            .decode_datafusion_expr(&TaskContext::default(), &schema, 1024)
+            .unwrap_err();
+
+        assert!(matches!(err, DataFusionError::Plan(_)));
+    }
+
+    #[test]
+    fn dyn_filter_payload_rejects_oversized_payload() {
+        let expr: Arc<dyn PhysicalExpr> = Arc::new(Column::new("host", 0));
+
+        let err = DynFilterPayload::from_datafusion_expr(&expr, 1).unwrap_err();
+
+        assert!(matches!(err, DataFusionError::Plan(_)));
+    }
 }

--- a/src/common/query/src/request.rs
+++ b/src/common/query/src/request.rs
@@ -99,6 +99,11 @@ impl DynFilterPayload {
         Ok(Self::Datafusion(bytes))
     }
 
+    /// Decodes a DataFusion dynamic filter payload against the provided input schema.
+    ///
+    /// The decoded expression is validated to ensure column indexes stay within the receiver-side
+    /// schema, column names are consistent (defensive check), and the payload stays within
+    /// `max_payload_bytes`.
     pub fn decode_datafusion_expr(
         &self,
         task_ctx: &TaskContext,
@@ -148,20 +153,35 @@ fn validate_supported_payload_expr(expr: &Arc<dyn PhysicalExpr>) -> DataFusionRe
     Ok(())
 }
 
+/// Validates decoded dynamic filter physical expressions against the receiver-side schema.
+///
+/// Rejects out-of-bounds column indexes and, as a defensive check, rejects columns whose
+/// name disagrees with the corresponding schema field. DataFusion physical `Column` is
+/// index-authoritative, so a name mismatch usually indicates a coordinator/receiver
+/// schema inconsistency that should be surfaced loudly.
 fn validate_decoded_payload_expr(
     expr: &Arc<dyn PhysicalExpr>,
     input_schema: &Schema,
 ) -> DataFusionResult<()> {
     expr.apply(|node| {
-        if let Some(column) = node.as_any().downcast_ref::<Column>()
-            && input_schema.fields().get(column.index()).is_none()
-        {
-            return Err(DataFusionError::Plan(format!(
-                "Decoded Column '{}' references out-of-bounds index {} for input schema of size {}",
-                column.name(),
-                column.index(),
-                input_schema.fields().len()
-            )));
+        if let Some(column) = node.as_any().downcast_ref::<Column>() {
+            let Some(field) = input_schema.fields().get(column.index()) else {
+                return Err(DataFusionError::Plan(format!(
+                    "Decoded Column '{}' references out-of-bounds index {} for input schema of size {}",
+                    column.name(),
+                    column.index(),
+                    input_schema.fields().len()
+                )));
+            };
+
+            if field.name() != column.name() {
+                return Err(DataFusionError::Plan(format!(
+                    "Decoded Column name/index mismatch: payload has '{}' at index {}, but schema field is '{}'",
+                    column.name(),
+                    column.index(),
+                    field.name()
+                )));
+            }
         }
 
         Ok(TreeNodeRecursion::Continue)
@@ -344,18 +364,22 @@ mod tests {
     }
 
     #[test]
-    fn dyn_filter_payload_decode_accepts_column_name_mismatch_when_index_is_valid() {
+    fn dyn_filter_payload_decode_rejects_column_name_index_mismatch() {
         let schema = Schema::new(vec![Field::new("host", DataType::Utf8, false)]);
         let expr: Arc<dyn PhysicalExpr> = Arc::new(Column::new("service", 0));
 
         let payload = DynFilterPayload::from_datafusion_expr(&expr, 1024).unwrap();
-        let decoded = payload
+        let err = payload
             .decode_datafusion_expr(&TaskContext::default(), &schema, 1024)
-            .unwrap();
+            .unwrap_err();
 
-        let decoded = decoded.as_any().downcast_ref::<Column>().unwrap();
-
-        assert_eq!(decoded.index(), 0);
+        let msg = err.to_string();
+        assert!(
+            msg.contains("name/index mismatch"),
+            "expected name/index mismatch error, got: {msg}"
+        );
+        assert!(msg.contains("service"));
+        assert!(msg.contains("host"));
     }
 
     #[test]

--- a/src/common/query/src/request.rs
+++ b/src/common/query/src/request.rs
@@ -31,16 +31,56 @@ use prost::Message;
 use serde::{Deserialize, Serialize};
 use store_api::storage::RegionId;
 
+/// Current wire-format version for remote dynamic filter payload updates.
 pub const DYN_FILTER_PROTOCOL_VERSION: u32 = 1;
 
+/// Serialized predicate payload for remote dynamic filter updates.
+///
+/// The payload is tagged in JSON so receivers can reject unsupported encodings
+/// before decoding engine-specific bytes. For DataFusion expressions the
+/// `payload` bytes are serialized by `serde_json` as a base64 string, for example:
+///
+/// ```json
+/// { "kind": "datafusion", "payload": "CQgH" }
+/// ```
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 #[serde(tag = "kind", content = "payload", rename_all = "snake_case")]
 pub enum DynFilterPayload {
-    Datafusion(Vec<u8>),
+    /// A serialized DataFusion [`PhysicalExpr`] encoded as a protobuf
+    /// [`PhysicalExprNode`].
+    Datafusion(#[serde(with = "base64_bytes")] Vec<u8>),
+}
+
+mod base64_bytes {
+    use base64::Engine;
+    use base64::prelude::BASE64_STANDARD;
+    use serde::de::Error;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&BASE64_STANDARD.encode(bytes))
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let encoded = String::deserialize(deserializer)?;
+        BASE64_STANDARD.decode(encoded).map_err(|err| {
+            D::Error::custom(format!("invalid base64 dynamic filter payload: {err}"))
+        })
+    }
 }
 
 impl DynFilterPayload {
+    /// Encodes a DataFusion physical expression into a bounded dynamic filter payload.
+    ///
+    /// This rejects expressions that cannot be safely shipped as dynamic filter
+    /// predicates and fails if the serialized payload exceeds `max_payload_bytes`.
     pub fn from_datafusion_expr(
         expr: &Arc<dyn PhysicalExpr>,
         max_payload_bytes: usize,
@@ -114,21 +154,12 @@ fn validate_decoded_payload_expr(
 ) -> DataFusionResult<()> {
     expr.apply(|node| {
         if let Some(column) = node.as_any().downcast_ref::<Column>() {
-            let Some(field) = input_schema.fields().get(column.index()) else {
+            if input_schema.fields().get(column.index()).is_none() {
                 return Err(DataFusionError::Plan(format!(
                     "Decoded Column '{}' references out-of-bounds index {} for input schema of size {}",
                     column.name(),
                     column.index(),
                     input_schema.fields().len()
-                )));
-            };
-
-            if field.name() != column.name() {
-                return Err(DataFusionError::Plan(format!(
-                    "Decoded Column name/index mismatch: payload has '{}' at index {}, but schema field is '{}'",
-                    column.name(),
-                    column.index(),
-                    field.name()
                 )));
             }
         }
@@ -139,21 +170,33 @@ fn validate_decoded_payload_expr(
     Ok(())
 }
 
+/// A remote dynamic filter update sent from a query coordinator to region servers.
+///
+/// `generation` is monotonic within a `query_id`/`filter_id` pair and matches the
+/// gRPC field name used by `RemoteDynFilterUpdate`. Receivers use it to ignore
+/// stale updates while `is_complete` marks the final payload for the filter.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DynFilterUpdate {
+    /// Protocol version used by this update payload.
     pub protocol_version: u32,
+    /// Internal query identifier that owns this dynamic filter lifecycle.
     pub query_id: String,
+    /// Identifier of the dynamic filter within the query.
     pub filter_id: String,
-    pub epoch: u64,
+    /// Monotonic update generation for this filter.
+    pub generation: u64,
+    /// Whether this update completes the dynamic filter stream.
     pub is_complete: bool,
+    /// Serialized predicate payload carried by this update.
     pub payload: DynFilterPayload,
 }
 
 impl DynFilterUpdate {
+    /// Creates a dynamic filter update with the current protocol version.
     pub fn new(
         query_id: String,
         filter_id: String,
-        epoch: u64,
+        generation: u64,
         is_complete: bool,
         payload: DynFilterPayload,
     ) -> Self {
@@ -161,7 +204,7 @@ impl DynFilterUpdate {
             protocol_version: DYN_FILTER_PROTOCOL_VERSION,
             query_id,
             filter_id,
-            epoch,
+            generation,
             is_complete,
             payload,
         }
@@ -185,6 +228,8 @@ pub struct QueryRequest {
 mod tests {
     use std::sync::Arc;
 
+    use base64::Engine;
+    use base64::prelude::BASE64_STANDARD;
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion::physical_expr::expressions::Column;
 
@@ -218,12 +263,53 @@ mod tests {
         );
 
         let json = serde_json::to_string(&update).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
         let decoded: DynFilterUpdate = serde_json::from_str(&json).unwrap();
 
+        assert_eq!(value["generation"], serde_json::json!(9));
+        assert!(value.get("epoch").is_none());
+        assert_eq!(
+            value["payload"],
+            serde_json::json!({ "kind": "datafusion", "payload": BASE64_STANDARD.encode([9, 8, 7]) })
+        );
         assert_eq!(decoded, update);
         assert!(decoded.is_complete);
         assert!(
             matches!(decoded.payload, DynFilterPayload::Datafusion(ref bytes) if bytes == &vec![9, 8, 7])
+        );
+    }
+
+    #[test]
+    fn dyn_filter_payload_json_uses_base64_for_empty_and_padded_payloads() {
+        let empty = serde_json::to_value(DynFilterPayload::Datafusion(vec![])).unwrap();
+        let one = serde_json::to_value(DynFilterPayload::Datafusion(vec![1])).unwrap();
+        let two = serde_json::to_value(DynFilterPayload::Datafusion(vec![1, 2])).unwrap();
+
+        assert_eq!(
+            empty,
+            serde_json::json!({"kind": "datafusion", "payload": ""})
+        );
+        assert_eq!(
+            one,
+            serde_json::json!({"kind": "datafusion", "payload": BASE64_STANDARD.encode([1])})
+        );
+        assert_eq!(
+            two,
+            serde_json::json!({"kind": "datafusion", "payload": BASE64_STANDARD.encode([1, 2])})
+        );
+    }
+
+    #[test]
+    fn dyn_filter_payload_json_rejects_invalid_base64() {
+        let err = serde_json::from_value::<DynFilterPayload>(serde_json::json!({
+            "kind": "datafusion",
+            "payload": "not base64!",
+        }))
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("invalid base64 dynamic filter payload")
         );
     }
 
@@ -258,11 +344,26 @@ mod tests {
     }
 
     #[test]
-    fn dyn_filter_payload_decode_rejects_column_name_index_mismatch() {
+    fn dyn_filter_payload_decode_accepts_column_name_mismatch_when_index_is_valid() {
         let schema = Schema::new(vec![Field::new("host", DataType::Utf8, false)]);
-        let mismatched_expr: Arc<dyn PhysicalExpr> = Arc::new(Column::new("service", 0));
+        let expr: Arc<dyn PhysicalExpr> = Arc::new(Column::new("service", 0));
 
-        let payload = DynFilterPayload::from_datafusion_expr(&mismatched_expr, 1024).unwrap();
+        let payload = DynFilterPayload::from_datafusion_expr(&expr, 1024).unwrap();
+        let decoded = payload
+            .decode_datafusion_expr(&TaskContext::default(), &schema, 1024)
+            .unwrap();
+
+        let decoded = decoded.as_any().downcast_ref::<Column>().unwrap();
+
+        assert_eq!(decoded.index(), 0);
+    }
+
+    #[test]
+    fn dyn_filter_payload_decode_rejects_out_of_bounds_column_index() {
+        let schema = Schema::new(vec![Field::new("host", DataType::Utf8, false)]);
+        let expr: Arc<dyn PhysicalExpr> = Arc::new(Column::new("host", 1));
+
+        let payload = DynFilterPayload::from_datafusion_expr(&expr, 1024).unwrap();
         let err = payload
             .decode_datafusion_expr(&TaskContext::default(), &schema, 1024)
             .unwrap_err();

--- a/src/common/query/src/request.rs
+++ b/src/common/query/src/request.rs
@@ -153,15 +153,15 @@ fn validate_decoded_payload_expr(
     input_schema: &Schema,
 ) -> DataFusionResult<()> {
     expr.apply(|node| {
-        if let Some(column) = node.as_any().downcast_ref::<Column>() {
-            if input_schema.fields().get(column.index()).is_none() {
-                return Err(DataFusionError::Plan(format!(
-                    "Decoded Column '{}' references out-of-bounds index {} for input schema of size {}",
-                    column.name(),
-                    column.index(),
-                    input_schema.fields().len()
-                )));
-            }
+        if let Some(column) = node.as_any().downcast_ref::<Column>()
+            && input_schema.fields().get(column.index()).is_none()
+        {
+            return Err(DataFusionError::Plan(format!(
+                "Decoded Column '{}' references out-of-bounds index {} for input schema of size {}",
+                column.name(),
+                column.index(),
+                input_schema.fields().len()
+            )));
         }
 
         Ok(TreeNodeRecursion::Continue)

--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -25,7 +25,8 @@ use api::region::RegionResponse;
 use api::v1::meta::TopicStat;
 use api::v1::region::sync_request::ManifestInfo;
 use api::v1::region::{
-    ListMetadataRequest, RegionResponse as RegionResponseV1, SyncRequest, region_request,
+    ListMetadataRequest, RegionResponse as RegionResponseV1, RemoteDynFilterRequest, SyncRequest,
+    region_request,
 };
 use api::v1::{ResponseHeader, Status};
 use arrow_flight::{FlightData, Ticket};
@@ -84,8 +85,9 @@ use crate::error::{
     ConcurrentQueryLimiterTimeoutSnafu, DataFusionSnafu, DecodeLogicalPlanSnafu,
     ExecuteLogicalPlanSnafu, FindLogicalRegionsSnafu, GetRegionMetadataSnafu,
     HandleBatchDdlRequestSnafu, HandleBatchOpenRequestSnafu, HandleRegionRequestSnafu,
-    NewPlanDecoderSnafu, RegionEngineNotFoundSnafu, RegionNotFoundSnafu, RegionNotReadySnafu,
-    Result, SerializeJsonSnafu, StopRegionEngineSnafu, UnexpectedSnafu, UnsupportedOutputSnafu,
+    NewPlanDecoderSnafu, NotYetImplementedSnafu, RegionEngineNotFoundSnafu, RegionNotFoundSnafu,
+    RegionNotReadySnafu, Result, SerializeJsonSnafu, StopRegionEngineSnafu, UnexpectedSnafu,
+    UnsupportedOutputSnafu,
 };
 use crate::event_listener::RegionServerEventListenerRef;
 use crate::region_server::catalog::{NameAwareCatalogList, NameAwareDataSourceInjectorBuilder};
@@ -696,6 +698,70 @@ impl RegionServer {
         Ok(response)
     }
 
+    async fn handle_remote_dyn_filter_request(
+        &self,
+        request: &RemoteDynFilterRequest,
+    ) -> Result<RegionResponse> {
+        if request.query_id.is_empty() {
+            return error::MissingRequiredFieldSnafu { name: "query_id" }.fail();
+        }
+
+        match request
+            .action
+            .as_ref()
+            .context(error::MissingRequiredFieldSnafu { name: "action" })?
+        {
+            api::v1::region::remote_dyn_filter_request::Action::Update(update) => {
+                self.handle_remote_dyn_filter_update(&request.query_id, update)
+                    .await
+            }
+            api::v1::region::remote_dyn_filter_request::Action::Unregister(unregister) => {
+                self.handle_remote_dyn_filter_unregister(&request.query_id, unregister)
+                    .await
+            }
+        }
+    }
+
+    async fn handle_remote_dyn_filter_update(
+        &self,
+        query_id: &str,
+        request: &api::v1::region::RemoteDynFilterUpdate,
+    ) -> Result<RegionResponse> {
+        if request.filter_id.is_empty() {
+            return error::MissingRequiredFieldSnafu { name: "filter_id" }.fail();
+        }
+
+        if request.payload.is_empty() {
+            return error::MissingRequiredFieldSnafu { name: "payload" }.fail();
+        }
+
+        NotYetImplementedSnafu {
+            what: format!(
+                "remote dyn filter update unary RPC placeholder for query_id {query_id}, filter_id {}",
+                request.filter_id
+            ),
+        }
+        .fail()
+    }
+
+    async fn handle_remote_dyn_filter_unregister(
+        &self,
+        query_id: &str,
+        request: &api::v1::region::RemoteDynFilterUnregister,
+    ) -> Result<RegionResponse> {
+        if request.filter_id.is_empty() {
+            return error::MissingRequiredFieldSnafu { name: "filter_id" }.fail();
+        }
+
+        NotYetImplementedSnafu {
+            what: format!(
+                "remote dyn filter unregister unary RPC placeholder for query_id {query_id}, filter_id {}",
+                request.filter_id
+            ),
+        }
+        .fail()
+    }
+
     /// Sync region manifest and registers new opened logical regions.
     pub async fn sync_region(
         &self,
@@ -765,6 +831,10 @@ impl RegionServerHandler for RegionServer {
             }
             region_request::Body::ListMetadata(list_metadata_request) => {
                 self.handle_list_metadata_request(list_metadata_request)
+                    .await
+            }
+            region_request::Body::RemoteDynFilter(remote_dyn_filter_request) => {
+                self.handle_remote_dyn_filter_request(remote_dyn_filter_request)
                     .await
             }
             _ => self.handle_requests_in_serial(request).await,
@@ -1670,6 +1740,10 @@ mod tests {
     use std::assert_matches;
 
     use api::v1::SemanticType;
+    use api::v1::region::{
+        RemoteDynFilterRequest, RemoteDynFilterUnregister, RemoteDynFilterUpdate,
+        remote_dyn_filter_request,
+    };
     use common_error::ext::ErrorExt;
     use datatypes::prelude::ConcreteDataType;
     use mito2::test_util::CreateRequestBuilder;
@@ -2303,5 +2377,136 @@ mod tests {
             .handle_list_metadata_request(&list_metadata_request)
             .await
             .unwrap_err();
+    }
+
+    #[tokio::test]
+    async fn test_handle_remote_dyn_filter_request_requires_query_id() {
+        let mock_region_server = mock_region_server();
+
+        let err = mock_region_server
+            .handle_remote_dyn_filter_request(&RemoteDynFilterRequest {
+                query_id: String::new(),
+                action: Some(remote_dyn_filter_request::Action::Unregister(
+                    RemoteDynFilterUnregister {
+                        filter_id: "filter-1".to_string(),
+                    },
+                )),
+            })
+            .await
+            .unwrap_err();
+
+        assert_matches!(
+            err,
+            crate::error::Error::MissingRequiredField { ref name, .. } if name == "query_id"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_remote_dyn_filter_request_requires_action() {
+        let mock_region_server = mock_region_server();
+
+        let err = mock_region_server
+            .handle_remote_dyn_filter_request(&RemoteDynFilterRequest {
+                query_id: "query-1".to_string(),
+                action: None,
+            })
+            .await
+            .unwrap_err();
+
+        assert_matches!(
+            err,
+            crate::error::Error::MissingRequiredField { ref name, .. } if name == "action"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_remote_dyn_filter_update_requires_filter_id() {
+        let mock_region_server = mock_region_server();
+
+        let err = mock_region_server
+            .handle_remote_dyn_filter_request(&RemoteDynFilterRequest {
+                query_id: "query-1".to_string(),
+                action: Some(remote_dyn_filter_request::Action::Update(
+                    RemoteDynFilterUpdate {
+                        filter_id: String::new(),
+                        payload: vec![1],
+                        generation: 1,
+                        is_complete: false,
+                    },
+                )),
+            })
+            .await
+            .unwrap_err();
+
+        assert_matches!(
+            err,
+            crate::error::Error::MissingRequiredField { ref name, .. } if name == "filter_id"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_remote_dyn_filter_update_requires_payload() {
+        let mock_region_server = mock_region_server();
+
+        let err = mock_region_server
+            .handle_remote_dyn_filter_request(&RemoteDynFilterRequest {
+                query_id: "query-1".to_string(),
+                action: Some(remote_dyn_filter_request::Action::Update(
+                    RemoteDynFilterUpdate {
+                        filter_id: "filter-1".to_string(),
+                        payload: Vec::new(),
+                        generation: 1,
+                        is_complete: false,
+                    },
+                )),
+            })
+            .await
+            .unwrap_err();
+
+        assert_matches!(
+            err,
+            crate::error::Error::MissingRequiredField { ref name, .. } if name == "payload"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_remote_dyn_filter_update_placeholder() {
+        let mock_region_server = mock_region_server();
+
+        let err = mock_region_server
+            .handle_remote_dyn_filter_request(&RemoteDynFilterRequest {
+                query_id: "query-1".to_string(),
+                action: Some(remote_dyn_filter_request::Action::Update(
+                    RemoteDynFilterUpdate {
+                        filter_id: "filter-1".to_string(),
+                        payload: vec![1],
+                        generation: 1,
+                        is_complete: false,
+                    },
+                )),
+            })
+            .await
+            .unwrap_err();
+
+        assert_matches!(err, crate::error::Error::NotYetImplemented { .. });
+    }
+
+    #[tokio::test]
+    async fn test_handle_remote_dyn_filter_unregister_placeholder() {
+        let mock_region_server = mock_region_server();
+
+        let err = mock_region_server
+            .handle_remote_dyn_filter_request(&RemoteDynFilterRequest {
+                query_id: "query-1".to_string(),
+                action: Some(remote_dyn_filter_request::Action::Unregister(
+                    RemoteDynFilterUnregister {
+                        filter_id: "filter-1".to_string(),
+                    },
+                )),
+            })
+            .await
+            .unwrap_err();
+
+        assert_matches!(err, crate::error::Error::NotYetImplemented { .. });
     }
 }

--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -25,6 +25,7 @@ use std::time::Duration;
 
 use api::region::RegionResponse;
 use api::v1::meta::TopicStat;
+use api::v1::region::remote_dyn_filter_request::Action;
 use api::v1::region::sync_request::ManifestInfo;
 use api::v1::region::{
     ListMetadataRequest, RegionResponse as RegionResponseV1, RemoteDynFilterRequest, SyncRequest,
@@ -728,11 +729,11 @@ impl RegionServer {
             .as_ref()
             .context(error::MissingRequiredFieldSnafu { name: "action" })?
         {
-            api::v1::region::remote_dyn_filter_request::Action::Update(update) => {
+            Action::Update(update) => {
                 self.handle_remote_dyn_filter_update(&request.query_id, update)
                     .await
             }
-            api::v1::region::remote_dyn_filter_request::Action::Unregister(unregister) => {
+            Action::Unregister(unregister) => {
                 self.handle_remote_dyn_filter_unregister(&request.query_id, unregister)
                     .await
             }

--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -27,7 +27,8 @@ use api::region::RegionResponse;
 use api::v1::meta::TopicStat;
 use api::v1::region::sync_request::ManifestInfo;
 use api::v1::region::{
-    ListMetadataRequest, RegionResponse as RegionResponseV1, SyncRequest, region_request,
+    ListMetadataRequest, RegionResponse as RegionResponseV1, RemoteDynFilterRequest, SyncRequest,
+    region_request,
 };
 use api::v1::{ResponseHeader, Status};
 use arrow_flight::{FlightData, Ticket};
@@ -89,8 +90,9 @@ use crate::error::{
     ConcurrentQueryLimiterTimeoutSnafu, DataFusionSnafu, DecodeLogicalPlanSnafu,
     ExecuteLogicalPlanSnafu, FindLogicalRegionsSnafu, GetRegionMetadataSnafu,
     HandleBatchDdlRequestSnafu, HandleBatchOpenRequestSnafu, HandleRegionRequestSnafu,
-    NewPlanDecoderSnafu, RegionEngineNotFoundSnafu, RegionNotFoundSnafu, RegionNotReadySnafu,
-    Result, SerializeJsonSnafu, StopRegionEngineSnafu, UnexpectedSnafu, UnsupportedOutputSnafu,
+    NewPlanDecoderSnafu, NotYetImplementedSnafu, RegionEngineNotFoundSnafu, RegionNotFoundSnafu,
+    RegionNotReadySnafu, Result, SerializeJsonSnafu, StopRegionEngineSnafu, UnexpectedSnafu,
+    UnsupportedOutputSnafu,
 };
 use crate::event_listener::RegionServerEventListenerRef;
 use crate::region_server::catalog::{NameAwareCatalogList, NameAwareDataSourceInjectorBuilder};
@@ -713,6 +715,70 @@ impl RegionServer {
         Ok(response)
     }
 
+    async fn handle_remote_dyn_filter_request(
+        &self,
+        request: &RemoteDynFilterRequest,
+    ) -> Result<RegionResponse> {
+        if request.query_id.is_empty() {
+            return error::MissingRequiredFieldSnafu { name: "query_id" }.fail();
+        }
+
+        match request
+            .action
+            .as_ref()
+            .context(error::MissingRequiredFieldSnafu { name: "action" })?
+        {
+            api::v1::region::remote_dyn_filter_request::Action::Update(update) => {
+                self.handle_remote_dyn_filter_update(&request.query_id, update)
+                    .await
+            }
+            api::v1::region::remote_dyn_filter_request::Action::Unregister(unregister) => {
+                self.handle_remote_dyn_filter_unregister(&request.query_id, unregister)
+                    .await
+            }
+        }
+    }
+
+    async fn handle_remote_dyn_filter_update(
+        &self,
+        query_id: &str,
+        request: &api::v1::region::RemoteDynFilterUpdate,
+    ) -> Result<RegionResponse> {
+        if request.filter_id.is_empty() {
+            return error::MissingRequiredFieldSnafu { name: "filter_id" }.fail();
+        }
+
+        if request.payload.is_empty() {
+            return error::MissingRequiredFieldSnafu { name: "payload" }.fail();
+        }
+
+        NotYetImplementedSnafu {
+            what: format!(
+                "remote dyn filter update unary RPC placeholder for query_id {query_id}, filter_id {}",
+                request.filter_id
+            ),
+        }
+        .fail()
+    }
+
+    async fn handle_remote_dyn_filter_unregister(
+        &self,
+        query_id: &str,
+        request: &api::v1::region::RemoteDynFilterUnregister,
+    ) -> Result<RegionResponse> {
+        if request.filter_id.is_empty() {
+            return error::MissingRequiredFieldSnafu { name: "filter_id" }.fail();
+        }
+
+        NotYetImplementedSnafu {
+            what: format!(
+                "remote dyn filter unregister unary RPC placeholder for query_id {query_id}, filter_id {}",
+                request.filter_id
+            ),
+        }
+        .fail()
+    }
+
     /// Sync region manifest and registers new opened logical regions.
     pub async fn sync_region(
         &self,
@@ -875,6 +941,10 @@ impl RegionServerHandler for RegionServer {
             }
             region_request::Body::ListMetadata(list_metadata_request) => {
                 self.handle_list_metadata_request(list_metadata_request)
+                    .await
+            }
+            region_request::Body::RemoteDynFilter(remote_dyn_filter_request) => {
+                self.handle_remote_dyn_filter_request(remote_dyn_filter_request)
                     .await
             }
             _ => self.handle_requests_in_serial(request).await,
@@ -1782,6 +1852,10 @@ mod tests {
     use std::sync::Arc;
 
     use api::v1::SemanticType;
+    use api::v1::region::{
+        RemoteDynFilterRequest, RemoteDynFilterUnregister, RemoteDynFilterUpdate,
+        remote_dyn_filter_request,
+    };
     use common_error::ext::ErrorExt;
     use common_recordbatch::RecordBatches;
     use common_recordbatch::adapter::{RecordBatchMetrics, RegionWatermarkEntry};
@@ -2559,5 +2633,136 @@ mod tests {
             .handle_list_metadata_request(&list_metadata_request)
             .await
             .unwrap_err();
+    }
+
+    #[tokio::test]
+    async fn test_handle_remote_dyn_filter_request_requires_query_id() {
+        let mock_region_server = mock_region_server();
+
+        let err = mock_region_server
+            .handle_remote_dyn_filter_request(&RemoteDynFilterRequest {
+                query_id: String::new(),
+                action: Some(remote_dyn_filter_request::Action::Unregister(
+                    RemoteDynFilterUnregister {
+                        filter_id: "filter-1".to_string(),
+                    },
+                )),
+            })
+            .await
+            .unwrap_err();
+
+        assert_matches!(
+            err,
+            crate::error::Error::MissingRequiredField { ref name, .. } if name == "query_id"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_remote_dyn_filter_request_requires_action() {
+        let mock_region_server = mock_region_server();
+
+        let err = mock_region_server
+            .handle_remote_dyn_filter_request(&RemoteDynFilterRequest {
+                query_id: "query-1".to_string(),
+                action: None,
+            })
+            .await
+            .unwrap_err();
+
+        assert_matches!(
+            err,
+            crate::error::Error::MissingRequiredField { ref name, .. } if name == "action"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_remote_dyn_filter_update_requires_filter_id() {
+        let mock_region_server = mock_region_server();
+
+        let err = mock_region_server
+            .handle_remote_dyn_filter_request(&RemoteDynFilterRequest {
+                query_id: "query-1".to_string(),
+                action: Some(remote_dyn_filter_request::Action::Update(
+                    RemoteDynFilterUpdate {
+                        filter_id: String::new(),
+                        payload: vec![1],
+                        generation: 1,
+                        is_complete: false,
+                    },
+                )),
+            })
+            .await
+            .unwrap_err();
+
+        assert_matches!(
+            err,
+            crate::error::Error::MissingRequiredField { ref name, .. } if name == "filter_id"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_remote_dyn_filter_update_requires_payload() {
+        let mock_region_server = mock_region_server();
+
+        let err = mock_region_server
+            .handle_remote_dyn_filter_request(&RemoteDynFilterRequest {
+                query_id: "query-1".to_string(),
+                action: Some(remote_dyn_filter_request::Action::Update(
+                    RemoteDynFilterUpdate {
+                        filter_id: "filter-1".to_string(),
+                        payload: Vec::new(),
+                        generation: 1,
+                        is_complete: false,
+                    },
+                )),
+            })
+            .await
+            .unwrap_err();
+
+        assert_matches!(
+            err,
+            crate::error::Error::MissingRequiredField { ref name, .. } if name == "payload"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_remote_dyn_filter_update_placeholder() {
+        let mock_region_server = mock_region_server();
+
+        let err = mock_region_server
+            .handle_remote_dyn_filter_request(&RemoteDynFilterRequest {
+                query_id: "query-1".to_string(),
+                action: Some(remote_dyn_filter_request::Action::Update(
+                    RemoteDynFilterUpdate {
+                        filter_id: "filter-1".to_string(),
+                        payload: vec![1],
+                        generation: 1,
+                        is_complete: false,
+                    },
+                )),
+            })
+            .await
+            .unwrap_err();
+
+        assert_matches!(err, crate::error::Error::NotYetImplemented { .. });
+    }
+
+    #[tokio::test]
+    async fn test_handle_remote_dyn_filter_unregister_placeholder() {
+        let mock_region_server = mock_region_server();
+
+        let err = mock_region_server
+            .handle_remote_dyn_filter_request(&RemoteDynFilterRequest {
+                query_id: "query-1".to_string(),
+                action: Some(remote_dyn_filter_request::Action::Unregister(
+                    RemoteDynFilterUnregister {
+                        filter_id: "filter-1".to_string(),
+                    },
+                )),
+            })
+            .await
+            .unwrap_err();
+
+        assert_matches!(err, crate::error::Error::NotYetImplemented { .. });
     }
 }

--- a/src/servers/src/grpc/context_auth.rs
+++ b/src/servers/src/grpc/context_auth.rs
@@ -20,7 +20,10 @@ use auth::{Identity, Password, UserInfoRef, UserProviderRef};
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_catalog::parse_catalog_and_schema_from_db_string;
 use common_error::ext::ErrorExt;
-use session::context::{Channel, QueryContextBuilder, QueryContextRef};
+use session::context::{
+    Channel, QueryContextBuilder, QueryContextRef, REMOTE_QUERY_ID_EXTENSION_KEY,
+    generate_remote_query_id,
+};
 use snafu::{OptionExt, ResultExt};
 use tonic::Status;
 use tonic::metadata::MetadataMap;
@@ -50,6 +53,10 @@ pub fn create_query_context_from_grpc_metadata(
             .current_catalog(catalog)
             .current_schema(schema)
             .channel(Channel::Grpc)
+            .set_extension(
+                REMOTE_QUERY_ID_EXTENSION_KEY.to_string(),
+                generate_remote_query_id(),
+            )
             .build(),
     ))
 }

--- a/src/servers/src/grpc/context_auth.rs
+++ b/src/servers/src/grpc/context_auth.rs
@@ -20,10 +20,7 @@ use auth::{Identity, Password, UserInfoRef, UserProviderRef};
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_catalog::parse_catalog_and_schema_from_db_string;
 use common_error::ext::ErrorExt;
-use session::context::{
-    Channel, QueryContextBuilder, QueryContextRef, REMOTE_QUERY_ID_EXTENSION_KEY,
-    generate_remote_query_id,
-};
+use session::context::{Channel, QueryContextBuilder, QueryContextRef};
 use snafu::{OptionExt, ResultExt};
 use tonic::Status;
 use tonic::metadata::MetadataMap;
@@ -53,10 +50,6 @@ pub fn create_query_context_from_grpc_metadata(
             .current_catalog(catalog)
             .current_schema(schema)
             .channel(Channel::Grpc)
-            .set_extension(
-                REMOTE_QUERY_ID_EXTENSION_KEY.to_string(),
-                generate_remote_query_id(),
-            )
             .build(),
     ))
 }

--- a/src/servers/src/grpc/greptime_handler.rs
+++ b/src/servers/src/grpc/greptime_handler.rs
@@ -35,9 +35,9 @@ use common_time::timezone::parse_timezone;
 use futures_util::StreamExt;
 use session::context::{
     Channel, QueryContextBuilder, QueryContextRef, REMOTE_QUERY_ID_EXTENSION_KEY,
-    generate_remote_query_id, is_reserved_extension_key,
+    generate_remote_query_id,
 };
-use session::hints::READ_PREFERENCE_HINT;
+use session::hints::{READ_PREFERENCE_HINT, is_reserved_extension_key};
 use snafu::{OptionExt, ResultExt};
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TrySendError;
@@ -239,6 +239,10 @@ pub(crate) fn create_query_context(
 
     for (key, value) in extensions {
         if is_reserved_extension_key(&key) {
+            debug!(
+                key = key.as_str(),
+                "Ignoring reserved external query context extension key"
+            );
             continue;
         }
         ctx_builder = ctx_builder.set_extension(key, value);

--- a/src/servers/src/grpc/greptime_handler.rs
+++ b/src/servers/src/grpc/greptime_handler.rs
@@ -35,7 +35,7 @@ use common_time::timezone::parse_timezone;
 use futures_util::StreamExt;
 use session::context::{
     Channel, QueryContextBuilder, QueryContextRef, REMOTE_QUERY_ID_EXTENSION_KEY,
-    generate_remote_query_id,
+    generate_remote_query_id, is_reserved_extension_key,
 };
 use session::hints::READ_PREFERENCE_HINT;
 use snafu::{OptionExt, ResultExt};
@@ -238,6 +238,9 @@ pub(crate) fn create_query_context(
     }
 
     for (key, value) in extensions {
+        if is_reserved_extension_key(&key) {
+            continue;
+        }
         ctx_builder = ctx_builder.set_extension(key, value);
     }
     Ok(ctx_builder.build().into())
@@ -325,6 +328,25 @@ mod tests {
         assert_eq!(
             query_context.remote_query_id(),
             Some(extensions[1].1.as_str())
+        );
+    }
+
+    #[test]
+    fn test_create_query_context_ignores_remote_query_id_extension() {
+        let query_context = create_query_context(
+            Channel::Grpc,
+            None,
+            vec![(
+                REMOTE_QUERY_ID_EXTENSION_KEY.to_string(),
+                "spoofed-query-id".to_string(),
+            )],
+        )
+        .unwrap();
+
+        assert_ne!(query_context.remote_query_id(), Some("spoofed-query-id"));
+        assert_eq!(
+            query_context.extension(REMOTE_QUERY_ID_EXTENSION_KEY),
+            query_context.remote_query_id()
         );
     }
 }

--- a/src/servers/src/grpc/greptime_handler.rs
+++ b/src/servers/src/grpc/greptime_handler.rs
@@ -33,7 +33,10 @@ use common_telemetry::tracing_context::{FutureExt, TracingContext};
 use common_telemetry::{debug, error, tracing, warn};
 use common_time::timezone::parse_timezone;
 use futures_util::StreamExt;
-use session::context::{Channel, QueryContextBuilder, QueryContextRef};
+use session::context::{
+    Channel, QueryContextBuilder, QueryContextRef, REMOTE_QUERY_ID_EXTENSION_KEY,
+    generate_remote_query_id,
+};
 use session::hints::READ_PREFERENCE_HINT;
 use snafu::{OptionExt, ResultExt};
 use tokio::sync::mpsc;
@@ -214,7 +217,11 @@ pub(crate) fn create_query_context(
         .current_catalog(catalog)
         .current_schema(schema)
         .timezone(timezone)
-        .channel(channel);
+        .channel(channel)
+        .set_extension(
+            REMOTE_QUERY_ID_EXTENSION_KEY.to_string(),
+            generate_remote_query_id(),
+        );
 
     if let Some(x) = extensions
         .iter()
@@ -308,9 +315,16 @@ mod tests {
             query_context.read_preference(),
             ReadPreference::Leader
         ));
+        let mut extensions = query_context.extensions().into_iter().collect::<Vec<_>>();
+        extensions.sort_unstable_by(|a, b| a.0.cmp(&b.0));
         assert_eq!(
-            query_context.extensions().into_iter().collect::<Vec<_>>(),
-            vec![("auto_create_table".to_string(), "true".to_string())]
+            extensions[0],
+            ("auto_create_table".to_string(), "true".to_string())
+        );
+        assert_eq!(extensions[1].0, REMOTE_QUERY_ID_EXTENSION_KEY.to_string());
+        assert_eq!(
+            query_context.remote_query_id(),
+            Some(extensions[1].1.as_str())
         );
     }
 }

--- a/src/servers/src/grpc/greptime_handler.rs
+++ b/src/servers/src/grpc/greptime_handler.rs
@@ -33,10 +33,7 @@ use common_telemetry::tracing_context::{FutureExt, TracingContext};
 use common_telemetry::{debug, error, tracing, warn};
 use common_time::timezone::parse_timezone;
 use futures_util::StreamExt;
-use session::context::{
-    Channel, QueryContextBuilder, QueryContextRef, REMOTE_QUERY_ID_EXTENSION_KEY,
-    generate_remote_query_id,
-};
+use session::context::{Channel, QueryContextBuilder, QueryContextRef};
 use session::hints::{READ_PREFERENCE_HINT, is_reserved_extension_key};
 use snafu::{OptionExt, ResultExt};
 use tokio::sync::mpsc;
@@ -217,11 +214,7 @@ pub(crate) fn create_query_context(
         .current_catalog(catalog)
         .current_schema(schema)
         .timezone(timezone)
-        .channel(channel)
-        .set_extension(
-            REMOTE_QUERY_ID_EXTENSION_KEY.to_string(),
-            generate_remote_query_id(),
-        );
+        .channel(channel);
 
     if let Some(x) = extensions
         .iter()
@@ -293,6 +286,7 @@ impl Drop for RequestTimer {
 mod tests {
     use chrono::FixedOffset;
     use common_time::Timezone;
+    use session::hints::REMOTE_QUERY_ID_EXTENSION_KEY;
 
     use super::*;
 

--- a/src/servers/src/http/authorize.rs
+++ b/src/servers/src/http/authorize.rs
@@ -28,7 +28,9 @@ use common_telemetry::warn;
 use common_time::Timezone;
 use common_time::timezone::parse_timezone;
 use headers::Header;
-use session::context::QueryContextBuilder;
+use session::context::{
+    QueryContextBuilder, REMOTE_QUERY_ID_EXTENSION_KEY, generate_remote_query_id,
+};
 use snafu::{OptionExt, ResultExt, ensure};
 
 use crate::error::{
@@ -64,7 +66,11 @@ pub async fn inner_auth<B>(
     let query_ctx_builder = QueryContextBuilder::default()
         .current_catalog(catalog.clone())
         .current_schema(schema.clone())
-        .timezone(timezone);
+        .timezone(timezone)
+        .set_extension(
+            REMOTE_QUERY_ID_EXTENSION_KEY.to_string(),
+            generate_remote_query_id(),
+        );
 
     let query_ctx = query_ctx_builder.build();
     let need_auth = need_auth(&req);
@@ -386,6 +392,19 @@ mod tests {
         let unsupported = "digest";
         let auth_scheme: Result<AuthScheme> = unsupported.try_into();
         assert!(auth_scheme.is_err());
+    }
+
+    #[test]
+    fn test_inner_auth_assigns_remote_query_id() {
+        let req =
+            mock_http_request(None, Some("http://127.0.0.1/v1/sql?db=greptime-public")).unwrap();
+        let req = futures::executor::block_on(inner_auth::<()>(None, req)).unwrap();
+        let query_ctx = req
+            .extensions()
+            .get::<session::context::QueryContext>()
+            .unwrap();
+
+        assert!(query_ctx.remote_query_id().is_some());
     }
 
     #[test]

--- a/src/servers/src/http/authorize.rs
+++ b/src/servers/src/http/authorize.rs
@@ -28,7 +28,9 @@ use common_telemetry::warn;
 use common_time::Timezone;
 use common_time::timezone::parse_timezone;
 use headers::Header;
-use session::context::QueryContextBuilder;
+use session::context::{
+    QueryContextBuilder, REMOTE_QUERY_ID_EXTENSION_KEY, generate_remote_query_id,
+};
 use snafu::{OptionExt, ResultExt, ensure};
 
 use crate::error::{
@@ -64,7 +66,11 @@ pub async fn inner_auth<B>(
     let query_ctx_builder = QueryContextBuilder::default()
         .current_catalog(catalog.clone())
         .current_schema(schema.clone())
-        .timezone(timezone);
+        .timezone(timezone)
+        .set_extension(
+            REMOTE_QUERY_ID_EXTENSION_KEY.to_string(),
+            generate_remote_query_id(),
+        );
 
     let query_ctx = query_ctx_builder.build();
     let need_auth = need_auth(&req);
@@ -385,6 +391,19 @@ mod tests {
         let unsupported = "digest";
         let auth_scheme: Result<AuthScheme> = unsupported.try_into();
         assert!(auth_scheme.is_err());
+    }
+
+    #[test]
+    fn test_inner_auth_assigns_remote_query_id() {
+        let req =
+            mock_http_request(None, Some("http://127.0.0.1/v1/sql?db=greptime-public")).unwrap();
+        let req = futures::executor::block_on(inner_auth::<()>(None, req)).unwrap();
+        let query_ctx = req
+            .extensions()
+            .get::<session::context::QueryContext>()
+            .unwrap();
+
+        assert!(query_ctx.remote_query_id().is_some());
     }
 
     #[test]

--- a/src/servers/src/http/authorize.rs
+++ b/src/servers/src/http/authorize.rs
@@ -28,9 +28,7 @@ use common_telemetry::warn;
 use common_time::Timezone;
 use common_time::timezone::parse_timezone;
 use headers::Header;
-use session::context::{
-    QueryContextBuilder, REMOTE_QUERY_ID_EXTENSION_KEY, generate_remote_query_id,
-};
+use session::context::QueryContextBuilder;
 use snafu::{OptionExt, ResultExt, ensure};
 
 use crate::error::{
@@ -66,11 +64,7 @@ pub async fn inner_auth<B>(
     let query_ctx_builder = QueryContextBuilder::default()
         .current_catalog(catalog.clone())
         .current_schema(schema.clone())
-        .timezone(timezone)
-        .set_extension(
-            REMOTE_QUERY_ID_EXTENSION_KEY.to_string(),
-            generate_remote_query_id(),
-        );
+        .timezone(timezone);
 
     let query_ctx = query_ctx_builder.build();
     let need_auth = need_auth(&req);

--- a/src/servers/src/http/hints.rs
+++ b/src/servers/src/http/hints.rs
@@ -16,7 +16,7 @@ use axum::body::Body;
 use axum::http::Request;
 use axum::middleware::Next;
 use axum::response::Response;
-use session::context::QueryContext;
+use session::context::{QueryContext, REMOTE_QUERY_ID_EXTENSION_KEY, is_reserved_extension_key};
 
 use crate::hint_headers;
 
@@ -24,8 +24,50 @@ pub async fn extract_hints(mut request: Request<Body>, next: Next) -> Response {
     let hints = hint_headers::extract_hints(request.headers());
     if let Some(query_ctx) = request.extensions_mut().get_mut::<QueryContext>() {
         for (key, value) in hints {
-            query_ctx.set_extension(key, value);
+            apply_hint(query_ctx, key, value);
         }
     }
     next.run(request).await
+}
+
+fn apply_hint(query_ctx: &mut QueryContext, key: String, value: String) {
+    if is_reserved_extension_key(&key) {
+        return;
+    }
+    query_ctx.set_extension(key, value);
+}
+
+#[cfg(test)]
+mod tests {
+    use session::context::{QueryContextBuilder, generate_remote_query_id};
+
+    use super::*;
+
+    #[test]
+    fn test_apply_hint_ignores_remote_query_id() {
+        let expected_remote_query_id = generate_remote_query_id();
+        let mut query_ctx = QueryContextBuilder::default()
+            .set_extension(
+                REMOTE_QUERY_ID_EXTENSION_KEY.to_string(),
+                expected_remote_query_id.clone(),
+            )
+            .build();
+
+        apply_hint(
+            &mut query_ctx,
+            REMOTE_QUERY_ID_EXTENSION_KEY.to_string(),
+            "spoofed-query-id".to_string(),
+        );
+        apply_hint(
+            &mut query_ctx,
+            "auto_create_table".to_string(),
+            "true".to_string(),
+        );
+
+        assert_eq!(
+            query_ctx.remote_query_id(),
+            Some(expected_remote_query_id.as_str())
+        );
+        assert_eq!(query_ctx.extension("auto_create_table"), Some("true"));
+    }
 }

--- a/src/servers/src/http/hints.rs
+++ b/src/servers/src/http/hints.rs
@@ -16,58 +16,65 @@ use axum::body::Body;
 use axum::http::Request;
 use axum::middleware::Next;
 use axum::response::Response;
-use session::context::{QueryContext, REMOTE_QUERY_ID_EXTENSION_KEY, is_reserved_extension_key};
+use common_telemetry::debug;
+use session::context::QueryContext;
+use session::hints::is_reserved_extension_key;
 
 use crate::hint_headers;
 
 pub async fn extract_hints(mut request: Request<Body>, next: Next) -> Response {
     let hints = hint_headers::extract_hints(request.headers());
     if let Some(query_ctx) = request.extensions_mut().get_mut::<QueryContext>() {
-        for (key, value) in hints {
-            apply_hint(query_ctx, key, value);
-        }
+        apply_hints(query_ctx, hints);
     }
     next.run(request).await
 }
 
-fn apply_hint(query_ctx: &mut QueryContext, key: String, value: String) {
-    if is_reserved_extension_key(&key) {
-        return;
+fn apply_hints(query_ctx: &mut QueryContext, hints: Vec<(String, String)>) {
+    for (key, value) in hints {
+        if is_reserved_extension_key(&key) {
+            debug!(
+                key = key.as_str(),
+                "Ignoring reserved external query context extension key"
+            );
+            continue;
+        }
+        query_ctx.set_extension(key, value);
     }
-    query_ctx.set_extension(key, value);
 }
 
 #[cfg(test)]
 mod tests {
     use session::context::{QueryContextBuilder, generate_remote_query_id};
+    use session::hints::REMOTE_QUERY_ID_EXTENSION_KEY;
 
-    use super::*;
+    use super::apply_hints;
 
     #[test]
-    fn test_apply_hint_ignores_remote_query_id() {
-        let expected_remote_query_id = generate_remote_query_id();
+    fn test_apply_hints_ignores_reserved_extension_keys() {
+        let original_query_id = generate_remote_query_id();
         let mut query_ctx = QueryContextBuilder::default()
             .set_extension(
                 REMOTE_QUERY_ID_EXTENSION_KEY.to_string(),
-                expected_remote_query_id.clone(),
+                original_query_id.clone(),
             )
             .build();
 
-        apply_hint(
+        apply_hints(
             &mut query_ctx,
-            REMOTE_QUERY_ID_EXTENSION_KEY.to_string(),
-            "spoofed-query-id".to_string(),
-        );
-        apply_hint(
-            &mut query_ctx,
-            "auto_create_table".to_string(),
-            "true".to_string(),
+            vec![
+                (
+                    REMOTE_QUERY_ID_EXTENSION_KEY.to_string(),
+                    "spoofed".to_string(),
+                ),
+                ("ttl".to_string(), "7d".to_string()),
+            ],
         );
 
         assert_eq!(
             query_ctx.remote_query_id(),
-            Some(expected_remote_query_id.as_str())
+            Some(original_query_id.as_str())
         );
-        assert_eq!(query_ctx.extension("auto_create_table"), Some("true"));
+        assert_eq!(query_ctx.extension("ttl"), Some("7d"));
     }
 }

--- a/src/session/Cargo.toml
+++ b/src/session/Cargo.toml
@@ -27,3 +27,4 @@ derive_builder.workspace = true
 derive_more.workspace = true
 snafu.workspace = true
 sql.workspace = true
+uuid.workspace = true

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -43,6 +43,10 @@ pub type ConnInfoRef = Arc<ConnInfo>;
 const CURSOR_COUNT_WARNING_LIMIT: usize = 10;
 pub const REMOTE_QUERY_ID_EXTENSION_KEY: &str = "remote_query_id";
 
+pub fn is_reserved_extension_key(key: &str) -> bool {
+    key == REMOTE_QUERY_ID_EXTENSION_KEY
+}
+
 pub fn generate_remote_query_id() -> String {
     generate_remote_query_id_value().to_string()
 }

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -32,6 +32,7 @@ use datafusion_common::config::ConfigOptions;
 use derive_builder::Builder;
 use sql::dialect::{Dialect, GenericDialect, GreptimeDbDialect, MySqlDialect, PostgreSqlDialect};
 
+pub use crate::hints::REMOTE_QUERY_ID_EXTENSION_KEY;
 use crate::protocol_ctx::ProtocolCtx;
 use crate::query_id::QueryId;
 use crate::session_config::{PGByteaOutputValue, PGDateOrder, PGDateTimeStyle, PGIntervalStyle};
@@ -41,11 +42,6 @@ pub type QueryContextRef = Arc<QueryContext>;
 pub type ConnInfoRef = Arc<ConnInfo>;
 
 const CURSOR_COUNT_WARNING_LIMIT: usize = 10;
-pub const REMOTE_QUERY_ID_EXTENSION_KEY: &str = "remote_query_id";
-
-pub fn is_reserved_extension_key(key: &str) -> bool {
-    key == REMOTE_QUERY_ID_EXTENSION_KEY
-}
 
 pub fn generate_remote_query_id() -> String {
     generate_remote_query_id_value().to_string()
@@ -793,7 +789,15 @@ mod test {
         assert_eq!(roundtrip_api.current_catalog, api_ctx.current_catalog);
         assert_eq!(roundtrip_api.current_schema, api_ctx.current_schema);
         assert_eq!(roundtrip_api.timezone, api_ctx.timezone);
-        assert_eq!(roundtrip_api.extensions, api_ctx.extensions);
+        assert_eq!(
+            roundtrip_api.extensions.get("flow.return_region_seq"),
+            Some(&"true".to_string())
+        );
+        assert!(
+            roundtrip_api
+                .extensions
+                .contains_key(REMOTE_QUERY_ID_EXTENSION_KEY)
+        );
         assert_eq!(roundtrip_api.channel, api_ctx.channel);
         assert_eq!(roundtrip_api.snapshot_seqs, api_ctx.snapshot_seqs);
     }

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -31,9 +31,9 @@ use common_time::timezone::parse_timezone;
 use datafusion_common::config::ConfigOptions;
 use derive_builder::Builder;
 use sql::dialect::{Dialect, GenericDialect, GreptimeDbDialect, MySqlDialect, PostgreSqlDialect};
-use uuid::Uuid;
 
 use crate::protocol_ctx::ProtocolCtx;
+use crate::query_id::QueryId;
 use crate::session_config::{PGByteaOutputValue, PGDateOrder, PGDateTimeStyle, PGIntervalStyle};
 use crate::{MutableInner, ReadPreference};
 
@@ -44,7 +44,11 @@ const CURSOR_COUNT_WARNING_LIMIT: usize = 10;
 pub const REMOTE_QUERY_ID_EXTENSION_KEY: &str = "remote_query_id";
 
 pub fn generate_remote_query_id() -> String {
-    Uuid::now_v7().to_string()
+    generate_remote_query_id_value().to_string()
+}
+
+pub fn generate_remote_query_id_value() -> QueryId {
+    QueryId::new()
 }
 
 #[derive(Debug, Builder, Clone)]
@@ -352,6 +356,11 @@ impl QueryContext {
 
     pub fn remote_query_id(&self) -> Option<&str> {
         self.extension(REMOTE_QUERY_ID_EXTENSION_KEY)
+    }
+
+    pub fn remote_query_id_value(&self) -> Option<QueryId> {
+        self.remote_query_id()
+            .and_then(|query_id| query_id.parse().ok())
     }
 
     pub fn extensions(&self) -> HashMap<String, String> {
@@ -798,9 +807,14 @@ mod test {
             .build();
 
         assert_eq!(ctx.remote_query_id(), Some(query_id));
+        assert_eq!(ctx.remote_query_id_value().unwrap().to_string(), query_id);
 
         let proto: api::v1::QueryContext = (&ctx).into();
         let restored = QueryContext::from(proto);
         assert_eq!(restored.remote_query_id(), Some(query_id));
+        assert_eq!(
+            restored.remote_query_id_value().unwrap().to_string(),
+            query_id
+        );
     }
 }

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -31,6 +31,7 @@ use common_time::timezone::parse_timezone;
 use datafusion_common::config::ConfigOptions;
 use derive_builder::Builder;
 use sql::dialect::{Dialect, GenericDialect, GreptimeDbDialect, MySqlDialect, PostgreSqlDialect};
+use uuid::Uuid;
 
 use crate::protocol_ctx::ProtocolCtx;
 use crate::session_config::{PGByteaOutputValue, PGDateOrder, PGDateTimeStyle, PGIntervalStyle};
@@ -40,6 +41,11 @@ pub type QueryContextRef = Arc<QueryContext>;
 pub type ConnInfoRef = Arc<ConnInfo>;
 
 const CURSOR_COUNT_WARNING_LIMIT: usize = 10;
+pub const REMOTE_QUERY_ID_EXTENSION_KEY: &str = "remote_query_id";
+
+pub fn generate_remote_query_id() -> String {
+    Uuid::now_v7().to_string()
+}
 
 #[derive(Debug, Builder, Clone)]
 #[builder(pattern = "owned")]
@@ -152,7 +158,12 @@ impl From<&RegionRequestHeader> for QueryContext {
         if let Some(ctx) = &value.query_context {
             ctx.clone().into()
         } else {
-            QueryContextBuilder::default().build()
+            QueryContextBuilder::default()
+                .set_extension(
+                    REMOTE_QUERY_ID_EXTENSION_KEY.to_string(),
+                    generate_remote_query_id(),
+                )
+                .build()
         }
     }
 }
@@ -219,7 +230,14 @@ impl From<&QueryContext> for api::v1::QueryContext {
 
 impl QueryContext {
     pub fn arc() -> QueryContextRef {
-        Arc::new(QueryContextBuilder::default().build())
+        Arc::new(
+            QueryContextBuilder::default()
+                .set_extension(
+                    REMOTE_QUERY_ID_EXTENSION_KEY.to_string(),
+                    generate_remote_query_id(),
+                )
+                .build(),
+        )
     }
 
     /// Create a new  datafusion's ConfigOptions instance based on the current QueryContext.
@@ -233,6 +251,10 @@ impl QueryContext {
         QueryContextBuilder::default()
             .current_catalog(catalog.to_string())
             .current_schema(schema.to_string())
+            .set_extension(
+                REMOTE_QUERY_ID_EXTENSION_KEY.to_string(),
+                generate_remote_query_id(),
+            )
             .build()
     }
 
@@ -241,6 +263,10 @@ impl QueryContext {
             .current_catalog(catalog.to_string())
             .current_schema(schema.to_string())
             .channel(channel)
+            .set_extension(
+                REMOTE_QUERY_ID_EXTENSION_KEY.to_string(),
+                generate_remote_query_id(),
+            )
             .build()
     }
 
@@ -259,6 +285,10 @@ impl QueryContext {
         QueryContextBuilder::default()
             .current_catalog(catalog)
             .current_schema(schema.clone())
+            .set_extension(
+                REMOTE_QUERY_ID_EXTENSION_KEY.to_string(),
+                generate_remote_query_id(),
+            )
             .build()
     }
 
@@ -318,6 +348,10 @@ impl QueryContext {
 
     pub fn extension<S: AsRef<str>>(&self, key: S) -> Option<&str> {
         self.extensions.get(key.as_ref()).map(|v| v.as_str())
+    }
+
+    pub fn remote_query_id(&self) -> Option<&str> {
+        self.extension(REMOTE_QUERY_ID_EXTENSION_KEY)
     }
 
     pub fn extensions(&self) -> HashMap<String, String> {
@@ -483,6 +517,10 @@ impl QueryContext {
 impl QueryContextBuilder {
     pub fn build(self) -> QueryContext {
         let channel = self.channel.unwrap_or_default();
+        let mut extensions = self.extensions.unwrap_or_default();
+        extensions
+            .entry(REMOTE_QUERY_ID_EXTENSION_KEY.to_string())
+            .or_insert_with(generate_remote_query_id);
         QueryContext {
             current_catalog: self
                 .current_catalog
@@ -494,7 +532,7 @@ impl QueryContextBuilder {
             sql_dialect: self
                 .sql_dialect
                 .unwrap_or_else(|| Arc::new(GreptimeDbDialect {})),
-            extensions: self.extensions.unwrap_or_default(),
+            extensions,
             configuration_parameter: self
                 .configuration_parameter
                 .unwrap_or_else(|| Arc::new(ConfigurationVariables::default())),
@@ -707,6 +745,9 @@ mod test {
 
         assert_eq!("mysql[127.0.0.1:9000]", session.conn_info().to_string());
         assert_eq!(100, session.process_id());
+
+        let query_ctx = session.new_query_context();
+        assert!(query_ctx.remote_query_id().is_some());
     }
 
     #[test]
@@ -742,5 +783,24 @@ mod test {
         assert_eq!(roundtrip_api.extensions, api_ctx.extensions);
         assert_eq!(roundtrip_api.channel, api_ctx.channel);
         assert_eq!(roundtrip_api.snapshot_seqs, api_ctx.snapshot_seqs);
+    }
+
+    #[test]
+    fn test_query_context_remote_query_id_round_trip() {
+        let query_id = "0195f4fd-c503-7c54-8b8f-7dfb8f6f9c4a";
+        let ctx = QueryContextBuilder::default()
+            .current_catalog(DEFAULT_CATALOG_NAME.to_string())
+            .current_schema("public".to_string())
+            .set_extension(
+                REMOTE_QUERY_ID_EXTENSION_KEY.to_string(),
+                query_id.to_string(),
+            )
+            .build();
+
+        assert_eq!(ctx.remote_query_id(), Some(query_id));
+
+        let proto: api::v1::QueryContext = (&ctx).into();
+        let restored = QueryContext::from(proto);
+        assert_eq!(restored.remote_query_id(), Some(query_id));
     }
 }

--- a/src/session/src/hints.rs
+++ b/src/session/src/hints.rs
@@ -16,8 +16,10 @@
 pub const HINTS_KEY: &str = "x-greptime-hints";
 /// Deprecated, use `HINTS_KEY` instead. Notes if "x-greptime-hints" is set, keys with this prefix will be ignored.
 pub const HINTS_KEY_PREFIX: &str = "x-greptime-hint-";
+pub const REMOTE_QUERY_ID_EXTENSION_KEY: &str = "remote_query_id";
 
 pub const READ_PREFERENCE_HINT: &str = "read_preference";
+pub const RESERVED_EXTENSION_KEYS: [&str; 1] = [REMOTE_QUERY_ID_EXTENSION_KEY];
 
 /// Deprecated, use `HINTS_KEY` instead.
 pub const HINT_KEYS: [&str; 7] = [
@@ -29,3 +31,18 @@ pub const HINT_KEYS: [&str; 7] = [
     "x-greptime-hint-skip_wal",
     "x-greptime-hint-read_preference",
 ];
+
+pub fn is_reserved_extension_key(key: &str) -> bool {
+    RESERVED_EXTENSION_KEYS.contains(&key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_reserved_extension_key() {
+        assert!(is_reserved_extension_key(REMOTE_QUERY_ID_EXTENSION_KEY));
+        assert!(!is_reserved_extension_key(READ_PREFERENCE_HINT));
+    }
+}

--- a/src/session/src/lib.rs
+++ b/src/session/src/lib.rs
@@ -15,6 +15,7 @@
 pub mod context;
 pub mod hints;
 pub mod protocol_ctx;
+pub mod query_id;
 pub mod session_config;
 pub mod table_name;
 

--- a/src/session/src/lib.rs
+++ b/src/session/src/lib.rs
@@ -30,7 +30,10 @@ use common_recordbatch::cursor::RecordBatchStreamCursor;
 pub use common_session::ReadPreference;
 use common_time::Timezone;
 use common_time::timezone::get_timezone;
-use context::{ConfigurationVariables, QueryContextBuilder};
+use context::{
+    ConfigurationVariables, QueryContextBuilder, REMOTE_QUERY_ID_EXTENSION_KEY,
+    generate_remote_query_id,
+};
 use derive_more::Debug;
 
 use crate::context::{Channel, ConnInfo, QueryContextRef};
@@ -106,6 +109,10 @@ impl Session {
             .channel(self.conn_info.channel)
             .process_id(self.process_id)
             .conn_info(self.conn_info.clone())
+            .set_extension(
+                REMOTE_QUERY_ID_EXTENSION_KEY.to_string(),
+                generate_remote_query_id(),
+            )
             .build()
             .into()
     }

--- a/src/session/src/lib.rs
+++ b/src/session/src/lib.rs
@@ -31,10 +31,7 @@ use common_recordbatch::cursor::RecordBatchStreamCursor;
 pub use common_session::ReadPreference;
 use common_time::Timezone;
 use common_time::timezone::get_timezone;
-use context::{
-    ConfigurationVariables, QueryContextBuilder, REMOTE_QUERY_ID_EXTENSION_KEY,
-    generate_remote_query_id,
-};
+use context::{ConfigurationVariables, QueryContextBuilder};
 use derive_more::Debug;
 
 use crate::context::{Channel, ConnInfo, QueryContextRef};
@@ -110,10 +107,6 @@ impl Session {
             .channel(self.conn_info.channel)
             .process_id(self.process_id)
             .conn_info(self.conn_info.clone())
-            .set_extension(
-                REMOTE_QUERY_ID_EXTENSION_KEY.to_string(),
-                generate_remote_query_id(),
-            )
             .build()
             .into()
     }

--- a/src/session/src/query_id.rs
+++ b/src/session/src/query_id.rs
@@ -1,0 +1,76 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
+
+use uuid::Uuid;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct QueryId(Uuid);
+
+impl QueryId {
+    pub fn new() -> Self {
+        Self(Uuid::now_v7())
+    }
+
+    pub fn as_uuid(&self) -> &Uuid {
+        &self.0
+    }
+}
+
+impl Default for QueryId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Display for QueryId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl FromStr for QueryId {
+    type Err = uuid::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(Uuid::parse_str(s)?))
+    }
+}
+
+impl From<Uuid> for QueryId {
+    fn from(value: Uuid) -> Self {
+        Self(value)
+    }
+}
+
+impl From<QueryId> for Uuid {
+    fn from(value: QueryId) -> Self {
+        value.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn query_id_round_trips_through_string() {
+        let query_id = QueryId::new();
+        let encoded = query_id.to_string();
+
+        assert_eq!(encoded.parse::<QueryId>().unwrap(), query_id);
+    }
+}

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -184,6 +184,10 @@ impl RegionRequest {
                 reason: "ListMetadata request should be handled separately by RegionServer",
             }
             .fail(),
+            region_request::Body::RemoteDynFilter(_) => UnexpectedSnafu {
+                reason: "RemoteDynFilter request should be handled separately by RegionServer",
+            }
+            .fail(),
             region_request::Body::ApplyStagingManifest(apply) => {
                 make_region_apply_staging_manifest(apply)
             }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptime-proto/pull/314

## Summary
- define the Phase 1 remote dynamic filter wire ABI, including `remote_query_id`, `DynFilterUpdate`, and shared payload encode/decode helpers
- add the region unary RPC scaffolding for remote dynamic filter `update` / `unregister` handling between frontend and datanode
- keep this PR scoped to scaffolding only, leaving frontend producer and datanode apply/runtime work to follow-up changes

## Why
This splits out the protocol and control-plane groundwork into a smaller reviewable PR before the larger end-to-end remote dynamic filter implementation. It gives us a stable ABI and RPC entrypoint first, so later work can build on a reviewed contract instead of mixing transport and runtime changes together.

## Included in this PR
- wire ABI groundwork
- region RPC scaffolding

## Not included
- frontend producer registration/build-link logic
- datanode apply/runtime wrapper integration
- lifecycle cleanup / observability / validation follow-ups

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
