### PR TITLE
fix(catalog): enforce global inspect limit

### DIFF
--- a/src/catalog/src/information_extension.rs
+++ b/src/catalog/src/information_extension.rs
@@ -23,7 +23,7 @@ use common_meta::rpc::procedure;
 use common_procedure::{ProcedureInfo, ProcedureState};
 use common_query::request::QueryRequest;
 use common_recordbatch::SendableRecordBatchStream;
-use common_recordbatch::util::ChainedRecordBatchStream;
+use common_recordbatch::util::{ChainedRecordBatchStream, LimitRecordBatchStream};
 use meta_client::MetaClientRef;
 use snafu::ResultExt;
 use store_api::storage::RegionId;
@@ -120,6 +120,7 @@ impl InformationExtension for DistributedInformationExtension {
             .map_err(BoxedError::new)
             .context(crate::error::ListNodesSnafu)?;
 
+        let global_limit = request.scan.limit;
         let plan = request
             .build_plan()
             .context(crate::error::DatafusionSnafu)?;
@@ -140,6 +141,13 @@ impl InformationExtension for DistributedInformationExtension {
 
         let chained =
             ChainedRecordBatchStream::new(streams).context(crate::error::CreateRecordBatchSnafu)?;
-        Ok(Box::pin(chained))
+        if let Some(limit) = global_limit {
+            Ok(Box::pin(LimitRecordBatchStream::new(
+                Box::pin(chained),
+                limit,
+            )))
+        } else {
+            Ok(Box::pin(chained))
+        }
     }
 }

--- a/src/common/recordbatch/src/util.rs
+++ b/src/common/recordbatch/src/util.rs
@@ -47,6 +47,82 @@ pub struct ChainedRecordBatchStream {
     metrics: Arc<ArcSwapOption<RecordBatchMetrics>>,
 }
 
