### PR TITLE
fix: optimize sorted run picking

### DIFF
--- a/src/mito2/Cargo.toml
+++ b/src/mito2/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [features]
 default = []
 test = ["common-test-util", "rstest", "rstest_reuse", "rskafka"]
+testing = ["test"]
 enterprise = []
 vector_index = ["dep:roaring", "index/vector_index"]
 
@@ -123,7 +124,7 @@ required-features = ["test"]
 [[bench]]
 name = "bench_compaction_picker"
 harness = false
-required-features = ["test"]
+required-features = ["testing"]
 
 [[bench]]
 name = "simple_bulk_memtable"

--- a/src/mito2/benches/bench_compaction_picker.rs
+++ b/src/mito2/benches/bench_compaction_picker.rs
@@ -16,13 +16,15 @@ use std::hint::black_box;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use mito2::compaction::run::{
-    Item, Ranged, SortedRun, find_overlapping_items, find_sorted_runs, merge_seq_files, reduce_runs,
+    Item, Ranged, SortedRun, find_overlapping_items, find_sorted_runs, find_sorted_runs_original,
+    merge_seq_files, reduce_runs,
 };
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct MockFile {
     start: i64,
     end: i64,
+    pk: usize,
     size: usize,
 }
 
@@ -31,6 +33,13 @@ impl Ranged for MockFile {
 
     fn range(&self) -> (Self::BoundType, Self::BoundType) {
         (self.start, self.end)
+    }
+
+    fn overlap(&self, other: &Self) -> bool {
+        let (lhs_start, lhs_end) = self.range();
+        let (rhs_start, rhs_end) = other.range();
+
+        lhs_start.max(rhs_start) < lhs_end.min(rhs_end) && self.pk == other.pk
     }
 }
 
@@ -47,20 +56,51 @@ fn generate_test_files(n: usize) -> Vec<MockFile> {
         files.push(MockFile {
             start: 0,
             end: 10,
+            pk: 0,
             size: 10,
         });
     }
     files
 }
 
