### PR TITLE
feat: allow ALTER TABLE to modify the skip_wal option dynamically

### DIFF
--- a/src/common/meta/src/ddl/tests/alter_table.rs
+++ b/src/common/meta/src/ddl/tests/alter_table.rs
@@ -38,7 +38,7 @@ use store_api::metric_engine_consts::{
 };
 use store_api::region_engine::RegionManifestInfo;
 use store_api::storage::RegionId;
-use table::requests::TTL_KEY;
+use table::requests::{SKIP_WAL_KEY, TTL_KEY};
 use tokio::sync::mpsc::{self};
 
 use crate::ddl::alter_table::AlterTableProcedure;
@@ -551,10 +551,16 @@ async fn test_on_update_table_options() {
             schema_name: DEFAULT_SCHEMA_NAME.to_string(),
             table_name: table_name.to_string(),
             kind: Some(Kind::SetTableOptions(SetTableOptions {
-                table_options: vec![api::v1::Option {
-                    key: TTL_KEY.to_string(),
-                    value: "1d".to_string(),
-                }],
+                table_options: vec![
+                    api::v1::Option {
+                        key: TTL_KEY.to_string(),
+                        value: "1d".to_string(),
+                    },
+                    api::v1::Option {
+                        key: SKIP_WAL_KEY.to_string(),
+                        value: "true".to_string(),
+                    },
+                ],
             })),
         },
     };
@@ -592,6 +598,8 @@ async fn test_on_update_table_options() {
         region_info.region_options,
         HashMap::from(&table_info.meta.options)
     );
