### PR TITLE
refactor(mito2): reshape extension range API

### DIFF
--- a/src/mito2/src/extension.rs
+++ b/src/mito2/src/extension.rs
@@ -8,13 +8,22 @@ use common_time::range::TimestampRange;
 use store_api::storage::{ScanRequest, SequenceNumber};
 
 use crate::error::Result;
+use crate::read::BoxedRecordBatchStream;
 use crate::read::range::RowGroupIndex;
 use crate::read::scan_region::StreamContext;
 use crate::read::scan_util::PartitionMetrics;
-use crate::read::{BoxedBatchStream, BoxedRecordBatchStream};
 use crate::region::MitoRegionRef;
+use crate::sst::parquet::file_range::PreFilterMode;
 
 pub type InclusiveTimeRange = (Timestamp, Timestamp);
+
+/// Per-range read options passed to [`ExtensionRange::flat_reader`].
+#[derive(Debug, Clone, Copy)]
+pub struct ExtensionRangeReadOptions {
+    /// How aggressively to pre-filter columns before merging with other sources
+    /// in the same partition range.
+    pub pre_filter_mode: PreFilterMode,
+}
 
 /// [`ExtensionRange`] is used to represent a scannable "range" for mito engine, just like the
 /// memtable range and sst file range, but resides on the outside.
@@ -30,28 +39,15 @@ pub trait ExtensionRange: Debug + Send + Sync {
     /// The row groups number in this range.
     fn num_row_groups(&self) -> u64;
 
-    /// Create the reader for reading this range.
-    fn reader(&self, context: &StreamContext) -> BoxedExtensionRangeReader;
-
     /// Create the flat reader for reading this range in flat format.
-    fn flat_reader(&self, context: &StreamContext) -> BoxedExtensionFlatRangeReader;
+    fn flat_reader(
+        &self,
+        context: &StreamContext,
+        options: ExtensionRangeReadOptions,
+    ) -> BoxedExtensionFlatRangeReader;
 }
 
 pub type BoxedExtensionRange = Box<dyn ExtensionRange>;
-
-/// The reader to read an extension range.
-#[async_trait]
-pub trait ExtensionRangeReader: Send {
-    /// Read the extension range by creating a stream that produces [`Batch`].
-    async fn read(
-        self: Box<Self>,
-        context: Arc<StreamContext>,
-        metrics: PartitionMetrics,
-        index: RowGroupIndex,
-    ) -> Result<BoxedBatchStream, BoxedError>;
-}
-
-pub type BoxedExtensionRangeReader = Box<dyn ExtensionRangeReader>;
 
 /// The reader to read an extension range in flat format (producing [`RecordBatch`]).
 #[async_trait]

--- a/src/mito2/src/read/scan_util.rs
+++ b/src/mito2/src/read/scan_util.rs
@@ -47,7 +47,7 @@ use crate::sst::file::{FileTimeRange, RegionFileId};
 use crate::sst::index::bloom_filter::applier::BloomFilterIndexApplyMetrics;
 use crate::sst::index::fulltext_index::applier::FulltextIndexApplyMetrics;
 use crate::sst::index::inverted_index::applier::InvertedIndexApplyMetrics;
-use crate::sst::parquet::file_range::FileRange;
+use crate::sst::parquet::file_range::{FileRange, PreFilterMode};
 use crate::sst::parquet::flat_format::time_index_column_index;
 use crate::sst::parquet::reader::{MetadataCacheMetrics, ReaderFilterMetrics, ReaderMetrics};
 use crate::sst::parquet::row_group::ParquetFetchMetrics;
