### PR TITLE
refactor: make extension mutable in query context

### DIFF
--- a/src/frontend/src/instance/grpc.rs
+++ b/src/frontend/src/instance/grpc.rs
@@ -81,7 +81,7 @@ impl GrpcQueryHandler for Instance {
                         self.handle_metric_row_inserts(
                             requests,
                             ctx.clone(),
-                            physical_table.to_string(),
+                            physical_table,
                         )
                         .await?
                     }

--- a/src/frontend/src/instance/jaeger.rs
+++ b/src/frontend/src/instance/jaeger.rs
@@ -264,9 +264,9 @@ impl JaegerQueryHandler for Instance {
                 // so we only need to return 1 span for each trace
                 let table_name = ctx
                     .extension(JAEGER_QUERY_TABLE_NAME_KEY)
-                    .unwrap_or(TRACE_TABLE_NAME);
+                    .unwrap_or_else(|| TRACE_TABLE_NAME.to_string());
 
-                let table = get_table(ctx.clone(), self.catalog_manager(), table_name).await?;
+                let table = get_table(ctx.clone(), self.catalog_manager(), &table_name).await?;
 
                 Ok(find_traces_rank_3(
                     table,
@@ -307,7 +307,7 @@ async fn query_trace_table(
 ) -> ServerResult<Output> {
     let trace_table_name = ctx
         .extension(JAEGER_QUERY_TABLE_NAME_KEY)
-        .unwrap_or(TRACE_TABLE_NAME);
+        .unwrap_or_else(|| TRACE_TABLE_NAME.to_string());
 
     // If only select services, use the trace services table.
     // If querying operations (distinct by span_name and span_kind), use the trace operations table.
@@ -316,14 +316,14 @@ async fn query_trace_table(
             [SelectExpr::Expression(x)] => x == &col(SERVICE_NAME_COLUMN),
             _ => false,
         } {
-            &trace_services_table_name(trace_table_name)
+            &trace_services_table_name(&trace_table_name)
         } else if !distincts.is_empty()
             && distincts.contains(&col(SPAN_NAME_COLUMN))
             && distincts.contains(&col(SPAN_KIND_COLUMN))
         {
-            &trace_operations_table_name(trace_table_name)
+            &trace_operations_table_name(&trace_table_name)
         } else {
-            trace_table_name
+            &trace_table_name
         }
     };
 

--- a/src/frontend/src/instance/otlp.rs
+++ b/src/frontend/src/instance/otlp.rs
@@ -148,8 +148,7 @@ impl OpenTelemetryProtocolHandler for Instance {
         } else {
             let physical_table = ctx
                 .extension(PHYSICAL_TABLE_PARAM)
-                .unwrap_or(GREPTIME_PHYSICAL_TABLE)
-                .to_string();
+                .unwrap_or_else(|| GREPTIME_PHYSICAL_TABLE.to_string());
             self.handle_metric_row_inserts(requests, ctx, physical_table.clone())
                 .await
                 .map_err(BoxedError::new)

--- a/src/frontend/src/instance/otlp.rs
+++ b/src/frontend/src/instance/otlp.rs
@@ -132,7 +132,7 @@ impl OpenTelemetryProtocolHandler for Instance {
         OTLP_METRICS_ROWS.inc_by(rows as u64);
 
         let ctx = if !is_legacy {
-            let mut c = (*ctx).clone();
+            let c = (*ctx).clone();
             c.set_extension(OTLP_METRIC_COMPAT_KEY, OTLP_METRIC_COMPAT_PROM.to_string());
             Arc::new(c)
         } else {

--- a/src/frontend/src/instance/prom_store.rs
+++ b/src/frontend/src/instance/prom_store.rs
@@ -573,7 +573,7 @@ mod tests {
 
     #[test]
     fn test_auto_create_table_type_for_prom_remote_write_metric_engine() {
-        let mut query_ctx = QueryContext::with(
+        let query_ctx = QueryContext::with(
             common_catalog::consts::DEFAULT_CATALOG_NAME,
             common_catalog::consts::DEFAULT_SCHEMA_NAME,
         );

--- a/src/frontend/src/instance/prom_store.rs
+++ b/src/frontend/src/instance/prom_store.rs
@@ -67,8 +67,7 @@ fn auto_create_table_type_for_prom_remote_write(
     if with_metric_engine {
         let physical_table = ctx
             .extension(PHYSICAL_TABLE_PARAM)
-            .unwrap_or(GREPTIME_PHYSICAL_TABLE)
-            .to_string();
+            .unwrap_or_else(|| GREPTIME_PHYSICAL_TABLE.to_string());
         AutoCreateTableType::Logical(physical_table)
     } else {
         AutoCreateTableType::Physical
@@ -378,8 +377,7 @@ impl PromStoreProtocolHandler for Instance {
         let output = if with_metric_engine {
             let physical_table = ctx
                 .extension(PHYSICAL_TABLE_PARAM)
-                .unwrap_or(GREPTIME_PHYSICAL_TABLE)
-                .to_string();
+                .unwrap_or_else(|| GREPTIME_PHYSICAL_TABLE.to_string());
             self.handle_metric_row_inserts(request, ctx.clone(), physical_table.clone())
                 .await
                 .map_err(BoxedError::new)

--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -1362,7 +1362,7 @@ mod tests {
 
     #[test]
     fn test_last_non_null_create_options_preserve_default_with_append_mode_false() {
-        let mut ctx = QueryContext::with(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME);
+        let ctx = QueryContext::with(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME);
         ctx.set_extension(APPEND_MODE_KEY, "false");
         let ctx = Arc::new(ctx);
         let mut table_options = Default::default();
@@ -1378,7 +1378,7 @@ mod tests {
 
     #[test]
     fn test_last_non_null_create_options_use_last_row_with_append_mode_true() {
-        let mut ctx = QueryContext::with(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME);
+        let ctx = QueryContext::with(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME);
         ctx.set_extension(APPEND_MODE_KEY, "true");
         let ctx = Arc::new(ctx);
         let mut table_options = Default::default();

--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -620,7 +620,7 @@ impl Inserter {
             AutoCreateTableType::Trace => {
                 let trace_table_name = ctx
                     .extension(TRACE_TABLE_NAME_SESSION_KEY)
-                    .unwrap_or(TRACE_TABLE_NAME);
+                    .unwrap_or_else(|| TRACE_TABLE_NAME.to_string());
 
                 let trace_table_partitions = if let Some(trace_table_partitions) =
                     ctx.extension(TRACE_TABLE_PARTITIONS_HINT_KEY)
@@ -642,8 +642,8 @@ impl Inserter {
                 // note that auto create table shouldn't be ttl instant table
                 // for it's a very unexpected behavior and should be set by user explicitly
                 for mut create_table in create_tables {
-                    if create_table.table_name == trace_services_table_name(trace_table_name)
-                        || create_table.table_name == trace_operations_table_name(trace_table_name)
+                    if create_table.table_name == trace_services_table_name(&trace_table_name)
+                        || create_table.table_name == trace_operations_table_name(&trace_table_name)
                     {
                         // Disable append mode for auxiliary tables (services/operations) since they require upsert behavior.
                         create_table
@@ -1057,7 +1057,7 @@ pub fn fill_table_options_for_create(
 ) {
     for key in VALID_TABLE_OPTION_KEYS {
         if let Some(value) = ctx.extension(key) {
-            table_options.insert(key.to_string(), value.to_string());
+            table_options.insert(key.to_string(), value);
         }
     }
 
@@ -1070,13 +1070,13 @@ pub fn fill_table_options_for_create(
         }
         AutoCreateTableType::Physical => {
             if let Some(append_mode) = ctx.extension(APPEND_MODE_KEY) {
-                table_options.insert(APPEND_MODE_KEY.to_string(), append_mode.to_string());
+                table_options.insert(APPEND_MODE_KEY.to_string(), append_mode);
             }
             if let Some(merge_mode) = ctx.extension(MERGE_MODE_KEY) {
-                table_options.insert(MERGE_MODE_KEY.to_string(), merge_mode.to_string());
+                table_options.insert(MERGE_MODE_KEY.to_string(), merge_mode);
             }
             if let Some(time_window) = ctx.extension(TWCS_TIME_WINDOW) {
-                table_options.insert(TWCS_TIME_WINDOW.to_string(), time_window.to_string());
+                table_options.insert(TWCS_TIME_WINDOW.to_string(), time_window);
                 // We need to set the compaction type explicitly.
                 table_options.insert(
                     COMPACTION_TYPE.to_string(),

--- a/src/operator/src/utils.rs
+++ b/src/operator/src/utils.rs
@@ -79,6 +79,9 @@ mod tests {
         assert_eq!(roundtrip.current_schema(), "s1");
         assert_eq!(roundtrip.snapshots(), HashMap::from([(10, 100)]));
         assert_eq!(roundtrip.sst_min_sequences(), HashMap::from([(10, 90)]));
-        assert_eq!(roundtrip.extension("flow.return_region_seq").as_deref(), Some("true"));
+        assert_eq!(
+            roundtrip.extension("flow.return_region_seq").as_deref(),
+            Some("true")
+        );
     }
 }

--- a/src/operator/src/utils.rs
+++ b/src/operator/src/utils.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::{Arc, RwLock};
-
 use common_time::Timezone;
 use session::context::{QueryContextBuilder, QueryContextRef};
 use snafu::ResultExt;
@@ -47,15 +45,14 @@ pub fn try_to_session_query_context(
         )
         .extensions(value.extensions)
         .channel((value.channel as u32).into())
-        .snapshot_seqs(Arc::new(RwLock::new(value.snapshot_seqs)))
-        .sst_min_sequences(Arc::new(RwLock::new(value.sst_min_sequences)))
+        .snapshot_seqs(value.snapshot_seqs)
+        .sst_min_sequences(value.sst_min_sequences)
         .build())
 }
 
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::sync::{Arc, RwLock};
 
     use common_time::Timezone;
     use session::context::QueryContextBuilder;
@@ -64,14 +61,14 @@ mod tests {
 
     #[test]
     fn test_query_context_meta_roundtrip_with_sequences() {
-        let session_ctx = Arc::new(
+        let session_ctx = std::sync::Arc::new(
             QueryContextBuilder::default()
                 .current_catalog("c1".to_string())
                 .current_schema("s1".to_string())
                 .timezone(Timezone::from_tz_string("UTC").unwrap())
                 .set_extension("flow.return_region_seq".to_string(), "true".to_string())
-                .snapshot_seqs(Arc::new(RwLock::new(HashMap::from([(10, 100)]))))
-                .sst_min_sequences(Arc::new(RwLock::new(HashMap::from([(10, 90)]))))
+                .snapshot_seqs(HashMap::from([(10, 100)]))
+                .sst_min_sequences(HashMap::from([(10, 90)]))
                 .build(),
         );
 
@@ -82,6 +79,6 @@ mod tests {
         assert_eq!(roundtrip.current_schema(), "s1");
         assert_eq!(roundtrip.snapshots(), HashMap::from([(10, 100)]));
         assert_eq!(roundtrip.sst_min_sequences(), HashMap::from([(10, 90)]));
-        assert_eq!(roundtrip.extension("flow.return_region_seq"), Some("true"));
+        assert_eq!(roundtrip.extension("flow.return_region_seq").as_deref(), Some("true"));
     }
 }

--- a/src/query/src/dummy_catalog.rs
+++ b/src/query/src/dummy_catalog.rs
@@ -627,14 +627,8 @@ mod tests {
                 "flow.return_region_seq".to_string(),
                 "true".to_string(),
             )]))
-            .snapshot_seqs(HashMap::from([(
-                region_id.as_u64(),
-                42_u64,
-            )]))
-            .sst_min_sequences(HashMap::from([(
-                region_id.as_u64(),
-                7_u64,
-            )]))
+            .snapshot_seqs(HashMap::from([(region_id.as_u64(), 42_u64)]))
+            .sst_min_sequences(HashMap::from([(region_id.as_u64(), 7_u64)]))
             .build();
 
         let request = scan_request_from_query_context(region_id, &query_ctx).unwrap();
@@ -665,14 +659,8 @@ mod tests {
     fn test_scan_request_from_query_context_keeps_snapshot_fields() {
         let region_id = test_region_id();
         let query_ctx = QueryContextBuilder::default()
-            .snapshot_seqs(HashMap::from([(
-                region_id.as_u64(),
-                100,
-            )]))
-            .sst_min_sequences(HashMap::from([(
-                region_id.as_u64(),
-                90,
-            )]))
+            .snapshot_seqs(HashMap::from([(region_id.as_u64(), 100)]))
+            .sst_min_sequences(HashMap::from([(region_id.as_u64(), 90)]))
             .build();
 
         let request = scan_request_from_query_context(region_id, &query_ctx).unwrap();
@@ -690,10 +678,7 @@ mod tests {
                 FLOW_INCREMENTAL_AFTER_SEQS.to_string(),
                 format!(r#"{{"{}":10}}"#, region_id.as_u64()),
             )]))
-            .snapshot_seqs(HashMap::from([(
-                region_id.as_u64(),
-                42_u64,
-            )]))
+            .snapshot_seqs(HashMap::from([(region_id.as_u64(), 42_u64)]))
             .build();
 
         let request = scan_request_from_query_context(region_id, &query_ctx).unwrap();
@@ -707,10 +692,7 @@ mod tests {
     fn test_apply_cached_snapshot_to_request_updates_cached_scan_request() {
         let region_id = test_region_id();
         let query_ctx = QueryContextBuilder::default()
-            .snapshot_seqs(HashMap::from([(
-                region_id.as_u64(),
-                88_u64,
-            )]))
+            .snapshot_seqs(HashMap::from([(region_id.as_u64(), 88_u64)]))
             .build();
         let mut request = ScanRequest {
             snapshot_on_scan: true,
@@ -727,10 +709,7 @@ mod tests {
     fn test_apply_cached_snapshot_to_request_skips_sink_scan() {
         let region_id = test_region_id();
         let query_ctx = QueryContextBuilder::default()
-            .snapshot_seqs(HashMap::from([(
-                region_id.as_u64(),
-                88_u64,
-            )]))
+            .snapshot_seqs(HashMap::from([(region_id.as_u64(), 88_u64)]))
             .build();
         let mut request = ScanRequest {
             snapshot_on_scan: true,
@@ -747,10 +726,7 @@ mod tests {
     fn test_bind_snapshot_bound_region_seq_reuses_existing_snapshot() {
         let region_id = test_region_id();
         let query_ctx = QueryContextBuilder::default()
-            .snapshot_seqs(HashMap::from([(
-                region_id.as_u64(),
-                42_u64,
-            )]))
+            .snapshot_seqs(HashMap::from([(region_id.as_u64(), 42_u64)]))
             .build();
 
         let err = bind_snapshot_bound_region_seq(&query_ctx, region_id, 99).unwrap_err();
@@ -808,14 +784,8 @@ mod tests {
                     region_id.table_id().to_string(),
                 ),
             ]))
-            .snapshot_seqs(HashMap::from([(
-                region_id.as_u64(),
-                88_u64,
-            )]))
-            .sst_min_sequences(HashMap::from([(
-                region_id.as_u64(),
-                77_u64,
-            )]))
+            .snapshot_seqs(HashMap::from([(region_id.as_u64(), 88_u64)]))
+            .sst_min_sequences(HashMap::from([(region_id.as_u64(), 77_u64)]))
             .build();
 
         let request = scan_request_from_query_context(region_id, &query_ctx).unwrap();

--- a/src/query/src/dummy_catalog.rs
+++ b/src/query/src/dummy_catalog.rs
@@ -606,7 +606,6 @@ impl CatalogManager for DummyCatalogManager {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::sync::{Arc, RwLock};
 
     use common_error::ext::ErrorExt;
     use common_error::status_code::StatusCode;
@@ -628,14 +627,14 @@ mod tests {
                 "flow.return_region_seq".to_string(),
                 "true".to_string(),
             )]))
-            .snapshot_seqs(Arc::new(RwLock::new(HashMap::from([(
+            .snapshot_seqs(HashMap::from([(
                 region_id.as_u64(),
                 42_u64,
-            )]))))
-            .sst_min_sequences(Arc::new(RwLock::new(HashMap::from([(
+            )]))
+            .sst_min_sequences(HashMap::from([(
                 region_id.as_u64(),
                 7_u64,
-            )]))))
+            )]))
             .build();
 
         let request = scan_request_from_query_context(region_id, &query_ctx).unwrap();
@@ -666,14 +665,14 @@ mod tests {
     fn test_scan_request_from_query_context_keeps_snapshot_fields() {
         let region_id = test_region_id();
         let query_ctx = QueryContextBuilder::default()
-            .snapshot_seqs(Arc::new(RwLock::new(HashMap::from([(
+            .snapshot_seqs(HashMap::from([(
                 region_id.as_u64(),
                 100,
-            )]))))
-            .sst_min_sequences(Arc::new(RwLock::new(HashMap::from([(
+            )]))
+            .sst_min_sequences(HashMap::from([(
                 region_id.as_u64(),
                 90,
-            )]))))
+            )]))
             .build();
 
         let request = scan_request_from_query_context(region_id, &query_ctx).unwrap();
@@ -691,10 +690,10 @@ mod tests {
                 FLOW_INCREMENTAL_AFTER_SEQS.to_string(),
                 format!(r#"{{"{}":10}}"#, region_id.as_u64()),
             )]))
-            .snapshot_seqs(Arc::new(RwLock::new(HashMap::from([(
+            .snapshot_seqs(HashMap::from([(
                 region_id.as_u64(),
                 42_u64,
-            )]))))
+            )]))
             .build();
 
         let request = scan_request_from_query_context(region_id, &query_ctx).unwrap();
@@ -708,10 +707,10 @@ mod tests {
     fn test_apply_cached_snapshot_to_request_updates_cached_scan_request() {
         let region_id = test_region_id();
         let query_ctx = QueryContextBuilder::default()
-            .snapshot_seqs(Arc::new(RwLock::new(HashMap::from([(
+            .snapshot_seqs(HashMap::from([(
                 region_id.as_u64(),
                 88_u64,
-            )]))))
+            )]))
             .build();
         let mut request = ScanRequest {
             snapshot_on_scan: true,
@@ -728,10 +727,10 @@ mod tests {
     fn test_apply_cached_snapshot_to_request_skips_sink_scan() {
         let region_id = test_region_id();
         let query_ctx = QueryContextBuilder::default()
-            .snapshot_seqs(Arc::new(RwLock::new(HashMap::from([(
+            .snapshot_seqs(HashMap::from([(
                 region_id.as_u64(),
                 88_u64,
-            )]))))
+            )]))
             .build();
         let mut request = ScanRequest {
             snapshot_on_scan: true,
@@ -748,10 +747,10 @@ mod tests {
     fn test_bind_snapshot_bound_region_seq_reuses_existing_snapshot() {
         let region_id = test_region_id();
         let query_ctx = QueryContextBuilder::default()
-            .snapshot_seqs(Arc::new(RwLock::new(HashMap::from([(
+            .snapshot_seqs(HashMap::from([(
                 region_id.as_u64(),
                 42_u64,
-            )]))))
+            )]))
             .build();
 
         let err = bind_snapshot_bound_region_seq(&query_ctx, region_id, 99).unwrap_err();
@@ -809,14 +808,14 @@ mod tests {
                     region_id.table_id().to_string(),
                 ),
             ]))
-            .snapshot_seqs(Arc::new(RwLock::new(HashMap::from([(
+            .snapshot_seqs(HashMap::from([(
                 region_id.as_u64(),
                 88_u64,
-            )]))))
-            .sst_min_sequences(Arc::new(RwLock::new(HashMap::from([(
+            )]))
+            .sst_min_sequences(HashMap::from([(
                 region_id.as_u64(),
                 77_u64,
-            )]))))
+            )]))
             .build();
 
         let request = scan_request_from_query_context(region_id, &query_ctx).unwrap();

--- a/src/servers/src/pending_rows_batcher.rs
+++ b/src/servers/src/pending_rows_batcher.rs
@@ -266,8 +266,7 @@ enum WorkerCommand {
 fn batch_key_from_ctx(ctx: &QueryContextRef) -> BatchKey {
     let physical_table = ctx
         .extension(PHYSICAL_TABLE_KEY)
-        .unwrap_or(GREPTIME_PHYSICAL_TABLE)
-        .to_string();
+        .unwrap_or_else(|| GREPTIME_PHYSICAL_TABLE.to_string());
     BatchKey {
         catalog: ctx.current_catalog().to_string(),
         schema: ctx.current_schema(),
@@ -1225,8 +1224,7 @@ async fn flush_batch(
     // into physical format and write them together.
     let physical_table_name = ctx
         .extension(PHYSICAL_TABLE_KEY)
-        .unwrap_or(GREPTIME_PHYSICAL_TABLE)
-        .to_string();
+        .unwrap_or_else(|| GREPTIME_PHYSICAL_TABLE.to_string());
     let partition_provider = PartitionManagerPhysicalFlushAdapter { partition_manager };
     let node_requester = NodeManagerPhysicalFlushAdapter { node_manager };
     let catalog_provider = CatalogManagerPhysicalFlushAdapter { catalog_manager };

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -41,25 +41,17 @@ pub type ConnInfoRef = Arc<ConnInfo>;
 
 const CURSOR_COUNT_WARNING_LIMIT: usize = 10;
 
-#[derive(Debug, Builder, Clone)]
+#[derive(Debug, Builder)]
 #[builder(pattern = "owned")]
 #[builder(build_fn(skip))]
 pub struct QueryContext {
     current_catalog: String,
-    /// mapping of RegionId to SequenceNumber, for snapshot read, meaning that the read should only
-    /// container data that was committed before(and include) the given sequence number
-    /// this field will only be filled if extensions contains a pair of "snapshot_read" and "true"
-    snapshot_seqs: Arc<RwLock<HashMap<u64, u64>>>,
-    /// Mappings of the RegionId to the minimal sequence of SST file to scan.
-    sst_min_sequences: Arc<RwLock<HashMap<u64, u64>>>,
     // we use Arc<RwLock>> for modifiable fields
     #[builder(default)]
     mutable_session_data: Arc<RwLock<MutableInner>>,
     #[builder(default)]
-    mutable_query_context_data: Arc<RwLock<QueryContextMutableFields>>,
+    mutable_query_context_data: RwLock<QueryContextMutableFields>,
     sql_dialect: Arc<dyn Dialect + Send + Sync>,
-    #[builder(default)]
-    extensions: HashMap<String, String>,
     /// The configuration parameter are used to store the parameters that are set by the user
     #[builder(default)]
     configuration_parameter: Arc<ConfigurationVariables>,
@@ -85,6 +77,32 @@ pub struct QueryContextMutableFields {
     explain_format: Option<String>,
     /// Explain options to control the verbose analyze output.
     explain_options: Option<ExplainOptions>,
+    /// key-value extensions
+    extensions: HashMap<String, String>,
+    /// mapping of RegionId to SequenceNumber, for snapshot read, meaning that the read should only
+    /// container data that was committed before(and include) the given sequence number
+    /// this field will only be filled if extensions contains a pair of "snapshot_read" and "true"
+    snapshot_seqs: HashMap<u64, u64>,
+    /// Mappings of the RegionId to the minimal sequence of SST file to scan.
+    sst_min_sequences: HashMap<u64, u64>,
+}
+
+impl Clone for QueryContext {
+    fn clone(&self) -> Self {
+        Self {
+            current_catalog: self.current_catalog.clone(),
+            mutable_session_data: self.mutable_session_data.clone(),
+            mutable_query_context_data: RwLock::new(
+                self.mutable_query_context_data.read().unwrap().clone(),
+            ),
+            sql_dialect: self.sql_dialect.clone(),
+            configuration_parameter: self.configuration_parameter.clone(),
+            channel: self.channel,
+            process_id: self.process_id,
+            conn_info: self.conn_info.clone(),
+            protocol_ctx: self.protocol_ctx.clone(),
+        }
+    }
 }
 
 impl Display for QueryContext {
@@ -166,16 +184,16 @@ impl From<api::v1::QueryContext> for QueryContext {
             .timezone(parse_timezone(Some(&ctx.timezone)))
             .extensions(ctx.extensions)
             .channel(ctx.channel.into())
-            .snapshot_seqs(Arc::new(RwLock::new(
+            .snapshot_seqs(
                 sequences
                     .map(|x| x.snapshot_seqs.clone())
                     .unwrap_or_default(),
-            )))
-            .sst_min_sequences(Arc::new(RwLock::new(
+            )
+            .sst_min_sequences(
                 sequences
                     .map(|x| x.sst_min_sequences.clone())
                     .unwrap_or_default(),
-            )))
+            )
             .explain_options(ctx.explain)
             .build()
     }
@@ -186,27 +204,24 @@ impl From<QueryContext> for api::v1::QueryContext {
         QueryContext {
             current_catalog,
             mutable_session_data: mutable_inner,
-            extensions,
             channel,
-            snapshot_seqs,
-            sst_min_sequences,
             mutable_query_context_data,
             ..
         }: QueryContext,
     ) -> Self {
-        let explain = mutable_query_context_data.read().unwrap().explain_options;
+        let query_data = mutable_query_context_data.read().unwrap();
         let mutable_inner = mutable_inner.read().unwrap();
         api::v1::QueryContext {
             current_catalog,
             current_schema: mutable_inner.schema.clone(),
             timezone: mutable_inner.timezone.to_string(),
-            extensions,
+            extensions: query_data.extensions.clone(),
             channel: channel as u32,
             snapshot_seqs: Some(api::v1::SnapshotSequences {
-                snapshot_seqs: snapshot_seqs.read().unwrap().clone(),
-                sst_min_sequences: sst_min_sequences.read().unwrap().clone(),
+                snapshot_seqs: query_data.snapshot_seqs.clone(),
+                sst_min_sequences: query_data.sst_min_sequences.clone(),
             }),
-            explain,
+            explain: query_data.explain_options,
         }
     }
 }
@@ -313,15 +328,28 @@ impl QueryContext {
     }
 
     pub fn set_extension<S1: Into<String>, S2: Into<String>>(&mut self, key: S1, value: S2) {
-        self.extensions.insert(key.into(), value.into());
+        self.mutable_query_context_data
+            .write()
+            .unwrap()
+            .extensions
+            .insert(key.into(), value.into());
     }
 
-    pub fn extension<S: AsRef<str>>(&self, key: S) -> Option<&str> {
-        self.extensions.get(key.as_ref()).map(|v| v.as_str())
+    pub fn extension<S: AsRef<str>>(&self, key: S) -> Option<String> {
+        self.mutable_query_context_data
+            .read()
+            .unwrap()
+            .extensions
+            .get(key.as_ref())
+            .cloned()
     }
 
     pub fn extensions(&self) -> HashMap<String, String> {
-        self.extensions.clone()
+        self.mutable_query_context_data
+            .read()
+            .unwrap()
+            .extensions
+            .clone()
     }
 
     /// Default to double quote and fallback to back quote
@@ -430,21 +458,35 @@ impl QueryContext {
     }
 
     pub fn snapshots(&self) -> HashMap<u64, u64> {
-        self.snapshot_seqs.read().unwrap().clone()
+        self.mutable_query_context_data
+            .read()
+            .unwrap()
+            .snapshot_seqs
+            .clone()
     }
 
     pub fn sst_min_sequences(&self) -> HashMap<u64, u64> {
-        self.sst_min_sequences.read().unwrap().clone()
+        self.mutable_query_context_data
+            .read()
+            .unwrap()
+            .sst_min_sequences
+            .clone()
     }
 
     pub fn get_snapshot(&self, region_id: u64) -> Option<u64> {
-        self.snapshot_seqs.read().unwrap().get(&region_id).cloned()
+        self.mutable_query_context_data
+            .read()
+            .unwrap()
+            .snapshot_seqs
+            .get(&region_id)
+            .cloned()
     }
 
     pub fn set_snapshot(&self, region_id: u64, sequence: u64) {
-        self.snapshot_seqs
+        self.mutable_query_context_data
             .write()
             .unwrap()
+            .snapshot_seqs
             .insert(region_id, sequence);
     }
 
@@ -455,9 +497,10 @@ impl QueryContext {
 
     /// Finds the minimal sequence of SST files to scan of a Region.
     pub fn sst_min_sequence(&self, region_id: u64) -> Option<u64> {
-        self.sst_min_sequences
+        self.mutable_query_context_data
             .read()
             .unwrap()
+            .sst_min_sequences
             .get(&region_id)
             .copied()
     }
@@ -487,14 +530,11 @@ impl QueryContextBuilder {
             current_catalog: self
                 .current_catalog
                 .unwrap_or_else(|| DEFAULT_CATALOG_NAME.to_string()),
-            snapshot_seqs: self.snapshot_seqs.unwrap_or_default(),
-            sst_min_sequences: self.sst_min_sequences.unwrap_or_default(),
             mutable_session_data: self.mutable_session_data.unwrap_or_default(),
             mutable_query_context_data: self.mutable_query_context_data.unwrap_or_default(),
             sql_dialect: self
                 .sql_dialect
                 .unwrap_or_else(|| Arc::new(GreptimeDbDialect {})),
-            extensions: self.extensions.unwrap_or_default(),
             configuration_parameter: self
                 .configuration_parameter
                 .unwrap_or_else(|| Arc::new(ConfigurationVariables::default())),
@@ -505,9 +545,39 @@ impl QueryContextBuilder {
         }
     }
 
+    pub fn extensions(mut self, extensions: HashMap<String, String>) -> Self {
+        self.mutable_query_context_data
+            .get_or_insert_default()
+            .write()
+            .unwrap()
+            .extensions = extensions;
+        self
+    }
+
+    pub fn snapshot_seqs(mut self, seqs: HashMap<u64, u64>) -> Self {
+        self.mutable_query_context_data
+            .get_or_insert_default()
+            .write()
+            .unwrap()
+            .snapshot_seqs = seqs;
+        self
+    }
+
+    pub fn sst_min_sequences(mut self, seqs: HashMap<u64, u64>) -> Self {
+        self.mutable_query_context_data
+            .get_or_insert_default()
+            .write()
+            .unwrap()
+            .sst_min_sequences = seqs;
+        self
+    }
+
     pub fn set_extension(mut self, key: String, value: String) -> Self {
-        self.extensions
-            .get_or_insert_with(HashMap::new)
+        self.mutable_query_context_data
+            .get_or_insert_default()
+            .write()
+            .unwrap()
+            .extensions
             .insert(key, value);
         self
     }

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -327,7 +327,7 @@ impl QueryContext {
         self.mutable_session_data.write().unwrap().user_info = user;
     }
 
-    pub fn set_extension<S1: Into<String>, S2: Into<String>>(&mut self, key: S1, value: S2) {
+    pub fn set_extension<S1: Into<String>, S2: Into<String>>(&self, key: S1, value: S2) {
         self.mutable_query_context_data
             .write()
             .unwrap()

--- a/tests-integration/src/prom_store.rs
+++ b/tests-integration/src/prom_store.rs
@@ -90,7 +90,7 @@ mod tests {
         };
 
         let db = "prometheus";
-        let mut ctx = Arc::into_inner(QueryContext::with(DEFAULT_CATALOG_NAME, db).into()).unwrap();
+        let ctx = Arc::into_inner(QueryContext::with(DEFAULT_CATALOG_NAME, db).into()).unwrap();
 
         // set physical table if provided
         if let Some(physical_table) = &physical_table {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

In order to store some information with `QueryContext`, I will need to make `extension` mutable. This patch moves all mutable items into `QueryContextMutableFields`.

It also changes it's clone to deep copy to match original behaviour.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
