### PR TITLE
feat: check open region requirements

### DIFF
--- a/src/cmd/src/datanode/scanbench.rs
+++ b/src/cmd/src/datanode/scanbench.rs
@@ -524,6 +524,7 @@ impl ScanbenchCommand {
             options: HashMap::default(),
             skip_wal_replay: !self.enable_wal,
             checkpoint: None,
+            requirements: Default::default(),
         };
 
         engine

--- a/src/common/meta/src/instruction.rs
+++ b/src/common/meta/src/instruction.rs
@@ -186,11 +186,8 @@ impl Display for OpenRegion {
 }
 
 /// The reason why an open region instruction is triggered.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum OpenRegionReason {
-    /// Open triggered by normal datanode startup or metadata recovery.
-    #[default]
-    NormalOpen,
     /// Open triggered before region migration.
     RegionMigration,
     /// Open triggered by region failover.
@@ -211,8 +208,8 @@ pub struct OpenRegion {
     pub region_wal_options: HashMap<RegionNumber, String>,
     #[serde(default)]
     pub skip_wal_replay: bool,
-    #[serde(default)]
-    pub reason: OpenRegionReason,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<OpenRegionReason>,
     #[serde(default)]
     pub requirements: RegionRequirements,
 }
@@ -224,7 +221,7 @@ impl OpenRegion {
         region_options: HashMap<String, String>,
         region_wal_options: HashMap<RegionNumber, String>,
         skip_wal_replay: bool,
-        reason: OpenRegionReason,
+        reason: Option<OpenRegionReason>,
         requirements: RegionRequirements,
     ) -> Self {
         Self {
@@ -1149,13 +1146,13 @@ mod tests {
             HashMap::new(),
             HashMap::new(),
             false,
-            OpenRegionReason::NormalOpen,
+            None,
             RegionRequirements::empty(),
         )]);
 
         let serialized = serde_json::to_string(&open_region).unwrap();
         assert_eq!(
-            r#"{"OpenRegions":[{"region_ident":{"datanode_id":2,"table_id":1024,"region_number":1,"engine":"mito2"},"region_storage_path":"test/foo","region_options":{},"region_wal_options":{},"skip_wal_replay":false,"reason":"NormalOpen","requirements":{"object_storage":false}}]}"#,
+            r#"{"OpenRegions":[{"region_ident":{"datanode_id":2,"table_id":1024,"region_number":1,"engine":"mito2"},"region_storage_path":"test/foo","region_options":{},"region_wal_options":{},"skip_wal_replay":false,"requirements":{"object_storage":false}}]}"#,
             serialized
         );
 
@@ -1238,7 +1235,7 @@ mod tests {
             HashMap::new(),
             HashMap::new(),
             false,
-            OpenRegionReason::NormalOpen,
+            None,
             RegionRequirements::empty(),
         )]);
         assert_eq!(open_region_instruction, open_region);
@@ -1395,14 +1392,14 @@ mod tests {
             region_options,
             region_wal_options: HashMap::new(),
             skip_wal_replay: false,
-            reason: OpenRegionReason::NormalOpen,
+            reason: None,
             requirements: RegionRequirements::empty(),
         };
         assert_eq!(expected, deserialized);
     }
 
     #[test]
-    fn test_serialize_open_region_with_reason_and_capabilities() {
+    fn test_serialize_open_region_with_reason_and_requirements() {
         let open_region = OpenRegion::new(
             RegionIdent {
                 datanode_id: 2,
@@ -1414,7 +1411,7 @@ mod tests {
             HashMap::new(),
             HashMap::new(),
             false,
-            OpenRegionReason::RegionMigration,
+            Some(OpenRegionReason::RegionMigration),
             RegionRequirements::object_storage(),
         );
 
@@ -1423,7 +1420,7 @@ mod tests {
         assert!(serialized.contains(r#""object_storage":true"#));
 
         let deserialized: OpenRegion = serde_json::from_str(&serialized).unwrap();
-        assert_eq!(OpenRegionReason::RegionMigration, deserialized.reason);
+        assert_eq!(Some(OpenRegionReason::RegionMigration), deserialized.reason);
         assert_eq!(
             RegionRequirements::object_storage(),
             deserialized.requirements

--- a/src/common/meta/src/instruction.rs
+++ b/src/common/meta/src/instruction.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use store_api::region_engine::SyncRegionFromRequest;
-use store_api::region_request::RegionFlushReason;
+use store_api::region_request::{RegionFlushReason, RegionRequirements};
 use store_api::storage::{FileRefsManifest, GcReport, RegionId, RegionNumber};
 use strum::Display;
 use table::metadata::TableId;
@@ -179,10 +179,25 @@ impl Display for OpenRegion {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "OpenRegion(region_ident={}, region_storage_path={})",
-            self.region_ident, self.region_storage_path
+            "OpenRegion(region_ident={}, region_storage_path={}, reason={:?})",
+            self.region_ident, self.region_storage_path, self.reason
         )
     }
+}
+
+/// The reason why an open region instruction is triggered.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub enum OpenRegionReason {
+    /// Open triggered by normal datanode startup or metadata recovery.
+    #[default]
+    NormalOpen,
+    /// Open triggered before region migration.
+    RegionMigration,
+    /// Open triggered by region failover.
+    RegionFailover,
+    /// Open triggered when adding a follower region.
+    #[cfg(feature = "enterprise")]
+    RegionFollower,
 }
 
 #[serde_with::serde_as]
@@ -196,6 +211,10 @@ pub struct OpenRegion {
     pub region_wal_options: HashMap<RegionNumber, String>,
     #[serde(default)]
     pub skip_wal_replay: bool,
+    #[serde(default)]
+    pub reason: OpenRegionReason,
+    #[serde(default)]
+    pub requirements: RegionRequirements,
 }
 
 impl OpenRegion {
@@ -205,6 +224,8 @@ impl OpenRegion {
         region_options: HashMap<String, String>,
         region_wal_options: HashMap<RegionNumber, String>,
         skip_wal_replay: bool,
+        reason: OpenRegionReason,
+        requirements: RegionRequirements,
     ) -> Self {
         Self {
             region_ident,
@@ -212,6 +233,8 @@ impl OpenRegion {
             region_options,
             region_wal_options,
             skip_wal_replay,
+            reason,
+            requirements,
         }
     }
 }
@@ -1126,11 +1149,13 @@ mod tests {
             HashMap::new(),
             HashMap::new(),
             false,
+            OpenRegionReason::NormalOpen,
+            RegionRequirements::empty(),
         )]);
 
         let serialized = serde_json::to_string(&open_region).unwrap();
         assert_eq!(
-            r#"{"OpenRegions":[{"region_ident":{"datanode_id":2,"table_id":1024,"region_number":1,"engine":"mito2"},"region_storage_path":"test/foo","region_options":{},"region_wal_options":{},"skip_wal_replay":false}]}"#,
+            r#"{"OpenRegions":[{"region_ident":{"datanode_id":2,"table_id":1024,"region_number":1,"engine":"mito2"},"region_storage_path":"test/foo","region_options":{},"region_wal_options":{},"skip_wal_replay":false,"reason":"NormalOpen","requirements":{"object_storage":false}}]}"#,
             serialized
         );
 
@@ -1213,6 +1238,8 @@ mod tests {
             HashMap::new(),
             HashMap::new(),
             false,
+            OpenRegionReason::NormalOpen,
+            RegionRequirements::empty(),
         )]);
         assert_eq!(open_region_instruction, open_region);
 
@@ -1368,8 +1395,39 @@ mod tests {
             region_options,
             region_wal_options: HashMap::new(),
             skip_wal_replay: false,
+            reason: OpenRegionReason::NormalOpen,
+            requirements: RegionRequirements::empty(),
         };
         assert_eq!(expected, deserialized);
+    }
+
+    #[test]
+    fn test_serialize_open_region_with_reason_and_capabilities() {
+        let open_region = OpenRegion::new(
+            RegionIdent {
+                datanode_id: 2,
+                table_id: 1024,
+                region_number: 1,
+                engine: "mito2".to_string(),
+            },
+            "test/foo",
+            HashMap::new(),
+            HashMap::new(),
+            false,
+            OpenRegionReason::RegionMigration,
+            RegionRequirements::object_storage(),
+        );
+
+        let serialized = serde_json::to_string(&open_region).unwrap();
+        assert!(serialized.contains(r#""reason":"RegionMigration""#));
+        assert!(serialized.contains(r#""object_storage":true"#));
+
+        let deserialized: OpenRegion = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(OpenRegionReason::RegionMigration, deserialized.reason);
+        assert_eq!(
+            RegionRequirements::object_storage(),
+            deserialized.requirements
+        );
     }
 
     #[test]

--- a/src/datanode/src/heartbeat/handler.rs
+++ b/src/datanode/src/heartbeat/handler.rs
@@ -305,8 +305,7 @@ mod tests {
         HeartbeatMailbox, IncomingMessage, MailboxRef, MessageMeta,
     };
     use common_meta::instruction::{
-        DowngradeRegion, EnterStagingRegion, OpenRegion, OpenRegionReason,
-        StagingPartitionDirective, UpgradeRegion,
+        DowngradeRegion, EnterStagingRegion, OpenRegion, StagingPartitionDirective, UpgradeRegion,
     };
     use common_meta::kv_backend::memory::MemoryKvBackend;
     use mito2::config::MitoConfig;
@@ -443,7 +442,7 @@ mod tests {
             HashMap::new(),
             HashMap::new(),
             false,
-            OpenRegionReason::NormalOpen,
+            None,
             RegionRequirements::empty(),
         )])
     }

--- a/src/datanode/src/heartbeat/handler.rs
+++ b/src/datanode/src/heartbeat/handler.rs
@@ -305,7 +305,8 @@ mod tests {
         HeartbeatMailbox, IncomingMessage, MailboxRef, MessageMeta,
     };
     use common_meta::instruction::{
-        DowngradeRegion, EnterStagingRegion, OpenRegion, StagingPartitionDirective, UpgradeRegion,
+        DowngradeRegion, EnterStagingRegion, OpenRegion, OpenRegionReason,
+        StagingPartitionDirective, UpgradeRegion,
     };
     use common_meta::kv_backend::memory::MemoryKvBackend;
     use mito2::config::MitoConfig;
@@ -313,7 +314,7 @@ mod tests {
     use mito2::test_util::{CreateRequestBuilder, TestEnv};
     use store_api::path_utils::table_dir;
     use store_api::region_engine::RegionRole;
-    use store_api::region_request::{RegionCloseRequest, RegionRequest};
+    use store_api::region_request::{RegionCloseRequest, RegionRequest, RegionRequirements};
     use store_api::storage::RegionId;
     use tokio::sync::mpsc::{self, Receiver};
 
@@ -442,6 +443,8 @@ mod tests {
             HashMap::new(),
             HashMap::new(),
             false,
+            OpenRegionReason::NormalOpen,
+            RegionRequirements::empty(),
         )])
     }
 

