### PR TITLE
feat: allow detailed index config in pipeline

### DIFF
--- a/src/common/grpc-expr/src/error.rs
+++ b/src/common/grpc-expr/src/error.rs
@@ -90,9 +90,9 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Fulltext or Skipping index only supports string type, column: {column_name}, unexpected type: {column_type:?}"
+        "Fulltext index only supports string type, column: {column_name}, unexpected type: {column_type:?}"
     ))]
-    InvalidStringIndexColumnType {
+    InvalidFulltextIndexColumnType {
         column_name: String,
         column_type: ColumnDataType,
         #[snafu(implicit)]
@@ -183,7 +183,7 @@ impl ErrorExt for Error {
             Error::InvalidColumnDef { source, .. } => source.status_code(),
             Error::UnknownLocationType { .. } => StatusCode::InvalidArguments,
 
-            Error::UnknownColumnDataType { .. } | Error::InvalidStringIndexColumnType { .. } => {
+            Error::UnknownColumnDataType { .. } | Error::InvalidFulltextIndexColumnType { .. } => {
                 StatusCode::InvalidArguments
             }
             Error::InvalidSetTableOptionRequest { .. }

--- a/src/common/grpc-expr/src/util.rs
+++ b/src/common/grpc-expr/src/util.rs
@@ -15,7 +15,7 @@
 use std::collections::HashSet;
 
 use api::v1::column_data_type_extension::TypeExt;
-use api::v1::column_def::{contains_fulltext, contains_skipping};
+use api::v1::column_def::contains_fulltext;
 use api::v1::{
     AddColumn, AddColumns, Column, ColumnDataType, ColumnDataTypeExtension, ColumnDef,
     ColumnOptions, ColumnSchema, CreateTableExpr, JsonTypeExtension, SemanticType,
@@ -27,7 +27,7 @@ use table::table_reference::TableReference;
 
 use crate::error::{
     self, DuplicatedColumnNameSnafu, DuplicatedTimestampColumnSnafu,
-    InvalidStringIndexColumnTypeSnafu, MissingTimestampColumnSnafu, Result,
+    InvalidFulltextIndexColumnTypeSnafu, MissingTimestampColumnSnafu, Result,
     UnknownColumnDataTypeSnafu,
 };
 pub struct ColumnExpr<'a> {
@@ -152,9 +152,8 @@ pub fn build_create_table_expr(
         let column_type = infer_column_datatype(datatype, datatype_extension)?;
 
         ensure!(
-            (!contains_fulltext(options) && !contains_skipping(options))
-                || column_type == ColumnDataType::String,
-            InvalidStringIndexColumnTypeSnafu {
+            !contains_fulltext(options) || column_type == ColumnDataType::String,
+            InvalidFulltextIndexColumnTypeSnafu {
                 column_name,
                 column_type,
             }
@@ -245,6 +244,7 @@ mod tests {
     use api::helper::ColumnDataTypeWrapper;
     use api::v1::column::Values;
     use api::v1::column_data_type_extension::TypeExt;
+    use api::v1::column_def::{options_from_fulltext, options_from_skipping};
     use api::v1::{
         Column, ColumnDataType, ColumnDataTypeExtension, Decimal128, DecimalTypeExtension,
         IntervalMonthDayNano, SemanticType,
@@ -253,7 +253,7 @@ mod tests {
     use common_time::interval::IntervalUnit;
     use common_time::timestamp::TimeUnit;
     use datatypes::data_type::ConcreteDataType;
-    use datatypes::schema::{ColumnSchema, SchemaBuilder};
+    use datatypes::schema::{ColumnSchema, FulltextOptions, SchemaBuilder, SkippingIndexOptions};
     use snafu::ResultExt;
 
     use super::*;
@@ -293,6 +293,21 @@ mod tests {
             engine,
             "Created on insertion",
         )
+    }
+
+    fn build_proto_column_schema(
+        column_name: &str,
+        datatype: ColumnDataType,
+        semantic_type: SemanticType,
+        options: Option<ColumnOptions>,
+    ) -> api::v1::ColumnSchema {
+        api::v1::ColumnSchema {
+            column_name: column_name.to_string(),
+            datatype: datatype as i32,
+            semantic_type: semantic_type as i32,
+            options,
+            ..Default::default()
+        }
     }
 
     #[test]
@@ -526,6 +541,68 @@ mod tests {
             )
         );
         assert!(host_column.add_if_not_exists);
+    }
+
+    #[test]
+    fn test_build_create_table_expr_allows_skipping_index_on_int_column() {
+        let table_name = TableReference::full("", "", "test_metric");
+        let column_schemas = vec![
+            build_proto_column_schema(
+                "value",
+                ColumnDataType::Int64,
+                SemanticType::Field,
+                options_from_skipping(&SkippingIndexOptions::default()).unwrap(),
+            ),
+            build_proto_column_schema(
+                "ts",
+                ColumnDataType::TimestampMillisecond,
+                SemanticType::Timestamp,
+                None,
+            ),
+        ];
+
+        let result = build_create_table_expr(
+            None,
+            &table_name,
+            ColumnExpr::from_column_schemas(&column_schemas),
+            MITO_ENGINE,
+            "Created on insertion",
+        );
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_build_create_table_expr_rejects_fulltext_index_on_non_string_column() {
+        let table_name = TableReference::full("", "", "test_metric");
+        let column_schemas = vec![
+            build_proto_column_schema(
+                "value",
+                ColumnDataType::Int64,
+                SemanticType::Field,
+                options_from_fulltext(&FulltextOptions {
+                    enable: true,
+                    ..Default::default()
+                })
+                .unwrap(),
+            ),
+            build_proto_column_schema(
+                "ts",
+                ColumnDataType::TimestampMillisecond,
+                SemanticType::Timestamp,
+                None,
+            ),
+        ];
+
+        let result = build_create_table_expr(
+            None,
+            &table_name,
+            ColumnExpr::from_column_schemas(&column_schemas),
+            MITO_ENGINE,
+            "Created on insertion",
+        );
+
+        assert!(result.is_err());
     }
 
     fn mock_insert_batch() -> (Vec<Column>, u32) {

--- a/src/pipeline/src/error.rs
+++ b/src/pipeline/src/error.rs
@@ -389,6 +389,61 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display("Transform index `type` must be set."))]
+    TransformIndexTypeMustBeSet {
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Unsupported field in transform index config: {field}"))]
+    TransformIndexUnsupportedField {
+        field: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display(
+        "Transform index option `{field}` must be a string, boolean, integer, or real scalar"
+    ))]
+    TransformIndexOptionMustBeScalar {
+        field: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Index type `{index}` does not support options in pipeline config"))]
+    TransformIndexOptionsUnsupported {
+        index: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Unsupported option `{key}` for `{index}` index"))]
+    TransformIndexOptionUnsupported {
+        index: String,
+        key: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Index `{index}` only supports {expected} columns, but got {actual}"))]
+    TransformIndexTypeMismatch {
+        index: String,
+        expected: String,
+        actual: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Invalid options for `{index}` index"))]
+    TransformIndexOption {
+        index: String,
+        #[snafu(source)]
+        source: datatypes::error::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Transform index `{index}` does not match options declared for `{options}`"))]
+    TransformIndexStateMismatch {
+        index: String,
+        options: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
     #[snafu(display("Column name must be unique, but got duplicated: {duplicates}"))]
     TransformColumnNameMustBeUnique {
         duplicates: String,
@@ -897,6 +952,14 @@ impl ErrorExt for Error {
             | TransformElementMustBeMap { .. }
             | TransformFieldMustBeSet { .. }
             | TransformTypeMustBeSet { .. }
+            | TransformIndexTypeMustBeSet { .. }
+            | TransformIndexUnsupportedField { .. }
+            | TransformIndexOptionMustBeScalar { .. }
+            | TransformIndexOptionsUnsupported { .. }
+            | TransformIndexOptionUnsupported { .. }
+            | TransformIndexTypeMismatch { .. }
+            | TransformIndexOption { .. }
+            | TransformIndexStateMismatch { .. }
             | TransformColumnNameMustBeUnique { .. }
             | TransformMultipleTimestampIndex { .. }
             | TransformTimestampIndexCount { .. }

--- a/src/pipeline/src/etl.rs
+++ b/src/pipeline/src/etl.rs
@@ -482,6 +482,7 @@ mod tests {
     use std::sync::Arc;
 
     use api::v1::Rows;
+    use datatypes::schema::{FulltextOptions, SkippingIndexOptions};
     use greptime_proto::v1::value::ValueData;
     use greptime_proto::v1::{self, ColumnDataType, SemanticType};
     use vrl::prelude::Bytes;
@@ -1466,5 +1467,89 @@ transform:
 
         // Empty array should produce empty HashMap
         assert_eq!(rows_by_context.len(), 0);
+    }
+
+    #[test]
+    fn test_pipeline_detailed_index_options_roundtrip() {
+        let pipeline_yaml = r#"
+transform:
+  - field: message
+    type: string
+    index:
+      type: fulltext
+      options:
+        analyzer: Chinese
+        case_sensitive: true
+        backend: tantivy
+  - field: trace_id
+    type: int64
+    index:
+      type: skipping
+      options:
+        granularity: 2048
+        false_positive_rate: 0.02
+        type: BLOOM
+  - field: ts
+    type: timestamp, ns
+    index: time
+"#;
+
+        let pipeline: Pipeline = parse(&Content::Yaml(pipeline_yaml)).unwrap();
+        let schema = pipeline.schemas().unwrap().clone();
+
+        let message = schema
+            .iter()
+            .find(|column| column.column_name == "message")
+            .unwrap();
+        let trace_id = schema
+            .iter()
+            .find(|column| column.column_name == "trace_id")
+            .unwrap();
+        let message_options = message.options.clone();
+        let trace_id_options = trace_id.options.clone();
+
+        let fulltext: FulltextOptions = serde_json::from_str(
+            message
+                .options
+                .as_ref()
+                .unwrap()
+                .options
+                .get("fulltext")
+                .unwrap(),
+        )
+        .unwrap();
+        assert!(fulltext.enable);
+        assert_eq!(fulltext.analyzer.to_string(), "Chinese");
+        assert!(fulltext.case_sensitive);
+        assert_eq!(fulltext.backend.to_string(), "tantivy");
+
+        let skipping: SkippingIndexOptions = serde_json::from_str(
+            trace_id
+                .options
+                .as_ref()
+                .unwrap()
+                .options
+                .get("skipping_index")
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(skipping.granularity, 2048);
+        assert_eq!(skipping.false_positive_rate(), 0.02);
+        assert_eq!(skipping.index_type.to_string(), "BLOOM");
+
+        let roundtrip_schema = SchemaInfo::from_schema_list(schema)
+            .column_schemas()
+            .unwrap();
+        let roundtrip_message = roundtrip_schema
+            .iter()
+            .find(|column| column.column_name == "message")
+            .unwrap();
+        let roundtrip_trace_id = roundtrip_schema
+            .iter()
+            .find(|column| column.column_name == "trace_id")
+            .unwrap();
+
+        assert_eq!(message_options, roundtrip_message.options);
+        assert_eq!(trace_id_options, roundtrip_trace_id.options);
     }
 }

--- a/src/pipeline/src/etl/transform.rs
+++ b/src/pipeline/src/etl/transform.rs
@@ -162,6 +162,7 @@ impl TransformIndexOptions {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn as_fulltext(&self) -> Option<&FulltextOptions> {
         match self {
             TransformIndexOptions::Fulltext(options) => Some(options),
@@ -169,6 +170,7 @@ impl TransformIndexOptions {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn as_skipping(&self) -> Option<&SkippingIndexOptions> {
         match self {
             TransformIndexOptions::Skipping(options) => Some(options),
@@ -281,44 +283,42 @@ fn parse_transform_index(
             let index_str = yaml_string(value, TRANSFORM_INDEX)?;
             Ok((index_str.try_into()?, None))
         }
-        yaml_rust::Yaml::Hash(hash) => parse_transform_index_map(hash),
+        yaml_rust::Yaml::Hash(hash) => {
+            let mut index = None;
+            let mut index_options = None;
+
+            for (k, v) in hash {
+                let key = k
+                    .as_str()
+                    .with_context(|| KeyMustBeStringSnafu { k: k.clone() })?;
+                match key {
+                    TRANSFORM_TYPE => {
+                        let index_str = yaml_string(v, TRANSFORM_INDEX_TYPE_FIELD)?;
+                        index = Some(index_str.try_into()?);
+                    }
+                    TRANSFORM_INDEX_OPTIONS => {
+                        index_options = Some(parse_transform_index_options(v)?);
+                    }
+                    _ => {
+                        return TransformIndexUnsupportedFieldSnafu {
+                            field: key.to_string(),
+                        }
+                        .fail();
+                    }
+                }
+            }
+
+            Ok((
+                index.context(TransformIndexTypeMustBeSetSnafu)?,
+                index_options,
+            ))
+        }
         _ => FieldMustBeTypeSnafu {
             field: TRANSFORM_INDEX,
             ty: "string or map",
         }
         .fail(),
     }
-}
-
-fn parse_transform_index_map(
-    hash: &yaml_rust::yaml::Hash,
-) -> Result<(Index, Option<HashMap<String, String>>)> {
-    let mut index = None;
-    let mut index_options = None;
-
-    for (k, v) in hash {
-        let key = k
-            .as_str()
-            .with_context(|| KeyMustBeStringSnafu { k: k.clone() })?;
-        match key {
-            TRANSFORM_TYPE => {
-                let index_str = yaml_string(v, TRANSFORM_INDEX_TYPE_FIELD)?;
-                index = Some(index_str.try_into()?);
-            }
-            TRANSFORM_INDEX_OPTIONS => {
-                index_options = Some(parse_transform_index_options(v)?);
-            }
-            _ => {
-                return TransformIndexUnsupportedFieldSnafu {
-                    field: key.to_string(),
-                }
-                .fail();
-            }
-        }
-    }
-
-    let index = index.context(TransformIndexTypeMustBeSetSnafu)?;
-    Ok((index, index_options))
 }
 
 fn parse_transform_index_options(value: &yaml_rust::Yaml) -> Result<HashMap<String, String>> {
@@ -332,44 +332,21 @@ fn parse_transform_index_options(value: &yaml_rust::Yaml) -> Result<HashMap<Stri
         let key = k
             .as_str()
             .with_context(|| KeyMustBeStringSnafu { k: k.clone() })?;
-        options.insert(
-            key.to_string(),
-            yaml_scalar_to_string(v, &format!("{TRANSFORM_INDEX_OPTIONS_FIELD}.{key}"))?,
-        );
+
+        let field = format!("{TRANSFORM_INDEX_OPTIONS_FIELD}.{key}");
+        let value = match v {
+            yaml_rust::Yaml::String(v) => v.clone(),
+            yaml_rust::Yaml::Boolean(v) => v.to_string(),
+            yaml_rust::Yaml::Integer(v) => v.to_string(),
+            yaml_rust::Yaml::Real(v) => v.clone(),
+            _ => {
+                return TransformIndexOptionMustBeScalarSnafu { field }.fail();
+            }
+        };
+        options.insert(key.to_string(), value);
     }
 
     Ok(options)
-}
-
-fn yaml_scalar_to_string(value: &yaml_rust::Yaml, field: &str) -> Result<String> {
-    match value {
-        yaml_rust::Yaml::String(v) => Ok(v.clone()),
-        yaml_rust::Yaml::Boolean(v) => Ok(v.to_string()),
-        yaml_rust::Yaml::Integer(v) => Ok(v.to_string()),
-        yaml_rust::Yaml::Real(v) => Ok(v.clone()),
-        _ => TransformIndexOptionMustBeScalarSnafu {
-            field: field.to_string(),
-        }
-        .fail(),
-    }
-}
-
-fn validate_index_option_keys(
-    index: Index,
-    options: &HashMap<String, String>,
-    validate: fn(&str) -> bool,
-) -> Result<()> {
-    for key in options.keys() {
-        ensure!(
-            validate(key),
-            TransformIndexOptionUnsupportedSnafu {
-                index: index.to_string(),
-                key: key.clone(),
-            }
-        );
-    }
-
-    Ok(())
 }
 
 fn lower_typed_transform_index_options<T>(
@@ -383,7 +360,15 @@ where
 {
     index_options
         .map(|opts| {
-            validate_index_option_keys(index, &opts, validate)?;
+            for key in opts.keys() {
+                ensure!(
+                    validate(key),
+                    TransformIndexOptionUnsupportedSnafu {
+                        index: index.to_string(),
+                        key: key.clone(),
+                    }
+                );
+            }
 
             let options = opts.try_into().context(TransformIndexOptionSnafu {
                 index: index.to_string(),

--- a/src/pipeline/src/etl/transform.rs
+++ b/src/pipeline/src/etl/transform.rs
@@ -15,15 +15,24 @@
 pub mod index;
 pub mod transformer;
 
+use std::collections::HashMap;
+
 use api::v1::ColumnDataType;
 use api::v1::value::ValueData;
 use chrono::Utc;
-use snafu::{OptionExt, ensure};
+use datatypes::schema::{FulltextOptions, SkippingIndexOptions};
+use snafu::{OptionExt, ResultExt, ensure};
+use sql::parsers::utils::{
+    validate_column_fulltext_create_option, validate_column_skipping_index_create_option,
+};
 
 use crate::error::{
-    Error, KeyMustBeStringSnafu, Result, TransformElementMustBeMapSnafu,
-    TransformFieldMustBeSetSnafu, TransformOnFailureInvalidValueSnafu, TransformTypeMustBeSetSnafu,
-    UnsupportedTypeInPipelineSnafu,
+    Error, FieldMustBeTypeSnafu, KeyMustBeStringSnafu, Result, TransformElementMustBeMapSnafu,
+    TransformFieldMustBeSetSnafu, TransformIndexOptionMustBeScalarSnafu, TransformIndexOptionSnafu,
+    TransformIndexOptionUnsupportedSnafu, TransformIndexOptionsUnsupportedSnafu,
+    TransformIndexTypeMismatchSnafu, TransformIndexTypeMustBeSetSnafu,
+    TransformIndexUnsupportedFieldSnafu, TransformOnFailureInvalidValueSnafu,
+    TransformTypeMustBeSetSnafu, UnsupportedTypeInPipelineSnafu,
 };
 use crate::etl::field::Fields;
 use crate::etl::processor::{yaml_bool, yaml_new_field, yaml_new_fields, yaml_string};
@@ -34,6 +43,9 @@ const TRANSFORM_FIELD: &str = "field";
 const TRANSFORM_FIELDS: &str = "fields";
 const TRANSFORM_TYPE: &str = "type";
 const TRANSFORM_INDEX: &str = "index";
+const TRANSFORM_INDEX_TYPE_FIELD: &str = "index.type";
+const TRANSFORM_INDEX_OPTIONS: &str = "options";
+const TRANSFORM_INDEX_OPTIONS_FIELD: &str = "index.options";
 const TRANSFORM_TAG: &str = "tag";
 const TRANSFORM_DEFAULT: &str = "default";
 const TRANSFORM_ON_FAILURE: &str = "on_failure";
@@ -131,8 +143,38 @@ pub struct Transform {
     pub type_: ColumnDataType,
     pub default: Option<ValueData>,
     pub index: Option<Index>,
+    pub index_options: Option<TransformIndexOptions>,
     pub tag: bool,
     pub on_failure: Option<OnFailure>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TransformIndexOptions {
+    Fulltext(FulltextOptions),
+    Skipping(SkippingIndexOptions),
+}
+
+impl TransformIndexOptions {
+    pub(crate) fn index(&self) -> Index {
+        match self {
+            TransformIndexOptions::Fulltext(_) => Index::Fulltext,
+            TransformIndexOptions::Skipping(_) => Index::Skipping,
+        }
+    }
+
+    pub(crate) fn as_fulltext(&self) -> Option<&FulltextOptions> {
+        match self {
+            TransformIndexOptions::Fulltext(options) => Some(options),
+            TransformIndexOptions::Skipping(_) => None,
+        }
+    }
+
+    pub(crate) fn as_skipping(&self) -> Option<&SkippingIndexOptions> {
+        match self {
+            TransformIndexOptions::Skipping(options) => Some(options),
+            TransformIndexOptions::Fulltext(_) => None,
+        }
+    }
 }
 
 // valid types
@@ -231,13 +273,177 @@ fn get_default_for_type(ty: &ColumnDataType) -> Result<ValueData> {
     Ok(v)
 }
 
+fn parse_transform_index(
+    value: &yaml_rust::Yaml,
+) -> Result<(Index, Option<HashMap<String, String>>)> {
+    match value {
+        yaml_rust::Yaml::String(_) => {
+            let index_str = yaml_string(value, TRANSFORM_INDEX)?;
+            Ok((index_str.try_into()?, None))
+        }
+        yaml_rust::Yaml::Hash(hash) => parse_transform_index_map(hash),
+        _ => FieldMustBeTypeSnafu {
+            field: TRANSFORM_INDEX,
+            ty: "string or map",
+        }
+        .fail(),
+    }
+}
+
+fn parse_transform_index_map(
+    hash: &yaml_rust::yaml::Hash,
+) -> Result<(Index, Option<HashMap<String, String>>)> {
+    let mut index = None;
+    let mut index_options = None;
+
+    for (k, v) in hash {
+        let key = k
+            .as_str()
+            .with_context(|| KeyMustBeStringSnafu { k: k.clone() })?;
+        match key {
+            TRANSFORM_TYPE => {
+                let index_str = yaml_string(v, TRANSFORM_INDEX_TYPE_FIELD)?;
+                index = Some(index_str.try_into()?);
+            }
+            TRANSFORM_INDEX_OPTIONS => {
+                index_options = Some(parse_transform_index_options(v)?);
+            }
+            _ => {
+                return TransformIndexUnsupportedFieldSnafu {
+                    field: key.to_string(),
+                }
+                .fail();
+            }
+        }
+    }
+
+    let index = index.context(TransformIndexTypeMustBeSetSnafu)?;
+    Ok((index, index_options))
+}
+
+fn parse_transform_index_options(value: &yaml_rust::Yaml) -> Result<HashMap<String, String>> {
+    let hash = value.as_hash().context(FieldMustBeTypeSnafu {
+        field: TRANSFORM_INDEX_OPTIONS_FIELD,
+        ty: "map",
+    })?;
+    let mut options = HashMap::with_capacity(hash.len());
+
+    for (k, v) in hash {
+        let key = k
+            .as_str()
+            .with_context(|| KeyMustBeStringSnafu { k: k.clone() })?;
+        options.insert(
+            key.to_string(),
+            yaml_scalar_to_string(v, &format!("{TRANSFORM_INDEX_OPTIONS_FIELD}.{key}"))?,
+        );
+    }
+
+    Ok(options)
+}
+
+fn yaml_scalar_to_string(value: &yaml_rust::Yaml, field: &str) -> Result<String> {
+    match value {
+        yaml_rust::Yaml::String(v) => Ok(v.clone()),
+        yaml_rust::Yaml::Boolean(v) => Ok(v.to_string()),
+        yaml_rust::Yaml::Integer(v) => Ok(v.to_string()),
+        yaml_rust::Yaml::Real(v) => Ok(v.clone()),
+        _ => TransformIndexOptionMustBeScalarSnafu {
+            field: field.to_string(),
+        }
+        .fail(),
+    }
+}
+
+fn validate_index_option_keys(
+    index: Index,
+    options: &HashMap<String, String>,
+    validate: fn(&str) -> bool,
+) -> Result<()> {
+    for key in options.keys() {
+        ensure!(
+            validate(key),
+            TransformIndexOptionUnsupportedSnafu {
+                index: index.to_string(),
+                key: key.clone(),
+            }
+        );
+    }
+
+    Ok(())
+}
+
+fn lower_transform_index_options(
+    index: Index,
+    column_type: &ColumnDataType,
+    index_options: Option<HashMap<String, String>>,
+) -> Result<Option<TransformIndexOptions>> {
+    match index {
+        Index::Fulltext => {
+            ensure!(
+                *column_type == ColumnDataType::String,
+                TransformIndexTypeMismatchSnafu {
+                    index: index.to_string(),
+                    expected: ColumnDataType::String.as_str_name().to_string(),
+                    actual: column_type.as_str_name().to_string(),
+                }
+            );
+
+            let Some(index_options) = index_options else {
+                return Ok(None);
+            };
+
+            validate_index_option_keys(
+                index,
+                &index_options,
+                validate_column_fulltext_create_option,
+            )?;
+
+            let options = index_options
+                .try_into()
+                .context(TransformIndexOptionSnafu {
+                    index: index.to_string(),
+                })?;
+
+            Ok(Some(TransformIndexOptions::Fulltext(options)))
+        }
+        Index::Skipping => {
+            let Some(index_options) = index_options else {
+                return Ok(None);
+            };
+
+            validate_index_option_keys(
+                index,
+                &index_options,
+                validate_column_skipping_index_create_option,
+            )?;
+
+            let options = index_options
+                .try_into()
+                .context(TransformIndexOptionSnafu {
+                    index: index.to_string(),
+                })?;
+
+            Ok(Some(TransformIndexOptions::Skipping(options)))
+        }
+        Index::Inverted | Index::Time | Index::Tag => {
+            ensure!(
+                index_options.is_none(),
+                TransformIndexOptionsUnsupportedSnafu {
+                    index: index.to_string(),
+                }
+            );
+            Ok(None)
+        }
+    }
+}
+
 impl TryFrom<&yaml_rust::yaml::Hash> for Transform {
     type Error = Error;
 
     fn try_from(hash: &yaml_rust::yaml::Hash) -> Result<Self> {
         let mut fields = Fields::default();
         let mut default = None;
-        let mut index = None;
+        let mut index_value = None;
         let mut tag = false;
         let mut on_failure = None;
 
@@ -262,8 +468,7 @@ impl TryFrom<&yaml_rust::yaml::Hash> for Transform {
                 }
 
                 TRANSFORM_INDEX => {
-                    let index_str = yaml_string(v, TRANSFORM_INDEX)?;
-                    index = Some(index_str.try_into()?);
+                    index_value = Some(v);
                 }
 
                 TRANSFORM_TAG => {
@@ -299,6 +504,16 @@ impl TryFrom<&yaml_rust::yaml::Hash> for Transform {
             fields: format!("{:?}", fields),
         })?;
 
+        let (index, index_options) = match index_value {
+            Some(value) => {
+                let (index, raw_index_options) = parse_transform_index(value)?;
+                let index_options =
+                    lower_transform_index_options(index, &type_, raw_index_options)?;
+                (Some(index), index_options)
+            }
+            None => (None, None),
+        };
+
         let final_default = if let Some(default_value) = default {
             let target = parse_str_value(&type_, &default_value)?;
             on_failure = Some(OnFailure::Default);
@@ -312,10 +527,222 @@ impl TryFrom<&yaml_rust::yaml::Hash> for Transform {
             type_,
             default: final_default,
             index,
+            index_options,
             on_failure,
             tag,
         };
 
         Ok(builder)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use yaml_rust::YamlLoader;
+
+    use super::*;
+
+    fn parse_transform(yaml: &str) -> Result<Transform> {
+        let docs = YamlLoader::load_from_str(yaml).unwrap();
+        docs[0].as_hash().unwrap().try_into()
+    }
+
+    #[test]
+    fn test_transform_parses_legacy_string_index() {
+        let transform = parse_transform(
+            r#"
+field: message
+type: string
+index: fulltext
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(transform.index, Some(Index::Fulltext));
+        assert!(transform.index_options.is_none());
+    }
+
+    #[test]
+    fn test_transform_parses_index_object_without_options() {
+        let transform = parse_transform(
+            r#"
+field: message
+type: string
+index:
+  type: inverted
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(transform.index, Some(Index::Inverted));
+        assert!(transform.index_options.is_none());
+    }
+
+    #[test]
+    fn test_transform_parses_index_object_with_scalar_options() {
+        let transform = parse_transform(
+            r#"
+field: message
+type: string
+index:
+  type: fulltext
+  options:
+    analyzer: English
+    case_sensitive: false
+    granularity: 2048
+    false_positive_rate: 0.02
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(transform.index, Some(Index::Fulltext));
+        let options = transform.index_options.as_ref().unwrap();
+        let fulltext = options.as_fulltext().unwrap();
+        assert!(fulltext.enable);
+        assert_eq!(fulltext.analyzer.to_string(), "English");
+        assert!(!fulltext.case_sensitive);
+        assert_eq!(fulltext.granularity, 2048);
+        assert_eq!(fulltext.false_positive_rate(), 0.02);
+    }
+
+    #[test]
+    fn test_transform_rejects_invalid_index_options_type() {
+        let result = parse_transform(
+            r#"
+field: message
+type: string
+index:
+  type: fulltext
+  options: invalid
+"#,
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_transform_rejects_non_scalar_index_option_value() {
+        let result = parse_transform(
+            r#"
+field: message
+type: string
+index:
+  type: fulltext
+  options:
+    analyzer:
+      kind: English
+"#,
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_transform_rejects_unknown_index_field() {
+        let result = parse_transform(
+            r#"
+field: message
+type: string
+index:
+  type: fulltext
+  config: {}
+"#,
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_transform_rejects_unsupported_fulltext_option_key() {
+        let result = parse_transform(
+            r#"
+field: message
+type: string
+index:
+  type: fulltext
+  options:
+    tokenizer: english
+"#,
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_transform_rejects_options_for_inverted_index() {
+        let result = parse_transform(
+            r#"
+field: message
+type: string
+index:
+  type: inverted
+  options:
+    backend: bloom
+"#,
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_transform_rejects_empty_options_for_unsupported_indexes() {
+        for index in ["inverted", "time", "tag"] {
+            let yaml = format!(
+                r#"
+field: message
+type: string
+index:
+  type: {index}
+  options: {{}}
+"#
+            );
+
+            let result = parse_transform(&yaml);
+            assert!(
+                result.is_err(),
+                "expected `{index}` to reject empty options"
+            );
+        }
+    }
+
+    #[test]
+    fn test_transform_rejects_fulltext_index_on_non_string_column() {
+        let result = parse_transform(
+            r#"
+field: count
+type: int64
+index: fulltext
+"#,
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_transform_allows_skipping_index_on_numeric_column() {
+        let transform = parse_transform(
+            r#"
+field: count
+type: int64
+index:
+  type: skipping
+  options:
+    granularity: 2048
+    false_positive_rate: 0.02
+    type: BLOOM
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(transform.index, Some(Index::Skipping));
+        let skipping = transform
+            .index_options
+            .as_ref()
+            .unwrap()
+            .as_skipping()
+            .unwrap();
+        assert_eq!(skipping.granularity, 2048);
+        assert_eq!(skipping.false_positive_rate(), 0.02);
+        assert_eq!(skipping.index_type.to_string(), "BLOOM");
     }
 }

--- a/src/pipeline/src/etl/transform.rs
+++ b/src/pipeline/src/etl/transform.rs
@@ -372,6 +372,28 @@ fn validate_index_option_keys(
     Ok(())
 }
 
+fn lower_typed_transform_index_options<T>(
+    index: Index,
+    index_options: Option<HashMap<String, String>>,
+    validate: fn(&str) -> bool,
+    wrap: fn(T) -> TransformIndexOptions,
+) -> Result<Option<TransformIndexOptions>>
+where
+    T: TryFrom<HashMap<String, String>, Error = datatypes::error::Error>,
+{
+    index_options
+        .map(|opts| {
+            validate_index_option_keys(index, &opts, validate)?;
+
+            let options = opts.try_into().context(TransformIndexOptionSnafu {
+                index: index.to_string(),
+            })?;
+
+            Ok(wrap(options))
+        })
+        .transpose()
+}
+
 fn lower_transform_index_options(
     index: Index,
     column_type: &ColumnDataType,
@@ -388,43 +410,19 @@ fn lower_transform_index_options(
                 }
             );
 
-            let Some(index_options) = index_options else {
-                return Ok(None);
-            };
-
-            validate_index_option_keys(
+            lower_typed_transform_index_options(
                 index,
-                &index_options,
+                index_options,
                 validate_column_fulltext_create_option,
-            )?;
-
-            let options = index_options
-                .try_into()
-                .context(TransformIndexOptionSnafu {
-                    index: index.to_string(),
-                })?;
-
-            Ok(Some(TransformIndexOptions::Fulltext(options)))
+                TransformIndexOptions::Fulltext,
+            )
         }
-        Index::Skipping => {
-            let Some(index_options) = index_options else {
-                return Ok(None);
-            };
-
-            validate_index_option_keys(
-                index,
-                &index_options,
-                validate_column_skipping_index_create_option,
-            )?;
-
-            let options = index_options
-                .try_into()
-                .context(TransformIndexOptionSnafu {
-                    index: index.to_string(),
-                })?;
-
-            Ok(Some(TransformIndexOptions::Skipping(options)))
-        }
+        Index::Skipping => lower_typed_transform_index_options(
+            index,
+            index_options,
+            validate_column_skipping_index_create_option,
+            TransformIndexOptions::Skipping,
+        ),
         Index::Inverted | Index::Time | Index::Tag => {
             ensure!(
                 index_options.is_none(),
@@ -436,7 +434,6 @@ fn lower_transform_index_options(
         }
     }
 }
-
 impl TryFrom<&yaml_rust::yaml::Hash> for Transform {
     type Error = Error;
 

--- a/src/pipeline/src/etl/transform/transformer/greptime.rs
+++ b/src/pipeline/src/etl/transform/transformer/greptime.rs
@@ -151,6 +151,7 @@ impl GreptimeTransformer {
             type_,
             default,
             index: Some(Index::Time),
+            index_options: None,
             on_failure: Some(crate::etl::transform::OnFailure::Default),
             tag: false,
         };

--- a/src/pipeline/src/etl/transform/transformer/greptime/coerce.rs
+++ b/src/pipeline/src/etl/transform/transformer/greptime/coerce.rs
@@ -18,17 +18,18 @@ use api::v1::{ColumnDataTypeExtension, ColumnOptions, JsonTypeExtension};
 use datatypes::schema::{FulltextOptions, SkippingIndexOptions};
 use greptime_proto::v1::value::ValueData;
 use greptime_proto::v1::{ColumnDataType, ColumnSchema, SemanticType};
-use snafu::{OptionExt, ResultExt};
+use snafu::{OptionExt, ResultExt, ensure};
 use vrl::value::Value as VrlValue;
 
 use crate::error::{
     CoerceIncompatibleTypesSnafu, CoerceJsonTypeToSnafu, CoerceStringToTypeSnafu,
     CoerceTypeToJsonSnafu, CoerceUnsupportedEpochTypeSnafu, ColumnOptionsSnafu,
-    InvalidTimestampSnafu, Result, UnsupportedTypeInPipelineSnafu, VrlRegexValueSnafu,
+    InvalidTimestampSnafu, Result, TransformIndexStateMismatchSnafu,
+    UnsupportedTypeInPipelineSnafu, VrlRegexValueSnafu,
 };
 use crate::etl::transform::index::Index;
 use crate::etl::transform::transformer::greptime::vrl_value_to_jsonb_value;
-use crate::etl::transform::{OnFailure, Transform};
+use crate::etl::transform::{OnFailure, Transform, TransformIndexOptions};
 
 pub(crate) fn coerce_columns(transform: &Transform) -> Result<Vec<ColumnSchema>> {
     let mut columns = Vec::new();
@@ -73,15 +74,68 @@ fn coerce_semantic_type(transform: &Transform) -> SemanticType {
     }
 }
 
-fn coerce_options(transform: &Transform) -> Result<Option<ColumnOptions>> {
-    match transform.index {
-        Some(Index::Fulltext) => options_from_fulltext(&FulltextOptions {
+fn transform_index_label(index: Option<Index>) -> String {
+    index
+        .map(|index| index.to_string())
+        .unwrap_or_else(|| "none".to_string())
+}
+
+fn validate_transform_index_state(transform: &Transform) -> Result<()> {
+    let Some(index_options) = transform.index_options.as_ref() else {
+        return Ok(());
+    };
+
+    let options_index = index_options.index();
+    let index = transform.index;
+    ensure!(
+        index == Some(options_index),
+        TransformIndexStateMismatchSnafu {
+            index: transform_index_label(index),
+            options: options_index.to_string(),
+        }
+    );
+
+    Ok(())
+}
+
+fn build_fulltext_index_options(transform: &Transform) -> Result<FulltextOptions> {
+    match transform.index_options.as_ref() {
+        None => Ok(FulltextOptions {
             enable: true,
             ..Default::default()
-        })
-        .context(ColumnOptionsSnafu),
+        }),
+        Some(TransformIndexOptions::Fulltext(options)) => Ok(options.clone()),
+        Some(options) => TransformIndexStateMismatchSnafu {
+            index: Index::Fulltext.to_string(),
+            options: options.index().to_string(),
+        }
+        .fail(),
+    }
+}
+
+fn build_skipping_index_options(transform: &Transform) -> Result<SkippingIndexOptions> {
+    match transform.index_options.as_ref() {
+        None => Ok(SkippingIndexOptions::default()),
+        Some(TransformIndexOptions::Skipping(options)) => Ok(options.clone()),
+        Some(options) => TransformIndexStateMismatchSnafu {
+            index: Index::Skipping.to_string(),
+            options: options.index().to_string(),
+        }
+        .fail(),
+    }
+}
+
+fn coerce_options(transform: &Transform) -> Result<Option<ColumnOptions>> {
+    validate_transform_index_state(transform)?;
+
+    match transform.index {
+        Some(Index::Fulltext) => {
+            let options = build_fulltext_index_options(transform)?;
+            options_from_fulltext(&options).context(ColumnOptionsSnafu)
+        }
         Some(Index::Skipping) => {
-            options_from_skipping(&SkippingIndexOptions::default()).context(ColumnOptionsSnafu)
+            let options = build_skipping_index_options(transform)?;
+            options_from_skipping(&options).context(ColumnOptionsSnafu)
         }
         Some(Index::Inverted) => Ok(Some(options_from_inverted())),
         _ => Ok(None),
@@ -382,6 +436,7 @@ fn coerce_json_value(v: &VrlValue, transform: &Transform) -> Result<Option<Value
 #[cfg(test)]
 mod tests {
 
+    use datatypes::schema::{FulltextAnalyzer, FulltextBackend, SkippingIndexType};
     use vrl::prelude::Bytes;
 
     use super::*;
@@ -394,6 +449,7 @@ mod tests {
             type_: ColumnDataType::Int32,
             default: None,
             index: None,
+            index_options: None,
             on_failure: None,
             tag: false,
         };
@@ -420,6 +476,7 @@ mod tests {
             type_: ColumnDataType::Int32,
             default: None,
             index: None,
+            index_options: None,
             on_failure: Some(OnFailure::Ignore),
             tag: false,
         };
@@ -436,6 +493,7 @@ mod tests {
             type_: ColumnDataType::Int32,
             default: None,
             index: None,
+            index_options: None,
             on_failure: Some(OnFailure::Default),
             tag: false,
         };
@@ -454,5 +512,100 @@ mod tests {
             let result = coerce_value(&val, &transform).unwrap();
             assert_eq!(result, Some(ValueData::I32Value(42)));
         }
+    }
+
+    #[test]
+    fn test_coerce_fulltext_options_with_custom_values() {
+        let transform = Transform {
+            fields: Fields::default(),
+            type_: ColumnDataType::String,
+            default: None,
+            index: Some(Index::Fulltext),
+            index_options: Some(TransformIndexOptions::Fulltext(
+                FulltextOptions::new_unchecked(
+                    true,
+                    FulltextAnalyzer::Chinese,
+                    true,
+                    FulltextBackend::Tantivy,
+                    10240,
+                    0.01,
+                ),
+            )),
+            on_failure: None,
+            tag: false,
+        };
+
+        let options = coerce_options(&transform).unwrap().unwrap();
+        let fulltext: FulltextOptions =
+            serde_json::from_str(options.options.get("fulltext").unwrap()).unwrap();
+
+        assert!(fulltext.enable);
+        assert_eq!(fulltext.analyzer.to_string(), "Chinese");
+        assert!(fulltext.case_sensitive);
+        assert_eq!(fulltext.backend.to_string(), "tantivy");
+    }
+
+    #[test]
+    fn test_coerce_skipping_options_with_custom_values() {
+        let transform = Transform {
+            fields: Fields::default(),
+            type_: ColumnDataType::Int64,
+            default: None,
+            index: Some(Index::Skipping),
+            index_options: Some(TransformIndexOptions::Skipping(
+                SkippingIndexOptions::new_unchecked(2048, 0.02, SkippingIndexType::BloomFilter),
+            )),
+            on_failure: None,
+            tag: false,
+        };
+
+        let options = coerce_options(&transform).unwrap().unwrap();
+        let skipping: SkippingIndexOptions =
+            serde_json::from_str(options.options.get("skipping_index").unwrap()).unwrap();
+
+        assert_eq!(skipping.granularity, 2048);
+        assert_eq!(skipping.false_positive_rate(), 0.02);
+        assert_eq!(skipping.index_type.to_string(), "BLOOM");
+    }
+
+    #[test]
+    fn test_coerce_rejects_mismatched_index_options() {
+        let transform = Transform {
+            fields: Fields::default(),
+            type_: ColumnDataType::String,
+            default: None,
+            index: Some(Index::Fulltext),
+            index_options: Some(TransformIndexOptions::Skipping(
+                SkippingIndexOptions::new_unchecked(2048, 0.02, SkippingIndexType::BloomFilter),
+            )),
+            on_failure: None,
+            tag: false,
+        };
+
+        assert!(coerce_options(&transform).is_err());
+    }
+
+    #[test]
+    fn test_coerce_rejects_index_options_without_index() {
+        let transform = Transform {
+            fields: Fields::default(),
+            type_: ColumnDataType::String,
+            default: None,
+            index: None,
+            index_options: Some(TransformIndexOptions::Fulltext(
+                FulltextOptions::new_unchecked(
+                    true,
+                    FulltextAnalyzer::Chinese,
+                    true,
+                    FulltextBackend::Tantivy,
+                    10240,
+                    0.01,
+                ),
+            )),
+            on_failure: None,
+            tag: false,
+        };
+
+        assert!(coerce_options(&transform).is_err());
     }
 }

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -135,6 +135,7 @@ macro_rules! http_tests {
                 test_pipeline_skip_error,
                 test_pipeline_filter,
                 test_pipeline_create_table,
+                test_pipeline_index_options,
 
                 test_otlp_metrics_new,
                 test_otlp_traces_v0,
@@ -3072,6 +3073,82 @@ transform:
         "CREATE TABLE IF NOT EXISTS `logs1` (\n  `timestamp` TIMESTAMP(9) NOT NULL,\n  `ip_address` STRING NULL SKIPPING INDEX WITH(false_positive_rate = '0.01', granularity = '10240', type = 'BLOOM'),\n  `username` STRING NULL,\n  `http_method` STRING NULL INVERTED INDEX,\n  `request_line` STRING NULL FULLTEXT INDEX WITH(analyzer = 'English', backend = 'bloom', case_sensitive = 'false', false_positive_rate = '0.01', granularity = '10240'),\n  `protocol` STRING NULL,\n  `status_code` INT NULL INVERTED INDEX,\n  `response_size` BIGINT NULL,\n  `message` STRING NULL,\n  TIME INDEX (`timestamp`),\n  PRIMARY KEY (`username`, `status_code`)\n)\nENGINE=mito\nWITH(\n  append_mode = 'true'\n)",
         sql
     );
+
+    guard.remove_all().await;
+}
+
+pub async fn test_pipeline_index_options(store_type: StorageType) {
+    common_telemetry::init_default_ut_logging();
+    let (app, mut guard) =
+        setup_test_http_app_with_frontend(store_type, "test_pipeline_index_options").await;
+
+    let client = TestClient::new(app).await;
+
+    let pipeline_body = r#"
+processors:
+  - date:
+      field: ts
+      formats:
+        - "%Y-%m-%d %H:%M:%S%.3f"
+      ignore_missing: true
+
+transform:
+  - field: message
+    type: string
+    index:
+      type: fulltext
+      options:
+        analyzer: Chinese
+        case_sensitive: true
+        backend: bloom
+        granularity: 2048
+        false_positive_rate: 0.02
+  - field: trace_id
+    type: int64
+    index:
+      type: skipping
+      options:
+        granularity: 1024
+        false_positive_rate: 0.05
+        type: BLOOM
+  - field: ts
+    type: time
+    index: timestamp
+"#;
+
+    let res = client
+        .post("/v1/pipelines/index_options")
+        .header("Content-Type", "application/x-yaml")
+        .body(pipeline_body)
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let data_body = r#"
+[
+  {
+    "message": "hello greptime",
+    "trace_id": 42,
+    "ts": "2024-05-25 20:16:37.217"
+  }
+]
+"#;
+    let res = client
+        .post("/v1/ingest?db=public&table=pipeline_index_options&pipeline_name=index_options")
+        .header("Content-Type", "application/json")
+        .body(data_body)
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let expected_schema = "[[\"pipeline_index_options\",\"CREATE TABLE IF NOT EXISTS \\\"pipeline_index_options\\\" (\\n  \\\"message\\\" STRING NULL FULLTEXT INDEX WITH(analyzer = 'Chinese', backend = 'bloom', case_sensitive = 'true', false_positive_rate = '0.02', granularity = '2048'),\\n  \\\"trace_id\\\" BIGINT NULL SKIPPING INDEX WITH(false_positive_rate = '0.05', granularity = '1024', type = 'BLOOM'),\\n  \\\"ts\\\" TIMESTAMP(9) NOT NULL,\\n  TIME INDEX (\\\"ts\\\")\\n)\\n\\nENGINE=mito\\nWITH(\\n  'comment' = 'Created on insertion',\\n  append_mode = 'true'\\n)\"]]";
+    validate_data(
+        "pipeline_index_options_schema",
+        &client,
+        "show create table pipeline_index_options",
+        expected_schema,
+    )
+    .await;
 
     guard.remove_all().await;
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

close: #7951 

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

This PR adds detailed index config support to pipeline YAML for `fulltext` and `skipping`, while keeping the existing `index: <type>` syntax backward compatible.

It introduces object-style index config with optional `options`, reuses existing SQL/Data Index option names and validation rules, rejects unsupported `options` on `inverted` / `time` / `tag`, and aligns pipeline auto-create behavior so only `fulltext` remains string-only.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
