### PR TITLE
fix: classify WAL prune Kafka retry errors

### DIFF
--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -1142,7 +1142,21 @@ impl Error {
         ) || matches!(
             self,
             Error::DeallocateRegions { source, .. } if source.is_retry_later()
+        ) || matches!(
+            self,
+            Error::DeleteRecords {  error, .. } if Self::is_retryable_kafka_client_error(error)
+        ) || matches!(
+            self,
+            Error::BuildPartitionClient {  error, .. } if Self::is_retryable_kafka_client_error(error)
+        ) || matches!(
+            self,
+            Error::GetOffset {  error, .. } if Self::is_retryable_kafka_client_error(error)
         )
+    }
+
+    /// Returns `true` if the Kafka client has exhausted its internal retry.
+    fn is_retryable_kafka_client_error(err: &rskafka::client::error::Error) -> bool {
+        matches!(err, rskafka::client::error::Error::RetryFailed(_))
     }
 }
 
@@ -1333,11 +1347,24 @@ pub(crate) fn match_for_io_error(err_status: &tonic::Status) -> Option<&std::io:
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use common_error::mock::MockError;
     use common_error::status_code::StatusCode;
+    use rskafka::BackoffError;
+    use rskafka::client::error::Error as KafkaClientError;
     use snafu::ResultExt;
 
-    use super::DeallocateRegionsSnafu;
+    use super::{
+        BuildPartitionClientSnafu, DeallocateRegionsSnafu, DeleteRecordsSnafu, GetOffsetSnafu,
+    };
+
+    fn retry_failed_kafka_error() -> KafkaClientError {
+        KafkaClientError::RetryFailed(BackoffError::DeadlineExceded {
+            deadline: Duration::from_secs(1),
+            source: Box::new(std::io::Error::other("retry failed")),
+        })
+    }
 
     #[test]
     fn test_deallocate_regions_is_retryable_when_source_is_retry_later() {
@@ -1360,5 +1387,57 @@ mod tests {
             .unwrap_err();
 
         assert!(!err.is_retryable());
+    }
+
+    #[test]
+    fn test_kafka_retry_failed_errors_are_retryable() {
+        let delete_records_err = Err::<(), _>(retry_failed_kafka_error())
+            .context(DeleteRecordsSnafu {
+                topic: "test_topic",
+                partition: 0,
+                offset: 1024u64,
+            })
+            .unwrap_err();
+        let build_partition_client_err = Err::<(), _>(retry_failed_kafka_error())
+            .context(BuildPartitionClientSnafu {
+                topic: "test_topic",
+                partition: 0,
+            })
+            .unwrap_err();
+        let get_offset_err = Err::<(), _>(retry_failed_kafka_error())
+            .context(GetOffsetSnafu {
+                topic: "test_topic",
+            })
+            .unwrap_err();
+
+        assert!(delete_records_err.is_retryable());
+        assert!(build_partition_client_err.is_retryable());
+        assert!(get_offset_err.is_retryable());
+    }
+
+    #[test]
+    fn test_kafka_non_retry_failed_errors_are_not_retryable() {
+        let delete_records_err = Err::<(), _>(KafkaClientError::Timeout)
+            .context(DeleteRecordsSnafu {
+                topic: "test_topic",
+                partition: 0,
+                offset: 1024u64,
+            })
+            .unwrap_err();
+        let build_partition_client_err = Err::<(), _>(KafkaClientError::Timeout)
+            .context(BuildPartitionClientSnafu {
+                topic: "test_topic",
+                partition: 0,
+            })
+            .unwrap_err();
+        let get_offset_err = Err::<(), _>(KafkaClientError::Timeout)
+            .context(GetOffsetSnafu {
+                topic: "test_topic",
+            })
+            .unwrap_err();
+
+        assert!(!delete_records_err.is_retryable());
+        assert!(!build_partition_client_err.is_retryable());
+        assert!(!get_offset_err.is_retryable());
     }
 }

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -1144,13 +1144,10 @@ impl Error {
             Error::DeallocateRegions { source, .. } if source.is_retry_later()
         ) || matches!(
             self,
-            Error::DeleteRecords {  error, .. } if Self::is_retryable_kafka_client_error(error)
-        ) || matches!(
-            self,
-            Error::BuildPartitionClient {  error, .. } if Self::is_retryable_kafka_client_error(error)
-        ) || matches!(
-            self,
-            Error::GetOffset {  error, .. } if Self::is_retryable_kafka_client_error(error)
+            Error::DeleteRecords { error, .. }
+                | Error::BuildPartitionClient { error, .. }
+                | Error::GetOffset { error, .. }
+                if Self::is_retryable_kafka_client_error(error)
         )
     }
 

--- a/src/meta-srv/src/procedure/wal_prune.rs
+++ b/src/meta-srv/src/procedure/wal_prune.rs
@@ -106,7 +106,7 @@ impl WalPruneProcedure {
     ///
     /// Retry:
     /// - Kafka client errors that have exhausted rskafka's internal retry.
-    /// - Failed to delete records.
+    /// - Failed to update the pruned entry id in the table metadata manager.
     pub async fn on_prune(&mut self) -> Result<Status> {
         let partition_client = get_partition_client(&self.context.client, &self.data.topic).await?;
         let (earliest_offset, latest_offset) =

--- a/src/meta-srv/src/procedure/wal_prune.rs
+++ b/src/meta-srv/src/procedure/wal_prune.rs
@@ -105,7 +105,7 @@ impl WalPruneProcedure {
     /// Prune the WAL and persist the minimum prunable entry id.
     ///
     /// Retry:
-    /// - Failed to update the minimum prunable entry id in kvbackend.
+    /// - Kafka client errors that have exhausted rskafka's internal retry.
     /// - Failed to delete records.
     pub async fn on_prune(&mut self) -> Result<Status> {
         let partition_client = get_partition_client(&self.context.client, &self.data.topic).await?;
@@ -125,14 +125,7 @@ impl WalPruneProcedure {
             &self.data.topic,
             self.data.prunable_entry_id,
         )
-        .await
-        .map_err(BoxedError::new)
-        .with_context(|_| error::RetryLaterWithSourceSnafu {
-            reason: format!(
-                "Failed to delete records for topic: {}, prunable entry id: {}, latest offset: {}",
-                self.data.topic, self.data.prunable_entry_id, latest_offset
-            ),
-        })?;
+        .await?;
 
         // Update the pruned entry id for the topic.
         update_pruned_entry_id(

--- a/typos.toml
+++ b/typos.toml
@@ -8,6 +8,9 @@ typs = "typs"
 unqualifed = "unqualifed"
 excluder = "excluder"
 consts = "consts"
+# Upstream crate rskafka defines a `DeadlineExceded` error variant, but it is misspelled. 
+# We need to extend the word list to avoid typos in our codebase.
+Exceded = "Exceded"
 
 [files]
 extend-exclude = [


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

- Classify WAL prune Kafka client errors as retryable only when rskafka has exhausted its internal retry.
- Stop wrapping all `delete_records` failures as retry-later errors.
- Add tests to verify `RetryFailed` is retryable while `Timeout` remains non-retryable for WAL prune-related Kafka errors.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
