### PR TITLE
chore: track region committed sequence metrics

### DIFF
--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -29,6 +29,10 @@ pub const FLUSH_REASON: &str = "reason";
 pub const FILE_TYPE_LABEL: &str = "file_type";
 /// Region worker id label.
 pub const WORKER_LABEL: &str = "worker";
+/// Region id label.
+pub const REGION_LABEL: &str = "region";
+/// Region role label.
+pub const ROLE_LABEL: &str = "role";
 /// Partition label.
 pub const PARTITION_LABEL: &str = "partition";
 /// Staging dir type label.
@@ -51,6 +55,13 @@ lazy_static! {
             "mito region count in each worker",
             &[WORKER_LABEL],
         ).unwrap();
+    /// Gauge for region committed sequence by role.
+    pub static ref REGION_SEQUENCE: IntGaugeVec = register_int_gauge_vec!(
+        "greptime_mito_region_sequence",
+        "mito region committed sequence by role",
+        &[REGION_LABEL, ROLE_LABEL],
+    )
+    .unwrap();
     /// Elapsed time to handle requests.
     pub static ref HANDLE_REQUEST_ELAPSED: HistogramVec = register_histogram_vec!(
             "greptime_mito_handle_request_elapsed",

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -52,6 +52,7 @@ use crate::manifest::action::{
     RegionChange, RegionManifest, RegionMetaAction, RegionMetaActionList,
 };
 use crate::manifest::manager::RegionManifestManager;
+use crate::metrics::REGION_SEQUENCE;
 use crate::region::version::{VersionControlRef, VersionRef};
 use crate::request::{OnFailure, OptionOutputTx};
 use crate::sst::file::FileMeta;
@@ -190,6 +191,45 @@ impl StagingPartitionInfo {
 }
 
 impl MitoRegion {
+    /// Observes the region sequence for leader/follower sync.
+    pub(crate) fn observe_committed_sequence(&self) {
+        let committed_sequence = self.version_control.current().committed_sequence;
+        if let Ok(sequence) = i64::try_from(committed_sequence) {
+            let region_id = self.region_id.to_string();
+            let role_label = Self::role_state_label(self.state());
+            REGION_SEQUENCE
+                .with_label_values(&[&region_id, role_label])
+                .set(sequence);
+        } else {
+            warn!(
+                "Region ({}) sequence overflows, skip reporting to metrics",
+                self.region_id
+            );
+        }
+    }
+
+    fn role_state_label(state: RegionRoleState) -> &'static str {
+        match state {
+            RegionRoleState::Leader(_) => "leader",
+            RegionRoleState::Follower => "follower",
+        }
+    }
+
+    /// Removes committed_sequence metrics in given role
+    fn remove_committed_sequence_metrics_for_role(&self, role: RegionRoleState) {
+        let region_id = self.region_id.to_string();
+        let role_label = Self::role_state_label(role);
+        let _ = REGION_SEQUENCE.remove_label_values(&[&region_id, role_label]);
+    }
+
+    /// Removes the committed_sequence metrics of all roles
+    pub(crate) fn remove_committed_sequence_metrics(&self) {
+        let region_id = self.region_id.to_string();
+        for role in ["leader", "follower"] {
+            let _ = REGION_SEQUENCE.remove_label_values(&[&region_id, role]);
+        }
+    }
+
     /// Stop background managers for this region.
     pub(crate) async fn stop(&self) {
         self.manifest_ctx
@@ -554,6 +594,13 @@ impl MitoRegion {
         }
 
         drop(manager);
+
+        let new_state = self.state();
+        if current_state != new_state {
+            // Role changed, remove previous role metrics.
+            self.remove_committed_sequence_metrics_for_role(current_state);
+        }
+        self.observe_committed_sequence();
 
         Ok(())
     }
@@ -1598,7 +1645,7 @@ mod tests {
     use object_store::ObjectStore;
     use object_store::services::Fs;
     use store_api::logstore::provider::Provider;
-    use store_api::region_engine::RegionRole;
+    use store_api::region_engine::{RegionRole, SettableRegionRoleState};
     use store_api::region_request::PathType;
     use store_api::storage::{FileId, RegionId};
 
@@ -1608,6 +1655,7 @@ mod tests {
         RegionChange, RegionEdit, RegionMetaAction, RegionMetaActionList, RegionPartitionExprChange,
     };
     use crate::manifest::manager::{RegionManifestManager, RegionManifestOptions};
+    use crate::metrics::REGION_SEQUENCE;
     use crate::region::{
         ManifestContext, ManifestStats, MitoRegion, RegionLeaderState, RegionRoleState,
     };
@@ -1713,6 +1761,78 @@ mod tests {
                 .await
                 .files
                 .contains_key(&file_id)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_observe_sync_status_metrics() {
+        let env = SchedulerEnv::new().await;
+        let region = build_test_region(&env).await;
+        let region_id = region.region_id.to_string();
+        let has_sequence_metric = |role: &str, value: f64| {
+            prometheus::gather().iter().any(|metric_family| {
+                metric_family.name() == "greptime_mito_region_sequence"
+                    && metric_family.get_metric().iter().any(|metric| {
+                        metric.gauge.value() == value
+                            && metric
+                                .label
+                                .iter()
+                                .any(|label| label.name() == "region" && label.value() == region_id)
+                            && metric
+                                .label
+                                .iter()
+                                .any(|label| label.name() == "role" && label.value() == role)
+                    })
+            })
+        };
+
+        region.version_control.apply_edit(
+            Some(RegionEdit {
+                flushed_entry_id: Some(7),
+                flushed_sequence: Some(42),
+                committed_sequence: Some(42),
+                ..empty_edit()
+            }),
+            &[],
+            region.file_purger.clone(),
+        );
+        region.observe_committed_sequence();
+
+        assert_eq!(
+            42,
+            REGION_SEQUENCE
+                .with_label_values(&[&region_id, "leader"])
+                .get()
+        );
+        assert!(has_sequence_metric("leader", 42.0));
+        assert!(!has_sequence_metric("follower", 0.0));
+
+        REGION_SEQUENCE
+            .with_label_values(&[&region_id, "follower"])
+            .set(24);
+        region.observe_committed_sequence();
+        assert!(has_sequence_metric("follower", 24.0));
+
+        region
+            .set_role_state_gracefully(SettableRegionRoleState::Follower)
+            .await
+            .unwrap();
+        region.observe_committed_sequence();
+
+        assert_eq!(
+            42,
+            REGION_SEQUENCE
+                .with_label_values(&[&region_id, "follower"])
+                .get()
+        );
+        assert!(has_sequence_metric("follower", 42.0));
+        assert!(!has_sequence_metric("leader", 0.0));
+
+        assert!(
+            !prometheus::gather()
+                .iter()
+                .any(|metric_family| metric_family.name()
+                    == "greptime_mito_region_last_flushed_entry_id")
         );
     }
 

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -1214,6 +1214,13 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         if let Err(e) = self.flush_periodically() {
             error!(e; "Failed to flush regions periodically");
         }
+        self.observe_region_sync_status_metrics();
+    }
+
+    fn observe_region_sync_status_metrics(&self) {
+        for region in self.regions.list_regions() {
+            region.observe_committed_sequence();
+        }
     }
 
     /// Handles region background request

--- a/src/mito2/src/worker/handle_catchup.rs
+++ b/src/mito2/src/worker/handle_catchup.rs
@@ -88,6 +88,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                             error!(err; "Failed to set region {region_id} to leader");
                         }
                     }
