### PR TITLE
feat(meta): add dropped table tombstone metadata helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ AGENTS.md
 .codex
 .gemini
 .opencode
+.worktrees/
 
 # local design docs
 docs/specs/

--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -131,6 +131,7 @@ use common_wal::options::WalOptions;
 use datanode_table::{DatanodeTableKey, DatanodeTableManager, DatanodeTableValue};
 use flow::flow_route::FlowRouteValue;
 use flow::table_flow::TableFlowValue;
+use futures_util::TryStreamExt;
 use lazy_static::lazy_static;
 use regex::Regex;
 pub use schema_metadata_manager::{SchemaMetadataManager, SchemaMetadataManagerRef};
@@ -430,6 +431,28 @@ pub struct DeserializedValueWithBytes<T: DeserializeOwned + Serialize> {
     bytes: Bytes,
     // The value was deserialized from the original bytes.
     inner: T,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DroppedTableName {
+    /// Table id stored in the tombstoned table-name mapping.
+    pub table_id: TableId,
+    /// Original fully qualified table name.
+    pub table_name: TableName,
+}
+
+#[derive(Debug, Clone)]
+pub struct DroppedTableMetadata {
+    /// Table id of the dropped table.
+    pub table_id: TableId,
+    /// Original fully qualified table name.
+    pub table_name: TableName,
+    /// Tombstoned table info value.
+    pub table_info_value: TableInfoValue,
+    /// Tombstoned table route value.
+    pub table_route_value: TableRouteValue,
+    /// Per-region WAL options recovered from tombstoned datanode metadata.
+    pub region_wal_options: HashMap<RegionNumber, WalOptions>,
 }
 
 impl<T: DeserializeOwned + Serialize> Deref for DeserializedValueWithBytes<T> {
@@ -980,6 +1003,51 @@ impl TableMetadataManager {
         self.tombstone_manager.create(keys).await.map(|_| ())
     }
 
+    /// Lists dropped tables from tombstoned table-name entries.
+    pub async fn list_dropped_tables(&self) -> Result<Vec<DroppedTableName>> {
+        let mut stream = self.tombstone_manager.tombstoned_table_names();
+        let mut dropped_tables = Vec::new();
+
+        while let Some(kv) = stream.try_next().await? {
+            let raw_key = self.tombstone_manager.strip_tombstone_prefix(&kv.key)?;
+            let table_name = TableNameKey::from_bytes(raw_key)?.into();
+            let table_id = TableNameValue::try_from_raw_value(&kv.value)?.table_id();
+            dropped_tables.push(DroppedTableName {
+                table_id,
+                table_name,
+            });
+        }
+
+        Ok(dropped_tables)
+    }
+
+    /// Gets dropped table metadata by its original full table name.
+    pub async fn get_dropped_table(
+        &self,
+        table_name: &TableName,
+    ) -> Result<Option<DroppedTableMetadata>> {
+        let table_name_key = TableNameKey::from(table_name);
+        let Some(kv) = self
+            .tombstone_manager
+            .get(&table_name_key.to_bytes())
+            .await?
+        else {
+            return Ok(None);
+        };
+
+        let table_id = TableNameValue::try_from_raw_value(&kv.value)?.table_id();
+        self.get_dropped_table_metadata(table_id, table_name.clone())
+            .await
+    }
+
+    /// Gets dropped table metadata by table id.
+    pub async fn get_dropped_table_by_id(
+        &self,
+        table_id: TableId,
+    ) -> Result<Option<DroppedTableMetadata>> {
+        self.get_dropped_table_metadata(table_id, None).await
+    }
+
     /// Deletes metadata tombstone for table **permanently**.
     /// The caller MUST ensure it has the exclusive access to `TableNameKey`.
     pub async fn delete_table_metadata_tombstone(
@@ -1027,6 +1095,85 @@ impl TableMetadataManager {
             .batch_delete(BatchDeleteRequest::new().with_keys(keys))
             .await?;
         Ok(())
+    }
+
+    /// Rebuilds dropped table metadata from tombstoned keys.
+    async fn get_dropped_table_metadata<T>(
+        &self,
+        table_id: TableId,
+        table_name: T,
+    ) -> Result<Option<DroppedTableMetadata>>
+    where
+        T: Into<Option<TableName>>,
+    {
+        let table_info_key = TableInfoKey::new(table_id);
+        let Some(table_info_kv) = self
+            .tombstone_manager
+            .get(&table_info_key.to_bytes())
+            .await?
+        else {
+            return Ok(None);
+        };
+
+        let table_info_value = TableInfoValue::try_from_raw_value(&table_info_kv.value)?;
+        let table_name = table_name
+            .into()
+            .unwrap_or_else(|| table_info_value.table_name());
+
+        let table_route_key = TableRouteKey::new(table_id);
+        let table_route_kv = self
+            .tombstone_manager
+            .get(&table_route_key.to_bytes())
+            .await?
+            .context(error::UnexpectedSnafu {
+                err_msg: format!("Missing tombstoned table route metadata for table id {table_id}"),
+            })?;
+        let mut table_route_value = TableRouteValue::try_from_raw_value(&table_route_kv.value)?;
+        self.table_route_manager
+            .table_route_storage()
+            .remap_table_route(&mut table_route_value)
+            .await?;
+
+        let region_wal_options = self.dropped_region_wal_options(table_id).await?;
+
+        Ok(Some(DroppedTableMetadata {
+            table_id,
+            table_name,
+            table_info_value,
+            table_route_value,
+            region_wal_options,
+        }))
+    }
+
+    /// Rebuilds region WAL options from tombstoned datanode-table entries.
+    async fn dropped_region_wal_options(
+        &self,
+        table_id: TableId,
+    ) -> Result<HashMap<RegionNumber, WalOptions>> {
+        let mut stream = self.tombstone_manager.tombstones();
+        let mut region_wal_options = HashMap::new();
+
+        while let Some(kv) = stream.try_next().await? {
+            let raw_key = self.tombstone_manager.strip_tombstone_prefix(&kv.key)?;
+            if !raw_key.starts_with(format!("{DATANODE_TABLE_KEY_PREFIX}/").as_bytes()) {
+                continue;
+            }
+
+            let datanode_table_key = DatanodeTableKey::from_bytes(raw_key)?;
+            if datanode_table_key.table_id != table_id {
+                continue;
+            }
+
+            let datanode_table_value = DatanodeTableValue::try_from_raw_value(&kv.value)?;
+            for (region_number, wal_options) in &datanode_table_value.region_info.region_wal_options {
+                region_wal_options.insert(
+                    *region_number,
+                    serde_json::from_str(wal_options).context(error::SerdeJsonSnafu)?,
+                );
+            }
+        }
+
+        Ok(region_wal_options)
     }
 
     fn view_info_keys(&self, view_id: TableId, view_name: &TableName) -> Result<Vec<Vec<u8>>> {
@@ -1608,6 +1755,15 @@ mod tests {
             .enumerate()
             .map(|(i, region_number)| (region_number, wal_options[i % wal_options.len()].clone()))
             .collect()
+    }
+
+    fn create_mixed_region_wal_options() -> HashMap<RegionNumber, WalOptions> {
+        HashMap::from([
+            (0, WalOptions::Kafka(KafkaWalOptions { topic: "greptimedb_topic0".to_string() })),
+            (1, WalOptions::RaftEngine),
+            (2, WalOptions::Noop),
+            (3, WalOptions::Kafka(KafkaWalOptions { topic: "greptimedb_topic1".to_string() })),
+        ])
     }
 
     #[tokio::test]
@@ -2551,7 +2707,7 @@ mod tests {
         let table_id = 1025;
         let table_name = "foo";
         let task = test_create_table_task(table_name, table_id);
-        let options = create_mock_region_wal_options();
+        let options = create_mixed_region_wal_options();
         let serialized_options = options
             .iter()
             .map(|(k, v)| (*k, serde_json::to_string(v).unwrap()))
@@ -2611,7 +2767,7 @@ mod tests {
         let table_id = 1025;
         let table_name = "foo";
         let task = test_create_table_task(table_name, table_id);
-        let options = create_mock_region_wal_options();
+        let options = create_mixed_region_wal_options();
         let serialized_options = options
             .iter()
             .map(|(k, v)| (*k, serde_json::to_string(v).unwrap()))
@@ -2677,6 +2833,212 @@ mod tests {
             .unwrap();
         let kvs = mem_kv.dump();
         assert_eq!(kvs, expected_result);
+    }
+
+    #[tokio::test]
+    async fn test_dropped_table_metadata_enumeration_and_lookup() {
+        let mem_kv = Arc::new(MemoryKvBackend::default());
+        let table_metadata_manager = TableMetadataManager::new(mem_kv.clone());
+        let table_id = 1025;
+        let table_name = "foo";
+        let task = test_create_table_task(table_name, table_id);
+        let table_info = task.table_info.clone();
+        let options = create_mixed_region_wal_options();
+        let serialized_options = options
+            .iter()
+            .map(|(k, v)| (*k, serde_json::to_string(v).unwrap()))
+            .collect::<HashMap<_, _>>();
+        table_metadata_manager
+            .create_table_metadata(
+                table_info.clone(),
+                TableRouteValue::physical(vec![
+                    RegionRoute {
+                        region: Region::new_test(RegionId::new(table_id, 1)),
+                        leader_peer: Some(Peer::empty(1)),
+                        follower_peers: vec![Peer::empty(5)],
+                        leader_state: None,
+                        leader_down_since: None,
+                        write_route_policy: None,
+                    },
+                    RegionRoute {
+                        region: Region::new_test(RegionId::new(table_id, 2)),
+                        leader_peer: Some(Peer::empty(2)),
+                        follower_peers: vec![Peer::empty(4)],
+                        leader_state: None,
+                        leader_down_since: None,
+                        write_route_policy: None,
+                    },
+                    RegionRoute {
+                        region: Region::new_test(RegionId::new(table_id, 3)),
+                        leader_peer: Some(Peer::empty(3)),
+                        follower_peers: vec![],
+                        leader_state: None,
+                        leader_down_since: None,
+                        write_route_policy: None,
+                    },
+                ]),
+                serialized_options,
+            )
+            .await
+            .unwrap();
+        let table_route_value = table_metadata_manager
+            .table_route_manager
+            .table_route_storage()
+            .get_with_raw_bytes(table_id)
+            .await
+            .unwrap()
+            .unwrap();
+        let region_routes = table_route_value.region_routes().unwrap();
+        let table_name = TableName::new(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, table_name);
+        let table_route_value = TableRouteValue::physical(region_routes.clone());
+
+        table_metadata_manager
+            .delete_table_metadata(table_id, &table_name, &table_route_value, &options)
+            .await
+            .unwrap();
+
+        let dropped_tables = table_metadata_manager.list_dropped_tables().await.unwrap();
+        assert_eq!(dropped_tables.len(), 1);
+        assert_eq!(dropped_tables[0].table_id, table_id);
+        assert_eq!(dropped_tables[0].table_name, table_name);
+
+        let dropped_table = table_metadata_manager
+            .get_dropped_table(&table_name)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(dropped_table.table_id, table_id);
+        assert_eq!(dropped_table.table_name, table_name);
+        assert_eq!(dropped_table.table_info_value.table_info, table_info);
+        assert_eq!(
+            dropped_table.table_route_value.region_routes().unwrap(),
+            region_routes
+        );
+        assert_eq!(dropped_table.region_wal_options, options);
+
+        let dropped_table_by_id = table_metadata_manager
+            .get_dropped_table_by_id(table_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(dropped_table_by_id.table_id, table_id);
+        assert_eq!(dropped_table_by_id.table_name, table_name);
+        assert_eq!(dropped_table_by_id.table_info_value.table_info, table_info);
+        assert_eq!(
+            dropped_table_by_id
+                .table_route_value
+                .region_routes()
+                .unwrap(),
+            region_routes
+        );
+        assert_eq!(dropped_table_by_id.region_wal_options, options);
+    }
+
+    #[tokio::test]
+    async fn test_dropped_table_lookup_survives_live_name_recreation() {
+        let mem_kv = Arc::new(MemoryKvBackend::default());
+        let table_metadata_manager = TableMetadataManager::new(mem_kv.clone());
+        let dropped_table_id = 1025;
+        let recreated_table_id = 1026;
+        let table_name = "foo";
+        let dropped_task = test_create_table_task(table_name, dropped_table_id);
+        let dropped_table_info = dropped_task.table_info.clone();
+        let options = create_mock_region_wal_options();
+        let serialized_options = options
+            .iter()
+            .map(|(k, v)| (*k, serde_json::to_string(v).unwrap()))
+            .collect::<HashMap<_, _>>();
+        table_metadata_manager
+            .create_table_metadata(
+                dropped_table_info.clone(),
+                TableRouteValue::physical(vec![
+                    RegionRoute {
+                        region: Region::new_test(RegionId::new(dropped_table_id, 1)),
+                        leader_peer: Some(Peer::empty(1)),
+                        follower_peers: vec![Peer::empty(5)],
+                        leader_state: None,
+                        leader_down_since: None,
+                        write_route_policy: None,
+                    },
+                    RegionRoute {
+                        region: Region::new_test(RegionId::new(dropped_table_id, 2)),
+                        leader_peer: Some(Peer::empty(2)),
+                        follower_peers: vec![Peer::empty(4)],
+                        leader_state: None,
+                        leader_down_since: None,
+                        write_route_policy: None,
+                    },
+                ]),
+                serialized_options.clone(),
+            )
+            .await
+            .unwrap();
+
+        let dropped_table_name =
+            TableName::new(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, table_name);
+        let dropped_table_route = table_metadata_manager
+            .table_route_manager
+            .table_route_storage()
+            .get_with_raw_bytes(dropped_table_id)
+            .await
+            .unwrap()
+            .unwrap();
+        let dropped_table_route =
+            TableRouteValue::physical(dropped_table_route.region_routes().unwrap().clone());
+        table_metadata_manager
+            .delete_table_metadata(
+                dropped_table_id,
+                &dropped_table_name,
+                &dropped_table_route,
+                &options,
+            )
+            .await
+            .unwrap();
+
+        let recreated_task = test_create_table_task(table_name, recreated_table_id);
+        table_metadata_manager
+            .create_table_metadata(
+                recreated_task.table_info,
+                TableRouteValue::physical(vec![RegionRoute {
+                    region: Region::new_test(RegionId::new(recreated_table_id, 1)),
+                    leader_peer: Some(Peer::empty(4)),
+                    follower_peers: vec![],
+                    leader_state: None,
+                    leader_down_since: None,
+                    write_route_policy: None,
+                }]),
+                serialized_options,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            table_metadata_manager
+                .table_name_manager()
+                .get(TableNameKey::from(&dropped_table_name))
+                .await
+                .unwrap()
+                .unwrap()
+                .table_id(),
+            recreated_table_id
+        );
+
+        let dropped_table = table_metadata_manager
+            .get_dropped_table(&dropped_table_name)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(dropped_table.table_id, dropped_table_id);
+        assert_eq!(dropped_table.table_name, dropped_table_name);
+        assert_eq!(
+            dropped_table.table_info_value.table_info,
+            dropped_table_info
+        );
+
+        let dropped_tables = table_metadata_manager.list_dropped_tables().await.unwrap();
+        assert_eq!(dropped_tables.len(), 1);
+        assert_eq!(dropped_tables[0].table_id, dropped_table_id);
+        assert_eq!(dropped_tables[0].table_name, dropped_table_name);
     }
 
     #[tokio::test]

--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -1125,7 +1125,7 @@ impl TableMetadataManager {
             .tombstone_manager
             .get(&table_route_key.to_bytes())
             .await?
-            .context(error::UnexpectedSnafu {
+            .with_context(|| error::UnexpectedSnafu {
                 err_msg: format!("Missing tombstoned table route metadata for table id {table_id}"),
             })?;
         let mut table_route_value = TableRouteValue::try_from_raw_value(&table_route_kv.value)?;

--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -1165,7 +1165,8 @@ impl TableMetadataManager {
             }
 
             let datanode_table_value = DatanodeTableValue::try_from_raw_value(&kv.value)?;
-            for (region_number, wal_options) in &datanode_table_value.region_info.region_wal_options {
+            for (region_number, wal_options) in &datanode_table_value.region_info.region_wal_options
+            {
                 region_wal_options.insert(
                     *region_number,
                     serde_json::from_str(wal_options).context(error::SerdeJsonSnafu)?,
@@ -1759,10 +1760,20 @@ mod tests {
 
     fn create_mixed_region_wal_options() -> HashMap<RegionNumber, WalOptions> {
         HashMap::from([
-            (0, WalOptions::Kafka(KafkaWalOptions { topic: "greptimedb_topic0".to_string() })),
+            (
+                0,
+                WalOptions::Kafka(KafkaWalOptions {
+                    topic: "greptimedb_topic0".to_string(),
+                }),
+            ),
             (1, WalOptions::RaftEngine),
             (2, WalOptions::Noop),
-            (3, WalOptions::Kafka(KafkaWalOptions { topic: "greptimedb_topic1".to_string() })),
+            (
+                3,
+                WalOptions::Kafka(KafkaWalOptions {
+                    topic: "greptimedb_topic1".to_string(),
+                }),
+            ),
         ])
     }
 

--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -1134,7 +1134,9 @@ impl TableMetadataManager {
             .remap_table_route(&mut table_route_value)
             .await?;
 
-        let region_wal_options = self.dropped_region_wal_options(table_id).await?;
+        let region_wal_options = self
+            .dropped_region_wal_options(table_id, &table_route_value)
+            .await?;
 
         Ok(Some(DroppedTableMetadata {
             table_id,
@@ -1149,20 +1151,26 @@ impl TableMetadataManager {
     async fn dropped_region_wal_options(
         &self,
         table_id: TableId,
+        table_route_value: &TableRouteValue,
     ) -> Result<HashMap<RegionNumber, WalOptions>> {
-        let mut stream = self.tombstone_manager.tombstones();
         let mut region_wal_options = HashMap::new();
+        let datanode_table_keys = region_distribution(table_route_value.region_routes()?)
+            .into_keys()
+            .map(|datanode_id| DatanodeTableKey::new(datanode_id, table_id))
+            .collect::<Vec<_>>();
+        let datanode_table_key_bytes = datanode_table_keys
+            .iter()
+            .map(|key| key.to_bytes())
+            .collect::<Vec<_>>();
+        let datanode_table_values = self
+            .tombstone_manager
+            .batch_get(&datanode_table_key_bytes)
+            .await?;
 
-        while let Some(kv) = stream.try_next().await? {
-            let raw_key = self.tombstone_manager.strip_tombstone_prefix(&kv.key)?;
-            if !raw_key.starts_with(format!("{DATANODE_TABLE_KEY_PREFIX}/").as_bytes()) {
+        for datanode_table_key in datanode_table_keys {
+            let Some(kv) = datanode_table_values.get(&datanode_table_key.to_bytes()) else {
                 continue;
-            }
-
-            let datanode_table_key = DatanodeTableKey::from_bytes(raw_key)?;
-            if datanode_table_key.table_id != table_id {
-                continue;
-            }
+            };
 
             let datanode_table_value = DatanodeTableValue::try_from_raw_value(&kv.value)?;
             for (region_number, wal_options) in &datanode_table_value.region_info.region_wal_options
@@ -3050,6 +3058,81 @@ mod tests {
         assert_eq!(dropped_tables.len(), 1);
         assert_eq!(dropped_tables[0].table_id, dropped_table_id);
         assert_eq!(dropped_tables[0].table_name, dropped_table_name);
+    }
+
+    #[tokio::test]
+    async fn test_dropped_table_lookup_ignores_unrelated_malformed_datanode_tombstones() {
+        let mem_kv = Arc::new(MemoryKvBackend::default());
+        let table_metadata_manager = TableMetadataManager::new(mem_kv.clone());
+        let table_id = 1025;
+        let table_name = "foo";
+        let task = test_create_table_task(table_name, table_id);
+        let table_info = task.table_info.clone();
+        let options = create_mixed_region_wal_options();
+        let serialized_options = options
+            .iter()
+            .map(|(k, v)| (*k, serde_json::to_string(v).unwrap()))
+            .collect::<HashMap<_, _>>();
+        table_metadata_manager
+            .create_table_metadata(
+                table_info.clone(),
+                TableRouteValue::physical(vec![
+                    RegionRoute {
+                        region: Region::new_test(RegionId::new(table_id, 1)),
+                        leader_peer: Some(Peer::empty(1)),
+                        follower_peers: vec![Peer::empty(5)],
+                        leader_state: None,
+                        leader_down_since: None,
+                        write_route_policy: None,
+                    },
+                    RegionRoute {
+                        region: Region::new_test(RegionId::new(table_id, 2)),
+                        leader_peer: Some(Peer::empty(2)),
+                        follower_peers: vec![Peer::empty(4)],
+                        leader_state: None,
+                        leader_down_since: None,
+                        write_route_policy: None,
+                    },
+                ]),
+                serialized_options,
+            )
+            .await
+            .unwrap();
+
+        let table_route_value = table_metadata_manager
+            .table_route_manager
+            .table_route_storage()
+            .get_with_raw_bytes(table_id)
+            .await
+            .unwrap()
+            .unwrap();
+        let region_routes = table_route_value.region_routes().unwrap();
+        let table_name = TableName::new(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, table_name);
+        let table_route_value = TableRouteValue::physical(region_routes.clone());
+
+        table_metadata_manager
+            .delete_table_metadata(table_id, &table_name, &table_route_value, &options)
+            .await
+            .unwrap();
+
+        mem_kv
+            .put(
+                PutRequest::new()
+                    .with_key("__tombstone/__dn_table/not-a-datanode-table-key")
+                    .with_value("malformed"),
+            )
+            .await
+            .unwrap();
+
+        let dropped_table = table_metadata_manager
+            .get_dropped_table(&table_name)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(dropped_table.table_id, table_id);
+        assert_eq!(dropped_table.table_name, table_name);
+        assert_eq!(dropped_table.table_info_value.table_info, table_info);
+        assert_eq!(dropped_table.region_wal_options, options);
     }
 
     #[tokio::test]

--- a/src/common/meta/src/key/tombstone.rs
+++ b/src/common/meta/src/key/tombstone.rs
@@ -15,13 +15,17 @@
 use std::collections::HashMap;
 
 use common_telemetry::debug;
+use futures_util::stream::BoxStream;
 use snafu::ensure;
 
 use crate::error::{self, Result};
+use crate::key::TABLE_NAME_KEY_PREFIX;
 use crate::key::txn_helper::TxnOpGetResponseSet;
 use crate::kv_backend::KvBackendRef;
 use crate::kv_backend::txn::{Compare, CompareOp, Txn, TxnOp};
-use crate::rpc::store::{BatchDeleteRequest, BatchGetRequest};
+use crate::range_stream::{DEFAULT_PAGE_SIZE, PaginationStream};
+use crate::rpc::KeyValue;
+use crate::rpc::store::{BatchDeleteRequest, BatchGetRequest, RangeRequest};
 
 /// [TombstoneManager] provides the ability to:
 /// - logically delete values
@@ -54,6 +58,49 @@ impl TombstoneManager {
 
     pub fn to_tombstone(&self, key: &[u8]) -> Vec<u8> {
         [self.tombstone_prefix.as_bytes(), key].concat()
+    }
+
+    /// Removes the tombstone prefix from a tombstoned key.
+    pub fn strip_tombstone_prefix<'a>(&self, tombstone_key: &'a [u8]) -> Result<&'a [u8]> {
+        ensure!(
+            tombstone_key.starts_with(self.tombstone_prefix.as_bytes()),
+            error::UnexpectedSnafu {
+                err_msg: format!(
+                    "The key '{}' does not start with tombstone prefix '{}'.",
+                    String::from_utf8_lossy(tombstone_key),
+                    self.tombstone_prefix
+                ),
+            }
+        );
+
+        Ok(&tombstone_key[self.tombstone_prefix.len()..])
+    }
+
+    /// Gets a single tombstoned value by its original key.
+    pub async fn get(&self, key: &[u8]) -> Result<Option<KeyValue>> {
+        let tombstone_key = self.to_tombstone(key);
+        self.kv_backend.get(&tombstone_key).await
+    }
+
+    /// Streams all tombstoned key-value pairs.
+    pub fn tombstones(&self) -> BoxStream<'static, Result<KeyValue>> {
+        self.scan_prefix(self.tombstone_prefix.as_bytes().to_vec())
+    }
+
+    /// Streams tombstoned table-name entries only.
+    pub fn tombstoned_table_names(&self) -> BoxStream<'static, Result<KeyValue>> {
+        self.scan_prefix(
+            format!("{}{}/", self.tombstone_prefix, TABLE_NAME_KEY_PREFIX).into_bytes(),
+        )
+    }
+
+    /// Streams tombstoned entries under the provided prefix.
+    fn scan_prefix(&self, prefix: Vec<u8>) -> BoxStream<'static, Result<KeyValue>> {
+        let req = RangeRequest::new().with_prefix(prefix);
+        let stream = PaginationStream::new(self.kv_backend.clone(), req, DEFAULT_PAGE_SIZE, Ok)
+            .into_stream();
+
+        Box::pin(stream)
     }
 
     #[cfg(test)]

--- a/src/common/meta/src/key/tombstone.rs
+++ b/src/common/meta/src/key/tombstone.rs
@@ -30,6 +30,26 @@ use crate::rpc::store::{BatchDeleteRequest, BatchGetRequest, RangeRequest};
 /// [TombstoneManager] provides the ability to:
 /// - logically delete values
 /// - restore the deleted values
+///
+/// The tombstone mechanism is primarily used for table metadata deletion.
+/// When a table is logically deleted, its associated metadata keys are moved
+/// to a tombstone area by prepending a prefix (default is `__tombstone/`).
+///
+/// All involved keys in the tombstone mechanism:
+/// - `__table_name/{catalog}/{schema}/{table_name}`: Maps table name to table ID.
+/// - `__table_info/{table_id}`: Stores table information/metadata.
+/// - `__table_route/{table_id}`: Stores table routing information.
+/// - `__table_repart/{table_id}`: Stores table repartition information.
+/// - `__dn_table/{datanode_id}/{table_id}`: Maps datanodes to table regions.
+/// - `__topic_region/{topic_name}/{region_id}`: Maps regions to WAL topics.
+///
+/// These keys are moved to:
+/// - `__tombstone/__table_name/...`
+/// - `__tombstone/__table_info/...`
+/// - `__tombstone/__table_route/...`
+/// - `__tombstone/__table_repart/...`
+/// - `__tombstone/__dn_table/...`
+/// - `__tombstone/__topic_region/...`
 pub struct TombstoneManager {
     kv_backend: KvBackendRef,
     tombstone_prefix: String,

--- a/src/common/meta/src/key/tombstone.rs
+++ b/src/common/meta/src/key/tombstone.rs
@@ -102,6 +102,23 @@ impl TombstoneManager {
         self.kv_backend.get(&tombstone_key).await
     }
 
+    /// Gets tombstoned values by their original keys.
+    pub async fn batch_get(&self, keys: &[Vec<u8>]) -> Result<HashMap<Vec<u8>, KeyValue>> {
+        let tombstone_keys = keys
+            .iter()
+            .map(|key| self.to_tombstone(key))
+            .collect::<Vec<_>>();
+        let resp = self
+            .kv_backend
+            .batch_get(BatchGetRequest::new().with_keys(tombstone_keys))
+            .await?;
+
+        resp.kvs
+            .into_iter()
+            .map(|kv| Ok((self.strip_tombstone_prefix(&kv.key)?.to_vec(), kv)))
+            .collect::<Result<HashMap<_, _>>>()
+    }
+
     /// Streams all tombstoned key-value pairs.
     pub fn tombstones(&self) -> BoxStream<'static, Result<KeyValue>> {
         self.scan_prefix(self.tombstone_prefix.as_bytes().to_vec())
@@ -466,6 +483,35 @@ mod tests {
             .await
             .unwrap();
         assert!(kv_backend.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_batch_get_tombstones() {
+        let kv_backend = Arc::new(MemoryKvBackend::default());
+        let tombstone_manager = TombstoneManager::new(kv_backend.clone());
+        kv_backend
+            .put(PutRequest::new().with_key("bar").with_value("baz"))
+            .await
+            .unwrap();
+        kv_backend
+            .put(PutRequest::new().with_key("foo").with_value("hi"))
+            .await
+            .unwrap();
+
+        tombstone_manager
+            .create(vec![b"bar".to_vec(), b"foo".to_vec()])
+            .await
+            .unwrap();
+
+        let kvs = tombstone_manager
+            .batch_get(&[b"bar".to_vec(), b"foo".to_vec(), b"missing".to_vec()])
+            .await
+            .unwrap();
+
+        assert_eq!(kvs.len(), 2);
+        assert_eq!(kvs.get(b"bar".as_slice()).unwrap().value, b"baz");
+        assert_eq!(kvs.get(b"foo".as_slice()).unwrap().value, b"hi");
+        assert!(!kvs.contains_key(b"missing".as_slice()));
     }
 
     #[tokio::test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

- Add tombstone scan and lookup helpers in `TableMetadataManager` so dropped table metadata can be discovered from the `__tombstone` keyspace.
- Recover dropped table route and per-region WAL metadata from tombstoned entries, including mixed WAL providers, and cover the new APIs with focused unit tests.
- Ignore local `.worktrees/` directories so worktree-based development does not dirty the repository.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.