### PR TITLE
feat: add soft-drop table recovery procedures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5938,7 +5938,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=b6b665d8b6fce4f1f0da49c8c79fb150636df4ff#b6b665d8b6fce4f1f0da49c8c79fb150636df4ff"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=d21d344eb357fd250e0d71b354c8d1b38a077b14#d21d344eb357fd250e0d71b354c8d1b38a077b14"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5938,7 +5938,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=013b3c4e6ad96a6acd2d2df80fa619a3a0ea655b#013b3c4e6ad96a6acd2d2df80fa619a3a0ea655b"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=ec2d8a899266ee98a43fa5ac90cc2d6e76970d3c#ec2d8a899266ee98a43fa5ac90cc2d6e76970d3c"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11114,7 +11114,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -11134,8 +11134,8 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.14.0",
+ "heck 0.5.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -11183,7 +11183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11196,7 +11196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -13483,7 +13483,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1961e2ef424c1424204d3a5d6975f934f56b6d50ff5732382d84ebf460e147f7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11135,7 +11135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -11183,7 +11183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11196,7 +11196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5938,7 +5938,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=d21d344eb357fd250e0d71b354c8d1b38a077b14#d21d344eb357fd250e0d71b354c8d1b38a077b14"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=013b3c4e6ad96a6acd2d2df80fa619a3a0ea655b#013b3c4e6ad96a6acd2d2df80fa619a3a0ea655b"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5938,7 +5938,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=ec2d8a899266ee98a43fa5ac90cc2d6e76970d3c#ec2d8a899266ee98a43fa5ac90cc2d6e76970d3c"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=4a69c9e75240a76afeb0796798085813669288f8#4a69c9e75240a76afeb0796798085813669288f8"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ fs2 = "0.4"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "d21d344eb357fd250e0d71b354c8d1b38a077b14" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "013b3c4e6ad96a6acd2d2df80fa619a3a0ea655b" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ fs2 = "0.4"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "ec2d8a899266ee98a43fa5ac90cc2d6e76970d3c" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "4a69c9e75240a76afeb0796798085813669288f8" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ fs2 = "0.4"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "b6b665d8b6fce4f1f0da49c8c79fb150636df4ff" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "d21d344eb357fd250e0d71b354c8d1b38a077b14" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ fs2 = "0.4"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "013b3c4e6ad96a6acd2d2df80fa619a3a0ea655b" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "ec2d8a899266ee98a43fa5ac90cc2d6e76970d3c" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/src/api/src/helper.rs
+++ b/src/api/src/helper.rs
@@ -713,6 +713,8 @@ fn ddl_request_type(request: &DdlRequest) -> &'static str {
         Some(Expr::DropView(_)) => "ddl.drop_view",
         Some(Expr::AlterDatabase(_)) => "ddl.alter_database",
         Some(Expr::CommentOn(_)) => "ddl.comment_on",
+        Some(Expr::UndropTable(_)) => "ddl.undrop_table",
+        Some(Expr::PurgeDroppedTable(_)) => "ddl.purge_dropped_table",
         None => "ddl.empty",
     }
 }

--- a/src/api/src/helper.rs
+++ b/src/api/src/helper.rs
@@ -713,8 +713,6 @@ fn ddl_request_type(request: &DdlRequest) -> &'static str {
         Some(Expr::DropView(_)) => "ddl.drop_view",
         Some(Expr::AlterDatabase(_)) => "ddl.alter_database",
         Some(Expr::CommentOn(_)) => "ddl.comment_on",
