### PR TITLE
chore: avoid reparsing partition expr in mito2 reader

### DIFF
--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -344,7 +344,7 @@ impl ParquetReaderBuilder {
             .as_ref()
             .and_then(|meta| meta.partition_expr.as_ref())
             .map(|expr| expr.as_str());
-        let (_, is_same_region_partition) = Self::is_same_region_partition(
+        let (region_partition_expr, is_same_region_partition) = Self::is_same_region_partition(
             region_partition_expr_str,
             self.file_handle.meta_ref().partition_expr.as_ref(),
         )?;
@@ -495,7 +495,12 @@ impl ParquetReaderBuilder {
             prefilter_builder,
         };
 
-        let partition_filter = self.build_partition_filter(&read_format, &prune_schema)?;
+        let partition_filter = self.build_partition_filter(
+            &read_format,
+            &prune_schema,
+            region_partition_expr.as_ref(),
+            is_same_region_partition,
+        )?;
 
         let context = FileRangeContext::new(
             reader_builder,
@@ -537,18 +542,9 @@ impl ParquetReaderBuilder {
         &self,
         read_format: &FlatReadFormat,
         prune_schema: &Arc<datatypes::schema::Schema>,
+        region_partition_expr: Option<&PartitionExpr>,
+        is_same_region_partition: bool,
     ) -> Result<Option<PartitionFilterContext>> {
-        let region_partition_expr_str = self
-            .expected_metadata
-            .as_ref()
-            .and_then(|meta| meta.partition_expr.as_ref());
-        let file_partition_expr_ref = self.file_handle.meta_ref().partition_expr.as_ref();
-
-        let (region_partition_expr, is_same_region_partition) = Self::is_same_region_partition(
-            region_partition_expr_str.map(|s| s.as_str()),
-            file_partition_expr_ref,
-        )?;
-
         if is_same_region_partition {
             return Ok(None);
         }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

in the read path there might be a opportunity to save a call on `get region_partition_expr` which link to `parse_partition_expr` with some json work.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
