### PR TITLE
feat: add flow query-context plumbing for terminal watermarks

### DIFF
--- a/src/catalog/src/table_source/dummy_catalog.rs
+++ b/src/catalog/src/table_source/dummy_catalog.rs
@@ -22,6 +22,7 @@ use async_trait::async_trait;
 use common_catalog::format_full_table_name;
 use datafusion::catalog::{CatalogProvider, CatalogProviderList, SchemaProvider};
 use datafusion::datasource::TableProvider;
+use session::context::QueryContextRef;
 use snafu::OptionExt;
 use table::table::adapter::DfTableProviderAdapter;
 
@@ -32,12 +33,27 @@ use crate::error::TableNotExistSnafu;
 #[derive(Clone)]
 pub struct DummyCatalogList {
     catalog_manager: CatalogManagerRef,
+    query_ctx: Option<QueryContextRef>,
 }
 
 impl DummyCatalogList {
-    /// Creates a new catalog list with the given catalog manager.
+    /// Creates a new catalog list with the given catalog manager (no query context).
     pub fn new(catalog_manager: CatalogManagerRef) -> Self {
-        Self { catalog_manager }
+        Self {
+            catalog_manager,
+            query_ctx: None,
+        }
+    }
+
+    /// Creates a new catalog list with the given catalog manager and query context.
+    pub fn new_with_query_ctx(
+        catalog_manager: CatalogManagerRef,
+        query_ctx: QueryContextRef,
+    ) -> Self {
+        Self {
+            catalog_manager,
+            query_ctx: Some(query_ctx),
+        }
     }
 }
 
@@ -68,6 +84,7 @@ impl CatalogProviderList for DummyCatalogList {
         Some(Arc::new(DummyCatalogProvider {
             catalog_name: catalog_name.to_string(),
             catalog_manager: self.catalog_manager.clone(),
+            query_ctx: self.query_ctx.clone(),
         }))
     }
 }
@@ -77,6 +94,7 @@ impl CatalogProviderList for DummyCatalogList {
 struct DummyCatalogProvider {
     catalog_name: String,
     catalog_manager: CatalogManagerRef,
+    query_ctx: Option<QueryContextRef>,
 }
 
 impl CatalogProvider for DummyCatalogProvider {
@@ -93,6 +111,7 @@ impl CatalogProvider for DummyCatalogProvider {
             catalog_name: self.catalog_name.clone(),
             schema_name: schema_name.to_string(),
             catalog_manager: self.catalog_manager.clone(),
+            query_ctx: self.query_ctx.clone(),
         }))
     }
 }
@@ -111,6 +130,7 @@ struct DummySchemaProvider {
     catalog_name: String,
     schema_name: String,
     catalog_manager: CatalogManagerRef,
+    query_ctx: Option<QueryContextRef>,
 }
 
 #[async_trait]
@@ -126,7 +146,12 @@ impl SchemaProvider for DummySchemaProvider {
     async fn table(&self, name: &str) -> datafusion::error::Result<Option<Arc<dyn TableProvider>>> {
         let table = self
             .catalog_manager
-            .table(&self.catalog_name, &self.schema_name, name, None)
+            .table(
+                &self.catalog_name,
+                &self.schema_name,
+                name,
+                self.query_ctx.as_deref(),
+            )
             .await?
             .with_context(|| TableNotExistSnafu {
                 table: format_full_table_name(&self.catalog_name, &self.schema_name, name),

--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -314,6 +314,7 @@ impl RegionServer {
         let ctx = request.header.as_ref().map(|h| h.into());
         let query_ctx = Arc::new(ctx.unwrap_or_else(|| QueryContextBuilder::default().build()));
 
+        let region_id = request.region_id;
         let injector_builder = NameAwareDataSourceInjectorBuilder::from_plan(&request.plan)
             .context(DataFusionSnafu)?;
         let mut injector = injector_builder
@@ -326,7 +327,6 @@ impl RegionServer {
             .context(DataFusionSnafu)?
             .data;
 
-        let region_id = request.region_id;
         let stream = self
             .inner
             .handle_read(QueryRequest { plan, ..request }, query_ctx.clone())
@@ -837,14 +837,13 @@ fn wrap_flow_region_watermark_stream(
     region_id: RegionId,
     query_ctx: &QueryContextRef,
 ) -> SendableRecordBatchStream {
-    let Some(seq) = should_collect_region_watermark_from_extensions(&query_ctx.extensions())
-        .then(|| query_ctx.get_snapshot(region_id.as_u64()))
-        .flatten()
-    else {
-        return stream;
-    };
-
-    Box::pin(RegionWatermarkStream::new(stream, region_id, seq))
+    if should_collect_region_watermark_from_extensions(&query_ctx.extensions())
+        && let Some(seq) = query_ctx.get_snapshot(region_id.as_u64())
+    {
+        Box::pin(RegionWatermarkStream::new(stream, region_id, seq)) as SendableRecordBatchStream
+    } else {
+        stream
+    }
 }
 
 /// Wraps a region read stream so terminal metrics can carry the scan-open watermark.

--- a/src/flow/src/batching_mode.rs
+++ b/src/flow/src/batching_mode.rs
@@ -20,12 +20,14 @@ use common_grpc::channel_manager::ClientTlsOption;
 use serde::{Deserialize, Serialize};
 use session::ReadPreference;
 
+mod checkpoint;
 pub(crate) mod engine;
 pub(crate) mod frontend_client;
 mod state;
+mod table_creator;
 mod task;
 mod time_window;
-mod utils;
+pub(crate) mod utils;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BatchingModeOptions {

--- a/src/flow/src/batching_mode/checkpoint.rs
+++ b/src/flow/src/batching_mode/checkpoint.rs
@@ -45,19 +45,20 @@ impl FlowQueryFallbackReason {
 /// each Flow query execution. Describes whether the task advanced its
 /// checkpoint-readiness state or fell back to full snapshot, and why.
 ///
-/// In PR3a, the task tracks checkpoint readiness internally (so that
-/// subsequent queries can prove that all participating regions have valid
-/// watermarks), but the query execution path **never** emits incremental
-/// scan extensions (`FLOW_INCREMENTAL_MODE` / `FLOW_INCREMENTAL_AFTER_SEQS`).
-/// Those remain deferred to PR3b.
+/// The task tracks checkpoint readiness internally so that subsequent queries
+/// can prove that all participating regions have valid watermarks. This
+/// decision only records readiness/fallback state; it does not by itself imply
+/// that a query emitted incremental scan extensions (`FLOW_INCREMENTAL_MODE` /
+/// `FLOW_INCREMENTAL_AFTER_SEQS`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum FlowCheckpointDecision {
     /// FullSnapshot → Incremental (checkpoint-readiness) transition.
     ///
     /// The query exercised every participating region, all returned valid
     /// watermarks, and the checkpoint map was populated from scratch.
-    /// The task is now checkpoint-ready. PR3b will additionally use those
-    /// checkpoints to drive actual incremental scan extensions.
+    /// The task is now checkpoint-ready. These checkpoints can be used by
+    /// incremental scan extension generation when that execution mode is
+    /// enabled.
     AdvancedFromFullSnapshot {
         participating_regions: usize,
         watermarks: usize,

--- a/src/flow/src/batching_mode/checkpoint.rs
+++ b/src/flow/src/batching_mode/checkpoint.rs
@@ -12,59 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::batching_mode::state::CheckpointMode;
-
-/// Why the task fell back to full snapshot mode.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum FlowQueryFallbackReason {
-    /// The query result did not include a region-watermark map at all.
-    MissingRegionWatermark,
-    /// Some participating regions could not prove safe advancement against
-    /// both the returned watermarks and the checkpoint map.
-    IncompleteRegionWatermark,
-    /// A query failure while the task was checkpoint-ready; the Flow resets
-    /// to full snapshot to avoid cascading errors.
-    CheckpointReadyQueryFailure,
-}
-
-/// Decision produced by `BatchingTask::apply_query_result_to_state` after
-/// each Flow query execution. Describes whether the task advanced its
-/// checkpoint-readiness state or fell back to full snapshot, and why.
-///
-/// The task tracks checkpoint readiness internally so that subsequent queries
-/// can prove that all participating regions have valid watermarks. This
-/// decision only records readiness/fallback state; it does not by itself imply
-/// that a query emitted incremental scan extensions (`FLOW_INCREMENTAL_MODE` /
-/// `FLOW_INCREMENTAL_AFTER_SEQS`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum FlowCheckpointDecision {
-    /// FullSnapshot → Incremental (checkpoint-readiness) transition.
-    ///
-    /// The query exercised every participating region, all returned valid
-    /// watermarks, and the checkpoint map was populated from scratch.
-    /// The task is now checkpoint-ready. These checkpoints can be used by
-    /// incremental scan extension generation when that execution mode is
-    /// enabled.
-    AdvancedFromFullSnapshot {
-        participating_region_count: usize,
-        watermark_count: usize,
-    },
-    /// Existing Incremental (checkpoint-ready) → Incremental (in-place advancement).
-    ///
-    /// A subset of participating regions advanced their watermarks. The
-    /// task stays checkpoint-ready with an updated checkpoint map.
-    AdvancedIncremental {
-        participating_region_count: usize,
-        watermark_count: usize,
-    },
-    /// Any mode → FullSnapshot.
-    ///
-    /// Watermark information was incomplete, a participating region was
-    /// absent from the existing checkpoint map, or the query itself
-    /// failed. The task resets to full snapshot semantics for the next
-    /// execution.
-    FallbackToFullSnapshot {
-        previous_mode: CheckpointMode,
-        reason: FlowQueryFallbackReason,
-    },
+pub(super) enum CheckpointMode {
+    /// Full-snapshot reads over the source tables.
+    FullSnapshot,
+    /// Incremental reads driven by explicitly emitted incremental scan
+    /// extensions.
+    Incremental,
 }

--- a/src/flow/src/batching_mode/checkpoint.rs
+++ b/src/flow/src/batching_mode/checkpoint.rs
@@ -1,0 +1,120 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::batching_mode::state::CheckpointMode;
+
+pub(super) const CHECKPOINT_DECISION_ADVANCE: &str = "advance";
+pub(super) const CHECKPOINT_DECISION_FALLBACK: &str = "fallback";
+pub(super) const CHECKPOINT_REASON_NONE: &str = "none";
+
+/// Why the task fell back to full snapshot mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum FlowQueryFallbackReason {
+    /// The query result did not include a region-watermark map at all.
+    MissingRegionWatermark,
+    /// Some participating regions could not prove safe advancement against
+    /// both the returned watermarks and the checkpoint map.
+    IncompleteRegionWatermark,
+    /// A query failure while the task was checkpoint-ready; the Flow resets
+    /// to full snapshot to avoid cascading errors.
+    CheckpointReadyQueryFailure,
+}
+
+impl FlowQueryFallbackReason {
+    pub(super) fn as_label(self) -> &'static str {
+        match self {
+            Self::MissingRegionWatermark => "missing_region_watermark",
+            Self::IncompleteRegionWatermark => "incomplete_region_watermark",
+            Self::CheckpointReadyQueryFailure => "checkpoint_ready_query_failure",
+        }
+    }
+}
+
+/// Decision produced by `BatchingTask::apply_query_result_to_state` after
+/// each Flow query execution. Describes whether the task advanced its
+/// checkpoint-readiness state or fell back to full snapshot, and why.
+///
+/// In PR3a, the task tracks checkpoint readiness internally (so that
+/// subsequent queries can prove that all participating regions have valid
+/// watermarks), but the query execution path **never** emits incremental
+/// scan extensions (`FLOW_INCREMENTAL_MODE` / `FLOW_INCREMENTAL_AFTER_SEQS`).
+/// Those remain deferred to PR3b.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum FlowCheckpointDecision {
+    /// FullSnapshot → Incremental (checkpoint-readiness) transition.
+    ///
+    /// The query exercised every participating region, all returned valid
+    /// watermarks, and the checkpoint map was populated from scratch.
+    /// The task is now checkpoint-ready. PR3b will additionally use those
+    /// checkpoints to drive actual incremental scan extensions.
+    AdvancedFromFullSnapshot {
+        participating_regions: usize,
+        watermarks: usize,
+    },
+    /// Existing Incremental (checkpoint-ready) → Incremental (in-place advancement).
+    ///
+    /// A subset of participating regions advanced their watermarks. The
+    /// task stays checkpoint-ready with an updated checkpoint map.
+    AdvancedIncremental {
+        participating_regions: usize,
+        watermarks: usize,
+    },
+    /// Any mode → FullSnapshot.
+    ///
+    /// Watermark information was incomplete, a participating region was
+    /// absent from the existing checkpoint map, or the query itself
+    /// failed. The task resets to full snapshot semantics for the next
+    /// execution.
+    FallbackToFullSnapshot {
+        previous_mode: CheckpointMode,
+        reason: FlowQueryFallbackReason,
+    },
+}
+
+impl FlowCheckpointDecision {
+    pub(super) fn mode_label(self) -> &'static str {
+        match self {
+            Self::AdvancedFromFullSnapshot { .. } => {
+                checkpoint_mode_label(CheckpointMode::FullSnapshot)
+            }
+            Self::AdvancedIncremental { .. } => checkpoint_mode_label(CheckpointMode::Incremental),
+            Self::FallbackToFullSnapshot { previous_mode, .. } => {
+                checkpoint_mode_label(previous_mode)
+            }
+        }
+    }
+
+    pub(super) fn decision_label(self) -> &'static str {
+        match self {
+            Self::AdvancedFromFullSnapshot { .. } | Self::AdvancedIncremental { .. } => {
+                CHECKPOINT_DECISION_ADVANCE
+            }
+            Self::FallbackToFullSnapshot { .. } => CHECKPOINT_DECISION_FALLBACK,
+        }
+    }
+
+    pub(super) fn reason_label(self) -> &'static str {
+        match self {
+            Self::FallbackToFullSnapshot { reason, .. } => reason.as_label(),
+            _ => CHECKPOINT_REASON_NONE,
+        }
+    }
+}
+
+pub(super) fn checkpoint_mode_label(mode: CheckpointMode) -> &'static str {
+    match mode {
+        CheckpointMode::FullSnapshot => "full_snapshot",
+        CheckpointMode::Incremental => "incremental",
+    }
+}

--- a/src/flow/src/batching_mode/checkpoint.rs
+++ b/src/flow/src/batching_mode/checkpoint.rs
@@ -14,10 +14,6 @@
 
 use crate::batching_mode::state::CheckpointMode;
 
-pub(super) const CHECKPOINT_DECISION_ADVANCE: &str = "advance";
-pub(super) const CHECKPOINT_DECISION_FALLBACK: &str = "fallback";
-pub(super) const CHECKPOINT_REASON_NONE: &str = "none";
-
 /// Why the task fell back to full snapshot mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum FlowQueryFallbackReason {
@@ -29,16 +25,6 @@ pub(super) enum FlowQueryFallbackReason {
     /// A query failure while the task was checkpoint-ready; the Flow resets
     /// to full snapshot to avoid cascading errors.
     CheckpointReadyQueryFailure,
-}
-
-impl FlowQueryFallbackReason {
-    pub(super) fn as_label(self) -> &'static str {
-        match self {
-            Self::MissingRegionWatermark => "missing_region_watermark",
-            Self::IncompleteRegionWatermark => "incomplete_region_watermark",
-            Self::CheckpointReadyQueryFailure => "checkpoint_ready_query_failure",
-        }
-    }
 }
 
 /// Decision produced by `BatchingTask::apply_query_result_to_state` after
@@ -60,16 +46,16 @@ pub(super) enum FlowCheckpointDecision {
     /// incremental scan extension generation when that execution mode is
     /// enabled.
     AdvancedFromFullSnapshot {
-        participating_regions: usize,
-        watermarks: usize,
+        participating_region_count: usize,
+        watermark_count: usize,
     },
     /// Existing Incremental (checkpoint-ready) → Incremental (in-place advancement).
     ///
     /// A subset of participating regions advanced their watermarks. The
     /// task stays checkpoint-ready with an updated checkpoint map.
     AdvancedIncremental {
-        participating_regions: usize,
-        watermarks: usize,
+        participating_region_count: usize,
+        watermark_count: usize,
     },
     /// Any mode → FullSnapshot.
     ///
@@ -81,41 +67,4 @@ pub(super) enum FlowCheckpointDecision {
         previous_mode: CheckpointMode,
         reason: FlowQueryFallbackReason,
     },
-}
-
-impl FlowCheckpointDecision {
-    pub(super) fn mode_label(self) -> &'static str {
-        match self {
-            Self::AdvancedFromFullSnapshot { .. } => {
-                checkpoint_mode_label(CheckpointMode::FullSnapshot)
-            }
-            Self::AdvancedIncremental { .. } => checkpoint_mode_label(CheckpointMode::Incremental),
-            Self::FallbackToFullSnapshot { previous_mode, .. } => {
-                checkpoint_mode_label(previous_mode)
-            }
-        }
-    }
-
-    pub(super) fn decision_label(self) -> &'static str {
-        match self {
-            Self::AdvancedFromFullSnapshot { .. } | Self::AdvancedIncremental { .. } => {
-                CHECKPOINT_DECISION_ADVANCE
-            }
-            Self::FallbackToFullSnapshot { .. } => CHECKPOINT_DECISION_FALLBACK,
-        }
-    }
-
-    pub(super) fn reason_label(self) -> &'static str {
-        match self {
-            Self::FallbackToFullSnapshot { reason, .. } => reason.as_label(),
-            _ => CHECKPOINT_REASON_NONE,
-        }
-    }
-}
-
-pub(super) fn checkpoint_mode_label(mode: CheckpointMode) -> &'static str {
-    match mode {
-        CheckpointMode::FullSnapshot => "full_snapshot",
-        CheckpointMode::Incremental => "incremental",
-    }
 }

--- a/src/flow/src/batching_mode/engine.rs
+++ b/src/flow/src/batching_mode/engine.rs
@@ -521,17 +521,63 @@ impl BatchingEngine {
         // check execute once first to detect any error early
         task.check_or_create_sink_table(&engine, &frontend).await?;
 
+        let (start_tx, start_rx) = oneshot::channel();
+
         // TODO(discord9): use time wheel or what for better
         let handle = common_runtime::spawn_global(async move {
-            task_inner.start_executing_loop(engine, frontend).await;
+            if start_rx.await.is_ok() {
+                task_inner.start_executing_loop(engine, frontend).await;
+            }
         });
         task.state.write().unwrap().task_handle = Some(handle);
+        let task_for_rollback = task.clone();
 
-        // only replace here not earlier because we want the old one intact if something went wrong before this line
-        let replaced_old_task_opt = self.tasks.write().await.insert(flow_id, task);
-        drop(replaced_old_task_opt);
+        // Only replace here, not earlier, because we want the old one intact if
+        // something went wrong before this line. Hold both registry locks while
+        // re-checking existence and updating the two maps so create/remove can't
+        // observe a task without its matching shutdown sender, or vice versa.
+        let (replaced_old_task_opt, replaced_old_shutdown_tx) = {
+            let mut tasks = self.tasks.write().await;
+            let mut shutdown_txs = self.shutdown_txs.write().await;
 
-        self.shutdown_txs.write().await.insert(flow_id, tx);
+            let is_exist = tasks.contains_key(&flow_id);
+            match (create_if_not_exists, or_replace, is_exist) {
+                (_, true, true) => {
+                    info!(
+                        "Replacing flow with id={} after final registry check",
+                        flow_id
+                    );
+                }
+                (false, false, true) => {
+                    abort_flow_task(flow_id, Some(task), "unregistered");
+                    return FlowAlreadyExistSnafu { id: flow_id }.fail();
+                }
+                (true, false, true) => {
+                    info!(
+                        "Flow with id={} already exists at final registry check, do nothing",
+                        flow_id
+                    );
+                    abort_flow_task(flow_id, Some(task), "unregistered");
+                    return Ok(None);
+                }
+                (_, _, false) => (),
+            }
+
+            let replaced_old_task_opt = tasks.insert(flow_id, task);
+            let replaced_old_shutdown_tx = shutdown_txs.insert(flow_id, tx);
+            (replaced_old_task_opt, replaced_old_shutdown_tx)
+        };
+
+        notify_flow_shutdown(flow_id, replaced_old_shutdown_tx, "replaced");
+        abort_flow_task(flow_id, replaced_old_task_opt, "replaced");
+        if start_tx.send(()).is_err() {
+            self.rollback_flow_runtime_if_current(flow_id, &task_for_rollback)
+                .await;
+            UnexpectedSnafu {
+                reason: format!("Failed to start flow {flow_id} due to task already dropped"),
+            }
+            .fail()?;
+        }
 
         Ok(Some(flow_id))
     }
