### PR TITLE
feat: fan out remote dynamic filter updates from FE

### DIFF
--- a/src/common/query/src/error.rs
+++ b/src/common/query/src/error.rs
@@ -199,6 +199,18 @@ pub enum Error {
 
     #[snafu(display("Invalid character in prefix config: {}", prefix))]
     InvalidColumnPrefix { prefix: String },
+
+    #[snafu(display(
+        "DynFilterPayload::Datafusion is {} bytes, which exceeds the configured limit of {} bytes",
+        payload_size_bytes,
+        max_payload_bytes
+    ))]
+    DynFilterPayloadTooLarge {
+        payload_size_bytes: usize,
+        max_payload_bytes: usize,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -228,6 +240,8 @@ impl ErrorExt for Error {
             | Error::TypeCast { .. }
             | Error::InvalidFuncArgs { .. }
             | Error::InvalidColumnPrefix { .. } => StatusCode::InvalidArguments,
+
+            Error::DynFilterPayloadTooLarge { .. } => StatusCode::PlanQuery,
 
             Error::ConvertDfRecordBatchStream { source, .. } => source.status_code(),
 

--- a/src/common/query/src/request.rs
+++ b/src/common/query/src/request.rs
@@ -19,10 +19,10 @@ use std::sync::Arc;
 
 use api::v1::region::RegionRequestHeader;
 use datafusion::execution::TaskContext;
-use datafusion::physical_expr::expressions::Column;
+use datafusion::physical_expr::expressions::{Column, InListExpr, lit};
 use datafusion::physical_plan::PhysicalExpr;
 use datafusion::physical_plan::joins::HashTableLookupExpr;
-use datafusion_common::tree_node::{TreeNode, TreeNodeRecursion};
+use datafusion_common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
 use datafusion_common::{DataFusionError, Result as DataFusionResult};
 use datafusion_expr::LogicalPlan;
 use datafusion_proto::physical_plan::DefaultPhysicalExtensionCodec;
@@ -31,6 +31,7 @@ use datafusion_proto::physical_plan::to_proto::serialize_physical_expr;
 use datafusion_proto::protobuf::PhysicalExprNode;
 use prost::Message;
 use serde::{Deserialize, Serialize};
+use snafu::ensure;
 use store_api::storage::RegionId;
 
 /// Current wire-format version for remote dynamic filter payload updates.
@@ -39,6 +40,7 @@ pub use self::initial_remote_dyn_filter_reg::{
     INITIAL_REMOTE_DYN_FILTER_REGS_MAX_TOTAL_PROTO_BYTES, InitialDynFilterReg,
     InitialDynFilterRegs, InitialDynFilterSnapshot,
 };
+use crate::error::{DynFilterPayloadTooLargeSnafu, Error as CommonQueryError};
 
 pub const DYN_FILTER_PROTOCOL_VERSION: u32 = 1;
 
@@ -63,24 +65,23 @@ pub enum DynFilterPayload {
 impl DynFilterPayload {
     /// Encodes a DataFusion physical expression into a bounded dynamic filter payload.
     ///
-    /// This rejects expressions that cannot be safely shipped as dynamic filter
-    /// predicates and fails if the serialized payload exceeds `max_payload_bytes`.
+    /// Runtime-only hash lookup predicates are degraded to `true` before encoding so
+    /// serializable min/max bounds around them can still be shipped to remote scans.
+    /// If the full serializable predicate is still larger than `max_payload_bytes`, large
+    /// membership predicates (`IN (...)`) are also degraded to `true` as a bounds-only fallback.
     pub fn from_datafusion_expr(
         expr: &Arc<dyn PhysicalExpr>,
         max_payload_bytes: usize,
     ) -> DataFusionResult<Self> {
-        validate_supported_payload_expr(expr)?;
-
-        let codec = DefaultPhysicalExtensionCodec {};
-        let proto = serialize_physical_expr(expr, &codec)?;
-        let mut bytes = Vec::new();
-        proto.encode(&mut bytes).map_err(|e| {
-            DataFusionError::Internal(format!("Failed to encode PhysicalExprNode: {e}"))
-        })?;
-
-        validate_payload_size(bytes.len(), max_payload_bytes)?;
-
-        Ok(Self::Datafusion(bytes))
+        match encode_remote_dyn_filter_expr(expr, max_payload_bytes, false) {
+            Ok(bytes) => Ok(Self::Datafusion(bytes)),
+            Err(CommonQueryError::DynFilterPayloadTooLarge { .. }) => {
+                encode_remote_dyn_filter_expr(expr, max_payload_bytes, true)
+                    .map(Self::Datafusion)
+                    .map_err(DataFusionError::from)
+            }
+            Err(error) => Err(DataFusionError::from(error)),
+        }
     }
 
     /// Decodes a DataFusion dynamic filter payload against the provided input schema.
@@ -95,7 +96,7 @@ impl DynFilterPayload {
         max_payload_bytes: usize,
     ) -> DataFusionResult<Arc<dyn PhysicalExpr>> {
         let Self::Datafusion(bytes) = self;
-        validate_payload_size(bytes.len(), max_payload_bytes)?;
+        validate_payload_size(bytes.len(), max_payload_bytes).map_err(DataFusionError::from)?;
         let codec = DefaultPhysicalExtensionCodec {};
         let proto = PhysicalExprNode::decode(bytes.as_slice()).map_err(|e| {
             DataFusionError::Internal(format!("Failed to decode PhysicalExprNode: {e}"))
@@ -118,13 +119,41 @@ fn encode_physical_expr_to_bytes(expr: &Arc<dyn PhysicalExpr>) -> DataFusionResu
     Ok(bytes)
 }
 
+fn encode_remote_dyn_filter_expr(
+    expr: &Arc<dyn PhysicalExpr>,
+    max_payload_bytes: usize,
+    bounds_only: bool,
+) -> Result<Vec<u8>, CommonQueryError> {
+    let expr = portable_remote_dyn_filter_expr(Arc::clone(expr), bounds_only)
+        .map_err(CommonQueryError::from)?;
+    let bytes = encode_physical_expr_to_bytes(&expr).map_err(CommonQueryError::from)?;
+    validate_payload_size(bytes.len(), max_payload_bytes)?;
+    Ok(bytes)
+}
+
+fn portable_remote_dyn_filter_expr(
+    expr: Arc<dyn PhysicalExpr>,
+    bounds_only: bool,
+) -> DataFusionResult<Arc<dyn PhysicalExpr>> {
+    expr.transform_up(|node| {
+        if node.as_any().is::<HashTableLookupExpr>()
+            || (bounds_only && node.as_any().is::<InListExpr>())
+        {
+            Ok(Transformed::yes(lit(true)))
+        } else {
+            Ok(Transformed::no(node))
+        }
+    })
+    .map(|transformed| transformed.data)
+}
+
 pub(crate) fn decode_physical_expr_from_bytes(
     bytes: &[u8],
     task_ctx: &TaskContext,
     input_schema: &datafusion::arrow::datatypes::Schema,
     max_payload_bytes: usize,
 ) -> DataFusionResult<Arc<dyn PhysicalExpr>> {
-    validate_payload_size(bytes.len(), max_payload_bytes)?;
+    validate_payload_size(bytes.len(), max_payload_bytes).map_err(DataFusionError::from)?;
     let codec = DefaultPhysicalExtensionCodec {};
     let proto = PhysicalExprNode::decode(bytes).map_err(|e| {
         DataFusionError::Internal(format!("Failed to decode PhysicalExprNode: {e}"))
@@ -139,13 +168,14 @@ pub(crate) fn decode_physical_expr_from_bytes(
 fn validate_payload_size(
     payload_size_bytes: usize,
     max_payload_bytes: usize,
-) -> DataFusionResult<()> {
-    if payload_size_bytes > max_payload_bytes {
-        return Err(DataFusionError::Plan(format!(
-            "DynFilterPayload::Datafusion is {} bytes, which exceeds the configured limit of {} bytes",
-            payload_size_bytes, max_payload_bytes
-        )));
-    }
+) -> Result<(), CommonQueryError> {
+    ensure!(
+        payload_size_bytes <= max_payload_bytes,
+        DynFilterPayloadTooLargeSnafu {
+            payload_size_bytes,
+            max_payload_bytes,
+        }
+    );
 
     Ok(())
 }
@@ -263,7 +293,11 @@ mod tests {
     use base64::Engine;
     use base64::prelude::BASE64_STANDARD;
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
-    use datafusion::physical_expr::expressions::Column;
+    use datafusion::physical_expr::expressions::{BinaryExpr, Column, InListExpr, lit};
+    use datafusion::physical_plan::expressions::col;
+    use datafusion::physical_plan::joins::join_hash_map::JoinHashMapU32;
+    use datafusion::physical_plan::joins::{HashTableLookupExpr, Map, SeededRandomState};
+    use datafusion_expr::Operator;
 
     use super::*;
 
@@ -408,11 +442,113 @@ mod tests {
     }
 
     #[test]
+    fn dyn_filter_payload_hash_lookup_fallback_preserves_bounds() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "device_id",
+            DataType::Int32,
+            false,
+        )]));
+        let device_id = col("device_id", &schema).unwrap();
+        let lower_bound = Arc::new(BinaryExpr::new(
+            Arc::clone(&device_id),
+            Operator::GtEq,
+            lit(10i32),
+        )) as Arc<dyn PhysicalExpr>;
+        let lookup = Arc::new(HashTableLookupExpr::new(
+            vec![Arc::clone(&device_id)],
+            SeededRandomState::with_seeds(0, 0, 0, 0),
+            Arc::new(Map::HashMap(Box::new(JoinHashMapU32::with_capacity(0)))),
+            "hash_lookup".to_string(),
+        )) as Arc<dyn PhysicalExpr>;
+        let expr =
+            Arc::new(BinaryExpr::new(lower_bound, Operator::And, lookup)) as Arc<dyn PhysicalExpr>;
+
+        let payload = DynFilterPayload::from_datafusion_expr(&expr, 1024).unwrap();
+        let decoded = payload
+            .decode_datafusion_expr(&TaskContext::default(), &schema, 1024)
+            .unwrap();
+
+        assert!(!contains_expr::<HashTableLookupExpr>(&decoded));
+        let decoded_display = decoded.to_string();
+        assert!(decoded_display.contains("device_id"));
+        assert!(decoded_display.contains(">="));
+        assert!(!decoded_display.contains("hash_lookup"));
+    }
+
+    #[test]
+    fn dyn_filter_payload_oversized_inlist_falls_back_to_bounds() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "device_id",
+            DataType::Int32,
+            false,
+        )]));
+        let device_id = col("device_id", &schema).unwrap();
+        let lower_bound = Arc::new(BinaryExpr::new(
+            Arc::clone(&device_id),
+            Operator::GtEq,
+            lit(8192i32),
+        )) as Arc<dyn PhysicalExpr>;
+        let upper_bound = Arc::new(BinaryExpr::new(
+            Arc::clone(&device_id),
+            Operator::LtEq,
+            lit(8255i32),
+        )) as Arc<dyn PhysicalExpr>;
+        let bounds = Arc::new(BinaryExpr::new(lower_bound, Operator::And, upper_bound))
+            as Arc<dyn PhysicalExpr>;
+        let in_list = Arc::new(
+            InListExpr::try_new(
+                Arc::clone(&device_id),
+                (8192..8256).map(lit).collect(),
+                false,
+                &schema,
+            )
+            .unwrap(),
+        ) as Arc<dyn PhysicalExpr>;
+        let expr = Arc::new(BinaryExpr::new(Arc::clone(&bounds), Operator::And, in_list))
+            as Arc<dyn PhysicalExpr>;
+        let bounds_only = portable_remote_dyn_filter_expr(Arc::clone(&expr), true).unwrap();
+        let bounds_only_size = encode_physical_expr_to_bytes(&bounds_only).unwrap().len();
+        let full_size = encode_physical_expr_to_bytes(&expr).unwrap().len();
+        assert!(full_size > bounds_only_size);
+
+        let payload = DynFilterPayload::from_datafusion_expr(&expr, bounds_only_size).unwrap();
+        let decoded = payload
+            .decode_datafusion_expr(&TaskContext::default(), &schema, bounds_only_size)
+            .unwrap();
+
+        assert!(!contains_expr::<InListExpr>(&decoded));
+        let decoded_display = decoded.to_string();
+        assert!(decoded_display.contains("device_id"));
+        assert!(decoded_display.contains(">="));
+        assert!(decoded_display.contains("<="));
+    }
+
+    #[test]
     fn dyn_filter_payload_rejects_oversized_payload() {
         let expr: Arc<dyn PhysicalExpr> = Arc::new(Column::new("host", 0));
 
         let err = DynFilterPayload::from_datafusion_expr(&expr, 1).unwrap_err();
 
-        assert!(matches!(err, DataFusionError::Plan(_)));
+        let DataFusionError::External(error) = err else {
+            panic!("expected external common query error, got: {err:?}");
+        };
+        assert!(matches!(
+            error.downcast_ref::<CommonQueryError>(),
+            Some(CommonQueryError::DynFilterPayloadTooLarge { .. })
+        ));
+    }
+
+    fn contains_expr<T: 'static>(expr: &Arc<dyn PhysicalExpr>) -> bool {
+        let mut found = false;
+        expr.apply(|node| {
+            if node.as_any().is::<T>() {
+                found = true;
+                Ok(TreeNodeRecursion::Stop)
+            } else {
+                Ok(TreeNodeRecursion::Continue)
+            }
+        })
+        .unwrap();
+        found
     }
 }