+
+    assert!(table_info.meta.options.skip_wal);
 }
 
 async fn prepare_alter_table_procedure(

--- a/src/common/meta/src/wal_provider.rs
+++ b/src/common/meta/src/wal_provider.rs
@@ -75,10 +75,7 @@ impl WalProvider {
 
     /// Allocates a batch of wal options where each wal options goes to a region.
     /// If skip_wal is true, the wal options will be set to Noop regardless of the provider type.
-    pub fn alloc_batch(&self, num_regions: usize, skip_wal: bool) -> Result<Vec<WalOptions>> {
-        if skip_wal {
-            return Ok(vec![WalOptions::Noop; num_regions]);
-        }
+    pub fn alloc_batch(&self, num_regions: usize, _skip_wal: bool) -> Result<Vec<WalOptions>> {
         match self {
             WalProvider::RaftEngine => Ok(vec![WalOptions::RaftEngine; num_regions]),
             WalProvider::Kafka(topic_manager) => {
@@ -269,7 +266,7 @@ mod tests {
         let got = provider.allocate(&regions, true).await.unwrap();
         assert_eq!(got.len(), num_regions as usize);
         for wal_options in got.values() {
-            assert_eq!(wal_options, &"{\"wal.provider\":\"noop\"}");
+            assert_eq!(wal_options, &"{\"wal.provider\":\"raft_engine\"}");
         }
     }
 }

--- a/src/common/meta/src/wal_provider.rs
+++ b/src/common/meta/src/wal_provider.rs
@@ -74,7 +74,7 @@ impl WalProvider {
     }
 
     /// Allocates a batch of wal options where each wal options goes to a region.
-    /// If skip_wal is true, the wal options will be set to Noop regardless of the provider type.
+    /// skip_wal does not affect provider allocation.
     pub fn alloc_batch(&self, num_regions: usize, _skip_wal: bool) -> Result<Vec<WalOptions>> {
         match self {
             WalProvider::RaftEngine => Ok(vec![WalOptions::RaftEngine; num_regions]),

--- a/src/mito2/src/compaction/window.rs
+++ b/src/mito2/src/compaction/window.rs
@@ -252,6 +252,7 @@ mod tests {
                 memtable: None,
                 merge_mode: None,
                 sst_format: None,
+                skip_wal: false,
             },
             compaction_time_window: None,
         }

--- a/src/mito2/src/engine/alter_test.rs
+++ b/src/mito2/src/engine/alter_test.rs
@@ -23,6 +23,7 @@ use api::v1::{ColumnDataType, Row, Rows, SemanticType, Value};
 use common_error::ext::ErrorExt;
 use common_meta::ddl::utils::{parse_column_metadatas, parse_manifest_infos_from_extensions};
 use common_recordbatch::RecordBatches;
+use common_wal::options::WAL_OPTIONS_KEY;
 use datafusion_expr::col;
 use datatypes::prelude::ConcreteDataType;
 use datatypes::schema::{ColumnSchema, FulltextAnalyzer, FulltextBackend, FulltextOptions};
@@ -1969,4 +1970,67 @@ async fn test_alter_region_skip_wal() {
 
     check_wal_options(&engine, &WalOptions::default());
     check_skip_wal(&engine, false);
+}
+
+#[tokio::test]
+async fn test_alter_region_enable_wal_on_legacy_noop_region_fails() {
+    common_telemetry::init_default_ut_logging();
+
+    let mut env = TestEnv::new().await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let wal_options = WalOptions::Noop;
+    let mut request = CreateRequestBuilder::new().build();
+    request.options.insert(
+        WAL_OPTIONS_KEY.to_string(),
+        serde_json::to_string(&wal_options).unwrap(),
+    );
+
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    let check_wal_options = |engine: &MitoEngine, expected: &WalOptions| {
+        let wal_mode = &engine
+            .get_region(region_id)
+            .unwrap()
+            .version()
+            .options
+            .wal_options;
+        assert_eq!(wal_mode, expected);
+    };
+
+    let check_skip_wal = |engine: &MitoEngine, expected: bool| {
+        let skip_wal = &engine
+            .get_region(region_id)
+            .unwrap()
+            .version()
+            .options
+            .skip_wal;
+        assert_eq!(*skip_wal, expected);
+    };
+
+    check_wal_options(&engine, &WalOptions::Noop);
+    check_skip_wal(&engine, false);
+
+    // Try to enable WAL for a legacy noop region
+    let alter_request = RegionAlterRequest {
+        kind: AlterKind::SetRegionOptions {
+            options: vec![SetRegionOption::SkipWal(false)],
+        },
+    };
+
+    let err = engine
+        .handle_request(region_id, RegionRequest::Alter(alter_request))
+        .await
+        .unwrap_err();
+
+    let msg = err.to_string();
+
+    assert!(
+        msg.contains("Cannot enable WAL for legacy regions with noop wal_options"),
+        "unexpected error: {msg}"
+    );
 }

--- a/src/mito2/src/engine/alter_test.rs
+++ b/src/mito2/src/engine/alter_test.rs
@@ -1918,7 +1918,7 @@ async fn test_alter_region_skip_wal() {
         .await
         .unwrap();
 
-    let check_skip_wal = |engine: &MitoEngine, expected: &WalOptions| {
+    let check_wal_options = |engine: &MitoEngine, expected: &WalOptions| {
         let wal_mode = &engine
             .get_region(region_id)
             .unwrap()
@@ -1927,7 +1927,19 @@ async fn test_alter_region_skip_wal() {
             .wal_options;
         assert_eq!(wal_mode, expected);
     };
-    check_skip_wal(&engine, &WalOptions::default());
+
+    let check_skip_wal = |engine: &MitoEngine, expected: bool| {
+        let skip_wal = &engine
+            .get_region(region_id)
+            .unwrap()
+            .version()
+            .options
+            .skip_wal;
+        assert_eq!(*skip_wal, expected);
+    };
+
+    check_wal_options(&engine, &WalOptions::default());
+    check_skip_wal(&engine, false);
 
     // Try to alter skip_wal from default to true
     let alter_request = RegionAlterRequest {
@@ -1940,8 +1952,9 @@ async fn test_alter_region_skip_wal() {
         .await
         .unwrap();
 
-    // WAL should switch to no op when disabled
-    check_skip_wal(&engine, &WalOptions::Noop);
+    // WAL shouldn't change wal options and skip wal should be true
+    check_wal_options(&engine, &WalOptions::default());
+    check_skip_wal(&engine, true);
 
     // Try to alter skip_wal from true to false
     let alter_request = RegionAlterRequest {
@@ -1954,5 +1967,6 @@ async fn test_alter_region_skip_wal() {
         .await
         .unwrap();
 
-    check_skip_wal(&engine, &WalOptions::default());
+    check_wal_options(&engine, &WalOptions::default());
+    check_skip_wal(&engine, false);
 }

--- a/src/mito2/src/engine/alter_test.rs
+++ b/src/mito2/src/engine/alter_test.rs
@@ -2027,7 +2027,7 @@ async fn test_alter_region_enable_wal_on_legacy_noop_region_fails() {
         .await
         .unwrap_err();
 
-    let msg = err.to_string();
+    let msg = err.output_msg();
 
     assert!(
         msg.contains("Cannot enable WAL for legacy regions with noop wal_options"),

--- a/src/mito2/src/engine/alter_test.rs
+++ b/src/mito2/src/engine/alter_test.rs
@@ -36,8 +36,8 @@ use store_api::region_request::{
 use store_api::storage::{ColumnId, RegionId, ScanRequest};
 
 use crate::config::MitoConfig;
-use crate::engine::MitoEngine;
 use crate::engine::listener::{AlterFlushListener, NotifyRegionChangeResultListener};
+use crate::engine::{MitoEngine, WalOptions};
 use crate::error;
 use crate::sst::FormatType;
 use crate::test_util::batch_util::sort_batches_and_print;
@@ -1901,4 +1901,58 @@ async fn test_alter_region_append_mode_invalid() {
 
     // append_mode should still be true
     check_append_mode(&engine, true);
+}
+
+#[tokio::test]
+async fn test_alter_region_skip_wal() {
+    common_telemetry::init_default_ut_logging();
+
+    let mut env = TestEnv::new().await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new().build();
+
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    let check_skip_wal = |engine: &MitoEngine, expected: &WalOptions| {
+        let wal_mode = &engine
+            .get_region(region_id)
+            .unwrap()
+            .version()
+            .options
+            .wal_options;
+        assert_eq!(wal_mode, expected);
+    };
+    check_skip_wal(&engine, &WalOptions::default());
+
+    // Try to alter skip_wal from default to true
+    let alter_request = RegionAlterRequest {
+        kind: AlterKind::SetRegionOptions {
+            options: vec![SetRegionOption::SkipWal(true)],
+        },
+    };
+    engine
+        .handle_request(region_id, RegionRequest::Alter(alter_request))
+        .await
+        .unwrap();
+
+    // WAL should switch to no op when disabled
+    check_skip_wal(&engine, &WalOptions::Noop);
+
+    // Try to alter skip_wal from true to false
+    let alter_request = RegionAlterRequest {
+        kind: AlterKind::SetRegionOptions {
+            options: vec![SetRegionOption::SkipWal(false)],
+        },
+    };
+    engine
+        .handle_request(region_id, RegionRequest::Alter(alter_request))
+        .await
+        .unwrap();
+
+    check_skip_wal(&engine, &WalOptions::default());
 }

--- a/src/mito2/src/engine/skip_wal_test.rs
+++ b/src/mito2/src/engine/skip_wal_test.rs
@@ -243,3 +243,76 @@ async fn test_close_region_after_truncate_skip_wal() {
     let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
     assert_eq!(3, total_rows);
 }
+#[tokio::test]
+async fn test_close_region_skip_wal_with_pending_data_via_skip_flag() {
+    test_close_region_skip_wal_via_skip_flag(true).await;
+}
+
+async fn test_close_region_skip_wal_via_skip_flag(insert: bool) {
+    common_telemetry::init_default_ut_logging();
+    let mut env = TestEnv::with_prefix(&format!("close-skip-wal-flag-{}", insert)).await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let mut request = CreateRequestBuilder::new().build();
+    let wal_options = WalOptions::RaftEngine;
+    request.options.insert(
+        WAL_OPTIONS_KEY.to_string(),
+        serde_json::to_string(&wal_options).unwrap(),
+    );
+    request
+        .options
+        .insert("skip_wal".to_string(), "true".to_string());
+    engine
+        .handle_request(region_id, RegionRequest::Create(request.clone()))
+        .await
+        .unwrap();
+    let region = engine.get_region(region_id).unwrap();
+    assert_eq!(region.version().options.wal_options, WalOptions::RaftEngine);
+    assert!(region.version().options.skip_wal);
+    if insert {
+        let column_schemas = rows_schema(&request);
+        let rows = Rows {
+            schema: column_schemas.clone(),
+            rows: build_rows(0, 3),
+        };
+        put_rows(&engine, region_id, rows).await;
+    }
+    let region = engine.get_region(region_id).unwrap();
+    if insert {
+        assert!(!region.version().memtables.is_empty());
+    } else {
+        assert!(region.version().memtables.is_empty());
+    }
+    engine
+        .handle_request(region_id, RegionRequest::Close(RegionCloseRequest {}))
+        .await
+        .unwrap();
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Open(RegionOpenRequest {
+                engine: String::new(),
+                table_dir: request.table_dir.clone(),
+                path_type: store_api::region_request::PathType::Bare,
+                options: request.options.clone(),
+                skip_wal_replay: false,
+                checkpoint: None,
+            }),
+        )
+        .await
+        .unwrap();
+    let stream = engine
+        .scan_to_stream(region_id, ScanRequest::default())
+        .await
+        .unwrap();
+    let batches = common_recordbatch::RecordBatches::try_collect(stream)
+        .await
+        .unwrap();
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    if insert {
+        assert_eq!(3, total_rows);
+    } else {
+        assert_eq!(0, total_rows);
+    }
+}

--- a/src/mito2/src/region/options.rs
+++ b/src/mito2/src/region/options.rs
@@ -89,6 +89,8 @@ pub struct RegionOptions {
     pub merge_mode: Option<MergeMode>,
     /// SST format type.
     pub sst_format: Option<FormatType>,
+    // Skip WAL options
+    pub skip_wal: bool,
 }
 
 impl RegionOptions {
@@ -170,6 +172,7 @@ impl TryFrom<&HashMap<String, String>> for RegionOptions {
             memtable,
             merge_mode: options.merge_mode,
             sst_format: options.sst_format,
+            skip_wal: options.skip_wal,
         };
         opts.validate()?;
 
@@ -277,6 +280,8 @@ struct RegionOptionsWithoutEnum {
     merge_mode: Option<MergeMode>,
     #[serde_as(as = "NoneAsEmptyString")]
     sst_format: Option<FormatType>,
+    #[serde_as(as = "DisplayFromStr")]
+    skip_wal: bool,
 }
 
 impl Default for RegionOptionsWithoutEnum {
@@ -288,6 +293,7 @@ impl Default for RegionOptionsWithoutEnum {
             append_mode: options.append_mode,
             merge_mode: options.merge_mode,
             sst_format: options.sst_format,
+            skip_wal: options.skip_wal,
         }
     }
 }
@@ -648,6 +654,7 @@ mod tests {
             ("memtable.partition_tree.data_freeze_threshold", "2048"),
             ("memtable.partition_tree.fork_dictionary_bytes", "128M"),
             ("merge_mode", "last_non_null"),
+            ("skip_wal", "true"),
         ]);
         let options = RegionOptions::try_from(&map).unwrap();
         let expect = RegionOptions {
@@ -677,6 +684,7 @@ mod tests {
             })),
             merge_mode: Some(MergeMode::LastNonNull),
             sst_format: None,
+            skip_wal: true,
         };
         assert_eq!(expect, options);
     }
@@ -712,6 +720,7 @@ mod tests {
             })),
             merge_mode: Some(MergeMode::LastNonNull),
             sst_format: None,
+            skip_wal: false,
         };
         let region_options_json_str = serde_json::to_string(&options).unwrap();
         let got: RegionOptions = serde_json::from_str(&region_options_json_str).unwrap();
@@ -777,6 +786,7 @@ mod tests {
             })),
             merge_mode: Some(MergeMode::LastNonNull),
             sst_format: None,
+            skip_wal: false,
         };
         assert_eq!(options, got);
     }

--- a/src/mito2/src/region/options.rs
+++ b/src/mito2/src/region/options.rs
@@ -125,6 +125,11 @@ impl RegionOptions {
                 memtable.primary_key_encoding()
             })
     }
+
+    /// Returns true if the WAL should be skipped for this region.
+    pub fn wal_skipped(&self) -> bool {
+        matches!(self.wal_options, WalOptions::Noop) || self.skip_wal
+    }
 }
 
 impl TryFrom<&HashMap<String, String>> for RegionOptions {

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -236,14 +236,9 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                     }
                 }
                 SetRegionOption::SkipWal(skip_wal) => {
-                    let new_wal_options = if skip_wal {
-                        WalOptions::Noop
-                    } else {
-                        WalOptions::default()
-                    };
-
-                    if current_options.wal_options != new_wal_options {
-                        current_options.wal_options = new_wal_options;
+                    if current_options.skip_wal != skip_wal {
+                        current_options.skip_wal = skip_wal;
+                        all_options_altered = false;
                     }
                 }
             }
