### PR TITLE
fix!: align gRPC CLI option names with config naming

### DIFF
--- a/.github/workflows/run-multi-lang-tests.yml
+++ b/.github/workflows/run-multi-lang-tests.yml
@@ -127,7 +127,7 @@ jobs:
         run: |
           ./bins/greptime standalone start \
             --http-addr 0.0.0.0:${{ inputs.http-port }} \
-            --rpc-addr 0.0.0.0:4001 \
+            --grpc-bind-addr 0.0.0.0:4001 \
             --mysql-addr 0.0.0.0:${{ inputs.mysql-port }} \
             --postgres-addr 0.0.0.0:${{ inputs.postgres-port }} \
             --user-provider=static_user_provider:cmd:${{ inputs.username }}=${{ inputs.password }} > /tmp/greptimedb.log 2>&1 &

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ docker run -p 127.0.0.1:4000-4003:4000-4003 \
   --name greptime --rm \
   greptime/greptimedb:latest standalone start \
   --http-addr 0.0.0.0:4000 \
-  --rpc-bind-addr 0.0.0.0:4001 \
+  --grpc-bind-addr 0.0.0.0:4001 \
   --mysql-addr 0.0.0.0:4002 \
   --postgres-addr 0.0.0.0:4003
 ```

--- a/config/config.md
+++ b/config/config.md
@@ -259,7 +259,7 @@
 | `grpc.tls.watch` | Bool | `false` | Watch for Certificate and key file change and auto reload.<br/>For now, gRPC tls config does not support auto reload. |
 | `internal_grpc` | -- | -- | The internal gRPC server options. Internal gRPC port for nodes inside cluster to access frontend. |
 | `internal_grpc.bind_addr` | String | `127.0.0.1:4010` | The address to bind the gRPC server. |
-| `internal_grpc.server_addr` | String | `127.0.0.1:4010` | The address advertised to the metasrv, and used for connections from outside the host.<br/>If left empty or unset, the server will automatically use the IP address of the first network interface<br/>on the host, with the same port number as the one specified in `grpc.bind_addr`. |
+| `internal_grpc.server_addr` | String | `127.0.0.1:4010` | The address advertised to the metasrv, and used for connections from outside the host.<br/>If left empty or unset, the server will automatically use the IP address of the first network interface<br/>on the host, with the same port number as the one specified in `internal_grpc.bind_addr`. |
 | `internal_grpc.runtime_size` | Integer | `8` | The number of server worker threads. |
 | `internal_grpc.flight_compression` | String | `arrow_ipc` | Compression mode for frontend side Arrow IPC service. Available options:<br/>- `none`: disable all compression<br/>- `transport`: only enable gRPC transport compression (zstd)<br/>- `arrow_ipc`: only enable Arrow IPC compression (lz4)<br/>- `all`: enable all compression.<br/>Default to `none` |
 | `internal_grpc.tls` | -- | -- | internal gRPC server TLS options, see `mysql.tls` section. |
@@ -378,7 +378,7 @@
 | `backend_client.connect_timeout` | String | `3s` | The connect timeout for backend client. |
 | `grpc` | -- | -- | The gRPC server options. |
 | `grpc.bind_addr` | String | `127.0.0.1:3002` | The address to bind the gRPC server. |
-| `grpc.server_addr` | String | `127.0.0.1:3002` | The communication server address for the frontend and datanode to connect to metasrv.<br/>If left empty or unset, the server will automatically use the IP address of the first network interface<br/>on the host, with the same port number as the one specified in `bind_addr`. |
+| `grpc.server_addr` | String | `127.0.0.1:3002` | The communication server address for the frontend and datanode to connect to metasrv.<br/>If left empty or unset, the server will automatically use the IP address of the first network interface<br/>on the host, with the same port number as the one specified in `grpc.bind_addr`. |
 | `grpc.runtime_size` | Integer | `8` | The number of server worker threads. |
 | `grpc.max_recv_message_size` | String | `512MB` | The maximum receive message size for gRPC server. |
 | `grpc.max_send_message_size` | String | `512MB` | The maximum send message size for gRPC server. |

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -100,7 +100,7 @@ watch = false
 bind_addr = "127.0.0.1:4010"
 ## The address advertised to the metasrv, and used for connections from outside the host.
 ## If left empty or unset, the server will automatically use the IP address of the first network interface
-## on the host, with the same port number as the one specified in `grpc.bind_addr`.
+## on the host, with the same port number as the one specified in `internal_grpc.bind_addr`.
 server_addr = "127.0.0.1:4010"
 ## The number of server worker threads.
 runtime_size = 8

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -136,7 +136,7 @@ ca_cert_path = ""
 bind_addr = "127.0.0.1:3002"
 ## The communication server address for the frontend and datanode to connect to metasrv.
 ## If left empty or unset, the server will automatically use the IP address of the first network interface
-## on the host, with the same port number as the one specified in `bind_addr`.
+## on the host, with the same port number as the one specified in `grpc.bind_addr`.
 server_addr = "127.0.0.1:3002"
 ## The number of server worker threads.
 runtime_size = 8

--- a/docker/docker-compose/cluster-with-etcd.yaml
+++ b/docker/docker-compose/cluster-with-etcd.yaml
@@ -85,8 +85,8 @@ services:
     command:
       - metasrv
       - start
-      - --rpc-bind-addr=0.0.0.0:3002
-      - --rpc-server-addr=metasrv:3002
+      - --grpc-bind-addr=0.0.0.0:3002
+      - --grpc-server-addr=metasrv:3002
       - --store-addrs=etcd0:2379
       - --http-addr=0.0.0.0:3000
     healthcheck:
@@ -111,8 +111,8 @@ services:
       - start
       - --node-id=0
       - --data-home=/greptimedb_data
-      - --rpc-bind-addr=0.0.0.0:3001
-      - --rpc-server-addr=datanode0:3001
+      - --grpc-bind-addr=0.0.0.0:3001
+      - --grpc-server-addr=datanode0:3001
       - --metasrv-addrs=metasrv:3002
       - --http-addr=0.0.0.0:5000
     volumes:
@@ -141,7 +141,7 @@ services:
       - start
       - --metasrv-addrs=metasrv:3002
       - --http-addr=0.0.0.0:4000
-      - --rpc-bind-addr=0.0.0.0:4001
+      - --grpc-bind-addr=0.0.0.0:4001
       - --mysql-addr=0.0.0.0:4002
       - --postgres-addr=0.0.0.0:4003
     healthcheck:
@@ -166,8 +166,8 @@ services:
       - start
       - --node-id=0
       - --metasrv-addrs=metasrv:3002
-      - --rpc-bind-addr=0.0.0.0:4004
-      - --rpc-server-addr=flownode0:4004
+      - --grpc-bind-addr=0.0.0.0:4004
+      - --grpc-server-addr=flownode0:4004
       - --http-addr=0.0.0.0:4005
     depends_on:
       frontend0:

--- a/src/cmd/src/cli.rs
+++ b/src/cmd/src/cli.rs
@@ -162,7 +162,7 @@ mod tests {
             &*output_dir.path().to_string_lossy(),
             "--http-addr",
             &http_addr,
-            "--rpc-bind-addr",
+            "--grpc-bind-addr",
             &rpc_addr,
             "--mysql-addr",
             &mysql_addr,

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -197,13 +197,17 @@ pub struct StartCommand {
     #[clap(long)]
     node_id: Option<u64>,
     /// The address to bind the gRPC server.
-    #[clap(long, alias = "rpc-addr")]
-    rpc_bind_addr: Option<String>,
+    #[clap(long = "grpc-bind-addr", alias = "rpc-bind-addr", alias = "rpc-addr")]
+    grpc_bind_addr: Option<String>,
     /// The address advertised to the metasrv, and used for connections from outside the host.
     /// If left empty or unset, the server will automatically use the IP address of the first network interface
-    /// on the host, with the same port number as the one specified in `rpc_bind_addr`.
-    #[clap(long, alias = "rpc-hostname")]
-    rpc_server_addr: Option<String>,
+    /// on the host, with the same port number as the one specified in `grpc_bind_addr`.
+    #[clap(
+        long = "grpc-server-addr",
+        alias = "rpc-server-addr",
+        alias = "rpc-hostname"
+    )]
+    grpc_server_addr: Option<String>,
     #[clap(long, value_delimiter = ',', num_args = 1..)]
     metasrv_addrs: Option<Vec<String>>,
     #[clap(short, long)]
@@ -256,20 +260,20 @@ impl StartCommand {
             tokio_console_addr: global_options.tokio_console_addr.clone(),
         };
 
-        if let Some(addr) = &self.rpc_bind_addr {
+        if let Some(addr) = &self.grpc_bind_addr {
             opts.grpc.bind_addr.clone_from(addr);
         } else if let Some(addr) = &opts.rpc_addr {
             warn!(
-                "Use the deprecated attribute `DatanodeOptions.rpc_addr`, please use `grpc.addr` instead."
+                "Use the deprecated attribute `DatanodeOptions.rpc_addr`, please use `grpc.bind_addr` instead."
             );
             opts.grpc.bind_addr.clone_from(addr);
         }
 
-        if let Some(server_addr) = &self.rpc_server_addr {
+        if let Some(server_addr) = &self.grpc_server_addr {
             opts.grpc.server_addr.clone_from(server_addr);
         } else if let Some(server_addr) = &opts.rpc_hostname {
             warn!(
-                "Use the deprecated attribute `DatanodeOptions.rpc_hostname`, please use `grpc.hostname` instead."
+                "Use the deprecated attribute `DatanodeOptions.rpc_hostname`, please use `grpc.server_addr` instead."
             );
             opts.grpc.server_addr.clone_from(server_addr);
         }
@@ -360,6 +364,7 @@ mod tests {
     use std::io::Write;
     use std::time::Duration;
 
+    use clap::{CommandFactory, Parser};
     use common_config::ENV_VAR_SEP;
     use common_test_util::temp_dir::create_named_temp_file;
     use object_store::config::{FileConfig, GcsConfig, ObjectStoreConfig, S3Config};
@@ -402,8 +407,8 @@ mod tests {
             node_id = 42
 
             [grpc]
-            addr = "127.0.0.1:3001"
-            hostname = "127.0.0.1"
+            bind_addr = "127.0.0.1:3001"
+            server_addr = "127.0.0.1"
             runtime_size = 8
 
             [meta_client]
@@ -449,6 +454,7 @@ mod tests {
         let options = cmd.load_options(&Default::default()).unwrap().component;
 
         assert_eq!("127.0.0.1:3001".to_string(), options.grpc.bind_addr);
+        assert_eq!("127.0.0.1".to_string(), options.grpc.server_addr);
         assert_eq!(Some(42), options.node_id);
 
         let DatanodeWalConfig::RaftEngine(raft_engine_config) = options.wal else {
@@ -660,5 +666,56 @@ mod tests {
                 assert_eq!(opts.grpc.server_addr, "10.103.174.219");
             },
         );
+    }
+
+    #[test]
+    fn test_parse_grpc_cli_aliases() {
+        let command = StartCommand::try_parse_from([
+            "datanode",
+            "--grpc-bind-addr",
+            "127.0.0.1:13001",
+            "--grpc-server-addr",
+            "10.0.0.1:13001",
+        ])
+        .unwrap();
+        assert_eq!(command.grpc_bind_addr.as_deref(), Some("127.0.0.1:13001"));
+        assert_eq!(command.grpc_server_addr.as_deref(), Some("10.0.0.1:13001"));
+
+        let command = StartCommand::try_parse_from([
+            "datanode",
+            "--rpc-bind-addr",
+            "127.0.0.1:23001",
+            "--rpc-server-addr",
+            "10.0.0.2:23001",
+        ])
+        .unwrap();
+        assert_eq!(command.grpc_bind_addr.as_deref(), Some("127.0.0.1:23001"));
+        assert_eq!(command.grpc_server_addr.as_deref(), Some("10.0.0.2:23001"));
+
+        let command = StartCommand::try_parse_from([
+            "datanode",
+            "--rpc-addr",
+            "127.0.0.1:33001",
+            "--rpc-hostname",
+            "10.0.0.3:33001",
+        ])
+        .unwrap();
+        assert_eq!(command.grpc_bind_addr.as_deref(), Some("127.0.0.1:33001"));
+        assert_eq!(command.grpc_server_addr.as_deref(), Some("10.0.0.3:33001"));
+    }
+
+    #[test]
+    fn test_help_uses_grpc_option_names() {
+        let mut cmd = StartCommand::command();
+        let mut help = Vec::new();
+        cmd.write_long_help(&mut help).unwrap();
+        let help = String::from_utf8(help).unwrap();
+
+        assert!(help.contains("--grpc-bind-addr"));
+        assert!(help.contains("--grpc-server-addr"));
+        assert!(!help.contains("--rpc-bind-addr"));
+        assert!(!help.contains("--rpc-server-addr"));
+        assert!(!help.contains("--rpc-addr"));
+        assert!(!help.contains("--rpc-hostname"));
     }
 }

--- a/src/cmd/src/flownode.rs
+++ b/src/cmd/src/flownode.rs
@@ -139,13 +139,17 @@ struct StartCommand {
     #[clap(long)]
     node_id: Option<u64>,
     /// Bind address for the gRPC server.
-    #[clap(long, alias = "rpc-addr")]
-    rpc_bind_addr: Option<String>,
+    #[clap(long = "grpc-bind-addr", alias = "rpc-bind-addr", alias = "rpc-addr")]
+    grpc_bind_addr: Option<String>,
     /// The address advertised to the metasrv, and used for connections from outside the host.
     /// If left empty or unset, the server will automatically use the IP address of the first network interface
-    /// on the host, with the same port number as the one specified in `rpc_bind_addr`.
-    #[clap(long, alias = "rpc-hostname")]
-    rpc_server_addr: Option<String>,
+    /// on the host, with the same port number as the one specified in `grpc_bind_addr`.
+    #[clap(
+        long = "grpc-server-addr",
+        alias = "rpc-server-addr",
+        alias = "rpc-hostname"
+    )]
+    grpc_server_addr: Option<String>,
     /// Metasrv address list;
     #[clap(long, value_delimiter = ',', num_args = 1..)]
     metasrv_addrs: Option<Vec<String>>,
@@ -207,11 +211,11 @@ impl StartCommand {
             tokio_console_addr: global_options.tokio_console_addr.clone(),
         };
 
-        if let Some(addr) = &self.rpc_bind_addr {
+        if let Some(addr) = &self.grpc_bind_addr {
             opts.grpc.bind_addr.clone_from(addr);
         }
 
-        if let Some(server_addr) = &self.rpc_server_addr {
+        if let Some(server_addr) = &self.grpc_server_addr {
             opts.grpc.server_addr.clone_from(server_addr);
         }
 
@@ -430,5 +434,63 @@ impl StartCommand {
             .await;
 
         Ok(Instance::new(flownode, guard))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::{CommandFactory, Parser};
+
+    use super::*;
+
+    #[test]
+    fn test_parse_grpc_cli_aliases() {
+        let command = StartCommand::try_parse_from([
+            "flownode",
+            "--grpc-bind-addr",
+            "127.0.0.1:14004",
+            "--grpc-server-addr",
+            "10.0.0.1:14004",
+        ])
+        .unwrap();
+        assert_eq!(command.grpc_bind_addr.as_deref(), Some("127.0.0.1:14004"));
+        assert_eq!(command.grpc_server_addr.as_deref(), Some("10.0.0.1:14004"));
+
+        let command = StartCommand::try_parse_from([
+            "flownode",
+            "--rpc-bind-addr",
+            "127.0.0.1:24004",
+            "--rpc-server-addr",
+            "10.0.0.2:24004",
+        ])
+        .unwrap();
+        assert_eq!(command.grpc_bind_addr.as_deref(), Some("127.0.0.1:24004"));
+        assert_eq!(command.grpc_server_addr.as_deref(), Some("10.0.0.2:24004"));
+
+        let command = StartCommand::try_parse_from([
+            "flownode",
+            "--rpc-addr",
+            "127.0.0.1:34004",
+            "--rpc-hostname",
+            "10.0.0.3:34004",
+        ])
+        .unwrap();
+        assert_eq!(command.grpc_bind_addr.as_deref(), Some("127.0.0.1:34004"));
+        assert_eq!(command.grpc_server_addr.as_deref(), Some("10.0.0.3:34004"));
+    }
+
+    #[test]
+    fn test_help_uses_grpc_option_names() {
+        let mut cmd = StartCommand::command();
+        let mut help = Vec::new();
+        cmd.write_long_help(&mut help).unwrap();
+        let help = String::from_utf8(help).unwrap();
+
+        assert!(help.contains("--grpc-bind-addr"));
+        assert!(help.contains("--grpc-server-addr"));
+        assert!(!help.contains("--rpc-bind-addr"));
+        assert!(!help.contains("--rpc-server-addr"));
+        assert!(!help.contains("--rpc-addr"));
+        assert!(!help.contains("--rpc-hostname"));
     }
 }

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -152,21 +152,33 @@ impl SubCommand {
 #[derive(Debug, Default, Parser)]
 pub struct StartCommand {
     /// The address to bind the gRPC server.
-    #[clap(long, alias = "rpc-addr")]
-    rpc_bind_addr: Option<String>,
+    #[clap(long = "grpc-bind-addr", alias = "rpc-bind-addr", alias = "rpc-addr")]
+    grpc_bind_addr: Option<String>,
     /// The address advertised to the metasrv, and used for connections from outside the host.
     /// If left empty or unset, the server will automatically use the IP address of the first network interface
-    /// on the host, with the same port number as the one specified in `rpc_bind_addr`.
-    #[clap(long, alias = "rpc-hostname")]
-    rpc_server_addr: Option<String>,
+    /// on the host, with the same port number as the one specified in `grpc_bind_addr`.
+    #[clap(
+        long = "grpc-server-addr",
+        alias = "rpc-server-addr",
+        alias = "rpc-hostname"
+    )]
+    grpc_server_addr: Option<String>,
     /// The address to bind the internal gRPC server.
-    #[clap(long, alias = "internal-rpc-addr")]
-    internal_rpc_bind_addr: Option<String>,
+    #[clap(
+        long = "internal-grpc-bind-addr",
+        alias = "internal-rpc-bind-addr",
+        alias = "internal-rpc-addr"
+    )]
+    internal_grpc_bind_addr: Option<String>,
     /// The address advertised to the metasrv, and used for connections from outside the host.
     /// If left empty or unset, the server will automatically use the IP address of the first network interface
-    /// on the host, with the same port number as the one specified in `internal_rpc_bind_addr`.
-    #[clap(long, alias = "internal-rpc-hostname")]
-    internal_rpc_server_addr: Option<String>,
+    /// on the host, with the same port number as the one specified in `internal_grpc_bind_addr`.
+    #[clap(
+        long = "internal-grpc-server-addr",
+        alias = "internal-rpc-server-addr",
+        alias = "internal-rpc-hostname"
+    )]
+    internal_grpc_server_addr: Option<String>,
     #[clap(long)]
     http_addr: Option<String>,
     #[clap(long)]
@@ -258,16 +270,16 @@ impl StartCommand {
             opts.http.disable_dashboard = disable_dashboard;
         }
 
-        if let Some(addr) = &self.rpc_bind_addr {
+        if let Some(addr) = &self.grpc_bind_addr {
             opts.grpc.bind_addr.clone_from(addr);
             opts.grpc.tls = merge_tls_option(&opts.grpc.tls, tls_opts.clone());
         }
 
-        if let Some(addr) = &self.rpc_server_addr {
+        if let Some(addr) = &self.grpc_server_addr {
             opts.grpc.server_addr.clone_from(addr);
         }
 
-        if let Some(addr) = &self.internal_rpc_bind_addr {
+        if let Some(addr) = &self.internal_grpc_bind_addr {
             if let Some(internal_grpc) = &mut opts.internal_grpc {
                 internal_grpc.bind_addr = addr.clone();
             } else {
@@ -280,7 +292,7 @@ impl StartCommand {
             }
         }
 
-        if let Some(addr) = &self.internal_rpc_server_addr {
+        if let Some(addr) = &self.internal_grpc_server_addr {
             if let Some(internal_grpc) = &mut opts.internal_grpc {
                 internal_grpc.server_addr = addr.clone();
             } else {
@@ -515,6 +527,7 @@ mod tests {
     use std::time::Duration;
 
     use auth::{Identity, Password, UserProviderRef};
+    use clap::{CommandFactory, Parser};
     use common_base::readable_size::ReadableSize;
     use common_config::ENV_VAR_SEP;
     use common_test_util::temp_dir::create_named_temp_file;
@@ -530,8 +543,8 @@ mod tests {
             http_addr: Some("127.0.0.1:1234".to_string()),
             mysql_addr: Some("127.0.0.1:5678".to_string()),
             postgres_addr: Some("127.0.0.1:5432".to_string()),
-            internal_rpc_bind_addr: Some("127.0.0.1:4010".to_string()),
-            internal_rpc_server_addr: Some("10.0.0.24:4010".to_string()),
+            internal_grpc_bind_addr: Some("127.0.0.1:4010".to_string()),
+            internal_grpc_server_addr: Some("10.0.0.24:4010".to_string()),
             influxdb_enable: Some(false),
             disable_dashboard: Some(false),
             ..Default::default()
@@ -743,5 +756,98 @@ mod tests {
                 assert_eq!(fe_opts.grpc.bind_addr, GrpcOptions::default().bind_addr);
             },
         );
+    }
+
+    #[test]
+    fn test_parse_grpc_cli_aliases() {
+        let command = StartCommand::try_parse_from([
+            "frontend",
+            "--grpc-bind-addr",
+            "127.0.0.1:14001",
+            "--grpc-server-addr",
+            "10.0.0.1:14001",
+            "--internal-grpc-bind-addr",
+            "127.0.0.1:14010",
+            "--internal-grpc-server-addr",
+            "10.0.0.1:14010",
+        ])
+        .unwrap();
+        assert_eq!(command.grpc_bind_addr.as_deref(), Some("127.0.0.1:14001"));
+        assert_eq!(command.grpc_server_addr.as_deref(), Some("10.0.0.1:14001"));
+        assert_eq!(
+            command.internal_grpc_bind_addr.as_deref(),
+            Some("127.0.0.1:14010")
+        );
+        assert_eq!(
+            command.internal_grpc_server_addr.as_deref(),
+            Some("10.0.0.1:14010")
+        );
+
+        let command = StartCommand::try_parse_from([
+            "frontend",
+            "--rpc-bind-addr",
+            "127.0.0.1:24001",
+            "--rpc-server-addr",
+            "10.0.0.2:24001",
+            "--internal-rpc-bind-addr",
+            "127.0.0.1:24010",
+            "--internal-rpc-server-addr",
+            "10.0.0.2:24010",
+        ])
+        .unwrap();
+        assert_eq!(command.grpc_bind_addr.as_deref(), Some("127.0.0.1:24001"));
+        assert_eq!(command.grpc_server_addr.as_deref(), Some("10.0.0.2:24001"));
+        assert_eq!(
+            command.internal_grpc_bind_addr.as_deref(),
+            Some("127.0.0.1:24010")
+        );
+        assert_eq!(
+            command.internal_grpc_server_addr.as_deref(),
+            Some("10.0.0.2:24010")
+        );
+
+        let command = StartCommand::try_parse_from([
+            "frontend",
+            "--rpc-addr",
+            "127.0.0.1:34001",
+            "--rpc-hostname",
+            "10.0.0.3:34001",
+            "--internal-rpc-addr",
+            "127.0.0.1:34010",
+            "--internal-rpc-hostname",
+            "10.0.0.3:34010",
+        ])
+        .unwrap();
+        assert_eq!(command.grpc_bind_addr.as_deref(), Some("127.0.0.1:34001"));
+        assert_eq!(command.grpc_server_addr.as_deref(), Some("10.0.0.3:34001"));
+        assert_eq!(
+            command.internal_grpc_bind_addr.as_deref(),
+            Some("127.0.0.1:34010")
+        );
+        assert_eq!(
+            command.internal_grpc_server_addr.as_deref(),
+            Some("10.0.0.3:34010")
+        );
+    }
+
+    #[test]
+    fn test_help_uses_grpc_option_names() {
+        let mut cmd = StartCommand::command();
+        let mut help = Vec::new();
+        cmd.write_long_help(&mut help).unwrap();
+        let help = String::from_utf8(help).unwrap();
+
+        assert!(help.contains("--grpc-bind-addr"));
+        assert!(help.contains("--grpc-server-addr"));
+        assert!(help.contains("--internal-grpc-bind-addr"));
+        assert!(help.contains("--internal-grpc-server-addr"));
+        assert!(!help.contains("--rpc-bind-addr"));
+        assert!(!help.contains("--rpc-server-addr"));
+        assert!(!help.contains("--rpc-addr"));
+        assert!(!help.contains("--rpc-hostname"));
+        assert!(!help.contains("--internal-rpc-bind-addr"));
+        assert!(!help.contains("--internal-rpc-server-addr"));
+        assert!(!help.contains("--internal-rpc-addr"));
+        assert!(!help.contains("--internal-rpc-hostname"));
     }
 }

--- a/src/cmd/src/metasrv.rs
+++ b/src/cmd/src/metasrv.rs
@@ -141,13 +141,17 @@ impl SubCommand {
 #[derive(Default, Parser)]
 pub struct StartCommand {
     /// The address to bind the gRPC server.
-    #[clap(long, alias = "bind-addr")]
-    rpc_bind_addr: Option<String>,
+    #[clap(long = "grpc-bind-addr", alias = "rpc-bind-addr", alias = "bind-addr")]
+    grpc_bind_addr: Option<String>,
     /// The communication server address for the frontend and datanode to connect to metasrv.
     /// If left empty or unset, the server will automatically use the IP address of the first network interface
-    /// on the host, with the same port number as the one specified in `rpc_bind_addr`.
-    #[clap(long, alias = "server-addr")]
-    rpc_server_addr: Option<String>,
+    /// on the host, with the same port number as the one specified in `grpc_bind_addr`.
+    #[clap(
+        long = "grpc-server-addr",
+        alias = "rpc-server-addr",
+        alias = "server-addr"
+    )]
+    grpc_server_addr: Option<String>,
     #[clap(long, alias = "store-addr", value_delimiter = ',', num_args = 1..)]
     store_addrs: Option<Vec<String>>,
     #[clap(short, long)]
@@ -179,8 +183,8 @@ pub struct StartCommand {
 impl Debug for StartCommand {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("StartCommand")
-            .field("rpc_bind_addr", &self.rpc_bind_addr)
-            .field("rpc_server_addr", &self.rpc_server_addr)
+            .field("grpc_bind_addr", &self.grpc_bind_addr)
+            .field("grpc_server_addr", &self.grpc_server_addr)
             .field("store_addrs", &self.sanitize_store_addrs())
             .field("config_file", &self.config_file)
             .field("selector", &self.selector)
@@ -240,7 +244,7 @@ impl StartCommand {
         };
 
         #[allow(deprecated)]
-        if let Some(addr) = &self.rpc_bind_addr {
+        if let Some(addr) = &self.grpc_bind_addr {
             opts.bind_addr.clone_from(addr);
             opts.grpc.bind_addr.clone_from(addr);
         } else if !opts.bind_addr.is_empty() {
@@ -248,7 +252,7 @@ impl StartCommand {
         }
 
         #[allow(deprecated)]
-        if let Some(addr) = &self.rpc_server_addr {
+        if let Some(addr) = &self.grpc_server_addr {
             opts.server_addr.clone_from(addr);
             opts.grpc.server_addr.clone_from(addr);
         } else if !opts.server_addr.is_empty() {
@@ -353,6 +357,7 @@ impl StartCommand {
 mod tests {
     use std::io::Write;
 
+    use clap::{CommandFactory, Parser};
     use common_base::readable_size::ReadableSize;
     use common_config::ENV_VAR_SEP;
     use common_test_util::temp_dir::create_named_temp_file;
@@ -363,8 +368,8 @@ mod tests {
     #[test]
     fn test_read_from_cmd() {
         let cmd = StartCommand {
-            rpc_bind_addr: Some("127.0.0.1:3002".to_string()),
-            rpc_server_addr: Some("127.0.0.1:3002".to_string()),
+            grpc_bind_addr: Some("127.0.0.1:3002".to_string()),
+            grpc_server_addr: Some("127.0.0.1:3002".to_string()),
             store_addrs: Some(vec!["127.0.0.1:2380".to_string()]),
             selector: Some("LoadBased".to_string()),
             ..Default::default()
@@ -432,8 +437,8 @@ mod tests {
     #[test]
     fn test_load_log_options_from_cli() {
         let cmd = StartCommand {
-            rpc_bind_addr: Some("127.0.0.1:3002".to_string()),
-            rpc_server_addr: Some("127.0.0.1:3002".to_string()),
+            grpc_bind_addr: Some("127.0.0.1:3002".to_string()),
+            grpc_server_addr: Some("127.0.0.1:3002".to_string()),
             store_addrs: Some(vec!["127.0.0.1:2380".to_string()]),
             selector: Some("LoadBased".to_string()),
             ..Default::default()
@@ -519,5 +524,56 @@ mod tests {
                 assert_eq!(opts.store_addrs, vec!["127.0.0.1:2379".to_string()]);
             },
         );
+    }
+
+    #[test]
+    fn test_parse_grpc_cli_aliases() {
+        let command = StartCommand::try_parse_from([
+            "metasrv",
+            "--grpc-bind-addr",
+            "127.0.0.1:13002",
+            "--grpc-server-addr",
+            "10.0.0.1:13002",
+        ])
+        .unwrap();
+        assert_eq!(command.grpc_bind_addr.as_deref(), Some("127.0.0.1:13002"));
+        assert_eq!(command.grpc_server_addr.as_deref(), Some("10.0.0.1:13002"));
+
+        let command = StartCommand::try_parse_from([
+            "metasrv",
+            "--rpc-bind-addr",
+            "127.0.0.1:23002",
+            "--rpc-server-addr",
+            "10.0.0.2:23002",
+        ])
+        .unwrap();
+        assert_eq!(command.grpc_bind_addr.as_deref(), Some("127.0.0.1:23002"));
+        assert_eq!(command.grpc_server_addr.as_deref(), Some("10.0.0.2:23002"));
+
+        let command = StartCommand::try_parse_from([
+            "metasrv",
+            "--bind-addr",
+            "127.0.0.1:33002",
+            "--server-addr",
+            "10.0.0.3:33002",
+        ])
+        .unwrap();
+        assert_eq!(command.grpc_bind_addr.as_deref(), Some("127.0.0.1:33002"));
+        assert_eq!(command.grpc_server_addr.as_deref(), Some("10.0.0.3:33002"));
+    }
+
+    #[test]
+    fn test_help_uses_grpc_option_names() {
+        let mut cmd = StartCommand::command();
+        let mut help = Vec::new();
+        cmd.write_long_help(&mut help).unwrap();
+        let help = String::from_utf8(help).unwrap();
+
+        assert!(help.contains("--grpc-bind-addr"));
+        assert!(help.contains("--grpc-server-addr"));
+        assert!(!help.contains("--rpc-bind-addr"));
+        assert!(!help.contains("--rpc-server-addr"));
+        assert!(!help.contains("--bind-addr"));
+        assert!(!help.contains("--server-addr"));
     }
 }

--- a/src/cmd/src/metasrv.rs
+++ b/src/cmd/src/metasrv.rs
@@ -21,8 +21,8 @@ use clap::Parser;
 use common_base::Plugins;
 use common_config::Configurable;
 use common_meta::distributed_time_constants::init_distributed_time_constants;
-use common_telemetry::info;
 use common_telemetry::logging::{DEFAULT_LOGGING_DIR, TracingOptions};
+use common_telemetry::{info, warn};
 use common_version::{short_version, verbose_version};
 use meta_srv::bootstrap::{MetasrvInstance, metasrv_builder};
 use meta_srv::metasrv::BackendImpl;
@@ -248,6 +248,9 @@ impl StartCommand {
             opts.bind_addr.clone_from(addr);
             opts.grpc.bind_addr.clone_from(addr);
         } else if !opts.bind_addr.is_empty() {
+            warn!(
+                "Use the deprecated attribute `MetasrvOptions.bind_addr`, please use `grpc.bind_addr` instead."
+            );
             opts.grpc.bind_addr.clone_from(&opts.bind_addr);
         }
 
@@ -256,6 +259,9 @@ impl StartCommand {
             opts.server_addr.clone_from(addr);
             opts.grpc.server_addr.clone_from(addr);
         } else if !opts.server_addr.is_empty() {
+            warn!(
+                "Use the deprecated attribute `MetasrvOptions.server_addr`, please use `grpc.server_addr` instead."
+            );
             opts.grpc.server_addr.clone_from(&opts.server_addr);
         }
 

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -212,8 +212,8 @@ impl App for Instance {
 pub struct StartCommand {
     #[clap(long)]
     http_addr: Option<String>,
-    #[clap(long, alias = "rpc-addr")]
-    rpc_bind_addr: Option<String>,
+    #[clap(long = "grpc-bind-addr", alias = "rpc-bind-addr", alias = "rpc-addr")]
+    grpc_bind_addr: Option<String>,
     #[clap(long)]
     mysql_addr: Option<String>,
     #[clap(long)]
@@ -299,7 +299,7 @@ impl StartCommand {
                 .to_string();
         }
 
-        if let Some(addr) = &self.rpc_bind_addr {
+        if let Some(addr) = &self.grpc_bind_addr {
             // frontend grpc addr conflict with datanode default grpc addr
             let datanode_grpc_addr = DatanodeOptions::default().grpc.bind_addr;
             if addr.eq(&datanode_grpc_addr) {
@@ -755,6 +755,7 @@ mod tests {
     use std::time::Duration;
 
     use auth::{Identity, Password, UserProviderRef};
+    use clap::{CommandFactory, Parser};
     use common_base::readable_size::ReadableSize;
     use common_config::ENV_VAR_SEP;
     use common_test_util::temp_dir::create_named_temp_file;
@@ -998,6 +999,35 @@ mod tests {
                 assert_eq!(fe_opts.grpc.bind_addr, GrpcOptions::default().bind_addr);
             },
         );
+    }
+
+    #[test]
+    fn test_parse_grpc_bind_addr_aliases() {
+        let command =
+            StartCommand::try_parse_from(["standalone", "--grpc-bind-addr", "127.0.0.1:14001"])
+                .unwrap();
+        assert_eq!(command.grpc_bind_addr.as_deref(), Some("127.0.0.1:14001"));
+
+        let command =
+            StartCommand::try_parse_from(["standalone", "--rpc-bind-addr", "127.0.0.1:24001"])
+                .unwrap();
+        assert_eq!(command.grpc_bind_addr.as_deref(), Some("127.0.0.1:24001"));
+
+        let command =
+            StartCommand::try_parse_from(["standalone", "--rpc-addr", "127.0.0.1:34001"]).unwrap();
+        assert_eq!(command.grpc_bind_addr.as_deref(), Some("127.0.0.1:34001"));
+    }
+
+    #[test]
+    fn test_help_uses_grpc_option_names() {
+        let mut cmd = StartCommand::command();
+        let mut help = Vec::new();
+        cmd.write_long_help(&mut help).unwrap();
+        let help = String::from_utf8(help).unwrap();
+
+        assert!(help.contains("--grpc-bind-addr"));
+        assert!(!help.contains("--rpc-bind-addr"));
+        assert!(!help.contains("--rpc-addr"));
     }
 
     #[test]

--- a/src/datanode/src/config.rs
+++ b/src/datanode/src/config.rs
@@ -84,9 +84,9 @@ pub struct DatanodeOptions {
     pub memory: MemoryOptions,
 
     /// Deprecated options, please use the new options instead.
-    #[deprecated(note = "Please use `grpc.addr` instead.")]
+    #[deprecated(note = "Please use `grpc.bind_addr` instead.")]
     pub rpc_addr: Option<String>,
-    #[deprecated(note = "Please use `grpc.hostname` instead.")]
+    #[deprecated(note = "Please use `grpc.server_addr` instead.")]
     pub rpc_hostname: Option<String>,
     #[deprecated(note = "Please use `grpc.runtime_size` instead.")]
     pub rpc_runtime_size: Option<usize>,

--- a/tests/runner/src/server_mode.rs
+++ b/tests/runner/src/server_mode.rs
@@ -355,7 +355,7 @@ impl ServerMode {
                     "-c".to_string(),
                     self.generate_config_file(sqlness_home, db_ctx, id),
                     format!("--http-addr={http_addr}"),
-                    format!("--rpc-addr={rpc_bind_addr}"),
+                    format!("--grpc-bind-addr={rpc_bind_addr}"),
                     format!("--mysql-addr={mysql_addr}"),
                     format!("--postgres-addr={postgres_addr}"),
                 ]);
@@ -370,10 +370,10 @@ impl ServerMode {
                 args.extend([
                     format!("--metasrv-addrs={metasrv_addr}"),
                     format!("--http-addr={http_addr}"),
-                    format!("--rpc-addr={rpc_bind_addr}"),
+                    format!("--grpc-bind-addr={rpc_bind_addr}"),
                     // since sqlness run on local, bind addr is the same as server addr
                     // this is needed so that `cluster_info`'s server addr column can be correct
-                    format!("--rpc-server-addr={rpc_bind_addr}"),
+                    format!("--grpc-server-addr={rpc_bind_addr}"),
                     format!("--mysql-addr={mysql_addr}"),
                     format!("--postgres-addr={postgres_addr}"),
                     format!(
@@ -391,9 +391,9 @@ impl ServerMode {
                 http_addr,
             } => {
                 args.extend([
-                    "--bind-addr".to_string(),
+                    "--grpc-bind-addr".to_string(),
                     rpc_bind_addr.clone(),
-                    "--server-addr".to_string(),
+                    "--grpc-server-addr".to_string(),
                     rpc_server_addr.clone(),
                     "--enable-region-failover".to_string(),
                     "false".to_string(),
@@ -476,8 +476,8 @@ impl ServerMode {
                     db_ctx.time()
                 ));
                 args.extend([
-                    format!("--rpc-addr={rpc_bind_addr}"),
-                    format!("--rpc-server-addr={rpc_server_addr}"),
+                    format!("--grpc-bind-addr={rpc_bind_addr}"),
+                    format!("--grpc-server-addr={rpc_server_addr}"),
                     format!("--http-addr={http_addr}"),
                     format!("--data-home={}", data_home.display()),
                     format!("--log-dir={}/logs", data_home.display()),
@@ -495,8 +495,8 @@ impl ServerMode {
                 node_id,
             } => {
                 args.extend([
-                    format!("--rpc-addr={rpc_bind_addr}"),
-                    format!("--rpc-server-addr={rpc_server_addr}"),
+                    format!("--grpc-bind-addr={rpc_bind_addr}"),
+                    format!("--grpc-server-addr={rpc_server_addr}"),
                     format!("--node-id={node_id}"),
                     format!(
                         "--log-dir={}/greptimedb-{}-flownode/logs",


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
close: #6769 

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

This PR aligns the canonical gRPC CLI option names with the existing `grpc` configuration naming.

It renames the user-facing CLI flags from `rpc-*` to `grpc-*` for `datanode`, `frontend`, `metasrv`, `flownode`, and `standalone`, while keeping the legacy aliases for backward compatibility. It also updates the related examples, scripts, and generated config docs, and adds tests to ensure `--help` only shows the new canonical names.

This change is limited to naming consistency and does not change the underlying gRPC behavior.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
