### PR TITLE
fix: accept JSONB OTLP logs against existing schema

### DIFF
--- a/src/servers/src/otlp/logs.rs
+++ b/src/servers/src/otlp/logs.rs
@@ -343,7 +343,8 @@ impl ExistingLogColumn {
                     .datatype_extension
                     .as_ref()
                     .and_then(|datatype_extension| datatype_extension.type_ext.as_ref()),
-                Some(TypeExt::JsonType(_))
+                Some(TypeExt::JsonType(json_type))
+                     if *json_type == JsonTypeExtension::JsonBinary as i32
             )
     }
 }

--- a/src/servers/src/otlp/logs.rs
+++ b/src/servers/src/otlp/logs.rs
@@ -327,6 +327,27 @@ struct ExistingLogColumn {
     datatype: ColumnDataType,
 }
 
+impl ExistingLogColumn {
+    fn schema_for_request_type(&self, request_type: ColumnDataType) -> ColumnSchema {
+        let mut schema = self.schema.clone();
+        if request_type == ColumnDataType::Binary && self.is_json_binary() {
+            schema.datatype = ColumnDataType::Binary as i32;
+        }
+        schema
+    }
+
+    fn is_json_binary(&self) -> bool {
+        self.datatype == ColumnDataType::Json
+            && matches!(
+                self.schema
+                    .datatype_extension
+                    .as_ref()
+                    .and_then(|datatype_extension| datatype_extension.type_ext.as_ref()),
+                Some(TypeExt::JsonType(_))
+            )
+    }
+}
+
 #[derive(Default)]
 struct ExistingLogSchema {
     columns: HashMap<String, ExistingLogColumn>,
@@ -581,6 +602,7 @@ fn decide_existing_column_schema_and_convert_value(
         existing_column.datatype,
         existing_column.schema.semantic_type(),
         request_type,
+        existing_column.is_json_binary(),
         column_name,
         table_name,
     )?;
@@ -655,11 +677,12 @@ fn align_rows_with_existing_schema(
                 target_type,
                 semantic_type,
                 request_type,
+                existing_column.is_json_binary(),
                 &schema.column_name,
                 table_name,
             )?;
         }
-        *schema = existing_column.schema.clone();
+        *schema = existing_column.schema_for_request_type(request_type);
     }
 
     Ok(())
@@ -670,6 +693,7 @@ fn coerce_log_value_data(
     target_type: ColumnDataType,
     _semantic_type: SemanticType,
     request_type: ColumnDataType,
+    target_is_json_binary: bool,
     column_name: &str,
     table_name: &str,
 ) -> Result<Option<ValueData>> {
@@ -678,6 +702,10 @@ fn coerce_log_value_data(
     };
 
     if request_type == target_type {
+        return Ok(Some(value_data));
+    }
+
+    if request_type == ColumnDataType::Binary && target_is_json_binary {
         return Ok(Some(value_data));
     }
 

--- a/src/servers/src/otlp/logs.rs
+++ b/src/servers/src/otlp/logs.rs
@@ -668,6 +668,7 @@ fn align_rows_with_existing_schema(
 
         let target_type = existing_column.datatype;
         let semantic_type = existing_column.schema.semantic_type();
+        let target_is_json_binary = existing_column.is_json_binary();
         for row in rows.iter_mut() {
             let Some(value) = row.values.get_mut(column_idx) else {
                 continue;
@@ -677,7 +678,7 @@ fn align_rows_with_existing_schema(
                 target_type,
                 semantic_type,
                 request_type,
-                existing_column.is_json_binary(),
+                target_is_json_binary,
                 &schema.column_name,
                 table_name,
             )?;

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -6387,6 +6387,28 @@ pub async fn test_otlp_logs(store_type: StorageType) {
             "[[1]]",
         )
         .await;
+
+        // Write another batch after the table exists. This verifies existing-schema
+        // alignment accepts the built-in JSONB columns in direct OTLP logs.
+        let res = send_req(
+            &client,
+            vec![(
+                HeaderName::from_static("content-type"),
+                HeaderValue::from_static("application/x-protobuf"),
+            )],
+            "/v1/otlp/v1/logs?db=public",
+            body.clone(),
+            false,
+        )
+        .await;
+        assert_eq!(StatusCode::OK, res.status());
+        validate_data(
+            "otlp_logs_multiple_batches",
+            &client,
+            "select count(*) from opentelemetry_logs;",
+            "[[4]]",
+        )
+        .await;
     }
 
     {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Fixes #8249.

## What's changed and what's your intention?

This PR fixes direct OTLP log ingestion after the auto-created log table already exists.

- Treat existing legacy JSONB log columns (`Json` + `JsonBinary`) as compatible with incoming direct OTLP log values that are already encoded as binary JSONB.
- Keep the insert wire schema as `Binary` + `JsonBinary` for those pre-encoded JSONB values, so operator preprocessing does not try to re-encode them from JSON strings.
- Add integration coverage that sends a second direct OTLP logs batch after `opentelemetry_logs` is auto-created.

The regression was introduced by existing-schema alignment for OTLP logs: the first batch creates built-in JSONB columns from a `Binary` + `JsonBinary` request schema, but reading the table schema back reports those columns as `Json` + `JsonBinary`. The second batch was rejected as an incompatible `Binary -> Json` alignment even though both representations refer to the same JSONB column on the direct insert path.

Test plan:

- `cargo fmt --package servers --package tests-integration -- --check`
- `cargo nextest run -p tests-integration integration_http_file_test::test_otlp_logs`

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
