### PR TITLE
perf: read primary key as binary if it overflows the dictionary

### DIFF
--- a/src/mito2/src/sst.rs
+++ b/src/mito2/src/sst.rs
@@ -270,6 +270,26 @@ pub(crate) fn internal_fields() -> [FieldRef; 3] {
     ]
 }
 
+/// Returns a copy of `schema` with the `__primary_key` field replaced by a plain `Binary` field.
+pub(crate) fn override_pk_field_to_binary(schema: &SchemaRef) -> SchemaRef {
+    let new_fields = schema
+        .fields()
+        .iter()
+        .map(|field| {
+            if field.name() == PRIMARY_KEY_COLUMN_NAME {
+                Arc::new(Field::new(
+                    PRIMARY_KEY_COLUMN_NAME,
+                    ArrowDataType::Binary,
+                    field.is_nullable(),
+                ))
+            } else {
+                field.clone()
+            }
+        })
+        .collect::<Vec<_>>();
+    Arc::new(Schema::new(new_fields))
+}
+
 /// Gets the estimated number of series from record batches.
 ///
 /// This struct tracks the last timestamp value to detect series boundaries

--- a/src/mito2/src/sst/parquet/flat_format.rs
+++ b/src/mito2/src/sst/parquet/flat_format.rs
@@ -125,6 +125,32 @@ pub(crate) fn primary_key_column_index(num_columns: usize) -> usize {
     num_columns - 3
 }
 