--- a/src/datanode/src/heartbeat/handler/open_region.rs
+++ b/src/datanode/src/heartbeat/handler/open_region.rs
@@ -14,6 +14,7 @@
 
 use common_meta::instruction::{InstructionReply, OpenRegion, SimpleReply};
 use common_meta::wal_provider::prepare_wal_options;
+use common_telemetry::info;
 use store_api::path_utils::table_dir;
 use store_api::region_request::{PathType, RegionOpenRequest};
 use store_api::storage::RegionId;
@@ -41,8 +42,13 @@ impl InstructionHandler for OpenRegionsHandler {
                     mut region_options,
                     region_wal_options,
                     skip_wal_replay,
+                    reason,
+                    requirements,
                 } = open_region;
                 let region_id = RegionId::new(region_ident.table_id, region_ident.region_number);
+                info!(
+                    "Received open region instruction, region_id: {region_id}, reason: {reason:?}"
+                );
                 prepare_wal_options(&mut region_options, region_id, &region_wal_options);
                 let request = RegionOpenRequest {
                     engine: region_ident.engine,
@@ -51,6 +57,7 @@ impl InstructionHandler for OpenRegionsHandler {
                     options: region_options,
                     skip_wal_replay,
                     checkpoint: None,
+                    requirements,
                 };
                 (region_id, request)
             })
@@ -98,17 +105,21 @@ mod tests {
     ) -> Instruction {
         let region_idents = region_ids
             .into_iter()
-            .map(|region_id| OpenRegion {
-                region_ident: RegionIdent {
-                    datanode_id: 0,
-                    table_id: region_id.table_id(),
-                    region_number: region_id.region_number(),
-                    engine: MITO_ENGINE_NAME.to_string(),
-                },
-                region_storage_path: storage_path.to_string(),
-                region_options: HashMap::new(),
-                region_wal_options: HashMap::new(),
-                skip_wal_replay: false,
+            .map(|region_id| {
+                OpenRegion::new(
+                    RegionIdent {
+                        datanode_id: 0,
+                        table_id: region_id.table_id(),
+                        region_number: region_id.region_number(),
+                        engine: MITO_ENGINE_NAME.to_string(),
+                    },
+                    storage_path,
+                    HashMap::new(),
+                    HashMap::new(),
+                    false,
+                    Default::default(),
+                    Default::default(),
+                )
             })
             .collect();
 

--- a/src/datanode/src/heartbeat/handler/open_region.rs
+++ b/src/datanode/src/heartbeat/handler/open_region.rs
@@ -92,7 +92,7 @@ mod tests {
     use mito2::engine::MITO_ENGINE_NAME;
     use mito2::test_util::{CreateRequestBuilder, TestEnv};
     use store_api::path_utils::table_dir;
-    use store_api::region_request::{RegionCloseRequest, RegionRequest};
+    use store_api::region_request::{RegionCloseRequest, RegionRequest, RegionRequirements};
     use store_api::storage::RegionId;
 
     use crate::heartbeat::handler::RegionHeartbeatResponseHandler;
@@ -117,8 +117,8 @@ mod tests {
                     HashMap::new(),
                     HashMap::new(),
                     false,
-                    Default::default(),
-                    Default::default(),
+                    None,
+                    RegionRequirements::empty(),
                 )
             })
             .collect();

--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -2057,6 +2057,7 @@ mod tests {
                     options: Default::default(),
                     skip_wal_replay: false,
                     checkpoint: None,
+                    requirements: Default::default(),
                 }),
             )
             .await
@@ -2235,6 +2236,7 @@ mod tests {
                             options: Default::default(),
                             skip_wal_replay: false,
                             checkpoint: None,
+                            requirements: Default::default(),
                         },
                     ),
                     (
@@ -2246,6 +2248,7 @@ mod tests {
                             options: Default::default(),
                             skip_wal_replay: false,
                             checkpoint: None,
+                            requirements: Default::default(),
                         },
                     ),
                 ],
