### PR TITLE
Refactor ChineseTokenizer to remove ASCII check

### DIFF
--- a/src/index/src/fulltext_index/tokenizer.rs
+++ b/src/index/src/fulltext_index/tokenizer.rs
@@ -92,11 +92,9 @@ impl Tokenizer for ChineseTokenizer {
     fn tokenize<'a>(&self, text: &'a str) -> Vec<&'a str> {
         // Search-mode tokenization emits finer-grained searchable terms, while HMM helps
         // merge some unknown fragments and avoid excessive token fragmentation.
-        JIEBA
-            .cut_for_search(text, true)
-            .into_iter()
-            .filter(|s| s.chars().any(|c| c.is_alphanumeric() || c == '_'))
-            .collect()
+        let mut tokens = JIEBA.cut_for_search(text, true);
+        tokens.retain(|s| s.chars().any(|c| c.is_alphanumeric() || c == '_'));
+        tokens
     }
 }
 

--- a/src/index/src/fulltext_index/tokenizer.rs
+++ b/src/index/src/fulltext_index/tokenizer.rs
@@ -90,17 +90,13 @@ pub struct ChineseTokenizer;
 
 impl Tokenizer for ChineseTokenizer {
     fn tokenize<'a>(&self, text: &'a str) -> Vec<&'a str> {
-        if text.is_ascii() {
-            EnglishTokenizer {}.tokenize(text)
-        } else {
-            // Search-mode tokenization emits finer-grained searchable terms, while HMM helps
-            // merge some unknown fragments and avoid excessive token fragmentation.
-            JIEBA
-                .cut_for_search(text, true)
-                .into_iter()
-                .filter(|s| s.chars().any(|c| c.is_alphanumeric() || c == '_'))
-                .collect()
-        }
+        // Search-mode tokenization emits finer-grained searchable terms, while HMM helps
+        // merge some unknown fragments and avoid excessive token fragmentation.
+        JIEBA
+            .cut_for_search(text, true)
+            .into_iter()
+            .filter(|s| s.chars().any(|c| c.is_alphanumeric() || c == '_'))
+            .collect()
     }
 }
 


### PR DESCRIPTION
 - 英文文本也会通过 Jieba 分词，可能会产生与 EnglishTokenizer 不同的分词结果
 - 但这是正确的行为：用户明确选择了中文分词器，应该始终使用中文分词逻辑

#7943

I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
