### PR TITLE
fix: reset procedure manager state on stop

### DIFF
--- a/src/common/procedure/src/local.rs
+++ b/src/common/procedure/src/local.rs
@@ -336,7 +336,15 @@ impl ManagerContext {
         self.procedures.write().unwrap().clear();
         self.running_procedures.lock().unwrap().clear();
         self.finished_procedures.lock().unwrap().clear();
-        self.runner_tasks.lock().unwrap().clear();
+        for handle in self
+            .runner_tasks
+            .lock()
+            .unwrap()
+            .drain()
+            .map(|(_, handle)| handle)
+        {
+            handle.abort();
+        }
         self.key_lock.clear();
         self.dynamic_key_lock.clear();
     }
@@ -351,12 +359,16 @@ impl ManagerContext {
         }
 
         let handle = spawn();
-        if handle.is_finished() {
-            return false;
-        }
-
         let _ = tasks.insert(procedure_id, handle);
         true
+    }
+
+    fn remove_procedure(&self, procedure_id: ProcedureId) {
+        self.procedures.write().unwrap().remove(&procedure_id);
+        self.running_procedures
+            .lock()
+            .unwrap()
+            .remove(&procedure_id);
     }
 
     pub(crate) fn remove_runner_task(&self, procedure_id: ProcedureId) {
@@ -736,19 +748,25 @@ impl LocalManager {
 
         let tracing_context = TracingContext::from_current_span();
 
-        self.manager_ctx.spawn_runner_task(procedure_id, || {
-            common_runtime::spawn_global(async move {
-                let span = tracing_context.attach(tracing::info_span!(
-                "LocalManager::submit_root_procedure",
-                    procedure_name = %runner.meta.type_name,
-                    procedure_id = %runner.meta.id,
-                ));
-                // Run the root procedure.
-                // The task was moved to another runtime for execution.
-                // In order not to interrupt tracing, a span needs to be created to continue tracing the current task.
-                runner.run().trace(span).await;
-            })
-        });
+        ensure!(
+            self.manager_ctx.spawn_runner_task(procedure_id, || {
+                common_runtime::spawn_global(async move {
+                    let span = tracing_context.attach(tracing::info_span!(
+                    "LocalManager::submit_root_procedure",
+                        procedure_name = %runner.meta.type_name,
+                        procedure_id = %runner.meta.id,
+                    ));
+                    // Run the root procedure.
+                    // The task was moved to another runtime for execution.
+                    // In order not to interrupt tracing, a span needs to be created to continue tracing the current task.
+                    runner.run().trace(span).await;
+                })
+            }),
+            {
+                self.manager_ctx.remove_procedure(procedure_id);
+                ManagerNotStartSnafu
+            }
+        );
 
         Ok(watcher)
     }

--- a/src/common/procedure/src/local.rs
+++ b/src/common/procedure/src/local.rs
@@ -342,6 +342,7 @@ impl ManagerContext {
     }
 
     fn insert_runner_task(&self, procedure_id: ProcedureId, handle: JoinHandle<()>) {
+        let mut tasks = self.runner_tasks.lock().unwrap();
         if !self.running() {
             handle.abort();
             return;
@@ -350,11 +351,7 @@ impl ManagerContext {
             return;
         }
 
-        let _ = self
-            .runner_tasks
-            .lock()
-            .unwrap()
-            .insert(procedure_id, handle);
+        let _ = tasks.insert(procedure_id, handle);
     }
 
     pub(crate) fn remove_runner_task(&self, procedure_id: ProcedureId) {

--- a/src/common/procedure/src/local.rs
+++ b/src/common/procedure/src/local.rs
@@ -1669,7 +1669,7 @@ mod tests {
         let state_store = Arc::new(ObjectStateStore::new(test_util::new_object_store(&dir)));
         let poison_manager = Arc::new(InMemoryPoisonStore::new());
         let manager = LocalManager::new(config, state_store, poison_manager, None, None);
-        manager.manager_ctx.set_running();
+        manager.start().await.unwrap();
 
         manager
             .manager_ctx
@@ -1677,7 +1677,6 @@ mod tests {
             .lock()
             .unwrap()
             .insert(ProcedureId::random());
-        manager.start().await.unwrap();
 
         // Submit a new procedure should fail.
         let mut procedure = ProcedureToLoad::new("submit");

--- a/src/common/procedure/src/local.rs
+++ b/src/common/procedure/src/local.rs
@@ -24,7 +24,7 @@ use async_trait::async_trait;
 use backon::ExponentialBuilder;
 use common_error::ext::BoxedError;
 use common_event_recorder::EventRecorderRef;
-use common_runtime::{RepeatedTask, TaskFunction};
+use common_runtime::{JoinHandle, RepeatedTask, TaskFunction};
 use common_telemetry::tracing_context::{FutureExt, TracingContext};
 use common_telemetry::{error, info, tracing};
 use snafu::{OptionExt, ResultExt, ensure};
@@ -254,6 +254,8 @@ pub(crate) struct ManagerContext {
     running_procedures: Mutex<HashSet<ProcedureId>>,
     /// Ids and finished time of finished procedures.
     finished_procedures: Mutex<VecDeque<(ProcedureId, Instant)>>,
+    /// Runner tasks of procedures.
+    runner_tasks: Mutex<HashMap<ProcedureId, JoinHandle<()>>>,
     /// Running flag.
     running: Arc<AtomicBool>,
     /// Poison manager.
@@ -310,6 +312,7 @@ impl ManagerContext {
             procedures: RwLock::new(HashMap::new()),
             running_procedures: Mutex::new(HashSet::new()),
             finished_procedures: Mutex::new(VecDeque::new()),
+            runner_tasks: Mutex::new(HashMap::new()),
             running: Arc::new(AtomicBool::new(false)),
             poison_manager,
         }
@@ -327,6 +330,62 @@ impl ManagerContext {
 
     pub(crate) fn stop(&self) {
         self.running.store(false, Ordering::Relaxed);
+    }
+
+    fn reset_runtime_state(&self) {
+        self.procedures.write().unwrap().clear();
+        self.running_procedures.lock().unwrap().clear();
+        self.finished_procedures.lock().unwrap().clear();
+        self.runner_tasks.lock().unwrap().clear();
+        self.key_lock.clear();
+        self.dynamic_key_lock.clear();
+    }
+
+    fn insert_runner_task(&self, procedure_id: ProcedureId, handle: JoinHandle<()>) {
+        if !self.running() {
+            handle.abort();
+            return;
+        }
+        if handle.is_finished() {
+            return;
+        }
+
+        let _ = self
+            .runner_tasks
+            .lock()
+            .unwrap()
+            .insert(procedure_id, handle);
+    }
+
+    pub(crate) fn remove_runner_task(&self, procedure_id: ProcedureId) {
+        let _ = self.runner_tasks.lock().unwrap().remove(&procedure_id);
+    }
+
+    fn take_runner_tasks(&self) -> Vec<JoinHandle<()>> {
+        self.runner_tasks
+            .lock()
+            .unwrap()
+            .drain()
+            .map(|(_, handle)| handle)
+            .collect()
+    }
+
+    async fn abort_runner_tasks(&self) {
+        let handles = self.take_runner_tasks();
+
+        for handle in &handles {
+            handle.abort();
+        }
+
+        for handle in handles {
+            if let Err(e) = handle.await
+                && !e.is_cancelled()
+            {
+                error!(
+                    e; "Procedure runner task exits unexpectedly during stop",
+                );
+            }
+        }
     }
 
     /// Return `ProcedureManager` is running.
@@ -675,7 +734,7 @@ impl LocalManager {
 
         let tracing_context = TracingContext::from_current_span();
 
-        let _handle = common_runtime::spawn_global(async move {
+        let handle = common_runtime::spawn_global(async move {
             let span = tracing_context.attach(tracing::info_span!(
             "LocalManager::submit_root_procedure",
                 procedure_name = %runner.meta.type_name,
@@ -686,6 +745,7 @@ impl LocalManager {
             // In order not to interrupt tracing, a span needs to be created to continue tracing the current task.
             runner.run().trace(span).await;
         });
+        self.manager_ctx.insert_runner_task(procedure_id, handle);
 
         Ok(watcher)
     }
@@ -830,13 +890,17 @@ impl ProcedureManager for LocalManager {
     }
 
     async fn stop(&self) -> Result<()> {
-        let mut task = self.remove_outdated_meta_task.lock().await;
-
-        if let Some(task) = task.take() {
-            task.stop().await.context(StopRemoveOutdatedMetaTaskSnafu)?;
-        }
-
         self.manager_ctx.stop();
+
+        let mut task = self.remove_outdated_meta_task.lock().await;
+        if let Some(task) = task.take()
+            && let Err(e) = task.stop().await.context(StopRemoveOutdatedMetaTaskSnafu)
+        {
+            error!(e; "Failed to stop remove outdated meta task");
+        };
+
+        self.manager_ctx.abort_runner_tasks().await;
+        self.manager_ctx.reset_runtime_state();
 
         info!("LocalManager is stopped.");
 
@@ -921,10 +985,12 @@ pub(crate) mod test_util {
 #[cfg(test)]
 mod tests {
     use std::assert_matches;
+    use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
 
     use common_error::mock::MockError;
     use common_error::status_code::StatusCode;
     use common_test_util::temp_dir::create_temp_dir;
+    use tokio::sync::oneshot;
     use tokio::time::timeout;
 
     use super::*;
@@ -952,6 +1018,63 @@ mod tests {
         assert!(ctx.state(meta.id).unwrap().is_running());
         meta.set_state(ProcedureState::Done { output: None });
         assert!(ctx.state(meta.id).unwrap().is_done());
+    }
+
+    #[test]
+    fn test_reset_runtime_state() {
+        let ctx = new_test_manager_context();
+        ctx.set_running();
+        let mut meta = test_util::procedure_meta_for_test();
+        meta.lock_key = LockKey::single_exclusive("test.reset_runtime_state");
+        let meta = Arc::new(meta);
+        let procedure_id = meta.id;
+
+        assert!(ctx.try_insert_procedure(meta.clone()));
+        ctx.finished_procedures
+            .lock()
+            .unwrap()
+            .push_back((procedure_id, Instant::now()));
+        let handle = common_runtime::spawn_global(async {});
+        ctx.insert_runner_task(procedure_id, handle);
+
+        drop(
+            ctx.key_lock
+                .try_write("test.reset_runtime_state".to_string()),
+        );
+        drop(
+            ctx.dynamic_key_lock
+                .try_write("test.reset_runtime_state.dynamic".to_string()),
+        );
+        assert!(ctx.contains_procedure(procedure_id));
+        assert_eq!(1, ctx.running_procedures.lock().unwrap().len());
+        assert_eq!(1, ctx.finished_procedures.lock().unwrap().len());
+        assert_eq!(1, ctx.runner_tasks.lock().unwrap().len());
+        assert_eq!(1, ctx.key_lock.len());
+        assert_eq!(1, ctx.dynamic_key_lock.len());
+
+        ctx.reset_runtime_state();
+
+        assert!(!ctx.contains_procedure(procedure_id));
+        assert!(ctx.running_procedures.lock().unwrap().is_empty());
+        assert!(ctx.finished_procedures.lock().unwrap().is_empty());
+        assert!(ctx.runner_tasks.lock().unwrap().is_empty());
+        assert!(ctx.key_lock.is_empty());
+        assert!(ctx.dynamic_key_lock.is_empty());
+    }
+
+    #[test]
+    fn test_insert_finished_runner_task() {
+        let ctx = new_test_manager_context();
+        ctx.set_running();
+        let procedure_id = ProcedureId::random();
+
+        let handle = common_runtime::spawn_global(async {});
+        while !handle.is_finished() {
+            std::thread::yield_now();
+        }
+        ctx.insert_runner_task(procedure_id, handle);
+
+        assert!(ctx.runner_tasks.lock().unwrap().is_empty());
     }
 
     #[test]
@@ -1044,6 +1167,105 @@ mod tests {
             };
             Box::new(f)
         }
+    }
+
+    #[derive(Debug)]
+    struct BlockingProcedure {
+        started_tx: Option<oneshot::Sender<()>>,
+        dropped: Arc<AtomicBool>,
+        lock_key: LockKey,
+    }
+
+    impl Drop for BlockingProcedure {
+        fn drop(&mut self) {
+            self.dropped.store(true, AtomicOrdering::Relaxed);
+        }
+    }
+
+    #[async_trait]
+    impl Procedure for BlockingProcedure {
+        fn type_name(&self) -> &str {
+            "BlockingProcedure"
+        }
+
+        async fn execute(&mut self, _ctx: &Context) -> Result<Status> {
+            if let Some(tx) = self.started_tx.take() {
+                let _ = tx.send(());
+            }
+            std::future::pending::<Result<Status>>().await
+        }
+
+        fn dump(&self) -> Result<String> {
+            Ok(String::new())
+        }
+
+        fn lock_key(&self) -> LockKey {
+            self.lock_key.clone()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_stop_aborts_runner_and_resets_runtime_state() {
+        let dir = create_temp_dir("stop_aborts_runner_and_resets_runtime_state");
+        let config = ManagerConfig::default();
+        let state_store = Arc::new(ObjectStateStore::new(test_util::new_object_store(&dir)));
+        let poison_manager = Arc::new(InMemoryPoisonStore::new());
+        let manager = LocalManager::new(config, state_store, poison_manager, None, None);
+        manager.start().await.unwrap();
+
+        let procedure_id = ProcedureId::random();
+        let (started_tx, started_rx) = oneshot::channel();
+        let dropped = Arc::new(AtomicBool::new(false));
+        let procedure = BlockingProcedure {
+            started_tx: Some(started_tx),
+            dropped: dropped.clone(),
+            lock_key: LockKey::single_exclusive("test.stop_aborts_runner"),
+        };
+
+        manager
+            .submit(ProcedureWithId {
+                id: procedure_id,
+                procedure: Box::new(procedure),
+            })
+            .await
+            .unwrap();
+        timeout(Duration::from_secs(5), started_rx)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(manager.manager_ctx.contains_procedure(procedure_id));
+        assert_eq!(
+            1,
+            manager.manager_ctx.running_procedures.lock().unwrap().len()
+        );
+        assert_eq!(1, manager.manager_ctx.runner_tasks.lock().unwrap().len());
+        assert_eq!(1, manager.manager_ctx.key_lock.len());
+
+        manager.stop().await.unwrap();
+
+        assert!(dropped.load(AtomicOrdering::Relaxed));
+        assert!(!manager.manager_ctx.running());
+        assert!(!manager.manager_ctx.contains_procedure(procedure_id));
+        assert!(
+            manager
+                .manager_ctx
+                .running_procedures
+                .lock()
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            manager
+                .manager_ctx
+                .finished_procedures
+                .lock()
+                .unwrap()
+                .is_empty()
+        );
+        assert!(manager.manager_ctx.runner_tasks.lock().unwrap().is_empty());
+        assert!(manager.manager_ctx.key_lock.is_empty());
+        assert!(manager.manager_ctx.dynamic_key_lock.is_empty());
     }
 
     #[test]

--- a/src/common/procedure/src/local.rs
+++ b/src/common/procedure/src/local.rs
@@ -341,17 +341,22 @@ impl ManagerContext {
         self.dynamic_key_lock.clear();
     }
 
-    fn insert_runner_task(&self, procedure_id: ProcedureId, handle: JoinHandle<()>) {
+    fn spawn_runner_task<F>(&self, procedure_id: ProcedureId, spawn: F) -> bool
+    where
+        F: FnOnce() -> JoinHandle<()>,
+    {
         let mut tasks = self.runner_tasks.lock().unwrap();
         if !self.running() {
-            handle.abort();
-            return;
+            return false;
         }
+
+        let handle = spawn();
         if handle.is_finished() {
-            return;
+            return false;
         }
 
         let _ = tasks.insert(procedure_id, handle);
+        true
     }
 
     pub(crate) fn remove_runner_task(&self, procedure_id: ProcedureId) {
@@ -731,18 +736,19 @@ impl LocalManager {
 
         let tracing_context = TracingContext::from_current_span();
 
-        let handle = common_runtime::spawn_global(async move {
-            let span = tracing_context.attach(tracing::info_span!(
-            "LocalManager::submit_root_procedure",
-                procedure_name = %runner.meta.type_name,
-                procedure_id = %runner.meta.id,
-            ));
-            // Run the root procedure.
-            // The task was moved to another runtime for execution.
-            // In order not to interrupt tracing, a span needs to be created to continue tracing the current task.
-            runner.run().trace(span).await;
+        self.manager_ctx.spawn_runner_task(procedure_id, || {
+            common_runtime::spawn_global(async move {
+                let span = tracing_context.attach(tracing::info_span!(
+                "LocalManager::submit_root_procedure",
+                    procedure_name = %runner.meta.type_name,
+                    procedure_id = %runner.meta.id,
+                ));
+                // Run the root procedure.
+                // The task was moved to another runtime for execution.
+                // In order not to interrupt tracing, a span needs to be created to continue tracing the current task.
+                runner.run().trace(span).await;
+            })
         });
-        self.manager_ctx.insert_runner_task(procedure_id, handle);
 
         Ok(watcher)
     }
@@ -879,6 +885,7 @@ impl ProcedureManager for LocalManager {
 
         *task = Some(task_inner);
 
+        self.manager_ctx.reset_runtime_state();
         self.manager_ctx.start();
 
         info!("LocalManager is start.");
@@ -1031,8 +1038,9 @@ mod tests {
             .lock()
             .unwrap()
             .push_back((procedure_id, Instant::now()));
-        let handle = common_runtime::spawn_global(async {});
-        ctx.insert_runner_task(procedure_id, handle);
+        ctx.spawn_runner_task(procedure_id, || {
+            common_runtime::spawn_global(std::future::pending::<()>())
+        });
 
         drop(
             ctx.key_lock
@@ -1060,17 +1068,20 @@ mod tests {
     }
 
     #[test]
-    fn test_insert_finished_runner_task() {
+    fn test_spawn_runner_task_not_started_after_stop() {
         let ctx = new_test_manager_context();
-        ctx.set_running();
         let procedure_id = ProcedureId::random();
 
-        let handle = common_runtime::spawn_global(async {});
-        while !handle.is_finished() {
-            std::thread::yield_now();
-        }
-        ctx.insert_runner_task(procedure_id, handle);
+        let spawned = Arc::new(AtomicBool::new(false));
+        let spawned_in_task = spawned.clone();
+        let started = ctx.spawn_runner_task(procedure_id, || {
+            common_runtime::spawn_global(async move {
+                spawned_in_task.store(true, AtomicOrdering::Relaxed);
+            })
+        });
 
+        assert!(!started);
+        assert!(!spawned.load(AtomicOrdering::Relaxed));
         assert!(ctx.runner_tasks.lock().unwrap().is_empty());
     }
 

--- a/src/common/procedure/src/local/runner.rs
+++ b/src/common/procedure/src/local/runner.rs
@@ -20,6 +20,7 @@ use backon::{BackoffBuilder, ExponentialBuilder};
 use common_error::ext::PlainError;
 use common_error::status_code::StatusCode;
 use common_event_recorder::EventRecorderRef;
+use common_telemetry::tracing::warn;
 use common_telemetry::tracing_context::{FutureExt, TracingContext};
 use common_telemetry::{debug, error, info, tracing};
 use rand::Rng;
@@ -480,6 +481,15 @@ impl Runner {
         procedure_state: ProcedureState,
         procedure: BoxedProcedure,
     ) {
+        if !self.running() {
+            warn!(
+                "ProcedureManager is not running, skip submitting subprocedure {}-{}",
+                procedure.type_name(),
+                procedure_id
+            );
+            return;
+        }
+
         if self.manager_ctx.contains_procedure(procedure_id) {
             // If the parent has already submitted this procedure, don't submit it again.
             return;
@@ -525,7 +535,7 @@ impl Runner {
         let parent_id = self.meta.id;
 
         let tracing_context = TracingContext::from_current_span();
-        let _handle = common_runtime::spawn_global(async move {
+        let handle = common_runtime::spawn_global(async move {
             let span = tracing_context.attach(tracing::info_span!(
                 "LocalManager::submit_subprocedure",
                 procedure_name = %runner.meta.type_name,
@@ -537,6 +547,7 @@ impl Runner {
             // In order not to interrupt tracing, a span needs to be created to continue tracing the current task.
             runner.run().trace(span).await
         });
+        self.manager_ctx.insert_runner_task(procedure_id, handle);
     }
 
     /// Extend the retry time to wait for the next retry.
@@ -699,6 +710,12 @@ impl Runner {
 
         // Mark the state of this procedure to done.
         self.meta.set_state(ProcedureState::Done { output });
+    }
+}
+
+impl Drop for Runner {
+    fn drop(&mut self) {
+        self.manager_ctx.remove_runner_task(self.meta.id);
     }
 }
 

--- a/src/common/procedure/src/local/runner.rs
+++ b/src/common/procedure/src/local/runner.rs
@@ -535,19 +535,20 @@ impl Runner {
         let parent_id = self.meta.id;
 
         let tracing_context = TracingContext::from_current_span();
-        let handle = common_runtime::spawn_global(async move {
-            let span = tracing_context.attach(tracing::info_span!(
-                "LocalManager::submit_subprocedure",
-                procedure_name = %runner.meta.type_name,
-                procedure_id = %runner.meta.id,
-                parent_id = %parent_id,
-            ));
-            // Run the root procedure.
-            // The task was moved to another runtime for execution.
-            // In order not to interrupt tracing, a span needs to be created to continue tracing the current task.
-            runner.run().trace(span).await
+        self.manager_ctx.spawn_runner_task(procedure_id, || {
+            common_runtime::spawn_global(async move {
+                let span = tracing_context.attach(tracing::info_span!(
+                    "LocalManager::submit_subprocedure",
+                    procedure_name = %runner.meta.type_name,
+                    procedure_id = %runner.meta.id,
+                    parent_id = %parent_id,
+                ));
+                // Run the root procedure.
+                // The task was moved to another runtime for execution.
+                // In order not to interrupt tracing, a span needs to be created to continue tracing the current task.
+                runner.run().trace(span).await
+            })
         });
-        self.manager_ctx.insert_runner_task(procedure_id, handle);
     }
 
     /// Extend the retry time to wait for the next retry.

--- a/src/common/procedure/src/local/runner.rs
+++ b/src/common/procedure/src/local/runner.rs
@@ -530,12 +530,10 @@ impl Runner {
             procedure_id,
         );
 
-        // Add the id of the subprocedure to the metadata.
-        self.meta.push_child(procedure_id);
         let parent_id = self.meta.id;
 
         let tracing_context = TracingContext::from_current_span();
-        self.manager_ctx.spawn_runner_task(procedure_id, || {
+        if !self.manager_ctx.spawn_runner_task(procedure_id, || {
             common_runtime::spawn_global(async move {
                 let span = tracing_context.attach(tracing::info_span!(
                     "LocalManager::submit_subprocedure",
@@ -548,7 +546,13 @@ impl Runner {
                 // In order not to interrupt tracing, a span needs to be created to continue tracing the current task.
                 runner.run().trace(span).await
             })
-        });
+        }) {
+            self.manager_ctx.remove_procedure(procedure_id);
+            return;
+        }
+
+        // Add the id of the subprocedure to the metadata.
+        self.meta.push_child(procedure_id);
     }
 
     /// Extend the retry time to wait for the next retry.

--- a/src/common/procedure/src/rwlock.rs
+++ b/src/common/procedure/src/rwlock.rs
@@ -106,6 +106,13 @@ where
             locks.remove(key);
         }
     }
+
+    /// Clears all key locks.
+    ///
+    /// Callers must ensure no tasks are holding or waiting for these locks.
+    pub fn clear(&self) {
+        self.inner.lock().unwrap().clear();
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR resets `ProcedureManager` runtime state when stopping the local procedure manager.
Previously, `LocalManager::stop()` only stopped the background outdated-meta task and marked the manager as not running. In-memory procedure metadata, running/finished procedure sets, key locks, and spawned runner tasks could remain after metasrv leader stepdown. If the same metasrv process became leader again, recovery could be blocked by stale in-memory procedure state, for example by duplicate procedure IDs.

This PR changes the stop lifecycle to best-effort terminate the in-memory execution lifecycle:
- Track spawned root and subprocedure runner tasks by `ProcedureId`.
- Mark the manager as stopped before cleanup.
- Stop the outdated-meta background task. If stopping it fails, log the error and continue cleanup.
- Abort and await active procedure runner tasks.
- Reset runtime-only state:
  - procedure metadata
  - running procedure set
  - finished procedure queue
  - runner task registry
  - procedure key locks
  - dynamic key locks
- Keep persistent procedure store data intact so unfinished procedures can be recovered on the next `start()`.
This does not introduce API or data compatibility changes.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