@@ -2268,6 +2271,7 @@ mod tests {
                             options: Default::default(),
                             skip_wal_replay: false,
                             checkpoint: None,
+                            requirements: Default::default(),
                         },
                     ),
                     (
@@ -2279,6 +2283,7 @@ mod tests {
                             options: Default::default(),
                             skip_wal_replay: false,
                             checkpoint: None,
+                            requirements: Default::default(),
                         },
                     ),
                 ],

--- a/src/datanode/src/utils.rs
+++ b/src/datanode/src/utils.rs
@@ -156,6 +156,7 @@ pub(crate) async fn build_region_open_requests(
                 options,
                 skip_wal_replay: false,
                 checkpoint,
+                requirements: Default::default(),
             },
         ));
     }
@@ -174,6 +175,7 @@ pub(crate) async fn build_region_open_requests(
                     options,
                     skip_wal_replay: true,
                     checkpoint: None,
+                    requirements: Default::default(),
                 },
             ));
         }

--- a/src/file-engine/src/engine.rs
+++ b/src/file-engine/src/engine.rs
@@ -32,7 +32,7 @@ use store_api::region_engine::{
 };
 use store_api::region_request::{
     AffectedRows, RegionCloseRequest, RegionCreateRequest, RegionDropRequest, RegionOpenRequest,
-    RegionRequest,
+    RegionRequest, RegionRequirements,
 };
 use store_api::storage::{RegionId, ScanRequest, SequenceNumber};
 use tokio::sync::Mutex;
@@ -186,6 +186,24 @@ struct EngineInner {
 
 type EngineInnerRef = Arc<EngineInner>;
 
+fn ensure_open_requirements(
+    requirements: RegionRequirements,
+    object_store: &ObjectStore,
+) -> EngineResult<()> {
+    if !requirements.object_storage {
+        return Ok(());
+    }
+
+    ensure!(
+        object_store::util::is_object_storage(object_store),
+        UnsupportedSnafu {
+            operation: "open region with object storage requirement on non-object storage"
+        }
+    );
+
+    Ok(())
+}
+
 impl EngineInner {
     fn new(object_store: ObjectStore) -> Self {
         Self {
@@ -289,6 +307,8 @@ impl EngineInner {
             return Ok(0);
         }
 
+        ensure_open_requirements(request.requirements, &self.object_store)?;
+
         let res = FileRegion::open(region_id, request, &self.object_store).await;
         let region = res.inspect_err(|err| {
             error!(
@@ -354,5 +374,55 @@ impl EngineInner {
 
     async fn exists(&self, region_id: RegionId) -> bool {
         self.regions.read().unwrap().contains_key(&region_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use object_store::services::{Fs, S3};
+
+    use super::*;
+    use crate::error::Error;
+
+    fn build_fs_object_store() -> ObjectStore {
+        ObjectStore::new(Fs::default().root("/tmp"))
+            .unwrap()
+            .finish()
+    }
+
+    fn build_s3_object_store() -> ObjectStore {
+        ObjectStore::new(
+            S3::default()
+                .bucket("test-bucket")
+                .region("us-east-1")
+                .disable_ec2_metadata(),
+        )
+        .unwrap()
+        .finish()
+    }
+
+    #[test]
+    fn test_empty_open_requirements_are_supported() {
+        ensure_open_requirements(RegionRequirements::empty(), &build_fs_object_store()).unwrap();
+    }
+
+    #[test]
+    fn test_object_storage_open_requirement_rejects_fs_object_store() {
+        let err = ensure_open_requirements(
+            RegionRequirements::object_storage(),
+            &build_fs_object_store(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, Error::Unsupported { .. }));
+    }
+
+    #[test]
+    fn test_object_storage_open_requirement_accepts_s3_object_store() {
+        ensure_open_requirements(
+            RegionRequirements::object_storage(),
+            &build_s3_object_store(),
+        )
+        .unwrap();
     }
 }

--- a/src/file-engine/src/region.rs
+++ b/src/file-engine/src/region.rs
@@ -181,6 +181,7 @@ mod tests {
             options: HashMap::default(),
             skip_wal_replay: false,
             checkpoint: None,
+            requirements: Default::default(),
         };
 
         let region = FileRegion::open(region_id, request, &object_store)
@@ -238,6 +239,7 @@ mod tests {
             options: HashMap::default(),
             skip_wal_replay: false,
             checkpoint: None,
+            requirements: Default::default(),
         };
         let err = FileRegion::open(region_id, request, &object_store)
             .await

--- a/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
@@ -104,7 +104,7 @@ impl OpenCandidateRegion {
                 region_options,
                 region_wal_options,
                 true,
-                reason,
+                Some(reason),
                 RegionRequirements::object_storage(),
             ));
         }
@@ -253,7 +253,7 @@ mod tests {
             Default::default(),
             Default::default(),
             true,
-            OpenRegionReason::RegionMigration,
+            Some(OpenRegionReason::RegionMigration),
             RegionRequirements::object_storage(),
         )])
     }
@@ -302,7 +302,10 @@ mod tests {
             .new_context(persistent_context.clone());
         let instruction = state.build_open_region_instruction(&mut ctx).await.unwrap();
         let open_regions = instruction.into_open_regions().unwrap();
-        assert_eq!(OpenRegionReason::RegionMigration, open_regions[0].reason);
+        assert_eq!(
+            Some(OpenRegionReason::RegionMigration),
+            open_regions[0].reason
+        );
         assert_eq!(
             RegionRequirements::object_storage(),
             open_regions[0].requirements
@@ -312,7 +315,10 @@ mod tests {
         let mut ctx = env.context_factory().new_context(persistent_context);
         let instruction = state.build_open_region_instruction(&mut ctx).await.unwrap();
         let open_regions = instruction.into_open_regions().unwrap();
-        assert_eq!(OpenRegionReason::RegionFailover, open_regions[0].reason);
+        assert_eq!(
+            Some(OpenRegionReason::RegionFailover),
+            open_regions[0].reason
+        );
         assert_eq!(
             RegionRequirements::object_storage(),
             open_regions[0].requirements

--- a/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
@@ -18,7 +18,9 @@ use std::ops::Div;
 use api::v1::meta::MailboxMessage;
 use common_meta::RegionIdent;
 use common_meta::distributed_time_constants::default_distributed_time_constants;
-use common_meta::instruction::{Instruction, InstructionReply, OpenRegion, SimpleReply};
+use common_meta::instruction::{
+    Instruction, InstructionReply, OpenRegion, OpenRegionReason, SimpleReply,
+};
 use common_meta::key::datanode_table::RegionInfo;
 use common_procedure::{Context as ProcedureContext, Status};
 use common_telemetry::info;
@@ -26,12 +28,13 @@ use common_telemetry::tracing_context::TracingContext;
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt};
 use store_api::region_engine::RegionRole;
+use store_api::region_request::RegionRequirements;
 use tokio::time::Instant;
 
 use crate::error::{self, Result};
 use crate::handler::HeartbeatMailbox;
 use crate::procedure::region_migration::flush_leader_region::PreFlushRegion;
-use crate::procedure::region_migration::{Context, State};
+use crate::procedure::region_migration::{Context, RegionMigrationTriggerReason, State};
 use crate::service::mailbox::Channel;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -67,6 +70,10 @@ impl OpenCandidateRegion {
         let region_ids = ctx.persistent_ctx.region_ids.clone();
         let from_peer_id = ctx.persistent_ctx.from_peer.id;
         let to_peer_id = ctx.persistent_ctx.to_peer.id;
+        let reason = match ctx.persistent_ctx.trigger_reason {
+            RegionMigrationTriggerReason::Failover => OpenRegionReason::RegionFailover,
+            _ => OpenRegionReason::RegionMigration,
+        };
         let datanode_table_values = ctx.get_from_peer_datanode_table_values().await?;
         let mut open_regions = Vec::with_capacity(region_ids.len());
 
@@ -97,6 +104,8 @@ impl OpenCandidateRegion {
                 region_options,
                 region_wal_options,
                 true,
+                reason,
+                RegionRequirements::object_storage(),
             ));
         }
 
@@ -233,18 +242,20 @@ mod tests {
     }
 
     fn new_mock_open_instruction(datanode_id: DatanodeId, region_id: RegionId) -> Instruction {
-        Instruction::OpenRegions(vec![OpenRegion {
-            region_ident: RegionIdent {
+        Instruction::OpenRegions(vec![OpenRegion::new(
+            RegionIdent {
                 datanode_id,
                 table_id: region_id.table_id(),
                 region_number: region_id.region_number(),
                 engine: MITO2_ENGINE.to_string(),
             },
-            region_storage_path: "/bar/foo/region/".to_string(),
-            region_options: Default::default(),
-            region_wal_options: Default::default(),
-            skip_wal_replay: true,
-        }])
+            "/bar/foo/region/",
+            Default::default(),
+            Default::default(),
+            true,
+            OpenRegionReason::RegionMigration,
+            RegionRequirements::object_storage(),
+        )])
     }
 
     #[tokio::test]
@@ -261,6 +272,51 @@ mod tests {
 
         assert_matches!(err, Error::DatanodeTableNotFound { .. });
         assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn test_build_open_region_instruction_reason() {
+        let state = OpenCandidateRegion;
+        let mut persistent_context = new_persistent_context();
+        let from_peer_id = persistent_context.from_peer.id;
+        let region_id = persistent_context.region_ids[0];
+        let env = TestingEnv::new();
+
+        let table_info = new_test_table_info(1024);
+        let region_routes = vec![RegionRoute {
+            region: Region::new_test(region_id),
+            leader_peer: Some(Peer::empty(from_peer_id)),
+            ..Default::default()
+        }];
+        env.table_metadata_manager()
+            .create_table_metadata(
+                table_info,
+                TableRouteValue::physical(region_routes),
+                HashMap::default(),
+            )
+            .await
+            .unwrap();
+
+        let mut ctx = env
+            .context_factory()
+            .new_context(persistent_context.clone());
+        let instruction = state.build_open_region_instruction(&mut ctx).await.unwrap();
+        let open_regions = instruction.into_open_regions().unwrap();
+        assert_eq!(OpenRegionReason::RegionMigration, open_regions[0].reason);
+        assert_eq!(
+            RegionRequirements::object_storage(),
+            open_regions[0].requirements
+        );
+
+        persistent_context.trigger_reason = RegionMigrationTriggerReason::Failover;
+        let mut ctx = env.context_factory().new_context(persistent_context);
+        let instruction = state.build_open_region_instruction(&mut ctx).await.unwrap();
+        let open_regions = instruction.into_open_regions().unwrap();
+        assert_eq!(OpenRegionReason::RegionFailover, open_regions[0].reason);
+        assert_eq!(
+            RegionRequirements::object_storage(),
+            open_regions[0].requirements
+        );
     }
 
     #[tokio::test]

--- a/src/metric-engine/src/engine.rs
+++ b/src/metric-engine/src/engine.rs
@@ -620,6 +620,7 @@ mod test {
             options: physical_region_option,
             skip_wal_replay: false,
             checkpoint: None,
+            requirements: Default::default(),
         };
         engine
             .handle_request(physical_region_id, RegionRequest::Open(open_request))
@@ -644,6 +645,7 @@ mod test {
             options: HashMap::new(),
             skip_wal_replay: false,
             checkpoint: None,
+            requirements: Default::default(),
         };
         engine
             .handle_request(
@@ -721,6 +723,7 @@ mod test {
             options: physical_region_option,
             skip_wal_replay: false,
             checkpoint: None,
+            requirements: Default::default(),
         };
         // Opening an already opened region should succeed.
         // Since the region is already open, no metadata recovery operations will be performed.
@@ -749,6 +752,7 @@ mod test {
             options: physical_region_option,
             skip_wal_replay: false,
             checkpoint: None,
+            requirements: Default::default(),
         };
         let err = metric_engine
             .handle_request(physical_region_id, RegionRequest::Open(open_request))
@@ -854,6 +858,7 @@ mod test {
                         options: options.clone(),
                         skip_wal_replay: true,
                         checkpoint: None,
+                        requirements: Default::default(),
                     },
                 )
             })

--- a/src/metric-engine/src/engine/open.rs
+++ b/src/metric-engine/src/engine/open.rs
@@ -222,6 +222,7 @@ impl MetricEngineInner {
                 entry_id: checkpoint.metadata_entry_id.unwrap_or_default(),
                 metadata_entry_id: None,
             }),
+            requirements: request.requirements,
         };
 
         let mut data_region_options = request.options;
@@ -239,6 +240,7 @@ impl MetricEngineInner {
                 entry_id: checkpoint.entry_id,
                 metadata_entry_id: None,
             }),
+            requirements: request.requirements,
         };
 
         (open_metadata_region_request, open_data_region_request)

--- a/src/metric-engine/src/engine/sync/region.rs
+++ b/src/metric-engine/src/engine/sync/region.rs
@@ -321,6 +321,7 @@ mod tests {
                     options: physical_region_option,
                     skip_wal_replay: false,
                     checkpoint: None,
+                    requirements: Default::default(),
                 }),
             )
             .await

