### PR TITLE
fix(server): describe EXPLAIN statements so bind parameters work

### DIFF
--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -710,16 +710,14 @@ impl Instance {
         // EXPLAIN / EXPLAIN ANALYZE wrap an inner statement; describe them when the
         // wrapped statement is something we already plan (so that bind parameters
         // in the inner query get their types inferred). See #8029.
-        let plannable = matches!(
-            stmt,
-            Statement::Insert(_) | Statement::Query(_) | Statement::Delete(_)
-        ) || matches!(
-            &stmt,
-            Statement::Explain(explain) if matches!(
-                explain.statement.as_ref(),
+        let is_inner_plannable = |s: &Statement| {
+            matches!(
+                s,
                 Statement::Insert(_) | Statement::Query(_) | Statement::Delete(_)
             )
-        );
+        };
+        let plannable = is_inner_plannable(&stmt)
+            || matches!(&stmt, Statement::Explain(explain) if is_inner_plannable(explain.statement.as_ref()));
 
         if plannable {
             self.plugins

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -707,10 +707,21 @@ impl Instance {
     ) -> Result<Option<DescribeResult>> {
         ensure!(!self.is_suspended(), error::SuspendedSnafu);
 
-        if matches!(
+        // EXPLAIN / EXPLAIN ANALYZE wrap an inner statement; describe them when the
+        // wrapped statement is something we already plan (so that bind parameters
+        // in the inner query get their types inferred). See #8029.
+        let plannable = matches!(
             stmt,
             Statement::Insert(_) | Statement::Query(_) | Statement::Delete(_)
-        ) {
+        ) || matches!(
+            &stmt,
+            Statement::Explain(explain) if matches!(
+                explain.statement.as_ref(),
+                Statement::Insert(_) | Statement::Query(_) | Statement::Delete(_)
+            )
+        );
+
+        if plannable {
             self.plugins
                 .get::<PermissionCheckerRef>()
                 .as_ref()

--- a/tests-integration/tests/sql.rs
+++ b/tests-integration/tests/sql.rs
@@ -83,6 +83,7 @@ macro_rules! sql_tests {
                 test_postgres_intervalstyle,
                 test_postgres_parameter_inference,
                 test_postgres_uint64_parameter,
+                test_postgres_explain_bind_parameter,
                 test_postgres_array_types,
                 test_mysql_prepare_stmt_insert_timestamp,
                 test_mysql_federated_prepare_stmt,
@@ -1345,6 +1346,65 @@ pub async fn test_postgres_uint64_parameter(store_type: StorageType) {
     assert_eq!(1, rows.len());
     let count: i64 = rows[0].get(0);
     assert_eq!(count, 1);
+
+    drop(client);
+    rx.await.unwrap();
+
+    let _ = fe_pg_server.shutdown().await;
+    guard.remove_all().await;
+}
+
+pub async fn test_postgres_explain_bind_parameter(store_type: StorageType) {
+    // Regression test for #8029: EXPLAIN / EXPLAIN ANALYZE must accept bind
+    // parameters over the Postgres extended query protocol.
+    let (mut guard, fe_pg_server) =
+        setup_pg_server(store_type, "test_postgres_explain_bind_parameter").await;
+    let addr = fe_pg_server.bind_addr().unwrap().to_string();
+
+    let (client, connection) = tokio_postgres::connect(&format!("postgres://{addr}/public"), NoTls)
+        .await
+        .unwrap();
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    tokio::spawn(async move {
+        connection.await.unwrap();
+        tx.send(()).unwrap();
+    });
+
+    let _ = client
+        .simple_query(
+            "create table t (k varchar(36) not null, ts timestamp(3) not null, time index(ts))",
+        )
+        .await
+        .unwrap();
+    let _ = client
+        .simple_query("insert into t (k, ts) values ('a', 1), ('b', 2), ('c', 3)")
+        .await
+        .unwrap();
+
+    // Sanity check: the underlying SELECT with a bind parameter works.
+    let rows = client
+        .query("SELECT k FROM t WHERE k = $1", &[&"a"])
+        .await
+        .unwrap();
+    assert_eq!(1, rows.len());
+
+    // EXPLAIN with a bind parameter must succeed.
+    let rows = client
+        .query("EXPLAIN SELECT k FROM t WHERE k = $1", &[&"a"])
+        .await
+        .unwrap();
+    assert!(!rows.is_empty(), "EXPLAIN should produce at least one row");
+
+    // EXPLAIN ANALYZE with a bind parameter must also succeed.
+    let rows = client
+        .query("EXPLAIN ANALYZE SELECT k FROM t WHERE k = $1", &[&"a"])
+        .await
+        .unwrap();
+    assert!(
+        !rows.is_empty(),
+        "EXPLAIN ANALYZE should produce at least one row"
+    );
 
     drop(client);
     rx.await.unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Fixes #8029

## What's changed and what's your intention?

Over the Postgres extended query protocol, `EXPLAIN` and `EXPLAIN ANALYZE` against a query with a bind parameter returned `unsupported_parameter_type` (SQLSTATE 22023) at the Bind step, while the same `SELECT` with a bind parameter and the same `EXPLAIN` with a literal both work. Postgres 17 and MySQL 8 both accept bind parameters in `EXPLAIN`, so this was a GreptimeDB-specific gap.

### Root cause

`Instance::do_describe_inner` (`src/frontend/src/instance.rs`) only planned `Statement::Insert`, `Statement::Query`, and `Statement::Delete`. For anything else it returned `Ok(None)`, which caused the Postgres handler to store the statement in `SqlPlan::Statement(..)` instead of `SqlPlan::Plan(..)`. Only the `SqlPlan::Plan(..)` arm in `do_describe_statement` runs `get_inferred_parameter_types`, so `EXPLAIN`-wrapped queries lost parameter type inference entirely, and the handler rejected the Bind.

### Fix

Recognize `Statement::Explain` when its inner statement is itself plannable (`Insert` / `Query` / `Delete`) and route it through the same describe path. The planner already supports `EXPLAIN` end-to-end via `explain_to_plan` and produces a `LogicalPlan::Explain` / `LogicalPlan::Analyze` that wraps the inner plan, so the existing DataFusion-based `get_parameter_types` traversal picks up the placeholders. `check_permission` (top level) already lets `Statement::Explain` through, so no permission change is needed. The fix benefits the MySQL extended protocol path as well, since it goes through the same `do_describe` hook.

### Before / after

```sql
CREATE TABLE t (k VARCHAR(36) NOT NULL, ts TIMESTAMP(3) NOT NULL, TIME INDEX(ts));
INSERT INTO t (k, ts) VALUES ('a', 1), ('b', 2), ('c', 3);

-- Before: fails at Bind with unsupported_parameter_type (22023).
-- After:  succeeds, returns the plan.
EXPLAIN SELECT k FROM t WHERE k = $1;

-- Before: same failure.
-- After:  succeeds, returns the analyzed plan.
EXPLAIN ANALYZE SELECT k FROM t WHERE k = $1;
```

### Test

Adds `test_postgres_explain_bind_parameter` in `tests-integration/tests/sql.rs`, which reproduces the original issue: it creates the table from the bug report, runs a plain parameterized `SELECT` as a sanity check, then runs `EXPLAIN` and `EXPLAIN ANALYZE` with a bind parameter using `tokio-postgres` (extended query protocol).

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.