--- a/src/query/src/dist_plan/merge_scan.rs
+++ b/src/query/src/dist_plan/merge_scan.rs
@@ -397,6 +397,13 @@ impl MergeScanExec {
                     })?;
                 let do_get_cost = do_get_start.elapsed();
 
+                if let Some(remote_dyn_filter_registry_lease) =
+                    remote_dyn_filter_registry_lease.as_ref()
+                {
+                    remote_dyn_filter_registry_lease
+                        .ensure_fanout_task(region_query_handler.clone());
+                }
+
                 ready_timer.stop();
 
                 let mut poll_duration = Duration::ZERO;

--- a/src/query/src/dist_plan/merge_scan.rs
+++ b/src/query/src/dist_plan/merge_scan.rs
@@ -85,6 +85,23 @@ fn acquire_remote_dyn_filter_registry_lease(
     )
 }
 
+fn query_context_for_remote_dyn_filter_region(
+    query_ctx: &QueryContextRef,
+    region_id: RegionId,
+    remote_dyn_filter_registry_lease: Option<&RemoteDynFilterRegistryLease>,
+    captured_dyn_filters: &[CapturedDynFilter],
+) -> session::context::QueryContext {
+    if let Some(remote_dyn_filter_registry_lease) = remote_dyn_filter_registry_lease {
+        register_dyn_filters_for_region(
+            remote_dyn_filter_registry_lease.registry(),
+            region_id,
+            captured_dyn_filters,
+        );
+    }
+
+    query_context_with_initial_dyn_filter_regs(query_ctx, region_id, captured_dyn_filters)
+}
+
 #[derive(Debug, Hash, PartialOrd, PartialEq, Eq, Clone)]
 pub struct MergeScanLogicalPlan {
     /// In logical plan phase it only contains one input
@@ -346,25 +363,16 @@ impl MergeScanExec {
                 .step_by(target_partition)
                 .copied()
             {
-                if let Some(remote_dyn_filter_registry_lease) =
-                    remote_dyn_filter_registry_lease.as_ref()
-                {
-                    register_dyn_filters_for_region(
-                        remote_dyn_filter_registry_lease.registry(),
-                        region_id,
-                        &captured_remote_dyn_filters,
-                    );
-                }
-
                 let region_span = tracing_context.attach(tracing::info_span!(
                     parent: &Span::current(),
                     "merge_scan_region",
                     region_id = %region_id,
                     partition = partition
                 ));
-                let region_query_ctx = query_context_with_initial_dyn_filter_regs(
+                let region_query_ctx = query_context_for_remote_dyn_filter_region(
                     &query_ctx,
                     region_id,
+                    remote_dyn_filter_registry_lease.as_ref(),
                     &captured_remote_dyn_filters,
                 );
                 let request = QueryRequest {
@@ -876,6 +884,7 @@ mod tests {
     use std::collections::BTreeSet;
 
     use async_trait::async_trait;
+    use common_query::request::INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY;
     use datafusion::config::ConfigOptions;
     use datafusion::execution::SessionStateBuilder;
     use datafusion::physical_plan::filter_pushdown::ChildFilterPushdownResult;
@@ -892,11 +901,52 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
-    use crate::dist_plan::DynFilterRegistryManager;
+    use crate::dist_plan::{DynFilterRegistryManager, Subscriber};
     use crate::region_query::RegionQueryHandler;
 
     fn test_query_id(value: u128) -> QueryId {
         QueryId::from(Uuid::from_u128(value))
+    }
+
+    #[test]
+    fn remote_dyn_filter_region_query_context_registers_before_do_get() {
+        let registry_manager = Arc::new(DynFilterRegistryManager::default());
+        let query_ctx = QueryContext::arc();
+        let query_id = query_ctx
+            .remote_query_id_value()
+            .expect("query context must have remote query id");
+        let lease = registry_manager.acquire_lease(query_id);
+        let region_id = RegionId::new(1024, 7);
+        let dyn_filter = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![Arc::new(Column::new("host", 0)) as Arc<_>],
+            physical_lit(true) as _,
+        )) as Arc<dyn datafusion_physical_expr::PhysicalExpr>;
+        let captured = capture_remote_dyn_filters_for_pushdown(
+            RemoteDynFilterProducerId::new(42),
+            vec![dyn_filter],
+        );
+        assert_eq!(captured.captured_dyn_filters.len(), 1);
+
+        let region_query_ctx = query_context_for_remote_dyn_filter_region(
+            &query_ctx,
+            region_id,
+            Some(&lease),
+            &captured.captured_dyn_filters,
+        );
+
+        let entries = lease.registry().entries();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].subscribers(), vec![Subscriber::new(region_id)]);
+        assert!(
+            !entries[0].fanout_started_for_test(),
+            "fanout must start only after do_get succeeds"
+        );
+        assert!(
+            region_query_ctx
+                .extension(INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY)
+                .is_some(),
+            "initial RDF registrations must be present in the do_get query context"
+        );
     }
 
     #[test]

--- a/src/query/src/dist_plan/remote_dyn_filter_registry.rs
+++ b/src/query/src/dist_plan/remote_dyn_filter_registry.rs
@@ -14,8 +14,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, RwLock, Weak};
+use std::sync::{Arc, Mutex, RwLock, Weak};
 use std::time::Duration;
 
 use api::v1::region::{RemoteDynFilterUnregister, RemoteDynFilterUpdate};
@@ -33,7 +32,8 @@ use crate::region_query::RegionQueryHandlerRef;
 
 const REMOTE_DYN_FILTER_UPDATE_PAYLOAD_MAX_BYTES: usize = 64 * 1024;
 const REMOTE_DYN_FILTER_RECONCILE_INTERVAL: Duration = Duration::from_secs(1);
-const REMOTE_DYN_FILTER_CONTROL_RPC_TIMEOUT: Duration = Duration::from_secs(30);
+/// Bound best-effort RDF control RPCs so one bad subscriber cannot stall fanout.
+const REMOTE_DYN_FILTER_CONTROL_RPC_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Region subscribed to a remote dynamic filter.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -73,10 +73,15 @@ pub struct DynFilterEntry {
     filter_id: FilterId,
     producer_filter: Weak<DynamicFilterPhysicalExpr>,
     subscribers: RwLock<HashSet<Subscriber>>,
-    last_sent_generation: AtomicU64,
-    unregistered: AtomicBool,
-    fanout_started: AtomicBool,
+    state: Mutex<DynFilterEntryState>,
     subscriber_changed: Notify,
+}
+
+#[derive(Debug, Default)]
+struct DynFilterEntryState {
+    last_sent_generation: u64,
+    unregistered: bool,
+    fanout_started: bool,
 }
 
 #[derive(Debug)]
@@ -90,9 +95,7 @@ impl DynFilterEntry {
             filter_id,
             producer_filter: Arc::downgrade(&producer_filter),
             subscribers: RwLock::new(HashSet::new()),
-            last_sent_generation: AtomicU64::new(0),
-            unregistered: AtomicBool::new(false),
-            fanout_started: AtomicBool::new(false),
+            state: Mutex::new(DynFilterEntryState::default()),
             subscriber_changed: Notify::new(),
         }
     }
@@ -115,43 +118,48 @@ impl DynFilterEntry {
     }
 
     fn mark_generation_sent(&self, generation: u64) -> bool {
-        let mut current = self.last_sent_generation.load(Ordering::SeqCst);
-        loop {
-            if generation <= current {
-                return false;
-            }
-
-            match self.last_sent_generation.compare_exchange(
-                current,
-                generation,
-                Ordering::SeqCst,
-                Ordering::SeqCst,
-            ) {
-                Ok(_) => return true,
-                Err(next) => current = next,
-            }
+        let mut state = self.state.lock().unwrap();
+        if generation <= state.last_sent_generation {
+            return false;
         }
+
+        state.last_sent_generation = generation;
+        true
     }
 
     fn try_mark_unregistered(&self) -> bool {
-        self.unregistered
-            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-            .is_ok()
+        let mut state = self.state.lock().unwrap();
+        if state.unregistered {
+            return false;
+        }
+
+        state.unregistered = true;
+        true
     }
 
     fn reactivate_for_new_subscriber(&self) {
-        self.last_sent_generation.store(0, Ordering::SeqCst);
-        self.unregistered.store(false, Ordering::SeqCst);
+        {
+            let mut state = self.state.lock().unwrap();
+            // Reset generation/unregister state so late subscribers get the current snapshot.
+            state.last_sent_generation = 0;
+            state.unregistered = false;
+        }
         self.subscriber_changed.notify_one();
     }
 
     fn mark_fanout_started(&self) -> bool {
-        !self.fanout_started.swap(true, Ordering::SeqCst)
+        let mut state = self.state.lock().unwrap();
+        if state.fanout_started {
+            return false;
+        }
+
+        state.fanout_started = true;
+        true
     }
 
     #[cfg(test)]
     pub(crate) fn fanout_started_for_test(&self) -> bool {
-        self.fanout_started.load(Ordering::SeqCst)
+        self.state.lock().unwrap().fanout_started
     }
 }
 
