### PR TITLE
feat: use SemanticType::FollowSchema for pre-defined tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5683,7 +5683,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=0de5437582920c8b30d6c34212f161db71d95c50#0de5437582920c8b30d6c34212f161db71d95c50"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=62d611cbc7b09333391f7df80500d227f988d94a#62d611cbc7b09333391f7df80500d227f988d94a"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,7 @@ etcd-client = { version = "0.17", features = [
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "0de5437582920c8b30d6c34212f161db71d95c50" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "62d611cbc7b09333391f7df80500d227f988d94a" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/src/api/src/helper.rs
+++ b/src/api/src/helper.rs
@@ -877,8 +877,10 @@ pub fn pb_value_to_value_ref<'a>(
 }
 
 /// Returns true if the pb semantic type is valid.
+/// If the input semantic type is [SemanticType::FollowSchema], it always returns true
+/// as the caller should use the table's semantic type instead.
 pub fn is_semantic_type_eq(type_value: i32, semantic_type: SemanticType) -> bool {
-    type_value == semantic_type as i32
+    type_value == semantic_type as i32 || type_value == SemanticType::FollowSchema as i32
 }
 
 /// Returns true if the pb type value is valid.

--- a/src/common/meta/src/ddl/utils/raw_table_info.rs
+++ b/src/common/meta/src/ddl/utils/raw_table_info.rs
@@ -53,7 +53,8 @@ pub(crate) fn build_new_physical_table_info(
                     primary_key_indices.push(idx);
                 }
             }
-            SemanticType::Field => value_indices.push(idx),
+            // treat followschema column as field
+            SemanticType::Field | SemanticType::FollowSchema => value_indices.push(idx),
             SemanticType::Timestamp => {
                 value_indices.push(idx);
             }

