### PR TITLE
fix: make sure interceptor is called for plan execution

### DIFF
--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -630,12 +630,24 @@ impl Instance {
     async fn do_exec_plan_inner(
         &self,
         plan: LogicalPlan,
-        query: String,
+        stmt: Option<Statement>,
         query_ctx: QueryContextRef,
     ) -> Result<Output> {
         ensure!(!self.is_suspended(), error::SuspendedSnafu);
 
-        if is_readonly_plan(&plan) {
+        let query_interceptor_opt = self.plugins.get::<SqlQueryInterceptorRef<Error>>();
+        let query_interceptor = query_interceptor_opt.as_ref();
+
+        if let Some(ref s) = stmt {
+            query_interceptor.pre_execute(s, Some(&plan), query_ctx.clone())?;
+        }
+
+        let query = stmt
+            .as_ref()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| plan.display_indent().to_string());
+
+        let result = if is_readonly_plan(&plan) {
             let slow_query_timer = self
                 .slow_query_options
                 .enable
@@ -660,7 +672,7 @@ impl Instance {
                 slow_query_timer,
             );
 
-            let query_fut = self.exec_plan_with_timeout(plan, query_ctx);
+            let query_fut = self.exec_plan_with_timeout(plan, query_ctx.clone());
 
             CancellableFuture::new(query_fut, ticket.cancellation_handle.clone())
                 .await
@@ -677,8 +689,10 @@ impl Instance {
                     Output { data, meta }
                 })
         } else {
-            self.exec_plan_with_timeout(plan, query_ctx).await
-        }
+            self.exec_plan_with_timeout(plan, query_ctx.clone()).await
+        };
+
+        result.and_then(|output| query_interceptor.post_execute(output, query_ctx))
     }
 
     #[tracing::instrument(skip_all, name = "SqlQueryHandler::do_promql_query")]
