### PR TITLE
chore: bump version to v1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,7 +212,7 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "api"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "arrow-schema 58.3.0",
  "common-base",
@@ -935,7 +935,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auth"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "api",
  "async-trait",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "catalog",
  "common-error",
@@ -1593,7 +1593,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "api",
  "arrow 58.3.0",
@@ -1934,7 +1934,7 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "cli"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -2024,7 +2024,7 @@ dependencies = [
  "serde_json",
  "snafu 0.8.6",
  "store-api",
- "substrait 1.0.0",
+ "substrait 1.1.0",
  "tokio",
  "tokio-stream",
  "tonic 0.14.2",
@@ -2064,7 +2064,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "api",
  "async-trait",
@@ -2206,7 +2206,7 @@ dependencies = [
 
 [[package]]
 name = "common-base"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "ahash 0.8.12",
  "anymap2",
@@ -2226,14 +2226,14 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "const_format",
 ]
 
 [[package]]
 name = "common-config"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "common-base",
  "common-error",
@@ -2257,7 +2257,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "arrow 58.3.0",
  "arrow-schema 58.3.0",
@@ -2292,7 +2292,7 @@ dependencies = [
 
 [[package]]
 name = "common-decimal"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "bigdecimal 0.4.8",
  "common-error",
@@ -2305,7 +2305,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "common-macro",
  "http 1.3.1",
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "common-event-recorder"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "api",
  "async-trait",
@@ -2339,7 +2339,7 @@ dependencies = [
 
 [[package]]
 name = "common-frontend"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "api",
  "async-trait",
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -2423,7 +2423,7 @@ dependencies = [
 
 [[package]]
 name = "common-greptimedb-telemetry"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "common-runtime",
@@ -2440,7 +2440,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -2475,7 +2475,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "api",
  "common-base",
@@ -2495,7 +2495,7 @@ dependencies = [
 
 [[package]]
 name = "common-macro"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "greptime-proto",
  "once_cell",
@@ -2506,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "common-error",
@@ -2522,7 +2522,7 @@ dependencies = [
 
 [[package]]
 name = "common-memory-manager"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2534,7 +2534,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anymap2",
  "api",
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "common-options"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "common-grpc",
  "humantime-serde",
@@ -2615,11 +2615,11 @@ dependencies = [
 
 [[package]]
 name = "common-plugins"
-version = "1.0.0"
+version = "1.1.0"
 
 [[package]]
 name = "common-pprof"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2630,7 +2630,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "api",
  "async-stream",
@@ -2659,7 +2659,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "api",
  "async-trait",
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "arc-swap",
  "common-base",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "common-session"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "serde",
  "strum 0.27.1",
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "common-sql"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "arrow-schema 58.3.0",
  "common-base",
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "common-stat"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "common-base",
  "common-runtime",
@@ -2796,7 +2796,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "backtrace",
  "common-base",
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "client",
  "common-grpc",
@@ -2838,7 +2838,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -2856,7 +2856,7 @@ dependencies = [
 
 [[package]]
 name = "common-version"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "cargo-manifest",
  "const_format",
@@ -2866,7 +2866,7 @@ dependencies = [
 
 [[package]]
 name = "common-wal"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "common-base",
  "common-error",
@@ -2889,7 +2889,7 @@ dependencies = [
 
 [[package]]
 name = "common-workload"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "common-telemetry",
  "serde",
@@ -4314,7 +4314,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -4382,7 +4382,7 @@ dependencies = [
 
 [[package]]
 name = "datatypes"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "arrow 58.3.0",
  "arrow-array 58.3.0",
@@ -5077,7 +5077,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "file-engine"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "api",
  "async-trait",
@@ -5207,7 +5207,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "flow"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "api",
  "arrow 58.3.0",
@@ -5276,7 +5276,7 @@ dependencies = [
  "sql",
  "store-api",
  "strum 0.27.1",
- "substrait 1.0.0",
+ "substrait 1.1.0",
  "table",
  "tokio",
  "tonic 0.14.2",
@@ -5337,7 +5337,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "frontend"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -6606,7 +6606,7 @@ dependencies = [
 
 [[package]]
 name = "index"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -7677,7 +7677,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "log-query"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "chrono",
  "common-error",
@@ -7689,7 +7689,7 @@ dependencies = [
 
 [[package]]
 name = "log-store"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7999,7 +7999,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "api",
  "async-trait",
@@ -8031,7 +8031,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "api",
  "async-trait",
@@ -8131,7 +8131,7 @@ dependencies = [
 
 [[package]]
 name = "metric-engine"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -8232,7 +8232,7 @@ dependencies = [
 
 [[package]]
 name = "mito-codec"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "api",
  "bytes",
@@ -8257,7 +8257,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -8983,7 +8983,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9521,7 +9521,7 @@ dependencies = [
 
 [[package]]
 name = "operator"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -9580,7 +9580,7 @@ dependencies = [
  "sql",
  "sqlparser",
  "store-api",
- "substrait 1.0.0",
+ "substrait 1.1.0",
  "table",
  "tokio",
  "tokio-util",
@@ -9856,7 +9856,7 @@ checksum = "e3c406c9e2aa74554e662d2c2ee11cd3e73756988800be7e6f5eddb16fed4699"
 
 [[package]]
 name = "partition"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "api",
  "async-trait",
@@ -10212,7 +10212,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeline"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -10369,7 +10369,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "auth",
  "catalog",
@@ -10696,7 +10696,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -11048,7 +11048,7 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "async-compression",
  "async-trait",
@@ -11110,7 +11110,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -11179,7 +11179,7 @@ dependencies = [
  "sql",
  "sqlparser",
  "store-api",
- "substrait 1.0.0",
+ "substrait 1.1.0",
  "table",
  "tokio",
  "tokio-stream",
@@ -12634,7 +12634,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -12771,7 +12771,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -13115,7 +13115,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "api",
  "arrow-buffer 58.3.0",
@@ -13176,7 +13176,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -13456,7 +13456,7 @@ dependencies = [
 
 [[package]]
 name = "standalone"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "catalog",
@@ -13500,7 +13500,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "store-api"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -13692,7 +13692,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -13814,7 +13814,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -14084,7 +14084,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tests-fuzz"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "arbitrary",
  "async-trait",
@@ -14129,7 +14129,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -14209,7 +14209,7 @@ dependencies = [
  "sqlx",
  "standalone",
  "store-api",
- "substrait 1.0.0",
+ "substrait 1.1.0",
  "table",
  "tempfile",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/8099

## What's changed and what's your intention?

We're preparing for the release of v1.1.0. Bump the version to v1.1.0 so the nightly version can be v1.1.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
