### PR TITLE
feat: implement soft drop for regions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5765,7 +5765,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=366943d0cdce76b134cadf79b16f164e0aeb4410#366943d0cdce76b134cadf79b16f164e0aeb4410"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=a107830d0c8844a78e5763809331e37fcc5cc790#a107830d0c8844a78e5763809331e37fcc5cc790"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5765,7 +5765,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=0de5437582920c8b30d6c34212f161db71d95c50#0de5437582920c8b30d6c34212f161db71d95c50"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=366943d0cdce76b134cadf79b16f164e0aeb4410#366943d0cdce76b134cadf79b16f164e0aeb4410"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ fs2 = "0.4"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "366943d0cdce76b134cadf79b16f164e0aeb4410" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "a107830d0c8844a78e5763809331e37fcc5cc790" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ fs2 = "0.4"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "0de5437582920c8b30d6c34212f161db71d95c50" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "366943d0cdce76b134cadf79b16f164e0aeb4410" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -531,6 +531,7 @@ impl StartCommand {
             flow_metadata_manager: flow_metadata_manager.clone(),
             flow_metadata_allocator: flow_metadata_allocator.clone(),
             region_failure_detector_controller: Arc::new(NoopRegionFailureDetectorControl),
+            soft_drop_enabled: false,
         };
 
         let ddl_manager = DdlManager::try_new(

--- a/src/common/meta/src/ddl.rs
+++ b/src/common/meta/src/ddl.rs
@@ -112,6 +112,8 @@ pub struct DdlContext {
     pub flow_metadata_allocator: FlowMetadataAllocatorRef,
     /// controller of region failure detector.
     pub region_failure_detector_controller: RegionFailureDetectorControllerRef,
+    /// Whether table drops should stop after tombstoning metadata.
+    pub soft_drop_enabled: bool,
 }
 
 impl DdlContext {

--- a/src/common/meta/src/ddl/drop_database/executor.rs
+++ b/src/common/meta/src/ddl/drop_database/executor.rs
@@ -142,6 +142,7 @@ impl State for DropDatabaseExecutor {
                 true,
                 false,
                 false,
+                false,
             )
             .await?;
         info!("Table: {}({}) is dropped", self.table_name, self.table_id);

--- a/src/common/meta/src/ddl/drop_table.rs
+++ b/src/common/meta/src/ddl/drop_table.rs
@@ -150,13 +150,6 @@ impl DropTableProcedure {
     async fn on_broadcast(&mut self) -> Result<Status> {
         self.executor.invalidate_table_cache(&self.context).await?;
 
-        // Soft-drop keeps tombstoned metadata in place for later recovery/purge work,
-        // so the procedure stops before any datanode region deletion.
-        if self.context.soft_drop_enabled {
-            self.dropping_regions.clear();
-            return Ok(Status::done());
-        }
-
         self.data.state = DropTableState::DatanodeDropRegions;
 
         Ok(Status::executing(true))
@@ -188,9 +181,15 @@ impl DropTableProcedure {
                 false,
                 false,
                 false,
-                false,
+                self.context.soft_drop_enabled,
             )
             .await?;
+
+        if self.context.soft_drop_enabled {
+            self.dropping_regions.clear();
+            return Ok(Status::done());
+        }
+
         self.data.state = DropTableState::DeleteTombstone;
         Ok(Status::executing(true))
     }

--- a/src/common/meta/src/ddl/drop_table.rs
+++ b/src/common/meta/src/ddl/drop_table.rs
@@ -149,6 +149,14 @@ impl DropTableProcedure {
     /// Broadcasts invalidate table cache instruction.
     async fn on_broadcast(&mut self) -> Result<Status> {
         self.executor.invalidate_table_cache(&self.context).await?;
+
+        // Soft-drop keeps tombstoned metadata in place for later recovery/purge work,
+        // so the procedure stops before any datanode region deletion.
+        if self.data.task.soft_drop {
+            self.dropping_regions.clear();
+            return Ok(Status::done());
+        }
+
         self.data.state = DropTableState::DatanodeDropRegions;
 
         Ok(Status::executing(true))

--- a/src/common/meta/src/ddl/drop_table.rs
+++ b/src/common/meta/src/ddl/drop_table.rs
@@ -152,7 +152,7 @@ impl DropTableProcedure {
 
         // Soft-drop keeps tombstoned metadata in place for later recovery/purge work,
         // so the procedure stops before any datanode region deletion.
-        if self.data.task.soft_drop {
+        if self.context.soft_drop_enabled {
             self.dropping_regions.clear();
             return Ok(Status::done());
         }

--- a/src/common/meta/src/ddl/drop_table.rs
+++ b/src/common/meta/src/ddl/drop_table.rs
@@ -188,6 +188,7 @@ impl DropTableProcedure {
                 false,
                 false,
                 false,
+                false,
             )
             .await?;
         self.data.state = DropTableState::DeleteTombstone;

--- a/src/common/meta/src/ddl/drop_table/executor.rs
+++ b/src/common/meta/src/ddl/drop_table/executor.rs
@@ -236,6 +236,7 @@ impl DropTableExecutor {
         fast_path: bool,
         force: bool,
         partial_drop: bool,
+        soft_drop: bool,
     ) -> Result<()> {
         // Drops leader regions on datanodes.
         let leaders = find_leaders(region_routes);
@@ -261,6 +262,7 @@ impl DropTableExecutor {
                         fast_path,
                         force,
                         partial_drop,
+                        soft_drop,
                     })),
                 };
                 let datanode = datanode.clone();

--- a/src/common/meta/src/ddl/drop_table/executor.rs
+++ b/src/common/meta/src/ddl/drop_table/executor.rs
@@ -227,7 +227,19 @@ impl DropTableExecutor {
         Ok(())
     }
 
-    /// Drops region on datanode.
+    /// Drops regions on datanodes.
+    ///
+    /// Arguments:
+    /// - `node_manager`: resolves datanode clients from peers in `region_routes`.
+    /// - `leader_region_registry`: tracks in-flight leader region operations.
+    /// - `region_routes`: table region placement; leaders receive drop requests and followers
+    ///   receive close requests.
+    /// - `fast_path`: forwards to datanode drop requests to skip extra cleanup when safe.
+    /// - `force`: forwards to datanode drop requests to allow forced region removal.
+    /// - `partial_drop`: forwards to datanode drop requests for partial table/region drops.
+    /// - `soft_drop`: forwards to datanode drop requests to flush/unregister regions while
+    ///   preserving files for later undrop or purge.
+    #[allow(clippy::too_many_arguments)]
     pub async fn on_drop_regions(
         &self,
         node_manager: &NodeManagerRef,

--- a/src/common/meta/src/ddl/drop_table/executor.rs
+++ b/src/common/meta/src/ddl/drop_table/executor.rs
@@ -108,10 +108,11 @@ impl DropTableExecutor {
             }
         );
 
-        if let Some(dropped_table) = ctx
-            .table_metadata_manager
-            .get_dropped_table(&self.table)
-            .await?
+        if ctx.soft_drop_enabled
+            && let Some(dropped_table) = ctx
+                .table_metadata_manager
+                .get_dropped_table(&self.table)
+                .await?
             && dropped_table.table_id != self.table_id
         {
             return error::TableNameTombstoneConflictSnafu {

--- a/src/common/meta/src/ddl/drop_table/executor.rs
+++ b/src/common/meta/src/ddl/drop_table/executor.rs
@@ -82,6 +82,8 @@ impl DropTableExecutor {
     /// Checks whether table exists.
     /// - Early returns if table not exists and `drop_if_exists` is `true`.
     /// - Throws an error if table not exists and `drop_if_exists` is `false`.
+    /// - Rejects dropping a recreated live table while an older tombstone still owns the same
+    ///   fully qualified name.
     pub async fn on_prepare(&self, ctx: &DdlContext) -> Result<Control<()>> {
         let table_ref = self.table.table_ref();
 
@@ -105,6 +107,20 @@ impl DropTableExecutor {
                 table_name: table_ref.to_string()
             }
         );
+
+        if let Some(dropped_table) = ctx
+            .table_metadata_manager
+            .get_dropped_table(&self.table)
+            .await?
+            && dropped_table.table_id != self.table_id
+        {
+            return error::TableNameTombstoneConflictSnafu {
+                table_name: table_ref.to_string(),
+                existing_table_id: dropped_table.table_id,
+                dropping_table_id: self.table_id,
+            }
+            .fail();
+        }
 
         Ok(Control::Continue(()))
     }

--- a/src/common/meta/src/ddl/tests/drop_table.rs
+++ b/src/common/meta/src/ddl/tests/drop_table.rs
@@ -236,7 +236,7 @@ async fn test_on_datanode_drop_regions_remaps_addresses_when_retrying() {
 }
 
 #[tokio::test]
-async fn test_soft_drop_stops_after_cache_invalidation_without_datanode_requests() {
+async fn test_soft_drop_sends_soft_drop_region_requests_and_keeps_tombstone() {
     let (tx, mut rx) = mpsc::channel(8);
     let datanode_handler = DatanodeWatcher::new(tx);
     let node_manager = Arc::new(MockDatanodeManager::new(datanode_handler));
@@ -269,6 +269,15 @@ async fn test_soft_drop_stops_after_cache_invalidation_without_datanode_requests
 
     assert!(procedure.dropping_regions.is_empty());
     assert_eq!(ddl_context.memory_region_keeper.len(), 0);
+
+    let (peer, request) = rx.try_recv().unwrap();
+    assert_eq!(peer.id, 1);
+    let Some(region_request::Body::Drop(req)) = request.body else {
+        unreachable!();
+    };
+    assert_eq!(req.region_id, RegionId::new(table_id, 1));
+    assert!(req.soft_drop);
+    assert!(!req.partial_drop);
     assert!(rx.try_recv().is_err());
 
     let table_name = procedure.data.task.table_name();

--- a/src/common/meta/src/ddl/tests/drop_table.rs
+++ b/src/common/meta/src/ddl/tests/drop_table.rs
@@ -433,6 +433,49 @@ async fn test_drop_recreated_table_fails_when_previous_tombstone_exists() {
 }
 
 #[tokio::test]
+async fn test_hard_drop_recreated_table_ignores_previous_orphan_tombstone() {
+    let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
+    let ddl_context = new_ddl_context(node_manager);
+    let original_table_id = 1024;
+    let recreated_table_id = 1025;
+    let table_name = "foo";
+    let task = test_create_table_task(table_name, original_table_id);
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            task.table_info.clone(),
+            TableRouteValue::physical(vec![]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+
+    let drop_task = new_drop_table_task(table_name, original_table_id, false);
+    let mut drop_procedure = DropTableProcedure::new(drop_task, ddl_context.clone());
+    execute_procedure_until(&mut drop_procedure, |p| {
+        p.data.state == DropTableState::DeleteTombstone
+    })
+    .await;
+
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            test_create_table_task(table_name, recreated_table_id).table_info,
+            TableRouteValue::physical(vec![]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+
+    let mut procedure = DropTableProcedure::new(
+        new_drop_table_task(table_name, recreated_table_id, false),
+        ddl_context,
+    );
+
+    procedure.on_prepare().await.unwrap();
+}
+
+#[tokio::test]
 async fn test_on_rollback() {
     let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
     let kv_backend = Arc::new(MemoryKvBackend::new());

--- a/src/common/meta/src/ddl/tests/drop_table.rs
+++ b/src/common/meta/src/ddl/tests/drop_table.rs
@@ -240,7 +240,8 @@ async fn test_soft_drop_stops_after_cache_invalidation_without_datanode_requests
     let (tx, mut rx) = mpsc::channel(8);
     let datanode_handler = DatanodeWatcher::new(tx);
     let node_manager = Arc::new(MockDatanodeManager::new(datanode_handler));
-    let ddl_context = new_ddl_context(node_manager);
+    let mut ddl_context = new_ddl_context(node_manager);
+    ddl_context.soft_drop_enabled = true;
     let table_id = 1024;
     let table_name = "foo";
     let task = test_create_table_task(table_name, table_id);
@@ -261,8 +262,7 @@ async fn test_soft_drop_stops_after_cache_invalidation_without_datanode_requests
         .await
         .unwrap();
 
-    let mut task = new_drop_table_task(table_name, table_id, false);
-    task.soft_drop = true;
+    let task = new_drop_table_task(table_name, table_id, false);
     let mut procedure = DropTableProcedure::new(task, ddl_context.clone());
 
     execute_procedure_until_done(&mut procedure).await;
@@ -335,7 +335,8 @@ async fn test_hard_drop_keeps_delete_tombstone_flow() {
 #[tokio::test]
 async fn test_create_table_succeeds_while_tombstone_exists() {
     let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
-    let ddl_context = new_ddl_context(node_manager);
+    let mut ddl_context = new_ddl_context(node_manager);
+    ddl_context.soft_drop_enabled = true;
     let dropped_table_id = 1024;
     let table_name = "foo";
     let task = test_create_table_task(table_name, dropped_table_id);
@@ -349,8 +350,7 @@ async fn test_create_table_succeeds_while_tombstone_exists() {
         .await
         .unwrap();
 
-    let mut drop_task = new_drop_table_task(table_name, dropped_table_id, false);
-    drop_task.soft_drop = true;
+    let drop_task = new_drop_table_task(table_name, dropped_table_id, false);
     let mut drop_procedure = DropTableProcedure::new(drop_task, ddl_context.clone());
     execute_procedure_until_done(&mut drop_procedure).await;
 
@@ -384,7 +384,8 @@ async fn test_create_table_succeeds_while_tombstone_exists() {
 #[tokio::test]
 async fn test_drop_recreated_table_fails_when_previous_tombstone_exists() {
     let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
-    let ddl_context = new_ddl_context(node_manager);
+    let mut ddl_context = new_ddl_context(node_manager);
+    ddl_context.soft_drop_enabled = true;
     let original_table_id = 1024;
     let recreated_table_id = 1025;
     let table_name = "foo";
@@ -399,8 +400,7 @@ async fn test_drop_recreated_table_fails_when_previous_tombstone_exists() {
         .await
         .unwrap();
 
-    let mut drop_task = new_drop_table_task(table_name, original_table_id, false);
-    drop_task.soft_drop = true;
+    let drop_task = new_drop_table_task(table_name, original_table_id, false);
     let mut drop_procedure = DropTableProcedure::new(drop_task, ddl_context.clone());
     execute_procedure_until_done(&mut drop_procedure).await;
 
@@ -491,7 +491,6 @@ fn new_drop_table_task(table_name: &str, table_id: TableId, drop_if_exists: bool
         table: table_name.to_string(),
         table_id,
         drop_if_exists,
-        soft_drop: false,
     }
 }
 

--- a/src/common/meta/src/ddl/tests/drop_table.rs
+++ b/src/common/meta/src/ddl/tests/drop_table.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::assert_matches;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -30,6 +31,7 @@ use tokio::sync::mpsc;
 
 use crate::ddl::TableMetadata;
 use crate::ddl::create_logical_tables::CreateLogicalTablesProcedure;
+use crate::ddl::create_table::CreateTableProcedure;
 use crate::ddl::drop_table::{DropTableProcedure, DropTableState};
 use crate::ddl::test_util::create_table::test_create_table_task;
 use crate::ddl::test_util::datanode_handler::{DatanodeWatcher, NaiveDatanodeHandler};
@@ -37,6 +39,8 @@ use crate::ddl::test_util::{
     create_logical_table, create_physical_table, create_physical_table_metadata,
     put_datanode_address, test_create_logical_table_task, test_create_physical_table_task,
 };
+use crate::error::Error;
+use crate::key::table_name::TableNameKey;
 use crate::key::table_route::TableRouteValue;
 use crate::kv_backend::memory::MemoryKvBackend;
 use crate::peer::Peer;
@@ -232,6 +236,194 @@ async fn test_on_datanode_drop_regions_remaps_addresses_when_retrying() {
 }
 
 #[tokio::test]
+async fn test_soft_drop_stops_after_cache_invalidation_without_datanode_requests() {
+    let (tx, mut rx) = mpsc::channel(8);
+    let datanode_handler = DatanodeWatcher::new(tx);
+    let node_manager = Arc::new(MockDatanodeManager::new(datanode_handler));
+    let ddl_context = new_ddl_context(node_manager);
+    let table_id = 1024;
+    let table_name = "foo";
+    let task = test_create_table_task(table_name, table_id);
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            task.table_info.clone(),
+            TableRouteValue::physical(vec![RegionRoute {
+                region: Region::new_test(RegionId::new(table_id, 1)),
+                leader_peer: Some(Peer::empty(1)),
+                follower_peers: vec![],
+                leader_state: None,
+                leader_down_since: None,
+                write_route_policy: None,
+            }]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+
+    let mut task = new_drop_table_task(table_name, table_id, false);
+    task.soft_drop = true;
+    let mut procedure = DropTableProcedure::new(task, ddl_context.clone());
+
+    execute_procedure_until_done(&mut procedure).await;
+
+    assert!(procedure.dropping_regions.is_empty());
+    assert_eq!(ddl_context.memory_region_keeper.len(), 0);
+    assert!(rx.try_recv().is_err());
+
+    let table_name = procedure.data.task.table_name();
+    let live_table = ddl_context
+        .table_metadata_manager
+        .table_name_manager()
+        .get(TableNameKey::from(&table_name))
+        .await
+        .unwrap();
+    assert!(live_table.is_none());
+
+    let dropped_table = ddl_context
+        .table_metadata_manager
+        .get_dropped_table(&table_name)
+        .await
+        .unwrap();
+    assert!(dropped_table.is_some());
+}
+
+#[tokio::test]
+async fn test_hard_drop_keeps_delete_tombstone_flow() {
+    let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
+    let ddl_context = new_ddl_context(node_manager);
+    let table_id = 1024;
+    let table_name = "foo";
+    let task = test_create_table_task(table_name, table_id);
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            task.table_info.clone(),
+            TableRouteValue::physical(vec![RegionRoute {
+                region: Region::new_test(RegionId::new(table_id, 1)),
+                leader_peer: Some(Peer::empty(1)),
+                follower_peers: vec![],
+                leader_state: None,
+                leader_down_since: None,
+                write_route_policy: None,
+            }]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+
+    let task = new_drop_table_task(table_name, table_id, false);
+    let mut procedure = DropTableProcedure::new(task, ddl_context.clone());
+
+    execute_procedure_until(&mut procedure, |p| {
+        p.data.state == DropTableState::DeleteTombstone
+    })
+    .await;
+
+    assert_eq!(procedure.data.state, DropTableState::DeleteTombstone);
+
+    execute_procedure_until_done(&mut procedure).await;
+
+    let dropped_table = ddl_context
+        .table_metadata_manager
+        .get_dropped_table(&procedure.data.task.table_name())
+        .await
+        .unwrap();
+    assert!(dropped_table.is_none());
+}
+
+#[tokio::test]
+async fn test_create_table_succeeds_while_tombstone_exists() {
+    let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
+    let ddl_context = new_ddl_context(node_manager);
+    let dropped_table_id = 1024;
+    let table_name = "foo";
+    let task = test_create_table_task(table_name, dropped_table_id);
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            task.table_info.clone(),
+            TableRouteValue::physical(vec![]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+
+    let mut drop_task = new_drop_table_task(table_name, dropped_table_id, false);
+    drop_task.soft_drop = true;
+    let mut drop_procedure = DropTableProcedure::new(drop_task, ddl_context.clone());
+    execute_procedure_until_done(&mut drop_procedure).await;
+
+    let mut create_task = test_create_table_task(table_name, 1025);
+    create_task.create_table.table_id = None;
+    create_task.table_info.ident.table_id = 0;
+    let mut create_procedure = CreateTableProcedure::new(create_task, ddl_context.clone()).unwrap();
+    execute_procedure_until_done(&mut create_procedure).await;
+
+    let live_table = ddl_context
+        .table_metadata_manager
+        .table_name_manager()
+        .get(TableNameKey::new(
+            DEFAULT_CATALOG_NAME,
+            DEFAULT_SCHEMA_NAME,
+            table_name,
+        ))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(live_table.table_id(), create_procedure.table_id());
+
+    let dropped_table = ddl_context
+        .table_metadata_manager
+        .get_dropped_table(&create_procedure.data.task.table_name())
+        .await
+        .unwrap();
+    assert_eq!(dropped_table.unwrap().table_id, dropped_table_id);
+}
+
+#[tokio::test]
+async fn test_drop_recreated_table_fails_when_previous_tombstone_exists() {
+    let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
+    let ddl_context = new_ddl_context(node_manager);
+    let original_table_id = 1024;
+    let recreated_table_id = 1025;
+    let table_name = "foo";
+    let task = test_create_table_task(table_name, original_table_id);
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            task.table_info.clone(),
+            TableRouteValue::physical(vec![]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+
+    let mut drop_task = new_drop_table_task(table_name, original_table_id, false);
+    drop_task.soft_drop = true;
+    let mut drop_procedure = DropTableProcedure::new(drop_task, ddl_context.clone());
+    execute_procedure_until_done(&mut drop_procedure).await;
+
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            test_create_table_task(table_name, recreated_table_id).table_info,
+            TableRouteValue::physical(vec![]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+
+    let mut procedure = DropTableProcedure::new(
+        new_drop_table_task(table_name, recreated_table_id, false),
+        ddl_context,
+    );
+    let err = procedure.on_prepare().await.unwrap_err();
+
+    assert_matches!(err, Error::TableNameTombstoneConflict { .. });
+}
+
+#[tokio::test]
 async fn test_on_rollback() {
     let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
     let kv_backend = Arc::new(MemoryKvBackend::new());
@@ -299,6 +491,7 @@ fn new_drop_table_task(table_name: &str, table_id: TableId, drop_if_exists: bool
         table: table_name.to_string(),
         table_id,
         drop_if_exists,
+        soft_drop: false,
     }
 }
 

--- a/src/common/meta/src/ddl_manager.rs
+++ b/src/common/meta/src/ddl_manager.rs
@@ -1190,6 +1190,7 @@ mod tests {
                 memory_region_keeper: Arc::new(MemoryRegionKeeper::default()),
                 leader_region_registry: Arc::new(LeaderRegionRegistry::default()),
                 region_failure_detector_controller: Arc::new(NoopRegionFailureDetectorControl),
+                soft_drop_enabled: false,
             },
             procedure_manager.clone(),
             Arc::new(DummyRepartitionProcedureFactory),

--- a/src/common/meta/src/error.rs
+++ b/src/common/meta/src/error.rs
@@ -363,6 +363,20 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display(
+        "Cannot drop table '{}': tombstoned table id {} already uses the same full name",
+        table_name,
+        existing_table_id
+    ))]
+    /// Raised when a live table is recreated with a name still reserved by an older tombstone.
+    TableNameTombstoneConflict {
+        table_name: String,
+        existing_table_id: TableId,
+        dropping_table_id: TableId,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("View already exists, view: {}", view_name))]
     ViewAlreadyExists {
         view_name: String,
@@ -1218,7 +1232,9 @@ impl ErrorExt for Error {
             ViewNotFound { .. } | TableNotFound { .. } | RegionNotFound { .. } => {
                 StatusCode::TableNotFound
             }
-            ViewAlreadyExists { .. } | TableAlreadyExists { .. } => StatusCode::TableAlreadyExists,
+            ViewAlreadyExists { .. }
+            | TableAlreadyExists { .. }
+            | TableNameTombstoneConflict { .. } => StatusCode::TableAlreadyExists,
 
             SubmitProcedure { source, .. }
             | QueryProcedure { source, .. }

--- a/src/common/meta/src/rpc/ddl.rs
+++ b/src/common/meta/src/rpc/ddl.rs
@@ -46,7 +46,7 @@ use common_time::{DatabaseTimeToLive, Timestamp};
 use prost::Message;
 use serde::{Deserialize, Serialize};
 use serde_with::{DefaultOnNull, serde_as};
-use snafu::{OptionExt, ResultExt};
+use snafu::{OptionExt, ResultExt, ensure};
 use table::metadata::{TableId, TableInfo};
 use table::requests::validate_database_option;
 use table::table_name::TableName;
@@ -141,6 +141,7 @@ impl DdlTask {
             table,
             table_id,
             drop_if_exists,
+            soft_drop: false,
         })
     }
 
@@ -326,7 +327,7 @@ impl TryFrom<SubmitDdlTaskRequest> for PbDdlTaskRequest {
     fn try_from(request: SubmitDdlTaskRequest) -> Result<Self> {
         let task = match request.task {
             DdlTask::CreateTable(task) => Task::CreateTableTask(task.try_into()?),
-            DdlTask::DropTable(task) => Task::DropTableTask(task.into()),
+            DdlTask::DropTable(task) => Task::DropTableTask(task.try_into()?),
             DdlTask::AlterTable(task) => Task::AlterTableTask(task.try_into()?),
             DdlTask::TruncateTable(task) => Task::TruncateTableTask(task.try_into()?),
             DdlTask::CreateLogicalTables(tasks) => {
@@ -340,8 +341,8 @@ impl TryFrom<SubmitDdlTaskRequest> for PbDdlTaskRequest {
             DdlTask::DropLogicalTables(tasks) => {
                 let tasks = tasks
                     .into_iter()
-                    .map(|task| task.into())
-                    .collect::<Vec<_>>();
+                    .map(|task| task.try_into())
+                    .collect::<Result<Vec<_>>>()?;
 
                 Task::DropTableTasks(PbDropTableTasks { tasks })
             }
@@ -586,6 +587,8 @@ pub struct DropTableTask {
     pub table_id: TableId,
     #[serde(default)]
     pub drop_if_exists: bool,
+    #[serde(default)]
+    pub soft_drop: bool,
 }
 
 impl DropTableTask {
@@ -625,13 +628,25 @@ impl TryFrom<PbDropTableTask> for DropTableTask {
                 })?
                 .id,
             drop_if_exists: drop_table.drop_if_exists,
+            soft_drop: false,
         })
     }
 }
 
-impl From<DropTableTask> for PbDropTableTask {
-    fn from(task: DropTableTask) -> Self {
-        PbDropTableTask {
+impl TryFrom<DropTableTask> for PbDropTableTask {
+    type Error = error::Error;
+
+    /// Soft-drop is intentionally not serialized through protobuf yet.
+    /// Callers must use local in-process task execution until proto support is added.
+    fn try_from(task: DropTableTask) -> Result<Self> {
+        ensure!(
+            !task.soft_drop,
+            error::UnsupportedSnafu {
+                operation: "submit soft drop table task over protobuf before proto support"
+            }
+        );
+
+        Ok(PbDropTableTask {
             drop_table: Some(DropTableExpr {
                 catalog_name: task.catalog,
                 schema_name: task.schema,
@@ -639,7 +654,7 @@ impl From<DropTableTask> for PbDropTableTask {
                 table_id: Some(api::v1::TableId { id: task.table_id }),
                 drop_if_exists: task.drop_if_exists,
             }),
-        }
+        })
     }
 }
 
@@ -1902,5 +1917,38 @@ mod tests {
         assert_eq!(pb_roundtrip.extensions, pb.extensions);
         assert_eq!(pb_roundtrip.channel, pb.channel);
         assert_eq!(pb_roundtrip.snapshot_seqs, pb.snapshot_seqs);
+    }
+
+    #[test]
+    fn test_submit_drop_table_task_rejects_soft_drop_proto_conversion() {
+        let request = SubmitDdlTaskRequest::new(
+            QueryContext::default(),
+            DdlTask::DropTable(DropTableTask {
+                catalog: "greptime".to_string(),
+                schema: "public".to_string(),
+                table: "foo".to_string(),
+                table_id: 1024,
+                drop_if_exists: false,
+                soft_drop: true,
+            }),
+        );
+
+        let err = PbDdlTaskRequest::try_from(request).unwrap_err();
+        assert!(matches!(err, error::Error::Unsupported { .. }));
+    }
+
+    #[test]
+    fn test_drop_table_task_rejects_soft_drop_direct_proto_conversion() {
+        let task = DropTableTask {
+            catalog: "greptime".to_string(),
+            schema: "public".to_string(),
+            table: "foo".to_string(),
+            table_id: 1024,
+            drop_if_exists: false,
+            soft_drop: true,
+        };
+
+        let err = PbDropTableTask::try_from(task).unwrap_err();
+        assert!(matches!(err, error::Error::Unsupported { .. }));
     }
 }

--- a/src/common/meta/src/rpc/ddl.rs
+++ b/src/common/meta/src/rpc/ddl.rs
@@ -46,7 +46,7 @@ use common_time::{DatabaseTimeToLive, Timestamp};
 use prost::Message;
 use serde::{Deserialize, Serialize};
 use serde_with::{DefaultOnNull, serde_as};
-use snafu::{OptionExt, ResultExt, ensure};
+use snafu::{OptionExt, ResultExt};
 use table::metadata::{TableId, TableInfo};
 use table::requests::validate_database_option;
 use table::table_name::TableName;
@@ -141,7 +141,6 @@ impl DdlTask {
             table,
             table_id,
             drop_if_exists,
-            soft_drop: false,
         })
     }
 
@@ -327,7 +326,7 @@ impl TryFrom<SubmitDdlTaskRequest> for PbDdlTaskRequest {
     fn try_from(request: SubmitDdlTaskRequest) -> Result<Self> {
         let task = match request.task {
             DdlTask::CreateTable(task) => Task::CreateTableTask(task.try_into()?),
-            DdlTask::DropTable(task) => Task::DropTableTask(task.try_into()?),
+            DdlTask::DropTable(task) => Task::DropTableTask(task.into()),
             DdlTask::AlterTable(task) => Task::AlterTableTask(task.try_into()?),
             DdlTask::TruncateTable(task) => Task::TruncateTableTask(task.try_into()?),
             DdlTask::CreateLogicalTables(tasks) => {
@@ -341,8 +340,8 @@ impl TryFrom<SubmitDdlTaskRequest> for PbDdlTaskRequest {
             DdlTask::DropLogicalTables(tasks) => {
                 let tasks = tasks
                     .into_iter()
-                    .map(|task| task.try_into())
-                    .collect::<Result<Vec<_>>>()?;
+                    .map(|task| task.into())
+                    .collect::<Vec<_>>();
 
                 Task::DropTableTasks(PbDropTableTasks { tasks })
             }
@@ -587,8 +586,6 @@ pub struct DropTableTask {
     pub table_id: TableId,
     #[serde(default)]
     pub drop_if_exists: bool,
-    #[serde(default)]
-    pub soft_drop: bool,
 }
 
 impl DropTableTask {
@@ -628,25 +625,13 @@ impl TryFrom<PbDropTableTask> for DropTableTask {
                 })?
                 .id,
             drop_if_exists: drop_table.drop_if_exists,
-            soft_drop: false,
         })
     }
 }
 
-impl TryFrom<DropTableTask> for PbDropTableTask {
-    type Error = error::Error;
-
-    /// Soft-drop is intentionally not serialized through protobuf yet.
-    /// Callers must use local in-process task execution until proto support is added.
-    fn try_from(task: DropTableTask) -> Result<Self> {
-        ensure!(
-            !task.soft_drop,
-            error::UnsupportedSnafu {
-                operation: "submit soft drop table task over protobuf before proto support"
-            }
-        );
-
-        Ok(PbDropTableTask {
+impl From<DropTableTask> for PbDropTableTask {
+    fn from(task: DropTableTask) -> Self {
+        PbDropTableTask {
             drop_table: Some(DropTableExpr {
                 catalog_name: task.catalog,
                 schema_name: task.schema,
@@ -654,7 +639,7 @@ impl TryFrom<DropTableTask> for PbDropTableTask {
                 table_id: Some(api::v1::TableId { id: task.table_id }),
                 drop_if_exists: task.drop_if_exists,
             }),
-        })
+        }
     }
 }
 
@@ -1917,38 +1902,5 @@ mod tests {
         assert_eq!(pb_roundtrip.extensions, pb.extensions);
         assert_eq!(pb_roundtrip.channel, pb.channel);
         assert_eq!(pb_roundtrip.snapshot_seqs, pb.snapshot_seqs);
-    }
-
-    #[test]
-    fn test_submit_drop_table_task_rejects_soft_drop_proto_conversion() {
-        let request = SubmitDdlTaskRequest::new(
-            QueryContext::default(),
-            DdlTask::DropTable(DropTableTask {
-                catalog: "greptime".to_string(),
-                schema: "public".to_string(),
-                table: "foo".to_string(),
-                table_id: 1024,
-                drop_if_exists: false,
-                soft_drop: true,
-            }),
-        );
-
-        let err = PbDdlTaskRequest::try_from(request).unwrap_err();
-        assert!(matches!(err, error::Error::Unsupported { .. }));
-    }
-
-    #[test]
-    fn test_drop_table_task_rejects_soft_drop_direct_proto_conversion() {
-        let task = DropTableTask {
-            catalog: "greptime".to_string(),
-            schema: "public".to_string(),
-            table: "foo".to_string(),
-            table_id: 1024,
-            drop_if_exists: false,
-            soft_drop: true,
-        };
-
-        let err = PbDropTableTask::try_from(task).unwrap_err();
-        assert!(matches!(err, error::Error::Unsupported { .. }));
     }
 }

--- a/src/common/meta/src/test_util.rs
+++ b/src/common/meta/src/test_util.rs
@@ -206,6 +206,7 @@ pub fn new_ddl_context_with_kv_backend(
         flow_metadata_allocator,
         flow_metadata_manager,
         region_failure_detector_controller: Arc::new(NoopRegionFailureDetectorControl),
+        soft_drop_enabled: false,
     }
 }
 

--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -1766,6 +1766,7 @@ mod tests {
                     fast_path: false,
                     force: false,
                     partial_drop: false,
+                    soft_drop: false,
                 }),
             )
             .await
@@ -1868,6 +1869,7 @@ mod tests {
                     fast_path: false,
                     force: false,
                     partial_drop: false,
+                    soft_drop: false,
                 }),
             )
             .await

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -401,6 +401,7 @@ impl MetasrvBuilder {
             flow_metadata_manager: flow_metadata_manager.clone(),
             flow_metadata_allocator: flow_metadata_allocator.clone(),
             region_failure_detector_controller,
+            soft_drop_enabled: ddl_soft_drop_enabled(&options),
         };
         let procedure_manager_c = procedure_manager.clone();
         let repartition_procedure_factory = Arc::new(DefaultRepartitionProcedureFactory::new(
@@ -644,6 +645,13 @@ fn build_procedure_manager(
         Some(runtime_switch_manager.clone()),
         Some(event_recorder),
     ))
+}
+
+/// Resolves if soft-drop is enabled from metasrv options.
+fn ddl_soft_drop_enabled(_options: &MetasrvOptions) -> bool {
+    // TODO(hl): add a dedicated soft-drop cluster config
+    // when wiring the user-facing option.
+    false
 }
 
 impl Default for MetasrvBuilder {

--- a/src/meta-srv/src/procedure/repartition/deallocate_region.rs
+++ b/src/meta-srv/src/procedure/repartition/deallocate_region.rs
@@ -135,6 +135,7 @@ impl DeallocateRegion {
                 false,
                 true,
                 true,
+                false,
             )
             .await
             .context(error::DeallocateRegionsSnafu { table_id })?;

--- a/src/meta-srv/src/procedure/utils.rs
+++ b/src/meta-srv/src/procedure/utils.rs
@@ -427,6 +427,7 @@ pub mod test_data {
             memory_region_keeper: Arc::new(MemoryRegionKeeper::new()),
             leader_region_registry: Arc::new(LeaderRegionRegistry::default()),
             region_failure_detector_controller: Arc::new(NoopRegionFailureDetectorControl),
+            soft_drop_enabled: false,
         }
     }
 }

--- a/src/metric-engine/src/engine.rs
+++ b/src/metric-engine/src/engine.rs
@@ -920,6 +920,7 @@ mod test {
                     fast_path: false,
                     force: false,
                     partial_drop: false,
+                    soft_drop: false,
                 }),
             )
             .await
@@ -936,6 +937,7 @@ mod test {
                     fast_path: false,
                     force: true,
                     partial_drop: false,
+                    soft_drop: false,
                 }),
             )
             .await

--- a/src/metric-engine/src/engine/drop.rs
+++ b/src/metric-engine/src/engine/drop.rs
@@ -36,6 +36,7 @@ impl MetricEngineInner {
         let data_region_id = utils::to_data_region_id(region_id);
         let fast_path = req.fast_path;
         let force = req.force;
+        let soft_drop = req.soft_drop;
 
         // enclose the guard in a block to prevent the guard from polluting the async context
         let (is_physical_region, is_physical_region_busy) = {
@@ -75,7 +76,7 @@ impl MetricEngineInner {
                 info!("Dropping physical region {} with force", data_region_id);
             }
             return self
-                .drop_physical_region(data_region_id, req.partial_drop)
+                .drop_physical_region(data_region_id, req.partial_drop, soft_drop)
                 .await;
         }
 
@@ -111,6 +112,7 @@ impl MetricEngineInner {
         &self,
         region_id: RegionId,
         partial_drop: bool,
+        soft_drop: bool,
     ) -> Result<AffectedRows> {
         let data_region_id = utils::to_data_region_id(region_id);
         let metadata_region_id = utils::to_metadata_region_id(region_id);
@@ -125,6 +127,7 @@ impl MetricEngineInner {
                     fast_path: false,
                     force: false,
                     partial_drop,
+                    soft_drop,
                 }),
             )
             .await
@@ -136,6 +139,7 @@ impl MetricEngineInner {
                     fast_path: false,
                     force: false,
                     partial_drop,
+                    soft_drop,
                 }),
             )
             .await

--- a/src/mito2/src/engine/drop_test.rs
+++ b/src/mito2/src/engine/drop_test.rs
@@ -18,6 +18,8 @@ use std::time::Duration;
 use api::v1::Rows;
 use common_meta::key::SchemaMetadataManager;
 use common_meta::kv_backend::KvBackendRef;
+use futures::TryStreamExt;
+use object_store::EntryMode;
 use object_store::util::join_path;
 use store_api::region_engine::RegionEngine;
 use store_api::region_request::{RegionDropRequest, RegionRequest};
@@ -35,6 +37,77 @@ use crate::worker::DROPPING_MARKER_FILE;
 async fn test_engine_drop_region() {
     test_engine_drop_region_with_format(false).await;
     test_engine_drop_region_with_format(true).await;
+}
+
+#[tokio::test]
+async fn test_engine_soft_drop_region_flushes_memtables() {
+    common_telemetry::init_default_ut_logging();
+
+    let mut env = TestEnv::with_prefix("soft_drop").await;
+    env.set_file_ref_gc_enabled(true);
+    let listener = Arc::new(DropListener::new(Duration::from_millis(100)));
+    let engine = env
+        .create_engine_with(MitoConfig::default(), None, Some(listener.clone()), None)
+        .await;
+
+    let region_id = RegionId::new(1, 1);
+    env.get_schema_metadata_manager()
+        .register_region_table_info(
+            region_id.table_id(),
+            "test_table",
+            "test_catalog",
+            "test_schema",
+            None,
+            env.get_kv_backend(),
+        )
+        .await;
+
+    let request = CreateRequestBuilder::new().build();
+    let column_schemas = rows_schema(&request);
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    let region = engine.get_region(region_id).unwrap();
+    let region_dir = region.access_layer.build_region_dir(region_id);
+    let object_store = env.get_object_store().unwrap();
+
+    let rows = Rows {
+        schema: column_schemas.clone(),
+        rows: build_rows_for_key("a", 0, 2, 0),
+    };
+    put_rows(&engine, region_id, rows).await;
+
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Drop(RegionDropRequest {
+                fast_path: false,
+                force: false,
+                partial_drop: false,
+                soft_drop: true,
+            }),
+        )
+        .await
+        .unwrap();
+
+    assert!(!engine.is_region_exists(region_id));
+
+    // The drop response must not return until the soft-drop flush has persisted the memtable.
+    let mut files = object_store.lister_with(&region_dir).await.unwrap();
+    let mut has_parquet_file = false;
+    while let Some(file) = files.try_next().await.unwrap() {
+        if file.metadata().mode() == EntryMode::FILE && file.path().ends_with(".parquet") {
+            has_parquet_file = true;
+            break;
+        }
+    }
+
+    assert!(has_parquet_file);
+
+    listener.wait().await;
+    assert!(object_store.exists(&region_dir).await.unwrap());
 }
 
 async fn test_engine_drop_region_with_format(flat_format: bool) {
@@ -75,6 +148,7 @@ async fn test_engine_drop_region_with_format(flat_format: bool) {
                 fast_path: false,
                 force: false,
                 partial_drop: false,
+                soft_drop: false,
             }),
         )
         .await
@@ -113,6 +187,7 @@ async fn test_engine_drop_region_with_format(flat_format: bool) {
                 fast_path: false,
                 force: false,
                 partial_drop: false,
+                soft_drop: false,
             }),
         )
         .await
@@ -261,6 +336,7 @@ async fn test_engine_drop_region_for_custom_store_with_format(flat_format: bool)
                 fast_path: false,
                 force: false,
                 partial_drop: false,
+                soft_drop: false,
             }),
         )
         .await

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -221,6 +221,8 @@ pub enum FlushReason {
     EnterStaging,
     /// Flush when region is closing.
     Closing,
+    /// Flush before soft-dropping a region.
+    SoftDropping,
 }
 
 impl FlushReason {

--- a/src/mito2/src/region/version.rs
+++ b/src/mito2/src/region/version.rs
@@ -160,8 +160,8 @@ impl VersionControl {
         version_data.version = new_version;
     }
 
-    /// Mark all opened files as deleted and set the delete marker in [VersionControlData]
-    pub(crate) fn mark_dropped(&self) {
+    /// Sets the delete marker in [VersionControlData].
+    pub(crate) fn mark_dropped(&self, delete_ssts: bool) {
         let version = self.current().version;
         let memtable_builder = version.memtables.mutable.memtable_builder().clone();
         let new_mutable =
@@ -169,7 +169,9 @@ impl VersionControl {
 
         let mut data = self.data.write().unwrap();
         data.is_dropped = true;
-        data.version.ssts.mark_all_deleted();
+        if delete_ssts {
+            data.version.ssts.mark_all_deleted();
+        }
         // Reset version so we can release the reference to memtables and SSTs.
         let new_version =
             Arc::new(VersionBuilder::new(version.metadata.clone(), new_mutable).build());

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -289,6 +289,10 @@ impl TestEnv {
             .map(|manager| manager.default_object_store().clone())
     }
 
+    pub(crate) fn set_file_ref_gc_enabled(&mut self, gc_enabled: bool) {
+        self.file_ref_manager = Arc::new(FileReferenceManager::with_gc_enabled(None, gc_enabled));
+    }
+
     pub fn data_home(&self) -> &Path {
         self.data_home.path()
     }

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -63,7 +63,7 @@ use crate::compaction::CompactionScheduler;
 use crate::compaction::memory_manager::{CompactionMemoryManager, new_compaction_memory_manager};
 use crate::config::MitoConfig;
 use crate::error::{self, CreateDirSnafu, JoinSnafu, Result, WorkerStoppedSnafu};
-use crate::flush::{FlushScheduler, WriteBufferManagerImpl, WriteBufferManagerRef};
+use crate::flush::{FlushReason, FlushScheduler, WriteBufferManagerImpl, WriteBufferManagerRef};
 use crate::gc::{GcLimiter, GcLimiterRef};
 use crate::memtable::MemtableBuilderProvider;
 use crate::metrics::{REGION_COUNT, REQUEST_WAIT_TIME, WRITE_STALLING};
@@ -1095,10 +1095,24 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         }
 
         for ddl in ddl_requests.drain(..) {
+            match self.maybe_schedule_soft_drop_flush(&ddl) {
+                Ok(true) => {
+                    // Keep the original DDL sender pending. The caller won't receive
+                    // the drop response until the flush finishes and replays this DDL.
+                    self.flush_scheduler.add_ddl_request_to_pending(ddl);
+                    continue;
+                }
+                Ok(false) => (),
+                Err(err) => {
+                    ddl.sender.send(Err(err));
+                    continue;
+                }
+            };
+
             let res = match ddl.request {
                 DdlRequest::Create(req) => self.handle_create_request(ddl.region_id, req).await,
                 DdlRequest::Drop(req) => {
-                    self.handle_drop_request(ddl.region_id, req.partial_drop)
+                    self.handle_drop_request(ddl.region_id, req.partial_drop, req.soft_drop)
                         .await
                 }
                 DdlRequest::Open((req, wal_entry_receiver)) => {
@@ -1157,6 +1171,52 @@ impl<S: LogStore> RegionWorkerLoop<S> {
 
             ddl.sender.send(res);
         }
+    }
+
+    /// Schedules a flush before soft-dropping a region with pending memtables.
+    ///
+    /// Returns `true` when the caller should put the original drop DDL into the
+    /// flush scheduler's pending queue and stop handling it for now. The DDL is
+    /// replayed after `handle_flush_finished()` observes a successful flush, so
+    /// the external drop request does not return success until the memtables are
+    /// durable. We must not await the flush here because flush completion is
+    /// delivered back through this same worker loop.
+    fn maybe_schedule_soft_drop_flush(&mut self, ddl: &SenderDdlRequest) -> Result<bool> {
+        let DdlRequest::Drop(req) = &ddl.request else {
+            return Ok(false);
+        };
+        if !req.soft_drop {
+            return Ok(false);
+        }
+
+        let Some(region) = self.regions.get_region(ddl.region_id) else {
+            return Ok(false);
+        };
+        if region
+            .version_control
+            .current()
+            .version
+            .memtables
+            .is_empty()
+        {
+            return Ok(false);
+        }
+
+        info!(
+            "Region {} has pending data, flushing before soft drop",
+            ddl.region_id
+        );
+        let task = self.new_flush_task(
+            &region,
+            FlushReason::SoftDropping,
+            None,
+            self.config.clone(),
+        );
+        // Do not await here: flush completion is delivered back to this worker.
+        // The pending DDL queue above is what makes the external drop request wait.
+        self.flush_scheduler
+            .schedule_flush(region.region_id, &region.version_control, task)?;
+        Ok(true)
     }
 
     /// Handle periodical tasks such as region auto flush.

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -1095,81 +1095,81 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         }
 
         for ddl in ddl_requests.drain(..) {
-            match self.maybe_schedule_soft_drop_flush(&ddl) {
-                Ok(true) => {
-                    // Keep the original DDL sender pending. The caller won't receive
-                    // the drop response until the flush finishes and replays this DDL.
-                    self.flush_scheduler.add_ddl_request_to_pending(ddl);
-                    continue;
-                }
-                Ok(false) => (),
-                Err(err) => {
-                    ddl.sender.send(Err(err));
-                    continue;
-                }
-            };
-
+            let region_id = ddl.region_id;
+            let sender = ddl.sender;
             let res = match ddl.request {
-                DdlRequest::Create(req) => self.handle_create_request(ddl.region_id, req).await,
+                DdlRequest::Create(req) => self.handle_create_request(region_id, req).await,
                 DdlRequest::Drop(req) => {
-                    self.handle_drop_request(ddl.region_id, req.partial_drop, req.soft_drop)
+                    match self.maybe_schedule_soft_drop_flush(region_id, &req) {
+                        Ok(true) => {
+                            // Keep the original DDL sender pending. The caller won't receive
+                            // the drop response until the flush finishes and replays this DDL.
+                            self.flush_scheduler
+                                .add_ddl_request_to_pending(SenderDdlRequest {
+                                    region_id,
+                                    request: DdlRequest::Drop(req),
+                                    sender,
+                                });
+                            continue;
+                        }
+                        Ok(false) => (),
+                        Err(err) => {
+                            sender.send(Err(err));
+                            continue;
+                        }
+                    }
+
+                    self.handle_drop_request(region_id, req.partial_drop, req.soft_drop)
                         .await
                 }
                 DdlRequest::Open((req, wal_entry_receiver)) => {
-                    self.handle_open_request(ddl.region_id, req, wal_entry_receiver, ddl.sender)
+                    self.handle_open_request(region_id, req, wal_entry_receiver, sender)
                         .await;
                     continue;
                 }
                 DdlRequest::Close(_) => {
-                    self.handle_close_request(ddl.region_id, ddl.sender).await;
+                    self.handle_close_request(region_id, sender).await;
                     continue;
                 }
                 DdlRequest::Alter(req) => {
-                    self.handle_alter_request(ddl.region_id, req, ddl.sender)
-                        .await;
+                    self.handle_alter_request(region_id, req, sender).await;
                     continue;
                 }
                 DdlRequest::Flush(req) => {
-                    self.handle_flush_request(ddl.region_id, req, None, ddl.sender);
+                    self.handle_flush_request(region_id, req, None, sender);
                     continue;
                 }
                 DdlRequest::Compact(req) => {
-                    self.handle_compaction_request(ddl.region_id, req, ddl.sender)
-                        .await;
+                    self.handle_compaction_request(region_id, req, sender).await;
                     continue;
                 }
                 DdlRequest::BuildIndex(req) => {
-                    self.handle_build_index_request(ddl.region_id, req, ddl.sender)
+                    self.handle_build_index_request(region_id, req, sender)
                         .await;
                     continue;
                 }
                 DdlRequest::Truncate(req) => {
-                    self.handle_truncate_request(ddl.region_id, req, ddl.sender)
-                        .await;
+                    self.handle_truncate_request(region_id, req, sender).await;
                     continue;
                 }
                 DdlRequest::Catchup((req, wal_entry_receiver)) => {
-                    self.handle_catchup_request(ddl.region_id, req, wal_entry_receiver, ddl.sender)
+                    self.handle_catchup_request(region_id, req, wal_entry_receiver, sender)
                         .await;
                     continue;
                 }
                 DdlRequest::EnterStaging(req) => {
-                    self.handle_enter_staging_request(
-                        ddl.region_id,
-                        req.partition_directive,
-                        ddl.sender,
-                    )
-                    .await;
+                    self.handle_enter_staging_request(region_id, req.partition_directive, sender)
+                        .await;
                     continue;
                 }
                 DdlRequest::ApplyStagingManifest(req) => {
-                    self.handle_apply_staging_manifest_request(ddl.region_id, req, ddl.sender)
+                    self.handle_apply_staging_manifest_request(region_id, req, sender)
                         .await;
                     continue;
                 }
             };
 
-            ddl.sender.send(res);
+            sender.send(res);
         }
     }
 
@@ -1181,15 +1181,16 @@ impl<S: LogStore> RegionWorkerLoop<S> {
     /// the external drop request does not return success until the memtables are
     /// durable. We must not await the flush here because flush completion is
     /// delivered back through this same worker loop.
-    fn maybe_schedule_soft_drop_flush(&mut self, ddl: &SenderDdlRequest) -> Result<bool> {
-        let DdlRequest::Drop(req) = &ddl.request else {
-            return Ok(false);
-        };
+    fn maybe_schedule_soft_drop_flush(
+        &mut self,
+        region_id: RegionId,
+        req: &store_api::region_request::RegionDropRequest,
+    ) -> Result<bool> {
         if !req.soft_drop {
             return Ok(false);
         }
 
-        let Some(region) = self.regions.get_region(ddl.region_id) else {
+        let Some(region) = self.regions.get_region(region_id) else {
             return Ok(false);
         };
         if region
@@ -1204,7 +1205,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
 
         info!(
             "Region {} has pending data, flushing before soft drop",
-            ddl.region_id
+            region_id
         );
         let task = self.new_flush_task(
             &region,

--- a/src/mito2/src/worker/handle_drop.rs
+++ b/src/mito2/src/worker/handle_drop.rs
@@ -42,6 +42,7 @@ where
         &mut self,
         region_id: RegionId,
         partial_drop: bool,
+        soft_drop: bool,
     ) -> Result<AffectedRows> {
         let region = self.regions.writable_region(region_id)?;
 
@@ -97,8 +98,8 @@ where
             .on_region_dropped(region_id)
             .await;
 
-        // Marks region version as dropped
-        region.version_control.mark_dropped();
+        // Marks region version as dropped. Soft-drop keeps flushed SSTs for recovery.
+        region.version_control.mark_dropped(!soft_drop);
         info!(
             "Region {} is dropped logically, but some files are not deleted yet",
             region_id
@@ -112,7 +113,6 @@ where
         let intm_manager = self.intermediate_manager.clone();
         let cache_manager = self.cache_manager.clone();
         let gc_enabled = self.file_ref_manager.is_gc_enabled();
-
         common_runtime::spawn_global(async move {
             let removed = if gc_enabled {
                 later_drop_task_with_global_gc(
@@ -122,6 +122,7 @@ where
                     object_store,
                     dropping_regions,
                     partial_drop,
+                    soft_drop,
                 )
                 .await
             } else {
@@ -230,12 +231,13 @@ async fn later_drop_task_with_global_gc(
     object_store: ObjectStore,
     dropping_regions: RegionMapRef,
     partial_drop: bool,
+    soft_drop: bool,
 ) -> bool {
     // For metadata regions or regions marked for full deletion (such as when dropping a table)
     // the region directory is forcefully removed immediately.
     //
     // TODO(discord9): Evaluate removing files instantly rather than waiting for the GC period.
-    if path_type == PathType::Metadata || !partial_drop {
+    if !should_defer_region_file_deletion(path_type, partial_drop, soft_drop) {
         remove_region_with_retry(
             region_id,
             region_path,
@@ -250,6 +252,18 @@ async fn later_drop_task_with_global_gc(
         dropping_regions.remove_region(region_id);
         true
     }
+}
+
+fn should_defer_region_file_deletion(
+    path_type: PathType,
+    partial_drop: bool,
+    soft_drop: bool,
+) -> bool {
+    if soft_drop {
+        return true;
+    }
+
+    partial_drop && path_type != PathType::Metadata
 }
 
 // TODO(ruihang): place the marker in a separate dir
@@ -297,5 +311,21 @@ pub(crate) async fn remove_region_dir_once(
         Ok(true)
     } else {
         Ok(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use store_api::region_request::PathType;
+
+    use super::*;
+
+    #[test]
+    fn test_should_defer_region_file_deletion_for_soft_drop_metadata_region() {
+        assert!(should_defer_region_file_deletion(
+            PathType::Metadata,
+            false,
+            true
+        ));
     }
 }

--- a/src/mito2/src/worker/handle_drop.rs
+++ b/src/mito2/src/worker/handle_drop.rs
@@ -233,7 +233,7 @@ async fn later_drop_task_with_global_gc(
     partial_drop: bool,
     soft_drop: bool,
 ) -> bool {
-    /// Forcefully remove the region directory immediately only when deletion is not deferred by
+    // Forcefully remove the region directory immediately only when deletion is not deferred by
     // `should_defer_region_file_deletion(path_type, partial_drop, soft_drop)`. In particular,
     // soft-drop flows may defer deletion even for metadata regions or full-drop cases.
     // TODO(discord9): Evaluate removing files instantly rather than waiting for the GC period.

--- a/src/mito2/src/worker/handle_drop.rs
+++ b/src/mito2/src/worker/handle_drop.rs
@@ -233,9 +233,9 @@ async fn later_drop_task_with_global_gc(
     partial_drop: bool,
     soft_drop: bool,
 ) -> bool {
-    // For metadata regions or regions marked for full deletion (such as when dropping a table)
-    // the region directory is forcefully removed immediately.
-    //
+    /// Forcefully remove the region directory immediately only when deletion is not deferred by
+    // `should_defer_region_file_deletion(path_type, partial_drop, soft_drop)`. In particular,
+    // soft-drop flows may defer deletion even for metadata regions or full-drop cases.
     // TODO(discord9): Evaluate removing files instantly rather than waiting for the GC period.
     if !should_defer_region_file_deletion(path_type, partial_drop, soft_drop) {
         remove_region_with_retry(

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -282,6 +282,7 @@ fn parse_region_drop(drop: DropRequest) -> Result<(RegionId, RegionDropRequest)>
             fast_path: drop.fast_path,
             force: drop.force,
             partial_drop: drop.partial_drop,
+            soft_drop: drop.soft_drop,
         },
     ))
 }
@@ -562,6 +563,9 @@ pub struct RegionDropRequest {
     /// If true, indicates that only a portion of the region is being dropped, and files may still be referenced by other regions.
     /// This is used to prevent deletion of files that are still in use by other regions.
     pub partial_drop: bool,
+
+    /// If true, flushes memtables before dropping the region from memory and defers region file deletion.
+    pub soft_drop: bool,
 }
 
 /// Open region request.
@@ -1573,6 +1577,23 @@ mod tests {
 
     use super::*;
     use crate::metadata::RegionMetadataBuilder;
+
+    #[test]
+    fn test_parse_region_drop_preserves_soft_drop() {
+        let region_id = RegionId::new(1, 1);
+        let drop = DropRequest {
+            region_id: region_id.as_u64(),
+            fast_path: false,
+            force: false,
+            partial_drop: false,
+            soft_drop: true,
+        };
+
+        let (parsed_region_id, request) = parse_region_drop(drop).unwrap();
+
+        assert_eq!(parsed_region_id, region_id);
+        assert!(request.soft_drop);
+    }
 
     #[test]
     fn test_from_proto_location() {

--- a/tests-integration/src/standalone.rs
+++ b/tests-integration/src/standalone.rs
@@ -242,6 +242,7 @@ impl GreptimeDbStandaloneBuilder {
                     flow_metadata_manager,
                     flow_metadata_allocator,
                     region_failure_detector_controller: Arc::new(NoopRegionFailureDetectorControl),
+                    soft_drop_enabled: false,
                 },
                 procedure_manager.clone(),
                 repartition_procedure_factory,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
- ~~Do not merge until https://github.com/GreptimeTeam/greptime-proto/pull/317 is merged~~

This PR covers the region/datanode side of soft-drop support and the initial DDL procedure wiring for table soft-drop.

- Adds `DropRequest.soft_drop` plumbing from protobuf parsing into `RegionDropRequest`, common-meta drop request construction, and metric-engine physical region drops.
- Implements mito2 soft-drop behavior: if a region has pending memtables, schedule a flush first, keep the original drop request pending until flush completion, then unregister/drop the region while preserving SST files for later undrop or purge.
- Defers region directory deletion for soft-dropped regions, including metadata regions under global file-reference GC, and keeps existing hard-drop/partial-drop behavior unchanged when `soft_drop = false`.
- Adds dropped-table tombstone metadata helpers/tests used by follow-up undrop and purge flows.
- Splits `DropTableProcedure` hard-drop and soft-drop transitions: hard-drop still proceeds through `DeleteTombstone`, while soft-drop sends datanode `DropRequest { soft_drop: true, partial_drop: false }` and finishes with tombstoned metadata preserved.
- Keeps create-table name reuse semantics unchanged while adding a drop-time tombstone collision check so dropping a recreated table fails if an older tombstone still owns the same full table name.

### Out of scope for this PR, to be added in later PRs:

- Add the user-facing/cluster-level configuration that enables soft-drop behavior instead of the current internal context flag defaulting to `false`.
- Implement the follow-up undrop and purge flows that consume tombstoned metadata and eventually remove preserved files.
- Add end-to-end SQL/integration coverage for table soft-drop, undrop, and purge once those flows are wired.

Compatibility notes:

- The protobuf field is backward-compatible because existing callers default `soft_drop` to `false`.
- Hard-drop and partial-drop requests keep their existing semantics unless `soft_drop` is explicitly set.
- Existing create-table behavior remains compatible: only live table names block creation; tombstoned names are checked when dropping a recreated table.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.

## Test Plan

- [x] `cargo fmt --all --check`
- [x] `cargo nextest run -p store-api --retries 0 parse_region_drop`
- [x] `cargo nextest run -p mito2 --retries 0 test_engine_soft_drop_region_flushes_memtables test_should_defer_region_file_deletion_for_soft_drop_metadata_region`
- [x] `cargo nextest run -p common-meta --retries 0 drop_table`
- [x] `cargo check -p common-meta -p datanode -p metric-engine`