+/// Wraps the `__primary_key` `BinaryArray` back into a `DictionaryArray<UInt32, Binary>` with identity keys.
+pub(crate) fn wrap_pk_binary_to_dict(
+    record_batch: RecordBatch,
+    dict_schema: &SchemaRef,
+) -> Result<RecordBatch> {
+    let pk_idx = primary_key_column_index(record_batch.num_columns());
+    let pk_column = record_batch.column(pk_idx);
+    let binary_array = pk_column
+        .as_any()
+        .downcast_ref::<BinaryArray>()
+        .with_context(|| InvalidRecordBatchSnafu {
+            reason: format!(
+                "expected BinaryArray for __primary_key, got {:?}",
+                pk_column.data_type()
+            ),
+        })?;
+    let n = binary_array.len();
+    let keys = UInt32Array::from_iter_values(0..n as u32);
+    let dict_array: ArrayRef = Arc::new(DictionaryArray::new(keys, Arc::new(binary_array.clone())));
+
+    let mut columns = record_batch.columns().to_vec();
+    columns[pk_idx] = dict_array;
+
+    RecordBatch::try_new(dict_schema.clone(), columns).context(NewRecordBatchSnafu)
+}
+
 /// Returns the position of the op type key column.
 pub(crate) fn op_type_column_index(num_columns: usize) -> usize {
     num_columns - 1
@@ -156,6 +182,8 @@ pub struct FlatReadFormat {
     override_sequence: Option<SequenceNumber>,
     /// Parquet format adapter.
     parquet_adapter: ParquetAdapter,
+    /// Output schema to wrap binary `__primary_key` back to a dictionary; `None` disables wrapping.
+    pk_dict_wrap_schema: Option<SchemaRef>,
 }
 
 impl FlatReadFormat {
@@ -198,12 +226,19 @@ impl FlatReadFormat {
         Ok(FlatReadFormat {
             override_sequence: None,
             parquet_adapter,
+            pk_dict_wrap_schema: None,
         })
     }
 
     /// Sets the sequence number to override.
     pub(crate) fn set_override_sequence(&mut self, sequence: Option<SequenceNumber>) {
         self.override_sequence = sequence;
+    }
+
+    /// Enables wrapping binary `__primary_key` batches back to a dictionary in [`Self::convert_batch`].
+    pub(crate) fn set_pk_as_binary(&mut self) -> Result<()> {
+        self.pk_dict_wrap_schema = Some(self.output_arrow_schema()?);
+        Ok(())
     }
 
     /// Index of a column in the projected batch by its column id.
@@ -317,6 +352,12 @@ impl FlatReadFormat {
         record_batch: RecordBatch,
         override_sequence_array: Option<&ArrayRef>,
     ) -> Result<RecordBatch> {
+        let record_batch = if let Some(dict_schema) = &self.pk_dict_wrap_schema {
+            wrap_pk_binary_to_dict(record_batch, dict_schema)?
+        } else {
+            record_batch
+        };
+
         // First, apply flat format conversion.
         let batch = match &self.parquet_adapter {
             ParquetAdapter::Flat(_) => record_batch,
@@ -809,13 +850,20 @@ mod tests {
     use std::sync::Arc;
 
     use api::v1::SemanticType;
+    use datatypes::arrow::array::{
+        BinaryArray, TimestampMillisecondArray, UInt8Array, UInt64Array,
+    };
+    use datatypes::arrow::datatypes::{
+        DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema, TimeUnit,
+    };
+    use datatypes::arrow::record_batch::RecordBatch;
     use datatypes::prelude::ConcreteDataType;
     use datatypes::schema::ColumnSchema;
     use store_api::codec::PrimaryKeyEncoding;
     use store_api::metadata::{ColumnMetadata, RegionMetadata, RegionMetadataBuilder};
     use store_api::storage::RegionId;
 
-    use super::{FlatReadFormat, field_column_start};
+    use super::{FlatReadFormat, field_column_start, wrap_pk_binary_to_dict};
     use crate::read::read_columns::ReadColumns;
     use crate::sst::{
         FlatSchemaOptions, flat_sst_arrow_schema_column_num, to_flat_sst_arrow_schema,
@@ -892,6 +940,71 @@ mod tests {
                 "num_tags={num_tags}, num_fields={num_fields}, encoding={encoding:?}"
             );
         }
+    }
+
+    #[test]
+    fn test_wrap_pk_binary_to_dict() {
+        use datatypes::arrow::array::{Array, DictionaryArray};
+        use datatypes::arrow::datatypes::UInt32Type;
+
+        // Repeat the second value to verify identity keys (no dedup).
+        let pk_values: Vec<&[u8]> = vec![b"alpha", b"beta", b"beta"];
+        let pk_array = Arc::new(BinaryArray::from_iter_values(pk_values.iter().copied()));
+        let ts_array = Arc::new(TimestampMillisecondArray::from(vec![1, 2, 3]));
+        let seq_array = Arc::new(UInt64Array::from(vec![10u64, 11, 12]));
+        let op_array = Arc::new(UInt8Array::from(vec![1u8, 1, 1]));
+
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new(
+                "ts",
+                ArrowDataType::Timestamp(TimeUnit::Millisecond, None),
+                false,
+            ),
+            ArrowField::new("__primary_key", ArrowDataType::Binary, false),
+            ArrowField::new("__sequence", ArrowDataType::UInt64, false),
+            ArrowField::new("__op_type", ArrowDataType::UInt8, false),
+        ]));
+        let dict_schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new(
+                "ts",
+                ArrowDataType::Timestamp(TimeUnit::Millisecond, None),
+                false,
+            ),
+            ArrowField::new_dictionary(
+                "__primary_key",
+                ArrowDataType::UInt32,
+                ArrowDataType::Binary,
+                false,
+            ),
+            ArrowField::new("__sequence", ArrowDataType::UInt64, false),
+            ArrowField::new("__op_type", ArrowDataType::UInt8, false),
+        ]));
+        let batch =
+            RecordBatch::try_new(schema, vec![ts_array, pk_array, seq_array, op_array]).unwrap();
+
+        let wrapped = wrap_pk_binary_to_dict(batch, &dict_schema).unwrap();
+        let pk_col = wrapped.column(1);
+        assert_eq!(
+            pk_col.data_type(),
+            &ArrowDataType::Dictionary(
+                Box::new(ArrowDataType::UInt32),
+                Box::new(ArrowDataType::Binary)
+            )
+        );
+        let dict = pk_col
+            .as_any()
+            .downcast_ref::<DictionaryArray<UInt32Type>>()
+            .unwrap();
+        assert_eq!(dict.keys().values(), &[0, 1, 2]);
+        let values = dict
+            .values()
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .unwrap();
+        assert_eq!(values.value(0), b"alpha");
+        assert_eq!(values.value(1), b"beta");
+        assert_eq!(values.value(2), b"beta");
+        assert_eq!(wrapped.schema().field(1).data_type(), pk_col.data_type());
     }
 
     #[test]

--- a/src/mito2/src/sst/parquet/flat_format.rs
+++ b/src/mito2/src/sst/parquet/flat_format.rs
@@ -143,7 +143,7 @@ pub(crate) fn wrap_pk_binary_to_dict(
         })?;
     let n = binary_array.len();
     let keys = UInt32Array::from_iter_values(0..n as u32);
