### PR TITLE
feat(meta-srv): add selector factory plugin hook

### DIFF
--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -47,6 +47,7 @@ use crate::error::OtherSnafu;
 use crate::metasrv::builder::MetasrvBuilder;
 use crate::metasrv::{
     BackendImpl, ElectionRef, Metasrv, MetasrvOptions, SelectTarget, SelectorRef,
+    SelectorWrapperRef,
 };
 use crate::selector::lease_based::LeaseBasedSelector;
 use crate::selector::load_based::LoadBasedSelector;
@@ -404,7 +405,12 @@ pub async fn metasrv_builder(
             "Using selector from options, selector type: {}",
             opts.selector.as_ref()
         );
-        selector
+        if let Some(wrapper) = plugins.get::<SelectorWrapperRef>() {
+            info!("Wrapping selector from options");
+            wrapper.wrap(selector)
+        } else {
+            selector
+        }
     };
 
     Ok(MetasrvBuilder::new()
@@ -428,4 +434,48 @@ pub(crate) fn build_default_meta_peer_client(
         .map(Arc::new)
         // Safety: all required fields set at initialization
         .unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use common_meta::kv_backend::memory::MemoryKvBackend;
+
+    use super::*;
+    use crate::metasrv::SelectorWrapper;
+
+    struct RecordingSelectorWrapper {
+        called: Arc<AtomicBool>,
+    }
+
+    impl SelectorWrapper for RecordingSelectorWrapper {
+        fn wrap(&self, selector: SelectorRef) -> SelectorRef {
+            self.called.store(true, Ordering::Relaxed);
+            selector
+        }
+    }
+
+    #[tokio::test]
+    async fn metasrv_builder_wraps_load_based_selector_from_plugins() {
+        let called = Arc::new(AtomicBool::new(false));
+        let plugins = Plugins::new();
+        plugins.insert(Arc::new(RecordingSelectorWrapper {
+            called: called.clone(),
+        }) as SelectorWrapperRef);
+        let opts = MetasrvOptions {
+            selector: SelectorType::LoadBased,
+            ..Default::default()
+        };
+
+        metasrv_builder(
+            &opts,
+            plugins,
+            Some(Arc::new(MemoryKvBackend::new()) as KvBackendRef),
+        )
+        .await
+        .unwrap();
+
+        assert!(called.load(Ordering::Relaxed));
+    }
 }

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -46,8 +46,8 @@ use crate::cluster::{MetaPeerClientBuilder, MetaPeerClientRef};
 use crate::error::OtherSnafu;
 use crate::metasrv::builder::MetasrvBuilder;
 use crate::metasrv::{
-    BackendImpl, ElectionRef, Metasrv, MetasrvOptions, SelectTarget, SelectorRef,
-    SelectorWrapperRef,
+    BackendImpl, ElectionRef, Metasrv, MetasrvOptions, SelectTarget, SelectorFactoryContext,
+    SelectorFactoryRef, SelectorRef,
 };
 use crate::selector::lease_based::LeaseBasedSelector;
 use crate::selector::load_based::LoadBasedSelector;
@@ -382,35 +382,37 @@ pub async fn metasrv_builder(
     let in_memory = Arc::new(MemoryKvBackend::new()) as ResettableKvBackendRef;
     let meta_peer_client = build_default_meta_peer_client(&election, &in_memory);
 
-    let selector = if let Some(selector) = plugins.get::<SelectorRef>() {
-        info!("Using selector from plugins");
-        selector
-    } else {
-        let selector: Arc<
-            dyn Selector<
-                    Context = crate::metasrv::SelectorContext,
-                    Output = Vec<common_meta::peer::Peer>,
-                >,
-        > = match opts.selector {
-            SelectorType::LoadBased => Arc::new(LoadBasedSelector::new(
-                RegionNumsBasedWeightCompute,
-                meta_peer_client.clone(),
-            )) as SelectorRef,
-            SelectorType::LeaseBased => Arc::new(LeaseBasedSelector) as SelectorRef,
-            SelectorType::RoundRobin => {
-                Arc::new(RoundRobinSelector::new(SelectTarget::Datanode)) as SelectorRef
-            }
-        };
-        info!(
-            "Using selector from options, selector type: {}",
-            opts.selector.as_ref()
-        );
-        if let Some(wrapper) = plugins.get::<SelectorWrapperRef>() {
-            info!("Wrapping selector from options");
-            wrapper.wrap(selector)
-        } else {
-            selector
+    let base_selector: Arc<
+        dyn Selector<
+                Context = crate::metasrv::SelectorContext,
+                Output = Vec<common_meta::peer::Peer>,
+            >,
+    > = match opts.selector {
+        SelectorType::LoadBased => Arc::new(LoadBasedSelector::new(
+            RegionNumsBasedWeightCompute,
+            meta_peer_client.clone(),
+        )) as SelectorRef,
+        SelectorType::LeaseBased => Arc::new(LeaseBasedSelector) as SelectorRef,
+        SelectorType::RoundRobin => {
+            Arc::new(RoundRobinSelector::new(SelectTarget::Datanode)) as SelectorRef
         }
+    };
+    info!(
+        "Using selector from options, selector type: {}",
+        opts.selector.as_ref()
+    );
+
+    let selector = if let Some(factory) = plugins.get::<SelectorFactoryRef>() {
+        info!("Building selector from plugin factory");
+        factory.build(SelectorFactoryContext {
+            metasrv_options: opts.clone(),
+            meta_peer_client: meta_peer_client.clone(),
+            in_memory: in_memory.clone(),
+            election: election.clone(),
+            base_selector,
+        })
+    } else {
+        base_selector
     };
 
     Ok(MetasrvBuilder::new()
@@ -443,26 +445,26 @@ mod tests {
     use common_meta::kv_backend::memory::MemoryKvBackend;
 
     use super::*;
-    use crate::metasrv::SelectorWrapper;
+    use crate::metasrv::{SelectorFactory, SelectorFactoryContext};
 
-    struct RecordingSelectorWrapper {
+    struct RecordingSelectorFactory {
         called: Arc<AtomicBool>,
     }
 
-    impl SelectorWrapper for RecordingSelectorWrapper {
-        fn wrap(&self, selector: SelectorRef) -> SelectorRef {
+    impl SelectorFactory for RecordingSelectorFactory {
+        fn build(&self, ctx: SelectorFactoryContext) -> SelectorRef {
             self.called.store(true, Ordering::Relaxed);
-            selector
+            ctx.base_selector
         }
     }
 
     #[tokio::test]
-    async fn metasrv_builder_wraps_load_based_selector_from_plugins() {
+    async fn metasrv_builder_builds_load_based_selector_from_plugin_factory() {
         let called = Arc::new(AtomicBool::new(false));
         let plugins = Plugins::new();
-        plugins.insert(Arc::new(RecordingSelectorWrapper {
+        plugins.insert(Arc::new(RecordingSelectorFactory {
             called: called.clone(),
-        }) as SelectorWrapperRef);
+        }) as SelectorFactoryRef);
         let opts = MetasrvOptions {
             selector: SelectorType::LoadBased,
             ..Default::default()

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -482,6 +482,23 @@ pub struct SelectorContext {
 }
 
 pub type SelectorRef = Arc<dyn Selector<Context = SelectorContext, Output = Vec<Peer>>>;
+
+/// Wraps the datanode selector constructed from [`MetasrvOptions`].
+///
+/// This hook lets plugins decorate the configured selector without rebuilding it
+/// themselves. For example, a plugin can first constrain the candidate datanodes
+/// and then delegate the final choice to the selector chosen by `MetasrvOptions`,
+/// such as load-based, lease-based, or round-robin selection.
+///
+/// A plugin-provided [`SelectorRef`] still takes precedence over this wrapper. The
+/// wrapper is only applied when metasrv bootstrap builds the selector from options.
+pub trait SelectorWrapper: Send + Sync {
+    /// Returns the selector metasrv should use after wrapping the configured base selector.
+    fn wrap(&self, selector: SelectorRef) -> SelectorRef;
+}
+
+/// Shared selector wrapper plugin registered through [`common_base::Plugins`].
+pub type SelectorWrapperRef = Arc<dyn SelectorWrapper>;
 pub type RegionStatAwareSelectorRef =
     Arc<dyn RegionStatAwareSelector<Context = SelectorContext, Output = Vec<(RegionId, Peer)>>>;
 

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -483,22 +483,27 @@ pub struct SelectorContext {
 
 pub type SelectorRef = Arc<dyn Selector<Context = SelectorContext, Output = Vec<Peer>>>;
 
-/// Wraps the datanode selector constructed from [`MetasrvOptions`].
+/// Context passed to a selector factory during metasrv bootstrap.
 ///
-/// This hook lets plugins decorate the configured selector without rebuilding it
-/// themselves. For example, a plugin can first constrain the candidate datanodes
-/// and then delegate the final choice to the selector chosen by `MetasrvOptions`,
-/// such as load-based, lease-based, or round-robin selection.
-///
-/// A plugin-provided [`SelectorRef`] still takes precedence over this wrapper. The
-/// wrapper is only applied when metasrv bootstrap builds the selector from options.
-pub trait SelectorWrapper: Send + Sync {
-    /// Returns the selector metasrv should use after wrapping the configured base selector.
-    fn wrap(&self, selector: SelectorRef) -> SelectorRef;
+/// The factory runs after bootstrap has constructed the selector configured by
+/// [`MetasrvOptions::selector`], so plugins can either decorate `base_selector` or
+/// build a completely different selector using bootstrap-only dependencies like
+/// [`MetaPeerClientRef`].
+pub struct SelectorFactoryContext {
+    pub metasrv_options: MetasrvOptions,
+    pub meta_peer_client: MetaPeerClientRef,
+    pub in_memory: ResettableKvBackendRef,
+    pub election: Option<ElectionRef>,
+    pub base_selector: SelectorRef,
 }
 
-/// Shared selector wrapper plugin registered through [`common_base::Plugins`].
-pub type SelectorWrapperRef = Arc<dyn SelectorWrapper>;
+/// Builds the final datanode selector metasrv should use.
+pub trait SelectorFactory: Send + Sync {
+    fn build(&self, ctx: SelectorFactoryContext) -> SelectorRef;
+}
+
+/// Shared selector factory plugin registered through [`common_base::Plugins`].
+pub type SelectorFactoryRef = Arc<dyn SelectorFactory>;
 pub type RegionStatAwareSelectorRef =
     Arc<dyn RegionStatAwareSelector<Context = SelectorContext, Output = Vec<(RegionId, Peer)>>>;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Enterprise PR: https://github.com/GreptimeTeam/greptimedb-enterprise/pull/678

## What's changed and what's your intention?

Introduce a metasrv selector factory plugin hook so plugins can build the final datanode selector during metasrv bootstrap, after bootstrap has constructed the selector configured by `MetasrvOptions::selector`.

### Details

- **`SelectorFactory` API**: Added `SelectorFactory`, `SelectorFactoryRef`, and `SelectorFactoryContext` in `src/meta-srv/src/metasrv.rs`.
- **Bootstrap context**: `SelectorFactoryContext` provides `metasrv_options`, `meta_peer_client`, `in_memory`, `election`, and the configured `base_selector`.
- **Selector construction flow**: `metasrv_builder` now always builds the configured base selector first, including `load_based`, then lets a registered `SelectorFactoryRef` build the final selector.
- **Plugin use case**: Plugins can either decorate `ctx.base_selector` or build a fully custom selector with bootstrap-only dependencies such as `MetaPeerClientRef`.
- **Tests**: Added `metasrv_builder_builds_load_based_selector_from_plugin_factory` to verify the factory is invoked after constructing a `load_based` base selector.

This replaces the previous wrapper-oriented approach with a single factory extension point for selector customization.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
