### PR TITLE
chore: add build info in panic message

### DIFF
--- a/src/common/telemetry/src/panic_hook.rs
+++ b/src/common/telemetry/src/panic_hook.rs
@@ -36,6 +36,7 @@ pub fn set_panic_hook() {
     panic::set_hook(Box::new(move |panic| {
         let backtrace = Backtrace::new();
         let backtrace = format!("{backtrace:?}");
+        let build_info = common_version::build_info();
         if let Some(location) = panic.location() {
             tracing::error!(
                 message = %panic,
@@ -43,9 +44,18 @@ pub fn set_panic_hook() {
                 panic.file = location.file(),
                 panic.line = location.line(),
                 panic.column = location.column(),
+                branch = %build_info.branch,
+                version = %build_info.version,
+                commit = %build_info.commit,
             );
         } else {
-            tracing::error!(message = %panic, backtrace = %backtrace);
+            tracing::error!(
+                message = %panic,
+                backtrace = %backtrace,
+                branch = %build_info.branch,
+                version = %build_info.version,
+                commit = %build_info.commit,
+            );
         }
         PANIC_COUNTER.inc();
         default_hook(panic);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Add build info to panic message.

```
2026-04-20T07:43:54.414848Z ERROR common_telemetry::panic_hook: panicked at src/cmd/src/standalone.rs:164:24:
Panic backtrace=   0: common_telemetry::panic_hook::set_panic_hook::{closure#0}
      ...
      <std::sys::thread::unix::Thread>::new::thread_start
             at /rustc/ac7f9ec7da74d37fd28667c86bf117a39ba5b02a/library/std/src/sys/thread/unix.rs:118:17
  32: <unknown>
  33: <unknown>
 panic.file="src/cmd/src/standalone.rs" panic.line=164 panic.column=24 branch=main version=1.0.0-rc.2 commit=233e35c0c91ba9859fa514511872834f6502cbd8
```


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