+/// A stream that returns at most `limit` rows from the input stream.
+pub struct LimitRecordBatchStream {
+    input: Option<SendableRecordBatchStream>,
+    schema: SchemaRef,
+    output_ordering: Option<Vec<OrderOption>>,
+    remaining: usize,
+}
+
+impl LimitRecordBatchStream {
+    pub fn new(input: SendableRecordBatchStream, limit: usize) -> Self {
+        let schema = input.schema();
+        let output_ordering = input.output_ordering().map(|ordering| ordering.to_vec());
+        Self {
+            input: Some(input),
+            schema,
+            output_ordering,
+            remaining: limit,
+        }
+    }
+
+    fn finish(&mut self) {
+        self.remaining = 0;
+        self.input = None;
+    }
+}
+
+impl RecordBatchStream for LimitRecordBatchStream {
+    fn name(&self) -> &str {
+        "LimitRecordBatchStream"
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn output_ordering(&self) -> Option<&[OrderOption]> {
+        self.output_ordering.as_deref()
+    }
+
+    fn metrics(&self) -> Option<RecordBatchMetrics> {
+        self.input.as_ref().and_then(|input| input.metrics())
+    }
+}
+
+impl Stream for LimitRecordBatchStream {
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if self.remaining == 0 {
+            self.input = None;
+            return Poll::Ready(None);
+        }
+
+        let Some(input) = self.input.as_mut() else {
+            return Poll::Ready(None);
+        };
+
+        match input.poll_next_unpin(ctx) {
+            Poll::Ready(Some(Ok(batch))) => {
+                let remaining = self.remaining;
+                if batch.num_rows() <= remaining {
+                    self.remaining -= batch.num_rows();
+                    if self.remaining == 0 {
+                        self.input = None;
+                    }
+                    Poll::Ready(Some(Ok(batch)))
+                } else {
+                    self.finish();
+                    Poll::Ready(Some(batch.slice(0, remaining)))
+                }
+            }
+            other => other,
+        }
+    }
+}
+
 impl ChainedRecordBatchStream {
     pub fn new(inputs: Vec<SendableRecordBatchStream>) -> Result<Self> {
         // check length
@@ -126,6 +202,7 @@ impl Stream for ChainedRecordBatchStream {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
     use std::pin::Pin;
     use std::sync::Arc;
 
@@ -140,7 +217,7 @@ mod tests {
     use crate::{OrderOption, RecordBatchStream};
 
     struct MockRecordBatchStream {
-        batch: Option<RecordBatch>,
+        batches: VecDeque<RecordBatch>,
         schema: SchemaRef,
     }
 
@@ -162,7 +239,7 @@ mod tests {
         type Item = Result<RecordBatch>;
 
         fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-            let batch = self.batch.take();
+            let batch = self.batches.pop_front();
 
             if let Some(batch) = batch {
                 Poll::Ready(Some(Ok(batch)))
@@ -184,7 +261,7 @@ mod tests {
 
         let stream = MockRecordBatchStream {
             schema: schema.clone(),
-            batch: None,
+            batches: VecDeque::new(),
         };
 
         let batches = collect(Box::pin(stream)).await.unwrap();
@@ -196,7 +273,7 @@ mod tests {
 
         let stream = MockRecordBatchStream {
             schema: schema.clone(),
-            batch: Some(batch.clone()),
+            batches: VecDeque::from([batch.clone()]),
         };
         let batches = collect(Box::pin(stream)).await.unwrap();
         assert_eq!(1, batches.len());
@@ -204,10 +281,69 @@ mod tests {
 
         let stream = MockRecordBatchStream {
             schema: schema.clone(),
-            batch: Some(batch.clone()),
+            batches: VecDeque::from([batch.clone()]),
         };
         let batches = collect_batches(Box::pin(stream)).await.unwrap();
         let expect_batches = RecordBatches::try_new(schema.clone(), vec![batch]).unwrap();
         assert_eq!(expect_batches, batches);
+    }
+
+    #[tokio::test]
+    async fn test_limit_record_batch_stream() {
+        let schema = Arc::new(
+            Schema::try_new(vec![ColumnSchema::new(
+                "number",
+                ConcreteDataType::uint32_datatype(),
+                false,
+            )])
+            .unwrap(),
+        );
+        let batch1 = RecordBatch::new(
+            schema.clone(),
+            [Arc::new(UInt32Vector::from_vec(vec![0, 1, 2])) as _],
+        )
+        .unwrap();
+        let batch2 = RecordBatch::new(
+            schema.clone(),
+            [Arc::new(UInt32Vector::from_vec(vec![3, 4, 5])) as _],
+        )
+        .unwrap();
+        let input = MockRecordBatchStream {
+            schema: schema.clone(),
+            batches: VecDeque::from([batch1, batch2]),
+        };
+
+        let batches = collect(Box::pin(LimitRecordBatchStream::new(Box::pin(input), 4)))
+            .await
+            .unwrap();
+        assert_eq!(2, batches.len());
+        assert_eq!(3, batches[0].num_rows());
+        assert_eq!(1, batches[1].num_rows());
+    }
+
+    #[tokio::test]
+    async fn test_limit_record_batch_stream_zero_limit() {
+        let schema = Arc::new(
+            Schema::try_new(vec![ColumnSchema::new(
+                "number",
+                ConcreteDataType::uint32_datatype(),
+                false,
+            )])
+            .unwrap(),
+        );
+        let batch = RecordBatch::new(
+            schema.clone(),
+            [Arc::new(UInt32Vector::from_vec(vec![0, 1, 2])) as _],
+        )
+        .unwrap();
+        let input = MockRecordBatchStream {
+            schema,
+            batches: VecDeque::from([batch]),
+        };
+
+        let batches = collect(Box::pin(LimitRecordBatchStream::new(Box::pin(input), 0)))
+            .await
+            .unwrap();
+        assert!(batches.is_empty());
     }
 }

--- a/tests/cases/distributed/information_schema/ssts_limit.result
+++ b/tests/cases/distributed/information_schema/ssts_limit.result
@@ -1,0 +1,56 @@
+CREATE TABLE ssts_limit_case (
+  a INT PRIMARY KEY INVERTED INDEX,
+  b STRING SKIPPING INDEX,
+  c STRING FULLTEXT INDEX,
+  ts TIMESTAMP TIME INDEX,
+)
+PARTITION ON COLUMNS (a) (
+  a < 1000,
+  a >= 1000 AND a < 2000,
+  a >= 2000
+);
+
+Affected Rows: 0
+
+INSERT INTO ssts_limit_case VALUES
+  (500, 'a', 'a', 1),
+  (1500, 'b', 'b', 2),
+  (2500, 'c', 'c', 3);
+
+Affected Rows: 3
+
+ADMIN FLUSH_TABLE('ssts_limit_case');
+
++--------------------------------------+
+| ADMIN FLUSH_TABLE('ssts_limit_case') |
++--------------------------------------+
+| 0                                    |
++--------------------------------------+
+
+SELECT COUNT(*) FROM (SELECT region_id FROM information_schema.ssts_manifest LIMIT 1);
+
++----------+
+| count(*) |
++----------+
+| 1        |
++----------+
+
+SELECT COUNT(*) FROM (SELECT index_file_path FROM information_schema.ssts_index_meta LIMIT 1);
+
++----------+
+| count(*) |
++----------+
+| 1        |
++----------+
+
+SELECT COUNT(*) FROM (SELECT file_path FROM information_schema.ssts_storage LIMIT 1);
+
++----------+
+| count(*) |
++----------+
+| 1        |
++----------+
+
+DROP TABLE ssts_limit_case;
+
+Affected Rows: 0

--- a/tests/cases/distributed/information_schema/ssts_limit.sql
+++ b/tests/cases/distributed/information_schema/ssts_limit.sql
@@ -1,0 +1,26 @@
+CREATE TABLE ssts_limit_case (
+  a INT PRIMARY KEY INVERTED INDEX,
+  b STRING SKIPPING INDEX,
+  c STRING FULLTEXT INDEX,
+  ts TIMESTAMP TIME INDEX,
+)
+PARTITION ON COLUMNS (a) (
+  a < 1000,
+  a >= 1000 AND a < 2000,
+  a >= 2000
+);
+
+INSERT INTO ssts_limit_case VALUES
+  (500, 'a', 'a', 1),
+  (1500, 'b', 'b', 2),
+  (2500, 'c', 'c', 3);
+
+ADMIN FLUSH_TABLE('ssts_limit_case');
+
+SELECT COUNT(*) FROM (SELECT region_id FROM information_schema.ssts_manifest LIMIT 1);
+
+SELECT COUNT(*) FROM (SELECT index_file_path FROM information_schema.ssts_index_meta LIMIT 1);
+
+SELECT COUNT(*) FROM (SELECT file_path FROM information_schema.ssts_storage LIMIT 1);
+
+DROP TABLE ssts_limit_case;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

as title

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