+fn generate_same_timestamp_files(total_files: usize, files_per_timestamp: usize) -> Vec<MockFile> {
+    const TIMESTAMP_INTERVAL_SECS: i64 = 10 * 60;
+
+    let mut files = Vec::with_capacity(total_files);
+    for idx in 0..total_files {
+        let timestamp_idx = idx / files_per_timestamp;
+        let start = timestamp_idx as i64 * TIMESTAMP_INTERVAL_SECS;
+        files.push(MockFile {
+            start,
+            end: start + TIMESTAMP_INTERVAL_SECS,
+            pk: idx % files_per_timestamp,
+            size: 10,
+        });
+    }
+
+    files
+}
+
 fn bench_find_sorted_runs(c: &mut Criterion) {
     let mut group = c.benchmark_group("find_sorted_runs");
 
-    for size in [10, 100, 1000].iter() {
-        group.bench_function(format!("size_{}", size), |b| {
-            let mut files = generate_test_files(*size);
+    for (total_files, files_per_timestamp) in [(5000, 1000), (50000, 1000), (50000, 5000)] {
+        let case_name = format!(
+            "{}_files_{}_per_timestamp_10min",
+            total_files, files_per_timestamp
+        );
+
+        group.bench_function(format!("{}_new", case_name), |b| {
+            let mut files = generate_same_timestamp_files(total_files, files_per_timestamp);
             b.iter(|| {
                 find_sorted_runs(black_box(&mut files));
+            });
+        });
+
+        group.bench_function(format!("{}_old", case_name), |b| {
+            let mut files = generate_same_timestamp_files(total_files, files_per_timestamp);
+            b.iter(|| {
+                find_sorted_runs_original(black_box(&mut files));
             });
         });
     }
@@ -95,12 +135,14 @@ fn bench_find_overlapping_items(c: &mut Criterion) {
                 files1.push(MockFile {
                     start: i as i64,
                     end: (i + 5) as i64,
+                    pk: 0,
                     size: 10,
                 });
 
                 files2.push(MockFile {
                     start: (i + 3) as i64,
                     end: (i + 8) as i64,
+                    pk: 0,
                     size: 10,
                 });
             }
@@ -137,6 +179,7 @@ fn bench_merge_seq_files(c: &mut Criterion) {
                 files.push(MockFile {
                     start: i as i64,
                     end: (i + 1) as i64,
+                    pk: 0,
                     size: file_size,
                 });
             }

--- a/src/mito2/src/compaction/run.rs
+++ b/src/mito2/src/compaction/run.rs
@@ -331,6 +331,7 @@ where
     let mut selection = BitVec::repeat(false, items.len());
     while !selection.all() {
         // until all items are assigned to some sorted run.
+        let mut last_pruned_start = None;
         for (item, mut selected) in items.iter().zip(selection.iter_mut()) {
             if *selected {
                 // item is already assigned.
@@ -346,10 +347,13 @@ where
                 // then it belongs to current run. Because now we introduced primary
                 // key range, we cannot simply use timestamps to check overlapping.
                 let (item_start, _) = item.range();
-                active_run_item_indices.retain(|idx| {
-                    let (_, run_item_end) = current_run.items[*idx].range();
-                    run_item_end > item_start
-                });
+                if last_pruned_start != Some(item_start) {
+                    active_run_item_indices.retain(|idx| {
+                        let (_, run_item_end) = current_run.items[*idx].range();
+                        run_item_end > item_start
+                    });
+                    last_pruned_start = Some(item_start);
+                }
 
                 let mut overlaps_any = false;
                 for idx in &active_run_item_indices {

--- a/src/mito2/src/compaction/run.rs
+++ b/src/mito2/src/compaction/run.rs
@@ -345,7 +345,7 @@ where
                 // the current item does not overlap with any item in current run,
                 // then it belongs to current run. Because now we introduced primary
                 // key range, we cannot simply use timestamps to check overlapping.
-                let (item_start, item_end) = item.range();
+                let (item_start, _) = item.range();
                 active_run_item_indices.retain(|idx| {
                     let (_, run_item_end) = current_run.items[*idx].range();
                     run_item_end > item_start
@@ -354,8 +354,7 @@ where
                 let mut overlaps_any = false;
                 for idx in &active_run_item_indices {
                     let run_item = &current_run.items[*idx];
-                    let (run_item_start, _) = run_item.range();
-                    if run_item_start < item_end && run_item.overlap(item) {
+                    if run_item.overlap(item) {
                         overlaps_any = true;
                         break;
                     }

--- a/src/mito2/src/compaction/run.rs
+++ b/src/mito2/src/compaction/run.rs
@@ -326,6 +326,69 @@ where
 
     let mut current_run = SortedRun::default();
     let mut runs = vec![];
+    let mut active_run_item_indices = Vec::new();
+
+    let mut selection = BitVec::repeat(false, items.len());
+    while !selection.all() {
+        // until all items are assigned to some sorted run.
+        for (item, mut selected) in items.iter().zip(selection.iter_mut()) {
+            if *selected {
+                // item is already assigned.
+                continue;
+            }
+            if current_run.items.is_empty() {
+                // current run is empty, just add current_item
+                selected.set(true);
+                current_run.push_item(item.clone());
+                active_run_item_indices.push(current_run.items.len() - 1);
+            } else {
+                // the current item does not overlap with any item in current run,
+                // then it belongs to current run. Because now we introduced primary
+                // key range, we cannot simply use timestamps to check overlapping.
+                let (item_start, item_end) = item.range();
+                active_run_item_indices.retain(|idx| {
+                    let (_, run_item_end) = current_run.items[*idx].range();
+                    run_item_end > item_start
+                });
+
+                let mut overlaps_any = false;
+                for idx in &active_run_item_indices {
+                    let run_item = &current_run.items[*idx];
+                    let (run_item_start, _) = run_item.range();
+                    if run_item_start < item_end && run_item.overlap(item) {
+                        overlaps_any = true;
+                        break;
+                    }
+                }
+                if !overlaps_any {
+                    // does not overlap, push to current run
+                    selected.set(true);
+                    let item_idx = current_run.items.len();
+                    current_run.push_item(item.clone());
+                    active_run_item_indices.push(item_idx);
+                }
+            }
+        }
+        // finished an iteration, we've found a new run.
+        runs.push(std::mem::take(&mut current_run));
+        active_run_item_indices.clear();
+    }
+    runs
+}
+
+#[cfg(any(test, feature = "test", feature = "testing"))]
+pub fn find_sorted_runs_original<T>(items: &mut [T]) -> Vec<SortedRun<T>>
+where
+    T: Item,
+{
+    if items.is_empty() {
+        return vec![];
+    }
+    // sort files
+    sort_ranged_items(items);
+
+    let mut current_run = SortedRun::default();
+    let mut runs = vec![];
 
     let mut selection = BitVec::repeat(false, items.len());
     while !selection.all() {
@@ -543,6 +606,30 @@ mod tests {
         runs
     }
 
+    fn sorted_run_ranges<T: Item>(runs: &[SortedRun<T>]) -> Vec<Vec<T::BoundType>> {
+        runs.iter()
+            .map(|r| {
+                r.items
+                    .iter()
+                    .flat_map(|f| {
+                        let (start, end) = f.range();
+                        [start, end]
+                    })
+                    .collect()
+            })
+            .collect()
+    }
+
+    fn check_find_sorted_runs_consistency(ranges: &[(i64, i64)]) {
+        let mut files = build_items(ranges);
+        let mut files_for_original = files.clone();
+
+        let runs = find_sorted_runs(&mut files);
+        let original_runs = find_sorted_runs_original(&mut files_for_original);
+
+        assert_eq!(sorted_run_ranges(&original_runs), sorted_run_ranges(&runs));
+    }
+
     #[test]
     fn test_find_sorted_runs() {
         check_sorted_runs(&[], &[]);
@@ -592,6 +679,27 @@ mod tests {
                 vec![(21, 22), (31, 32), (32, 42)],
             ],
         );
+    }
+
+    #[test]
+    fn test_find_sorted_runs_matches_original_impl() {
+        for ranges in [
+            &[][..],
+            &[(1, 1), (2, 2)],
+            &[(1, 2), (2, 3)],
+            &[(2, 4), (1, 3)],
+            &[(1, 3), (2, 4), (4, 5)],
+            &[(1, 2), (3, 4), (3, 5)],
+            &[(1, 3), (2, 4), (5, 6)],
+            &[(1, 2), (3, 5), (4, 6)],
+            &[(1, 2), (3, 4), (4, 6), (7, 8)],
+            &[(1, 2), (3, 4), (5, 6), (3, 6), (7, 8), (8, 9)],
+            &[(10, 19), (20, 21), (20, 29), (30, 39)],
+            &[(10, 19), (20, 29), (21, 22), (30, 39), (31, 32), (32, 42)],
+            &[(32, 42), (10, 19), (31, 32), (20, 29), (21, 22), (30, 39)],
+        ] {
+            check_find_sorted_runs_consistency(ranges);
+        }
     }
 
     fn check_reduce_runs(


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR optimizes `find_sorted_runs` in mito compaction by pruning current-run candidates whose timestamp ranges can no longer overlap with the item being considered. The full overlap check is still preserved for active timestamp-overlapping candidates, so primary-key-aware correctness remains unchanged.

Summary:
- Keep active current-run item indices in `find_sorted_runs` to avoid repeatedly checking timestamp-disjoint items.
- Add a test-only `find_sorted_runs_original` implementation and consistency coverage, including unsorted input.
- Add old/new Criterion benchmark cases for same-timestamp files with different primary keys.

Benchmark result:

```text
find_sorted_runs/5000_files_1000_per_timestamp_10min_new
                        time:   [2.5319 ms 2.5393 ms 2.5460 ms]
                        change: [−0.0818% +0.1498% +0.4041%] (p = 0.33 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) low severe
  5 (5.00%) high mild
  3 (3.00%) high severe
find_sorted_runs/5000_files_1000_per_timestamp_10min_old
                        time:   [5.5611 ms 5.6648 ms 5.7795 ms]
                        change: [+6.0514% +7.9381% +10.193%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 17 outliers among 100 measurements (17.00%)
  6 (6.00%) high mild
  11 (11.00%) high severe
find_sorted_runs/50000_files_1000_per_timestamp_10min_new
                        time:   [25.330 ms 25.359 ms 25.389 ms]
Benchmarking find_sorted_runs/50000_files_1000_per_timestamp_10min_old: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 54.3s, or reduce sample count to 10.
find_sorted_runs/50000_files_1000_per_timestamp_10min_old
                        time:   [542.91 ms 545.72 ms 548.72 ms]
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
Benchmarking find_sorted_runs/50000_files_5000_per_timestamp_10min_new: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 12.6s, or reduce sample count to 30.
find_sorted_runs/50000_files_5000_per_timestamp_10min_new
                        time:   [124.71 ms 125.21 ms 125.63 ms]
                        change: [−0.8007% −0.3448% +0.1078%] (p = 0.15 > 0.05)
                        No change in performance detected.
Found 13 outliers among 100 measurements (13.00%)
  8 (8.00%) low severe
  5 (5.00%) high mild
Benchmarking find_sorted_runs/50000_files_5000_per_timestamp_10min_old: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 54.2s, or reduce sample count to 10.
find_sorted_runs/50000_files_5000_per_timestamp_10min_old
                        time:   [545.57 ms 547.92 ms 550.42 ms]
                        change: [+3.2092% +3.5879% +4.0656%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
```

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