--- a/src/metric-engine/src/test_util.rs
+++ b/src/metric-engine/src/test_util.rs
@@ -144,6 +144,7 @@ impl TestEnv {
                     options: physical_region_option,
                     skip_wal_replay: true,
                     checkpoint: None,
+                    requirements: Default::default(),
                 }),
             )
             .await

--- a/src/mito2/Cargo.toml
+++ b/src/mito2/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 default = []
 test = ["common-test-util", "rstest", "rstest_reuse", "rskafka"]
 testing = ["test"]
+test-shared-fs-region-migration = []
 enterprise = []
 vector_index = ["dep:roaring", "index/vector_index"]
 

--- a/src/mito2/src/engine/alter_test.rs
+++ b/src/mito2/src/engine/alter_test.rs
@@ -277,6 +277,7 @@ async fn test_alter_region_with_format(flat_format: bool) {
                 options: HashMap::default(),
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await
@@ -481,6 +482,7 @@ async fn test_put_after_alter_with_format(flat_format: bool) {
                 options: HashMap::default(),
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await
@@ -844,6 +846,7 @@ async fn test_alter_column_fulltext_options_with_format(flat_format: bool) {
                 options: HashMap::default(),
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await
@@ -979,6 +982,7 @@ async fn test_alter_column_set_inverted_index_with_format(flat_format: bool) {
                 options: HashMap::default(),
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await
@@ -1248,6 +1252,7 @@ async fn test_alter_region_sst_format_with_flush() {
                 options: HashMap::default(),
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await
@@ -1366,6 +1371,7 @@ async fn test_alter_region_sst_format_without_flush() {
                 options: HashMap::default(),
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await
@@ -1492,6 +1498,7 @@ async fn test_alter_region_sst_format_flat_to_pk_with_flush() {
                 options: HashMap::default(),
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await
@@ -1610,6 +1617,7 @@ async fn test_alter_region_sst_format_flat_to_pk_without_flush() {
                 options: HashMap::default(),
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await
@@ -1725,6 +1733,7 @@ async fn test_alter_region_append_mode_with_flush() {
                 options: HashMap::default(),
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await
@@ -1843,6 +1852,7 @@ async fn test_alter_region_append_mode_without_flush() {
                 options: HashMap::default(),
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await

--- a/src/mito2/src/engine/append_mode_test.rs
+++ b/src/mito2/src/engine/append_mode_test.rs
@@ -348,6 +348,7 @@ async fn test_alter_append_mode_clears_merge_mode_with_format(flat_format: bool)
                 options,
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await

--- a/src/mito2/src/engine/basic_test.rs
+++ b/src/mito2/src/engine/basic_test.rs
@@ -196,6 +196,7 @@ async fn test_region_replay_with_format(factory: Option<LogStoreFactory>, flat_f
                 options,
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await

--- a/src/mito2/src/engine/batch_catchup_test.rs
+++ b/src/mito2/src/engine/batch_catchup_test.rs
@@ -160,6 +160,7 @@ async fn test_batch_catchup_with_format(factory: Option<LogStoreFactory>, flat_f
                     skip_wal_replay: true,
                     path_type: PathType::Bare,
                     checkpoint: None,
+                    requirements: Default::default(),
                 },
             )
         })

--- a/src/mito2/src/engine/batch_open_test.rs
+++ b/src/mito2/src/engine/batch_open_test.rs
@@ -136,6 +136,7 @@ async fn test_batch_open_with_format(factory: Option<LogStoreFactory>, flat_form
                     skip_wal_replay: false,
                     path_type: PathType::Bare,
                     checkpoint: None,
+                    requirements: Default::default(),
                 },
             )
         })
@@ -149,6 +150,7 @@ async fn test_batch_open_with_format(factory: Option<LogStoreFactory>, flat_form
             skip_wal_replay: false,
             path_type: PathType::Bare,
             checkpoint: None,
+            requirements: Default::default(),
         },
     ));
 
@@ -221,6 +223,7 @@ async fn test_batch_open_err_with_format(factory: Option<LogStoreFactory>, flat_
                     skip_wal_replay: false,
                     path_type: PathType::Bare,
                     checkpoint: None,
+                    requirements: Default::default(),
                 },
             )
         })

