### PR TITLE
fix(metric-engine): validate column types and require time index in verify_rows

### DIFF
--- a/src/metric-engine/src/batch_modifier.rs
+++ b/src/metric-engine/src/batch_modifier.rs
@@ -204,6 +204,7 @@ mod tests {
     use store_api::storage::consts::PRIMARY_KEY_COLUMN_NAME;
 
     use super::*;
+    use crate::engine::PhysicalColumnInfo;
     use crate::row_modifier::{RowModifier, RowsIter, TableIdInput};
 
     fn build_sparse_test_batch() -> RecordBatch {
@@ -364,11 +365,16 @@ mod tests {
         let modified =
             modify_batch_sparse(batch, table_id, &tag_columns, &non_tag_indices).unwrap();
 
-        let name_to_column_id: HashMap<String, ColumnId> = [
-            ("greptime_timestamp".to_string(), 0),
-            ("greptime_value".to_string(), 1),
-            ("namespace".to_string(), 2),
-            ("host".to_string(), 3),
+        let make_info = |column_id: ColumnId| PhysicalColumnInfo {
+            column_id,
+            data_type: datatypes::prelude::ConcreteDataType::string_datatype(),
+            semantic_type: SemanticType::Tag,
+        };
+        let name_to_column_id: HashMap<String, PhysicalColumnInfo> = [
+            ("greptime_timestamp".to_string(), make_info(0)),
+            ("greptime_value".to_string(), make_info(1)),
+            ("namespace".to_string(), make_info(2)),
+            ("host".to_string(), make_info(3)),
         ]
         .into_iter()
         .collect();

--- a/src/metric-engine/src/batch_modifier.rs
+++ b/src/metric-engine/src/batch_modifier.rs
@@ -201,10 +201,10 @@ mod tests {
     use datatypes::arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
     use datatypes::arrow::record_batch::RecordBatch;
     use store_api::codec::PrimaryKeyEncoding;
+    use store_api::metadata::ColumnMetadata;
     use store_api::storage::consts::PRIMARY_KEY_COLUMN_NAME;
 
     use super::*;
-    use crate::engine::PhysicalColumnInfo;
     use crate::row_modifier::{RowModifier, RowsIter, TableIdInput};
 
     fn build_sparse_test_batch() -> RecordBatch {
@@ -365,18 +365,23 @@ mod tests {
         let modified =
             modify_batch_sparse(batch, table_id, &tag_columns, &non_tag_indices).unwrap();
 
-        let make_info = |column_id: ColumnId| PhysicalColumnInfo {
-            column_id,
-            data_type: datatypes::prelude::ConcreteDataType::string_datatype(),
-            is_nullable: false,
-            default_constraint: None,
+        let make_info = |name: &str, column_id: ColumnId| ColumnMetadata {
+            column_schema: datatypes::schema::ColumnSchema::new(
+                name.to_string(),
+                datatypes::prelude::ConcreteDataType::string_datatype(),
+                false,
+            ),
             semantic_type: SemanticType::Tag,
+            column_id,
         };
-        let name_to_column_id: HashMap<String, PhysicalColumnInfo> = [
-            ("greptime_timestamp".to_string(), make_info(0)),
-            ("greptime_value".to_string(), make_info(1)),
-            ("namespace".to_string(), make_info(2)),
-            ("host".to_string(), make_info(3)),
+        let name_to_column_id: HashMap<String, ColumnMetadata> = [
+            (
+                "greptime_timestamp".to_string(),
+                make_info("greptime_timestamp", 0),
+            ),
+            ("greptime_value".to_string(), make_info("greptime_value", 1)),
+            ("namespace".to_string(), make_info("namespace", 2)),
+            ("host".to_string(), make_info("host", 3)),
         ]
         .into_iter()
         .collect();

--- a/src/metric-engine/src/batch_modifier.rs
+++ b/src/metric-engine/src/batch_modifier.rs
@@ -368,6 +368,8 @@ mod tests {
         let make_info = |column_id: ColumnId| PhysicalColumnInfo {
             column_id,
             data_type: datatypes::prelude::ConcreteDataType::string_datatype(),
+            is_nullable: false,
+            default_constraint: None,
             semantic_type: SemanticType::Tag,
         };
         let name_to_column_id: HashMap<String, PhysicalColumnInfo> = [

--- a/src/metric-engine/src/data_region.rs
+++ b/src/metric-engine/src/data_region.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use api::v1::SemanticType;
-use common_telemetry::{debug, info, warn};
+use common_telemetry::{debug, info};
 use datatypes::schema::{SkippingIndexOptions, SkippingIndexType};
 use mito2::engine::MitoEngine;
 use snafu::ResultExt;
@@ -27,8 +27,8 @@ use store_api::storage::{ConcreteDataType, RegionId};
 
 use crate::engine::IndexOptions;
 use crate::error::{
-    ColumnTypeMismatchSnafu, ForbiddenPhysicalAlterSnafu, MitoReadOperationSnafu,
-    MitoWriteOperationSnafu, Result, SetSkippingIndexOptionSnafu,
+    AddingFieldColumnSnafu, ColumnTypeMismatchSnafu, ForbiddenPhysicalAlterSnafu,
+    MitoReadOperationSnafu, MitoWriteOperationSnafu, Result, SetSkippingIndexOptionSnafu,
 };
 use crate::metrics::{FORBIDDEN_OPERATION_COUNT, MITO_DDL_DURATION, PHYSICAL_COLUMN_COUNT};
 use crate::utils;
@@ -132,10 +132,10 @@ impl DataRegion {
                         .fail();
                     }
                 } else {
-                    warn!(
-                        "Column {} in region {region_id} is not a tag",
-                        c.column_schema.name
-                    );
+                    return AddingFieldColumnSnafu {
+                        name: &c.column_schema.name,
+                    }
+                    .fail();
                 };
 
                 c.column_id = new_column_id_start + delta as u32;

--- a/src/metric-engine/src/engine.rs
+++ b/src/metric-engine/src/engine.rs
@@ -40,7 +40,7 @@ use common_runtime::RepeatedTask;
 use mito2::engine::MitoEngine;
 pub(crate) use options::IndexOptions;
 use snafu::{OptionExt, ResultExt};
-pub(crate) use state::{MetricEngineState, PhysicalColumnInfo};
+pub(crate) use state::MetricEngineState;
 use store_api::metadata::RegionMetadataRef;
 use store_api::metric_engine_consts::METRIC_ENGINE_NAME;
 use store_api::region_engine::{

--- a/src/metric-engine/src/engine.rs
+++ b/src/metric-engine/src/engine.rs
@@ -40,7 +40,7 @@ use common_runtime::RepeatedTask;
 use mito2::engine::MitoEngine;
 pub(crate) use options::IndexOptions;
 use snafu::{OptionExt, ResultExt};
-pub(crate) use state::MetricEngineState;
+pub(crate) use state::{MetricEngineState, PhysicalColumnInfo};
 use store_api::metadata::RegionMetadataRef;
 use store_api::metric_engine_consts::METRIC_ENGINE_NAME;
 use store_api::region_engine::{

--- a/src/metric-engine/src/engine/alter.rs
+++ b/src/metric-engine/src/engine/alter.rs
@@ -26,7 +26,6 @@ use store_api::storage::RegionId;
 use validate::validate_alter_region_requests;
 
 use crate::engine::MetricEngineInner;
-use crate::engine::state::PhysicalColumnInfo;
 use crate::error::{
     LogicalRegionNotFoundSnafu, PhysicalRegionNotFoundSnafu, Result, SerializeColumnMetadataSnafu,
     UnexpectedRequestSnafu,
@@ -190,14 +189,7 @@ impl MetricEngineInner {
         let new_add_columns = new_column_names.iter().map(|name| {
             // Safety: previous steps ensure the physical region exist
             let column_metadata = *physical_schema_map.get(name).unwrap();
-            (
-                name.to_string(),
-                PhysicalColumnInfo {
-                    column_id: column_metadata.column_id,
-                    data_type: column_metadata.column_schema.data_type.clone(),
-                    semantic_type: column_metadata.semantic_type,
-                },
-            )
+            (name.to_string(), column_metadata.into())
         });
 
         // Writes logical regions metadata to metadata region

--- a/src/metric-engine/src/engine/alter.rs
+++ b/src/metric-engine/src/engine/alter.rs
@@ -26,6 +26,7 @@ use store_api::storage::RegionId;
 use validate::validate_alter_region_requests;
 
 use crate::engine::MetricEngineInner;
+use crate::engine::state::PhysicalColumnInfo;
 use crate::error::{
     LogicalRegionNotFoundSnafu, PhysicalRegionNotFoundSnafu, Result, SerializeColumnMetadataSnafu,
     UnexpectedRequestSnafu,
@@ -189,7 +190,14 @@ impl MetricEngineInner {
         let new_add_columns = new_column_names.iter().map(|name| {
             // Safety: previous steps ensure the physical region exist
             let column_metadata = *physical_schema_map.get(name).unwrap();
-            (name.to_string(), column_metadata.column_id)
+            (
+                name.to_string(),
+                PhysicalColumnInfo {
+                    column_id: column_metadata.column_id,
+                    data_type: column_metadata.column_schema.data_type.clone(),
+                    semantic_type: column_metadata.semantic_type,
+                },
+            )
         });
 
         // Writes logical regions metadata to metadata region

--- a/src/metric-engine/src/engine/alter.rs
+++ b/src/metric-engine/src/engine/alter.rs
@@ -189,7 +189,7 @@ impl MetricEngineInner {
         let new_add_columns = new_column_names.iter().map(|name| {
             // Safety: previous steps ensure the physical region exist
             let column_metadata = *physical_schema_map.get(name).unwrap();
-            (name.to_string(), column_metadata.into())
+            (name.to_string(), column_metadata.clone())
         });
 
         // Writes logical regions metadata to metadata region

--- a/src/metric-engine/src/engine/alter/extract_new_columns.rs
+++ b/src/metric-engine/src/engine/alter/extract_new_columns.rs
@@ -16,8 +16,9 @@ use std::collections::{HashMap, HashSet};
 
 use store_api::metadata::ColumnMetadata;
 use store_api::region_request::{AlterKind, RegionAlterRequest};
-use store_api::storage::{ColumnId, RegionId};
+use store_api::storage::RegionId;
 
+use crate::engine::state::PhysicalColumnInfo;
 use crate::error::Result;
 
 /// Extract new columns from the create requests.
@@ -27,7 +28,7 @@ use crate::error::Result;
 /// This function will panic if the alter kind is not `AddColumns`.
 pub fn extract_new_columns<'a>(
     requests: &'a [(RegionId, RegionAlterRequest)],
-    physical_columns: &HashMap<String, ColumnId>,
+    physical_columns: &HashMap<String, PhysicalColumnInfo>,
     new_column_names: &mut HashSet<&'a str>,
     new_columns: &mut Vec<ColumnMetadata>,
 ) -> Result<()> {

--- a/src/metric-engine/src/engine/alter/extract_new_columns.rs
+++ b/src/metric-engine/src/engine/alter/extract_new_columns.rs
@@ -14,12 +14,14 @@
 
 use std::collections::{HashMap, HashSet};
 
+use api::v1::SemanticType;
+use snafu::ensure;
 use store_api::metadata::ColumnMetadata;
 use store_api::region_request::{AlterKind, RegionAlterRequest};
 use store_api::storage::RegionId;
 
 use crate::engine::state::PhysicalColumnInfo;
-use crate::error::Result;
+use crate::error::{AddingFieldColumnSnafu, Result};
 
 /// Extract new columns from the create requests.
 ///
@@ -41,6 +43,12 @@ pub fn extract_new_columns<'a>(
             if !physical_columns.contains_key(column_name)
                 && !new_column_names.contains(column_name)
             {
+                ensure!(
+                    col.column_metadata.semantic_type != SemanticType::Field,
+                    AddingFieldColumnSnafu {
+                        name: column_name.to_string(),
+                    }
+                );
                 new_column_names.insert(column_name);
                 // TODO(weny): avoid clone
                 new_columns.push(col.column_metadata.clone());
@@ -49,4 +57,56 @@ pub fn extract_new_columns<'a>(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+
+    use api::v1::SemanticType;
+    use datatypes::prelude::ConcreteDataType;
+    use datatypes::schema::ColumnSchema;
+    use store_api::metadata::ColumnMetadata;
+    use store_api::region_request::{AddColumn, AlterKind, RegionAlterRequest};
+    use store_api::storage::RegionId;
+
+    use super::*;
+    use crate::error::Error;
+
+    #[test]
+    fn test_extract_new_columns_with_field_type() {
+        let requests = vec![(
+            RegionId::new(1, 1),
+            RegionAlterRequest {
+                kind: AlterKind::AddColumns {
+                    columns: vec![AddColumn {
+                        column_metadata: ColumnMetadata {
+                            column_schema: ColumnSchema::new(
+                                "new_column".to_string(),
+                                ConcreteDataType::string_datatype(),
+                                false,
+                            ),
+                            semantic_type: SemanticType::Field,
+                            column_id: 0,
+                        },
+                        location: None,
+                    }],
+                },
+            },
+        )];
+
+        let physical_columns = HashMap::new();
+        let mut new_column_names = HashSet::new();
+        let mut new_columns = Vec::new();
+
+        let err = extract_new_columns(
+            &requests,
+            &physical_columns,
+            &mut new_column_names,
+            &mut new_columns,
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, Error::AddingFieldColumn { .. }));
+    }
 }

--- a/src/metric-engine/src/engine/alter/extract_new_columns.rs
+++ b/src/metric-engine/src/engine/alter/extract_new_columns.rs
@@ -20,7 +20,6 @@ use store_api::metadata::ColumnMetadata;
 use store_api::region_request::{AlterKind, RegionAlterRequest};
 use store_api::storage::RegionId;
 
-use crate::engine::state::PhysicalColumnInfo;
 use crate::error::{AddingFieldColumnSnafu, Result};
 
 /// Extract new columns from the create requests.
@@ -30,7 +29,7 @@ use crate::error::{AddingFieldColumnSnafu, Result};
 /// This function will panic if the alter kind is not `AddColumns`.
 pub fn extract_new_columns<'a>(
     requests: &'a [(RegionId, RegionAlterRequest)],
-    physical_columns: &HashMap<String, PhysicalColumnInfo>,
+    physical_columns: &HashMap<String, ColumnMetadata>,
     new_column_names: &mut HashSet<&'a str>,
     new_columns: &mut Vec<ColumnMetadata>,
 ) -> Result<()> {

--- a/src/metric-engine/src/engine/bulk_insert.rs
+++ b/src/metric-engine/src/engine/bulk_insert.rs
@@ -190,13 +190,13 @@ impl MetricEngineInner {
 
             for (index, field) in batch.schema().fields().iter().enumerate() {
                 let name = field.name();
-                let column_id =
-                    *physical_columns
-                        .get(name)
-                        .with_context(|| error::ColumnNotFoundSnafu {
-                            name: name.clone(),
-                            region_id: logical_region_id,
-                        })?;
+                let column_id = physical_columns
+                    .get(name)
+                    .map(|info| info.column_id)
+                    .with_context(|| error::ColumnNotFoundSnafu {
+                        name: name.clone(),
+                        region_id: logical_region_id,
+                    })?;
                 if tag_names.contains(name.as_str()) {
                     tag_columns.push(TagColumnInfo {
                         name: name.clone(),

--- a/src/metric-engine/src/engine/create.rs
+++ b/src/metric-engine/src/engine/create.rs
@@ -42,7 +42,6 @@ use store_api::storage::consts::ReservedColumnId;
 use crate::engine::MetricEngineInner;
 use crate::engine::create::extract_new_columns::extract_new_columns;
 use crate::engine::options::{PhysicalRegionOptions, set_data_region_options};
-use crate::engine::state::PhysicalColumnInfo;
 use crate::error::{
     ColumnTypeMismatchSnafu, ConflictRegionOptionSnafu, CreateMitoRegionSnafu,
     InternalColumnOccupiedSnafu, InvalidMetadataSnafu, MissingRegionOptionSnafu,
@@ -146,16 +145,7 @@ impl MetricEngineInner {
         let physical_columns = create_data_region_request
             .column_metadatas
             .iter()
-            .map(|metadata| {
-                (
-                    metadata.column_schema.name.clone(),
-                    PhysicalColumnInfo {
-                        column_id: metadata.column_id,
-                        data_type: metadata.column_schema.data_type.clone(),
-                        semantic_type: metadata.semantic_type,
-                    },
-                )
-            })
+            .map(|metadata| (metadata.column_schema.name.clone(), metadata.into()))
             .collect::<HashMap<_, _>>();
         let time_index_unit = create_data_region_request
             .column_metadatas
@@ -331,14 +321,7 @@ impl MetricEngineInner {
         let new_add_columns = new_column_names.iter().map(|name| {
             // Safety: previous steps ensure the physical region exist
             let column_metadata = *physical_schema_map.get(name).unwrap();
-            (
-                name.to_string(),
-                PhysicalColumnInfo {
-                    column_id: column_metadata.column_id,
-                    data_type: column_metadata.column_schema.data_type.clone(),
-                    semantic_type: column_metadata.semantic_type,
-                },
-            )
+            (name.to_string(), column_metadata.into())
         });
 
         extension_return_value.insert(

--- a/src/metric-engine/src/engine/create.rs
+++ b/src/metric-engine/src/engine/create.rs
@@ -42,6 +42,7 @@ use store_api::storage::consts::ReservedColumnId;
 use crate::engine::MetricEngineInner;
 use crate::engine::create::extract_new_columns::extract_new_columns;
 use crate::engine::options::{PhysicalRegionOptions, set_data_region_options};
+use crate::engine::state::PhysicalColumnInfo;
 use crate::error::{
     ColumnTypeMismatchSnafu, ConflictRegionOptionSnafu, CreateMitoRegionSnafu,
     InternalColumnOccupiedSnafu, InvalidMetadataSnafu, MissingRegionOptionSnafu,
@@ -145,7 +146,16 @@ impl MetricEngineInner {
         let physical_columns = create_data_region_request
             .column_metadatas
             .iter()
-            .map(|metadata| (metadata.column_schema.name.clone(), metadata.column_id))
+            .map(|metadata| {
+                (
+                    metadata.column_schema.name.clone(),
+                    PhysicalColumnInfo {
+                        column_id: metadata.column_id,
+                        data_type: metadata.column_schema.data_type.clone(),
+                        semantic_type: metadata.semantic_type,
+                    },
+                )
+            })
             .collect::<HashMap<_, _>>();
         let time_index_unit = create_data_region_request
             .column_metadatas
@@ -321,7 +331,14 @@ impl MetricEngineInner {
         let new_add_columns = new_column_names.iter().map(|name| {
             // Safety: previous steps ensure the physical region exist
             let column_metadata = *physical_schema_map.get(name).unwrap();
-            (name.to_string(), column_metadata.column_id)
+            (
+                name.to_string(),
+                PhysicalColumnInfo {
+                    column_id: column_metadata.column_id,
+                    data_type: column_metadata.column_schema.data_type.clone(),
+                    semantic_type: column_metadata.semantic_type,
+                },
+            )
         });
 
         extension_return_value.insert(

--- a/src/metric-engine/src/engine/create.rs
+++ b/src/metric-engine/src/engine/create.rs
@@ -145,7 +145,7 @@ impl MetricEngineInner {
         let physical_columns = create_data_region_request
             .column_metadatas
             .iter()
-            .map(|metadata| (metadata.column_schema.name.clone(), metadata.into()))
+            .map(|metadata| (metadata.column_schema.name.clone(), metadata.clone()))
             .collect::<HashMap<_, _>>();
         let time_index_unit = create_data_region_request
             .column_metadatas
@@ -321,7 +321,7 @@ impl MetricEngineInner {
         let new_add_columns = new_column_names.iter().map(|name| {
             // Safety: previous steps ensure the physical region exist
             let column_metadata = *physical_schema_map.get(name).unwrap();
-            (name.to_string(), column_metadata.into())
+            (name.to_string(), column_metadata.clone())
         });
 
         extension_return_value.insert(

--- a/src/metric-engine/src/engine/create/extract_new_columns.rs
+++ b/src/metric-engine/src/engine/create/extract_new_columns.rs
@@ -18,14 +18,15 @@ use api::v1::SemanticType;
 use snafu::ensure;
 use store_api::metadata::ColumnMetadata;
 use store_api::region_request::RegionCreateRequest;
-use store_api::storage::{ColumnId, RegionId};
+use store_api::storage::RegionId;
 
+use crate::engine::state::PhysicalColumnInfo;
 use crate::error::{AddingFieldColumnSnafu, Result};
 
 /// Extract new columns from the create requests.
 pub fn extract_new_columns<'a>(
     requests: &'a [(RegionId, RegionCreateRequest)],
-    physical_columns: &HashMap<String, ColumnId>,
+    physical_columns: &HashMap<String, PhysicalColumnInfo>,
     new_column_names: &mut HashSet<&'a str>,
     new_columns: &mut Vec<ColumnMetadata>,
 ) -> Result<()> {
@@ -123,7 +124,14 @@ mod tests {
         ];
 
         let mut physical_columns = HashMap::new();
-        physical_columns.insert("existing_column".to_string(), 0);
+        physical_columns.insert(
+            "existing_column".to_string(),
+            PhysicalColumnInfo {
+                column_id: 0,
+                data_type: ConcreteDataType::string_datatype(),
+                semantic_type: SemanticType::Tag,
+            },
+        );
         let mut new_column_names = HashSet::new();
         let mut new_columns = Vec::new();
 

--- a/src/metric-engine/src/engine/create/extract_new_columns.rs
+++ b/src/metric-engine/src/engine/create/extract_new_columns.rs
@@ -129,6 +129,8 @@ mod tests {
             PhysicalColumnInfo {
                 column_id: 0,
                 data_type: ConcreteDataType::string_datatype(),
+                is_nullable: false,
+                default_constraint: None,
                 semantic_type: SemanticType::Tag,
             },
         );

--- a/src/metric-engine/src/engine/create/extract_new_columns.rs
+++ b/src/metric-engine/src/engine/create/extract_new_columns.rs
@@ -20,13 +20,12 @@ use store_api::metadata::ColumnMetadata;
 use store_api::region_request::RegionCreateRequest;
 use store_api::storage::RegionId;
 
-use crate::engine::state::PhysicalColumnInfo;
 use crate::error::{AddingFieldColumnSnafu, Result};
 
 /// Extract new columns from the create requests.
 pub fn extract_new_columns<'a>(
     requests: &'a [(RegionId, RegionCreateRequest)],
-    physical_columns: &HashMap<String, PhysicalColumnInfo>,
+    physical_columns: &HashMap<String, ColumnMetadata>,
     new_column_names: &mut HashSet<&'a str>,
     new_columns: &mut Vec<ColumnMetadata>,
 ) -> Result<()> {
@@ -126,12 +125,14 @@ mod tests {
         let mut physical_columns = HashMap::new();
         physical_columns.insert(
             "existing_column".to_string(),
-            PhysicalColumnInfo {
-                column_id: 0,
-                data_type: ConcreteDataType::string_datatype(),
-                is_nullable: false,
-                default_constraint: None,
+            ColumnMetadata {
+                column_schema: ColumnSchema::new(
+                    "existing_column".to_string(),
+                    ConcreteDataType::string_datatype(),
+                    false,
+                ),
                 semantic_type: SemanticType::Tag,
+                column_id: 0,
             },
         );
         let mut new_column_names = HashSet::new();

--- a/src/metric-engine/src/engine/open.rs
+++ b/src/metric-engine/src/engine/open.rs
@@ -28,7 +28,6 @@ use store_api::storage::RegionId;
 use crate::engine::MetricEngineInner;
 use crate::engine::create::region_options_for_metadata_region;
 use crate::engine::options::{PhysicalRegionOptions, set_data_region_options};
-use crate::engine::state::PhysicalColumnInfo;
 use crate::error::{
     BatchOpenMitoRegionSnafu, NoOpenRegionResultSnafu, OpenMitoRegionSnafu,
     PhysicalRegionNotFoundSnafu, Result,
@@ -327,16 +326,7 @@ impl MetricEngineInner {
                 .unwrap();
             let physical_columns = physical_columns
                 .into_iter()
-                .map(|col| {
-                    (
-                        col.column_schema.name.clone(),
-                        PhysicalColumnInfo {
-                            column_id: col.column_id,
-                            data_type: col.column_schema.data_type.clone(),
-                            semantic_type: col.semantic_type,
-                        },
-                    )
-                })
+                .map(|col| (col.column_schema.name.clone(), col.into()))
                 .collect();
             state.add_physical_region(
                 physical_region_id,

--- a/src/metric-engine/src/engine/open.rs
+++ b/src/metric-engine/src/engine/open.rs
@@ -28,6 +28,7 @@ use store_api::storage::RegionId;
 use crate::engine::MetricEngineInner;
 use crate::engine::create::region_options_for_metadata_region;
 use crate::engine::options::{PhysicalRegionOptions, set_data_region_options};
+use crate::engine::state::PhysicalColumnInfo;
 use crate::error::{
     BatchOpenMitoRegionSnafu, NoOpenRegionResultSnafu, OpenMitoRegionSnafu,
     PhysicalRegionNotFoundSnafu, Result,
@@ -326,7 +327,16 @@ impl MetricEngineInner {
                 .unwrap();
             let physical_columns = physical_columns
                 .into_iter()
-                .map(|col| (col.column_schema.name, col.column_id))
+                .map(|col| {
+                    (
+                        col.column_schema.name.clone(),
+                        PhysicalColumnInfo {
+                            column_id: col.column_id,
+                            data_type: col.column_schema.data_type.clone(),
+                            semantic_type: col.semantic_type,
+                        },
+                    )
+                })
                 .collect();
             state.add_physical_region(
                 physical_region_id,

--- a/src/metric-engine/src/engine/open.rs
+++ b/src/metric-engine/src/engine/open.rs
@@ -326,7 +326,7 @@ impl MetricEngineInner {
                 .unwrap();
             let physical_columns = physical_columns
                 .into_iter()
-                .map(|col| (col.column_schema.name.clone(), col.into()))
+                .map(|col| (col.column_schema.name.clone(), col))
                 .collect();
             state.add_physical_region(
                 physical_region_id,

--- a/src/metric-engine/src/engine/put.rs
+++ b/src/metric-engine/src/engine/put.rs
@@ -255,9 +255,12 @@ impl MetricEngineInner {
                     region_id: data_region_id,
                 })?
                 .physical_columns();
-            let name_to_id: HashMap<String, ColumnId> = physical_columns
+            // Borrow the physical column names rather than cloning them: the
+            // state guard is held for the whole block and the map doesn't
+            // outlive this scope.
+            let name_to_id: HashMap<&str, ColumnId> = physical_columns
                 .iter()
-                .map(|(name, info)| (name.clone(), info.column_id))
+                .map(|(name, info)| (name.as_str(), info.column_id))
                 .collect();
 
             let iter = RowsIter::new(
@@ -605,9 +608,11 @@ impl MetricEngineInner {
                     region_id: physical_region_id,
                 })?
                 .physical_columns();
-            let name_to_id: HashMap<String, ColumnId> = physical_columns
+            // Borrow the physical column names rather than cloning them; the
+            // map is scoped to this block and the state guard holds.
+            let name_to_id: HashMap<&str, ColumnId> = physical_columns
                 .iter()
-                .map(|(name, info)| (name.clone(), info.column_id))
+                .map(|(name, info)| (name.as_str(), info.column_id))
                 .collect();
             RowsIter::new(input, &name_to_id)
         };

--- a/src/metric-engine/src/engine/put.rs
+++ b/src/metric-engine/src/engine/put.rs
@@ -510,13 +510,13 @@ impl MetricEngineInner {
         }
 
         // Type + semantic check on every column in the request schema.
-        let physical_columns = state
+        let physical_state = state
             .physical_region_states()
             .get(&data_region_id)
             .context(PhysicalRegionNotFoundSnafu {
                 region_id: data_region_id,
-            })?
-            .physical_columns();
+            })?;
+        let physical_columns = physical_state.physical_columns();
         for col in &rows.schema {
             let info = physical_columns
                 .get(&col.column_name)
@@ -570,11 +570,8 @@ impl MetricEngineInner {
         // require a specific tag without per-logical-region metadata here;
         // missing tags are handled by mito's default-fill. Field columns are
         // always optional.
-        let time_index_column = physical_columns
-            .iter()
-            .find(|(_, info)| info.semantic_type == api::v1::SemanticType::Timestamp)
-            .map(|(name, _)| name.as_str());
-        if let Some(ts_name) = time_index_column {
+        let ts_name = physical_state.time_index_column_name();
+        if !ts_name.is_empty() {
             let present = rows.schema.iter().any(|col| col.column_name == ts_name);
             ensure!(
                 present,

--- a/src/metric-engine/src/engine/put.rs
+++ b/src/metric-engine/src/engine/put.rs
@@ -521,7 +521,7 @@ impl MetricEngineInner {
             let info = physical_columns
                 .get(&col.column_name)
                 .context(ColumnNotFoundSnafu {
-                    name: col.column_name.clone(),
+                    name: &col.column_name,
                     region_id: logical_region_id,
                 })?;
 

--- a/src/metric-engine/src/engine/put.rs
+++ b/src/metric-engine/src/engine/put.rs
@@ -24,7 +24,7 @@ use store_api::codec::PrimaryKeyEncoding;
 use store_api::region_request::{
     AffectedRows, RegionDeleteRequest, RegionPutRequest, RegionRequest,
 };
-use store_api::storage::{RegionId, TableId};
+use store_api::storage::{ColumnId, RegionId, TableId};
 
 use crate::engine::MetricEngineInner;
 use crate::error::{
@@ -248,20 +248,24 @@ impl MetricEngineInner {
         // Batch-modify all rows (add __table_id and __tsid columns)
         let final_rows = {
             let state = self.state.read().unwrap();
-            let name_to_id = state
+            let physical_columns = state
                 .physical_region_states()
                 .get(&data_region_id)
                 .with_context(|| PhysicalRegionNotFoundSnafu {
                     region_id: data_region_id,
                 })?
                 .physical_columns();
+            let name_to_id: HashMap<String, ColumnId> = physical_columns
+                .iter()
+                .map(|(name, info)| (name.clone(), info.column_id))
+                .collect();
 
             let iter = RowsIter::new(
                 Rows {
                     schema: merged_schema,
                     rows: merged_rows,
                 },
-                name_to_id,
+                &name_to_id,
             );
 
             self.row_modifier.modify_rows(
@@ -484,7 +488,10 @@ impl MetricEngineInner {
     ///
     /// Includes:
     /// - Check if the logical region exists
-    /// - Check if the columns exist
+    /// - Check if every column in the request exists in the physical region
+    /// - Check each column's datatype and semantic type match the physical region's schema
+    /// - Check that all required physical columns (time index and tag columns) are present;
+    ///   field columns are optional.
     async fn verify_rows(
         &self,
         logical_region_id: RegionId,
@@ -502,7 +509,7 @@ impl MetricEngineInner {
             .fail();
         }
 
-        // Check if a physical column exists
+        // Type + semantic check on every column in the request schema.
         let physical_columns = state
             .physical_region_states()
             .get(&data_region_id)
@@ -511,11 +518,69 @@ impl MetricEngineInner {
             })?
             .physical_columns();
         for col in &rows.schema {
-            ensure!(
-                physical_columns.contains_key(&col.column_name),
-                ColumnNotFoundSnafu {
+            let info = physical_columns
+                .get(&col.column_name)
+                .context(ColumnNotFoundSnafu {
                     name: col.column_name.clone(),
                     region_id: logical_region_id,
+                })?;
+
+            ensure!(
+                api::helper::is_column_type_value_eq(
+                    col.datatype,
+                    col.datatype_extension.clone(),
+                    &info.data_type
+                ),
+                InvalidRequestSnafu {
+                    region_id: logical_region_id,
+                    reason: format!(
+                        "column {} expect type {:?}, given: {}({})",
+                        col.column_name,
+                        info.data_type,
+                        api::v1::ColumnDataType::try_from(col.datatype)
+                            .map(|v| v.as_str_name())
+                            .unwrap_or("Unknown"),
+                        col.datatype,
+                    ),
+                }
+            );
+
+            ensure!(
+                api::helper::is_semantic_type_eq(col.semantic_type, info.semantic_type),
+                InvalidRequestSnafu {
+                    region_id: logical_region_id,
+                    reason: format!(
+                        "column {} expect semantic type {:?}, given: {}({})",
+                        col.column_name,
+                        info.semantic_type,
+                        api::v1::SemanticType::try_from(col.semantic_type)
+                            .map(|v| v.as_str_name())
+                            .unwrap_or("Unknown"),
+                        col.semantic_type,
+                    ),
+                }
+            );
+        }
+
+        // Completeness check: the physical region's time index column MUST be
+        // present in the request. Without it, mito would previously panic at
+        // `ValueBuilder::push` when building the timestamp column
+        // (see issue #7990). Tag columns are per-logical-region (the physical
+        // region aggregates tags from many logical regions), so we can't
+        // require a specific tag without per-logical-region metadata here;
+        // missing tags are handled by mito's default-fill. Field columns are
+        // always optional.
+        let time_index_column = physical_columns
+            .iter()
+            .find(|(_, info)| info.semantic_type == api::v1::SemanticType::Timestamp)
+            .map(|(name, _)| name.as_str());
+        if let Some(ts_name) = time_index_column {
+            let present = rows.schema.iter().any(|col| col.column_name == ts_name);
+            ensure!(
+                present,
+                InvalidRequestSnafu {
+                    region_id: logical_region_id,
+                    reason: format!("missing required time index column {ts_name}"),
                 }
             );
         }
@@ -536,14 +601,18 @@ impl MetricEngineInner {
         let input = std::mem::take(rows);
         let iter = {
             let state = self.state.read().unwrap();
-            let name_to_id = state
+            let physical_columns = state
                 .physical_region_states()
                 .get(&physical_region_id)
                 .with_context(|| PhysicalRegionNotFoundSnafu {
                     region_id: physical_region_id,
                 })?
                 .physical_columns();
-            RowsIter::new(input, name_to_id)
+            let name_to_id: HashMap<String, ColumnId> = physical_columns
+                .iter()
+                .map(|(name, info)| (name.clone(), info.column_id))
+                .collect();
+            RowsIter::new(input, &name_to_id)
         };
         let output =
             self.row_modifier
@@ -1257,5 +1326,196 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.affected_rows, 3);
+    }
+
+    /// Regression test for issue #7990: the metric engine must reject a row
+    /// whose timestamp column carries a non-timestamp datatype, rather than
+    /// letting it panic inside mito's `ValueBuilder::push`.
+    #[tokio::test]
+    async fn test_verify_rows_rejects_wrong_type() {
+        use api::v1::value::ValueData;
+        use api::v1::{ColumnDataType, ColumnSchema as PbColumnSchema, SemanticType};
+        use common_query::prelude::{greptime_timestamp, greptime_value};
+
+        let env = TestEnv::new().await;
+        env.init_metric_region().await;
+
+        let logical_region_id = env.default_logical_region_id();
+
+        // Timestamp column is declared as String — the very payload that
+        // caused #7990. It should surface a typed error rather than panic.
+        let schema = vec![
+            PbColumnSchema {
+                column_name: greptime_timestamp().to_string(),
+                datatype: ColumnDataType::String as i32,
+                semantic_type: SemanticType::Timestamp as _,
+                datatype_extension: None,
+                options: None,
+            },
+            PbColumnSchema {
+                column_name: greptime_value().to_string(),
+                datatype: ColumnDataType::Float64 as i32,
+                semantic_type: SemanticType::Field as _,
+                datatype_extension: None,
+                options: None,
+            },
+            PbColumnSchema {
+                column_name: "job".to_string(),
+                datatype: ColumnDataType::String as i32,
+                semantic_type: SemanticType::Tag as _,
+                datatype_extension: None,
+                options: None,
+            },
+        ];
+        let rows = vec![Row {
+            values: vec![
+                Value {
+                    value_data: Some(ValueData::StringValue("not-a-timestamp".to_string())),
+                },
+                Value {
+                    value_data: Some(ValueData::F64Value(1.0)),
+                },
+                Value {
+                    value_data: Some(ValueData::StringValue("tag_0".to_string())),
+                },
+            ],
+        }];
+
+        let err = env
+            .metric()
+            .handle_request(
+                logical_region_id,
+                RegionRequest::Put(RegionPutRequest {
+                    rows: Rows { schema, rows },
+                    hint: None,
+                    partition_expr_version: None,
+                }),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(err.status_code(), StatusCode::InvalidArguments);
+    }
+
+    /// The completeness check must reject requests that omit the time index
+    /// column, since mito cannot default-fill a `TimeIndex` column and would
+    /// previously panic on the empty builder.
+    #[tokio::test]
+    async fn test_verify_rows_rejects_missing_time_index() {
+        use api::v1::{ColumnDataType, ColumnSchema as PbColumnSchema, SemanticType};
+        use common_query::prelude::greptime_value;
+
+        let env = TestEnv::new().await;
+        env.init_metric_region().await;
+
+        let logical_region_id = env.default_logical_region_id();
+
+        // Payload only carries the field and a tag — no timestamp column.
+        let schema = vec![
+            PbColumnSchema {
+                column_name: greptime_value().to_string(),
+                datatype: ColumnDataType::Float64 as i32,
+                semantic_type: SemanticType::Field as _,
+                datatype_extension: None,
+                options: None,
+            },
+            PbColumnSchema {
+                column_name: "job".to_string(),
+                datatype: ColumnDataType::String as i32,
+                semantic_type: SemanticType::Tag as _,
+                datatype_extension: None,
+                options: None,
+            },
+        ];
+        let rows = vec![Row {
+            values: vec![
+                Value {
+                    value_data: Some(api::v1::value::ValueData::F64Value(1.0)),
+                },
+                Value {
+                    value_data: Some(api::v1::value::ValueData::StringValue("tag_0".to_string())),
+                },
+            ],
+        }];
+
+        let err = env
+            .metric()
+            .handle_request(
+                logical_region_id,
+                RegionRequest::Put(RegionPutRequest {
+                    rows: Rows { schema, rows },
+                    hint: None,
+                    partition_expr_version: None,
+                }),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(err.status_code(), StatusCode::InvalidArguments);
+    }
+
+    /// Completeness check must not reject a request just because the field
+    /// column is missing: fields are optional from the metric engine's
+    /// perspective. In the default test region `greptime_value` is declared
+    /// non-nullable, so the request still fails, but the error comes from
+    /// mito (about a null in a non-null column) — proving our check let the
+    /// request through rather than blocking it pre-flight.
+    #[tokio::test]
+    async fn test_verify_rows_accepts_missing_field() {
+        use api::v1::value::ValueData;
+        use api::v1::{ColumnDataType, ColumnSchema as PbColumnSchema, SemanticType};
+        use common_query::prelude::greptime_timestamp;
+
+        let env = TestEnv::new().await;
+        env.init_metric_region().await;
+
+        let logical_region_id = env.default_logical_region_id();
+
+        // Schema has timestamp + tag but no field column.
+        let schema = vec![
+            PbColumnSchema {
+                column_name: greptime_timestamp().to_string(),
+                datatype: ColumnDataType::TimestampMillisecond as i32,
+                semantic_type: SemanticType::Timestamp as _,
+                datatype_extension: None,
+                options: None,
+            },
+            PbColumnSchema {
+                column_name: "job".to_string(),
+                datatype: ColumnDataType::String as i32,
+                semantic_type: SemanticType::Tag as _,
+                datatype_extension: None,
+                options: None,
+            },
+        ];
+        let rows = vec![Row {
+            values: vec![
+                Value {
+                    value_data: Some(ValueData::TimestampMillisecondValue(0)),
+                },
+                Value {
+                    value_data: Some(ValueData::StringValue("tag_0".to_string())),
+                },
+            ],
+        }];
+
+        let err = env
+            .metric()
+            .handle_request(
+                logical_region_id,
+                RegionRequest::Put(RegionPutRequest {
+                    rows: Rows { schema, rows },
+                    hint: None,
+                    partition_expr_version: None,
+                }),
+            )
+            .await
+            .unwrap_err();
+        // The failure must NOT be our completeness check (InvalidArguments on
+        // "missing required ... column"). It should come from mito, after
+        // verify_rows allowed the request through.
+        let message = err.to_string();
+        assert!(
+            !message.contains("missing required"),
+            "completeness check must not block requests missing only a field column: {message}"
+        );
     }
 }

--- a/src/metric-engine/src/engine/put.rs
+++ b/src/metric-engine/src/engine/put.rs
@@ -15,7 +15,8 @@
 use std::collections::HashMap;
 
 use api::v1::{
-    ColumnSchema, PrimaryKeyEncoding as PrimaryKeyEncodingProto, Row, Rows, Value, WriteHint,
+    ColumnSchema, PrimaryKeyEncoding as PrimaryKeyEncodingProto, Row, Rows, SemanticType, Value,
+    WriteHint,
 };
 use common_telemetry::{error, info};
 use fxhash::FxHashMap;
@@ -24,7 +25,7 @@ use store_api::codec::PrimaryKeyEncoding;
 use store_api::region_request::{
     AffectedRows, RegionDeleteRequest, RegionPutRequest, RegionRequest,
 };
-use store_api::storage::{ColumnId, RegionId, TableId};
+use store_api::storage::{RegionId, TableId};
 
 use crate::engine::MetricEngineInner;
 use crate::error::{
@@ -160,7 +161,7 @@ impl MetricEngineInner {
         requests: &[(RegionId, RegionPutRequest)],
     ) -> Result<()> {
         for (logical_region_id, request) in requests {
-            self.verify_rows(*logical_region_id, physical_region_id, &request.rows)
+            self.verify_rows(*logical_region_id, physical_region_id, &request.rows, true)
                 .await?;
         }
         Ok(())
@@ -255,20 +256,13 @@ impl MetricEngineInner {
                     region_id: data_region_id,
                 })?
                 .physical_columns();
-            // Borrow the physical column names rather than cloning them: the
-            // state guard is held for the whole block and the map doesn't
-            // outlive this scope.
-            let name_to_id: HashMap<&str, ColumnId> = physical_columns
-                .iter()
-                .map(|(name, info)| (name.as_str(), info.column_id))
-                .collect();
 
             let iter = RowsIter::new(
                 Rows {
                     schema: merged_schema,
                     rows: merged_rows,
                 },
-                &name_to_id,
+                physical_columns,
             );
 
             self.row_modifier.modify_rows(
@@ -413,7 +407,7 @@ impl MetricEngineInner {
         let (physical_region_id, data_region_id, primary_key_encoding) =
             self.find_data_region_meta(logical_region_id)?;
 
-        self.verify_rows(logical_region_id, physical_region_id, &request.rows)
+        self.verify_rows(logical_region_id, physical_region_id, &request.rows, true)
             .await?;
 
         // write to data region
@@ -446,7 +440,7 @@ impl MetricEngineInner {
         let (physical_region_id, data_region_id, primary_key_encoding) =
             self.find_data_region_meta(logical_region_id)?;
 
-        self.verify_rows(logical_region_id, physical_region_id, &request.rows)
+        self.verify_rows(logical_region_id, physical_region_id, &request.rows, false)
             .await?;
 
         // write to data region
@@ -493,13 +487,16 @@ impl MetricEngineInner {
     /// - Check if the logical region exists
     /// - Check if every column in the request exists in the physical region
     /// - Check each column's datatype and semantic type match the physical region's schema
-    /// - Check that all required physical columns (time index and tag columns) are present;
-    ///   field columns are optional.
+    /// - Check the time index column is present
+    /// - When `check_fields` is true, check every physical field column is present.
+    ///   Set this to `false` for delete requests, which legitimately carry only
+    ///   the primary key + timestamp.
     async fn verify_rows(
         &self,
         logical_region_id: RegionId,
         physical_region_id: RegionId,
         rows: &Rows,
+        check_fields: bool,
     ) -> Result<()> {
         // Check if the region exists
         let data_region_id = to_data_region_id(physical_region_id);
@@ -565,22 +562,27 @@ impl MetricEngineInner {
             );
         }
 
-        // Completeness check: the physical region's time index column MUST be
-        // present in the request. Without it, mito would previously panic at
-        // `ValueBuilder::push` when building the timestamp column
-        // (see issue #7990). Tag columns are per-logical-region (the physical
-        // region aggregates tags from many logical regions), so we can't
-        // require a specific tag without per-logical-region metadata here;
-        // missing tags are handled by mito's default-fill. Field columns are
-        // always optional.
         let ts_name = physical_state.time_index_column_name();
-        if !ts_name.is_empty() {
-            let present = rows.schema.iter().any(|col| col.column_name == ts_name);
+        ensure!(
+            rows.schema.iter().any(|col| col.column_name == ts_name),
+            InvalidRequestSnafu {
+                region_id: logical_region_id,
+                reason: format!("missing required time index column {ts_name}"),
+            }
+        );
+
+        if check_fields {
+            let mut field_columns = rows.schema.iter().filter(|col| {
+                api::helper::is_semantic_type_eq(col.semantic_type, SemanticType::Field)
+            });
+            let field_name = physical_state.field_column_name();
+            let field_column = field_columns.next();
             ensure!(
-                present,
+                field_column.is_some_and(|col| col.column_name == field_name)
+                    && field_columns.next().is_none(),
                 InvalidRequestSnafu {
                     region_id: logical_region_id,
-                    reason: format!("missing required time index column {ts_name}"),
+                    reason: format!("missing required field column {field_name}"),
                 }
             );
         }
@@ -608,13 +610,7 @@ impl MetricEngineInner {
                     region_id: physical_region_id,
                 })?
                 .physical_columns();
-            // Borrow the physical column names rather than cloning them; the
-            // map is scoped to this block and the state guard holds.
-            let name_to_id: HashMap<&str, ColumnId> = physical_columns
-                .iter()
-                .map(|(name, info)| (name.as_str(), info.column_id))
-                .collect();
-            RowsIter::new(input, &name_to_id)
+            RowsIter::new(input, physical_columns)
         };
         let output =
             self.row_modifier
@@ -1454,14 +1450,8 @@ mod tests {
         assert_eq!(err.status_code(), StatusCode::InvalidArguments);
     }
 
-    /// Completeness check must not reject a request just because the field
-    /// column is missing: fields are optional from the metric engine's
-    /// perspective. In the default test region `greptime_value` is declared
-    /// non-nullable, so the request still fails, but the error comes from
-    /// mito (about a null in a non-null column) — proving our check let the
-    /// request through rather than blocking it pre-flight.
     #[tokio::test]
-    async fn test_verify_rows_accepts_missing_field() {
+    async fn test_verify_rows_rejects_missing_field() {
         use api::v1::value::ValueData;
         use api::v1::{ColumnDataType, ColumnSchema as PbColumnSchema, SemanticType};
         use common_query::prelude::greptime_timestamp;
@@ -1511,13 +1501,91 @@ mod tests {
             )
             .await
             .unwrap_err();
-        // The failure must NOT be our completeness check (InvalidArguments on
-        // "missing required ... column"). It should come from mito, after
-        // verify_rows allowed the request through.
         let message = err.to_string();
         assert!(
-            !message.contains("missing required"),
-            "completeness check must not block requests missing only a field column: {message}"
+            message.contains("missing required field column"),
+            "expected field-completeness rejection, got: {message}"
         );
+        assert_eq!(err.status_code(), StatusCode::InvalidArguments);
+    }
+
+    #[tokio::test]
+    async fn test_verify_rows_rejects_multiple_fields() {
+        use api::v1::value::ValueData;
+        use api::v1::{ColumnDataType, ColumnSchema as PbColumnSchema, SemanticType};
+        use common_query::prelude::{greptime_timestamp, greptime_value};
+
+        let env = TestEnv::new().await;
+        env.init_metric_region().await;
+
+        let logical_region_id = env.default_logical_region_id();
+
+        // Duplicate field columns should be rejected even if each field matches
+        // the physical column definition.
+        let schema = vec![
+            PbColumnSchema {
+                column_name: greptime_timestamp().to_string(),
+                datatype: ColumnDataType::TimestampMillisecond as i32,
+                semantic_type: SemanticType::Timestamp as _,
+                datatype_extension: None,
+                options: None,
+            },
+            PbColumnSchema {
+                column_name: greptime_value().to_string(),
+                datatype: ColumnDataType::Float64 as i32,
+                semantic_type: SemanticType::Field as _,
+                datatype_extension: None,
+                options: None,
+            },
+            PbColumnSchema {
+                column_name: greptime_value().to_string(),
+                datatype: ColumnDataType::Float64 as i32,
+                semantic_type: SemanticType::Field as _,
+                datatype_extension: None,
+                options: None,
+            },
+            PbColumnSchema {
+                column_name: "job".to_string(),
+                datatype: ColumnDataType::String as i32,
+                semantic_type: SemanticType::Tag as _,
+                datatype_extension: None,
+                options: None,
+            },
+        ];
+        let rows = vec![Row {
+            values: vec![
+                Value {
+                    value_data: Some(ValueData::TimestampMillisecondValue(0)),
+                },
+                Value {
+                    value_data: Some(ValueData::F64Value(1.0)),
+                },
+                Value {
+                    value_data: Some(ValueData::F64Value(2.0)),
+                },
+                Value {
+                    value_data: Some(ValueData::StringValue("tag_0".to_string())),
+                },
+            ],
+        }];
+
+        let err = env
+            .metric()
+            .handle_request(
+                logical_region_id,
+                RegionRequest::Put(RegionPutRequest {
+                    rows: Rows { schema, rows },
+                    hint: None,
+                    partition_expr_version: None,
+                }),
+            )
+            .await
+            .unwrap_err();
+        let message = err.to_string();
+        assert!(
+            message.contains("missing required field column"),
+            "expected field-completeness rejection, got: {message}"
+        );
+        assert_eq!(err.status_code(), StatusCode::InvalidArguments);
     }
 }

--- a/src/metric-engine/src/engine/put.rs
+++ b/src/metric-engine/src/engine/put.rs
@@ -23,6 +23,7 @@ use common_telemetry::{error, info};
 use fxhash::FxHashMap;
 use snafu::{OptionExt, ResultExt, ensure};
 use store_api::codec::PrimaryKeyEncoding;
+use store_api::metadata::ColumnMetadata;
 use store_api::region_request::{
     AffectedRows, RegionDeleteRequest, RegionPutRequest, RegionRequest,
 };
@@ -31,7 +32,8 @@ use store_api::storage::{RegionId, TableId};
 use crate::engine::MetricEngineInner;
 use crate::error::{
     ColumnNotFoundSnafu, CreateDefaultSnafu, ForbiddenPhysicalAlterSnafu, InvalidRequestSnafu,
-    LogicalRegionNotFoundSnafu, PhysicalRegionNotFoundSnafu, Result, UnsupportedRegionRequestSnafu,
+    LogicalRegionNotFoundSnafu, PhysicalRegionNotFoundSnafu, Result, UnexpectedRequestSnafu,
+    UnsupportedRegionRequestSnafu,
 };
 use crate::metrics::{FORBIDDEN_OPERATION_COUNT, MITO_OPERATION_ELAPSED};
 use crate::row_modifier::{RowsIter, TableIdInput};
@@ -545,14 +547,14 @@ impl MetricEngineInner {
                 api::helper::is_column_type_value_eq(
                     col.datatype,
                     col.datatype_extension.clone(),
-                    &info.data_type
+                    &info.column_schema.data_type
                 ),
                 InvalidRequestSnafu {
                     region_id: logical_region_id,
                     reason: format!(
                         "column {} expect type {:?}, given: {}({})",
                         col.column_name,
-                        info.data_type,
+                        info.column_schema.data_type,
                         api::v1::ColumnDataType::try_from(col.datatype)
                             .map(|v| v.as_str_name())
                             .unwrap_or("Unknown"),
@@ -590,14 +592,14 @@ impl MetricEngineInner {
         if check_fields {
             let field_name = physical_state.field_column_name();
             if !rows.schema.iter().any(|col| col.column_name == field_name) {
-                let field_info =
+                let field_meta =
                     physical_columns
                         .get(field_name)
                         .with_context(|| ColumnNotFoundSnafu {
                             name: field_name,
                             region_id: logical_region_id,
                         })?;
-                Self::fill_missing_field_column(logical_region_id, field_name, field_info, rows)?;
+                Self::fill_missing_field_column(logical_region_id, field_name, field_meta, rows)?;
             }
         }
 
@@ -607,32 +609,39 @@ impl MetricEngineInner {
     fn fill_missing_field_column(
         logical_region_id: RegionId,
         field_name: &str,
-        field_info: &crate::engine::state::PhysicalColumnInfo,
+        field_meta: &ColumnMetadata,
         rows: &mut Rows,
     ) -> Result<()> {
-        let Some(default_constraint) = field_info.default_constraint.as_ref() else {
-            return InvalidRequestSnafu {
-                region_id: logical_region_id,
-                reason: format!("missing required field column {field_name}"),
+        ensure!(
+            !field_meta.column_schema.is_default_impure(),
+            UnexpectedRequestSnafu {
+                reason: format!(
+                    "unexpected impure default value with region_id: {logical_region_id}, column: {field_name}, default_value: {:?}",
+                    field_meta.column_schema.default_constraint(),
+                ),
             }
-            .fail();
-        };
+        );
 
-        let default_value = default_constraint
-            .create_default(&field_info.data_type, field_info.is_nullable)
+        let default_value = field_meta
+            .column_schema
+            .create_default()
             .context(CreateDefaultSnafu {
                 region_id: logical_region_id,
                 column: field_name,
+            })?
+            .with_context(|| InvalidRequestSnafu {
+                region_id: logical_region_id,
+                reason: format!("missing required field column {field_name}"),
             })?;
         let default_value = api::helper::to_grpc_value(default_value);
         let (datatype, datatype_extension) =
-            ColumnDataTypeWrapper::try_from(field_info.data_type.clone())
+            ColumnDataTypeWrapper::try_from(field_meta.column_schema.data_type.clone())
                 .map_err(|e| {
                     InvalidRequestSnafu {
                         region_id: logical_region_id,
                         reason: format!(
                             "no protobuf type for field column {field_name} ({:?}): {e}",
-                            field_info.data_type
+                            field_meta.column_schema.data_type
                         ),
                     }
                     .build()
@@ -688,12 +697,17 @@ impl MetricEngineInner {
 mod tests {
     use std::collections::HashSet;
 
+    use api::v1::value::ValueData;
+    use api::v1::{ColumnDataType, ColumnSchema as PbColumnSchema};
     use common_error::ext::ErrorExt;
     use common_error::status_code::StatusCode;
     use common_function::utils::partition_expr_version;
     use common_recordbatch::RecordBatches;
+    use datatypes::prelude::ConcreteDataType;
+    use datatypes::schema::{ColumnDefaultConstraint, ColumnSchema};
     use datatypes::value::Value as PartitionValue;
     use partition::expr::col;
+    use store_api::metadata::ColumnMetadata;
     use store_api::metric_engine_consts::{
         DATA_SCHEMA_TABLE_ID_COLUMN_NAME, DATA_SCHEMA_TSID_COLUMN_NAME,
         MEMTABLE_PARTITION_TREE_PRIMARY_KEY_ENCODING,
@@ -1571,5 +1585,89 @@ mod tests {
             "expected field-completeness rejection, got: {message}"
         );
         assert_eq!(err.status_code(), StatusCode::InvalidArguments);
+    }
+
+    #[test]
+    fn test_fill_missing_field_column_nullable_no_default() {
+        let field_meta = ColumnMetadata {
+            column_id: 1,
+            semantic_type: SemanticType::Field,
+            column_schema: ColumnSchema::new(
+                "greptime_value".to_string(),
+                ConcreteDataType::float64_datatype(),
+                true, // nullable, no default
+            ),
+        };
+        let mut rows = Rows {
+            schema: vec![PbColumnSchema {
+                column_name: "ts".to_string(),
+                datatype: ColumnDataType::TimestampMillisecond as i32,
+                semantic_type: SemanticType::Timestamp as _,
+                datatype_extension: None,
+                options: None,
+            }],
+            rows: vec![Row {
+                values: vec![Value {
+                    value_data: Some(ValueData::TimestampMillisecondValue(0)),
+                }],
+            }],
+        };
+
+        MetricEngineInner::fill_missing_field_column(
+            RegionId::new(1, 1),
+            "greptime_value",
+            &field_meta,
+            &mut rows,
+        )
+        .unwrap();
+
+        assert_eq!(rows.schema.len(), 2);
+        assert_eq!(rows.schema[1].column_name, "greptime_value");
+        assert_eq!(rows.rows[0].values.len(), 2);
+        assert!(
+            rows.rows[0].values[1].value_data.is_none(),
+            "missing nullable field should be filled with null"
+        );
+    }
+
+    #[test]
+    fn test_fill_missing_field_column_rejects_impure_default() {
+        let field_meta = ColumnMetadata {
+            column_id: 1,
+            semantic_type: SemanticType::Field,
+            column_schema: ColumnSchema::new(
+                "greptime_value".to_string(),
+                ConcreteDataType::timestamp_millisecond_datatype(),
+                false,
+            )
+            .with_default_constraint(Some(ColumnDefaultConstraint::Function("now()".to_string())))
+            .unwrap(),
+        };
+        let mut rows = Rows {
+            schema: vec![PbColumnSchema {
+                column_name: "ts".to_string(),
+                datatype: api::v1::ColumnDataType::TimestampMillisecond as i32,
+                semantic_type: SemanticType::Timestamp as _,
+                datatype_extension: None,
+                options: None,
+            }],
+            rows: vec![Row {
+                values: vec![Value {
+                    value_data: Some(ValueData::TimestampMillisecondValue(0)),
+                }],
+            }],
+        };
+
+        let err = MetricEngineInner::fill_missing_field_column(
+            RegionId::new(1, 1),
+            "greptime_value",
+            &field_meta,
+            &mut rows,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("impure default value"),
+            "expected impure-default rejection, got: {err}"
+        );
     }
 }

--- a/src/metric-engine/src/engine/put.rs
+++ b/src/metric-engine/src/engine/put.rs
@@ -14,13 +14,14 @@
 
 use std::collections::HashMap;
 
+use api::helper::ColumnDataTypeWrapper;
 use api::v1::{
     ColumnSchema, PrimaryKeyEncoding as PrimaryKeyEncodingProto, Row, Rows, SemanticType, Value,
     WriteHint,
 };
 use common_telemetry::{error, info};
 use fxhash::FxHashMap;
-use snafu::{OptionExt, ensure};
+use snafu::{OptionExt, ResultExt, ensure};
 use store_api::codec::PrimaryKeyEncoding;
 use store_api::region_request::{
     AffectedRows, RegionDeleteRequest, RegionPutRequest, RegionRequest,
@@ -29,7 +30,7 @@ use store_api::storage::{RegionId, TableId};
 
 use crate::engine::MetricEngineInner;
 use crate::error::{
-    ColumnNotFoundSnafu, ForbiddenPhysicalAlterSnafu, InvalidRequestSnafu,
+    ColumnNotFoundSnafu, CreateDefaultSnafu, ForbiddenPhysicalAlterSnafu, InvalidRequestSnafu,
     LogicalRegionNotFoundSnafu, PhysicalRegionNotFoundSnafu, Result, UnsupportedRegionRequestSnafu,
 };
 use crate::metrics::{FORBIDDEN_OPERATION_COUNT, MITO_OPERATION_ELAPSED};
@@ -117,7 +118,7 @@ impl MetricEngineInner {
     async fn put_regions_batch_single_physical(
         &self,
         physical_region_id: RegionId,
-        requests: Vec<(RegionId, RegionPutRequest)>,
+        mut requests: Vec<(RegionId, RegionPutRequest)>,
     ) -> Result<AffectedRows> {
         if requests.is_empty() {
             return Ok(0);
@@ -127,7 +128,7 @@ impl MetricEngineInner {
         let primary_key_encoding = self.get_primary_key_encoding(data_region_id)?;
 
         // Validate all requests
-        self.validate_batch_requests(physical_region_id, &requests)
+        self.validate_batch_requests(physical_region_id, &mut requests)
             .await?;
 
         // Merge requests according to encoding strategy
@@ -158,11 +159,16 @@ impl MetricEngineInner {
     async fn validate_batch_requests(
         &self,
         physical_region_id: RegionId,
-        requests: &[(RegionId, RegionPutRequest)],
+        requests: &mut [(RegionId, RegionPutRequest)],
     ) -> Result<()> {
         for (logical_region_id, request) in requests {
-            self.verify_rows(*logical_region_id, physical_region_id, &request.rows, true)
-                .await?;
+            self.verify_rows(
+                *logical_region_id,
+                physical_region_id,
+                &mut request.rows,
+                true,
+            )
+            .await?;
         }
         Ok(())
     }
@@ -407,8 +413,13 @@ impl MetricEngineInner {
         let (physical_region_id, data_region_id, primary_key_encoding) =
             self.find_data_region_meta(logical_region_id)?;
 
-        self.verify_rows(logical_region_id, physical_region_id, &request.rows, true)
-            .await?;
+        self.verify_rows(
+            logical_region_id,
+            physical_region_id,
+            &mut request.rows,
+            true,
+        )
+        .await?;
 
         // write to data region
         // TODO: retrieve table name
@@ -440,8 +451,13 @@ impl MetricEngineInner {
         let (physical_region_id, data_region_id, primary_key_encoding) =
             self.find_data_region_meta(logical_region_id)?;
 
-        self.verify_rows(logical_region_id, physical_region_id, &request.rows, false)
-            .await?;
+        self.verify_rows(
+            logical_region_id,
+            physical_region_id,
+            &mut request.rows,
+            false,
+        )
+        .await?;
 
         // write to data region
         // TODO: retrieve table name
@@ -495,7 +511,7 @@ impl MetricEngineInner {
         &self,
         logical_region_id: RegionId,
         physical_region_id: RegionId,
-        rows: &Rows,
+        rows: &mut Rows,
         check_fields: bool,
     ) -> Result<()> {
         // Check if the region exists
@@ -572,19 +588,67 @@ impl MetricEngineInner {
         );
 
         if check_fields {
-            let mut field_columns = rows.schema.iter().filter(|col| {
-                api::helper::is_semantic_type_eq(col.semantic_type, SemanticType::Field)
-            });
             let field_name = physical_state.field_column_name();
-            let field_column = field_columns.next();
-            ensure!(
-                field_column.is_some_and(|col| col.column_name == field_name)
-                    && field_columns.next().is_none(),
-                InvalidRequestSnafu {
-                    region_id: logical_region_id,
-                    reason: format!("missing required field column {field_name}"),
-                }
-            );
+            if !rows.schema.iter().any(|col| col.column_name == field_name) {
+                let field_info =
+                    physical_columns
+                        .get(field_name)
+                        .with_context(|| ColumnNotFoundSnafu {
+                            name: field_name,
+                            region_id: logical_region_id,
+                        })?;
+                Self::fill_missing_field_column(logical_region_id, field_name, field_info, rows)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn fill_missing_field_column(
+        logical_region_id: RegionId,
+        field_name: &str,
+        field_info: &crate::engine::state::PhysicalColumnInfo,
+        rows: &mut Rows,
+    ) -> Result<()> {
+        let Some(default_constraint) = field_info.default_constraint.as_ref() else {
+            return InvalidRequestSnafu {
+                region_id: logical_region_id,
+                reason: format!("missing required field column {field_name}"),
+            }
+            .fail();
+        };
+
+        let default_value = default_constraint
+            .create_default(&field_info.data_type, field_info.is_nullable)
+            .context(CreateDefaultSnafu {
+                region_id: logical_region_id,
+                column: field_name,
+            })?;
+        let default_value = api::helper::to_grpc_value(default_value);
+        let (datatype, datatype_extension) =
+            ColumnDataTypeWrapper::try_from(field_info.data_type.clone())
+                .map_err(|e| {
+                    InvalidRequestSnafu {
+                        region_id: logical_region_id,
+                        reason: format!(
+                            "no protobuf type for field column {field_name} ({:?}): {e}",
+                            field_info.data_type
+                        ),
+                    }
+                    .build()
+                })?
+                .to_parts();
+
+        rows.schema.push(ColumnSchema {
+            column_name: field_name.to_string(),
+            datatype: datatype as i32,
+            semantic_type: SemanticType::Field as i32,
+            datatype_extension,
+            options: None,
+        });
+
+        for row in &mut rows.rows {
+            row.values.push(default_value.clone());
         }
 
         Ok(())
@@ -1482,86 +1546,6 @@ mod tests {
             values: vec![
                 Value {
                     value_data: Some(ValueData::TimestampMillisecondValue(0)),
-                },
-                Value {
-                    value_data: Some(ValueData::StringValue("tag_0".to_string())),
-                },
-            ],
-        }];
-
-        let err = env
-            .metric()
-            .handle_request(
-                logical_region_id,
-                RegionRequest::Put(RegionPutRequest {
-                    rows: Rows { schema, rows },
-                    hint: None,
-                    partition_expr_version: None,
-                }),
-            )
-            .await
-            .unwrap_err();
-        let message = err.to_string();
-        assert!(
-            message.contains("missing required field column"),
-            "expected field-completeness rejection, got: {message}"
-        );
-        assert_eq!(err.status_code(), StatusCode::InvalidArguments);
-    }
-
-    #[tokio::test]
-    async fn test_verify_rows_rejects_multiple_fields() {
-        use api::v1::value::ValueData;
-        use api::v1::{ColumnDataType, ColumnSchema as PbColumnSchema, SemanticType};
-        use common_query::prelude::{greptime_timestamp, greptime_value};
-
-        let env = TestEnv::new().await;
-        env.init_metric_region().await;
-
-        let logical_region_id = env.default_logical_region_id();
-
-        // Duplicate field columns should be rejected even if each field matches
-        // the physical column definition.
-        let schema = vec![
-            PbColumnSchema {
-                column_name: greptime_timestamp().to_string(),
-                datatype: ColumnDataType::TimestampMillisecond as i32,
-                semantic_type: SemanticType::Timestamp as _,
-                datatype_extension: None,
-                options: None,
-            },
-            PbColumnSchema {
-                column_name: greptime_value().to_string(),
-                datatype: ColumnDataType::Float64 as i32,
-                semantic_type: SemanticType::Field as _,
-                datatype_extension: None,
-                options: None,
-            },
-            PbColumnSchema {
-                column_name: greptime_value().to_string(),
-                datatype: ColumnDataType::Float64 as i32,
-                semantic_type: SemanticType::Field as _,
-                datatype_extension: None,
-                options: None,
-            },
-            PbColumnSchema {
-                column_name: "job".to_string(),
-                datatype: ColumnDataType::String as i32,
-                semantic_type: SemanticType::Tag as _,
-                datatype_extension: None,
-                options: None,
-            },
-        ];
-        let rows = vec![Row {
-            values: vec![
-                Value {
-                    value_data: Some(ValueData::TimestampMillisecondValue(0)),
-                },
-                Value {
-                    value_data: Some(ValueData::F64Value(1.0)),
-                },
-                Value {
-                    value_data: Some(ValueData::F64Value(2.0)),
                 },
                 Value {
                     value_data: Some(ValueData::StringValue("tag_0".to_string())),

--- a/src/metric-engine/src/engine/state.rs
+++ b/src/metric-engine/src/engine/state.rs
@@ -63,6 +63,11 @@ impl From<ColumnMetadata> for PhysicalColumnInfo {
 pub struct PhysicalRegionState {
     logical_regions: HashSet<RegionId>,
     physical_columns: HashMap<String, PhysicalColumnInfo>,
+    /// Name of the time index column, cached at region load so that the write
+    /// path doesn't have to scan `physical_columns` for the timestamp on every
+    /// row batch. The time index is fixed at region creation and never
+    /// changes, so this stays in sync with `physical_columns`.
+    time_index_column_name: String,
     primary_key_encoding: PrimaryKeyEncoding,
     options: PhysicalRegionOptions,
     time_index_unit: TimeUnit,
@@ -75,9 +80,18 @@ impl PhysicalRegionState {
         options: PhysicalRegionOptions,
         time_index_unit: TimeUnit,
     ) -> Self {
+        // Safety: a valid physical region always has exactly one time index
+        // column; callers validate this before reaching here (see
+        // `create_data_region_request` and the open path).
+        let time_index_column_name = physical_columns
+            .iter()
+            .find(|(_, info)| info.semantic_type == SemanticType::Timestamp)
+            .map(|(name, _)| name.clone())
+            .unwrap_or_default();
         Self {
             logical_regions: HashSet::new(),
             physical_columns,
+            time_index_column_name,
             primary_key_encoding,
             options,
             time_index_unit,
@@ -92,6 +106,11 @@ impl PhysicalRegionState {
     /// Returns a reference to the physical columns.
     pub fn physical_columns(&self) -> &HashMap<String, PhysicalColumnInfo> {
         &self.physical_columns
+    }
+
+    /// Returns the cached name of the time index column.
+    pub fn time_index_column_name(&self) -> &str {
+        &self.time_index_column_name
     }
 
     /// Returns a reference to the physical region options.
@@ -150,6 +169,13 @@ impl MetricEngineState {
         let physical_region_id = to_data_region_id(physical_region_id);
         let state = self.physical_regions.get_mut(&physical_region_id).unwrap();
         for (col, info) in physical_columns {
+            // The time index is fixed at region creation and alter cannot add
+            // a new one; keep the cached name in sync defensively.
+            debug_assert_ne!(
+                info.semantic_type,
+                SemanticType::Timestamp,
+                "unexpected time index column {col} added to an existing physical region"
+            );
             state.physical_columns.insert(col, info);
         }
     }

--- a/src/metric-engine/src/engine/state.rs
+++ b/src/metric-engine/src/engine/state.rs
@@ -40,6 +40,26 @@ pub struct PhysicalColumnInfo {
     pub semantic_type: SemanticType,
 }
 
+impl From<&ColumnMetadata> for PhysicalColumnInfo {
+    fn from(metadata: &ColumnMetadata) -> Self {
+        Self {
+            column_id: metadata.column_id,
+            data_type: metadata.column_schema.data_type.clone(),
+            semantic_type: metadata.semantic_type,
+        }
+    }
+}
+
+impl From<ColumnMetadata> for PhysicalColumnInfo {
+    fn from(metadata: ColumnMetadata) -> Self {
+        Self {
+            column_id: metadata.column_id,
+            data_type: metadata.column_schema.data_type,
+            semantic_type: metadata.semantic_type,
+        }
+    }
+}
+
 pub struct PhysicalRegionState {
     logical_regions: HashSet<RegionId>,
     physical_columns: HashMap<String, PhysicalColumnInfo>,

--- a/src/metric-engine/src/engine/state.rs
+++ b/src/metric-engine/src/engine/state.rs
@@ -16,7 +16,9 @@
 
 use std::collections::{HashMap, HashSet};
 
+use api::v1::SemanticType;
 use common_time::timestamp::TimeUnit;
+use datatypes::prelude::ConcreteDataType;
 use snafu::OptionExt;
 use store_api::codec::PrimaryKeyEncoding;
 use store_api::metadata::ColumnMetadata;
@@ -27,9 +29,20 @@ use crate::error::{PhysicalRegionNotFoundSnafu, Result};
 use crate::metrics::LOGICAL_REGION_COUNT;
 use crate::utils::to_data_region_id;
 
+/// Metadata cached for each physical column in a physical region.
+///
+/// Only the subset needed for validation and row-modification is cached here
+/// to avoid holding the full [`ColumnMetadata`] in memory for every column.
+#[derive(Debug, Clone)]
+pub struct PhysicalColumnInfo {
+    pub column_id: ColumnId,
+    pub data_type: ConcreteDataType,
+    pub semantic_type: SemanticType,
+}
+
 pub struct PhysicalRegionState {
     logical_regions: HashSet<RegionId>,
-    physical_columns: HashMap<String, ColumnId>,
+    physical_columns: HashMap<String, PhysicalColumnInfo>,
     primary_key_encoding: PrimaryKeyEncoding,
     options: PhysicalRegionOptions,
     time_index_unit: TimeUnit,
@@ -37,7 +50,7 @@ pub struct PhysicalRegionState {
 
 impl PhysicalRegionState {
     pub fn new(
-        physical_columns: HashMap<String, ColumnId>,
+        physical_columns: HashMap<String, PhysicalColumnInfo>,
         primary_key_encoding: PrimaryKeyEncoding,
         options: PhysicalRegionOptions,
         time_index_unit: TimeUnit,
@@ -57,7 +70,7 @@ impl PhysicalRegionState {
     }
 
     /// Returns a reference to the physical columns.
-    pub fn physical_columns(&self) -> &HashMap<String, ColumnId> {
+    pub fn physical_columns(&self) -> &HashMap<String, PhysicalColumnInfo> {
         &self.physical_columns
     }
 
@@ -90,7 +103,7 @@ impl MetricEngineState {
     pub fn add_physical_region(
         &mut self,
         physical_region_id: RegionId,
-        physical_columns: HashMap<String, ColumnId>,
+        physical_columns: HashMap<String, PhysicalColumnInfo>,
         primary_key_encoding: PrimaryKeyEncoding,
         options: PhysicalRegionOptions,
         time_index_unit: TimeUnit,
@@ -112,12 +125,12 @@ impl MetricEngineState {
     pub fn add_physical_columns(
         &mut self,
         physical_region_id: RegionId,
-        physical_columns: impl IntoIterator<Item = (String, ColumnId)>,
+        physical_columns: impl IntoIterator<Item = (String, PhysicalColumnInfo)>,
     ) {
         let physical_region_id = to_data_region_id(physical_region_id);
         let state = self.physical_regions.get_mut(&physical_region_id).unwrap();
-        for (col, id) in physical_columns {
-            state.physical_columns.insert(col, id);
+        for (col, info) in physical_columns {
+            state.physical_columns.insert(col, info);
         }
     }
 

--- a/src/metric-engine/src/engine/state.rs
+++ b/src/metric-engine/src/engine/state.rs
@@ -68,6 +68,10 @@ pub struct PhysicalRegionState {
     /// row batch. The time index is fixed at region creation and never
     /// changes, so this stays in sync with `physical_columns`.
     time_index_column_name: String,
+    /// Name of the field column. Metric regions have exactly one field column
+    /// verified at creation time, so the write path can validate completeness
+    /// without consulting per-logical-region metadata.
+    field_column_name: String,
     primary_key_encoding: PrimaryKeyEncoding,
     options: PhysicalRegionOptions,
     time_index_unit: TimeUnit,
@@ -88,10 +92,16 @@ impl PhysicalRegionState {
             .find(|(_, info)| info.semantic_type == SemanticType::Timestamp)
             .map(|(name, _)| name.clone())
             .unwrap_or_default();
+        let field_column_name = physical_columns
+            .iter()
+            .find(|(_, info)| info.semantic_type == SemanticType::Field)
+            .map(|(name, _)| name.clone())
+            .unwrap_or_default();
         Self {
             logical_regions: HashSet::new(),
             physical_columns,
             time_index_column_name,
+            field_column_name,
             primary_key_encoding,
             options,
             time_index_unit,
@@ -111,6 +121,11 @@ impl PhysicalRegionState {
     /// Returns the cached name of the time index column.
     pub fn time_index_column_name(&self) -> &str {
         &self.time_index_column_name
+    }
+
+    /// Returns the cached name of the field column.
+    pub fn field_column_name(&self) -> &str {
+        &self.field_column_name
     }
 
     /// Returns a reference to the physical region options.
@@ -175,6 +190,11 @@ impl MetricEngineState {
                 info.semantic_type,
                 SemanticType::Timestamp,
                 "unexpected time index column {col} added to an existing physical region"
+            );
+            debug_assert_ne!(
+                info.semantic_type,
+                SemanticType::Field,
+                "unexpected field column {col} added to an existing physical region"
             );
             state.physical_columns.insert(col, info);
         }

--- a/src/metric-engine/src/engine/state.rs
+++ b/src/metric-engine/src/engine/state.rs
@@ -20,6 +20,7 @@ use api::v1::SemanticType;
 use common_telemetry::warn;
 use common_time::timestamp::TimeUnit;
 use datatypes::prelude::ConcreteDataType;
+use datatypes::schema::ColumnDefaultConstraint;
 use snafu::OptionExt;
 use store_api::codec::PrimaryKeyEncoding;
 use store_api::metadata::ColumnMetadata;
@@ -38,6 +39,8 @@ use crate::utils::to_data_region_id;
 pub struct PhysicalColumnInfo {
     pub column_id: ColumnId,
     pub data_type: ConcreteDataType,
+    pub is_nullable: bool,
+    pub default_constraint: Option<ColumnDefaultConstraint>,
     pub semantic_type: SemanticType,
 }
 
@@ -46,6 +49,8 @@ impl From<&ColumnMetadata> for PhysicalColumnInfo {
         Self {
             column_id: metadata.column_id,
             data_type: metadata.column_schema.data_type.clone(),
+            is_nullable: metadata.column_schema.is_nullable(),
+            default_constraint: metadata.column_schema.default_constraint().cloned(),
             semantic_type: metadata.semantic_type,
         }
     }
@@ -53,9 +58,13 @@ impl From<&ColumnMetadata> for PhysicalColumnInfo {
 
 impl From<ColumnMetadata> for PhysicalColumnInfo {
     fn from(metadata: ColumnMetadata) -> Self {
+        let is_nullable = metadata.column_schema.is_nullable();
+        let default_constraint = metadata.column_schema.default_constraint().cloned();
         Self {
             column_id: metadata.column_id,
             data_type: metadata.column_schema.data_type,
+            is_nullable,
+            default_constraint,
             semantic_type: metadata.semantic_type,
         }
     }

--- a/src/metric-engine/src/engine/state.rs
+++ b/src/metric-engine/src/engine/state.rs
@@ -17,6 +17,7 @@
 use std::collections::{HashMap, HashSet};
 
 use api::v1::SemanticType;
+use common_telemetry::warn;
 use common_time::timestamp::TimeUnit;
 use datatypes::prelude::ConcreteDataType;
 use snafu::OptionExt;
@@ -191,11 +192,12 @@ impl MetricEngineState {
                 SemanticType::Timestamp,
                 "unexpected time index column {col} added to an existing physical region"
             );
-            debug_assert_ne!(
-                info.semantic_type,
-                SemanticType::Field,
-                "unexpected field column {col} added to an existing physical region"
-            );
+            if info.semantic_type == SemanticType::Field {
+                warn!(
+                    "Unexpected field column {col} added to physical region {physical_region_id}; cached field column remains {}",
+                    state.field_column_name
+                );
+            }
             state.physical_columns.insert(col, info);
         }
     }

--- a/src/metric-engine/src/engine/state.rs
+++ b/src/metric-engine/src/engine/state.rs
@@ -19,60 +19,19 @@ use std::collections::{HashMap, HashSet};
 use api::v1::SemanticType;
 use common_telemetry::warn;
 use common_time::timestamp::TimeUnit;
-use datatypes::prelude::ConcreteDataType;
-use datatypes::schema::ColumnDefaultConstraint;
 use snafu::OptionExt;
 use store_api::codec::PrimaryKeyEncoding;
 use store_api::metadata::ColumnMetadata;
-use store_api::storage::{ColumnId, RegionId};
+use store_api::storage::RegionId;
 
 use crate::engine::options::PhysicalRegionOptions;
 use crate::error::{PhysicalRegionNotFoundSnafu, Result};
 use crate::metrics::LOGICAL_REGION_COUNT;
 use crate::utils::to_data_region_id;
 
-/// Metadata cached for each physical column in a physical region.
-///
-/// Only the subset needed for validation and row-modification is cached here
-/// to avoid holding the full [`ColumnMetadata`] in memory for every column.
-#[derive(Debug, Clone)]
-pub struct PhysicalColumnInfo {
-    pub column_id: ColumnId,
-    pub data_type: ConcreteDataType,
-    pub is_nullable: bool,
-    pub default_constraint: Option<ColumnDefaultConstraint>,
-    pub semantic_type: SemanticType,
-}
-
-impl From<&ColumnMetadata> for PhysicalColumnInfo {
-    fn from(metadata: &ColumnMetadata) -> Self {
-        Self {
-            column_id: metadata.column_id,
-            data_type: metadata.column_schema.data_type.clone(),
-            is_nullable: metadata.column_schema.is_nullable(),
-            default_constraint: metadata.column_schema.default_constraint().cloned(),
-            semantic_type: metadata.semantic_type,
-        }
-    }
-}
-
-impl From<ColumnMetadata> for PhysicalColumnInfo {
-    fn from(metadata: ColumnMetadata) -> Self {
-        let is_nullable = metadata.column_schema.is_nullable();
-        let default_constraint = metadata.column_schema.default_constraint().cloned();
-        Self {
-            column_id: metadata.column_id,
-            data_type: metadata.column_schema.data_type,
-            is_nullable,
-            default_constraint,
-            semantic_type: metadata.semantic_type,
-        }
-    }
-}
-
 pub struct PhysicalRegionState {
     logical_regions: HashSet<RegionId>,
-    physical_columns: HashMap<String, PhysicalColumnInfo>,
+    physical_columns: HashMap<String, ColumnMetadata>,
     /// Name of the time index column, cached at region load so that the write
     /// path doesn't have to scan `physical_columns` for the timestamp on every
     /// row batch. The time index is fixed at region creation and never
@@ -89,7 +48,7 @@ pub struct PhysicalRegionState {
 
 impl PhysicalRegionState {
     pub fn new(
-        physical_columns: HashMap<String, PhysicalColumnInfo>,
+        physical_columns: HashMap<String, ColumnMetadata>,
         primary_key_encoding: PrimaryKeyEncoding,
         options: PhysicalRegionOptions,
         time_index_unit: TimeUnit,
@@ -99,12 +58,12 @@ impl PhysicalRegionState {
         // `create_data_region_request` and the open path).
         let time_index_column_name = physical_columns
             .iter()
-            .find(|(_, info)| info.semantic_type == SemanticType::Timestamp)
+            .find(|(_, meta)| meta.semantic_type == SemanticType::Timestamp)
             .map(|(name, _)| name.clone())
             .unwrap_or_default();
         let field_column_name = physical_columns
             .iter()
-            .find(|(_, info)| info.semantic_type == SemanticType::Field)
+            .find(|(_, meta)| meta.semantic_type == SemanticType::Field)
             .map(|(name, _)| name.clone())
             .unwrap_or_default();
         Self {
@@ -124,7 +83,7 @@ impl PhysicalRegionState {
     }
 
     /// Returns a reference to the physical columns.
-    pub fn physical_columns(&self) -> &HashMap<String, PhysicalColumnInfo> {
+    pub fn physical_columns(&self) -> &HashMap<String, ColumnMetadata> {
         &self.physical_columns
     }
 
@@ -167,7 +126,7 @@ impl MetricEngineState {
     pub fn add_physical_region(
         &mut self,
         physical_region_id: RegionId,
-        physical_columns: HashMap<String, PhysicalColumnInfo>,
+        physical_columns: HashMap<String, ColumnMetadata>,
         primary_key_encoding: PrimaryKeyEncoding,
         options: PhysicalRegionOptions,
         time_index_unit: TimeUnit,
@@ -189,25 +148,25 @@ impl MetricEngineState {
     pub fn add_physical_columns(
         &mut self,
         physical_region_id: RegionId,
-        physical_columns: impl IntoIterator<Item = (String, PhysicalColumnInfo)>,
+        physical_columns: impl IntoIterator<Item = (String, ColumnMetadata)>,
     ) {
         let physical_region_id = to_data_region_id(physical_region_id);
         let state = self.physical_regions.get_mut(&physical_region_id).unwrap();
-        for (col, info) in physical_columns {
+        for (col, meta) in physical_columns {
             // The time index is fixed at region creation and alter cannot add
             // a new one; keep the cached name in sync defensively.
             debug_assert_ne!(
-                info.semantic_type,
+                meta.semantic_type,
                 SemanticType::Timestamp,
                 "unexpected time index column {col} added to an existing physical region"
             );
-            if info.semantic_type == SemanticType::Field {
+            if meta.semantic_type == SemanticType::Field {
                 warn!(
                     "Unexpected field column {col} added to physical region {physical_region_id}; cached field column remains {}",
                     state.field_column_name
                 );
             }
-            state.physical_columns.insert(col, info);
+            state.physical_columns.insert(col, meta);
         }
     }
 

--- a/src/metric-engine/src/error.rs
+++ b/src/metric-engine/src/error.rs
@@ -343,6 +343,19 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display(
+        "Failed to create default value for column {} of region {}",
+        column,
+        region_id
+    ))]
+    CreateDefault {
+        region_id: RegionId,
+        column: String,
+        source: datatypes::error::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Unexpected request: {}", reason))]
     UnexpectedRequest {
         reason: String,
@@ -394,7 +407,8 @@ impl ErrorExt for Error {
             | UnsupportedAlterKind { .. }
             | UnsupportedRemapManifestsRequest { .. }
             | UnsupportedSyncRegionFromRequest { .. }
-            | InvalidRequest { .. } => StatusCode::InvalidArguments,
+            | InvalidRequest { .. }
+            | CreateDefault { .. } => StatusCode::InvalidArguments,
 
             ForbiddenPhysicalAlter { .. }
             | UnsupportedRegionRequest { .. }

--- a/src/metric-engine/src/row_modifier.rs
+++ b/src/metric-engine/src/row_modifier.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Borrow;
 use std::collections::{BTreeMap, HashMap};
-use std::hash::Hasher;
+use std::hash::{Hash, Hasher};
 
 use api::v1::value::ValueData;
 use api::v1::{ColumnDataType, ColumnSchema, Row, Rows, SemanticType, Value};
@@ -264,7 +265,10 @@ struct IterIndex {
 }
 
 impl IterIndex {
-    fn new(row_schema: &[ColumnSchema], name_to_column_id: &HashMap<String, ColumnId>) -> Self {
+    fn new<K>(row_schema: &[ColumnSchema], name_to_column_id: &HashMap<K, ColumnId>) -> Self
+    where
+        K: Eq + Hash + Borrow<str>,
+    {
         let mut reserved_indices = SmallVec::<[ValueIndex; 2]>::new();
         // Uses BTreeMap to keep the primary key column name order (lexicographical)
         let mut primary_key_indices = BTreeMap::new();
@@ -290,7 +294,9 @@ impl IterIndex {
                         primary_key_indices.insert(
                             col.column_name.as_str(),
                             ValueIndex {
-                                column_id: *name_to_column_id.get(&col.column_name).unwrap(),
+                                column_id: *name_to_column_id
+                                    .get(col.column_name.as_str())
+                                    .unwrap(),
                                 index: idx,
                             },
                         );
@@ -298,13 +304,13 @@ impl IterIndex {
                 },
                 SemanticType::Field => {
                     field_indices.push(ValueIndex {
-                        column_id: *name_to_column_id.get(&col.column_name).unwrap(),
+                        column_id: *name_to_column_id.get(col.column_name.as_str()).unwrap(),
                         index: idx,
                     });
                 }
                 SemanticType::Timestamp => {
                     ts_index = Some(ValueIndex {
-                        column_id: *name_to_column_id.get(&col.column_name).unwrap(),
+                        column_id: *name_to_column_id.get(col.column_name.as_str()).unwrap(),
                         index: idx,
                     });
                 }
@@ -338,7 +344,10 @@ pub struct RowsIter {
 }
 
 impl RowsIter {
-    pub fn new(rows: Rows, name_to_column_id: &HashMap<String, ColumnId>) -> Self {
+    pub fn new<K>(rows: Rows, name_to_column_id: &HashMap<K, ColumnId>) -> Self
+    where
+        K: Eq + Hash + Borrow<str>,
+    {
         let index: IterIndex = IterIndex::new(&rows.schema, name_to_column_id);
         Self { rows, index }
     }

--- a/src/metric-engine/src/row_modifier.rs
+++ b/src/metric-engine/src/row_modifier.rs
@@ -23,13 +23,13 @@ use mito_codec::row_converter::SparsePrimaryKeyCodec;
 use smallvec::SmallVec;
 use snafu::ResultExt;
 use store_api::codec::PrimaryKeyEncoding;
+use store_api::metadata::ColumnMetadata;
 use store_api::metric_engine_consts::{
     DATA_SCHEMA_TABLE_ID_COLUMN_NAME, DATA_SCHEMA_TSID_COLUMN_NAME,
 };
 use store_api::storage::consts::{PRIMARY_KEY_COLUMN_NAME, ReservedColumnId};
 use store_api::storage::{ColumnId, TableId};
 
-use crate::engine::PhysicalColumnInfo;
 use crate::error::{EncodePrimaryKeySnafu, Result, TableIdCountMismatchSnafu};
 
 /// A row modifier modifies [`Rows`].
@@ -267,7 +267,7 @@ struct IterIndex {
 impl IterIndex {
     fn new(
         row_schema: &[ColumnSchema],
-        physical_columns: &HashMap<String, PhysicalColumnInfo>,
+        physical_columns: &HashMap<String, ColumnMetadata>,
     ) -> Self {
         let mut reserved_indices = SmallVec::<[ValueIndex; 2]>::new();
         // Uses BTreeMap to keep the primary key column name order (lexicographical)
@@ -345,7 +345,7 @@ pub struct RowsIter {
 }
 
 impl RowsIter {
-    pub fn new(rows: Rows, physical_columns: &HashMap<String, PhysicalColumnInfo>) -> Self {
+    pub fn new(rows: Rows, physical_columns: &HashMap<String, ColumnMetadata>) -> Self {
         let index: IterIndex = IterIndex::new(&rows.schema, physical_columns);
         Self { rows, index }
     }
@@ -462,20 +462,22 @@ mod tests {
         }
     }
 
-    fn make_info(column_id: ColumnId) -> PhysicalColumnInfo {
-        PhysicalColumnInfo {
-            column_id,
-            data_type: datatypes::prelude::ConcreteDataType::string_datatype(),
-            is_nullable: false,
-            default_constraint: None,
+    fn make_info(name: &str, column_id: ColumnId) -> ColumnMetadata {
+        ColumnMetadata {
+            column_schema: datatypes::schema::ColumnSchema::new(
+                name.to_string(),
+                datatypes::prelude::ConcreteDataType::string_datatype(),
+                false,
+            ),
             semantic_type: SemanticType::Tag,
+            column_id,
         }
     }
 
-    fn test_name_to_column_id() -> HashMap<String, PhysicalColumnInfo> {
+    fn test_name_to_column_id() -> HashMap<String, ColumnMetadata> {
         HashMap::from([
-            ("namespace".to_string(), make_info(1)),
-            ("host".to_string(), make_info(2)),
+            ("namespace".to_string(), make_info("namespace", 1)),
+            ("host".to_string(), make_info("host", 2)),
         ])
     }
 
@@ -677,11 +679,11 @@ mod tests {
     }
 
     /// Helper function to create a name_to_column_id map
-    fn create_name_to_column_id(labels: &[&str]) -> HashMap<String, PhysicalColumnInfo> {
+    fn create_name_to_column_id(labels: &[&str]) -> HashMap<String, ColumnMetadata> {
         labels
             .iter()
             .enumerate()
-            .map(|(idx, name)| (name.to_string(), make_info(idx as ColumnId + 1)))
+            .map(|(idx, name)| (name.to_string(), make_info(name, idx as ColumnId + 1)))
             .collect()
     }
 
@@ -712,7 +714,7 @@ mod tests {
     fn extract_tsid(
         schema: Vec<ColumnSchema>,
         row: Row,
-        name_to_column_id: &HashMap<String, PhysicalColumnInfo>,
+        name_to_column_id: &HashMap<String, ColumnMetadata>,
         table_id: TableId,
     ) -> u64 {
         let rows = Rows {

--- a/src/metric-engine/src/row_modifier.rs
+++ b/src/metric-engine/src/row_modifier.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::Borrow;
 use std::collections::{BTreeMap, HashMap};
-use std::hash::{Hash, Hasher};
+use std::hash::Hasher;
 
 use api::v1::value::ValueData;
 use api::v1::{ColumnDataType, ColumnSchema, Row, Rows, SemanticType, Value};
@@ -30,6 +29,7 @@ use store_api::metric_engine_consts::{
 use store_api::storage::consts::{PRIMARY_KEY_COLUMN_NAME, ReservedColumnId};
 use store_api::storage::{ColumnId, TableId};
 
+use crate::engine::PhysicalColumnInfo;
 use crate::error::{EncodePrimaryKeySnafu, Result, TableIdCountMismatchSnafu};
 
 /// A row modifier modifies [`Rows`].
@@ -265,10 +265,10 @@ struct IterIndex {
 }
 
 impl IterIndex {
-    fn new<K>(row_schema: &[ColumnSchema], name_to_column_id: &HashMap<K, ColumnId>) -> Self
-    where
-        K: Eq + Hash + Borrow<str>,
-    {
+    fn new(
+        row_schema: &[ColumnSchema],
+        physical_columns: &HashMap<String, PhysicalColumnInfo>,
+    ) -> Self {
         let mut reserved_indices = SmallVec::<[ValueIndex; 2]>::new();
         // Uses BTreeMap to keep the primary key column name order (lexicographical)
         let mut primary_key_indices = BTreeMap::new();
@@ -294,9 +294,10 @@ impl IterIndex {
                         primary_key_indices.insert(
                             col.column_name.as_str(),
                             ValueIndex {
-                                column_id: *name_to_column_id
-                                    .get(col.column_name.as_str())
-                                    .unwrap(),
+                                column_id: physical_columns
+                                    .get(&col.column_name)
+                                    .unwrap()
+                                    .column_id,
                                 index: idx,
                             },
                         );
@@ -304,13 +305,13 @@ impl IterIndex {
                 },
                 SemanticType::Field => {
                     field_indices.push(ValueIndex {
-                        column_id: *name_to_column_id.get(col.column_name.as_str()).unwrap(),
+                        column_id: physical_columns.get(&col.column_name).unwrap().column_id,
                         index: idx,
                     });
                 }
                 SemanticType::Timestamp => {
                     ts_index = Some(ValueIndex {
-                        column_id: *name_to_column_id.get(col.column_name.as_str()).unwrap(),
+                        column_id: physical_columns.get(&col.column_name).unwrap().column_id,
                         index: idx,
                     });
                 }
@@ -344,11 +345,8 @@ pub struct RowsIter {
 }
 
 impl RowsIter {
-    pub fn new<K>(rows: Rows, name_to_column_id: &HashMap<K, ColumnId>) -> Self
-    where
-        K: Eq + Hash + Borrow<str>,
-    {
-        let index: IterIndex = IterIndex::new(&rows.schema, name_to_column_id);
+    pub fn new(rows: Rows, physical_columns: &HashMap<String, PhysicalColumnInfo>) -> Self {
+        let index: IterIndex = IterIndex::new(&rows.schema, physical_columns);
         Self { rows, index }
     }
 
@@ -464,8 +462,19 @@ mod tests {
         }
     }
 
-    fn test_name_to_column_id() -> HashMap<String, ColumnId> {
-        HashMap::from([("namespace".to_string(), 1), ("host".to_string(), 2)])
+    fn make_info(column_id: ColumnId) -> PhysicalColumnInfo {
+        PhysicalColumnInfo {
+            column_id,
+            data_type: datatypes::prelude::ConcreteDataType::string_datatype(),
+            semantic_type: SemanticType::Tag,
+        }
+    }
+
+    fn test_name_to_column_id() -> HashMap<String, PhysicalColumnInfo> {
+        HashMap::from([
+            ("namespace".to_string(), make_info(1)),
+            ("host".to_string(), make_info(2)),
+        ])
     }
 
     #[test]
@@ -666,11 +675,11 @@ mod tests {
     }
 
     /// Helper function to create a name_to_column_id map
-    fn create_name_to_column_id(labels: &[&str]) -> HashMap<String, ColumnId> {
+    fn create_name_to_column_id(labels: &[&str]) -> HashMap<String, PhysicalColumnInfo> {
         labels
             .iter()
             .enumerate()
-            .map(|(idx, name)| (name.to_string(), idx as ColumnId + 1))
+            .map(|(idx, name)| (name.to_string(), make_info(idx as ColumnId + 1)))
             .collect()
     }
 
@@ -701,7 +710,7 @@ mod tests {
     fn extract_tsid(
         schema: Vec<ColumnSchema>,
         row: Row,
-        name_to_column_id: &HashMap<String, ColumnId>,
+        name_to_column_id: &HashMap<String, PhysicalColumnInfo>,
         table_id: TableId,
     ) -> u64 {
         let rows = Rows {

--- a/src/metric-engine/src/row_modifier.rs
+++ b/src/metric-engine/src/row_modifier.rs
@@ -466,6 +466,8 @@ mod tests {
         PhysicalColumnInfo {
             column_id,
             data_type: datatypes::prelude::ConcreteDataType::string_datatype(),
+            is_nullable: false,
+            default_constraint: None,
             semantic_type: SemanticType::Tag,
         }
     }

--- a/tests/cases/standalone/common/alter/alter_table.result
+++ b/tests/cases/standalone/common/alter/alter_table.result
@@ -508,42 +508,42 @@ Affected Rows: 0
 ALTER TABLE
     t1
 ADD
-    COLUMN `at` STRING;
+    COLUMN `at` STRING PRIMARY KEY;
 
 Affected Rows: 0
 
 ALTER TABLE
     t2
 ADD
-    COLUMN at3 STRING;
+    COLUMN at3 STRING PRIMARY KEY;
 
 Affected Rows: 0
 
 ALTER TABLE
     t2
 ADD
-    COLUMN `at` STRING;
+    COLUMN `at` STRING PRIMARY KEY;
 
 Affected Rows: 0
 
 ALTER TABLE
     t2
 ADD
-    COLUMN at2 STRING;
+    COLUMN at2 STRING PRIMARY KEY;
 
 Affected Rows: 0
 
 ALTER TABLE
     t2
 ADD
-    COLUMN at4 UINT16;
+    COLUMN at4 STRING PRIMARY KEY;
 
 Affected Rows: 0
 
 INSERT INTO
     t2
 VALUES
-    ("loc_1", "loc_2", "loc_3", 2, 'job1', 0, 1);
+    ("loc_1", "loc_2", "loc_3", "loc_4", 'job1', 0, 1);
 
 Affected Rows: 1
 
@@ -552,11 +552,11 @@ SELECT
 FROM
     t2;
 
-+-------+-------+-------+-----+------+---------------------+-----+
-| at    | at2   | at3   | at4 | job  | ts                  | val |
-+-------+-------+-------+-----+------+---------------------+-----+
-| loc_1 | loc_2 | loc_3 | 2   | job1 | 1970-01-01T00:00:00 | 1.0 |
-+-------+-------+-------+-----+------+---------------------+-----+
++-------+-------+-------+-------+------+---------------------+-----+
+| at    | at2   | at3   | at4   | job  | ts                  | val |
++-------+-------+-------+-------+------+---------------------+-----+
+| loc_1 | loc_2 | loc_3 | loc_4 | job1 | 1970-01-01T00:00:00 | 1.0 |
++-------+-------+-------+-------+------+---------------------+-----+
 
 DROP TABLE t1;
 

--- a/tests/cases/standalone/common/alter/alter_table.sql
+++ b/tests/cases/standalone/common/alter/alter_table.sql
@@ -184,32 +184,32 @@ CREATE TABLE t2 (
 ALTER TABLE
     t1
 ADD
-    COLUMN `at` STRING;
+    COLUMN `at` STRING PRIMARY KEY;
 
 ALTER TABLE
     t2
 ADD
-    COLUMN at3 STRING;
+    COLUMN at3 STRING PRIMARY KEY;
 
 ALTER TABLE
     t2
 ADD
-    COLUMN `at` STRING;
+    COLUMN `at` STRING PRIMARY KEY;
 
 ALTER TABLE
     t2
 ADD
-    COLUMN at2 STRING;
+    COLUMN at2 STRING PRIMARY KEY;
 
 ALTER TABLE
     t2
 ADD
-    COLUMN at4 UINT16;
+    COLUMN at4 STRING PRIMARY KEY;
 
 INSERT INTO
     t2
 VALUES
-    ("loc_1", "loc_2", "loc_3", 2, 'job1', 0, 1);
+    ("loc_1", "loc_2", "loc_3", "loc_4", 'job1', 0, 1);
 
 SELECT
     *

--- a/tests/cases/standalone/common/insert/logical_metric_table.result
+++ b/tests/cases/standalone/common/insert/logical_metric_table.result
@@ -77,6 +77,39 @@ DROP TABLE phy;
 
 Affected Rows: 0
 
+CREATE TABLE phy_default (ts timestamp time index, val double default 42) engine=metric with ("physical_metric_table" = "");
+
+Affected Rows: 0
+
+CREATE TABLE t_default (ts timestamp time index, val double default 42, host string primary key) engine = metric with ("on_physical_table" = "phy_default");
+
+Affected Rows: 0
+
+INSERT INTO t_default (host, ts) VALUES ('host1', 0), ('host2', 1);
+
+Affected Rows: 2
+
+SELECT host, ts, val FROM t_default ORDER BY host;
+
++-------+-------------------------+------+
+| host  | ts                      | val  |
++-------+-------------------------+------+
+| host1 | 1970-01-01T00:00:00     | 42.0 |
+| host2 | 1970-01-01T00:00:00.001 | 42.0 |
++-------+-------------------------+------+
+
+INSERT INTO t_default (host, val) VALUES ('host3', 3);
+
+Error: 1004(InvalidArguments), Invalid request for region 4415226380288(1028, 0), reason: missing required time index column ts
+
+DROP TABLE t_default;
+
+Affected Rows: 0
+
+DROP TABLE phy_default;
+
+Affected Rows: 0
+
 CREATE TABLE phy (
     ts timestamp time index,
     val double

--- a/tests/cases/standalone/common/insert/logical_metric_table.result
+++ b/tests/cases/standalone/common/insert/logical_metric_table.result
@@ -98,9 +98,10 @@ SELECT host, ts, val FROM t_default ORDER BY host;
 | host2 | 1970-01-01T00:00:00.001 | 42.0 |
 +-------+-------------------------+------+
 
+-- SQLNESS REPLACE (region\s\d+\(\d+\,\s\d+\)) region
 INSERT INTO t_default (host, val) VALUES ('host3', 3);
 
-Error: 1004(InvalidArguments), Invalid request for region 4415226380288(1028, 0), reason: missing required time index column ts
+Error: 1004(InvalidArguments), Invalid request for region, reason: missing required time index column ts
 
 DROP TABLE t_default;
 

--- a/tests/cases/standalone/common/insert/logical_metric_table.sql
+++ b/tests/cases/standalone/common/insert/logical_metric_table.sql
@@ -32,6 +32,7 @@ INSERT INTO t_default (host, ts) VALUES ('host1', 0), ('host2', 1);
 
 SELECT host, ts, val FROM t_default ORDER BY host;
 
+-- SQLNESS REPLACE (region\s\d+\(\d+\,\s\d+\)) region
 INSERT INTO t_default (host, val) VALUES ('host3', 3);
 
 DROP TABLE t_default;

--- a/tests/cases/standalone/common/insert/logical_metric_table.sql
+++ b/tests/cases/standalone/common/insert/logical_metric_table.sql
@@ -24,6 +24,20 @@ SELECT ts, val, __tsid, host, job FROM phy;
 
 DROP TABLE phy;
 
+CREATE TABLE phy_default (ts timestamp time index, val double default 42) engine=metric with ("physical_metric_table" = "");
+
+CREATE TABLE t_default (ts timestamp time index, val double default 42, host string primary key) engine = metric with ("on_physical_table" = "phy_default");
+
+INSERT INTO t_default (host, ts) VALUES ('host1', 0), ('host2', 1);
+
+SELECT host, ts, val FROM t_default ORDER BY host;
+
+INSERT INTO t_default (host, val) VALUES ('host3', 3);
+
+DROP TABLE t_default;
+
+DROP TABLE phy_default;
+
 CREATE TABLE phy (
     ts timestamp time index,
     val double


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Fixes #7990.

## What's changed and what's your intention?

The remote-write path into the metric engine previously bypassed schema validation. When a row's time index column carried a non-timestamp datatype (e.g. a string), the request reached mito's `ValueBuilder::push` for the timestamp builder and panicked instead of surfacing a typed error.

Per discussion on #7990, the cache on `PhysicalRegionState` now keeps the tuple needed for validation:

```rust
pub struct PhysicalColumnInfo {
    pub column_id: ColumnId,
    pub data_type: ConcreteDataType,
    pub semantic_type: SemanticType,
}
```

`verify_rows` now:

- rejects columns whose `datatype` or `semantic_type` disagrees with the physical region's schema (mirrors mito's `WriteRequest::check_schema`)
- rejects requests that omit the time index column entirely

Field columns stay optional — the metric engine doesn't require every value column on every write. Tag completeness needs per-logical-region metadata that `verify_rows` doesn't have, and is left to a follow-up.

### Before / After

| | Before | After |
|---|---|---|
| Put \`String\` into time index column | Panic inside \`ValueBuilder::push\` (#7990) | \`InvalidArguments\` error with clear type-mismatch message |
| Put without a time index column | Panic inside mito at \`ValueBuilder::push\` on empty builder | \`InvalidArguments\` error: \`missing required time index column <name>\` |
| Put without a field column (non-null column still rejected downstream) | Same behaviour | Same behaviour — \`verify_rows\` does not block |

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.