@@ -662,21 +708,28 @@ impl BatchingEngine {
     }
 
     pub async fn remove_flow_inner(&self, flow_id: FlowId) -> Result<(), Error> {
-        if self.tasks.write().await.remove(&flow_id).is_none() {
-            warn!("Flow {flow_id} not found in tasks");
-            FlowNotFoundSnafu { id: flow_id }.fail()?;
-        }
-        let Some(tx) = self.shutdown_txs.write().await.remove(&flow_id) else {
+        let (task, shutdown_tx) = {
+            let mut tasks = self.tasks.write().await;
+            let mut shutdown_txs = self.shutdown_txs.write().await;
+
+            let Some(task) = tasks.remove(&flow_id) else {
+                warn!("Flow {flow_id} not found in tasks");
+                FlowNotFoundSnafu { id: flow_id }.fail()?
+            };
+            let shutdown_tx = shutdown_txs.remove(&flow_id);
+            (task, shutdown_tx)
+        };
+
+        let had_shutdown_tx = notify_flow_shutdown(flow_id, shutdown_tx, "removed");
+        abort_flow_task(flow_id, Some(task), "removed");
+
+        if !had_shutdown_tx {
             UnexpectedSnafu {
                 reason: format!("Can't found shutdown tx for flow {flow_id}"),
             }
             .fail()?
-        };
-        if tx.send(()).is_err() {
-            warn!(
-                "Fail to shutdown flow {flow_id} due to receiver already dropped, maybe flow {flow_id} is already dropped?"
-            )
         }
+
         Ok(())
     }
 
@@ -725,6 +778,53 @@ impl BatchingEngine {
     pub async fn flow_exist_inner(&self, flow_id: FlowId) -> bool {
         self.tasks.read().await.contains_key(&flow_id)
     }
+
+    async fn rollback_flow_runtime_if_current(&self, flow_id: FlowId, task: &BatchingTask) {
+        let (removed_task, removed_shutdown_tx) = {
+            let mut tasks = self.tasks.write().await;
+            let mut shutdown_txs = self.shutdown_txs.write().await;
+
+            if tasks
+                .get(&flow_id)
+                .is_some_and(|current| Arc::ptr_eq(&current.state, &task.state))
+            {
+                (tasks.remove(&flow_id), shutdown_txs.remove(&flow_id))
+            } else {
+                (None, None)
+            }
+        };
+
+        notify_flow_shutdown(flow_id, removed_shutdown_tx, "rolled back");
+        abort_flow_task(flow_id, removed_task, "rolled back");
+    }
+}
+
+fn notify_flow_shutdown(flow_id: FlowId, tx: Option<oneshot::Sender<()>>, action: &str) -> bool {
+    let Some(tx) = tx else {
+        return false;
+    };
+
+    if tx.send(()).is_err() {
+        warn!(
+            "Fail to shutdown {action} flow {flow_id} due to receiver already dropped, maybe flow {flow_id} is already dropped?"
+        );
+    }
+
+    true
+}
+
+fn abort_flow_task(flow_id: FlowId, task: Option<BatchingTask>, action: &str) -> bool {
+    let Some(task) = task else {
+        return false;
+    };
+
+    if let Some(handle) = task.state.write().unwrap().task_handle.take() {
+        handle.abort();
+        debug!("Aborted {action} flow task {flow_id}");
+        return true;
+    }
+
+    false
 }
 
 impl FlowEngine for BatchingEngine {
@@ -754,5 +854,180 @@ impl FlowEngine for BatchingEngine {
         req: api::v1::flow::DirtyWindowRequests,
     ) -> Result<(), Error> {
         self.handle_mark_dirty_time_window(req).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use catalog::memory::new_memory_catalog_manager;
+    use common_meta::key::TableMetadataManager;
+    use common_meta::key::flow::FlowMetadataManager;
+    use common_meta::kv_backend::memory::MemoryKvBackend;
+    use query::options::QueryOptions;
+    use session::context::QueryContext;
+
+    use super::*;
+    use crate::test_utils::create_test_query_engine;
+
+    struct DropNotify(Option<oneshot::Sender<()>>);
+
+    impl Drop for DropNotify {
+        fn drop(&mut self) {
+            if let Some(tx) = self.0.take() {
+                let _ = tx.send(());
+            }
+        }
+    }
+
+    async fn new_test_engine() -> BatchingEngine {
+        let kv_backend = Arc::new(MemoryKvBackend::new());
+        let table_meta = Arc::new(TableMetadataManager::new(kv_backend.clone()));
+        table_meta.init().await.unwrap();
+        let flow_meta = Arc::new(FlowMetadataManager::new(kv_backend));
+        let catalog_manager = new_memory_catalog_manager().unwrap();
+        let query_engine = create_test_query_engine();
+        let (frontend_client, _handler) =
+            FrontendClient::from_empty_grpc_handler(QueryOptions::default());
+
+        BatchingEngine::new(
+            Arc::new(frontend_client),
+            query_engine,
+            flow_meta,
+            table_meta,
+            catalog_manager,
+            BatchingModeOptions::default(),
+        )
+    }
+
+    async fn new_test_task(flow_id: FlowId) -> (BatchingTask, oneshot::Sender<()>) {
+        let query_engine = create_test_query_engine();
+        let ctx = QueryContext::arc();
+        let plan = sql_to_df_plan(
+            ctx.clone(),
+            query_engine.clone(),
+            "SELECT number, ts FROM numbers_with_ts",
+            true,
+        )
+        .await
+        .unwrap();
+        let (tx, rx) = oneshot::channel();
+
+        let task = BatchingTask::try_new(TaskArgs {
+            flow_id,
+            query: "SELECT number, ts FROM numbers_with_ts",
+            plan,
+            time_window_expr: None,
+            expire_after: None,
+            sink_table_name: [
+                "greptime".to_string(),
+                "public".to_string(),
+                "sink".to_string(),
+            ],
+            source_table_names: vec![[
+                "greptime".to_string(),
+                "public".to_string(),
+                "numbers_with_ts".to_string(),
+            ]],
+            query_ctx: ctx,
+            catalog_manager: query_engine.engine_state().catalog_manager().clone(),
+            shutdown_rx: rx,
+            batch_opts: Arc::new(BatchingModeOptions::default()),
+            flow_eval_interval: None,
+        })
+        .unwrap();
+
+        (task, tx)
+    }
+
+    async fn install_abort_observed_handle(task: &BatchingTask) -> oneshot::Receiver<()> {
+        let (drop_tx, drop_rx) = oneshot::channel();
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let handle = tokio::spawn(async move {
+            let _guard = DropNotify(Some(drop_tx));
+            let _ = entered_tx.send(());
+            std::future::pending::<()>().await;
+        });
+        task.state.write().unwrap().task_handle = Some(handle);
+        tokio::time::timeout(Duration::from_secs(1), entered_rx)
+            .await
+            .expect("test task handle should start")
+            .expect("test task handle should report start");
+        drop_rx
+    }
+
+    #[tokio::test]
+    async fn test_notify_flow_shutdown_sends_signal() {
+        let (tx, rx) = oneshot::channel();
+
+        assert!(notify_flow_shutdown(42, Some(tx), "test"));
+
+        rx.await.expect("replaced flow should receive shutdown");
+    }
+
+    #[test]
+    fn test_notify_flow_shutdown_accepts_missing_sender() {
+        assert!(!notify_flow_shutdown(42, None, "test"));
+    }
+
+    #[tokio::test]
+    async fn test_abort_flow_task_aborts_handle() {
+        let (task, _shutdown_tx) = new_test_task(42).await;
+        let drop_rx = install_abort_observed_handle(&task).await;
+
+        assert!(abort_flow_task(42, Some(task), "test"));
+
+        tokio::time::timeout(Duration::from_secs(1), drop_rx)
+            .await
+            .expect("aborted task should be dropped")
+            .expect("drop notifier should fire");
+    }
+
+    #[tokio::test]
+    async fn test_remove_flow_inner_aborts_registered_task() {
+        let engine = new_test_engine().await;
+        let (task, shutdown_tx) = new_test_task(42).await;
+        let drop_rx = install_abort_observed_handle(&task).await;
+
+        engine.tasks.write().await.insert(42, task);
+        engine.shutdown_txs.write().await.insert(42, shutdown_tx);
+
+        engine.remove_flow_inner(42).await.unwrap();
+
+        tokio::time::timeout(Duration::from_secs(1), drop_rx)
+            .await
+            .expect("removed task should be dropped")
+            .expect("drop notifier should fire");
+        assert!(!engine.flow_exist_inner(42).await);
+        assert!(!engine.shutdown_txs.read().await.contains_key(&42));
+    }
+
+    #[tokio::test]
+    async fn test_rollback_flow_runtime_if_current_removes_matching_task_only() {
+        let engine = new_test_engine().await;
+        let (old_task, _old_shutdown_tx) = new_test_task(42).await;
+        let (current_task, current_shutdown_tx) = new_test_task(42).await;
+        let current_task_identity = current_task.clone();
+
+        engine.tasks.write().await.insert(42, current_task);
+        engine
+            .shutdown_txs
+            .write()
+            .await
+            .insert(42, current_shutdown_tx);
+
+        engine.rollback_flow_runtime_if_current(42, &old_task).await;
+
+        let registered_task = engine.tasks.read().await.get(&42).cloned().unwrap();
+        assert!(Arc::ptr_eq(
+            &registered_task.state,
+            &current_task_identity.state
+        ));
+        assert!(engine.shutdown_txs.read().await.contains_key(&42));
+
+        engine
+            .rollback_flow_runtime_if_current(42, &current_task_identity)
+            .await;
+        assert!(!engine.flow_exist_inner(42).await);
+        assert!(!engine.shutdown_txs.read().await.contains_key(&42));
     }
 }

--- a/src/flow/src/batching_mode/engine.rs
+++ b/src/flow/src/batching_mode/engine.rs
@@ -766,7 +766,7 @@ impl BatchingEngine {
             )
             .await?;
 
-        let affected_rows = res.map(|(r, _)| r).unwrap_or_default() as usize;
+        let affected_rows = res.map(|(r, _)| r).unwrap_or_default();
         debug!(
             "Successfully flush flow {flow_id}, affected rows={}",
             affected_rows

--- a/src/flow/src/batching_mode/engine.rs
+++ b/src/flow/src/batching_mode/engine.rs
@@ -59,8 +59,7 @@ use crate::{CreateFlowArgs, Error, FlowId, TableName};
 ///
 /// TODO(discord9): determine how to configure refresh rate
 pub struct BatchingEngine {
-    tasks: RwLock<BTreeMap<FlowId, BatchingTask>>,
-    shutdown_txs: RwLock<BTreeMap<FlowId, oneshot::Sender<()>>>,
+    runtime: RwLock<FlowRuntimeRegistry>,
     /// frontend client for insert request
     pub(crate) frontend_client: Arc<FrontendClient>,
     flow_metadata_manager: FlowMetadataManagerRef,
@@ -70,6 +69,51 @@ pub struct BatchingEngine {
     /// Batching mode options for control how batching mode query works
     ///
     pub(crate) batch_opts: Arc<BatchingModeOptions>,
+}
+
+#[derive(Default)]
+struct FlowRuntimeRegistry {
+    tasks: BTreeMap<FlowId, BatchingTask>,
+    shutdown_txs: BTreeMap<FlowId, oneshot::Sender<()>>,
+}
+
+impl FlowRuntimeRegistry {
+    fn insert(
+        &mut self,
+        flow_id: FlowId,
+        task: BatchingTask,
+        shutdown_tx: oneshot::Sender<()>,
+    ) -> (Option<BatchingTask>, Option<oneshot::Sender<()>>) {
+        (
+            self.tasks.insert(flow_id, task),
+            self.shutdown_txs.insert(flow_id, shutdown_tx),
+        )
+    }
+
+    fn remove(&mut self, flow_id: FlowId) -> Option<(BatchingTask, Option<oneshot::Sender<()>>)> {
+        let task = self.tasks.remove(&flow_id)?;
+        let shutdown_tx = self.shutdown_txs.remove(&flow_id);
+        Some((task, shutdown_tx))
+    }
+
+    fn remove_if_current(
+        &mut self,
+        flow_id: FlowId,
+        task: &BatchingTask,
+    ) -> (Option<BatchingTask>, Option<oneshot::Sender<()>>) {
+        if self
+            .tasks
+            .get(&flow_id)
+            .is_some_and(|current| Arc::ptr_eq(&current.state, &task.state))
+        {
+            let Some((removed_task, removed_shutdown_tx)) = self.remove(flow_id) else {
+                return (None, None);
+            };
+            (Some(removed_task), removed_shutdown_tx)
+        } else {
+            (None, None)
+        }
+    }
 }
 
 impl BatchingEngine {
@@ -82,8 +126,7 @@ impl BatchingEngine {
         batch_opts: BatchingModeOptions,
     ) -> Self {
         Self {
-            tasks: Default::default(),
-            shutdown_txs: Default::default(),
+            runtime: Default::default(),
             frontend_client,
             flow_metadata_manager,
             table_meta,
@@ -95,8 +138,9 @@ impl BatchingEngine {
 
     /// Returns last execution timestamps (millisecond) for all batching flows.
     pub async fn get_last_exec_time_map(&self) -> BTreeMap<FlowId, i64> {
-        let tasks = self.tasks.read().await;
-        tasks
+        let runtime = self.runtime.read().await;
+        runtime
+            .tasks
             .iter()
             .filter_map(|(flow_id, task)| {
                 task.last_execution_time_millis()
@@ -151,10 +195,17 @@ impl BatchingEngine {
 
         let group_by_table_name = Arc::new(group_by_table_name);
 
+        let tasks = self
+            .runtime
+            .read()
+            .await
+            .tasks
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
         let mut handles = Vec::new();
-        let tasks = self.tasks.read().await;
 
-        for (_flow_id, task) in tasks.iter() {
+        for task in tasks {
             let src_table_names = &task.config.source_table_names;
 
             if src_table_names
@@ -204,7 +255,6 @@ impl BatchingEngine {
             });
             handles.push(handle);
         }
-        drop(tasks);
         for handle in handles {
             match handle.await {
                 Err(e) => {
@@ -274,9 +324,16 @@ impl BatchingEngine {
 
         let group_by_table_name = Arc::new(group_by_table_name);
 
+        let tasks = self
+            .runtime
+            .read()
+            .await
+            .tasks
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
         let mut handles = Vec::new();
-        let tasks = self.tasks.read().await;
-        for (_flow_id, task) in tasks.iter() {
+        for task in tasks {
             let src_table_names = &task.config.source_table_names;
 
             if src_table_names
@@ -327,8 +384,6 @@ impl BatchingEngine {
                 }
             }
         }
-        drop(tasks);
-
         Ok(())
     }
 }
@@ -390,7 +445,7 @@ impl BatchingEngine {
 
         // or replace logic
         {
-            let is_exist = self.tasks.read().await.contains_key(&flow_id);
+            let is_exist = self.runtime.read().await.tasks.contains_key(&flow_id);
             match (create_if_not_exists, or_replace, is_exist) {
                 // if replace, ignore that old flow exists
                 (_, true, true) => {
@@ -533,14 +588,13 @@ impl BatchingEngine {
         let task_for_rollback = task.clone();
 
         // Only replace here, not earlier, because we want the old one intact if
-        // something went wrong before this line. Hold both registry locks while
-        // re-checking existence and updating the two maps so create/remove can't
-        // observe a task without its matching shutdown sender, or vice versa.
+        // something went wrong before this line. Keep the task and shutdown
+        // sender in one registry lock so create/remove can't observe one
+        // without the other.
         let (replaced_old_task_opt, replaced_old_shutdown_tx) = {
-            let mut tasks = self.tasks.write().await;
-            let mut shutdown_txs = self.shutdown_txs.write().await;
+            let mut runtime = self.runtime.write().await;
 
-            let is_exist = tasks.contains_key(&flow_id);
+            let is_exist = runtime.tasks.contains_key(&flow_id);
             match (create_if_not_exists, or_replace, is_exist) {
                 (_, true, true) => {
                     info!(
@@ -563,9 +617,7 @@ impl BatchingEngine {
                 (_, _, false) => (),
             }
 
-            let replaced_old_task_opt = tasks.insert(flow_id, task);
-            let replaced_old_shutdown_tx = shutdown_txs.insert(flow_id, tx);
-            (replaced_old_task_opt, replaced_old_shutdown_tx)
+            runtime.insert(flow_id, task, tx)
         };
 
         notify_flow_shutdown(flow_id, replaced_old_shutdown_tx, "replaced");
@@ -709,14 +761,11 @@ impl BatchingEngine {
 
     pub async fn remove_flow_inner(&self, flow_id: FlowId) -> Result<(), Error> {
         let (task, shutdown_tx) = {
-            let mut tasks = self.tasks.write().await;
-            let mut shutdown_txs = self.shutdown_txs.write().await;
-
-            let Some(task) = tasks.remove(&flow_id) else {
+            let mut runtime = self.runtime.write().await;
+            let Some((task, shutdown_tx)) = runtime.remove(flow_id) else {
                 warn!("Flow {flow_id} not found in tasks");
                 FlowNotFoundSnafu { id: flow_id }.fail()?
             };
-            let shutdown_tx = shutdown_txs.remove(&flow_id);
             (task, shutdown_tx)
         };
 
@@ -741,7 +790,7 @@ impl BatchingEngine {
         // this is only useful for the case when we are flushing the flow right after inserting data into it
         // TODO(discord9): find a better way to ensure the data is ready, maybe inform flownode from frontend?
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        let task = self.tasks.read().await.get(&flow_id).cloned();
+        let task = self.runtime.read().await.tasks.get(&flow_id).cloned();
         let task = task.with_context(|| FlowNotFoundSnafu { id: flow_id })?;
 
         let time_window_size = task
@@ -776,22 +825,13 @@ impl BatchingEngine {
 
     /// Determine if the batching mode flow task exists with given flow id
     pub async fn flow_exist_inner(&self, flow_id: FlowId) -> bool {
-        self.tasks.read().await.contains_key(&flow_id)
+        self.runtime.read().await.tasks.contains_key(&flow_id)
     }
 
     async fn rollback_flow_runtime_if_current(&self, flow_id: FlowId, task: &BatchingTask) {
         let (removed_task, removed_shutdown_tx) = {
-            let mut tasks = self.tasks.write().await;
-            let mut shutdown_txs = self.shutdown_txs.write().await;
-
-            if tasks
-                .get(&flow_id)
-                .is_some_and(|current| Arc::ptr_eq(&current.state, &task.state))
-            {
-                (tasks.remove(&flow_id), shutdown_txs.remove(&flow_id))
-            } else {
-                (None, None)
-            }
+            let mut runtime = self.runtime.write().await;
+            runtime.remove_if_current(flow_id, task)
         };
 
         notify_flow_shutdown(flow_id, removed_shutdown_tx, "rolled back");
@@ -841,7 +881,14 @@ impl FlowEngine for BatchingEngine {
         Ok(self.flow_exist_inner(flow_id).await)
     }
     async fn list_flows(&self) -> Result<impl IntoIterator<Item = FlowId>, Error> {
-        Ok(self.tasks.read().await.keys().cloned().collect::<Vec<_>>())
+        Ok(self
+            .runtime
+            .read()
+            .await
+            .tasks
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>())
     }
     async fn handle_flow_inserts(
         &self,
@@ -988,8 +1035,7 @@ mod tests {
         let (task, shutdown_tx) = new_test_task(42).await;
         let drop_rx = install_abort_observed_handle(&task).await;
 
-        engine.tasks.write().await.insert(42, task);
-        engine.shutdown_txs.write().await.insert(42, shutdown_tx);
+        engine.runtime.write().await.insert(42, task, shutdown_tx);
 
         engine.remove_flow_inner(42).await.unwrap();
 
@@ -998,7 +1044,72 @@ mod tests {
             .expect("removed task should be dropped")
             .expect("drop notifier should fire");
         assert!(!engine.flow_exist_inner(42).await);
-        assert!(!engine.shutdown_txs.read().await.contains_key(&42));
+        assert!(!engine.runtime.read().await.shutdown_txs.contains_key(&42));
+    }
+
+    #[tokio::test]
+    async fn test_or_replace_flow_runtime_replaces_old_handles_and_keeps_new_task() {
+        let engine = new_test_engine().await;
+        let (old_task, old_shutdown_tx) = new_test_task(42).await;
+        let old_task_identity = old_task.clone();
+        let old_drop_rx = install_abort_observed_handle(&old_task).await;
+        let (new_task, new_shutdown_tx) = new_test_task(42).await;
+        let new_task_identity = new_task.clone();
+
+        engine
+            .runtime
+            .write()
+            .await
+            .insert(42, old_task, old_shutdown_tx);
+        let (replaced_old_task, replaced_old_shutdown_tx) =
+            engine
+                .runtime
+                .write()
+                .await
+                .insert(42, new_task, new_shutdown_tx);
+
+        let replaced_old_task = replaced_old_task.expect("old task should be returned");
+        assert!(Arc::ptr_eq(
+            &replaced_old_task.state,
+            &old_task_identity.state
+        ));
+        assert!(notify_flow_shutdown(
+            42,
+            replaced_old_shutdown_tx,
+            "replaced"
+        ));
+        old_task_identity
+            .state
+            .write()
+            .unwrap()
+            .shutdown_rx
+            .try_recv()
+            .expect("old shutdown receiver should receive signal");
+        assert!(abort_flow_task(42, Some(replaced_old_task), "replaced"));
+
+        tokio::time::timeout(Duration::from_secs(1), old_drop_rx)
+            .await
+            .expect("replaced task should be dropped")
+            .expect("drop notifier should fire");
+
+        let runtime = engine.runtime.read().await;
+        assert_eq!(1, runtime.tasks.len());
+        assert_eq!(1, runtime.shutdown_txs.len());
+        let registered_task = runtime.tasks.get(&42).expect("new task should remain");
+        assert!(Arc::ptr_eq(
+            &registered_task.state,
+            &new_task_identity.state
+        ));
+        assert!(runtime.shutdown_txs.contains_key(&42));
+        assert!(matches!(
+            new_task_identity
+                .state
+                .write()
+                .unwrap()
+                .shutdown_rx
+                .try_recv(),
+            Err(oneshot::error::TryRecvError::Empty)
+        ));
     }
 
     #[tokio::test]
@@ -1008,26 +1119,25 @@ mod tests {
         let (current_task, current_shutdown_tx) = new_test_task(42).await;
         let current_task_identity = current_task.clone();
 
-        engine.tasks.write().await.insert(42, current_task);
         engine
-            .shutdown_txs
+            .runtime
             .write()
             .await
-            .insert(42, current_shutdown_tx);
+            .insert(42, current_task, current_shutdown_tx);
 
         engine.rollback_flow_runtime_if_current(42, &old_task).await;
 
-        let registered_task = engine.tasks.read().await.get(&42).cloned().unwrap();
+        let registered_task = engine.runtime.read().await.tasks.get(&42).cloned().unwrap();
         assert!(Arc::ptr_eq(
             &registered_task.state,
             &current_task_identity.state
         ));
-        assert!(engine.shutdown_txs.read().await.contains_key(&42));
+        assert!(engine.runtime.read().await.shutdown_txs.contains_key(&42));
 
         engine
             .rollback_flow_runtime_if_current(42, &current_task_identity)
             .await;
         assert!(!engine.flow_exist_inner(42).await);
-        assert!(!engine.shutdown_txs.read().await.contains_key(&42));
+        assert!(!engine.runtime.read().await.shutdown_txs.contains_key(&42));
     }
 }

--- a/src/flow/src/batching_mode/frontend_client.rs
+++ b/src/flow/src/batching_mode/frontend_client.rs
@@ -20,15 +20,17 @@ use std::sync::{Arc, Mutex, Weak};
 use api::v1::greptime_request::Request;
 use api::v1::query_request::Query;
 use api::v1::{CreateTableExpr, QueryRequest};
-use client::{Client, Database};
+use client::{Client, Database, OutputWithMetrics};
 use common_error::ext::BoxedError;
 use common_grpc::channel_manager::{ChannelConfig, ChannelManager, load_client_tls_config};
 use common_meta::peer::{Peer, PeerDiscovery};
-use common_query::Output;
+use common_query::{Output, OutputData};
+use common_recordbatch::adapter::{RecordBatchMetrics, RegionWatermarkEntry};
 use common_telemetry::warn;
 use meta_client::client::MetaClient;
 use query::datafusion::QUERY_PARALLELISM_HINT;
-use query::options::QueryOptions;
+use query::metrics::terminal_recordbatch_metrics_from_plan;
+use query::options::{FlowQueryExtensions, QueryOptions};
 use rand::rng;
 use rand::seq::SliceRandom;
 use servers::query_handler::grpc::GrpcQueryHandler;
@@ -196,9 +198,6 @@ impl DatabaseWithPeer {
 }
 
 impl FrontendClient {
-    // TODO: support more fine-grained load balancing strategies for frontend
-    // selection, such as AZ (availability zone) awareness, to prefer frontends
-    // in the same zone as the flownode and reduce cross-AZ latency.
     /// scan for available frontend from metadata
     pub(crate) async fn scan_for_frontend(&self) -> Result<Vec<Peer>, Error> {
         let Self::Distributed { meta_client, .. } = self else {
@@ -341,6 +340,78 @@ impl FrontendClient {
         }
     }
 
+    pub async fn query_with_terminal_metrics(
+        &self,
+        catalog: &str,
+        schema: &str,
+        request: QueryRequest,
+        extensions: &[(&str, &str)],
+    ) -> Result<OutputWithMetrics, Error> {
+        let flow_extensions = build_flow_extensions(extensions)?;
+        match self {
+            FrontendClient::Distributed {
+                query, batch_opts, ..
+            } => {
+                let query_parallelism = query.parallelism.to_string();
+                let hints = vec![
+                    (QUERY_PARALLELISM_HINT, query_parallelism.as_str()),
+                    (READ_PREFERENCE_HINT, batch_opts.read_preference.as_ref()),
+                ];
+                let db = self.get_random_active_frontend(catalog, schema).await?;
+                db.database
+                    .query_with_terminal_metrics_and_flow_extensions(request, &hints, extensions)
+                    .await
+                    .map_err(BoxedError::new)
+                    .context(ExternalSnafu)
+            }
+            FrontendClient::Standalone {
+                database_client,
+                query,
+            } => {
+                let mut extensions_map = HashMap::from([(
+                    QUERY_PARALLELISM_HINT.to_string(),
+                    query.parallelism.to_string(),
+                )]);
+                for (key, value) in extensions {
+                    extensions_map.insert((*key).to_string(), (*value).to_string());
+                }
+                let ctx = QueryContextBuilder::default()
+                    .current_catalog(catalog.to_string())
+                    .current_schema(schema.to_string())
+                    .extensions(extensions_map)
+                    .build();
+                let ctx = Arc::new(ctx);
+                let database_client = {
+                    database_client
+                        .handler
+                        .lock()
+                        .map_err(|e| {
+                            UnexpectedSnafu {
+                                reason: format!("Failed to lock database client: {e}"),
+                            }
+                            .build()
+                        })?
+                        .as_ref()
+                        .context(UnexpectedSnafu {
+                            reason: "Standalone's frontend instance is not set",
+                        })?
+                        .upgrade()
+                        .context(UnexpectedSnafu {
+                            reason: "Failed to upgrade database client",
+                        })?
+                };
+                database_client
+                    .do_query(Request::Query(request), ctx.clone())
+                    .await
+                    .map(|output| {
+                        wrap_standalone_output_with_terminal_metrics(output, &flow_extensions, &ctx)
+                    })
+                    .map_err(BoxedError::new)
+                    .context(ExternalSnafu)
+            }
+        }
+    }
+
     /// Handle a request to frontend
     pub(crate) async fn handle(
         &self,
@@ -426,6 +497,64 @@ impl FrontendClient {
     }
 }
 
+fn build_flow_extensions(extensions: &[(&str, &str)]) -> Result<FlowQueryExtensions, Error> {
+    let flow_extensions = HashMap::from_iter(
+        extensions
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string())),
+    );
+    FlowQueryExtensions::parse_flow_extensions(&flow_extensions)
+        .map_err(BoxedError::new)
+        .context(ExternalSnafu)
+        .map(|extensions| extensions.unwrap_or_default())
+}
+
+fn wrap_standalone_output_with_terminal_metrics(
+    output: Output,
+    flow_extensions: &FlowQueryExtensions,
+    query_ctx: &QueryContextRef,
+) -> OutputWithMetrics {
+    let should_collect_region_watermark = flow_extensions.should_collect_region_watermark();
+    let terminal_metrics =
+        if should_collect_region_watermark && !matches!(&output.data, OutputData::Stream(_)) {
+            output
+                .meta
+                .plan
+                .clone()
+                .and_then(terminal_recordbatch_metrics_from_plan)
+                .or_else(|| terminal_recordbatch_metrics_from_snapshots(query_ctx))
+        } else {
+            None
+        };
+    let result = OutputWithMetrics::from_output(output);
+    if let Some(metrics) = terminal_metrics {
+        result.metrics.update(Some(metrics));
+    }
+    result
+}
+
+fn terminal_recordbatch_metrics_from_snapshots(
+    query_ctx: &QueryContextRef,
+) -> Option<RecordBatchMetrics> {
+    let mut region_watermarks = query_ctx
+        .snapshots()
+        .into_iter()
+        .map(|(region_id, watermark)| RegionWatermarkEntry {
+            region_id,
+            watermark: Some(watermark),
+        })
+        .collect::<Vec<_>>();
+    if region_watermarks.is_empty() {
+        return None;
+    }
+
+    region_watermarks.sort_by_key(|entry| entry.region_id);
+    Some(RecordBatchMetrics {
+        region_watermarks,
+        ..Default::default()
+    })
+}
+
 /// Describe a peer of frontend
 #[derive(Debug, Default)]
 pub(crate) enum PeerDesc {
@@ -450,15 +579,75 @@ impl std::fmt::Display for PeerDesc {
 
 #[cfg(test)]
 mod tests {
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
     use std::time::Duration;
 
-    use common_query::Output;
+    use common_query::{Output, OutputData};
+    use common_recordbatch::adapter::RecordBatchMetrics;
+    use common_recordbatch::{OrderOption, RecordBatch, RecordBatchStream};
+    use datatypes::prelude::{ConcreteDataType, VectorRef};
+    use datatypes::schema::{ColumnSchema, Schema};
+    use datatypes::vectors::Int32Vector;
+    use futures::StreamExt;
     use tokio::time::timeout;
 
     use super::*;
 
     #[derive(Debug)]
     struct NoopHandler;
+
+    struct MockMetricsStream {
+        schema: datatypes::schema::SchemaRef,
+        batch: Option<RecordBatch>,
+        metrics: RecordBatchMetrics,
+        terminal_metrics_only: bool,
+    }
+
+    impl futures::Stream for MockMetricsStream {
+        type Item = common_recordbatch::error::Result<RecordBatch>;
+
+        fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            Poll::Ready(self.batch.take().map(Ok))
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            (
+                usize::from(self.batch.is_some()),
+                Some(usize::from(self.batch.is_some())),
+            )
+        }
+    }
+
+    impl RecordBatchStream for MockMetricsStream {
+        fn name(&self) -> &str {
+            "MockMetricsStream"
+        }
+
+        fn schema(&self) -> datatypes::schema::SchemaRef {
+            self.schema.clone()
+        }
+
+        fn output_ordering(&self) -> Option<&[OrderOption]> {
+            None
+        }
+
+        fn metrics(&self) -> Option<RecordBatchMetrics> {
+            if self.terminal_metrics_only && self.batch.is_some() {
+                return None;
+            }
+            Some(self.metrics.clone())
+        }
+    }
+
+    #[derive(Debug)]
+    struct MetricsHandler;
+
+    #[derive(Debug)]
+    struct ExtensionAwareHandler;
+
+    #[derive(Debug)]
+    struct SnapshotBindingHandler;
 
     #[async_trait::async_trait]
     impl GrpcQueryHandlerWithBoxedError for NoopHandler {
@@ -468,6 +657,63 @@ mod tests {
             _ctx: QueryContextRef,
         ) -> std::result::Result<Output, BoxedError> {
             Ok(Output::new_with_affected_rows(0))
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl GrpcQueryHandlerWithBoxedError for MetricsHandler {
+        async fn do_query(
+            &self,
+            _query: Request,
+            _ctx: QueryContextRef,
+        ) -> std::result::Result<Output, BoxedError> {
+            let schema = Arc::new(Schema::new(vec![ColumnSchema::new(
+                "v",
+                ConcreteDataType::int32_datatype(),
+                false,
+            )]));
+            let batch = RecordBatch::new(
+                schema.clone(),
+                vec![Arc::new(Int32Vector::from_slice([1, 2])) as VectorRef],
+            )
+            .unwrap();
+            Ok(Output::new_with_stream(Box::pin(MockMetricsStream {
+                schema,
+                batch: Some(batch),
+                metrics: RecordBatchMetrics {
+                    region_watermarks: vec![common_recordbatch::adapter::RegionWatermarkEntry {
+                        region_id: 42,
+                        watermark: Some(99),
+                    }],
+                    ..Default::default()
+                },
+                terminal_metrics_only: true,
+            })))
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl GrpcQueryHandlerWithBoxedError for ExtensionAwareHandler {
+        async fn do_query(
+            &self,
+            _query: Request,
+            ctx: QueryContextRef,
+        ) -> std::result::Result<Output, BoxedError> {
+            assert_eq!(ctx.extension("flow.return_region_seq"), Some("true"));
+            Ok(Output::new_with_affected_rows(1))
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl GrpcQueryHandlerWithBoxedError for SnapshotBindingHandler {
+        async fn do_query(
+            &self,
+            _query: Request,
+            ctx: QueryContextRef,
+        ) -> std::result::Result<Output, BoxedError> {
+            assert_eq!(ctx.extension("flow.return_region_seq"), Some("true"));
+            ctx.set_snapshot(42, 99);
+            Ok(Output::new_with_affected_rows(1))
         }
     }
 
@@ -515,5 +761,107 @@ mod tests {
                 .await
                 .is_ok()
         );
+    }
+
+    #[tokio::test]
+    async fn test_query_with_terminal_metrics_tracks_watermark_in_standalone_mode() {
+        let handler: Arc<dyn GrpcQueryHandlerWithBoxedError> = Arc::new(MetricsHandler);
+        let client =
+            FrontendClient::from_grpc_handler(Arc::downgrade(&handler), QueryOptions::default());
+
+        let result = client
+            .query_with_terminal_metrics(
+                "greptime",
+                "public",
+                QueryRequest {
+                    query: Some(Query::Sql("select 1".to_string())),
+                },
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let terminal_metrics = result.metrics.clone();
+        assert!(!result.metrics.is_ready());
+        assert!(terminal_metrics.get().is_none());
+
+        let OutputData::Stream(mut stream) = result.output.data else {
+            panic!("expected stream output");
+        };
+        while stream.next().await.is_some() {}
+
+        assert!(terminal_metrics.is_ready());
+        assert_eq!(
+            terminal_metrics.region_watermark_map(),
+            Some(HashMap::from([(42_u64, 99_u64)]))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_query_with_terminal_metrics_forwards_flow_extensions_in_standalone_mode() {
+        let handler: Arc<dyn GrpcQueryHandlerWithBoxedError> = Arc::new(ExtensionAwareHandler);
+        let client =
+            FrontendClient::from_grpc_handler(Arc::downgrade(&handler), QueryOptions::default());
+
+        let result = client
+            .query_with_terminal_metrics(
+                "greptime",
+                "public",
+                QueryRequest {
+                    query: Some(Query::Sql("insert into t select 1".to_string())),
+                },
+                &[("flow.return_region_seq", "true")],
+            )
+            .await
+            .unwrap();
+
+        assert!(result.metrics.is_ready());
+        assert!(result.region_watermark_map().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_query_with_terminal_metrics_uses_standalone_snapshot_bounds() {
+        let handler: Arc<dyn GrpcQueryHandlerWithBoxedError> = Arc::new(SnapshotBindingHandler);
+        let client =
+            FrontendClient::from_grpc_handler(Arc::downgrade(&handler), QueryOptions::default());
+
+        let result = client
+            .query_with_terminal_metrics(
+                "greptime",
+                "public",
+                QueryRequest {
+                    query: Some(Query::Sql("insert into t select * from src".to_string())),
+                },
+                &[("flow.return_region_seq", "true")],
+            )
+            .await
+            .unwrap();
+
+        assert!(result.metrics.is_ready());
+        assert_eq!(
+            result.region_watermark_map(),
+            Some(HashMap::from([(42, 99)]))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_query_with_terminal_metrics_rejects_invalid_flow_extensions() {
+        let handler: Arc<dyn GrpcQueryHandlerWithBoxedError> = Arc::new(NoopHandler);
+        let client =
+            FrontendClient::from_grpc_handler(Arc::downgrade(&handler), QueryOptions::default());
+
+        let err = client
+            .query_with_terminal_metrics(
+                "greptime",
+                "public",
+                QueryRequest {
+                    query: Some(Query::Sql("select 1".to_string())),
+                },
+                &[("flow.return_region_seq", "not-a-bool")],
+            )
+            .await
+            .unwrap_err();
+
+        assert!(format!("{err:?}").contains("Invalid value for flow.return_region_seq"));
     }
 }

--- a/src/flow/src/batching_mode/state.rs
+++ b/src/flow/src/batching_mode/state.rs
@@ -14,15 +14,13 @@
 
 //! Batching mode task state, which changes frequently
 //!
-//! PR3a checkpoint-readiness model:
+//! Checkpoint-readiness model:
 //! - `CheckpointMode::FullSnapshot`: the task executes full-snapshot queries
 //!   and collects region watermarks to prove safe advancement.
 //! - `CheckpointMode::Incremental`: the task has populated a complete
-//!   checkpoint map covering all participating regions.  In PR3a this is
-//!   an **internal readiness state** only — query execution continues to
-//!   use full-snapshot semantics.  PR3b will additionally emit incremental
-//!   scan extensions (`FLOW_INCREMENTAL_MODE` /
-//!   `FLOW_INCREMENTAL_AFTER_SEQS`) when the task is checkpoint-ready.
+//!   checkpoint map covering all participating regions. This mode records
+//!   readiness; actual incremental scan reads are only used when the query
+//!   execution path explicitly emits incremental scan extensions.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::time::Duration;
@@ -275,12 +273,42 @@ impl DirtyTimeWindows {
     }
 
     pub fn add_window(&mut self, start: Timestamp, end: Option<Timestamp>) {
-        self.windows.insert(start, end);
+        self.add_or_merge_window(start, end);
     }
 
     pub fn add_windows(&mut self, time_ranges: Vec<(Timestamp, Timestamp)>) {
         for (start, end) in time_ranges {
-            self.windows.insert(start, Some(end));
+            self.add_or_merge_window(start, Some(end));
+        }
+    }
+
+    /// Add all dirty markers from another dirty-window set.
+    pub fn add_dirty_windows(&mut self, dirty_windows: &DirtyTimeWindows) {
+        for (start, end) in &dirty_windows.windows {
+            self.add_or_merge_window(*start, *end);
+        }
+    }
+
+    fn add_or_merge_window(&mut self, start: Timestamp, end: Option<Timestamp>) {
+        self.windows
+            .entry(start)
+            .and_modify(|current_end| {
+                *current_end = Self::union_window_end(*current_end, end);
+            })
+            .or_insert(end);
+    }
+
+    fn union_window_end(
+        current_end: Option<Timestamp>,
+        incoming_end: Option<Timestamp>,
+    ) -> Option<Timestamp> {
+        match (current_end, incoming_end) {
+            (Some(current), Some(incoming)) => Some(current.max(incoming)),
+            // `None` is a dirty marker without a known upper bound.  When one
+            // side has a concrete end, keep it so merging a restored snapshot
+            // never shrinks an already-known dirty range with the same start.
+            (Some(end), None) | (None, Some(end)) => Some(end),
+            (None, None) => None,
         }
     }
 
@@ -292,7 +320,7 @@ impl DirtyTimeWindows {
     /// Set windows to be dirty, only useful for full aggr without time window
     /// to mark some new data is inserted
     pub fn set_dirty(&mut self) {
-        self.windows.insert(Timestamp::new_second(0), None);
+        self.add_or_merge_window(Timestamp::new_second(0), None);
     }
 
     /// Number of dirty windows.
@@ -641,10 +669,9 @@ pub enum CheckpointMode {
     /// region watermarks to build a checkpoint map.
     FullSnapshot,
     /// Incremental: the task has populated a complete checkpoint map and is
-    /// **checkpoint-ready**. PR3a tracks this readiness internally but does
-    /// NOT emit incremental scan extensions (`FLOW_INCREMENTAL_MODE` /
-    /// `FLOW_INCREMENTAL_AFTER_SEQS`); actual incremental reads are deferred
-    /// to PR3b.
+    /// **checkpoint-ready**. This mode records readiness; it does not by
+    /// itself imply that a query emitted incremental scan extensions
+    /// (`FLOW_INCREMENTAL_MODE` / `FLOW_INCREMENTAL_AFTER_SEQS`).
     Incremental,
 }
 

--- a/src/flow/src/batching_mode/state.rs
+++ b/src/flow/src/batching_mode/state.rs
@@ -13,8 +13,18 @@
 // limitations under the License.
 
 //! Batching mode task state, which changes frequently
+//!
+//! PR3a checkpoint-readiness model:
+//! - `CheckpointMode::FullSnapshot`: the task executes full-snapshot queries
+//!   and collects region watermarks to prove safe advancement.
+//! - `CheckpointMode::Incremental`: the task has populated a complete
+//!   checkpoint map covering all participating regions.  In PR3a this is
+//!   an **internal readiness state** only — query execution continues to
+//!   use full-snapshot semantics.  PR3b will additionally emit incremental
+//!   scan extensions (`FLOW_INCREMENTAL_MODE` /
+//!   `FLOW_INCREMENTAL_AFTER_SEQS`) when the task is checkpoint-ready.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::time::Duration;
 
 use common_telemetry::debug;
@@ -49,6 +59,8 @@ pub struct TaskState {
     /// Dirty Time windows need to be updated
     /// mapping of `start -> end` and non-overlapping
     pub(crate) dirty_time_windows: DirtyTimeWindows,
+    checkpoint_mode: CheckpointMode,
+    checkpoints: BTreeMap<u64, u64>,
     exec_state: ExecState,
     /// Shutdown receiver
     pub(crate) shutdown_rx: oneshot::Receiver<()>,
@@ -63,6 +75,8 @@ impl TaskState {
             last_query_duration: Duration::from_secs(0),
             last_exec_time_millis: None,
             dirty_time_windows: Default::default(),
+            checkpoint_mode: CheckpointMode::FullSnapshot,
+            checkpoints: Default::default(),
             exec_state: ExecState::Idle,
             shutdown_rx,
             task_handle: None,
@@ -82,6 +96,68 @@ impl TaskState {
 
     pub fn last_execution_time_millis(&self) -> Option<i64> {
         self.last_exec_time_millis
+    }
+
+    pub fn checkpoint_mode(&self) -> CheckpointMode {
+        self.checkpoint_mode
+    }
+
+    pub fn checkpoints(&self) -> &BTreeMap<u64, u64> {
+        &self.checkpoints
+    }
+
+    pub fn mark_full_snapshot(&mut self) {
+        self.checkpoint_mode = CheckpointMode::FullSnapshot;
+    }
+
+    pub fn advance_checkpoints(&mut self, watermark_map: HashMap<u64, u64>) {
+        self.checkpoints = watermark_map.into_iter().collect();
+        self.checkpoint_mode = CheckpointMode::Incremental;
+    }
+
+    pub fn advance_incremental_checkpoints_with_participation(
+        &mut self,
+        participating_regions: &BTreeSet<u64>,
+        watermark_map: HashMap<u64, u64>,
+    ) {
+        for region_id in participating_regions {
+            if let Some(seq) = watermark_map.get(region_id) {
+                self.checkpoints.insert(*region_id, *seq);
+            }
+        }
+        self.checkpoint_mode = CheckpointMode::Incremental;
+    }
+
+    pub fn can_advance_full_snapshot_checkpoints(
+        &self,
+        participating_regions: &BTreeSet<u64>,
+        watermark_map: &HashMap<u64, u64>,
+    ) -> bool {
+        !participating_regions.is_empty()
+            && participating_regions.len() == watermark_map.len()
+            && participating_regions
+                .iter()
+                .all(|region_id| watermark_map.contains_key(region_id))
+    }
+
+    pub fn can_advance_incremental_checkpoints_with_participation(
+        &self,
+        participating_regions: &BTreeSet<u64>,
+        watermark_map: &HashMap<u64, u64>,
+    ) -> bool {
+        !self.checkpoints.is_empty()
+            && !participating_regions.is_empty()
+            && participating_regions.len() == watermark_map.len()
+            && participating_regions
+                .iter()
+                .all(|region_id| self.checkpoints.contains_key(region_id))
+            && participating_regions.iter().all(|region_id| {
+                let checkpoint = self.checkpoints.get(region_id);
+                watermark_map
+                    .get(region_id)
+                    .zip(checkpoint)
+                    .is_some_and(|(seq, checkpoint)| seq >= checkpoint)
+            })
     }
 
     /// Compute the next query delay based on the time window size or the last query duration.
@@ -559,6 +635,19 @@ enum ExecState {
     Executing,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CheckpointMode {
+    /// FullSnapshot: the task executes full-snapshot queries and collects
+    /// region watermarks to build a checkpoint map.
+    FullSnapshot,
+    /// Incremental: the task has populated a complete checkpoint map and is
+    /// **checkpoint-ready**. PR3a tracks this readiness internally but does
+    /// NOT emit incremental scan extensions (`FLOW_INCREMENTAL_MODE` /
+    /// `FLOW_INCREMENTAL_AFTER_SEQS`); actual incremental reads are deferred
+    /// to PR3b.
+    Incremental,
+}
+
 /// Filter Expression's information
 #[derive(Debug, Clone)]
 pub struct FilterExprInfo {
@@ -600,6 +689,109 @@ mod test {
 
         state.after_query_exec(std::time::Duration::from_millis(1), true);
         assert!(state.last_execution_time_millis().is_some());
+    }
+
+    #[test]
+    fn test_task_state_checkpoint_mode_and_advancement() {
+        let query_ctx = QueryContext::arc();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let mut state = TaskState::new(query_ctx, rx);
+
+        assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
+        assert!(state.checkpoints().is_empty());
+
+        state.advance_checkpoints(HashMap::from([(1_u64, 10_u64), (2_u64, 20_u64)]));
+        assert_eq!(state.checkpoint_mode(), CheckpointMode::Incremental);
+        assert_eq!(
+            state.checkpoints(),
+            &BTreeMap::from([(1_u64, 10_u64), (2_u64, 20_u64)])
+        );
+
+        state.mark_full_snapshot();
+        assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
+        assert_eq!(
+            state.checkpoints(),
+            &BTreeMap::from([(1_u64, 10_u64), (2_u64, 20_u64)])
+        );
+    }
+
+    #[test]
+    fn test_full_snapshot_checkpoint_advancement_requires_participating_regions() {
+        let query_ctx = QueryContext::arc();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let state = TaskState::new(query_ctx, rx);
+
+        assert!(!state.can_advance_full_snapshot_checkpoints(&BTreeSet::new(), &HashMap::new()));
+        assert!(!state.can_advance_full_snapshot_checkpoints(
+            &BTreeSet::from([1_u64, 2_u64]),
+            &HashMap::from([(1_u64, 10_u64)]),
+        ));
+        assert!(state.can_advance_full_snapshot_checkpoints(
+            &BTreeSet::from([1_u64, 2_u64]),
+            &HashMap::from([(1_u64, 10_u64), (2_u64, 20_u64)]),
+        ));
+    }
+
+    #[test]
+    fn test_incremental_checkpoint_advancement_requires_participation_alignment() {
+        let query_ctx = QueryContext::arc();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let mut state = TaskState::new(query_ctx, rx);
+        state.advance_checkpoints(HashMap::from([(1_u64, 10_u64), (2_u64, 20_u64)]));
+
+        assert!(
+            state.can_advance_incremental_checkpoints_with_participation(
+                &BTreeSet::from([1_u64]),
+                &HashMap::from([(1_u64, 11_u64)]),
+            )
+        );
+        assert!(
+            !state.can_advance_incremental_checkpoints_with_participation(
+                &BTreeSet::from([1_u64, 2_u64]),
+                &HashMap::from([(1_u64, 11_u64)]),
+            )
+        );
+        assert!(
+            !state.can_advance_incremental_checkpoints_with_participation(
+                &BTreeSet::from([3_u64]),
+                &HashMap::from([(3_u64, 11_u64)]),
+            )
+        );
+        assert!(
+            !state.can_advance_incremental_checkpoints_with_participation(
+                &BTreeSet::from([1_u64]),
+                &HashMap::from([(1_u64, 9_u64)]),
+            )
+        );
+        assert!(
+            state.can_advance_incremental_checkpoints_with_participation(
+                &BTreeSet::from([1_u64, 2_u64]),
+                &HashMap::from([(1_u64, 11_u64), (2_u64, 21_u64)]),
+            )
+        );
+    }
+
+    #[test]
+    fn test_incremental_checkpoint_advancement_merges_participating_subset() {
+        let query_ctx = QueryContext::arc();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let mut state = TaskState::new(query_ctx, rx);
+        state.advance_checkpoints(HashMap::from([
+            (1_u64, 10_u64),
+            (2_u64, 20_u64),
+            (3_u64, 30_u64),
+        ]));
+
+        state.advance_incremental_checkpoints_with_participation(
+            &BTreeSet::from([1_u64, 3_u64]),
+            HashMap::from([(1_u64, 12_u64), (3_u64, 35_u64)]),
+        );
+
+        assert_eq!(state.checkpoint_mode(), CheckpointMode::Incremental);
+        assert_eq!(
+            state.checkpoints(),
+            &BTreeMap::from([(1_u64, 12_u64), (2_u64, 20_u64), (3_u64, 35_u64)])
+        );
     }
 
     #[test]

--- a/src/flow/src/batching_mode/state.rs
+++ b/src/flow/src/batching_mode/state.rs
@@ -14,15 +14,8 @@
 
 //! Batching mode task state, which changes frequently
 //!
-//! Checkpoint-readiness model:
-//! - `CheckpointMode::FullSnapshot`: the task executes full-snapshot queries
-//!   and collects region watermarks to prove safe advancement.
-//! - `CheckpointMode::Incremental`: the task has populated a complete
-//!   checkpoint map covering all participating regions. This mode records
-//!   readiness; actual incremental scan reads are only used when the query
-//!   execution path explicitly emits incremental scan extensions.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 use common_telemetry::debug;
@@ -57,8 +50,6 @@ pub struct TaskState {
     /// Dirty Time windows need to be updated
     /// mapping of `start -> end` and non-overlapping
     pub(crate) dirty_time_windows: DirtyTimeWindows,
-    checkpoint_mode: CheckpointMode,
-    checkpoints: BTreeMap<u64, u64>,
     exec_state: ExecState,
     /// Shutdown receiver
     pub(crate) shutdown_rx: oneshot::Receiver<()>,
@@ -73,8 +64,6 @@ impl TaskState {
             last_query_duration: Duration::from_secs(0),
             last_exec_time_millis: None,
             dirty_time_windows: Default::default(),
-            checkpoint_mode: CheckpointMode::FullSnapshot,
-            checkpoints: Default::default(),
             exec_state: ExecState::Idle,
             shutdown_rx,
             task_handle: None,
@@ -94,68 +83,6 @@ impl TaskState {
 
     pub fn last_execution_time_millis(&self) -> Option<i64> {
         self.last_exec_time_millis
-    }
-
-    pub fn checkpoint_mode(&self) -> CheckpointMode {
-        self.checkpoint_mode
-    }
-
-    pub fn checkpoints(&self) -> &BTreeMap<u64, u64> {
-        &self.checkpoints
-    }
-
-    pub fn mark_full_snapshot(&mut self) {
-        self.checkpoint_mode = CheckpointMode::FullSnapshot;
-    }
-
-    pub fn advance_checkpoints(&mut self, watermark_map: HashMap<u64, u64>) {
-        self.checkpoints = watermark_map.into_iter().collect();
-        self.checkpoint_mode = CheckpointMode::Incremental;
-    }
-
-    pub fn advance_incremental_checkpoints_with_participation(
-        &mut self,
-        participating_regions: &BTreeSet<u64>,
-        watermark_map: HashMap<u64, u64>,
-    ) {
-        for region_id in participating_regions {
-            if let Some(seq) = watermark_map.get(region_id) {
-                self.checkpoints.insert(*region_id, *seq);
-            }
-        }
-        self.checkpoint_mode = CheckpointMode::Incremental;
-    }
-
-    pub fn can_advance_full_snapshot_checkpoints(
-        &self,
-        participating_regions: &BTreeSet<u64>,
-        watermark_map: &HashMap<u64, u64>,
-    ) -> bool {
-        !participating_regions.is_empty()
-            && participating_regions.len() == watermark_map.len()
-            && participating_regions
-                .iter()
-                .all(|region_id| watermark_map.contains_key(region_id))
-    }
-
-    pub fn can_advance_incremental_checkpoints_with_participation(
-        &self,
-        participating_regions: &BTreeSet<u64>,
-        watermark_map: &HashMap<u64, u64>,
-    ) -> bool {
-        !self.checkpoints.is_empty()
-            && !participating_regions.is_empty()
-            && participating_regions.len() == watermark_map.len()
-            && participating_regions
-                .iter()
-                .all(|region_id| self.checkpoints.contains_key(region_id))
-            && participating_regions.iter().all(|region_id| {
-                let checkpoint = self.checkpoints.get(region_id);
-                watermark_map
-                    .get(region_id)
-                    .zip(checkpoint)
-                    .is_some_and(|(seq, checkpoint)| seq >= checkpoint)
-            })
     }
 
     /// Compute the next query delay based on the time window size or the last query duration.
@@ -663,18 +590,6 @@ enum ExecState {
     Executing,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CheckpointMode {
-    /// FullSnapshot: the task executes full-snapshot queries and collects
-    /// region watermarks to build a checkpoint map.
-    FullSnapshot,
-    /// Incremental: the task has populated a complete checkpoint map and is
-    /// **checkpoint-ready**. This mode records readiness; it does not by
-    /// itself imply that a query emitted incremental scan extensions
-    /// (`FLOW_INCREMENTAL_MODE` / `FLOW_INCREMENTAL_AFTER_SEQS`).
-    Incremental,
-}
-
 /// Filter Expression's information
 #[derive(Debug, Clone)]
 pub struct FilterExprInfo {
@@ -716,109 +631,6 @@ mod test {
 
         state.after_query_exec(std::time::Duration::from_millis(1), true);
         assert!(state.last_execution_time_millis().is_some());
-    }
-
-    #[test]
-    fn test_task_state_checkpoint_mode_and_advancement() {
-        let query_ctx = QueryContext::arc();
-        let (_tx, rx) = tokio::sync::oneshot::channel();
-        let mut state = TaskState::new(query_ctx, rx);
-
-        assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
-        assert!(state.checkpoints().is_empty());
-
-        state.advance_checkpoints(HashMap::from([(1_u64, 10_u64), (2_u64, 20_u64)]));
-        assert_eq!(state.checkpoint_mode(), CheckpointMode::Incremental);
-        assert_eq!(
-            state.checkpoints(),
-            &BTreeMap::from([(1_u64, 10_u64), (2_u64, 20_u64)])
-        );
-
-        state.mark_full_snapshot();
-        assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
-        assert_eq!(
-            state.checkpoints(),
-            &BTreeMap::from([(1_u64, 10_u64), (2_u64, 20_u64)])
-        );
-    }
-
-    #[test]
-    fn test_full_snapshot_checkpoint_advancement_requires_participating_regions() {
-        let query_ctx = QueryContext::arc();
-        let (_tx, rx) = tokio::sync::oneshot::channel();
-        let state = TaskState::new(query_ctx, rx);
-
-        assert!(!state.can_advance_full_snapshot_checkpoints(&BTreeSet::new(), &HashMap::new()));
-        assert!(!state.can_advance_full_snapshot_checkpoints(
-            &BTreeSet::from([1_u64, 2_u64]),
-            &HashMap::from([(1_u64, 10_u64)]),
-        ));
-        assert!(state.can_advance_full_snapshot_checkpoints(
-            &BTreeSet::from([1_u64, 2_u64]),
-            &HashMap::from([(1_u64, 10_u64), (2_u64, 20_u64)]),
-        ));
-    }
-
-    #[test]
-    fn test_incremental_checkpoint_advancement_requires_participation_alignment() {
-        let query_ctx = QueryContext::arc();
-        let (_tx, rx) = tokio::sync::oneshot::channel();
-        let mut state = TaskState::new(query_ctx, rx);
-        state.advance_checkpoints(HashMap::from([(1_u64, 10_u64), (2_u64, 20_u64)]));
-
-        assert!(
-            state.can_advance_incremental_checkpoints_with_participation(
-                &BTreeSet::from([1_u64]),
-                &HashMap::from([(1_u64, 11_u64)]),
-            )
-        );
-        assert!(
-            !state.can_advance_incremental_checkpoints_with_participation(
-                &BTreeSet::from([1_u64, 2_u64]),
-                &HashMap::from([(1_u64, 11_u64)]),
-            )
-        );
-        assert!(
-            !state.can_advance_incremental_checkpoints_with_participation(
-                &BTreeSet::from([3_u64]),
-                &HashMap::from([(3_u64, 11_u64)]),
-            )
-        );
-        assert!(
-            !state.can_advance_incremental_checkpoints_with_participation(
-                &BTreeSet::from([1_u64]),
-                &HashMap::from([(1_u64, 9_u64)]),
-            )
-        );
-        assert!(
-            state.can_advance_incremental_checkpoints_with_participation(
-                &BTreeSet::from([1_u64, 2_u64]),
-                &HashMap::from([(1_u64, 11_u64), (2_u64, 21_u64)]),
-            )
-        );
-    }
-
-    #[test]
-    fn test_incremental_checkpoint_advancement_merges_participating_subset() {
-        let query_ctx = QueryContext::arc();
-        let (_tx, rx) = tokio::sync::oneshot::channel();
-        let mut state = TaskState::new(query_ctx, rx);
-        state.advance_checkpoints(HashMap::from([
-            (1_u64, 10_u64),
-            (2_u64, 20_u64),
-            (3_u64, 30_u64),
-        ]));
-
-        state.advance_incremental_checkpoints_with_participation(
-            &BTreeSet::from([1_u64, 3_u64]),
-            HashMap::from([(1_u64, 12_u64), (3_u64, 35_u64)]),
-        );
-
-        assert_eq!(state.checkpoint_mode(), CheckpointMode::Incremental);
-        assert_eq!(
-            state.checkpoints(),
-            &BTreeMap::from([(1_u64, 12_u64), (2_u64, 20_u64), (3_u64, 35_u64)])
-        );
     }
 
     #[test]

--- a/src/flow/src/batching_mode/table_creator.rs
+++ b/src/flow/src/batching_mode/table_creator.rs
@@ -1,0 +1,377 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use api::v1::CreateTableExpr;
+use datafusion_common::tree_node::TreeNode;
+use datafusion_expr::LogicalPlan;
+use datatypes::prelude::ConcreteDataType;
+use datatypes::schema::ColumnSchema;
+use operator::expr_helper::column_schemas_to_defs;
+use snafu::ResultExt;
+
+use crate::Error;
+use crate::adapter::{AUTO_CREATED_PLACEHOLDER_TS_COL, AUTO_CREATED_UPDATE_AT_TS_COL};
+use crate::batching_mode::utils::FindGroupByFinalName;
+use crate::error::{ConvertColumnSchemaSnafu, DatafusionSnafu};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QueryType {
+    /// query is a tql query
+    Tql,
+    /// query is a sql query
+    Sql,
+}
+
+// auto created table have a auto added column `update_at`, and optional have a `AUTO_CREATED_PLACEHOLDER_TS_COL` column for time index placeholder if no timestamp column is specified
+// TODO(discord9): for now no default value is set for auto added column for compatibility reason with streaming mode, but this might change in favor of simpler code?
+pub(super) fn create_table_with_expr(
+    plan: &LogicalPlan,
+    sink_table_name: &[String; 3],
+    query_type: &QueryType,
+) -> Result<CreateTableExpr, Error> {
+    let table_def = match query_type {
+        &QueryType::Sql => {
+            if let Some(def) = build_pk_from_aggr(plan)? {
+                def
+            } else {
+                build_by_sql_schema(plan)?
+            }
+        }
+        QueryType::Tql => {
+            // first try build from aggr, then from tql schema because tql query might not have aggr node
+            if let Some(table_def) = build_pk_from_aggr(plan)? {
+                table_def
+            } else {
+                build_by_tql_schema(plan)?
+            }
+        }
+    };
+    let first_time_stamp = table_def.ts_col;
+    let primary_keys = table_def.pks;
+
+    let mut column_schemas = Vec::new();
+    for field in plan.schema().fields() {
+        let name = field.name();
+        let ty = ConcreteDataType::from_arrow_type(field.data_type());
+        let col_schema = if first_time_stamp == Some(name.clone()) {
+            ColumnSchema::new(name, ty, false).with_time_index(true)
+        } else {
+            ColumnSchema::new(name, ty, true)
+        };
+
+        match query_type {
+            QueryType::Sql => {
+                column_schemas.push(col_schema);
+            }
+            QueryType::Tql => {
+                // if is val column, need to rename as val DOUBLE NULL
+                // if is tag column, need to cast type as STRING NULL
+                let is_tag_column = primary_keys.contains(name);
+                let is_val_column = !is_tag_column && first_time_stamp.as_ref() != Some(name);
+                if is_val_column {
+                    let col_schema =
+                        ColumnSchema::new(name, ConcreteDataType::float64_datatype(), true);
+                    column_schemas.push(col_schema);
+                } else if is_tag_column {
+                    let col_schema =
+                        ColumnSchema::new(name, ConcreteDataType::string_datatype(), true);
+                    column_schemas.push(col_schema);
+                } else {
+                    // time index column
+                    column_schemas.push(col_schema);
+                }
+            }
+        }
+    }
+
+    if query_type == &QueryType::Sql {
+        let update_at_schema = ColumnSchema::new(
+            AUTO_CREATED_UPDATE_AT_TS_COL,
+            ConcreteDataType::timestamp_millisecond_datatype(),
+            true,
+        );
+        column_schemas.push(update_at_schema);
+    }
+
+    let time_index = if let Some(time_index) = first_time_stamp {
+        time_index
+    } else {
+        column_schemas.push(
+            ColumnSchema::new(
+                AUTO_CREATED_PLACEHOLDER_TS_COL,
+                ConcreteDataType::timestamp_millisecond_datatype(),
+                false,
+            )
+            .with_time_index(true),
+        );
+        AUTO_CREATED_PLACEHOLDER_TS_COL.to_string()
+    };
+
+    let column_defs =
+        column_schemas_to_defs(column_schemas, &primary_keys).context(ConvertColumnSchemaSnafu)?;
+    Ok(CreateTableExpr {
+        catalog_name: sink_table_name[0].clone(),
+        schema_name: sink_table_name[1].clone(),
+        table_name: sink_table_name[2].clone(),
+        desc: "Auto created table by flow engine".to_string(),
+        column_defs,
+        time_index,
+        primary_keys,
+        create_if_not_exists: true,
+        table_options: Default::default(),
+        table_id: None,
+        engine: "mito".to_string(),
+    })
+}
+
+/// simply build by schema, return first timestamp column and no primary key
+fn build_by_sql_schema(plan: &LogicalPlan) -> Result<TableDef, Error> {
+    let first_time_stamp = plan.schema().fields().iter().find_map(|f| {
+        if ConcreteDataType::from_arrow_type(f.data_type()).is_timestamp() {
+            Some(f.name().clone())
+        } else {
+            None
+        }
+    });
+    Ok(TableDef {
+        ts_col: first_time_stamp,
+        pks: vec![],
+    })
+}
+
+/// Return first timestamp column found in output schema and all string columns
+fn build_by_tql_schema(plan: &LogicalPlan) -> Result<TableDef, Error> {
+    let first_time_stamp = plan.schema().fields().iter().find_map(|f| {
+        if ConcreteDataType::from_arrow_type(f.data_type()).is_timestamp() {
+            Some(f.name().clone())
+        } else {
+            None
+        }
+    });
+    let string_columns = plan
+        .schema()
+        .fields()
+        .iter()
+        .filter_map(|f| {
+            if ConcreteDataType::from_arrow_type(f.data_type()).is_string() {
+                Some(f.name().clone())
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    Ok(TableDef {
+        ts_col: first_time_stamp,
+        pks: string_columns,
+    })
+}
+
+struct TableDef {
+    ts_col: Option<String>,
+    pks: Vec<String>,
+}
+
+/// Return first timestamp column which is in group by clause and other columns which are also in group by clause
+///
+/// # Returns
+///
+/// * `Option<String>` - first timestamp column which is in group by clause
+/// * `Vec<String>` - other columns which are also in group by clause
+///
+/// if no aggregation found, return None
+fn build_pk_from_aggr(plan: &LogicalPlan) -> Result<Option<TableDef>, Error> {
+    let fields = plan.schema().fields();
+    let mut pk_names = FindGroupByFinalName::default();
+
+    plan.visit(&mut pk_names)
+        .with_context(|_| DatafusionSnafu {
+            context: format!("Can't find aggr expr in plan {plan:?}"),
+        })?;
+
+    // if no group by clause, return empty with first timestamp column found in output schema
+    let Some(pk_final_names) = pk_names.get_group_expr_names() else {
+        return Ok(None);
+    };
+    if pk_final_names.is_empty() {
+        let first_ts_col = fields
+            .iter()
+            .find(|f| ConcreteDataType::from_arrow_type(f.data_type()).is_timestamp())
+            .map(|f| f.name().clone());
+        return Ok(Some(TableDef {
+            ts_col: first_ts_col,
+            pks: vec![],
+        }));
+    }
+
+    let all_pk_cols: Vec<_> = fields
+        .iter()
+        .filter(|f| pk_final_names.contains(f.name()))
+        .map(|f| f.name().clone())
+        .collect();
+    // auto create table use first timestamp column in group by clause as time index
+    let first_time_stamp = fields
+        .iter()
+        .find(|f| {
+            all_pk_cols.contains(&f.name().clone())
+                && ConcreteDataType::from_arrow_type(f.data_type()).is_timestamp()
+        })
+        .map(|f| f.name().clone());
+
+    let all_pk_cols: Vec<_> = all_pk_cols
+        .into_iter()
+        .filter(|col| first_time_stamp.as_ref() != Some(col))
+        .collect();
+
+    Ok(Some(TableDef {
+        ts_col: first_time_stamp,
+        pks: all_pk_cols,
+    }))
+}
+
+#[cfg(test)]
+mod test {
+    use api::v1::column_def::try_as_column_schema;
+    use datatypes::prelude::ConcreteDataType;
+    use datatypes::schema::ColumnSchema;
+    use pretty_assertions::assert_eq;
+    use session::context::QueryContext;
+
+    use super::*;
+    use crate::adapter::{AUTO_CREATED_PLACEHOLDER_TS_COL, AUTO_CREATED_UPDATE_AT_TS_COL};
+    use crate::batching_mode::utils::sql_to_df_plan;
+    use crate::test_utils::create_test_query_engine;
+
+    #[tokio::test]
+    async fn test_gen_create_table_sql() {
+        let query_engine = create_test_query_engine();
+        let ctx = QueryContext::arc();
+        struct TestCase {
+            sql: String,
+            sink_table_name: String,
+            column_schemas: Vec<ColumnSchema>,
+            primary_keys: Vec<String>,
+            time_index: String,
+        }
+
+        let update_at_schema = ColumnSchema::new(
+            AUTO_CREATED_UPDATE_AT_TS_COL,
+            ConcreteDataType::timestamp_millisecond_datatype(),
+            true,
+        );
+
+        let ts_placeholder_schema = ColumnSchema::new(
+            AUTO_CREATED_PLACEHOLDER_TS_COL,
+            ConcreteDataType::timestamp_millisecond_datatype(),
+            false,
+        )
+        .with_time_index(true);
+
+        let testcases = vec![
+            TestCase {
+                sql: "SELECT number, ts FROM numbers_with_ts".to_string(),
+                sink_table_name: "new_table".to_string(),
+                column_schemas: vec![
+                    ColumnSchema::new("number", ConcreteDataType::uint32_datatype(), true),
+                    ColumnSchema::new(
+                        "ts",
+                        ConcreteDataType::timestamp_millisecond_datatype(),
+                        false,
+                    )
+                    .with_time_index(true),
+                    update_at_schema.clone(),
+                ],
+                primary_keys: vec![],
+                time_index: "ts".to_string(),
+            },
+            TestCase {
+                sql: "SELECT number, max(ts) FROM numbers_with_ts GROUP BY number".to_string(),
+                sink_table_name: "new_table".to_string(),
+                column_schemas: vec![
+                    ColumnSchema::new("number", ConcreteDataType::uint32_datatype(), true),
+                    ColumnSchema::new(
+                        "max(numbers_with_ts.ts)",
+                        ConcreteDataType::timestamp_millisecond_datatype(),
+                        true,
+                    ),
+                    update_at_schema.clone(),
+                    ts_placeholder_schema.clone(),
+                ],
+                primary_keys: vec!["number".to_string()],
+                time_index: AUTO_CREATED_PLACEHOLDER_TS_COL.to_string(),
+            },
+            TestCase {
+                sql: "SELECT max(number), ts FROM numbers_with_ts GROUP BY ts".to_string(),
+                sink_table_name: "new_table".to_string(),
+                column_schemas: vec![
+                    ColumnSchema::new(
+                        "max(numbers_with_ts.number)",
+                        ConcreteDataType::uint32_datatype(),
+                        true,
+                    ),
+                    ColumnSchema::new(
+                        "ts",
+                        ConcreteDataType::timestamp_millisecond_datatype(),
+                        false,
+                    )
+                    .with_time_index(true),
+                    update_at_schema.clone(),
+                ],
+                primary_keys: vec![],
+                time_index: "ts".to_string(),
+            },
+            TestCase {
+                sql: "SELECT number, ts FROM numbers_with_ts GROUP BY ts, number".to_string(),
+                sink_table_name: "new_table".to_string(),
+                column_schemas: vec![
+                    ColumnSchema::new("number", ConcreteDataType::uint32_datatype(), true),
+                    ColumnSchema::new(
+                        "ts",
+                        ConcreteDataType::timestamp_millisecond_datatype(),
+                        false,
+                    )
+                    .with_time_index(true),
+                    update_at_schema.clone(),
+                ],
+                primary_keys: vec!["number".to_string()],
+                time_index: "ts".to_string(),
+            },
+        ];
+
+        for tc in testcases {
+            let plan = sql_to_df_plan(ctx.clone(), query_engine.clone(), &tc.sql, true)
+                .await
+                .unwrap();
+            let expr = create_table_with_expr(
+                &plan,
+                &[
+                    "greptime".to_string(),
+                    "public".to_string(),
+                    tc.sink_table_name.clone(),
+                ],
+                &QueryType::Sql,
+            )
+            .unwrap();
+            // TODO(discord9): assert expr
+            let column_schemas = expr
+                .column_defs
+                .iter()
+                .map(|c| try_as_column_schema(c).unwrap())
+                .collect::<Vec<_>>();
+            assert_eq!(tc.column_schemas, column_schemas, "{:?}", tc.sql);
+            assert_eq!(tc.primary_keys, expr.primary_keys, "{:?}", tc.sql);
+            assert_eq!(tc.time_index, expr.time_index, "{:?}", tc.sql);
+        }
+    }
+}

--- a/src/flow/src/batching_mode/table_creator.rs
+++ b/src/flow/src/batching_mode/table_creator.rs
@@ -220,7 +220,11 @@ fn build_pk_from_aggr(plan: &LogicalPlan) -> Result<Option<TableDef>, Error> {
         .filter(|f| pk_final_names.contains(f.name()))
         .map(|f| f.name().clone())
         .collect();
-    // auto create table use first timestamp column in group by clause as time index
+    // Auto-created tables use the first timestamp column in the group-by keys
+    // as the time index. It is possible that timestamp columns appear only as
+    // aggregate outputs (for example `max(ts)`) and are not group-by keys; in
+    // that case `first_time_stamp` stays `None` and the caller falls back to a
+    // placeholder time index column.
     let first_time_stamp = fields
         .iter()
         .find(|f| {

--- a/src/flow/src/batching_mode/task.rs
+++ b/src/flow/src/batching_mode/task.rs
@@ -686,9 +686,8 @@ impl BatchingTask {
         filter: &FilterExprInfo,
         result: Result<T, Error>,
     ) -> Result<T, Error> {
-        result.map_err(|err| {
+        result.inspect_err(|_| {
             self.restore_scoped_dirty_windows(filter);
-            err
         })
     }
 

--- a/src/flow/src/batching_mode/task.rs
+++ b/src/flow/src/batching_mode/task.rs
@@ -18,6 +18,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use api::v1::CreateTableExpr;
 use catalog::CatalogManagerRef;
+use client::OutputWithMetrics;
 use common_error::ext::BoxedError;
 use common_query::logical_plan::breakup_insert_plan;
 use common_telemetry::tracing::warn;
@@ -28,10 +29,9 @@ use datafusion::sql::unparser::expr_to_sql;
 use datafusion_common::DFSchemaRef;
 use datafusion_common::tree_node::{Transformed, TreeNode};
 use datafusion_expr::{DmlStatement, LogicalPlan, WriteOp};
-use datatypes::prelude::ConcreteDataType;
-use datatypes::schema::{ColumnSchema, Schema};
-use operator::expr_helper::column_schemas_to_defs;
+use datatypes::schema::Schema;
 use query::QueryEngineRef;
+use query::options::FLOW_SINK_TABLE_ID;
 use query::query_engine::DefaultSerializer;
 use session::context::QueryContextRef;
 use snafu::{OptionExt, ResultExt, ensure};
@@ -43,22 +43,26 @@ use tokio::sync::oneshot;
 use tokio::sync::oneshot::error::TryRecvError;
 use tokio::time::Instant;
 
-use crate::adapter::{AUTO_CREATED_PLACEHOLDER_TS_COL, AUTO_CREATED_UPDATE_AT_TS_COL};
 use crate::batching_mode::BatchingModeOptions;
+use crate::batching_mode::checkpoint::{
+    FlowCheckpointDecision, FlowQueryFallbackReason, checkpoint_mode_label,
+};
 use crate::batching_mode::frontend_client::FrontendClient;
-use crate::batching_mode::state::{FilterExprInfo, TaskState};
+use crate::batching_mode::state::{CheckpointMode, FilterExprInfo, TaskState};
+use crate::batching_mode::table_creator::{QueryType, create_table_with_expr};
 use crate::batching_mode::time_window::TimeWindowExpr;
 use crate::batching_mode::utils::{
-    AddFilterRewriter, ColumnMatcherRewriter, FindGroupByFinalName, gen_plan_with_matching_schema,
+    AddFilterRewriter, ColumnMatcherRewriter, gen_plan_with_matching_schema,
     get_table_info_df_schema, sql_to_df_plan,
 };
 use crate::df_optimizer::apply_df_optimizer;
 use crate::error::{
-    ConvertColumnSchemaSnafu, DatafusionSnafu, ExternalSnafu, InvalidQuerySnafu,
-    SubstraitEncodeLogicalPlanSnafu, UnexpectedSnafu,
+    DatafusionSnafu, ExternalSnafu, InvalidQuerySnafu, SubstraitEncodeLogicalPlanSnafu,
+    UnexpectedSnafu,
 };
 use crate::metrics::{
-    METRIC_FLOW_BATCHING_ENGINE_ERROR_CNT, METRIC_FLOW_BATCHING_ENGINE_QUERY_TIME,
+    METRIC_FLOW_BATCHING_ENGINE_CHECKPOINT_DECISION_CNT, METRIC_FLOW_BATCHING_ENGINE_ERROR_CNT,
+    METRIC_FLOW_BATCHING_ENGINE_QUERY_MODE_CNT, METRIC_FLOW_BATCHING_ENGINE_QUERY_TIME,
     METRIC_FLOW_BATCHING_ENGINE_SLOW_QUERY, METRIC_FLOW_BATCHING_ENGINE_START_QUERY_CNT,
     METRIC_FLOW_ROWS,
 };
@@ -98,14 +102,6 @@ fn is_merge_mode_last_non_null(options: &HashMap<String, String>) -> bool {
         .get(MERGE_MODE_KEY)
         .map(|mode| mode.eq_ignore_ascii_case("last_non_null"))
         .unwrap_or(false)
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum QueryType {
-    /// query is a tql query
-    Tql,
-    /// query is a sql query
-    Sql,
 }
 
 #[derive(Clone)]
@@ -244,8 +240,16 @@ impl BatchingTask {
     ) -> Result<Option<(u32, Duration)>, Error> {
         if let Some(new_query) = self.gen_insert_plan(engine, max_window_cnt).await? {
             debug!("Generate new query: {}", new_query.plan);
-            self.execute_logical_plan(frontend_client, &new_query.plan)
+            match self
+                .execute_logical_plan(frontend_client, &new_query.plan, new_query.filter.as_ref())
                 .await
+            {
+                Ok(result) => Ok(result),
+                Err(err) => {
+                    self.handle_executed_query_failure(&err, Some(&new_query));
+                    Err(err)
+                }
+            }
         } else {
             debug!("Generate no query");
             Ok(None)
@@ -349,6 +353,7 @@ impl BatchingTask {
         &self,
         frontend_client: &Arc<FrontendClient>,
         plan: &LogicalPlan,
+        _dirty_filter: Option<&FilterExprInfo>,
     ) -> Result<Option<(u32, Duration)>, Error> {
         let instant = Instant::now();
         let flow_id = self.config.flow_id;
@@ -378,81 +383,312 @@ impl BatchingTask {
             })?
             .data;
 
-        let mut peer_desc = None;
+        let extensions = self.build_flow_query_extensions().await?;
+        let extension_refs = extensions
+            .iter()
+            .map(|(key, value)| (*key, value.as_str()))
+            .collect::<Vec<_>>();
+        let query_mode = self.state.read().unwrap().checkpoint_mode();
+        Self::record_query_mode(flow_id, query_mode);
+        debug!(
+            "Flow {flow_id} executing batching query with checkpoint_mode={}, extension_count={} (PR3a: no incremental scan extensions)",
+            checkpoint_mode_label(query_mode),
+            extensions.len()
+        );
 
         let res = {
             let _timer = METRIC_FLOW_BATCHING_ENGINE_QUERY_TIME
                 .with_label_values(&[flow_id.to_string().as_str()])
                 .start_timer();
 
-            // hack and special handling the insert logical plan
             let req = if let Some((insert_to, insert_plan)) =
                 breakup_insert_plan(&plan, catalog, schema)
             {
                 let message = DFLogicalSubstraitConvertor {}
                     .encode(&insert_plan, DefaultSerializer)
                     .context(SubstraitEncodeLogicalPlanSnafu)?;
-                api::v1::greptime_request::Request::Query(api::v1::QueryRequest {
+                api::v1::QueryRequest {
                     query: Some(api::v1::query_request::Query::InsertIntoPlan(
                         api::v1::InsertIntoPlan {
                             table_name: Some(insert_to),
                             logical_plan: message.to_vec(),
                         },
                     )),
-                })
+                }
             } else {
                 let message = DFLogicalSubstraitConvertor {}
                     .encode(&plan, DefaultSerializer)
                     .context(SubstraitEncodeLogicalPlanSnafu)?;
 
-                api::v1::greptime_request::Request::Query(api::v1::QueryRequest {
+                api::v1::QueryRequest {
                     query: Some(api::v1::query_request::Query::LogicalPlan(message.to_vec())),
-                })
+                }
             };
 
             frontend_client
-                .handle(req, catalog, schema, &mut peer_desc)
+                .query_with_terminal_metrics(catalog, schema, req, &extension_refs)
                 .await
         };
 
         let elapsed = instant.elapsed();
-        if let Ok(affected_rows) = &res {
-            debug!(
-                "Flow {flow_id} executed, affected_rows: {affected_rows:?}, elapsed: {:?}",
-                elapsed
-            );
-            METRIC_FLOW_ROWS
-                .with_label_values(&[format!("{}-out-batching", flow_id).as_str()])
-                .inc_by(*affected_rows as _);
-        } else if let Err(err) = &res {
+        if let Err(err) = &res {
             warn!(
-                "Failed to execute Flow {flow_id} on frontend {:?}, result: {err:?}, elapsed: {:?} with query: {}",
-                peer_desc, elapsed, &plan
+                "Failed to execute Flow {flow_id}, result: {err:?}, elapsed: {:?} with query: {}",
+                elapsed, &plan
             );
+            self.state.write().unwrap().after_query_exec(elapsed, false);
         }
 
         // record slow query
         if elapsed >= self.config.batch_opts.slow_query_threshold {
             warn!(
-                "Flow {flow_id} on frontend {:?} executed for {:?} before complete, query: {}",
-                peer_desc, elapsed, &plan
+                "Flow {flow_id} executed for {:?} before complete, query: {}",
+                elapsed, &plan
             );
             METRIC_FLOW_BATCHING_ENGINE_SLOW_QUERY
-                .with_label_values(&[
-                    flow_id.to_string().as_str(),
-                    &peer_desc.unwrap_or_default().to_string(),
-                ])
+                .with_label_values(&[flow_id.to_string().as_str(), "watermark-path"])
                 .observe(elapsed.as_secs_f64());
         }
 
-        self.state
-            .write()
-            .unwrap()
-            .after_query_exec(elapsed, res.is_ok());
-
         let res = res?;
+        let (affected_rows, _) = res.output.extract_rows_and_cost();
+        debug!(
+            "Flow {flow_id} executed, affected_rows: {affected_rows:?}, elapsed: {:?}, watermark: {:?}",
+            elapsed,
+            res.region_watermark_map()
+        );
+        METRIC_FLOW_ROWS
+            .with_label_values(&[format!("{}-out-batching", flow_id).as_str()])
+            .inc_by(affected_rows as _);
+        let affected_rows: u32 = affected_rows.try_into().map_err(|_| {
+            UnexpectedSnafu {
+                reason: format!("Failed to convert rows to u32: {}", affected_rows),
+            }
+            .build()
+        })?;
 
-        Ok(Some((res, elapsed)))
+        {
+            let mut state = self.state.write().unwrap();
+            let decision = Self::apply_query_result_to_state(&mut state, &res, elapsed);
+            Self::record_checkpoint_decision(flow_id, decision);
+        }
+
+        Ok(Some((affected_rows, elapsed)))
+    }
+
+    fn apply_query_result_to_state(
+        state: &mut TaskState,
+        res: &OutputWithMetrics,
+        elapsed: Duration,
+    ) -> FlowCheckpointDecision {
+        state.after_query_exec(elapsed, true);
+        let checkpoint_mode = state.checkpoint_mode();
+
+        if let (Some(participating_regions), Some(watermark_map)) =
+            (res.participating_regions(), res.region_watermark_map())
+        {
+            let can_advance = match checkpoint_mode {
+                CheckpointMode::FullSnapshot => state
+                    .can_advance_full_snapshot_checkpoints(&participating_regions, &watermark_map),
+                CheckpointMode::Incremental => state
+                    .can_advance_incremental_checkpoints_with_participation(
+                        &participating_regions,
+                        &watermark_map,
+                    ),
+            };
+
+            if can_advance {
+                let participating_region_count = participating_regions.len();
+                let watermark_count = watermark_map.len();
+                match checkpoint_mode {
+                    CheckpointMode::FullSnapshot => {
+                        state.advance_checkpoints(watermark_map);
+                        FlowCheckpointDecision::AdvancedFromFullSnapshot {
+                            participating_regions: participating_region_count,
+                            watermarks: watermark_count,
+                        }
+                    }
+                    CheckpointMode::Incremental => {
+                        state.advance_incremental_checkpoints_with_participation(
+                            &participating_regions,
+                            watermark_map,
+                        );
+                        FlowCheckpointDecision::AdvancedIncremental {
+                            participating_regions: participating_region_count,
+                            watermarks: watermark_count,
+                        }
+                    }
+                }
+            } else {
+                state.mark_full_snapshot();
+                FlowCheckpointDecision::FallbackToFullSnapshot {
+                    previous_mode: checkpoint_mode,
+                    reason: FlowQueryFallbackReason::IncompleteRegionWatermark,
+                }
+            }
+        } else {
+            state.mark_full_snapshot();
+            FlowCheckpointDecision::FallbackToFullSnapshot {
+                previous_mode: checkpoint_mode,
+                reason: FlowQueryFallbackReason::MissingRegionWatermark,
+            }
+        }
+    }
+
+    fn record_checkpoint_decision(flow_id: FlowId, decision: FlowCheckpointDecision) {
+        let flow_id = flow_id.to_string();
+        METRIC_FLOW_BATCHING_ENGINE_CHECKPOINT_DECISION_CNT
+            .with_label_values(&[
+                flow_id.as_str(),
+                decision.mode_label(),
+                decision.decision_label(),
+                decision.reason_label(),
+            ])
+            .inc();
+
+        match decision {
+            FlowCheckpointDecision::AdvancedFromFullSnapshot {
+                participating_regions,
+                watermarks,
+            } => {
+                info!(
+                    "Flow {flow_id} is now checkpoint-ready after full snapshot (PR3a: no incremental scan), participating_regions={participating_regions}, watermarks={watermarks}"
+                );
+            }
+            FlowCheckpointDecision::AdvancedIncremental {
+                participating_regions,
+                watermarks,
+            } => {
+                debug!(
+                    "Flow {flow_id} advanced checkpoint-readiness (PR3a: no incremental scan), participating_regions={participating_regions}, watermarks={watermarks}"
+                );
+            }
+            FlowCheckpointDecision::FallbackToFullSnapshot {
+                previous_mode,
+                reason,
+            } => {
+                warn!(
+                    "Flow {flow_id} switched to full snapshot mode, previous_mode={}, reason={}",
+                    checkpoint_mode_label(previous_mode),
+                    reason.as_label()
+                );
+            }
+        }
+    }
+
+    fn record_query_mode(flow_id: FlowId, mode: CheckpointMode) {
+        let flow_id = flow_id.to_string();
+        METRIC_FLOW_BATCHING_ENGINE_QUERY_MODE_CNT
+            .with_label_values(&[flow_id.as_str(), checkpoint_mode_label(mode)])
+            .inc();
+    }
+
+    fn record_failure_fallback(
+        &self,
+        previous_mode: CheckpointMode,
+        reason: FlowQueryFallbackReason,
+    ) {
+        Self::record_checkpoint_decision(
+            self.config.flow_id,
+            FlowCheckpointDecision::FallbackToFullSnapshot {
+                previous_mode,
+                reason,
+            },
+        );
+    }
+
+    /// Handle a query failure. Returns true if the task was in
+    /// checkpoint-ready (`Incremental`) mode before the failure, which
+    /// means a full fallback + dirty-window restore is needed.
+    ///
+    /// PR3a semantics (no stale-cursor handling):
+    /// - If the task was checkpoint-ready, fall back to full snapshot,
+    ///   record the fallback decision, and conservatively mark all
+    ///   windows dirty when the failure did not carry a scoped query.
+    /// - If the task was already in full-snapshot mode, the failure
+    ///   does not require additional state change.
+    fn handle_flow_query_failure(&self, _err: &Error, query: Option<&PlanInfo>) -> bool {
+        let previous_mode = { self.state.read().unwrap().checkpoint_mode() };
+        let checkpoint_was_ready = previous_mode == CheckpointMode::Incremental;
+        if checkpoint_was_ready {
+            warn!(
+                "Flow {} query failed while checkpoint-ready, falling back to full snapshot",
+                self.config.flow_id
+            );
+            self.state.write().unwrap().mark_full_snapshot();
+            self.record_failure_fallback(
+                previous_mode,
+                FlowQueryFallbackReason::CheckpointReadyQueryFailure,
+            );
+
+            // Conservatively mark all windows dirty when the failure
+            // was not scoped to a specific time-window filter (i.e. no
+            // scoped query), so the next full-snapshot execution covers
+            // the full dirty range.
+            if query.is_none_or(|query| query.filter.is_none())
+                && let Err(mark_err) = self.mark_all_windows_as_dirty()
+            {
+                warn!(
+                    "Flow {} failed to mark all windows dirty after checkpoint-ready query failure without time-window scope: {}",
+                    self.config.flow_id, mark_err
+                );
+            }
+        }
+
+        checkpoint_was_ready
+    }
+
+    /// Restore the scoped dirty time windows from a failed query so they
+    /// are retried on the next execution.
+    ///
+    /// If the task was checkpoint-ready and the query carried no
+    /// time-window filter, the dirty windows were already marked
+    /// conservatively by `handle_flow_query_failure`; skip double-add.
+    fn restore_dirty_windows_after_failure(&self, query: &PlanInfo, checkpoint_was_ready: bool) {
+        if checkpoint_was_ready && query.filter.is_none() {
+            return;
+        }
+
+        self.state.write().unwrap().dirty_time_windows.add_windows(
+            query
+                .filter
+                .as_ref()
+                .map(|f| f.time_ranges.clone())
+                .unwrap_or_default(),
+        );
+    }
+
+    fn handle_executed_query_failure(&self, err: &Error, query: Option<&PlanInfo>) -> bool {
+        let checkpoint_was_ready = self.handle_flow_query_failure(err, query);
+        if let Some(query) = query {
+            self.restore_dirty_windows_after_failure(query, checkpoint_was_ready);
+        }
+        checkpoint_was_ready
+    }
+
+    async fn build_flow_query_extensions(&self) -> Result<Vec<(&'static str, String)>, Error> {
+        let mut extensions = vec![("flow.return_region_seq", "true".to_string())];
+
+        if let Some(table) = self
+            .config
+            .catalog_manager
+            .table(
+                &self.config.sink_table_name[0],
+                &self.config.sink_table_name[1],
+                &self.config.sink_table_name[2],
+                None,
+            )
+            .await
+            .map_err(BoxedError::new)
+            .context(ExternalSnafu)?
+        {
+            extensions.push((
+                FLOW_SINK_TABLE_ID,
+                table.table_info().table_id().to_string(),
+            ));
+        }
+
+        Ok(extensions)
     }
 
     /// start executing query in a loop, break when receive shutdown signal
@@ -506,8 +742,12 @@ impl BatchingTask {
             };
 
             let res = if let Some(new_query) = &new_query {
-                self.execute_logical_plan(&frontend_client, &new_query.plan)
-                    .await
+                self.execute_logical_plan(
+                    &frontend_client,
+                    &new_query.plan,
+                    new_query.filter.as_ref(),
+                )
+                .await
             } else {
                 Ok(None)
             };
@@ -558,16 +798,13 @@ impl BatchingTask {
                 }
                 // TODO(discord9): this error should have better place to go, but for now just print error, also more context is needed
                 Err(err) => {
+                    self.handle_executed_query_failure(&err, new_query.as_ref());
                     METRIC_FLOW_BATCHING_ENGINE_ERROR_CNT
                         .with_label_values(&[&flow_id_str])
                         .inc();
                     match new_query {
                         Some(query) => {
                             common_telemetry::error!(err; "Failed to execute query for flow={} with query: {}", self.config.flow_id, query.plan);
-                            // Re-add dirty windows back since query failed
-                            self.state.write().unwrap().dirty_time_windows.add_windows(
-                                query.filter.map(|f| f.time_ranges).unwrap_or_default(),
-                            );
                             // TODO(discord9): add some backoff here? half the query time window or what
                             // backoff meaning use smaller `max_window_cnt` for next query
 
@@ -641,8 +878,12 @@ impl BatchingTask {
                         self.config.flow_id
                     );
                     // clean dirty time window too, this could be from create flow's check_execute
-                    let is_dirty = !self.state.read().unwrap().dirty_time_windows.is_empty();
-                    self.state.write().unwrap().dirty_time_windows.clean();
+                    let is_dirty = {
+                        let mut state = self.state.write().unwrap();
+                        let is_dirty = !state.dirty_time_windows.is_empty();
+                        state.dirty_time_windows.clean();
+                        is_dirty
+                    };
 
                     if !is_dirty {
                         // no dirty data, hence no need to update
@@ -650,7 +891,7 @@ impl BatchingTask {
                         return Ok(None);
                     }
 
-                    let plan = gen_plan_with_matching_schema(
+                    let plan = match gen_plan_with_matching_schema(
                         &self.config.query,
                         query_ctx,
                         engine,
@@ -658,15 +899,27 @@ impl BatchingTask {
                         primary_key_indices,
                         allow_partial,
                     )
-                    .await?;
+                    .await
+                    {
+                        Ok(plan) => plan,
+                        Err(err) => {
+                            self.state.write().unwrap().dirty_time_windows.set_dirty();
+                            return Err(err);
+                        }
+                    };
 
                     return Ok(Some(PlanInfo { plan, filter: None }));
                 }
                 _ => {
                     // clean for tql have no use for time window
-                    self.state.write().unwrap().dirty_time_windows.clean();
+                    let had_dirty_windows = {
+                        let mut state = self.state.write().unwrap();
+                        let had_dirty_windows = !state.dirty_time_windows.is_empty();
+                        state.dirty_time_windows.clean();
+                        had_dirty_windows
+                    };
 
-                    let plan = gen_plan_with_matching_schema(
+                    let plan = match gen_plan_with_matching_schema(
                         &self.config.query,
                         query_ctx,
                         engine,
@@ -674,7 +927,16 @@ impl BatchingTask {
                         primary_key_indices,
                         allow_partial,
                     )
-                    .await?;
+                    .await
+                    {
+                        Ok(plan) => plan,
+                        Err(err) => {
+                            if had_dirty_windows {
+                                self.state.write().unwrap().dirty_time_windows.set_dirty();
+                            }
+                            return Err(err);
+                        }
+                    };
 
                     return Ok(Some(PlanInfo { plan, filter: None }));
                 }
@@ -769,341 +1031,5 @@ impl BatchingTask {
     }
 }
 
-// auto created table have a auto added column `update_at`, and optional have a `AUTO_CREATED_PLACEHOLDER_TS_COL` column for time index placeholder if no timestamp column is specified
-// TODO(discord9): for now no default value is set for auto added column for compatibility reason with streaming mode, but this might change in favor of simpler code?
-fn create_table_with_expr(
-    plan: &LogicalPlan,
-    sink_table_name: &[String; 3],
-    query_type: &QueryType,
-) -> Result<CreateTableExpr, Error> {
-    let table_def = match query_type {
-        &QueryType::Sql => {
-            if let Some(def) = build_pk_from_aggr(plan)? {
-                def
-            } else {
-                build_by_sql_schema(plan)?
-            }
-        }
-        QueryType::Tql => {
-            // first try build from aggr, then from tql schema because tql query might not have aggr node
-            if let Some(table_def) = build_pk_from_aggr(plan)? {
-                table_def
-            } else {
-                build_by_tql_schema(plan)?
-            }
-        }
-    };
-    let first_time_stamp = table_def.ts_col;
-    let primary_keys = table_def.pks;
-
-    let mut column_schemas = Vec::new();
-    for field in plan.schema().fields() {
-        let name = field.name();
-        let ty = ConcreteDataType::from_arrow_type(field.data_type());
-        let col_schema = if first_time_stamp == Some(name.clone()) {
-            ColumnSchema::new(name, ty, false).with_time_index(true)
-        } else {
-            ColumnSchema::new(name, ty, true)
-        };
-
-        match query_type {
-            QueryType::Sql => {
-                column_schemas.push(col_schema);
-            }
-            QueryType::Tql => {
-                // if is val column, need to rename as val DOUBLE NULL
-                // if is tag column, need to cast type as STRING NULL
-                let is_tag_column = primary_keys.contains(name);
-                let is_val_column = !is_tag_column && first_time_stamp.as_ref() != Some(name);
-                if is_val_column {
-                    let col_schema =
-                        ColumnSchema::new(name, ConcreteDataType::float64_datatype(), true);
-                    column_schemas.push(col_schema);
-                } else if is_tag_column {
-                    let col_schema =
-                        ColumnSchema::new(name, ConcreteDataType::string_datatype(), true);
-                    column_schemas.push(col_schema);
-                } else {
-                    // time index column
-                    column_schemas.push(col_schema);
-                }
-            }
-        }
-    }
-
-    if query_type == &QueryType::Sql {
-        let update_at_schema = ColumnSchema::new(
-            AUTO_CREATED_UPDATE_AT_TS_COL,
-            ConcreteDataType::timestamp_millisecond_datatype(),
-            true,
-        );
-        column_schemas.push(update_at_schema);
-    }
-
-    let time_index = if let Some(time_index) = first_time_stamp {
-        time_index
-    } else {
-        column_schemas.push(
-            ColumnSchema::new(
-                AUTO_CREATED_PLACEHOLDER_TS_COL,
-                ConcreteDataType::timestamp_millisecond_datatype(),
-                false,
-            )
-            .with_time_index(true),
-        );
-        AUTO_CREATED_PLACEHOLDER_TS_COL.to_string()
-    };
-
-    let column_defs =
-        column_schemas_to_defs(column_schemas, &primary_keys).context(ConvertColumnSchemaSnafu)?;
-    Ok(CreateTableExpr {
-        catalog_name: sink_table_name[0].clone(),
-        schema_name: sink_table_name[1].clone(),
-        table_name: sink_table_name[2].clone(),
-        desc: "Auto created table by flow engine".to_string(),
-        column_defs,
-        time_index,
-        primary_keys,
-        create_if_not_exists: true,
-        table_options: Default::default(),
-        table_id: None,
-        engine: "mito".to_string(),
-    })
-}
-
-/// simply build by schema, return first timestamp column and no primary key
-fn build_by_sql_schema(plan: &LogicalPlan) -> Result<TableDef, Error> {
-    let first_time_stamp = plan.schema().fields().iter().find_map(|f| {
-        if ConcreteDataType::from_arrow_type(f.data_type()).is_timestamp() {
-            Some(f.name().clone())
-        } else {
-            None
-        }
-    });
-    Ok(TableDef {
-        ts_col: first_time_stamp,
-        pks: vec![],
-    })
-}
-
-/// Return first timestamp column found in output schema and all string columns
-fn build_by_tql_schema(plan: &LogicalPlan) -> Result<TableDef, Error> {
-    let first_time_stamp = plan.schema().fields().iter().find_map(|f| {
-        if ConcreteDataType::from_arrow_type(f.data_type()).is_timestamp() {
-            Some(f.name().clone())
-        } else {
-            None
-        }
-    });
-    let string_columns = plan
-        .schema()
-        .fields()
-        .iter()
-        .filter_map(|f| {
-            if ConcreteDataType::from_arrow_type(f.data_type()).is_string() {
-                Some(f.name().clone())
-            } else {
-                None
-            }
-        })
-        .collect::<Vec<_>>();
-
-    Ok(TableDef {
-        ts_col: first_time_stamp,
-        pks: string_columns,
-    })
-}
-
-struct TableDef {
-    ts_col: Option<String>,
-    pks: Vec<String>,
-}
-
-/// Return first timestamp column which is in group by clause and other columns which are also in group by clause
-///
-/// # Returns
-///
-/// * `Option<String>` - first timestamp column which is in group by clause
-/// * `Vec<String>` - other columns which are also in group by clause
-///
-/// if no aggregation found, return None
-fn build_pk_from_aggr(plan: &LogicalPlan) -> Result<Option<TableDef>, Error> {
-    let fields = plan.schema().fields();
-    let mut pk_names = FindGroupByFinalName::default();
-
-    plan.visit(&mut pk_names)
-        .with_context(|_| DatafusionSnafu {
-            context: format!("Can't find aggr expr in plan {plan:?}"),
-        })?;
-
-    // if no group by clause, return empty with first timestamp column found in output schema
-    let Some(pk_final_names) = pk_names.get_group_expr_names() else {
-        return Ok(None);
-    };
-    if pk_final_names.is_empty() {
-        let first_ts_col = fields
-            .iter()
-            .find(|f| ConcreteDataType::from_arrow_type(f.data_type()).is_timestamp())
-            .map(|f| f.name().clone());
-        return Ok(Some(TableDef {
-            ts_col: first_ts_col,
-            pks: vec![],
-        }));
-    }
-
-    let all_pk_cols: Vec<_> = fields
-        .iter()
-        .filter(|f| pk_final_names.contains(f.name()))
-        .map(|f| f.name().clone())
-        .collect();
-    // auto create table use first timestamp column in group by clause as time index
-    let first_time_stamp = fields
-        .iter()
-        .find(|f| {
-            all_pk_cols.contains(&f.name().clone())
-                && ConcreteDataType::from_arrow_type(f.data_type()).is_timestamp()
-        })
-        .map(|f| f.name().clone());
-
-    let all_pk_cols: Vec<_> = all_pk_cols
-        .into_iter()
-        .filter(|col| first_time_stamp.as_ref() != Some(col))
-        .collect();
-
-    Ok(Some(TableDef {
-        ts_col: first_time_stamp,
-        pks: all_pk_cols,
-    }))
-}
-
 #[cfg(test)]
-mod test {
-    use api::v1::column_def::try_as_column_schema;
-    use pretty_assertions::assert_eq;
-    use session::context::QueryContext;
-
-    use super::*;
-    use crate::test_utils::create_test_query_engine;
-
-    #[tokio::test]
-    async fn test_gen_create_table_sql() {
-        let query_engine = create_test_query_engine();
-        let ctx = QueryContext::arc();
-        struct TestCase {
-            sql: String,
-            sink_table_name: String,
-            column_schemas: Vec<ColumnSchema>,
-            primary_keys: Vec<String>,
-            time_index: String,
-        }
-
-        let update_at_schema = ColumnSchema::new(
-            AUTO_CREATED_UPDATE_AT_TS_COL,
-            ConcreteDataType::timestamp_millisecond_datatype(),
-            true,
-        );
-
-        let ts_placeholder_schema = ColumnSchema::new(
-            AUTO_CREATED_PLACEHOLDER_TS_COL,
-            ConcreteDataType::timestamp_millisecond_datatype(),
-            false,
-        )
-        .with_time_index(true);
-
-        let testcases = vec![
-            TestCase {
-                sql: "SELECT number, ts FROM numbers_with_ts".to_string(),
-                sink_table_name: "new_table".to_string(),
-                column_schemas: vec![
-                    ColumnSchema::new("number", ConcreteDataType::uint32_datatype(), true),
-                    ColumnSchema::new(
-                        "ts",
-                        ConcreteDataType::timestamp_millisecond_datatype(),
-                        false,
-                    )
-                    .with_time_index(true),
-                    update_at_schema.clone(),
-                ],
-                primary_keys: vec![],
-                time_index: "ts".to_string(),
-            },
-            TestCase {
-                sql: "SELECT number, max(ts) FROM numbers_with_ts GROUP BY number".to_string(),
-                sink_table_name: "new_table".to_string(),
-                column_schemas: vec![
-                    ColumnSchema::new("number", ConcreteDataType::uint32_datatype(), true),
-                    ColumnSchema::new(
-                        "max(numbers_with_ts.ts)",
-                        ConcreteDataType::timestamp_millisecond_datatype(),
-                        true,
-                    ),
-                    update_at_schema.clone(),
-                    ts_placeholder_schema.clone(),
-                ],
-                primary_keys: vec!["number".to_string()],
-                time_index: AUTO_CREATED_PLACEHOLDER_TS_COL.to_string(),
-            },
-            TestCase {
-                sql: "SELECT max(number), ts FROM numbers_with_ts GROUP BY ts".to_string(),
-                sink_table_name: "new_table".to_string(),
-                column_schemas: vec![
-                    ColumnSchema::new(
-                        "max(numbers_with_ts.number)",
-                        ConcreteDataType::uint32_datatype(),
-                        true,
-                    ),
-                    ColumnSchema::new(
-                        "ts",
-                        ConcreteDataType::timestamp_millisecond_datatype(),
-                        false,
-                    )
-                    .with_time_index(true),
-                    update_at_schema.clone(),
-                ],
-                primary_keys: vec![],
-                time_index: "ts".to_string(),
-            },
-            TestCase {
-                sql: "SELECT number, ts FROM numbers_with_ts GROUP BY ts, number".to_string(),
-                sink_table_name: "new_table".to_string(),
-                column_schemas: vec![
-                    ColumnSchema::new("number", ConcreteDataType::uint32_datatype(), true),
-                    ColumnSchema::new(
-                        "ts",
-                        ConcreteDataType::timestamp_millisecond_datatype(),
-                        false,
-                    )
-                    .with_time_index(true),
-                    update_at_schema.clone(),
-                ],
-                primary_keys: vec!["number".to_string()],
-                time_index: "ts".to_string(),
-            },
-        ];
-
-        for tc in testcases {
-            let plan = sql_to_df_plan(ctx.clone(), query_engine.clone(), &tc.sql, true)
-                .await
-                .unwrap();
-            let expr = create_table_with_expr(
-                &plan,
-                &[
-                    "greptime".to_string(),
-                    "public".to_string(),
-                    tc.sink_table_name.clone(),
-                ],
-                &QueryType::Sql,
-            )
-            .unwrap();
-            // TODO(discord9): assert expr
-            let column_schemas = expr
-                .column_defs
-                .iter()
-                .map(|c| try_as_column_schema(c).unwrap())
-                .collect::<Vec<_>>();
-            assert_eq!(tc.column_schemas, column_schemas, "{:?}", tc.sql);
-            assert_eq!(tc.primary_keys, expr.primary_keys, "{:?}", tc.sql);
-            assert_eq!(tc.time_index, expr.time_index, "{:?}", tc.sql);
-        }
-    }
-}
+mod test;

--- a/src/flow/src/batching_mode/task.rs
+++ b/src/flow/src/batching_mode/task.rs
@@ -18,7 +18,6 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use api::v1::CreateTableExpr;
 use catalog::CatalogManagerRef;
-use client::OutputWithMetrics;
 use common_error::ext::BoxedError;
 use common_query::logical_plan::breakup_insert_plan;
 use common_telemetry::tracing::warn;
@@ -31,7 +30,6 @@ use datafusion_common::tree_node::{Transformed, TreeNode};
 use datafusion_expr::{DmlStatement, LogicalPlan, WriteOp};
 use datatypes::schema::Schema;
 use query::QueryEngineRef;
-use query::options::FLOW_SINK_TABLE_ID;
 use query::query_engine::DefaultSerializer;
 use session::context::QueryContextRef;
 use snafu::{OptionExt, ResultExt};
@@ -44,9 +42,8 @@ use tokio::sync::oneshot::error::TryRecvError;
 use tokio::time::Instant;
 
 use crate::batching_mode::BatchingModeOptions;
-use crate::batching_mode::checkpoint::{FlowCheckpointDecision, FlowQueryFallbackReason};
 use crate::batching_mode::frontend_client::FrontendClient;
-use crate::batching_mode::state::{CheckpointMode, DirtyTimeWindows, FilterExprInfo, TaskState};
+use crate::batching_mode::state::{DirtyTimeWindows, FilterExprInfo, TaskState};
 use crate::batching_mode::table_creator::{QueryType, create_table_with_expr};
 use crate::batching_mode::time_window::TimeWindowExpr;
 use crate::batching_mode::utils::{
@@ -59,13 +56,7 @@ use crate::error::{
     UnexpectedSnafu,
 };
 use crate::metrics::{
-    FLOW_CHECKPOINT_DECISION_ADVANCE_LABEL, FLOW_CHECKPOINT_DECISION_FALLBACK_LABEL,
-    FLOW_CHECKPOINT_MODE_FULL_SNAPSHOT_LABEL, FLOW_CHECKPOINT_MODE_INCREMENTAL_LABEL,
-    FLOW_CHECKPOINT_REASON_INCOMPLETE_WATERMARK_LABEL,
-    FLOW_CHECKPOINT_REASON_MISSING_WATERMARK_LABEL, FLOW_CHECKPOINT_REASON_NONE_LABEL,
-    FLOW_CHECKPOINT_REASON_QUERY_FAILURE_LABEL,
-    METRIC_FLOW_BATCHING_ENGINE_CHECKPOINT_DECISION_CNT, METRIC_FLOW_BATCHING_ENGINE_ERROR_CNT,
-    METRIC_FLOW_BATCHING_ENGINE_QUERY_MODE_CNT, METRIC_FLOW_BATCHING_ENGINE_QUERY_TIME,
+    METRIC_FLOW_BATCHING_ENGINE_ERROR_CNT, METRIC_FLOW_BATCHING_ENGINE_QUERY_TIME,
     METRIC_FLOW_BATCHING_ENGINE_SLOW_QUERY, METRIC_FLOW_BATCHING_ENGINE_START_QUERY_CNT,
     METRIC_FLOW_ROWS,
 };
@@ -256,7 +247,7 @@ impl BatchingTask {
             {
                 Ok(result) => Ok(result),
                 Err(err) => {
-                    self.handle_executed_query_failure(&err, Some(&new_query));
+                    self.handle_executed_query_failure(Some(&new_query));
                     Err(err)
                 }
             }
@@ -404,18 +395,7 @@ impl BatchingTask {
             })?
             .data;
 
-        let extensions = self.build_flow_query_extensions().await?;
-        let extension_refs = extensions
-            .iter()
-            .map(|(key, value)| (*key, value.as_str()))
-            .collect::<Vec<_>>();
-        let query_mode = self.state.read().unwrap().checkpoint_mode();
-        Self::record_query_mode(flow_id, query_mode);
-        debug!(
-            "Flow {flow_id} executing batching query with checkpoint_mode={}, extension_count={}",
-            checkpoint_mode_label(query_mode),
-            extensions.len()
-        );
+        let mut peer_desc = None;
 
         let res = {
             let _timer = METRIC_FLOW_BATCHING_ENGINE_QUERY_TIME
@@ -428,229 +408,66 @@ impl BatchingTask {
                 let message = DFLogicalSubstraitConvertor {}
                     .encode(&insert_plan, DefaultSerializer)
                     .context(SubstraitEncodeLogicalPlanSnafu)?;
-                api::v1::QueryRequest {
+                api::v1::greptime_request::Request::Query(api::v1::QueryRequest {
                     query: Some(api::v1::query_request::Query::InsertIntoPlan(
                         api::v1::InsertIntoPlan {
                             table_name: Some(insert_to),
                             logical_plan: message.to_vec(),
                         },
                     )),
-                }
+                })
             } else {
                 let message = DFLogicalSubstraitConvertor {}
                     .encode(&plan, DefaultSerializer)
                     .context(SubstraitEncodeLogicalPlanSnafu)?;
 
-                api::v1::QueryRequest {
+                api::v1::greptime_request::Request::Query(api::v1::QueryRequest {
                     query: Some(api::v1::query_request::Query::LogicalPlan(message.to_vec())),
-                }
+                })
             };
 
             frontend_client
-                .query_with_terminal_metrics(catalog, schema, req, &extension_refs)
+                .handle(req, catalog, schema, &mut peer_desc)
                 .await
         };
 
         let elapsed = instant.elapsed();
-        if let Err(err) = &res {
-            warn!(
-                "Failed to execute Flow {flow_id}, result: {err:?}, elapsed: {:?} with query: {}",
-                elapsed, &plan
+        if let Ok(affected_rows) = &res {
+            debug!(
+                "Flow {flow_id} executed, affected_rows: {affected_rows:?}, elapsed: {:?}",
+                elapsed
             );
-            self.state.write().unwrap().after_query_exec(elapsed, false);
+            METRIC_FLOW_ROWS
+                .with_label_values(&[format!("{}-out-batching", flow_id).as_str()])
+                .inc_by(*affected_rows as _);
+        } else if let Err(err) = &res {
+            warn!(
+                "Failed to execute Flow {flow_id} on frontend {:?}, result: {err:?}, elapsed: {:?} with query: {}",
+                peer_desc, elapsed, &plan
+            );
         }
 
         // record slow query
         if elapsed >= self.config.batch_opts.slow_query_threshold {
             warn!(
-                "Flow {flow_id} executed for {:?} before complete, query: {}",
-                elapsed, &plan
+                "Flow {flow_id} on frontend {:?} executed for {:?} before complete, query: {}",
+                peer_desc, elapsed, &plan
             );
             METRIC_FLOW_BATCHING_ENGINE_SLOW_QUERY
-                .with_label_values(&[flow_id.to_string().as_str(), "watermark-path"])
+                .with_label_values(&[
+                    flow_id.to_string().as_str(),
+                    &peer_desc.unwrap_or_default().to_string(),
+                ])
                 .observe(elapsed.as_secs_f64());
         }
 
+        self.state
+            .write()
+            .unwrap()
+            .after_query_exec(elapsed, res.is_ok());
+
         let res = res?;
-        let (affected_rows, _) = res.output.extract_rows_and_cost();
-        debug!(
-            "Flow {flow_id} executed, affected_rows: {affected_rows:?}, elapsed: {:?}, watermark: {:?}",
-            elapsed,
-            res.region_watermark_map()
-        );
-        METRIC_FLOW_ROWS
-            .with_label_values(&[format!("{}-out-batching", flow_id).as_str()])
-            .inc_by(affected_rows as _);
-
-        {
-            let mut state = self.state.write().unwrap();
-            let decision = Self::apply_query_result_to_state(&mut state, &res, elapsed);
-            Self::record_checkpoint_decision(flow_id, decision);
-        }
-
-        Ok(Some((affected_rows, elapsed)))
-    }
-
-    fn apply_query_result_to_state(
-        state: &mut TaskState,
-        res: &OutputWithMetrics,
-        elapsed: Duration,
-    ) -> FlowCheckpointDecision {
-        state.after_query_exec(elapsed, true);
-        let checkpoint_mode = state.checkpoint_mode();
-
-        if let (Some(participating_regions), Some(watermark_map)) =
-            (res.participating_regions(), res.region_watermark_map())
-        {
-            let can_advance = match checkpoint_mode {
-                CheckpointMode::FullSnapshot => state
-                    .can_advance_full_snapshot_checkpoints(&participating_regions, &watermark_map),
-                CheckpointMode::Incremental => state
-                    .can_advance_incremental_checkpoints_with_participation(
-                        &participating_regions,
-                        &watermark_map,
-                    ),
-            };
-
-            if can_advance {
-                let participating_region_count = participating_regions.len();
-                let watermark_count = watermark_map.len();
-                match checkpoint_mode {
-                    CheckpointMode::FullSnapshot => {
-                        state.advance_checkpoints(watermark_map);
-                        FlowCheckpointDecision::AdvancedFromFullSnapshot {
-                            participating_region_count,
-                            watermark_count,
-                        }
-                    }
-                    CheckpointMode::Incremental => {
-                        state.advance_incremental_checkpoints_with_participation(
-                            &participating_regions,
-                            watermark_map,
-                        );
-                        FlowCheckpointDecision::AdvancedIncremental {
-                            participating_region_count,
-                            watermark_count,
-                        }
-                    }
-                }
-            } else {
-                state.mark_full_snapshot();
-                FlowCheckpointDecision::FallbackToFullSnapshot {
-                    previous_mode: checkpoint_mode,
-                    reason: FlowQueryFallbackReason::IncompleteRegionWatermark,
-                }
-            }
-        } else {
-            state.mark_full_snapshot();
-            FlowCheckpointDecision::FallbackToFullSnapshot {
-                previous_mode: checkpoint_mode,
-                reason: FlowQueryFallbackReason::MissingRegionWatermark,
-            }
-        }
-    }
-
-    fn record_checkpoint_decision(flow_id: FlowId, decision: FlowCheckpointDecision) {
-        let flow_id = flow_id.to_string();
-        let labels = checkpoint_decision_metric_labels(decision);
-        METRIC_FLOW_BATCHING_ENGINE_CHECKPOINT_DECISION_CNT
-            .with_label_values(&[
-                flow_id.as_str(),
-                labels.mode,
-                labels.decision,
-                labels.reason,
-            ])
-            .inc();
-
-        match decision {
-            FlowCheckpointDecision::AdvancedFromFullSnapshot {
-                participating_region_count,
-                watermark_count,
-            } => {
-                info!(
-                    "Flow {flow_id} is now checkpoint-ready after full snapshot, participating_region_count={participating_region_count}, watermark_count={watermark_count}"
-                );
-            }
-            FlowCheckpointDecision::AdvancedIncremental {
-                participating_region_count,
-                watermark_count,
-            } => {
-                debug!(
-                    "Flow {flow_id} advanced checkpoint-readiness, participating_region_count={participating_region_count}, watermark_count={watermark_count}"
-                );
-            }
-            FlowCheckpointDecision::FallbackToFullSnapshot {
-                previous_mode,
-                reason,
-            } => {
-                warn!(
-                    "Flow {flow_id} switched to full snapshot mode, previous_mode={}, reason={}",
-                    checkpoint_mode_label(previous_mode),
-                    checkpoint_fallback_reason_metric_label(reason)
-                );
-            }
-        }
-    }
-
-    fn record_query_mode(flow_id: FlowId, mode: CheckpointMode) {
-        let flow_id = flow_id.to_string();
-        METRIC_FLOW_BATCHING_ENGINE_QUERY_MODE_CNT
-            .with_label_values(&[flow_id.as_str(), checkpoint_mode_label(mode)])
-            .inc();
-    }
-
-    fn record_failure_fallback(
-        &self,
-        previous_mode: CheckpointMode,
-        reason: FlowQueryFallbackReason,
-    ) {
-        Self::record_checkpoint_decision(
-            self.config.flow_id,
-            FlowCheckpointDecision::FallbackToFullSnapshot {
-                previous_mode,
-                reason,
-            },
-        );
-    }
-
-    /// Handle a query failure. Returns true if the task was in
-    /// checkpoint-ready (`Incremental`) mode before the failure and therefore
-    /// fell back to full-snapshot mode.
-    ///
-    /// Current failure semantics:
-    /// - If the task was checkpoint-ready, fall back to full snapshot and
-    ///   record the fallback decision. Dirty windows consumed by a planned
-    ///   query are restored by `restore_dirty_windows_after_failure`.
-    /// - If the task was already in full-snapshot mode, the failure
-    ///   does not require additional state change.
-    fn handle_flow_query_failure(&self, _err: &Error, query: Option<&PlanInfo>) -> bool {
-        let previous_mode = { self.state.read().unwrap().checkpoint_mode() };
-        let checkpoint_was_ready = previous_mode == CheckpointMode::Incremental;
-        if checkpoint_was_ready {
-            warn!(
-                "Flow {} query failed while checkpoint-ready, falling back to full snapshot",
-                self.config.flow_id
-            );
-            self.state.write().unwrap().mark_full_snapshot();
-            self.record_failure_fallback(
-                previous_mode,
-                FlowQueryFallbackReason::CheckpointReadyQueryFailure,
-            );
-
-            // If no plan info is available, there is no consumed dirty
-            // snapshot to restore. Conservatively mark the full dirty range
-            // so the next execution can rebuild from full-snapshot mode.
-            if query.is_none()
-                && let Err(mark_err) = self.mark_all_windows_as_dirty()
-            {
-                warn!(
-                    "Flow {} failed to mark all windows dirty after checkpoint-ready query failure without plan info: {}",
-                    self.config.flow_id, mark_err
-                );
-            }
-        }
-
-        checkpoint_was_ready
+        Ok(Some((res as usize, elapsed)))
     }
 
     /// Restore dirty windows consumed by a failed query so they are retried on
@@ -691,37 +508,10 @@ impl BatchingTask {
         })
     }
 
-    fn handle_executed_query_failure(&self, err: &Error, query: Option<&PlanInfo>) -> bool {
-        let checkpoint_was_ready = self.handle_flow_query_failure(err, query);
+    fn handle_executed_query_failure(&self, query: Option<&PlanInfo>) {
         if let Some(query) = query {
             self.restore_dirty_windows_after_failure(query);
         }
-        checkpoint_was_ready
-    }
-
-    async fn build_flow_query_extensions(&self) -> Result<Vec<(&'static str, String)>, Error> {
-        let mut extensions = vec![("flow.return_region_seq", "true".to_string())];
-
-        if let Some(table) = self
-            .config
-            .catalog_manager
-            .table(
-                &self.config.sink_table_name[0],
-                &self.config.sink_table_name[1],
-                &self.config.sink_table_name[2],
-                None,
-            )
-            .await
-            .map_err(BoxedError::new)
-            .context(ExternalSnafu)?
-        {
-            extensions.push((
-                FLOW_SINK_TABLE_ID,
-                table.table_info().table_id().to_string(),
-            ));
-        }
-
-        Ok(extensions)
     }
 
     /// start executing query in a loop, break when receive shutdown signal
@@ -827,7 +617,7 @@ impl BatchingTask {
                 }
                 // TODO(discord9): this error should have better place to go, but for now just print error, also more context is needed
                 Err(err) => {
-                    self.handle_executed_query_failure(&err, new_query.as_ref());
+                    self.handle_executed_query_failure(new_query.as_ref());
                     METRIC_FLOW_BATCHING_ENGINE_ERROR_CNT
                         .with_label_values(&[&flow_id_str])
                         .inc();
@@ -1076,58 +866,6 @@ impl BatchingTask {
         };
 
         Ok(Some(info))
-    }
-}
-
-struct CheckpointDecisionMetricLabels {
-    mode: &'static str,
-    decision: &'static str,
-    reason: &'static str,
-}
-
-fn checkpoint_decision_metric_labels(
-    decision: FlowCheckpointDecision,
-) -> CheckpointDecisionMetricLabels {
-    match decision {
-        FlowCheckpointDecision::AdvancedFromFullSnapshot { .. } => CheckpointDecisionMetricLabels {
-            mode: checkpoint_mode_label(CheckpointMode::FullSnapshot),
-            decision: FLOW_CHECKPOINT_DECISION_ADVANCE_LABEL,
-            reason: FLOW_CHECKPOINT_REASON_NONE_LABEL,
-        },
-        FlowCheckpointDecision::AdvancedIncremental { .. } => CheckpointDecisionMetricLabels {
-            mode: checkpoint_mode_label(CheckpointMode::Incremental),
-            decision: FLOW_CHECKPOINT_DECISION_ADVANCE_LABEL,
-            reason: FLOW_CHECKPOINT_REASON_NONE_LABEL,
-        },
-        FlowCheckpointDecision::FallbackToFullSnapshot {
-            previous_mode,
-            reason,
-        } => CheckpointDecisionMetricLabels {
-            mode: checkpoint_mode_label(previous_mode),
-            decision: FLOW_CHECKPOINT_DECISION_FALLBACK_LABEL,
-            reason: checkpoint_fallback_reason_metric_label(reason),
-        },
-    }
-}
-
-fn checkpoint_fallback_reason_metric_label(reason: FlowQueryFallbackReason) -> &'static str {
-    match reason {
-        FlowQueryFallbackReason::MissingRegionWatermark => {
-            FLOW_CHECKPOINT_REASON_MISSING_WATERMARK_LABEL
-        }
-        FlowQueryFallbackReason::IncompleteRegionWatermark => {
-            FLOW_CHECKPOINT_REASON_INCOMPLETE_WATERMARK_LABEL
-        }
-        FlowQueryFallbackReason::CheckpointReadyQueryFailure => {
-            FLOW_CHECKPOINT_REASON_QUERY_FAILURE_LABEL
-        }
-    }
-}
-
-fn checkpoint_mode_label(mode: CheckpointMode) -> &'static str {
-    match mode {
-        CheckpointMode::FullSnapshot => FLOW_CHECKPOINT_MODE_FULL_SNAPSHOT_LABEL,
-        CheckpointMode::Incremental => FLOW_CHECKPOINT_MODE_INCREMENTAL_LABEL,
     }
 }
 

--- a/src/flow/src/batching_mode/task.rs
+++ b/src/flow/src/batching_mode/task.rs
@@ -34,7 +34,7 @@ use query::QueryEngineRef;
 use query::options::FLOW_SINK_TABLE_ID;
 use query::query_engine::DefaultSerializer;
 use session::context::QueryContextRef;
-use snafu::{OptionExt, ResultExt, ensure};
+use snafu::{OptionExt, ResultExt};
 use sql::parsers::utils::is_tql;
 use store_api::mito_engine_options::MERGE_MODE_KEY;
 use substrait::{DFLogicalSubstraitConvertor, SubstraitPlan};
@@ -48,7 +48,7 @@ use crate::batching_mode::checkpoint::{
     FlowCheckpointDecision, FlowQueryFallbackReason, checkpoint_mode_label,
 };
 use crate::batching_mode::frontend_client::FrontendClient;
-use crate::batching_mode::state::{CheckpointMode, FilterExprInfo, TaskState};
+use crate::batching_mode::state::{CheckpointMode, DirtyTimeWindows, FilterExprInfo, TaskState};
 use crate::batching_mode::table_creator::{QueryType, create_table_with_expr};
 use crate::batching_mode::time_window::TimeWindowExpr;
 use crate::batching_mode::utils::{
@@ -129,6 +129,13 @@ pub struct TaskArgs<'a> {
 pub struct PlanInfo {
     pub plan: LogicalPlan,
     pub filter: Option<FilterExprInfo>,
+    /// Dirty windows consumed while building a filterless query.
+    ///
+    /// Scoped queries restore failed work from `filter.time_ranges`.  A
+    /// filterless query has no such scope, so keep the exact dirty markers
+    /// that were cleaned before planning and merge them back if execution
+    /// fails.
+    pub filterless_dirty_windows_to_restore: Option<DirtyTimeWindows>,
 }
 
 impl BatchingTask {
@@ -282,57 +289,69 @@ impl BatchingTask {
             )
             .await?;
 
-        let insert_into_info = if let Some(new_query) = new_query {
-            // first check if all columns in input query exists in sink table
-            // since insert into ref to names in record batch generate by given query
-            let table_columns = df_schema
-                .columns()
-                .into_iter()
-                .map(|c| c.name)
-                .collect::<BTreeSet<_>>();
-            for column in new_query.plan.schema().columns() {
-                ensure!(
-                    table_columns.contains(column.name()),
-                    InvalidQuerySnafu {
-                        reason: format!(
-                            "Column {} not found in sink table with columns {:?}",
-                            column, table_columns
-                        ),
-                    }
-                );
-            }
-
-            let table_provider = Arc::new(DfTableProviderAdapter::new(table));
-            let table_source = Arc::new(DefaultTableSource::new(table_provider));
-
-            // update_at& time index placeholder (if exists) should have default value
-            let plan = LogicalPlan::Dml(DmlStatement::new(
-                datafusion_common::TableReference::Full {
-                    catalog: self.config.sink_table_name[0].clone().into(),
-                    schema: self.config.sink_table_name[1].clone().into(),
-                    table: self.config.sink_table_name[2].clone().into(),
-                },
-                table_source,
-                WriteOp::Insert(datafusion_expr::dml::InsertOp::Append),
-                Arc::new(new_query.plan),
-            ));
-            PlanInfo {
-                plan,
-                filter: new_query.filter,
-            }
-        } else {
+        let Some(new_query) = new_query else {
             return Ok(None);
         };
-        let insert_into = insert_into_info
-            .plan
-            .recompute_schema()
-            .context(DatafusionSnafu {
-                context: "Failed to recompute schema",
-            })?;
+
+        // first check if all columns in input query exists in sink table
+        // since insert into ref to names in record batch generate by given query
+        let table_columns = df_schema
+            .columns()
+            .into_iter()
+            .map(|c| c.name)
+            .collect::<BTreeSet<_>>();
+        for column in new_query.plan.schema().columns() {
+            if !table_columns.contains(column.name()) {
+                self.restore_dirty_windows_after_failure(&new_query);
+                return InvalidQuerySnafu {
+                    reason: format!(
+                        "Column {} not found in sink table with columns {:?}",
+                        column, table_columns
+                    ),
+                }
+                .fail();
+            }
+        }
+
+        let table_provider = Arc::new(DfTableProviderAdapter::new(table));
+        let table_source = Arc::new(DefaultTableSource::new(table_provider));
+
+        // update_at& time index placeholder (if exists) should have default value
+        let plan = LogicalPlan::Dml(DmlStatement::new(
+            datafusion_common::TableReference::Full {
+                catalog: self.config.sink_table_name[0].clone().into(),
+                schema: self.config.sink_table_name[1].clone().into(),
+                table: self.config.sink_table_name[2].clone().into(),
+            },
+            table_source,
+            WriteOp::Insert(datafusion_expr::dml::InsertOp::Append),
+            Arc::new(new_query.plan.clone()),
+        ));
+        let insert_into_info = PlanInfo {
+            plan,
+            filter: new_query.filter,
+            filterless_dirty_windows_to_restore: new_query.filterless_dirty_windows_to_restore,
+        };
+        let insert_into =
+            match insert_into_info
+                .plan
+                .clone()
+                .recompute_schema()
+                .context(DatafusionSnafu {
+                    context: "Failed to recompute schema",
+                }) {
+                Ok(insert_into) => insert_into,
+                Err(err) => {
+                    self.restore_dirty_windows_after_failure(&insert_into_info);
+                    return Err(err);
+                }
+            };
 
         Ok(Some(PlanInfo {
             plan: insert_into,
             filter: insert_into_info.filter,
+            filterless_dirty_windows_to_restore: insert_into_info
+                .filterless_dirty_windows_to_restore,
         }))
     }
 
@@ -391,7 +410,7 @@ impl BatchingTask {
         let query_mode = self.state.read().unwrap().checkpoint_mode();
         Self::record_query_mode(flow_id, query_mode);
         debug!(
-            "Flow {flow_id} executing batching query with checkpoint_mode={}, extension_count={} (PR3a: no incremental scan extensions)",
+            "Flow {flow_id} executing batching query with checkpoint_mode={}, extension_count={}",
             checkpoint_mode_label(query_mode),
             extensions.len()
         );
@@ -552,7 +571,7 @@ impl BatchingTask {
                 watermarks,
             } => {
                 info!(
-                    "Flow {flow_id} is now checkpoint-ready after full snapshot (PR3a: no incremental scan), participating_regions={participating_regions}, watermarks={watermarks}"
+                    "Flow {flow_id} is now checkpoint-ready after full snapshot, participating_regions={participating_regions}, watermarks={watermarks}"
                 );
             }
             FlowCheckpointDecision::AdvancedIncremental {
@@ -560,7 +579,7 @@ impl BatchingTask {
                 watermarks,
             } => {
                 debug!(
-                    "Flow {flow_id} advanced checkpoint-readiness (PR3a: no incremental scan), participating_regions={participating_regions}, watermarks={watermarks}"
+                    "Flow {flow_id} advanced checkpoint-readiness, participating_regions={participating_regions}, watermarks={watermarks}"
                 );
             }
             FlowCheckpointDecision::FallbackToFullSnapshot {
@@ -598,13 +617,13 @@ impl BatchingTask {
     }
 
     /// Handle a query failure. Returns true if the task was in
-    /// checkpoint-ready (`Incremental`) mode before the failure, which
-    /// means a full fallback + dirty-window restore is needed.
+    /// checkpoint-ready (`Incremental`) mode before the failure and therefore
+    /// fell back to full-snapshot mode.
     ///
-    /// PR3a semantics (no stale-cursor handling):
-    /// - If the task was checkpoint-ready, fall back to full snapshot,
-    ///   record the fallback decision, and conservatively mark all
-    ///   windows dirty when the failure did not carry a scoped query.
+    /// Current failure semantics:
+    /// - If the task was checkpoint-ready, fall back to full snapshot and
+    ///   record the fallback decision. Dirty windows consumed by a planned
+    ///   query are restored by `restore_dirty_windows_after_failure`.
     /// - If the task was already in full-snapshot mode, the failure
     ///   does not require additional state change.
     fn handle_flow_query_failure(&self, _err: &Error, query: Option<&PlanInfo>) -> bool {
@@ -621,15 +640,14 @@ impl BatchingTask {
                 FlowQueryFallbackReason::CheckpointReadyQueryFailure,
             );
 
-            // Conservatively mark all windows dirty when the failure
-            // was not scoped to a specific time-window filter (i.e. no
-            // scoped query), so the next full-snapshot execution covers
-            // the full dirty range.
-            if query.is_none_or(|query| query.filter.is_none())
+            // If no plan info is available, there is no consumed dirty
+            // snapshot to restore. Conservatively mark the full dirty range
+            // so the next execution can rebuild from full-snapshot mode.
+            if query.is_none()
                 && let Err(mark_err) = self.mark_all_windows_as_dirty()
             {
                 warn!(
-                    "Flow {} failed to mark all windows dirty after checkpoint-ready query failure without time-window scope: {}",
+                    "Flow {} failed to mark all windows dirty after checkpoint-ready query failure without plan info: {}",
                     self.config.flow_id, mark_err
                 );
             }
@@ -638,14 +656,18 @@ impl BatchingTask {
         checkpoint_was_ready
     }
 
-    /// Restore the scoped dirty time windows from a failed query so they
-    /// are retried on the next execution.
+    /// Restore dirty windows consumed by a failed query so they are retried on
+    /// the next execution.
     ///
-    /// If the task was checkpoint-ready and the query carried no
-    /// time-window filter, the dirty windows were already marked
-    /// conservatively by `handle_flow_query_failure`; skip double-add.
-    fn restore_dirty_windows_after_failure(&self, query: &PlanInfo, checkpoint_was_ready: bool) {
-        if checkpoint_was_ready && query.filter.is_none() {
+    fn restore_dirty_windows_after_failure(&self, query: &PlanInfo) {
+        if query.filter.is_none() {
+            if let Some(dirty_windows) = &query.filterless_dirty_windows_to_restore {
+                self.state
+                    .write()
+                    .unwrap()
+                    .dirty_time_windows
+                    .add_dirty_windows(dirty_windows);
+            }
             return;
         }
 
@@ -661,7 +683,7 @@ impl BatchingTask {
     fn handle_executed_query_failure(&self, err: &Error, query: Option<&PlanInfo>) -> bool {
         let checkpoint_was_ready = self.handle_flow_query_failure(err, query);
         if let Some(query) = query {
-            self.restore_dirty_windows_after_failure(query, checkpoint_was_ready);
+            self.restore_dirty_windows_after_failure(query);
         }
         checkpoint_was_ready
     }
@@ -878,11 +900,12 @@ impl BatchingTask {
                         self.config.flow_id
                     );
                     // clean dirty time window too, this could be from create flow's check_execute
-                    let is_dirty = {
+                    let (is_dirty, dirty_windows_to_restore) = {
                         let mut state = self.state.write().unwrap();
-                        let is_dirty = !state.dirty_time_windows.is_empty();
+                        let dirty_windows_to_restore = state.dirty_time_windows.clone();
+                        let is_dirty = !dirty_windows_to_restore.is_empty();
                         state.dirty_time_windows.clean();
-                        is_dirty
+                        (is_dirty, dirty_windows_to_restore)
                     };
 
                     if !is_dirty {
@@ -903,20 +926,28 @@ impl BatchingTask {
                     {
                         Ok(plan) => plan,
                         Err(err) => {
-                            self.state.write().unwrap().dirty_time_windows.set_dirty();
+                            self.state
+                                .write()
+                                .unwrap()
+                                .dirty_time_windows
+                                .add_dirty_windows(&dirty_windows_to_restore);
                             return Err(err);
                         }
                     };
 
-                    return Ok(Some(PlanInfo { plan, filter: None }));
+                    return Ok(Some(PlanInfo {
+                        plan,
+                        filter: None,
+                        filterless_dirty_windows_to_restore: Some(dirty_windows_to_restore),
+                    }));
                 }
                 _ => {
                     // clean for tql have no use for time window
-                    let had_dirty_windows = {
+                    let dirty_windows_to_restore = {
                         let mut state = self.state.write().unwrap();
-                        let had_dirty_windows = !state.dirty_time_windows.is_empty();
+                        let dirty_windows_to_restore = state.dirty_time_windows.clone();
                         state.dirty_time_windows.clean();
-                        had_dirty_windows
+                        dirty_windows_to_restore
                     };
 
                     let plan = match gen_plan_with_matching_schema(
@@ -931,14 +962,20 @@ impl BatchingTask {
                     {
                         Ok(plan) => plan,
                         Err(err) => {
-                            if had_dirty_windows {
-                                self.state.write().unwrap().dirty_time_windows.set_dirty();
-                            }
+                            self.state
+                                .write()
+                                .unwrap()
+                                .dirty_time_windows
+                                .add_dirty_windows(&dirty_windows_to_restore);
                             return Err(err);
                         }
                     };
 
-                    return Ok(Some(PlanInfo { plan, filter: None }));
+                    return Ok(Some(PlanInfo {
+                        plan,
+                        filter: None,
+                        filterless_dirty_windows_to_restore: Some(dirty_windows_to_restore),
+                    }));
                 }
             };
 
@@ -1025,6 +1062,7 @@ impl BatchingTask {
         let info = PlanInfo {
             plan: new_plan.clone(),
             filter: Some(expr),
+            filterless_dirty_windows_to_restore: None,
         };
 
         Ok(Some(info))

--- a/src/flow/src/batching_mode/task.rs
+++ b/src/flow/src/batching_mode/task.rs
@@ -44,9 +44,7 @@ use tokio::sync::oneshot::error::TryRecvError;
 use tokio::time::Instant;
 
 use crate::batching_mode::BatchingModeOptions;
-use crate::batching_mode::checkpoint::{
-    FlowCheckpointDecision, FlowQueryFallbackReason, checkpoint_mode_label,
-};
+use crate::batching_mode::checkpoint::{FlowCheckpointDecision, FlowQueryFallbackReason};
 use crate::batching_mode::frontend_client::FrontendClient;
 use crate::batching_mode::state::{CheckpointMode, DirtyTimeWindows, FilterExprInfo, TaskState};
 use crate::batching_mode::table_creator::{QueryType, create_table_with_expr};
@@ -61,6 +59,11 @@ use crate::error::{
     UnexpectedSnafu,
 };
 use crate::metrics::{
+    FLOW_CHECKPOINT_DECISION_ADVANCE_LABEL, FLOW_CHECKPOINT_DECISION_FALLBACK_LABEL,
+    FLOW_CHECKPOINT_MODE_FULL_SNAPSHOT_LABEL, FLOW_CHECKPOINT_MODE_INCREMENTAL_LABEL,
+    FLOW_CHECKPOINT_REASON_INCOMPLETE_WATERMARK_LABEL,
+    FLOW_CHECKPOINT_REASON_MISSING_WATERMARK_LABEL, FLOW_CHECKPOINT_REASON_NONE_LABEL,
+    FLOW_CHECKPOINT_REASON_QUERY_FAILURE_LABEL,
     METRIC_FLOW_BATCHING_ENGINE_CHECKPOINT_DECISION_CNT, METRIC_FLOW_BATCHING_ENGINE_ERROR_CNT,
     METRIC_FLOW_BATCHING_ENGINE_QUERY_MODE_CNT, METRIC_FLOW_BATCHING_ENGINE_QUERY_TIME,
     METRIC_FLOW_BATCHING_ENGINE_SLOW_QUERY, METRIC_FLOW_BATCHING_ENGINE_START_QUERY_CNT,
@@ -523,8 +526,8 @@ impl BatchingTask {
                     CheckpointMode::FullSnapshot => {
                         state.advance_checkpoints(watermark_map);
                         FlowCheckpointDecision::AdvancedFromFullSnapshot {
-                            participating_regions: participating_region_count,
-                            watermarks: watermark_count,
+                            participating_region_count,
+                            watermark_count,
                         }
                     }
                     CheckpointMode::Incremental => {
@@ -533,8 +536,8 @@ impl BatchingTask {
                             watermark_map,
                         );
                         FlowCheckpointDecision::AdvancedIncremental {
-                            participating_regions: participating_region_count,
-                            watermarks: watermark_count,
+                            participating_region_count,
+                            watermark_count,
                         }
                     }
                 }
@@ -556,30 +559,31 @@ impl BatchingTask {
 
     fn record_checkpoint_decision(flow_id: FlowId, decision: FlowCheckpointDecision) {
         let flow_id = flow_id.to_string();
+        let labels = checkpoint_decision_metric_labels(decision);
         METRIC_FLOW_BATCHING_ENGINE_CHECKPOINT_DECISION_CNT
             .with_label_values(&[
                 flow_id.as_str(),
-                decision.mode_label(),
-                decision.decision_label(),
-                decision.reason_label(),
+                labels.mode,
+                labels.decision,
+                labels.reason,
             ])
             .inc();
 
         match decision {
             FlowCheckpointDecision::AdvancedFromFullSnapshot {
-                participating_regions,
-                watermarks,
+                participating_region_count,
+                watermark_count,
             } => {
                 info!(
-                    "Flow {flow_id} is now checkpoint-ready after full snapshot, participating_regions={participating_regions}, watermarks={watermarks}"
+                    "Flow {flow_id} is now checkpoint-ready after full snapshot, participating_region_count={participating_region_count}, watermark_count={watermark_count}"
                 );
             }
             FlowCheckpointDecision::AdvancedIncremental {
-                participating_regions,
-                watermarks,
+                participating_region_count,
+                watermark_count,
             } => {
                 debug!(
-                    "Flow {flow_id} advanced checkpoint-readiness, participating_regions={participating_regions}, watermarks={watermarks}"
+                    "Flow {flow_id} advanced checkpoint-readiness, participating_region_count={participating_region_count}, watermark_count={watermark_count}"
                 );
             }
             FlowCheckpointDecision::FallbackToFullSnapshot {
@@ -589,7 +593,7 @@ impl BatchingTask {
                 warn!(
                     "Flow {flow_id} switched to full snapshot mode, previous_mode={}, reason={}",
                     checkpoint_mode_label(previous_mode),
-                    reason.as_label()
+                    checkpoint_fallback_reason_metric_label(reason)
                 );
             }
         }
@@ -1066,6 +1070,58 @@ impl BatchingTask {
         };
 
         Ok(Some(info))
+    }
+}
+
+struct CheckpointDecisionMetricLabels {
+    mode: &'static str,
+    decision: &'static str,
+    reason: &'static str,
+}
+
+fn checkpoint_decision_metric_labels(
+    decision: FlowCheckpointDecision,
+) -> CheckpointDecisionMetricLabels {
+    match decision {
+        FlowCheckpointDecision::AdvancedFromFullSnapshot { .. } => CheckpointDecisionMetricLabels {
+            mode: checkpoint_mode_label(CheckpointMode::FullSnapshot),
+            decision: FLOW_CHECKPOINT_DECISION_ADVANCE_LABEL,
+            reason: FLOW_CHECKPOINT_REASON_NONE_LABEL,
+        },
+        FlowCheckpointDecision::AdvancedIncremental { .. } => CheckpointDecisionMetricLabels {
+            mode: checkpoint_mode_label(CheckpointMode::Incremental),
+            decision: FLOW_CHECKPOINT_DECISION_ADVANCE_LABEL,
+            reason: FLOW_CHECKPOINT_REASON_NONE_LABEL,
+        },
+        FlowCheckpointDecision::FallbackToFullSnapshot {
+            previous_mode,
+            reason,
+        } => CheckpointDecisionMetricLabels {
+            mode: checkpoint_mode_label(previous_mode),
+            decision: FLOW_CHECKPOINT_DECISION_FALLBACK_LABEL,
+            reason: checkpoint_fallback_reason_metric_label(reason),
+        },
+    }
+}
+
+fn checkpoint_fallback_reason_metric_label(reason: FlowQueryFallbackReason) -> &'static str {
+    match reason {
+        FlowQueryFallbackReason::MissingRegionWatermark => {
+            FLOW_CHECKPOINT_REASON_MISSING_WATERMARK_LABEL
+        }
+        FlowQueryFallbackReason::IncompleteRegionWatermark => {
+            FLOW_CHECKPOINT_REASON_INCOMPLETE_WATERMARK_LABEL
+        }
+        FlowQueryFallbackReason::CheckpointReadyQueryFailure => {
+            FLOW_CHECKPOINT_REASON_QUERY_FAILURE_LABEL
+        }
+    }
+}
+
+fn checkpoint_mode_label(mode: CheckpointMode) -> &'static str {
+    match mode {
+        CheckpointMode::FullSnapshot => FLOW_CHECKPOINT_MODE_FULL_SNAPSHOT_LABEL,
+        CheckpointMode::Incremental => FLOW_CHECKPOINT_MODE_INCREMENTAL_LABEL,
     }
 }
 

--- a/src/flow/src/batching_mode/task.rs
+++ b/src/flow/src/batching_mode/task.rs
@@ -251,7 +251,7 @@ impl BatchingTask {
         if let Some(new_query) = self.gen_insert_plan(engine, max_window_cnt).await? {
             debug!("Generate new query: {}", new_query.plan);
             match self
-                .execute_logical_plan(frontend_client, &new_query.plan, new_query.filter.as_ref())
+                .execute_logical_plan(frontend_client, &new_query.plan)
                 .await
             {
                 Ok(result) => Ok(result),
@@ -375,7 +375,6 @@ impl BatchingTask {
         &self,
         frontend_client: &Arc<FrontendClient>,
         plan: &LogicalPlan,
-        _dirty_filter: Option<&FilterExprInfo>,
     ) -> Result<Option<(usize, Duration)>, Error> {
         let instant = Instant::now();
         let flow_id = self.config.flow_id;
@@ -682,6 +681,17 @@ impl BatchingTask {
             .add_windows(filter.time_ranges.clone());
     }
 
+    fn restore_scoped_dirty_windows_on_err<T>(
+        &self,
+        filter: &FilterExprInfo,
+        result: Result<T, Error>,
+    ) -> Result<T, Error> {
+        result.map_err(|err| {
+            self.restore_scoped_dirty_windows(filter);
+            err
+        })
+    }
+
     fn handle_executed_query_failure(&self, err: &Error, query: Option<&PlanInfo>) -> bool {
         let checkpoint_was_ready = self.handle_flow_query_failure(err, query);
         if let Some(query) = query {
@@ -766,12 +776,8 @@ impl BatchingTask {
             };
 
             let res = if let Some(new_query) = &new_query {
-                self.execute_logical_plan(
-                    &frontend_client,
-                    &new_query.plan,
-                    new_query.filter.as_ref(),
-                )
-                .await
+                self.execute_logical_plan(&frontend_client, &new_query.plan)
+                    .await
             } else {
                 Ok(None)
             };
@@ -1044,41 +1050,25 @@ impl BatchingTask {
             allow_partial,
         );
 
-        let plan = match sql_to_df_plan(
-            query_ctx.clone(),
-            engine.clone(),
-            &self.config.query,
-            false,
-        )
-        .await
-        {
-            Ok(plan) => plan,
-            Err(err) => {
-                self.restore_scoped_dirty_windows(&expr);
-                return Err(err);
-            }
-        };
-        let rewrite = match plan
-            .clone()
-            .rewrite(&mut add_filter)
-            .and_then(|p| p.data.rewrite(&mut add_auto_column))
-            .with_context(|_| DatafusionSnafu {
-                context: format!("Failed to rewrite plan:\n {}\n", plan),
-            }) {
-            Ok(rewrite) => rewrite.data,
-            Err(err) => {
-                self.restore_scoped_dirty_windows(&expr);
-                return Err(err);
-            }
-        };
+        let plan = self.restore_scoped_dirty_windows_on_err(
+            &expr,
+            sql_to_df_plan(query_ctx.clone(), engine.clone(), &self.config.query, false).await,
+        )?;
+        let rewrite = self.restore_scoped_dirty_windows_on_err(
+            &expr,
+            plan.clone()
+                .rewrite(&mut add_filter)
+                .and_then(|p| p.data.rewrite(&mut add_auto_column))
+                .with_context(|_| DatafusionSnafu {
+                    context: format!("Failed to rewrite plan:\n {}\n", plan),
+                })
+                .map(|rewrite| rewrite.data),
+        )?;
         // only apply optimize after complex rewrite is done
-        let new_plan = match apply_df_optimizer(rewrite, &query_ctx).await {
-            Ok(new_plan) => new_plan,
-            Err(err) => {
-                self.restore_scoped_dirty_windows(&expr);
-                return Err(err);
-            }
-        };
+        let new_plan = self.restore_scoped_dirty_windows_on_err(
+            &expr,
+            apply_df_optimizer(rewrite, &query_ctx).await,
+        )?;
 
         let info = PlanInfo {
             plan: new_plan.clone(),

--- a/src/flow/src/batching_mode/task.rs
+++ b/src/flow/src/batching_mode/task.rs
@@ -216,7 +216,7 @@ impl BatchingTask {
         &self,
         engine: &QueryEngineRef,
         frontend_client: &Arc<FrontendClient>,
-    ) -> Result<Option<(u32, Duration)>, Error> {
+    ) -> Result<Option<(usize, Duration)>, Error> {
         if !self.is_table_exist(&self.config.sink_table_name).await? {
             let create_table = self.gen_create_table_expr(engine.clone()).await?;
             info!(
@@ -247,7 +247,7 @@ impl BatchingTask {
         engine: &QueryEngineRef,
         frontend_client: &Arc<FrontendClient>,
         max_window_cnt: Option<usize>,
-    ) -> Result<Option<(u32, Duration)>, Error> {
+    ) -> Result<Option<(usize, Duration)>, Error> {
         if let Some(new_query) = self.gen_insert_plan(engine, max_window_cnt).await? {
             debug!("Generate new query: {}", new_query.plan);
             match self
@@ -376,7 +376,7 @@ impl BatchingTask {
         frontend_client: &Arc<FrontendClient>,
         plan: &LogicalPlan,
         _dirty_filter: Option<&FilterExprInfo>,
-    ) -> Result<Option<(u32, Duration)>, Error> {
+    ) -> Result<Option<(usize, Duration)>, Error> {
         let instant = Instant::now();
         let flow_id = self.config.flow_id;
 
@@ -482,12 +482,6 @@ impl BatchingTask {
         METRIC_FLOW_ROWS
             .with_label_values(&[format!("{}-out-batching", flow_id).as_str()])
             .inc_by(affected_rows as _);
-        let affected_rows: u32 = affected_rows.try_into().map_err(|_| {
-            UnexpectedSnafu {
-                reason: format!("Failed to convert rows to u32: {}", affected_rows),
-            }
-            .build()
-        })?;
 
         {
             let mut state = self.state.write().unwrap();
@@ -675,13 +669,17 @@ impl BatchingTask {
             return;
         }
 
-        self.state.write().unwrap().dirty_time_windows.add_windows(
-            query
-                .filter
-                .as_ref()
-                .map(|f| f.time_ranges.clone())
-                .unwrap_or_default(),
-        );
+        if let Some(filter) = query.filter.as_ref() {
+            self.restore_scoped_dirty_windows(filter);
+        }
+    }
+
+    fn restore_scoped_dirty_windows(&self, filter: &FilterExprInfo) {
+        self.state
+            .write()
+            .unwrap()
+            .dirty_time_windows
+            .add_windows(filter.time_ranges.clone());
     }
 
     fn handle_executed_query_failure(&self, err: &Error, query: Option<&PlanInfo>) -> bool {
@@ -1024,24 +1022,20 @@ impl BatchingTask {
                 Some(self),
             )?;
 
-        debug!(
-            "Flow id={:?}, Generated filter expr: {:?}",
-            self.config.flow_id,
-            expr.as_ref()
-                .map(
-                    |expr| expr_to_sql(&expr.expr).with_context(|_| DatafusionSnafu {
-                        context: format!("Failed to generate filter expr from {expr:?}"),
-                    })
-                )
-                .transpose()?
-                .map(|s| s.to_string())
-        );
-
         let Some(expr) = expr else {
             // no new data, hence no need to update
             debug!("Flow id={:?}, no new data, not update", self.config.flow_id);
             return Ok(None);
         };
+
+        let filter_sql = expr_to_sql(&expr.expr)
+            .map(|sql| sql.to_string())
+            .unwrap_or_else(|err| format!("<failed to format filter expr: {err}>"));
+
+        debug!(
+            "Flow id={:?}, Generated filter expr: {:?}",
+            self.config.flow_id, filter_sql
+        );
 
         let mut add_filter = AddFilterRewriter::new(expr.expr.clone());
         let mut add_auto_column = ColumnMatcherRewriter::new(
@@ -1050,18 +1044,41 @@ impl BatchingTask {
             allow_partial,
         );
 
-        let plan =
-            sql_to_df_plan(query_ctx.clone(), engine.clone(), &self.config.query, false).await?;
-        let rewrite = plan
+        let plan = match sql_to_df_plan(
+            query_ctx.clone(),
+            engine.clone(),
+            &self.config.query,
+            false,
+        )
+        .await
+        {
+            Ok(plan) => plan,
+            Err(err) => {
+                self.restore_scoped_dirty_windows(&expr);
+                return Err(err);
+            }
+        };
+        let rewrite = match plan
             .clone()
             .rewrite(&mut add_filter)
             .and_then(|p| p.data.rewrite(&mut add_auto_column))
             .with_context(|_| DatafusionSnafu {
                 context: format!("Failed to rewrite plan:\n {}\n", plan),
-            })?
-            .data;
+            }) {
+            Ok(rewrite) => rewrite.data,
+            Err(err) => {
+                self.restore_scoped_dirty_windows(&expr);
+                return Err(err);
+            }
+        };
         // only apply optimize after complex rewrite is done
-        let new_plan = apply_df_optimizer(rewrite, &query_ctx).await?;
+        let new_plan = match apply_df_optimizer(rewrite, &query_ctx).await {
+            Ok(new_plan) => new_plan,
+            Err(err) => {
+                self.restore_scoped_dirty_windows(&expr);
+                return Err(err);
+            }
+        };
 
         let info = PlanInfo {
             plan: new_plan.clone(),

--- a/src/flow/src/batching_mode/task.rs
+++ b/src/flow/src/batching_mode/task.rs
@@ -122,14 +122,20 @@ pub struct TaskArgs<'a> {
 
 pub struct PlanInfo {
     pub plan: LogicalPlan,
-    pub filter: Option<FilterExprInfo>,
-    /// Dirty windows consumed while building a filterless query.
+    pub dirty_restore: DirtyRestore,
+}
+
+pub enum DirtyRestore {
+    /// The query was scoped to dirty time ranges; restore those ranges if the
+    /// run fails.
+    Scoped(FilterExprInfo),
+    /// The query could not be scoped to dirty time ranges, so the dirty-window
+    /// state is only a dirty signal. Restore the consumed signal if the full
+    /// run fails.
     ///
-    /// Scoped queries restore failed work from `filter.time_ranges`.  A
-    /// filterless query has no such scope, so keep the exact dirty markers
-    /// that were cleaned before planning and merge them back if execution
-    /// fails.
-    pub filterless_dirty_windows_to_restore: Option<DirtyTimeWindows>,
+    /// TODO(discord9): Full-query runs only need a dirty bool flag. Refactor
+    /// the unscoped path to stop reusing `DirtyTimeWindows` for this signal.
+    Unscoped(DirtyTimeWindows),
 }
 
 impl BatchingTask {
@@ -323,8 +329,7 @@ impl BatchingTask {
         ));
         let insert_into_info = PlanInfo {
             plan,
-            filter: new_query.filter,
-            filterless_dirty_windows_to_restore: new_query.filterless_dirty_windows_to_restore,
+            dirty_restore: new_query.dirty_restore,
         };
         let insert_into =
             match insert_into_info
@@ -343,9 +348,7 @@ impl BatchingTask {
 
         Ok(Some(PlanInfo {
             plan: insert_into,
-            filter: insert_into_info.filter,
-            filterless_dirty_windows_to_restore: insert_into_info
-                .filterless_dirty_windows_to_restore,
+            dirty_restore: insert_into_info.dirty_restore,
         }))
     }
 
@@ -474,19 +477,14 @@ impl BatchingTask {
     /// the next execution.
     ///
     fn restore_dirty_windows_after_failure(&self, query: &PlanInfo) {
-        if query.filter.is_none() {
-            if let Some(dirty_windows) = &query.filterless_dirty_windows_to_restore {
-                self.state
-                    .write()
-                    .unwrap()
-                    .dirty_time_windows
-                    .add_dirty_windows(dirty_windows);
-            }
-            return;
-        }
-
-        if let Some(filter) = query.filter.as_ref() {
-            self.restore_scoped_dirty_windows(filter);
+        match &query.dirty_restore {
+            DirtyRestore::Scoped(filter) => self.restore_scoped_dirty_windows(filter),
+            DirtyRestore::Unscoped(dirty_windows) => self
+                .state
+                .write()
+                .unwrap()
+                .dirty_time_windows
+                .add_dirty_windows(dirty_windows),
         }
     }
 
@@ -734,12 +732,12 @@ impl BatchingTask {
 
                     return Ok(Some(PlanInfo {
                         plan,
-                        filter: None,
-                        filterless_dirty_windows_to_restore: Some(dirty_windows_to_restore),
+                        dirty_restore: DirtyRestore::Unscoped(dirty_windows_to_restore),
                     }));
                 }
                 _ => {
-                    // clean for tql have no use for time window
+                    // Clean dirty windows for full-query/non-scoped paths,
+                    // such as TQL, that cannot use a time-window filter.
                     let dirty_windows_to_restore = {
                         let mut state = self.state.write().unwrap();
                         let dirty_windows_to_restore = state.dirty_time_windows.clone();
@@ -770,8 +768,7 @@ impl BatchingTask {
 
                     return Ok(Some(PlanInfo {
                         plan,
-                        filter: None,
-                        filterless_dirty_windows_to_restore: Some(dirty_windows_to_restore),
+                        dirty_restore: DirtyRestore::Unscoped(dirty_windows_to_restore),
                     }));
                 }
             };
@@ -861,8 +858,7 @@ impl BatchingTask {
 
         let info = PlanInfo {
             plan: new_plan.clone(),
-            filter: Some(expr),
-            filterless_dirty_windows_to_restore: None,
+            dirty_restore: DirtyRestore::Scoped(expr),
         };
 
         Ok(Some(info))

--- a/src/flow/src/batching_mode/task/test.rs
+++ b/src/flow/src/batching_mode/task/test.rs
@@ -12,52 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeMap;
-
 use catalog::RegisterTableRequest;
 use catalog::memory::MemoryCatalogManager;
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
-use common_error::ext::PlainError;
-use common_error::status_code::StatusCode;
-use common_query::Output;
 use common_recordbatch::RecordBatch;
-use common_recordbatch::adapter::{RecordBatchMetrics, RegionWatermarkEntry};
 use datatypes::data_type::ConcreteDataType as CDT;
 use datatypes::schema::ColumnSchema;
 use datatypes::vectors::{UInt32Vector, VectorRef};
 use pretty_assertions::assert_eq;
-use query::options::{
-    FLOW_INCREMENTAL_AFTER_SEQS, FLOW_INCREMENTAL_MODE, FLOW_RETURN_REGION_SEQ, FLOW_SINK_TABLE_ID,
-};
 use session::context::QueryContext;
-use snafu::GenerateImplicitData;
 use table::test_util::MemTable;
 
 use super::*;
 use crate::batching_mode::time_window::find_time_window_expr;
 use crate::test_utils::create_test_query_engine;
-
-fn output_with_region_watermarks(
-    watermarks: impl IntoIterator<Item = (u64, Option<u64>)>,
-) -> OutputWithMetrics {
-    let result = OutputWithMetrics::from_output(Output::new_with_affected_rows(0));
-    result.metrics.update(Some(RecordBatchMetrics {
-        region_watermarks: watermarks
-            .into_iter()
-            .map(|(region_id, watermark)| RegionWatermarkEntry {
-                region_id,
-                watermark,
-            })
-            .collect(),
-        ..Default::default()
-    }));
-    result.metrics.mark_ready();
-    result
-}
-
-async fn new_test_task_with_missing_sink() -> BatchingTask {
-    new_test_task_and_plan_with_missing_sink().await.0
-}
 
 async fn new_test_task_and_plan_with_missing_sink() -> (BatchingTask, LogicalPlan) {
     new_test_task_engine_and_plan_with_query(
@@ -204,29 +172,6 @@ fn register_number_only_sink(query_engine: &QueryEngineRef, table_name: &str) {
     memory_catalog.register_table_sync(request).unwrap();
 }
 
-fn ordinary_query_error() -> Error {
-    Error::External {
-        source: BoxedError::new(PlainError::new(
-            "ordinary query failure".to_string(),
-            StatusCode::EngineExecuteQuery,
-        )),
-        location: snafu::Location::generate(),
-    }
-}
-
-fn assert_no_incremental_scan_extensions(extensions: &[(&'static str, String)]) {
-    assert!(
-        !extensions
-            .iter()
-            .any(|(key, _)| *key == FLOW_INCREMENTAL_MODE)
-    );
-    assert!(
-        !extensions
-            .iter()
-            .any(|(key, _)| *key == FLOW_INCREMENTAL_AFTER_SEQS)
-    );
-}
-
 fn dirty_marker() -> DirtyTimeWindows {
     let mut dirty = DirtyTimeWindows::default();
     dirty.set_dirty();
@@ -245,16 +190,12 @@ fn dirty_range(start: i64, end: i64) -> DirtyTimeWindows {
 async fn assert_filterless_failure_restore(
     consumed_dirty_windows: DirtyTimeWindows,
     current_dirty_windows: DirtyTimeWindows,
-    checkpoint_ready: bool,
     expected_len: usize,
     expected_window_size_secs: u64,
 ) {
     let (task, plan) = new_test_task_and_plan_with_missing_sink().await;
     {
         let mut state = task.state.write().unwrap();
-        if checkpoint_ready {
-            state.advance_checkpoints(HashMap::from([(1_u64, 10_u64)]));
-        }
         state.dirty_time_windows.clean();
         state
             .dirty_time_windows
@@ -266,15 +207,9 @@ async fn assert_filterless_failure_restore(
         filterless_dirty_windows_to_restore: Some(consumed_dirty_windows),
     };
 
-    let checkpoint_was_ready =
-        task.handle_executed_query_failure(&ordinary_query_error(), Some(&filterless_query));
+    task.handle_executed_query_failure(Some(&filterless_query));
 
-    assert_eq!(checkpoint_was_ready, checkpoint_ready);
     let state = task.state.read().unwrap();
-    assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
-    if checkpoint_ready {
-        assert_eq!(state.checkpoints(), &BTreeMap::from([(1_u64, 10_u64)]));
-    }
     assert_eq!(state.dirty_time_windows.len(), expected_len);
     assert_eq!(
         state.dirty_time_windows.window_size(),
@@ -282,143 +217,11 @@ async fn assert_filterless_failure_restore(
     );
 }
 
-#[test]
-fn test_apply_query_result_to_state_checkpoint_decisions() {
-    let elapsed = std::time::Duration::from_millis(1);
-
-    {
-        let query_ctx = QueryContext::arc();
-        let (_tx, rx) = tokio::sync::oneshot::channel();
-        let mut state = TaskState::new(query_ctx, rx);
-        let result = output_with_region_watermarks([(1_u64, Some(10_u64)), (2_u64, Some(20_u64))]);
-
-        let decision = BatchingTask::apply_query_result_to_state(&mut state, &result, elapsed);
-
-        assert_eq!(
-            decision,
-            FlowCheckpointDecision::AdvancedFromFullSnapshot {
-                participating_region_count: 2,
-                watermark_count: 2,
-            }
-        );
-        assert_eq!(state.checkpoint_mode(), CheckpointMode::Incremental);
-        assert_eq!(
-            state.checkpoints(),
-            &BTreeMap::from([(1_u64, 10_u64), (2_u64, 20_u64)])
-        );
-    }
-
-    {
-        let query_ctx = QueryContext::arc();
-        let (_tx, rx) = tokio::sync::oneshot::channel();
-        let mut state = TaskState::new(query_ctx, rx);
-        let result = output_with_region_watermarks([(1_u64, Some(10_u64)), (2_u64, None)]);
-
-        let decision = BatchingTask::apply_query_result_to_state(&mut state, &result, elapsed);
-
-        assert_eq!(
-            decision,
-            FlowCheckpointDecision::FallbackToFullSnapshot {
-                previous_mode: CheckpointMode::FullSnapshot,
-                reason: FlowQueryFallbackReason::IncompleteRegionWatermark,
-            }
-        );
-        assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
-        assert!(state.checkpoints().is_empty());
-    }
-
-    {
-        let query_ctx = QueryContext::arc();
-        let (_tx, rx) = tokio::sync::oneshot::channel();
-        let mut state = TaskState::new(query_ctx, rx);
-        let result = OutputWithMetrics::from_output(Output::new_with_affected_rows(0));
-
-        let decision = BatchingTask::apply_query_result_to_state(&mut state, &result, elapsed);
-
-        assert_eq!(
-            decision,
-            FlowCheckpointDecision::FallbackToFullSnapshot {
-                previous_mode: CheckpointMode::FullSnapshot,
-                reason: FlowQueryFallbackReason::MissingRegionWatermark,
-            }
-        );
-        assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
-        assert!(state.checkpoints().is_empty());
-    }
-
-    {
-        let query_ctx = QueryContext::arc();
-        let (_tx, rx) = tokio::sync::oneshot::channel();
-        let mut state = TaskState::new(query_ctx, rx);
-        state.advance_checkpoints(HashMap::from([
-            (1_u64, 10_u64),
-            (2_u64, 20_u64),
-            (3_u64, 30_u64),
-        ]));
-        let result = output_with_region_watermarks([(1_u64, Some(12_u64)), (3_u64, Some(35_u64))]);
-
-        let decision = BatchingTask::apply_query_result_to_state(&mut state, &result, elapsed);
-
-        assert_eq!(
-            decision,
-            FlowCheckpointDecision::AdvancedIncremental {
-                participating_region_count: 2,
-                watermark_count: 2,
-            }
-        );
-        assert_eq!(state.checkpoint_mode(), CheckpointMode::Incremental);
-        assert_eq!(
-            state.checkpoints(),
-            &BTreeMap::from([(1_u64, 12_u64), (2_u64, 20_u64), (3_u64, 35_u64)])
-        );
-    }
-}
-
-#[test]
-fn test_checkpoint_decision_metric_labels_are_stable() {
-    let advance = FlowCheckpointDecision::AdvancedIncremental {
-        participating_region_count: 1,
-        watermark_count: 1,
-    };
-    let fallback = FlowCheckpointDecision::FallbackToFullSnapshot {
-        previous_mode: CheckpointMode::Incremental,
-        reason: FlowQueryFallbackReason::CheckpointReadyQueryFailure,
-    };
-    let advance_labels = checkpoint_decision_metric_labels(advance);
-    let fallback_labels = checkpoint_decision_metric_labels(fallback);
-
-    assert_eq!(advance_labels.mode, "incremental");
-    assert_eq!(advance_labels.decision, "advance");
-    assert_eq!(advance_labels.reason, "none");
-    assert_eq!(fallback_labels.mode, "incremental");
-    assert_eq!(fallback_labels.decision, "fallback");
-    assert_eq!(fallback_labels.reason, "checkpoint_ready_query_failure");
-}
-
-#[tokio::test]
-async fn test_incremental_failure_without_query_scope_falls_back_and_marks_dirty() {
-    let task = new_test_task_with_missing_sink().await;
-    {
-        let mut state = task.state.write().unwrap();
-        state.advance_checkpoints(HashMap::from([(1_u64, 10_u64)]));
-        state.dirty_time_windows.clean();
-    }
-
-    let checkpoint_was_ready = task.handle_flow_query_failure(&ordinary_query_error(), None);
-
-    assert!(checkpoint_was_ready);
-    let state = task.state.read().unwrap();
-    assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
-    assert_eq!(state.checkpoints(), &BTreeMap::from([(1_u64, 10_u64)]));
-    assert_eq!(state.dirty_time_windows.len(), 1);
-}
-
 #[tokio::test]
 async fn test_executed_query_failure_restores_scoped_dirty_windows_for_flush_path() {
     let (task, plan) = new_test_task_and_plan_with_missing_sink().await;
     {
         let mut state = task.state.write().unwrap();
-        state.advance_checkpoints(HashMap::from([(1_u64, 10_u64)]));
         state.dirty_time_windows.clean();
     }
     let scoped_query = PlanInfo {
@@ -432,29 +235,17 @@ async fn test_executed_query_failure_restores_scoped_dirty_windows_for_flush_pat
         filterless_dirty_windows_to_restore: None,
     };
 
-    let checkpoint_was_ready =
-        task.handle_executed_query_failure(&ordinary_query_error(), Some(&scoped_query));
+    task.handle_executed_query_failure(Some(&scoped_query));
 
-    assert!(checkpoint_was_ready);
     let state = task.state.read().unwrap();
-    assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
     assert_eq!(state.dirty_time_windows.len(), 1);
 }
 
 #[tokio::test]
 async fn test_filterless_failure_restores_consumed_dirty_windows() {
-    assert_filterless_failure_restore(dirty_marker(), DirtyTimeWindows::default(), false, 1, 0)
-        .await;
-    assert_filterless_failure_restore(dirty_range(30, 40), dirty_range(10, 20), false, 2, 20).await;
-    assert_filterless_failure_restore(dirty_range(30, 40), dirty_range(30, 50), false, 1, 20).await;
-    assert_filterless_failure_restore(
-        dirty_range(30, 40),
-        DirtyTimeWindows::default(),
-        true,
-        1,
-        10,
-    )
-    .await;
+    assert_filterless_failure_restore(dirty_marker(), DirtyTimeWindows::default(), 1, 0).await;
+    assert_filterless_failure_restore(dirty_range(30, 40), dirty_range(10, 20), 2, 20).await;
+    assert_filterless_failure_restore(dirty_range(30, 40), dirty_range(30, 50), 1, 20).await;
 }
 
 #[tokio::test]
@@ -478,7 +269,6 @@ async fn test_filterless_plan_generation_failure_restores_consumed_dirty_marker(
 
     assert!(result.is_err());
     let state = task.state.read().unwrap();
-    assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
     assert_eq!(state.dirty_time_windows.len(), 1);
     assert_eq!(
         state.dirty_time_windows.window_size(),
@@ -513,7 +303,6 @@ async fn test_scoped_plan_generation_failure_restores_consumed_dirty_windows() {
 
     assert!(result.is_err());
     let state = task.state.read().unwrap();
-    assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
     assert_eq!(state.dirty_time_windows.len(), 1);
     assert_eq!(
         state.dirty_time_windows.window_size(),
@@ -542,54 +331,9 @@ async fn test_insert_plan_matching_failure_restores_consumed_dirty_marker() {
         Err(err) => err,
     };
     let state = task.state.read().unwrap();
-    assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
     assert_eq!(state.dirty_time_windows.len(), 1);
     assert_eq!(
         state.dirty_time_windows.window_size(),
         std::time::Duration::from_secs(0)
     );
-}
-
-#[tokio::test]
-async fn test_build_flow_query_extensions_do_not_emit_incremental_scan_keys() {
-    let task = new_test_task_with_missing_sink().await;
-
-    let extensions = task.build_flow_query_extensions().await.unwrap();
-    assert_eq!(
-        extensions,
-        vec![(FLOW_RETURN_REGION_SEQ, "true".to_string())]
-    );
-    assert_no_incremental_scan_extensions(&extensions);
-
-    task.state
-        .write()
-        .unwrap()
-        .advance_checkpoints(HashMap::from([(1_u64, 10_u64), (2_u64, 20_u64)]));
-
-    let extensions = task.build_flow_query_extensions().await.unwrap();
-    assert_eq!(
-        extensions,
-        vec![(FLOW_RETURN_REGION_SEQ, "true".to_string())]
-    );
-    assert_no_incremental_scan_extensions(&extensions);
-
-    let sink_table = "extension_sink";
-    let TestTaskParts {
-        task: task_with_sink,
-        query_engine,
-        ..
-    } = new_test_task_engine_and_plan_with_query(
-        "SELECT number, ts FROM numbers_with_ts",
-        sink_table,
-    )
-    .await;
-    register_number_only_sink(&query_engine, sink_table);
-
-    let extensions = task_with_sink.build_flow_query_extensions().await.unwrap();
-
-    assert!(extensions.contains(&(FLOW_RETURN_REGION_SEQ, "true".to_string())));
-    assert!(extensions.iter().any(|(key, value)| {
-        *key == FLOW_SINK_TABLE_ID && value.parse::<table::metadata::TableId>().is_ok()
-    }));
-    assert_no_incremental_scan_extensions(&extensions);
 }

--- a/src/flow/src/batching_mode/task/test.rs
+++ b/src/flow/src/batching_mode/task/test.rs
@@ -1,0 +1,311 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use common_error::ext::PlainError;
+use common_error::status_code::StatusCode;
+use common_query::Output;
+use common_recordbatch::adapter::{RecordBatchMetrics, RegionWatermarkEntry};
+use pretty_assertions::assert_eq;
+use session::context::QueryContext;
+use snafu::GenerateImplicitData;
+
+use super::*;
+use crate::batching_mode::checkpoint::{
+    CHECKPOINT_DECISION_ADVANCE, CHECKPOINT_DECISION_FALLBACK, CHECKPOINT_REASON_NONE,
+};
+use crate::test_utils::create_test_query_engine;
+
+fn output_with_region_watermarks(
+    watermarks: impl IntoIterator<Item = (u64, Option<u64>)>,
+) -> OutputWithMetrics {
+    let result = OutputWithMetrics::from_output(Output::new_with_affected_rows(0));
+    result.metrics.update(Some(RecordBatchMetrics {
+        region_watermarks: watermarks
+            .into_iter()
+            .map(|(region_id, watermark)| RegionWatermarkEntry {
+                region_id,
+                watermark,
+            })
+            .collect(),
+        ..Default::default()
+    }));
+    result.metrics.mark_ready();
+    result
+}
+
+async fn new_test_task_with_missing_sink() -> BatchingTask {
+    new_test_task_and_plan_with_missing_sink().await.0
+}
+
+async fn new_test_task_and_plan_with_missing_sink() -> (BatchingTask, LogicalPlan) {
+    let query_engine = create_test_query_engine();
+    let ctx = QueryContext::arc();
+    let plan = sql_to_df_plan(
+        ctx.clone(),
+        query_engine.clone(),
+        "SELECT number, ts FROM numbers_with_ts",
+        true,
+    )
+    .await
+    .unwrap();
+    let (_tx, rx) = tokio::sync::oneshot::channel();
+
+    let task = BatchingTask::try_new(TaskArgs {
+        flow_id: 1,
+        query: "SELECT number, ts FROM numbers_with_ts",
+        plan: plan.clone(),
+        time_window_expr: None,
+        expire_after: None,
+        sink_table_name: [
+            "greptime".to_string(),
+            "public".to_string(),
+            "missing_sink".to_string(),
+        ],
+        source_table_names: vec![[
+            "greptime".to_string(),
+            "public".to_string(),
+            "numbers_with_ts".to_string(),
+        ]],
+        query_ctx: ctx,
+        catalog_manager: query_engine.engine_state().catalog_manager().clone(),
+        shutdown_rx: rx,
+        batch_opts: Arc::new(BatchingModeOptions::default()),
+        flow_eval_interval: None,
+    })
+    .unwrap();
+
+    (task, plan)
+}
+
+fn ordinary_query_error() -> Error {
+    Error::External {
+        source: BoxedError::new(PlainError::new(
+            "ordinary query failure".to_string(),
+            StatusCode::EngineExecuteQuery,
+        )),
+        location: snafu::Location::generate(),
+    }
+}
+
+#[test]
+fn test_apply_query_result_to_state_advances_full_snapshot_to_incremental() {
+    let query_ctx = QueryContext::arc();
+    let (_tx, rx) = tokio::sync::oneshot::channel();
+    let mut state = TaskState::new(query_ctx, rx);
+    let result = output_with_region_watermarks([(1_u64, Some(10_u64)), (2_u64, Some(20_u64))]);
+
+    let decision = BatchingTask::apply_query_result_to_state(
+        &mut state,
+        &result,
+        std::time::Duration::from_millis(1),
+    );
+
+    assert_eq!(
+        decision,
+        FlowCheckpointDecision::AdvancedFromFullSnapshot {
+            participating_regions: 2,
+            watermarks: 2,
+        }
+    );
+    assert_eq!(state.checkpoint_mode(), CheckpointMode::Incremental);
+    assert_eq!(
+        state.checkpoints(),
+        &BTreeMap::from([(1_u64, 10_u64), (2_u64, 20_u64)])
+    );
+}
+
+#[test]
+fn test_apply_query_result_to_state_rejects_unproved_watermark() {
+    let query_ctx = QueryContext::arc();
+    let (_tx, rx) = tokio::sync::oneshot::channel();
+    let mut state = TaskState::new(query_ctx, rx);
+    let result = output_with_region_watermarks([(1_u64, Some(10_u64)), (2_u64, None)]);
+
+    let decision = BatchingTask::apply_query_result_to_state(
+        &mut state,
+        &result,
+        std::time::Duration::from_millis(1),
+    );
+
+    assert_eq!(
+        decision,
+        FlowCheckpointDecision::FallbackToFullSnapshot {
+            previous_mode: CheckpointMode::FullSnapshot,
+            reason: FlowQueryFallbackReason::IncompleteRegionWatermark,
+        }
+    );
+    assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
+    assert!(state.checkpoints().is_empty());
+}
+
+#[test]
+fn test_apply_query_result_to_state_reports_missing_watermark() {
+    let query_ctx = QueryContext::arc();
+    let (_tx, rx) = tokio::sync::oneshot::channel();
+    let mut state = TaskState::new(query_ctx, rx);
+    let result = OutputWithMetrics::from_output(Output::new_with_affected_rows(0));
+
+    let decision = BatchingTask::apply_query_result_to_state(
+        &mut state,
+        &result,
+        std::time::Duration::from_millis(1),
+    );
+
+    assert_eq!(
+        decision,
+        FlowCheckpointDecision::FallbackToFullSnapshot {
+            previous_mode: CheckpointMode::FullSnapshot,
+            reason: FlowQueryFallbackReason::MissingRegionWatermark,
+        }
+    );
+    assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
+    assert!(state.checkpoints().is_empty());
+}
+
+#[test]
+fn test_apply_query_result_to_state_advances_incremental_subset() {
+    let query_ctx = QueryContext::arc();
+    let (_tx, rx) = tokio::sync::oneshot::channel();
+    let mut state = TaskState::new(query_ctx, rx);
+    state.advance_checkpoints(HashMap::from([
+        (1_u64, 10_u64),
+        (2_u64, 20_u64),
+        (3_u64, 30_u64),
+    ]));
+    let result = output_with_region_watermarks([(1_u64, Some(12_u64)), (3_u64, Some(35_u64))]);
+
+    let decision = BatchingTask::apply_query_result_to_state(
+        &mut state,
+        &result,
+        std::time::Duration::from_millis(1),
+    );
+
+    assert_eq!(
+        decision,
+        FlowCheckpointDecision::AdvancedIncremental {
+            participating_regions: 2,
+            watermarks: 2,
+        }
+    );
+    assert_eq!(state.checkpoint_mode(), CheckpointMode::Incremental);
+    assert_eq!(
+        state.checkpoints(),
+        &BTreeMap::from([(1_u64, 12_u64), (2_u64, 20_u64), (3_u64, 35_u64)])
+    );
+}
+
+#[test]
+fn test_checkpoint_decision_labels_are_stable() {
+    let advance = FlowCheckpointDecision::AdvancedIncremental {
+        participating_regions: 1,
+        watermarks: 1,
+    };
+    let fallback = FlowCheckpointDecision::FallbackToFullSnapshot {
+        previous_mode: CheckpointMode::Incremental,
+        reason: FlowQueryFallbackReason::CheckpointReadyQueryFailure,
+    };
+
+    assert_eq!(advance.mode_label(), "incremental");
+    assert_eq!(advance.decision_label(), CHECKPOINT_DECISION_ADVANCE);
+    assert_eq!(advance.reason_label(), CHECKPOINT_REASON_NONE);
+    assert_eq!(fallback.mode_label(), "incremental");
+    assert_eq!(fallback.decision_label(), CHECKPOINT_DECISION_FALLBACK);
+    assert_eq!(fallback.reason_label(), "checkpoint_ready_query_failure");
+}
+
+#[tokio::test]
+async fn test_incremental_failure_falls_back_to_full_snapshot() {
+    let task = new_test_task_with_missing_sink().await;
+    task.state
+        .write()
+        .unwrap()
+        .advance_checkpoints(HashMap::from([(1_u64, 10_u64)]));
+
+    let checkpoint_was_ready = task.handle_flow_query_failure(&ordinary_query_error(), None);
+
+    assert!(checkpoint_was_ready);
+    let state = task.state.read().unwrap();
+    assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
+    assert_eq!(state.checkpoints(), &BTreeMap::from([(1_u64, 10_u64)]));
+}
+
+#[tokio::test]
+async fn test_incremental_failure_without_query_scope_marks_full_flow_dirty() {
+    let task = new_test_task_with_missing_sink().await;
+    {
+        let mut state = task.state.write().unwrap();
+        state.advance_checkpoints(HashMap::from([(1_u64, 10_u64)]));
+        state.dirty_time_windows.clean();
+    }
+
+    let checkpoint_was_ready = task.handle_flow_query_failure(&ordinary_query_error(), None);
+
+    assert!(checkpoint_was_ready);
+    let state = task.state.read().unwrap();
+    assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
+    assert_eq!(state.dirty_time_windows.len(), 1);
+}
+
+#[tokio::test]
+async fn test_executed_query_failure_restores_scoped_dirty_windows_for_flush_path() {
+    let (task, plan) = new_test_task_and_plan_with_missing_sink().await;
+    {
+        let mut state = task.state.write().unwrap();
+        state.advance_checkpoints(HashMap::from([(1_u64, 10_u64)]));
+        state.dirty_time_windows.clean();
+    }
+    let scoped_query = PlanInfo {
+        plan,
+        filter: Some(FilterExprInfo {
+            expr: datafusion_expr::lit(true),
+            col_name: "ts".to_string(),
+            time_ranges: vec![(Timestamp::new_second(10), Timestamp::new_second(20))],
+            window_size: chrono::Duration::seconds(10),
+        }),
+    };
+
+    let checkpoint_was_ready =
+        task.handle_executed_query_failure(&ordinary_query_error(), Some(&scoped_query));
+
+    assert!(checkpoint_was_ready);
+    let state = task.state.read().unwrap();
+    assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
+    assert_eq!(state.dirty_time_windows.len(), 1);
+}
+
+#[tokio::test]
+async fn test_build_flow_query_extensions_switches_with_checkpoint_mode() {
+    let task = new_test_task_with_missing_sink().await;
+
+    // PR3a only sends plumbing extensions.
+    let extensions = task.build_flow_query_extensions().await.unwrap();
+    assert_eq!(
+        extensions,
+        vec![("flow.return_region_seq", "true".to_string())]
+    );
+
+    task.state
+        .write()
+        .unwrap()
+        .advance_checkpoints(HashMap::from([(1_u64, 10_u64), (2_u64, 20_u64)]));
+
+    // Even after advancing to Incremental mode, still only plumbing extensions.
+    let extensions = task.build_flow_query_extensions().await.unwrap();
+    assert_eq!(
+        extensions,
+        vec![("flow.return_region_seq", "true".to_string())]
+    );
+}

--- a/src/flow/src/batching_mode/task/test.rs
+++ b/src/flow/src/batching_mode/task/test.rs
@@ -31,9 +31,6 @@ use snafu::GenerateImplicitData;
 use table::test_util::MemTable;
 
 use super::*;
-use crate::batching_mode::checkpoint::{
-    CHECKPOINT_DECISION_ADVANCE, CHECKPOINT_DECISION_FALLBACK, CHECKPOINT_REASON_NONE,
-};
 use crate::test_utils::create_test_query_engine;
 
 fn output_with_region_watermarks(
@@ -173,8 +170,8 @@ fn test_apply_query_result_to_state_advances_full_snapshot_to_incremental() {
     assert_eq!(
         decision,
         FlowCheckpointDecision::AdvancedFromFullSnapshot {
-            participating_regions: 2,
-            watermarks: 2,
+            participating_region_count: 2,
+            watermark_count: 2,
         }
     );
     assert_eq!(state.checkpoint_mode(), CheckpointMode::Incremental);
@@ -253,8 +250,8 @@ fn test_apply_query_result_to_state_advances_incremental_subset() {
     assert_eq!(
         decision,
         FlowCheckpointDecision::AdvancedIncremental {
-            participating_regions: 2,
-            watermarks: 2,
+            participating_region_count: 2,
+            watermark_count: 2,
         }
     );
     assert_eq!(state.checkpoint_mode(), CheckpointMode::Incremental);
@@ -265,22 +262,24 @@ fn test_apply_query_result_to_state_advances_incremental_subset() {
 }
 
 #[test]
-fn test_checkpoint_decision_labels_are_stable() {
+fn test_checkpoint_decision_metric_labels_are_stable() {
     let advance = FlowCheckpointDecision::AdvancedIncremental {
-        participating_regions: 1,
-        watermarks: 1,
+        participating_region_count: 1,
+        watermark_count: 1,
     };
     let fallback = FlowCheckpointDecision::FallbackToFullSnapshot {
         previous_mode: CheckpointMode::Incremental,
         reason: FlowQueryFallbackReason::CheckpointReadyQueryFailure,
     };
+    let advance_labels = checkpoint_decision_metric_labels(advance);
+    let fallback_labels = checkpoint_decision_metric_labels(fallback);
 
-    assert_eq!(advance.mode_label(), "incremental");
-    assert_eq!(advance.decision_label(), CHECKPOINT_DECISION_ADVANCE);
-    assert_eq!(advance.reason_label(), CHECKPOINT_REASON_NONE);
-    assert_eq!(fallback.mode_label(), "incremental");
-    assert_eq!(fallback.decision_label(), CHECKPOINT_DECISION_FALLBACK);
-    assert_eq!(fallback.reason_label(), "checkpoint_ready_query_failure");
+    assert_eq!(advance_labels.mode, "incremental");
+    assert_eq!(advance_labels.decision, "advance");
+    assert_eq!(advance_labels.reason, "none");
+    assert_eq!(fallback_labels.mode, "incremental");
+    assert_eq!(fallback_labels.decision, "fallback");
+    assert_eq!(fallback_labels.reason, "checkpoint_ready_query_failure");
 }
 
 #[tokio::test]

--- a/src/flow/src/batching_mode/task/test.rs
+++ b/src/flow/src/batching_mode/task/test.rs
@@ -14,13 +14,21 @@
 
 use std::collections::BTreeMap;
 
+use catalog::RegisterTableRequest;
+use catalog::memory::MemoryCatalogManager;
+use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_error::ext::PlainError;
 use common_error::status_code::StatusCode;
 use common_query::Output;
+use common_recordbatch::RecordBatch;
 use common_recordbatch::adapter::{RecordBatchMetrics, RegionWatermarkEntry};
+use datatypes::data_type::ConcreteDataType as CDT;
+use datatypes::schema::ColumnSchema;
+use datatypes::vectors::{UInt32Vector, VectorRef};
 use pretty_assertions::assert_eq;
 use session::context::QueryContext;
 use snafu::GenerateImplicitData;
+use table::test_util::MemTable;
 
 use super::*;
 use crate::batching_mode::checkpoint::{
@@ -51,6 +59,27 @@ async fn new_test_task_with_missing_sink() -> BatchingTask {
 }
 
 async fn new_test_task_and_plan_with_missing_sink() -> (BatchingTask, LogicalPlan) {
+    new_test_task_engine_and_plan_with_query(
+        "SELECT number, ts FROM numbers_with_ts",
+        "missing_sink",
+    )
+    .await
+    .into_task_and_plan()
+}
+
+struct TestTaskParts {
+    task: BatchingTask,
+    query_engine: QueryEngineRef,
+    plan: LogicalPlan,
+}
+
+impl TestTaskParts {
+    fn into_task_and_plan(self) -> (BatchingTask, LogicalPlan) {
+        (self.task, self.plan)
+    }
+}
+
+async fn new_test_task_engine_and_plan_with_query(query: &str, sink_table: &str) -> TestTaskParts {
     let query_engine = create_test_query_engine();
     let ctx = QueryContext::arc();
     let plan = sql_to_df_plan(
@@ -65,14 +94,14 @@ async fn new_test_task_and_plan_with_missing_sink() -> (BatchingTask, LogicalPla
 
     let task = BatchingTask::try_new(TaskArgs {
         flow_id: 1,
-        query: "SELECT number, ts FROM numbers_with_ts",
+        query,
         plan: plan.clone(),
         time_window_expr: None,
         expire_after: None,
         sink_table_name: [
             "greptime".to_string(),
             "public".to_string(),
-            "missing_sink".to_string(),
+            sink_table.to_string(),
         ],
         source_table_names: vec![[
             "greptime".to_string(),
@@ -87,7 +116,35 @@ async fn new_test_task_and_plan_with_missing_sink() -> (BatchingTask, LogicalPla
     })
     .unwrap();
 
-    (task, plan)
+    TestTaskParts {
+        task,
+        query_engine,
+        plan,
+    }
+}
+
+fn register_number_only_sink(query_engine: &QueryEngineRef, table_name: &str) {
+    let schema = Arc::new(Schema::new(vec![ColumnSchema::new(
+        "number",
+        CDT::uint32_datatype(),
+        false,
+    )]));
+    let columns: Vec<VectorRef> = vec![Arc::new(UInt32Vector::from_slice([1_u32]))];
+    let recordbatch = RecordBatch::new(schema, columns).unwrap();
+    let table = MemTable::table(table_name, recordbatch);
+    let request = RegisterTableRequest {
+        catalog: DEFAULT_CATALOG_NAME.to_string(),
+        schema: DEFAULT_SCHEMA_NAME.to_string(),
+        table_name: table_name.to_string(),
+        table_id: 9001,
+        table,
+    };
+    let catalog_manager = query_engine.engine_state().catalog_manager();
+    let memory_catalog = catalog_manager
+        .as_any()
+        .downcast_ref::<MemoryCatalogManager>()
+        .unwrap();
+    memory_catalog.register_table_sync(request).unwrap();
 }
 
 fn ordinary_query_error() -> Error {
@@ -275,6 +332,7 @@ async fn test_executed_query_failure_restores_scoped_dirty_windows_for_flush_pat
             time_ranges: vec![(Timestamp::new_second(10), Timestamp::new_second(20))],
             window_size: chrono::Duration::seconds(10),
         }),
+        filterless_dirty_windows_to_restore: None,
     };
 
     let checkpoint_was_ready =
@@ -287,10 +345,185 @@ async fn test_executed_query_failure_restores_scoped_dirty_windows_for_flush_pat
 }
 
 #[tokio::test]
+async fn test_filterless_full_snapshot_failure_restores_consumed_dirty_marker() {
+    let (task, plan) = new_test_task_and_plan_with_missing_sink().await;
+    let mut consumed_dirty_windows = DirtyTimeWindows::default();
+    consumed_dirty_windows.set_dirty();
+    task.state.write().unwrap().dirty_time_windows.clean();
+    let filterless_query = PlanInfo {
+        plan,
+        filter: None,
+        filterless_dirty_windows_to_restore: Some(consumed_dirty_windows),
+    };
+
+    let checkpoint_was_ready =
+        task.handle_executed_query_failure(&ordinary_query_error(), Some(&filterless_query));
+
+    assert!(!checkpoint_was_ready);
+    let state = task.state.read().unwrap();
+    assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
+    assert_eq!(state.dirty_time_windows.len(), 1);
+    // A filterless dirty marker should be restored as-is, not expanded into
+    // a mark-all time range.
+    assert_eq!(
+        state.dirty_time_windows.window_size(),
+        std::time::Duration::from_secs(0)
+    );
+}
+
+#[tokio::test]
+async fn test_filterless_full_snapshot_failure_merges_consumed_dirty_windows() {
+    let (task, plan) = new_test_task_and_plan_with_missing_sink().await;
+    let mut consumed_dirty_windows = DirtyTimeWindows::default();
+    consumed_dirty_windows.add_window(Timestamp::new_second(30), Some(Timestamp::new_second(40)));
+    {
+        let mut state = task.state.write().unwrap();
+        state.dirty_time_windows.clean();
+        // Simulate new dirty data arriving while the failed query was running.
+        state
+            .dirty_time_windows
+            .add_window(Timestamp::new_second(10), Some(Timestamp::new_second(20)));
+    }
+    let filterless_query = PlanInfo {
+        plan,
+        filter: None,
+        filterless_dirty_windows_to_restore: Some(consumed_dirty_windows),
+    };
+
+    task.handle_executed_query_failure(&ordinary_query_error(), Some(&filterless_query));
+
+    let state = task.state.read().unwrap();
+    assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
+    assert_eq!(state.dirty_time_windows.len(), 2);
+    assert_eq!(
+        state.dirty_time_windows.window_size(),
+        std::time::Duration::from_secs(20)
+    );
+}
+
+#[tokio::test]
+async fn test_filterless_failure_keeps_larger_same_start_dirty_window() {
+    let (task, plan) = new_test_task_and_plan_with_missing_sink().await;
+    let mut consumed_dirty_windows = DirtyTimeWindows::default();
+    consumed_dirty_windows.add_window(Timestamp::new_second(30), Some(Timestamp::new_second(40)));
+    {
+        let mut state = task.state.write().unwrap();
+        state.dirty_time_windows.clean();
+        // Simulate new dirty data with the same start but a wider end arriving
+        // while the failed query was running.
+        state
+            .dirty_time_windows
+            .add_window(Timestamp::new_second(30), Some(Timestamp::new_second(50)));
+    }
+    let filterless_query = PlanInfo {
+        plan,
+        filter: None,
+        filterless_dirty_windows_to_restore: Some(consumed_dirty_windows),
+    };
+
+    task.handle_executed_query_failure(&ordinary_query_error(), Some(&filterless_query));
+
+    let state = task.state.read().unwrap();
+    assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
+    assert_eq!(state.dirty_time_windows.len(), 1);
+    assert_eq!(
+        state.dirty_time_windows.window_size(),
+        std::time::Duration::from_secs(20)
+    );
+}
+
+#[tokio::test]
+async fn test_filterless_plan_generation_failure_restores_consumed_dirty_marker() {
+    let TestTaskParts {
+        task, query_engine, ..
+    } = new_test_task_engine_and_plan_with_query(
+        "SELECT missing_column FROM numbers_with_ts",
+        "missing_sink",
+    )
+    .await;
+    task.state.write().unwrap().dirty_time_windows.set_dirty();
+    let sink_schema = Arc::new(Schema::new(vec![
+        ColumnSchema::new("number", CDT::uint32_datatype(), false),
+        ColumnSchema::new("ts", CDT::timestamp_millisecond_datatype(), false).with_time_index(true),
+    ]));
+
+    let result = task
+        .gen_query_with_time_window(query_engine, &sink_schema, &[], false, None)
+        .await;
+
+    assert!(result.is_err());
+    let state = task.state.read().unwrap();
+    assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
+    assert_eq!(state.dirty_time_windows.len(), 1);
+    assert_eq!(
+        state.dirty_time_windows.window_size(),
+        std::time::Duration::from_secs(0)
+    );
+}
+
+#[tokio::test]
+async fn test_insert_plan_matching_failure_restores_consumed_dirty_marker() {
+    let sink_table = "partial_sink";
+    let TestTaskParts {
+        task, query_engine, ..
+    } = new_test_task_engine_and_plan_with_query(
+        "SELECT number, ts FROM numbers_with_ts",
+        sink_table,
+    )
+    .await;
+    register_number_only_sink(&query_engine, sink_table);
+    task.state.write().unwrap().dirty_time_windows.set_dirty();
+
+    let result = task.gen_insert_plan(&query_engine, None).await;
+
+    assert!(result.is_err());
+    let _err = match result {
+        Ok(_) => panic!("gen_insert_plan should fail with a sink column mismatch"),
+        Err(err) => err,
+    };
+    let state = task.state.read().unwrap();
+    assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
+    assert_eq!(state.dirty_time_windows.len(), 1);
+    assert_eq!(
+        state.dirty_time_windows.window_size(),
+        std::time::Duration::from_secs(0)
+    );
+}
+
+#[tokio::test]
+async fn test_filterless_incremental_failure_restores_consumed_dirty_windows_after_fallback() {
+    let (task, plan) = new_test_task_and_plan_with_missing_sink().await;
+    let mut consumed_dirty_windows = DirtyTimeWindows::default();
+    consumed_dirty_windows.add_window(Timestamp::new_second(30), Some(Timestamp::new_second(40)));
+    {
+        let mut state = task.state.write().unwrap();
+        state.advance_checkpoints(HashMap::from([(1_u64, 10_u64)]));
+        state.dirty_time_windows.clean();
+    }
+    let filterless_query = PlanInfo {
+        plan,
+        filter: None,
+        filterless_dirty_windows_to_restore: Some(consumed_dirty_windows),
+    };
+
+    let checkpoint_was_ready =
+        task.handle_executed_query_failure(&ordinary_query_error(), Some(&filterless_query));
+
+    assert!(checkpoint_was_ready);
+    let state = task.state.read().unwrap();
+    assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
+    assert_eq!(state.dirty_time_windows.len(), 1);
+    assert_eq!(
+        state.dirty_time_windows.window_size(),
+        std::time::Duration::from_secs(10)
+    );
+}
+
+#[tokio::test]
 async fn test_build_flow_query_extensions_switches_with_checkpoint_mode() {
     let task = new_test_task_with_missing_sink().await;
 
-    // PR3a only sends plumbing extensions.
+    // Checkpoint readiness alone does not send incremental scan extensions.
     let extensions = task.build_flow_query_extensions().await.unwrap();
     assert_eq!(
         extensions,
@@ -302,7 +535,8 @@ async fn test_build_flow_query_extensions_switches_with_checkpoint_mode() {
         .unwrap()
         .advance_checkpoints(HashMap::from([(1_u64, 10_u64), (2_u64, 20_u64)]));
 
-    // Even after advancing to Incremental mode, still only plumbing extensions.
+    // Even after advancing to Incremental mode, checkpoint readiness alone
+    // still does not send incremental scan extensions.
     let extensions = task.build_flow_query_extensions().await.unwrap();
     assert_eq!(
         extensions,

--- a/src/flow/src/batching_mode/task/test.rs
+++ b/src/flow/src/batching_mode/task/test.rs
@@ -227,111 +227,151 @@ fn assert_no_incremental_scan_extensions(extensions: &[(&'static str, String)]) 
     );
 }
 
-#[test]
-fn test_apply_query_result_to_state_advances_full_snapshot_to_incremental() {
-    let query_ctx = QueryContext::arc();
-    let (_tx, rx) = tokio::sync::oneshot::channel();
-    let mut state = TaskState::new(query_ctx, rx);
-    let result = output_with_region_watermarks([(1_u64, Some(10_u64)), (2_u64, Some(20_u64))]);
-
-    let decision = BatchingTask::apply_query_result_to_state(
-        &mut state,
-        &result,
-        std::time::Duration::from_millis(1),
-    );
-
-    assert_eq!(
-        decision,
-        FlowCheckpointDecision::AdvancedFromFullSnapshot {
-            participating_region_count: 2,
-            watermark_count: 2,
-        }
-    );
-    assert_eq!(state.checkpoint_mode(), CheckpointMode::Incremental);
-    assert_eq!(
-        state.checkpoints(),
-        &BTreeMap::from([(1_u64, 10_u64), (2_u64, 20_u64)])
-    );
+fn dirty_marker() -> DirtyTimeWindows {
+    let mut dirty = DirtyTimeWindows::default();
+    dirty.set_dirty();
+    dirty
 }
 
-#[test]
-fn test_apply_query_result_to_state_rejects_unproved_watermark() {
-    let query_ctx = QueryContext::arc();
-    let (_tx, rx) = tokio::sync::oneshot::channel();
-    let mut state = TaskState::new(query_ctx, rx);
-    let result = output_with_region_watermarks([(1_u64, Some(10_u64)), (2_u64, None)]);
-
-    let decision = BatchingTask::apply_query_result_to_state(
-        &mut state,
-        &result,
-        std::time::Duration::from_millis(1),
+fn dirty_range(start: i64, end: i64) -> DirtyTimeWindows {
+    let mut dirty = DirtyTimeWindows::default();
+    dirty.add_window(
+        Timestamp::new_second(start),
+        Some(Timestamp::new_second(end)),
     );
+    dirty
+}
 
-    assert_eq!(
-        decision,
-        FlowCheckpointDecision::FallbackToFullSnapshot {
-            previous_mode: CheckpointMode::FullSnapshot,
-            reason: FlowQueryFallbackReason::IncompleteRegionWatermark,
+async fn assert_filterless_failure_restore(
+    consumed_dirty_windows: DirtyTimeWindows,
+    current_dirty_windows: DirtyTimeWindows,
+    checkpoint_ready: bool,
+    expected_len: usize,
+    expected_window_size_secs: u64,
+) {
+    let (task, plan) = new_test_task_and_plan_with_missing_sink().await;
+    {
+        let mut state = task.state.write().unwrap();
+        if checkpoint_ready {
+            state.advance_checkpoints(HashMap::from([(1_u64, 10_u64)]));
         }
-    );
+        state.dirty_time_windows.clean();
+        state
+            .dirty_time_windows
+            .add_dirty_windows(&current_dirty_windows);
+    }
+    let filterless_query = PlanInfo {
+        plan,
+        filter: None,
+        filterless_dirty_windows_to_restore: Some(consumed_dirty_windows),
+    };
+
+    let checkpoint_was_ready =
+        task.handle_executed_query_failure(&ordinary_query_error(), Some(&filterless_query));
+
+    assert_eq!(checkpoint_was_ready, checkpoint_ready);
+    let state = task.state.read().unwrap();
     assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
-    assert!(state.checkpoints().is_empty());
+    if checkpoint_ready {
+        assert_eq!(state.checkpoints(), &BTreeMap::from([(1_u64, 10_u64)]));
+    }
+    assert_eq!(state.dirty_time_windows.len(), expected_len);
+    assert_eq!(
+        state.dirty_time_windows.window_size(),
+        std::time::Duration::from_secs(expected_window_size_secs)
+    );
 }
 
 #[test]
-fn test_apply_query_result_to_state_reports_missing_watermark() {
-    let query_ctx = QueryContext::arc();
-    let (_tx, rx) = tokio::sync::oneshot::channel();
-    let mut state = TaskState::new(query_ctx, rx);
-    let result = OutputWithMetrics::from_output(Output::new_with_affected_rows(0));
+fn test_apply_query_result_to_state_checkpoint_decisions() {
+    let elapsed = std::time::Duration::from_millis(1);
 
-    let decision = BatchingTask::apply_query_result_to_state(
-        &mut state,
-        &result,
-        std::time::Duration::from_millis(1),
-    );
+    {
+        let query_ctx = QueryContext::arc();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let mut state = TaskState::new(query_ctx, rx);
+        let result = output_with_region_watermarks([(1_u64, Some(10_u64)), (2_u64, Some(20_u64))]);
 
-    assert_eq!(
-        decision,
-        FlowCheckpointDecision::FallbackToFullSnapshot {
-            previous_mode: CheckpointMode::FullSnapshot,
-            reason: FlowQueryFallbackReason::MissingRegionWatermark,
-        }
-    );
-    assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
-    assert!(state.checkpoints().is_empty());
-}
+        let decision = BatchingTask::apply_query_result_to_state(&mut state, &result, elapsed);
 
-#[test]
-fn test_apply_query_result_to_state_advances_incremental_subset() {
-    let query_ctx = QueryContext::arc();
-    let (_tx, rx) = tokio::sync::oneshot::channel();
-    let mut state = TaskState::new(query_ctx, rx);
-    state.advance_checkpoints(HashMap::from([
-        (1_u64, 10_u64),
-        (2_u64, 20_u64),
-        (3_u64, 30_u64),
-    ]));
-    let result = output_with_region_watermarks([(1_u64, Some(12_u64)), (3_u64, Some(35_u64))]);
+        assert_eq!(
+            decision,
+            FlowCheckpointDecision::AdvancedFromFullSnapshot {
+                participating_region_count: 2,
+                watermark_count: 2,
+            }
+        );
+        assert_eq!(state.checkpoint_mode(), CheckpointMode::Incremental);
+        assert_eq!(
+            state.checkpoints(),
+            &BTreeMap::from([(1_u64, 10_u64), (2_u64, 20_u64)])
+        );
+    }
 
-    let decision = BatchingTask::apply_query_result_to_state(
-        &mut state,
-        &result,
-        std::time::Duration::from_millis(1),
-    );
+    {
+        let query_ctx = QueryContext::arc();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let mut state = TaskState::new(query_ctx, rx);
+        let result = output_with_region_watermarks([(1_u64, Some(10_u64)), (2_u64, None)]);
 
-    assert_eq!(
-        decision,
-        FlowCheckpointDecision::AdvancedIncremental {
-            participating_region_count: 2,
-            watermark_count: 2,
-        }
-    );
-    assert_eq!(state.checkpoint_mode(), CheckpointMode::Incremental);
-    assert_eq!(
-        state.checkpoints(),
-        &BTreeMap::from([(1_u64, 12_u64), (2_u64, 20_u64), (3_u64, 35_u64)])
-    );
+        let decision = BatchingTask::apply_query_result_to_state(&mut state, &result, elapsed);
+
+        assert_eq!(
+            decision,
+            FlowCheckpointDecision::FallbackToFullSnapshot {
+                previous_mode: CheckpointMode::FullSnapshot,
+                reason: FlowQueryFallbackReason::IncompleteRegionWatermark,
+            }
+        );
+        assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
+        assert!(state.checkpoints().is_empty());
+    }
+
+    {
+        let query_ctx = QueryContext::arc();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let mut state = TaskState::new(query_ctx, rx);
+        let result = OutputWithMetrics::from_output(Output::new_with_affected_rows(0));
+
+        let decision = BatchingTask::apply_query_result_to_state(&mut state, &result, elapsed);
+
+        assert_eq!(
+            decision,
+            FlowCheckpointDecision::FallbackToFullSnapshot {
+                previous_mode: CheckpointMode::FullSnapshot,
+                reason: FlowQueryFallbackReason::MissingRegionWatermark,
+            }
+        );
+        assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
+        assert!(state.checkpoints().is_empty());
+    }
+
+    {
+        let query_ctx = QueryContext::arc();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let mut state = TaskState::new(query_ctx, rx);
+        state.advance_checkpoints(HashMap::from([
+            (1_u64, 10_u64),
+            (2_u64, 20_u64),
+            (3_u64, 30_u64),
+        ]));
+        let result = output_with_region_watermarks([(1_u64, Some(12_u64)), (3_u64, Some(35_u64))]);
+
+        let decision = BatchingTask::apply_query_result_to_state(&mut state, &result, elapsed);
+
+        assert_eq!(
+            decision,
+            FlowCheckpointDecision::AdvancedIncremental {
+                participating_region_count: 2,
+                watermark_count: 2,
+            }
+        );
+        assert_eq!(state.checkpoint_mode(), CheckpointMode::Incremental);
+        assert_eq!(
+            state.checkpoints(),
+            &BTreeMap::from([(1_u64, 12_u64), (2_u64, 20_u64), (3_u64, 35_u64)])
+        );
+    }
 }
 
 #[test]
@@ -356,23 +396,7 @@ fn test_checkpoint_decision_metric_labels_are_stable() {
 }
 
 #[tokio::test]
-async fn test_incremental_failure_falls_back_to_full_snapshot() {
-    let task = new_test_task_with_missing_sink().await;
-    task.state
-        .write()
-        .unwrap()
-        .advance_checkpoints(HashMap::from([(1_u64, 10_u64)]));
-
-    let checkpoint_was_ready = task.handle_flow_query_failure(&ordinary_query_error(), None);
-
-    assert!(checkpoint_was_ready);
-    let state = task.state.read().unwrap();
-    assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
-    assert_eq!(state.checkpoints(), &BTreeMap::from([(1_u64, 10_u64)]));
-}
-
-#[tokio::test]
-async fn test_incremental_failure_without_query_scope_marks_full_flow_dirty() {
+async fn test_incremental_failure_without_query_scope_falls_back_and_marks_dirty() {
     let task = new_test_task_with_missing_sink().await;
     {
         let mut state = task.state.write().unwrap();
@@ -385,6 +409,7 @@ async fn test_incremental_failure_without_query_scope_marks_full_flow_dirty() {
     assert!(checkpoint_was_ready);
     let state = task.state.read().unwrap();
     assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
+    assert_eq!(state.checkpoints(), &BTreeMap::from([(1_u64, 10_u64)]));
     assert_eq!(state.dirty_time_windows.len(), 1);
 }
 
@@ -417,91 +442,19 @@ async fn test_executed_query_failure_restores_scoped_dirty_windows_for_flush_pat
 }
 
 #[tokio::test]
-async fn test_filterless_full_snapshot_failure_restores_consumed_dirty_marker() {
-    let (task, plan) = new_test_task_and_plan_with_missing_sink().await;
-    let mut consumed_dirty_windows = DirtyTimeWindows::default();
-    consumed_dirty_windows.set_dirty();
-    task.state.write().unwrap().dirty_time_windows.clean();
-    let filterless_query = PlanInfo {
-        plan,
-        filter: None,
-        filterless_dirty_windows_to_restore: Some(consumed_dirty_windows),
-    };
-
-    let checkpoint_was_ready =
-        task.handle_executed_query_failure(&ordinary_query_error(), Some(&filterless_query));
-
-    assert!(!checkpoint_was_ready);
-    let state = task.state.read().unwrap();
-    assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
-    assert_eq!(state.dirty_time_windows.len(), 1);
-    // A filterless dirty marker should be restored as-is, not expanded into
-    // a mark-all time range.
-    assert_eq!(
-        state.dirty_time_windows.window_size(),
-        std::time::Duration::from_secs(0)
-    );
-}
-
-#[tokio::test]
-async fn test_filterless_full_snapshot_failure_merges_consumed_dirty_windows() {
-    let (task, plan) = new_test_task_and_plan_with_missing_sink().await;
-    let mut consumed_dirty_windows = DirtyTimeWindows::default();
-    consumed_dirty_windows.add_window(Timestamp::new_second(30), Some(Timestamp::new_second(40)));
-    {
-        let mut state = task.state.write().unwrap();
-        state.dirty_time_windows.clean();
-        // Simulate new dirty data arriving while the failed query was running.
-        state
-            .dirty_time_windows
-            .add_window(Timestamp::new_second(10), Some(Timestamp::new_second(20)));
-    }
-    let filterless_query = PlanInfo {
-        plan,
-        filter: None,
-        filterless_dirty_windows_to_restore: Some(consumed_dirty_windows),
-    };
-
-    task.handle_executed_query_failure(&ordinary_query_error(), Some(&filterless_query));
-
-    let state = task.state.read().unwrap();
-    assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
-    assert_eq!(state.dirty_time_windows.len(), 2);
-    assert_eq!(
-        state.dirty_time_windows.window_size(),
-        std::time::Duration::from_secs(20)
-    );
-}
-
-#[tokio::test]
-async fn test_filterless_failure_keeps_larger_same_start_dirty_window() {
-    let (task, plan) = new_test_task_and_plan_with_missing_sink().await;
-    let mut consumed_dirty_windows = DirtyTimeWindows::default();
-    consumed_dirty_windows.add_window(Timestamp::new_second(30), Some(Timestamp::new_second(40)));
-    {
-        let mut state = task.state.write().unwrap();
-        state.dirty_time_windows.clean();
-        // Simulate new dirty data with the same start but a wider end arriving
-        // while the failed query was running.
-        state
-            .dirty_time_windows
-            .add_window(Timestamp::new_second(30), Some(Timestamp::new_second(50)));
-    }
-    let filterless_query = PlanInfo {
-        plan,
-        filter: None,
-        filterless_dirty_windows_to_restore: Some(consumed_dirty_windows),
-    };
-
-    task.handle_executed_query_failure(&ordinary_query_error(), Some(&filterless_query));
-
-    let state = task.state.read().unwrap();
-    assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
-    assert_eq!(state.dirty_time_windows.len(), 1);
-    assert_eq!(
-        state.dirty_time_windows.window_size(),
-        std::time::Duration::from_secs(20)
-    );
+async fn test_filterless_failure_restores_consumed_dirty_windows() {
+    assert_filterless_failure_restore(dirty_marker(), DirtyTimeWindows::default(), false, 1, 0)
+        .await;
+    assert_filterless_failure_restore(dirty_range(30, 40), dirty_range(10, 20), false, 2, 20).await;
+    assert_filterless_failure_restore(dirty_range(30, 40), dirty_range(30, 50), false, 1, 20).await;
+    assert_filterless_failure_restore(
+        dirty_range(30, 40),
+        DirtyTimeWindows::default(),
+        true,
+        1,
+        10,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -598,39 +551,9 @@ async fn test_insert_plan_matching_failure_restores_consumed_dirty_marker() {
 }
 
 #[tokio::test]
-async fn test_filterless_incremental_failure_restores_consumed_dirty_windows_after_fallback() {
-    let (task, plan) = new_test_task_and_plan_with_missing_sink().await;
-    let mut consumed_dirty_windows = DirtyTimeWindows::default();
-    consumed_dirty_windows.add_window(Timestamp::new_second(30), Some(Timestamp::new_second(40)));
-    {
-        let mut state = task.state.write().unwrap();
-        state.advance_checkpoints(HashMap::from([(1_u64, 10_u64)]));
-        state.dirty_time_windows.clean();
-    }
-    let filterless_query = PlanInfo {
-        plan,
-        filter: None,
-        filterless_dirty_windows_to_restore: Some(consumed_dirty_windows),
-    };
-
-    let checkpoint_was_ready =
-        task.handle_executed_query_failure(&ordinary_query_error(), Some(&filterless_query));
-
-    assert!(checkpoint_was_ready);
-    let state = task.state.read().unwrap();
-    assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
-    assert_eq!(state.dirty_time_windows.len(), 1);
-    assert_eq!(
-        state.dirty_time_windows.window_size(),
-        std::time::Duration::from_secs(10)
-    );
-}
-
-#[tokio::test]
-async fn test_build_flow_query_extensions_switches_with_checkpoint_mode() {
+async fn test_build_flow_query_extensions_do_not_emit_incremental_scan_keys() {
     let task = new_test_task_with_missing_sink().await;
 
-    // Checkpoint readiness alone does not send incremental scan extensions.
     let extensions = task.build_flow_query_extensions().await.unwrap();
     assert_eq!(
         extensions,
@@ -643,21 +566,18 @@ async fn test_build_flow_query_extensions_switches_with_checkpoint_mode() {
         .unwrap()
         .advance_checkpoints(HashMap::from([(1_u64, 10_u64), (2_u64, 20_u64)]));
 
-    // Even after advancing to Incremental mode, checkpoint readiness alone
-    // still does not send incremental scan extensions.
     let extensions = task.build_flow_query_extensions().await.unwrap();
     assert_eq!(
         extensions,
         vec![(FLOW_RETURN_REGION_SEQ, "true".to_string())]
     );
     assert_no_incremental_scan_extensions(&extensions);
-}
 
-#[tokio::test]
-async fn test_build_flow_query_extensions_include_sink_id_without_incremental_scan() {
     let sink_table = "extension_sink";
     let TestTaskParts {
-        task, query_engine, ..
+        task: task_with_sink,
+        query_engine,
+        ..
     } = new_test_task_engine_and_plan_with_query(
         "SELECT number, ts FROM numbers_with_ts",
         sink_table,
@@ -665,7 +585,7 @@ async fn test_build_flow_query_extensions_include_sink_id_without_incremental_sc
     .await;
     register_number_only_sink(&query_engine, sink_table);
 
-    let extensions = task.build_flow_query_extensions().await.unwrap();
+    let extensions = task_with_sink.build_flow_query_extensions().await.unwrap();
 
     assert!(extensions.contains(&(FLOW_RETURN_REGION_SEQ, "true".to_string())));
     assert!(extensions.iter().any(|(key, value)| {

--- a/src/flow/src/batching_mode/task/test.rs
+++ b/src/flow/src/batching_mode/task/test.rs
@@ -26,11 +26,15 @@ use datatypes::data_type::ConcreteDataType as CDT;
 use datatypes::schema::ColumnSchema;
 use datatypes::vectors::{UInt32Vector, VectorRef};
 use pretty_assertions::assert_eq;
+use query::options::{
+    FLOW_INCREMENTAL_AFTER_SEQS, FLOW_INCREMENTAL_MODE, FLOW_RETURN_REGION_SEQ, FLOW_SINK_TABLE_ID,
+};
 use session::context::QueryContext;
 use snafu::GenerateImplicitData;
 use table::test_util::MemTable;
 
 use super::*;
+use crate::batching_mode::time_window::find_time_window_expr;
 use crate::test_utils::create_test_query_engine;
 
 fn output_with_region_watermarks(
@@ -120,6 +124,62 @@ async fn new_test_task_engine_and_plan_with_query(query: &str, sink_table: &str)
     }
 }
 
+async fn new_time_window_test_task_with_query(query: &str) -> TestTaskParts {
+    let query_engine = create_test_query_engine();
+    let ctx = QueryContext::arc();
+    let plan_query = "SELECT number, date_bin(INTERVAL '5 second', ts) AS time_window FROM numbers_with_ts GROUP BY time_window, number";
+    let plan = sql_to_df_plan(ctx.clone(), query_engine.clone(), plan_query, true)
+        .await
+        .unwrap();
+    let (column_name, time_window_expr, _, df_schema) = find_time_window_expr(
+        &plan,
+        query_engine.engine_state().catalog_manager().clone(),
+        ctx.clone(),
+    )
+    .await
+    .unwrap();
+    let time_window_expr = time_window_expr.map(|expr| {
+        TimeWindowExpr::from_expr(
+            &expr,
+            &column_name,
+            &df_schema,
+            &query_engine.engine_state().session_state(),
+        )
+        .unwrap()
+    });
+    let (_tx, rx) = tokio::sync::oneshot::channel();
+
+    let task = BatchingTask::try_new(TaskArgs {
+        flow_id: 1,
+        query,
+        plan: plan.clone(),
+        time_window_expr,
+        expire_after: None,
+        sink_table_name: [
+            "greptime".to_string(),
+            "public".to_string(),
+            "missing_sink".to_string(),
+        ],
+        source_table_names: vec![[
+            "greptime".to_string(),
+            "public".to_string(),
+            "numbers_with_ts".to_string(),
+        ]],
+        query_ctx: ctx,
+        catalog_manager: query_engine.engine_state().catalog_manager().clone(),
+        shutdown_rx: rx,
+        batch_opts: Arc::new(BatchingModeOptions::default()),
+        flow_eval_interval: None,
+    })
+    .unwrap();
+
+    TestTaskParts {
+        task,
+        query_engine,
+        plan,
+    }
+}
+
 fn register_number_only_sink(query_engine: &QueryEngineRef, table_name: &str) {
     let schema = Arc::new(Schema::new(vec![ColumnSchema::new(
         "number",
@@ -152,6 +212,19 @@ fn ordinary_query_error() -> Error {
         )),
         location: snafu::Location::generate(),
     }
+}
+
+fn assert_no_incremental_scan_extensions(extensions: &[(&'static str, String)]) {
+    assert!(
+        !extensions
+            .iter()
+            .any(|(key, _)| *key == FLOW_INCREMENTAL_MODE)
+    );
+    assert!(
+        !extensions
+            .iter()
+            .any(|(key, _)| *key == FLOW_INCREMENTAL_AFTER_SEQS)
+    );
 }
 
 #[test]
@@ -461,6 +534,41 @@ async fn test_filterless_plan_generation_failure_restores_consumed_dirty_marker(
 }
 
 #[tokio::test]
+async fn test_scoped_plan_generation_failure_restores_consumed_dirty_windows() {
+    let TestTaskParts {
+        task,
+        query_engine,
+        ..
+    } = new_time_window_test_task_with_query(
+        "SELECT missing_column, date_bin(INTERVAL '5 second', ts) AS time_window FROM numbers_with_ts GROUP BY time_window, missing_column",
+    )
+    .await;
+    task.state
+        .write()
+        .unwrap()
+        .dirty_time_windows
+        .add_window(Timestamp::new_second(10), Some(Timestamp::new_second(15)));
+    let sink_schema = Arc::new(Schema::new(vec![
+        ColumnSchema::new("number", CDT::uint32_datatype(), false),
+        ColumnSchema::new("time_window", CDT::timestamp_millisecond_datatype(), false)
+            .with_time_index(true),
+    ]));
+
+    let result = task
+        .gen_query_with_time_window(query_engine, &sink_schema, &[], false, None)
+        .await;
+
+    assert!(result.is_err());
+    let state = task.state.read().unwrap();
+    assert_eq!(state.checkpoint_mode(), CheckpointMode::FullSnapshot);
+    assert_eq!(state.dirty_time_windows.len(), 1);
+    assert_eq!(
+        state.dirty_time_windows.window_size(),
+        std::time::Duration::from_secs(5)
+    );
+}
+
+#[tokio::test]
 async fn test_insert_plan_matching_failure_restores_consumed_dirty_marker() {
     let sink_table = "partial_sink";
     let TestTaskParts {
@@ -526,8 +634,9 @@ async fn test_build_flow_query_extensions_switches_with_checkpoint_mode() {
     let extensions = task.build_flow_query_extensions().await.unwrap();
     assert_eq!(
         extensions,
-        vec![("flow.return_region_seq", "true".to_string())]
+        vec![(FLOW_RETURN_REGION_SEQ, "true".to_string())]
     );
+    assert_no_incremental_scan_extensions(&extensions);
 
     task.state
         .write()
@@ -539,6 +648,28 @@ async fn test_build_flow_query_extensions_switches_with_checkpoint_mode() {
     let extensions = task.build_flow_query_extensions().await.unwrap();
     assert_eq!(
         extensions,
-        vec![("flow.return_region_seq", "true".to_string())]
+        vec![(FLOW_RETURN_REGION_SEQ, "true".to_string())]
     );
+    assert_no_incremental_scan_extensions(&extensions);
+}
+
+#[tokio::test]
+async fn test_build_flow_query_extensions_include_sink_id_without_incremental_scan() {
+    let sink_table = "extension_sink";
+    let TestTaskParts {
+        task, query_engine, ..
+    } = new_test_task_engine_and_plan_with_query(
+        "SELECT number, ts FROM numbers_with_ts",
+        sink_table,
+    )
+    .await;
+    register_number_only_sink(&query_engine, sink_table);
+
+    let extensions = task.build_flow_query_extensions().await.unwrap();
+
+    assert!(extensions.contains(&(FLOW_RETURN_REGION_SEQ, "true".to_string())));
+    assert!(extensions.iter().any(|(key, value)| {
+        *key == FLOW_SINK_TABLE_ID && value.parse::<table::metadata::TableId>().is_ok()
+    }));
+    assert_no_incremental_scan_extensions(&extensions);
 }

--- a/src/flow/src/batching_mode/task/test.rs
+++ b/src/flow/src/batching_mode/task/test.rs
@@ -187,7 +187,7 @@ fn dirty_range(start: i64, end: i64) -> DirtyTimeWindows {
     dirty
 }
 
-async fn assert_filterless_failure_restore(
+async fn assert_unscoped_failure_restore(
     consumed_dirty_windows: DirtyTimeWindows,
     current_dirty_windows: DirtyTimeWindows,
     expected_len: usize,
@@ -201,13 +201,12 @@ async fn assert_filterless_failure_restore(
             .dirty_time_windows
             .add_dirty_windows(&current_dirty_windows);
     }
-    let filterless_query = PlanInfo {
+    let unscoped_query = PlanInfo {
         plan,
-        filter: None,
-        filterless_dirty_windows_to_restore: Some(consumed_dirty_windows),
+        dirty_restore: DirtyRestore::Unscoped(consumed_dirty_windows),
     };
 
-    task.handle_executed_query_failure(Some(&filterless_query));
+    task.handle_executed_query_failure(Some(&unscoped_query));
 
     let state = task.state.read().unwrap();
     assert_eq!(state.dirty_time_windows.len(), expected_len);
@@ -226,13 +225,12 @@ async fn test_executed_query_failure_restores_scoped_dirty_windows_for_flush_pat
     }
     let scoped_query = PlanInfo {
         plan,
-        filter: Some(FilterExprInfo {
+        dirty_restore: DirtyRestore::Scoped(FilterExprInfo {
             expr: datafusion_expr::lit(true),
             col_name: "ts".to_string(),
             time_ranges: vec![(Timestamp::new_second(10), Timestamp::new_second(20))],
             window_size: chrono::Duration::seconds(10),
         }),
-        filterless_dirty_windows_to_restore: None,
     };
 
     task.handle_executed_query_failure(Some(&scoped_query));
@@ -242,14 +240,14 @@ async fn test_executed_query_failure_restores_scoped_dirty_windows_for_flush_pat
 }
 
 #[tokio::test]
-async fn test_filterless_failure_restores_consumed_dirty_windows() {
-    assert_filterless_failure_restore(dirty_marker(), DirtyTimeWindows::default(), 1, 0).await;
-    assert_filterless_failure_restore(dirty_range(30, 40), dirty_range(10, 20), 2, 20).await;
-    assert_filterless_failure_restore(dirty_range(30, 40), dirty_range(30, 50), 1, 20).await;
+async fn test_unscoped_failure_restores_consumed_dirty_signal() {
+    assert_unscoped_failure_restore(dirty_marker(), DirtyTimeWindows::default(), 1, 0).await;
+    assert_unscoped_failure_restore(dirty_range(30, 40), dirty_range(10, 20), 2, 20).await;
+    assert_unscoped_failure_restore(dirty_range(30, 40), dirty_range(30, 50), 1, 20).await;
 }
 
 #[tokio::test]
-async fn test_filterless_plan_generation_failure_restores_consumed_dirty_marker() {
+async fn test_unscoped_plan_generation_failure_restores_consumed_dirty_signal() {
     let TestTaskParts {
         task, query_engine, ..
     } = new_test_task_engine_and_plan_with_query(

--- a/src/flow/src/metrics.rs
+++ b/src/flow/src/metrics.rs
@@ -17,17 +17,6 @@
 use lazy_static::lazy_static;
 use prometheus::*;
 
-pub(crate) const FLOW_CHECKPOINT_DECISION_ADVANCE_LABEL: &str = "advance";
-pub(crate) const FLOW_CHECKPOINT_DECISION_FALLBACK_LABEL: &str = "fallback";
-pub(crate) const FLOW_CHECKPOINT_MODE_FULL_SNAPSHOT_LABEL: &str = "full_snapshot";
-pub(crate) const FLOW_CHECKPOINT_MODE_INCREMENTAL_LABEL: &str = "incremental";
-pub(crate) const FLOW_CHECKPOINT_REASON_NONE_LABEL: &str = "none";
-pub(crate) const FLOW_CHECKPOINT_REASON_MISSING_WATERMARK_LABEL: &str = "missing_region_watermark";
-pub(crate) const FLOW_CHECKPOINT_REASON_INCOMPLETE_WATERMARK_LABEL: &str =
-    "incomplete_region_watermark";
-pub(crate) const FLOW_CHECKPOINT_REASON_QUERY_FAILURE_LABEL: &str =
-    "checkpoint_ready_query_failure";
-
 lazy_static! {
     pub static ref METRIC_FLOW_TASK_COUNT: IntGauge =
         register_int_gauge!("greptime_flow_task_count", "flow task count").unwrap();
@@ -96,20 +85,6 @@ lazy_static! {
             "greptime_flow_batching_error_count",
             "flow batching engine error count per flow id",
             &["flow_id"],
-        )
-        .unwrap();
-    pub static ref METRIC_FLOW_BATCHING_ENGINE_CHECKPOINT_DECISION_CNT: IntCounterVec =
-        register_int_counter_vec!(
-            "greptime_flow_batching_checkpoint_decision_count",
-            "flow batching checkpoint state-machine decisions",
-            &["flow_id", "mode", "decision", "reason"],
-        )
-        .unwrap();
-    pub static ref METRIC_FLOW_BATCHING_ENGINE_QUERY_MODE_CNT: IntCounterVec =
-        register_int_counter_vec!(
-            "greptime_flow_batching_query_mode_count",
-            "flow batching query attempts by checkpoint mode",
-            &["flow_id", "mode"],
         )
         .unwrap();
     pub static ref METRIC_FLOW_RUN_INTERVAL_MS: IntGauge =

--- a/src/flow/src/metrics.rs
+++ b/src/flow/src/metrics.rs
@@ -87,6 +87,20 @@ lazy_static! {
             &["flow_id"],
         )
         .unwrap();
+    pub static ref METRIC_FLOW_BATCHING_ENGINE_CHECKPOINT_DECISION_CNT: IntCounterVec =
+        register_int_counter_vec!(
+            "greptime_flow_batching_checkpoint_decision_count",
+            "flow batching checkpoint state-machine decisions",
+            &["flow_id", "mode", "decision", "reason"],
+        )
+        .unwrap();
+    pub static ref METRIC_FLOW_BATCHING_ENGINE_QUERY_MODE_CNT: IntCounterVec =
+        register_int_counter_vec!(
+            "greptime_flow_batching_query_mode_count",
+            "flow batching query attempts by checkpoint mode",
+            &["flow_id", "mode"],
+        )
+        .unwrap();
     pub static ref METRIC_FLOW_RUN_INTERVAL_MS: IntGauge =
         register_int_gauge!("greptime_flow_run_interval_ms", "flow run interval in ms").unwrap();
     pub static ref METRIC_FLOW_ROWS: IntCounterVec = register_int_counter_vec!(

--- a/src/flow/src/metrics.rs
+++ b/src/flow/src/metrics.rs
@@ -17,6 +17,17 @@
 use lazy_static::lazy_static;
 use prometheus::*;
 
+pub(crate) const FLOW_CHECKPOINT_DECISION_ADVANCE_LABEL: &str = "advance";
+pub(crate) const FLOW_CHECKPOINT_DECISION_FALLBACK_LABEL: &str = "fallback";
+pub(crate) const FLOW_CHECKPOINT_MODE_FULL_SNAPSHOT_LABEL: &str = "full_snapshot";
+pub(crate) const FLOW_CHECKPOINT_MODE_INCREMENTAL_LABEL: &str = "incremental";
+pub(crate) const FLOW_CHECKPOINT_REASON_NONE_LABEL: &str = "none";
+pub(crate) const FLOW_CHECKPOINT_REASON_MISSING_WATERMARK_LABEL: &str = "missing_region_watermark";
+pub(crate) const FLOW_CHECKPOINT_REASON_INCOMPLETE_WATERMARK_LABEL: &str =
+    "incomplete_region_watermark";
+pub(crate) const FLOW_CHECKPOINT_REASON_QUERY_FAILURE_LABEL: &str =
+    "checkpoint_ready_query_failure";
+
 lazy_static! {
     pub static ref METRIC_FLOW_TASK_COUNT: IntGauge =
         register_int_gauge!("greptime_flow_task_count", "flow task count").unwrap();

--- a/src/frontend/src/instance/grpc.rs
+++ b/src/frontend/src/instance/grpc.rs
@@ -121,8 +121,9 @@ impl GrpcQueryHandler for Instance {
                                 .context(PlanStatementSnafu)?;
 
                             let dummy_catalog_list =
-                                Arc::new(catalog::table_source::dummy_catalog::DummyCatalogList::new(
+                                Arc::new(catalog::table_source::dummy_catalog::DummyCatalogList::new_with_query_ctx(
                                     self.catalog_manager().clone(),
+                                    ctx.clone(),
                                 ));
 
                             let logical_plan = plan_decoder
@@ -416,10 +417,12 @@ impl Instance {
             .new_plan_decoder()
             .context(PlanStatementSnafu)?;
 
-        let dummy_catalog_list =
-            Arc::new(catalog::table_source::dummy_catalog::DummyCatalogList::new(
+        let dummy_catalog_list = Arc::new(
+            catalog::table_source::dummy_catalog::DummyCatalogList::new_with_query_ctx(
                 self.catalog_manager().clone(),
-            ));
+                ctx.clone(),
+            ),
+        );
 
         // no optimize yet since we still need to add stuff
         let logical_plan = plan_decoder

--- a/src/query/src/dummy_catalog.rs
+++ b/src/query/src/dummy_catalog.rs
@@ -620,7 +620,10 @@ mod tests {
 
     use super::*;
     use crate::error::Error;
-    use crate::options::{FLOW_INCREMENTAL_AFTER_SEQS, FLOW_INCREMENTAL_MODE, FLOW_SINK_TABLE_ID};
+    use crate::options::{
+        FLOW_INCREMENTAL_AFTER_SEQS, FLOW_INCREMENTAL_MODE, FLOW_RETURN_REGION_SEQ,
+        FLOW_SINK_TABLE_ID,
+    };
 
     fn test_region_id() -> RegionId {
         RegionId::new(1024, 1)
@@ -649,6 +652,53 @@ mod tests {
         assert!(!request.snapshot_on_scan);
         assert_eq!(request.memtable_max_sequence, Some(42));
         assert_eq!(request.sst_min_sequence, Some(7));
+    }
+
+    #[test]
+    fn test_terminal_watermark_context_uses_snapshot_upper_bound_for_source_scan() {
+        let region_id = test_region_id();
+        let query_ctx = QueryContextBuilder::default()
+            .extensions(HashMap::from([(
+                FLOW_RETURN_REGION_SEQ.to_string(),
+                "true".to_string(),
+            )]))
+            .build();
+
+        let request = scan_request_from_query_context(region_id, &query_ctx).unwrap();
+
+        assert!(request.snapshot_on_scan);
+        assert_eq!(request.memtable_min_sequence, None);
+        assert_eq!(request.memtable_max_sequence, None);
+        assert_eq!(request.sst_min_sequence, None);
+    }
+
+    #[test]
+    fn test_terminal_watermark_context_skips_sink_scan_semantics() {
+        let region_id = test_region_id();
+        let query_ctx = QueryContextBuilder::default()
+            .extensions(HashMap::from([
+                (FLOW_RETURN_REGION_SEQ.to_string(), "true".to_string()),
+                (
+                    FLOW_SINK_TABLE_ID.to_string(),
+                    region_id.table_id().to_string(),
+                ),
+            ]))
+            .snapshot_seqs(Arc::new(RwLock::new(HashMap::from([(
+                region_id.as_u64(),
+                88_u64,
+            )]))))
+            .sst_min_sequences(Arc::new(RwLock::new(HashMap::from([(
+                region_id.as_u64(),
+                77_u64,
+            )]))))
+            .build();
+
+        let request = scan_request_from_query_context(region_id, &query_ctx).unwrap();
+
+        assert!(!request.snapshot_on_scan);
+        assert_eq!(request.memtable_min_sequence, None);
+        assert_eq!(request.memtable_max_sequence, None);
+        assert_eq!(request.sst_min_sequence, None);
     }
 
     #[test]

--- a/src/query/src/dummy_catalog.rs
+++ b/src/query/src/dummy_catalog.rs
@@ -655,7 +655,7 @@ mod tests {
     }
 
     #[test]
-    fn test_terminal_watermark_context_uses_snapshot_upper_bound_for_source_scan() {
+    fn test_terminal_watermark_context_source_and_sink_scan_semantics() {
         let region_id = test_region_id();
         let query_ctx = QueryContextBuilder::default()
             .extensions(HashMap::from([(
@@ -670,11 +670,7 @@ mod tests {
         assert_eq!(request.memtable_min_sequence, None);
         assert_eq!(request.memtable_max_sequence, None);
         assert_eq!(request.sst_min_sequence, None);
-    }
 
-    #[test]
-    fn test_terminal_watermark_context_skips_sink_scan_semantics() {
-        let region_id = test_region_id();
         let query_ctx = QueryContextBuilder::default()
             .extensions(HashMap::from([
                 (FLOW_RETURN_REGION_SEQ.to_string(), "true".to_string()),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Refs #8125

## What's changed and what's your intention?

This PR narrows PR3a to **Flow query-context / terminal-watermark plumbing only**. It prepares the lower-level paths needed by a follow-up PR to enable incremental Flow reads, but it does **not** activate those paths from normal Flow batching execution.

Core plumbing:

- Propagate `QueryContext` through frontend Substrait decode and dummy catalog table lookup.
- Add `FrontendClient::query_with_terminal_metrics(...)` so a future Flow path can forward flow extensions and collect terminal region watermark metrics.
- Keep datanode/query scan plumbing able to expose terminal region watermark metadata when explicitly requested through query context extensions.
- Add low-level tests for terminal-watermark source scan semantics and sink-scan exclusion.

Reviewability / independent correctness cleanup:

- Split batching task table-creation helpers and task tests into focused modules.
- Make batching task replace/remove lifecycle safer.
- Restore dirty-window state correctly when scoped or filterless query planning/execution fails.
- Return Flow batching affected-row counts as `usize` to avoid narrowing `OutputRows`.

Scope boundaries:

- Normal Flow batching execution still uses `FrontendClient::handle(...)`.
- Flow tasks do not emit `FLOW_RETURN_REGION_SEQ`, `FLOW_SINK_TABLE_ID`, `FLOW_INCREMENTAL_MODE`, or `FLOW_INCREMENTAL_AFTER_SEQS` in this PR.
- `TaskState` does not maintain checkpoint maps or checkpoint mode.
- Checkpoint state machine, incremental extension gating, aggregate rewrite wiring, sink dirty-window filtering, stale cursor handling, and standalone SQL incremental-read behavior are left to follow-up changes.

Validation:

- `cargo fmt --all --check`
- `cargo test -p flow --lib` (130 passed)
- `cargo test -p query terminal_watermark_context --lib`
- `cargo check -p flow -p frontend -p datanode -p catalog -p query`

Note: `.cargo/config.toml` was modified locally by build tooling and is intentionally not included in this PR.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
