### PR TITLE
fix: allow ipv4_num_to_string to accept valid integers

### DIFF
--- a/src/common/function/src/scalars/ip/ipv4.rs
+++ b/src/common/function/src/scalars/ip/ipv4.rs
@@ -20,7 +20,10 @@ use common_query::error::InvalidFuncArgsSnafu;
 use datafusion_common::arrow::array::{Array, AsArray, StringViewBuilder, UInt32Builder};
 use datafusion_common::arrow::compute;
 use datafusion_common::arrow::datatypes::{DataType, UInt32Type};
-use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, Signature, TypeSignature, Volatility};
+use datafusion_expr::{
+    Coercion, ColumnarValue, ScalarFunctionArgs, Signature, TypeSignature, TypeSignatureClass,
+    Volatility,
+};
 use derive_more::Display;
 
 use crate::function::{Function, extract_args};
@@ -43,13 +46,8 @@ pub struct Ipv4NumToString {
 impl Default for Ipv4NumToString {
     fn default() -> Self {
         Self {
-            signature: Signature::one_of(
-                vec![
-                    TypeSignature::Exact(vec![DataType::UInt32]),
-                    TypeSignature::Exact(vec![DataType::UInt64]),
-                    TypeSignature::Exact(vec![DataType::Int32]),
-                    TypeSignature::Exact(vec![DataType::Int64]),
-                ],
+            signature: Signature::new(
+                TypeSignature::Coercible(vec![Coercion::new_exact(TypeSignatureClass::Integer)]),
                 Volatility::Immutable,
             ),
             aliases: ["inet_ntoa".to_string()],

--- a/src/common/function/src/scalars/ip/ipv4.rs
+++ b/src/common/function/src/scalars/ip/ipv4.rs
@@ -43,8 +43,13 @@ pub struct Ipv4NumToString {
 impl Default for Ipv4NumToString {
     fn default() -> Self {
         Self {
-            signature: Signature::new(
-                TypeSignature::Exact(vec![DataType::UInt32]),
+            signature: Signature::one_of(
+                vec![
+                    TypeSignature::Exact(vec![DataType::UInt32]),
+                    TypeSignature::Exact(vec![DataType::UInt64]),
+                    TypeSignature::Exact(vec![DataType::Int32]),
+                    TypeSignature::Exact(vec![DataType::Int64]),
+                ],
                 Volatility::Immutable,
             ),
             aliases: ["inet_ntoa".to_string()],
@@ -70,6 +75,14 @@ impl Function for Ipv4NumToString {
         args: ScalarFunctionArgs,
     ) -> datafusion_common::Result<ColumnarValue> {
         let [arg0] = extract_args(self.name(), &args)?;
+        let arg0 = compute::cast_with_options(
+            &arg0,
+            &DataType::UInt32,
+            &compute::CastOptions {
+                safe: false,
+                ..Default::default()
+            },
+        )?;
         let uint_vec = arg0.as_primitive::<UInt32Type>();
 
         let size = uint_vec.len();
@@ -171,7 +184,7 @@ mod tests {
     use std::sync::Arc;
 
     use arrow_schema::Field;
-    use datafusion_common::arrow::array::{StringViewArray, UInt32Array};
+    use datafusion_common::arrow::array::{Int64Array, StringViewArray, UInt32Array};
 
     use super::*;
 
@@ -198,6 +211,51 @@ mod tests {
         assert_eq!(result.value(1), "192.168.0.1");
         assert_eq!(result.value(2), "0.0.0.0");
         assert_eq!(result.value(3), "255.255.255.255");
+    }
+
+    #[test]
+    fn test_ipv4_num_to_string_accepts_int64() {
+        let func = Ipv4NumToString::default();
+
+        // Test data
+        let values = vec![167772161i64, 3232235521i64, 0i64, 4294967295i64];
+        let input = ColumnarValue::Array(Arc::new(Int64Array::from(values)));
+
+        let args = ScalarFunctionArgs {
+            args: vec![input],
+            arg_fields: vec![],
+            number_rows: 4,
+            return_field: Arc::new(Field::new("x", DataType::Utf8View, false)),
+            config_options: Arc::new(Default::default()),
+        };
+        let result = func.invoke_with_args(args).unwrap();
+        let result = result.to_array(4).unwrap();
+        let result = result.as_string_view();
+
+        assert_eq!(result.value(0), "10.0.0.1");
+        assert_eq!(result.value(1), "192.168.0.1");
+        assert_eq!(result.value(2), "0.0.0.0");
+        assert_eq!(result.value(3), "255.255.255.255");
+    }
+
+    #[test]
+    fn test_ipv4_num_to_string_rejects_negative_int64() {
+        let func = Ipv4NumToString::default();
+
+        // Test data
+        let values = vec![-1i64];
+        let input = ColumnarValue::Array(Arc::new(Int64Array::from(values)));
+
+        let args = ScalarFunctionArgs {
+            args: vec![input],
+            arg_fields: vec![],
+            number_rows: 1,
+            return_field: Arc::new(Field::new("x", DataType::Utf8View, false)),
+            config_options: Arc::new(Default::default()),
+        };
+        let result = func.invoke_with_args(args);
+
+        assert!(result.is_err());
     }
 
     #[test]

--- a/tests/cases/standalone/common/function/ip.result
+++ b/tests/cases/standalone/common/function/ip.result
@@ -341,3 +341,4 @@ Affected Rows: 0
 drop table network_traffic;
 
 Affected Rows: 0
+

--- a/tests/cases/standalone/common/function/ip.result
+++ b/tests/cases/standalone/common/function/ip.result
@@ -122,6 +122,15 @@ FROM ip_v4_data;
 | 8  | 0.0.0.0         | 0          | 0                | 0.0.0.0         |
 +----+-----------------+------------+------------------+-----------------+
 
+-- Test IPv4 number to string conversion function without explicit cast
+SELECT ipv4_num_to_string(3232235521);
+
++---------------------------------------+
+| ipv4_num_to_string(Int64(3232235521)) |
++---------------------------------------+
+| 192.168.0.1                           |
++---------------------------------------+
+
 -- Test IPv4 CIDR functions
 -- SQLNESS SORT_RESULT 3 1
 SELECT
@@ -332,4 +341,3 @@ Affected Rows: 0
 drop table network_traffic;
 
 Affected Rows: 0
-

--- a/tests/cases/standalone/common/function/ip.sql
+++ b/tests/cases/standalone/common/function/ip.sql
@@ -84,6 +84,9 @@ SELECT
     inet_ntoa(ip_numeric) AS computed_addr
 FROM ip_v4_data;
 
+-- Test IPv4 number to string conversion function without explicit cast
+SELECT ipv4_num_to_string(3232235521);
+
 -- Test IPv4 CIDR functions
 -- SQLNESS SORT_RESULT 3 1
 SELECT


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Closes [issue 7977](https://github.com/GreptimeTeam/greptimedb/issues/7977)

## What's changed and what's your intention?

Previously, the `ipv4_num_to_string` function would reject any integers that were not of type `uint32` even if the passed in integer could be casted into a valid `uint32`. This PR broadens the `ipv4_num_to_string` signature to take in any of `UInt32`, `UInt64`, `Int32`, or `Int64, and then strictly casts the input to `UInt32` before formatting it as an IPv4 string.

This removes the need for explicit `::uint32` casts for valid integers while still rejecting invalid values, such as negative numbers or integers larger than `UInt32::MAX`. This PR also has unit tests and a sqlness regression test for the `Int64` case reported in the issue.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