@@ -273,7 +268,7 @@ fn new_region_options_on_empty_memtable(
     let mut current_options = current_options.clone();
     for option in options {
         match option {
-            SetRegionOption::Ttl(_) | SetRegionOption::Twsc(_, _) | SetRegionOption::SkipWal(_) => (),
+            SetRegionOption::Ttl(_) | SetRegionOption::Twsc(_, _) => (),
             SetRegionOption::Format(format_str) => {
                 // Safety: handle_alter_region_options_fast() has validated this.
                 let new_format = format_str.parse::<FormatType>().unwrap();
@@ -285,6 +280,9 @@ fn new_region_options_on_empty_memtable(
 
                 current_options.append_mode = true;
                 current_options.merge_mode = None;
+            }
+            SetRegionOption::SkipWal(skip_wal) => {
+                current_options.skip_wal = *skip_wal;
             }
         }
     }

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -236,6 +236,14 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                     }
                 }
                 SetRegionOption::SkipWal(skip_wal) => {
+                    // Validates: don't allow no-op regions to enable WAL
+                    ensure!(
+                        !(current_options.wal_options == WalOptions::Noop && !skip_wal),
+                        store_api::metadata::InvalidRegionRequestSnafu {
+                            region_id: region.region_id,
+                            err: "Cannot enable WAL for legacy regions with noop wal_options",
+                        }
+                    );
                     if current_options.skip_wal != skip_wal {
                         current_options.skip_wal = skip_wal;
                         all_options_altered = false;

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -237,13 +237,15 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                 }
                 SetRegionOption::SkipWal(skip_wal) => {
                     // Validates: don't allow no-op regions to enable WAL
-                    ensure!(
-                        !(current_options.wal_options == WalOptions::Noop && !skip_wal),
-                        store_api::metadata::InvalidRegionRequestSnafu {
-                            region_id: region.region_id,
-                            err: "Cannot enable WAL for legacy regions with noop wal_options",
-                        }
-                    );
+                    if matches!(current_options.wal_options, WalOptions::Noop) {
+                        ensure!(
+                            skip_wal,
+                            store_api::metadata::InvalidRegionRequestSnafu {
+                                region_id: region.region_id,
+                                err: "Cannot enable WAL for regions that were created with WAL disabled (legacy noop WAL)",
+                            }
+                        );
+                    }
                     if current_options.skip_wal != skip_wal {
                         current_options.skip_wal = skip_wal;
                         all_options_altered = false;

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use common_base::readable_size::ReadableSize;
 use common_telemetry::info;
 use common_telemetry::tracing::warn;
+use common_wal::options::WalOptions;
 use humantime_serde::re::humantime;
 use snafu::{ResultExt, ensure};
 use store_api::logstore::LogStore;
@@ -234,6 +235,17 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                         all_options_altered = false;
                     }
                 }
+                SetRegionOption::SkipWal(skip_wal) => {
+                    let new_wal_options = if skip_wal {
+                        WalOptions::Noop
+                    } else {
+                        WalOptions::default()
+                    };
+
+                    if current_options.wal_options != new_wal_options {
+                        current_options.wal_options = new_wal_options;
+                    }
+                }
             }
         }
         region.version_control.alter_options(current_options);