-        Some(Expr::UndropTable(_)) => "ddl.undrop_table",
-        Some(Expr::PurgeDroppedTable(_)) => "ddl.purge_dropped_table",
         None => "ddl.empty",
     }
 }

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -551,6 +551,7 @@ impl StartCommand {
             flow_metadata_manager: flow_metadata_manager.clone(),
             flow_metadata_allocator: flow_metadata_allocator.clone(),
             region_failure_detector_controller: Arc::new(NoopRegionFailureDetectorControl),
+            soft_drop_enabled: false,
         };
 
         let ddl_manager = DdlManager::try_new(

--- a/src/common/meta/src/ddl.rs
+++ b/src/common/meta/src/ddl.rs
@@ -44,12 +44,14 @@ pub mod drop_flow;
 pub mod drop_table;
 pub mod drop_view;
 pub mod flow_meta;
+pub mod purge_dropped_table;
 pub mod table_meta;
 #[cfg(any(test, feature = "testing"))]
 pub mod test_util;
 #[cfg(test)]
 pub(crate) mod tests;
 pub mod truncate_table;
+pub mod undrop_table;
 pub mod utils;
 
 /// Metadata allocated to a table.

--- a/src/common/meta/src/ddl.rs
+++ b/src/common/meta/src/ddl.rs
@@ -117,6 +117,8 @@ pub struct DdlContext {
     pub flow_metadata_allocator: FlowMetadataAllocatorRef,
     /// controller of region failure detector.
     pub region_failure_detector_controller: RegionFailureDetectorControllerRef,
+    /// Whether table drops should stop after tombstoning metadata.
+    pub soft_drop_enabled: bool,
 }
 
 impl DdlContext {

--- a/src/common/meta/src/ddl.rs
+++ b/src/common/meta/src/ddl.rs
@@ -138,7 +138,10 @@ impl DdlContext {
     ///
     /// Once the regions were dropped, subsequent heartbeats no longer include these regions.
     /// Therefore, we should remove the failure detectors for these dropped regions.
-    async fn deregister_failure_detectors(&self, detecting_regions: Vec<DetectingRegion>) {
+    pub(crate) async fn deregister_failure_detectors(
+        &self,
+        detecting_regions: Vec<DetectingRegion>,
+    ) {
         self.region_failure_detector_controller
             .deregister_failure_detectors(detecting_regions)
             .await;

--- a/src/common/meta/src/ddl/drop_table.rs
+++ b/src/common/meta/src/ddl/drop_table.rs
@@ -149,6 +149,7 @@ impl DropTableProcedure {
     /// Broadcasts invalidate table cache instruction.
     async fn on_broadcast(&mut self) -> Result<Status> {
         self.executor.invalidate_table_cache(&self.context).await?;
+
         self.data.state = DropTableState::DatanodeDropRegions;
 
         Ok(Status::executing(true))
@@ -172,6 +173,18 @@ impl DropTableProcedure {
                 .await?;
         }
 
+        if self.context.soft_drop_enabled {
+            self.executor
+                .on_close_regions(
+                    &self.context.node_manager,
+                    &self.context.leader_region_registry,
+                    &self.data.physical_region_routes,
+                )
+                .await?;
+            self.dropping_regions.clear();
+            return Ok(Status::done());
+        }
+
         self.executor
             .on_drop_regions(
                 &self.context.node_manager,
@@ -182,6 +195,7 @@ impl DropTableProcedure {
                 false,
             )
             .await?;
+
         self.data.state = DropTableState::DeleteTombstone;
         Ok(Status::executing(true))
     }

--- a/src/common/meta/src/ddl/drop_table.rs
+++ b/src/common/meta/src/ddl/drop_table.rs
@@ -36,7 +36,7 @@ use table::table_reference::TableReference;
 
 use self::executor::DropTableExecutor;
 use crate::ddl::DdlContext;
-use crate::ddl::utils::map_to_procedure_error;
+use crate::ddl::utils::{convert_region_routes_to_detecting_regions, map_to_procedure_error};
 use crate::error::{self, Result};
 use crate::key::table_route::TableRouteValue;
 use crate::lock_key::{CatalogLock, SchemaLock, TableLock};
@@ -181,6 +181,11 @@ impl DropTableProcedure {
                     &self.data.physical_region_routes,
                 )
                 .await?;
+            self.context
+                .deregister_failure_detectors(convert_region_routes_to_detecting_regions(
+                    &self.data.physical_region_routes,
+                ))
+                .await;
             self.dropping_regions.clear();
             return Ok(Status::done());
         }

--- a/src/common/meta/src/ddl/drop_table.rs
+++ b/src/common/meta/src/ddl/drop_table.rs
@@ -200,6 +200,11 @@ impl DropTableProcedure {
                 false,
             )
             .await?;
+        self.context
+            .deregister_failure_detectors(convert_region_routes_to_detecting_regions(
+                &self.data.physical_region_routes,
+            ))
+            .await;
 
         self.data.state = DropTableState::DeleteTombstone;
         Ok(Status::executing(true))

--- a/src/common/meta/src/ddl/drop_table/executor.rs
+++ b/src/common/meta/src/ddl/drop_table/executor.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use api::v1::region::{
     CloseRequest as PbCloseRegionRequest, DropRequest as PbDropRegionRequest, RegionRequest,
@@ -82,6 +82,8 @@ impl DropTableExecutor {
     /// Checks whether table exists.
     /// - Early returns if table not exists and `drop_if_exists` is `true`.
     /// - Throws an error if table not exists and `drop_if_exists` is `false`.
+    /// - Rejects dropping a recreated live table while an older tombstone still owns the same
+    ///   fully qualified name.
     pub async fn on_prepare(&self, ctx: &DdlContext) -> Result<Control<()>> {
         let table_ref = self.table.table_ref();
 
@@ -105,6 +107,21 @@ impl DropTableExecutor {
                 table_name: table_ref.to_string()
             }
         );
+
+        if ctx.soft_drop_enabled
+            && let Some(dropped_table) = ctx
+                .table_metadata_manager
+                .get_dropped_table(&self.table)
+                .await?
+            && dropped_table.table_id != self.table_id
+        {
+            return error::TableNameTombstoneConflictSnafu {
+                table_name: table_ref.to_string(),
+                existing_table_id: dropped_table.table_id,
+                dropping_table_id: self.table_id,
+            }
+            .fail();
+        }
 
         Ok(Control::Continue(()))
     }
@@ -211,7 +228,17 @@ impl DropTableExecutor {
         Ok(())
     }
 
-    /// Drops region on datanode.
+    /// Drops regions on datanodes.
+    ///
+    /// Arguments:
+    /// - `node_manager`: resolves datanode clients from peers in `region_routes`.
+    /// - `leader_region_registry`: tracks in-flight leader region operations.
+    /// - `region_routes`: table region placement; leaders receive drop requests and followers
+    ///   receive close requests.
+    /// - `fast_path`: forwards to datanode drop requests to skip extra cleanup when safe.
+    /// - `force`: forwards to datanode drop requests to allow forced region removal.
+    /// - `partial_drop`: forwards to datanode drop requests for partial table/region drops.
+    #[allow(clippy::too_many_arguments)]
     pub async fn on_drop_regions(
         &self,
         node_manager: &NodeManagerRef,
@@ -314,6 +341,64 @@ impl DropTableExecutor {
         }
 
         // Deletes the leader region from registry.
+        let region_ids = operating_leader_regions(region_routes);
+        leader_region_registry.batch_delete(region_ids.into_iter().map(|(region_id, _)| region_id));
+
+        Ok(())
+    }
+
+    /// Closes all table regions on datanodes without deleting region files or metadata tombstones.
+    pub async fn on_close_regions(
+        &self,
+        node_manager: &NodeManagerRef,
+        leader_region_registry: &LeaderRegionRegistryRef,
+        region_routes: &[RegionRoute],
+    ) -> Result<()> {
+        let table_id = self.table_id;
+        let mut seen_peer_ids = HashSet::new();
+        let peers = find_leaders(region_routes)
+            .into_iter()
+            .chain(find_followers(region_routes))
+            .filter(|peer| seen_peer_ids.insert(peer.id));
+        let mut close_region_tasks = Vec::new();
+
+        for datanode in peers {
+            let requester = node_manager.datanode(&datanode).await;
+            let region_ids = find_leader_regions(region_routes, &datanode)
+                .into_iter()
+                .chain(find_follower_regions(region_routes, &datanode))
+                .map(|region_number| RegionId::new(table_id, region_number));
+
+            for region_id in region_ids {
+                debug!("Closing region {region_id} on Datanode {datanode:?}");
+                let request = RegionRequest {
+                    header: Some(RegionRequestHeader {
+                        tracing_context: TracingContext::from_current_span().to_w3c(),
+                        ..Default::default()
+                    }),
+                    body: Some(region_request::Body::Close(PbCloseRegionRequest {
+                        region_id: region_id.as_u64(),
+                    })),
+                };
+
+                let datanode = datanode.clone();
+                let requester = requester.clone();
+                close_region_tasks.push(async move {
+                    if let Err(err) = requester.handle(request).await
+                        && err.status_code() != StatusCode::RegionNotFound
+                    {
+                        return Err(add_peer_context_if_needed(datanode)(err));
+                    }
+                    Ok(())
+                });
+            }
+        }
+
+        join_all(close_region_tasks)
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>>>()?;
+
         let region_ids = operating_leader_regions(region_routes);
         leader_region_registry.batch_delete(region_ids.into_iter().map(|(region_id, _)| region_id));
 

--- a/src/common/meta/src/ddl/drop_table/metadata.rs
+++ b/src/common/meta/src/ddl/drop_table/metadata.rs
@@ -13,12 +13,13 @@
 // limitations under the License.
 
 use common_catalog::format_full_table_name;
-use snafu::OptionExt;
+use snafu::{OptionExt, ensure};
 use store_api::metric_engine_consts::METRIC_ENGINE_NAME;
 
 use crate::ddl::drop_table::DropTableProcedure;
-use crate::ddl::utils::extract_region_wal_options;
+use crate::ddl::utils::{extract_region_wal_options, is_metric_engine_logical_table};
 use crate::error::{self, Result};
+use crate::key::table_route::TableRouteValue;
 
 impl DropTableProcedure {
     /// Fetches the table info and physical table route.
@@ -31,18 +32,34 @@ impl DropTableProcedure {
             .get_physical_table_route(task.table_id)
             .await?;
 
-        if physical_table_id == self.data.table_id() {
-            let table_info_value = self
-                .context
-                .table_metadata_manager
-                .table_info_manager()
-                .get(task.table_id)
-                .await?
-                .with_context(|| error::TableInfoNotFoundSnafu {
-                    table: format_full_table_name(&task.catalog, &task.schema, &task.table),
-                })?
-                .into_inner();
+        let table_info_value = self
+            .context
+            .table_metadata_manager
+            .table_info_manager()
+            .get(task.table_id)
+            .await?
+            .with_context(|| error::TableInfoNotFoundSnafu {
+                table: format_full_table_name(&task.catalog, &task.schema, &task.table),
+            })?
+            .into_inner();
+        let table_route_value = TableRouteValue::new(
+            self.data.table_id(),
+            physical_table_id,
+            physical_table_route_value.region_routes.clone(),
+        );
+        // TODO(hl): support soft-dropping logical tables.
+        ensure!(
+            !(self.context.soft_drop_enabled
+                && is_metric_engine_logical_table(
+                    &table_info_value.table_info,
+                    &table_route_value
+                )),
+            error::UnsupportedSnafu {
+                operation: "soft-dropping metric logical tables".to_string()
+            }
+        );
 
+        if physical_table_id == self.data.table_id() {
             let engine = table_info_value.table_info.meta.engine;
             // rollback only if dropping the metric physical table fails
             self.data.allow_rollback = engine.as_str() == METRIC_ENGINE_NAME;

--- a/src/common/meta/src/ddl/purge_dropped_table.rs
+++ b/src/common/meta/src/ddl/purge_dropped_table.rs
@@ -21,7 +21,7 @@ use common_procedure::{
 };
 use common_wal::options::WalOptions;
 use serde::{Deserialize, Serialize};
-use snafu::ResultExt;
+use snafu::{ResultExt, ensure};
 use store_api::storage::{RegionNumber, TableId};
 use strum::AsRefStr;
 use table::metadata::TableInfo;
@@ -30,8 +30,8 @@ use table::table_name::TableName;
 use crate::ddl::DdlContext;
 use crate::ddl::drop_table::executor::DropTableExecutor;
 use crate::ddl::undrop_table::open_regions;
-use crate::ddl::utils::map_to_procedure_error;
-use crate::error::Result;
+use crate::ddl::utils::{is_metric_engine_logical_table, map_to_procedure_error};
+use crate::error::{self, Result};
 use crate::key::table_route::TableRouteValue;
 use crate::lock_key::{CatalogLock, SchemaLock, TableLock, TableNameLock};
 use crate::rpc::ddl::PurgeDroppedTableTask;
@@ -73,6 +73,15 @@ impl PurgeDroppedTableProcedure {
         let Some(dropped_table) = dropped_table else {
             return Ok(Status::done());
         };
+        ensure!(
+            !is_metric_engine_logical_table(
+                &dropped_table.table_info_value.table_info,
+                &dropped_table.table_route_value
+            ),
+            error::UnsupportedSnafu {
+                operation: "purging metric logical tables".to_string()
+            }
+        );
         self.data.table_id = Some(dropped_table.table_id);
         self.data.table_name = Some(dropped_table.table_name);
         self.data.table_info = Some(dropped_table.table_info_value.table_info);

--- a/src/common/meta/src/ddl/purge_dropped_table.rs
+++ b/src/common/meta/src/ddl/purge_dropped_table.rs
@@ -30,7 +30,10 @@ use table::table_name::TableName;
 use crate::ddl::DdlContext;
 use crate::ddl::drop_table::executor::DropTableExecutor;
 use crate::ddl::undrop_table::open_regions;
-use crate::ddl::utils::{is_metric_engine_logical_table, map_to_procedure_error};
+use crate::ddl::utils::{
+    convert_region_routes_to_detecting_regions, is_metric_engine_logical_table,
+    map_to_procedure_error,
+};
 use crate::error::{self, Result};
 use crate::key::table_route::TableRouteValue;
 use crate::lock_key::{CatalogLock, SchemaLock, TableLock, TableNameLock};
@@ -119,6 +122,11 @@ impl PurgeDroppedTableProcedure {
                     false,
                 )
                 .await?;
+            self.context
+                .deregister_failure_detectors(convert_region_routes_to_detecting_regions(
+                    region_routes,
+                ))
+                .await;
         }
         self.data.state = PurgeDroppedTableState::DeleteTombstone;
         Ok(Status::executing(true))

--- a/src/common/meta/src/ddl/purge_dropped_table.rs
+++ b/src/common/meta/src/ddl/purge_dropped_table.rs
@@ -1,0 +1,202 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use common_procedure::error::{FromJsonSnafu, ToJsonSnafu};
+use common_procedure::{
+    Context as ProcedureContext, LockKey, Procedure, Result as ProcedureResult, Status,
+};
+use common_wal::options::WalOptions;
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+use store_api::storage::{RegionNumber, TableId};
+use strum::AsRefStr;
+use table::table_name::TableName;
+
+use crate::ddl::DdlContext;
+use crate::ddl::drop_table::executor::DropTableExecutor;
+use crate::ddl::utils::map_to_procedure_error;
+use crate::error::Result;
+use crate::key::table_route::TableRouteValue;
+use crate::lock_key::{CatalogLock, SchemaLock, TableLock, TableNameLock};
+use crate::rpc::ddl::PurgeDroppedTableTask;
+use crate::rpc::router::RegionRoute;
+
+pub struct PurgeDroppedTableProcedure {
+    context: DdlContext,
+    data: PurgeDroppedTableData,
+}
+
+impl PurgeDroppedTableProcedure {
+    pub const TYPE_NAME: &'static str = "metasrv-procedure::PurgeDroppedTable";
+
+    pub fn new(task: PurgeDroppedTableTask, context: DdlContext) -> Self {
+        Self {
+            context,
+            data: PurgeDroppedTableData::new(task),
+        }
+    }
+
+    pub fn from_json(json: &str, context: DdlContext) -> ProcedureResult<Self> {
+        let data: PurgeDroppedTableData = serde_json::from_str(json).context(FromJsonSnafu)?;
+        Ok(Self { context, data })
+    }
+
+    async fn on_prepare(&mut self) -> Result<Status> {
+        let dropped_table = if let Some(table_id) = self.data.task.table_id {
+            self.context
+                .table_metadata_manager
+                .get_dropped_table_by_id(table_id)
+                .await?
+        } else {
+            self.context
+                .table_metadata_manager
+                .get_dropped_table(&self.data.task.table_name())
+                .await?
+        };
+
+        let Some(dropped_table) = dropped_table else {
+            return Ok(Status::done());
+        };
+        self.data.table_id = Some(dropped_table.table_id);
+        self.data.table_name = Some(dropped_table.table_name);
+        self.data.table_route_value = Some(dropped_table.table_route_value);
+        self.data.region_wal_options = dropped_table.region_wal_options;
+        self.data.state = PurgeDroppedTableState::DropRegions;
+        Ok(Status::executing(true))
+    }
+
+    async fn on_drop_regions(&mut self) -> Result<Status> {
+        if let Some(region_routes) = self.data.physical_region_routes() {
+            self.executor()
+                .on_drop_regions(
+                    &self.context.node_manager,
+                    &self.context.leader_region_registry,
+                    region_routes,
+                    false,
+                    false,
+                    false,
+                )
+                .await?;
+        }
+        self.data.state = PurgeDroppedTableState::DeleteTombstone;
+        Ok(Status::executing(true))
+    }
+
+    async fn on_delete_tombstone(&mut self) -> Result<Status> {
+        self.context
+            .table_metadata_manager
+            .delete_table_metadata_tombstone(
+                self.data.table_id(),
+                self.data.table_name(),
+                self.data.table_route_value(),
+                &self.data.region_wal_options,
+            )
+            .await?;
+        Ok(Status::done())
+    }
+
+    fn executor(&self) -> DropTableExecutor {
+        DropTableExecutor::new(self.data.table_name().clone(), self.data.table_id(), false)
+    }
+}
+
+#[async_trait]
+impl Procedure for PurgeDroppedTableProcedure {
+    fn type_name(&self) -> &str {
+        Self::TYPE_NAME
+    }
+
+    fn recover(&mut self) -> ProcedureResult<()> {
+        Ok(())
+    }
+
+    async fn execute(&mut self, _: &ProcedureContext) -> ProcedureResult<Status> {
+        match self.data.state {
+            PurgeDroppedTableState::Prepare => self.on_prepare().await,
+            PurgeDroppedTableState::DropRegions => self.on_drop_regions().await,
+            PurgeDroppedTableState::DeleteTombstone => self.on_delete_tombstone().await,
+        }
+        .map_err(map_to_procedure_error)
+    }
+
+    fn dump(&self) -> ProcedureResult<String> {
+        serde_json::to_string(&self.data).context(ToJsonSnafu)
+    }
+
+    fn lock_key(&self) -> LockKey {
+        let table_ref = self.data.task.table_ref();
+        let mut keys = vec![
+            CatalogLock::Read(table_ref.catalog).into(),
+            SchemaLock::read(table_ref.catalog, table_ref.schema).into(),
+            TableNameLock::new(table_ref.catalog, table_ref.schema, table_ref.table).into(),
+        ];
+        if let Some(table_id) = self.data.task.table_id {
+            keys.push(TableLock::Write(table_id).into());
+        }
+        LockKey::new(keys)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PurgeDroppedTableData {
+    state: PurgeDroppedTableState,
+    task: PurgeDroppedTableTask,
+    table_id: Option<TableId>,
+    table_name: Option<TableName>,
+    table_route_value: Option<TableRouteValue>,
+    #[serde(default)]
+    region_wal_options: HashMap<RegionNumber, WalOptions>,
+}
+
+impl PurgeDroppedTableData {
+    fn new(task: PurgeDroppedTableTask) -> Self {
+        Self {
+            state: PurgeDroppedTableState::Prepare,
+            task,
+            table_id: None,
+            table_name: None,
+            table_route_value: None,
+            region_wal_options: HashMap::new(),
+        }
+    }
+
+    fn table_id(&self) -> TableId {
+        self.table_id.unwrap()
+    }
+
+    fn table_name(&self) -> &TableName {
+        self.table_name.as_ref().unwrap()
+    }
+
+    fn table_route_value(&self) -> &TableRouteValue {
+        self.table_route_value.as_ref().unwrap()
+    }
+
+    fn physical_region_routes(&self) -> Option<&[RegionRoute]> {
+        match self.table_route_value() {
+            TableRouteValue::Physical(route) => Some(&route.region_routes),
+            TableRouteValue::Logical(_) => None,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, AsRefStr, PartialEq)]
+enum PurgeDroppedTableState {
+    Prepare,
+    DropRegions,
+    DeleteTombstone,
+}

--- a/src/common/meta/src/ddl/purge_dropped_table.rs
+++ b/src/common/meta/src/ddl/purge_dropped_table.rs
@@ -24,10 +24,12 @@ use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use store_api::storage::{RegionNumber, TableId};
 use strum::AsRefStr;
+use table::metadata::TableInfo;
 use table::table_name::TableName;
 
 use crate::ddl::DdlContext;
 use crate::ddl::drop_table::executor::DropTableExecutor;
+use crate::ddl::undrop_table::open_regions;
 use crate::ddl::utils::map_to_procedure_error;
 use crate::error::Result;
 use crate::key::table_route::TableRouteValue;
@@ -73,8 +75,25 @@ impl PurgeDroppedTableProcedure {
         };
         self.data.table_id = Some(dropped_table.table_id);
         self.data.table_name = Some(dropped_table.table_name);
+        self.data.table_info = Some(dropped_table.table_info_value.table_info);
         self.data.table_route_value = Some(dropped_table.table_route_value);
         self.data.region_wal_options = dropped_table.region_wal_options;
+        self.data.state = PurgeDroppedTableState::OpenRegions;
+        Ok(Status::executing(true))
+    }
+
+    async fn on_open_regions(&mut self) -> Result<Status> {
+        if let Some(region_routes) = self.data.physical_region_routes() {
+            open_regions(
+                &self.context,
+                self.data.table_id(),
+                self.data.table_name(),
+                self.data.table_info(),
+                region_routes,
+                &self.data.region_wal_options,
+            )
+            .await?;
+        }
         self.data.state = PurgeDroppedTableState::DropRegions;
         Ok(Status::executing(true))
     }
@@ -127,6 +146,7 @@ impl Procedure for PurgeDroppedTableProcedure {
     async fn execute(&mut self, _: &ProcedureContext) -> ProcedureResult<Status> {
         match self.data.state {
             PurgeDroppedTableState::Prepare => self.on_prepare().await,
+            PurgeDroppedTableState::OpenRegions => self.on_open_regions().await,
             PurgeDroppedTableState::DropRegions => self.on_drop_regions().await,
             PurgeDroppedTableState::DeleteTombstone => self.on_delete_tombstone().await,
         }
@@ -157,6 +177,7 @@ pub struct PurgeDroppedTableData {
     task: PurgeDroppedTableTask,
     table_id: Option<TableId>,
     table_name: Option<TableName>,
+    table_info: Option<TableInfo>,
     table_route_value: Option<TableRouteValue>,
     #[serde(default)]
     region_wal_options: HashMap<RegionNumber, WalOptions>,
@@ -169,6 +190,7 @@ impl PurgeDroppedTableData {
             task,
             table_id: None,
             table_name: None,
+            table_info: None,
             table_route_value: None,
             region_wal_options: HashMap::new(),
         }
@@ -180,6 +202,10 @@ impl PurgeDroppedTableData {
 
     fn table_name(&self) -> &TableName {
         self.table_name.as_ref().unwrap()
+    }
+
+    fn table_info(&self) -> &TableInfo {
+        self.table_info.as_ref().unwrap()
     }
 
     fn table_route_value(&self) -> &TableRouteValue {
@@ -197,6 +223,7 @@ impl PurgeDroppedTableData {
 #[derive(Debug, Serialize, Deserialize, AsRefStr, PartialEq)]
 enum PurgeDroppedTableState {
     Prepare,
+    OpenRegions,
     DropRegions,
     DeleteTombstone,
 }

--- a/src/common/meta/src/ddl/purge_dropped_table.rs
+++ b/src/common/meta/src/ddl/purge_dropped_table.rs
@@ -29,7 +29,7 @@ use table::table_name::TableName;
 
 use crate::ddl::DdlContext;
 use crate::ddl::drop_table::executor::DropTableExecutor;
-use crate::ddl::undrop_table::open_regions;
+use crate::ddl::undrop_table::open_regions_ignore_region_not_found;
 use crate::ddl::utils::{
     convert_region_routes_to_detecting_regions, is_metric_engine_logical_table,
     map_to_procedure_error,
@@ -90,7 +90,7 @@ impl PurgeDroppedTableProcedure {
 
     async fn on_open_regions(&mut self) -> Result<Status> {
         if let Some(region_routes) = self.data.physical_region_routes() {
-            open_regions(
+            open_regions_ignore_region_not_found(
                 &self.context,
                 self.data.table_id(),
                 self.data.table_name(),

--- a/src/common/meta/src/ddl/purge_dropped_table.rs
+++ b/src/common/meta/src/ddl/purge_dropped_table.rs
@@ -36,7 +36,7 @@ use crate::ddl::utils::{
 };
 use crate::error::{self, Result};
 use crate::key::table_route::TableRouteValue;
-use crate::lock_key::{CatalogLock, SchemaLock, TableLock, TableNameLock};
+use crate::lock_key::TableLock;
 use crate::rpc::ddl::PurgeDroppedTableTask;
 use crate::rpc::router::RegionRoute;
 
@@ -61,17 +61,11 @@ impl PurgeDroppedTableProcedure {
     }
 
     async fn on_prepare(&mut self) -> Result<Status> {
-        let dropped_table = if let Some(table_id) = self.data.task.table_id {
-            self.context
-                .table_metadata_manager
-                .get_dropped_table_by_id(table_id)
-                .await?
-        } else {
-            self.context
-                .table_metadata_manager
-                .get_dropped_table(&self.data.task.table_name())
-                .await?
-        };
+        let dropped_table = self
+            .context
+            .table_metadata_manager
+            .get_dropped_table_by_id(self.data.task.table_id)
+            .await?;
 
         let Some(dropped_table) = dropped_table else {
             return Ok(Status::done());
@@ -175,16 +169,7 @@ impl Procedure for PurgeDroppedTableProcedure {
     }
 
     fn lock_key(&self) -> LockKey {
-        let table_ref = self.data.task.table_ref();
-        let mut keys = vec![
-            CatalogLock::Read(table_ref.catalog).into(),
-            SchemaLock::read(table_ref.catalog, table_ref.schema).into(),
-            TableNameLock::new(table_ref.catalog, table_ref.schema, table_ref.table).into(),
-        ];
-        if let Some(table_id) = self.data.task.table_id {
-            keys.push(TableLock::Write(table_id).into());
-        }
-        LockKey::new(keys)
+        LockKey::new(vec![TableLock::Write(self.data.task.table_id).into()])
     }
 }
 

--- a/src/common/meta/src/ddl/tests/drop_table.rs
+++ b/src/common/meta/src/ddl/tests/drop_table.rs
@@ -716,13 +716,14 @@ async fn test_purge_dropped_table_drops_regions_and_deletes_tombstone() {
     execute_procedure_until_done(&mut procedure).await;
 
     let mut requests = Vec::new();
-    for _ in 0..2 {
+    for _ in 0..3 {
         let (peer, request) = rx.try_recv().unwrap();
         requests.push((peer.id, request.body.unwrap()));
     }
     requests.sort_unstable_by_key(|(peer_id, _)| *peer_id);
-    assert_matches!(requests[0].1, region_request::Body::Drop(_));
-    assert_matches!(requests[1].1, region_request::Body::Close(_));
+    assert_matches!(requests[0].1, region_request::Body::Open(_));
+    assert_matches!(requests[1].1, region_request::Body::Drop(_));
+    assert_matches!(requests[2].1, region_request::Body::Close(_));
     assert!(
         ddl_context
             .table_metadata_manager
@@ -793,6 +794,12 @@ async fn test_purge_dropped_table_by_name_selects_tombstone_when_live_table_exis
         .unwrap()
         .unwrap();
     assert_eq!(live_table.table_id(), live_table_id);
+
+    let (_, request) = rx.try_recv().unwrap();
+    let Some(region_request::Body::Open(req)) = request.body else {
+        unreachable!();
+    };
+    assert_eq!(req.region_id, RegionId::new(dropped_table_id, 1).as_u64());
 
     let (_, request) = rx.try_recv().unwrap();
     let Some(region_request::Body::Drop(req)) = request.body else {

--- a/src/common/meta/src/ddl/tests/drop_table.rs
+++ b/src/common/meta/src/ddl/tests/drop_table.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::assert_matches;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -30,6 +31,7 @@ use tokio::sync::mpsc;
 
 use crate::ddl::TableMetadata;
 use crate::ddl::create_logical_tables::CreateLogicalTablesProcedure;
+use crate::ddl::create_table::CreateTableProcedure;
 use crate::ddl::drop_table::{DropTableProcedure, DropTableState};
 use crate::ddl::test_util::create_table::test_create_table_task;
 use crate::ddl::test_util::datanode_handler::{DatanodeWatcher, NaiveDatanodeHandler};
@@ -37,6 +39,8 @@ use crate::ddl::test_util::{
     create_logical_table, create_physical_table, create_physical_table_metadata,
     put_datanode_address, test_create_logical_table_task, test_create_physical_table_task,
 };
+use crate::error::Error;
+use crate::key::table_name::TableNameKey;
 use crate::key::table_route::TableRouteValue;
 use crate::kv_backend::memory::MemoryKvBackend;
 use crate::peer::Peer;
@@ -229,6 +233,266 @@ async fn test_on_datanode_drop_regions_remaps_addresses_when_retrying() {
     peers.sort_unstable_by_key(|p| p.id);
     assert_eq!(peers[0].addr, "new-leader");
     assert_eq!(peers[1].addr, "new-follower");
+}
+
+#[tokio::test]
+async fn test_soft_drop_closes_regions_and_keeps_tombstone() {
+    let (tx, mut rx) = mpsc::channel(8);
+    let datanode_handler = DatanodeWatcher::new(tx);
+    let node_manager = Arc::new(MockDatanodeManager::new(datanode_handler));
+    let mut ddl_context = new_ddl_context(node_manager);
+    ddl_context.soft_drop_enabled = true;
+    let table_id = 1024;
+    let table_name = "foo";
+    let task = test_create_table_task(table_name, table_id);
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            task.table_info.clone(),
+            TableRouteValue::physical(vec![
+                RegionRoute {
+                    region: Region::new_test(RegionId::new(table_id, 1)),
+                    leader_peer: Some(Peer::empty(1)),
+                    follower_peers: vec![Peer::empty(2)],
+                    leader_state: None,
+                    leader_down_since: None,
+                    write_route_policy: None,
+                },
+                RegionRoute {
+                    region: Region::new_test(RegionId::new(table_id, 2)),
+                    leader_peer: Some(Peer::empty(2)),
+                    follower_peers: vec![Peer::empty(1)],
+                    leader_state: None,
+                    leader_down_since: None,
+                    write_route_policy: None,
+                },
+            ]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+
+    let task = new_drop_table_task(table_name, table_id, false);
+    let mut procedure = DropTableProcedure::new(task, ddl_context.clone());
+
+    execute_procedure_until_done(&mut procedure).await;
+
+    assert!(procedure.dropping_regions.is_empty());
+    assert_eq!(ddl_context.memory_region_keeper.len(), 0);
+
+    let mut requests = Vec::new();
+    for _ in 0..4 {
+        let (peer, request) = rx.try_recv().unwrap();
+        let Some(region_request::Body::Close(req)) = request.body else {
+            unreachable!();
+        };
+        requests.push((peer.id, req.region_id));
+    }
+    requests.sort_unstable();
+    assert_eq!(
+        requests,
+        vec![
+            (1, RegionId::new(table_id, 1).as_u64()),
+            (1, RegionId::new(table_id, 2).as_u64()),
+            (2, RegionId::new(table_id, 1).as_u64()),
+            (2, RegionId::new(table_id, 2).as_u64()),
+        ]
+    );
+    assert!(rx.try_recv().is_err());
+
+    let table_name = procedure.data.task.table_name();
+    let live_table = ddl_context
+        .table_metadata_manager
+        .table_name_manager()
+        .get(TableNameKey::from(&table_name))
+        .await
+        .unwrap();
+    assert!(live_table.is_none());
+
+    let dropped_table = ddl_context
+        .table_metadata_manager
+        .get_dropped_table(&table_name)
+        .await
+        .unwrap();
+    assert!(dropped_table.is_some());
+}
+
+#[tokio::test]
+async fn test_hard_drop_keeps_delete_tombstone_flow() {
+    let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
+    let ddl_context = new_ddl_context(node_manager);
+    let table_id = 1024;
+    let table_name = "foo";
+    let task = test_create_table_task(table_name, table_id);
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            task.table_info.clone(),
+            TableRouteValue::physical(vec![RegionRoute {
+                region: Region::new_test(RegionId::new(table_id, 1)),
+                leader_peer: Some(Peer::empty(1)),
+                follower_peers: vec![],
+                leader_state: None,
+                leader_down_since: None,
+                write_route_policy: None,
+            }]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+
+    let task = new_drop_table_task(table_name, table_id, false);
+    let mut procedure = DropTableProcedure::new(task, ddl_context.clone());
+
+    execute_procedure_until(&mut procedure, |p| {
+        p.data.state == DropTableState::DeleteTombstone
+    })
+    .await;
+
+    assert_eq!(procedure.data.state, DropTableState::DeleteTombstone);
+
+    execute_procedure_until_done(&mut procedure).await;
+
+    let dropped_table = ddl_context
+        .table_metadata_manager
+        .get_dropped_table(&procedure.data.task.table_name())
+        .await
+        .unwrap();
+    assert!(dropped_table.is_none());
+}
+
+#[tokio::test]
+async fn test_create_table_succeeds_while_tombstone_exists() {
+    let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
+    let mut ddl_context = new_ddl_context(node_manager);
+    ddl_context.soft_drop_enabled = true;
+    let dropped_table_id = 1024;
+    let table_name = "foo";
+    let task = test_create_table_task(table_name, dropped_table_id);
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            task.table_info.clone(),
+            TableRouteValue::physical(vec![]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+
+    let drop_task = new_drop_table_task(table_name, dropped_table_id, false);
+    let mut drop_procedure = DropTableProcedure::new(drop_task, ddl_context.clone());
+    execute_procedure_until_done(&mut drop_procedure).await;
+
+    let mut create_task = test_create_table_task(table_name, 1025);
+    create_task.create_table.table_id = None;
+    create_task.table_info.ident.table_id = 0;
+    let mut create_procedure = CreateTableProcedure::new(create_task, ddl_context.clone()).unwrap();
+    execute_procedure_until_done(&mut create_procedure).await;
+
+    let live_table = ddl_context
+        .table_metadata_manager
+        .table_name_manager()
+        .get(TableNameKey::new(
+            DEFAULT_CATALOG_NAME,
+            DEFAULT_SCHEMA_NAME,
+            table_name,
+        ))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(live_table.table_id(), create_procedure.table_id());
+
+    let dropped_table = ddl_context
+        .table_metadata_manager
+        .get_dropped_table(&create_procedure.data.task.table_name())
+        .await
+        .unwrap();
+    assert_eq!(dropped_table.unwrap().table_id, dropped_table_id);
+}
+
+#[tokio::test]
+async fn test_drop_recreated_table_fails_when_previous_tombstone_exists() {
+    let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
+    let mut ddl_context = new_ddl_context(node_manager);
+    ddl_context.soft_drop_enabled = true;
+    let original_table_id = 1024;
+    let recreated_table_id = 1025;
+    let table_name = "foo";
+    let task = test_create_table_task(table_name, original_table_id);
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            task.table_info.clone(),
+            TableRouteValue::physical(vec![]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+
+    let drop_task = new_drop_table_task(table_name, original_table_id, false);
+    let mut drop_procedure = DropTableProcedure::new(drop_task, ddl_context.clone());
+    execute_procedure_until_done(&mut drop_procedure).await;
+
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            test_create_table_task(table_name, recreated_table_id).table_info,
+            TableRouteValue::physical(vec![]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+
+    let mut procedure = DropTableProcedure::new(
+        new_drop_table_task(table_name, recreated_table_id, false),
+        ddl_context,
+    );
+    let err = procedure.on_prepare().await.unwrap_err();
+
+    assert_matches!(err, Error::TableNameTombstoneConflict { .. });
+}
+
+#[tokio::test]
+async fn test_hard_drop_recreated_table_ignores_previous_orphan_tombstone() {
+    let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
+    let ddl_context = new_ddl_context(node_manager);
+    let original_table_id = 1024;
+    let recreated_table_id = 1025;
+    let table_name = "foo";
+    let task = test_create_table_task(table_name, original_table_id);
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            task.table_info.clone(),
+            TableRouteValue::physical(vec![]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+
+    let drop_task = new_drop_table_task(table_name, original_table_id, false);
+    let mut drop_procedure = DropTableProcedure::new(drop_task, ddl_context.clone());
+    execute_procedure_until(&mut drop_procedure, |p| {
+        p.data.state == DropTableState::DeleteTombstone
+    })
+    .await;
+
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            test_create_table_task(table_name, recreated_table_id).table_info,
+            TableRouteValue::physical(vec![]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+
+    let mut procedure = DropTableProcedure::new(
+        new_drop_table_task(table_name, recreated_table_id, false),
+        ddl_context,
+    );
+
+    procedure.on_prepare().await.unwrap();
 }
 
 #[tokio::test]

--- a/src/common/meta/src/ddl/tests/drop_table.rs
+++ b/src/common/meta/src/ddl/tests/drop_table.rs
@@ -243,8 +243,10 @@ async fn test_soft_drop_closes_regions_and_keeps_tombstone() {
     let (tx, mut rx) = mpsc::channel(8);
     let datanode_handler = DatanodeWatcher::new(tx);
     let node_manager = Arc::new(MockDatanodeManager::new(datanode_handler));
+    let detector_controller = Arc::new(RecordingRegionFailureDetectorController::default());
     let mut ddl_context = new_ddl_context(node_manager);
     ddl_context.soft_drop_enabled = true;
+    ddl_context.region_failure_detector_controller = detector_controller.clone();
     let table_id = 1024;
     let table_name = "foo";
     let task = test_create_table_task(table_name, table_id);
@@ -318,44 +320,13 @@ async fn test_soft_drop_closes_regions_and_keeps_tombstone() {
         .await
         .unwrap();
     assert!(dropped_table.is_some());
-}
-
-#[tokio::test]
-async fn test_soft_drop_deregisters_failure_detectors() {
-    let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
-    let detector_controller = Arc::new(RecordingRegionFailureDetectorController::default());
-    let mut ddl_context = new_ddl_context(node_manager);
-    ddl_context.soft_drop_enabled = true;
-    ddl_context.region_failure_detector_controller = detector_controller.clone();
-    let table_id = 1024;
-    let table_name = "foo";
-    let task = test_create_table_task(table_name, table_id);
-    ddl_context
-        .table_metadata_manager
-        .create_table_metadata(
-            task.table_info.clone(),
-            TableRouteValue::physical(vec![RegionRoute {
-                region: Region::new_test(RegionId::new(table_id, 1)),
-                leader_peer: Some(Peer::empty(1)),
-                follower_peers: vec![Peer::empty(2)],
-                leader_state: None,
-                leader_down_since: None,
-                write_route_policy: None,
-            }]),
-            HashMap::new(),
-        )
-        .await
-        .unwrap();
-
-    let mut procedure = DropTableProcedure::new(
-        new_drop_table_task(table_name, table_id, false),
-        ddl_context,
-    );
-    execute_procedure_until_done(&mut procedure).await;
 
     assert_eq!(
         detector_controller.deregistered().await,
-        vec![(1, RegionId::new(table_id, 1))]
+        vec![
+            (1, RegionId::new(table_id, 1)),
+            (2, RegionId::new(table_id, 2))
+        ]
     );
 }
 
@@ -542,8 +513,10 @@ async fn test_undrop_table_restores_metadata_and_reopens_regions() {
     let (tx, mut rx) = mpsc::channel(8);
     let datanode_handler = DatanodeWatcher::new(tx);
     let node_manager = Arc::new(MockDatanodeManager::new(datanode_handler));
+    let detector_controller = Arc::new(RecordingRegionFailureDetectorController::default());
     let mut ddl_context = new_ddl_context(node_manager);
     ddl_context.soft_drop_enabled = true;
+    ddl_context.region_failure_detector_controller = detector_controller.clone();
     let table_id = 1024;
     let table_name = "foo";
     let task = test_create_table_task(table_name, table_id);
@@ -569,6 +542,7 @@ async fn test_undrop_table_restores_metadata_and_reopens_regions() {
         ddl_context.clone(),
     );
     execute_procedure_until_done(&mut drop_procedure).await;
+    detector_controller.clear().await;
 
     while rx.try_recv().is_ok() {}
 
@@ -606,44 +580,6 @@ async fn test_undrop_table_restores_metadata_and_reopens_regions() {
     };
     assert_eq!(req.region_id, RegionId::new(table_id, 1).as_u64());
     assert!(rx.try_recv().is_err());
-}
-
-#[tokio::test]
-async fn test_undrop_table_registers_failure_detectors() {
-    let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
-    let detector_controller = Arc::new(RecordingRegionFailureDetectorController::default());
-    let mut ddl_context = new_ddl_context(node_manager);
-    ddl_context.soft_drop_enabled = true;
-    ddl_context.region_failure_detector_controller = detector_controller.clone();
-    let table_id = 1024;
-    let table_name = "foo";
-    let task = test_create_table_task(table_name, table_id);
-    ddl_context
-        .table_metadata_manager
-        .create_table_metadata(
-            task.table_info.clone(),
-            TableRouteValue::physical(vec![RegionRoute {
-                region: Region::new_test(RegionId::new(table_id, 1)),
-                leader_peer: Some(Peer::empty(1)),
-                follower_peers: vec![],
-                leader_state: None,
-                leader_down_since: None,
-                write_route_policy: None,
-            }]),
-            HashMap::new(),
-        )
-        .await
-        .unwrap();
-    let mut drop_procedure = DropTableProcedure::new(
-        new_drop_table_task(table_name, table_id, false),
-        ddl_context.clone(),
-    );
-    execute_procedure_until_done(&mut drop_procedure).await;
-    detector_controller.clear().await;
-
-    let mut procedure =
-        UndropTableProcedure::new(new_undrop_table_task(table_name, table_id), ddl_context);
-    execute_procedure_until_done(&mut procedure).await;
 
     assert_eq!(
         detector_controller.registered().await,
@@ -817,8 +753,10 @@ async fn test_purge_dropped_table_drops_regions_and_deletes_tombstone() {
     let (tx, mut rx) = mpsc::channel(8);
     let datanode_handler = DatanodeWatcher::new(tx);
     let node_manager = Arc::new(MockDatanodeManager::new(datanode_handler));
+    let detector_controller = Arc::new(RecordingRegionFailureDetectorController::default());
     let mut ddl_context = new_ddl_context(node_manager);
     ddl_context.soft_drop_enabled = true;
+    ddl_context.region_failure_detector_controller = detector_controller.clone();
     let table_id = 1024;
     let table_name = "foo";
     let task = test_create_table_task(table_name, table_id);
@@ -844,6 +782,7 @@ async fn test_purge_dropped_table_drops_regions_and_deletes_tombstone() {
     );
     execute_procedure_until_done(&mut drop_procedure).await;
     while rx.try_recv().is_ok() {}
+    detector_controller.clear().await;
 
     let mut procedure = PurgeDroppedTableProcedure::new(
         new_purge_dropped_table_task(table_name, Some(table_id)),
@@ -868,50 +807,6 @@ async fn test_purge_dropped_table_drops_regions_and_deletes_tombstone() {
             .unwrap()
             .is_none()
     );
-}
-
-#[tokio::test]
-async fn test_purge_dropped_table_deregisters_failure_detectors() {
-    let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
-    let detector_controller = Arc::new(RecordingRegionFailureDetectorController::default());
-    let mut ddl_context = new_ddl_context(node_manager);
-    ddl_context.region_failure_detector_controller = detector_controller.clone();
-    let table_id = 1024;
-    let table_name = "foo";
-    let task = test_create_table_task(table_name, table_id);
-    let table_route_value = TableRouteValue::physical(vec![RegionRoute {
-        region: Region::new_test(RegionId::new(table_id, 1)),
-        leader_peer: Some(Peer::empty(1)),
-        follower_peers: vec![],
-        leader_state: None,
-        leader_down_since: None,
-        write_route_policy: None,
-    }]);
-    ddl_context
-        .table_metadata_manager
-        .create_table_metadata(
-            task.table_info.clone(),
-            table_route_value.clone(),
-            HashMap::new(),
-        )
-        .await
-        .unwrap();
-    ddl_context
-        .table_metadata_manager
-        .delete_table_metadata(
-            table_id,
-            &task.table_name(),
-            &table_route_value,
-            &HashMap::new(),
-        )
-        .await
-        .unwrap();
-
-    let mut procedure = PurgeDroppedTableProcedure::new(
-        new_purge_dropped_table_task(table_name, Some(table_id)),
-        ddl_context,
-    );
-    execute_procedure_until_done(&mut procedure).await;
 
     assert_eq!(
         detector_controller.deregistered().await,

--- a/src/common/meta/src/ddl/tests/drop_table.rs
+++ b/src/common/meta/src/ddl/tests/drop_table.rs
@@ -17,6 +17,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use api::v1::region::{RegionRequest, region_request};
+use async_trait::async_trait;
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_error::ext::ErrorExt;
 use common_error::status_code::StatusCode;
@@ -27,9 +28,8 @@ use common_procedure_test::{
 use store_api::region_engine::RegionRole;
 use store_api::storage::RegionId;
 use table::metadata::TableId;
-use tokio::sync::mpsc;
+use tokio::sync::{Mutex, mpsc};
 
-use crate::ddl::TableMetadata;
 use crate::ddl::create_logical_tables::CreateLogicalTablesProcedure;
 use crate::ddl::create_table::CreateTableProcedure;
 use crate::ddl::drop_table::{DropTableProcedure, DropTableState};
@@ -41,6 +41,7 @@ use crate::ddl::test_util::{
     put_datanode_address, test_create_logical_table_task, test_create_physical_table_task,
 };
 use crate::ddl::undrop_table::UndropTableProcedure;
+use crate::ddl::{DetectingRegion, RegionFailureDetectorController, TableMetadata};
 use crate::error::Error;
 use crate::key::table_name::TableNameKey;
 use crate::key::table_route::TableRouteValue;
@@ -320,6 +321,45 @@ async fn test_soft_drop_closes_regions_and_keeps_tombstone() {
 }
 
 #[tokio::test]
+async fn test_soft_drop_deregisters_failure_detectors() {
+    let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
+    let detector_controller = Arc::new(RecordingRegionFailureDetectorController::default());
+    let mut ddl_context = new_ddl_context(node_manager);
+    ddl_context.soft_drop_enabled = true;
+    ddl_context.region_failure_detector_controller = detector_controller.clone();
+    let table_id = 1024;
+    let table_name = "foo";
+    let task = test_create_table_task(table_name, table_id);
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            task.table_info.clone(),
+            TableRouteValue::physical(vec![RegionRoute {
+                region: Region::new_test(RegionId::new(table_id, 1)),
+                leader_peer: Some(Peer::empty(1)),
+                follower_peers: vec![Peer::empty(2)],
+                leader_state: None,
+                leader_down_since: None,
+                write_route_policy: None,
+            }]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+
+    let mut procedure = DropTableProcedure::new(
+        new_drop_table_task(table_name, table_id, false),
+        ddl_context,
+    );
+    execute_procedure_until_done(&mut procedure).await;
+
+    assert_eq!(
+        detector_controller.deregistered().await,
+        vec![(1, RegionId::new(table_id, 1))]
+    );
+}
+
+#[tokio::test]
 async fn test_hard_drop_keeps_delete_tombstone_flow() {
     let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
     let ddl_context = new_ddl_context(node_manager);
@@ -569,6 +609,49 @@ async fn test_undrop_table_restores_metadata_and_reopens_regions() {
 }
 
 #[tokio::test]
+async fn test_undrop_table_registers_failure_detectors() {
+    let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
+    let detector_controller = Arc::new(RecordingRegionFailureDetectorController::default());
+    let mut ddl_context = new_ddl_context(node_manager);
+    ddl_context.soft_drop_enabled = true;
+    ddl_context.region_failure_detector_controller = detector_controller.clone();
+    let table_id = 1024;
+    let table_name = "foo";
+    let task = test_create_table_task(table_name, table_id);
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            task.table_info.clone(),
+            TableRouteValue::physical(vec![RegionRoute {
+                region: Region::new_test(RegionId::new(table_id, 1)),
+                leader_peer: Some(Peer::empty(1)),
+                follower_peers: vec![],
+                leader_state: None,
+                leader_down_since: None,
+                write_route_policy: None,
+            }]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+    let mut drop_procedure = DropTableProcedure::new(
+        new_drop_table_task(table_name, table_id, false),
+        ddl_context.clone(),
+    );
+    execute_procedure_until_done(&mut drop_procedure).await;
+    detector_controller.clear().await;
+
+    let mut procedure =
+        UndropTableProcedure::new(new_undrop_table_task(table_name, table_id), ddl_context);
+    execute_procedure_until_done(&mut procedure).await;
+
+    assert_eq!(
+        detector_controller.registered().await,
+        vec![(1, RegionId::new(table_id, 1))]
+    );
+}
+
+#[tokio::test]
 async fn test_undrop_logical_table_skips_datanode_open() {
     let (tx, mut rx) = mpsc::channel(8);
     let datanode_handler = DatanodeWatcher::new(tx);
@@ -788,6 +871,55 @@ async fn test_purge_dropped_table_drops_regions_and_deletes_tombstone() {
 }
 
 #[tokio::test]
+async fn test_purge_dropped_table_deregisters_failure_detectors() {
+    let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
+    let detector_controller = Arc::new(RecordingRegionFailureDetectorController::default());
+    let mut ddl_context = new_ddl_context(node_manager);
+    ddl_context.region_failure_detector_controller = detector_controller.clone();
+    let table_id = 1024;
+    let table_name = "foo";
+    let task = test_create_table_task(table_name, table_id);
+    let table_route_value = TableRouteValue::physical(vec![RegionRoute {
+        region: Region::new_test(RegionId::new(table_id, 1)),
+        leader_peer: Some(Peer::empty(1)),
+        follower_peers: vec![],
+        leader_state: None,
+        leader_down_since: None,
+        write_route_policy: None,
+    }]);
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            task.table_info.clone(),
+            table_route_value.clone(),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+    ddl_context
+        .table_metadata_manager
+        .delete_table_metadata(
+            table_id,
+            &task.table_name(),
+            &table_route_value,
+            &HashMap::new(),
+        )
+        .await
+        .unwrap();
+
+    let mut procedure = PurgeDroppedTableProcedure::new(
+        new_purge_dropped_table_task(table_name, Some(table_id)),
+        ddl_context,
+    );
+    execute_procedure_until_done(&mut procedure).await;
+
+    assert_eq!(
+        detector_controller.deregistered().await,
+        vec![(1, RegionId::new(table_id, 1))]
+    );
+}
+
+#[tokio::test]
 async fn test_purge_dropped_table_by_name_selects_tombstone_when_live_table_exists() {
     let (tx, mut rx) = mpsc::channel(8);
     let datanode_handler = DatanodeWatcher::new(tx);
@@ -974,6 +1106,38 @@ async fn create_metric_logical_table_tombstone(
         .await
         .unwrap();
     logical_table_id
+}
+
+#[derive(Default)]
+struct RecordingRegionFailureDetectorController {
+    registered: Mutex<Vec<DetectingRegion>>,
+    deregistered: Mutex<Vec<DetectingRegion>>,
+}
+
+impl RecordingRegionFailureDetectorController {
+    async fn registered(&self) -> Vec<DetectingRegion> {
+        self.registered.lock().await.clone()
+    }
+
+    async fn deregistered(&self) -> Vec<DetectingRegion> {
+        self.deregistered.lock().await.clone()
+    }
+
+    async fn clear(&self) {
+        self.registered.lock().await.clear();
+        self.deregistered.lock().await.clear();
+    }
+}
+
+#[async_trait]
+impl RegionFailureDetectorController for RecordingRegionFailureDetectorController {
+    async fn register_failure_detectors(&self, detecting_regions: Vec<DetectingRegion>) {
+        self.registered.lock().await.extend(detecting_regions);
+    }
+
+    async fn deregister_failure_detectors(&self, detecting_regions: Vec<DetectingRegion>) {
+        self.deregistered.lock().await.extend(detecting_regions);
+    }
 }
 
 #[tokio::test]

--- a/src/common/meta/src/ddl/tests/drop_table.rs
+++ b/src/common/meta/src/ddl/tests/drop_table.rs
@@ -635,6 +635,59 @@ async fn test_undrop_logical_table_skips_datanode_open() {
 }
 
 #[tokio::test]
+async fn test_soft_drop_metric_logical_table_fails() {
+    let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
+    let mut ddl_context = new_ddl_context(node_manager);
+    ddl_context.soft_drop_enabled = true;
+    let physical_table_id = create_physical_table(&ddl_context, "phy").await;
+    let logical_table_id =
+        create_logical_table(ddl_context.clone(), physical_table_id, "foo").await;
+
+    let mut procedure = DropTableProcedure::new(
+        new_drop_table_task("foo", logical_table_id, false),
+        ddl_context,
+    );
+    let err = procedure.on_prepare().await.unwrap_err();
+
+    assert_eq!(err.status_code(), StatusCode::Unsupported);
+}
+
+#[tokio::test]
+async fn test_undrop_metric_logical_table_fails() {
+    let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
+    let ddl_context = new_ddl_context(node_manager);
+    let physical_table_id = create_physical_table(&ddl_context, "phy").await;
+    let logical_table_id =
+        create_metric_logical_table_tombstone(&ddl_context, physical_table_id, "foo").await;
+
+    let mut procedure =
+        UndropTableProcedure::new(new_undrop_table_task("foo", logical_table_id), ddl_context);
+    let err = procedure.on_prepare().await.unwrap_err();
+
+    assert_eq!(err.status_code(), StatusCode::Unsupported);
+}
+
+#[tokio::test]
+async fn test_purge_metric_logical_table_fails() {
+    let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
+    let ddl_context = new_ddl_context(node_manager);
+    let physical_table_id = create_physical_table(&ddl_context, "phy").await;
+    let logical_table_id =
+        create_metric_logical_table_tombstone(&ddl_context, physical_table_id, "foo").await;
+
+    let mut procedure = PurgeDroppedTableProcedure::new(
+        new_purge_dropped_table_task("foo", Some(logical_table_id)),
+        ddl_context,
+    );
+    let err = procedure
+        .execute(&new_test_procedure_context())
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.status_code(), StatusCode::Unsupported);
+}
+
+#[tokio::test]
 async fn test_undrop_table_fails_when_live_name_exists() {
     let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
     let mut ddl_context = new_ddl_context(node_manager);
@@ -899,6 +952,28 @@ fn new_purge_dropped_table_task(
         table: table_name.to_string(),
         table_id,
     }
+}
+
+async fn create_metric_logical_table_tombstone(
+    ddl_context: &crate::ddl::DdlContext,
+    physical_table_id: TableId,
+    table_name: &str,
+) -> TableId {
+    let logical_table_id =
+        create_logical_table(ddl_context.clone(), physical_table_id, table_name).await;
+    let mut task = test_create_logical_table_task(table_name);
+    task.set_table_id(logical_table_id);
+    ddl_context
+        .table_metadata_manager
+        .delete_table_metadata(
+            logical_table_id,
+            &task.table_name(),
+            &TableRouteValue::logical(physical_table_id),
+            &HashMap::new(),
+        )
+        .await
+        .unwrap();
+    logical_table_id
 }
 
 #[tokio::test]

--- a/src/common/meta/src/ddl/tests/drop_table.rs
+++ b/src/common/meta/src/ddl/tests/drop_table.rs
@@ -33,18 +33,20 @@ use crate::ddl::TableMetadata;
 use crate::ddl::create_logical_tables::CreateLogicalTablesProcedure;
 use crate::ddl::create_table::CreateTableProcedure;
 use crate::ddl::drop_table::{DropTableProcedure, DropTableState};
+use crate::ddl::purge_dropped_table::PurgeDroppedTableProcedure;
 use crate::ddl::test_util::create_table::test_create_table_task;
 use crate::ddl::test_util::datanode_handler::{DatanodeWatcher, NaiveDatanodeHandler};
 use crate::ddl::test_util::{
     create_logical_table, create_physical_table, create_physical_table_metadata,
     put_datanode_address, test_create_logical_table_task, test_create_physical_table_task,
 };
+use crate::ddl::undrop_table::UndropTableProcedure;
 use crate::error::Error;
 use crate::key::table_name::TableNameKey;
 use crate::key::table_route::TableRouteValue;
 use crate::kv_backend::memory::MemoryKvBackend;
 use crate::peer::Peer;
-use crate::rpc::ddl::DropTableTask;
+use crate::rpc::ddl::{DropTableTask, PurgeDroppedTableTask, UndropTableTask};
 use crate::rpc::router::{Region, RegionRoute};
 use crate::test_util::{MockDatanodeManager, new_ddl_context, new_ddl_context_with_kv_backend};
 
@@ -496,6 +498,311 @@ async fn test_hard_drop_recreated_table_ignores_previous_orphan_tombstone() {
 }
 
 #[tokio::test]
+async fn test_undrop_table_restores_metadata_and_reopens_regions() {
+    let (tx, mut rx) = mpsc::channel(8);
+    let datanode_handler = DatanodeWatcher::new(tx);
+    let node_manager = Arc::new(MockDatanodeManager::new(datanode_handler));
+    let mut ddl_context = new_ddl_context(node_manager);
+    ddl_context.soft_drop_enabled = true;
+    let table_id = 1024;
+    let table_name = "foo";
+    let task = test_create_table_task(table_name, table_id);
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            task.table_info.clone(),
+            TableRouteValue::physical(vec![RegionRoute {
+                region: Region::new_test(RegionId::new(table_id, 1)),
+                leader_peer: Some(Peer::empty(1)),
+                follower_peers: vec![Peer::empty(2)],
+                leader_state: None,
+                leader_down_since: None,
+                write_route_policy: None,
+            }]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+
+    let mut drop_procedure = DropTableProcedure::new(
+        new_drop_table_task(table_name, table_id, false),
+        ddl_context.clone(),
+    );
+    execute_procedure_until_done(&mut drop_procedure).await;
+
+    while rx.try_recv().is_ok() {}
+
+    let mut procedure = UndropTableProcedure::new(
+        new_undrop_table_task(table_name, table_id),
+        ddl_context.clone(),
+    );
+    execute_procedure_until_done(&mut procedure).await;
+
+    let live_table = ddl_context
+        .table_metadata_manager
+        .table_name_manager()
+        .get(TableNameKey::new(
+            DEFAULT_CATALOG_NAME,
+            DEFAULT_SCHEMA_NAME,
+            table_name,
+        ))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(live_table.table_id(), table_id);
+    assert!(
+        ddl_context
+            .table_metadata_manager
+            .get_dropped_table(&drop_procedure.data.task.table_name())
+            .await
+            .unwrap()
+            .is_none()
+    );
+
+    let (peer, request) = rx.try_recv().unwrap();
+    assert_eq!(peer.id, 1);
+    let Some(region_request::Body::Open(req)) = request.body else {
+        unreachable!();
+    };
+    assert_eq!(req.region_id, RegionId::new(table_id, 1).as_u64());
+    assert!(rx.try_recv().is_err());
+}
+
+#[tokio::test]
+async fn test_undrop_logical_table_skips_datanode_open() {
+    let (tx, mut rx) = mpsc::channel(8);
+    let datanode_handler = DatanodeWatcher::new(tx);
+    let node_manager = Arc::new(MockDatanodeManager::new(datanode_handler));
+    let mut ddl_context = new_ddl_context(node_manager);
+    ddl_context.soft_drop_enabled = true;
+    let physical_table_id = 1024;
+    let logical_table_id = 1025;
+    let table_name = "foo";
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            test_create_table_task("phy", physical_table_id).table_info,
+            TableRouteValue::physical(vec![RegionRoute {
+                region: Region::new_test(RegionId::new(physical_table_id, 1)),
+                leader_peer: Some(Peer::empty(1)),
+                follower_peers: vec![],
+                leader_state: None,
+                leader_down_since: None,
+                write_route_policy: None,
+            }]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+    let task = test_create_table_task(table_name, logical_table_id);
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            task.table_info.clone(),
+            TableRouteValue::logical(physical_table_id),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+
+    let mut drop_procedure = DropTableProcedure::new(
+        new_drop_table_task(table_name, logical_table_id, false),
+        ddl_context.clone(),
+    );
+    execute_procedure_until_done(&mut drop_procedure).await;
+
+    while rx.try_recv().is_ok() {}
+
+    let mut procedure = UndropTableProcedure::new(
+        new_undrop_table_task(table_name, logical_table_id),
+        ddl_context.clone(),
+    );
+    execute_procedure_until_done(&mut procedure).await;
+
+    let live_table = ddl_context
+        .table_metadata_manager
+        .table_name_manager()
+        .get(TableNameKey::new(
+            DEFAULT_CATALOG_NAME,
+            DEFAULT_SCHEMA_NAME,
+            table_name,
+        ))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(live_table.table_id(), logical_table_id);
+    assert!(rx.try_recv().is_err());
+}
+
+#[tokio::test]
+async fn test_undrop_table_fails_when_live_name_exists() {
+    let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
+    let mut ddl_context = new_ddl_context(node_manager);
+    ddl_context.soft_drop_enabled = true;
+    let dropped_table_id = 1024;
+    let live_table_id = 1025;
+    let table_name = "foo";
+    let task = test_create_table_task(table_name, dropped_table_id);
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            task.table_info.clone(),
+            TableRouteValue::physical(vec![]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+    let mut drop_procedure = DropTableProcedure::new(
+        new_drop_table_task(table_name, dropped_table_id, false),
+        ddl_context.clone(),
+    );
+    execute_procedure_until_done(&mut drop_procedure).await;
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            test_create_table_task(table_name, live_table_id).table_info,
+            TableRouteValue::physical(vec![]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+
+    let mut procedure = UndropTableProcedure::new(
+        new_undrop_table_task(table_name, dropped_table_id),
+        ddl_context,
+    );
+    let err = procedure.on_prepare().await.unwrap_err();
+
+    assert_matches!(err, Error::TableAlreadyExists { .. });
+}
+
+#[tokio::test]
+async fn test_purge_dropped_table_drops_regions_and_deletes_tombstone() {
+    let (tx, mut rx) = mpsc::channel(8);
+    let datanode_handler = DatanodeWatcher::new(tx);
+    let node_manager = Arc::new(MockDatanodeManager::new(datanode_handler));
+    let mut ddl_context = new_ddl_context(node_manager);
+    ddl_context.soft_drop_enabled = true;
+    let table_id = 1024;
+    let table_name = "foo";
+    let task = test_create_table_task(table_name, table_id);
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            task.table_info.clone(),
+            TableRouteValue::physical(vec![RegionRoute {
+                region: Region::new_test(RegionId::new(table_id, 1)),
+                leader_peer: Some(Peer::empty(1)),
+                follower_peers: vec![Peer::empty(2)],
+                leader_state: None,
+                leader_down_since: None,
+                write_route_policy: None,
+            }]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+    let mut drop_procedure = DropTableProcedure::new(
+        new_drop_table_task(table_name, table_id, false),
+        ddl_context.clone(),
+    );
+    execute_procedure_until_done(&mut drop_procedure).await;
+    while rx.try_recv().is_ok() {}
+
+    let mut procedure = PurgeDroppedTableProcedure::new(
+        new_purge_dropped_table_task(table_name, Some(table_id)),
+        ddl_context.clone(),
+    );
+    execute_procedure_until_done(&mut procedure).await;
+
+    let mut requests = Vec::new();
+    for _ in 0..2 {
+        let (peer, request) = rx.try_recv().unwrap();
+        requests.push((peer.id, request.body.unwrap()));
+    }
+    requests.sort_unstable_by_key(|(peer_id, _)| *peer_id);
+    assert_matches!(requests[0].1, region_request::Body::Drop(_));
+    assert_matches!(requests[1].1, region_request::Body::Close(_));
+    assert!(
+        ddl_context
+            .table_metadata_manager
+            .get_dropped_table(&drop_procedure.data.task.table_name())
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn test_purge_dropped_table_by_name_selects_tombstone_when_live_table_exists() {
+    let (tx, mut rx) = mpsc::channel(8);
+    let datanode_handler = DatanodeWatcher::new(tx);
+    let node_manager = Arc::new(MockDatanodeManager::new(datanode_handler));
+    let mut ddl_context = new_ddl_context(node_manager);
+    ddl_context.soft_drop_enabled = true;
+    let dropped_table_id = 1024;
+    let live_table_id = 1025;
+    let table_name = "foo";
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            test_create_table_task(table_name, dropped_table_id).table_info,
+            TableRouteValue::physical(vec![RegionRoute {
+                region: Region::new_test(RegionId::new(dropped_table_id, 1)),
+                leader_peer: Some(Peer::empty(1)),
+                follower_peers: vec![],
+                leader_state: None,
+                leader_down_since: None,
+                write_route_policy: None,
+            }]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+    let mut drop_procedure = DropTableProcedure::new(
+        new_drop_table_task(table_name, dropped_table_id, false),
+        ddl_context.clone(),
+    );
+    execute_procedure_until_done(&mut drop_procedure).await;
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            test_create_table_task(table_name, live_table_id).table_info,
+            TableRouteValue::physical(vec![]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+    while rx.try_recv().is_ok() {}
+
+    let mut procedure = PurgeDroppedTableProcedure::new(
+        new_purge_dropped_table_task(table_name, None),
+        ddl_context.clone(),
+    );
+    execute_procedure_until_done(&mut procedure).await;
+
+    let live_table = ddl_context
+        .table_metadata_manager
+        .table_name_manager()
+        .get(TableNameKey::new(
+            DEFAULT_CATALOG_NAME,
+            DEFAULT_SCHEMA_NAME,
+            table_name,
+        ))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(live_table.table_id(), live_table_id);
+
+    let (_, request) = rx.try_recv().unwrap();
+    let Some(region_request::Body::Drop(req)) = request.body else {
+        unreachable!();
+    };
+    assert_eq!(req.region_id, RegionId::new(dropped_table_id, 1).as_u64());
+    assert!(rx.try_recv().is_err());
+}
+
+#[tokio::test]
 async fn test_on_rollback() {
     let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
     let kv_backend = Arc::new(MemoryKvBackend::new());
@@ -563,6 +870,27 @@ fn new_drop_table_task(table_name: &str, table_id: TableId, drop_if_exists: bool
         table: table_name.to_string(),
         table_id,
         drop_if_exists,
+    }
+}
+
+fn new_undrop_table_task(table_name: &str, table_id: TableId) -> UndropTableTask {
+    UndropTableTask {
+        catalog: DEFAULT_CATALOG_NAME.to_string(),
+        schema: DEFAULT_SCHEMA_NAME.to_string(),
+        table: table_name.to_string(),
+        table_id,
+    }
+}
+
+fn new_purge_dropped_table_task(
+    table_name: &str,
+    table_id: Option<TableId>,
+) -> PurgeDroppedTableTask {
+    PurgeDroppedTableTask {
+        catalog: DEFAULT_CATALOG_NAME.to_string(),
+        schema: DEFAULT_SCHEMA_NAME.to_string(),
+        table: table_name.to_string(),
+        table_id,
     }
 }
 

--- a/src/common/meta/src/ddl/tests/drop_table.rs
+++ b/src/common/meta/src/ddl/tests/drop_table.rs
@@ -573,12 +573,21 @@ async fn test_undrop_table_restores_metadata_and_reopens_regions() {
             .is_none()
     );
 
-    let (peer, request) = rx.try_recv().unwrap();
-    assert_eq!(peer.id, 1);
-    let Some(region_request::Body::Open(req)) = request.body else {
-        unreachable!();
-    };
-    assert_eq!(req.region_id, RegionId::new(table_id, 1).as_u64());
+    let mut opened_regions = HashSet::new();
+    for _ in 0..2 {
+        let (peer, request) = rx.try_recv().unwrap();
+        let Some(region_request::Body::Open(req)) = request.body else {
+            unreachable!();
+        };
+        opened_regions.insert((peer.id, req.region_id));
+    }
+    assert_eq!(
+        opened_regions,
+        HashSet::from([
+            (1, RegionId::new(table_id, 1).as_u64()),
+            (2, RegionId::new(table_id, 1).as_u64()),
+        ])
+    );
     assert!(rx.try_recv().is_err());
 
     assert_eq!(
@@ -791,14 +800,16 @@ async fn test_purge_dropped_table_drops_regions_and_deletes_tombstone() {
     execute_procedure_until_done(&mut procedure).await;
 
     let mut requests = Vec::new();
-    for _ in 0..3 {
+    for _ in 0..4 {
         let (peer, request) = rx.try_recv().unwrap();
         requests.push((peer.id, request.body.unwrap()));
     }
     requests.sort_unstable_by_key(|(peer_id, _)| *peer_id);
     assert_matches!(requests[0].1, region_request::Body::Open(_));
     assert_matches!(requests[1].1, region_request::Body::Drop(_));
-    assert_matches!(requests[2].1, region_request::Body::Close(_));
+    assert_matches!(requests[2].1, region_request::Body::Open(_));
+    assert_matches!(requests[3].1, region_request::Body::Close(_));
+    assert!(rx.try_recv().is_err());
     assert!(
         ddl_context
             .table_metadata_manager

--- a/src/common/meta/src/ddl/tests/drop_table.rs
+++ b/src/common/meta/src/ddl/tests/drop_table.rs
@@ -603,6 +603,63 @@ async fn test_undrop_table_restores_metadata_and_reopens_regions() {
 }
 
 #[tokio::test]
+async fn test_undrop_table_opens_regions_before_restoring_live_metadata() {
+    let (tx, mut rx) = mpsc::channel(8);
+    let datanode_handler = DatanodeWatcher::new(tx);
+    let node_manager = Arc::new(MockDatanodeManager::new(datanode_handler));
+    let mut ddl_context = new_ddl_context(node_manager);
+    ddl_context.soft_drop_enabled = true;
+    let table_id = 1024;
+    let table_name = "foo";
+    let task = test_create_table_task(table_name, table_id);
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            task.table_info.clone(),
+            TableRouteValue::physical(vec![RegionRoute {
+                region: Region::new_test(RegionId::new(table_id, 1)),
+                leader_peer: Some(Peer::empty(1)),
+                follower_peers: vec![],
+                leader_state: None,
+                leader_down_since: None,
+                write_route_policy: None,
+            }]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+    let mut drop_procedure = DropTableProcedure::new(
+        new_drop_table_task(table_name, table_id, false),
+        ddl_context.clone(),
+    );
+    execute_procedure_until_done(&mut drop_procedure).await;
+    while rx.try_recv().is_ok() {}
+
+    let mut procedure =
+        UndropTableProcedure::new(new_undrop_table_task(table_id), ddl_context.clone());
+    let ctx = new_test_procedure_context();
+    procedure.execute(&ctx).await.unwrap();
+    procedure.execute(&ctx).await.unwrap();
+
+    let (_, request) = rx.try_recv().unwrap();
+    assert_matches!(request.body, Some(region_request::Body::Open(_)));
+    assert!(rx.try_recv().is_err());
+    assert!(
+        ddl_context
+            .table_metadata_manager
+            .table_name_manager()
+            .get(TableNameKey::new(
+                DEFAULT_CATALOG_NAME,
+                DEFAULT_SCHEMA_NAME,
+                table_name,
+            ))
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
 async fn test_undrop_logical_table_skips_datanode_open() {
     let (tx, mut rx) = mpsc::channel(8);
     let datanode_handler = DatanodeWatcher::new(tx);

--- a/src/common/meta/src/ddl/tests/drop_table.rs
+++ b/src/common/meta/src/ddl/tests/drop_table.rs
@@ -752,6 +752,62 @@ async fn test_undrop_table_fails_when_live_name_exists() {
 }
 
 #[tokio::test]
+async fn test_undrop_table_fails_when_live_name_is_created_after_prepare() {
+    let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
+    let mut ddl_context = new_ddl_context(node_manager);
+    ddl_context.soft_drop_enabled = true;
+    let dropped_table_id = 1024;
+    let live_table_id = 1025;
+    let table_name = "foo";
+    let task = test_create_table_task(table_name, dropped_table_id);
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            task.table_info.clone(),
+            TableRouteValue::physical(vec![]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+    let mut drop_procedure = DropTableProcedure::new(
+        new_drop_table_task(table_name, dropped_table_id, false),
+        ddl_context.clone(),
+    );
+    execute_procedure_until_done(&mut drop_procedure).await;
+
+    let mut procedure =
+        UndropTableProcedure::new(new_undrop_table_task(dropped_table_id), ddl_context.clone());
+    procedure.on_prepare().await.unwrap();
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            test_create_table_task(table_name, live_table_id).table_info,
+            TableRouteValue::physical(vec![]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+
+    let err = procedure
+        .execute(&new_test_procedure_context())
+        .await
+        .unwrap_err();
+    assert_eq!(err.status_code(), StatusCode::TableAlreadyExists);
+    let live_table = ddl_context
+        .table_metadata_manager
+        .table_name_manager()
+        .get(TableNameKey::new(
+            DEFAULT_CATALOG_NAME,
+            DEFAULT_SCHEMA_NAME,
+            table_name,
+        ))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(live_table.table_id(), live_table_id);
+}
+
+#[tokio::test]
 async fn test_purge_dropped_table_drops_regions_and_deletes_tombstone() {
     let (tx, mut rx) = mpsc::channel(8);
     let datanode_handler = DatanodeWatcher::new(tx);

--- a/src/common/meta/src/ddl/tests/drop_table.rs
+++ b/src/common/meta/src/ddl/tests/drop_table.rs
@@ -546,10 +546,8 @@ async fn test_undrop_table_restores_metadata_and_reopens_regions() {
 
     while rx.try_recv().is_ok() {}
 
-    let mut procedure = UndropTableProcedure::new(
-        new_undrop_table_task(table_name, table_id),
-        ddl_context.clone(),
-    );
+    let mut procedure =
+        UndropTableProcedure::new(new_undrop_table_task(table_id), ddl_context.clone());
     execute_procedure_until_done(&mut procedure).await;
 
     let live_table = ddl_context
@@ -641,10 +639,8 @@ async fn test_undrop_logical_table_skips_datanode_open() {
 
     while rx.try_recv().is_ok() {}
 
-    let mut procedure = UndropTableProcedure::new(
-        new_undrop_table_task(table_name, logical_table_id),
-        ddl_context.clone(),
-    );
+    let mut procedure =
+        UndropTableProcedure::new(new_undrop_table_task(logical_table_id), ddl_context.clone());
     execute_procedure_until_done(&mut procedure).await;
 
     let live_table = ddl_context
@@ -689,7 +685,7 @@ async fn test_undrop_metric_logical_table_fails() {
         create_metric_logical_table_tombstone(&ddl_context, physical_table_id, "foo").await;
 
     let mut procedure =
-        UndropTableProcedure::new(new_undrop_table_task("foo", logical_table_id), ddl_context);
+        UndropTableProcedure::new(new_undrop_table_task(logical_table_id), ddl_context);
     let err = procedure.on_prepare().await.unwrap_err();
 
     assert_eq!(err.status_code(), StatusCode::Unsupported);
@@ -748,44 +744,11 @@ async fn test_undrop_table_fails_when_live_name_exists() {
         .await
         .unwrap();
 
-    let mut procedure = UndropTableProcedure::new(
-        new_undrop_table_task(table_name, dropped_table_id),
-        ddl_context,
-    );
+    let mut procedure =
+        UndropTableProcedure::new(new_undrop_table_task(dropped_table_id), ddl_context);
     let err = procedure.on_prepare().await.unwrap_err();
 
     assert_matches!(err, Error::TableAlreadyExists { .. });
-}
-
-#[tokio::test]
-async fn test_undrop_table_fails_when_task_name_mismatches_table_id() {
-    let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
-    let mut ddl_context = new_ddl_context(node_manager);
-    ddl_context.soft_drop_enabled = true;
-    let table_id = 1024;
-    let task = test_create_table_task("foo", table_id);
-    ddl_context
-        .table_metadata_manager
-        .create_table_metadata(
-            task.table_info.clone(),
-            TableRouteValue::physical(vec![]),
-            HashMap::new(),
-        )
-        .await
-        .unwrap();
-    let mut drop_procedure = DropTableProcedure::new(
-        new_drop_table_task("foo", table_id, false),
-        ddl_context.clone(),
-    );
-    execute_procedure_until_done(&mut drop_procedure).await;
-
-    let mut procedure = UndropTableProcedure::new(
-        new_undrop_table_task("bar", table_id),
-        ddl_context,
-    );
-    let err = procedure.on_prepare().await.unwrap_err();
-
-    assert_eq!(err.status_code(), StatusCode::TableNotFound);
 }
 
 #[tokio::test]
@@ -1002,13 +965,8 @@ fn new_drop_table_task(table_name: &str, table_id: TableId, drop_if_exists: bool
     }
 }
 
-fn new_undrop_table_task(table_name: &str, table_id: TableId) -> UndropTableTask {
-    UndropTableTask {
-        catalog: DEFAULT_CATALOG_NAME.to_string(),
-        schema: DEFAULT_SCHEMA_NAME.to_string(),
-        table: table_name.to_string(),
-        table_id,
-    }
+fn new_undrop_table_task(table_id: TableId) -> UndropTableTask {
+    UndropTableTask { table_id }
 }
 
 fn new_purge_dropped_table_task(

--- a/src/common/meta/src/ddl/tests/drop_table.rs
+++ b/src/common/meta/src/ddl/tests/drop_table.rs
@@ -758,6 +758,37 @@ async fn test_undrop_table_fails_when_live_name_exists() {
 }
 
 #[tokio::test]
+async fn test_undrop_table_fails_when_task_name_mismatches_table_id() {
+    let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
+    let mut ddl_context = new_ddl_context(node_manager);
+    ddl_context.soft_drop_enabled = true;
+    let table_id = 1024;
+    let task = test_create_table_task("foo", table_id);
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            task.table_info.clone(),
+            TableRouteValue::physical(vec![]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+    let mut drop_procedure = DropTableProcedure::new(
+        new_drop_table_task("foo", table_id, false),
+        ddl_context.clone(),
+    );
+    execute_procedure_until_done(&mut drop_procedure).await;
+
+    let mut procedure = UndropTableProcedure::new(
+        new_undrop_table_task("bar", table_id),
+        ddl_context,
+    );
+    let err = procedure.on_prepare().await.unwrap_err();
+
+    assert_eq!(err.status_code(), StatusCode::TableNotFound);
+}
+
+#[tokio::test]
 async fn test_purge_dropped_table_drops_regions_and_deletes_tombstone() {
     let (tx, mut rx) = mpsc::channel(8);
     let datanode_handler = DatanodeWatcher::new(tx);

--- a/src/common/meta/src/ddl/tests/drop_table.rs
+++ b/src/common/meta/src/ddl/tests/drop_table.rs
@@ -700,7 +700,7 @@ async fn test_purge_metric_logical_table_fails() {
         create_metric_logical_table_tombstone(&ddl_context, physical_table_id, "foo").await;
 
     let mut procedure = PurgeDroppedTableProcedure::new(
-        new_purge_dropped_table_task("foo", Some(logical_table_id)),
+        new_purge_dropped_table_task(logical_table_id),
         ddl_context,
     );
     let err = procedure
@@ -844,7 +844,7 @@ async fn test_purge_dropped_table_drops_regions_and_deletes_tombstone() {
     detector_controller.clear().await;
 
     let mut procedure = PurgeDroppedTableProcedure::new(
-        new_purge_dropped_table_task(table_name, Some(table_id)),
+        new_purge_dropped_table_task(table_id),
         ddl_context.clone(),
     );
     execute_procedure_until_done(&mut procedure).await;
@@ -876,7 +876,7 @@ async fn test_purge_dropped_table_drops_regions_and_deletes_tombstone() {
 }
 
 #[tokio::test]
-async fn test_purge_dropped_table_by_name_selects_tombstone_when_live_table_exists() {
+async fn test_purge_dropped_table_by_id_selects_tombstone_when_live_table_exists() {
     let (tx, mut rx) = mpsc::channel(8);
     let datanode_handler = DatanodeWatcher::new(tx);
     let node_manager = Arc::new(MockDatanodeManager::new(datanode_handler));
@@ -918,7 +918,7 @@ async fn test_purge_dropped_table_by_name_selects_tombstone_when_live_table_exis
     while rx.try_recv().is_ok() {}
 
     let mut procedure = PurgeDroppedTableProcedure::new(
-        new_purge_dropped_table_task(table_name, None),
+        new_purge_dropped_table_task(dropped_table_id),
         ddl_context.clone(),
     );
     execute_procedure_until_done(&mut procedure).await;
@@ -1025,16 +1025,8 @@ fn new_undrop_table_task(table_id: TableId) -> UndropTableTask {
     UndropTableTask { table_id }
 }
 
-fn new_purge_dropped_table_task(
-    table_name: &str,
-    table_id: Option<TableId>,
-) -> PurgeDroppedTableTask {
-    PurgeDroppedTableTask {
-        catalog: DEFAULT_CATALOG_NAME.to_string(),
-        schema: DEFAULT_SCHEMA_NAME.to_string(),
-        table: table_name.to_string(),
-        table_id,
-    }
+fn new_purge_dropped_table_task(table_id: TableId) -> PurgeDroppedTableTask {
+    PurgeDroppedTableTask { table_id }
 }
 
 async fn create_metric_logical_table_tombstone(

--- a/src/common/meta/src/ddl/tests/drop_table.rs
+++ b/src/common/meta/src/ddl/tests/drop_table.rs
@@ -14,17 +14,19 @@
 
 use std::assert_matches;
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex};
 
+use api::region::RegionResponse;
 use api::v1::region::{RegionRequest, region_request};
 use async_trait::async_trait;
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
-use common_error::ext::ErrorExt;
+use common_error::ext::{BoxedError, ErrorExt, StackError};
 use common_error::status_code::StatusCode;
 use common_procedure::Procedure;
 use common_procedure_test::{
     execute_procedure_until, execute_procedure_until_done, new_test_procedure_context,
 };
+use snafu::ResultExt;
 use store_api::region_engine::RegionRole;
 use store_api::storage::RegionId;
 use table::metadata::TableId;
@@ -42,7 +44,7 @@ use crate::ddl::test_util::{
 };
 use crate::ddl::undrop_table::UndropTableProcedure;
 use crate::ddl::{DetectingRegion, RegionFailureDetectorController, TableMetadata};
-use crate::error::Error;
+use crate::error::{self, Error};
 use crate::key::table_name::TableNameKey;
 use crate::key::table_route::TableRouteValue;
 use crate::kv_backend::memory::MemoryKvBackend;
@@ -333,7 +335,9 @@ async fn test_soft_drop_closes_regions_and_keeps_tombstone() {
 #[tokio::test]
 async fn test_hard_drop_keeps_delete_tombstone_flow() {
     let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
-    let ddl_context = new_ddl_context(node_manager);
+    let detector_controller = Arc::new(RecordingRegionFailureDetectorController::default());
+    let mut ddl_context = new_ddl_context(node_manager);
+    ddl_context.region_failure_detector_controller = detector_controller.clone();
     let table_id = 1024;
     let table_name = "foo";
     let task = test_create_table_task(table_name, table_id);
@@ -372,6 +376,10 @@ async fn test_hard_drop_keeps_delete_tombstone_flow() {
         .await
         .unwrap();
     assert!(dropped_table.is_none());
+    assert_eq!(
+        detector_controller.deregistered().await,
+        vec![(1, RegionId::new(table_id, 1))]
+    );
 }
 
 #[tokio::test]
@@ -808,6 +816,54 @@ async fn test_undrop_table_fails_when_live_name_is_created_after_prepare() {
 }
 
 #[tokio::test]
+async fn test_undrop_table_replayed_restore_metadata_is_idempotent() {
+    let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
+    let mut ddl_context = new_ddl_context(node_manager);
+    ddl_context.soft_drop_enabled = true;
+    let table_id = 1024;
+    let table_name = "foo";
+    let task = test_create_table_task(table_name, table_id);
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            task.table_info.clone(),
+            TableRouteValue::physical(vec![]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+    let mut drop_procedure = DropTableProcedure::new(
+        new_drop_table_task(table_name, table_id, false),
+        ddl_context.clone(),
+    );
+    execute_procedure_until_done(&mut drop_procedure).await;
+
+    let mut procedure =
+        UndropTableProcedure::new(new_undrop_table_task(table_id), ddl_context.clone());
+    let ctx = new_test_procedure_context();
+    procedure.execute(&ctx).await.unwrap();
+    let restore_metadata_data = procedure.dump().unwrap();
+    procedure.execute(&ctx).await.unwrap();
+
+    let mut replayed =
+        UndropTableProcedure::from_json(&restore_metadata_data, ddl_context.clone()).unwrap();
+    execute_procedure_until_done(&mut replayed).await;
+
+    let live_table = ddl_context
+        .table_metadata_manager
+        .table_name_manager()
+        .get(TableNameKey::new(
+            DEFAULT_CATALOG_NAME,
+            DEFAULT_SCHEMA_NAME,
+            table_name,
+        ))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(live_table.table_id(), table_id);
+}
+
+#[tokio::test]
 async fn test_purge_dropped_table_drops_regions_and_deletes_tombstone() {
     let (tx, mut rx) = mpsc::channel(8);
     let datanode_handler = DatanodeWatcher::new(tx);
@@ -948,6 +1004,106 @@ async fn test_purge_dropped_table_by_id_selects_tombstone_when_live_table_exists
     };
     assert_eq!(req.region_id, RegionId::new(dropped_table_id, 1).as_u64());
     assert!(rx.try_recv().is_err());
+}
+
+#[tokio::test]
+async fn test_purge_dropped_table_replayed_open_regions_ignores_dropped_regions() {
+    let (tx, mut rx) = mpsc::channel(8);
+    let dropped_regions = Arc::new(StdMutex::new(HashSet::new()));
+    let datanode_handler = DatanodeWatcher::new(tx).with_handler({
+        let dropped_regions = dropped_regions.clone();
+        move |_peer, request| {
+            let Some(body) = request.body.as_ref() else {
+                return Ok(RegionResponse::new(0));
+            };
+            match body {
+                region_request::Body::Open(req)
+                    if dropped_regions.lock().unwrap().contains(&req.region_id) =>
+                {
+                    Err::<RegionResponse, _>(BoxedError::new(MockRegionNotFoundError))
+                        .context(error::ExternalSnafu)
+                }
+                region_request::Body::Drop(req) => {
+                    dropped_regions.lock().unwrap().insert(req.region_id);
+                    Ok(RegionResponse::new(0))
+                }
+                _ => Ok(RegionResponse::new(0)),
+            }
+        }
+    });
+    let node_manager = Arc::new(MockDatanodeManager::new(datanode_handler));
+    let mut ddl_context = new_ddl_context(node_manager);
+    ddl_context.soft_drop_enabled = true;
+    let table_id = 1024;
+    let table_name = "foo";
+    let task = test_create_table_task(table_name, table_id);
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            task.table_info.clone(),
+            TableRouteValue::physical(vec![RegionRoute {
+                region: Region::new_test(RegionId::new(table_id, 1)),
+                leader_peer: Some(Peer::empty(1)),
+                follower_peers: vec![],
+                leader_state: None,
+                leader_down_since: None,
+                write_route_policy: None,
+            }]),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+    let mut drop_procedure = DropTableProcedure::new(
+        new_drop_table_task(table_name, table_id, false),
+        ddl_context.clone(),
+    );
+    execute_procedure_until_done(&mut drop_procedure).await;
+    while rx.try_recv().is_ok() {}
+
+    let mut procedure = PurgeDroppedTableProcedure::new(
+        new_purge_dropped_table_task(table_id),
+        ddl_context.clone(),
+    );
+    let ctx = new_test_procedure_context();
+    procedure.execute(&ctx).await.unwrap();
+    let open_regions_data = procedure.dump().unwrap();
+    procedure.execute(&ctx).await.unwrap();
+    procedure.execute(&ctx).await.unwrap();
+
+    let mut replayed =
+        PurgeDroppedTableProcedure::from_json(&open_regions_data, ddl_context.clone()).unwrap();
+    execute_procedure_until_done(&mut replayed).await;
+
+    assert!(
+        ddl_context
+            .table_metadata_manager
+            .get_dropped_table(&drop_procedure.data.task.table_name())
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[derive(Debug, snafu::Snafu)]
+#[snafu(display("mock region not found"))]
+struct MockRegionNotFoundError;
+
+impl StackError for MockRegionNotFoundError {
+    fn debug_fmt(&self, _: usize, _: &mut Vec<String>) {}
+
+    fn next(&self) -> Option<&dyn StackError> {
+        None
+    }
+}
+
+impl ErrorExt for MockRegionNotFoundError {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn status_code(&self) -> StatusCode {
+        StatusCode::RegionNotFound
+    }
 }
 
 #[tokio::test]

--- a/src/common/meta/src/ddl/tests/drop_table.rs
+++ b/src/common/meta/src/ddl/tests/drop_table.rs
@@ -1041,6 +1041,10 @@ impl RegionFailureDetectorController for RecordingRegionFailureDetectorControlle
         self.registered.lock().await.extend(detecting_regions);
     }
 
+    async fn reset_failure_detectors(&self, detecting_regions: Vec<DetectingRegion>) {
+        self.registered.lock().await.extend(detecting_regions);
+    }
+
     async fn deregister_failure_detectors(&self, detecting_regions: Vec<DetectingRegion>) {
         self.deregistered.lock().await.extend(detecting_regions);
     }

--- a/src/common/meta/src/ddl/undrop_table.rs
+++ b/src/common/meta/src/ddl/undrop_table.rs
@@ -188,7 +188,7 @@ impl Procedure for UndropTableProcedure {
     }
 }
 
-async fn open_regions(
+pub(crate) async fn open_regions(
     context: &DdlContext,
     table_id: TableId,
     table_name: &TableName,

--- a/src/common/meta/src/ddl/undrop_table.rs
+++ b/src/common/meta/src/ddl/undrop_table.rs
@@ -34,8 +34,8 @@ use table::table_name::TableName;
 use table::table_reference::TableReference;
 
 use crate::ddl::utils::{
-    add_peer_context_if_needed, is_metric_engine_logical_table, map_to_procedure_error,
-    region_storage_path,
+    add_peer_context_if_needed, convert_region_routes_to_detecting_regions,
+    is_metric_engine_logical_table, map_to_procedure_error, region_storage_path,
 };
 use crate::ddl::{CreateRequestBuilder, DdlContext, build_template_from_raw_table_info};
 use crate::error::{self, Result};
@@ -258,6 +258,9 @@ pub(crate) async fn open_regions(
         .await
         .into_iter()
         .collect::<Result<Vec<_>>>()?;
+    context
+        .register_failure_detectors(convert_region_routes_to_detecting_regions(region_routes))
+        .await;
     Ok(())
 }
 

--- a/src/common/meta/src/ddl/undrop_table.rs
+++ b/src/common/meta/src/ddl/undrop_table.rs
@@ -33,7 +33,10 @@ use table::metadata::TableId;
 use table::table_name::TableName;
 use table::table_reference::TableReference;
 
-use crate::ddl::utils::{add_peer_context_if_needed, map_to_procedure_error, region_storage_path};
+use crate::ddl::utils::{
+    add_peer_context_if_needed, is_metric_engine_logical_table, map_to_procedure_error,
+    region_storage_path,
+};
 use crate::ddl::{CreateRequestBuilder, DdlContext, build_template_from_raw_table_info};
 use crate::error::{self, Result};
 use crate::instruction::CacheIdent;
@@ -92,6 +95,15 @@ impl UndropTableProcedure {
         self.data.table_name = Some(dropped_table.table_name.clone());
         self.data.table_route_value = Some(dropped_table.table_route_value.clone());
         self.data.region_wal_options = dropped_table.region_wal_options;
+        ensure!(
+            !is_metric_engine_logical_table(
+                &dropped_table.table_info_value.table_info,
+                self.data.table_route_value()
+            ),
+            error::UnsupportedSnafu {
+                operation: "undropping metric logical tables".to_string()
+            }
+        );
         self.data.table_info = Some(dropped_table.table_info_value.table_info);
         self.data.state = UndropTableState::RestoreMetadata;
         Ok(Status::executing(true))

--- a/src/common/meta/src/ddl/undrop_table.rs
+++ b/src/common/meta/src/ddl/undrop_table.rs
@@ -1,0 +1,298 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use api::v1::region::{
+    OpenRequest as PbOpenRegionRequest, RegionRequest, RegionRequestHeader, region_request,
+};
+use async_trait::async_trait;
+use common_procedure::error::{FromJsonSnafu, ToJsonSnafu};
+use common_procedure::{
+    Context as ProcedureContext, LockKey, Procedure, Result as ProcedureResult, Status,
+};
+use common_telemetry::tracing_context::TracingContext;
+use common_wal::options::WalOptions;
+use futures::future::join_all;
+use serde::{Deserialize, Serialize};
+use snafu::{OptionExt, ResultExt, ensure};
+use store_api::storage::{RegionId, RegionNumber};
+use strum::AsRefStr;
+use table::metadata::TableId;
+use table::table_name::TableName;
+use table::table_reference::TableReference;
+
+use crate::ddl::utils::{add_peer_context_if_needed, map_to_procedure_error, region_storage_path};
+use crate::ddl::{CreateRequestBuilder, DdlContext, build_template_from_raw_table_info};
+use crate::error::{self, Result};
+use crate::instruction::CacheIdent;
+use crate::key::table_name::TableNameKey;
+use crate::key::table_route::TableRouteValue;
+use crate::lock_key::{CatalogLock, SchemaLock, TableLock, TableNameLock};
+use crate::rpc::ddl::UndropTableTask;
+use crate::rpc::router::{RegionRoute, find_leader_regions, find_leaders};
+
+pub struct UndropTableProcedure {
+    context: DdlContext,
+    data: UndropTableData,
+}
+
+impl UndropTableProcedure {
+    pub const TYPE_NAME: &'static str = "metasrv-procedure::UndropTable";
+
+    pub fn new(task: UndropTableTask, context: DdlContext) -> Self {
+        Self {
+            context,
+            data: UndropTableData::new(task),
+        }
+    }
+
+    pub fn from_json(json: &str, context: DdlContext) -> ProcedureResult<Self> {
+        let data: UndropTableData = serde_json::from_str(json).context(FromJsonSnafu)?;
+        Ok(Self { context, data })
+    }
+
+    pub(crate) async fn on_prepare(&mut self) -> Result<Status> {
+        let table_ref = self.data.table_ref();
+        ensure!(
+            !self
+                .context
+                .table_metadata_manager
+                .table_name_manager()
+                .exists(TableNameKey::new(
+                    table_ref.catalog,
+                    table_ref.schema,
+                    table_ref.table
+                ))
+                .await?,
+            error::TableAlreadyExistsSnafu {
+                table_name: table_ref.to_string()
+            }
+        );
+
+        let dropped_table = self
+            .context
+            .table_metadata_manager
+            .get_dropped_table_by_id(self.data.task.table_id)
+            .await?
+            .with_context(|| error::TableNotFoundSnafu {
+                table_name: table_ref.to_string(),
+            })?;
+        self.data.table_name = Some(dropped_table.table_name.clone());
+        self.data.table_route_value = Some(dropped_table.table_route_value.clone());
+        self.data.region_wal_options = dropped_table.region_wal_options;
+        self.data.table_info = Some(dropped_table.table_info_value.table_info);
+        self.data.state = UndropTableState::RestoreMetadata;
+        Ok(Status::executing(true))
+    }
+
+    async fn on_restore_metadata(&mut self) -> Result<Status> {
+        let table_route_value = self.data.table_route_value();
+        self.context
+            .table_metadata_manager
+            .restore_table_metadata(
+                self.data.task.table_id,
+                self.data.table_name(),
+                table_route_value,
+                &self.data.region_wal_options,
+            )
+            .await?;
+        self.data.state = UndropTableState::OpenRegions;
+        Ok(Status::executing(true))
+    }
+
+    async fn on_open_regions(&mut self) -> Result<Status> {
+        let TableRouteValue::Physical(route) = self.data.table_route_value() else {
+            self.data.state = UndropTableState::InvalidateTableCache;
+            return Ok(Status::executing(true));
+        };
+
+        open_regions(
+            &self.context,
+            self.data.task.table_id,
+            self.data.table_name(),
+            self.data.table_info(),
+            &route.region_routes,
+            &self.data.region_wal_options,
+        )
+        .await?;
+        self.data.state = UndropTableState::InvalidateTableCache;
+        Ok(Status::executing(true))
+    }
+
+    async fn on_broadcast(&mut self) -> Result<Status> {
+        let ctx = crate::cache_invalidator::Context {
+            subject: Some(format!(
+                "Invalidate table cache by undropping table {}, table_id: {}",
+                self.data.table_name().table_ref(),
+                self.data.task.table_id,
+            )),
+        };
+        self.context
+            .cache_invalidator
+            .invalidate(
+                &ctx,
+                &[
+                    CacheIdent::TableName(self.data.table_name().table_ref().into()),
+                    CacheIdent::TableId(self.data.task.table_id),
+                ],
+            )
+            .await?;
+        Ok(Status::done())
+    }
+}
+
+#[async_trait]
+impl Procedure for UndropTableProcedure {
+    fn type_name(&self) -> &str {
+        Self::TYPE_NAME
+    }
+
+    fn recover(&mut self) -> ProcedureResult<()> {
+        Ok(())
+    }
+
+    async fn execute(&mut self, _: &ProcedureContext) -> ProcedureResult<Status> {
+        match self.data.state {
+            UndropTableState::Prepare => self.on_prepare().await,
+            UndropTableState::RestoreMetadata => self.on_restore_metadata().await,
+            UndropTableState::OpenRegions => self.on_open_regions().await,
+            UndropTableState::InvalidateTableCache => self.on_broadcast().await,
+        }
+        .map_err(map_to_procedure_error)
+    }
+
+    fn dump(&self) -> ProcedureResult<String> {
+        serde_json::to_string(&self.data).context(ToJsonSnafu)
+    }
+
+    fn lock_key(&self) -> LockKey {
+        let table_ref = self.data.table_ref();
+        LockKey::new(vec![
+            CatalogLock::Read(table_ref.catalog).into(),
+            SchemaLock::read(table_ref.catalog, table_ref.schema).into(),
+            TableNameLock::new(table_ref.catalog, table_ref.schema, table_ref.table).into(),
+            TableLock::Write(self.data.task.table_id).into(),
+        ])
+    }
+}
+
+async fn open_regions(
+    context: &DdlContext,
+    table_id: TableId,
+    table_name: &TableName,
+    table_info: &table::metadata::TableInfo,
+    region_routes: &[RegionRoute],
+    region_wal_options: &HashMap<RegionNumber, WalOptions>,
+) -> Result<()> {
+    let template = build_template_from_raw_table_info(table_info)?;
+    let builder = CreateRequestBuilder::new(template, None);
+    let storage_path = region_storage_path(&table_name.catalog_name, &table_name.schema_name);
+    let wal_options = region_wal_options
+        .iter()
+        .map(|(region_number, wal_options)| {
+            serde_json::to_string(wal_options)
+                .map(|wal_options| (*region_number, wal_options))
+                .context(error::SerdeJsonSnafu)
+        })
+        .collect::<Result<HashMap<_, _>>>()?;
+    let leaders = find_leaders(region_routes);
+    let mut tasks = Vec::with_capacity(leaders.len());
+    for datanode in leaders {
+        let requester = context.node_manager.datanode(&datanode).await;
+        for region_number in find_leader_regions(region_routes, &datanode) {
+            let region_id = RegionId::new(table_id, region_number);
+            let create_request = builder.build_one(
+                region_id,
+                storage_path.clone(),
+                &wal_options,
+                &HashMap::new(),
+            );
+            let request = RegionRequest {
+                header: Some(RegionRequestHeader {
+                    tracing_context: TracingContext::from_current_span().to_w3c(),
+                    ..Default::default()
+                }),
+                body: Some(region_request::Body::Open(PbOpenRegionRequest {
+                    region_id: create_request.region_id,
+                    engine: create_request.engine,
+                    path: create_request.path,
+                    options: create_request.options,
+                })),
+            };
+            let datanode = datanode.clone();
+            let requester = requester.clone();
+            tasks.push(async move {
+                requester
+                    .handle(request)
+                    .await
+                    .map_err(add_peer_context_if_needed(datanode))
+            });
+        }
+    }
+
+    join_all(tasks)
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>>>()?;
+    Ok(())
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UndropTableData {
+    state: UndropTableState,
+    task: UndropTableTask,
+    table_name: Option<TableName>,
+    table_info: Option<table::metadata::TableInfo>,
+    table_route_value: Option<TableRouteValue>,
+    #[serde(default)]
+    region_wal_options: HashMap<RegionNumber, WalOptions>,
+}
+
+impl UndropTableData {
+    fn new(task: UndropTableTask) -> Self {
+        Self {
+            state: UndropTableState::Prepare,
+            task,
+            table_name: None,
+            table_info: None,
+            table_route_value: None,
+            region_wal_options: HashMap::new(),
+        }
+    }
+
+    fn table_ref(&self) -> TableReference<'_> {
+        self.task.table_ref()
+    }
+
+    fn table_name(&self) -> &TableName {
+        self.table_name.as_ref().unwrap()
+    }
+
+    fn table_info(&self) -> &table::metadata::TableInfo {
+        self.table_info.as_ref().unwrap()
+    }
+
+    fn table_route_value(&self) -> &TableRouteValue {
+        self.table_route_value.as_ref().unwrap()
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, AsRefStr, PartialEq)]
+enum UndropTableState {
+    Prepare,
+    RestoreMetadata,
+    OpenRegions,
+    InvalidateTableCache,
+}

--- a/src/common/meta/src/ddl/undrop_table.rs
+++ b/src/common/meta/src/ddl/undrop_table.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use api::v1::region::{
     OpenRequest as PbOpenRegionRequest, RegionRequest, RegionRequestHeader, region_request,
@@ -44,7 +44,9 @@ use crate::key::table_name::TableNameKey;
 use crate::key::table_route::TableRouteValue;
 use crate::lock_key::{CatalogLock, SchemaLock, TableLock, TableNameLock};
 use crate::rpc::ddl::UndropTableTask;
-use crate::rpc::router::{RegionRoute, find_leader_regions, find_leaders};
+use crate::rpc::router::{
+    RegionRoute, find_follower_regions, find_followers, find_leader_regions, find_leaders,
+};
 
 pub struct UndropTableProcedure {
     context: DdlContext,
@@ -219,11 +221,18 @@ pub(crate) async fn open_regions(
                 .context(error::SerdeJsonSnafu)
         })
         .collect::<Result<HashMap<_, _>>>()?;
-    let leaders = find_leaders(region_routes);
-    let mut tasks = Vec::with_capacity(leaders.len());
-    for datanode in leaders {
+    let mut seen_peer_ids = HashSet::new();
+    let peers = find_leaders(region_routes)
+        .into_iter()
+        .chain(find_followers(region_routes))
+        .filter(|peer| seen_peer_ids.insert(peer.id));
+    let mut tasks = Vec::new();
+    for datanode in peers {
         let requester = context.node_manager.datanode(&datanode).await;
-        for region_number in find_leader_regions(region_routes, &datanode) {
+        let region_numbers = find_leader_regions(region_routes, &datanode)
+            .into_iter()
+            .chain(find_follower_regions(region_routes, &datanode));
+        for region_number in region_numbers {
             let region_id = RegionId::new(table_id, region_number);
             let create_request = builder.build_one(
                 region_id,

--- a/src/common/meta/src/ddl/undrop_table.rs
+++ b/src/common/meta/src/ddl/undrop_table.rs
@@ -31,7 +31,6 @@ use store_api::storage::{RegionId, RegionNumber};
 use strum::AsRefStr;
 use table::metadata::TableId;
 use table::table_name::TableName;
-use table::table_reference::TableReference;
 
 use crate::ddl::utils::{
     add_peer_context_if_needed, convert_region_routes_to_detecting_regions,
@@ -42,7 +41,7 @@ use crate::error::{self, Result};
 use crate::instruction::CacheIdent;
 use crate::key::table_name::TableNameKey;
 use crate::key::table_route::TableRouteValue;
-use crate::lock_key::{CatalogLock, SchemaLock, TableLock, TableNameLock};
+use crate::lock_key::TableLock;
 use crate::rpc::ddl::UndropTableTask;
 use crate::rpc::router::{
     RegionRoute, find_follower_regions, find_followers, find_leader_regions, find_leaders,
@@ -69,35 +68,24 @@ impl UndropTableProcedure {
     }
 
     pub(crate) async fn on_prepare(&mut self) -> Result<Status> {
-        let table_ref = self.data.table_ref();
-        ensure!(
-            !self
-                .context
-                .table_metadata_manager
-                .table_name_manager()
-                .exists(TableNameKey::new(
-                    table_ref.catalog,
-                    table_ref.schema,
-                    table_ref.table
-                ))
-                .await?,
-            error::TableAlreadyExistsSnafu {
-                table_name: table_ref.to_string()
-            }
-        );
-
         let dropped_table = self
             .context
             .table_metadata_manager
             .get_dropped_table_by_id(self.data.task.table_id)
             .await?
             .with_context(|| error::TableNotFoundSnafu {
-                table_name: table_ref.to_string(),
+                table_name: self.data.task.table_id.to_string(),
             })?;
+        let table_name = &dropped_table.table_name;
         ensure!(
-            dropped_table.table_name == self.data.task.table_name(),
-            error::TableNotFoundSnafu {
-                table_name: table_ref.to_string()
+            !self
+                .context
+                .table_metadata_manager
+                .table_name_manager()
+                .exists(TableNameKey::from(table_name))
+                .await?,
+            error::TableAlreadyExistsSnafu {
+                table_name: table_name.to_string()
             }
         );
         self.data.table_name = Some(dropped_table.table_name.clone());
@@ -198,13 +186,7 @@ impl Procedure for UndropTableProcedure {
     }
 
     fn lock_key(&self) -> LockKey {
-        let table_ref = self.data.table_ref();
-        LockKey::new(vec![
-            CatalogLock::Read(table_ref.catalog).into(),
-            SchemaLock::read(table_ref.catalog, table_ref.schema).into(),
-            TableNameLock::new(table_ref.catalog, table_ref.schema, table_ref.table).into(),
-            TableLock::Write(self.data.task.table_id).into(),
-        ])
+        LockKey::new(vec![TableLock::Write(self.data.task.table_id).into()])
     }
 }
 
@@ -292,10 +274,6 @@ impl UndropTableData {
             table_route_value: None,
             region_wal_options: HashMap::new(),
         }
-    }
-
-    fn table_ref(&self) -> TableReference<'_> {
-        self.task.table_ref()
     }
 
     fn table_name(&self) -> &TableName {

--- a/src/common/meta/src/ddl/undrop_table.rs
+++ b/src/common/meta/src/ddl/undrop_table.rs
@@ -103,7 +103,7 @@ impl UndropTableProcedure {
             }
         );
         self.data.table_info = Some(dropped_table.table_info_value.table_info);
-        self.data.state = UndropTableState::RestoreMetadata;
+        self.data.state = UndropTableState::OpenRegions;
         Ok(Status::executing(true))
     }
 
@@ -127,13 +127,14 @@ impl UndropTableProcedure {
                 }
                 err => err,
             })?;
-        self.data.state = UndropTableState::OpenRegions;
+        self.data.state = UndropTableState::InvalidateTableCache;
         Ok(Status::executing(true))
     }
 
     async fn on_open_regions(&mut self) -> Result<Status> {
+        self.ensure_live_table_not_exists().await?;
         let TableRouteValue::Physical(route) = self.data.table_route_value() else {
-            self.data.state = UndropTableState::InvalidateTableCache;
+            self.data.state = UndropTableState::RestoreMetadata;
             return Ok(Status::executing(true));
         };
 
@@ -146,8 +147,23 @@ impl UndropTableProcedure {
             &self.data.region_wal_options,
         )
         .await?;
-        self.data.state = UndropTableState::InvalidateTableCache;
+        self.data.state = UndropTableState::RestoreMetadata;
         Ok(Status::executing(true))
+    }
+
+    async fn ensure_live_table_not_exists(&self) -> Result<()> {
+        ensure!(
+            !self
+                .context
+                .table_metadata_manager
+                .table_name_manager()
+                .exists(TableNameKey::from(self.data.table_name()))
+                .await?,
+            error::TableAlreadyExistsSnafu {
+                table_name: self.data.table_name().to_string()
+            }
+        );
+        Ok(())
     }
 
     async fn on_broadcast(&mut self) -> Result<Status> {

--- a/src/common/meta/src/ddl/undrop_table.rs
+++ b/src/common/meta/src/ddl/undrop_table.rs
@@ -115,7 +115,16 @@ impl UndropTableProcedure {
                 table_route_value,
                 &self.data.region_wal_options,
             )
-            .await?;
+            .await
+            .map_err(|err| match err {
+                error::Error::TombstoneTargetAlreadyExists { .. } => {
+                    error::TableAlreadyExistsSnafu {
+                        table_name: self.data.table_name().to_string(),
+                    }
+                    .build()
+                }
+                err => err,
+            })?;
         self.data.state = UndropTableState::OpenRegions;
         Ok(Status::executing(true))
     }

--- a/src/common/meta/src/ddl/undrop_table.rs
+++ b/src/common/meta/src/ddl/undrop_table.rs
@@ -213,14 +213,6 @@ pub(crate) async fn open_regions(
     let template = build_template_from_raw_table_info(table_info)?;
     let builder = CreateRequestBuilder::new(template, None);
     let storage_path = region_storage_path(&table_name.catalog_name, &table_name.schema_name);
-    let wal_options = region_wal_options
-        .iter()
-        .map(|(region_number, wal_options)| {
-            serde_json::to_string(wal_options)
-                .map(|wal_options| (*region_number, wal_options))
-                .context(error::SerdeJsonSnafu)
-        })
-        .collect::<Result<HashMap<_, _>>>()?;
     let mut seen_peer_ids = HashSet::new();
     let peers = find_leaders(region_routes)
         .into_iter()
@@ -237,9 +229,9 @@ pub(crate) async fn open_regions(
             let create_request = builder.build_one(
                 region_id,
                 storage_path.clone(),
-                &wal_options,
+                region_wal_options,
                 &HashMap::new(),
-            );
+            )?;
             let request = RegionRequest {
                 header: Some(RegionRequestHeader {
                     tracing_context: TracingContext::from_current_span().to_w3c(),

--- a/src/common/meta/src/ddl/undrop_table.rs
+++ b/src/common/meta/src/ddl/undrop_table.rs
@@ -94,6 +94,12 @@ impl UndropTableProcedure {
             .with_context(|| error::TableNotFoundSnafu {
                 table_name: table_ref.to_string(),
             })?;
+        ensure!(
+            dropped_table.table_name == self.data.task.table_name(),
+            error::TableNotFoundSnafu {
+                table_name: table_ref.to_string()
+            }
+        );
         self.data.table_name = Some(dropped_table.table_name.clone());
         self.data.table_route_value = Some(dropped_table.table_route_value.clone());
         self.data.region_wal_options = dropped_table.region_wal_options;

--- a/src/common/meta/src/ddl/undrop_table.rs
+++ b/src/common/meta/src/ddl/undrop_table.rs
@@ -18,6 +18,8 @@ use api::v1::region::{
     OpenRequest as PbOpenRegionRequest, RegionRequest, RegionRequestHeader, region_request,
 };
 use async_trait::async_trait;
+use common_error::ext::ErrorExt;
+use common_error::status_code::StatusCode;
 use common_procedure::error::{FromJsonSnafu, ToJsonSnafu};
 use common_procedure::{
     Context as ProcedureContext, LockKey, Procedure, Result as ProcedureResult, Status,
@@ -207,6 +209,47 @@ pub(crate) async fn open_regions(
     region_routes: &[RegionRoute],
     region_wal_options: &HashMap<RegionNumber, WalOptions>,
 ) -> Result<()> {
+    open_regions_inner(
+        context,
+        table_id,
+        table_name,
+        table_info,
+        region_routes,
+        region_wal_options,
+        false,
+    )
+    .await
+}
+
+pub(crate) async fn open_regions_ignore_region_not_found(
+    context: &DdlContext,
+    table_id: TableId,
+    table_name: &TableName,
+    table_info: &table::metadata::TableInfo,
+    region_routes: &[RegionRoute],
+    region_wal_options: &HashMap<RegionNumber, WalOptions>,
+) -> Result<()> {
+    open_regions_inner(
+        context,
+        table_id,
+        table_name,
+        table_info,
+        region_routes,
+        region_wal_options,
+        true,
+    )
+    .await
+}
+
+async fn open_regions_inner(
+    context: &DdlContext,
+    table_id: TableId,
+    table_name: &TableName,
+    table_info: &table::metadata::TableInfo,
+    region_routes: &[RegionRoute],
+    region_wal_options: &HashMap<RegionNumber, WalOptions>,
+    ignore_region_not_found: bool,
+) -> Result<()> {
     let template = build_template_from_raw_table_info(table_info)?;
     let builder = CreateRequestBuilder::new(template, None);
     let storage_path = region_storage_path(&table_name.catalog_name, &table_name.schema_name);
@@ -244,10 +287,12 @@ pub(crate) async fn open_regions(
             let datanode = datanode.clone();
             let requester = requester.clone();
             tasks.push(async move {
-                requester
-                    .handle(request)
-                    .await
-                    .map_err(add_peer_context_if_needed(datanode))
+                if let Err(err) = requester.handle(request).await
+                    && !(ignore_region_not_found && err.status_code() == StatusCode::RegionNotFound)
+                {
+                    return Err(add_peer_context_if_needed(datanode)(err));
+                }
+                Ok(())
             });
         }
     }

--- a/src/common/meta/src/ddl/utils.rs
+++ b/src/common/meta/src/ddl/utils.rs
@@ -37,8 +37,8 @@ use snafu::{OptionExt, ResultExt, ensure};
 use store_api::metadata::ColumnMetadata;
 use store_api::metric_engine_consts::{LOGICAL_TABLE_METADATA_KEY, MANIFEST_INFO_EXTENSION_KEY};
 use store_api::region_engine::RegionManifestInfo;
-use store_api::storage::RegionId;
-use table::metadata::TableId;
+use store_api::storage::{RegionId, RegionNumber};
+use table::metadata::{TableId, TableInfo};
 use table::table_reference::TableReference;
 
 use crate::ddl::{DdlContext, DetectingRegion};
@@ -66,6 +66,14 @@ pub fn add_peer_context_if_needed(datanode: Peer) -> impl FnOnce(Error) -> Error
         }
         err
     }
+}
+
+pub(crate) fn is_metric_engine_logical_table(
+    table_info: &TableInfo,
+    table_route_value: &TableRouteValue,
+) -> bool {
+    table_info.meta.engine == METRIC_ENGINE
+        && matches!(table_route_value, TableRouteValue::Logical(_))
 }
 
 /// Maps the error to the corresponding procedure error.

--- a/src/common/meta/src/ddl/utils.rs
+++ b/src/common/meta/src/ddl/utils.rs
@@ -37,7 +37,7 @@ use snafu::{OptionExt, ResultExt, ensure};
 use store_api::metadata::ColumnMetadata;
 use store_api::metric_engine_consts::{LOGICAL_TABLE_METADATA_KEY, MANIFEST_INFO_EXTENSION_KEY};
 use store_api::region_engine::RegionManifestInfo;
-use store_api::storage::{RegionId, RegionNumber};
+use store_api::storage::RegionId;
 use table::metadata::{TableId, TableInfo};
 use table::table_reference::TableReference;
 

--- a/src/common/meta/src/ddl_manager.rs
+++ b/src/common/meta/src/ddl_manager.rs
@@ -43,7 +43,9 @@ use crate::ddl::drop_database::DropDatabaseProcedure;
 use crate::ddl::drop_flow::DropFlowProcedure;
 use crate::ddl::drop_table::DropTableProcedure;
 use crate::ddl::drop_view::DropViewProcedure;
+use crate::ddl::purge_dropped_table::PurgeDroppedTableProcedure;
 use crate::ddl::truncate_table::TruncateTableProcedure;
+use crate::ddl::undrop_table::UndropTableProcedure;
 use crate::ddl::{DdlContext, utils};
 use crate::error::{
     self, CreateRepartitionProcedureSnafu, EmptyDdlTasksSnafu, ProcedureOutputSnafu,
@@ -62,7 +64,7 @@ use crate::rpc::ddl::DdlTask::DropTrigger;
 use crate::rpc::ddl::DdlTask::{
     AlterDatabase, AlterLogicalTables, AlterTable, CommentOn, CreateDatabase, CreateFlow,
     CreateLogicalTables, CreateTable, CreateView, DropDatabase, DropFlow, DropLogicalTables,
-    DropTable, DropView, TruncateTable,
+    DropTable, DropView, PurgeDroppedTable, TruncateTable, UndropTable,
 };
 #[cfg(feature = "enterprise")]
 use crate::rpc::ddl::trigger::CreateTriggerTask;
@@ -71,7 +73,8 @@ use crate::rpc::ddl::trigger::DropTriggerTask;
 use crate::rpc::ddl::{
     AlterDatabaseTask, AlterTableTask, CommentOnTask, CreateDatabaseTask, CreateFlowTask,
     CreateTableTask, CreateViewTask, DropDatabaseTask, DropFlowTask, DropTableTask, DropViewTask,
-    QueryContext, SubmitDdlTaskRequest, SubmitDdlTaskResponse, TruncateTableTask,
+    PurgeDroppedTableTask, QueryContext, SubmitDdlTaskRequest, SubmitDdlTaskResponse,
+    TruncateTableTask, UndropTableTask,
 };
 
 /// A configurator that customizes or enhances a [`DdlManager`].
@@ -252,6 +255,8 @@ impl DdlManager {
             AlterLogicalTablesProcedure,
             AlterDatabaseProcedure,
             DropTableProcedure,
+            UndropTableProcedure,
+            PurgeDroppedTableProcedure,
             DropFlowProcedure,
             TruncateTableProcedure,
             CreateDatabaseProcedure,
@@ -468,6 +473,32 @@ impl DdlManager {
         self.execute_procedure_and_wait(procedure_with_id).await
     }
 
+    /// Submits and executes an undrop table task.
+    #[tracing::instrument(skip_all)]
+    pub async fn submit_undrop_table_task(
+        &self,
+        undrop_table_task: UndropTableTask,
+    ) -> Result<(ProcedureId, Option<Output>)> {
+        let context = self.create_context();
+        let procedure = UndropTableProcedure::new(undrop_table_task, context);
+        let procedure_with_id = ProcedureWithId::with_random_id(Box::new(procedure));
+
+        self.execute_procedure_and_wait(procedure_with_id).await
+    }
+
+    /// Submits and executes a purge dropped table task.
+    #[tracing::instrument(skip_all)]
+    pub async fn submit_purge_dropped_table_task(
+        &self,
+        purge_dropped_table_task: PurgeDroppedTableTask,
+    ) -> Result<(ProcedureId, Option<Output>)> {
+        let context = self.create_context();
+        let procedure = PurgeDroppedTableProcedure::new(purge_dropped_table_task, context);
+        let procedure_with_id = ProcedureWithId::with_random_id(Box::new(procedure));
+
+        self.execute_procedure_and_wait(procedure_with_id).await
+    }
+
     /// Submits and executes a create database task.
     #[tracing::instrument(skip_all)]
     pub async fn submit_create_database(
@@ -643,6 +674,12 @@ impl DdlManager {
                     handle_create_table_task(self, create_table_task, request.query_context).await
                 }
                 DropTable(drop_table_task) => handle_drop_table_task(self, drop_table_task).await,
+                UndropTable(undrop_table_task) => {
+                    handle_undrop_table_task(self, undrop_table_task).await
+                }
+                PurgeDroppedTable(purge_dropped_table_task) => {
+                    handle_purge_dropped_table_task(self, purge_dropped_table_task).await
+                }
                 AlterTable(alter_table_task) => {
                     handle_alter_table_task(self, alter_table_task, ddl_options).await
                 }
@@ -783,6 +820,39 @@ async fn handle_drop_table_task(
     let (id, _) = ddl_manager.submit_drop_table_task(drop_table_task).await?;
 
     info!("Table: {table_id} is dropped via procedure_id {id:?}");
+
+    Ok(SubmitDdlTaskResponse {
+        key: id.to_string().into(),
+        ..Default::default()
+    })
+}
+
+async fn handle_undrop_table_task(
+    ddl_manager: &DdlManager,
+    undrop_table_task: UndropTableTask,
+) -> Result<SubmitDdlTaskResponse> {
+    let table_id = undrop_table_task.table_id;
+    let (id, _) = ddl_manager
+        .submit_undrop_table_task(undrop_table_task)
+        .await?;
+
+    info!("Table: {table_id} is undropped via procedure_id {id:?}");
+
+    Ok(SubmitDdlTaskResponse {
+        key: id.to_string().into(),
+        ..Default::default()
+    })
+}
+
+async fn handle_purge_dropped_table_task(
+    ddl_manager: &DdlManager,
+    purge_dropped_table_task: PurgeDroppedTableTask,
+) -> Result<SubmitDdlTaskResponse> {
+    let (id, _) = ddl_manager
+        .submit_purge_dropped_table_task(purge_dropped_table_task)
+        .await?;
+
+    info!("Dropped table is purged via procedure_id {id:?}");
 
     Ok(SubmitDdlTaskResponse {
         key: id.to_string().into(),

--- a/src/common/meta/src/ddl_manager.rs
+++ b/src/common/meta/src/ddl_manager.rs
@@ -1238,6 +1238,7 @@ mod tests {
                 memory_region_keeper: Arc::new(MemoryRegionKeeper::default()),
                 leader_region_registry: Arc::new(LeaderRegionRegistry::default()),
                 region_failure_detector_controller: Arc::new(NoopRegionFailureDetectorControl),
+                soft_drop_enabled: false,
             },
             procedure_manager.clone(),
             Arc::new(DummyRepartitionProcedureFactory),

--- a/src/common/meta/src/error.rs
+++ b/src/common/meta/src/error.rs
@@ -379,6 +379,20 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display(
+        "Cannot drop table '{}': tombstoned table id {} already uses the same full name",
+        table_name,
+        existing_table_id
+    ))]
+    /// Raised when a live table is recreated with a name still reserved by an older tombstone.
+    TableNameTombstoneConflict {
+        table_name: String,
+        existing_table_id: TableId,
+        dropping_table_id: TableId,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("View already exists, view: {}", view_name))]
     ViewAlreadyExists {
         view_name: String,
@@ -1221,7 +1235,9 @@ impl ErrorExt for Error {
             ViewNotFound { .. } | TableNotFound { .. } | RegionNotFound { .. } => {
                 StatusCode::TableNotFound
             }
-            ViewAlreadyExists { .. } | TableAlreadyExists { .. } => StatusCode::TableAlreadyExists,
+            ViewAlreadyExists { .. }
+            | TableAlreadyExists { .. }
+            | TableNameTombstoneConflict { .. } => StatusCode::TableAlreadyExists,
 
             SubmitProcedure { source, .. }
             | QueryProcedure { source, .. }

--- a/src/common/meta/src/error.rs
+++ b/src/common/meta/src/error.rs
@@ -741,6 +741,13 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display("Failed to restore tombstone, target key already exists: {key}"))]
+    TombstoneTargetAlreadyExists {
+        key: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Failed to parse {} from utf8", name))]
     FromUtf8 {
         name: String,
@@ -1144,6 +1151,7 @@ impl ErrorExt for Error {
             | EtcdTxnFailed { .. }
             | ConnectEtcd { .. }
             | MoveValues { .. }
+            | TombstoneTargetAlreadyExists { .. }
             | GetCache { .. }
             | GetLatestCacheRetryExceeded { .. }
             | SerializeToJson { .. }

--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -1812,15 +1812,11 @@ mod tests {
         let table_metadata_manager = TableMetadataManager::new(mem_kv.clone());
         let task = test_create_table_task(table_name, table_id);
         let table_info = task.table_info.clone();
-        let serialized_options = region_wal_options
-            .iter()
-            .map(|(k, v)| (*k, serde_json::to_string(v).unwrap()))
-            .collect::<HashMap<_, _>>();
         table_metadata_manager
             .create_table_metadata(
                 table_info.clone(),
                 TableRouteValue::physical(region_routes),
-                serialized_options,
+                region_wal_options.clone(),
             )
             .await
             .unwrap();

--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -1640,7 +1640,7 @@ mod tests {
     use common_wal::options::{KafkaWalOptions, WalOptions};
     use futures::TryStreamExt;
     use store_api::storage::{RegionId, RegionNumber};
-    use table::metadata::TableInfo;
+    use table::metadata::{TableId, TableInfo};
     use table::table_name::TableName;
 
     use super::datanode_table::DatanodeTableKey;
@@ -1648,7 +1648,7 @@ mod tests {
     use crate::ddl::allocator::wal_options::WalOptionsAllocator;
     use crate::ddl::test_util::create_table::test_create_table_task;
     use crate::ddl::utils::region_storage_path;
-    use crate::error::Result;
+    use crate::error::{Error, Result};
     use crate::key::datanode_table::RegionInfo;
     use crate::key::node_address::{NodeAddressKey, NodeAddressValue};
     use crate::key::table_info::TableInfoValue;
@@ -1656,8 +1656,8 @@ mod tests {
     use crate::key::table_route::TableRouteValue;
     use crate::key::topic_region::TopicRegionKey;
     use crate::key::{
-        DeserializedValueWithBytes, MetadataValue, RegionDistribution, RegionRoleSet,
-        TOPIC_REGION_PREFIX, TableMetadataManager, ViewInfoValue,
+        DeserializedValueWithBytes, DroppedTableMetadata, MetadataValue, RegionDistribution,
+        RegionRoleSet, TOPIC_REGION_PREFIX, TableMetadataManager, ViewInfoValue,
     };
     use crate::kv_backend::KvBackend;
     use crate::kv_backend::memory::MemoryKvBackend;
@@ -1777,6 +1777,100 @@ mod tests {
                 WalOptions::Kafka(KafkaWalOptions::new("greptimedb_topic1".to_string())),
             ),
         ])
+    }
+
+    fn test_physical_region_route(
+        table_id: TableId,
+        region_number: RegionNumber,
+        leader_peer: u64,
+        follower_peers: Vec<u64>,
+    ) -> RegionRoute {
+        RegionRoute {
+            region: Region::new_test(RegionId::new(table_id, region_number)),
+            leader_peer: Some(Peer::empty(leader_peer)),
+            follower_peers: follower_peers.into_iter().map(Peer::empty).collect(),
+            leader_state: None,
+            leader_down_since: None,
+            write_route_policy: None,
+        }
+    }
+
+    async fn create_dropped_physical_table_metadata(
+        table_id: TableId,
+        table_name: &str,
+        region_routes: Vec<RegionRoute>,
+        region_wal_options: HashMap<RegionNumber, WalOptions>,
+    ) -> (
+        Arc<MemoryKvBackend<Error>>,
+        TableMetadataManager,
+        TableName,
+        TableInfo,
+        Vec<RegionRoute>,
+        HashMap<RegionNumber, WalOptions>,
+    ) {
+        let mem_kv = Arc::new(MemoryKvBackend::default());
+        let table_metadata_manager = TableMetadataManager::new(mem_kv.clone());
+        let task = test_create_table_task(table_name, table_id);
+        let table_info = task.table_info.clone();
+        let serialized_options = region_wal_options
+            .iter()
+            .map(|(k, v)| (*k, serde_json::to_string(v).unwrap()))
+            .collect::<HashMap<_, _>>();
+        table_metadata_manager
+            .create_table_metadata(
+                table_info.clone(),
+                TableRouteValue::physical(region_routes),
+                serialized_options,
+            )
+            .await
+            .unwrap();
+
+        let table_route_value = table_metadata_manager
+            .table_route_manager
+            .table_route_storage()
+            .get_with_raw_bytes(table_id)
+            .await
+            .unwrap()
+            .unwrap();
+        let region_routes = table_route_value.region_routes().unwrap().clone();
+        let table_name = TableName::new(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, table_name);
+        let table_route_value = TableRouteValue::physical(region_routes.clone());
+        table_metadata_manager
+            .delete_table_metadata(
+                table_id,
+                &table_name,
+                &table_route_value,
+                &region_wal_options,
+            )
+            .await
+            .unwrap();
+
+        (
+            mem_kv,
+            table_metadata_manager,
+            table_name,
+            table_info,
+            region_routes,
+            region_wal_options,
+        )
+    }
+
+    fn assert_dropped_table_metadata(
+        dropped_table: &DroppedTableMetadata,
+        table_id: TableId,
+        table_name: &TableName,
+        table_info: &TableInfo,
+        region_routes: &[RegionRoute],
+        region_wal_options: &HashMap<RegionNumber, WalOptions>,
+    ) {
+        assert_eq!(dropped_table.table_id, table_id);
+        assert_eq!(&dropped_table.table_name, table_name);
+        assert_eq!(&dropped_table.table_info_value.table_info, table_info);
+        assert_eq!(
+            dropped_table.table_route_value.region_routes().unwrap(),
+            region_routes
+        );
+        assert_eq!(&dropped_table.region_wal_options, region_wal_options);
     }
 
     #[tokio::test]
@@ -2857,62 +2951,20 @@ mod tests {
 
     #[tokio::test]
     async fn test_dropped_table_metadata_enumeration_and_lookup() {
-        let mem_kv = Arc::new(MemoryKvBackend::default());
-        let table_metadata_manager = TableMetadataManager::new(mem_kv.clone());
         let table_id = 1025;
         let table_name = "foo";
-        let task = test_create_table_task(table_name, table_id);
-        let table_info = task.table_info.clone();
-        let options = create_mixed_region_wal_options();
-        let serialized_options = options.clone();
-        table_metadata_manager
-            .create_table_metadata(
-                table_info.clone(),
-                TableRouteValue::physical(vec![
-                    RegionRoute {
-                        region: Region::new_test(RegionId::new(table_id, 1)),
-                        leader_peer: Some(Peer::empty(1)),
-                        follower_peers: vec![Peer::empty(5)],
-                        leader_state: None,
-                        leader_down_since: None,
-                        write_route_policy: None,
-                    },
-                    RegionRoute {
-                        region: Region::new_test(RegionId::new(table_id, 2)),
-                        leader_peer: Some(Peer::empty(2)),
-                        follower_peers: vec![Peer::empty(4)],
-                        leader_state: None,
-                        leader_down_since: None,
-                        write_route_policy: None,
-                    },
-                    RegionRoute {
-                        region: Region::new_test(RegionId::new(table_id, 3)),
-                        leader_peer: Some(Peer::empty(3)),
-                        follower_peers: vec![],
-                        leader_state: None,
-                        leader_down_since: None,
-                        write_route_policy: None,
-                    },
-                ]),
-                serialized_options,
+        let (_, table_metadata_manager, table_name, table_info, region_routes, options) =
+            create_dropped_physical_table_metadata(
+                table_id,
+                table_name,
+                vec![
+                    test_physical_region_route(table_id, 1, 1, vec![5]),
+                    test_physical_region_route(table_id, 2, 2, vec![4]),
+                    test_physical_region_route(table_id, 3, 3, vec![]),
+                ],
+                create_mixed_region_wal_options(),
             )
-            .await
-            .unwrap();
-        let table_route_value = table_metadata_manager
-            .table_route_manager
-            .table_route_storage()
-            .get_with_raw_bytes(table_id)
-            .await
-            .unwrap()
-            .unwrap();
-        let region_routes = table_route_value.region_routes().unwrap();
-        let table_name = TableName::new(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, table_name);
-        let table_route_value = TableRouteValue::physical(region_routes.clone());
-
-        table_metadata_manager
-            .delete_table_metadata(table_id, &table_name, &table_route_value, &options)
-            .await
-            .unwrap();
+            .await;
 
         let dropped_tables = table_metadata_manager.list_dropped_tables().await.unwrap();
         assert_eq!(dropped_tables.len(), 1);
@@ -2924,104 +2976,64 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(dropped_table.table_id, table_id);
-        assert_eq!(dropped_table.table_name, table_name);
-        assert_eq!(dropped_table.table_info_value.table_info, table_info);
-        assert_eq!(
-            dropped_table.table_route_value.region_routes().unwrap(),
-            region_routes
+        assert_dropped_table_metadata(
+            &dropped_table,
+            table_id,
+            &table_name,
+            &table_info,
+            &region_routes,
+            &options,
         );
-        assert_eq!(dropped_table.region_wal_options, options);
 
         let dropped_table_by_id = table_metadata_manager
             .get_dropped_table_by_id(table_id)
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(dropped_table_by_id.table_id, table_id);
-        assert_eq!(dropped_table_by_id.table_name, table_name);
-        assert_eq!(dropped_table_by_id.table_info_value.table_info, table_info);
-        assert_eq!(
-            dropped_table_by_id
-                .table_route_value
-                .region_routes()
-                .unwrap(),
-            region_routes
+        assert_dropped_table_metadata(
+            &dropped_table_by_id,
+            table_id,
+            &table_name,
+            &table_info,
+            &region_routes,
+            &options,
         );
-        assert_eq!(dropped_table_by_id.region_wal_options, options);
     }
 
     #[tokio::test]
     async fn test_dropped_table_lookup_survives_live_name_recreation() {
-        let mem_kv = Arc::new(MemoryKvBackend::default());
-        let table_metadata_manager = TableMetadataManager::new(mem_kv.clone());
         let dropped_table_id = 1025;
         let recreated_table_id = 1026;
         let table_name = "foo";
-        let dropped_task = test_create_table_task(table_name, dropped_table_id);
-        let dropped_table_info = dropped_task.table_info.clone();
-        let options = create_mock_region_wal_options();
-        let serialized_options = options.clone();
-        table_metadata_manager
-            .create_table_metadata(
-                dropped_table_info.clone(),
-                TableRouteValue::physical(vec![
-                    RegionRoute {
-                        region: Region::new_test(RegionId::new(dropped_table_id, 1)),
-                        leader_peer: Some(Peer::empty(1)),
-                        follower_peers: vec![Peer::empty(5)],
-                        leader_state: None,
-                        leader_down_since: None,
-                        write_route_policy: None,
-                    },
-                    RegionRoute {
-                        region: Region::new_test(RegionId::new(dropped_table_id, 2)),
-                        leader_peer: Some(Peer::empty(2)),
-                        follower_peers: vec![Peer::empty(4)],
-                        leader_state: None,
-                        leader_down_since: None,
-                        write_route_policy: None,
-                    },
-                ]),
-                serialized_options.clone(),
-            )
-            .await
-            .unwrap();
-
-        let dropped_table_name =
-            TableName::new(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, table_name);
-        let dropped_table_route = table_metadata_manager
-            .table_route_manager
-            .table_route_storage()
-            .get_with_raw_bytes(dropped_table_id)
-            .await
-            .unwrap()
-            .unwrap();
-        let dropped_table_route =
-            TableRouteValue::physical(dropped_table_route.region_routes().unwrap().clone());
-        table_metadata_manager
-            .delete_table_metadata(
-                dropped_table_id,
-                &dropped_table_name,
-                &dropped_table_route,
-                &options,
-            )
-            .await
-            .unwrap();
+        let (
+            _,
+            table_metadata_manager,
+            dropped_table_name,
+            dropped_table_info,
+            region_routes,
+            options,
+        ) = create_dropped_physical_table_metadata(
+            dropped_table_id,
+            table_name,
+            vec![
+                test_physical_region_route(dropped_table_id, 1, 1, vec![5]),
+                test_physical_region_route(dropped_table_id, 2, 2, vec![4]),
+            ],
+            create_mock_region_wal_options(),
+        )
+        .await;
 
         let recreated_task = test_create_table_task(table_name, recreated_table_id);
         table_metadata_manager
             .create_table_metadata(
                 recreated_task.table_info,
-                TableRouteValue::physical(vec![RegionRoute {
-                    region: Region::new_test(RegionId::new(recreated_table_id, 1)),
-                    leader_peer: Some(Peer::empty(4)),
-                    follower_peers: vec![],
-                    leader_state: None,
-                    leader_down_since: None,
-                    write_route_policy: None,
-                }]),
-                serialized_options,
+                TableRouteValue::physical(vec![test_physical_region_route(
+                    recreated_table_id,
+                    1,
+                    4,
+                    vec![],
+                )]),
+                HashMap::new(),
             )
             .await
             .unwrap();
@@ -3042,11 +3054,13 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(dropped_table.table_id, dropped_table_id);
-        assert_eq!(dropped_table.table_name, dropped_table_name);
-        assert_eq!(
-            dropped_table.table_info_value.table_info,
-            dropped_table_info
+        assert_dropped_table_metadata(
+            &dropped_table,
+            dropped_table_id,
+            &dropped_table_name,
+            &dropped_table_info,
+            &region_routes,
+            &options,
         );
 
         let dropped_tables = table_metadata_manager.list_dropped_tables().await.unwrap();
@@ -3057,55 +3071,19 @@ mod tests {
 
     #[tokio::test]
     async fn test_dropped_table_lookup_ignores_unrelated_malformed_datanode_tombstones() {
-        let mem_kv = Arc::new(MemoryKvBackend::default());
-        let table_metadata_manager = TableMetadataManager::new(mem_kv.clone());
         let table_id = 1025;
         let table_name = "foo";
-        let task = test_create_table_task(table_name, table_id);
-        let table_info = task.table_info.clone();
-        let options = create_mixed_region_wal_options();
-        let serialized_options = options.clone();
-        table_metadata_manager
-            .create_table_metadata(
-                table_info.clone(),
-                TableRouteValue::physical(vec![
-                    RegionRoute {
-                        region: Region::new_test(RegionId::new(table_id, 1)),
-                        leader_peer: Some(Peer::empty(1)),
-                        follower_peers: vec![Peer::empty(5)],
-                        leader_state: None,
-                        leader_down_since: None,
-                        write_route_policy: None,
-                    },
-                    RegionRoute {
-                        region: Region::new_test(RegionId::new(table_id, 2)),
-                        leader_peer: Some(Peer::empty(2)),
-                        follower_peers: vec![Peer::empty(4)],
-                        leader_state: None,
-                        leader_down_since: None,
-                        write_route_policy: None,
-                    },
-                ]),
-                serialized_options,
+        let (mem_kv, table_metadata_manager, table_name, table_info, region_routes, options) =
+            create_dropped_physical_table_metadata(
+                table_id,
+                table_name,
+                vec![
+                    test_physical_region_route(table_id, 1, 1, vec![5]),
+                    test_physical_region_route(table_id, 2, 2, vec![4]),
+                ],
+                create_mixed_region_wal_options(),
             )
-            .await
-            .unwrap();
-
-        let table_route_value = table_metadata_manager
-            .table_route_manager
-            .table_route_storage()
-            .get_with_raw_bytes(table_id)
-            .await
-            .unwrap()
-            .unwrap();
-        let region_routes = table_route_value.region_routes().unwrap();
-        let table_name = TableName::new(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, table_name);
-        let table_route_value = TableRouteValue::physical(region_routes.clone());
-
-        table_metadata_manager
-            .delete_table_metadata(table_id, &table_name, &table_route_value, &options)
-            .await
-            .unwrap();
+            .await;
 
         mem_kv
             .put(
@@ -3121,10 +3099,14 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(dropped_table.table_id, table_id);
-        assert_eq!(dropped_table.table_name, table_name);
-        assert_eq!(dropped_table.table_info_value.table_info, table_info);
-        assert_eq!(dropped_table.region_wal_options, options);
+        assert_dropped_table_metadata(
+            &dropped_table,
+            table_id,
+            &table_name,
+            &table_info,
+            &region_routes,
+            &options,
+        );
     }
 
     #[tokio::test]

--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -1155,7 +1155,10 @@ impl TableMetadataManager {
         table_route_value: &TableRouteValue,
     ) -> Result<HashMap<RegionNumber, WalOptions>> {
         let mut region_wal_options = HashMap::new();
-        let datanode_table_keys = region_distribution(table_route_value.region_routes()?)
+        let Some(region_routes) = table_route_value.region_routes().ok() else {
+            return Ok(region_wal_options);
+        };
+        let datanode_table_keys = region_distribution(region_routes)
             .into_keys()
             .map(|datanode_id| DatanodeTableKey::new(datanode_id, table_id))
             .collect::<Vec<_>>();

--- a/src/common/meta/src/key/tombstone.rs
+++ b/src/common/meta/src/key/tombstone.rs
@@ -299,7 +299,16 @@ impl TombstoneManager {
         } else {
             MOVE_VALUE_TXN_OPS_PER_KEY
         };
-        let chunk_size = (self.max_txn_ops() / txn_ops_per_key).max(1);
+        let max_txn_ops = self.max_txn_ops();
+        ensure!(
+            max_txn_ops >= txn_ops_per_key,
+            error::UnexpectedSnafu {
+                err_msg: format!(
+                    "max_txn_ops {max_txn_ops} is smaller than required txn ops per key {txn_ops_per_key}"
+                )
+            }
+        );
+        let chunk_size = max_txn_ops / txn_ops_per_key;
         if keys.len() > chunk_size {
             debug!(
                 "Moving values with multiple chunks, keys len: {}, chunk_size: {}",
@@ -761,6 +770,33 @@ mod tests {
             .unwrap();
 
         assert_eq!(kvs.len(), restored);
+    }
+
+    #[tokio::test]
+    async fn test_restore_fails_fast_when_txn_op_limit_too_small() {
+        let inner = Arc::new(MemoryKvBackend::default());
+        let kv_backend = Arc::new(TxnOpLimitKvBackend {
+            inner: inner.clone(),
+            max_txn_ops: 5,
+        });
+        let tombstone_manager = TombstoneManager::new(kv_backend);
+        let key = b"foo".to_vec();
+        inner
+            .put(
+                PutRequest::new()
+                    .with_key(tombstone_manager.to_tombstone(&key))
+                    .with_value(b"hi".to_vec()),
+            )
+            .await
+            .unwrap();
+
+        let err = tombstone_manager.restore(vec![key]).await.unwrap_err();
+
+        assert!(matches!(err, Error::Unexpected { .. }));
+        assert!(
+            err.to_string()
+                .contains("max_txn_ops 5 is smaller than required txn ops per key 6")
+        );
     }
 
     #[tokio::test]

--- a/src/common/meta/src/key/tombstone.rs
+++ b/src/common/meta/src/key/tombstone.rs
@@ -155,23 +155,40 @@ impl TombstoneManager {
         src_key: Vec<u8>,
         value: Vec<u8>,
         dest_key: Vec<u8>,
-    ) -> (Txn, impl FnMut(&mut TxnOpGetResponseSet) -> Option<Vec<u8>>) {
-        let txn = Txn::new()
-            .when(vec![Compare::with_value(
-                src_key.clone(),
+        require_dest_not_exists: bool,
+    ) -> Txn {
+        let mut compares = vec![Compare::with_value(
+            src_key.clone(),
+            CompareOp::Equal,
+            value.clone(),
+        )];
+        if require_dest_not_exists {
+            compares.push(Compare::with_value_not_exists(
+                dest_key.clone(),
                 CompareOp::Equal,
-                value.clone(),
-            )])
+            ));
+        }
+
+        let mut failure = vec![TxnOp::Get(src_key.clone())];
+        if require_dest_not_exists {
+            failure.push(TxnOp::Get(dest_key.clone()));
+        }
+
+        Txn::new()
+            .when(compares)
             .and_then(vec![
                 TxnOp::Put(dest_key.clone(), value.clone()),
                 TxnOp::Delete(src_key.clone()),
             ])
-            .or_else(vec![TxnOp::Get(src_key.clone())]);
-
-        (txn, TxnOpGetResponseSet::filter(src_key))
+            .or_else(failure)
     }
 
-    async fn move_values_inner(&self, keys: &[Vec<u8>], dest_keys: &[Vec<u8>]) -> Result<usize> {
+    async fn move_values_inner(
+        &self,
+        keys: &[Vec<u8>],
+        dest_keys: &[Vec<u8>],
+        require_dest_not_exists: bool,
+    ) -> Result<usize> {
         ensure!(
             keys.len() == dest_keys.len(),
             error::UnexpectedSnafu {
@@ -197,15 +214,16 @@ impl TombstoneManager {
 
         const MAX_RETRIES: usize = 8;
         for _ in 0..MAX_RETRIES {
-            let (txns, (keys, filters)): (Vec<_>, (Vec<_>, Vec<_>)) = results
+            let (txns, keys): (Vec<_>, Vec<_>) = results
                 .iter()
                 .map(|(key, value)| {
-                    let (txn, filter) = self.build_move_value_txn(
+                    let txn = self.build_move_value_txn(
                         key.clone(),
                         value.clone(),
                         lookup_table[&key].clone(),
+                        require_dest_not_exists,
                     );
-                    (txn, (key.clone(), filter))
+                    (txn, key.clone())
                 })
                 .unzip();
             let mut resp = self.kv_backend.txn(Txn::merge_all(txns)).await?;
@@ -214,11 +232,23 @@ impl TombstoneManager {
             }
             let mut set = TxnOpGetResponseSet::from(&mut resp.responses);
             // Updates results.
-            for (idx, mut filter) in filters.into_iter().enumerate() {
+            for key in &keys {
+                let dest_key = lookup_table[&key].clone();
+                if require_dest_not_exists {
+                    let mut filter = TxnOpGetResponseSet::filter(dest_key.clone());
+                    if filter(&mut set).is_some() {
+                        return error::TombstoneTargetAlreadyExistsSnafu {
+                            key: String::from_utf8_lossy(&dest_key).to_string(),
+                        }
+                        .fail();
+                    }
+                }
+
+                let mut filter = TxnOpGetResponseSet::filter(key.clone());
                 if let Some(value) = filter(&mut set) {
-                    results.insert(keys[idx].clone(), value);
+                    results.insert(key.clone(), value);
                 } else {
-                    results.remove(&keys[idx]);
+                    results.remove(key);
                 }
             }
         }
@@ -243,7 +273,12 @@ impl TombstoneManager {
     /// Moves values to `dest_key`.
     ///
     /// Returns the number of keys that were moved.
-    async fn move_values(&self, keys: Vec<Vec<u8>>, dest_keys: Vec<Vec<u8>>) -> Result<usize> {
+    async fn move_values(
+        &self,
+        keys: Vec<Vec<u8>>,
+        dest_keys: Vec<Vec<u8>>,
+        require_dest_not_exists: bool,
+    ) -> Result<usize> {
         ensure!(
             keys.len() == dest_keys.len(),
             error::UnexpectedSnafu {
@@ -268,11 +303,14 @@ impl TombstoneManager {
             let keys_chunks = keys.chunks(chunk_size).collect::<Vec<_>>();
             let dest_keys_chunks = dest_keys.chunks(chunk_size).collect::<Vec<_>>();
             for (keys, dest_keys) in keys_chunks.into_iter().zip(dest_keys_chunks) {
-                moved_keys += self.move_values_inner(keys, dest_keys).await?;
+                moved_keys += self
+                    .move_values_inner(keys, dest_keys, require_dest_not_exists)
+                    .await?;
             }
             Ok(moved_keys)
         } else {
-            self.move_values_inner(&keys, &dest_keys).await
+            self.move_values_inner(&keys, &dest_keys, require_dest_not_exists)
+                .await
         }
     }
 
@@ -292,7 +330,7 @@ impl TombstoneManager {
             })
             .unzip();
 
-        self.move_values(keys, dest_keys).await
+        self.move_values(keys, dest_keys, false).await
     }
 
     /// Restores tombstones for keys.
@@ -311,7 +349,7 @@ impl TombstoneManager {
             })
             .unzip();
 
-        self.move_values(keys, dest_keys).await
+        self.move_values(keys, dest_keys, true).await
     }
 
     /// Deletes tombstones values for the specified `keys`.
@@ -547,14 +585,14 @@ mod tests {
             .map(|kv| (kv.key, kv.dest_key))
             .unzip();
         let moved_keys = tombstone_manager
-            .move_values(keys.clone(), dest_keys.clone())
+            .move_values(keys.clone(), dest_keys.clone(), false)
             .await
             .unwrap();
         assert_eq!(kvs.len(), moved_keys);
         check_moved_values(kv_backend.clone(), &move_values).await;
         // Moves again
         let moved_keys = tombstone_manager
-            .move_values(keys.clone(), dest_keys.clone())
+            .move_values(keys.clone(), dest_keys.clone(), false)
             .await
             .unwrap();
         assert_eq!(0, moved_keys);
@@ -602,14 +640,14 @@ mod tests {
             .map(|kv| (kv.key, kv.dest_key))
             .unzip();
         let moved_keys = tombstone_manager
-            .move_values(keys.clone(), dest_keys.clone())
+            .move_values(keys.clone(), dest_keys.clone(), false)
             .await
             .unwrap();
         assert_eq!(kvs.len(), moved_keys);
         check_moved_values(kv_backend.clone(), &move_values).await;
         // Moves again
         let moved_keys = tombstone_manager
-            .move_values(keys.clone(), dest_keys.clone())
+            .move_values(keys.clone(), dest_keys.clone(), false)
             .await
             .unwrap();
         assert_eq!(0, moved_keys);
@@ -651,14 +689,14 @@ mod tests {
         keys.push(b"non-exists".to_vec());
         dest_keys.push(b"hi/non-exists".to_vec());
         let moved_keys = tombstone_manager
-            .move_values(keys.clone(), dest_keys.clone())
+            .move_values(keys.clone(), dest_keys.clone(), false)
             .await
             .unwrap();
         check_moved_values(kv_backend.clone(), &move_values).await;
         assert_eq!(3, moved_keys);
         // Moves again
         let moved_keys = tombstone_manager
-            .move_values(keys.clone(), dest_keys.clone())
+            .move_values(keys.clone(), dest_keys.clone(), false)
             .await
             .unwrap();
         check_moved_values(kv_backend.clone(), &move_values).await;
@@ -704,7 +742,7 @@ mod tests {
             .map(|kv| (kv.key, kv.dest_key))
             .unzip();
         let moved_keys = tombstone_manager
-            .move_values(keys, dest_keys)
+            .move_values(keys, dest_keys, false)
             .await
             .unwrap();
         assert_eq!(kvs.len(), moved_keys);
@@ -745,7 +783,7 @@ mod tests {
             .map(|kv| (kv.key, kv.dest_key))
             .unzip();
         tombstone_manager
-            .move_values(keys, dest_keys)
+            .move_values(keys, dest_keys, false)
             .await
             .unwrap();
         check_moved_values(kv_backend.clone(), &move_values).await;
@@ -780,7 +818,7 @@ mod tests {
             .map(|kv| (kv.key, kv.dest_key))
             .unzip();
         tombstone_manager
-            .move_values(keys, dest_keys)
+            .move_values(keys, dest_keys, false)
             .await
             .unwrap();
         check_moved_values(kv_backend.clone(), &move_values).await;
@@ -795,7 +833,7 @@ mod tests {
         let dest_keys = vec![b"bar".to_vec(), b"foo".to_vec(), b"baz".to_vec()];
 
         let err = tombstone_manager
-            .move_values(keys, dest_keys)
+            .move_values(keys, dest_keys, false)
             .await
             .unwrap_err();
         assert!(
@@ -803,7 +841,10 @@ mod tests {
                 .contains("The length of keys(2) does not match the length of dest_keys(3)."),
         );
 
-        let moved_keys = tombstone_manager.move_values(vec![], vec![]).await.unwrap();
+        let moved_keys = tombstone_manager
+            .move_values(vec![], vec![], false)
+            .await
+            .unwrap();
         assert_eq!(0, moved_keys);
     }
 }

--- a/src/common/meta/src/key/tombstone.rs
+++ b/src/common/meta/src/key/tombstone.rs
@@ -59,6 +59,8 @@ pub struct TombstoneManager {
 }
 
 const TOMBSTONE_PREFIX: &str = "__tombstone/";
+const MOVE_VALUE_TXN_OPS_PER_KEY: usize = 4;
+const RESTORE_VALUE_TXN_OPS_PER_KEY: usize = 6;
 
 impl TombstoneManager {
     /// Returns [TombstoneManager].
@@ -292,7 +294,12 @@ impl TombstoneManager {
         if keys.is_empty() {
             return Ok(0);
         }
-        let chunk_size = self.max_txn_ops() / 2;
+        let txn_ops_per_key = if require_dest_not_exists {
+            RESTORE_VALUE_TXN_OPS_PER_KEY
+        } else {
+            MOVE_VALUE_TXN_OPS_PER_KEY
+        };
+        let chunk_size = (self.max_txn_ops() / txn_ops_per_key).max(1);
         if keys.len() > chunk_size {
             debug!(
                 "Moving values with multiple chunks, keys len: {}, chunk_size: {}",
@@ -374,14 +381,84 @@ impl TombstoneManager {
 #[cfg(test)]
 mod tests {
 
+    use std::any::Any;
     use std::collections::HashMap;
     use std::sync::Arc;
 
-    use crate::error::Error;
+    use crate::error::{Error, Result};
     use crate::key::tombstone::TombstoneManager;
-    use crate::kv_backend::KvBackend;
     use crate::kv_backend::memory::MemoryKvBackend;
-    use crate::rpc::store::PutRequest;
+    use crate::kv_backend::txn::{Txn, TxnRequest, TxnResponse};
+    use crate::kv_backend::{KvBackend, TxnService};
+    use crate::rpc::store::{
+        BatchDeleteRequest, BatchDeleteResponse, BatchGetRequest, BatchGetResponse,
+        BatchPutRequest, BatchPutResponse, DeleteRangeRequest, DeleteRangeResponse, PutRequest,
+        PutResponse, RangeRequest, RangeResponse,
+    };
+
+    struct TxnOpLimitKvBackend {
+        inner: Arc<MemoryKvBackend<Error>>,
+        max_txn_ops: usize,
+    }
+
+    #[async_trait::async_trait]
+    impl TxnService for TxnOpLimitKvBackend {
+        type Error = Error;
+
+        async fn txn(&self, txn: Txn) -> Result<TxnResponse> {
+            let TxnRequest {
+                compare,
+                success,
+                failure,
+            } = txn.req();
+            let txn_ops = compare.len() + success.len() + failure.len();
+            assert!(
+                txn_ops <= self.max_txn_ops,
+                "txn ops {txn_ops} exceeds limit {}",
+                self.max_txn_ops
+            );
+            self.inner.txn(txn).await
+        }
+
+        fn max_txn_ops(&self) -> usize {
+            self.max_txn_ops
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl KvBackend for TxnOpLimitKvBackend {
+        fn name(&self) -> &str {
+            "txn_op_limit"
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        async fn range(&self, req: RangeRequest) -> Result<RangeResponse> {
+            self.inner.range(req).await
+        }
+
+        async fn put(&self, req: PutRequest) -> Result<PutResponse> {
+            self.inner.put(req).await
+        }
+
+        async fn batch_put(&self, req: BatchPutRequest) -> Result<BatchPutResponse> {
+            self.inner.batch_put(req).await
+        }
+
+        async fn batch_get(&self, req: BatchGetRequest) -> Result<BatchGetResponse> {
+            self.inner.batch_get(req).await
+        }
+
+        async fn delete_range(&self, req: DeleteRangeRequest) -> Result<DeleteRangeResponse> {
+            self.inner.delete_range(req).await
+        }
+
+        async fn batch_delete(&self, req: BatchDeleteRequest) -> Result<BatchDeleteResponse> {
+            self.inner.batch_delete(req).await
+        }
+    }
 
     #[derive(Debug, Clone)]
     struct MoveValue {
@@ -652,6 +729,70 @@ mod tests {
             .unwrap();
         assert_eq!(0, moved_keys);
         check_moved_values(kv_backend.clone(), &move_values).await;
+    }
+
+    #[tokio::test]
+    async fn test_restore_chunks_by_total_txn_ops_limit() {
+        let inner = Arc::new(MemoryKvBackend::default());
+        let kv_backend = Arc::new(TxnOpLimitKvBackend {
+            inner: inner.clone(),
+            max_txn_ops: 6,
+        });
+        let tombstone_manager = TombstoneManager::new(kv_backend);
+        let kvs = HashMap::from([
+            (b"bar".to_vec(), b"baz".to_vec()),
+            (b"foo".to_vec(), b"hi".to_vec()),
+            (b"baz".to_vec(), b"hello".to_vec()),
+        ]);
+        for (key, value) in &kvs {
+            inner
+                .put(
+                    PutRequest::new()
+                        .with_key(tombstone_manager.to_tombstone(key))
+                        .with_value(value.clone()),
+                )
+                .await
+                .unwrap();
+        }
+
+        let restored = tombstone_manager
+            .restore(kvs.keys().cloned().collect())
+            .await
+            .unwrap();
+
+        assert_eq!(kvs.len(), restored);
+    }
+
+    #[tokio::test]
+    async fn test_create_chunks_by_total_txn_ops_limit() {
+        let inner = Arc::new(MemoryKvBackend::default());
+        let kv_backend = Arc::new(TxnOpLimitKvBackend {
+            inner: inner.clone(),
+            max_txn_ops: 4,
+        });
+        let tombstone_manager = TombstoneManager::new(kv_backend);
+        let kvs = HashMap::from([
+            (b"bar".to_vec(), b"baz".to_vec()),
+            (b"foo".to_vec(), b"hi".to_vec()),
+            (b"baz".to_vec(), b"hello".to_vec()),
+        ]);
+        for (key, value) in &kvs {
+            inner
+                .put(
+                    PutRequest::new()
+                        .with_key(key.clone())
+                        .with_value(value.clone()),
+                )
+                .await
+                .unwrap();
+        }
+
+        let moved = tombstone_manager
+            .create(kvs.keys().cloned().collect())
+            .await
+            .unwrap();
+
+        assert_eq!(kvs.len(), moved);
     }
 
     #[tokio::test]

--- a/src/common/meta/src/rpc/ddl.rs
+++ b/src/common/meta/src/rpc/ddl.rs
@@ -1949,6 +1949,36 @@ mod tests {
     }
 
     #[test]
+    fn test_undrop_table_task_json_roundtrip() {
+        let task = UndropTableTask {
+            catalog: "greptime".to_string(),
+            schema: "public".to_string(),
+            table: "foo".to_string(),
+            table_id: 1024,
+        };
+
+        let output = serde_json::to_vec(&task).unwrap();
+
+        let de = serde_json::from_slice(&output).unwrap();
+        assert_eq!(task, de);
+    }
+
+    #[test]
+    fn test_purge_dropped_table_task_json_roundtrip() {
+        let task = PurgeDroppedTableTask {
+            catalog: "greptime".to_string(),
+            schema: "public".to_string(),
+            table: "foo".to_string(),
+            table_id: Some(1024),
+        };
+
+        let output = serde_json::to_vec(&task).unwrap();
+
+        let de = serde_json::from_slice(&output).unwrap();
+        assert_eq!(task, de);
+    }
+
+    #[test]
     fn test_sort_columns() {
         // construct RawSchema
         let schema = Arc::new(Schema::new(vec![

--- a/src/common/meta/src/rpc/ddl.rs
+++ b/src/common/meta/src/rpc/ddl.rs
@@ -669,7 +669,6 @@ impl From<PurgeDroppedTableTask> for PbPurgeDroppedTableTask {
     fn from(task: PurgeDroppedTableTask) -> Self {
         Self {
             table_id: Some(api::v1::TableId { id: task.table_id }),
-            ..Default::default()
         }
     }
 }

--- a/src/common/meta/src/rpc/ddl.rs
+++ b/src/common/meta/src/rpc/ddl.rs
@@ -31,7 +31,8 @@ use api::v1::meta::{
     DdlTaskResponse as PbDdlTaskResponse, DropDatabaseTask as PbDropDatabaseTask,
     DropFlowTask as PbDropFlowTask, DropTableTask as PbDropTableTask,
     DropTableTasks as PbDropTableTasks, DropViewTask as PbDropViewTask, Partition, ProcedureId,
-    TruncateTableTask as PbTruncateTableTask,
+    PurgeDroppedTableTask as PbPurgeDroppedTableTask, TruncateTableTask as PbTruncateTableTask,
+    UndropTableTask as PbUndropTableTask,
 };
 use api::v1::{
     AlterDatabaseExpr, AlterTableExpr, CommentObjectType as PbCommentObjectType, CommentOnExpr,
@@ -71,6 +72,8 @@ pub const ORIGIN_FRONTEND_ADDR_EXTENSION_KEY: &str = "__greptime_origin_frontend
 pub enum DdlTask {
     CreateTable(CreateTableTask),
     DropTable(DropTableTask),
+    UndropTable(UndropTableTask),
+    PurgeDroppedTable(PurgeDroppedTableTask),
     AlterTable(AlterTableTask),
     TruncateTable(TruncateTableTask),
     CreateLogicalTables(Vec<CreateTableTask>),
@@ -152,6 +155,36 @@ impl DdlTask {
         })
     }
 
+    /// Creates a [`DdlTask`] to undrop a table.
+    pub fn new_undrop_table(
+        catalog: String,
+        schema: String,
+        table: String,
+        table_id: TableId,
+    ) -> Self {
+        DdlTask::UndropTable(UndropTableTask {
+            catalog,
+            schema,
+            table,
+            table_id,
+        })
+    }
+
+    /// Creates a [`DdlTask`] to purge a dropped table.
+    pub fn new_purge_dropped_table(
+        catalog: String,
+        schema: String,
+        table: String,
+        table_id: Option<TableId>,
+    ) -> Self {
+        DdlTask::PurgeDroppedTable(PurgeDroppedTableTask {
+            catalog,
+            schema,
+            table,
+            table_id,
+        })
+    }
+
     /// Creates a [`DdlTask`] to create a database.
     pub fn new_create_database(
         catalog: String,
@@ -225,6 +258,12 @@ impl TryFrom<Task> for DdlTask {
                 Ok(DdlTask::CreateTable(create_table.try_into()?))
             }
             Task::DropTableTask(drop_table) => Ok(DdlTask::DropTable(drop_table.try_into()?)),
+            Task::UndropTableTask(undrop_table) => {
+                Ok(DdlTask::UndropTable(undrop_table.try_into()?))
+            }
+            Task::PurgeDroppedTableTask(purge_dropped_table) => {
+                Ok(DdlTask::PurgeDroppedTable(purge_dropped_table.into()))
+            }
             Task::AlterTableTask(alter_table) => Ok(DdlTask::AlterTable(alter_table.try_into()?)),
             Task::TruncateTableTask(truncate_table) => {
                 Ok(DdlTask::TruncateTable(truncate_table.try_into()?))
@@ -335,6 +374,8 @@ impl TryFrom<SubmitDdlTaskRequest> for PbDdlTaskRequest {
         let task = match request.task {
             DdlTask::CreateTable(task) => Task::CreateTableTask(task.try_into()?),
             DdlTask::DropTable(task) => Task::DropTableTask(task.into()),
+            DdlTask::UndropTable(task) => Task::UndropTableTask(task.into()),
+            DdlTask::PurgeDroppedTable(task) => Task::PurgeDroppedTableTask(task.into()),
             DdlTask::AlterTable(task) => Task::AlterTableTask(task.try_into()?),
             DdlTask::TruncateTable(task) => Task::TruncateTableTask(task.try_into()?),
             DdlTask::CreateLogicalTables(tasks) => {
@@ -594,6 +635,109 @@ pub struct DropTableTask {
     pub table_id: TableId,
     #[serde(default)]
     pub drop_if_exists: bool,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub struct UndropTableTask {
+    pub catalog: String,
+    pub schema: String,
+    pub table: String,
+    pub table_id: TableId,
+}
+
+impl UndropTableTask {
+    pub fn table_ref(&self) -> TableReference<'_> {
+        TableReference {
+            catalog: &self.catalog,
+            schema: &self.schema,
+            table: &self.table,
+        }
+    }
+
+    pub fn table_name(&self) -> TableName {
+        TableName {
+            catalog_name: self.catalog.clone(),
+            schema_name: self.schema.clone(),
+            table_name: self.table.clone(),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub struct PurgeDroppedTableTask {
+    pub catalog: String,
+    pub schema: String,
+    pub table: String,
+    pub table_id: Option<TableId>,
+}
+
+impl PurgeDroppedTableTask {
+    pub fn table_ref(&self) -> TableReference<'_> {
+        TableReference {
+            catalog: &self.catalog,
+            schema: &self.schema,
+            table: &self.table,
+        }
+    }
+
+    pub fn table_name(&self) -> TableName {
+        TableName {
+            catalog_name: self.catalog.clone(),
+            schema_name: self.schema.clone(),
+            table_name: self.table.clone(),
+        }
+    }
+}
+
+impl TryFrom<PbUndropTableTask> for UndropTableTask {
+    type Error = error::Error;
+
+    fn try_from(pb: PbUndropTableTask) -> Result<Self> {
+        Ok(Self {
+            catalog: pb.catalog_name,
+            schema: pb.schema_name,
+            table: pb.table_name,
+            table_id: pb
+                .table_id
+                .context(error::InvalidProtoMsgSnafu {
+                    err_msg: "expected table_id",
+                })?
+                .id,
+        })
+    }
+}
+
+impl From<UndropTableTask> for PbUndropTableTask {
+    fn from(task: UndropTableTask) -> Self {
+        Self {
+            catalog_name: task.catalog,
+            schema_name: task.schema,
+            table_name: task.table,
+            table_id: Some(api::v1::TableId { id: task.table_id }),
+        }
+    }
+}
+
+impl From<PbPurgeDroppedTableTask> for PurgeDroppedTableTask {
+    fn from(pb: PbPurgeDroppedTableTask) -> Self {
+        Self {
+            catalog: pb.catalog_name,
+            schema: pb.schema_name,
+            table: pb.table_name,
+            table_id: pb.table_id.map(|table_id| table_id.id),
+        }
+    }
+}
+
+impl From<PurgeDroppedTableTask> for PbPurgeDroppedTableTask {
+    fn from(task: PurgeDroppedTableTask) -> Self {
+        Self {
+            catalog_name: task.catalog,
+            schema_name: task.schema,
+            table_name: task.table,
+            table_id: task.table_id.map(|id| api::v1::TableId { id }),
+        }
+    }
 }
 
 impl DropTableTask {
@@ -1762,6 +1906,46 @@ mod tests {
 
         let de = serde_json::from_slice(&output).unwrap();
         assert_eq!(task, de);
+    }
+
+    #[test]
+    fn test_undrop_table_task_pb_roundtrip() {
+        let expected = UndropTableTask {
+            catalog: "greptime".to_string(),
+            schema: "public".to_string(),
+            table: "foo".to_string(),
+            table_id: 1024,
+        };
+        let request = SubmitDdlTaskRequest::new(
+            QueryContext::default(),
+            DdlTask::UndropTable(expected.clone()),
+        );
+
+        let pb = PbDdlTaskRequest::try_from(request).unwrap();
+        let pb_task = pb.task.unwrap();
+        let de = DdlTask::try_from(pb_task).unwrap();
+
+        assert!(matches!(de, DdlTask::UndropTable(task) if task == expected));
+    }
+
+    #[test]
+    fn test_purge_dropped_table_task_pb_roundtrip() {
+        let expected = PurgeDroppedTableTask {
+            catalog: "greptime".to_string(),
+            schema: "public".to_string(),
+            table: "foo".to_string(),
+            table_id: Some(1024),
+        };
+        let request = SubmitDdlTaskRequest::new(
+            QueryContext::default(),
+            DdlTask::PurgeDroppedTable(expected.clone()),
+        );
+
+        let pb = PbDdlTaskRequest::try_from(request).unwrap();
+        let pb_task = pb.task.unwrap();
+        let de = DdlTask::try_from(pb_task).unwrap();
+
+        assert!(matches!(de, DdlTask::PurgeDroppedTable(task) if task == expected));
     }
 
     #[test]

--- a/src/common/meta/src/rpc/ddl.rs
+++ b/src/common/meta/src/rpc/ddl.rs
@@ -161,18 +161,8 @@ impl DdlTask {
     }
 
     /// Creates a [`DdlTask`] to purge a dropped table.
-    pub fn new_purge_dropped_table(
-        catalog: String,
-        schema: String,
-        table: String,
-        table_id: Option<TableId>,
-    ) -> Self {
-        DdlTask::PurgeDroppedTable(PurgeDroppedTableTask {
-            catalog,
-            schema,
-            table,
-            table_id,
-        })
+    pub fn new_purge_dropped_table(table_id: TableId) -> Self {
+        DdlTask::PurgeDroppedTable(PurgeDroppedTableTask { table_id })
     }
 
     /// Creates a [`DdlTask`] to create a database.
@@ -252,7 +242,7 @@ impl TryFrom<Task> for DdlTask {
                 Ok(DdlTask::UndropTable(undrop_table.try_into()?))
             }
             Task::PurgeDroppedTableTask(purge_dropped_table) => {
-                Ok(DdlTask::PurgeDroppedTable(purge_dropped_table.into()))
+                Ok(DdlTask::PurgeDroppedTable(purge_dropped_table.try_into()?))
             }
             Task::AlterTableTask(alter_table) => Ok(DdlTask::AlterTable(alter_table.try_into()?)),
             Task::TruncateTableTask(truncate_table) => {
@@ -634,28 +624,7 @@ pub struct UndropTableTask {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct PurgeDroppedTableTask {
-    pub catalog: String,
-    pub schema: String,
-    pub table: String,
-    pub table_id: Option<TableId>,
-}
-
-impl PurgeDroppedTableTask {
-    pub fn table_ref(&self) -> TableReference<'_> {
-        TableReference {
-            catalog: &self.catalog,
-            schema: &self.schema,
-            table: &self.table,
-        }
-    }
-
-    pub fn table_name(&self) -> TableName {
-        TableName {
-            catalog_name: self.catalog.clone(),
-            schema_name: self.schema.clone(),
-            table_name: self.table.clone(),
-        }
-    }
+    pub table_id: TableId,
 }
 
 impl TryFrom<PbUndropTableTask> for UndropTableTask {
@@ -681,24 +650,26 @@ impl From<UndropTableTask> for PbUndropTableTask {
     }
 }
 
-impl From<PbPurgeDroppedTableTask> for PurgeDroppedTableTask {
-    fn from(pb: PbPurgeDroppedTableTask) -> Self {
-        Self {
-            catalog: pb.catalog_name,
-            schema: pb.schema_name,
-            table: pb.table_name,
-            table_id: pb.table_id.map(|table_id| table_id.id),
-        }
+impl TryFrom<PbPurgeDroppedTableTask> for PurgeDroppedTableTask {
+    type Error = error::Error;
+
+    fn try_from(pb: PbPurgeDroppedTableTask) -> Result<Self> {
+        Ok(Self {
+            table_id: pb
+                .table_id
+                .context(error::InvalidProtoMsgSnafu {
+                    err_msg: "expected table_id",
+                })?
+                .id,
+        })
     }
 }
 
 impl From<PurgeDroppedTableTask> for PbPurgeDroppedTableTask {
     fn from(task: PurgeDroppedTableTask) -> Self {
         Self {
-            catalog_name: task.catalog,
-            schema_name: task.schema,
-            table_name: task.table,
-            table_id: task.table_id.map(|id| api::v1::TableId { id }),
+            table_id: Some(api::v1::TableId { id: task.table_id }),
+            ..Default::default()
         }
     }
 }
@@ -1888,12 +1859,7 @@ mod tests {
 
     #[test]
     fn test_purge_dropped_table_task_pb_roundtrip() {
-        let expected = PurgeDroppedTableTask {
-            catalog: "greptime".to_string(),
-            schema: "public".to_string(),
-            table: "foo".to_string(),
-            table_id: Some(1024),
-        };
+        let expected = PurgeDroppedTableTask { table_id: 1024 };
         let request = SubmitDdlTaskRequest::new(
             QueryContext::default(),
             DdlTask::PurgeDroppedTable(expected.clone()),
@@ -1918,12 +1884,7 @@ mod tests {
 
     #[test]
     fn test_purge_dropped_table_task_json_roundtrip() {
-        let task = PurgeDroppedTableTask {
-            catalog: "greptime".to_string(),
-            schema: "public".to_string(),
-            table: "foo".to_string(),
-            table_id: Some(1024),
-        };
+        let task = PurgeDroppedTableTask { table_id: 1024 };
 
         let output = serde_json::to_vec(&task).unwrap();
 

--- a/src/common/meta/src/rpc/ddl.rs
+++ b/src/common/meta/src/rpc/ddl.rs
@@ -156,18 +156,8 @@ impl DdlTask {
     }
 
     /// Creates a [`DdlTask`] to undrop a table.
-    pub fn new_undrop_table(
-        catalog: String,
-        schema: String,
-        table: String,
-        table_id: TableId,
-    ) -> Self {
-        DdlTask::UndropTable(UndropTableTask {
-            catalog,
-            schema,
-            table,
-            table_id,
-        })
+    pub fn new_undrop_table(table_id: TableId) -> Self {
+        DdlTask::UndropTable(UndropTableTask { table_id })
     }
 
     /// Creates a [`DdlTask`] to purge a dropped table.
@@ -639,28 +629,7 @@ pub struct DropTableTask {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct UndropTableTask {
-    pub catalog: String,
-    pub schema: String,
-    pub table: String,
     pub table_id: TableId,
-}
-
-impl UndropTableTask {
-    pub fn table_ref(&self) -> TableReference<'_> {
-        TableReference {
-            catalog: &self.catalog,
-            schema: &self.schema,
-            table: &self.table,
-        }
-    }
-
-    pub fn table_name(&self) -> TableName {
-        TableName {
-            catalog_name: self.catalog.clone(),
-            schema_name: self.schema.clone(),
-            table_name: self.table.clone(),
-        }
-    }
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
@@ -694,9 +663,6 @@ impl TryFrom<PbUndropTableTask> for UndropTableTask {
 
     fn try_from(pb: PbUndropTableTask) -> Result<Self> {
         Ok(Self {
-            catalog: pb.catalog_name,
-            schema: pb.schema_name,
-            table: pb.table_name,
             table_id: pb
                 .table_id
                 .context(error::InvalidProtoMsgSnafu {
@@ -710,9 +676,6 @@ impl TryFrom<PbUndropTableTask> for UndropTableTask {
 impl From<UndropTableTask> for PbUndropTableTask {
     fn from(task: UndropTableTask) -> Self {
         Self {
-            catalog_name: task.catalog,
-            schema_name: task.schema,
-            table_name: task.table,
             table_id: Some(api::v1::TableId { id: task.table_id }),
         }
     }
@@ -1910,12 +1873,7 @@ mod tests {
 
     #[test]
     fn test_undrop_table_task_pb_roundtrip() {
-        let expected = UndropTableTask {
-            catalog: "greptime".to_string(),
-            schema: "public".to_string(),
-            table: "foo".to_string(),
-            table_id: 1024,
-        };
+        let expected = UndropTableTask { table_id: 1024 };
         let request = SubmitDdlTaskRequest::new(
             QueryContext::default(),
             DdlTask::UndropTable(expected.clone()),
@@ -1950,12 +1908,7 @@ mod tests {
 
     #[test]
     fn test_undrop_table_task_json_roundtrip() {
-        let task = UndropTableTask {
-            catalog: "greptime".to_string(),
-            schema: "public".to_string(),
-            table: "foo".to_string(),
-            table_id: 1024,
-        };
+        let task = UndropTableTask { table_id: 1024 };
 
         let output = serde_json::to_vec(&task).unwrap();
 

--- a/src/common/meta/src/rpc/ddl.rs
+++ b/src/common/meta/src/rpc/ddl.rs
@@ -38,7 +38,7 @@ use api::v1::{
     AlterDatabaseExpr, AlterTableExpr, CommentObjectType as PbCommentObjectType, CommentOnExpr,
     CreateDatabaseExpr, CreateFlowExpr, CreateTableExpr, CreateViewExpr, DropDatabaseExpr,
     DropFlowExpr, DropTableExpr, DropViewExpr, EvalInterval, ExpireAfter, Option as PbOption,
-    PurgeDroppedTableExpr, QueryContext as PbQueryContext, TruncateTableExpr, UndropTableExpr,
+    QueryContext as PbQueryContext, TruncateTableExpr,
 };
 use base64::Engine as _;
 use base64::engine::general_purpose;
@@ -262,7 +262,7 @@ impl TryFrom<Task> for DdlTask {
                 Ok(DdlTask::UndropTable(undrop_table.try_into()?))
             }
             Task::PurgeDroppedTableTask(purge_dropped_table) => {
-                Ok(DdlTask::PurgeDroppedTable(purge_dropped_table.try_into()?))
+                Ok(DdlTask::PurgeDroppedTable(purge_dropped_table.into()))
             }
             Task::AlterTableTask(alter_table) => Ok(DdlTask::AlterTable(alter_table.try_into()?)),
             Task::TruncateTableTask(truncate_table) => {
@@ -693,15 +693,11 @@ impl TryFrom<PbUndropTableTask> for UndropTableTask {
     type Error = error::Error;
 
     fn try_from(pb: PbUndropTableTask) -> Result<Self> {
-        let undrop_table = pb.undrop_table.context(error::InvalidProtoMsgSnafu {
-            err_msg: "expected undrop table",
-        })?;
-
         Ok(Self {
-            catalog: undrop_table.catalog_name,
-            schema: undrop_table.schema_name,
-            table: undrop_table.table_name,
-            table_id: undrop_table
+            catalog: pb.catalog_name,
+            schema: pb.schema_name,
+            table: pb.table_name,
+            table_id: pb
                 .table_id
                 .context(error::InvalidProtoMsgSnafu {
                     err_msg: "expected table_id",
@@ -714,44 +710,32 @@ impl TryFrom<PbUndropTableTask> for UndropTableTask {
 impl From<UndropTableTask> for PbUndropTableTask {
     fn from(task: UndropTableTask) -> Self {
         Self {
-            undrop_table: Some(UndropTableExpr {
-                catalog_name: task.catalog,
-                schema_name: task.schema,
-                table_name: task.table,
-                table_id: Some(api::v1::TableId { id: task.table_id }),
-            }),
+            catalog_name: task.catalog,
+            schema_name: task.schema,
+            table_name: task.table,
+            table_id: Some(api::v1::TableId { id: task.table_id }),
         }
     }
 }
 
-impl TryFrom<PbPurgeDroppedTableTask> for PurgeDroppedTableTask {
-    type Error = error::Error;
-
-    fn try_from(pb: PbPurgeDroppedTableTask) -> Result<Self> {
-        let purge_dropped_table = pb
-            .purge_dropped_table
-            .context(error::InvalidProtoMsgSnafu {
-                err_msg: "expected purge dropped table",
-            })?;
-
-        Ok(Self {
-            catalog: purge_dropped_table.catalog_name,
-            schema: purge_dropped_table.schema_name,
-            table: purge_dropped_table.table_name,
-            table_id: purge_dropped_table.table_id.map(|table_id| table_id.id),
-        })
+impl From<PbPurgeDroppedTableTask> for PurgeDroppedTableTask {
+    fn from(pb: PbPurgeDroppedTableTask) -> Self {
+        Self {
+            catalog: pb.catalog_name,
+            schema: pb.schema_name,
+            table: pb.table_name,
+            table_id: pb.table_id.map(|table_id| table_id.id),
+        }
     }
 }
 
 impl From<PurgeDroppedTableTask> for PbPurgeDroppedTableTask {
     fn from(task: PurgeDroppedTableTask) -> Self {
         Self {
-            purge_dropped_table: Some(PurgeDroppedTableExpr {
-                catalog_name: task.catalog,
-                schema_name: task.schema,
-                table_name: task.table,
-                table_id: task.table_id.map(|id| api::v1::TableId { id }),
-            }),
+            catalog_name: task.catalog,
+            schema_name: task.schema,
+            table_name: task.table,
+            table_id: task.table_id.map(|id| api::v1::TableId { id }),
         }
     }
 }
@@ -1962,15 +1946,6 @@ mod tests {
         let de = DdlTask::try_from(pb_task).unwrap();
 
         assert!(matches!(de, DdlTask::PurgeDroppedTable(task) if task == expected));
-    }
-
-    #[test]
-    fn test_purge_dropped_table_task_requires_expr() {
-        let result = DdlTask::try_from(Task::PurgeDroppedTableTask(
-            PbPurgeDroppedTableTask::default(),
-        ));
-
-        assert!(result.is_err());
     }
 
     #[test]

--- a/src/common/meta/src/rpc/ddl.rs
+++ b/src/common/meta/src/rpc/ddl.rs
@@ -38,7 +38,7 @@ use api::v1::{
     AlterDatabaseExpr, AlterTableExpr, CommentObjectType as PbCommentObjectType, CommentOnExpr,
     CreateDatabaseExpr, CreateFlowExpr, CreateTableExpr, CreateViewExpr, DropDatabaseExpr,
     DropFlowExpr, DropTableExpr, DropViewExpr, EvalInterval, ExpireAfter, Option as PbOption,
-    QueryContext as PbQueryContext, TruncateTableExpr,
+    PurgeDroppedTableExpr, QueryContext as PbQueryContext, TruncateTableExpr, UndropTableExpr,
 };
 use base64::Engine as _;
 use base64::engine::general_purpose;
@@ -262,7 +262,7 @@ impl TryFrom<Task> for DdlTask {
                 Ok(DdlTask::UndropTable(undrop_table.try_into()?))
             }
             Task::PurgeDroppedTableTask(purge_dropped_table) => {
-                Ok(DdlTask::PurgeDroppedTable(purge_dropped_table.into()))
+                Ok(DdlTask::PurgeDroppedTable(purge_dropped_table.try_into()?))
             }
             Task::AlterTableTask(alter_table) => Ok(DdlTask::AlterTable(alter_table.try_into()?)),
             Task::TruncateTableTask(truncate_table) => {
@@ -693,11 +693,15 @@ impl TryFrom<PbUndropTableTask> for UndropTableTask {
     type Error = error::Error;
 
     fn try_from(pb: PbUndropTableTask) -> Result<Self> {
+        let undrop_table = pb.undrop_table.context(error::InvalidProtoMsgSnafu {
+            err_msg: "expected undrop table",
+        })?;
+
         Ok(Self {
-            catalog: pb.catalog_name,
-            schema: pb.schema_name,
-            table: pb.table_name,
-            table_id: pb
+            catalog: undrop_table.catalog_name,
+            schema: undrop_table.schema_name,
+            table: undrop_table.table_name,
+            table_id: undrop_table
                 .table_id
                 .context(error::InvalidProtoMsgSnafu {
                     err_msg: "expected table_id",
@@ -710,32 +714,44 @@ impl TryFrom<PbUndropTableTask> for UndropTableTask {
 impl From<UndropTableTask> for PbUndropTableTask {
     fn from(task: UndropTableTask) -> Self {
         Self {
-            catalog_name: task.catalog,
-            schema_name: task.schema,
-            table_name: task.table,
-            table_id: Some(api::v1::TableId { id: task.table_id }),
+            undrop_table: Some(UndropTableExpr {
+                catalog_name: task.catalog,
+                schema_name: task.schema,
+                table_name: task.table,
+                table_id: Some(api::v1::TableId { id: task.table_id }),
+            }),
         }
     }
 }
 
-impl From<PbPurgeDroppedTableTask> for PurgeDroppedTableTask {
-    fn from(pb: PbPurgeDroppedTableTask) -> Self {
-        Self {
-            catalog: pb.catalog_name,
-            schema: pb.schema_name,
-            table: pb.table_name,
-            table_id: pb.table_id.map(|table_id| table_id.id),
-        }
+impl TryFrom<PbPurgeDroppedTableTask> for PurgeDroppedTableTask {
+    type Error = error::Error;
+
+    fn try_from(pb: PbPurgeDroppedTableTask) -> Result<Self> {
+        let purge_dropped_table = pb
+            .purge_dropped_table
+            .context(error::InvalidProtoMsgSnafu {
+                err_msg: "expected purge dropped table",
+            })?;
+
+        Ok(Self {
+            catalog: purge_dropped_table.catalog_name,
+            schema: purge_dropped_table.schema_name,
+            table: purge_dropped_table.table_name,
+            table_id: purge_dropped_table.table_id.map(|table_id| table_id.id),
+        })
     }
 }
 
 impl From<PurgeDroppedTableTask> for PbPurgeDroppedTableTask {
     fn from(task: PurgeDroppedTableTask) -> Self {
         Self {
-            catalog_name: task.catalog,
-            schema_name: task.schema,
-            table_name: task.table,
-            table_id: task.table_id.map(|id| api::v1::TableId { id }),
+            purge_dropped_table: Some(PurgeDroppedTableExpr {
+                catalog_name: task.catalog,
+                schema_name: task.schema,
+                table_name: task.table,
+                table_id: task.table_id.map(|id| api::v1::TableId { id }),
+            }),
         }
     }
 }
@@ -1946,6 +1962,15 @@ mod tests {
         let de = DdlTask::try_from(pb_task).unwrap();
 
         assert!(matches!(de, DdlTask::PurgeDroppedTable(task) if task == expected));
+    }
+
+    #[test]
+    fn test_purge_dropped_table_task_requires_expr() {
+        let result = DdlTask::try_from(Task::PurgeDroppedTableTask(
+            PbPurgeDroppedTableTask::default(),
+        ));
+
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/common/meta/src/test_util.rs
+++ b/src/common/meta/src/test_util.rs
@@ -206,6 +206,7 @@ pub fn new_ddl_context_with_kv_backend(
         flow_metadata_allocator,
         flow_metadata_manager,
         region_failure_detector_controller: Arc::new(NoopRegionFailureDetectorControl),
+        soft_drop_enabled: false,
     }
 }
 

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -425,6 +425,7 @@ impl MetasrvBuilder {
             flow_metadata_manager: flow_metadata_manager.clone(),
             flow_metadata_allocator: flow_metadata_allocator.clone(),
             region_failure_detector_controller,
+            soft_drop_enabled: ddl_soft_drop_enabled(&options),
         };
         let procedure_manager_c = procedure_manager.clone();
         let repartition_procedure_factory = Arc::new(DefaultRepartitionProcedureFactory::new(
@@ -671,6 +672,13 @@ fn build_procedure_manager(
         Some(runtime_switch_manager.clone()),
         Some(event_recorder),
     ))
+}
+
+/// Resolves if soft-drop is enabled from metasrv options.
+fn ddl_soft_drop_enabled(_options: &MetasrvOptions) -> bool {
+    // TODO(hl): add a dedicated soft-drop cluster config
+    // when wiring the user-facing option.
+    false
 }
 
 impl Default for MetasrvBuilder {

--- a/src/meta-srv/src/procedure/utils.rs
+++ b/src/meta-srv/src/procedure/utils.rs
@@ -546,6 +546,7 @@ pub mod test_data {
             memory_region_keeper: Arc::new(MemoryRegionKeeper::new()),
             leader_region_registry: Arc::new(LeaderRegionRegistry::default()),
             region_failure_detector_controller: Arc::new(NoopRegionFailureDetectorControl),
+            soft_drop_enabled: false,
         }
     }
 }

--- a/src/mito2/src/engine/open_test.rs
+++ b/src/mito2/src/engine/open_test.rs
@@ -125,14 +125,8 @@ async fn test_engine_reopen_region() {
     test_engine_reopen_region_with_format(true).await;
 }
 
-#[tokio::test]
-async fn test_engine_reopens_closed_soft_dropped_region() {
-    test_engine_reopens_closed_soft_dropped_region_with_format(false).await;
-    test_engine_reopens_closed_soft_dropped_region_with_format(true).await;
-}
-
-async fn test_engine_reopens_closed_soft_dropped_region_with_format(flat_format: bool) {
-    let mut env = TestEnv::with_prefix("reopen-soft-dropped-region").await;
+async fn test_engine_reopen_region_with_format(flat_format: bool) {
+    let mut env = TestEnv::with_prefix("reopen-region").await;
     let engine = env
         .create_engine(MitoConfig {
             default_flat_format: flat_format,
@@ -152,32 +146,13 @@ async fn test_engine_reopens_closed_soft_dropped_region_with_format(flat_format:
         &engine,
         region_id,
         Rows {
-            schema: column_schemas.clone(),
+            schema: column_schemas,
             rows: build_rows(0, 2),
         },
     )
     .await;
 
-    engine
-        .handle_request(region_id, RegionRequest::Close(RegionCloseRequest {}))
-        .await
-        .unwrap();
-    assert!(!engine.is_region_exists(region_id));
-
-    engine
-        .handle_request(
-            region_id,
-            RegionRequest::Open(RegionOpenRequest {
-                engine: String::new(),
-                table_dir,
-                path_type: PathType::Bare,
-                options: HashMap::default(),
-                skip_wal_replay: false,
-                checkpoint: None,
-            }),
-        )
-        .await
-        .unwrap();
+    reopen_region(&engine, region_id, table_dir, false, Default::default()).await;
     assert!(engine.is_region_exists(region_id));
 
     let scanner = engine
@@ -187,27 +162,6 @@ async fn test_engine_reopens_closed_soft_dropped_region_with_format(flat_format:
     let stream = scanner.scan().await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
     assert_eq!(2, batches.iter().map(|b| b.num_rows()).sum::<usize>());
-}
-
-async fn test_engine_reopen_region_with_format(flat_format: bool) {
-    let mut env = TestEnv::with_prefix("reopen-region").await;
-    let engine = env
-        .create_engine(MitoConfig {
-            default_flat_format: flat_format,
-            ..Default::default()
-        })
-        .await;
-
-    let region_id = RegionId::new(1, 1);
-    let request = CreateRequestBuilder::new().build();
-    let table_dir = request.table_dir.clone();
-    engine
-        .handle_request(region_id, RegionRequest::Create(request))
-        .await
-        .unwrap();
-
-    reopen_region(&engine, region_id, table_dir, false, Default::default()).await;
-    assert!(engine.is_region_exists(region_id));
 }
 
 #[tokio::test]

--- a/src/mito2/src/engine/open_test.rs
+++ b/src/mito2/src/engine/open_test.rs
@@ -125,6 +125,70 @@ async fn test_engine_reopen_region() {
     test_engine_reopen_region_with_format(true).await;
 }
 
+#[tokio::test]
+async fn test_engine_reopens_closed_soft_dropped_region() {
+    test_engine_reopens_closed_soft_dropped_region_with_format(false).await;
+    test_engine_reopens_closed_soft_dropped_region_with_format(true).await;
+}
+
+async fn test_engine_reopens_closed_soft_dropped_region_with_format(flat_format: bool) {
+    let mut env = TestEnv::with_prefix("reopen-soft-dropped-region").await;
+    let engine = env
+        .create_engine(MitoConfig {
+            default_flat_format: flat_format,
+            ..Default::default()
+        })
+        .await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new().build();
+    let table_dir = request.table_dir.clone();
+    let column_schemas = rows_schema(&request);
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+    put_rows(
+        &engine,
+        region_id,
+        Rows {
+            schema: column_schemas.clone(),
+            rows: build_rows(0, 2),
+        },
+    )
+    .await;
+
+    engine
+        .handle_request(region_id, RegionRequest::Close(RegionCloseRequest {}))
+        .await
+        .unwrap();
+    assert!(!engine.is_region_exists(region_id));
+
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Open(RegionOpenRequest {
+                engine: String::new(),
+                table_dir,
+                path_type: PathType::Bare,
+                options: HashMap::default(),
+                skip_wal_replay: false,
+                checkpoint: None,
+            }),
+        )
+        .await
+        .unwrap();
+    assert!(engine.is_region_exists(region_id));
+
+    let scanner = engine
+        .scanner(region_id, ScanRequest::default())
+        .await
+        .unwrap();
+    let stream = scanner.scan().await.unwrap();
+    let batches = RecordBatches::try_collect(stream).await.unwrap();
+    assert_eq!(2, batches.iter().map(|b| b.num_rows()).sum::<usize>());
+}
+
 async fn test_engine_reopen_region_with_format(flat_format: bool) {
     let mut env = TestEnv::with_prefix("reopen-region").await;
     let engine = env

--- a/tests-integration/src/standalone.rs
+++ b/tests-integration/src/standalone.rs
@@ -250,6 +250,7 @@ impl GreptimeDbStandaloneBuilder {
                     flow_metadata_manager,
                     flow_metadata_allocator,
                     region_failure_detector_controller: Arc::new(NoopRegionFailureDetectorControl),
+                    soft_drop_enabled: false,
                 },
                 procedure_manager.clone(),
                 repartition_procedure_factory,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Refs https://github.com/GreptimeTeam/greptimedb-enterprise/issues/851

Related proto PR: https://github.com/GreptimeTeam/greptime-proto/pull/318

## What's changed and what's your intention?

This PR implements Tasks 3 and 4 of the soft-drop table plan.

- Adds close-first soft-drop behavior for `DROP TABLE` when soft-drop is enabled: metadata is tombstoned, caches are invalidated, regions are closed, and physical cleanup is deferred.
- Adds `UndropTableProcedure` to restore tombstoned metadata, reopen preserved physical regions, refresh cache state, and re-register failure detectors.
- Adds `PurgeDroppedTableProcedure` to resolve tombstoned tables, reopen closed physical regions before issuing real drop requests, delete tombstones, and deregister failure detectors.
- Wires the new DDL task variants, procedure loaders, protobuf conversions, and submit/dispatch paths.
- Keeps metric-engine logical soft-drop/undrop/purge unsupported for now to avoid closing or dropping shared physical metric regions through logical table operations.

### Undrop table procedure flow

`UNDROP TABLE` is table-id based and restores the tombstoned table through these steps:

1. `Prepare`: load the dropped-table tombstone by table id, recover the original table name, table info, route, and WAL options, reject unsupported metric logical tables, and verify that the live table name does not already exist.
2. `OpenRegions`: for physical tables, reopen preserved regions from the tombstone-derived table info, route, and WAL options before the table metadata becomes live again. Logical tables skip datanode region open and proceed directly to metadata restore.
3. `RestoreMetadata`: atomically move tombstoned metadata back to live metadata keys. The restore transaction requires destination keys to be absent, so a concurrent same-name table creation fails the undrop with `TableAlreadyExists` instead of overwriting live metadata.
4. `InvalidateTableCache`: invalidate table-name and table-id cache entries after metadata is restored.

### Design considerations

- `UNDROP` and `PURGE` use table-id-only tasks to avoid caller-supplied table-name/table-id mismatches. The original table name is authoritative from the tombstone.
- The procedure opens physical regions before restoring live metadata. This avoids exposing a restored table whose regions are still closed.
- The procedure does not explicitly wait for reopened leader regions to become writable leaders before restoring metadata. A reopened Mito leader region can temporarily be follower/read-only until heartbeat lease convergence promotes it back to leader. During that short window, writes may return `RegionNotReady` and should be retried. Waiting inside `UNDROP` would keep the table invisible for the same convergence window and add extra state/registry waiting complexity without removing the transient inability to write.
- The restore path still guards against concurrent live-name creation with metadata-level destination-exists checks, because the tombstone table name is only known after `Prepare` and cannot be protected solely by the initial lock key.

Current limitation:

- Soft-drop recovery currently supports physical table region lifecycle. Metric logical tables are explicitly rejected for soft-drop, undrop, and purge until a dedicated logical-table design is added.

Test plan run during development:

- `cargo nextest run -p common-meta drop_table`
- `cargo nextest run -p common-meta undrop purge_dropped`
- `cargo nextest run -p mito2 test_engine_reopens_closed_soft_dropped_region`
- `cargo check -p common-meta --all-targets`

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
