### PR TITLE
feat: tune range cache

### DIFF
--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -50,7 +50,7 @@ use crate::cache::index::inverted_index::{InvertedIndexCache, InvertedIndexCache
 #[cfg(feature = "vector_index")]
 use crate::cache::index::vector_index::{VectorIndexCache, VectorIndexCacheRef};
 use crate::cache::write_cache::WriteCacheRef;
-use crate::error::{InvalidMetadataSnafu, InvalidParquetSnafu, Result};
+use crate::error::{InvalidMetadataSnafu, InvalidParquetSnafu, Result, UnexpectedSnafu};
 use crate::memtable::record_batch_estimated_size;
 use crate::metrics::{CACHE_BYTES, CACHE_EVICTION, CACHE_HIT, CACHE_MISS};
 use crate::read::Batch;
@@ -80,6 +80,7 @@ const RANGE_RESULT_CONCAT_MEMORY_PERMIT: ReadableSize = ReadableSize::kb(1);
 pub(crate) struct RangeResultMemoryLimiter {
     semaphore: Arc<tokio::sync::Semaphore>,
     permit_bytes: usize,
+    total_permits: usize,
 }
 
 impl Default for RangeResultMemoryLimiter {
@@ -94,13 +95,17 @@ impl Default for RangeResultMemoryLimiter {
 impl RangeResultMemoryLimiter {
     pub(crate) fn new(limit_bytes: usize, permit_bytes: usize) -> Self {
         let permit_bytes = permit_bytes.max(1);
-        let permits = limit_bytes.div_ceil(permit_bytes).max(1);
+        let total_permits = limit_bytes
+            .div_ceil(permit_bytes)
+            .clamp(1, tokio::sync::Semaphore::MAX_PERMITS);
         Self {
-            semaphore: Arc::new(tokio::sync::Semaphore::new(permits)),
+            semaphore: Arc::new(tokio::sync::Semaphore::new(total_permits)),
             permit_bytes,
+            total_permits,
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn permit_bytes(&self) -> usize {
         self.permit_bytes
     }
@@ -110,12 +115,26 @@ impl RangeResultMemoryLimiter {
         self.semaphore.available_permits()
     }
 
-    pub(crate) async fn acquire(
-        &self,
-        bytes: usize,
-    ) -> std::result::Result<tokio::sync::SemaphorePermit<'_>, tokio::sync::AcquireError> {
-        let permits = bytes.div_ceil(self.permit_bytes()).max(1) as u32;
-        self.semaphore.acquire_many(permits).await
+    pub(crate) async fn acquire(&self, bytes: usize) -> Result<tokio::sync::SemaphorePermit<'_>> {
+        let permits = bytes.div_ceil(self.permit_bytes).max(1);
+        if permits > self.total_permits {
+            return UnexpectedSnafu {
+                reason: format!(
+                    "range result memory request of {bytes} bytes exceeds limiter capacity of {} bytes",
+                    self.total_permits.saturating_mul(self.permit_bytes)
+                ),
+            }
+            .fail();
+        }
+        self.semaphore
+            .acquire_many(permits as u32)
+            .await
+            .map_err(|_| {
+                UnexpectedSnafu {
+                    reason: "range result memory limiter is unexpectedly closed",
+                }
+                .build()
+            })
     }
 }
 
@@ -1488,6 +1507,28 @@ mod tests {
             cache.range_result_memory_limiter().available_permits(),
             (cache_size as usize).div_ceil(RANGE_RESULT_CONCAT_MEMORY_PERMIT.as_bytes() as usize)
         );
+    }
+
+    #[tokio::test]
+    async fn range_result_memory_limiter_rejects_oversized_request() {
+        let limiter = RangeResultMemoryLimiter::new(2 * 1024, 1024);
+        assert_eq!(limiter.available_permits(), 2);
+
+        let err = limiter.acquire(10 * 1024).await.unwrap_err();
+        assert!(
+            err.to_string().contains("exceeds limiter capacity"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(limiter.available_permits(), 2);
+    }
+
+    #[tokio::test]
+    async fn range_result_memory_limiter_allows_request_up_to_capacity() {
+        let limiter = RangeResultMemoryLimiter::new(2 * 1024, 1024);
+        let permit = limiter.acquire(2 * 1024).await.unwrap();
+        assert_eq!(limiter.available_permits(), 0);
+        drop(permit);
+        assert_eq!(limiter.available_permits(), 2);
     }
 
     #[tokio::test]

--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -105,6 +105,11 @@ impl RangeResultMemoryLimiter {
         self.permit_bytes
     }
 
+    #[cfg(test)]
+    pub(crate) fn available_permits(&self) -> usize {
+        self.semaphore.available_permits()
+    }
+
     pub(crate) async fn acquire(
         &self,
         bytes: usize,
@@ -431,6 +436,15 @@ impl CacheStrategy {
         }
     }
 
+    pub(crate) fn range_result_cache_size(&self) -> Option<usize> {
+        match self {
+            CacheStrategy::EnableAll(cache_manager) => {
+                Some(cache_manager.range_result_cache_size())
+            }
+            CacheStrategy::Compaction(_) | CacheStrategy::Disabled => None,
+        }
+    }
+
     /// Calls [CacheManager::write_cache()].
     /// It returns None if the strategy is [CacheStrategy::Disabled].
     pub fn write_cache(&self) -> Option<&WriteCacheRef> {
@@ -534,6 +548,8 @@ pub struct CacheManager {
     selector_result_cache: Option<SelectorResultCache>,
     /// Cache for range scan outputs in flat format.
     range_result_cache: Option<RangeResultCache>,
+    /// Configured capacity for range scan outputs in flat format.
+    range_result_cache_size: u64,
     /// Shared memory limiter for async range-result cache tasks.
     range_result_memory_limiter: Arc<RangeResultMemoryLimiter>,
     /// Cache for index result.
@@ -804,6 +820,10 @@ impl CacheManager {
         &self.range_result_memory_limiter
     }
 
+    pub(crate) fn range_result_cache_size(&self) -> usize {
+        self.range_result_cache_size as usize
+    }
+
     /// Gets the write cache.
     pub(crate) fn write_cache(&self) -> Option<&WriteCacheRef> {
         self.write_cache.as_ref()
@@ -1038,7 +1058,11 @@ impl CacheManagerBuilder {
             puffin_metadata_cache: Some(Arc::new(puffin_metadata_cache)),
             selector_result_cache,
             range_result_cache,
-            range_result_memory_limiter: Arc::new(RangeResultMemoryLimiter::default()),
+            range_result_cache_size: self.range_result_cache_size,
+            range_result_memory_limiter: Arc::new(RangeResultMemoryLimiter::new(
+                self.range_result_cache_size as usize,
+                RANGE_RESULT_CONCAT_MEMORY_PERMIT.as_bytes() as usize,
+            )),
             index_result_cache,
         }
     }
@@ -1446,6 +1470,24 @@ mod tests {
         assert!(disabled.get_range_result(&key).is_none());
         disabled.put_range_result(key.clone(), value);
         assert!(cache.get_range_result(&key).is_some());
+    }
+
+    #[test]
+    fn test_range_result_cache_size_configures_limiter() {
+        let cache_size = 3 * 1024_u64;
+        let cache = CacheManager::builder()
+            .range_result_cache_size(cache_size)
+            .build();
+
+        assert_eq!(cache.range_result_cache_size(), cache_size as usize);
+        assert_eq!(
+            cache.range_result_memory_limiter().permit_bytes(),
+            RANGE_RESULT_CONCAT_MEMORY_PERMIT.as_bytes() as usize
+        );
+        assert_eq!(
+            cache.range_result_memory_limiter().available_permits(),
+            (cache_size as usize).div_ceil(RANGE_RESULT_CONCAT_MEMORY_PERMIT.as_bytes() as usize)
+        );
     }
 
     #[tokio::test]

--- a/src/mito2/src/read/range_cache.rs
+++ b/src/mito2/src/read/range_cache.rs
@@ -38,7 +38,7 @@ use crate::region::options::MergeMode;
 use crate::sst::file::FileTimeRange;
 use crate::sst::parquet::DEFAULT_READ_BATCH_SIZE;
 
-const RANGE_CACHE_COMPACT_THRESHOLD_BYTES: usize = 2 * 1024 * 1024;
+const RANGE_CACHE_COMPACT_THRESHOLD_BYTES: usize = 8 * 1024 * 1024;
 
 /// Fingerprint of the scan request fields that affect partition range cache reuse.
 ///
@@ -499,8 +499,9 @@ impl CacheBatchBuffer {
         self.buffered_size += batch_size;
         self.buffered_batches.push(batch);
 
-        if self.buffered_rows > DEFAULT_READ_BATCH_SIZE
-            || self.buffered_size > RANGE_CACHE_COMPACT_THRESHOLD_BYTES
+        if self.buffered_batches.len() > 1
+            && (self.buffered_rows > DEFAULT_READ_BATCH_SIZE
+                || self.buffered_size > RANGE_CACHE_COMPACT_THRESHOLD_BYTES)
         {
             self.notify_compact();
         }
@@ -553,8 +554,8 @@ impl CacheBatchBuffer {
 
 fn estimate_batch_weight(batch: &RecordBatch, num_sources: usize) -> usize {
     let num_rows = batch.num_rows().max(1);
-    batch
-        .get_array_memory_size()
+    let memory_size = batch.get_array_memory_size();
+    memory_size
         .saturating_mul(num_sources.max(1))
         .saturating_mul(num_rows)
         .div_ceil(DEFAULT_READ_BATCH_SIZE)
@@ -994,13 +995,18 @@ mod tests {
         let large_batch = make_large_binary_batch(DEFAULT_READ_BATCH_SIZE, 4096);
         let strategy = CacheStrategy::EnableAll(Arc::new(
             CacheManager::builder()
-                .range_result_cache_size((large_batch.get_array_memory_size() + 1024) as u64)
+                .range_result_cache_size((large_batch.get_array_memory_size() * 3) as u64)
                 .build(),
         ));
         let (key, part_metrics) = test_cache_context(&strategy);
 
         let mut buffer = CacheBatchBuffer::new(&strategy, 1);
         buffer.skip_threshold_bytes = usize::MAX;
+        buffer.push(large_batch.clone()).unwrap();
+
+        assert_eq!(buffer.buffered_rows, large_batch.num_rows());
+        assert_eq!(buffer.buffered_batches.len(), 1);
+
         buffer.push(large_batch.clone()).unwrap();
 
         assert_eq!(buffer.buffered_rows, 0);
@@ -1012,7 +1018,7 @@ mod tests {
         assert_eq!(value.cached_batches.len(), 1);
         assert_eq!(
             value.cached_batches[0].slice_lengths,
-            vec![large_batch.num_rows()]
+            vec![large_batch.num_rows(), large_batch.num_rows()]
         );
     }
 

--- a/src/mito2/src/read/range_cache.rs
+++ b/src/mito2/src/read/range_cache.rs
@@ -39,7 +39,6 @@ use crate::sst::file::FileTimeRange;
 use crate::sst::parquet::DEFAULT_READ_BATCH_SIZE;
 
 const RANGE_CACHE_COMPACT_THRESHOLD_BYTES: usize = 2 * 1024 * 1024;
-const RANGE_CACHE_SKIP_BYTES: usize = 512 * 1024 * 1024;
 
 /// Fingerprint of the scan request fields that affect partition range cache reuse.
 ///
@@ -453,6 +452,8 @@ async fn run_cache_concat_task(
 }
 
 struct CacheBatchBuffer {
+    num_sources: usize,
+    skip_threshold_bytes: usize,
     buffered_batches: Vec<RecordBatch>,
     buffered_rows: usize,
     buffered_size: usize,
@@ -461,7 +462,7 @@ struct CacheBatchBuffer {
 }
 
 impl CacheBatchBuffer {
-    fn new(cache_strategy: &CacheStrategy) -> Self {
+    fn new(cache_strategy: &CacheStrategy, num_sources: usize) -> Self {
         let sender = cache_strategy.range_result_memory_limiter().map(|limiter| {
             let (tx, rx) = mpsc::unbounded_channel();
             common_runtime::spawn_global(run_cache_concat_task(rx, limiter.clone()));
@@ -469,6 +470,8 @@ impl CacheBatchBuffer {
         });
 
         Self {
+            num_sources,
+            skip_threshold_bytes: cache_strategy.range_result_cache_size().unwrap_or(0),
             buffered_batches: Vec::new(),
             buffered_rows: 0,
             buffered_size: 0,
@@ -483,8 +486,8 @@ impl CacheBatchBuffer {
         }
 
         let batch_size = batch.get_array_memory_size();
-        self.total_weight += batch_size;
-        if self.total_weight > RANGE_CACHE_SKIP_BYTES {
+        self.total_weight += estimate_batch_weight(&batch, self.num_sources);
+        if self.total_weight > self.skip_threshold_bytes {
             self.buffered_batches.clear();
             self.buffered_rows = 0;
             self.buffered_size = 0;
@@ -548,15 +551,25 @@ impl CacheBatchBuffer {
     }
 }
 
+fn estimate_batch_weight(batch: &RecordBatch, num_sources: usize) -> usize {
+    let num_rows = batch.num_rows().max(1);
+    batch
+        .get_array_memory_size()
+        .saturating_mul(num_sources.max(1))
+        .saturating_mul(num_rows)
+        .div_ceil(DEFAULT_READ_BATCH_SIZE)
+}
+
 /// Wraps a stream to cache its output for future range cache hits.
 pub(crate) fn cache_flat_range_stream(
     mut stream: BoxedRecordBatchStream,
     cache_strategy: CacheStrategy,
     key: RangeScanCacheKey,
     part_metrics: PartitionMetrics,
+    num_sources: usize,
 ) -> BoxedRecordBatchStream {
     Box::pin(try_stream! {
-        let mut buffer = CacheBatchBuffer::new(&cache_strategy);
+        let mut buffer = CacheBatchBuffer::new(&cache_strategy, num_sources);
         while let Some(batch) = stream.try_next().await? {
             buffer.push(batch.clone())?;
             yield batch;
@@ -612,7 +625,7 @@ pub fn bench_cache_flat_range_stream(
     let part_metrics =
         PartitionMetrics::new(region_id, 0, "bench", Instant::now(), false, &metrics_set);
 
-    cache_flat_range_stream(stream, cache_strategy, key, part_metrics)
+    cache_flat_range_stream(stream, cache_strategy, key, part_metrics, 1)
 }
 
 #[cfg(test)]
@@ -641,7 +654,7 @@ mod tests {
     fn test_cache_strategy() -> CacheStrategy {
         CacheStrategy::EnableAll(Arc::new(
             CacheManager::builder()
-                .range_result_cache_size(1024)
+                .range_result_cache_size(1024 * 1024)
                 .build(),
         ))
     }
@@ -935,7 +948,7 @@ mod tests {
         let expected_size = batch.get_array_memory_size();
         let (key, part_metrics) = test_cache_context(&strategy);
 
-        let mut buffer = CacheBatchBuffer::new(&strategy);
+        let mut buffer = CacheBatchBuffer::new(&strategy, 1);
         buffer.push(batch).unwrap();
 
         let value = finish_cache_batch_buffer(buffer, key.clone(), strategy.clone(), part_metrics)
@@ -956,7 +969,7 @@ mod tests {
         let batch = make_batch(&vec![1; DEFAULT_READ_BATCH_SIZE / 2 + 1]);
         let (key, part_metrics) = test_cache_context(&strategy);
 
-        let mut buffer = CacheBatchBuffer::new(&strategy);
+        let mut buffer = CacheBatchBuffer::new(&strategy, 1);
         buffer.push(batch.clone()).unwrap();
         buffer.push(batch).unwrap();
 
@@ -978,11 +991,16 @@ mod tests {
 
     #[tokio::test]
     async fn cache_batch_buffer_compacts_when_buffered_size_exceeds_threshold() {
-        let strategy = test_cache_strategy();
         let large_batch = make_large_binary_batch(DEFAULT_READ_BATCH_SIZE, 4096);
+        let strategy = CacheStrategy::EnableAll(Arc::new(
+            CacheManager::builder()
+                .range_result_cache_size((large_batch.get_array_memory_size() + 1024) as u64)
+                .build(),
+        ));
         let (key, part_metrics) = test_cache_context(&strategy);
 
-        let mut buffer = CacheBatchBuffer::new(&strategy);
+        let mut buffer = CacheBatchBuffer::new(&strategy, 1);
+        buffer.skip_threshold_bytes = usize::MAX;
         buffer.push(large_batch.clone()).unwrap();
 
         assert_eq!(buffer.buffered_rows, 0);
@@ -998,40 +1016,44 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn cache_batch_buffer_uses_compacted_size_for_weight() {
-        let strategy = test_cache_strategy();
-        let batch1 = make_batch(&[1, 2]);
-        let batch2 = make_batch(&[3, 4]);
-        let (key, part_metrics) = test_cache_context(&strategy);
-        let expected = concat_batches(&test_schema(), &[batch1.clone(), batch2.clone()])
-            .unwrap()
-            .get_array_memory_size();
+    #[test]
+    fn estimate_batch_weight_uses_scale_and_num_sources() {
+        let batch = make_batch(&[1, 2]);
+        let expected = batch
+            .get_array_memory_size()
+            .saturating_mul(3)
+            .saturating_mul(batch.num_rows())
+            .div_ceil(DEFAULT_READ_BATCH_SIZE);
 
-        let mut buffer = CacheBatchBuffer::new(&strategy);
-        buffer.push(batch1).unwrap();
-        buffer.push(batch2).unwrap();
-
-        let value = finish_cache_batch_buffer(buffer, key, strategy, part_metrics)
-            .await
-            .unwrap();
-        assert_eq!(value.estimated_batches_size, expected);
+        assert_eq!(estimate_batch_weight(&batch, 3), expected);
     }
 
     #[tokio::test]
     async fn cache_batch_buffer_skips_cache_when_weight_exceeds_limit() {
         let strategy = test_cache_strategy();
         let (key, part_metrics) = test_cache_context(&strategy);
-        let mut buffer = CacheBatchBuffer::new(&strategy);
-        buffer.total_weight = RANGE_CACHE_SKIP_BYTES;
+        let batch = make_batch(&[1]);
+        let mut buffer = CacheBatchBuffer::new(&strategy, 1);
+        buffer.skip_threshold_bytes = 0;
 
-        buffer.push(make_batch(&[1])).unwrap();
+        buffer.push(batch).unwrap();
 
         assert!(buffer.sender.is_none());
         assert!(
             finish_cache_batch_buffer(buffer, key, strategy, part_metrics)
                 .await
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn cache_batch_buffer_uses_configured_skip_threshold() {
+        let strategy = test_cache_strategy();
+        let buffer = CacheBatchBuffer::new(&strategy, 1);
+
+        assert_eq!(
+            buffer.skip_threshold_bytes,
+            strategy.range_result_cache_size().unwrap()
         );
     }
 }

--- a/src/mito2/src/read/range_cache.rs
+++ b/src/mito2/src/read/range_cache.rs
@@ -30,7 +30,7 @@ use store_api::storage::{ColumnId, FileId, RegionId, TimeSeriesRowSelector};
 use tokio::sync::{mpsc, oneshot};
 
 use crate::cache::CacheStrategy;
-use crate::error::{ComputeArrowSnafu, Result, UnexpectedSnafu};
+use crate::error::{ComputeArrowSnafu, Result};
 use crate::read::BoxedRecordBatchStream;
 use crate::read::scan_region::StreamContext;
 use crate::read::scan_util::PartitionMetrics;
@@ -341,7 +341,7 @@ enum CacheConcatCommand {
         key: RangeScanCacheKey,
         cache_strategy: CacheStrategy,
         part_metrics: PartitionMetrics,
-        result_tx: Option<oneshot::Sender<Option<Arc<RangeScanCacheValue>>>>,
+        result_tx: Option<oneshot::Sender<Result<Arc<RangeScanCacheValue>>>>,
     },
 }
 
@@ -365,12 +365,7 @@ impl CacheConcatState {
             .iter()
             .map(RecordBatch::get_array_memory_size)
             .sum::<usize>();
-        let _permit = limiter.acquire(input_size).await.map_err(|_| {
-            UnexpectedSnafu {
-                reason: "range result memory limiter is unexpectedly closed",
-            }
-            .build()
-        })?;
+        let _permit = limiter.acquire(input_size).await?;
 
         let compacted = compact_record_batches(batches)?;
         self.estimated_size += compacted.batch.get_array_memory_size();
@@ -410,6 +405,7 @@ fn build_cached_batch_slice(
 async fn run_cache_concat_task(
     mut rx: mpsc::UnboundedReceiver<CacheConcatCommand>,
     limiter: Arc<crate::cache::RangeResultMemoryLimiter>,
+    skip_threshold_bytes: usize,
 ) {
     let mut state = CacheConcatState::default();
 
@@ -420,6 +416,11 @@ async fn run_cache_concat_task(
                     warn!(err; "Failed to compact range cache batches");
                     return;
                 }
+                // Close the channel to stop further work as soon as the cached
+                // size exceeds the configured cache budget.
+                if state.estimated_size > skip_threshold_bytes {
+                    return;
+                }
             }
             CacheConcatCommand::Finish {
                 pending,
@@ -428,54 +429,60 @@ async fn run_cache_concat_task(
                 part_metrics,
                 result_tx,
             } => {
-                let result = state
+                let compact_result = state
                     .compact(pending, &limiter)
                     .await
                     .map(|()| state.finish());
-                if let Err(err) = &result {
-                    warn!(err; "Failed to finalize range cache batches");
+                let result = match compact_result {
+                    Ok(v) => {
+                        let value = Arc::new(v);
+                        part_metrics
+                            .inc_range_cache_size(key.estimated_size() + value.estimated_size());
+                        cache_strategy.put_range_result(key, value.clone());
+
+                        Ok(value)
+                    }
+                    Err(e) => {
+                        warn!(e; "Failed to finalize range cache batches");
+
+                        Err(e)
+                    }
+                };
+
+                if let Some(tx) = result_tx {
+                    let _ = tx.send(result);
                 }
 
-                let value = result.ok().map(Arc::new);
-                if let Some(value) = &value {
-                    part_metrics
-                        .inc_range_cache_size(key.estimated_size() + value.estimated_size());
-                    cache_strategy.put_range_result(key, value.clone());
-                }
-                if let Some(tx) = result_tx {
-                    let _ = tx.send(value);
-                }
-                return;
+                break;
             }
         }
     }
 }
 
 struct CacheBatchBuffer {
-    num_sources: usize,
-    skip_threshold_bytes: usize,
     buffered_batches: Vec<RecordBatch>,
     buffered_rows: usize,
     buffered_size: usize,
-    total_weight: usize,
     sender: Option<mpsc::UnboundedSender<CacheConcatCommand>>,
 }
 
 impl CacheBatchBuffer {
-    fn new(cache_strategy: &CacheStrategy, num_sources: usize) -> Self {
+    fn new(cache_strategy: &CacheStrategy) -> Self {
         let sender = cache_strategy.range_result_memory_limiter().map(|limiter| {
+            let skip_threshold_bytes = cache_strategy.range_result_cache_size().unwrap_or(0);
             let (tx, rx) = mpsc::unbounded_channel();
-            common_runtime::spawn_global(run_cache_concat_task(rx, limiter.clone()));
+            common_runtime::spawn_global(run_cache_concat_task(
+                rx,
+                limiter.clone(),
+                skip_threshold_bytes,
+            ));
             tx
         });
 
         Self {
-            num_sources,
-            skip_threshold_bytes: cache_strategy.range_result_cache_size().unwrap_or(0),
             buffered_batches: Vec::new(),
             buffered_rows: 0,
             buffered_size: 0,
-            total_weight: 0,
             sender,
         }
     }
@@ -485,18 +492,8 @@ impl CacheBatchBuffer {
             return Ok(());
         }
 
-        let batch_size = batch.get_array_memory_size();
-        self.total_weight += estimate_batch_weight(&batch, self.num_sources);
-        if self.total_weight > self.skip_threshold_bytes {
-            self.buffered_batches.clear();
-            self.buffered_rows = 0;
-            self.buffered_size = 0;
-            self.sender = None;
-            return Ok(());
-        }
-
         self.buffered_rows += batch.num_rows();
-        self.buffered_size += batch_size;
+        self.buffered_size += batch.get_array_memory_size();
         self.buffered_batches.push(batch);
 
         if self.buffered_batches.len() > 1
@@ -531,7 +528,7 @@ impl CacheBatchBuffer {
         key: RangeScanCacheKey,
         cache_strategy: CacheStrategy,
         part_metrics: PartitionMetrics,
-        result_tx: Option<oneshot::Sender<Option<Arc<RangeScanCacheValue>>>>,
+        result_tx: Option<oneshot::Sender<Result<Arc<RangeScanCacheValue>>>>,
     ) {
         let Some(sender) = self.sender.take() else {
             return;
@@ -552,25 +549,15 @@ impl CacheBatchBuffer {
     }
 }
 
-fn estimate_batch_weight(batch: &RecordBatch, num_sources: usize) -> usize {
-    let num_rows = batch.num_rows().max(1);
-    let memory_size = batch.get_array_memory_size();
-    memory_size
-        .saturating_mul(num_sources.max(1))
-        .saturating_mul(num_rows)
-        .div_ceil(DEFAULT_READ_BATCH_SIZE)
-}
-
 /// Wraps a stream to cache its output for future range cache hits.
 pub(crate) fn cache_flat_range_stream(
     mut stream: BoxedRecordBatchStream,
     cache_strategy: CacheStrategy,
     key: RangeScanCacheKey,
     part_metrics: PartitionMetrics,
-    num_sources: usize,
 ) -> BoxedRecordBatchStream {
     Box::pin(try_stream! {
-        let mut buffer = CacheBatchBuffer::new(&cache_strategy, num_sources);
+        let mut buffer = CacheBatchBuffer::new(&cache_strategy);
         while let Some(batch) = stream.try_next().await? {
             buffer.push(batch.clone())?;
             yield batch;
@@ -626,7 +613,7 @@ pub fn bench_cache_flat_range_stream(
     let part_metrics =
         PartitionMetrics::new(region_id, 0, "bench", Instant::now(), false, &metrics_set);
 
-    cache_flat_range_stream(stream, cache_strategy, key, part_metrics, 1)
+    cache_flat_range_stream(stream, cache_strategy, key, part_metrics)
 }
 
 #[cfg(test)]
@@ -702,10 +689,12 @@ mod tests {
         key: RangeScanCacheKey,
         cache_strategy: CacheStrategy,
         part_metrics: PartitionMetrics,
-    ) -> Option<Arc<RangeScanCacheValue>> {
+    ) -> Result<Arc<RangeScanCacheValue>> {
         let (tx, rx) = oneshot::channel();
+        common_telemetry::info!("finish start");
         buffer.finish(key, cache_strategy, part_metrics, Some(tx));
-        rx.await.context(crate::error::RecvSnafu).ok().flatten()
+        common_telemetry::info!("finish end");
+        rx.await.context(crate::error::RecvSnafu)?
     }
 
     async fn new_stream_context(
@@ -945,7 +934,7 @@ mod tests {
         let expected_size = batch.get_array_memory_size();
         let (key, part_metrics) = test_cache_context(&strategy);
 
-        let mut buffer = CacheBatchBuffer::new(&strategy, 1);
+        let mut buffer = CacheBatchBuffer::new(&strategy);
         buffer.push(batch).unwrap();
 
         let value = finish_cache_batch_buffer(buffer, key.clone(), strategy.clone(), part_metrics)
@@ -966,7 +955,7 @@ mod tests {
         let batch = make_batch(&vec![1; DEFAULT_READ_BATCH_SIZE / 2 + 1]);
         let (key, part_metrics) = test_cache_context(&strategy);
 
-        let mut buffer = CacheBatchBuffer::new(&strategy, 1);
+        let mut buffer = CacheBatchBuffer::new(&strategy);
         buffer.push(batch.clone()).unwrap();
         buffer.push(batch).unwrap();
 
@@ -996,8 +985,7 @@ mod tests {
         ));
         let (key, part_metrics) = test_cache_context(&strategy);
 
-        let mut buffer = CacheBatchBuffer::new(&strategy, 1);
-        buffer.skip_threshold_bytes = usize::MAX;
+        let mut buffer = CacheBatchBuffer::new(&strategy);
         buffer.push(large_batch.clone()).unwrap();
 
         assert_eq!(buffer.buffered_rows, large_batch.num_rows());
@@ -1018,44 +1006,27 @@ mod tests {
         );
     }
 
-    #[test]
-    fn estimate_batch_weight_uses_scale_and_num_sources() {
-        let batch = make_batch(&[1, 2]);
-        let expected = batch
-            .get_array_memory_size()
-            .saturating_mul(3)
-            .saturating_mul(batch.num_rows())
-            .div_ceil(DEFAULT_READ_BATCH_SIZE);
-
-        assert_eq!(estimate_batch_weight(&batch, 3), expected);
-    }
-
     #[tokio::test]
-    async fn cache_batch_buffer_skips_cache_when_weight_exceeds_limit() {
-        let strategy = test_cache_strategy();
+    async fn cache_batch_buffer_skips_cache_when_compacted_size_exceeds_limit() {
+        let large_batch = make_large_binary_batch(DEFAULT_READ_BATCH_SIZE / 2 + 1, 4096);
+        // Budget only fits two large batches.
+        let budget = (large_batch.get_array_memory_size() as u64) * 2 + 1;
+        let strategy = CacheStrategy::EnableAll(Arc::new(
+            CacheManager::builder()
+                .range_result_cache_size(budget)
+                .build(),
+        ));
         let (key, part_metrics) = test_cache_context(&strategy);
-        let batch = make_batch(&[1]);
-        let mut buffer = CacheBatchBuffer::new(&strategy, 1);
-        buffer.skip_threshold_bytes = 0;
 
-        buffer.push(batch).unwrap();
-
-        assert!(buffer.sender.is_none());
+        let mut buffer = CacheBatchBuffer::new(&strategy);
+        for _ in 0..4 {
+            buffer.push(large_batch.clone()).unwrap();
+        }
         assert!(
-            finish_cache_batch_buffer(buffer, key, strategy, part_metrics)
+            finish_cache_batch_buffer(buffer, key.clone(), strategy.clone(), part_metrics)
                 .await
-                .is_none()
+                .is_err()
         );
-    }
-
-    #[test]
-    fn cache_batch_buffer_uses_configured_skip_threshold() {
-        let strategy = test_cache_strategy();
-        let buffer = CacheBatchBuffer::new(&strategy, 1);
-
-        assert_eq!(
-            buffer.skip_threshold_bytes,
-            strategy.range_result_cache_size().unwrap()
-        );
+        assert!(strategy.get_range_result(&key).is_none());
     }
 }

--- a/src/mito2/src/read/range_cache.rs
+++ b/src/mito2/src/read/range_cache.rs
@@ -660,23 +660,33 @@ mod tests {
         ))
     }
 
+    fn test_scan_fingerprint(
+        filters: Vec<String>,
+        time_filters: Vec<String>,
+        series_row_selector: Option<TimeSeriesRowSelector>,
+        filter_deleted: bool,
+        partition_expr_version: u64,
+    ) -> ScanRequestFingerprint {
+        ScanRequestFingerprintBuilder {
+            read_column_ids: vec![1, 2],
+            read_column_types: vec![None, None],
+            filters,
+            time_filters,
+            series_row_selector,
+            append_mode: false,
+            filter_deleted,
+            merge_mode: MergeMode::LastRow,
+            partition_expr_version,
+        }
+        .build()
+    }
+
     fn test_cache_context(strategy: &CacheStrategy) -> (RangeScanCacheKey, PartitionMetrics) {
         let region_id = RegionId::new(1, 1);
         let key = RangeScanCacheKey {
             region_id,
             row_groups: vec![],
-            scan: ScanRequestFingerprintBuilder {
-                read_column_ids: vec![],
-                read_column_types: vec![],
-                filters: vec![],
-                time_filters: vec![],
-                series_row_selector: None,
-                append_mode: false,
-                filter_deleted: false,
-                merge_mode: MergeMode::LastRow,
-                partition_expr_version: 0,
-            }
-            .build(),
+            scan: test_scan_fingerprint(vec![], vec![], None, false, 0),
         };
 
         let metrics_set = ExecutionPlanMetricsSet::new();
@@ -747,9 +757,40 @@ mod tests {
         lit(ScalarValue::TimestampMillisecond(Some(val), None))
     }
 
+    fn normalized_exprs(exprs: impl IntoIterator<Item = Expr>) -> Vec<String> {
+        let mut exprs = exprs
+            .into_iter()
+            .map(|expr| expr.to_string())
+            .collect::<Vec<_>>();
+        exprs.sort_unstable();
+        exprs
+    }
+
+    async fn assert_range_cache_filters(
+        filters: Vec<Expr>,
+        query_time_range: Option<TimestampRange>,
+        partition_time_range: FileTimeRange,
+        expected_filters: Vec<Expr>,
+        expected_time_filters: Vec<Expr>,
+    ) {
+        let (stream_ctx, part_range) =
+            new_stream_context(filters, query_time_range, partition_time_range).await;
+
+        let key = build_range_cache_key(&stream_ctx, &part_range).unwrap();
+
+        assert_eq!(
+            key.scan.filters(),
+            normalized_exprs(expected_filters).as_slice()
+        );
+        assert_eq!(
+            key.scan.time_filters(),
+            normalized_exprs(expected_time_filters).as_slice()
+        );
+    }
+
     #[tokio::test]
     async fn strips_time_only_filters_when_query_covers_partition_range() {
-        let (stream_ctx, part_range) = new_stream_context(
+        assert_range_cache_filters(
             vec![
                 col("ts").gt_eq(ts_lit(1000)),
                 col("ts").lt(ts_lit(2001)),
@@ -761,50 +802,30 @@ mod tests {
                 Timestamp::new_millisecond(1000),
                 Timestamp::new_millisecond(2000),
             ),
+            vec![col("k0").eq(lit("foo")), col("ts").is_not_null()],
+            vec![],
         )
         .await;
-
-        let key = build_range_cache_key(&stream_ctx, &part_range).unwrap();
-
-        // Range-reducible time filters should be cleared when query covers partition range.
-        assert!(key.scan.time_filters().is_empty());
-        // Non-range time predicates stay in filters.
-        let mut expected_filters = [
-            col("k0").eq(lit("foo")).to_string(),
-            col("ts").is_not_null().to_string(),
-        ];
-        expected_filters.sort_unstable();
-        assert_eq!(key.scan.filters(), expected_filters.as_slice());
     }
 
     #[tokio::test]
     async fn preserves_time_filters_when_query_does_not_cover_partition_range() {
-        let (stream_ctx, part_range) = new_stream_context(
+        assert_range_cache_filters(
             vec![col("ts").gt_eq(ts_lit(1000)), col("k0").eq(lit("foo"))],
             TimestampRange::with_unit(1000, 1500, TimeUnit::Millisecond),
             (
                 Timestamp::new_millisecond(1000),
                 Timestamp::new_millisecond(2000),
             ),
+            vec![col("k0").eq(lit("foo"))],
+            vec![col("ts").gt_eq(ts_lit(1000))],
         )
         .await;
-
-        let key = build_range_cache_key(&stream_ctx, &part_range).unwrap();
-
-        // Time filters should be preserved when query does not cover partition range.
-        assert_eq!(
-            key.scan.time_filters(),
-            [col("ts").gt_eq(ts_lit(1000)).to_string()].as_slice()
-        );
-        assert_eq!(
-            key.scan.filters(),
-            [col("k0").eq(lit("foo")).to_string()].as_slice()
-        );
     }
 
     #[tokio::test]
     async fn strips_time_only_filters_when_query_has_no_time_range_limit() {
-        let (stream_ctx, part_range) = new_stream_context(
+        assert_range_cache_filters(
             vec![
                 col("ts").gt_eq(ts_lit(1000)),
                 col("ts").is_not_null(),
@@ -815,51 +836,26 @@ mod tests {
                 Timestamp::new_millisecond(1000),
                 Timestamp::new_millisecond(2000),
             ),
+            vec![col("k0").eq(lit("foo")), col("ts").is_not_null()],
+            vec![],
         )
         .await;
-
-        let key = build_range_cache_key(&stream_ctx, &part_range).unwrap();
-
-        // Range-reducible time filters should be cleared when query has no time range limit.
-        assert!(key.scan.time_filters().is_empty());
-        // Non-range time predicates stay in filters.
-        let mut expected_filters = [
-            col("k0").eq(lit("foo")).to_string(),
-            col("ts").is_not_null().to_string(),
-        ];
-        expected_filters.sort_unstable();
-        assert_eq!(key.scan.filters(), expected_filters.as_slice());
     }
 
     #[test]
     fn normalizes_and_clears_time_filters() {
-        let normalized = ScanRequestFingerprintBuilder {
-            read_column_ids: vec![1, 2],
-            read_column_types: vec![None, None],
-            filters: vec!["k0 = 'foo'".to_string()],
-            time_filters: vec![],
-            series_row_selector: None,
-            append_mode: false,
-            filter_deleted: true,
-            merge_mode: MergeMode::LastRow,
-            partition_expr_version: 0,
-        }
-        .build();
+        let normalized =
+            test_scan_fingerprint(vec!["k0 = 'foo'".to_string()], vec![], None, true, 0);
 
         assert!(normalized.time_filters().is_empty());
 
-        let fingerprint = ScanRequestFingerprintBuilder {
-            read_column_ids: vec![1, 2],
-            read_column_types: vec![None, None],
-            filters: vec!["k0 = 'foo'".to_string()],
-            time_filters: vec!["ts >= 1000".to_string()],
-            series_row_selector: Some(TimeSeriesRowSelector::LastRow),
-            append_mode: false,
-            filter_deleted: true,
-            merge_mode: MergeMode::LastRow,
-            partition_expr_version: 7,
-        }
-        .build();
+        let fingerprint = test_scan_fingerprint(
+            vec!["k0 = 'foo'".to_string()],
+            vec!["ts >= 1000".to_string()],
+            Some(TimeSeriesRowSelector::LastRow),
+            true,
+            7,
+        );
 
         let reset = fingerprint.without_time_filters();
 

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -296,7 +296,6 @@ impl SeqScan {
             file_scan_semaphore,
         )
         .await?;
-        let num_sources = sources.len();
         let estimated_rows_per_batch = split_batch_size.unwrap_or(DEFAULT_READ_BATCH_SIZE);
         let channel_size = compute_parallel_channel_size(estimated_rows_per_batch);
         let stream = Self::build_flat_reader_from_sources(
@@ -315,7 +314,6 @@ impl SeqScan {
                 stream_ctx.input.cache_strategy.clone(),
                 key,
                 part_metrics.clone(),
-                num_sources,
             ),
             None => stream,
         };

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -296,6 +296,7 @@ impl SeqScan {
             file_scan_semaphore,
         )
         .await?;
+        let num_sources = sources.len();
         let estimated_rows_per_batch = split_batch_size.unwrap_or(DEFAULT_READ_BATCH_SIZE);
         let channel_size = compute_parallel_channel_size(estimated_rows_per_batch);
         let stream = Self::build_flat_reader_from_sources(
@@ -314,6 +315,7 @@ impl SeqScan {
                 stream_ctx.input.cache_strategy.clone(),
                 key,
                 part_metrics.clone(),
+                num_sources,
             ),
             None => stream,
         };


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

This PR tunes mito2 range-result caching so cache admission and compaction track the configured cache capacity more closely.

The main changes are:
- Use the configured `range_result_cache_size` to size the shared memory limiter instead of relying on the default limiter configuration.
- Thread the number of flat-read sources into `cache_flat_range_stream()` and scale cached batch weight estimation by both batch size and source count, so wide multi-source scans stop trying to cache oversized results.
- Replace the fixed skip threshold with the configured range-result cache size, so entries larger than the cache budget are skipped instead of entering the async concat path.
- Raise the concat compaction threshold from 2 MiB to 8 MiB and only compact when multiple buffered batches have accumulated, which avoids unnecessary compaction for single large batches.
- Extend unit tests to cover the new limiter sizing, skip-threshold behavior, compaction behavior, and batch-weight estimation.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
