### PR TITLE
fix(mito): allow compaction publish during editing

### DIFF
--- a/src/mito2/src/compaction/compactor.rs
+++ b/src/mito2/src/compaction/compactor.rs
@@ -620,7 +620,7 @@ where
         // TODO: We might leak files if we fail to update manifest. We can add a cleanup task to remove them later.
         compaction_region
             .manifest_ctx
-            .update_manifest(RegionLeaderState::Writable, action_list, false)
+            .update_manifest_for_compaction(action_list)
             .await?;
 
         Ok(edit)

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -438,7 +438,7 @@ impl MitoEngine {
     }
 
     /// Edit region's metadata by [RegionEdit] directly. Use with care.
-    /// Now we only allow adding files or removing files from region (the [RegionEdit] struct can only contain a non-empty "files_to_add" or "files_to_remove" field).
+    /// Now we only allow adding files to the region.
     /// Other region editing intention will result in an "invalid request" error.
     /// Also note that if a region is to be edited directly, we MUST not write data to it thereafter.
     pub async fn edit_region(&self, region_id: RegionId, edit: RegionEdit) -> Result<()> {
@@ -685,9 +685,10 @@ impl MitoEngine {
 
 /// Check whether the region edit is valid.
 ///
-/// Only adding or removing files to region is considered valid now.
+/// Only adding files to region is considered valid now.
 fn is_valid_region_edit(edit: &RegionEdit) -> bool {
-    (!edit.files_to_add.is_empty() || !edit.files_to_remove.is_empty())
+    !edit.files_to_add.is_empty()
+        && edit.files_to_remove.is_empty()
         && matches!(
             edit,
             RegionEdit {

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -438,7 +438,7 @@ impl MitoEngine {
     }
 
     /// Edit region's metadata by [RegionEdit] directly. Use with care.
-    /// Now we only allow adding files to the region.
+    /// Now we only allow adding files or removing files from region (the [RegionEdit] struct can only contain a non-empty "files_to_add" or "files_to_remove" field).
     /// Other region editing intention will result in an "invalid request" error.
     /// Also note that if a region is to be edited directly, we MUST not write data to it thereafter.
     pub async fn edit_region(&self, region_id: RegionId, edit: RegionEdit) -> Result<()> {
@@ -685,10 +685,9 @@ impl MitoEngine {
 
 /// Check whether the region edit is valid.
 ///
-/// Only adding files to region is considered valid now.
+/// Only adding or removing files to region is considered valid now.
 fn is_valid_region_edit(edit: &RegionEdit) -> bool {
-    !edit.files_to_add.is_empty()
-        && edit.files_to_remove.is_empty()
+    (!edit.files_to_add.is_empty() || !edit.files_to_remove.is_empty())
         && matches!(
             edit,
             RegionEdit {
@@ -1467,7 +1466,19 @@ mod tests {
         };
         assert!(!is_valid_region_edit(&edit));
 
-        // Valid: "files_to_remove" is not empty
+        // Valid: has only "files_to_remove"
+        let edit = RegionEdit {
+            files_to_add: vec![],
+            files_to_remove: vec![FileMeta::default()],
+            timestamp_ms: None,
+            compaction_time_window: None,
+            flushed_entry_id: None,
+            flushed_sequence: None,
+            committed_sequence: None,
+        };
+        assert!(is_valid_region_edit(&edit));
+
+        // Valid: both "files_to_add" and "files_to_remove" are not empty
         let edit = RegionEdit {
             files_to_add: vec![FileMeta::default()],
             files_to_remove: vec![FileMeta::default()],

--- a/src/mito2/src/engine/edit_region_test.rs
+++ b/src/mito2/src/engine/edit_region_test.rs
@@ -46,44 +46,6 @@ async fn test_edit_region_schedule_compaction() {
     test_edit_region_schedule_compaction_with_format(true).await;
 }
 
-#[tokio::test]
-async fn test_edit_region_rejects_removing_files() {
-    let mut env = TestEnv::new().await;
-    let engine = env.create_engine(Default::default()).await;
-
-    let region_id = RegionId::new(1, 1);
-    engine
-        .handle_request(
-            region_id,
-            RegionRequest::Create(CreateRequestBuilder::new().build()),
-        )
-        .await
-        .unwrap();
-
-    let err = engine
-        .edit_region(
-            region_id,
-            RegionEdit {
-                files_to_add: vec![],
-                files_to_remove: vec![FileMeta {
-                    region_id,
-                    file_id: FileId::random(),
-                    level: 0,
-                    ..Default::default()
-                }],
-                timestamp_ms: None,
-                compaction_time_window: None,
-                flushed_entry_id: None,
-                flushed_sequence: None,
-                committed_sequence: None,
-            },
-        )
-        .await
-        .unwrap_err();
-
-    assert_eq!(StatusCode::InvalidArguments, err.status_code());
-}
-
 async fn test_edit_region_schedule_compaction_with_format(flat_format: bool) {
     let mut env = TestEnv::new().await;
 

--- a/src/mito2/src/engine/edit_region_test.rs
+++ b/src/mito2/src/engine/edit_region_test.rs
@@ -46,6 +46,44 @@ async fn test_edit_region_schedule_compaction() {
     test_edit_region_schedule_compaction_with_format(true).await;
 }
 
+#[tokio::test]
+async fn test_edit_region_rejects_removing_files() {
+    let mut env = TestEnv::new().await;
+    let engine = env.create_engine(Default::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Create(CreateRequestBuilder::new().build()),
+        )
+        .await
+        .unwrap();
+
+    let err = engine
+        .edit_region(
+            region_id,
+            RegionEdit {
+                files_to_add: vec![],
+                files_to_remove: vec![FileMeta {
+                    region_id,
+                    file_id: FileId::random(),
+                    level: 0,
+                    ..Default::default()
+                }],
+                timestamp_ms: None,
+                compaction_time_window: None,
+                flushed_entry_id: None,
+                flushed_sequence: None,
+                committed_sequence: None,
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(StatusCode::InvalidArguments, err.status_code());
+}
+
 async fn test_edit_region_schedule_compaction_with_format(flat_format: bool) {
     let mut env = TestEnv::new().await;
 

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -986,7 +986,7 @@ impl ManifestContext {
             if expect_state != RegionLeaderState::Downgrading {
                 if current_state == RegionRoleState::Leader(RegionLeaderState::Downgrading) {
                     info!(
-                        "Region {} is in downgrading leader state, updating manifest. state is {:?}",
+                        "Region {} is in downgrading leader state, updating manifest. Expect state is {:?}",
                         region_id, expect_state
                     );
                 }
@@ -1017,10 +1017,11 @@ impl ManifestContext {
     /// Updates the manifest for compaction.
     ///
     /// Compaction may finish while a direct external region edit is in the transient
-    /// `Editing` state. External direct edits may remove files, but the remove-capable
-    /// sync-region path only runs on followers, where compaction is not scheduled. On
-    /// leaders, compaction can publish under the manifest write lock while still
-    /// rechecking its input files.
+    /// `Editing` state. Direct external edits can remove files both when followers
+    /// apply sync-region metadata and when a writable leader performs a direct edit
+    /// such as `edit_region()`. Allowing compaction to publish in `Editing` is still
+    /// safe because publication happens under the manifest write lock and compaction
+    /// rechecks that its input files are still valid before committing.
     pub(crate) async fn update_manifest_for_compaction(
         &self,
         action_list: RegionMetaActionList,

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -1017,8 +1017,10 @@ impl ManifestContext {
     /// Updates the manifest for compaction.
     ///
     /// Compaction may finish while a direct external region edit is in the transient
-    /// `Editing` state. External edits are add-only, so it is safe for compaction to
-    /// publish under the manifest write lock while still rechecking its input files.
+    /// `Editing` state. External direct edits may remove files, but the remove-capable
+    /// sync-region path only runs on followers, where compaction is not scheduled. On
+    /// leaders, compaction can publish under the manifest write lock while still
+    /// rechecking its input files.
     pub(crate) async fn update_manifest_for_compaction(
         &self,
         action_list: RegionMetaActionList,

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -1022,6 +1022,14 @@ impl ManifestContext {
     /// such as `edit_region()`. Allowing compaction to publish in `Editing` is still
     /// safe because publication happens under the manifest write lock and compaction
     /// rechecks that its input files are still valid before committing.
+    ///
+    /// This intentionally writes to the normal manifest path (`is_staging = false`).
+    /// Entering staging cancels or waits for active compactions before switching the
+    /// region to `Staging`, so a compaction that started before staging still finishes
+    /// against the normal manifest. Even if a manual compaction is requested while the
+    /// region is already staging, compaction only sees SSTs in the normal visible
+    /// region version; SSTs from staging manifests are not applied to region version
+    /// control until staging exits successfully.
     pub(crate) async fn update_manifest_for_compaction(
         &self,
         action_list: RegionMetaActionList,

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -978,6 +978,76 @@ impl ManifestContext {
         action_list: RegionMetaActionList,
         is_staging: bool,
     ) -> Result<ManifestVersion> {
+        self.update_manifest_with_state_check(action_list, is_staging, |current_state, region_id| {
+            // If expect_state is not downgrading, the current state must be either `expect_state` or downgrading.
+            //
+            // A downgrading leader rejects user writes but still allows
+            // flushing the memtable and updating the manifest.
+            if expect_state != RegionLeaderState::Downgrading {
+                if current_state == RegionRoleState::Leader(RegionLeaderState::Downgrading) {
+                    info!(
+                        "Region {} is in downgrading leader state, updating manifest. state is {:?}",
+                        region_id, expect_state
+                    );
+                }
+                ensure!(
+                    current_state == RegionRoleState::Leader(expect_state)
+                        || current_state == RegionRoleState::Leader(RegionLeaderState::Downgrading),
+                    UpdateManifestSnafu {
+                        region_id,
+                        state: current_state,
+                    }
+                );
+            } else {
+                ensure!(
+                    current_state == RegionRoleState::Leader(expect_state),
+                    RegionStateSnafu {
+                        region_id,
+                        state: current_state,
+                        expect: RegionRoleState::Leader(expect_state),
+                    }
+                );
+            }
+
+            Ok(())
+        })
+        .await
+    }
+
+    /// Updates the manifest for compaction.
+    ///
+    /// Compaction may finish while a direct external region edit is in the transient
+    /// `Editing` state. External edits are add-only, so it is safe for compaction to
+    /// publish under the manifest write lock while still rechecking its input files.
+    pub(crate) async fn update_manifest_for_compaction(
+        &self,
+        action_list: RegionMetaActionList,
+    ) -> Result<ManifestVersion> {
+        self.update_manifest_with_state_check(action_list, false, |current_state, region_id| {
+            ensure!(
+                matches!(
+                    current_state,
+                    RegionRoleState::Leader(RegionLeaderState::Writable)
+                        | RegionRoleState::Leader(RegionLeaderState::Editing)
+                        | RegionRoleState::Leader(RegionLeaderState::Downgrading)
+                ),
+                UpdateManifestSnafu {
+                    region_id,
+                    state: current_state,
+                }
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    async fn update_manifest_with_state_check(
+        &self,
+        action_list: RegionMetaActionList,
+        is_staging: bool,
+        check_state: impl FnOnce(RegionRoleState, RegionId) -> Result<()>,
+    ) -> Result<ManifestVersion> {
         // Acquires the write lock of the manifest manager.
         let mut manager = self.manifest_manager.write().await;
         // Gets current manifest.
@@ -985,36 +1055,7 @@ impl ManifestContext {
         // Checks state inside the lock. This is to ensure that we won't update the manifest
         // after `set_readonly_gracefully()` is called.
         let current_state = self.state.load();
-
-        // If expect_state is not downgrading, the current state must be either `expect_state` or downgrading.
-        //
-        // A downgrading leader rejects user writes but still allows
-        // flushing the memtable and updating the manifest.
-        if expect_state != RegionLeaderState::Downgrading {
-            if current_state == RegionRoleState::Leader(RegionLeaderState::Downgrading) {
-                info!(
-                    "Region {} is in downgrading leader state, updating manifest. state is {:?}",
-                    manifest.metadata.region_id, expect_state
-                );
-            }
-            ensure!(
-                current_state == RegionRoleState::Leader(expect_state)
-                    || current_state == RegionRoleState::Leader(RegionLeaderState::Downgrading),
-                UpdateManifestSnafu {
-                    region_id: manifest.metadata.region_id,
-                    state: current_state,
-                }
-            );
-        } else {
-            ensure!(
-                current_state == RegionRoleState::Leader(expect_state),
-                RegionStateSnafu {
-                    region_id: manifest.metadata.region_id,
-                    state: current_state,
-                    expect: RegionRoleState::Leader(expect_state),
-                }
-            );
-        }
+        check_state(current_state, manifest.metadata.region_id)?;
 
         for action in &action_list.actions {
             // Checks whether the edit is still applicable.
@@ -1562,7 +1603,7 @@ mod tests {
     use store_api::logstore::provider::Provider;
     use store_api::region_engine::RegionRole;
     use store_api::region_request::PathType;
-    use store_api::storage::RegionId;
+    use store_api::storage::{FileId, RegionId};
 
     use crate::access_layer::AccessLayer;
     use crate::error::Error;
@@ -1638,6 +1679,44 @@ mod tests {
             flushed_sequence: None,
             committed_sequence: None,
         }
+    }
+
+    #[tokio::test]
+    async fn test_compaction_update_manifest_allows_editing_state() {
+        let env = SchedulerEnv::new().await;
+        let region = build_test_region(&env).await;
+        region.set_editing(RegionLeaderState::Writable).unwrap();
+
+        let file_id = FileId::random();
+        let action_list = RegionMetaActionList::with_action(RegionMetaAction::Edit(RegionEdit {
+            files_to_add: vec![crate::sst::file::FileMeta {
+                region_id: region.region_id,
+                file_id,
+                level: 1,
+                ..Default::default()
+            }],
+            files_to_remove: Vec::new(),
+            timestamp_ms: None,
+            compaction_time_window: None,
+            flushed_entry_id: None,
+            flushed_sequence: None,
+            committed_sequence: None,
+        }));
+
+        region
+            .manifest_ctx
+            .update_manifest_for_compaction(action_list)
+            .await
+            .unwrap();
+
+        assert!(
+            region
+                .manifest_ctx
+                .manifest()
+                .await
+                .files
+                .contains_key(&file_id)
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

N/A

## What's changed and what's your intention?

This PR fixes compaction manifest publication while a Mito region is in the transient direct-editing state.

Changes:

- Add `ManifestContext::update_manifest_for_compaction()` so compaction can publish manifest updates when the region leader state is `Writable`, `Editing`, or `Downgrading`.
- Refactor manifest update state validation through a shared helper while keeping the state check under the manifest write lock.
- Keep direct `MitoEngine::edit_region()` scoped to file add/remove edits, including remove-only edits needed by sync-region.
- Document the safety guarantee for remove-capable external edits: sync-region runs on followers, where compaction is not scheduled; leader-side compaction can therefore publish during `Editing` while still rechecking input files under the manifest lock.
- Add/update regression coverage for allowing compaction manifest updates during `Editing` and accepting remove-only direct region edits.

The root issue is that direct external region edits temporarily mark a region as `Editing`, while compaction can still finish and needs to publish a manifest edit. Compaction now uses a dedicated manifest update path that tolerates the transient `Editing` state. The manifest update path still checks that files in `files_to_remove` are present before publishing, and remove-capable sync-region edits are follower-only, so they cannot race with leader-side compaction.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.

Validation:

- `cargo fmt --all`
- `cargo test -p mito2 test_is_valid_region_edit --lib`
- `cargo test -p mito2 test_compaction_update_manifest_allows_editing_state --lib`
- `git diff --check`