--- a/src/mito2/src/engine/bump_committed_sequence_test.rs
+++ b/src/mito2/src/engine/bump_committed_sequence_test.rs
@@ -112,6 +112,7 @@ async fn test_bump_committed_sequence_with_format(flat_format: bool) {
                 options: HashMap::default(),
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await
@@ -151,6 +152,7 @@ async fn test_bump_committed_sequence_with_format(flat_format: bool) {
                 options: HashMap::default(),
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await

--- a/src/mito2/src/engine/catchup_test.rs
+++ b/src/mito2/src/engine/catchup_test.rs
@@ -97,6 +97,7 @@ async fn test_catchup_with_last_entry_id(factory: Option<LogStoreFactory>) {
                 options,
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await
@@ -218,6 +219,7 @@ async fn test_catchup_with_incorrect_last_entry_id(factory: Option<LogStoreFacto
                 options,
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await
@@ -321,6 +323,7 @@ async fn test_catchup_without_last_entry_id(factory: Option<LogStoreFactory>) {
                 options,
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await
@@ -423,6 +426,7 @@ async fn test_catchup_with_manifest_update(factory: Option<LogStoreFactory>) {
                 options,
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await
@@ -527,6 +531,7 @@ async fn open_region(
                 skip_wal_replay,
                 path_type: PathType::Bare,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await
@@ -622,6 +627,7 @@ async fn test_local_catchup(factory: Option<LogStoreFactory>) {
                 skip_wal_replay: true,
                 path_type: PathType::Bare,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await

--- a/src/mito2/src/engine/compaction_test.rs
+++ b/src/mito2/src/engine/compaction_test.rs
@@ -1023,6 +1023,7 @@ async fn test_change_region_compaction_window_with_format(flat_format: bool) {
                 options: Default::default(),
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await
@@ -1125,6 +1126,7 @@ async fn test_open_overwrite_compaction_window_with_format(flat_format: bool) {
                 options,
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await

--- a/src/mito2/src/engine/open_test.rs
+++ b/src/mito2/src/engine/open_test.rs
@@ -64,6 +64,7 @@ async fn test_engine_open_empty_with_format(flat_format: bool) {
                 options: HashMap::default(),
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await
@@ -110,6 +111,7 @@ async fn test_engine_open_existing_with_format(flat_format: bool) {
                 options: HashMap::default(),
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await
@@ -237,6 +239,7 @@ async fn test_engine_region_open_with_options_with_format(flat_format: bool) {
                 options: HashMap::from([("ttl".to_string(), "4d".to_string())]),
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await
@@ -297,6 +300,7 @@ async fn test_engine_region_open_with_custom_store_with_format(flat_format: bool
                 options: HashMap::from([("storage".to_string(), "Gcs".to_string())]),
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await
@@ -392,6 +396,7 @@ async fn test_open_region_skip_wal_replay_with_format(flat_format: bool) {
                 options: Default::default(),
                 skip_wal_replay: true,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await
@@ -431,6 +436,7 @@ async fn test_open_region_skip_wal_replay_with_format(flat_format: bool) {
                 options: Default::default(),
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await
@@ -484,6 +490,7 @@ async fn test_open_region_wait_for_opening_region_ok_with_format(flat_format: bo
                     options: HashMap::default(),
                     skip_wal_replay: false,
                     checkpoint: None,
+                    requirements: Default::default(),
                 }),
             )
             .await
@@ -535,6 +542,7 @@ async fn test_open_region_wait_for_opening_region_err_with_format(flat_format: b
                     options: HashMap::default(),
                     skip_wal_replay: false,
                     checkpoint: None,
+                    requirements: Default::default(),
                 }),
             )
             .await
@@ -691,6 +699,7 @@ async fn test_open_backfills_partition_expr_with_fetcher() {
                 options: HashMap::default(),
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await
@@ -725,6 +734,7 @@ async fn test_open_backfills_partition_expr_with_fetcher() {
                 options: HashMap::default(),
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await
@@ -766,6 +776,7 @@ async fn test_open_keeps_none_without_fetcher() {
                 options: HashMap::default(),
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await

--- a/src/mito2/src/engine/parallel_test.rs
+++ b/src/mito2/src/engine/parallel_test.rs
@@ -52,6 +52,7 @@ async fn scan_in_parallel(
                 skip_wal_replay: false,
                 path_type: PathType::Bare,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await

--- a/src/mito2/src/engine/skip_wal_test.rs
+++ b/src/mito2/src/engine/skip_wal_test.rs
@@ -87,6 +87,7 @@ async fn test_close_region_skip_wal(insert: bool) {
                 options: request.options.clone(),
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await
@@ -154,6 +155,7 @@ async fn test_close_follower_region_skip_wal() {
                 options: request.options.clone(),
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await
@@ -271,6 +273,7 @@ async fn test_close_region_after_truncate_skip_wal() {
                 options: request.options,
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await

--- a/src/mito2/src/engine/sync_test.rs
+++ b/src/mito2/src/engine/sync_test.rs
@@ -127,6 +127,7 @@ async fn test_sync_after_flush_region_with_format(flat_format: bool) {
                 // Ensure the region is not replayed from the WAL.
                 skip_wal_replay: true,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await
@@ -239,6 +240,7 @@ async fn test_sync_after_alter_region_with_format(flat_format: bool) {
                 // Ensure the region is not replayed from the WAL.
                 skip_wal_replay: true,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await

--- a/src/mito2/src/engine/truncate_test.rs
+++ b/src/mito2/src/engine/truncate_test.rs
@@ -323,6 +323,7 @@ async fn test_engine_truncate_reopen_with_format(flat_format: bool) {
                 options: HashMap::default(),
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await
@@ -447,6 +448,7 @@ async fn test_engine_truncate_during_flush_with_format(flat_format: bool) {
                 options: HashMap::default(),
                 skip_wal_replay: false,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -916,6 +916,20 @@ pub enum Error {
         source: Arc<Error>,
     },
 
+    #[snafu(display(
+        "Region {} does not satisfy open capability '{}': {}",
+        region_id,
+        capability,
+        reason
+    ))]
+    OpenRegionCapability {
+        region_id: RegionId,
+        capability: &'static str,
+        reason: &'static str,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Failed to parse job id"))]
     ParseJobId {
         #[snafu(implicit)]
@@ -1376,6 +1390,7 @@ impl ErrorExt for Error {
             PrimaryKeyLengthMismatch { .. } => StatusCode::InvalidArguments,
             InvalidSender { .. } => StatusCode::InvalidArguments,
             InvalidSchedulerState { .. } => StatusCode::InvalidArguments,
+            OpenRegionCapability { .. } => StatusCode::InvalidArguments,
             DeleteSsts { .. } | DeleteIndex { .. } | DeleteIndexes { .. } => {
                 StatusCode::StorageUnavailable
             }

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -917,14 +917,14 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Region {} does not satisfy open capability '{}': {}",
+        "Region {} does not satisfy open requirement '{}': {}",
         region_id,
-        capability,
+        requirement,
         reason
     ))]
-    OpenRegionCapability {
+    OpenRegionRequirement {
         region_id: RegionId,
-        capability: &'static str,
+        requirement: &'static str,
         reason: &'static str,
         #[snafu(implicit)]
         location: Location,
@@ -1390,7 +1390,7 @@ impl ErrorExt for Error {
             PrimaryKeyLengthMismatch { .. } => StatusCode::InvalidArguments,
             InvalidSender { .. } => StatusCode::InvalidArguments,
             InvalidSchedulerState { .. } => StatusCode::InvalidArguments,
-            OpenRegionCapability { .. } => StatusCode::InvalidArguments,
+            OpenRegionRequirement { .. } => StatusCode::InvalidArguments,
             DeleteSsts { .. } | DeleteIndex { .. } | DeleteIndexes { .. } => {
                 StatusCode::StorageUnavailable
             }

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -28,7 +28,7 @@ use log_store::kafka::log_store::KafkaLogStore;
 use log_store::noop::log_store::NoopLogStore;
 use log_store::raft_engine::log_store::RaftEngineLogStore;
 use object_store::manager::ObjectStoreManagerRef;
-use object_store::util::normalize_dir;
+use object_store::util::{is_object_storage, normalize_dir};
 use snafu::{OptionExt, ResultExt, ensure};
 use store_api::logstore::LogStore;
 use store_api::logstore::provider::Provider;
@@ -36,7 +36,7 @@ use store_api::metadata::{
     ColumnMetadata, RegionMetadata, RegionMetadataBuilder, RegionMetadataRef,
 };
 use store_api::region_engine::RegionRole;
-use store_api::region_request::PathType;
+use store_api::region_request::{PathType, RegionRequirements};
 use store_api::storage::{ColumnId, RegionId};
 use tokio::sync::Semaphore;
 
@@ -46,8 +46,8 @@ use crate::cache::file_cache::{FileCache, FileType, IndexKey};
 use crate::config::MitoConfig;
 use crate::error;
 use crate::error::{
-    EmptyRegionDirSnafu, InvalidMetadataSnafu, ObjectStoreNotFoundSnafu, RegionCorruptedSnafu,
-    Result, StaleLogEntrySnafu,
+    EmptyRegionDirSnafu, InvalidMetadataSnafu, InvalidRegionOptionsSnafu, ObjectStoreNotFoundSnafu,
+    RegionCorruptedSnafu, Result, StaleLogEntrySnafu,
 };
 use crate::manifest::action::RegionManifest;
 use crate::manifest::manager::{RegionManifestManager, RegionManifestOptions};
@@ -204,6 +204,23 @@ impl RegionOpener {
         options.validate()?;
         self.options = Some(options);
         Ok(self)
+    }
+
+    /// Ensures the current region open request satisfies its requirements.
+    pub(crate) fn ensure_open_requirements(&self, requirements: RegionRequirements) -> Result<()> {
+        if !requirements.object_storage {
+            return Ok(());
+        }
+
+        let options = self.options.as_ref().context(InvalidRegionOptionsSnafu {
+            reason: "missing region options before capability check".to_string(),
+        })?;
+        let object_store = get_object_store(&options.storage, &self.object_store_manager)?;
+        ensure_open_requirements_inner(
+            self.region_id,
+            requirements,
+            is_object_storage(&object_store),
+        )
     }
 
     /// Sets the cache manager for the region.
@@ -595,6 +612,27 @@ impl RegionOpener {
 
         Ok(Some(region))
     }
+}
+
+fn ensure_open_requirements_inner(
+    region_id: RegionId,
+    requirements: RegionRequirements,
+    is_object_storage: bool,
+) -> Result<()> {
+    if !requirements.object_storage {
+        return Ok(());
+    }
+
+    ensure!(
+        is_object_storage,
+        error::OpenRegionCapabilitySnafu {
+            region_id,
+            capability: "object storage",
+            reason: "region data must be accessible from another datanode",
+        }
+    );
+
+    Ok(())
 }
 
 /// Creates a version builder from a region manifest.
@@ -1176,12 +1214,16 @@ mod tests {
     use parquet::arrow::ArrowWriter;
     use parquet::file::metadata::KeyValue;
     use parquet::file::properties::WriterProperties;
-    use store_api::region_request::PathType;
+    use store_api::region_request::{PathType, RegionRequirements};
     use store_api::storage::{FileId, RegionId};
 
-    use super::{preload_parquet_meta_cache_for_files, sanitize_region_options};
+    use super::{
+        ensure_open_requirements_inner, preload_parquet_meta_cache_for_files,
+        sanitize_region_options,
+    };
     use crate::cache::CacheManager;
     use crate::cache::file_cache::{FileType, IndexKey};
+    use crate::error::Error;
     use crate::manifest::action::{RegionManifest, RemovedFilesRecord};
     use crate::region::options::RegionOptions;
     use crate::sst::FormatType;
@@ -1205,6 +1247,34 @@ mod tests {
             sst_format,
             append_mode: None,
         }
+    }
+
+    #[test]
+    fn test_open_requirement_rejects_non_object_store() {
+        let err = ensure_open_requirements_inner(
+            RegionId::new(1, 1),
+            RegionRequirements::object_storage(),
+            false,
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, Error::OpenRegionCapability { .. }));
+    }
+
+    #[test]
+    fn test_open_requirement_accepts_object_store() {
+        ensure_open_requirements_inner(
+            RegionId::new(1, 1),
+            RegionRequirements::object_storage(),
+            true,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_empty_open_capability_skips_storage_check() {
+        ensure_open_requirements_inner(RegionId::new(1, 1), RegionRequirements::empty(), false)
+            .unwrap();
     }
 
     #[test]

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -214,15 +214,15 @@ impl RegionOpener {
         }
 
         let options = self.options.as_ref().context(InvalidRegionOptionsSnafu {
-            reason: "missing region options before capability check".to_string(),
+            reason: "missing region options before requirement check".to_string(),
         })?;
         let object_store = get_object_store(&options.storage, &self.object_store_manager)?;
 
         ensure!(
             supports_open_region_object_storage_requirement(&object_store),
-            error::OpenRegionCapabilitySnafu {
+            error::OpenRegionRequirementSnafu {
                 region_id: self.region_id,
-                capability: "object storage",
+                requirement: "object storage",
                 reason: "region data must be accessible from another datanode",
             }
         );

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -632,7 +632,8 @@ fn supports_open_region_object_storage_requirement(object_store: &ObjectStore) -
     // temporary home dir. That makes file storage accessible to all test
     // datanodes, but production file storage still does not satisfy this
     // requirement.
-    is_object_storage(object_store) || object_store.info().scheme() == "fs"
+    is_object_storage(object_store)
+        || object_store.info().scheme() == object_store::services::FS_SCHEME
 }
 
 /// Creates a version builder from a region manifest.

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -27,6 +27,7 @@ use futures::future::BoxFuture;
 use log_store::kafka::log_store::KafkaLogStore;
 use log_store::noop::log_store::NoopLogStore;
 use log_store::raft_engine::log_store::RaftEngineLogStore;
+use object_store::ObjectStore;
 use object_store::manager::ObjectStoreManagerRef;
 use object_store::util::{is_object_storage, normalize_dir};
 use snafu::{OptionExt, ResultExt, ensure};
@@ -216,11 +217,17 @@ impl RegionOpener {
             reason: "missing region options before capability check".to_string(),
         })?;
         let object_store = get_object_store(&options.storage, &self.object_store_manager)?;
-        ensure_open_requirements_inner(
-            self.region_id,
-            requirements,
-            is_object_storage(&object_store),
-        )
+
+        ensure!(
+            supports_open_region_object_storage_requirement(&object_store),
+            error::OpenRegionCapabilitySnafu {
+                region_id: self.region_id,
+                capability: "object storage",
+                reason: "region data must be accessible from another datanode",
+            }
+        );
+
+        Ok(())
     }
 
     /// Sets the cache manager for the region.
@@ -614,25 +621,18 @@ impl RegionOpener {
     }
 }
 
-fn ensure_open_requirements_inner(
-    region_id: RegionId,
-    requirements: RegionRequirements,
-    is_object_storage: bool,
-) -> Result<()> {
-    if !requirements.object_storage {
-        return Ok(());
-    }
+#[cfg(not(feature = "test-shared-fs-region-migration"))]
+fn supports_open_region_object_storage_requirement(object_store: &ObjectStore) -> bool {
+    is_object_storage(object_store)
+}
 
-    ensure!(
-        is_object_storage,
-        error::OpenRegionCapabilitySnafu {
-            region_id,
-            capability: "object storage",
-            reason: "region data must be accessible from another datanode",
-        }
-    );
-
-    Ok(())
+#[cfg(feature = "test-shared-fs-region-migration")]
+fn supports_open_region_object_storage_requirement(object_store: &ObjectStore) -> bool {
+    // Integration tests can configure multiple datanodes to share the same
+    // temporary home dir. That makes file storage accessible to all test
+    // datanodes, but production file storage still does not satisfy this
+    // requirement.
+    is_object_storage(object_store) || object_store.info().scheme() == "fs"
 }
 
 /// Creates a version builder from a region manifest.
@@ -1214,16 +1214,12 @@ mod tests {
     use parquet::arrow::ArrowWriter;
     use parquet::file::metadata::KeyValue;
     use parquet::file::properties::WriterProperties;
-    use store_api::region_request::{PathType, RegionRequirements};
+    use store_api::region_request::PathType;
     use store_api::storage::{FileId, RegionId};
 
-    use super::{
-        ensure_open_requirements_inner, preload_parquet_meta_cache_for_files,
-        sanitize_region_options,
-    };
+    use super::{preload_parquet_meta_cache_for_files, sanitize_region_options};
     use crate::cache::CacheManager;
     use crate::cache::file_cache::{FileType, IndexKey};
-    use crate::error::Error;
     use crate::manifest::action::{RegionManifest, RemovedFilesRecord};
     use crate::region::options::RegionOptions;
     use crate::sst::FormatType;
@@ -1247,34 +1243,6 @@ mod tests {
             sst_format,
             append_mode: None,
         }
-    }
-
-    #[test]
-    fn test_open_requirement_rejects_non_object_store() {
-        let err = ensure_open_requirements_inner(
-            RegionId::new(1, 1),
-            RegionRequirements::object_storage(),
-            false,
-        )
-        .unwrap_err();
-
-        assert!(matches!(err, Error::OpenRegionCapability { .. }));
-    }
-
-    #[test]
-    fn test_open_requirement_accepts_object_store() {
-        ensure_open_requirements_inner(
-            RegionId::new(1, 1),
-            RegionRequirements::object_storage(),
-            true,
-        )
-        .unwrap();
-    }
-
-    #[test]
-    fn test_empty_open_capability_skips_storage_check() {
-        ensure_open_requirements_inner(RegionId::new(1, 1), RegionRequirements::empty(), false)
-            .unwrap();
     }
 
     #[test]

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -1211,14 +1211,17 @@ mod tests {
     use datatypes::arrow::array::{ArrayRef, BinaryArray, Int64Array};
     use datatypes::arrow::record_batch::RecordBatch;
     use object_store::ObjectStore;
-    use object_store::services::{Fs, Memory};
+    use object_store::services::{Fs, Memory, S3};
     use parquet::arrow::ArrowWriter;
     use parquet::file::metadata::KeyValue;
     use parquet::file::properties::WriterProperties;
     use store_api::region_request::PathType;
     use store_api::storage::{FileId, RegionId};
 
-    use super::{preload_parquet_meta_cache_for_files, sanitize_region_options};
+    use super::{
+        preload_parquet_meta_cache_for_files, sanitize_region_options,
+        supports_open_region_object_storage_requirement,
+    };
     use crate::cache::CacheManager;
     use crate::cache::file_cache::{FileType, IndexKey};
     use crate::manifest::action::{RegionManifest, RemovedFilesRecord};
@@ -1244,6 +1247,48 @@ mod tests {
             sst_format,
             append_mode: None,
         }
+    }
+
+    fn build_fs_object_store() -> ObjectStore {
+        ObjectStore::new(Fs::default().root("/tmp"))
+            .unwrap()
+            .finish()
+    }
+
+    #[test]
+    #[cfg(not(feature = "test-shared-fs-region-migration"))]
+    fn test_open_requirement_rejects_fs_object_store() {
+        let object_store = build_fs_object_store();
+
+        assert!(!supports_open_region_object_storage_requirement(
+            &object_store
+        ));
+    }
+
+    #[test]
+    #[cfg(feature = "test-shared-fs-region-migration")]
+    fn test_open_requirement_accepts_shared_fs_object_store_for_tests() {
+        let object_store = build_fs_object_store();
+
+        assert!(supports_open_region_object_storage_requirement(
+            &object_store
+        ));
+    }
+
+    #[test]
+    fn test_open_requirement_accepts_s3_object_store() {
+        let object_store = ObjectStore::new(
+            S3::default()
+                .bucket("test-bucket")
+                .region("us-east-1")
+                .disable_ec2_metadata(),
+        )
+        .unwrap()
+        .finish();
+
+        assert!(supports_open_region_object_storage_requirement(
+            &object_store
+        ));
     }
 
     #[test]

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -1282,6 +1282,7 @@ pub async fn reopen_region(
                 skip_wal_replay: false,
                 path_type: PathType::Bare,
                 checkpoint: None,
+                requirements: Default::default(),
             }),
         )
         .await

--- a/src/mito2/src/worker/handle_open.rs
+++ b/src/mito2/src/worker/handle_open.rs
@@ -87,14 +87,11 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         else {
             return;
         };
-        if let Err(err) = self.check_and_cleanup_region(region_id, &request).await {
-            sender.send(Err(err));
-            return;
-        }
         info!("Try to open region {}, worker: {}", region_id, self.id);
         sanitize_open_request_options(&mut request.options);
 
         // Open region from specific region dir.
+        let requirements = request.requirements;
         let opener = match RegionOpener::new(
             region_id,
             &request.table_dir,
@@ -112,7 +109,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         .cache(Some(self.cache_manager.clone()))
         .wal_entry_reader(wal_entry_receiver.map(|receiver| Box::new(receiver) as _))
         .replay_checkpoint(request.checkpoint.map(|checkpoint| checkpoint.entry_id))
-        .parse_options(request.options)
+        .parse_options(request.options.clone())
         {
             Ok(opener) => opener,
             Err(err) => {
@@ -120,6 +117,16 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                 return;
             }
         };
+
+        if let Err(err) = opener.ensure_open_requirements(requirements) {
+            sender.send(Err(err));
+            return;
+        }
+
+        if let Err(err) = self.check_and_cleanup_region(region_id, &request).await {
+            sender.send(Err(err));
+            return;
+        }
 
         let now = Instant::now();
         let regions = self.regions.clone();

--- a/src/object-store/src/util.rs
+++ b/src/object-store/src/util.rs
@@ -27,6 +27,11 @@ use snafu::ResultExt;
 use crate::config::HttpClientConfig;
 use crate::{ObjectStore, error};
 
+/// Returns true if the object store is not backed by local filesystem.
+pub fn is_object_storage(object_store: &ObjectStore) -> bool {
+    object_store.info().scheme() != "fs"
+}
+
 /// Join two paths and normalize the output dir.
 ///
 /// The output dir is always ends with `/`. e.g.
@@ -249,7 +254,11 @@ impl RetryInterceptor for PrintDetailedError {
 
 #[cfg(test)]
 mod tests {
+    use opendal::services::Fs;
+
     use super::*;
+    use crate::ObjectStore;
+    use crate::util::is_object_storage;
 
     #[test]
     fn test_normalize_dir() {
@@ -288,5 +297,15 @@ mod tests {
         assert_eq!("abc/def", join_path(" abc", "/def "));
         assert_eq!("/abc", join_path("//", "/abc"));
         assert_eq!("abc/def", join_path("abc/", "//def"));
+    }
+
+    #[test]
+    fn test_fs_is_not_object_storage() {
+        let object_store = ObjectStore::new(Fs::default().root("/tmp"))
+            .unwrap()
+            .finish();
+
+        assert_eq!("fs", object_store.info().scheme());
+        assert!(!is_object_storage(&object_store));
     }
 }

--- a/src/object-store/src/util.rs
+++ b/src/object-store/src/util.rs
@@ -22,6 +22,7 @@ use opendal::layers::{
     LoggingInterceptor, LoggingLayer, RetryEvent, RetryInterceptor, RetryLayer, TracingLayer,
 };
 use opendal::raw::{AccessorInfo, HttpClient, Operation};
+use opendal::services::FS_SCHEME;
 use snafu::ResultExt;
 
 use crate::config::HttpClientConfig;
@@ -29,7 +30,7 @@ use crate::{ObjectStore, error};
 
 /// Returns true if the object store is not backed by local filesystem.
 pub fn is_object_storage(object_store: &ObjectStore) -> bool {
-    object_store.info().scheme() != "fs"
+    object_store.info().scheme() != FS_SCHEME
 }
 
 /// Join two paths and normalize the output dir.
@@ -305,7 +306,7 @@ mod tests {
             .unwrap()
             .finish();
 
-        assert_eq!("fs", object_store.info().scheme());
+        assert_eq!(FS_SCHEME, object_store.info().scheme());
         assert!(!is_object_storage(&object_store));
     }
 }

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -315,6 +315,7 @@ fn make_region_open(open: OpenRequest) -> Result<Vec<(RegionId, RegionRequest)>>
             options: open.options,
             skip_wal_replay: false,
             checkpoint: None,
+            requirements: Default::default(),
         }),
     )])
 }
@@ -566,6 +567,28 @@ pub struct RegionDropRequest {
     pub partial_drop: bool,
 }
 
+/// Requirements for a region request.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct RegionRequirements {
+    /// Whether the region data must be backed by object storage.
+    pub object_storage: bool,
+}
+
+impl RegionRequirements {
+    /// Returns empty requirements.
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Returns requirements for object storage.
+    pub fn object_storage() -> Self {
+        Self {
+            object_storage: true,
+        }
+    }
+}
+
 /// Open region request.
 #[derive(Debug, Clone)]
 pub struct RegionOpenRequest {
@@ -581,6 +604,8 @@ pub struct RegionOpenRequest {
     pub skip_wal_replay: bool,
     /// Replay checkpoint.
     pub checkpoint: Option<ReplayCheckpoint>,
+    /// Requirements for opening the region.
+    pub requirements: RegionRequirements,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -63,7 +63,7 @@ log-query = { workspace = true }
 loki-proto.workspace = true
 meta-client.workspace = true
 meta-srv = { workspace = true, features = ["mock"] }
-mito2.workspace = true
+mito2 = { workspace = true, features = ["test-shared-fs-region-migration"] }
 object-store.workspace = true
 operator = { workspace = true, features = ["testing"] }
 plugins.workspace = true


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
Related to #8171

## What's changed and what's your intention?

This PR adds explicit region open requirements to prevent region migration/failover from opening regions whose data is not backed by object storage.
Main changes:
- Add `OpenRegionReason` to meta `OpenRegion` instructions.
  - `RegionMigration`
  - `RegionFailover`
  - `RegionFollower` behind the `enterprise` feature
- Add `RegionRequirements` to describe requirements for region operations.
  - Currently supports `object_storage`.
  - The type is defined in `store-api` so it can be reused by future request paths, such as create region.
- Make `OpenRegion::new()` require both `reason` and `requirements` explicitly.
  - This avoids missing requirement propagation when adding new open-region paths.
- Pass requirements from metasrv open-region instructions through datanode heartbeat handling into `RegionOpenRequest`.
- Require object storage for region migration/failover candidate opens.
- Validate open requirements in Mito before opening the region.
  - The object-store check is centralized in `object_store::util::is_object_storage()`.
  - The core requirement check is extracted into a pure function and covered by unit tests.
- Log open-region reason when datanode receives an open-region instruction.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