@@ -165,6 +173,7 @@ pub struct QueryDynFilterRegistry {
 
 impl QueryDynFilterRegistry {
     pub fn new(query_id: QueryId) -> Self {
+        // Close-only lifecycle signal; dropping the registry closes it for watchers.
         let (lifecycle_tx, _) = watch::channel(());
         Self {
             query_id,
@@ -260,6 +269,7 @@ impl QueryDynFilterRegistry {
             filter,
             is_complete,
             &mut lifecycle_rx,
+            REMOTE_DYN_FILTER_CONTROL_RPC_TIMEOUT,
         )
         .await;
     }
@@ -294,12 +304,12 @@ async fn run_entry_fanout(
     mut lifecycle_rx: watch::Receiver<()>,
 ) {
     let mut is_complete = false;
-    // `interval()` ticks immediately for the first tick. Start after one full interval so the
-    // reconcile branch remains a periodic fallback instead of an eager re-poll right after fanout.
+    // Start reconcile after one interval and skip missed ticks; it is only a coalescing fallback.
     let mut reconcile_interval = tokio::time::interval_at(
         tokio::time::Instant::now() + REMOTE_DYN_FILTER_RECONCILE_INTERVAL,
         REMOTE_DYN_FILTER_RECONCILE_INTERVAL,
     );
+    reconcile_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     loop {
         let Some(filter) = entry.upgrade_producer_filter() else {
@@ -314,6 +324,7 @@ async fn run_entry_fanout(
             &filter,
             is_complete,
             &mut lifecycle_rx,
+            REMOTE_DYN_FILTER_CONTROL_RPC_TIMEOUT,
         )
         .await
         {
@@ -359,11 +370,15 @@ async fn fanout_snapshot_for_query(
     filter: &DynamicFilterPhysicalExpr,
     is_complete: bool,
     lifecycle_rx: &mut watch::Receiver<()>,
+    control_rpc_timeout: Duration,
 ) -> bool {
     let Some((generation, current)) = current_stable_snapshot(filter, lifecycle_rx).await else {
         return true;
     };
 
+    // The entry-global watermark advances before best-effort fanout. A timed-out
+    // subscriber may miss this generation; later/complete snapshots supersede it,
+    // and RDF only prunes.
     if !is_complete && !entry.mark_generation_sent(generation) {
         return true;
     }
@@ -395,10 +410,12 @@ async fn fanout_snapshot_for_query(
         is_complete,
         payload,
         lifecycle_rx,
+        control_rpc_timeout,
     )
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn fanout_update_for_query(
     query_id: QueryId,
     region_query_handler: &RegionQueryHandlerRef,
@@ -407,6 +424,7 @@ async fn fanout_update_for_query(
     is_complete: bool,
     payload: Vec<u8>,
     lifecycle_rx: &mut watch::Receiver<()>,
+    control_rpc_timeout: Duration,
 ) -> bool {
     let query_id = query_id.to_string();
     let filter_id = entry.filter_id().to_string();
@@ -419,7 +437,7 @@ async fn fanout_update_for_query(
             is_complete,
         };
 
-        let Some(result) = await_control_rpc_or_lifecycle_close(
+        match await_control_rpc_or_lifecycle_close(
             lifecycle_rx,
             format!(
                 "update query_id={} filter_id={} region_id={}",
@@ -432,20 +450,23 @@ async fn fanout_update_for_query(
                 query_id.clone(),
                 update,
             ),
+            control_rpc_timeout,
         )
         .await
-        else {
-            return false;
-        };
-
-        if let Err(error) = result {
-            warn!(
-                error;
-                "Failed to fan out remote dynamic filter update, query_id={}, filter_id={}, region_id={}",
-                query_id,
-                filter_id,
-                subscriber.region_id()
-            );
+        {
+            ControlRpcResult::Ok(result) => {
+                if let Err(error) = result {
+                    warn!(
+                        error;
+                        "Failed to fan out remote dynamic filter update, query_id={}, filter_id={}, region_id={}",
+                        query_id,
+                        filter_id,
+                        subscriber.region_id()
+                    );
+                }
+            }
+            ControlRpcResult::TimedOut => {}
+            ControlRpcResult::LifecycleClosed => return false,
         }
     }
 
@@ -501,13 +522,20 @@ async fn unregister_entry_once_for_query(
     debug!("Remote dynamic filter producer unregistered subscribers");
 }
 
+enum ControlRpcResult<T> {
+    Ok(T),
+    TimedOut,
+    LifecycleClosed,
+}
+
 async fn await_control_rpc_or_lifecycle_close<T>(
     lifecycle_rx: &mut watch::Receiver<()>,
     operation: String,
     rpc: impl Future<Output = T>,
-) -> Option<T> {
+    control_rpc_timeout: Duration,
+) -> ControlRpcResult<T> {
     if lifecycle_rx.has_changed().is_err() {
-        return None;
+        return ControlRpcResult::LifecycleClosed;
     }
 
     tokio::select! {
@@ -516,12 +544,12 @@ async fn await_control_rpc_or_lifecycle_close<T>(
             if result.is_err() {
                 debug!("Cancelled remote dynamic filter control RPC after lifecycle close");
             }
-            None
+            ControlRpcResult::LifecycleClosed
         }
-        result = rpc => Some(result),
-        _ = tokio::time::sleep(REMOTE_DYN_FILTER_CONTROL_RPC_TIMEOUT) => {
+        result = rpc => ControlRpcResult::Ok(result),
+        _ = tokio::time::sleep(control_rpc_timeout) => {
             warn!("Timed out remote dynamic filter control RPC: {}", operation);
-            None
+            ControlRpcResult::TimedOut
         }
     }
 }
@@ -1263,7 +1291,7 @@ mod tests {
         lease.ensure_fanout_task(handler.clone() as RegionQueryHandlerRef);
         lease.ensure_fanout_task(handler.clone() as RegionQueryHandlerRef);
 
-        assert!(entry.fanout_started.load(Ordering::SeqCst));
+        assert!(entry.fanout_started_for_test());
         handler.wait_for_update_count(1).await;
         tokio::time::sleep(Duration::from_millis(50)).await;
         assert_eq!(handler.updates().len(), 1);
@@ -1437,6 +1465,96 @@ mod tests {
         assert_eq!(unregisters[0].region_id, subscriber.region_id());
         assert_eq!(unregisters[0].filter_id, filter_id.to_string());
         wait_for_registry_drop(registry_weak).await;
+    }
+
+    #[tokio::test]
+    async fn update_timeout_does_not_stop_fanout_for_other_subscribers() {
+        let query_id = test_query_id(9);
+        let registry = QueryDynFilterRegistry::new(query_id);
+        let filter = test_dyn_filter(&["host"]);
+        let filter_id = test_filter_id(1);
+        let entry = match registry.register_remote_dyn_filter(filter_id.clone(), filter.clone()) {
+            EntryRegistration::Inserted(entry) => entry,
+            other => panic!("unexpected registration result: {other:?}"),
+        };
+        let first_subscriber = Subscriber::new(RegionId::new(1024, 7));
+        let second_subscriber = Subscriber::new(RegionId::new(1024, 8));
+        assert_eq!(
+            registry.register_subscriber(&filter_id, first_subscriber.clone()),
+            SubscriberRegistration::Added
+        );
+        assert_eq!(
+            registry.register_subscriber(&filter_id, second_subscriber.clone()),
+            SubscriberRegistration::Added
+        );
+
+        let handler = Arc::new(RecordingRegionQueryHandler::default());
+        let handler_ref = handler.clone() as RegionQueryHandlerRef;
+        let mut lifecycle_rx = registry.lifecycle_tx.subscribe();
+        handler.block_next_update();
+        assert!(
+            fanout_snapshot_for_query(
+                query_id,
+                &handler_ref,
+                &entry,
+                filter.as_ref(),
+                false,
+                &mut lifecycle_rx,
+                Duration::from_millis(100),
+            )
+            .await
+        );
+
+        handler.wait_for_blocked_update().await;
+        // Fanout is serial and the blocked RPC stays blocked; the second update proves
+        // timeout continued to the next subscriber.
+        handler.wait_for_update_count(2).await;
+
+        let initial_updates = handler.updates();
+        assert_eq!(
+            initial_updates.len(),
+            2,
+            "the healthy subscriber must still receive the update after another subscriber times out"
+        );
+        assert!(
+            initial_updates
+                .iter()
+                .any(|update| update.region_id == first_subscriber.region_id())
+        );
+        assert!(
+            initial_updates
+                .iter()
+                .any(|update| update.region_id == second_subscriber.region_id())
+        );
+
+        filter.update(lit(false) as _).unwrap();
+        assert!(
+            fanout_snapshot_for_query(
+                query_id,
+                &handler_ref,
+                &entry,
+                filter.as_ref(),
+                false,
+                &mut lifecycle_rx,
+                Duration::from_millis(100),
+            )
+            .await
+        );
+        handler.wait_for_update_count(4).await;
+        let updates = handler.updates();
+        assert!(
+            updates[2..]
+                .iter()
+                .any(|update| update.region_id == first_subscriber.region_id())
+        );
+        assert!(
+            updates[2..]
+                .iter()
+                .any(|update| update.region_id == second_subscriber.region_id())
+        );
+
+        registry.unregister_all_once(&handler_ref).await;
+        handler.wait_for_unregister_count(1).await;
     }
 
     #[tokio::test]

--- a/src/query/src/dist_plan/remote_dyn_filter_registry.rs
+++ b/src/query/src/dist_plan/remote_dyn_filter_registry.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::future::Future;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, RwLock, Weak};
 use std::time::Duration;
 
@@ -32,8 +33,9 @@ use crate::region_query::RegionQueryHandlerRef;
 
 const REMOTE_DYN_FILTER_UPDATE_PAYLOAD_MAX_BYTES: usize = 64 * 1024;
 const REMOTE_DYN_FILTER_RECONCILE_INTERVAL: Duration = Duration::from_secs(1);
+const REMOTE_DYN_FILTER_CONTROL_RPC_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Routing metadata for a remote dynamic filter subscriber.
+/// Region subscribed to a remote dynamic filter.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Subscriber {
     region_id: RegionId,
@@ -65,14 +67,11 @@ pub enum SubscriberRegistration {
     MissingFilter,
 }
 
-/// A registered query-local remote dynamic filter entry.
-///
-/// The frontend query owns the strong DataFusion filter handle until the query finishes; the
-/// registry only keeps a weak reference for later updates.
+/// A registered query-local producer filter and its region subscribers.
 #[derive(Debug)]
 pub struct DynFilterEntry {
     filter_id: FilterId,
-    alive_dyn_filter: Weak<DynamicFilterPhysicalExpr>,
+    producer_filter: Weak<DynamicFilterPhysicalExpr>,
     subscribers: RwLock<HashSet<Subscriber>>,
     last_sent_generation: AtomicU64,
     unregistered: AtomicBool,
@@ -86,10 +85,10 @@ struct QueryDynFilterRegistryInner {
 }
 
 impl DynFilterEntry {
-    pub fn new(filter_id: FilterId, alive_dyn_filter: Arc<DynamicFilterPhysicalExpr>) -> Self {
+    pub fn new(filter_id: FilterId, producer_filter: Arc<DynamicFilterPhysicalExpr>) -> Self {
         Self {
             filter_id,
-            alive_dyn_filter: Arc::downgrade(&alive_dyn_filter),
+            producer_filter: Arc::downgrade(&producer_filter),
             subscribers: RwLock::new(HashSet::new()),
             last_sent_generation: AtomicU64::new(0),
             unregistered: AtomicBool::new(false),
@@ -102,8 +101,8 @@ impl DynFilterEntry {
         &self.filter_id
     }
 
-    pub fn upgrade_alive_dyn_filter(&self) -> Option<Arc<DynamicFilterPhysicalExpr>> {
-        self.alive_dyn_filter.upgrade()
+    pub fn upgrade_producer_filter(&self) -> Option<Arc<DynamicFilterPhysicalExpr>> {
+        self.producer_filter.upgrade()
     }
 
     pub fn subscribers(&self) -> Vec<Subscriber> {
@@ -149,27 +148,26 @@ impl DynFilterEntry {
     fn mark_fanout_started(&self) -> bool {
         !self.fanout_started.swap(true, Ordering::SeqCst)
     }
+
+    #[cfg(test)]
+    pub(crate) fn fanout_started_for_test(&self) -> bool {
+        self.fanout_started.load(Ordering::SeqCst)
+    }
 }
 
 /// Query-scoped registry that owns all remote dynamic filters for one query.
 #[derive(Debug)]
 pub struct QueryDynFilterRegistry {
     query_id: QueryId,
-    active_streams: AtomicUsize,
-    fanout_started: AtomicBool,
-    registry_changed: Notify,
-    lifecycle_tx: watch::Sender<bool>,
+    lifecycle_tx: watch::Sender<()>,
     inner: RwLock<QueryDynFilterRegistryInner>,
 }
 
 impl QueryDynFilterRegistry {
     pub fn new(query_id: QueryId) -> Self {
-        let (lifecycle_tx, _) = watch::channel(false);
+        let (lifecycle_tx, _) = watch::channel(());
         Self {
             query_id,
-            active_streams: AtomicUsize::new(0),
-            fanout_started: AtomicBool::new(false),
-            registry_changed: Notify::new(),
             lifecycle_tx,
             inner: RwLock::new(QueryDynFilterRegistryInner {
                 entries: HashMap::new(),
@@ -179,23 +177,6 @@ impl QueryDynFilterRegistry {
 
     pub fn query_id(&self) -> QueryId {
         self.query_id
-    }
-
-    fn acquire_stream(&self) {
-        if self.active_streams.fetch_add(1, Ordering::SeqCst) == 0 {
-            let _ = self.lifecycle_tx.send(false);
-        }
-    }
-
-    fn release_stream(&self) {
-        if self.active_streams.fetch_sub(1, Ordering::SeqCst) == 1 {
-            let _ = self.lifecycle_tx.send(true);
-            self.registry_changed.notify_one();
-        }
-    }
-
-    fn active_stream_count(&self) -> usize {
-        self.active_streams.load(Ordering::SeqCst)
     }
 
     pub fn entry_count(&self) -> usize {
@@ -219,16 +200,15 @@ impl QueryDynFilterRegistry {
     pub fn register_remote_dyn_filter(
         &self,
         filter_id: FilterId,
-        alive_dyn_filter: Arc<DynamicFilterPhysicalExpr>,
+        producer_filter: Arc<DynamicFilterPhysicalExpr>,
     ) -> EntryRegistration {
         let mut inner = self.inner.write().unwrap();
         if let Some(existing) = inner.entries.get(&filter_id) {
             return EntryRegistration::Existing(existing.clone());
         }
 
-        let entry = Arc::new(DynFilterEntry::new(filter_id.clone(), alive_dyn_filter));
+        let entry = Arc::new(DynFilterEntry::new(filter_id.clone(), producer_filter));
         inner.entries.insert(filter_id, entry.clone());
-        self.registry_changed.notify_one();
         EntryRegistration::Inserted(entry)
     }
 
@@ -242,9 +222,7 @@ impl QueryDynFilterRegistry {
         };
 
         if entry.register_subscriber(subscriber) {
-            // A newly added subscriber has not seen the latest snapshot yet. Reset the
-            // entry-level generation watermark so the next fanout tick resends the current
-            // snapshot to all subscribers; receivers treat duplicate generations idempotently.
+            // New subscribers need the current snapshot; existing subscribers may see a duplicate.
             entry.reactivate_for_new_subscriber();
             SubscriberRegistration::Added
         } else {
@@ -252,120 +230,21 @@ impl QueryDynFilterRegistry {
         }
     }
 
-    /// Starts one query-scoped producer fanout task if it has not already been started.
+    /// Starts missing producer fanout watchers for the registry's entries.
     ///
-    /// The supervisor starts one async watcher per registered source-side
-    /// [`DynamicFilterPhysicalExpr`]. Each watcher waits on DataFusion's
-    /// `wait_update()`/`wait_complete()` notifications and sends best-effort
-    /// update/unregister RPCs to subscribed datanodes. The supervisor exits once
-    /// all remote scan streams release their registry leases.
+    /// Watchers do not hold the registry alive; dropping the registry closes their lifecycle channel.
     pub fn ensure_fanout_task(self: &Arc<Self>, region_query_handler: RegionQueryHandlerRef) {
-        self.registry_changed.notify_one();
-        if self.fanout_started.swap(true, Ordering::SeqCst) {
-            return;
-        }
-
-        let registry = self.clone();
-        let _handle = spawn_global(async move {
-            registry.run_fanout(region_query_handler).await;
-        });
-    }
-
-    async fn run_fanout(self: Arc<Self>, region_query_handler: RegionQueryHandlerRef) {
-        let mut lifecycle_rx = self.lifecycle_tx.subscribe();
-
-        loop {
-            for entry in self.entries() {
-                self.ensure_entry_fanout_task(entry, region_query_handler.clone());
-            }
-
-            if *lifecycle_rx.borrow() || self.active_stream_count() == 0 {
-                break;
-            }
-
-            tokio::select! {
-                _ = self.registry_changed.notified() => {}
-                result = lifecycle_rx.changed() => {
-                    if result.is_err() || *lifecycle_rx.borrow() {
-                        break;
-                    }
-                }
-            }
-        }
-
-        self.unregister_all_once(&region_query_handler).await;
-    }
-
-    fn ensure_entry_fanout_task(
-        self: &Arc<Self>,
-        entry: Arc<DynFilterEntry>,
-        region_query_handler: RegionQueryHandlerRef,
-    ) {
-        if !entry.mark_fanout_started() {
-            return;
-        }
-
-        let registry = self.clone();
-        let _handle = spawn_global(async move {
-            registry.run_entry_fanout(entry, region_query_handler).await;
-        });
-    }
-
-    async fn run_entry_fanout(
-        self: Arc<Self>,
-        entry: Arc<DynFilterEntry>,
-        region_query_handler: RegionQueryHandlerRef,
-    ) {
-        let mut lifecycle_rx = self.lifecycle_tx.subscribe();
-        let mut is_complete = false;
-        let mut reconcile_interval = tokio::time::interval(REMOTE_DYN_FILTER_RECONCILE_INTERVAL);
-
-        loop {
-            if *lifecycle_rx.borrow() || self.active_stream_count() == 0 {
-                break;
-            }
-
-            let Some(filter) = entry.upgrade_alive_dyn_filter() else {
-                self.unregister_entry_once(&region_query_handler, &entry)
-                    .await;
-                return;
-            };
-
-            self.fanout_snapshot(&region_query_handler, &entry, &filter, is_complete)
-                .await;
-
-            if is_complete {
-                tokio::select! {
-                    _ = entry.subscriber_changed.notified() => {}
-                    result = lifecycle_rx.changed() => {
-                        if result.is_err() || *lifecycle_rx.borrow() {
-                            break;
-                        }
-                    }
-                }
-                continue;
-            }
-
-            tokio::select! {
-                _ = filter.wait_update() => {}
-                _ = filter.wait_complete() => {
-                    is_complete = true;
-                }
-                // `wait_update()` subscribes when called, so an update that happens between
-                // the post-send generation check and the wait call can be missed. This
-                // low-frequency reconcile tick bounds that race by periodically re-reading
-                // `snapshot_generation()` and coalescing to the latest snapshot.
-                _ = reconcile_interval.tick() => {}
-                _ = entry.subscriber_changed.notified() => {}
-                result = lifecycle_rx.changed() => {
-                    if result.is_err() || *lifecycle_rx.borrow() {
-                        break;
-                    }
-                }
-            }
+        for entry in self.entries() {
+            ensure_entry_fanout_task(
+                self.query_id,
+                entry,
+                region_query_handler.clone(),
+                self.lifecycle_tx.subscribe(),
+            );
         }
     }
 
+    #[cfg(test)]
     async fn fanout_snapshot(
         &self,
         region_query_handler: &RegionQueryHandlerRef,
@@ -373,115 +252,302 @@ impl QueryDynFilterRegistry {
         filter: &DynamicFilterPhysicalExpr,
         is_complete: bool,
     ) {
-        let Some((generation, current)) = current_stable_snapshot(filter).await else {
-            return;
-        };
-
-        if !is_complete && !entry.mark_generation_sent(generation) {
-            return;
-        }
-
-        if is_complete {
-            let _ = entry.mark_generation_sent(generation);
-        }
-
-        let payload = match DynFilterPayload::from_datafusion_expr(
-            &current,
-            REMOTE_DYN_FILTER_UPDATE_PAYLOAD_MAX_BYTES,
-        ) {
-            Ok(DynFilterPayload::Datafusion(payload)) => payload,
-            Ok(_) => {
-                warn!("Ignored unsupported remote dynamic filter producer payload");
-                return;
-            }
-            Err(error) => {
-                warn!(error; "Failed to encode remote dynamic filter producer snapshot");
-                return;
-            }
-        };
-
-        self.fanout_update(
+        let mut lifecycle_rx = self.lifecycle_tx.subscribe();
+        fanout_snapshot_for_query(
+            self.query_id,
             region_query_handler,
             entry,
-            generation,
+            filter,
             is_complete,
-            payload,
+            &mut lifecycle_rx,
         )
         .await;
     }
 
-    async fn fanout_update(
-        &self,
-        region_query_handler: &RegionQueryHandlerRef,
-        entry: &DynFilterEntry,
-        generation: u64,
-        is_complete: bool,
-        payload: Vec<u8>,
-    ) {
-        let query_id = self.query_id.to_string();
-        let filter_id = entry.filter_id().to_string();
-
-        for subscriber in entry.subscribers() {
-            let update = RemoteDynFilterUpdate {
-                filter_id: filter_id.clone(),
-                payload: payload.clone(),
-                generation,
-                is_complete,
-            };
-
-            if let Err(error) = region_query_handler
-                .handle_remote_dyn_filter_update(subscriber.region_id(), query_id.clone(), update)
-                .await
-            {
-                warn!(error; "Failed to fan out remote dynamic filter update");
-            }
-        }
-    }
-
+    #[cfg(test)]
     async fn unregister_all_once(&self, region_query_handler: &RegionQueryHandlerRef) {
         for entry in self.entries() {
-            self.unregister_entry_once(region_query_handler, &entry)
-                .await;
+            unregister_entry_once_for_query(region_query_handler, self.query_id, &entry).await;
+        }
+    }
+}
+
+fn ensure_entry_fanout_task(
+    query_id: QueryId,
+    entry: Arc<DynFilterEntry>,
+    region_query_handler: RegionQueryHandlerRef,
+    lifecycle_rx: watch::Receiver<()>,
+) {
+    if !entry.mark_fanout_started() {
+        return;
+    }
+
+    let _handle = spawn_global(async move {
+        run_entry_fanout(query_id, entry, region_query_handler, lifecycle_rx).await;
+    });
+}
+
+async fn run_entry_fanout(
+    query_id: QueryId,
+    entry: Arc<DynFilterEntry>,
+    region_query_handler: RegionQueryHandlerRef,
+    mut lifecycle_rx: watch::Receiver<()>,
+) {
+    let mut is_complete = false;
+    // `interval()` ticks immediately for the first tick. Start after one full interval so the
+    // reconcile branch remains a periodic fallback instead of an eager re-poll right after fanout.
+    let mut reconcile_interval = tokio::time::interval_at(
+        tokio::time::Instant::now() + REMOTE_DYN_FILTER_RECONCILE_INTERVAL,
+        REMOTE_DYN_FILTER_RECONCILE_INTERVAL,
+    );
+
+    loop {
+        let Some(filter) = entry.upgrade_producer_filter() else {
+            unregister_entry_once_for_query(&region_query_handler, query_id, &entry).await;
+            return;
+        };
+
+        if !fanout_snapshot_for_query(
+            query_id,
+            &region_query_handler,
+            &entry,
+            &filter,
+            is_complete,
+            &mut lifecycle_rx,
+        )
+        .await
+        {
+            break;
+        }
+
+        if is_complete {
+            tokio::select! {
+                _ = entry.subscriber_changed.notified() => {}
+                result = lifecycle_rx.changed() => {
+                    if result.is_err() {
+                        break;
+                    }
+                }
+            }
+            continue;
+        }
+
+        tokio::select! {
+            _ = filter.wait_update() => {}
+            _ = filter.wait_complete() => {
+                is_complete = true;
+            }
+            // `wait_update()` can miss an update sent while an RPC is in-flight.
+            // Re-read periodically to coalesce to the latest generation.
+            _ = reconcile_interval.tick() => {}
+            _ = entry.subscriber_changed.notified() => {}
+            result = lifecycle_rx.changed() => {
+                if result.is_err() {
+                    break;
+                }
+            }
         }
     }
 
-    async fn unregister_entry_once(
-        &self,
-        region_query_handler: &RegionQueryHandlerRef,
-        entry: &DynFilterEntry,
+    unregister_entry_once_for_query(&region_query_handler, query_id, &entry).await;
+}
+
+async fn fanout_snapshot_for_query(
+    query_id: QueryId,
+    region_query_handler: &RegionQueryHandlerRef,
+    entry: &DynFilterEntry,
+    filter: &DynamicFilterPhysicalExpr,
+    is_complete: bool,
+    lifecycle_rx: &mut watch::Receiver<()>,
+) -> bool {
+    let Some((generation, current)) = current_stable_snapshot(filter, lifecycle_rx).await else {
+        return true;
+    };
+
+    if !is_complete && !entry.mark_generation_sent(generation) {
+        return true;
+    }
+
+    if is_complete {
+        let _ = entry.mark_generation_sent(generation);
+    }
+
+    let payload = match DynFilterPayload::from_datafusion_expr(
+        &current,
+        REMOTE_DYN_FILTER_UPDATE_PAYLOAD_MAX_BYTES,
     ) {
-        if !entry.try_mark_unregistered() {
-            return;
+        Ok(DynFilterPayload::Datafusion(payload)) => payload,
+        Ok(_) => {
+            warn!("Ignored unsupported remote dynamic filter producer payload");
+            return true;
         }
+        Err(error) => {
+            warn!(error; "Failed to encode remote dynamic filter producer snapshot");
+            return true;
+        }
+    };
 
-        let query_id = self.query_id.to_string();
-        let filter_id = entry.filter_id().to_string();
+    fanout_update_for_query(
+        query_id,
+        region_query_handler,
+        entry,
+        generation,
+        is_complete,
+        payload,
+        lifecycle_rx,
+    )
+    .await
+}
 
-        for subscriber in entry.subscribers() {
-            let unregister = RemoteDynFilterUnregister {
-                filter_id: filter_id.clone(),
-            };
+async fn fanout_update_for_query(
+    query_id: QueryId,
+    region_query_handler: &RegionQueryHandlerRef,
+    entry: &DynFilterEntry,
+    generation: u64,
+    is_complete: bool,
+    payload: Vec<u8>,
+    lifecycle_rx: &mut watch::Receiver<()>,
+) -> bool {
+    let query_id = query_id.to_string();
+    let filter_id = entry.filter_id().to_string();
 
-            if let Err(error) = region_query_handler
-                .handle_remote_dyn_filter_unregister(
-                    subscriber.region_id(),
-                    query_id.clone(),
-                    unregister,
-                )
-                .await
-            {
-                warn!(error; "Failed to fan out remote dynamic filter unregister");
+    for subscriber in entry.subscribers() {
+        let update = RemoteDynFilterUpdate {
+            filter_id: filter_id.clone(),
+            payload: payload.clone(),
+            generation,
+            is_complete,
+        };
+
+        let Some(result) = await_control_rpc_or_lifecycle_close(
+            lifecycle_rx,
+            format!(
+                "update query_id={} filter_id={} region_id={}",
+                query_id,
+                filter_id,
+                subscriber.region_id()
+            ),
+            region_query_handler.handle_remote_dyn_filter_update(
+                subscriber.region_id(),
+                query_id.clone(),
+                update,
+            ),
+        )
+        .await
+        else {
+            return false;
+        };
+
+        if let Err(error) = result {
+            warn!(
+                error;
+                "Failed to fan out remote dynamic filter update, query_id={}, filter_id={}, region_id={}",
+                query_id,
+                filter_id,
+                subscriber.region_id()
+            );
+        }
+    }
+
+    true
+}
+
+async fn unregister_entry_once_for_query(
+    region_query_handler: &RegionQueryHandlerRef,
+    query_id: QueryId,
+    entry: &DynFilterEntry,
+) {
+    if !entry.try_mark_unregistered() {
+        return;
+    }
+
+    let query_id = query_id.to_string();
+    let filter_id = entry.filter_id().to_string();
+
+    for subscriber in entry.subscribers() {
+        let unregister = RemoteDynFilterUnregister {
+            filter_id: filter_id.clone(),
+        };
+
+        let Some(result) = await_control_rpc_timeout(
+            format!(
+                "unregister query_id={} filter_id={} region_id={}",
+                query_id,
+                filter_id,
+                subscriber.region_id()
+            ),
+            region_query_handler.handle_remote_dyn_filter_unregister(
+                subscriber.region_id(),
+                query_id.clone(),
+                unregister,
+            ),
+        )
+        .await
+        else {
+            continue;
+        };
+
+        if let Err(error) = result {
+            warn!(
+                error;
+                "Failed to fan out remote dynamic filter unregister, query_id={}, filter_id={}, region_id={}",
+                query_id,
+                filter_id,
+                subscriber.region_id()
+            );
+        }
+    }
+
+    debug!("Remote dynamic filter producer unregistered subscribers");
+}
+
+async fn await_control_rpc_or_lifecycle_close<T>(
+    lifecycle_rx: &mut watch::Receiver<()>,
+    operation: String,
+    rpc: impl Future<Output = T>,
+) -> Option<T> {
+    if lifecycle_rx.has_changed().is_err() {
+        return None;
+    }
+
+    tokio::select! {
+        biased;
+        result = lifecycle_rx.changed() => {
+            if result.is_err() {
+                debug!("Cancelled remote dynamic filter control RPC after lifecycle close");
             }
+            None
         }
+        result = rpc => Some(result),
+        _ = tokio::time::sleep(REMOTE_DYN_FILTER_CONTROL_RPC_TIMEOUT) => {
+            warn!("Timed out remote dynamic filter control RPC: {}", operation);
+            None
+        }
+    }
+}
 
-        debug!("Remote dynamic filter producer unregistered subscribers");
+async fn await_control_rpc_timeout<T>(
+    operation: String,
+    rpc: impl Future<Output = T>,
+) -> Option<T> {
+    tokio::select! {
+        result = rpc => Some(result),
+        _ = tokio::time::sleep(REMOTE_DYN_FILTER_CONTROL_RPC_TIMEOUT) => {
+            warn!("Timed out remote dynamic filter control RPC: {}", operation);
+            None
+        }
     }
 }
 
 async fn current_stable_snapshot(
     filter: &DynamicFilterPhysicalExpr,
+    lifecycle_rx: &mut watch::Receiver<()>,
 ) -> Option<(u64, Arc<dyn PhysicalExpr>)> {
     loop {
+        if lifecycle_rx.has_changed().is_err() {
+            return None;
+        }
+
         let before = filter.snapshot_generation();
         let current = match filter.current() {
             Ok(current) => current,
@@ -496,13 +562,21 @@ async fn current_stable_snapshot(
             return Some((after, current));
         }
 
-        tokio::task::yield_now().await;
+        tokio::select! {
+            biased;
+            result = lifecycle_rx.changed() => {
+                if result.is_err() {
+                    return None;
+                }
+            }
+            _ = tokio::task::yield_now() => {}
+        }
     }
 }
 
 /// Stream-scoped lease that keeps a query registry alive.
 ///
-/// Production code owns registries through this lease; the manager only keeps a weak index.
+/// Stream leases own registry lifecycle; the manager only keeps a weak index.
 #[derive(Debug)]
 pub struct RemoteDynFilterRegistryLease {
     registry_manager: Arc<DynFilterRegistryManager>,
@@ -517,7 +591,6 @@ impl RemoteDynFilterRegistryLease {
         registry_manager: Arc<DynFilterRegistryManager>,
         registry: Arc<QueryDynFilterRegistry>,
     ) -> Self {
-        registry.acquire_stream();
         Self {
             registry_manager,
             registry: Some(registry),
@@ -554,20 +627,18 @@ impl Drop for RemoteDynFilterRegistryLease {
         let query_id = registry.query_id();
         let registry_weak = Arc::downgrade(&registry);
 
-        registry.release_stream();
-
-        // Release this lease before pruning; concurrent drops must not observe each other's stream refs.
+        // Release this lease before pruning; concurrent drops must not observe each other's strong refs.
         drop(registry);
 
         let _ = self
             .registry_manager
-            .remove_if_inactive_registry(&query_id, &registry_weak);
+            .remove_if_dropped_registry(&query_id, &registry_weak);
     }
 }
 
 /// Query-engine manager for query-scoped remote dynamic filter registries.
 ///
-/// Weak index only; active streams own registries through [`RemoteDynFilterRegistryLease`].
+/// Weak index only; stream leases own registries through [`RemoteDynFilterRegistryLease`].
 #[derive(Debug, Default)]
 pub struct DynFilterRegistryManager {
     registries: RwLock<HashMap<QueryId, Weak<QueryDynFilterRegistry>>>,
@@ -595,10 +666,10 @@ impl DynFilterRegistryManager {
         self.registries.write().unwrap().remove(query_id)
     }
 
-    fn remove_if_inactive_registry(
+    fn remove_if_dropped_registry(
         &self,
         query_id: &QueryId,
-        registry_weak: &Weak<QueryDynFilterRegistry>,
+        dropped_registry: &Weak<QueryDynFilterRegistry>,
     ) -> Option<Weak<QueryDynFilterRegistry>> {
         let mut registries = self
             .registries
@@ -606,14 +677,8 @@ impl DynFilterRegistryManager {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         let current = registries.get(query_id)?;
 
-        // `ptr_eq` protects a newer registry for the same query id. In 03b the fanout
-        // task can briefly hold a strong `Arc`, so stream lifecycle uses active_streams
-        // instead of relying only on `Weak::upgrade().is_none()`.
-        let inactive = match current.upgrade() {
-            Some(registry) => registry.active_stream_count() == 0,
-            None => true,
-        };
-        if current.ptr_eq(registry_weak) && inactive {
+        // `ptr_eq` protects a newer registry for the same query id; `upgrade` ensures it is dead.
+        if current.ptr_eq(dropped_registry) && current.upgrade().is_none() {
             registries.remove(query_id)
         } else {
             None
@@ -758,6 +823,16 @@ mod tests {
             }
             panic!("timed out waiting for {expected} remote dyn filter unregisters");
         }
+    }
+
+    async fn wait_for_registry_drop(registry: Weak<QueryDynFilterRegistry>) {
+        for _ in 0..300 {
+            if registry.upgrade().is_none() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("timed out waiting for remote dyn filter registry drop");
     }
 
     #[async_trait]
@@ -1011,7 +1086,7 @@ mod tests {
 
         assert!(
             manager
-                .remove_if_inactive_registry(&query_id, &old_registry)
+                .remove_if_dropped_registry(&query_id, &old_registry)
                 .is_none(),
             "old registry cleanup must not remove the replacement weak entry"
         );
@@ -1120,18 +1195,22 @@ mod tests {
         let query_id = test_query_id(3);
         let manager = Arc::new(DynFilterRegistryManager::default());
         let lease = manager.acquire_lease(query_id);
-        let registry = manager.get(&query_id).unwrap();
+        let registry_weak = Arc::downgrade(lease.registry.as_ref().unwrap());
         let filter = test_dyn_filter(&["host"]);
         let filter_id = test_filter_id(1);
-        let _ = registry.register_remote_dyn_filter(filter_id.clone(), filter.clone());
+        let _ = lease
+            .registry()
+            .register_remote_dyn_filter(filter_id.clone(), filter.clone());
         let subscriber = Subscriber::new(RegionId::new(1024, 7));
         assert_eq!(
-            registry.register_subscriber(&filter_id, subscriber.clone()),
+            lease
+                .registry()
+                .register_subscriber(&filter_id, subscriber.clone()),
             SubscriberRegistration::Added
         );
 
         let handler = Arc::new(RecordingRegionQueryHandler::default());
-        registry.ensure_fanout_task(handler.clone() as RegionQueryHandlerRef);
+        lease.ensure_fanout_task(handler.clone() as RegionQueryHandlerRef);
 
         handler.wait_for_update_count(1).await;
         let initial_generation = handler.updates()[0].generation;
@@ -1153,6 +1232,137 @@ mod tests {
         let unregisters = handler.unregisters();
         assert_eq!(unregisters[0].region_id, subscriber.region_id());
         assert_eq!(unregisters[0].filter_id, filter_id.to_string());
+
+        wait_for_registry_drop(registry_weak).await;
+    }
+
+    #[tokio::test]
+    async fn repeated_ensure_fanout_task_keeps_single_watcher() {
+        let query_id = test_query_id(6);
+        let manager = Arc::new(DynFilterRegistryManager::default());
+        let lease = manager.acquire_lease(query_id);
+        let registry_weak = Arc::downgrade(lease.registry.as_ref().unwrap());
+        let filter = test_dyn_filter(&["host"]);
+        let filter_id = test_filter_id(1);
+        let entry = match lease
+            .registry()
+            .register_remote_dyn_filter(filter_id.clone(), filter.clone())
+        {
+            EntryRegistration::Inserted(entry) => entry,
+            other => panic!("unexpected registration result: {other:?}"),
+        };
+        let subscriber = Subscriber::new(RegionId::new(1024, 7));
+        assert_eq!(
+            lease
+                .registry()
+                .register_subscriber(&filter_id, subscriber.clone()),
+            SubscriberRegistration::Added
+        );
+
+        let handler = Arc::new(RecordingRegionQueryHandler::default());
+        lease.ensure_fanout_task(handler.clone() as RegionQueryHandlerRef);
+        lease.ensure_fanout_task(handler.clone() as RegionQueryHandlerRef);
+
+        assert!(entry.fanout_started.load(Ordering::SeqCst));
+        handler.wait_for_update_count(1).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(handler.updates().len(), 1);
+
+        filter.update(lit(false) as _).unwrap();
+        handler.wait_for_update_count(2).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(handler.updates().len(), 2);
+
+        drop(lease);
+        handler.wait_for_unregister_count(1).await;
+        wait_for_registry_drop(registry_weak).await;
+    }
+
+    #[tokio::test]
+    async fn fanout_task_resends_complete_snapshot_to_late_subscriber() {
+        let query_id = test_query_id(7);
+        let manager = Arc::new(DynFilterRegistryManager::default());
+        let lease = manager.acquire_lease(query_id);
+        let registry_weak = Arc::downgrade(lease.registry.as_ref().unwrap());
+        let filter = test_dyn_filter(&["host"]);
+        let filter_id = test_filter_id(1);
+        let _ = lease
+            .registry()
+            .register_remote_dyn_filter(filter_id.clone(), filter.clone());
+        let first_subscriber = Subscriber::new(RegionId::new(1024, 7));
+        assert_eq!(
+            lease
+                .registry()
+                .register_subscriber(&filter_id, first_subscriber.clone()),
+            SubscriberRegistration::Added
+        );
+
+        let handler = Arc::new(RecordingRegionQueryHandler::default());
+        lease.ensure_fanout_task(handler.clone() as RegionQueryHandlerRef);
+        handler.wait_for_update_count(1).await;
+
+        filter.mark_complete();
+        handler.wait_for_update_count(2).await;
+        assert!(handler.updates()[1].is_complete);
+
+        let late_subscriber = Subscriber::new(RegionId::new(1024, 8));
+        assert_eq!(
+            lease
+                .registry()
+                .register_subscriber(&filter_id, late_subscriber.clone()),
+            SubscriberRegistration::Added
+        );
+
+        handler.wait_for_update_count(4).await;
+        let updates = handler.updates();
+        assert!(
+            updates[2..].iter().any(
+                |update| update.region_id == first_subscriber.region_id() && update.is_complete
+            )
+        );
+        assert!(
+            updates[2..]
+                .iter()
+                .any(|update| update.region_id == late_subscriber.region_id()
+                    && update.is_complete)
+        );
+
+        drop(lease);
+        handler.wait_for_unregister_count(1).await;
+        wait_for_registry_drop(registry_weak).await;
+    }
+
+    #[tokio::test]
+    async fn fanout_task_unregisters_when_producer_filter_is_dropped() {
+        let query_id = test_query_id(8);
+        let manager = Arc::new(DynFilterRegistryManager::default());
+        let lease = manager.acquire_lease(query_id);
+        let registry_weak = Arc::downgrade(lease.registry.as_ref().unwrap());
+        let filter = test_dyn_filter(&["host"]);
+        let filter_id = test_filter_id(1);
+        let _ = lease
+            .registry()
+            .register_remote_dyn_filter(filter_id.clone(), filter.clone());
+        let subscriber = Subscriber::new(RegionId::new(1024, 7));
+        assert_eq!(
+            lease
+                .registry()
+                .register_subscriber(&filter_id, subscriber.clone()),
+            SubscriberRegistration::Added
+        );
+
+        let handler = Arc::new(RecordingRegionQueryHandler::default());
+        lease.ensure_fanout_task(handler.clone() as RegionQueryHandlerRef);
+        handler.wait_for_update_count(1).await;
+
+        drop(filter);
+        handler.wait_for_unregister_count(1).await;
+        let unregisters = handler.unregisters();
+        assert_eq!(unregisters[0].region_id, subscriber.region_id());
+        assert_eq!(unregisters[0].filter_id, filter_id.to_string());
+
+        drop(lease);
+        wait_for_registry_drop(registry_weak).await;
     }
 
     #[tokio::test]
@@ -1160,27 +1370,28 @@ mod tests {
         let query_id = test_query_id(4);
         let manager = Arc::new(DynFilterRegistryManager::default());
         let lease = manager.acquire_lease(query_id);
-        let registry = manager.get(&query_id).unwrap();
+        let registry_weak = Arc::downgrade(lease.registry.as_ref().unwrap());
         let filter = test_dyn_filter(&["host"]);
         let filter_id = test_filter_id(1);
-        let _ = registry.register_remote_dyn_filter(filter_id.clone(), filter.clone());
+        let _ = lease
+            .registry()
+            .register_remote_dyn_filter(filter_id.clone(), filter.clone());
         let subscriber = Subscriber::new(RegionId::new(1024, 7));
         assert_eq!(
-            registry.register_subscriber(&filter_id, subscriber.clone()),
+            lease
+                .registry()
+                .register_subscriber(&filter_id, subscriber.clone()),
             SubscriberRegistration::Added
         );
 
         let handler = Arc::new(RecordingRegionQueryHandler::default());
         handler.block_next_update();
-        registry.ensure_fanout_task(handler.clone() as RegionQueryHandlerRef);
+        lease.ensure_fanout_task(handler.clone() as RegionQueryHandlerRef);
 
         handler.wait_for_blocked_update().await;
         let initial_generation = handler.updates()[0].generation;
 
-        // Update while the first RPC is still in-flight. A pure `wait_update()` loop can
-        // subscribe after this update and miss the edge; the reconcile tick must still
-        // observe `snapshot_generation() > last_sent_generation` and fan out the latest
-        // snapshot.
+        // Update before the watcher can subscribe again; reconcile must catch it.
         filter.update(lit(false) as _).unwrap();
         handler.release_blocked_update();
 
@@ -1192,6 +1403,40 @@ mod tests {
 
         drop(lease);
         handler.wait_for_unregister_count(1).await;
+        wait_for_registry_drop(registry_weak).await;
+    }
+
+    #[tokio::test]
+    async fn fanout_task_unregisters_after_lifecycle_close_during_blocked_update() {
+        let query_id = test_query_id(5);
+        let manager = Arc::new(DynFilterRegistryManager::default());
+        let lease = manager.acquire_lease(query_id);
+        let registry_weak = Arc::downgrade(lease.registry.as_ref().unwrap());
+        let filter = test_dyn_filter(&["host"]);
+        let filter_id = test_filter_id(1);
+        let _ = lease
+            .registry()
+            .register_remote_dyn_filter(filter_id.clone(), filter.clone());
+        let subscriber = Subscriber::new(RegionId::new(1024, 7));
+        assert_eq!(
+            lease
+                .registry()
+                .register_subscriber(&filter_id, subscriber.clone()),
+            SubscriberRegistration::Added
+        );
+
+        let handler = Arc::new(RecordingRegionQueryHandler::default());
+        handler.block_next_update();
+        lease.ensure_fanout_task(handler.clone() as RegionQueryHandlerRef);
+
+        handler.wait_for_blocked_update().await;
+        drop(lease);
+
+        handler.wait_for_unregister_count(1).await;
+        let unregisters = handler.unregisters();
+        assert_eq!(unregisters[0].region_id, subscriber.region_id());
+        assert_eq!(unregisters[0].filter_id, filter_id.to_string());
+        wait_for_registry_drop(registry_weak).await;
     }
 
     #[tokio::test]

--- a/src/query/src/dist_plan/remote_dyn_filter_registry.rs
+++ b/src/query/src/dist_plan/remote_dyn_filter_registry.rs
@@ -13,13 +13,25 @@
 // limitations under the License.
 
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock, Weak};
+use std::time::Duration;
 
+use api::v1::region::{RemoteDynFilterUnregister, RemoteDynFilterUpdate};
+use common_query::request::DynFilterPayload;
+use common_runtime::spawn_global;
+use common_telemetry::{debug, warn};
+use datafusion_physical_expr::PhysicalExpr;
 use datafusion_physical_expr::expressions::DynamicFilterPhysicalExpr;
 use session::query_id::QueryId;
 use store_api::storage::RegionId;
+use tokio::sync::{Notify, watch};
 
 use crate::dist_plan::FilterId;
+use crate::region_query::RegionQueryHandlerRef;
+
+const REMOTE_DYN_FILTER_UPDATE_PAYLOAD_MAX_BYTES: usize = 64 * 1024;
+const REMOTE_DYN_FILTER_RECONCILE_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Routing metadata for a remote dynamic filter subscriber.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -62,6 +74,10 @@ pub struct DynFilterEntry {
     filter_id: FilterId,
     alive_dyn_filter: Weak<DynamicFilterPhysicalExpr>,
     subscribers: RwLock<HashSet<Subscriber>>,
+    last_sent_generation: AtomicU64,
+    unregistered: AtomicBool,
+    fanout_started: AtomicBool,
+    subscriber_changed: Notify,
 }
 
 #[derive(Debug)]
@@ -75,6 +91,10 @@ impl DynFilterEntry {
             filter_id,
             alive_dyn_filter: Arc::downgrade(&alive_dyn_filter),
             subscribers: RwLock::new(HashSet::new()),
+            last_sent_generation: AtomicU64::new(0),
+            unregistered: AtomicBool::new(false),
+            fanout_started: AtomicBool::new(false),
+            subscriber_changed: Notify::new(),
         }
     }
 
@@ -94,19 +114,63 @@ impl DynFilterEntry {
         let mut subscribers = self.subscribers.write().unwrap();
         subscribers.insert(subscriber)
     }
+
+    fn mark_generation_sent(&self, generation: u64) -> bool {
+        let mut current = self.last_sent_generation.load(Ordering::SeqCst);
+        loop {
+            if generation <= current {
+                return false;
+            }
+
+            match self.last_sent_generation.compare_exchange(
+                current,
+                generation,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            ) {
+                Ok(_) => return true,
+                Err(next) => current = next,
+            }
+        }
+    }
+
+    fn try_mark_unregistered(&self) -> bool {
+        self.unregistered
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+    }
+
+    fn reactivate_for_new_subscriber(&self) {
+        self.last_sent_generation.store(0, Ordering::SeqCst);
+        self.unregistered.store(false, Ordering::SeqCst);
+        self.subscriber_changed.notify_one();
+    }
+
+    fn mark_fanout_started(&self) -> bool {
+        !self.fanout_started.swap(true, Ordering::SeqCst)
+    }
 }
 
 /// Query-scoped registry that owns all remote dynamic filters for one query.
 #[derive(Debug)]
 pub struct QueryDynFilterRegistry {
     query_id: QueryId,
+    active_streams: AtomicUsize,
+    fanout_started: AtomicBool,
+    registry_changed: Notify,
+    lifecycle_tx: watch::Sender<bool>,
     inner: RwLock<QueryDynFilterRegistryInner>,
 }
 
 impl QueryDynFilterRegistry {
     pub fn new(query_id: QueryId) -> Self {
+        let (lifecycle_tx, _) = watch::channel(false);
         Self {
             query_id,
+            active_streams: AtomicUsize::new(0),
+            fanout_started: AtomicBool::new(false),
+            registry_changed: Notify::new(),
+            lifecycle_tx,
             inner: RwLock::new(QueryDynFilterRegistryInner {
                 entries: HashMap::new(),
             }),
@@ -115,6 +179,23 @@ impl QueryDynFilterRegistry {
 
     pub fn query_id(&self) -> QueryId {
         self.query_id
+    }
+
+    fn acquire_stream(&self) {
+        if self.active_streams.fetch_add(1, Ordering::SeqCst) == 0 {
+            let _ = self.lifecycle_tx.send(false);
+        }
+    }
+
+    fn release_stream(&self) {
+        if self.active_streams.fetch_sub(1, Ordering::SeqCst) == 1 {
+            let _ = self.lifecycle_tx.send(true);
+            self.registry_changed.notify_one();
+        }
+    }
+
+    fn active_stream_count(&self) -> usize {
+        self.active_streams.load(Ordering::SeqCst)
     }
 
     pub fn entry_count(&self) -> usize {
@@ -147,6 +228,7 @@ impl QueryDynFilterRegistry {
 
         let entry = Arc::new(DynFilterEntry::new(filter_id.clone(), alive_dyn_filter));
         inner.entries.insert(filter_id, entry.clone());
+        self.registry_changed.notify_one();
         EntryRegistration::Inserted(entry)
     }
 
@@ -160,10 +242,261 @@ impl QueryDynFilterRegistry {
         };
 
         if entry.register_subscriber(subscriber) {
+            // A newly added subscriber has not seen the latest snapshot yet. Reset the
+            // entry-level generation watermark so the next fanout tick resends the current
+            // snapshot to all subscribers; receivers treat duplicate generations idempotently.
+            entry.reactivate_for_new_subscriber();
             SubscriberRegistration::Added
         } else {
             SubscriberRegistration::Duplicate
         }
+    }
+
+    /// Starts one query-scoped producer fanout task if it has not already been started.
+    ///
+    /// The supervisor starts one async watcher per registered source-side
+    /// [`DynamicFilterPhysicalExpr`]. Each watcher waits on DataFusion's
+    /// `wait_update()`/`wait_complete()` notifications and sends best-effort
+    /// update/unregister RPCs to subscribed datanodes. The supervisor exits once
+    /// all remote scan streams release their registry leases.
+    pub fn ensure_fanout_task(self: &Arc<Self>, region_query_handler: RegionQueryHandlerRef) {
+        self.registry_changed.notify_one();
+        if self.fanout_started.swap(true, Ordering::SeqCst) {
+            return;
+        }
+
+        let registry = self.clone();
+        let _handle = spawn_global(async move {
+            registry.run_fanout(region_query_handler).await;
+        });
+    }
+
+    async fn run_fanout(self: Arc<Self>, region_query_handler: RegionQueryHandlerRef) {
+        let mut lifecycle_rx = self.lifecycle_tx.subscribe();
+
+        loop {
+            for entry in self.entries() {
+                self.ensure_entry_fanout_task(entry, region_query_handler.clone());
+            }
+
+            if *lifecycle_rx.borrow() || self.active_stream_count() == 0 {
+                break;
+            }
+
+            tokio::select! {
+                _ = self.registry_changed.notified() => {}
+                result = lifecycle_rx.changed() => {
+                    if result.is_err() || *lifecycle_rx.borrow() {
+                        break;
+                    }
+                }
+            }
+        }
+
+        self.unregister_all_once(&region_query_handler).await;
+    }
+
+    fn ensure_entry_fanout_task(
+        self: &Arc<Self>,
+        entry: Arc<DynFilterEntry>,
+        region_query_handler: RegionQueryHandlerRef,
+    ) {
+        if !entry.mark_fanout_started() {
+            return;
+        }
+
+        let registry = self.clone();
+        let _handle = spawn_global(async move {
+            registry.run_entry_fanout(entry, region_query_handler).await;
+        });
+    }
+
+    async fn run_entry_fanout(
+        self: Arc<Self>,
+        entry: Arc<DynFilterEntry>,
+        region_query_handler: RegionQueryHandlerRef,
+    ) {
+        let mut lifecycle_rx = self.lifecycle_tx.subscribe();
+        let mut is_complete = false;
+        let mut reconcile_interval = tokio::time::interval(REMOTE_DYN_FILTER_RECONCILE_INTERVAL);
+
+        loop {
+            if *lifecycle_rx.borrow() || self.active_stream_count() == 0 {
+                break;
+            }
+
+            let Some(filter) = entry.upgrade_alive_dyn_filter() else {
+                self.unregister_entry_once(&region_query_handler, &entry)
+                    .await;
+                return;
+            };
+
+            self.fanout_snapshot(&region_query_handler, &entry, &filter, is_complete)
+                .await;
+
+            if is_complete {
+                tokio::select! {
+                    _ = entry.subscriber_changed.notified() => {}
+                    result = lifecycle_rx.changed() => {
+                        if result.is_err() || *lifecycle_rx.borrow() {
+                            break;
+                        }
+                    }
+                }
+                continue;
+            }
+
+            tokio::select! {
+                _ = filter.wait_update() => {}
+                _ = filter.wait_complete() => {
+                    is_complete = true;
+                }
+                // `wait_update()` subscribes when called, so an update that happens between
+                // the post-send generation check and the wait call can be missed. This
+                // low-frequency reconcile tick bounds that race by periodically re-reading
+                // `snapshot_generation()` and coalescing to the latest snapshot.
+                _ = reconcile_interval.tick() => {}
+                _ = entry.subscriber_changed.notified() => {}
+                result = lifecycle_rx.changed() => {
+                    if result.is_err() || *lifecycle_rx.borrow() {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    async fn fanout_snapshot(
+        &self,
+        region_query_handler: &RegionQueryHandlerRef,
+        entry: &DynFilterEntry,
+        filter: &DynamicFilterPhysicalExpr,
+        is_complete: bool,
+    ) {
+        let Some((generation, current)) = current_stable_snapshot(filter).await else {
+            return;
+        };
+
+        if !is_complete && !entry.mark_generation_sent(generation) {
+            return;
+        }
+
+        if is_complete {
+            let _ = entry.mark_generation_sent(generation);
+        }
+
+        let payload = match DynFilterPayload::from_datafusion_expr(
+            &current,
+            REMOTE_DYN_FILTER_UPDATE_PAYLOAD_MAX_BYTES,
+        ) {
+            Ok(DynFilterPayload::Datafusion(payload)) => payload,
+            Ok(_) => {
+                warn!("Ignored unsupported remote dynamic filter producer payload");
+                return;
+            }
+            Err(error) => {
+                warn!(error; "Failed to encode remote dynamic filter producer snapshot");
+                return;
+            }
+        };
+
+        self.fanout_update(
+            region_query_handler,
+            entry,
+            generation,
+            is_complete,
+            payload,
+        )
+        .await;
+    }
+
+    async fn fanout_update(
+        &self,
+        region_query_handler: &RegionQueryHandlerRef,
+        entry: &DynFilterEntry,
+        generation: u64,
+        is_complete: bool,
+        payload: Vec<u8>,
+    ) {
+        let query_id = self.query_id.to_string();
+        let filter_id = entry.filter_id().to_string();
+
+        for subscriber in entry.subscribers() {
+            let update = RemoteDynFilterUpdate {
+                filter_id: filter_id.clone(),
+                payload: payload.clone(),
+                generation,
+                is_complete,
+            };
+
+            if let Err(error) = region_query_handler
+                .handle_remote_dyn_filter_update(subscriber.region_id(), query_id.clone(), update)
+                .await
+            {
+                warn!(error; "Failed to fan out remote dynamic filter update");
+            }
+        }
+    }
+
+    async fn unregister_all_once(&self, region_query_handler: &RegionQueryHandlerRef) {
+        for entry in self.entries() {
+            self.unregister_entry_once(region_query_handler, &entry)
+                .await;
+        }
+    }
+
+    async fn unregister_entry_once(
+        &self,
+        region_query_handler: &RegionQueryHandlerRef,
+        entry: &DynFilterEntry,
+    ) {
+        if !entry.try_mark_unregistered() {
+            return;
+        }
+
+        let query_id = self.query_id.to_string();
+        let filter_id = entry.filter_id().to_string();
+
+        for subscriber in entry.subscribers() {
+            let unregister = RemoteDynFilterUnregister {
+                filter_id: filter_id.clone(),
+            };
+
+            if let Err(error) = region_query_handler
+                .handle_remote_dyn_filter_unregister(
+                    subscriber.region_id(),
+                    query_id.clone(),
+                    unregister,
+                )
+                .await
+            {
+                warn!(error; "Failed to fan out remote dynamic filter unregister");
+            }
+        }
+
+        debug!("Remote dynamic filter producer unregistered subscribers");
+    }
+}
+
+async fn current_stable_snapshot(
+    filter: &DynamicFilterPhysicalExpr,
+) -> Option<(u64, Arc<dyn PhysicalExpr>)> {
+    loop {
+        let before = filter.snapshot_generation();
+        let current = match filter.current() {
+            Ok(current) => current,
+            Err(error) => {
+                warn!(error; "Failed to read remote dynamic filter producer snapshot");
+                return None;
+            }
+        };
+        let after = filter.snapshot_generation();
+
+        if before == after {
+            return Some((after, current));
+        }
+
+        tokio::task::yield_now().await;
     }
 }
 
@@ -184,6 +517,7 @@ impl RemoteDynFilterRegistryLease {
         registry_manager: Arc<DynFilterRegistryManager>,
         registry: Arc<QueryDynFilterRegistry>,
     ) -> Self {
+        registry.acquire_stream();
         Self {
             registry_manager,
             registry: Some(registry),
@@ -194,6 +528,13 @@ impl RemoteDynFilterRegistryLease {
         self.registry
             .as_deref()
             .expect("remote dyn filter registry lease must hold a registry")
+    }
+
+    pub fn ensure_fanout_task(&self, region_query_handler: RegionQueryHandlerRef) {
+        self.registry
+            .as_ref()
+            .expect("remote dyn filter registry lease must hold a registry")
+            .ensure_fanout_task(region_query_handler);
     }
 
     #[cfg(test)]
@@ -213,12 +554,14 @@ impl Drop for RemoteDynFilterRegistryLease {
         let query_id = registry.query_id();
         let registry_weak = Arc::downgrade(&registry);
 
-        // Release this lease before pruning; concurrent drops must not observe each other's strong refs.
+        registry.release_stream();
+
+        // Release this lease before pruning; concurrent drops must not observe each other's stream refs.
         drop(registry);
 
         let _ = self
             .registry_manager
-            .remove_if_dropped_registry(&query_id, &registry_weak);
+            .remove_if_inactive_registry(&query_id, &registry_weak);
     }
 }
 
@@ -252,10 +595,10 @@ impl DynFilterRegistryManager {
         self.registries.write().unwrap().remove(query_id)
     }
 
-    fn remove_if_dropped_registry(
+    fn remove_if_inactive_registry(
         &self,
         query_id: &QueryId,
-        dropped_registry: &Weak<QueryDynFilterRegistry>,
+        registry_weak: &Weak<QueryDynFilterRegistry>,
     ) -> Option<Weak<QueryDynFilterRegistry>> {
         let mut registries = self
             .registries
@@ -263,8 +606,14 @@ impl DynFilterRegistryManager {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         let current = registries.get(query_id)?;
 
-        // `ptr_eq` protects a newer registry for the same query id; `upgrade` ensures it is dead.
-        if current.ptr_eq(dropped_registry) && current.upgrade().is_none() {
+        // `ptr_eq` protects a newer registry for the same query id. In 03b the fanout
+        // task can briefly hold a strong `Arc`, so stream lifecycle uses active_streams
+        // instead of relying only on `Weak::upgrade().is_none()`.
+        let inactive = match current.upgrade() {
+            Some(registry) => registry.active_stream_count() == 0,
+            None => true,
+        };
+        if current.ptr_eq(registry_weak) && inactive {
             registries.remove(query_id)
         } else {
             None
@@ -326,14 +675,137 @@ impl DynFilterRegistryManager {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Barrier;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Barrier, Mutex};
     use std::thread;
+    use std::time::Duration;
 
+    use api::v1::region::{RemoteDynFilterUnregister, RemoteDynFilterUpdate};
+    use async_trait::async_trait;
+    use common_query::request::QueryRequest;
     use datafusion_physical_expr::expressions::{Column, lit};
+    use session::ReadPreference;
     use uuid::Uuid;
 
     use super::*;
     use crate::dist_plan::{FilterFingerprint, RemoteDynFilterProducerId};
+    use crate::error::Result as QueryResult;
+    use crate::region_query::RegionQueryHandler;
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct RecordedUpdate {
+        region_id: RegionId,
+        query_id: String,
+        filter_id: String,
+        generation: u64,
+        is_complete: bool,
+        payload: Vec<u8>,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct RecordedUnregister {
+        region_id: RegionId,
+        query_id: String,
+        filter_id: String,
+    }
+
+    #[derive(Default)]
+    struct RecordingRegionQueryHandler {
+        updates: Mutex<Vec<RecordedUpdate>>,
+        unregisters: Mutex<Vec<RecordedUnregister>>,
+        block_next_update: AtomicBool,
+        update_blocked: Notify,
+        release_update: Notify,
+    }
+
+    impl RecordingRegionQueryHandler {
+        fn updates(&self) -> Vec<RecordedUpdate> {
+            self.updates.lock().unwrap().clone()
+        }
+
+        fn unregisters(&self) -> Vec<RecordedUnregister> {
+            self.unregisters.lock().unwrap().clone()
+        }
+
+        fn block_next_update(&self) {
+            self.block_next_update.store(true, Ordering::SeqCst);
+        }
+
+        async fn wait_for_blocked_update(&self) {
+            self.update_blocked.notified().await;
+        }
+
+        fn release_blocked_update(&self) {
+            self.release_update.notify_one();
+        }
+
+        async fn wait_for_update_count(&self, expected: usize) {
+            for _ in 0..300 {
+                if self.updates().len() >= expected {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            panic!("timed out waiting for {expected} remote dyn filter updates");
+        }
+
+        async fn wait_for_unregister_count(&self, expected: usize) {
+            for _ in 0..300 {
+                if self.unregisters().len() >= expected {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            panic!("timed out waiting for {expected} remote dyn filter unregisters");
+        }
+    }
+
+    #[async_trait]
+    impl RegionQueryHandler for RecordingRegionQueryHandler {
+        async fn do_get(
+            &self,
+            _read_preference: ReadPreference,
+            _request: QueryRequest,
+        ) -> QueryResult<common_recordbatch::SendableRecordBatchStream> {
+            unreachable!("remote dyn filter registry tests should not execute remote queries")
+        }
+
+        async fn handle_remote_dyn_filter_update(
+            &self,
+            region_id: RegionId,
+            query_id: String,
+            update: RemoteDynFilterUpdate,
+        ) -> QueryResult<()> {
+            let should_block = self.block_next_update.swap(false, Ordering::SeqCst);
+            self.updates.lock().unwrap().push(RecordedUpdate {
+                region_id,
+                query_id,
+                filter_id: update.filter_id,
+                generation: update.generation,
+                is_complete: update.is_complete,
+                payload: update.payload,
+            });
+            if should_block {
+                self.update_blocked.notify_one();
+                self.release_update.notified().await;
+            }
+            Ok(())
+        }
+
+        async fn handle_remote_dyn_filter_unregister(
+            &self,
+            region_id: RegionId,
+            query_id: String,
+            unregister: RemoteDynFilterUnregister,
+        ) -> QueryResult<()> {
+            self.unregisters.lock().unwrap().push(RecordedUnregister {
+                region_id,
+                query_id,
+                filter_id: unregister.filter_id,
+            });
+            Ok(())
+        }
+    }
 
     fn test_query_id(value: u128) -> QueryId {
         QueryId::from(Uuid::from_u128(value))
@@ -539,7 +1011,7 @@ mod tests {
 
         assert!(
             manager
-                .remove_if_dropped_registry(&query_id, &old_registry)
+                .remove_if_inactive_registry(&query_id, &old_registry)
                 .is_none(),
             "old registry cleanup must not remove the replacement weak entry"
         );
@@ -574,5 +1046,177 @@ mod tests {
             SubscriberRegistration::Duplicate
         );
         assert_eq!(entry.subscribers().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn fanout_sends_changed_generations_to_subscribers() {
+        let query_id = test_query_id(1);
+        let registry = Arc::new(QueryDynFilterRegistry::new(query_id));
+        let filter = test_dyn_filter(&["host"]);
+        let filter_id = test_filter_id(1);
+        let entry = match registry.register_remote_dyn_filter(filter_id.clone(), filter.clone()) {
+            EntryRegistration::Inserted(entry) => entry,
+            other => panic!("unexpected registration result: {other:?}"),
+        };
+        let subscriber = Subscriber::new(RegionId::new(1024, 7));
+        assert_eq!(
+            registry.register_subscriber(&filter_id, subscriber.clone()),
+            SubscriberRegistration::Added
+        );
+
+        let handler = Arc::new(RecordingRegionQueryHandler::default());
+        let handler_ref = handler.clone() as RegionQueryHandlerRef;
+
+        registry
+            .fanout_snapshot(&handler_ref, &entry, filter.as_ref(), false)
+            .await;
+        let updates = handler.updates();
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].region_id, subscriber.region_id());
+        assert_eq!(updates[0].query_id, query_id.to_string());
+        assert_eq!(updates[0].filter_id, filter_id.to_string());
+        assert_eq!(updates[0].generation, filter.snapshot_generation());
+        assert!(!updates[0].is_complete);
+        assert!(!updates[0].payload.is_empty());
+
+        registry
+            .fanout_snapshot(&handler_ref, &entry, filter.as_ref(), false)
+            .await;
+        assert_eq!(handler.updates().len(), 1);
+
+        filter.update(lit(false) as _).unwrap();
+        registry
+            .fanout_snapshot(&handler_ref, &entry, filter.as_ref(), false)
+            .await;
+        let updates = handler.updates();
+        assert_eq!(updates.len(), 2);
+        assert_eq!(updates[1].generation, filter.snapshot_generation());
+
+        let second_subscriber = Subscriber::new(RegionId::new(1024, 8));
+        assert_eq!(
+            registry.register_subscriber(&filter_id, second_subscriber.clone()),
+            SubscriberRegistration::Added
+        );
+        registry
+            .fanout_snapshot(&handler_ref, &entry, filter.as_ref(), false)
+            .await;
+        let updates = handler.updates();
+        assert_eq!(updates.len(), 4);
+        assert!(
+            updates[2..]
+                .iter()
+                .any(|update| update.region_id == subscriber.region_id())
+        );
+        assert!(
+            updates[2..]
+                .iter()
+                .any(|update| update.region_id == second_subscriber.region_id())
+        );
+        assert_eq!(entry.subscribers().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn fanout_task_waits_for_dynamic_filter_notifications() {
+        let query_id = test_query_id(3);
+        let manager = Arc::new(DynFilterRegistryManager::default());
+        let lease = manager.acquire_lease(query_id);
+        let registry = manager.get(&query_id).unwrap();
+        let filter = test_dyn_filter(&["host"]);
+        let filter_id = test_filter_id(1);
+        let _ = registry.register_remote_dyn_filter(filter_id.clone(), filter.clone());
+        let subscriber = Subscriber::new(RegionId::new(1024, 7));
+        assert_eq!(
+            registry.register_subscriber(&filter_id, subscriber.clone()),
+            SubscriberRegistration::Added
+        );
+
+        let handler = Arc::new(RecordingRegionQueryHandler::default());
+        registry.ensure_fanout_task(handler.clone() as RegionQueryHandlerRef);
+
+        handler.wait_for_update_count(1).await;
+        let initial_generation = handler.updates()[0].generation;
+
+        filter.update(lit(false) as _).unwrap();
+        handler.wait_for_update_count(2).await;
+        let updates = handler.updates();
+        assert!(updates[1].generation > initial_generation);
+        assert_eq!(updates[1].region_id, subscriber.region_id());
+        assert_eq!(updates[1].filter_id, filter_id.to_string());
+
+        filter.mark_complete();
+        handler.wait_for_update_count(3).await;
+        let updates = handler.updates();
+        assert!(updates[2].is_complete);
+
+        drop(lease);
+        handler.wait_for_unregister_count(1).await;
+        let unregisters = handler.unregisters();
+        assert_eq!(unregisters[0].region_id, subscriber.region_id());
+        assert_eq!(unregisters[0].filter_id, filter_id.to_string());
+    }
+
+    #[tokio::test]
+    async fn reconcile_tick_catches_update_while_fanout_is_in_flight() {
+        let query_id = test_query_id(4);
+        let manager = Arc::new(DynFilterRegistryManager::default());
+        let lease = manager.acquire_lease(query_id);
+        let registry = manager.get(&query_id).unwrap();
+        let filter = test_dyn_filter(&["host"]);
+        let filter_id = test_filter_id(1);
+        let _ = registry.register_remote_dyn_filter(filter_id.clone(), filter.clone());
+        let subscriber = Subscriber::new(RegionId::new(1024, 7));
+        assert_eq!(
+            registry.register_subscriber(&filter_id, subscriber.clone()),
+            SubscriberRegistration::Added
+        );
+
+        let handler = Arc::new(RecordingRegionQueryHandler::default());
+        handler.block_next_update();
+        registry.ensure_fanout_task(handler.clone() as RegionQueryHandlerRef);
+
+        handler.wait_for_blocked_update().await;
+        let initial_generation = handler.updates()[0].generation;
+
+        // Update while the first RPC is still in-flight. A pure `wait_update()` loop can
+        // subscribe after this update and miss the edge; the reconcile tick must still
+        // observe `snapshot_generation() > last_sent_generation` and fan out the latest
+        // snapshot.
+        filter.update(lit(false) as _).unwrap();
+        handler.release_blocked_update();
+
+        handler.wait_for_update_count(2).await;
+        let updates = handler.updates();
+        assert!(updates[1].generation > initial_generation);
+        assert_eq!(updates[1].region_id, subscriber.region_id());
+        assert_eq!(updates[1].filter_id, filter_id.to_string());
+
+        drop(lease);
+        handler.wait_for_unregister_count(1).await;
+    }
+
+    #[tokio::test]
+    async fn unregister_fanout_is_idempotent() {
+        let query_id = test_query_id(2);
+        let registry = QueryDynFilterRegistry::new(query_id);
+        let filter = test_dyn_filter(&["host"]);
+        let filter_id = test_filter_id(1);
+        let _ = registry.register_remote_dyn_filter(filter_id.clone(), filter);
+        let subscriber = Subscriber::new(RegionId::new(1024, 7));
+        assert_eq!(
+            registry.register_subscriber(&filter_id, subscriber.clone()),
+            SubscriberRegistration::Added
+        );
+
+        let handler = Arc::new(RecordingRegionQueryHandler::default());
+        let handler_ref = handler.clone() as RegionQueryHandlerRef;
+
+        registry.unregister_all_once(&handler_ref).await;
+        registry.unregister_all_once(&handler_ref).await;
+
+        let unregisters = handler.unregisters();
+        assert_eq!(unregisters.len(), 1);
+        assert_eq!(unregisters[0].region_id, subscriber.region_id());
+        assert_eq!(unregisters[0].query_id, query_id.to_string());
+        assert_eq!(unregisters[0].filter_id, filter_id.to_string());
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Part of the remote dynamic filter work. Builds on the initial FE registration / filter-id plumbing that has landed on `main`.

## What's changed and what's your intention?

This PR adds FE-side producer fanout for remote dynamic filters.

Summary:

- Watches FE-side `DynamicFilterPhysicalExpr` producers and fans out stable snapshots as `RemoteDynFilterUpdate` to region subscribers.
- Registers query-scoped remote dynamic filter entries and region subscribers from `MergeScanExec`.
- Starts fanout watchers only after region `do_get()` succeeds, so updates do not race ahead of initial registrations in the query context.
- Keeps registry lifecycle based on the existing `Arc` / `Weak` model:
  - `DynFilterRegistryManager` keeps only a weak index.
  - stream-owned `RemoteDynFilterRegistryLease` owns the registry `Arc`.
  - watcher tasks do not hold registry `Arc`.
  - registry drop closes a lifecycle watch channel, causing watchers to unregister and exit.
- Keeps producer filter ownership weak via `Weak<DynamicFilterPhysicalExpr>` so fanout does not keep producers alive.
- Sends unregister at most once per entry when registry lifecycle ends or the producer weak handle is gone.
- Adds a reconcile tick to catch producer updates that happen while an update RPC is in flight.
- Adds lifecycle-aware / timeout bounded RDF control RPCs:
  - update fanout can be cancelled by registry lifecycle close and has a 30s timeout;
  - unregister is cleanup, so it is not cancelled by lifecycle close, but it has a 30s timeout;
  - unregister timeout for one subscriber does not block later subscribers.

RDF remains an optimization. Update/unregister failures only degrade pruning and do not affect query correctness.

Limitations / follow-ups:

- This PR does not add DN runtime apply / scan wrapper integration.
- This PR does not reintroduce target-peer pinning; subscribers are still keyed by `region_id`.
- Large subscriber sets still fan out sequentially; bounded concurrency can be considered later.
- Timeout metrics and richer log context can be added later.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.

Validation:

- `cargo fmt --check`
- `cargo test -p query remote_dyn_filter_registry --lib`
- `cargo test -p query remote_dyn_filter --lib`
- `cargo check -p query`
- `cargo check -p frontend`