### PR TITLE
feat: update trace table data model for flat sst

### DIFF
--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -680,8 +680,7 @@ impl Inserter {
                         // - trace_id: when searching by trace id
                         // - parent_span_id: when searching root span
                         // - span_name: when searching certain types of span
-                        let index_columns =
-                            [TRACE_ID_COLUMN, PARENT_SPAN_ID_COLUMN, SERVICE_NAME_COLUMN];
+                        let index_columns = [PARENT_SPAN_ID_COLUMN, SERVICE_NAME_COLUMN];
                         for index_column in index_columns {
                             if let Some(col) = create_table
                                 .column_defs

--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -677,7 +677,6 @@ impl Inserter {
                         };
 
                         // add skip index to
-                        // - trace_id: when searching by trace id
                         // - parent_span_id: when searching root span
                         // - span_name: when searching certain types of span
                         let index_columns = [PARENT_SPAN_ID_COLUMN, SERVICE_NAME_COLUMN];

--- a/src/servers/src/otlp/trace/v1.rs
+++ b/src/servers/src/otlp/trace/v1.rs
@@ -118,8 +118,8 @@ pub fn write_span_to_row(writer: &mut TableData, span: TraceSpan) -> Result<()> 
                 span.end_in_nanosecond - span.start_in_nanosecond,
             )),
         ),
+        make_string_column_data(SERVICE_NAME_COLUMN, span.service_name),
         make_string_column_data(PARENT_SPAN_ID_COLUMN, span.parent_span_id),
-        make_string_column_data(TRACE_ID_COLUMN, Some(span.trace_id)),
         make_string_column_data(SPAN_ID_COLUMN, Some(span.span_id)),
         make_string_column_data(SPAN_KIND_COLUMN, Some(span.span_kind)),
         make_string_column_data(SPAN_NAME_COLUMN, Some(span.span_name)),
@@ -131,13 +131,11 @@ pub fn write_span_to_row(writer: &mut TableData, span: TraceSpan) -> Result<()> 
     ];
     row_writer::write_fields(writer, fields.into_iter(), &mut row)?;
 
-    if let Some(service_name) = span.service_name {
-        row_writer::write_tags(
-            writer,
-            std::iter::once((SERVICE_NAME_COLUMN.to_string(), service_name)),
-            &mut row,
-        )?;
-    }
+    row_writer::write_tags(
+        writer,
+        std::iter::once((TRACE_ID_COLUMN.to_string(), span.trace_id)),
+        &mut row,
+    )?;
 
     write_attributes(writer, "span_attributes", span.span_attributes, &mut row)?;
     write_attributes(writer, "scope_attributes", span.scope_attributes, &mut row)?;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

#7983

## What's changed and what's your intention?

- use trace_id as primary key
- make service_name a field
- remove default index on trace_id

Benchmark:

https://gist.github.com/sunng87/240f1887c823c6881d74899c1fec358a

Before the change:

```
=== Trace Query Benchmark ===
  Host:         http://localhost:4000/
  Table:        opentelemetry_traces
  Concurrency:  8
  Trace ID pool size: 1000
  Rounds:       10
  Total queries: 10000

Fetching 1000 random trace IDs...
Fetched 1000 trace IDs in 0.12 s

Warming up...
Warmup done (400 queries).

Running benchmark...
  Progress: 10000 / 10000

=== Results ===
  Successful:  10000
  Failed:      0
  Total time:  12.83 s
  QPS:         779.7

  Latency (ms):
    min:      4.90
    p50:     10.13
    p90:     12.29
    p99:     14.25
    max:     17.98
    avg:     10.20
```

After the change:

```
=== Trace Query Benchmark ===
  Host:         http://localhost:4000
  Table:        opentelemetry_traces2
  Concurrency:  8
  Trace ID pool size: 1000
  Rounds:       10
  Total queries: 10000

Fetching 1000 random trace IDs...
Fetched 1000 trace IDs in 0.11 s

Warming up...
Warmup done (400 queries).

Running benchmark...
  Progress: 10000 / 10000

=== Results ===
  Successful:  10000
  Failed:      0
  Total time:  29.73 s
  QPS:         336.4

  Latency (ms):
    min:      7.38
    p50:     24.01
    p90:     29.05
    p99:     33.74
    max:     38.16
    avg:     23.68
```

With 2x spans in the table:

```
=== Trace Query Benchmark ===
  Host:         http://localhost:4000
  Table:        opentelemetry_traces2
  Concurrency:  8
  Trace ID pool size: 1000
  Rounds:       10
  Total queries: 10000

Fetching 1000 random trace IDs...
Fetched 1000 trace IDs in 0.19 s

Warming up...
Warmup done (400 queries).

Running benchmark...
  Progress: 10000 / 10000

=== Results ===
  Successful:  10000
  Failed:      0
  Total time:  68.10 s
  QPS:         146.9

  Latency (ms):
    min:     17.12
    p50:     54.77
    p90:     63.82
    p99:     72.99
    max:     90.94
    avg:     54.27
```

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