-    let dict_array: ArrayRef = Arc::new(DictionaryArray::new(keys, Arc::new(binary_array.clone())));
+    let dict_array: ArrayRef = Arc::new(DictionaryArray::new(keys, pk_column.clone()));
 
     let mut columns = record_batch.columns().to_vec();
     columns[pk_idx] = dict_array;
@@ -851,11 +851,9 @@ mod tests {
 
     use api::v1::SemanticType;
     use datatypes::arrow::array::{
-        BinaryArray, TimestampMillisecondArray, UInt8Array, UInt64Array,
+        ArrayRef, BinaryArray, TimestampMillisecondArray, UInt8Array, UInt32Array, UInt64Array,
     };
-    use datatypes::arrow::datatypes::{
-        DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema, TimeUnit,
-    };
+    use datatypes::arrow::datatypes::DataType as ArrowDataType;
     use datatypes::arrow::record_batch::RecordBatch;
     use datatypes::prelude::ConcreteDataType;
     use datatypes::schema::ColumnSchema;
@@ -863,10 +861,11 @@ mod tests {
     use store_api::metadata::{ColumnMetadata, RegionMetadata, RegionMetadataBuilder};
     use store_api::storage::RegionId;
 
-    use super::{FlatReadFormat, field_column_start, wrap_pk_binary_to_dict};
+    use super::*;
     use crate::read::read_columns::ReadColumns;
     use crate::sst::{
-        FlatSchemaOptions, flat_sst_arrow_schema_column_num, to_flat_sst_arrow_schema,
+        FlatSchemaOptions, flat_sst_arrow_schema_column_num, override_pk_field_to_binary,
+        to_flat_sst_arrow_schema,
     };
 
     /// Builds a `RegionMetadata` with the given number of tags and fields.
@@ -943,47 +942,63 @@ mod tests {
     }
 
     #[test]
-    fn test_wrap_pk_binary_to_dict() {
-        use datatypes::arrow::array::{Array, DictionaryArray};
+    fn test_convert_batch_wraps_binary_pk_to_dict() {
+        use datatypes::arrow::array::{Array, DictionaryArray, StringArray};
         use datatypes::arrow::datatypes::UInt32Type;
 
-        // Repeat the second value to verify identity keys (no dedup).
-        let pk_values: Vec<&[u8]> = vec![b"alpha", b"beta", b"beta"];
-        let pk_array = Arc::new(BinaryArray::from_iter_values(pk_values.iter().copied()));
-        let ts_array = Arc::new(TimestampMillisecondArray::from(vec![1, 2, 3]));
-        let seq_array = Arc::new(UInt64Array::from(vec![10u64, 11, 12]));
-        let op_array = Arc::new(UInt8Array::from(vec![1u8, 1, 1]));
+        // build_metadata(1, 1, Dense) projects to:
+        // [tag_0: Dict<UInt32, Utf8>, field_0: UInt64, ts: Timestamp(ms),
+        //  __primary_key: Dict<UInt32, Binary>, __sequence: UInt64, __op_type: UInt8]
+        let metadata = Arc::new(build_metadata(1, 1, PrimaryKeyEncoding::Dense));
+        let column_ids: Vec<u32> = metadata
+            .column_metadatas
+            .iter()
+            .map(|c| c.column_id)
+            .collect();
+        let mut read_format = FlatReadFormat::new(
+            metadata.clone(),
+            ReadColumns::from_deduped_column_ids(column_ids),
+            None,
+            "test",
+            false,
+        )
+        .unwrap();
+        read_format.set_pk_as_binary().unwrap();
 
-        let schema = Arc::new(ArrowSchema::new(vec![
-            ArrowField::new(
-                "ts",
-                ArrowDataType::Timestamp(TimeUnit::Millisecond, None),
-                false,
-            ),
-            ArrowField::new("__primary_key", ArrowDataType::Binary, false),
-            ArrowField::new("__sequence", ArrowDataType::UInt64, false),
-            ArrowField::new("__op_type", ArrowDataType::UInt8, false),
-        ]));
-        let dict_schema = Arc::new(ArrowSchema::new(vec![
-            ArrowField::new(
-                "ts",
-                ArrowDataType::Timestamp(TimeUnit::Millisecond, None),
-                false,
-            ),
-            ArrowField::new_dictionary(
-                "__primary_key",
-                ArrowDataType::UInt32,
-                ArrowDataType::Binary,
-                false,
-            ),
-            ArrowField::new("__sequence", ArrowDataType::UInt64, false),
-            ArrowField::new("__op_type", ArrowDataType::UInt8, false),
-        ]));
-        let batch =
-            RecordBatch::try_new(schema, vec![ts_array, pk_array, seq_array, op_array]).unwrap();
+        let output_schema = read_format.output_arrow_schema().unwrap();
+        let binary_schema = override_pk_field_to_binary(&output_schema);
 
-        let wrapped = wrap_pk_binary_to_dict(batch, &dict_schema).unwrap();
-        let pk_col = wrapped.column(1);
+        // Repeat the second pk to verify identity keys (no dedup).
+        let tag_keys = UInt32Array::from(vec![0u32, 1, 1]);
+        let tag_values = Arc::new(StringArray::from(vec!["t0", "t1"]));
+        let tag_array: ArrayRef =
+            Arc::new(DictionaryArray::<UInt32Type>::new(tag_keys, tag_values));
+        let field_array: ArrayRef = Arc::new(UInt64Array::from(vec![10u64, 11, 12]));
+        let ts_array: ArrayRef = Arc::new(TimestampMillisecondArray::from(vec![1i64, 2, 3]));
+        let pk_array: ArrayRef = Arc::new(BinaryArray::from_iter_values(
+            [b"alpha".as_ref(), b"beta", b"beta"].iter().copied(),
+        ));
+        let seq_array: ArrayRef = Arc::new(UInt64Array::from(vec![100u64, 101, 102]));
+        let op_array: ArrayRef = Arc::new(UInt8Array::from(vec![1u8, 1, 1]));
+
+        let batch = RecordBatch::try_new(
+            binary_schema,
+            vec![
+                tag_array,
+                field_array,
+                ts_array,
+                pk_array,
+                seq_array,
+                op_array,
+            ],
+        )
+        .unwrap();
+
+        let wrapped = read_format.convert_batch(batch, None).unwrap();
+        assert_eq!(wrapped.schema(), output_schema);
+
+        let pk_idx = primary_key_column_index(wrapped.num_columns());
+        let pk_col = wrapped.column(pk_idx);
         assert_eq!(
             pk_col.data_type(),
             &ArrowDataType::Dictionary(
@@ -1004,7 +1019,6 @@ mod tests {
         assert_eq!(values.value(0), b"alpha");
         assert_eq!(values.value(1), b"beta");
         assert_eq!(values.value(2), b"beta");
-        assert_eq!(wrapped.schema().field(1).data_type(), pk_col.data_type());
     }
 
     #[test]

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -1686,7 +1686,7 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_filters_to_batch_handles_binary_pk_column() {
+    fn test_eval_pk_group_mask_handles_binary_pk_column() {
         let metadata = Arc::new(sst_region_metadata());
         let filters = Arc::new(new_test_filters(&[col("tag_0").eq(lit("a"))]));
         let mut pk_filter = Some(Box::new(CachedPrimaryKeyFilter::new(
@@ -1704,9 +1704,7 @@ mod tests {
             &[10, 11, 12, 13],
         );
 
-        let mask = apply_filters_to_batch(&batch, &mut pk_filter, &[], &[], "test")
-            .unwrap()
-            .unwrap();
+        let mask = eval_pk_group_mask(&batch, pk_filter.as_mut().unwrap().as_mut()).unwrap();
 
         assert_eq!(mask.count_set_bits(), 2);
     }

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -57,13 +57,49 @@ pub(crate) fn matching_row_ranges_by_primary_key(
     pk_column_index: usize,
     pk_filter: &mut dyn PrimaryKeyFilter,
 ) -> Result<Vec<Range<usize>>> {
-    let pk_dict_array = input
-        .column(pk_column_index)
-        .as_any()
-        .downcast_ref::<PrimaryKeyArray>()
-        .context(UnexpectedSnafu {
-            reason: "Primary key column is not a dictionary array",
-        })?;
+    let pk_column = input.column(pk_column_index);
+    if let Some(pk_dict_array) = pk_column.as_any().downcast_ref::<PrimaryKeyArray>() {
+        matching_row_ranges_from_dict(pk_dict_array, input.num_rows(), pk_filter)
+    } else if let Some(pk_binary_array) = pk_column.as_any().downcast_ref::<BinaryArray>() {
+        matching_row_ranges_from_binary(pk_binary_array, input.num_rows(), pk_filter)
+    } else {
+        UnexpectedSnafu {
+            reason: format!(
+                "Primary key column is neither a dictionary nor a binary array, got {:?}",
+                pk_column.data_type()
+            ),
+        }
+        .fail()
+    }
+}
+
+/// If `pk_filter` matches `pk`, records the row range `start..end`, coalescing
+/// it with the previous range when adjacent.
+fn push_matched_range(
+    matched_row_ranges: &mut Vec<Range<usize>>,
+    pk_filter: &mut dyn PrimaryKeyFilter,
+    pk: &[u8],
+    start: usize,
+    end: usize,
+) -> Result<()> {
+    if pk_filter.matches(pk).context(DecodeSnafu)? {
+        if let Some(last) = matched_row_ranges.last_mut()
+            && last.end == start
+        {
+            last.end = end;
+        } else {
+            matched_row_ranges.push(start..end);
+        }
+    }
+    Ok(())
+}
+
+/// Computes matched row ranges from a dictionary-encoded `__primary_key` column.
+fn matching_row_ranges_from_dict(
+    pk_dict_array: &PrimaryKeyArray,
+    num_rows: usize,
+    pk_filter: &mut dyn PrimaryKeyFilter,
+) -> Result<Vec<Range<usize>>> {
     let pk_values = pk_dict_array
         .values()
         .as_any()
@@ -75,7 +111,7 @@ pub(crate) fn matching_row_ranges_by_primary_key(
     let key_values = keys.values();
 
     if key_values.is_empty() {
-        return Ok(std::iter::once(0..input.num_rows()).collect());
+        return Ok(std::iter::once(0..num_rows).collect());
     }
 
     let mut matched_row_ranges: Vec<Range<usize>> = Vec::new();
@@ -87,18 +123,44 @@ pub(crate) fn matching_row_ranges_by_primary_key(
             end += 1;
         }
 
-        if pk_filter
-            .matches(pk_values.value(key as usize))
-            .context(DecodeSnafu)?
-        {
-            if let Some(last) = matched_row_ranges.last_mut()
-                && last.end == start
-            {
-                last.end = end;
-            } else {
-                matched_row_ranges.push(start..end);
-            }
+        push_matched_range(
+            &mut matched_row_ranges,
+            pk_filter,
+            pk_values.value(key as usize),
+            start,
+            end,
+        )?;
+
+        start = end;
+    }
+
+    Ok(matched_row_ranges)
+}
+
+/// Computes matched row ranges from a plain binary `__primary_key` column.
+///
+/// The writer falls back to plain binary encoding when the `__primary_key`
+/// chunk exceeds the dictionary page size limit (see `should_read_pk_as_binary`
+/// in the parquet reader), so the prefilter pass must handle this form too.
+fn matching_row_ranges_from_binary(
+    pk_array: &BinaryArray,
+    num_rows: usize,
+    pk_filter: &mut dyn PrimaryKeyFilter,
+) -> Result<Vec<Range<usize>>> {
+    if pk_array.is_empty() {
+        return Ok(std::iter::once(0..num_rows).collect());
+    }
+
+    let mut matched_row_ranges: Vec<Range<usize>> = Vec::new();
+    let mut start = 0;
+    while start < pk_array.len() {
+        let value = pk_array.value(start);
+        let mut end = start + 1;
+        while end < pk_array.len() && pk_array.value(end) == value {
+            end += 1;
         }
+
+        push_matched_range(&mut matched_row_ranges, pk_filter, value, start, end)?;
 
         start = end;
     }
@@ -1059,7 +1121,7 @@ mod tests {
     use datatypes::arrow::array::{
         ArrayRef, DictionaryArray, TimestampMillisecondArray, UInt8Array, UInt32Array, UInt64Array,
     };
-    use datatypes::arrow::datatypes::{Schema, UInt32Type};
+    use datatypes::arrow::datatypes::{DataType, Field, Schema, UInt32Type};
     use mito_codec::row_converter::{PrimaryKeyFilter, build_primary_key_codec};
     use store_api::codec::PrimaryKeyEncoding;
 
@@ -1216,6 +1278,39 @@ mod tests {
             UInt32Array::from(keys),
             Arc::new(BinaryArray::from_iter_values(dict_values.iter().copied())),
         ));
+
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(UInt64Array::from(field_values.to_vec())),
+                Arc::new(TimestampMillisecondArray::from_iter_values(
+                    0..primary_keys.len() as i64,
+                )),
+                pk_array,
+            ],
+        )
+        .unwrap()
+    }
+
+    fn new_prefilter_batch_binary_pk(primary_keys: &[&[u8]], field_values: &[u64]) -> RecordBatch {
+        assert_eq!(primary_keys.len(), field_values.len());
+
+        let metadata = Arc::new(sst_region_metadata());
+        let arrow_schema = metadata.schema.arrow_schema();
+        let field_column = arrow_schema
+            .field(arrow_schema.index_of("field_0").unwrap())
+            .clone();
+        let time_index_column = arrow_schema
+            .field(arrow_schema.index_of("ts").unwrap())
+            .clone();
+        let schema = Arc::new(Schema::new(vec![
+            field_column,
+            time_index_column,
+            Field::new(PRIMARY_KEY_COLUMN_NAME, DataType::Binary, false),
+        ]));
+
+        let pk_array: ArrayRef =
+            Arc::new(BinaryArray::from_iter_values(primary_keys.iter().copied()));
 
         RecordBatch::try_new(
             schema,
@@ -1586,6 +1681,32 @@ mod tests {
         );
 
         let mask = eval_pk_group_mask(&batch, pk_filter.as_mut().unwrap().as_mut()).unwrap();
+
+        assert_eq!(mask.count_set_bits(), 2);
+    }
+
+    #[test]
+    fn test_apply_filters_to_batch_handles_binary_pk_column() {
+        let metadata = Arc::new(sst_region_metadata());
+        let filters = Arc::new(new_test_filters(&[col("tag_0").eq(lit("a"))]));
+        let mut pk_filter = Some(Box::new(CachedPrimaryKeyFilter::new(
+            build_primary_key_codec(metadata.as_ref()).primary_key_filter(&metadata, filters),
+        )) as Box<dyn PrimaryKeyFilter>);
+        let pk_a = new_primary_key(&["a", "x"]);
+        let pk_b = new_primary_key(&["b", "x"]);
+        let batch = new_prefilter_batch_binary_pk(
+            &[
+                pk_a.as_slice(),
+                pk_a.as_slice(),
+                pk_b.as_slice(),
+                pk_b.as_slice(),
+            ],
+            &[10, 11, 12, 13],
+        );
+
+        let mask = apply_filters_to_batch(&batch, &mut pk_filter, &[], &[], "test")
+            .unwrap()
+            .unwrap();
 
         assert_eq!(mask.count_set_bits(), 2);
     }

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -41,6 +41,7 @@ use object_store::ObjectStore;
 use parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions, RowSelection};
 use parquet::arrow::{ProjectionMask, parquet_to_arrow_schema};
 use parquet::file::metadata::{PageIndexPolicy, ParquetMetaData};
+use parquet::file::properties::DEFAULT_DICTIONARY_PAGE_SIZE_LIMIT;
 use partition::expr::PartitionExpr;
 use snafu::ResultExt;
 use store_api::codec::PrimaryKeyEncoding;
@@ -80,8 +81,8 @@ use crate::sst::parquet::DEFAULT_READ_BATCH_SIZE;
 use crate::sst::parquet::file_range::{
     FileRangeContext, FileRangeContextRef, PartitionFilterContext, PreFilterMode, RangeBase,
 };
-use crate::sst::parquet::flat_format::FlatReadFormat;
-use crate::sst::parquet::format::need_override_sequence;
+use crate::sst::parquet::flat_format::{FlatReadFormat, primary_key_column_index};
+use crate::sst::parquet::format::{INTERNAL_COLUMN_NUM, need_override_sequence};
 use crate::sst::parquet::metadata::MetadataLoader;
 use crate::sst::parquet::prefilter::{
     PrefilterContextBuilder, build_reader_filter_plan, execute_prefilter,
@@ -93,9 +94,35 @@ use crate::sst::parquet::read_columns::{ProjectionMaskPlan, build_projection_pla
 use crate::sst::parquet::row_group::ParquetFetchMetrics;
 use crate::sst::parquet::row_selection::RowGroupSelection;
 use crate::sst::parquet::stats::RowGroupPruningStats;
-use crate::sst::tag_maybe_to_dictionary_field;
+use crate::sst::{override_pk_field_to_binary, tag_maybe_to_dictionary_field};
 
 const INDEX_TYPE_FULLTEXT: &str = "fulltext";
+
+/// Number of leading row groups sampled by [`should_read_pk_as_binary`].
+const MAX_ROW_GROUPS_TO_CHECK_PK: usize = 4;
+
+/// Returns `true` if the `__primary_key` chunk in any of the first
+/// [`MAX_ROW_GROUPS_TO_CHECK_PK`] row groups exceeds the dictionary page size
+/// limit, signalling the writer likely fell back to plain encoding.
+fn should_read_pk_as_binary(parquet_meta: &ParquetMetaData) -> bool {
+    should_read_pk_as_binary_with_limit(parquet_meta, DEFAULT_DICTIONARY_PAGE_SIZE_LIMIT)
+}
+
+fn should_read_pk_as_binary_with_limit(
+    parquet_meta: &ParquetMetaData,
+    dict_page_size_limit: usize,
+) -> bool {
+    let num_columns = parquet_meta.file_metadata().schema_descr().num_columns();
+    if num_columns < INTERNAL_COLUMN_NUM {
+        return false;
+    }
+    let pk_idx = primary_key_column_index(num_columns);
+    parquet_meta
+        .row_groups()
+        .iter()
+        .take(MAX_ROW_GROUPS_TO_CHECK_PK)
+        .any(|rg| rg.column(pk_idx).uncompressed_size() as usize > dict_page_size_limit)
+}
 const INDEX_TYPE_INVERTED: &str = "inverted";
 const INDEX_TYPE_BLOOM: &str = "bloom filter";
 const INDEX_TYPE_VECTOR: &str = "vector";
@@ -431,6 +458,7 @@ impl ParquetReaderBuilder {
         // Computes the projection mask.
         let parquet_read_cols = read_format.parquet_read_columns();
         let projection_plan = build_projection_plan(parquet_read_cols, parquet_schema_desc);
+        let has_nested_projection = parquet_read_cols.has_nested();
         let selection = self
             .row_groups_to_read(&read_format, &parquet_meta, &mut metrics.filter_metrics)
             .await;
@@ -498,8 +526,15 @@ impl ParquetReaderBuilder {
         // Create ArrowReaderMetadata for async stream building.
         let mut arrow_reader_options = ArrowReaderOptions::new();
         if !read_format.arrow_schema().has_json_extension_field() {
-            arrow_reader_options =
-                arrow_reader_options.with_schema(read_format.arrow_schema().clone());
+            // Read `__primary_key` as Binary when it's too large for dictionary
+            // encoding; convert_batch wraps it back to a DictionaryArray.
+            let schema_for_reader = if should_read_pk_as_binary(&parquet_meta) {
+                read_format.set_pk_as_binary()?;
+                override_pk_field_to_binary(read_format.arrow_schema())
+            } else {
+                read_format.arrow_schema().clone()
+            };
+            arrow_reader_options = arrow_reader_options.with_schema(schema_for_reader);
         }
         let arrow_metadata =
             ArrowReaderMetadata::try_new(parquet_meta.clone(), arrow_reader_options)
@@ -515,7 +550,7 @@ impl ParquetReaderBuilder {
             output_schema,
             object_store: self.object_store.clone(),
             projection: projection_plan,
-            has_nested_projection: parquet_read_cols.has_nested(),
+            has_nested_projection,
             cache_strategy: self.cache_strategy.clone(),
             prefilter_builder: filter_plan.prefilter_builder,
         };
@@ -2671,5 +2706,68 @@ mod tests {
         // Binary expr is handled by SimpleFilterEvaluator — rejected here.
         let binary = col("tag_0").eq(lit("a"));
         assert!(PhysicalFilterContext::new_opt(&metadata, None, &read_format, &binary).is_none());
+    }
+
+    fn write_test_parquet_with_pk_column(values: &[&[u8]]) -> bytes::Bytes {
+        use datatypes::arrow::array::{
+            BinaryArray, TimestampMillisecondArray, UInt8Array, UInt64Array,
+        };
+        use datatypes::arrow::datatypes::{Field as ArrowField, Schema as ArrowSchema, TimeUnit};
+        use store_api::storage::consts::{
+            OP_TYPE_COLUMN_NAME, PRIMARY_KEY_COLUMN_NAME, SEQUENCE_COLUMN_NAME,
+        };
+
+        let n = values.len();
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new(
+                "ts",
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                false,
+            ),
+            ArrowField::new(PRIMARY_KEY_COLUMN_NAME, DataType::Binary, false),
+            ArrowField::new(SEQUENCE_COLUMN_NAME, DataType::UInt64, false),
+            ArrowField::new(OP_TYPE_COLUMN_NAME, DataType::UInt8, false),
+        ]));
+        let ts: ArrayRef = Arc::new(TimestampMillisecondArray::from(vec![0_i64; n]));
+        let pk: ArrayRef = Arc::new(BinaryArray::from_iter_values(values.iter().copied()));
+        let seq: ArrayRef = Arc::new(UInt64Array::from(vec![0_u64; n]));
+        let op: ArrayRef = Arc::new(UInt8Array::from(vec![0_u8; n]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![ts, pk, seq, op]).unwrap();
+
+        let mut bytes = Vec::new();
+        let mut writer = ArrowWriter::try_new(&mut bytes, schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+        bytes::Bytes::from(bytes)
+    }
+
+    fn load_parquet_meta(bytes: bytes::Bytes) -> Arc<ParquetMetaData> {
+        let builder =
+            parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(bytes).unwrap();
+        builder.metadata().clone()
+    }
+
+    #[test]
+    fn test_should_read_pk_as_binary_small_chunk_returns_false() {
+        let bytes = write_test_parquet_with_pk_column(&[b"a", b"b", b"c"]);
+        let meta = load_parquet_meta(bytes);
+
+        assert!(!should_read_pk_as_binary_with_limit(&meta, 1024));
+    }
+
+    #[test]
+    fn test_should_read_pk_as_binary_large_chunk_returns_true() {
+        let owned: Vec<Vec<u8>> = (0..512u32)
+            .map(|i| {
+                let mut v = vec![0u8; 16];
+                v[..4].copy_from_slice(&i.to_le_bytes());
+                v
+            })
+            .collect();
+        let refs: Vec<&[u8]> = owned.iter().map(|v| v.as_slice()).collect();
+        let bytes = write_test_parquet_with_pk_column(&refs);
+        let meta = load_parquet_meta(bytes);
+
+        assert!(should_read_pk_as_binary_with_limit(&meta, 1024));
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

When the `__primary_key` chunk in an SST is large, the parquet writer falls back from dictionary encoding to plain encoding. Reading such a chunk back into a `DictionaryArray<UInt32, Binary>` (as the flat-format reader's target schema requests) forces Arrow to rebuild the dictionary on the fly, which is expensive for wide / high-cardinality PKs.

This PR adds a small reader-side heuristic and adapter so we read those chunks as plain `Binary` and wrap the result back into an identity `DictionaryArray` ourselves, while keeping the downstream batch layout unchanged.

- `should_read_pk_as_binary` (in `sst/parquet/reader.rs`) samples the first 4 row groups and returns `true` if any of them has a `__primary_key` chunk whose uncompressed size exceeds `DEFAULT_DICTIONARY_PAGE_SIZE_LIMIT` — the same threshold the writer uses to bail out of dictionary encoding.
- When that fires, `ParquetReaderBuilder` overrides the schema given to `ArrowReaderMetadata` so the `__primary_key` field is `Binary` instead of `Dictionary<UInt32, Binary>` (`override_pk_field_to_binary` in `sst.rs`), and `FlatReadFormat::set_pk_as_binary` arms `convert_batch` to wrap the column back via `wrap_pk_binary_to_dict` (identity keys `0..n`, no dedup), so consumers still see the canonical dictionary layout.
- `matching_row_ranges_by_primary_key` in `sst/parquet/prefilter.rs` now accepts either `PrimaryKeyArray` (existing dict path) or `BinaryArray` (new plain path), sharing the matched-range coalescing via `push_matched_range`. Without this, prefiltering would fail with "Primary key column is not a dictionary array" on the same files this optimization enables.

Unit tests cover the heuristic on small vs large chunks, the dict-wrap conversion (with a repeated value to verify identity keys / no dedup), and `eval_pk_group_mask` against a binary PK batch.

On the same dataset that has L0 files.

Before
```
Summary Average: 1983150 rows in 84.362665ms over 10 iterations
```

After
```
Summary Average: 1983150 rows in 73.115644ms over 10 iterations
```

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.