### PR TITLE
fix: preserve case in database name from connection string

### DIFF
--- a/src/common/catalog/src/lib.rs
+++ b/src/common/catalog/src/lib.rs
@@ -74,9 +74,9 @@ pub fn parse_catalog_and_schema_from_db_string(db: &str) -> (String, String) {
 pub fn parse_optional_catalog_and_schema_from_db_string(db: &str) -> (Option<String>, String) {
     let parts = db.splitn(2, '-').collect::<Vec<&str>>();
     if parts.len() == 2 {
-        (Some(parts[0].to_lowercase()), parts[1].to_lowercase())
+        (Some(parts[0].to_string()), parts[1].to_string())
     } else {
-        (None, db.to_lowercase())
+        (None, db.to_string())
     }
 }
 
@@ -118,7 +118,7 @@ mod tests {
         );
 
         assert_eq!(
-            (Some("catalog".to_string()), "schema".to_string()),
+            (Some("CATALOG".to_string()), "SCHEMA".to_string()),
             parse_optional_catalog_and_schema_from_db_string("CATALOG-SCHEMA")
         );
 


### PR DESCRIPTION

I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
Fixes #8059


## What's changed and what's your intention?

`parse_optional_catalog_and_schema_from_db_string` unconditionally lowercased database/schema names, causing quoted database names (e.g. `CREATE DATABASE "TestQuery"`) to be stored with preserved case but looked up as lowercase on connection, resulting in "Database not found".

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
