### PR TITLE
refactor: make InsertForwarder use shared metasrv database operator

### DIFF
--- a/src/client/src/error.rs
+++ b/src/client/src/error.rs
@@ -173,20 +173,31 @@ impl ErrorExt for Error {
 define_from_tonic_status!(Error, Tonic);
 
 impl Error {
-    pub fn should_retry(&self) -> bool {
-        // TODO(weny): figure out each case of these codes.
-        matches!(
-            self,
-            Self::RegionServer {
-                code: Code::Cancelled,
-                ..
-            } | Self::RegionServer {
-                code: Code::DeadlineExceeded,
-                ..
-            } | Self::RegionServer {
-                code: Code::Unavailable,
-                ..
+    /// Returns the gRPC status code if this error is caused by a gRPC request failure.
+    pub fn tonic_code(&self) -> Option<Code> {
+        match self {
+            Self::FlightGet { tonic_code, .. }
+            | Self::RegionServer {
+                code: tonic_code, ..
             }
-        )
+            | Self::FlowServer {
+                code: tonic_code, ..
+            }
+            | Self::Tonic { tonic_code, .. } => Some(*tonic_code),
+            _ => None,
+        }
+    }
+
+    /// Returns true if the error is a connection error that may be resolved by retrying the request.
+    pub fn is_connection_error(&self) -> bool {
+        matches!(self.tonic_code(), Some(Code::Unavailable))
+    }
+
+    pub fn should_retry(&self) -> bool {
+        self.is_connection_error()
+            || matches!(
+                self.tonic_code(),
+                Some(Code::Cancelled) | Some(Code::DeadlineExceeded)
+            )
     }
 }

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -83,6 +83,7 @@ use crate::selector::{RegionStatAwareSelector, Selector, SelectorType};
 use crate::service::mailbox::MailboxRef;
 use crate::service::store::cached_kv::LeaderCachedKvBackend;
 use crate::state::{StateRef, become_follower, become_leader};
+use crate::utils::database::DatabaseOperatorRef;
 
 pub const TABLE_ID_SEQ: &str = "table_id";
 pub const FLOW_ID_SEQ: &str = "flow_id";
@@ -570,6 +571,7 @@ pub struct Metasrv {
     reconciliation_manager: ReconciliationManagerRef,
     resource_stat: ResourceStatRef,
     gc_ticker: Option<GcTickerRef>,
+    database_operator: DatabaseOperatorRef,
 
     plugins: Plugins,
 }
@@ -867,6 +869,10 @@ impl Metasrv {
 
     pub fn reconciliation_manager(&self) -> &ReconciliationManagerRef {
         &self.reconciliation_manager
+    }
+
+    pub fn database_operator(&self) -> &DatabaseOperatorRef {
+        &self.database_operator
     }
 
     pub fn plugins(&self) -> &Plugins {

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -84,6 +84,7 @@ use crate::selector::round_robin::RoundRobinSelector;
 use crate::service::mailbox::MailboxRef;
 use crate::service::store::cached_kv::LeaderCachedKvBackend;
 use crate::state::State;
+use crate::utils::database::DatabaseOperator;
 use crate::utils::insert_forwarder::InsertForwarder;
 
 /// The time window for twcs compaction of the region stats table.
@@ -206,9 +207,10 @@ impl MetasrvBuilder {
 
         let meta_peer_client = meta_peer_client
             .unwrap_or_else(|| build_default_meta_peer_client(&election, &in_memory));
+        let database_operator = Arc::new(DatabaseOperator::new(meta_peer_client.clone()));
 
         let event_inserter = Box::new(InsertForwarder::new(
-            meta_peer_client.clone(),
+            database_operator.clone(),
             Some(InsertOptions {
                 ttl: options.event_recorder.ttl,
                 append_mode: true,
@@ -501,7 +503,7 @@ impl MetasrvBuilder {
 
         let persist_region_stats_handler = if !options.stats_persistence.ttl.is_zero() {
             let inserter = Box::new(InsertForwarder::new(
-                meta_peer_client.clone(),
+                database_operator.clone(),
                 Some(InsertOptions {
                     ttl: options.stats_persistence.ttl,
                     append_mode: true,
@@ -600,6 +602,7 @@ impl MetasrvBuilder {
             topic_stats_registry,
             resource_stat: Arc::new(resource_stat),
             gc_ticker,
+            database_operator,
         })
     }
 }

--- a/src/meta-srv/src/utils.rs
+++ b/src/meta-srv/src/utils.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod database;
 pub mod etcd;
 pub mod insert_forwarder;
 #[cfg(feature = "mysql_kvbackend")]

--- a/src/meta-srv/src/utils/database.rs
+++ b/src/meta-srv/src/utils/database.rs
@@ -1,0 +1,135 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use client::{Client, Database, Output};
+use common_error::ext::BoxedError;
+use common_meta::peer::PeerDiscoveryRef;
+use common_telemetry::{debug, warn};
+use snafu::{ResultExt, ensure};
+use tokio::sync::RwLock;
+
+use crate::error::{ListActiveFrontendsSnafu, NoAvailableFrontendSnafu, OtherSnafu, Result};
+
+pub type DatabaseOperatorRef = Arc<DatabaseOperator>;
+
+#[derive(Debug, Clone, Copy)]
+/// Database-level request context used by metasrv forwarding.
+pub struct DatabaseContext<'a> {
+    /// Catalog name carried in forwarded requests.
+    pub catalog: &'a str,
+    /// Schema name carried in forwarded requests.
+    pub schema: &'a str,
+}
+
+impl<'a> DatabaseContext<'a> {
+    /// Creates a new database context from catalog and schema.
+    pub fn new(catalog: &'a str, schema: &'a str) -> Self {
+        Self { catalog, schema }
+    }
+}
+
+/// A cached frontend database operator used by metasrv.
+pub struct DatabaseOperator {
+    peer_discovery: PeerDiscoveryRef,
+    client: RwLock<Option<Client>>,
+}
+
+impl DatabaseOperator {
+    /// Creates a database operator backed by discovered frontend peers.
+    pub fn new(peer_discovery: PeerDiscoveryRef) -> Self {
+        Self {
+            peer_discovery,
+            client: RwLock::new(None),
+        }
+    }
+
+    /// Forwards row inserts to an available frontend database client.
+    pub async fn insert(
+        &self,
+        ctx: &DatabaseContext<'_>,
+        requests: api::v1::RowInsertRequests,
+        hints: &[(&str, &str)],
+    ) -> Result<u32> {
+        let client = self.maybe_init_client().await?;
+        let database = Database::new(ctx.catalog, ctx.schema, client);
+
+        let result = database
+            .row_inserts_with_hints(requests, hints)
+            .await
+            .map_err(BoxedError::new)
+            .context(OtherSnafu);
+
+        if result.is_err() {
+            self.reset_client().await;
+        }
+
+        result
+    }
+
+    /// Executes a serialized logical plan on an available frontend.
+    pub async fn logical_plan(&self, ctx: &DatabaseContext<'_>, plan: Vec<u8>) -> Result<Output> {
+        let client = self.maybe_init_client().await?;
+        let database = Database::new(ctx.catalog, ctx.schema, client);
+
+        let result = database
+            .logical_plan(plan)
+            .await
+            .map_err(BoxedError::new)
+            .context(OtherSnafu);
+
+        if result.is_err() {
+            self.reset_client().await;
+        }
+
+        result
+    }
+
+    async fn build_client(&self) -> Result<Client> {
+        let frontends = self
+            .peer_discovery
+            .active_frontends()
+            .await
+            .context(ListActiveFrontendsSnafu)?;
+
+        ensure!(!frontends.is_empty(), NoAvailableFrontendSnafu);
+
+        let urls = frontends
+            .into_iter()
+            .map(|peer| peer.addr)
+            .collect::<Vec<_>>();
+
+        debug!("Available frontend addresses: {:?}", urls);
+
+        Ok(Client::with_urls(urls))
+    }
+
+    async fn maybe_init_client(&self) -> Result<Client> {
+        let mut guard = self.client.write().await;
+        if let Some(client) = guard.as_ref() {
+            return Ok(client.clone());
+        }
+
+        let client = self.build_client().await?;
+        *guard = Some(client.clone());
+        Ok(client)
+    }
+
+    async fn reset_client(&self) {
+        warn!("Resetting the client");
+        let mut guard = self.client.write().await;
+        guard.take();
+    }
+}

--- a/src/meta-srv/src/utils/database.rs
+++ b/src/meta-srv/src/utils/database.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use client::error::{ExternalSnafu, Result as ClientResult};
 use client::{Client, Database, Output};
 use common_error::ext::BoxedError;
 use common_meta::peer::PeerDiscoveryRef;
@@ -21,7 +22,7 @@ use common_telemetry::{debug, warn};
 use snafu::{ResultExt, ensure};
 use tokio::sync::RwLock;
 
-use crate::error::{ListActiveFrontendsSnafu, NoAvailableFrontendSnafu, OtherSnafu, Result};
+use crate::error::{ListActiveFrontendsSnafu, NoAvailableFrontendSnafu, Result};
 
 pub type DatabaseOperatorRef = Arc<DatabaseOperator>;
 
@@ -62,17 +63,13 @@ impl DatabaseOperator {
         ctx: &DatabaseContext<'_>,
         requests: api::v1::RowInsertRequests,
         hints: &[(&str, &str)],
-    ) -> Result<u32> {
+    ) -> ClientResult<u32> {
         let client = self.maybe_init_client().await?;
         let database = Database::new(ctx.catalog, ctx.schema, client);
 
-        let result = database
-            .row_inserts_with_hints(requests, hints)
-            .await
-            .map_err(BoxedError::new)
-            .context(OtherSnafu);
+        let result = database.row_inserts_with_hints(requests, hints).await;
 
-        if result.is_err() {
+        if should_reset_client(&result) {
             self.reset_client().await;
         }
 
@@ -80,17 +77,17 @@ impl DatabaseOperator {
     }
 
     /// Executes a serialized logical plan on an available frontend.
-    pub async fn logical_plan(&self, ctx: &DatabaseContext<'_>, plan: Vec<u8>) -> Result<Output> {
+    pub async fn logical_plan(
+        &self,
+        ctx: &DatabaseContext<'_>,
+        plan: Vec<u8>,
+    ) -> ClientResult<Output> {
         let client = self.maybe_init_client().await?;
         let database = Database::new(ctx.catalog, ctx.schema, client);
 
-        let result = database
-            .logical_plan(plan)
-            .await
-            .map_err(BoxedError::new)
-            .context(OtherSnafu);
+        let result = database.logical_plan(plan).await;
 
-        if result.is_err() {
+        if should_reset_client(&result) {
             self.reset_client().await;
         }
 
@@ -116,13 +113,22 @@ impl DatabaseOperator {
         Ok(Client::with_urls(urls))
     }
 
-    async fn maybe_init_client(&self) -> Result<Client> {
+    async fn maybe_init_client(&self) -> ClientResult<Client> {
+        if let Some(client) = self.client.read().await.as_ref() {
+            return Ok(client.clone());
+        }
+
+        let client = self
+            .build_client()
+            .await
+            .map_err(BoxedError::new)
+            .context(ExternalSnafu)?;
+
         let mut guard = self.client.write().await;
         if let Some(client) = guard.as_ref() {
             return Ok(client.clone());
         }
 
-        let client = self.build_client().await?;
         *guard = Some(client.clone());
         Ok(client)
     }
@@ -132,4 +138,12 @@ impl DatabaseOperator {
         let mut guard = self.client.write().await;
         guard.take();
     }
+}
+
+fn should_reset_client<T>(result: &client::error::Result<T>) -> bool {
+    result
+        .as_ref()
+        .err()
+        .map(|err| err.is_connection_error())
+        .unwrap_or(false)
 }

--- a/src/meta-srv/src/utils/insert_forwarder.rs
+++ b/src/meta-srv/src/utils/insert_forwarder.rs
@@ -17,72 +17,27 @@ use std::sync::Arc;
 use api::v1::RowInsertRequests;
 use client::error::{ExternalSnafu, Result as ClientResult};
 use client::inserter::{Context, InsertOptions, Inserter};
-use client::{Client, Database};
 use common_error::ext::BoxedError;
-use common_meta::peer::PeerDiscoveryRef;
-use common_telemetry::{debug, warn};
-use snafu::{ResultExt, ensure};
-use tokio::sync::RwLock;
+use snafu::ResultExt;
 
-use crate::error::{ListActiveFrontendsSnafu, NoAvailableFrontendSnafu};
+use crate::utils::database::{DatabaseContext, DatabaseOperatorRef};
 
 pub type InsertForwarderRef = Arc<InsertForwarder>;
 
 /// [`InsertForwarder`] is the inserter for the metasrv.
 /// It forwards insert requests to available frontend instances.
 pub struct InsertForwarder {
-    peer_discovery: PeerDiscoveryRef,
-    client: RwLock<Option<Client>>,
+    database_operator: DatabaseOperatorRef,
     options: Option<InsertOptions>,
 }
 
 impl InsertForwarder {
     /// Creates a new InsertForwarder with the given peer lookup service.
-    pub fn new(peer_discovery: PeerDiscoveryRef, options: Option<InsertOptions>) -> Self {
+    pub fn new(database_operator: DatabaseOperatorRef, options: Option<InsertOptions>) -> Self {
         Self {
-            peer_discovery,
-            client: RwLock::new(None),
+            database_operator,
             options,
         }
-    }
-
-    /// Builds a new client.
-    async fn build_client(&self) -> crate::error::Result<Client> {
-        let frontends = self
-            .peer_discovery
-            .active_frontends()
-            .await
-            .context(ListActiveFrontendsSnafu)?;
-
-        ensure!(!frontends.is_empty(), NoAvailableFrontendSnafu);
-
-        let urls = frontends
-            .into_iter()
-            .map(|peer| peer.addr)
-            .collect::<Vec<_>>();
-
-        debug!("Available frontend addresses: {:?}", urls);
-
-        Ok(Client::with_urls(urls))
-    }
-
-    /// Initializes the client if it hasn't been initialized yet, or returns the cached client.
-    async fn maybe_init_client(&self) -> Result<Client, BoxedError> {
-        let mut guard = self.client.write().await;
-        if guard.is_none() {
-            let client = self.build_client().await.map_err(BoxedError::new)?;
-            *guard = Some(client);
-        }
-
-        // Safety: checked above that the client is Some.
-        Ok(guard.as_ref().unwrap().clone())
-    }
-
-    /// Resets the cached client, forcing a rebuild on the next use.
-    async fn reset_client(&self) {
-        warn!("Resetting the client");
-        let mut guard = self.client.write().await;
-        guard.take();
     }
 }
 
@@ -93,12 +48,12 @@ impl Inserter for InsertForwarder {
         context: &Context<'_>,
         requests: RowInsertRequests,
     ) -> ClientResult<()> {
-        let client = self.maybe_init_client().await.context(ExternalSnafu)?;
-        let database = Database::new(context.catalog, context.schema, client);
+        let ctx = DatabaseContext::new(context.catalog, context.schema);
         let hints = self.options.as_ref().map_or(vec![], |o| o.to_hints());
 
-        if let Err(e) = database
-            .row_inserts_with_hints(
+        self.database_operator
+            .insert(
+                &ctx,
                 requests,
                 &hints
                     .iter()
@@ -107,12 +62,7 @@ impl Inserter for InsertForwarder {
             )
             .await
             .map_err(BoxedError::new)
-            .context(ExternalSnafu)
-        {
-            // Resets the client so it will be rebuilt next time.
-            self.reset_client().await;
-            return Err(e);
-        };
+            .context(ExternalSnafu)?;
 
         Ok(())
     }

--- a/src/meta-srv/src/utils/insert_forwarder.rs
+++ b/src/meta-srv/src/utils/insert_forwarder.rs
@@ -15,10 +15,8 @@
 use std::sync::Arc;
 
 use api::v1::RowInsertRequests;
-use client::error::{ExternalSnafu, Result as ClientResult};
+use client::error::Result as ClientResult;
 use client::inserter::{Context, InsertOptions, Inserter};
-use common_error::ext::BoxedError;
-use snafu::ResultExt;
 
 use crate::utils::database::{DatabaseContext, DatabaseOperatorRef};
 
@@ -32,7 +30,8 @@ pub struct InsertForwarder {
 }
 
 impl InsertForwarder {
-    /// Creates a new InsertForwarder with the given peer lookup service.
+    /// Creates a new [`InsertForwarder`] with the given shared database operator
+    /// and optional insert options.
     pub fn new(database_operator: DatabaseOperatorRef, options: Option<InsertOptions>) -> Self {
         Self {
             database_operator,
@@ -60,9 +59,7 @@ impl Inserter for InsertForwarder {
                     .map(|(k, v)| (*k, v.as_str()))
                     .collect::<Vec<_>>(),
             )
-            .await
-            .map_err(BoxedError::new)
-            .context(ExternalSnafu)?;
+            .await?;
 
         Ok(())
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR extracts metasrv's frontend database forwarding logic into a shared `utils::database` helper.

It introduces a minimal `DatabaseContext<'a>` and a `DatabaseOperator` that encapsulates frontend discovery, cached client initialization, client reset on failure, and forwarded database operations. `InsertForwarder` is refactored to use this helper instead of managing its own cached client state.
The change keeps current behavior unchanged, while preparing metasrv to share one database operator across multiple components

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