+                    region.observe_committed_sequence();
                     catchup_regions.remove_region(region_id);
                     sender.send(Ok(0));
                 }
@@ -130,6 +131,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         .open(&self.config, &self.wal)
         .await?;
         debug_assert!(!reopened_region.is_writable());
+        reopened_region.observe_committed_sequence();
         self.regions.insert_region(reopened_region.clone());
 
         Ok(reopened_region)

--- a/src/mito2/src/worker/handle_close.rs
+++ b/src/mito2/src/worker/handle_close.rs
@@ -79,6 +79,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         self.compaction_scheduler.on_region_closed(region_id);
         // clean index build status.
         self.index_build_scheduler.on_region_closed(region_id).await;
+        region.remove_committed_sequence_metrics();
         self.region_count.dec();
     }
 }

--- a/src/mito2/src/worker/handle_create.rs
+++ b/src/mito2/src/worker/handle_create.rs
@@ -80,6 +80,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         );
 
         self.region_count.inc();
+        region.observe_committed_sequence();
 
         // Insert the MitoRegion into the RegionMap.
         self.regions.insert_region(region);

--- a/src/mito2/src/worker/handle_flush.rs
+++ b/src/mito2/src/worker/handle_flush.rs
@@ -273,6 +273,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         }
 
         region.update_flush_millis();
+        region.observe_committed_sequence();
 
         // Delete wal.
         info!(

--- a/src/mito2/src/worker/handle_manifest.rs
+++ b/src/mito2/src/worker/handle_manifest.rs
@@ -274,6 +274,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         );
         let version = version_builder.build();
         region.version_control.overwrite_current(Arc::new(version));
+        region.observe_committed_sequence();
 
         let updated = manifest.manifest_version > original_manifest_version;
         let _ = sender.send(Ok((manifest.manifest_version, updated)));
@@ -418,6 +419,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             if edit_result.update_region_state {
                 region.switch_state_to_writable(RegionLeaderState::Editing);
             }
+            region.observe_committed_sequence();
 
             need_compaction
         };

--- a/src/mito2/src/worker/handle_open.rs
+++ b/src/mito2/src/worker/handle_open.rs
@@ -139,6 +139,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                         now.elapsed()
                     );
                     region_count.inc();
+                    region.observe_committed_sequence();
 
                     // Insert the Region into the RegionMap.
                     regions.insert_region(region);

--- a/src/mito2/src/worker/handle_write.rs
+++ b/src/mito2/src/worker/handle_write.rs
@@ -161,6 +161,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         WRITE_ROWS_TOTAL
             .with_label_values(&["delete"])
             .inc_by(delete_rows as u64);
+        self.observe_region_sync_status_metrics();
     }
 
     /// Handles all stalled write requests.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR adds a Mito region committed sequence gauge to help compare leader/follower sync progress.

- Adds `greptime_mito_region_sequence` with `region` and `role` labels.
- Observes committed sequence during region create/open/catchup/flush/manifest/write paths and periodic worker work.
- Removes stale committed sequence metrics when regions close or role labels change.
- Adds a unit test covering metric observation and role-label cleanup.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
