### PR TITLE
fix(config): align scan memory limit default with code

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -169,7 +169,7 @@
 | `region_engine.mito.sst_write_buffer_size` | String | `8MB` | Buffer size for SST writing. |
 | `region_engine.mito.max_concurrent_scan_files` | Integer | `384` | Maximum number of SST files to scan concurrently. |
 | `region_engine.mito.allow_stale_entries` | Bool | `false` | Whether to allow stale WAL entries read during replay. |
-| `region_engine.mito.scan_memory_limit` | String | `50%` | Memory limit for table scans across all queries.<br/>Supports absolute size (e.g., "2GB") or percentage of system memory (e.g., "20%").<br/>Setting it to 0 disables the limit. |
+| `region_engine.mito.scan_memory_limit` | String | `unlimited` | Memory limit for table scans across all queries.<br/>Supports absolute size (e.g., "2GB") or percentage of system memory (e.g., "20%").<br/>Setting it to 0 or "unlimited" disables the limit. |
 | `region_engine.mito.scan_memory_on_exhausted` | String | `fail` | Controls what happens when a scan cannot get memory immediately.<br/>"fail" (default) fails fast and is the recommended option for most users.<br/>"wait" / "wait(<duration>)" waits for memory to become available. This is mainly<br/>for advanced tuning in bursty workloads where temporary contention is common and<br/>higher latency is acceptable.<br/>"wait" means "wait(10s)", not unlimited waiting. |
 | `region_engine.mito.min_compaction_interval` | String | `0m` | Minimum time interval between two compactions.<br/>To align with the old behavior, the default value is 0 (no restrictions). |
 | `region_engine.mito.default_flat_format` | Bool | `true` | Whether to enable flat format as the default SST format. |
@@ -561,7 +561,7 @@
 | `region_engine.mito.sst_write_buffer_size` | String | `8MB` | Buffer size for SST writing. |
 | `region_engine.mito.max_concurrent_scan_files` | Integer | `384` | Maximum number of SST files to scan concurrently. |
 | `region_engine.mito.allow_stale_entries` | Bool | `false` | Whether to allow stale WAL entries read during replay. |
-| `region_engine.mito.scan_memory_limit` | String | `50%` | Memory limit for table scans across all queries.<br/>Supports absolute size (e.g., "2GB") or percentage of system memory (e.g., "20%").<br/>Setting it to 0 disables the limit. |
+| `region_engine.mito.scan_memory_limit` | String | `unlimited` | Memory limit for table scans across all queries.<br/>Supports absolute size (e.g., "2GB") or percentage of system memory (e.g., "20%").<br/>Setting it to 0 or "unlimited" disables the limit. |
 | `region_engine.mito.scan_memory_on_exhausted` | String | `fail` | Controls what happens when a scan cannot get memory immediately.<br/>"fail" (default) fails fast and is the recommended option for most users.<br/>"wait" / "wait(<duration>)" waits for memory to become available. This is mainly<br/>for advanced tuning in bursty workloads where temporary contention is common and<br/>higher latency is acceptable.<br/>"wait" means "wait(10s)", not unlimited waiting. |
 | `region_engine.mito.min_compaction_interval` | String | `0m` | Minimum time interval between two compactions.<br/>To align with the old behavior, the default value is 0 (no restrictions). |
 | `region_engine.mito.default_flat_format` | Bool | `true` | Whether to enable flat format as the default SST format. |

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -535,8 +535,8 @@ allow_stale_entries = false
 
 ## Memory limit for table scans across all queries.
 ## Supports absolute size (e.g., "2GB") or percentage of system memory (e.g., "20%").
-## Setting it to 0 disables the limit.
-scan_memory_limit = "50%"
+## Setting it to 0 or "unlimited" disables the limit.
+scan_memory_limit = "unlimited"
 ## Controls what happens when a scan cannot get memory immediately.
 ## "fail" (default) fails fast and is the recommended option for most users.
 ## "wait" / "wait(<duration>)" waits for memory to become available. This is mainly

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -655,8 +655,8 @@ allow_stale_entries = false
 
 ## Memory limit for table scans across all queries.
 ## Supports absolute size (e.g., "2GB") or percentage of system memory (e.g., "20%").
-## Setting it to 0 disables the limit.
-scan_memory_limit = "50%"
+## Setting it to 0 or "unlimited" disables the limit.
+scan_memory_limit = "unlimited"
 ## Controls what happens when a scan cannot get memory immediately.
 ## "fail" (default) fails fast and is the recommended option for most users.
 ## "wait" / "wait(<duration>)" waits for memory to become available. This is mainly

--- a/src/cmd/tests/load_config_test.rs
+++ b/src/cmd/tests/load_config_test.rs
@@ -73,7 +73,7 @@ fn test_load_datanode_example_config() {
                 RegionEngineConfig::Mito(MitoConfig {
                     auto_flush_interval: Duration::from_secs(3600),
                     write_cache_ttl: Some(Duration::from_secs(60 * 60 * 8)),
-                    scan_memory_limit: MemoryLimit::Percentage(50),
+                    scan_memory_limit: MemoryLimit::Unlimited,
                     ..Default::default()
                 }),
                 RegionEngineConfig::File(FileEngineConfig {}),
@@ -279,7 +279,7 @@ fn test_load_standalone_example_config() {
                 RegionEngineConfig::Mito(MitoConfig {
                     auto_flush_interval: Duration::from_secs(3600),
                     write_cache_ttl: Some(Duration::from_secs(60 * 60 * 8)),
-                    scan_memory_limit: MemoryLimit::Percentage(50),
+                    scan_memory_limit: MemoryLimit::Unlimited,
                     ..Default::default()
                 }),
                 RegionEngineConfig::File(FileEngineConfig {}),

--- a/src/mito2/src/config.rs
+++ b/src/mito2/src/config.rs
@@ -149,7 +149,7 @@ pub struct MitoConfig {
     pub allow_stale_entries: bool,
     /// Memory limit for table scans across all queries.
     /// Setting it to 0 or "unlimited" disables the limit.
-    /// Supports absolute size (e.g., "2GB") or percentage (e.g., "50%").
+    /// Supports absolute size (e.g., "2GB") or percentage of system memory (e.g., "50%").
     pub scan_memory_limit: MemoryLimit,
     /// Behavior when scan memory tracking cannot acquire memory from the budget.
     /// `wait` means `wait(10s)`, not unlimited waiting.

--- a/src/mito2/src/config.rs
+++ b/src/mito2/src/config.rs
@@ -147,7 +147,8 @@ pub struct MitoConfig {
     pub max_concurrent_scan_files: usize,
     /// Whether to allow stale entries read during replay.
     pub allow_stale_entries: bool,
-    /// Memory limit for table scans across all queries. Setting it to 0 disables the limit.
+    /// Memory limit for table scans across all queries.
+    /// Setting it to 0 or "unlimited" disables the limit.
     /// Supports absolute size (e.g., "2GB") or percentage (e.g., "50%").
     pub scan_memory_limit: MemoryLimit,
     /// Behavior when scan memory tracking cannot acquire memory from the budget.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What

Update the documented/example `region_engine.mito.scan_memory_limit` default from `50%` to `unlimited` in the datanode and standalone configs, and regenerate `config.md`.

## Why

The runtime default comes from `MitoConfig::default()`, where `scan_memory_limit` is `MemoryLimit::default()`, i.e. `unlimited`.

The previous docs and example configs showed `50%`, which was inconsistent with the actual default startup behavior and could mislead users.

## Notes

This only fixes config documentation and example defaults. It does not change the runtime default or scan memory tracking behavior.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
