### PR TITLE
fix: remove unparsed [heartbeat] sections from node example configs

### DIFF
--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -80,14 +80,6 @@ watch = false
 ## The number of threads to execute the runtime for global write operations.
 #+ compact_rt_size = 4
 
-## The heartbeat options.
-[heartbeat]
-## Interval for sending heartbeat messages to the metasrv.
-interval = "3s"
-
-## Interval for retrying to send heartbeat messages to the metasrv.
-retry_interval = "3s"
-
 ## The metasrv client options.
 [meta_client]
 ## The addresses of the metasrv.

--- a/config/flownode.example.toml
+++ b/config/flownode.example.toml
@@ -97,14 +97,6 @@ metadata_cache_ttl = "10m"
 # TTI of the metadata cache.
 metadata_cache_tti = "5m"
 
-## The heartbeat options.
-[heartbeat]
-## Interval for sending heartbeat messages to the metasrv.
-interval = "3s"
-
-## Interval for retrying to send heartbeat messages to the metasrv.
-retry_interval = "3s"
-
 ## The logging options.
 [logging]
 ## The directory to store the log files. If set to empty, logs will not be written to files.

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -28,14 +28,6 @@ default_column_prefix = "greptime"
 ## The number of threads to execute the runtime for global write operations.
 #+ compact_rt_size = 4
 
-## The heartbeat options.
-[heartbeat]
-## Interval for sending heartbeat messages to the metasrv.
-interval = "18s"
-
-## Interval for retrying to send heartbeat messages to the metasrv.
-retry_interval = "3s"
-
 ## The HTTP server options.
 [http]
 ## The address to bind the HTTP server.

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -79,7 +79,7 @@ node_max_idle_time = "24hours"
 ## The frontend heartbeat interval is 6 times of the base heartbeat interval.
 ## The flownode/datanode heartbeat interval is 1 times of the base heartbeat interval.
 ## e.g., If the base heartbeat interval is 3s, the frontend heartbeat interval is 18s, the flownode/datanode heartbeat interval is 3s.
-## If you change this value, you need to change the heartbeat interval of the flownode/frontend/datanode accordingly.
+## Heartbeat intervals are negotiated from metasrv during handshake; local node configs do not override this.
 #+ heartbeat_interval = "3s"
 
 ## Whether to enable greptimedb telemetry. Enabled by default.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Fixes #8087

## What's changed and what's your intention?

The `[heartbeat]` sections in `frontend.example.toml`, `datanode.example.toml`, and `flownode.example.toml` were misleading because heartbeat intervals are negotiated from metasrv during handshake, not read from local node configs.

This PR removes those ignored config sections and updates the metasrv example comment to clarify the handshake mechanism.

Verified in `src/meta-client/src/client/heartbeat.rs`: `HeartbeatConfig::from_response` extracts both `interval` and `retry_interval` from the metasrv's `HeartbeatResponse`. No `HeartbeatOptions` structs exist in datanode/frontend/flownode config parsing.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.