@@ -261,7 +273,7 @@ fn new_region_options_on_empty_memtable(
     let mut current_options = current_options.clone();
     for option in options {
         match option {
-            SetRegionOption::Ttl(_) | SetRegionOption::Twsc(_, _) => (),
+            SetRegionOption::Ttl(_) | SetRegionOption::Twsc(_, _) | SetRegionOption::SkipWal(_) => (),
             SetRegionOption::Format(format_str) => {
                 // Safety: handle_alter_region_options_fast() has validated this.
                 let new_format = format_str.parse::<FormatType>().unwrap();

--- a/src/mito2/src/worker/handle_close.rs
+++ b/src/mito2/src/worker/handle_close.rs
@@ -39,7 +39,8 @@ impl<S: LogStore> RegionWorkerLoop<S> {
 
         // If the region is using Noop WAL and has data in memtable,
         // we should flush it before closing to ensure durability.
-        if region.provider == Provider::Noop
+        if (region.provider == Provider::Noop
+            || region.version_control.current().version.options.skip_wal)
             && !region
                 .version_control
                 .current()

--- a/src/mito2/src/worker/handle_close.rs
+++ b/src/mito2/src/worker/handle_close.rs
@@ -39,8 +39,12 @@ impl<S: LogStore> RegionWorkerLoop<S> {
 
         // If the region is using Noop WAL and has data in memtable,
         // we should flush it before closing to ensure durability.
-        if (region.provider == Provider::Noop
-            || region.version_control.current().version.options.skip_wal)
+        if region
+            .version_control
+            .current()
+            .version
+            .options
+            .wal_skipped()
             && !region
                 .version_control
                 .current()

--- a/src/mito2/src/worker/handle_write.rs
+++ b/src/mito2/src/worker/handle_write.rs
@@ -85,7 +85,9 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                 .start_timer();
             let mut wal_writer = self.wal.writer();
             for region_ctx in region_ctxs.values_mut() {
-                if let WalOptions::Noop = &region_ctx.version().options.wal_options {
+                if matches!(region_ctx.version().options.wal_options, WalOptions::Noop)
+                    || region_ctx.version().options.skip_wal
+                {
                     // Skip wal write for noop region.
                     continue;
                 }
@@ -96,7 +98,9 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             match wal_writer.write_to_wal().await.map_err(Arc::new) {
                 Ok(response) => {
                     for (region_id, region_ctx) in region_ctxs.iter_mut() {
-                        if let WalOptions::Noop = &region_ctx.version().options.wal_options {
+                        if matches!(region_ctx.version().options.wal_options, WalOptions::Noop)
+                            || region_ctx.version().options.skip_wal
+                        {
                             continue;
                         }
 

--- a/src/mito2/src/worker/handle_write.rs
+++ b/src/mito2/src/worker/handle_write.rs
@@ -85,9 +85,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                 .start_timer();
             let mut wal_writer = self.wal.writer();
             for region_ctx in region_ctxs.values_mut() {
-                if matches!(region_ctx.version().options.wal_options, WalOptions::Noop)
-                    || region_ctx.version().options.skip_wal
-                {
+                if region_ctx.version().options.wal_skipped() {
                     // Skip wal write for noop region.
                     continue;
                 }
@@ -98,9 +96,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             match wal_writer.write_to_wal().await.map_err(Arc::new) {
                 Ok(response) => {
                     for (region_id, region_ctx) in region_ctxs.iter_mut() {
-                        if matches!(region_ctx.version().options.wal_options, WalOptions::Noop)
-                            || region_ctx.version().options.skip_wal
-                        {
+                        if region_ctx.version().options.wal_skipped() {
                             continue;
                         }
 

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -52,8 +52,8 @@ use crate::metadata::{
 use crate::metric_engine_consts::PHYSICAL_TABLE_METADATA_KEY;
 use crate::metrics;
 use crate::mito_engine_options::{
-    APPEND_MODE_KEY, SST_FORMAT_KEY, TTL_KEY, TWCS_MAX_OUTPUT_FILE_SIZE, TWCS_TIME_WINDOW,
-    TWCS_TRIGGER_FILE_NUM,
+    APPEND_MODE_KEY, SKIP_WAL_KEY, SST_FORMAT_KEY, TTL_KEY, TWCS_MAX_OUTPUT_FILE_SIZE,
+    TWCS_TIME_WINDOW, TWCS_TRIGGER_FILE_NUM,
 };
 use crate::path_utils::table_dir;
 use crate::storage::{ColumnId, RegionId, ScanRequest};
@@ -1319,6 +1319,8 @@ pub enum SetRegionOption {
     Format(String),
     // Modifying the append mode.
     AppendMode(bool),
+    // Modifying the WAL mode.
+    SkipWal(bool),
 }
 
 impl TryFrom<&PbOption> for SetRegionOption {
@@ -1342,6 +1344,12 @@ impl TryFrom<&PbOption> for SetRegionOption {
                     .parse::<bool>()
                     .map_err(|_| InvalidSetRegionOptionRequestSnafu { key, value }.build())?;
                 Ok(Self::AppendMode(append_mode))
+            }
+            SKIP_WAL_KEY => {
+                let skip_wal = value
+                    .parse::<bool>()
+                    .map_err(|_| InvalidSetRegionOptionRequestSnafu { key, value }.build())?;
+                Ok(Self::SkipWal(skip_wal))
             }
             _ => InvalidSetRegionOptionRequestSnafu { key, value }.fail(),
         }
@@ -2147,5 +2155,35 @@ mod tests {
             PathType::try_from(PathType::Metadata as u8).unwrap(),
             PathType::Metadata
         );
+    }
+
+    #[test]
+    fn test_parse_skip_wal_set_region_option_success() {
+        let skip_wal_true: PbOption = PbOption {
+            key: SKIP_WAL_KEY.to_string(),
+            value: "true".to_string(),
+        };
+
+        let skip_wal_false: PbOption = PbOption {
+            key: SKIP_WAL_KEY.to_string(),
+            value: "false".to_string(),
+        };
+        let skip_wal_true_res = SetRegionOption::try_from(&skip_wal_true).unwrap();
+        let skip_wal_false_res = SetRegionOption::try_from(&skip_wal_false).unwrap();
+
+        assert_eq!(SetRegionOption::SkipWal(true), skip_wal_true_res);
+        assert_eq!(SetRegionOption::SkipWal(false), skip_wal_false_res);
+    }
+
+    #[test]
+    fn test_parse_skip_wal_set_region_option_failure() {
+        let invalid_skip_wal_option: PbOption = PbOption {
+            key: SKIP_WAL_KEY.to_string(),
+            value: "invalid".to_string(),
+        };
+
+        let invalid_skip_wal_option_res = SetRegionOption::try_from(&invalid_skip_wal_option);
+
+        assert!(invalid_skip_wal_option_res.is_err());
     }
 }

--- a/src/table/src/metadata.rs
+++ b/src/table/src/metadata.rs
@@ -376,9 +376,6 @@ impl TableMeta {
                     }
                 }
                 SetRegionOption::SkipWal(value) => {
-                    new_options
-                        .extra_options
-                        .insert(SKIP_WAL_KEY.to_string(), value.to_string());
                     new_options.skip_wal = *value;
                 }
             }

--- a/src/table/src/metadata.rs
+++ b/src/table/src/metadata.rs
@@ -29,7 +29,8 @@ use serde::{Deserialize, Deserializer, Serialize};
 use snafu::{OptionExt, ResultExt, ensure};
 use store_api::metric_engine_consts::PHYSICAL_TABLE_METADATA_KEY;
 use store_api::mito_engine_options::{
-    APPEND_MODE_KEY, COMPACTION_TYPE, COMPACTION_TYPE_TWCS, MERGE_MODE_KEY, SST_FORMAT_KEY,
+    APPEND_MODE_KEY, COMPACTION_TYPE, COMPACTION_TYPE_TWCS, MERGE_MODE_KEY, SKIP_WAL_KEY,
+    SST_FORMAT_KEY,
 };
 use store_api::region_request::{SetRegionOption, UnsetRegionOption};
 use store_api::storage::{ColumnDescriptor, ColumnDescriptorBuilder, ColumnId};
@@ -373,6 +374,12 @@ impl TableMeta {
                     if *value {
                         new_options.extra_options.remove(MERGE_MODE_KEY);
                     }
+                }
+                SetRegionOption::SkipWal(value) => {
+                    new_options
+                        .extra_options
+                        .insert(SKIP_WAL_KEY.to_string(), value.to_string());
+                    new_options.skip_wal = *value;
                 }
             }
         }
@@ -1392,6 +1399,7 @@ mod tests {
 
     use common_error::ext::ErrorExt;
     use common_error::status_code::StatusCode;
+    use datatypes::arrow::ipc::Bool;
     use datatypes::data_type::ConcreteDataType;
     use datatypes::schema::{
         ColumnSchema, FulltextAnalyzer, FulltextBackend, Schema, SchemaBuilder,
@@ -1590,6 +1598,74 @@ mod tests {
                 .get(MERGE_MODE_KEY)
                 .map(String::as_str)
         );
+    }
+
+    #[test]
+    fn test_set_skip_wal_true_updates_table_options() {
+        let schema = Arc::new(new_test_schema());
+        let table_options = TableOptions::default();
+        let meta = TableMetaBuilder::empty()
+            .schema(schema)
+            .primary_key_indices(vec![0])
+            .engine("engine")
+            .next_column_id(3)
+            .options(table_options)
+            .build()
+            .unwrap();
+
+        let alter_kind = AlterKind::SetTableOptions {
+            options: vec![SetRegionOption::SkipWal(true)],
+        };
+        let new_meta = meta
+            .builder_with_alter_kind("my_table", &alter_kind)
+            .unwrap()
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            Some("true"),
+            new_meta
+                .options
+                .extra_options
+                .get(SKIP_WAL_KEY)
+                .map(String::as_str)
+        );
+
+        assert!(new_meta.options.skip_wal);
+    }
+
+    #[test]
+    fn test_set_skip_wal_false_updates_table_options() {
+        let schema = Arc::new(new_test_schema());
+        let table_options = TableOptions::default();
+        let meta = TableMetaBuilder::empty()
+            .schema(schema)
+            .primary_key_indices(vec![0])
+            .engine("engine")
+            .next_column_id(3)
+            .options(table_options)
+            .build()
+            .unwrap();
+
+        let alter_kind = AlterKind::SetTableOptions {
+            options: vec![SetRegionOption::SkipWal(false)],
+        };
+        let new_meta = meta
+            .builder_with_alter_kind("my_table", &alter_kind)
+            .unwrap()
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            Some("false"),
+            new_meta
+                .options
+                .extra_options
+                .get(SKIP_WAL_KEY)
+                .map(String::as_str)
+        );
+
+        assert!(!new_meta.options.skip_wal);
     }
 
     #[test]

--- a/src/table/src/metadata.rs
+++ b/src/table/src/metadata.rs
@@ -1619,16 +1619,12 @@ mod tests {
             .build()
             .unwrap();
 
-        assert_eq!(
-            Some("true"),
-            new_meta
-                .options
-                .extra_options
-                .get(SKIP_WAL_KEY)
-                .map(String::as_str)
-        );
-
         assert!(new_meta.options.skip_wal);
+
+        assert_eq!(
+            Some(&"true".to_string()),
+            HashMap::from(&new_meta.options).get(SKIP_WAL_KEY)
+        );
     }
 
     #[test]
@@ -1653,16 +1649,12 @@ mod tests {
             .build()
             .unwrap();
 
-        assert_eq!(
-            Some("false"),
-            new_meta
-                .options
-                .extra_options
-                .get(SKIP_WAL_KEY)
-                .map(String::as_str)
-        );
-
         assert!(!new_meta.options.skip_wal);
+
+        assert_eq!(
+            Some(&"false".to_string()),
+            HashMap::from(&new_meta.options).get(SKIP_WAL_KEY)
+        );
     }
 
     #[test]

--- a/src/table/src/metadata.rs
+++ b/src/table/src/metadata.rs
@@ -29,8 +29,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use snafu::{OptionExt, ResultExt, ensure};
 use store_api::metric_engine_consts::PHYSICAL_TABLE_METADATA_KEY;
 use store_api::mito_engine_options::{
-    APPEND_MODE_KEY, COMPACTION_TYPE, COMPACTION_TYPE_TWCS, MERGE_MODE_KEY, SKIP_WAL_KEY,
-    SST_FORMAT_KEY,
+    APPEND_MODE_KEY, COMPACTION_TYPE, COMPACTION_TYPE_TWCS, MERGE_MODE_KEY, SST_FORMAT_KEY,
 };
 use store_api::region_request::{SetRegionOption, UnsetRegionOption};
 use store_api::storage::{ColumnDescriptor, ColumnDescriptorBuilder, ColumnId};
@@ -1404,6 +1403,7 @@ mod tests {
 
     use super::*;
     use crate::Error;
+    use crate::requests::SKIP_WAL_KEY;
 
     /// Create a test schema with 3 columns: `[col1 int32, ts timestampmills, col2 int32]`.
     fn new_test_schema() -> Schema {

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -40,6 +40,7 @@ use store_api::mito_engine_options::{
     TWCS_FALLBACK_TO_LOCAL, TWCS_MAX_OUTPUT_FILE_SIZE, TWCS_TIME_WINDOW, TWCS_TRIGGER_FILE_NUM,
     is_mito_engine_option_key,
 };
+use store_api::path_utils::WAL_DIR;
 use store_api::region_request::{SetRegionOption, UnsetRegionOption};
 
 use crate::error::{ParseTableOptionSnafu, Result};
@@ -224,7 +225,7 @@ impl fmt::Display for TableOptions {
 
 impl From<&TableOptions> for HashMap<String, String> {
     fn from(opts: &TableOptions) -> Self {
-        let mut res = HashMap::with_capacity(2 + opts.extra_options.len());
+        let mut res = HashMap::with_capacity(3 + opts.extra_options.len());
         if let Some(write_buffer_size) = opts.write_buffer_size {
             let _ = res.insert(
                 WRITE_BUFFER_SIZE_KEY.to_string(),
@@ -234,6 +235,7 @@ impl From<&TableOptions> for HashMap<String, String> {
         if let Some(ttl_str) = opts.ttl.map(|ttl| ttl.to_string()) {
             let _ = res.insert(TTL_KEY.to_string(), ttl_str);
         }
+        let _ = res.insert(SKIP_WAL_KEY.to_string(), opts.skip_wal.to_string());
         res.extend(
             opts.extra_options
                 .iter()

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -40,7 +40,6 @@ use store_api::mito_engine_options::{
     TWCS_FALLBACK_TO_LOCAL, TWCS_MAX_OUTPUT_FILE_SIZE, TWCS_TIME_WINDOW, TWCS_TRIGGER_FILE_NUM,
     is_mito_engine_option_key,
 };
-use store_api::path_utils::WAL_DIR;
 use store_api::region_request::{SetRegionOption, UnsetRegionOption};
 
 use crate::error::{ParseTableOptionSnafu, Result};
@@ -193,7 +192,7 @@ impl TableOptions {
 
         options.extra_options = HashMap::from_iter(
             kvs.into_iter()
-                .filter(|(k, _)| k != WRITE_BUFFER_SIZE_KEY && k != TTL_KEY),
+                .filter(|(k, _)| k != WRITE_BUFFER_SIZE_KEY && k != TTL_KEY && k != SKIP_WAL_KEY),
         );
 
         Ok(options)

--- a/tests/cases/standalone/common/alter/alter_table_options.result
+++ b/tests/cases/standalone/common/alter/alter_table_options.result
@@ -214,6 +214,10 @@ ALTER TABLE ato SET 'compaction.twcs.trigger_file_num'='';
 
 Affected Rows: 0
 
+ALTER TABLE ato SET 'skip_wal'='true';
+
+Affected Rows: 0
+
 SHOW CREATE TABLE ato;
 
 +-------+-----------------------------------------------------+
@@ -231,6 +235,32 @@ SHOW CREATE TABLE ato;
 |       |   'compaction.twcs.max_output_file_size' = '500MB', |
 |       |   'compaction.type' = 'twcs',                       |
 |       |   ttl = '1s'                                        |
+|       |   skip_wal = 'true'                                 |
+|       | )                                                   |
++-------+-----------------------------------------------------+
+
+ALTER TABLE ato SET 'skip_wal'='false';
+
+Affected Rows: 0
+
+SHOW CREATE TABLE ato;
+
++-------+-----------------------------------------------------+
+| Table | Create Table                                        |
++-------+-----------------------------------------------------+
+| ato   | CREATE TABLE IF NOT EXISTS "ato" (                  |
+|       |   "i" INT NULL,                                     |
+|       |   "j" TIMESTAMP(3) NOT NULL,                        |
+|       |   TIME INDEX ("j"),                                 |
+|       |   PRIMARY KEY ("i")                                 |
+|       | )                                                   |
+|       |                                                     |
+|       | ENGINE=mito                                         |
+|       | WITH(                                               |
+|       |   'compaction.twcs.max_output_file_size' = '500MB', |
+|       |   'compaction.type' = 'twcs',                       |
+|       |   ttl = '1s'                                        |
+|       |   skip_wal = 'false'                                |
 |       | )                                                   |
 +-------+-----------------------------------------------------+
 
@@ -252,6 +282,7 @@ SHOW CREATE TABLE ato;
 |       |   'compaction.twcs.max_output_file_size' = '500MB', |
 |       |   'compaction.type' = 'twcs',                       |
 |       |   ttl = '1s'                                        |
+|       |   skip_wal = 'false'                                |
 |       | )                                                   |
 +-------+-----------------------------------------------------+
 
@@ -309,4 +340,3 @@ SHOW CREATE TABLE phy;
 DROP TABLE phy;
 
 Affected Rows: 0
-

--- a/tests/cases/standalone/common/alter/alter_table_options.sql
+++ b/tests/cases/standalone/common/alter/alter_table_options.sql
@@ -48,6 +48,12 @@ SHOW CREATE TABLE ato;
 
 ALTER TABLE ato SET 'compaction.twcs.trigger_file_num'='';
 
+ALTER TABLE ato SET 'skip_wal'='true';
+
+SHOW CREATE TABLE ato;
+
+ALTER TABLE ato SET 'skip_wal'='false';
+
 SHOW CREATE TABLE ato;
 
 -- SQLNESS ARG restart=true


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Fixes this [issue](https://github.com/GreptimeTeam/greptimedb/issues/7544)

## What's changed and what's your intention?

This PR now allows the ALTER TABLE command to update `skip_wal` at runtime instead of only at table creation time. To support this operation safely, this PR separates WAL provider configuration from the runtime “skip WAL” toggle. Previously, Greptime used `WalOptions::Noop` to indicate that a region should skip WAL writes. This makes re-enabling WAL unsafe because the original provider information will be be discarded. ([see discussion](https://github.com/GreptimeTeam/greptimedb/issues/7544#issuecomment-4278990044))

This PR introduces skip_wal as a new region option and uses it as the runtime signal for whether WAL writes should be skipped, while preserving the region’s provider specific wal_options. New regions created with skip_wal=true still keep real WAL provider metadata, so WAL can later be re-enabled safely.

For backwards compatibility, legacy regions that already persist WalOptions::Noop are still supported as "skip wal" regions, but attempting to re-enable WAL for those legacy regions now fails explicitly because the original provider information is unavailable (please let me know if there is a better solution for this).

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
