### PR TITLE
perf: collect narrow binary join

### DIFF
--- a/src/query/src/optimizer.rs
+++ b/src/query/src/optimizer.rs
@@ -19,6 +19,7 @@ pub mod count_wildcard;
 pub(crate) mod json_type_concretize;
 pub mod parallelize_scan;
 pub mod pass_distribution;
+pub mod promql_join;
 pub mod remove_duplicate;
 pub mod scan_hint;
 pub mod string_normalization;

--- a/src/query/src/optimizer.rs
+++ b/src/query/src/optimizer.rs
@@ -19,7 +19,7 @@ pub mod count_wildcard;
 pub(crate) mod json_type_concretize;
 pub mod parallelize_scan;
 pub mod pass_distribution;
-pub mod promql_join;
+pub mod promql_tsid_narrow_join;
 pub mod remove_duplicate;
 pub mod scan_hint;
 pub mod string_normalization;

--- a/src/query/src/optimizer/promql_join.rs
+++ b/src/query/src/optimizer/promql_join.rs
@@ -1,0 +1,305 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use arrow_schema::{DataType, SchemaRef};
+use datafusion::config::ConfigOptions;
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::joins::{HashJoinExec, PartitionMode};
+use datafusion_common::Result as DfResult;
+use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
+use datafusion_expr::JoinType;
+use datafusion_physical_expr::expressions::Column;
+use store_api::metric_engine_consts::DATA_SCHEMA_TSID_COLUMN_NAME;
+
+/// Chooses a broadcast-style hash join for the PromQL vector-vector shape where
+/// the build side only carries value, `__tsid`, and timestamp columns.
+///
+/// PromQL arithmetic joins often keep one side narrow and the other side wide
+/// with all output labels. Partitioning both sides shuffles the wide stream.
+/// `CollectLeft` only gathers the narrow build side and lets the wide probe side
+/// keep its existing partitioning.
+#[derive(Debug)]
+pub struct PromqlJoinSelection;
+
+impl PhysicalOptimizerRule for PromqlJoinSelection {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        _config: &ConfigOptions,
+    ) -> DfResult<Arc<dyn ExecutionPlan>> {
+        plan.transform_up(Self::rewrite_join).data()
+    }
+
+    fn name(&self) -> &str {
+        "PromqlJoinSelection"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+}
+
+impl PromqlJoinSelection {
+    fn rewrite_join(plan: Arc<dyn ExecutionPlan>) -> DfResult<Transformed<Arc<dyn ExecutionPlan>>> {
+        let Some(hash_join) = plan.as_any().downcast_ref::<HashJoinExec>() else {
+            return Ok(Transformed::no(plan));
+        };
+
+        if !Self::should_collect_left(hash_join) {
+            return Ok(Transformed::no(plan));
+        }
+
+        let projection = hash_join
+            .contains_projection()
+            .then(|| Self::infer_projection(hash_join.join_schema(), &hash_join.schema()))
+            .transpose()?;
+
+        let new_join = HashJoinExec::try_new(
+            Arc::clone(hash_join.left()),
+            Arc::clone(hash_join.right()),
+            hash_join.on().to_vec(),
+            hash_join.filter().cloned(),
+            hash_join.join_type(),
+            projection,
+            PartitionMode::CollectLeft,
+            hash_join.null_equality(),
+            false,
+        )?;
+
+        Ok(Transformed::yes(Arc::new(new_join)))
+    }
+
+    fn should_collect_left(hash_join: &HashJoinExec) -> bool {
+        hash_join.partition_mode() == &PartitionMode::Partitioned
+            && hash_join.join_type() == &JoinType::Inner
+            && hash_join.filter().is_none()
+            && hash_join.left().schema().fields().len() <= 3
+            && hash_join.right().schema().fields().len() > hash_join.left().schema().fields().len()
+            && Self::is_promql_value_tsid_time_schema(&hash_join.left().schema())
+            && Self::joins_on_tsid_and_time(hash_join)
+    }
+
+    fn is_promql_value_tsid_time_schema(schema: &SchemaRef) -> bool {
+        let mut has_value = false;
+        let mut has_tsid = false;
+        let mut has_time = false;
+
+        for field in schema.fields() {
+            match field.name().as_str() {
+                "greptime_value" => has_value = true,
+                DATA_SCHEMA_TSID_COLUMN_NAME => has_tsid = true,
+                _ if matches!(field.data_type(), DataType::Timestamp(_, _)) => has_time = true,
+                _ => return false,
+            }
+        }
+
+        has_value && has_tsid && has_time
+    }
+
+    fn joins_on_tsid_and_time(hash_join: &HashJoinExec) -> bool {
+        let mut has_tsid = false;
+        let mut has_time = false;
+
+        for (left, right) in hash_join.on() {
+            let (Some(left_col), Some(right_col)) = (
+                left.as_any().downcast_ref::<Column>(),
+                right.as_any().downcast_ref::<Column>(),
+            ) else {
+                return false;
+            };
+
+            if left_col.name() == DATA_SCHEMA_TSID_COLUMN_NAME
+                && right_col.name() == DATA_SCHEMA_TSID_COLUMN_NAME
+            {
+                has_tsid = true;
+            } else if matches!(
+                hash_join
+                    .left()
+                    .schema()
+                    .field(left_col.index())
+                    .data_type(),
+                DataType::Timestamp(_, _)
+            ) && matches!(
+                hash_join
+                    .right()
+                    .schema()
+                    .field(right_col.index())
+                    .data_type(),
+                DataType::Timestamp(_, _)
+            ) {
+                has_time = true;
+            }
+        }
+
+        has_tsid && has_time
+    }
+
+    fn infer_projection(
+        full_schema: &SchemaRef,
+        output_schema: &SchemaRef,
+    ) -> DfResult<Vec<usize>> {
+        let mut used = vec![false; full_schema.fields().len()];
+        let mut projection = Vec::with_capacity(output_schema.fields().len());
+
+        for output_field in output_schema.fields() {
+            let Some((idx, _)) = full_schema
+                .fields()
+                .iter()
+                .enumerate()
+                .find(|(idx, field)| {
+                    !used[*idx]
+                        && field.name() == output_field.name()
+                        && field.data_type() == output_field.data_type()
+                })
+            else {
+                return datafusion_common::plan_err!(
+                    "failed to infer PromQL hash join projection for field {}",
+                    output_field.name()
+                );
+            };
+
+            used[idx] = true;
+            projection.push(idx);
+        }
+
+        Ok(projection)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow_schema::{DataType, Field, Schema, TimeUnit};
+    use datafusion::common::NullEquality;
+    use datafusion::physical_optimizer::PhysicalOptimizerRule;
+    use datafusion::physical_plan::empty::EmptyExec;
+    use datafusion::physical_plan::joins::HashJoinExec;
+    use datafusion_common::config::ConfigOptions;
+    use datafusion_physical_expr::PhysicalExpr;
+
+    use super::*;
+
+    #[test]
+    fn chooses_collect_left_for_narrow_promql_build_side() {
+        let left = Arc::new(EmptyExec::new(Arc::new(Schema::new(vec![
+            Field::new("greptime_value", DataType::Float64, true),
+            Field::new(DATA_SCHEMA_TSID_COLUMN_NAME, DataType::UInt64, false),
+            Field::new(
+                "greptime_timestamp",
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                false,
+            ),
+        ])))) as Arc<dyn ExecutionPlan>;
+        let right = Arc::new(EmptyExec::new(Arc::new(Schema::new(vec![
+            Field::new("greptime_value", DataType::Float64, true),
+            Field::new("host", DataType::Utf8, true),
+            Field::new(DATA_SCHEMA_TSID_COLUMN_NAME, DataType::UInt64, false),
+            Field::new(
+                "greptime_timestamp",
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                false,
+            ),
+        ])))) as Arc<dyn ExecutionPlan>;
+        let on = vec![
+            (
+                Arc::new(Column::new(DATA_SCHEMA_TSID_COLUMN_NAME, 1)) as Arc<dyn PhysicalExpr>,
+                Arc::new(Column::new(DATA_SCHEMA_TSID_COLUMN_NAME, 2)) as Arc<dyn PhysicalExpr>,
+            ),
+            (
+                Arc::new(Column::new("greptime_timestamp", 2)) as Arc<dyn PhysicalExpr>,
+                Arc::new(Column::new("greptime_timestamp", 3)) as Arc<dyn PhysicalExpr>,
+            ),
+        ];
+        let join = Arc::new(
+            HashJoinExec::try_new(
+                left,
+                right,
+                on,
+                None,
+                &JoinType::Inner,
+                Some(vec![0, 3, 4, 5, 6]),
+                PartitionMode::Partitioned,
+                NullEquality::NullEqualsNull,
+                false,
+            )
+            .unwrap(),
+        ) as Arc<dyn ExecutionPlan>;
+        let original_schema = join.schema();
+
+        let optimized = PromqlJoinSelection
+            .optimize(join, &ConfigOptions::default())
+            .unwrap();
+        let optimized_join = optimized.as_any().downcast_ref::<HashJoinExec>().unwrap();
+
+        assert_eq!(optimized_join.partition_mode(), &PartitionMode::CollectLeft);
+        assert_eq!(optimized.schema(), original_schema);
+    }
+
+    #[test]
+    fn keeps_partitioned_join_when_left_side_carries_labels() {
+        let left = Arc::new(EmptyExec::new(Arc::new(Schema::new(vec![
+            Field::new("greptime_value", DataType::Float64, true),
+            Field::new("host", DataType::Utf8, true),
+            Field::new(DATA_SCHEMA_TSID_COLUMN_NAME, DataType::UInt64, false),
+            Field::new(
+                "greptime_timestamp",
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                false,
+            ),
+        ])))) as Arc<dyn ExecutionPlan>;
+        let right = Arc::new(EmptyExec::new(Arc::new(Schema::new(vec![
+            Field::new("greptime_value", DataType::Float64, true),
+            Field::new(DATA_SCHEMA_TSID_COLUMN_NAME, DataType::UInt64, false),
+            Field::new(
+                "greptime_timestamp",
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                false,
+            ),
+        ])))) as Arc<dyn ExecutionPlan>;
+        let join = Arc::new(
+            HashJoinExec::try_new(
+                left,
+                right,
+                vec![
+                    (
+                        Arc::new(Column::new(DATA_SCHEMA_TSID_COLUMN_NAME, 2))
+                            as Arc<dyn PhysicalExpr>,
+                        Arc::new(Column::new(DATA_SCHEMA_TSID_COLUMN_NAME, 1))
+                            as Arc<dyn PhysicalExpr>,
+                    ),
+                    (
+                        Arc::new(Column::new("greptime_timestamp", 3)) as Arc<dyn PhysicalExpr>,
+                        Arc::new(Column::new("greptime_timestamp", 2)) as Arc<dyn PhysicalExpr>,
+                    ),
+                ],
+                None,
+                &JoinType::Inner,
+                None,
+                PartitionMode::Partitioned,
+                NullEquality::NullEqualsNull,
+                false,
+            )
+            .unwrap(),
+        ) as Arc<dyn ExecutionPlan>;
+
+        let optimized = PromqlJoinSelection
+            .optimize(join, &ConfigOptions::default())
+            .unwrap();
+        let optimized_join = optimized.as_any().downcast_ref::<HashJoinExec>().unwrap();
+
+        assert_eq!(optimized_join.partition_mode(), &PartitionMode::Partitioned);
+    }
+}

--- a/src/query/src/optimizer/promql_join.rs
+++ b/src/query/src/optimizer/promql_join.rs
@@ -63,24 +63,13 @@ impl PromqlJoinSelection {
             return Ok(Transformed::no(plan));
         }
 
-        let projection = hash_join
-            .contains_projection()
-            .then(|| Self::infer_projection(hash_join.join_schema(), &hash_join.schema()))
-            .transpose()?;
-
-        let new_join = HashJoinExec::try_new(
-            Arc::clone(hash_join.left()),
-            Arc::clone(hash_join.right()),
-            hash_join.on().to_vec(),
-            hash_join.filter().cloned(),
-            hash_join.join_type(),
-            projection,
-            PartitionMode::CollectLeft,
-            hash_join.null_equality(),
-            false,
-        )?;
-
-        Ok(Transformed::yes(Arc::new(new_join)))
+        Ok(Transformed::yes(
+            hash_join
+                .builder()
+                .with_partition_mode(PartitionMode::CollectLeft)
+                .reset_state()
+                .build_exec()?,
+        ))
     }
 
     fn should_collect_left(hash_join: &HashJoinExec) -> bool {
@@ -147,37 +136,6 @@ impl PromqlJoinSelection {
 
         has_tsid && has_time
     }
-
-    fn infer_projection(
-        full_schema: &SchemaRef,
-        output_schema: &SchemaRef,
-    ) -> DfResult<Vec<usize>> {
-        let mut used = vec![false; full_schema.fields().len()];
-        let mut projection = Vec::with_capacity(output_schema.fields().len());
-
-        for output_field in output_schema.fields() {
-            let Some((idx, _)) = full_schema
-                .fields()
-                .iter()
-                .enumerate()
-                .find(|(idx, field)| {
-                    !used[*idx]
-                        && field.name() == output_field.name()
-                        && field.data_type() == output_field.data_type()
-                })
-            else {
-                return datafusion_common::plan_err!(
-                    "failed to infer PromQL hash join projection for field {}",
-                    output_field.name()
-                );
-            };
-
-            used[idx] = true;
-            projection.push(idx);
-        }
-
-        Ok(projection)
-    }
 }
 
 #[cfg(test)]
