### PR TITLE
fix: expose flight timestamp range metadata

### DIFF
--- a/src/common/grpc/src/flight/do_put.rs
+++ b/src/common/grpc/src/flight/do_put.rs
@@ -57,7 +57,9 @@ impl DoPutMetadata {
     }
 
     pub fn timestamp_range(&self) -> Option<(i64, i64)> {
-        self.min_timestamp.zip(self.max_timestamp)
+        self.min_timestamp
+            .zip(self.max_timestamp)
+            .filter(|(min, max)| max >= min)
     }
 }
 

--- a/src/common/grpc/src/flight/do_put.rs
+++ b/src/common/grpc/src/flight/do_put.rs
@@ -55,6 +55,10 @@ impl DoPutMetadata {
     pub fn max_timestamp(&self) -> Option<i64> {
         self.max_timestamp
     }
+
+    pub fn timestamp_range(&self) -> Option<(i64, i64)> {
+        self.min_timestamp.zip(self.max_timestamp)
+    }
 }
 
 /// The response in the "DoPut" returned stream.
@@ -107,6 +111,14 @@ mod tests {
         let serialized = r#"{"request_id":42}"#;
         let metadata = serde_json::from_str::<DoPutMetadata>(serialized).unwrap();
         assert_eq!(metadata.request_id(), 42);
+    }
+
+    #[test]
+    fn test_serde_do_put_metadata_with_timestamp_range() {
+        let serialized = r#"{"request_id":42,"min_timestamp":1000,"max_timestamp":2000}"#;
+        let metadata = serde_json::from_str::<DoPutMetadata>(serialized).unwrap();
+        assert_eq!(metadata.request_id(), 42);
+        assert_eq!(metadata.timestamp_range(), Some((1000, 2000)));
     }
 
     #[test]

--- a/src/servers/src/grpc/flight.rs
+++ b/src/servers/src/grpc/flight.rs
@@ -257,6 +257,7 @@ impl FlightCraft for GreptimeRequestHandler {
 pub struct PutRecordBatchRequest {
     pub table_name: TableName,
     pub request_id: i64,
+    pub timestamp_range: Option<(i64, i64)>,
     pub record_batch: DfRecordBatch,
     pub schema_bytes: Bytes,
     pub flight_data: FlightData,
@@ -268,6 +269,7 @@ impl PutRecordBatchRequest {
         table_name: TableName,
         record_batch: DfRecordBatch,
         request_id: i64,
+        timestamp_range: Option<(i64, i64)>,
         schema_bytes: Bytes,
         flight_data: FlightData,
         limiter: Option<&ServerMemoryLimiter>,
@@ -292,6 +294,7 @@ impl PutRecordBatchRequest {
         Ok(Self {
             table_name,
             request_id,
+            timestamp_range,
             record_batch,
             schema_bytes,
             flight_data,
@@ -457,13 +460,17 @@ impl Stream for PutRecordBatchRequestStream {
                             decoder,
                         } => {
                             // Extract request_id and body_size from FlightData before decoding
-                            let request_id = if !flight_data.app_metadata.is_empty() {
+                            let metadata = if !flight_data.app_metadata.is_empty() {
                                 serde_json::from_slice::<DoPutMetadata>(&flight_data.app_metadata)
-                                    .map(|meta| meta.request_id())
-                                    .unwrap_or_default()
+                                    .ok()
                             } else {
-                                0
+                                None
                             };
+                            let request_id = metadata
+                                .as_ref()
+                                .map(|meta| meta.request_id())
+                                .unwrap_or_default();
+                            let timestamp_range = metadata.and_then(|meta| meta.timestamp_range());
 
                             // Decode FlightData to RecordBatch
                             match decoder.try_decode(&flight_data) {
@@ -475,6 +482,7 @@ impl Stream for PutRecordBatchRequestStream {
                                             table_name,
                                             record_batch,
                                             request_id,
+                                            timestamp_range,
                                             schema_bytes,
                                             flight_data,
                                             limiter.as_ref(),

--- a/src/servers/src/grpc/flight.rs
+++ b/src/servers/src/grpc/flight.rs
@@ -459,7 +459,7 @@ impl Stream for PutRecordBatchRequestStream {
                             schema_bytes,
                             decoder,
                         } => {
-                            // Extract request_id and body_size from FlightData before decoding
+                            // Extract request_id and time range from FlightData before decoding
                             let metadata = if !flight_data.app_metadata.is_empty() {
                                 serde_json::from_slice::<DoPutMetadata>(&flight_data.app_metadata)
                                     .ok()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Enterprise follow-up will consume this metadata to skip redundant time-window splitting when the Rust ingester provides batch timestamp bounds.

## What's changed and what's your intention?

- Exposes optional `min_timestamp` and `max_timestamp` from Flight DoPut metadata as `DoPutMetadata::timestamp_range()`.
- Carries the decoded timestamp range on `PutRecordBatchRequest` so upper-layer handlers can choose ingestion fast paths without reparsing Flight metadata.
- Keeps the metadata optional and falls back to existing `request_id` behavior when clients omit or send invalid app metadata.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.

## Test Plan

- `cargo test -p common-grpc test_serde_do_put_metadata_with_timestamp_range`
- `cargo check -p enterprise -p servers`