@@ -767,10 +781,10 @@ impl SqlQueryHandler for Instance {
     async fn do_exec_plan(
         &self,
         plan: LogicalPlan,
-        query: String,
+        stmt: Option<Statement>,
         query_ctx: QueryContextRef,
     ) -> server_error::Result<Output> {
-        self.do_exec_plan_inner(plan, query, query_ctx)
+        self.do_exec_plan_inner(plan, stmt, query_ctx)
             .await
             .map_err(BoxedError::new)
             .context(server_error::ExecutePlanSnafu)

--- a/src/frontend/src/instance/grpc.rs
+++ b/src/frontend/src/instance/grpc.rs
@@ -129,9 +129,8 @@ impl GrpcQueryHandler for Instance {
                                 .decode(bytes::Bytes::from(plan), dummy_catalog_list, true)
                                 .await
                                 .context(SubstraitDecodeLogicalPlanSnafu)?;
-                            let query = logical_plan.display_indent().to_string();
                             let output =
-                                self.do_exec_plan_inner(logical_plan, query, ctx.clone()).await?;
+                                self.do_exec_plan_inner(logical_plan, None, ctx.clone()).await?;
 
                             attach_timer(output, timer)
                         }
@@ -467,9 +466,8 @@ impl Instance {
         // Optimize the plan
         let optimized_plan = state.optimize(&analyzed_plan).context(DataFusionSnafu)?;
 
-        let query = optimized_plan.display_indent().to_string();
         let output = self
-            .do_exec_plan_inner(optimized_plan, query, ctx.clone())
+            .do_exec_plan_inner(optimized_plan, None, ctx.clone())
             .await?;
 
         Ok(attach_timer(output, timer))

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -1329,6 +1329,7 @@ mod test {
     use query::parser::PromQuery;
     use query::query_engine::DescribeResult;
     use session::context::QueryContextRef;
+    use sql::statements::statement::Statement;
     use tokio::sync::mpsc;
     use tokio::time::Instant;
 
@@ -1354,7 +1355,7 @@ mod test {
         async fn do_exec_plan(
             &self,
             _plan: LogicalPlan,
-            _query: String,
+            _stmt: Option<Statement>,
             _query_ctx: QueryContextRef,
         ) -> Result<Output> {
             unimplemented!()

--- a/src/servers/src/lib.rs
+++ b/src/servers/src/lib.rs
@@ -60,8 +60,8 @@ pub enum SqlPlan {
     Empty,
     /// Hardcoded SQL shortcuts
     Shortcut(String),
-    /// Datafusion parsed execution plan with the original query string
-    Plan(LogicalPlan, String),
+    /// Datafusion parsed execution plan with the original statement
+    Plan(LogicalPlan, Statement),
     /// Parsed statement when execution is not managed by datafusion
     /// eg. CREATE TABLE
     /// The String is the original query string to avoid AST round-trip issues

--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -240,7 +240,7 @@ impl MysqlInstanceShim {
 
         match plan {
             Some(plan) if params.len() == param_num - 1 => {
-                self.save_plan(SqlPlan::Plan(plan, query.clone()), stmt_key)
+                self.save_plan(SqlPlan::Plan(plan, statement), stmt_key)
                     .inspect_err(|e| {
                         error!(e; "Failed to save prepared statement");
                     })?;
@@ -270,7 +270,7 @@ impl MysqlInstanceShim {
         };
 
         let outputs = match sql_plan {
-            SqlPlan::Plan(plan, query) => {
+            SqlPlan::Plan(plan, stmt) => {
                 let param_types = DfLogicalPlanner::get_inferred_parameter_types(&plan)
                     .context(InferParameterTypesSnafu)?
                     .into_iter()
@@ -299,7 +299,7 @@ impl MysqlInstanceShim {
                 );
                 vec![
                     self.query_handler
-                        .do_exec_plan(replaced_plan, query, query_ctx.clone())
+                        .do_exec_plan(replaced_plan, Some(stmt), query_ctx.clone())
                         .await,
                 ]
             }
@@ -823,7 +823,7 @@ mod tests {
         async fn do_exec_plan(
             &self,
             _: LogicalPlan,
-            _: String,
+            _: Option<Statement>,
             _: QueryContextRef,
         ) -> Result<Output> {
             unimplemented!()

--- a/src/servers/src/postgres/handler.rs
+++ b/src/servers/src/postgres/handler.rs
@@ -365,7 +365,7 @@ impl QueryParser for DefaultQueryParser {
                 .map(|DescribeResult { logical_plan }| logical_plan)
             {
                 Ok(PgSqlPlan {
-                    plan: SqlPlan::Plan(logical_plan, sql),
+                    plan: SqlPlan::Plan(logical_plan, stmt),
                     copy_to_stdout_format,
                 })
             } else {
@@ -442,7 +442,7 @@ impl ExtendedQueryHandler for PostgresServerHandlerInner {
                     return Ok(Response::EmptyQuery);
                 }
             }
-            SqlPlan::Plan(plan, query) => {
+            SqlPlan::Plan(plan, stmt) => {
                 let values = parameters_to_scalar_values(plan, portal)?;
                 let plan = plan
                     .clone()
@@ -452,7 +452,7 @@ impl ExtendedQueryHandler for PostgresServerHandlerInner {
                     .context(DataFusionSnafu)
                     .map_err(convert_err)?;
                 self.query_handler
-                    .do_exec_plan(plan, query.clone(), query_ctx.clone())
+                    .do_exec_plan(plan, Some(stmt.clone()), query_ctx.clone())
                     .await
             }
             SqlPlan::Statement(_stmt, query) => {

--- a/src/servers/src/query_handler/sql.rs
+++ b/src/servers/src/query_handler/sql.rs
@@ -33,7 +33,7 @@ pub trait SqlQueryHandler {
     async fn do_exec_plan(
         &self,
         plan: LogicalPlan,
-        query: String,
+        stmt: Option<Statement>,
         query_ctx: QueryContextRef,
     ) -> Result<Output>;
 

--- a/src/servers/tests/http/influxdb_test.rs
+++ b/src/servers/tests/http/influxdb_test.rs
@@ -31,6 +31,7 @@ use servers::influxdb::InfluxdbRequest;
 use servers::query_handler::InfluxdbLineProtocolHandler;
 use servers::query_handler::sql::SqlQueryHandler;
 use session::context::QueryContextRef;
+use sql::statements::statement::Statement;
 use tokio::sync::mpsc;
 
 struct DummyInstance {
@@ -58,7 +59,7 @@ impl SqlQueryHandler for DummyInstance {
     async fn do_exec_plan(
         &self,
         _plan: LogicalPlan,
-        _query: String,
+        _stmt: Option<Statement>,
         _query_ctx: QueryContextRef,
     ) -> Result<Output> {
         unimplemented!()

--- a/src/servers/tests/http/opentsdb_test.rs
+++ b/src/servers/tests/http/opentsdb_test.rs
@@ -28,6 +28,7 @@ use servers::opentsdb::codec::DataPoint;
 use servers::query_handler::OpentsdbProtocolHandler;
 use servers::query_handler::sql::SqlQueryHandler;
 use session::context::QueryContextRef;
+use sql::statements::statement::Statement;
 use tokio::sync::mpsc;
 
 struct DummyInstance {
@@ -58,7 +59,7 @@ impl SqlQueryHandler for DummyInstance {
     async fn do_exec_plan(
         &self,
         _plan: LogicalPlan,
-        _query: String,
+        _stmt: Option<Statement>,
         _query_ctx: QueryContextRef,
     ) -> Result<Output> {
         unimplemented!()

--- a/src/servers/tests/http/prom_store_test.rs
+++ b/src/servers/tests/http/prom_store_test.rs
@@ -36,6 +36,7 @@ use servers::prom_store::{Metrics, snappy_compress};
 use servers::query_handler::sql::SqlQueryHandler;
 use servers::query_handler::{PromStoreProtocolHandler, PromStoreResponse};
 use session::context::QueryContextRef;
+use sql::statements::statement::Statement;
 use tokio::sync::mpsc;
 
 struct DummyInstance {
@@ -87,7 +88,7 @@ impl SqlQueryHandler for DummyInstance {
     async fn do_exec_plan(
         &self,
         _plan: LogicalPlan,
-        _query: String,
+        _stmt: Option<Statement>,
         _query_ctx: QueryContextRef,
     ) -> Result<Output> {
         unimplemented!()

--- a/src/servers/tests/mod.rs
+++ b/src/servers/tests/mod.rs
@@ -83,7 +83,7 @@ impl SqlQueryHandler for DummyInstance {
     async fn do_exec_plan(
         &self,
         plan: LogicalPlan,
-        _query: String,
+        _stmt: Option<Statement>,
         query_ctx: QueryContextRef,
     ) -> Result<Output> {
         Ok(self.query_engine.execute(plan, query_ctx).await.unwrap())

--- a/tests-integration/src/instance.rs
+++ b/tests-integration/src/instance.rs
@@ -33,7 +33,7 @@ mod tests {
     use datafusion_expr::LogicalPlan;
     use frontend::error::{Error, Result};
     use frontend::instance::Instance;
-    use query::parser::QueryLanguageParser;
+    use query::parser::{QueryLanguageParser, QueryStatement};
     use query::query_engine::DefaultSerializer;
     use servers::interceptor::{SqlQueryInterceptor, SqlQueryInterceptorRef};
     use servers::query_handler::sql::SqlQueryHandler;
@@ -379,6 +379,82 @@ mod tests {
             OutputData::AffectedRows(rows) => assert_eq!(rows, 10),
             _ => unreachable!(),
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_exec_plan_interceptor_plugin() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        #[derive(Default)]
+        struct ExecPlanHook {
+            pub(crate) pre_execute_called: AtomicBool,
+            pub(crate) post_execute_called: AtomicBool,
+        }
+
+        impl SqlQueryInterceptor for ExecPlanHook {
+            type Error = Error;
+
+            fn pre_execute(
+                &self,
+                _statement: &Statement,
+                _plan: Option<&LogicalPlan>,
+                _query_ctx: QueryContextRef,
+            ) -> Result<()> {
+                self.pre_execute_called.store(true, Ordering::Relaxed);
+                Ok(())
+            }
+
+            fn post_execute(&self, output: Output, _query_ctx: QueryContextRef) -> Result<Output> {
+                self.post_execute_called.store(true, Ordering::Relaxed);
+                Ok(output)
+            }
+        }
+
+        let plugins = Plugins::new();
+        let hook = Arc::new(ExecPlanHook::default());
+        plugins.insert::<SqlQueryInterceptorRef<Error>>(hook.clone());
+
+        let standalone = GreptimeDbStandaloneBuilder::new("test_exec_plan_interceptor_plugin")
+            .with_plugin(plugins)
+            .build()
+            .await;
+        let instance = standalone.fe_instance().clone();
+
+        let sql = r#"CREATE TABLE demo(
+                            host STRING,
+                            ts TIMESTAMP,
+                            cpu DOUBLE NULL,
+                            TIME INDEX (ts),
+                            PRIMARY KEY(host)
+                        ) engine=mito;"#;
+        SqlQueryHandler::do_query(&*instance, sql, QueryContext::arc())
+            .await
+            .remove(0)
+            .unwrap();
+
+        let query_ctx = QueryContext::arc();
+        let stmt = QueryLanguageParser::parse_sql("SELECT * FROM demo", &query_ctx).unwrap();
+        let plan = instance
+            .statement_executor()
+            .plan(&stmt, query_ctx.clone())
+            .await
+            .unwrap();
+        let QueryStatement::Sql(sql_stmt) = stmt else {
+            unreachable!()
+        };
+
+        SqlQueryHandler::do_exec_plan(&*instance, plan, Some(sql_stmt), query_ctx.clone())
+            .await
+            .unwrap();
+
+        assert!(
+            hook.pre_execute_called.load(Ordering::Relaxed),
+            "pre_execute should be called for do_exec_plan"
+        );
+        assert!(
+            hook.post_execute_called.load(Ordering::Relaxed),
+            "post_execute should be called for do_exec_plan"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This patch ensures interceptor is called for plan execution path.

It also updates `SqlPlan::Plan` to hold statement. 

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