@@ -185,6 +143,7 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema, TimeUnit};
     use datafusion::common::NullEquality;
     use datafusion::physical_optimizer::PhysicalOptimizerRule;
+    use datafusion::physical_plan::displayable;
     use datafusion::physical_plan::empty::EmptyExec;
     use datafusion::physical_plan::joins::HashJoinExec;
     use datafusion_common::config::ConfigOptions;
@@ -246,6 +205,14 @@ mod tests {
 
         assert_eq!(optimized_join.partition_mode(), &PartitionMode::CollectLeft);
         assert_eq!(optimized.schema(), original_schema);
+        assert!(
+            displayable(optimized.as_ref())
+                .one_line()
+                .to_string()
+                .contains(
+                    "projection=[greptime_value@0, greptime_value@3, host@4, __tsid@5, greptime_timestamp@6]"
+                )
+        );
     }
 
     #[test]

--- a/src/query/src/optimizer/promql_tsid_narrow_join.rs
+++ b/src/query/src/optimizer/promql_tsid_narrow_join.rs
@@ -28,14 +28,14 @@ use store_api::metric_engine_consts::DATA_SCHEMA_TSID_COLUMN_NAME;
 /// Chooses a broadcast-style hash join for the PromQL vector-vector shape where
 /// the build side only carries value, `__tsid`, and timestamp columns.
 ///
