### PR TITLE
chore: use into_parts for owned record batches columns in mito2

### DIFF
--- a/src/mito2/src/read/compat.rs
+++ b/src/mito2/src/read/compat.rs
@@ -435,10 +435,11 @@ impl FlatRewritePrimaryKey {
         let new_pk_dict_array =
             PrimaryKeyArray::new(old_pk_dict_array.keys().clone(), new_pk_values_array);
 
-        let mut columns = batch.columns().to_vec();
-        columns[primary_key_column_index(batch.num_columns())] = Arc::new(new_pk_dict_array);
+        let (schema, mut columns, _) = batch.into_parts();
+        let primary_key_idx = primary_key_column_index(columns.len());
+        columns[primary_key_idx] = Arc::new(new_pk_dict_array);
 
-        RecordBatch::try_new(batch.schema(), columns).context(NewRecordBatchSnafu)
+        RecordBatch::try_new(schema, columns).context(NewRecordBatchSnafu)
     }
 }
 
@@ -569,10 +570,11 @@ impl FlatCompatPrimaryKey {
             PrimaryKeyArray::new(old_pk_dict_array.keys().clone(), new_pk_values_array);
 
         // Overrides the primary key column.
-        let mut columns = batch.columns().to_vec();
-        columns[primary_key_column_index(batch.num_columns())] = Arc::new(new_pk_dict_array);
+        let (schema, mut columns, _) = batch.into_parts();
+        let primary_key_idx = primary_key_column_index(columns.len());
+        columns[primary_key_idx] = Arc::new(new_pk_dict_array);
 
-        RecordBatch::try_new(batch.schema(), columns).context(NewRecordBatchSnafu)
+        RecordBatch::try_new(schema, columns).context(NewRecordBatchSnafu)
     }
 }
 

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -1468,11 +1468,12 @@ mod tests {
         assert_eq!(normal_batches.len(), override_batches.len());
         for (normal, override_batch) in normal_batches.into_iter().zip(override_batches.iter()) {
             let expected_batch = {
-                let mut columns = normal.columns().to_vec();
+                let num_rows = normal.num_rows();
+                let (schema, mut columns, _) = normal.into_parts();
                 let num_cols = columns.len();
                 columns[num_cols - 2] =
-                    Arc::new(UInt64Array::from_value(custom_sequence, normal.num_rows()));
-                RecordBatch::try_new(normal.schema(), columns).unwrap()
+                    Arc::new(UInt64Array::from_value(custom_sequence, num_rows));
+                RecordBatch::try_new(schema, columns).unwrap()
             };
 
             // Override batch should match expected batch

--- a/src/mito2/src/sst/parquet/flat_format.rs
+++ b/src/mito2/src/sst/parquet/flat_format.rs
@@ -315,19 +315,20 @@ impl FlatReadFormat {
             return Ok(batch);
         };
 
-        let mut columns = batch.columns().to_vec();
-        let sequence_column_idx = sequence_column_index(batch.num_columns());
+        let batch_num_rows = batch.num_rows();
+        let (schema, mut columns, _) = batch.into_parts();
+        let sequence_column_idx = sequence_column_index(columns.len());
 
         // Use the provided override sequence array, slicing if necessary to match batch length
-        let sequence_array = if override_array.len() > batch.num_rows() {
-            override_array.slice(0, batch.num_rows())
+        let sequence_array = if override_array.len() > batch_num_rows {
+            override_array.slice(0, batch_num_rows)
         } else {
             override_array.clone()
         };
 
         columns[sequence_column_idx] = sequence_array;
 
-        RecordBatch::try_new(batch.schema(), columns).context(NewRecordBatchSnafu)
+        RecordBatch::try_new(schema, columns).context(NewRecordBatchSnafu)
     }
 
     /// Checks whether the batch from the parquet file needs to be converted to match the flat format.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

avoids one extra Vec<ArrayRef> allocation

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