--- a/src/common/meta/src/reconciliation/utils.rs
+++ b/src/common/meta/src/reconciliation/utils.rs
@@ -370,7 +370,7 @@ pub(crate) fn build_table_meta_from_column_metadatas(
             SemanticType::Tag => {
                 primary_key_indices.push(idx);
             }
-            SemanticType::Field => {
+            SemanticType::Field | SemanticType::FollowSchema => {
                 value_indices.push(idx);
             }
             SemanticType::Timestamp => {

--- a/src/metric-engine/src/engine/create.rs
+++ b/src/metric-engine/src/engine/create.rs
@@ -405,7 +405,7 @@ impl MetricEngineInner {
                         actual: col.column_schema.data_type.clone(),
                     }
                 ),
-                SemanticType::Field => {
+                SemanticType::Field | SemanticType::FollowSchema => {
                     if let Some(field_col) = field_col {
                         MultipleFieldColumnSnafu {
                             previous: field_col.column_schema.name.clone(),

--- a/src/metric-engine/src/row_modifier.rs
+++ b/src/metric-engine/src/row_modifier.rs
@@ -296,7 +296,7 @@ impl IterIndex {
                         );
                     }
                 },
-                SemanticType::Field => {
+                SemanticType::Field | SemanticType::FollowSchema => {
                     field_indices.push(ValueIndex {
                         column_id: *name_to_column_id.get(&col.column_name).unwrap(),
                         index: idx,

--- a/src/mito2/src/read/compat.rs
+++ b/src/mito2/src/read/compat.rs
@@ -613,7 +613,7 @@ mod tests {
                 SemanticType::Tag => {
                     ColumnSchema::new(format!("tag_{id}"), data_type.clone(), true)
                 }
-                SemanticType::Field => {
+                SemanticType::Field | SemanticType::FollowSchema => {
                     ColumnSchema::new(format!("field_{id}"), data_type.clone(), true)
                 }
                 SemanticType::Timestamp => ColumnSchema::new("ts", data_type.clone(), false),

--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -176,22 +176,27 @@ impl WriteRequest {
     ///
     /// If column with default value is missing, it returns a special [FillDefault](crate::error::Error::FillDefault)
     /// error.
-    pub(crate) fn check_schema(&self, metadata: &RegionMetadata) -> Result<()> {
+    /// If a column's semantic type is FollowSchema, it means we will use table semantic type.
+    pub(crate) fn check_schema(&mut self, metadata: &RegionMetadata) -> Result<()> {
         debug_assert_eq!(self.region_id, metadata.region_id);
 
         let region_id = self.region_id;
         // Index all columns in rows.
-        let mut rows_columns: HashMap<_, _> = self
+        let mut name_to_index: HashMap<_, _> = self
             .rows
             .schema
             .iter()
-            .map(|column| (&column.column_name, column))
+            .enumerate()
+            .map(|(i, column)| (&column.column_name, i))
             .collect();
 
         let mut need_fill_default = false;
+        let mut follow_schema_fixups: Vec<(usize, i32)> = vec![];
         // Checks all columns in this region.
         for column in &metadata.column_metadatas {
-            if let Some(input_col) = rows_columns.remove(&column.column_schema.name) {
+            if let Some(idx) = name_to_index.remove(&column.column_schema.name) {
+                let input_col = &self.rows.schema[idx];
+
                 // Check data type.
                 ensure!(
                     is_column_type_value_eq(
@@ -230,9 +235,14 @@ impl WriteRequest {
                     }
                 );
 
+                // If input semantic type is FollowSchema, record the fixup to apply later.
+                if input_col.semantic_type == SemanticType::FollowSchema as i32 {
+                    follow_schema_fixups.push((idx, column.semantic_type as i32));
+                }
+
                 // Check nullable.
-                // Safety: `rows_columns` ensures this column exists.
-                let has_null = self.has_null[self.name_to_index[&column.column_schema.name]];
+                // Safety: `name_to_index` ensures this column exists.
+                let has_null = self.has_null[idx];
                 ensure!(
                     !has_null || column.column_schema.is_nullable(),
                     InvalidRequestSnafu {
@@ -252,8 +262,8 @@ impl WriteRequest {
         }
 
         // Checks all columns in rows exist in the region.
-        if !rows_columns.is_empty() {
-            let names: Vec<_> = rows_columns.into_keys().collect();
+        if !name_to_index.is_empty() {
+            let names: Vec<_> = name_to_index.into_keys().collect();
             return InvalidRequestSnafu {
                 region_id,
                 reason: format!("unknown columns: {:?}", names),
@@ -263,6 +273,12 @@ impl WriteRequest {
 
         // If we need to fill default values, return a special error.
         ensure!(!need_fill_default, FillDefaultSnafu { region_id });
+
+        // Apply FollowSchema fixups: replace with the table's semantic type.
+        // This must happen after `name_to_index` is dropped to release the borrow on `self.rows.schema`.
+        for (idx, semantic_type) in follow_schema_fixups {
+            self.rows.schema[idx].semantic_type = semantic_type;
+        }
 
         Ok(())
     }
@@ -1312,7 +1328,7 @@ mod tests {
         };
         let metadata = new_region_metadata();
 
-        let request = WriteRequest::new(RegionId::new(1, 1), OpType::Put, rows, None).unwrap();
+        let mut request = WriteRequest::new(RegionId::new(1, 1), OpType::Put, rows, None).unwrap();
         request.check_schema(&metadata).unwrap();
     }
 
@@ -1329,7 +1345,7 @@ mod tests {
         };
         let metadata = new_region_metadata();
 
-        let request = WriteRequest::new(RegionId::new(1, 1), OpType::Put, rows, None).unwrap();
+        let mut request = WriteRequest::new(RegionId::new(1, 1), OpType::Put, rows, None).unwrap();
         let err = request.check_schema(&metadata).unwrap_err();
         check_invalid_request(
             &err,
@@ -1354,7 +1370,7 @@ mod tests {
         };
         let metadata = new_region_metadata();
 
-        let request = WriteRequest::new(RegionId::new(1, 1), OpType::Put, rows, None).unwrap();
+        let mut request = WriteRequest::new(RegionId::new(1, 1), OpType::Put, rows, None).unwrap();
         let err = request.check_schema(&metadata).unwrap_err();
         check_invalid_request(&err, "column ts has semantic type Timestamp, given: TAG(0)");
     }
@@ -1376,7 +1392,7 @@ mod tests {
         };
         let metadata = new_region_metadata();
 
-        let request = WriteRequest::new(RegionId::new(1, 1), OpType::Put, rows, None).unwrap();
+        let mut request = WriteRequest::new(RegionId::new(1, 1), OpType::Put, rows, None).unwrap();
         let err = request.check_schema(&metadata).unwrap_err();
         check_invalid_request(&err, "column ts is not null but input has null");
     }
@@ -1395,7 +1411,7 @@ mod tests {
         };
         let metadata = new_region_metadata();
 
-        let request = WriteRequest::new(RegionId::new(1, 1), OpType::Put, rows, None).unwrap();
+        let mut request = WriteRequest::new(RegionId::new(1, 1), OpType::Put, rows, None).unwrap();
         let err = request.check_schema(&metadata).unwrap_err();
         check_invalid_request(&err, "missing column ts");
     }
@@ -1418,7 +1434,7 @@ mod tests {
         };
         let metadata = new_region_metadata();
 
-        let request = WriteRequest::new(RegionId::new(1, 1), OpType::Put, rows, None).unwrap();
+        let mut request = WriteRequest::new(RegionId::new(1, 1), OpType::Put, rows, None).unwrap();
         let err = request.check_schema(&metadata).unwrap_err();
         check_invalid_request(&err, r#"unknown columns: ["k1"]"#);
     }
@@ -1728,7 +1744,7 @@ mod tests {
         };
         let metadata = region_metadata_two_fields();
 
-        let request = WriteRequest::new(RegionId::new(1, 1), OpType::Put, rows, None).unwrap();
+        let mut request = WriteRequest::new(RegionId::new(1, 1), OpType::Put, rows, None).unwrap();
         let err = request.check_schema(&metadata).unwrap_err();
         check_invalid_request(
             &err,

--- a/src/mito2/src/sst/parquet/format.rs
+++ b/src/mito2/src/sst/parquet/format.rs
@@ -385,7 +385,7 @@ impl PrimaryKeyReadFormat {
         };
         match column.semantic_type {
             SemanticType::Tag => self.tag_values(row_groups, column, true),
-            SemanticType::Field => {
+            SemanticType::Field | SemanticType::FollowSchema => {
                 // Safety: `field_id_to_index` is initialized by the semantic type.
                 let index = self.field_id_to_index.get(&column_id).unwrap();
                 let stats = column_values(row_groups, column, *index, true);
@@ -411,7 +411,7 @@ impl PrimaryKeyReadFormat {
         };
         match column.semantic_type {
             SemanticType::Tag => self.tag_values(row_groups, column, false),
-            SemanticType::Field => {
+            SemanticType::Field | SemanticType::FollowSchema => {
                 // Safety: `field_id_to_index` is initialized by the semantic type.
                 let index = self.field_id_to_index.get(&column_id).unwrap();
                 let stats = column_values(row_groups, column, *index, false);
@@ -437,7 +437,7 @@ impl PrimaryKeyReadFormat {
         };
         match column.semantic_type {
             SemanticType::Tag => StatValues::NoStats,
-            SemanticType::Field => {
+            SemanticType::Field | SemanticType::FollowSchema => {
                 // Safety: `field_id_to_index` is initialized by the semantic type.
                 let index = self.field_id_to_index.get(&column_id).unwrap();
                 let stats = column_null_counts(row_groups, *index);

--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -565,6 +565,21 @@ impl Inserter {
                     }
                 }
                 None => {
+                    if let Some(rows) = &req.rows
+                        && rows
+                            .schema
+                            .iter()
+                            .any(|col| col.semantic_type == SemanticType::FollowSchema as i32)
+                    {
+                        return InvalidInsertRequestSnafu {
+                                reason: format!(
+                                    "Table `{}` does not exist, cannot use semantic type FollowSchema for auto-created table",
+                                    req.table_name
+                                ),
+                            }
+                            .fail();
+                    }
+
                     let create_expr =
                         self.get_create_table_expr_on_demand(req, &auto_create_table_type, ctx)?;
                     create_tables.push(create_expr);

--- a/src/servers/src/row_writer.rs
+++ b/src/servers/src/row_writer.rs
@@ -193,6 +193,16 @@ pub fn write_fields(
     write_by_semantic_type(table_data, SemanticType::Field, fields, one_row)
 }
 
+#[allow(dead_code)]
+/// When table is already there, use table schema for data semantictype
+pub fn write_column_follow_schema(
+    table_data: &mut TableData,
+    fields: impl Iterator<Item = (String, ColumnDataType, Option<ValueData>)>,
+    one_row: &mut Vec<Value>,
+) -> Result<()> {
+    write_by_semantic_type(table_data, SemanticType::FollowSchema, fields, one_row)
+}
+
 /// Write data as a tag into the table data.
 pub fn write_tag(
     table_data: &mut TableData,

--- a/tests-integration/tests/grpc.rs
+++ b/tests-integration/tests/grpc.rs
@@ -83,6 +83,7 @@ macro_rules! grpc_tests {
                 test_auto_create_table_with_hints,
                 test_otel_arrow_auth,
                 test_insert_and_select,
+                test_insert_with_follow_table,
                 test_dbname,
                 test_grpc_message_size_ok,
                 test_grpc_zstd_compression,
@@ -693,6 +694,227 @@ fn testing_create_expr() -> CreateTableExpr {
         table_id: None,
         engine: MITO_ENGINE.to_string(),
     }
+}
+
+pub async fn test_insert_with_follow_table(store_type: StorageType) {
+    common_telemetry::init_default_ut_logging();
+    let (_db, fe_grpc_server) =
+        setup_grpc_server(store_type, "test_insert_with_follow_table").await;
+    let addr = fe_grpc_server.bind_addr().unwrap().to_string();
+
+    let grpc_client = Client::with_urls(vec![addr]);
+    let db = Database::new(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, grpc_client);
+
+    // Negative test: inserting with FollowSchema into a non-existent table should fail
+    let row_insert_request = RowInsertRequest {
+        table_name: "non_existent_table".to_string(),
+        rows: Some(api::v1::Rows {
+            schema: vec![
+                api::v1::ColumnSchema {
+                    column_name: "host".to_string(),
+                    datatype: ColumnDataType::String as i32,
+                    semantic_type: SemanticType::FollowSchema as i32,
+                    ..Default::default()
+                },
+                api::v1::ColumnSchema {
+                    column_name: "ts".to_string(),
+                    datatype: ColumnDataType::TimestampMillisecond as i32,
+                    semantic_type: SemanticType::Timestamp as i32,
+                    ..Default::default()
+                },
+            ],
+            rows: vec![api::v1::Row {
+                values: vec![
+                    Value {
+                        value_data: Some(ValueData::StringValue("host1".to_string())),
+                    },
+                    Value {
+                        value_data: Some(ValueData::TimestampMillisecondValue(100)),
+                    },
+                ],
+            }],
+        }),
+    };
+    let result = db
+        .row_inserts(RowInsertRequests {
+            inserts: vec![row_insert_request],
+        })
+        .await;
+    assert!(result.is_err(), "Should fail when table does not exist with FollowSchema semantic type");
+
+    // Positive test: create table first, then insert with FollowSchema should succeed
+    let column_defs = vec![
+        ColumnDef {
+            name: "host".to_string(),
+            data_type: ColumnDataType::String as i32,
+            is_nullable: false,
+            default_constraint: vec![],
+            semantic_type: SemanticType::Tag as i32,
+            ..Default::default()
+        },
+        ColumnDef {
+            name: "cpu".to_string(),
+            data_type: ColumnDataType::Float64 as i32,
+            is_nullable: true,
+            default_constraint: vec![],
+            semantic_type: SemanticType::Field as i32,
+            ..Default::default()
+        },
+        ColumnDef {
+            name: "ts".to_string(),
+            data_type: ColumnDataType::TimestampMillisecond as i32,
+            is_nullable: false,
+            default_constraint: vec![],
+            semantic_type: SemanticType::Timestamp as i32,
+            ..Default::default()
+        },
+    ];
+    let expr = CreateTableExpr {
+        catalog_name: DEFAULT_CATALOG_NAME.to_string(),
+        schema_name: DEFAULT_SCHEMA_NAME.to_string(),
+        table_name: "follow_schema_demo".to_string(),
+        desc: String::new(),
+        column_defs,
+        time_index: "ts".to_string(),
+        primary_keys: vec!["host".to_string()],
+        create_if_not_exists: true,
+        table_options: Default::default(),
+        table_id: None,
+        engine: MITO_ENGINE.to_string(),
+    };
+    let result = db.create(expr).await.unwrap();
+    assert!(matches!(result.data, OutputData::AffectedRows(0)));
+
+    // Insert data with FOLLOW_SCHEMA semantic type on the host column
+    let host_col = Column {
+        column_name: "host".to_string(),
+        values: Some(column::Values {
+            string_values: vec!["host1".to_string(), "host2".to_string()],
+            ..Default::default()
+        }),
+        semantic_type: SemanticType::FollowSchema as i32,
+        datatype: ColumnDataType::String as i32,
+        ..Default::default()
+    };
+    let cpu_col = Column {
+        column_name: "cpu".to_string(),
+        values: Some(column::Values {
+            f64_values: vec![0.31, 0.41],
+            ..Default::default()
+        }),
+        semantic_type: SemanticType::Field as i32,
+        datatype: ColumnDataType::Float64 as i32,
+        ..Default::default()
+    };
+    let ts_col = Column {
+        column_name: "ts".to_string(),
+        values: Some(column::Values {
+            timestamp_millisecond_values: vec![100, 101],
+            ..Default::default()
+        }),
+        semantic_type: SemanticType::Timestamp as i32,
+        datatype: ColumnDataType::TimestampMillisecond as i32,
+        ..Default::default()
+    };
+
+    let request = InsertRequest {
+        table_name: "follow_schema_demo".to_string(),
+        columns: vec![host_col, cpu_col, ts_col],
+        row_count: 2,
+    };
+    let result = db
+        .insert(InsertRequests {
+            inserts: vec![request],
+        })
+        .await;
+    assert_eq!(result.unwrap(), 2);
+
+    // Select and verify
+    let output = db
+        .sql("SELECT host, cpu, ts FROM follow_schema_demo ORDER BY host")
+        .await
+        .unwrap();
+    let record_batches = match output.data {
+        OutputData::RecordBatches(record_batches) => record_batches,
+        OutputData::Stream(stream) => RecordBatches::try_collect(stream).await.unwrap(),
+        OutputData::AffectedRows(_) => unreachable!(),
+    };
+    assert!(record_batches.iter().all(|r| r.num_rows() > 0));
+
+    // Insert a new column "memory" with FollowSchema semantic type; it should be stored as FIELD
+    let host_col = Column {
+        column_name: "host".to_string(),
+        values: Some(column::Values {
+            string_values: vec!["host3".to_string()],
+            ..Default::default()
+        }),
+        semantic_type: SemanticType::Tag as i32,
+        datatype: ColumnDataType::String as i32,
+        ..Default::default()
+    };
+    let cpu_col = Column {
+        column_name: "cpu".to_string(),
+        values: Some(column::Values {
+            f64_values: vec![0.55],
+            ..Default::default()
+        }),
+        semantic_type: SemanticType::Field as i32,
+        datatype: ColumnDataType::Float64 as i32,
+        ..Default::default()
+    };
+    let mem_col = Column {
+        column_name: "memory".to_string(),
+        values: Some(column::Values {
+            f64_values: vec![2048.0],
+            ..Default::default()
+        }),
+        semantic_type: SemanticType::FollowSchema as i32,
+        datatype: ColumnDataType::Float64 as i32,
+        ..Default::default()
+    };
+    let ts_col = Column {
+        column_name: "ts".to_string(),
+        values: Some(column::Values {
+            timestamp_millisecond_values: vec![200],
+            ..Default::default()
+        }),
+        semantic_type: SemanticType::Timestamp as i32,
+        datatype: ColumnDataType::TimestampMillisecond as i32,
+        ..Default::default()
+    };
+
+    let request = InsertRequest {
+        table_name: "follow_schema_demo".to_string(),
+        columns: vec![host_col, cpu_col, mem_col, ts_col],
+        row_count: 1,
+    };
+    let result = db
+        .insert(InsertRequests {
+            inserts: vec![request],
+        })
+        .await;
+    assert_eq!(result.unwrap(), 1);
+
+    // Verify the "memory" column was stored with semantic_type FIELD
+    let output = db
+        .sql(
+            "select column_name, semantic_type from information_schema.columns \
+             where table_name = 'follow_schema_demo' and column_name = 'memory'",
+        )
+        .await
+        .unwrap();
+    let record_batches = match output.data {
+        OutputData::RecordBatches(record_batches) => record_batches,
+        OutputData::Stream(stream) => RecordBatches::try_collect(stream).await.unwrap(),
+        OutputData::AffectedRows(_) => unreachable!(),
+    };
+    let pretty = record_batches.pretty_print().unwrap();
+    assert!(
+        pretty.contains("FIELD"),
+        "Expected 'memory' column to have semantic_type FIELD, got:\n{pretty}"
+    );
+
+    let _ = fe_grpc_server.shutdown().await;
 }
 
 pub async fn test_health_check(store_type: StorageType) {

--- a/tests-integration/tests/grpc.rs
+++ b/tests-integration/tests/grpc.rs
@@ -740,7 +740,45 @@ pub async fn test_insert_with_follow_table(store_type: StorageType) {
             inserts: vec![row_insert_request],
         })
         .await;
-    assert!(result.is_err(), "Should fail when table does not exist with FollowSchema semantic type");
+    assert!(
+        result.is_err(),
+        "Should fail when table does not exist with FollowSchema semantic type"
+    );
+
+    // Negative test: column-based insert with FollowSchema into a non-existent table should also fail
+    let host_col = Column {
+        column_name: "host".to_string(),
+        values: Some(column::Values {
+            string_values: vec!["host1".to_string()],
+            ..Default::default()
+        }),
+        semantic_type: SemanticType::FollowSchema as i32,
+        datatype: ColumnDataType::String as i32,
+        ..Default::default()
+    };
+    let ts_col = Column {
+        column_name: "ts".to_string(),
+        values: Some(column::Values {
+            timestamp_millisecond_values: vec![100],
+            ..Default::default()
+        }),
+        semantic_type: SemanticType::Timestamp as i32,
+        datatype: ColumnDataType::TimestampMillisecond as i32,
+        ..Default::default()
+    };
+    let result = db
+        .insert(InsertRequests {
+            inserts: vec![InsertRequest {
+                table_name: "another_non_existent_table".to_string(),
+                columns: vec![host_col, ts_col],
+                row_count: 1,
+            }],
+        })
+        .await;
+    assert!(
+        result.is_err(),
+        "Should fail when table does not exist with FollowSchema semantic type"
+    );
 
     // Positive test: create table first, then insert with FollowSchema should succeed
     let column_defs = vec![


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Rationale:

For created table, this semantic type in our grpc protocol becomes verbose information. For example, when we adjust table schema in #8008 , we will also need to adjust semantic types when constructing `InsertRequest`, by updating tag/field for certain columns. This will make the server layer code a breaking change, those created table won't work even if column names didn't change at all.

In this patch, I just add a new semantic type called `FollowSchema`. As its name suggests, it will follow the table schema for the column's semantic type. 

1. when table is not found, the server will throw an error
2. when column with follow schema is not found, it treats the column as field

Related change: https://github.com/GreptimeTeam/greptime-proto/pull/316

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