-/// PromQL arithmetic joins often keep one side narrow and the other side wide
+/// PromQL arithmetic joins often keep one side narrow (without raw labels) and the other side wide
 /// with all output labels. Partitioning both sides shuffles the wide stream.
 /// `CollectLeft` only gathers the narrow build side and lets the wide probe side
 /// keep its existing partitioning.
 #[derive(Debug)]
-pub struct PromqlJoinSelection;
+pub struct PromqlTsidNarrowJoin;
 
-impl PhysicalOptimizerRule for PromqlJoinSelection {
+impl PhysicalOptimizerRule for PromqlTsidNarrowJoin {
     fn optimize(
         &self,
         plan: Arc<dyn ExecutionPlan>,
@@ -45,7 +45,7 @@ impl PhysicalOptimizerRule for PromqlJoinSelection {
     }
 
     fn name(&self) -> &str {
-        "PromqlJoinSelection"
+        "PromqlTsidNarrowJoin"
     }
 
     fn schema_check(&self) -> bool {
@@ -53,7 +53,7 @@ impl PhysicalOptimizerRule for PromqlJoinSelection {
     }
 }
 
-impl PromqlJoinSelection {
+impl PromqlTsidNarrowJoin {
     fn rewrite_join(plan: Arc<dyn ExecutionPlan>) -> DfResult<Transformed<Arc<dyn ExecutionPlan>>> {
         let Some(hash_join) = plan.as_any().downcast_ref::<HashJoinExec>() else {
             return Ok(Transformed::no(plan));
@@ -76,7 +76,6 @@ impl PromqlJoinSelection {
         hash_join.partition_mode() == &PartitionMode::Partitioned
             && hash_join.join_type() == &JoinType::Inner
             && hash_join.filter().is_none()
-            && hash_join.left().schema().fields().len() <= 3
             && hash_join.right().schema().fields().len() > hash_join.left().schema().fields().len()
             && Self::is_promql_value_tsid_time_schema(&hash_join.left().schema())
             && Self::joins_on_tsid_and_time(hash_join)
@@ -198,7 +197,7 @@ mod tests {
         ) as Arc<dyn ExecutionPlan>;
         let original_schema = join.schema();
 
-        let optimized = PromqlJoinSelection
+        let optimized = PromqlTsidNarrowJoin
             .optimize(join, &ConfigOptions::default())
             .unwrap();
         let optimized_join = optimized.as_any().downcast_ref::<HashJoinExec>().unwrap();
@@ -262,7 +261,7 @@ mod tests {
             .unwrap(),
         ) as Arc<dyn ExecutionPlan>;
 
-        let optimized = PromqlJoinSelection
+        let optimized = PromqlTsidNarrowJoin
             .optimize(join, &ConfigOptions::default())
             .unwrap();
         let optimized_join = optimized.as_any().downcast_ref::<HashJoinExec>().unwrap();

--- a/src/query/src/query_engine/state.rs
+++ b/src/query/src/query_engine/state.rs
@@ -66,7 +66,7 @@ use crate::optimizer::count_wildcard::CountWildcardToTimeIndexRule;
 use crate::optimizer::json_type_concretize::JsonTypeConcretizeRule;
 use crate::optimizer::parallelize_scan::ParallelizeScan;
 use crate::optimizer::pass_distribution::PassDistribution;
-use crate::optimizer::promql_join::PromqlJoinSelection;
+use crate::optimizer::promql_join::PromqlTsidNarrowJoin;
 use crate::optimizer::remove_duplicate::RemoveDuplicate;
 use crate::optimizer::scan_hint::ScanHintRule;
 use crate::optimizer::string_normalization::StringNormalizationRule;
@@ -193,7 +193,7 @@ impl QueryEngineState {
         // Prefer collecting narrow PromQL build sides over repartitioning wide label streams.
         physical_optimizer
             .rules
-            .insert(7, Arc::new(PromqlJoinSelection));
+            .insert(7, Arc::new(PromqlTsidNarrowJoin));
         // Enforce sorting AFTER custom rules that modify the plan structure
         physical_optimizer.rules.insert(
             8,

--- a/src/query/src/query_engine/state.rs
+++ b/src/query/src/query_engine/state.rs
@@ -66,7 +66,7 @@ use crate::optimizer::count_wildcard::CountWildcardToTimeIndexRule;
 use crate::optimizer::json_type_concretize::JsonTypeConcretizeRule;
 use crate::optimizer::parallelize_scan::ParallelizeScan;
 use crate::optimizer::pass_distribution::PassDistribution;
-use crate::optimizer::promql_join::PromqlTsidNarrowJoin;
+use crate::optimizer::promql_tsid_narrow_join::PromqlTsidNarrowJoin;
 use crate::optimizer::remove_duplicate::RemoveDuplicate;
 use crate::optimizer::scan_hint::ScanHintRule;
 use crate::optimizer::string_normalization::StringNormalizationRule;

--- a/src/query/src/query_engine/state.rs
+++ b/src/query/src/query_engine/state.rs
@@ -66,6 +66,7 @@ use crate::optimizer::count_wildcard::CountWildcardToTimeIndexRule;
 use crate::optimizer::json_type_concretize::JsonTypeConcretizeRule;
 use crate::optimizer::parallelize_scan::ParallelizeScan;
 use crate::optimizer::pass_distribution::PassDistribution;
+use crate::optimizer::promql_join::PromqlJoinSelection;
 use crate::optimizer::remove_duplicate::RemoveDuplicate;
 use crate::optimizer::scan_hint::ScanHintRule;
 use crate::optimizer::string_normalization::StringNormalizationRule;
@@ -189,9 +190,13 @@ impl QueryEngineState {
         physical_optimizer
             .rules
             .insert(6, Arc::new(PassDistribution));
+        // Prefer collecting narrow PromQL build sides over repartitioning wide label streams.
+        physical_optimizer
+            .rules
+            .insert(7, Arc::new(PromqlJoinSelection));
         // Enforce sorting AFTER custom rules that modify the plan structure
         physical_optimizer.rules.insert(
-            7,
+            8,
             Arc::new(datafusion::physical_optimizer::enforce_sorting::EnforceSorting {}),
         );
         // Add rule for windowed sort

--- a/tests/cases/standalone/common/promql/tsid_binary_join_regression.result
+++ b/tests/cases/standalone/common/promql/tsid_binary_join_regression.result
@@ -71,11 +71,11 @@ TQL ANALYZE (0, 5, '5s') tsid_binary_join_left / tsid_binary_join_right;
 | stage | node | plan_|
 +-+-+-+
 | 0_| 0_|_ProjectionExec: expr=[host@2 as host, job@3 as job, ts@5 as ts, __tsid@4 as __tsid, greptime_value@0 / greptime_value@1 as tsid_binary_join_left.greptime_value / tsid_binary_join_right.greptime_value] REDACTED
-|_|_|_HashJoinExec: mode=Partitioned, join_type=Inner, on=[(__tsid@1, __tsid@3), (ts@2, ts@4)], projection=[greptime_value@0, greptime_value@3, host@4, job@5, __tsid@6, ts@7], NullsEqual: true REDACTED
-|_|_|_RepartitionExec: partitioning=Hash([__tsid@1, ts@2],REDACTED
+|_|_|_HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(__tsid@1, __tsid@3), (ts@2, ts@4)], projection=[greptime_value@0, greptime_value@3, host@4, job@5, __tsid@6, ts@7], NullsEqual: true REDACTED
+|_|_|_CoalescePartitionsExec REDACTED
 |_|_|_ProjectionExec: expr=[greptime_value@0 as greptime_value, __tsid@3 as __tsid, ts@4 as ts] REDACTED
 |_|_|_MergeScanExec: REDACTED
-|_|_|_RepartitionExec: partitioning=Hash([__tsid@3, ts@4],REDACTED
+|_|_|_CooperativeExec REDACTED
 |_|_|_MergeScanExec: REDACTED
 |_|_|_|
 | 1_| 0_|_PromInstantManipulateExec: range=[0..5000], lookback=[300000], interval=[5000], time index=[ts] REDACTED
@@ -189,11 +189,11 @@ TQL ANALYZE (0, 5, '5s') tsid_binary_join_left > bool tsid_binary_join_right;
 | stage | node | plan_|
 +-+-+-+
 | 0_| 0_|_ProjectionExec: expr=[host@2 as host, job@3 as job, ts@5 as ts, __tsid@4 as __tsid, CAST(greptime_value@1 < greptime_value@0 AS Float64) as tsid_binary_join_left.greptime_value > tsid_binary_join_right.greptime_value] REDACTED
-|_|_|_HashJoinExec: mode=Partitioned, join_type=Inner, on=[(__tsid@1, __tsid@3), (ts@2, ts@4)], projection=[greptime_value@0, greptime_value@3, host@4, job@5, __tsid@6, ts@7], NullsEqual: true REDACTED
-|_|_|_RepartitionExec: partitioning=Hash([__tsid@1, ts@2],REDACTED
+|_|_|_HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(__tsid@1, __tsid@3), (ts@2, ts@4)], projection=[greptime_value@0, greptime_value@3, host@4, job@5, __tsid@6, ts@7], NullsEqual: true REDACTED
+|_|_|_CoalescePartitionsExec REDACTED
 |_|_|_ProjectionExec: expr=[greptime_value@0 as greptime_value, __tsid@3 as __tsid, ts@4 as ts] REDACTED
 |_|_|_MergeScanExec: REDACTED
-|_|_|_RepartitionExec: partitioning=Hash([__tsid@3, ts@4],REDACTED
+|_|_|_CooperativeExec REDACTED
 |_|_|_MergeScanExec: REDACTED
 |_|_|_|
 | 1_| 0_|_PromInstantManipulateExec: range=[0..5000], lookback=[300000], interval=[5000], time index=[ts] REDACTED

--- a/tests/cases/standalone/common/tql-explain-analyze/explain.result
+++ b/tests/cases/standalone/common/tql-explain-analyze/explain.result
@@ -182,6 +182,7 @@ TQL EXPLAIN VERBOSE (0, 10, '5s') test;
 | physical_plan after FilterPushdown_| SAME TEXT AS ABOVE_|
 | physical_plan after parallelize_scan_| SAME TEXT AS ABOVE_|
 | physical_plan after PassDistributionRule_| SAME TEXT AS ABOVE_|
+| physical_plan after PromqlJoinSelection_| SAME TEXT AS ABOVE_|
 | physical_plan after EnforceSorting_| SAME TEXT AS ABOVE_|
 | physical_plan after EnforceDistribution_| SAME TEXT AS ABOVE_|
 | physical_plan after CombinePartialFinalAggregate_| SAME TEXT AS ABOVE_|
@@ -332,6 +333,7 @@ TQL EXPLAIN VERBOSE (0, 10, '5s') test AS series;
 | physical_plan after FilterPushdown_| SAME TEXT AS ABOVE_|
 | physical_plan after parallelize_scan_| SAME TEXT AS ABOVE_|
 | physical_plan after PassDistributionRule_| SAME TEXT AS ABOVE_|
+| physical_plan after PromqlJoinSelection_| SAME TEXT AS ABOVE_|
 | physical_plan after EnforceSorting_| SAME TEXT AS ABOVE_|
 | physical_plan after EnforceDistribution_| SAME TEXT AS ABOVE_|
 | physical_plan after CombinePartialFinalAggregate_| SAME TEXT AS ABOVE_|
@@ -654,6 +656,7 @@ TQL EXPLAIN VERBOSE (0, 10, '5s') test_nano;
 | physical_plan after FilterPushdown_| SAME TEXT AS ABOVE_|
 | physical_plan after parallelize_scan_| SAME TEXT AS ABOVE_|
 | physical_plan after PassDistributionRule_| SAME TEXT AS ABOVE_|
+| physical_plan after PromqlJoinSelection_| SAME TEXT AS ABOVE_|
 | physical_plan after EnforceSorting_| OutputRequirementExec: order_by=[], dist_by=Unspecified_|
 |_|_PromInstantManipulateExec: range=[0..10000], lookback=[300000], interval=[5000], time index=[j]_|
 |_|_PromSeriesDivideExec: tags=["k"]_|

--- a/tests/cases/standalone/common/tql-explain-analyze/explain.result
+++ b/tests/cases/standalone/common/tql-explain-analyze/explain.result
@@ -182,7 +182,7 @@ TQL EXPLAIN VERBOSE (0, 10, '5s') test;
 | physical_plan after FilterPushdown_| SAME TEXT AS ABOVE_|
 | physical_plan after parallelize_scan_| SAME TEXT AS ABOVE_|
 | physical_plan after PassDistributionRule_| SAME TEXT AS ABOVE_|
-| physical_plan after PromqlJoinSelection_| SAME TEXT AS ABOVE_|
+| physical_plan after PromqlTsidNarrowJoin_| SAME TEXT AS ABOVE_|
 | physical_plan after EnforceSorting_| SAME TEXT AS ABOVE_|
 | physical_plan after EnforceDistribution_| SAME TEXT AS ABOVE_|
 | physical_plan after CombinePartialFinalAggregate_| SAME TEXT AS ABOVE_|
@@ -333,7 +333,7 @@ TQL EXPLAIN VERBOSE (0, 10, '5s') test AS series;
 | physical_plan after FilterPushdown_| SAME TEXT AS ABOVE_|
 | physical_plan after parallelize_scan_| SAME TEXT AS ABOVE_|
 | physical_plan after PassDistributionRule_| SAME TEXT AS ABOVE_|
-| physical_plan after PromqlJoinSelection_| SAME TEXT AS ABOVE_|
+| physical_plan after PromqlTsidNarrowJoin_| SAME TEXT AS ABOVE_|
 | physical_plan after EnforceSorting_| SAME TEXT AS ABOVE_|
 | physical_plan after EnforceDistribution_| SAME TEXT AS ABOVE_|
 | physical_plan after CombinePartialFinalAggregate_| SAME TEXT AS ABOVE_|
@@ -656,7 +656,7 @@ TQL EXPLAIN VERBOSE (0, 10, '5s') test_nano;
 | physical_plan after FilterPushdown_| SAME TEXT AS ABOVE_|
 | physical_plan after parallelize_scan_| SAME TEXT AS ABOVE_|
 | physical_plan after PassDistributionRule_| SAME TEXT AS ABOVE_|
-| physical_plan after PromqlJoinSelection_| SAME TEXT AS ABOVE_|
+| physical_plan after PromqlTsidNarrowJoin_| SAME TEXT AS ABOVE_|
 | physical_plan after EnforceSorting_| OutputRequirementExec: order_by=[], dist_by=Unspecified_|
 |_|_PromInstantManipulateExec: range=[0..10000], lookback=[300000], interval=[5000], time index=[j]_|
 |_|_PromSeriesDivideExec: tags=["k"]_|


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


Use `CollectLeft` in promql join to avoid repartition.

On local test set:

| metric | before | after | change |
|---|---:|---:|---:|
| warm max scan avg | `275ms` | `178.5ms` | `-35.1%` |
| warm join elapsed avg | `614.5ms` | `143ms` | `-76.7%` |
| warm join build avg | `87.5ms` | `17.5ms` | `-80.0%` |
| warm join time avg | `490.5ms` | `124.5ms` | `-74.6%` |

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
