### PR TITLE
feat: support gRPC-Web on frontend gRPC server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ AGENTS.md
 
 # local design docs
 docs/specs/
+.vs/ 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12116,6 +12116,7 @@ dependencies = [
  "tokio-util",
  "tonic 0.14.2",
  "tonic-reflection",
+ "tonic-web",
  "tower 0.5.2",
  "tower-http 0.6.6",
  "tracing",
@@ -14098,6 +14099,24 @@ dependencies = [
  "tokio-stream",
  "tonic 0.14.2",
  "tonic-prost",
+]
+
+[[package]]
+name = "tonic-web"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29453d84de05f4f1b573db22e6f9f6c95c189a6089a440c9a098aa9dea009299"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "pin-project",
+ "tokio-stream",
+ "tonic 0.14.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -133,6 +133,7 @@ tokio-stream = { workspace = true, features = ["net"] }
 tokio-util.workspace = true
 tonic.workspace = true
 tonic-reflection = "0.14"
+tonic-web = "0.14"
 tower = { workspace = true, features = ["full"] }
 tower-http = { version = "0.6", features = ["full"] }
 tracing.workspace = true

--- a/src/servers/src/grpc.rs
+++ b/src/servers/src/grpc.rs
@@ -355,7 +355,11 @@ impl Server for GrpcServer {
             .layer(MetricsMiddlewareLayer)
             .into_inner();
 
-        let mut builder = tonic::transport::Server::builder().layer(metrics_layer);
+        let mut builder = tonic::transport::Server::builder()
+            .accept_http1(true)
+            .layer(metrics_layer)
+            .layer(tonic_web::GrpcWebLayer::new());
+
         if let Some(tls_config) = self.tls_config.clone() {
             builder = builder.tls_config(tls_config).context(StartGrpcSnafu)?;
         }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Closes #8016

## What's changed and what's your intention?

### Summary
This PR adds basic gRPC-Web support to the frontend gRPC server using `tonic-web`.

### How it works
- Enables HTTP/1 support via `accept_http1(true)` to allow browser-based clients
- Adds `GrpcWebLayer` to the server builder to translate gRPC-Web requests into standard gRPC

### Details
The change integrates `tonic-web` as a middleware layer on the existing gRPC server without modifying existing services or server logic. This allows browser and edge runtimes (e.g., Cloudflare Workers, Deno) to communicate with gRPC endpoints directly.

### Limitations
- CORS handling is not implemented
- gRPC-Web compression is limited to gzip (zstd not supported)
- Only unary and server-streaming RPCs are supported (as per gRPC-Web limitations)

These are noted for follow-up work as mentioned in the issue.

### Compatibility
- No API or data compatibility is affected
- Existing gRPC functionality remains unchanged

## PR Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.