### PR TITLE
fix: avoid stale metadata cache after invalidation

### DIFF
--- a/src/common/meta/src/cache/table/table_info.rs
+++ b/src/common/meta/src/cache/table/table_info.rs
@@ -20,7 +20,7 @@ use snafu::OptionExt;
 use store_api::storage::TableId;
 use table::metadata::TableInfo;
 
-use crate::cache::{CacheContainer, Initializer};
+use crate::cache::{CacheContainer, InitStrategy, Initializer};
 use crate::error;
 use crate::error::Result;
 use crate::instruction::CacheIdent;
@@ -41,7 +41,14 @@ pub fn new_table_info_cache(
     let table_info_manager = Arc::new(TableInfoManager::new(kv_backend));
     let init = init_factory(table_info_manager);
 
-    CacheContainer::new(name, cache, Box::new(invalidator), init, filter)
+    CacheContainer::with_strategy(
+        name,
+        cache,
+        Box::new(invalidator),
+        init,
+        filter,
+        InitStrategy::VersionChecked,
+    )
 }
 
 fn init_factory(table_info_manager: TableInfoManagerRef) -> Initializer<TableId, Arc<TableInfo>> {

--- a/src/partition/src/cache.rs
+++ b/src/partition/src/cache.rs
@@ -16,7 +16,9 @@ use std::sync::Arc;
 
 use common_base::hash::partition_expr_version;
 use common_error::ext::BoxedError;
-use common_meta::cache::{CacheContainer, Initializer, TableRoute, TableRouteCacheRef};
+use common_meta::cache::{
+    CacheContainer, InitStrategy, Initializer, TableRoute, TableRouteCacheRef,
+};
 use common_meta::instruction::CacheIdent;
 use common_meta::rpc::router::RegionRoute;
 use moka::future::Cache;
@@ -118,7 +120,7 @@ pub fn new_partition_info_cache(
     cache: Cache<TableId, CachedPartitionInfo>,
     table_route_cache: TableRouteCacheRef,
 ) -> PartitionInfoCache {
-    CacheContainer::new(
+    CacheContainer::with_strategy(
         name,
         cache,
         Box::new(|cache, idents| {
@@ -133,6 +135,7 @@ pub fn new_partition_info_cache(
         }),
         init_factory(table_route_cache),
         |ident| matches!(ident, CacheIdent::TableId(_)),
+        InitStrategy::VersionChecked,
     )
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR avoids returning stale table metadata or partition metadata when cache initialization races with cache invalidation.

Previously, `TableInfoCache` and `PartitionInfoCache` used the default unchecked cache initialization strategy. If an invalidation happened while a cache-miss initialization was still loading metadata, the stale loaded value could still be inserted into the cache and later reused.

This PR switches both caches to `InitStrategy::VersionChecked`, so cache initialization retries when the cache version changes during loading:

- `TableInfoCache` now uses `InitStrategy::VersionChecked`.
- `PartitionInfoCache` now uses `InitStrategy::VersionChecked`.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