@@ -1594,10 +1594,11 @@ pub(crate) async fn maybe_scan_flat_other_ranges(
     context: &Arc<StreamContext>,
     index: RowGroupIndex,
     metrics: &PartitionMetrics,
-    options: crate::extension::ExtensionRangeReadOptions,
+    pre_filter_mode: PreFilterMode,
 ) -> Result<BoxedRecordBatchStream> {
     #[cfg(feature = "enterprise")]
     {
+        let options = crate::extension::ExtensionRangeReadOptions { pre_filter_mode };
         scan_flat_extension_range(context.clone(), index, metrics.clone(), options).await
     }
 
@@ -1606,7 +1607,7 @@ pub(crate) async fn maybe_scan_flat_other_ranges(
         let _ = context;
         let _ = index;
         let _ = metrics;
-        let _ = options;
+        let _ = pre_filter_mode;
 
         crate::error::UnexpectedSnafu {
             reason: "no other ranges scannable in flat format",

--- a/src/mito2/src/read/scan_util.rs
+++ b/src/mito2/src/read/scan_util.rs
@@ -1577,11 +1577,12 @@ pub(crate) async fn scan_flat_extension_range(
     context: Arc<StreamContext>,
     index: RowGroupIndex,
     partition_metrics: PartitionMetrics,
+    options: crate::extension::ExtensionRangeReadOptions,
 ) -> Result<BoxedRecordBatchStream> {
     use snafu::ResultExt;
 
     let range = context.input.extension_range(index.index);
-    let reader = range.flat_reader(context.as_ref());
+    let reader = range.flat_reader(context.as_ref(), options);
     let stream = reader
         .read(context, partition_metrics, index)
         .await
@@ -1593,10 +1594,11 @@ pub(crate) async fn maybe_scan_flat_other_ranges(
     context: &Arc<StreamContext>,
     index: RowGroupIndex,
     metrics: &PartitionMetrics,
+    options: crate::extension::ExtensionRangeReadOptions,
 ) -> Result<BoxedRecordBatchStream> {
     #[cfg(feature = "enterprise")]
     {
-        scan_flat_extension_range(context.clone(), index, metrics.clone()).await
+        scan_flat_extension_range(context.clone(), index, metrics.clone(), options).await
     }
 
     #[cfg(not(feature = "enterprise"))]
@@ -1604,6 +1606,7 @@ pub(crate) async fn maybe_scan_flat_other_ranges(
         let _ = context;
         let _ = index;
         let _ = metrics;
+        let _ = options;
 
         crate::error::UnexpectedSnafu {
             reason: "no other ranges scannable in flat format",

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -692,8 +692,16 @@ pub(crate) async fn build_flat_sources(
                 ordered_sources[position] = Some(Box::pin(stream) as _);
             }
         } else {
-            let stream =
-                scan_util::maybe_scan_flat_other_ranges(stream_ctx, *index, part_metrics).await?;
+            let ext_options = crate::extension::ExtensionRangeReadOptions {
+                pre_filter_mode: stream_ctx.range_pre_filter_mode(part_range),
+            };
+            let stream = scan_util::maybe_scan_flat_other_ranges(
+                stream_ctx,
+                *index,
+                part_metrics,
+                ext_options,
+            )
+            .await?;
             ordered_sources[position] = Some(stream);
         }
     }

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -649,9 +649,7 @@ pub(crate) async fn build_flat_sources(
     let mut ordered_sources = Vec::with_capacity(num_indices);
     ordered_sources.resize_with(num_indices, || None);
     let mut file_scan_tasks = Vec::new();
-    let ext_options = crate::extension::ExtensionRangeReadOptions {
-        pre_filter_mode: stream_ctx.range_pre_filter_mode(part_range),
-    };
+    let pre_filter_mode = stream_ctx.range_pre_filter_mode(part_range);
 
     for (position, index) in range_meta.row_group_indices.iter().enumerate() {
         if stream_ctx.is_mem_range_index(*index) {
@@ -699,7 +697,7 @@ pub(crate) async fn build_flat_sources(
                 stream_ctx,
                 *index,
                 part_metrics,
-                ext_options,
+                pre_filter_mode,
             )
             .await?;
             ordered_sources[position] = Some(stream);

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -649,6 +649,9 @@ pub(crate) async fn build_flat_sources(
     let mut ordered_sources = Vec::with_capacity(num_indices);
     ordered_sources.resize_with(num_indices, || None);
     let mut file_scan_tasks = Vec::new();
+    let ext_options = crate::extension::ExtensionRangeReadOptions {
+        pre_filter_mode: stream_ctx.range_pre_filter_mode(part_range),
+    };
 
     for (position, index) in range_meta.row_group_indices.iter().enumerate() {
         if stream_ctx.is_mem_range_index(*index) {
@@ -692,9 +695,6 @@ pub(crate) async fn build_flat_sources(
                 ordered_sources[position] = Some(Box::pin(stream) as _);
             }
         } else {
-            let ext_options = crate::extension::ExtensionRangeReadOptions {
-                pre_filter_mode: stream_ctx.range_pre_filter_mode(part_range),
-            };
             let stream = scan_util::maybe_scan_flat_other_ranges(
                 stream_ctx,
                 *index,

--- a/src/mito2/src/read/unordered_scan.rs
+++ b/src/mito2/src/read/unordered_scan.rs
@@ -120,9 +120,7 @@ impl UnorderedScan {
             // Gets range meta.
             let range_meta = &stream_ctx.ranges[part_range_id];
             let part_range = range_meta.new_partition_range(part_range_id);
-            let ext_options = crate::extension::ExtensionRangeReadOptions {
-                pre_filter_mode: stream_ctx.range_pre_filter_mode(&part_range),
-            };
+            let pre_filter_mode = stream_ctx.range_pre_filter_mode(&part_range);
             for index in &range_meta.row_group_indices {
                 if stream_ctx.is_mem_range_index(*index) {
                     let stream = scan_flat_mem_ranges(
@@ -150,7 +148,7 @@ impl UnorderedScan {
                         &stream_ctx,
                         *index,
                         &part_metrics,
-                        ext_options,
+                        pre_filter_mode,
                     ).await?;
                     for await record_batch in stream {
                         yield record_batch?;

--- a/src/mito2/src/read/unordered_scan.rs
+++ b/src/mito2/src/read/unordered_scan.rs
@@ -142,10 +142,15 @@ impl UnorderedScan {
                         yield record_batch?;
                     }
                 } else {
+                    let part_range = range_meta.new_partition_range(part_range_id);
+                    let ext_options = crate::extension::ExtensionRangeReadOptions {
+                        pre_filter_mode: stream_ctx.range_pre_filter_mode(&part_range),
+                    };
                     let stream = scan_util::maybe_scan_flat_other_ranges(
                         &stream_ctx,
                         *index,
                         &part_metrics,
+                        ext_options,
                     ).await?;
                     for await record_batch in stream {
                         yield record_batch?;

--- a/src/mito2/src/read/unordered_scan.rs
+++ b/src/mito2/src/read/unordered_scan.rs
@@ -119,6 +119,10 @@ impl UnorderedScan {
         try_stream! {
             // Gets range meta.
             let range_meta = &stream_ctx.ranges[part_range_id];
+            let part_range = range_meta.new_partition_range(part_range_id);
+            let ext_options = crate::extension::ExtensionRangeReadOptions {
+                pre_filter_mode: stream_ctx.range_pre_filter_mode(&part_range),
+            };
             for index in &range_meta.row_group_indices {
                 if stream_ctx.is_mem_range_index(*index) {
                     let stream = scan_flat_mem_ranges(
@@ -142,10 +146,6 @@ impl UnorderedScan {
                         yield record_batch?;
                     }
                 } else {
-                    let part_range = range_meta.new_partition_range(part_range_id);
-                    let ext_options = crate::extension::ExtensionRangeReadOptions {
-                        pre_filter_mode: stream_ctx.range_pre_filter_mode(&part_range),
-                    };
                     let stream = scan_util::maybe_scan_flat_other_ranges(
                         &stream_ctx,
                         *index,


### PR DESCRIPTION


I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Thread per-range read options into the extension range flat reader so it can honor PreFilterMode like other range kinds, and drop the unused legacy Batch reader surface.

- extension.rs: introduce ExtensionRangeReadOptions; remove reader(), ExtensionRangeReader, and BoxedExtensionRangeReader (no in-tree or out-of-tree call sites use the Batch-format reader path anymore).
- scan_util.rs: plumb options through maybe_scan_flat_other_ranges and scan_flat_extension_range.
- seq_scan.rs / unordered_scan.rs: build options at the call site via StreamContext::range_pre_filter_mode.

Using an options struct (rather than a bare PreFilterMode argument) keeps future additions additive for out-of-tree ExtensionRange impls.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
