### PR TITLE
fix: format detected IPv6 grpc address

### DIFF
--- a/src/servers/src/grpc.rs
+++ b/src/servers/src/grpc.rs
@@ -24,7 +24,7 @@ pub mod prom_query_gateway;
 pub mod region_server;
 
 use std::any::Any;
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::time::Duration;
 
 use api::v1::health_check_server::{HealthCheck, HealthCheckServer};
@@ -95,14 +95,8 @@ impl GrpcOptions {
         if self.server_addr.is_empty() {
             match local_ip_address::local_ip() {
                 Ok(ip) => {
-                    let detected_addr = format!(
-                        "{}:{}",
-                        ip,
-                        self.bind_addr
-                            .split(':')
-                            .nth(1)
-                            .unwrap_or(DEFAULT_GRPC_ADDR_PORT)
-                    );
+                    let port = port_from_bind_addr(&self.bind_addr);
+                    let detected_addr = format_server_addr(ip, port);
                     info!("Using detected: {} as server address", detected_addr);
                     self.server_addr = detected_addr;
                 }
@@ -131,7 +125,18 @@ impl GrpcOptions {
     }
 }
 
-const DEFAULT_GRPC_ADDR_PORT: &str = "4001";
+const DEFAULT_GRPC_ADDR_PORT: u16 = 4001;
+
+fn port_from_bind_addr(bind_addr: &str) -> u16 {
+    bind_addr
+        .rsplit_once(':')
+        .and_then(|(_, port)| port.parse().ok())
+        .unwrap_or(DEFAULT_GRPC_ADDR_PORT)
+}
+
+fn format_server_addr(ip: IpAddr, port: u16) -> String {
+    SocketAddr::new(ip, port).to_string()
+}
 
 const DEFAULT_INTERNAL_GRPC_ADDR_PORT: &str = "4010";
 
@@ -413,5 +418,38 @@ impl Server for GrpcServer {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    use super::{DEFAULT_GRPC_ADDR_PORT, format_server_addr, port_from_bind_addr};
+
+    #[test]
+    fn test_port_from_bind_addr() {
+        assert_eq!(3002, port_from_bind_addr("127.0.0.1:3002"));
+        assert_eq!(3002, port_from_bind_addr("[::]:3002"));
+        assert_eq!(
+            3002,
+            port_from_bind_addr("greptimedb-metasrv.default.svc.cluster.local:3002")
+        );
+        assert_eq!(
+            DEFAULT_GRPC_ADDR_PORT,
+            port_from_bind_addr("invalid-bind-addr")
+        );
+    }
+
+    #[test]
+    fn test_format_server_addr() {
+        assert_eq!(
+            "127.0.0.1:3002",
+            format_server_addr(IpAddr::V4(Ipv4Addr::LOCALHOST), 3002)
+        );
+        assert_eq!(
+            "[::1]:3002",
+            format_server_addr(IpAddr::V6(Ipv6Addr::LOCALHOST), 3002)
+        );
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
fix #8220
## What's changed and what's your intention?

This PR fixes detected gRPC server address formatting when the local IP is IPv6.

Previously, `GrpcOptions::detect_server_addr()` formatted the detected address with string concatenation:

```rust
format!("{}:{}", ip, port)
```

When local_ip_address::local_ip() returned an IPv6 address, metasrv could advertise an address like:
fd00:10:244::1d:3002
This is not a valid URI authority for tonic, causing meta clients to fail with InvalidUri(InvalidAuthority) while creating gRPC channels.
The new logic:
- extracts the port from bind_addr via SocketAddr parsing
- formats the detected IpAddr + port through SocketAddr::new(ip, port).to_string()
- keeps IPv4 unchanged
- formats IPv6 as [ipv6]:port
Unit tests cover port extraction and IPv4/IPv6 address formatting.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
