### PR TITLE
feat(operator): allow last_row merge mode with append mode

### DIFF
--- a/src/mito2/src/region/options.rs
+++ b/src/mito2/src/region/options.rs
@@ -96,9 +96,10 @@ impl RegionOptions {
     pub fn validate(&self) -> Result<()> {
         if self.append_mode {
             ensure!(
-                self.merge_mode.is_none(),
+                self.merge_mode
+                    .is_none_or(|mode| mode == MergeMode::LastRow),
                 InvalidRegionOptionsSnafu {
-                    reason: "merge_mode is not allowed when append_mode is enabled",
+                    reason: "only last_row merge_mode is allowed when append_mode is enabled",
                 }
             );
         }
@@ -618,6 +619,18 @@ mod tests {
         assert_eq!(MergeMode::LastNonNull, options.merge_mode());
 
         let map = make_map(&[("merge_mode", "unknown")]);
+        let err = RegionOptions::try_from(&map).unwrap_err();
+        assert_eq!(StatusCode::InvalidArguments, err.status_code());
+    }
+
+    #[test]
+    fn test_append_mode_allows_last_row_merge_mode() {
+        let map = make_map(&[("append_mode", "true"), ("merge_mode", "last_row")]);
+        let options = RegionOptions::try_from(&map).unwrap();
+        assert!(options.append_mode);
+        assert_eq!(MergeMode::LastRow, options.merge_mode());
+
+        let map = make_map(&[("append_mode", "true"), ("merge_mode", "last_non_null")]);
         let err = RegionOptions::try_from(&map).unwrap_err();
         assert_eq!(StatusCode::InvalidArguments, err.status_code());
     }

--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -1090,7 +1090,20 @@ pub fn fill_table_options_for_create(
             table_options.insert(APPEND_MODE_KEY.to_string(), "true".to_string());
         }
         AutoCreateTableType::LastNonNull => {
-            table_options.insert(MERGE_MODE_KEY.to_string(), "last_non_null".to_string());
+            let append_mode_enabled = ctx
+                .extension(APPEND_MODE_KEY)
+                .is_some_and(|value| value.eq_ignore_ascii_case("true"));
+            if append_mode_enabled {
+                table_options.insert(APPEND_MODE_KEY.to_string(), "true".to_string());
+            }
+            table_options.insert(
+                MERGE_MODE_KEY.to_string(),
+                if append_mode_enabled {
+                    "last_row".to_string()
+                } else {
+                    "last_non_null".to_string()
+                },
+            );
         }
         AutoCreateTableType::Trace => {
             table_options.insert(APPEND_MODE_KEY.to_string(), "true".to_string());
@@ -1333,5 +1346,57 @@ mod tests {
         let req_schema = req.rows.as_ref().unwrap().schema.clone();
         assert_eq!(req_schema[0].column_name, ts_name);
         assert_eq!(req_schema[1].column_name, field_name);
+    }
+
+    #[test]
+    fn test_last_non_null_create_options_preserve_default_without_append_mode() {
+        let ctx = Arc::new(QueryContext::with(
+            DEFAULT_CATALOG_NAME,
+            DEFAULT_SCHEMA_NAME,
+        ));
+        let mut table_options = Default::default();
+
+        fill_table_options_for_create(&mut table_options, &AutoCreateTableType::LastNonNull, &ctx);
+
+        assert_eq!(
+            Some("last_non_null"),
+            table_options.get(MERGE_MODE_KEY).map(String::as_str)
+        );
+        assert!(!table_options.contains_key(APPEND_MODE_KEY));
+    }
+
+    #[test]
+    fn test_last_non_null_create_options_preserve_default_with_append_mode_false() {
+        let mut ctx = QueryContext::with(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME);
+        ctx.set_extension(APPEND_MODE_KEY, "false");
+        let ctx = Arc::new(ctx);
+        let mut table_options = Default::default();
+
+        fill_table_options_for_create(&mut table_options, &AutoCreateTableType::LastNonNull, &ctx);
+
+        assert!(!table_options.contains_key(APPEND_MODE_KEY));
+        assert_eq!(
+            Some("last_non_null"),
+            table_options.get(MERGE_MODE_KEY).map(String::as_str)
+        );
+    }
+
+    #[test]
+    fn test_last_non_null_create_options_use_last_row_with_append_mode_true() {
+        let mut ctx = QueryContext::with(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME);
+        ctx.set_extension(APPEND_MODE_KEY, "true");
+        let ctx = Arc::new(ctx);
+        let mut table_options = Default::default();
+
+        fill_table_options_for_create(&mut table_options, &AutoCreateTableType::LastNonNull, &ctx);
+
+        assert_eq!(
+            Some("true"),
+            table_options.get(APPEND_MODE_KEY).map(String::as_str)
+        );
+        assert_eq!(
+            Some("last_row"),
+            table_options.get(MERGE_MODE_KEY).map(String::as_str)
+        );
     }
 }

--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -1090,20 +1090,15 @@ pub fn fill_table_options_for_create(
             table_options.insert(APPEND_MODE_KEY.to_string(), "true".to_string());
         }
         AutoCreateTableType::LastNonNull => {
-            let append_mode_enabled = ctx
+            if ctx
                 .extension(APPEND_MODE_KEY)
-                .is_some_and(|value| value.eq_ignore_ascii_case("true"));
-            if append_mode_enabled {
+                .is_some_and(|value| value.eq_ignore_ascii_case("true"))
+            {
                 table_options.insert(APPEND_MODE_KEY.to_string(), "true".to_string());
+                table_options.insert(MERGE_MODE_KEY.to_string(), "last_row".to_string());
+            } else {
+                table_options.insert(MERGE_MODE_KEY.to_string(), "last_non_null".to_string());
             }
-            table_options.insert(
-                MERGE_MODE_KEY.to_string(),
-                if append_mode_enabled {
-                    "last_row".to_string()
-                } else {
-                    "last_non_null".to_string()
-                },
-            );
         }
         AutoCreateTableType::Trace => {
             table_options.insert(APPEND_MODE_KEY.to_string(), "true".to_string());

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -153,6 +153,7 @@ macro_rules! http_tests {
 
                 test_influxdb_write,
                 test_influxdb_write_with_hints,
+                test_influxdb_write_with_append_mode_hint,
                 test_http_memory_limit,
             );
         )*
@@ -3770,6 +3771,42 @@ pub async fn test_influxdb_write_with_hints(storage_type: StorageType) {
     assert!(
         resp.contains("skip_wal = 'true'"),
         "expected skip_wal = 'true' in SHOW CREATE TABLE output, got: {resp}"
+    );
+
+    guard.remove_all().await;
+}
+
+pub async fn test_influxdb_write_with_append_mode_hint(storage_type: StorageType) {
+    common_telemetry::init_default_ut_logging();
+    let (app, mut guard) = setup_test_http_app_with_frontend(
+        storage_type,
+        "test_influxdb_write_with_append_mode_hint",
+    )
+    .await;
+
+    let client = TestClient::new(app).await;
+
+    let result = client
+        .post("/v1/influxdb/write?db=public")
+        .header("x-greptime-hint-append_mode", "true")
+        .body("append_mode_table,host=host1 cpu=1.2 1664370459457010101")
+        .send()
+        .await;
+    assert_eq!(result.status(), 204);
+
+    let res = client
+        .get("/v1/sql?sql=show create table append_mode_table")
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+    let resp = res.text().await;
+    assert!(
+        resp.contains("append_mode = 'true'"),
+        "expected append_mode = 'true' in SHOW CREATE TABLE output, got: {resp}"
+    );
+    assert!(
+        resp.contains("merge_mode = 'last_row'"),
+        "expected merge_mode = 'last_row' in SHOW CREATE TABLE output, got: {resp}"
     );
 
     guard.remove_all().await;

--- a/tests/cases/standalone/common/insert/merge_mode.result
+++ b/tests/cases/standalone/common/insert/merge_mode.result
@@ -181,5 +181,5 @@ create table if not exists invalid_merge_mode(
 engine=mito
 with('merge_mode'='last_non_null', 'append_mode'='true');
 
-Error: 1004(InvalidArguments), Invalid region options, merge_mode is not allowed when append_mode is enabled
+Error: 1004(InvalidArguments), Invalid region options, only last_row merge_mode is allowed when append_mode is enabled
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR honors the explicit InfluxDB line protocol HTTP `append_mode=true` hint when auto-creating tables.

- If the `append_mode` hint is absent or false, InfluxDB auto-created tables keep the existing `last_non_null` merge mode behavior.
- If `append_mode=true` is explicitly provided, auto-created tables set `append_mode = 'true'` and `merge_mode = 'last_row'`.
- `RegionOptions` now permits `merge_mode = last_row` with append mode while continuing to reject incompatible merge modes like `last_non_null`.
- Added unit coverage for option construction and validation, plus HTTP integration coverage for the InfluxDB hint path.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.

## Test Plan

- `cargo fmt --check`
- `CARGO_TARGET_DIR="/tmp/opencode/greptimedb-target" cargo test -p operator test_last_non_null_create_options --lib`
- `CARGO_TARGET_DIR="/tmp/opencode/greptimedb-target" cargo test -p mito2 test_append_mode_allows_last_row_merge_mode --lib`
- `CARGO_TARGET_DIR="/tmp/opencode/greptimedb-target" cargo test -p tests-integration --test main test_influxdb_write_with_append_mode_hint`