### PR TITLE
fix(mysql): keep unknown prepare placeholders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12705,6 +12705,7 @@ dependencies = [
  "metric-engine",
  "mime_guess",
  "mysql_async",
+ "mysql_common 0.34.1",
  "notify",
  "object-pool",
  "once_cell",

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -82,6 +82,7 @@ log-query.workspace = true
 loki-proto.workspace = true
 metric-engine.workspace = true
 mime_guess = "2.0"
+mysql_common = "0.34"
 notify.workspace = true
 object-pool = "0.5"
 once_cell.workspace = true

--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -30,6 +30,7 @@ use datafusion_expr::LogicalPlan;
 use datatypes::prelude::ConcreteDataType;
 use datatypes::schema::Schema;
 use itertools::Itertools;
+use mysql_common::Value as MysqlValue;
 use opensrv_mysql::{
     AsyncMysqlShim, Column, ErrorKind, InitWriter, ParamParser, ParamValue, QueryResultWriter,
     StatementMetaWriter, ValueInner,
@@ -51,9 +52,7 @@ use crate::error::{
     self, DataFrameSnafu, InferParameterTypesSnafu, InvalidPrepareStatementSnafu, Result,
 };
 use crate::metrics::METRIC_AUTH_FAILURE;
-use crate::mysql::helper::{
-    self, format_placeholder, replace_placeholders, transform_placeholders,
-};
+use crate::mysql::helper::{self, format_placeholder, transform_placeholders_with_count};
 use crate::mysql::writer;
 use crate::mysql::writer::{create_mysql_column, handle_err};
 use crate::query_handler::sql::ServerSqlQueryHandlerRef;
@@ -192,28 +191,32 @@ impl MysqlInstanceShim {
             return Ok((vec![], vec![]));
         }
 
-        let (query, param_num) = replace_placeholders(raw_query);
-
         let statement = validate_query(raw_query).await?;
 
         // We have to transform the placeholder, because DataFusion only parses placeholders
         // in the form of "$i", it can't process "?" right now.
-        let statement = transform_placeholders(statement);
+        let (statement, placeholder_count) = transform_placeholders_with_count(statement);
+        let query = statement.to_string();
+        let param_num = placeholder_count + 1;
 
         let describe_result = self
             .do_describe(statement.clone(), query_ctx.clone())
             .await?;
         let plan = describe_result.map(|DescribeResult { logical_plan }| logical_plan);
 
-        let params = if let Some(plan) = &plan {
+        let (params, can_cache_as_plan) = if let Some(plan) = &plan {
             let param_types = DfLogicalPlanner::get_inferred_parameter_types(plan)
                 .context(InferParameterTypesSnafu)?
                 .into_iter()
                 .map(|(k, v)| (k, v.map(|v| ConcreteDataType::from_arrow_type(&v))))
                 .collect();
-            prepared_params(&param_types)?
+
+            (
+                prepared_params(&param_types, param_num)?,
+                all_params_have_types(&param_types, param_num),
+            )
         } else {
-            dummy_params(param_num)?
+            (dummy_params(param_num)?, false)
         };
 
         let columns =
@@ -239,7 +242,7 @@ impl MysqlInstanceShim {
                 .unwrap_or_default();
 
         match plan {
-            Some(plan) if params.len() == param_num - 1 => {
+            Some(plan) if can_cache_as_plan => {
                 self.save_plan(SqlPlan::Plan(plan, statement), stmt_key)
                     .inspect_err(|e| {
                         error!(e; "Failed to save prepared statement");
@@ -662,7 +665,7 @@ fn convert_param_value_to_string(param: &ParamValue) -> String {
         ValueInner::UInt(u) => u.to_string(),
         ValueInner::Double(u) => u.to_string(),
         ValueInner::NULL => "NULL".to_string(),
-        ValueInner::Bytes(b) => format!("'{}'", &String::from_utf8_lossy(b)),
+        ValueInner::Bytes(b) => MysqlValue::Bytes(b.to_vec()).as_sql(false),
         ValueInner::Date(_) => format!("'{}'", NaiveDate::from(param.value)),
         ValueInner::Datetime(_) => format!("'{}'", NaiveDateTime::from(param.value)),
         ValueInner::Time(_) => format_duration(Duration::from(param.value)),
@@ -670,11 +673,112 @@ fn convert_param_value_to_string(param: &ParamValue) -> String {
 }
 
 fn replace_params(params: Vec<String>, query: String) -> String {
-    let mut query = query;
-    for (index, param) in (1..).zip(params) {
-        query = query.replace(&format_placeholder(index), &param);
+    let mut output = String::with_capacity(query.len());
+    let mut index = 0;
+    let bytes = query.as_bytes();
+
+    while index < bytes.len() {
+        if matches!(bytes[index], b'\'' | b'"' | b'`') {
+            let quote = bytes[index];
+            push_quoted_segment(&mut output, &query, &mut index, quote);
+        } else if index + 1 < bytes.len() && bytes[index] == b'-' && bytes[index + 1] == b'-' {
+            push_line_comment(&mut output, &query, &mut index);
+        } else if index + 1 < bytes.len() && bytes[index] == b'/' && bytes[index + 1] == b'*' {
+            push_block_comment(&mut output, &query, &mut index);
+        } else if bytes[index] == b'$' {
+            let placeholder_start = index;
+            index += 1;
+            let digit_start = index;
+
+            while index < bytes.len() && bytes[index].is_ascii_digit() {
+                index += 1;
+            }
+
+            if digit_start < index
+                && let Ok(param_index) = query[digit_start..index].parse::<usize>()
+                && let Some(param) = param_index.checked_sub(1).and_then(|idx| params.get(idx))
+            {
+                output.push_str(param);
+            } else {
+                output.push_str(&query[placeholder_start..index]);
+            }
+        } else {
+            let ch = query[index..]
+                .chars()
+                .next()
+                .expect("index should be on a char boundary");
+            output.push(ch);
+            index += ch.len_utf8();
+        }
     }
-    query
+
+    output
+}
+
+fn push_quoted_segment(output: &mut String, query: &str, index: &mut usize, quote: u8) {
+    let bytes = query.as_bytes();
+    output.push(quote as char);
+    *index += 1;
+
+    while *index < bytes.len() {
+        let ch = query[*index..]
+            .chars()
+            .next()
+            .expect("index should be on a char boundary");
+        output.push(ch);
+        *index += ch.len_utf8();
+
+        if ch == '\\' {
+            if *index < bytes.len() {
+                let next = query[*index..]
+                    .chars()
+                    .next()
+                    .expect("index should be on a char boundary");
+                output.push(next);
+                *index += next.len_utf8();
+            }
+        } else if ch as u8 == quote {
+            if *index < bytes.len() && bytes[*index] == quote {
+                output.push(quote as char);
+                *index += 1;
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+fn push_line_comment(output: &mut String, query: &str, index: &mut usize) {
+    let bytes = query.as_bytes();
+    while *index < bytes.len() {
+        let ch = query[*index..]
+            .chars()
+            .next()
+            .expect("index should be on a char boundary");
+        output.push(ch);
+        *index += ch.len_utf8();
+        if ch == '\n' {
+            break;
+        }
+    }
+}
+
+fn push_block_comment(output: &mut String, query: &str, index: &mut usize) {
+    let bytes = query.as_bytes();
+    while *index < bytes.len() {
+        if *index + 1 < bytes.len() && bytes[*index] == b'*' && bytes[*index + 1] == b'/' {
+            output.push_str("*/");
+            *index += 2;
+            break;
+        }
+
+        let ch = query[*index..]
+            .chars()
+            .next()
+            .expect("index should be on a char boundary");
+        output.push(ch);
+        *index += ch.len_utf8();
+    }
 }
 
 fn format_duration(duration: Duration) -> String {
@@ -778,18 +882,32 @@ fn dummy_params(index: usize) -> Result<Vec<Column>> {
 }
 
 /// Parameters that the client must provide when executing the prepared statement.
-fn prepared_params(param_types: &HashMap<String, Option<ConcreteDataType>>) -> Result<Vec<Column>> {
-    let mut params = Vec::with_capacity(param_types.len());
+fn prepared_params(
+    param_types: &HashMap<String, Option<ConcreteDataType>>,
+    index: usize,
+) -> Result<Vec<Column>> {
+    let mut params = Vec::with_capacity(index - 1);
 
     // Placeholder index starts from 1
-    for index in 1..=param_types.len() {
-        if let Some(Some(t)) = param_types.get(&format_placeholder(index)) {
-            let column = create_mysql_column(t, "")?;
-            params.push(column);
-        }
+    for index in 1..index {
+        let column = if let Some(Some(t)) = param_types.get(&format_placeholder(index)) {
+            create_mysql_column(t, "")?
+        } else {
+            create_mysql_column(&ConcreteDataType::null_datatype(), "")?
+        };
+        params.push(column);
     }
 
     Ok(params)
+}
+
+fn all_params_have_types(
+    param_types: &HashMap<String, Option<ConcreteDataType>>,
+    index: usize,
+) -> bool {
+    param_types.len() == index - 1
+        && (1..index)
+            .all(|index| matches!(param_types.get(&format_placeholder(index)), Some(Some(_))))
 }
 
 #[cfg(test)]
@@ -850,6 +968,47 @@ mod tests {
             1,
             1024,
         )
+    }
+
+    #[test]
+    fn test_prepared_params_keep_unknown_type_placeholders() {
+        let mut param_types = HashMap::new();
+        param_types.insert(format_placeholder(1), None);
+        param_types.insert(
+            format_placeholder(2),
+            Some(ConcreteDataType::int32_datatype()),
+        );
+
+        let params = prepared_params(&param_types, 3).unwrap();
+        assert_eq!(params.len(), 2);
+        assert!(!all_params_have_types(&param_types, 3));
+    }
+
+    #[test]
+    fn test_replace_params_single_pass() {
+        let query = "SELECT $1, $2".to_string();
+        let params = vec!["'$2 should stay'".to_string(), "'value'".to_string()];
+
+        assert_eq!(
+            "SELECT '$2 should stay', 'value'",
+            replace_params(params, query)
+        );
+
+        let query = "SELECT '$1', \"$2\", `$3`, $1, $10".to_string();
+        let params = (1..=10).map(|idx| format!("'{idx}'")).collect();
+
+        assert_eq!(
+            "SELECT '$1', \"$2\", `$3`, '1', '10'",
+            replace_params(params, query)
+        );
+
+        let query = "SELECT /* $1 */ $1 -- $2\n, $2".to_string();
+        let params = vec!["'first'".to_string(), "'second'".to_string()];
+
+        assert_eq!(
+            "SELECT /* $1 */ 'first' -- $2\n, 'second'",
+            replace_params(params, query)
+        );
     }
 
     #[tokio::test]

--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -791,6 +791,8 @@ fn location_to_byte_offset(query: &str, line: u64, column: u64) -> Option<usize>
         }
     }
 
+    // The exclusive end location of a trailing placeholder points just past
+    // the last character, for example the end span of `SELECT ?`.
     (current_line == line && current_column == column).then_some(query.len())
 }
 
@@ -897,13 +899,13 @@ fn dummy_params(index: usize) -> Result<Vec<Column>> {
 /// Parameters that the client must provide when executing the prepared statement.
 fn prepared_params(
     param_types: &HashMap<String, Option<ConcreteDataType>>,
-    index: usize,
+    param_num: usize,
 ) -> Result<Vec<Column>> {
-    let mut params = Vec::with_capacity(index - 1);
+    let mut params = Vec::with_capacity(param_num - 1);
 
     // Placeholder index starts from 1
-    for index in 1..index {
-        let column = if let Some(Some(t)) = param_types.get(&format_placeholder(index)) {
+    for i in 1..param_num {
+        let column = if let Some(Some(t)) = param_types.get(&format_placeholder(i)) {
             create_mysql_column(t, "")?
         } else {
             create_mysql_column(&ConcreteDataType::null_datatype(), "")?
@@ -916,11 +918,10 @@ fn prepared_params(
 
 fn all_params_have_types(
     param_types: &HashMap<String, Option<ConcreteDataType>>,
-    index: usize,
+    param_num: usize,
 ) -> bool {
-    param_types.len() == index - 1
-        && (1..index)
-            .all(|index| matches!(param_types.get(&format_placeholder(index)), Some(Some(_))))
+    param_types.len() == param_num - 1
+        && (1..param_num).all(|i| matches!(param_types.get(&format_placeholder(i)), Some(Some(_))))
 }
 
 #[cfg(test)]
@@ -1086,6 +1087,15 @@ mod tests {
 
         assert_eq!(
             "SELECT CAST(1 AS INT64), 2 + (SELECT 3)",
+            replace_params(params, stmt, query).unwrap()
+        );
+
+        let query = "SET time_zone = ?".to_string();
+        let stmt = statement_with_transformed_placeholders(&query);
+        let params = vec!["'UTC'".to_string()];
+
+        assert_eq!(
+            "SET time_zone = 'UTC'",
             replace_params(params, stmt, query).unwrap()
         );
     }

--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -196,7 +196,6 @@ impl MysqlInstanceShim {
         // We have to transform the placeholder, because DataFusion only parses placeholders
         // in the form of "$i", it can't process "?" right now.
         let (statement, placeholder_count) = transform_placeholders_with_count(statement);
-        let query = statement.to_string();
         let param_num = placeholder_count + 1;
 
         let describe_result = self
@@ -249,10 +248,13 @@ impl MysqlInstanceShim {
                     })?;
             }
             _ => {
-                self.save_plan(SqlPlan::Statement(statement, query), stmt_key)
-                    .inspect_err(|e| {
-                        error!(e; "Failed to save prepared statement");
-                    })?;
+                self.save_plan(
+                    SqlPlan::Statement(statement, raw_query.to_string()),
+                    stmt_key,
+                )
+                .inspect_err(|e| {
+                    error!(e; "Failed to save prepared statement");
+                })?;
             }
         }
 
@@ -315,7 +317,7 @@ impl MysqlInstanceShim {
                     self.do_query(&query, query_ctx.clone()).await
                 }
             }
-            SqlPlan::Statement(_stmt, query) => {
+            SqlPlan::Statement(stmt, query) => {
                 let param_strs = match params {
                     Params::ProtocolParams(params) => {
                         params.iter().map(convert_param_value_to_string).collect()
@@ -326,7 +328,7 @@ impl MysqlInstanceShim {
                     "do_execute Replacing with Params: {:?}, Original Query: {}",
                     param_strs, query
                 );
-                let query = replace_params(param_strs, query);
+                let query = replace_params(param_strs, stmt, query)?;
                 debug!("Mysql execute replaced query: {}", query);
                 self.do_query(&query, query_ctx.clone()).await
             }
@@ -665,6 +667,10 @@ fn convert_param_value_to_string(param: &ParamValue) -> String {
         ValueInner::UInt(u) => u.to_string(),
         ValueInner::Double(u) => u.to_string(),
         ValueInner::NULL => "NULL".to_string(),
+        // MySQL prepared fallback emits SQL text. Delegate bytes/string literal
+        // escaping to mysql_common. `false` means normal MySQL backslash escapes;
+        // if NO_BACKSLASH_ESCAPES is supported in this path later, wire the
+        // session SQL mode here.
         ValueInner::Bytes(b) => MysqlValue::Bytes(b.to_vec()).as_sql(false),
         ValueInner::Date(_) => format!("'{}'", NaiveDate::from(param.value)),
         ValueInner::Datetime(_) => format!("'{}'", NaiveDateTime::from(param.value)),
@@ -672,113 +678,120 @@ fn convert_param_value_to_string(param: &ParamValue) -> String {
     }
 }
 
-fn replace_params(params: Vec<String>, query: String) -> String {
-    let mut output = String::with_capacity(query.len());
-    let mut index = 0;
-    let bytes = query.as_bytes();
-
-    while index < bytes.len() {
-        if matches!(bytes[index], b'\'' | b'"' | b'`') {
-            let quote = bytes[index];
-            push_quoted_segment(&mut output, &query, &mut index, quote);
-        } else if index + 1 < bytes.len() && bytes[index] == b'-' && bytes[index + 1] == b'-' {
-            push_line_comment(&mut output, &query, &mut index);
-        } else if index + 1 < bytes.len() && bytes[index] == b'/' && bytes[index + 1] == b'*' {
-            push_block_comment(&mut output, &query, &mut index);
-        } else if bytes[index] == b'$' {
-            let placeholder_start = index;
-            index += 1;
-            let digit_start = index;
-
-            while index < bytes.len() && bytes[index].is_ascii_digit() {
-                index += 1;
-            }
-
-            if digit_start < index
-                && let Ok(param_index) = query[digit_start..index].parse::<usize>()
-                && let Some(param) = param_index.checked_sub(1).and_then(|idx| params.get(idx))
-            {
-                output.push_str(param);
-            } else {
-                output.push_str(&query[placeholder_start..index]);
-            }
-        } else {
-            let ch = query[index..]
-                .chars()
-                .next()
-                .expect("index should be on a char boundary");
-            output.push(ch);
-            index += ch.len_utf8();
+fn replace_params(params: Vec<String>, stmt: Statement, mut query: String) -> Result<String> {
+    let spans = helper::placeholder_spans(stmt);
+    ensure!(
+        spans.len() == params.len(),
+        error::InternalSnafu {
+            err_msg: format!(
+                "Prepared statement expected {} parameters but got {}",
+                spans.len(),
+                params.len()
+            )
         }
+    );
+
+    let mut replacements = Vec::with_capacity(spans.len());
+    for span in spans {
+        let start = location_to_byte_offset(&query, span.start_line, span.start_column)
+            .ok_or_else(|| {
+                error::InternalSnafu {
+                    err_msg: format!(
+                        "Invalid placeholder start span: line {}, column {}",
+                        span.start_line, span.start_column
+                    ),
+                }
+                .build()
+            })?;
+        let end =
+            location_to_byte_offset(&query, span.end_line, span.end_column).ok_or_else(|| {
+                error::InternalSnafu {
+                    err_msg: format!(
+                        "Invalid placeholder end span: line {}, column {}",
+                        span.end_line, span.end_column
+                    ),
+                }
+                .build()
+            })?;
+        let param = span
+            .index
+            .checked_sub(1)
+            .and_then(|idx| params.get(idx))
+            .ok_or_else(|| {
+                error::InternalSnafu {
+                    err_msg: format!("Missing prepared statement parameter {}", span.index),
+                }
+                .build()
+            })?;
+
+        ensure!(
+            start < end && end <= query.len(),
+            error::InternalSnafu {
+                err_msg: format!(
+                    "Invalid placeholder byte span: {}..{} for query length {}",
+                    start,
+                    end,
+                    query.len()
+                )
+            }
+        );
+        ensure!(
+            query.get(start..end) == Some("?"),
+            error::InternalSnafu {
+                err_msg: format!(
+                    "Prepared statement placeholder span maps to {:?} instead of '?'",
+                    query.get(start..end)
+                )
+            }
+        );
+
+        replacements.push((start, end, param.clone()));
     }
 
-    output
-}
-
-fn push_quoted_segment(output: &mut String, query: &str, index: &mut usize, quote: u8) {
-    let bytes = query.as_bytes();
-    output.push(quote as char);
-    *index += 1;
-
-    while *index < bytes.len() {
-        let ch = query[*index..]
-            .chars()
-            .next()
-            .expect("index should be on a char boundary");
-        output.push(ch);
-        *index += ch.len_utf8();
-
-        if ch == '\\' {
-            if *index < bytes.len() {
-                let next = query[*index..]
-                    .chars()
-                    .next()
-                    .expect("index should be on a char boundary");
-                output.push(next);
-                *index += next.len_utf8();
+    replacements.sort_unstable_by_key(|(start, _, _)| *start);
+    for windows in replacements.windows(2) {
+        ensure!(
+            windows[0].1 <= windows[1].0,
+            error::InternalSnafu {
+                err_msg: "Overlapping placeholder spans in prepared statement".to_string()
             }
-        } else if ch as u8 == quote {
-            if *index < bytes.len() && bytes[*index] == quote {
-                output.push(quote as char);
-                *index += 1;
-            } else {
-                break;
-            }
-        }
+        );
     }
+
+    // All spans are computed against the original query. Apply replacements
+    // from right to left so changing one parameter's string length never shifts
+    // the byte offsets of placeholders that have not been replaced yet.
+    for (start, end, param) in replacements.into_iter().rev() {
+        query.replace_range(start..end, &param);
+    }
+
+    Ok(query)
 }
 
-fn push_line_comment(output: &mut String, query: &str, index: &mut usize) {
-    let bytes = query.as_bytes();
-    while *index < bytes.len() {
-        let ch = query[*index..]
-            .chars()
-            .next()
-            .expect("index should be on a char boundary");
-        output.push(ch);
-        *index += ch.len_utf8();
+fn location_to_byte_offset(query: &str, line: u64, column: u64) -> Option<usize> {
+    // sqlparser spans are 1-based line/column locations, and columns advance by
+    // Rust `char`s rather than bytes. Convert them to byte offsets before using
+    // `String::replace_range` on the original SQL text.
+    if line == 0 || column == 0 {
+        return None;
+    }
+
+    let mut current_line = 1;
+    let mut current_column = 1;
+    for (index, ch) in query.char_indices() {
+        if current_line == line && current_column == column {
+            return Some(index);
+        }
+
         if ch == '\n' {
-            break;
+            current_line += 1;
+            current_column = 1;
+        } else {
+            current_column += 1;
         }
     }
-}
 
-fn push_block_comment(output: &mut String, query: &str, index: &mut usize) {
-    let bytes = query.as_bytes();
-    while *index < bytes.len() {
-        if *index + 1 < bytes.len() && bytes[*index] == b'*' && bytes[*index + 1] == b'/' {
-            output.push_str("*/");
-            *index += 2;
-            break;
-        }
-
-        let ch = query[*index..]
-            .chars()
-            .next()
-            .expect("index should be on a char boundary");
-        output.push(ch);
-        *index += ch.len_utf8();
-    }
+    (current_line == line && current_column == column).then_some(query.len())
 }
 
 fn format_duration(duration: Duration) -> String {
@@ -970,6 +983,14 @@ mod tests {
         )
     }
 
+    fn statement_with_transformed_placeholders(query: &str) -> Statement {
+        let mut statements =
+            ParserContext::create_with_dialect(query, &MySqlDialect {}, ParseOptions::default())
+                .unwrap();
+        assert_eq!(statements.len(), 1);
+        transform_placeholders_with_count(statements.remove(0)).0
+    }
+
     #[test]
     fn test_prepared_params_keep_unknown_type_placeholders() {
         let mut param_types = HashMap::new();
@@ -985,29 +1006,87 @@ mod tests {
     }
 
     #[test]
-    fn test_replace_params_single_pass() {
-        let query = "SELECT $1, $2".to_string();
+    fn test_replace_params_by_placeholder_span() {
+        let query = "SELECT ?, ?".to_string();
+        let stmt = statement_with_transformed_placeholders(&query);
         let params = vec!["'$2 should stay'".to_string(), "'value'".to_string()];
 
         assert_eq!(
             "SELECT '$2 should stay', 'value'",
-            replace_params(params, query)
+            replace_params(params, stmt, query).unwrap()
         );
 
-        let query = "SELECT '$1', \"$2\", `$3`, $1, $10".to_string();
-        let params = (1..=10).map(|idx| format!("'{idx}'")).collect();
+        let query = "SELECT ?, ?, ?".to_string();
+        let stmt = statement_with_transformed_placeholders(&query);
+        let params = vec![
+            "'much longer than a placeholder'".to_string(),
+            "0".to_string(),
+            "'also much longer than a placeholder'".to_string(),
+        ];
 
         assert_eq!(
-            "SELECT '$1', \"$2\", `$3`, '1', '10'",
-            replace_params(params, query)
+            "SELECT 'much longer than a placeholder', 0, 'also much longer than a placeholder'",
+            replace_params(params, stmt, query).unwrap()
         );
 
-        let query = "SELECT /* $1 */ $1 -- $2\n, $2".to_string();
+        let query = "SELECT '$1', \"$2\", `$3`, ?, ?".to_string();
+        let stmt = statement_with_transformed_placeholders(&query);
+        let params = vec!["'1'".to_string(), "'2'".to_string()];
+
+        assert_eq!(
+            "SELECT '$1', \"$2\", `$3`, '1', '2'",
+            replace_params(params, stmt, query).unwrap()
+        );
+
+        let query = "SELECT /* ? */ ? -- ?\n, ?".to_string();
+        let stmt = statement_with_transformed_placeholders(&query);
         let params = vec!["'first'".to_string(), "'second'".to_string()];
 
         assert_eq!(
-            "SELECT /* $1 */ 'first' -- $2\n, 'second'",
-            replace_params(params, query)
+            "SELECT /* ? */ 'first' -- ?\n, 'second'",
+            replace_params(params, stmt, query).unwrap()
+        );
+
+        let query = "SELECT '中文', ?".to_string();
+        let stmt = statement_with_transformed_placeholders(&query);
+        let params = vec!["'value'".to_string()];
+
+        assert_eq!(
+            "SELECT '中文', 'value'",
+            replace_params(params, stmt, query).unwrap()
+        );
+
+        let query = "SELECT '中文',\n  ?".to_string();
+        let stmt = statement_with_transformed_placeholders(&query);
+        let params = vec!["'value'".to_string()];
+
+        assert_eq!(
+            "SELECT '中文',\n  'value'",
+            replace_params(params, stmt, query).unwrap()
+        );
+
+        let query = "SELECT 'x'\r\n, ?".to_string();
+        let stmt = statement_with_transformed_placeholders(&query);
+        let params = vec!["'crlf'".to_string()];
+
+        assert_eq!(
+            "SELECT 'x'\r\n, 'crlf'",
+            replace_params(params, stmt, query).unwrap()
+        );
+
+        let query = "SELECT\t?".to_string();
+        let stmt = statement_with_transformed_placeholders(&query);
+        let params = vec!["NULL".to_string()];
+
+        assert_eq!("SELECT\tNULL", replace_params(params, stmt, query).unwrap());
+
+        let query = "SELECT CAST(? AS INT64), ? + (SELECT ?)".to_string();
+        let stmt = statement_with_transformed_placeholders(&query);
+        let params = vec!["1".to_string(), "2".to_string(), "3".to_string()];
+
+        assert_eq!(
+            "SELECT CAST(1 AS INT64), 2 + (SELECT 3)",
+            replace_params(params, stmt, query).unwrap()
         );
     }
 

--- a/src/servers/src/mysql/helper.rs
+++ b/src/servers/src/mysql/helper.rs
@@ -71,12 +71,6 @@ pub fn replace_placeholders(query: &str) -> (String, usize) {
     (query, index + 1)
 }
 
-/// Transform all the "?" placeholder into "$i".
-#[cfg(test)]
-pub fn transform_placeholders(stmt: Statement) -> Statement {
-    transform_placeholders_with_count(stmt).0
-}
-
 /// Transform all the "?" placeholders into "$i" and return the number of
 /// transformed placeholders.
 pub fn transform_placeholders_with_count(mut stmt: Statement) -> (Statement, usize) {
@@ -385,33 +379,39 @@ mod tests {
     #[test]
     fn test_transform_placeholders() {
         let insert = parse_sql("insert into demo values(?,?,?)");
-        let Statement::Insert(insert) = transform_placeholders(insert) else {
+        let (stmt, count) = transform_placeholders_with_count(insert);
+        let Statement::Insert(insert) = stmt else {
             unreachable!()
         };
         assert_eq!(
             "INSERT INTO demo VALUES ($1, $2, $3)",
             insert.inner.to_string()
         );
+        assert_eq!(3, count);
 
         let delete = parse_sql("delete from demo where host=? and idc=?");
-        let Statement::Delete(delete) = transform_placeholders(delete) else {
+        let (stmt, count) = transform_placeholders_with_count(delete);
+        let Statement::Delete(delete) = stmt else {
             unreachable!()
         };
         assert_eq!(
             "DELETE FROM demo WHERE host = $1 AND idc = $2",
             delete.inner.to_string()
         );
+        assert_eq!(2, count);
 
         let select = parse_sql(
             "select * from demo where host=? and idc in (select idc from idcs where name=?) and cpu>?",
         );
-        let Statement::Query(select) = transform_placeholders(select) else {
+        let (stmt, count) = transform_placeholders_with_count(select);
+        let Statement::Query(select) = stmt else {
             unreachable!()
         };
         assert_eq!(
             "SELECT * FROM demo WHERE host = $1 AND idc IN (SELECT idc FROM idcs WHERE name = $2) AND cpu > $3",
             select.inner.to_string()
         );
+        assert_eq!(3, count);
 
         let select = parse_sql("select '?', ?");
         let (stmt, count) = transform_placeholders_with_count(select);

--- a/src/servers/src/mysql/helper.rs
+++ b/src/servers/src/mysql/helper.rs
@@ -72,7 +72,6 @@ pub fn replace_placeholders(query: &str) -> (String, usize) {
 }
 
 /// Transform all the "?" placeholder into "$i".
-/// Only works for Insert,Query and Delete statements.
 #[cfg(test)]
 pub fn transform_placeholders(stmt: Statement) -> Statement {
     transform_placeholders_with_count(stmt).0
@@ -80,40 +79,15 @@ pub fn transform_placeholders(stmt: Statement) -> Statement {
 
 /// Transform all the "?" placeholders into "$i" and return the number of
 /// transformed placeholders.
-/// Only works for Insert,Query and Delete statements.
-pub fn transform_placeholders_with_count(stmt: Statement) -> (Statement, usize) {
-    match stmt {
-        Statement::Query(mut query) => {
-            let count = visit_placeholders(&mut query.inner);
-            (Statement::Query(query), count)
-        }
-        Statement::Insert(mut insert) => {
-            let count = visit_placeholders(&mut insert.inner);
-            (Statement::Insert(insert), count)
-        }
-        Statement::Delete(mut delete) => {
-            let count = visit_placeholders(&mut delete.inner);
-            (Statement::Delete(delete), count)
-        }
-        stmt => (stmt, 0),
-    }
+pub fn transform_placeholders_with_count(mut stmt: Statement) -> (Statement, usize) {
+    let count = visit_placeholders(&mut stmt);
+    (stmt, count)
 }
 
 /// Collect spans of "$i" placeholders in a statement.
-/// Only works for Insert, Query and Delete statements.
 pub(crate) fn placeholder_spans(mut stmt: Statement) -> Vec<PlaceholderSpan> {
     let mut spans = Vec::new();
-    match stmt {
-        Statement::Query(ref mut query) => collect_placeholder_spans(&mut query.inner, &mut spans),
-        Statement::Insert(ref mut insert) => {
-            collect_placeholder_spans(&mut insert.inner, &mut spans)
-        }
-        Statement::Delete(ref mut delete) => {
-            collect_placeholder_spans(&mut delete.inner, &mut spans)
-        }
-        _ => {}
-    };
-
+    collect_placeholder_spans(&mut stmt, &mut spans);
     spans
 }
 
@@ -445,6 +419,11 @@ mod tests {
             unreachable!()
         };
         assert_eq!("SELECT '?', $1", select.inner.to_string());
+        assert_eq!(1, count);
+
+        let set = parse_sql("set time_zone = ?");
+        let (stmt, count) = transform_placeholders_with_count(set);
+        assert_eq!("SET time_zone = $1", stmt.to_string());
         assert_eq!(1, count);
     }
 

--- a/src/servers/src/mysql/helper.rs
+++ b/src/servers/src/mysql/helper.rs
@@ -32,6 +32,17 @@ use sql::statements::statement::Statement;
 
 use crate::error::{self, Result};
 
+/// Location of a prepared-statement placeholder in the original SQL text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PlaceholderSpan {
+    /// 1-based placeholder index.
+    pub(crate) index: usize,
+    pub(crate) start_line: u64,
+    pub(crate) start_column: u64,
+    pub(crate) end_line: u64,
+    pub(crate) end_column: u64,
+}
+
 /// Returns the placeholder string "$i".
 pub fn format_placeholder(i: usize) -> String {
     format!("${}", i)
@@ -88,6 +99,54 @@ pub fn transform_placeholders_with_count(stmt: Statement) -> (Statement, usize) 
     }
 }
 
+/// Collect spans of "$i" placeholders in a statement.
+/// Only works for Insert, Query and Delete statements.
+pub(crate) fn placeholder_spans(mut stmt: Statement) -> Vec<PlaceholderSpan> {
+    let mut spans = Vec::new();
+    match stmt {
+        Statement::Query(ref mut query) => collect_placeholder_spans(&mut query.inner, &mut spans),
+        Statement::Insert(ref mut insert) => {
+            collect_placeholder_spans(&mut insert.inner, &mut spans)
+        }
+        Statement::Delete(ref mut delete) => {
+            collect_placeholder_spans(&mut delete.inner, &mut spans)
+        }
+        _ => {}
+    };
+
+    spans
+}
+
+fn collect_placeholder_spans<V>(v: &mut V, spans: &mut Vec<PlaceholderSpan>)
+where
+    V: VisitMut,
+{
+    let _ = visit_expressions_mut(v, |expr| {
+        if let Expr::Value(ValueWithSpan {
+            value: ValueExpr::Placeholder(s),
+            span,
+        }) = expr
+            && let Some(index) = placeholder_index(s)
+        {
+            spans.push(PlaceholderSpan {
+                index,
+                start_line: span.start.line,
+                start_column: span.start.column,
+                end_line: span.end.line,
+                end_column: span.end.column,
+            });
+        }
+        ControlFlow::<()>::Continue(())
+    });
+}
+
+fn placeholder_index(s: &str) -> Option<usize> {
+    s.strip_prefix('$')?
+        .parse::<usize>()
+        .ok()
+        .filter(|i| *i > 0)
+}
+
 fn visit_placeholders<V>(v: &mut V) -> usize
 where
     V: VisitMut,
@@ -98,6 +157,7 @@ where
             value: ValueExpr::Placeholder(s),
             ..
         }) = expr
+            && s == "?"
         {
             *s = format_placeholder(index);
             index += 1;

--- a/src/servers/src/mysql/helper.rs
+++ b/src/servers/src/mysql/helper.rs
@@ -23,6 +23,7 @@ use datatypes::prelude::ConcreteDataType;
 use datatypes::schema::ColumnSchema;
 use datatypes::types::TimestampType;
 use datatypes::value::{self, Value};
+#[cfg(test)]
 use itertools::Itertools;
 use opensrv_mysql::{ParamValue, ValueInner, to_naive_datetime};
 use snafu::ResultExt;
@@ -38,6 +39,7 @@ pub fn format_placeholder(i: usize) -> String {
 
 /// Replace all the "?" placeholder into "$i" in SQL,
 /// returns the new SQL and the last placeholder index.
+#[cfg(test)]
 pub fn replace_placeholders(query: &str) -> (String, usize) {
     let query_parts = query.split('?').collect::<Vec<_>>();
     let parts_len = query_parts.len();
@@ -60,25 +62,33 @@ pub fn replace_placeholders(query: &str) -> (String, usize) {
 
 /// Transform all the "?" placeholder into "$i".
 /// Only works for Insert,Query and Delete statements.
+#[cfg(test)]
 pub fn transform_placeholders(stmt: Statement) -> Statement {
+    transform_placeholders_with_count(stmt).0
+}
+
+/// Transform all the "?" placeholders into "$i" and return the number of
+/// transformed placeholders.
+/// Only works for Insert,Query and Delete statements.
+pub fn transform_placeholders_with_count(stmt: Statement) -> (Statement, usize) {
     match stmt {
         Statement::Query(mut query) => {
-            visit_placeholders(&mut query.inner);
-            Statement::Query(query)
+            let count = visit_placeholders(&mut query.inner);
+            (Statement::Query(query), count)
         }
         Statement::Insert(mut insert) => {
-            visit_placeholders(&mut insert.inner);
-            Statement::Insert(insert)
+            let count = visit_placeholders(&mut insert.inner);
+            (Statement::Insert(insert), count)
         }
         Statement::Delete(mut delete) => {
-            visit_placeholders(&mut delete.inner);
-            Statement::Delete(delete)
+            let count = visit_placeholders(&mut delete.inner);
+            (Statement::Delete(delete), count)
         }
-        stmt => stmt,
+        stmt => (stmt, 0),
     }
 }
 
-fn visit_placeholders<V>(v: &mut V)
+fn visit_placeholders<V>(v: &mut V) -> usize
 where
     V: VisitMut,
 {
@@ -94,6 +104,7 @@ where
         }
         ControlFlow::<()>::Continue(())
     });
+    index - 1
 }
 
 /// Convert [`ParamValue`] into [`Value`] according to param type.
@@ -367,6 +378,14 @@ mod tests {
             "SELECT * FROM demo WHERE host = $1 AND idc IN (SELECT idc FROM idcs WHERE name = $2) AND cpu > $3",
             select.inner.to_string()
         );
+
+        let select = parse_sql("select '?', ?");
+        let (stmt, count) = transform_placeholders_with_count(select);
+        let Statement::Query(select) = stmt else {
+            unreachable!()
+        };
+        assert_eq!("SELECT '?', $1", select.inner.to_string());
+        assert_eq!(1, count);
     }
 
     #[test]

--- a/src/servers/tests/mysql/mysql_server_test.rs
+++ b/src/servers/tests/mysql/mysql_server_test.rs
@@ -548,6 +548,98 @@ async fn test_query_prepared() -> Result<()> {
         assert_eq!(rows.len(), 1, "LIMIT 1 should return 1 row");
     }
 
+    // Untyped placeholders should still be advertised in the MySQL prepare
+    // response. This used to fail on the client side because the server
+    // reported 0 parameters for `SELECT ?`.
+    {
+        let stmt = connection.prep("SELECT ?").await.unwrap();
+        assert_eq!(stmt.num_params(), 1);
+
+        let row: Option<String> = connection
+            .exec_first(stmt, vec![mysql_async::Value::Bytes(b"can't".to_vec())])
+            .await
+            .unwrap();
+        assert_eq!(row, Some("can't".to_string()));
+
+        let stmt = connection.prep("SELECT ?").await.unwrap();
+        let row: Option<String> = connection
+            .exec_first(stmt, vec![mysql_async::Value::Bytes(b"a\\'b".to_vec())])
+            .await
+            .unwrap();
+        assert_eq!(row, Some("a\\'b".to_string()));
+
+        let stmt = connection.prep("SELECT ?").await.unwrap();
+        let row: Option<Vec<u8>> = connection
+            .exec_first(stmt, vec![mysql_async::Value::Bytes(vec![0xFF, 0xFE])])
+            .await
+            .unwrap();
+        assert_eq!(row, Some(vec![0xFF, 0xFE]));
+    }
+
+    // Values inserted into the SQL text must not be processed again while
+    // replacing later placeholders.
+    {
+        let stmt = connection.prep("SELECT ?, ?").await.unwrap();
+        assert_eq!(stmt.num_params(), 2);
+
+        let row: Option<(String, String)> = connection
+            .exec_first(
+                stmt,
+                vec![
+                    mysql_async::Value::Bytes(b"keep $2".to_vec()),
+                    mysql_async::Value::Bytes(b"second".to_vec()),
+                ],
+            )
+            .await
+            .unwrap();
+        assert_eq!(row, Some(("keep $2".to_string(), "second".to_string())));
+    }
+
+    // Non-placeholder question marks inside string literals must not affect
+    // the advertised prepare parameter count.
+    {
+        let stmt = connection.prep("SELECT '?', ?").await.unwrap();
+        assert_eq!(stmt.num_params(), 1);
+
+        let row: Option<(String, String)> = connection
+            .exec_first(stmt, vec![mysql_async::Value::Bytes(b"actual".to_vec())])
+            .await
+            .unwrap();
+        assert_eq!(row, Some(("?".to_string(), "actual".to_string())));
+
+        let stmt = connection.prep("SELECT '$1', ?").await.unwrap();
+        assert_eq!(stmt.num_params(), 1);
+
+        let row: Option<(String, String)> = connection
+            .exec_first(stmt, vec![mysql_async::Value::Bytes(b"actual".to_vec())])
+            .await
+            .unwrap();
+        assert_eq!(row, Some(("$1".to_string(), "actual".to_string())));
+    }
+
+    // Also cover mixed known and unknown placeholders. The projection
+    // placeholder is untyped, while the WHERE placeholder is inferred from the
+    // column type. The prepare response must advertise both parameters.
+    {
+        let stmt = connection
+            .prep("SELECT ?, uint32s FROM all_datatypes WHERE uint32s >= ?")
+            .await
+            .unwrap();
+        assert_eq!(stmt.num_params(), 2);
+
+        let rows: Vec<Row> = connection
+            .exec(
+                stmt,
+                vec![
+                    mysql_async::Value::Bytes(b"unknown".to_vec()),
+                    mysql_async::Value::UInt(0),
+                ],
+            )
+            .await
+            .unwrap();
+        assert!(!rows.is_empty());
+    }
+
     Ok(())
 }
 

--- a/src/servers/tests/mysql/mysql_server_test.rs
+++ b/src/servers/tests/mysql/mysql_server_test.rs
@@ -574,6 +574,13 @@ async fn test_query_prepared() -> Result<()> {
             .await
             .unwrap();
         assert_eq!(row, Some(vec![0xFF, 0xFE]));
+
+        let stmt = connection.prep("SELECT ?").await.unwrap();
+        let row: Option<Option<String>> = connection
+            .exec_first(stmt, vec![mysql_async::Value::NULL])
+            .await
+            .unwrap();
+        assert_eq!(row, Some(None));
     }
 
     // Values inserted into the SQL text must not be processed again while
@@ -615,6 +622,24 @@ async fn test_query_prepared() -> Result<()> {
             .await
             .unwrap();
         assert_eq!(row, Some(("$1".to_string(), "actual".to_string())));
+
+        let stmt = connection.prep("SELECT /* ? */ ? -- ?\n").await.unwrap();
+        assert_eq!(stmt.num_params(), 1);
+
+        let row: Option<String> = connection
+            .exec_first(stmt, vec![mysql_async::Value::Bytes(b"commented".to_vec())])
+            .await
+            .unwrap();
+        assert_eq!(row, Some("commented".to_string()));
+
+        let stmt = connection.prep("SELECT '中文', ?").await.unwrap();
+        assert_eq!(stmt.num_params(), 1);
+
+        let row: Option<(String, String)> = connection
+            .exec_first(stmt, vec![mysql_async::Value::Bytes(b"actual".to_vec())])
+            .await
+            .unwrap();
+        assert_eq!(row, Some(("中文".to_string(), "actual".to_string())));
     }
 
     // Also cover mixed known and unknown placeholders. The projection
@@ -638,6 +663,23 @@ async fn test_query_prepared() -> Result<()> {
             .await
             .unwrap();
         assert!(!rows.is_empty());
+    }
+
+    // LIMIT placeholders used to be a common case where DataFusion did not
+    // infer a parameter type. The prepare response must still advertise the
+    // parameter and execution must substitute it correctly.
+    {
+        let stmt = connection
+            .prep("SELECT uint32s FROM all_datatypes ORDER BY uint32s LIMIT ?")
+            .await
+            .unwrap();
+        assert_eq!(stmt.num_params(), 1);
+
+        let rows: Vec<Row> = connection
+            .exec(stmt, vec![mysql_async::Value::UInt(1)])
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
     }
 
     Ok(())


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Fixes #8142.

Related history:

- #5734 added a fix for inferring placeholder types in `LIMIT`.
- #7712 refactored the planner path and the `LIMIT ?` type inference regressed.
- #8149 restores the narrow `LIMIT/OFFSET ?` inference behavior.
- This PR fixes the broader MySQL prepared-statement protocol issue: placeholders must be advertised even when their concrete type is unknown.

## What's changed and what's your intention?

This PR fixes MySQL prepared statements whose placeholders are present in the SQL but do not have concrete types inferred by the planner.

Before this change, the MySQL prepare response only advertised placeholders with concrete inferred types. If DataFusion returned `None` for a placeholder type, `prepared_params()` skipped it, so the client could see fewer parameters than the SQL actually contains and fail before execution with an argument count mismatch.

The changes are:

- Count real prepared-statement placeholders from the SQL AST and return one MySQL parameter column per counted placeholder.
- Use inferred concrete types when available and `NULL` metadata for unknown placeholder types.
- Cache `SqlPlan::Plan` only when all placeholders have concrete inferred types; otherwise keep the statement fallback path.
- Preserve the original raw SQL in the fallback path instead of relying on AST `to_string()` round-trips.
- Replace fallback parameters by collecting placeholder spans from the transformed AST and replacing those original-query ranges from right to left.
- Guard span replacement by verifying each span maps back to a real `?` in the original SQL.
- Format string/binary parameters in the fallback path with `mysql_common::Value::as_sql(false)`.
- Add tests for unknown placeholders, mixed known/unknown placeholders, comments/literals, UTF-8 and CRLF span handling, replacement length shifts, `NULL`, binary bytes, and `LIMIT ?`.

This does not change public APIs, schemas, or persisted data.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.

Tests:

- `cargo fmt --check`
- `cargo check -p servers`
- `cargo test -p servers --lib mysql::handler::tests`
- `cargo test -p servers --features testing --test mod mysql::mysql_server_test::test_query_prepared`
