### PR TITLE
feat: apply remote dynamic filters on datanode scans

### DIFF
--- a/src/common/query/src/error.rs
+++ b/src/common/query/src/error.rs
@@ -199,6 +199,18 @@ pub enum Error {
 
     #[snafu(display("Invalid character in prefix config: {}", prefix))]
     InvalidColumnPrefix { prefix: String },
+
+    #[snafu(display(
+        "DynFilterPayload::Datafusion is {} bytes, which exceeds the configured limit of {} bytes",
+        payload_size_bytes,
+        max_payload_bytes
+    ))]
+    DynFilterPayloadTooLarge {
+        payload_size_bytes: usize,
+        max_payload_bytes: usize,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -228,6 +240,8 @@ impl ErrorExt for Error {
             | Error::TypeCast { .. }
             | Error::InvalidFuncArgs { .. }
             | Error::InvalidColumnPrefix { .. } => StatusCode::InvalidArguments,
+
+            Error::DynFilterPayloadTooLarge { .. } => StatusCode::PlanQuery,
 
             Error::ConvertDfRecordBatchStream { source, .. } => source.status_code(),
 

--- a/src/common/query/src/request.rs
+++ b/src/common/query/src/request.rs
@@ -19,10 +19,10 @@ use std::sync::Arc;
 
 use api::v1::region::RegionRequestHeader;
 use datafusion::execution::TaskContext;
-use datafusion::physical_expr::expressions::Column;
+use datafusion::physical_expr::expressions::{Column, InListExpr, lit};
 use datafusion::physical_plan::PhysicalExpr;
 use datafusion::physical_plan::joins::HashTableLookupExpr;
-use datafusion_common::tree_node::{TreeNode, TreeNodeRecursion};
+use datafusion_common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
 use datafusion_common::{DataFusionError, Result as DataFusionResult};
 use datafusion_expr::LogicalPlan;
 use datafusion_proto::physical_plan::DefaultPhysicalExtensionCodec;
@@ -31,6 +31,7 @@ use datafusion_proto::physical_plan::to_proto::serialize_physical_expr;
 use datafusion_proto::protobuf::PhysicalExprNode;
 use prost::Message;
 use serde::{Deserialize, Serialize};
+use snafu::ensure;
 use store_api::storage::RegionId;
 
 /// Current wire-format version for remote dynamic filter payload updates.
@@ -39,6 +40,7 @@ pub use self::initial_remote_dyn_filter_reg::{
     INITIAL_REMOTE_DYN_FILTER_REGS_MAX_TOTAL_PROTO_BYTES, InitialDynFilterReg,
     InitialDynFilterRegs, InitialDynFilterSnapshot,
 };
+use crate::error::{DynFilterPayloadTooLargeSnafu, Error as CommonQueryError};
 
 pub const DYN_FILTER_PROTOCOL_VERSION: u32 = 1;
 
@@ -63,24 +65,23 @@ pub enum DynFilterPayload {
 impl DynFilterPayload {
     /// Encodes a DataFusion physical expression into a bounded dynamic filter payload.
     ///
-    /// This rejects expressions that cannot be safely shipped as dynamic filter
-    /// predicates and fails if the serialized payload exceeds `max_payload_bytes`.
+    /// Runtime-only hash lookup predicates are degraded to `true` before encoding so
+    /// serializable min/max bounds around them can still be shipped to remote scans.
+    /// If the full serializable predicate is still larger than `max_payload_bytes`, large
+    /// membership predicates (`IN (...)`) are also degraded to `true` as a bounds-only fallback.
     pub fn from_datafusion_expr(
         expr: &Arc<dyn PhysicalExpr>,
         max_payload_bytes: usize,
     ) -> DataFusionResult<Self> {
-        validate_supported_payload_expr(expr)?;
-
-        let codec = DefaultPhysicalExtensionCodec {};
-        let proto = serialize_physical_expr(expr, &codec)?;
-        let mut bytes = Vec::new();
-        proto.encode(&mut bytes).map_err(|e| {
-            DataFusionError::Internal(format!("Failed to encode PhysicalExprNode: {e}"))
-        })?;
-
-        validate_payload_size(bytes.len(), max_payload_bytes)?;
-
-        Ok(Self::Datafusion(bytes))
+        match encode_remote_dyn_filter_expr(expr, max_payload_bytes, false) {
+            Ok(bytes) => Ok(Self::Datafusion(bytes)),
+            Err(CommonQueryError::DynFilterPayloadTooLarge { .. }) => {
+                encode_remote_dyn_filter_expr(expr, max_payload_bytes, true)
+                    .map(Self::Datafusion)
+                    .map_err(DataFusionError::from)
+            }
+            Err(error) => Err(DataFusionError::from(error)),
+        }
     }
 
     /// Decodes a DataFusion dynamic filter payload against the provided input schema.
@@ -95,7 +96,7 @@ impl DynFilterPayload {
         max_payload_bytes: usize,
     ) -> DataFusionResult<Arc<dyn PhysicalExpr>> {
         let Self::Datafusion(bytes) = self;
-        validate_payload_size(bytes.len(), max_payload_bytes)?;
+        validate_payload_size(bytes.len(), max_payload_bytes).map_err(DataFusionError::from)?;
         let codec = DefaultPhysicalExtensionCodec {};
         let proto = PhysicalExprNode::decode(bytes.as_slice()).map_err(|e| {
             DataFusionError::Internal(format!("Failed to decode PhysicalExprNode: {e}"))
@@ -118,13 +119,41 @@ fn encode_physical_expr_to_bytes(expr: &Arc<dyn PhysicalExpr>) -> DataFusionResu
     Ok(bytes)
 }
 
+fn encode_remote_dyn_filter_expr(
+    expr: &Arc<dyn PhysicalExpr>,
+    max_payload_bytes: usize,
+    bounds_only: bool,
+) -> Result<Vec<u8>, CommonQueryError> {
+    let expr = portable_remote_dyn_filter_expr(Arc::clone(expr), bounds_only)
+        .map_err(CommonQueryError::from)?;
+    let bytes = encode_physical_expr_to_bytes(&expr).map_err(CommonQueryError::from)?;
+    validate_payload_size(bytes.len(), max_payload_bytes)?;
+    Ok(bytes)
+}
+
+fn portable_remote_dyn_filter_expr(
+    expr: Arc<dyn PhysicalExpr>,
+    bounds_only: bool,
+) -> DataFusionResult<Arc<dyn PhysicalExpr>> {
+    expr.transform_up(|node| {
+        if node.as_any().is::<HashTableLookupExpr>()
+            || (bounds_only && node.as_any().is::<InListExpr>())
+        {
+            Ok(Transformed::yes(lit(true)))
+        } else {
+            Ok(Transformed::no(node))
+        }
+    })
+    .map(|transformed| transformed.data)
+}
+
 pub(crate) fn decode_physical_expr_from_bytes(
     bytes: &[u8],
     task_ctx: &TaskContext,
     input_schema: &datafusion::arrow::datatypes::Schema,
     max_payload_bytes: usize,
 ) -> DataFusionResult<Arc<dyn PhysicalExpr>> {
-    validate_payload_size(bytes.len(), max_payload_bytes)?;
+    validate_payload_size(bytes.len(), max_payload_bytes).map_err(DataFusionError::from)?;
     let codec = DefaultPhysicalExtensionCodec {};
     let proto = PhysicalExprNode::decode(bytes).map_err(|e| {
         DataFusionError::Internal(format!("Failed to decode PhysicalExprNode: {e}"))
@@ -139,13 +168,14 @@ pub(crate) fn decode_physical_expr_from_bytes(
 fn validate_payload_size(
     payload_size_bytes: usize,
     max_payload_bytes: usize,
-) -> DataFusionResult<()> {
-    if payload_size_bytes > max_payload_bytes {
-        return Err(DataFusionError::Plan(format!(
-            "DynFilterPayload::Datafusion is {} bytes, which exceeds the configured limit of {} bytes",
-            payload_size_bytes, max_payload_bytes
-        )));
-    }
+) -> Result<(), CommonQueryError> {
+    ensure!(
+        payload_size_bytes <= max_payload_bytes,
+        DynFilterPayloadTooLargeSnafu {
+            payload_size_bytes,
+            max_payload_bytes,
+        }
+    );
 
     Ok(())
 }
@@ -263,7 +293,11 @@ mod tests {
     use base64::Engine;
     use base64::prelude::BASE64_STANDARD;
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
-    use datafusion::physical_expr::expressions::Column;
+    use datafusion::physical_expr::expressions::{BinaryExpr, Column, InListExpr, lit};
+    use datafusion::physical_plan::expressions::col;
+    use datafusion::physical_plan::joins::join_hash_map::JoinHashMapU32;
+    use datafusion::physical_plan::joins::{HashTableLookupExpr, Map, SeededRandomState};
+    use datafusion_expr::Operator;
 
     use super::*;
 
@@ -408,11 +442,113 @@ mod tests {
     }
 
     #[test]
+    fn dyn_filter_payload_hash_lookup_fallback_preserves_bounds() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "device_id",
+            DataType::Int32,
+            false,
+        )]));
+        let device_id = col("device_id", &schema).unwrap();
+        let lower_bound = Arc::new(BinaryExpr::new(
+            Arc::clone(&device_id),
+            Operator::GtEq,
+            lit(10i32),
+        )) as Arc<dyn PhysicalExpr>;
+        let lookup = Arc::new(HashTableLookupExpr::new(
+            vec![Arc::clone(&device_id)],
+            SeededRandomState::with_seeds(0, 0, 0, 0),
+            Arc::new(Map::HashMap(Box::new(JoinHashMapU32::with_capacity(0)))),
+            "hash_lookup".to_string(),
+        )) as Arc<dyn PhysicalExpr>;
+        let expr =
+            Arc::new(BinaryExpr::new(lower_bound, Operator::And, lookup)) as Arc<dyn PhysicalExpr>;
+
+        let payload = DynFilterPayload::from_datafusion_expr(&expr, 1024).unwrap();
+        let decoded = payload
+            .decode_datafusion_expr(&TaskContext::default(), &schema, 1024)
+            .unwrap();
+
+        assert!(!contains_expr::<HashTableLookupExpr>(&decoded));
+        let decoded_display = decoded.to_string();
+        assert!(decoded_display.contains("device_id"));
+        assert!(decoded_display.contains(">="));
+        assert!(!decoded_display.contains("hash_lookup"));
+    }
+
+    #[test]
+    fn dyn_filter_payload_oversized_inlist_falls_back_to_bounds() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "device_id",
+            DataType::Int32,
+            false,
+        )]));
+        let device_id = col("device_id", &schema).unwrap();
+        let lower_bound = Arc::new(BinaryExpr::new(
+            Arc::clone(&device_id),
+            Operator::GtEq,
+            lit(8192i32),
+        )) as Arc<dyn PhysicalExpr>;
+        let upper_bound = Arc::new(BinaryExpr::new(
+            Arc::clone(&device_id),
+            Operator::LtEq,
+            lit(8255i32),
+        )) as Arc<dyn PhysicalExpr>;
+        let bounds = Arc::new(BinaryExpr::new(lower_bound, Operator::And, upper_bound))
+            as Arc<dyn PhysicalExpr>;
+        let in_list = Arc::new(
+            InListExpr::try_new(
+                Arc::clone(&device_id),
+                (8192..8256).map(lit).collect(),
+                false,
+                &schema,
+            )
+            .unwrap(),
+        ) as Arc<dyn PhysicalExpr>;
+        let expr = Arc::new(BinaryExpr::new(Arc::clone(&bounds), Operator::And, in_list))
+            as Arc<dyn PhysicalExpr>;
+        let bounds_only = portable_remote_dyn_filter_expr(Arc::clone(&expr), true).unwrap();
+        let bounds_only_size = encode_physical_expr_to_bytes(&bounds_only).unwrap().len();
+        let full_size = encode_physical_expr_to_bytes(&expr).unwrap().len();
+        assert!(full_size > bounds_only_size);
+
+        let payload = DynFilterPayload::from_datafusion_expr(&expr, bounds_only_size).unwrap();
+        let decoded = payload
+            .decode_datafusion_expr(&TaskContext::default(), &schema, bounds_only_size)
+            .unwrap();
+
+        assert!(!contains_expr::<InListExpr>(&decoded));
+        let decoded_display = decoded.to_string();
+        assert!(decoded_display.contains("device_id"));
+        assert!(decoded_display.contains(">="));
+        assert!(decoded_display.contains("<="));
+    }
+
+    #[test]
     fn dyn_filter_payload_rejects_oversized_payload() {
         let expr: Arc<dyn PhysicalExpr> = Arc::new(Column::new("host", 0));
 
         let err = DynFilterPayload::from_datafusion_expr(&expr, 1).unwrap_err();
 
-        assert!(matches!(err, DataFusionError::Plan(_)));
+        let DataFusionError::External(error) = err else {
+            panic!("expected external common query error, got: {err:?}");
+        };
+        assert!(matches!(
+            error.downcast_ref::<CommonQueryError>(),
+            Some(CommonQueryError::DynFilterPayloadTooLarge { .. })
+        ));
+    }
+
+    fn contains_expr<T: 'static>(expr: &Arc<dyn PhysicalExpr>) -> bool {
+        let mut found = false;
+        expr.apply(|node| {
+            if node.as_any().is::<T>() {
+                found = true;
+                Ok(TreeNodeRecursion::Stop)
+            } else {
+                Ok(TreeNodeRecursion::Continue)
+            }
+        })
+        .unwrap();
+        found
     }
 }

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -448,6 +448,7 @@ impl DatanodeBuilder {
             opts.concurrent_query_limiter_timeout,
             opts.grpc.flight_compression,
         );
+        region_server.install_remote_dyn_filter_physical_plan_wrapper(&self.plugins);
 
         let object_store_manager = Self::build_object_store_manager(&opts.storage).await?;
         let engines = self

--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -2586,16 +2586,8 @@ mod tests {
         remove_initial_dyn_filter_regs(&regs_by_query, &query_id, region_id, &first_subscription);
 
         let query_regs = regs_by_query.get(&query_id).unwrap();
-        assert!(
-            query_regs
-                .get(&RemoteDynFilterId::new("filter-1"))
-                .is_none()
-        );
-        assert!(
-            query_regs
-                .get(&RemoteDynFilterId::new("filter-2"))
-                .is_some()
-        );
+        assert!(!query_regs.contains_key(&RemoteDynFilterId::new("filter-1")));
+        assert!(query_regs.contains_key(&RemoteDynFilterId::new("filter-2")));
     }
 
     #[tokio::test]
@@ -3577,11 +3569,7 @@ mod tests {
     }
 
     fn contains_filter_exec(plan: &Arc<dyn ExecutionPlan>) -> bool {
-        plan.as_any().is::<FilterExec>()
-            || plan
-                .children()
-                .into_iter()
-                .any(|child| contains_filter_exec(child))
+        plan.as_any().is::<FilterExec>() || plan.children().into_iter().any(contains_filter_exec)
     }
 
     fn sort_with_fetch(input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
@@ -3850,16 +3838,8 @@ mod tests {
         assert_eq!(outcome, RemoteDynFilterUpdateOutcome::Applied);
 
         let query_regs = regs_by_query.get(&query_id).unwrap();
-        assert!(
-            query_regs
-                .get(&RemoteDynFilterId::new("filter-1"))
-                .is_none()
-        );
-        assert!(
-            query_regs
-                .get(&RemoteDynFilterId::new("filter-2"))
-                .is_some()
-        );
+        assert!(!query_regs.contains_key(&RemoteDynFilterId::new("filter-1")));
+        assert!(query_regs.contains_key(&RemoteDynFilterId::new("filter-2")));
     }
 
     #[tokio::test]

--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -13,13 +13,14 @@
 // limitations under the License.
 
 mod catalog;
+mod registrations;
 
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::ops::Deref;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, RwLock, Weak};
 use std::task::{Context, Poll};
 use std::time::Duration;
 
@@ -35,6 +36,7 @@ use api::v1::{ResponseHeader, Status};
 use arrow_flight::{FlightData, Ticket};
 use async_trait::async_trait;
 use bytes::Bytes;
+use common_base::Plugins;
 use common_error::ext::{BoxedError, ErrorExt};
 use common_error::status_code::StatusCode;
 use common_meta::datanode::TopicStatsReporter;
@@ -47,7 +49,13 @@ use common_telemetry::tracing::{self, info_span};
 use common_telemetry::tracing_context::{FutureExt, TracingContext};
 use common_telemetry::{debug, error, info, warn};
 use dashmap::DashMap;
+use datafusion::config::ConfigOptions;
 use datafusion::datasource::TableProvider;
+use datafusion::physical_expr::utils::conjunction;
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_optimizer::filter_pushdown::FilterPushdown;
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::filter::FilterExec;
 use datafusion_common::tree_node::TreeNode;
 use datatypes::schema::SchemaRef;
 use either::Either;
@@ -61,6 +69,7 @@ pub use query::dummy_catalog::{
     DummyCatalogList, DummyTableProviderFactory, TableProviderFactoryRef,
 };
 use query::options::should_collect_region_watermark_from_extensions;
+use query::physical_wrapper::{PhysicalPlanWrapper, PhysicalPlanWrappers, PhysicalPlanWrappersRef};
 use serde_json;
 use servers::error::{
     self as servers_error, ExecuteGrpcRequestSnafu, Result as ServerResult, SuspendedSnafu,
@@ -69,6 +78,7 @@ use servers::grpc::FlightCompression;
 use servers::grpc::flight::{FlightCraft, FlightRecordBatchStream, TonicStream};
 use servers::grpc::region_server::RegionServerHandler;
 use session::context::{QueryContext, QueryContextBuilder, QueryContextRef};
+use session::query_id::QueryId;
 use snafu::{OptionExt, ResultExt, ensure};
 use store_api::metric_engine_consts::{
     FILE_ENGINE_NAME, LOGICAL_TABLE_METADATA_KEY, METRIC_ENGINE_NAME,
@@ -92,12 +102,17 @@ use crate::error::{
     ConcurrentQueryLimiterTimeoutSnafu, DataFusionSnafu, DecodeLogicalPlanSnafu,
     ExecuteLogicalPlanSnafu, FindLogicalRegionsSnafu, GetRegionMetadataSnafu,
     HandleBatchDdlRequestSnafu, HandleBatchOpenRequestSnafu, HandleRegionRequestSnafu,
-    NewPlanDecoderSnafu, NotYetImplementedSnafu, RegionEngineNotFoundSnafu, RegionNotFoundSnafu,
-    RegionNotReadySnafu, Result, SerializeJsonSnafu, StopRegionEngineSnafu, UnexpectedSnafu,
-    UnsupportedOutputSnafu,
+    NewPlanDecoderSnafu, RegionEngineNotFoundSnafu, RegionNotFoundSnafu, RegionNotReadySnafu,
+    Result, SerializeJsonSnafu, StopRegionEngineSnafu, UnexpectedSnafu, UnsupportedOutputSnafu,
 };
 use crate::event_listener::RegionServerEventListenerRef;
 use crate::region_server::catalog::{NameAwareCatalogList, NameAwareDataSourceInjectorBuilder};
+use crate::region_server::registrations::{
+    RemoteDynFilterId, RemoteDynFilterRegistry, RemoteDynFilterUpdateOutcome,
+    apply_remote_dyn_filter_update, initial_dyn_filter_regs_from_query_ctx,
+    register_initial_dyn_filter_regs, remote_dyn_filter_exprs_for_initial_regs,
+    remove_initial_dyn_filter_regs, unregister_remote_dyn_filter,
+};
 
 #[derive(Clone)]
 pub struct RegionServer {
@@ -110,6 +125,60 @@ pub struct RegionStat {
     pub region_id: RegionId,
     pub engine: String,
     pub role: RegionRole,
+}
+
+struct RemoteDynFilterPhysicalPlanWrapper {
+    server: Weak<RegionServerInner>,
+}
+
+impl PhysicalPlanWrapper for RemoteDynFilterPhysicalPlanWrapper {
+    fn wrap(
+        &self,
+        origin: Arc<dyn ExecutionPlan>,
+        ctx: QueryContextRef,
+        config: &ConfigOptions,
+    ) -> Arc<dyn ExecutionPlan> {
+        let Some(query_id) = ctx.remote_query_id_value() else {
+            return origin;
+        };
+
+        let Some(initial_regs) = initial_dyn_filter_regs_from_query_ctx(&ctx) else {
+            return origin;
+        };
+
+        let Some(server) = self.server.upgrade() else {
+            return origin;
+        };
+
+        let input_schema = origin.schema();
+        let dyn_filters = remote_dyn_filter_exprs_for_initial_regs(
+            &server.initial_remote_dyn_filter_registrations,
+            &query_id,
+            &initial_regs,
+            input_schema.as_ref(),
+        );
+
+        if dyn_filters.is_empty() {
+            return origin;
+        }
+
+        let predicate = conjunction(dyn_filters);
+        let filter_plan = match FilterExec::try_new(predicate, Arc::clone(&origin)) {
+            Ok(plan) => Arc::new(plan) as Arc<dyn ExecutionPlan>,
+            Err(error) => {
+                warn!(error; "Failed to build remote dynamic filter FilterExec");
+                return origin;
+            }
+        };
+
+        match FilterPushdown::new().optimize(Arc::clone(&filter_plan), config) {
+            Ok(plan) => plan,
+            Err(error) => {
+                warn!(error; "Failed to push down remote dynamic filters; keeping FilterExec fallback");
+                filter_plan
+            }
+        }
+    }
 }
 
 impl RegionServer {
@@ -153,6 +222,15 @@ impl RegionServer {
             flight_compression,
             suspend: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    pub fn install_remote_dyn_filter_physical_plan_wrapper(&self, plugins: &Plugins) {
+        let wrappers = plugins.get_or_insert::<PhysicalPlanWrappersRef, _>(|| {
+            Arc::new(PhysicalPlanWrappers::default())
+        });
+        wrappers.push(Arc::new(RemoteDynFilterPhysicalPlanWrapper {
+            server: Arc::downgrade(&self.inner),
+        }));
     }
 
     /// Registers an engine.
@@ -245,11 +323,14 @@ impl RegionServer {
             RegionNotReadySnafu { region_id }
         );
 
-        self.inner
+        let provider = self
+            .inner
             .table_provider_factory
             .create(region_id, status.into_engine(), ctx)
             .await
-            .context(ExecuteLogicalPlanSnafu)
+            .context(ExecuteLogicalPlanSnafu)?;
+
+        Ok(provider)
     }
 
     /// Handle reads from remote. They're often query requests received by our Arrow Flight service.
@@ -287,6 +368,30 @@ impl RegionServer {
             .await
             .context(DecodeLogicalPlanSnafu)?;
 
+        let initial_dyn_filter_regs = initial_dyn_filter_regs_from_query_ctx(&query_ctx);
+        let query_id = query_ctx.remote_query_id_value();
+        let registered_filter_ids = if let (Some(query_id), Some(regs)) =
+            (query_id.as_ref(), initial_dyn_filter_regs.as_ref())
+        {
+            register_initial_dyn_filter_regs(
+                &self.inner.initial_remote_dyn_filter_registrations,
+                query_id,
+                region_id,
+                regs,
+            )
+        } else {
+            Vec::new()
+        };
+        let cleanup = match (query_id, registered_filter_ids.is_empty()) {
+            (Some(query_id), false) => Some(RemoteDynFilterCleanup::new(
+                self.clone(),
+                query_id,
+                region_id,
+                registered_filter_ids,
+            )),
+            _ => None,
+        };
+
         let stream = self
             .inner
             .handle_read(
@@ -298,7 +403,13 @@ impl RegionServer {
                 query_ctx.clone(),
             )
             .await?;
+
         let stream = wrap_flow_region_watermark_stream(stream, region_id, &query_ctx);
+        let stream = if let Some(cleanup) = cleanup {
+            wrap_remote_dyn_filter_cleanup_stream(stream, cleanup)
+        } else {
+            stream
+        };
         Ok(maybe_guard_stream(stream, permit))
     }
 
@@ -722,17 +833,26 @@ impl RegionServer {
             return error::MissingRequiredFieldSnafu { name: "query_id" }.fail();
         }
 
+        let query_id = request.query_id.parse::<QueryId>();
+        ensure!(
+            query_id.is_ok(),
+            UnexpectedSnafu {
+                violated: "remote dynamic filter query_id must be a valid QueryId"
+            }
+        );
+        let query_id = query_id.unwrap();
+
         match request
             .action
             .as_ref()
             .context(error::MissingRequiredFieldSnafu { name: "action" })?
         {
             Action::Update(update) => {
-                self.handle_remote_dyn_filter_update(&request.query_id, update)
+                self.handle_remote_dyn_filter_update(&query_id, update)
                     .await
             }
             Action::Unregister(unregister) => {
-                self.handle_remote_dyn_filter_unregister(&request.query_id, unregister)
+                self.handle_remote_dyn_filter_unregister(&query_id, unregister)
                     .await
             }
         }
@@ -740,7 +860,7 @@ impl RegionServer {
 
     async fn handle_remote_dyn_filter_update(
         &self,
-        query_id: &str,
+        query_id: &QueryId,
         request: &api::v1::region::RemoteDynFilterUpdate,
     ) -> Result<RegionResponse> {
         if request.filter_id.is_empty() {
@@ -751,31 +871,96 @@ impl RegionServer {
             return error::MissingRequiredFieldSnafu { name: "payload" }.fail();
         }
 
-        NotYetImplementedSnafu {
-            what: format!(
-                "remote dyn filter update unary RPC placeholder for query_id {query_id}, filter_id {}",
-                request.filter_id
-            ),
-        }
-        .fail()
+        let filter_id = RemoteDynFilterId::new(request.filter_id.clone());
+        let outcome = apply_remote_dyn_filter_update(
+            &self.inner.initial_remote_dyn_filter_registrations,
+            query_id,
+            &filter_id,
+            &request.payload,
+            request.generation,
+            request.is_complete,
+        );
+        self.log_remote_dyn_filter_update_outcome(query_id, &filter_id, outcome);
+
+        Ok(RegionResponse::new(0))
     }
 
     async fn handle_remote_dyn_filter_unregister(
         &self,
-        query_id: &str,
+        query_id: &QueryId,
         request: &api::v1::region::RemoteDynFilterUnregister,
     ) -> Result<RegionResponse> {
         if request.filter_id.is_empty() {
             return error::MissingRequiredFieldSnafu { name: "filter_id" }.fail();
         }
 
-        NotYetImplementedSnafu {
-            what: format!(
-                "remote dyn filter unregister unary RPC placeholder for query_id {query_id}, filter_id {}",
-                request.filter_id
-            ),
+        let filter_id = RemoteDynFilterId::new(request.filter_id.clone());
+        let outcome = unregister_remote_dyn_filter(
+            &self.inner.initial_remote_dyn_filter_registrations,
+            query_id,
+            &filter_id,
+        );
+        self.log_remote_dyn_filter_update_outcome(query_id, &filter_id, outcome);
+
+        Ok(RegionResponse::new(0))
+    }
+
+    fn log_remote_dyn_filter_update_outcome(
+        &self,
+        query_id: &QueryId,
+        filter_id: &RemoteDynFilterId,
+        outcome: RemoteDynFilterUpdateOutcome,
+    ) {
+        match outcome {
+            RemoteDynFilterUpdateOutcome::MissingRegistration => {
+                warn!(
+                    "Remote dynamic filter update had no active registration, query_id: {}, filter_id: {}",
+                    query_id, filter_id
+                );
+            }
+            RemoteDynFilterUpdateOutcome::Buffered => {
+                debug!(
+                    "Buffered early remote dynamic filter update, query_id: {}, filter_id: {}",
+                    query_id, filter_id
+                );
+            }
+            RemoteDynFilterUpdateOutcome::Applied => {
+                debug!(
+                    "Applied remote dynamic filter update, query_id: {}, filter_id: {}",
+                    query_id, filter_id
+                );
+            }
+            RemoteDynFilterUpdateOutcome::Idempotent => {
+                debug!(
+                    "Ignored idempotent remote dynamic filter update, query_id: {}, filter_id: {}",
+                    query_id, filter_id
+                );
+            }
+            RemoteDynFilterUpdateOutcome::Stale => {
+                debug!(
+                    "Discarded stale remote dynamic filter update, query_id: {}, filter_id: {}",
+                    query_id, filter_id
+                );
+            }
+            RemoteDynFilterUpdateOutcome::AlreadyComplete => {
+                warn!(
+                    "Discarded remote dynamic filter update after completion, query_id: {}, filter_id: {}",
+                    query_id, filter_id
+                );
+            }
+            RemoteDynFilterUpdateOutcome::PayloadTooLarge => {
+                warn!(
+                    "Discarded oversized remote dynamic filter update, query_id: {}, filter_id: {}",
+                    query_id, filter_id
+                );
+            }
+            RemoteDynFilterUpdateOutcome::DecodeFailed => {
+                warn!(
+                    "Remote dynamic filter update failed to decode or apply, query_id: {}, filter_id: {}",
+                    query_id, filter_id
+                );
+            }
         }
-        .fail()
     }
 
     /// Sync region manifest and registers new opened logical regions.
@@ -841,6 +1026,101 @@ fn wrap_flow_region_watermark_stream(
         Box::pin(RegionWatermarkStream::new(stream, region_id, seq)) as SendableRecordBatchStream
     } else {
         stream
+    }
+}
+
+fn wrap_remote_dyn_filter_cleanup_stream(
+    stream: SendableRecordBatchStream,
+    cleanup: RemoteDynFilterCleanup,
+) -> SendableRecordBatchStream {
+    Box::pin(RemoteDynFilterCleanupStream { stream, cleanup })
+}
+
+/// Removes query-scoped remote dynamic filter subscriptions unless ownership is moved elsewhere.
+struct RemoteDynFilterCleanup {
+    server: RegionServer,
+    query_id: QueryId,
+    region_id: RegionId,
+    filter_ids: Vec<RemoteDynFilterId>,
+    cleaned: bool,
+}
+
+impl RemoteDynFilterCleanup {
+    fn new(
+        server: RegionServer,
+        query_id: QueryId,
+        region_id: RegionId,
+        filter_ids: Vec<RemoteDynFilterId>,
+    ) -> Self {
+        Self {
+            server,
+            query_id,
+            region_id,
+            filter_ids,
+            cleaned: false,
+        }
+    }
+
+    fn cleanup_once(&mut self) {
+        if self.cleaned {
+            return;
+        }
+
+        remove_initial_dyn_filter_regs(
+            &self.server.inner.initial_remote_dyn_filter_registrations,
+            &self.query_id,
+            self.region_id,
+            &self.filter_ids,
+        );
+        self.cleaned = true;
+    }
+}
+
+impl Drop for RemoteDynFilterCleanup {
+    fn drop(&mut self) {
+        self.cleanup_once();
+    }
+}
+
+/// Removes query-scoped remote dynamic filter subscriptions when a remote read stream is done.
+struct RemoteDynFilterCleanupStream {
+    stream: SendableRecordBatchStream,
+    cleanup: RemoteDynFilterCleanup,
+}
+
+impl RecordBatchStream for RemoteDynFilterCleanupStream {
+    fn name(&self) -> &str {
+        self.stream.name()
+    }
+
+    fn schema(&self) -> datatypes::schema::SchemaRef {
+        self.stream.schema()
+    }
+
+    fn output_ordering(&self) -> Option<&[OrderOption]> {
+        self.stream.output_ordering()
+    }
+
+    fn metrics(&self) -> Option<RecordBatchMetrics> {
+        self.stream.metrics()
+    }
+}
+
+impl Stream for RemoteDynFilterCleanupStream {
+    type Item = common_recordbatch::error::Result<RecordBatch>;
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.stream.size_hint()
+    }
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match Pin::new(&mut self.stream).poll_next(cx) {
+            Poll::Ready(None) => {
+                self.cleanup.cleanup_once();
+                Poll::Ready(None)
+            }
+            other => other,
+        }
     }
 }
 
@@ -1053,6 +1333,9 @@ struct RegionServerInner {
     /// server with a concrete engine; acceptable for now to fetch Mito-specific
     /// info (e.g., list SSTs). Consider a diagnostics trait later.
     mito_engine: RwLock<Option<MitoEngine>>,
+    /// TODO(remote-dyn-filter): Reap this query-scoped placeholder registry on query finish/cancel
+    /// and later fold it into the real remote dyn filter runtime state lifecycle.
+    initial_remote_dyn_filter_registrations: RemoteDynFilterRegistry,
 }
 
 struct RegionServerParallelism {
@@ -1169,6 +1452,7 @@ impl RegionServerInner {
             parallelism,
             topic_stats_reporter: RwLock::new(None),
             mito_engine: RwLock::new(None),
+            initial_remote_dyn_filter_registrations: RemoteDynFilterRegistry::new(),
         }
     }
 
@@ -1904,24 +2188,50 @@ mod tests {
         remote_dyn_filter_request,
     };
     use common_error::ext::ErrorExt;
+    use common_query::request::{
+        DynFilterPayload, INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY,
+        InitialDynFilterReg, InitialDynFilterRegs, InitialDynFilterSnapshot,
+    };
     use common_recordbatch::RecordBatches;
     use common_recordbatch::adapter::{RecordBatchMetrics, RegionWatermarkEntry};
+    use datafusion::arrow::datatypes::Schema as ArrowSchema;
+    use datafusion::physical_expr::expressions::Column;
+    use datafusion::physical_expr::{LexOrdering, PhysicalSortExpr};
+    use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
+    use datafusion::physical_plan::expressions::{DynamicFilterPhysicalExpr, lit as physical_lit};
+    use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
+    use datafusion::physical_plan::sorts::sort::SortExec;
+    use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PhysicalExpr};
     use datatypes::prelude::{ConcreteDataType, VectorRef};
     use datatypes::schema::{ColumnSchema, Schema};
     use datatypes::vectors::Int32Vector;
     use futures_util::StreamExt;
     use mito2::test_util::CreateRequestBuilder;
     use query::options::FLOW_RETURN_REGION_SEQ;
+    use session::context::REMOTE_QUERY_ID_EXTENSION_KEY;
     use store_api::metadata::{ColumnMetadata, RegionMetadata, RegionMetadataBuilder};
-    use store_api::region_engine::RegionEngine;
+    use store_api::region_engine::{
+        PrepareRequest, QueryScanContext, RegionEngine, RegionScanner, ScannerProperties,
+        SinglePartitionScanner,
+    };
     use store_api::region_request::{
         PathType, RegionDropRequest, RegionOpenRequest, RegionTruncateRequest,
     };
-    use store_api::storage::RegionId;
+    use store_api::storage::{RegionId, ScanRequest};
+    use table::table::scan::RegionScanExec;
 
     use super::*;
     use crate::error::Result;
+    use crate::region_server::registrations::REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES;
     use crate::tests::{MockRegionEngine, mock_region_server};
+
+    fn test_remote_query_id() -> QueryId {
+        QueryId::new()
+    }
+
+    fn test_remote_dyn_filter_region_id() -> RegionId {
+        RegionId::new(1024, 7)
+    }
 
     fn single_value_stream() -> SendableRecordBatchStream {
         let schema = Arc::new(Schema::new(vec![ColumnSchema::new(
@@ -2059,6 +2369,233 @@ mod tests {
         while pinned.next().await.is_some() {}
 
         assert!(pinned.as_ref().get_ref().metrics().is_none());
+    }
+
+    #[test]
+    fn initial_dyn_filter_regs_can_be_read_from_query_context() {
+        let mut query_ctx = QueryContext::with("greptime", "public");
+        query_ctx.set_extension(
+            INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY,
+            InitialDynFilterRegs::new(vec![InitialDynFilterReg::new(
+                "filter-1",
+                vec![vec![1, 2, 3]],
+            )])
+            .to_extension_value()
+            .unwrap(),
+        );
+
+        let regs = initial_dyn_filter_regs_from_query_ctx(&Arc::new(query_ctx)).unwrap();
+
+        assert_eq!(regs.regs.len(), 1);
+        assert_eq!(regs.regs[0].filter_id, "filter-1");
+    }
+
+    #[test]
+    fn initial_dyn_filter_regs_from_query_context_rejects_duplicate_filter_ids() {
+        let mut query_ctx = QueryContext::with("greptime", "public");
+        query_ctx.set_extension(
+            INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY,
+            InitialDynFilterRegs::new(vec![
+                InitialDynFilterReg::new("filter-1", vec![vec![1, 2, 3]]),
+                InitialDynFilterReg::new("filter-1", vec![vec![4, 5, 6]]),
+            ])
+            .to_extension_value()
+            .unwrap(),
+        );
+
+        let regs = initial_dyn_filter_regs_from_query_ctx(&Arc::new(query_ctx));
+
+        assert!(regs.is_none());
+    }
+
+    #[test]
+    fn register_initial_dyn_filter_regs_creates_query_scoped_entries() {
+        let regs_by_query = RemoteDynFilterRegistry::new();
+        let regs = InitialDynFilterRegs::new(vec![
+            InitialDynFilterReg::new("filter-1", vec![vec![1, 2, 3]]),
+            InitialDynFilterReg::new("filter-2", vec![vec![4, 5, 6]]),
+        ]);
+        let query_id = test_remote_query_id();
+        let region_id = test_remote_dyn_filter_region_id();
+
+        let registered_filter_ids =
+            register_initial_dyn_filter_regs(&regs_by_query, &query_id, region_id, &regs);
+
+        let query_regs = regs_by_query.get(&query_id).unwrap();
+        assert_eq!(query_regs.len(), 2);
+        assert_eq!(
+            registered_filter_ids,
+            vec![
+                RemoteDynFilterId::new("filter-1"),
+                RemoteDynFilterId::new("filter-2")
+            ]
+        );
+        let registered = query_regs.get(&RemoteDynFilterId::new("filter-1")).unwrap();
+        assert_eq!(registered.filter_id, RemoteDynFilterId::new("filter-1"));
+        assert_eq!(registered.child_exprs_datafusion_proto, vec![vec![1, 2, 3]]);
+        assert_eq!(registered.subscriber_regions.len(), 1);
+        assert!(registered.subscriber_regions.contains(&region_id));
+    }
+
+    #[test]
+    fn register_initial_dyn_filter_regs_same_region_duplicate_is_idempotent() {
+        let regs_by_query = RemoteDynFilterRegistry::new();
+        let regs = InitialDynFilterRegs::new(vec![InitialDynFilterReg::new(
+            "filter-1",
+            vec![vec![1, 2, 3]],
+        )]);
+        let query_id = test_remote_query_id();
+        let region_id = test_remote_dyn_filter_region_id();
+
+        let first = register_initial_dyn_filter_regs(&regs_by_query, &query_id, region_id, &regs);
+        let duplicate =
+            register_initial_dyn_filter_regs(&regs_by_query, &query_id, region_id, &regs);
+
+        let query_regs = regs_by_query.get(&query_id).unwrap();
+        assert_eq!(query_regs.len(), 1);
+        assert_eq!(first, vec![RemoteDynFilterId::new("filter-1")]);
+        assert!(duplicate.is_empty());
+        let registered = query_regs.get(&RemoteDynFilterId::new("filter-1")).unwrap();
+        assert_eq!(registered.subscriber_regions.len(), 1);
+        assert!(registered.subscriber_regions.contains(&region_id));
+    }
+
+    #[test]
+    fn register_initial_dyn_filter_regs_ignores_invalid_duplicate_payload_set() {
+        let regs_by_query = RemoteDynFilterRegistry::new();
+        let regs = InitialDynFilterRegs::new(vec![
+            InitialDynFilterReg::new("filter-1", vec![vec![1, 2, 3]]),
+            InitialDynFilterReg::new("filter-1", vec![vec![4, 5, 6]]),
+        ]);
+        let query_id = test_remote_query_id();
+        let region_id = test_remote_dyn_filter_region_id();
+
+        register_initial_dyn_filter_regs(&regs_by_query, &query_id, region_id, &regs);
+
+        assert!(regs_by_query.get(&query_id).is_none());
+    }
+
+    #[test]
+    fn register_initial_dyn_filter_regs_tracks_different_region_subscribers_for_same_filter() {
+        let regs_by_query = RemoteDynFilterRegistry::new();
+        let regs = InitialDynFilterRegs::new(vec![InitialDynFilterReg::new(
+            "filter-1",
+            vec![vec![1, 2, 3]],
+        )]);
+        let query_id = test_remote_query_id();
+        let first_region_id = RegionId::new(1024, 7);
+        let second_region_id = RegionId::new(1024, 8);
+
+        register_initial_dyn_filter_regs(&regs_by_query, &query_id, first_region_id, &regs);
+        register_initial_dyn_filter_regs(&regs_by_query, &query_id, second_region_id, &regs);
+
+        let query_regs = regs_by_query.get(&query_id).unwrap();
+        assert_eq!(query_regs.len(), 1);
+        let registered = query_regs.get(&RemoteDynFilterId::new("filter-1")).unwrap();
+        assert_eq!(registered.subscriber_regions.len(), 2);
+        assert!(registered.subscriber_regions.contains(&first_region_id));
+        assert!(registered.subscriber_regions.contains(&second_region_id));
+    }
+
+    #[test]
+    fn remove_initial_dyn_filter_regs_removes_registered_filter_entries() {
+        let regs_by_query = RemoteDynFilterRegistry::new();
+        let query_id = test_remote_query_id();
+        let other_query_id = test_remote_query_id();
+        let region_id = test_remote_dyn_filter_region_id();
+
+        let registered_filter_ids = register_initial_dyn_filter_regs(
+            &regs_by_query,
+            &query_id,
+            region_id,
+            &InitialDynFilterRegs::new(vec![InitialDynFilterReg::new(
+                "filter-1",
+                vec![vec![1, 2, 3]],
+            )]),
+        );
+        register_initial_dyn_filter_regs(
+            &regs_by_query,
+            &other_query_id,
+            region_id,
+            &InitialDynFilterRegs::new(vec![InitialDynFilterReg::new(
+                "filter-2",
+                vec![vec![4, 5, 6]],
+            )]),
+        );
+
+        remove_initial_dyn_filter_regs(
+            &regs_by_query,
+            &query_id,
+            region_id,
+            &registered_filter_ids,
+        );
+
+        assert!(regs_by_query.get(&query_id).is_none());
+        let other_query_regs = regs_by_query.get(&other_query_id).unwrap();
+        assert_eq!(other_query_regs.len(), 1);
+    }
+
+    #[test]
+    fn remove_initial_dyn_filter_regs_keeps_other_subscribers() {
+        let regs_by_query = RemoteDynFilterRegistry::new();
+        let query_id = test_remote_query_id();
+        let regs = InitialDynFilterRegs::new(vec![InitialDynFilterReg::new(
+            "filter-1",
+            vec![vec![1, 2, 3]],
+        )]);
+        let first_region_id = RegionId::new(1024, 7);
+        let second_region_id = RegionId::new(1024, 8);
+
+        let first_subscription =
+            register_initial_dyn_filter_regs(&regs_by_query, &query_id, first_region_id, &regs);
+        register_initial_dyn_filter_regs(&regs_by_query, &query_id, second_region_id, &regs);
+
+        remove_initial_dyn_filter_regs(
+            &regs_by_query,
+            &query_id,
+            first_region_id,
+            &first_subscription,
+        );
+
+        let query_regs = regs_by_query.get(&query_id).unwrap();
+        assert_eq!(query_regs.len(), 1);
+        let registered = query_regs.get(&RemoteDynFilterId::new("filter-1")).unwrap();
+        assert_eq!(registered.subscriber_regions.len(), 1);
+        assert!(registered.subscriber_regions.contains(&second_region_id));
+    }
+
+    #[test]
+    fn remove_initial_remote_dyn_filter_regs_keeps_other_filters_for_same_query() {
+        let regs_by_query = RemoteDynFilterRegistry::new();
+        let query_id = test_remote_query_id();
+        let region_id = test_remote_dyn_filter_region_id();
+
+        let first_subscription = register_initial_dyn_filter_regs(
+            &regs_by_query,
+            &query_id,
+            region_id,
+            &InitialDynFilterRegs::new(vec![InitialDynFilterReg::new("filter-1", vec![])]),
+        );
+        register_initial_dyn_filter_regs(
+            &regs_by_query,
+            &query_id,
+            region_id,
+            &InitialDynFilterRegs::new(vec![InitialDynFilterReg::new("filter-2", vec![])]),
+        );
+
+        remove_initial_dyn_filter_regs(&regs_by_query, &query_id, region_id, &first_subscription);
+
+        let query_regs = regs_by_query.get(&query_id).unwrap();
+        assert!(
+            query_regs
+                .get(&RemoteDynFilterId::new("filter-1"))
+                .is_none()
+        );
+        assert!(
+            query_regs
+                .get(&RemoteDynFilterId::new("filter-2"))
+                .is_some()
+        );
     }
 
     #[tokio::test]
@@ -2715,7 +3252,7 @@ mod tests {
 
         let err = mock_region_server
             .handle_remote_dyn_filter_request(&RemoteDynFilterRequest {
-                query_id: "query-1".to_string(),
+                query_id: test_remote_query_id().to_string(),
                 action: None,
             })
             .await
@@ -2733,7 +3270,7 @@ mod tests {
 
         let err = mock_region_server
             .handle_remote_dyn_filter_request(&RemoteDynFilterRequest {
-                query_id: "query-1".to_string(),
+                query_id: test_remote_query_id().to_string(),
                 action: Some(remote_dyn_filter_request::Action::Update(
                     RemoteDynFilterUpdate {
                         filter_id: String::new(),
@@ -2758,7 +3295,7 @@ mod tests {
 
         let err = mock_region_server
             .handle_remote_dyn_filter_request(&RemoteDynFilterRequest {
-                query_id: "query-1".to_string(),
+                query_id: test_remote_query_id().to_string(),
                 action: Some(remote_dyn_filter_request::Action::Update(
                     RemoteDynFilterUpdate {
                         filter_id: "filter-1".to_string(),
@@ -2778,12 +3315,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handle_remote_dyn_filter_update_placeholder() {
+    async fn test_handle_remote_dyn_filter_update_no_registration() {
         let mock_region_server = mock_region_server();
 
-        let err = mock_region_server
+        let response = mock_region_server
             .handle_remote_dyn_filter_request(&RemoteDynFilterRequest {
-                query_id: "query-1".to_string(),
+                query_id: test_remote_query_id().to_string(),
                 action: Some(remote_dyn_filter_request::Action::Update(
                     RemoteDynFilterUpdate {
                         filter_id: "filter-1".to_string(),
@@ -2794,18 +3331,18 @@ mod tests {
                 )),
             })
             .await
-            .unwrap_err();
+            .unwrap();
 
-        assert_matches!(err, crate::error::Error::NotYetImplemented { .. });
+        assert_eq!(response.affected_rows, 0);
     }
 
     #[tokio::test]
-    async fn test_handle_remote_dyn_filter_unregister_placeholder() {
+    async fn test_handle_remote_dyn_filter_unregister_no_registration() {
         let mock_region_server = mock_region_server();
 
-        let err = mock_region_server
+        let response = mock_region_server
             .handle_remote_dyn_filter_request(&RemoteDynFilterRequest {
-                query_id: "query-1".to_string(),
+                query_id: test_remote_query_id().to_string(),
                 action: Some(remote_dyn_filter_request::Action::Unregister(
                     RemoteDynFilterUnregister {
                         filter_id: "filter-1".to_string(),
@@ -2813,8 +3350,657 @@ mod tests {
                 )),
             })
             .await
-            .unwrap_err();
+            .unwrap();
 
-        assert_matches!(err, crate::error::Error::NotYetImplemented { .. });
+        assert_eq!(response.affected_rows, 0);
+    }
+
+    #[test]
+    fn test_apply_remote_dyn_filter_update_missing_registration() {
+        let regs_by_query = RemoteDynFilterRegistry::new();
+        let query_id = test_remote_query_id();
+        let filter_id = RemoteDynFilterId::new("filter-1");
+
+        let outcome =
+            apply_remote_dyn_filter_update(&regs_by_query, &query_id, &filter_id, &[1], 1, false);
+        assert_eq!(outcome, RemoteDynFilterUpdateOutcome::MissingRegistration);
+
+        let outcome = unregister_remote_dyn_filter(&regs_by_query, &query_id, &filter_id);
+        assert_eq!(outcome, RemoteDynFilterUpdateOutcome::MissingRegistration);
+    }
+
+    #[test]
+    fn test_apply_remote_dyn_filter_update_buffering_before_scan() {
+        let regs_by_query = RemoteDynFilterRegistry::new();
+        let regs = InitialDynFilterRegs::new(vec![InitialDynFilterReg::new(
+            "filter-1",
+            vec![vec![1, 2, 3]],
+        )]);
+        let query_id = test_remote_query_id();
+        let filter_id = RemoteDynFilterId::new("filter-1");
+
+        register_initial_dyn_filter_regs(
+            &regs_by_query,
+            &query_id,
+            test_remote_dyn_filter_region_id(),
+            &regs,
+        );
+
+        // First update with generation 1: should be Buffered (no runtime installed yet)
+        let outcome =
+            apply_remote_dyn_filter_update(&regs_by_query, &query_id, &filter_id, &[1], 1, false);
+        assert_eq!(outcome, RemoteDynFilterUpdateOutcome::Buffered);
+
+        // Update with generation 0: should be Stale (older than pending generation 1)
+        let outcome =
+            apply_remote_dyn_filter_update(&regs_by_query, &query_id, &filter_id, &[2], 0, false);
+        assert_eq!(outcome, RemoteDynFilterUpdateOutcome::Stale);
+
+        // Update with generation 1 again: should be Idempotent (same generation)
+        let outcome =
+            apply_remote_dyn_filter_update(&regs_by_query, &query_id, &filter_id, &[3], 1, false);
+        assert_eq!(outcome, RemoteDynFilterUpdateOutcome::Idempotent);
+    }
+
+    fn datafusion_payload_bytes(expr: Arc<dyn PhysicalExpr>) -> Vec<u8> {
+        match DynFilterPayload::from_datafusion_expr(&expr, REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES)
+            .unwrap()
+        {
+            DynFilterPayload::Datafusion(bytes) => bytes,
+            _ => unreachable!(
+                "DynFilterPayload::from_datafusion_expr only returns datafusion payloads"
+            ),
+        }
+    }
+
+    fn empty_arrow_schema() -> ArrowSchema {
+        ArrowSchema::empty()
+    }
+
+    fn register_empty_remote_dyn_filter(
+        regs_by_query: &RemoteDynFilterRegistry,
+        query_id: &QueryId,
+    ) -> Vec<RemoteDynFilterId> {
+        register_empty_remote_dyn_filter_for_region(
+            regs_by_query,
+            query_id,
+            test_remote_dyn_filter_region_id(),
+        )
+    }
+
+    fn register_empty_remote_dyn_filter_for_region(
+        regs_by_query: &RemoteDynFilterRegistry,
+        query_id: &QueryId,
+        region_id: RegionId,
+    ) -> Vec<RemoteDynFilterId> {
+        register_initial_dyn_filter_regs(
+            regs_by_query,
+            query_id,
+            region_id,
+            &InitialDynFilterRegs::new(vec![InitialDynFilterReg::new("filter-1", vec![])]),
+        )
+    }
+
+    #[test]
+    fn initial_remote_dyn_filter_snapshot_initializes_runtime_filter() {
+        let regs_by_query = RemoteDynFilterRegistry::new();
+        let query_id = test_remote_query_id();
+        let payload = DynFilterPayload::Datafusion(datafusion_payload_bytes(physical_lit(false)));
+        let regs = InitialDynFilterRegs::new(vec![
+            InitialDynFilterReg::new("filter-1", vec![])
+                .with_initial_snapshot(InitialDynFilterSnapshot::new(payload, 7, false)),
+        ]);
+
+        register_initial_dyn_filter_regs(
+            &regs_by_query,
+            &query_id,
+            test_remote_dyn_filter_region_id(),
+            &regs,
+        );
+        let exprs = remote_dyn_filter_exprs_for_initial_regs(
+            &regs_by_query,
+            &query_id,
+            &regs,
+            &empty_arrow_schema(),
+        );
+
+        assert_eq!(exprs.len(), 1);
+        assert_eq!(format!("{}", exprs[0]), "DynamicFilter [ false ]");
+    }
+
+    struct DynFilterAcceptingScanner {
+        inner: SinglePartitionScanner,
+    }
+
+    impl std::fmt::Debug for DynFilterAcceptingScanner {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "DynFilterAcceptingScanner")
+        }
+    }
+
+    impl DisplayAs for DynFilterAcceptingScanner {
+        fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            self.inner.fmt_as(t, f)
+        }
+    }
+
+    impl RegionScanner for DynFilterAcceptingScanner {
+        fn name(&self) -> &str {
+            self.inner.name()
+        }
+
+        fn properties(&self) -> &ScannerProperties {
+            self.inner.properties()
+        }
+
+        fn schema(&self) -> Arc<Schema> {
+            self.inner.schema()
+        }
+
+        fn metadata(&self) -> Arc<RegionMetadata> {
+            self.inner.metadata()
+        }
+
+        fn prepare(&mut self, request: PrepareRequest) -> std::result::Result<(), BoxedError> {
+            self.inner.prepare(request)
+        }
+
+        fn scan_partition(
+            &self,
+            ctx: &QueryScanContext,
+            metrics_set: &ExecutionPlanMetricsSet,
+            partition: usize,
+        ) -> std::result::Result<SendableRecordBatchStream, BoxedError> {
+            self.inner.scan_partition(ctx, metrics_set, partition)
+        }
+
+        fn has_predicate_without_region(&self) -> bool {
+            self.inner.has_predicate_without_region()
+        }
+
+        fn add_dyn_filter_to_predicate(
+            &mut self,
+            filter_exprs: Vec<Arc<dyn PhysicalExpr>>,
+        ) -> Vec<bool> {
+            vec![true; filter_exprs.len()]
+        }
+
+        fn set_logical_region(&mut self, logical_region: bool) {
+            self.inner.set_logical_region(logical_region)
+        }
+    }
+
+    fn region_scan_exec(region_id: RegionId) -> Arc<RegionScanExec> {
+        let scanner = Box::new(DynFilterAcceptingScanner {
+            inner: SinglePartitionScanner::new(
+                single_value_stream(),
+                false,
+                Arc::new(mock_region_metadata(region_id)),
+                None,
+            ),
+        });
+        Arc::new(RegionScanExec::new(scanner, ScanRequest::default(), None).unwrap())
+    }
+
+    fn remote_dyn_filter_query_ctx(
+        query_id: &QueryId,
+        regs: &InitialDynFilterRegs,
+    ) -> QueryContextRef {
+        Arc::new(
+            QueryContextBuilder::default()
+                .set_extension(
+                    REMOTE_QUERY_ID_EXTENSION_KEY.to_string(),
+                    query_id.to_string(),
+                )
+                .set_extension(
+                    INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY.to_string(),
+                    regs.to_extension_value().unwrap(),
+                )
+                .build(),
+        )
+    }
+
+    fn wrap_remote_dyn_filter_plan(
+        server: &RegionServer,
+        plan: Arc<dyn ExecutionPlan>,
+        query_id: &QueryId,
+        regs: &InitialDynFilterRegs,
+    ) -> Arc<dyn ExecutionPlan> {
+        let wrapper = RemoteDynFilterPhysicalPlanWrapper {
+            server: Arc::downgrade(&server.inner),
+        };
+        wrapper.wrap(
+            plan,
+            remote_dyn_filter_query_ctx(query_id, regs),
+            &ConfigOptions::default(),
+        )
+    }
+
+    fn contains_filter_exec(plan: &Arc<dyn ExecutionPlan>) -> bool {
+        plan.as_any().is::<FilterExec>()
+            || plan
+                .children()
+                .into_iter()
+                .any(|child| contains_filter_exec(child))
+    }
+
+    fn sort_with_fetch(input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+        let ordering =
+            LexOrdering::new([PhysicalSortExpr::new_default(
+                Arc::new(Column::new("timestamp", 0)) as Arc<dyn PhysicalExpr>,
+            )])
+            .unwrap();
+        Arc::new(SortExec::new(ordering, input).with_fetch(Some(1)))
+    }
+
+    fn only_remote_dyn_filter(
+        regs_by_query: &RemoteDynFilterRegistry,
+        query_id: &QueryId,
+    ) -> Arc<DynamicFilterPhysicalExpr> {
+        let initial_regs =
+            InitialDynFilterRegs::new(vec![InitialDynFilterReg::new("filter-1", vec![])]);
+        let exprs = remote_dyn_filter_exprs_for_initial_regs(
+            regs_by_query,
+            query_id,
+            &initial_regs,
+            &empty_arrow_schema(),
+        );
+        assert_eq!(1, exprs.len());
+        let expr = exprs.into_iter().next().unwrap();
+        let expr = expr as Arc<dyn std::any::Any + Send + Sync>;
+        expr.downcast::<DynamicFilterPhysicalExpr>().unwrap()
+    }
+
+    #[test]
+    fn test_remote_dyn_filter_filter_exec_pushes_through_transparent_node() {
+        let mock_region_server = mock_region_server();
+        let query_id = test_remote_query_id();
+        let region_id = RegionId::new(1024, 7);
+        let regs = InitialDynFilterRegs::new(vec![InitialDynFilterReg::new("filter-1", vec![])]);
+        register_empty_remote_dyn_filter(
+            &mock_region_server
+                .inner
+                .initial_remote_dyn_filter_registrations,
+            &query_id,
+        );
+
+        let scan = region_scan_exec(region_id);
+        let plan = Arc::new(CoalescePartitionsExec::new(scan)) as Arc<dyn ExecutionPlan>;
+        let wrapped = wrap_remote_dyn_filter_plan(&mock_region_server, plan, &query_id, &regs);
+
+        assert!(wrapped.as_any().is::<CoalescePartitionsExec>());
+        assert!(!contains_filter_exec(&wrapped));
+
+        let payload = datafusion_payload_bytes(physical_lit(false));
+        let outcome = apply_remote_dyn_filter_update(
+            &mock_region_server
+                .inner
+                .initial_remote_dyn_filter_registrations,
+            &query_id,
+            &RemoteDynFilterId::new("filter-1"),
+            &payload,
+            0,
+            false,
+        );
+        assert_eq!(outcome, RemoteDynFilterUpdateOutcome::Applied);
+    }
+
+    #[test]
+    fn test_remote_dyn_filter_filter_exec_stays_above_pushdown_barrier() {
+        let mock_region_server = mock_region_server();
+        let query_id = test_remote_query_id();
+        let region_id = RegionId::new(1024, 7);
+        let regs = InitialDynFilterRegs::new(vec![InitialDynFilterReg::new("filter-1", vec![])]);
+        register_empty_remote_dyn_filter(
+            &mock_region_server
+                .inner
+                .initial_remote_dyn_filter_registrations,
+            &query_id,
+        );
+
+        let scan: Arc<dyn ExecutionPlan> = region_scan_exec(region_id);
+        let plan = sort_with_fetch(scan);
+        let wrapped = wrap_remote_dyn_filter_plan(&mock_region_server, plan, &query_id, &regs);
+
+        let filter = wrapped.as_any().downcast_ref::<FilterExec>().unwrap();
+        assert!(filter.input().as_any().is::<SortExec>());
+
+        let payload = datafusion_payload_bytes(physical_lit(false));
+        let outcome = apply_remote_dyn_filter_update(
+            &mock_region_server
+                .inner
+                .initial_remote_dyn_filter_registrations,
+            &query_id,
+            &RemoteDynFilterId::new("filter-1"),
+            &payload,
+            0,
+            false,
+        );
+        assert_eq!(outcome, RemoteDynFilterUpdateOutcome::Applied);
+    }
+
+    #[test]
+    fn test_remote_dyn_filter_rejects_oversized_payload_before_buffering() {
+        let regs_by_query = RemoteDynFilterRegistry::new();
+        let query_id = test_remote_query_id();
+        let filter_id = RemoteDynFilterId::new("filter-1");
+        register_empty_remote_dyn_filter(&regs_by_query, &query_id);
+
+        let oversized = vec![0; REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES + 1];
+        let outcome = apply_remote_dyn_filter_update(
+            &regs_by_query,
+            &query_id,
+            &filter_id,
+            &oversized,
+            1,
+            false,
+        );
+        assert_eq!(outcome, RemoteDynFilterUpdateOutcome::PayloadTooLarge);
+
+        // The rejected generation must not become the pending generation.
+        let outcome =
+            apply_remote_dyn_filter_update(&regs_by_query, &query_id, &filter_id, &[1], 0, false);
+        assert_eq!(outcome, RemoteDynFilterUpdateOutcome::Buffered);
+    }
+
+    #[test]
+    fn test_remote_dyn_filter_generation_zero_applies_as_first_update() {
+        let regs_by_query = RemoteDynFilterRegistry::new();
+        let query_id = test_remote_query_id();
+        let filter_id = RemoteDynFilterId::new("filter-1");
+        register_empty_remote_dyn_filter(&regs_by_query, &query_id);
+
+        // Installing the wrapper before the update exercises the runtime apply path directly.
+        let dyn_filter = only_remote_dyn_filter(&regs_by_query, &query_id);
+        let payload = datafusion_payload_bytes(physical_lit(false));
+        let outcome = apply_remote_dyn_filter_update(
+            &regs_by_query,
+            &query_id,
+            &filter_id,
+            &payload,
+            0,
+            false,
+        );
+
+        assert_eq!(outcome, RemoteDynFilterUpdateOutcome::Applied);
+        assert!(dyn_filter.snapshot_generation() > 1);
+        assert_eq!(format!("{}", dyn_filter.current().unwrap()), "false");
+    }
+
+    #[test]
+    fn test_buffered_update_applies_when_scan_installs_wrapper() {
+        let regs_by_query = RemoteDynFilterRegistry::new();
+        let query_id = test_remote_query_id();
+        let filter_id = RemoteDynFilterId::new("filter-1");
+        register_empty_remote_dyn_filter(&regs_by_query, &query_id);
+
+        let payload = datafusion_payload_bytes(physical_lit(false));
+        let outcome = apply_remote_dyn_filter_update(
+            &regs_by_query,
+            &query_id,
+            &filter_id,
+            &payload,
+            1,
+            false,
+        );
+        assert_eq!(outcome, RemoteDynFilterUpdateOutcome::Buffered);
+
+        let dyn_filter = only_remote_dyn_filter(&regs_by_query, &query_id);
+        assert!(dyn_filter.snapshot_generation() > 1);
+        assert_eq!(format!("{}", dyn_filter.current().unwrap()), "false");
+    }
+
+    #[test]
+    fn test_unregister_completes_installed_remote_dyn_filter_without_relaxing() {
+        let regs_by_query = RemoteDynFilterRegistry::new();
+        let query_id = test_remote_query_id();
+        let filter_id = RemoteDynFilterId::new("filter-1");
+        register_empty_remote_dyn_filter(&regs_by_query, &query_id);
+
+        let dyn_filter = only_remote_dyn_filter(&regs_by_query, &query_id);
+        let payload = datafusion_payload_bytes(physical_lit(false));
+        let outcome = apply_remote_dyn_filter_update(
+            &regs_by_query,
+            &query_id,
+            &filter_id,
+            &payload,
+            1,
+            false,
+        );
+        assert_eq!(outcome, RemoteDynFilterUpdateOutcome::Applied);
+        assert_eq!(format!("{}", dyn_filter.current().unwrap()), "false");
+
+        let outcome = unregister_remote_dyn_filter(&regs_by_query, &query_id, &filter_id);
+        assert_eq!(outcome, RemoteDynFilterUpdateOutcome::Applied);
+        assert!(regs_by_query.get(&query_id).is_none());
+        assert_eq!(format!("{}", dyn_filter.current().unwrap()), "false");
+    }
+
+    #[test]
+    fn test_remote_dyn_filter_unregister_removes_all_region_subscribers_for_filter() {
+        let regs_by_query = RemoteDynFilterRegistry::new();
+        let query_id = test_remote_query_id();
+        let filter_id = RemoteDynFilterId::new("filter-1");
+        let first_region_id = RegionId::new(1024, 7);
+        let second_region_id = RegionId::new(1024, 8);
+        let regs = InitialDynFilterRegs::new(vec![InitialDynFilterReg::new("filter-1", vec![])]);
+
+        let first_subscription =
+            register_initial_dyn_filter_regs(&regs_by_query, &query_id, first_region_id, &regs);
+        let second_subscription =
+            register_initial_dyn_filter_regs(&regs_by_query, &query_id, second_region_id, &regs);
+        let dyn_filter = only_remote_dyn_filter(&regs_by_query, &query_id);
+
+        let payload = datafusion_payload_bytes(physical_lit(false));
+        let outcome = apply_remote_dyn_filter_update(
+            &regs_by_query,
+            &query_id,
+            &filter_id,
+            &payload,
+            1,
+            false,
+        );
+        assert_eq!(outcome, RemoteDynFilterUpdateOutcome::Applied);
+
+        let outcome = unregister_remote_dyn_filter(&regs_by_query, &query_id, &filter_id);
+        assert_eq!(outcome, RemoteDynFilterUpdateOutcome::Applied);
+        assert!(regs_by_query.get(&query_id).is_none());
+        assert_eq!(format!("{}", dyn_filter.current().unwrap()), "false");
+
+        // Stream-local cleanup may run after FE's peer-deduplicated unregister. It should be benign.
+        remove_initial_dyn_filter_regs(
+            &regs_by_query,
+            &query_id,
+            first_region_id,
+            &first_subscription,
+        );
+        remove_initial_dyn_filter_regs(
+            &regs_by_query,
+            &query_id,
+            second_region_id,
+            &second_subscription,
+        );
+        assert!(regs_by_query.get(&query_id).is_none());
+    }
+
+    #[test]
+    fn test_remote_dyn_filter_unregister_keeps_other_filters_for_same_query() {
+        let regs_by_query = RemoteDynFilterRegistry::new();
+        let query_id = test_remote_query_id();
+        let region_id = test_remote_dyn_filter_region_id();
+
+        register_initial_dyn_filter_regs(
+            &regs_by_query,
+            &query_id,
+            region_id,
+            &InitialDynFilterRegs::new(vec![InitialDynFilterReg::new("filter-1", vec![])]),
+        );
+        register_initial_dyn_filter_regs(
+            &regs_by_query,
+            &query_id,
+            region_id,
+            &InitialDynFilterRegs::new(vec![InitialDynFilterReg::new("filter-2", vec![])]),
+        );
+
+        let outcome = unregister_remote_dyn_filter(
+            &regs_by_query,
+            &query_id,
+            &RemoteDynFilterId::new("filter-1"),
+        );
+        assert_eq!(outcome, RemoteDynFilterUpdateOutcome::Applied);
+
+        let query_regs = regs_by_query.get(&query_id).unwrap();
+        assert!(
+            query_regs
+                .get(&RemoteDynFilterId::new("filter-1"))
+                .is_none()
+        );
+        assert!(
+            query_regs
+                .get(&RemoteDynFilterId::new("filter-2"))
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_remote_dyn_filter_cleanup_stream_removes_on_eof() {
+        let mock_region_server = mock_region_server();
+        let query_id = test_remote_query_id();
+        let region_id = test_remote_dyn_filter_region_id();
+        let registered_filter_ids = register_empty_remote_dyn_filter(
+            &mock_region_server
+                .inner
+                .initial_remote_dyn_filter_registrations,
+            &query_id,
+        );
+        let cleanup = RemoteDynFilterCleanup::new(
+            mock_region_server.clone(),
+            query_id,
+            region_id,
+            registered_filter_ids,
+        );
+
+        let stream = wrap_remote_dyn_filter_cleanup_stream(single_value_stream(), cleanup);
+        let mut pinned = Box::pin(stream);
+        while pinned.next().await.is_some() {}
+
+        assert!(
+            mock_region_server
+                .inner
+                .initial_remote_dyn_filter_registrations
+                .get(&query_id)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_remote_dyn_filter_cleanup_stream_removes_on_drop() {
+        let mock_region_server = mock_region_server();
+        let query_id = test_remote_query_id();
+        let region_id = test_remote_dyn_filter_region_id();
+        let registered_filter_ids = register_empty_remote_dyn_filter(
+            &mock_region_server
+                .inner
+                .initial_remote_dyn_filter_registrations,
+            &query_id,
+        );
+        let cleanup = RemoteDynFilterCleanup::new(
+            mock_region_server.clone(),
+            query_id,
+            region_id,
+            registered_filter_ids,
+        );
+
+        let stream = wrap_remote_dyn_filter_cleanup_stream(single_value_stream(), cleanup);
+        drop(stream);
+
+        assert!(
+            mock_region_server
+                .inner
+                .initial_remote_dyn_filter_registrations
+                .get(&query_id)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_remote_dyn_filter_cleanup_guard_removes_on_drop_before_stream_wrap() {
+        let mock_region_server = mock_region_server();
+        let query_id = test_remote_query_id();
+        let region_id = test_remote_dyn_filter_region_id();
+        let registered_filter_ids = register_empty_remote_dyn_filter(
+            &mock_region_server
+                .inner
+                .initial_remote_dyn_filter_registrations,
+            &query_id,
+        );
+
+        let cleanup = RemoteDynFilterCleanup::new(
+            mock_region_server.clone(),
+            query_id,
+            region_id,
+            registered_filter_ids,
+        );
+        drop(cleanup);
+
+        assert!(
+            mock_region_server
+                .inner
+                .initial_remote_dyn_filter_registrations
+                .get(&query_id)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_remote_dyn_filter_multi_region_subscription_cleanup() {
+        let regs_by_query = RemoteDynFilterRegistry::new();
+        let regs = InitialDynFilterRegs::new(vec![InitialDynFilterReg::new(
+            "filter-1",
+            vec![vec![1, 2, 3]],
+        )]);
+        let query_id = test_remote_query_id();
+        let first_region_id = RegionId::new(1024, 7);
+        let second_region_id = RegionId::new(1024, 8);
+
+        // Register the same logical filter for two regions on the same datanode.
+        let first_subscription =
+            register_initial_dyn_filter_regs(&regs_by_query, &query_id, first_region_id, &regs);
+        let second_subscription =
+            register_initial_dyn_filter_regs(&regs_by_query, &query_id, second_region_id, &regs);
+
+        // Verify only one filter entry exists and both region subscribers are tracked explicitly.
+        {
+            let query_regs = regs_by_query.get(&query_id).unwrap();
+            assert_eq!(query_regs.len(), 1);
+            let registered = query_regs.get(&RemoteDynFilterId::new("filter-1")).unwrap();
+            assert_eq!(registered.subscriber_regions.len(), 2);
+            assert!(registered.subscriber_regions.contains(&first_region_id));
+            assert!(registered.subscriber_regions.contains(&second_region_id));
+        }
+
+        // One region cleanup should not drop the entry while another region is subscribed.
+        remove_initial_dyn_filter_regs(
+            &regs_by_query,
+            &query_id,
+            first_region_id,
+            &first_subscription,
+        );
+        assert!(regs_by_query.get(&query_id).is_some());
+        {
+            let query_regs = regs_by_query.get(&query_id).unwrap();
+            let registered = query_regs.get(&RemoteDynFilterId::new("filter-1")).unwrap();
+            assert_eq!(registered.subscriber_regions.len(), 1);
+            assert!(registered.subscriber_regions.contains(&second_region_id));
+        }
+
+        // Last region cleanup should drop the entry.
+        remove_initial_dyn_filter_regs(
+            &regs_by_query,
+            &query_id,
+            second_region_id,
+            &second_subscription,
+        );
+        assert!(regs_by_query.get(&query_id).is_none());
     }
 }

--- a/src/datanode/src/region_server/registrations.rs
+++ b/src/datanode/src/region_server/registrations.rs
@@ -1,0 +1,682 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::hash_map::Entry;
+use std::collections::{HashMap, HashSet};
+use std::fmt::{Display, Formatter};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use common_query::request::{
+    DynFilterPayload, INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY, InitialDynFilterReg,
+    InitialDynFilterRegs,
+};
+use common_telemetry::warn;
+use dashmap::DashMap;
+use datafusion::arrow::datatypes::{Schema, SchemaRef};
+use datafusion::execution::{SessionStateBuilder, TaskContext};
+use datafusion::physical_plan::PhysicalExpr;
+use datafusion::physical_plan::expressions::{DynamicFilterPhysicalExpr, lit};
+use datafusion_common::Result as DataFusionResult;
+use session::context::QueryContextRef;
+use session::query_id::QueryId;
+use store_api::storage::RegionId;
+
+pub(super) const REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES: usize = 64 * 1024;
+
+type QueryRemoteDynFilterRegs = HashMap<RemoteDynFilterId, RegisteredDynFilter>;
+
+#[derive(Debug, Default)]
+pub(super) struct RemoteDynFilterRegistry {
+    // Keep cross-query concurrency while making each query's RDF state machine a
+    // single critical section. RDF count per query is small
+    queries: DashMap<QueryId, Arc<Mutex<QueryRemoteDynFilterRegs>>>,
+}
+
+impl RemoteDynFilterRegistry {
+    pub(super) fn new() -> Self {
+        Self::default()
+    }
+
+    fn get_or_insert_query(&self, query_id: QueryId) -> Arc<Mutex<QueryRemoteDynFilterRegs>> {
+        self.queries
+            .entry(query_id)
+            .or_insert_with(|| Arc::new(Mutex::new(HashMap::new())))
+            .clone()
+    }
+
+    fn get_query(&self, query_id: &QueryId) -> Option<Arc<Mutex<QueryRemoteDynFilterRegs>>> {
+        self.queries
+            .get(query_id)
+            .map(|query_regs| query_regs.clone())
+    }
+
+    fn remove_query_if_empty(
+        &self,
+        query_id: &QueryId,
+        expected: &Arc<Mutex<QueryRemoteDynFilterRegs>>,
+    ) {
+        // Protect against stale cleanup of an old per-query state: remove the
+        // outer entry only if it still points to the same inner mutex and that
+        // inner map is still empty.
+        self.queries.remove_if(query_id, |_, query_regs| {
+            Arc::ptr_eq(query_regs, expected) && query_regs.lock().unwrap().is_empty()
+        });
+    }
+
+    #[cfg(test)]
+    pub(super) fn get(
+        &self,
+        query_id: &QueryId,
+    ) -> Option<HashMap<RemoteDynFilterId, RegisteredDynFilter>> {
+        self.get_query(query_id)
+            .map(|query_regs| query_regs.lock().unwrap().clone())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(super) struct RemoteDynFilterId(String);
+
+impl RemoteDynFilterId {
+    pub(super) fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+}
+
+impl Display for RemoteDynFilterId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RemoteDynFilterUpdateOutcome {
+    MissingRegistration,
+    Buffered,
+    Applied,
+    Idempotent,
+    Stale,
+    AlreadyComplete,
+    PayloadTooLarge,
+    DecodeFailed,
+}
+
+#[derive(Debug, Clone)]
+struct PendingDynFilterUpdate {
+    payload: Vec<u8>,
+    generation: u64,
+    is_complete: bool,
+}
+
+impl PendingDynFilterUpdate {
+    fn from_initial_reg(reg: &InitialDynFilterReg) -> Option<Self> {
+        let snapshot = reg.initial_snapshot.as_ref()?;
+        match &snapshot.payload {
+            DynFilterPayload::Datafusion(payload) => Some(Self {
+                payload: payload.clone(),
+                generation: snapshot.generation,
+                is_complete: snapshot.is_complete,
+            }),
+            #[allow(unreachable_patterns)]
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct RemoteDynFilterEpochState {
+    generation: Option<u64>,
+    is_complete: bool,
+}
+
+#[derive(Debug)]
+struct RemoteDynFilterState {
+    filter: Arc<DynamicFilterPhysicalExpr>,
+    input_schema: SchemaRef,
+    epoch: Mutex<RemoteDynFilterEpochState>,
+}
+
+impl RemoteDynFilterState {
+    fn new(filter: Arc<DynamicFilterPhysicalExpr>, input_schema: SchemaRef) -> Self {
+        Self {
+            filter,
+            input_schema,
+            epoch: Mutex::new(RemoteDynFilterEpochState {
+                generation: None,
+                is_complete: false,
+            }),
+        }
+    }
+
+    fn filter(&self) -> Arc<DynamicFilterPhysicalExpr> {
+        self.filter.clone()
+    }
+
+    fn apply_update(
+        &self,
+        payload: &[u8],
+        generation: u64,
+        is_complete: bool,
+    ) -> RemoteDynFilterUpdateOutcome {
+        if !validate_update_payload_size(payload) {
+            return RemoteDynFilterUpdateOutcome::PayloadTooLarge;
+        }
+
+        let mut epoch = self.epoch.lock().unwrap();
+        if let Some(current_generation) = epoch.generation {
+            if generation < current_generation {
+                return RemoteDynFilterUpdateOutcome::Stale;
+            }
+
+            if generation == current_generation {
+                if is_complete && !epoch.is_complete {
+                    self.filter.mark_complete();
+                    epoch.is_complete = true;
+                    return RemoteDynFilterUpdateOutcome::Applied;
+                }
+                return RemoteDynFilterUpdateOutcome::Idempotent;
+            }
+        }
+
+        if epoch.is_complete {
+            return RemoteDynFilterUpdateOutcome::AlreadyComplete;
+        }
+
+        let expr = match decode_update_payload(payload, self.input_schema.as_ref()) {
+            Ok(expr) => expr,
+            Err(error) => {
+                warn!(error; "Failed to decode remote dynamic filter update payload");
+                return RemoteDynFilterUpdateOutcome::DecodeFailed;
+            }
+        };
+
+        if let Err(error) = self.filter.update(expr) {
+            warn!(error; "Failed to apply remote dynamic filter update");
+            return RemoteDynFilterUpdateOutcome::DecodeFailed;
+        }
+
+        epoch.generation = Some(generation);
+        if is_complete {
+            self.filter.mark_complete();
+            epoch.is_complete = true;
+        }
+
+        RemoteDynFilterUpdateOutcome::Applied
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct RegisteredDynFilter {
+    pub(super) filter_id: RemoteDynFilterId,
+    pub(super) child_exprs_datafusion_proto: Vec<Vec<u8>>,
+    pub(super) subscriber_regions: HashSet<RegionId>,
+    runtime: Option<Arc<RemoteDynFilterState>>,
+    pending_update: Option<PendingDynFilterUpdate>,
+}
+
+impl RegisteredDynFilter {
+    fn new(
+        filter_id: RemoteDynFilterId,
+        child_exprs_datafusion_proto: Vec<Vec<u8>>,
+        pending_update: Option<PendingDynFilterUpdate>,
+        region_id: RegionId,
+    ) -> Self {
+        let mut subscriber_regions = HashSet::new();
+        subscriber_regions.insert(region_id);
+
+        Self {
+            filter_id,
+            child_exprs_datafusion_proto,
+            subscriber_regions,
+            runtime: None,
+            pending_update,
+        }
+    }
+
+    fn apply_initial_snapshot(
+        &mut self,
+        reg: &InitialDynFilterReg,
+    ) -> RemoteDynFilterUpdateOutcome {
+        let Some(snapshot) = PendingDynFilterUpdate::from_initial_reg(reg) else {
+            return RemoteDynFilterUpdateOutcome::Idempotent;
+        };
+
+        self.apply_or_buffer_update(&snapshot.payload, snapshot.generation, snapshot.is_complete)
+    }
+
+    fn register_subscriber(&mut self, region_id: RegionId) -> bool {
+        if !self.subscriber_regions.insert(region_id) {
+            warn!(
+                "Duplicate remote dynamic filter subscriber region, filter_id: {}, region_id: {}",
+                self.filter_id, region_id
+            );
+            return false;
+        }
+
+        true
+    }
+
+    fn has_subscribers(&self) -> bool {
+        !self.subscriber_regions.is_empty()
+    }
+
+    fn should_drop_after_remove(&mut self, region_id: RegionId) -> bool {
+        self.subscriber_regions.remove(&region_id);
+        !self.has_subscribers()
+    }
+
+    fn buffer_update(
+        &mut self,
+        payload: &[u8],
+        generation: u64,
+        is_complete: bool,
+    ) -> RemoteDynFilterUpdateOutcome {
+        if !validate_update_payload_size(payload) {
+            return RemoteDynFilterUpdateOutcome::PayloadTooLarge;
+        }
+
+        if let Some(pending) = self.pending_update.as_mut() {
+            if generation < pending.generation {
+                return RemoteDynFilterUpdateOutcome::Stale;
+            }
+
+            if generation == pending.generation {
+                pending.is_complete |= is_complete;
+                return RemoteDynFilterUpdateOutcome::Idempotent;
+            }
+
+            if pending.is_complete {
+                return RemoteDynFilterUpdateOutcome::AlreadyComplete;
+            }
+        }
+
+        self.pending_update = Some(PendingDynFilterUpdate {
+            payload: payload.to_vec(),
+            generation,
+            is_complete,
+        });
+        RemoteDynFilterUpdateOutcome::Buffered
+    }
+
+    fn apply_or_buffer_update(
+        &mut self,
+        payload: &[u8],
+        generation: u64,
+        is_complete: bool,
+    ) -> RemoteDynFilterUpdateOutcome {
+        if let Some(runtime) = &self.runtime {
+            return runtime.apply_update(payload, generation, is_complete);
+        }
+
+        self.buffer_update(payload, generation, is_complete)
+    }
+
+    fn decode_children(
+        &self,
+        input_schema: &Schema,
+    ) -> DataFusionResult<Vec<Arc<dyn PhysicalExpr>>> {
+        InitialDynFilterReg::new(
+            self.filter_id.to_string(),
+            self.child_exprs_datafusion_proto.clone(),
+        )
+        .decode_children(
+            remote_dyn_filter_task_context(),
+            input_schema,
+            REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES,
+        )
+    }
+
+    fn dyn_filter(&mut self, input_schema: &Schema) -> Option<Arc<dyn PhysicalExpr>> {
+        let children = match self.decode_children(input_schema) {
+            Ok(children) => children,
+            Err(error) => {
+                warn!(error; "Failed to decode remote dynamic filter initial children");
+                return None;
+            }
+        };
+
+        let runtime = match &self.runtime {
+            Some(runtime) => runtime.clone(),
+            None => {
+                let filter = Arc::new(DynamicFilterPhysicalExpr::new(children.clone(), lit(true)));
+                let runtime = Arc::new(RemoteDynFilterState::new(
+                    filter,
+                    Arc::new(input_schema.clone()),
+                ));
+                if let Some(pending) = self.pending_update.take() {
+                    let outcome = runtime.apply_update(
+                        &pending.payload,
+                        pending.generation,
+                        pending.is_complete,
+                    );
+                    if matches!(outcome, RemoteDynFilterUpdateOutcome::DecodeFailed) {
+                        warn!(
+                            "Dropped buffered remote dynamic filter update after decode failure, filter_id: {}, generation: {}",
+                            self.filter_id, pending.generation
+                        );
+                    }
+                }
+                self.runtime = Some(runtime.clone());
+                runtime
+            }
+        };
+
+        match runtime.filter().with_new_children(children) {
+            Ok(expr) => Some(expr),
+            Err(error) => {
+                warn!(error; "Failed to remap remote dynamic filter children for scan");
+                None
+            }
+        }
+    }
+
+    fn deactivate(&self) {
+        if let Some(runtime) = &self.runtime {
+            runtime.filter.mark_complete();
+        }
+    }
+}
+
+pub(super) fn initial_dyn_filter_regs_from_query_ctx(
+    query_ctx: &QueryContextRef,
+) -> Option<InitialDynFilterRegs> {
+    let registrations =
+        query_ctx.extension(INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY)?;
+    match InitialDynFilterRegs::from_extension_value(registrations) {
+        Ok(registrations) => match registrations.validate_default_bounds() {
+            Ok(()) => Some(registrations),
+            Err(error) => {
+                warn!(error; "Initial remote dyn filter registrations exceeded Task 03 bounds");
+                None
+            }
+        },
+        Err(error) => {
+            warn!(error; "Failed to decode initial remote dyn filter registrations from query context");
+            None
+        }
+    }
+}
+
+pub(super) fn register_initial_dyn_filter_regs(
+    regs_by_query: &RemoteDynFilterRegistry,
+    query_id: &QueryId,
+    region_id: RegionId,
+    regs: &InitialDynFilterRegs,
+) -> Vec<RemoteDynFilterId> {
+    if regs.is_empty() {
+        return Vec::new();
+    }
+
+    if let Err(error) = regs.validate_default_bounds() {
+        warn!(error; "Ignored invalid initial dyn filter registrations for query_id {}", query_id);
+        return Vec::new();
+    }
+
+    let query_regs = regs_by_query.get_or_insert_query(*query_id);
+    let mut query_regs = query_regs.lock().unwrap();
+    let mut registered_filter_ids = Vec::with_capacity(regs.regs.len());
+
+    for reg in &regs.regs {
+        let filter_id = RemoteDynFilterId::new(reg.filter_id.clone());
+        match query_regs.entry(filter_id.clone()) {
+            Entry::Occupied(mut entry) => {
+                let registered = entry.get_mut();
+                if registered.child_exprs_datafusion_proto != reg.child_exprs_datafusion_proto {
+                    warn!(
+                        "Remote dynamic filter registration reused filter_id with different children, query_id: {}, filter_id: {}, region_id: {}",
+                        query_id, filter_id, region_id
+                    );
+                }
+                if registered.register_subscriber(region_id) {
+                    registered_filter_ids.push(filter_id);
+                }
+                let _ = registered.apply_initial_snapshot(reg);
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(RegisteredDynFilter::new(
+                    filter_id.clone(),
+                    reg.child_exprs_datafusion_proto.clone(),
+                    PendingDynFilterUpdate::from_initial_reg(reg),
+                    region_id,
+                ));
+                registered_filter_ids.push(filter_id);
+            }
+        }
+    }
+
+    registered_filter_ids
+}
+
+pub(super) fn remote_dyn_filter_exprs_for_initial_regs(
+    regs_by_query: &RemoteDynFilterRegistry,
+    query_id: &QueryId,
+    initial_regs: &InitialDynFilterRegs,
+    input_schema: &Schema,
+) -> Vec<Arc<dyn PhysicalExpr>> {
+    let Some(query_regs) = regs_by_query.get_query(query_id) else {
+        return Vec::new();
+    };
+
+    let mut query_regs = query_regs.lock().unwrap();
+    initial_regs
+        .regs
+        .iter()
+        .filter_map(|reg| {
+            let filter_id = RemoteDynFilterId::new(reg.filter_id.clone());
+            let registered = query_regs.get_mut(&filter_id)?;
+            registered.dyn_filter(input_schema)
+        })
+        .collect()
+}
+
+pub(super) fn apply_remote_dyn_filter_update(
+    regs_by_query: &RemoteDynFilterRegistry,
+    query_id: &QueryId,
+    filter_id: &RemoteDynFilterId,
+    payload: &[u8],
+    generation: u64,
+    is_complete: bool,
+) -> RemoteDynFilterUpdateOutcome {
+    if !validate_update_payload_size(payload) {
+        warn!(
+            "Ignored oversized remote dynamic filter update, query_id: {}, filter_id: {}, payload_size: {}, max_payload_size: {}",
+            query_id,
+            filter_id,
+            payload.len(),
+            REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES
+        );
+        return RemoteDynFilterUpdateOutcome::PayloadTooLarge;
+    }
+
+    let Some(query_regs) = regs_by_query.get_query(query_id) else {
+        warn!(
+            "Ignored remote dynamic filter update without query registration, query_id: {}, filter_id: {}",
+            query_id, filter_id
+        );
+        return RemoteDynFilterUpdateOutcome::MissingRegistration;
+    };
+
+    let mut query_regs = query_regs.lock().unwrap();
+    let Some(registered) = query_regs.get_mut(filter_id) else {
+        warn!(
+            "Ignored remote dynamic filter update without filter registration, query_id: {}, filter_id: {}",
+            query_id, filter_id
+        );
+        return RemoteDynFilterUpdateOutcome::MissingRegistration;
+    };
+
+    registered.apply_or_buffer_update(payload, generation, is_complete)
+}
+
+pub(super) fn unregister_remote_dyn_filter(
+    regs_by_query: &RemoteDynFilterRegistry,
+    query_id: &QueryId,
+    filter_id: &RemoteDynFilterId,
+) -> RemoteDynFilterUpdateOutcome {
+    let Some(query_regs) = regs_by_query.get_query(query_id) else {
+        warn!(
+            "Ignored remote dynamic filter unregister without query registration, query_id: {}, filter_id: {}",
+            query_id, filter_id
+        );
+        return RemoteDynFilterUpdateOutcome::MissingRegistration;
+    };
+
+    let (registered, should_remove_query) = {
+        let mut locked = query_regs.lock().unwrap();
+        let Some(registered) = locked.remove(filter_id) else {
+            warn!(
+                "Ignored remote dynamic filter unregister without filter registration, query_id: {}, filter_id: {}",
+                query_id, filter_id
+            );
+            return RemoteDynFilterUpdateOutcome::MissingRegistration;
+        };
+        let should_remove_query = locked.is_empty();
+        (registered, should_remove_query)
+    };
+
+    registered.deactivate();
+    if should_remove_query {
+        regs_by_query.remove_query_if_empty(query_id, &query_regs);
+    }
+
+    RemoteDynFilterUpdateOutcome::Applied
+}
+
+pub(super) fn remove_initial_dyn_filter_regs(
+    regs_by_query: &RemoteDynFilterRegistry,
+    query_id: &QueryId,
+    region_id: RegionId,
+    filter_ids: &[RemoteDynFilterId],
+) {
+    if filter_ids.is_empty() {
+        return;
+    }
+
+    let Some(query_regs) = regs_by_query.get_query(query_id) else {
+        return;
+    };
+
+    let (removed_filters, should_remove_query) = {
+        let mut locked = query_regs.lock().unwrap();
+        let mut removed_filters = Vec::new();
+
+        for filter_id in filter_ids {
+            let should_remove_filter = locked
+                .get_mut(filter_id)
+                .map(|registered| registered.should_drop_after_remove(region_id))
+                .unwrap_or(false);
+
+            if should_remove_filter && let Some(registered) = locked.remove(filter_id) {
+                removed_filters.push(registered);
+            }
+        }
+
+        let should_remove_query = locked.is_empty();
+        (removed_filters, should_remove_query)
+    };
+
+    for registered in removed_filters {
+        registered.deactivate();
+    }
+
+    if should_remove_query {
+        regs_by_query.remove_query_if_empty(query_id, &query_regs);
+    }
+}
+
+fn decode_update_payload(
+    payload: &[u8],
+    input_schema: &Schema,
+) -> DataFusionResult<Arc<dyn PhysicalExpr>> {
+    DynFilterPayload::Datafusion(payload.to_vec()).decode_datafusion_expr(
+        remote_dyn_filter_task_context(),
+        input_schema,
+        REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES,
+    )
+}
+
+fn remote_dyn_filter_task_context() -> &'static TaskContext {
+    static TASK_CONTEXT: OnceLock<TaskContext> = OnceLock::new();
+
+    TASK_CONTEXT.get_or_init(|| {
+        // RDF payloads can contain DataFusion built-in scalar functions. For
+        // example, multi-column join dynamic filters use `struct(...) IN (...)`.
+        // `TaskContext::default()` has an empty function registry and cannot
+        // decode those expressions.
+        let session_state = SessionStateBuilder::new().with_default_features().build();
+        TaskContext::from(&session_state)
+    })
+}
+
+fn validate_update_payload_size(payload: &[u8]) -> bool {
+    payload.len() <= REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remote_dyn_filter_same_query_reuses_one_inner_lock() {
+        let regs_by_query = RemoteDynFilterRegistry::new();
+        let query_id = QueryId::new();
+
+        let first = regs_by_query.get_or_insert_query(query_id);
+        let second = regs_by_query.get_or_insert_query(query_id);
+
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[test]
+    fn remote_dyn_filter_stale_query_remove_does_not_remove_new_query_state() {
+        let regs_by_query = RemoteDynFilterRegistry::new();
+        let query_id = QueryId::new();
+        let stale_query_regs = regs_by_query.get_or_insert_query(query_id);
+
+        regs_by_query.remove_query_if_empty(&query_id, &stale_query_regs);
+        assert!(regs_by_query.get_query(&query_id).is_none());
+
+        let new_query_regs = regs_by_query.get_or_insert_query(query_id);
+        let filter_id = RemoteDynFilterId::new("filter-1");
+        let region_id = RegionId::new(1024, 7);
+        new_query_regs.lock().unwrap().insert(
+            filter_id.clone(),
+            RegisteredDynFilter::new(filter_id.clone(), vec![], None, region_id),
+        );
+
+        regs_by_query.remove_query_if_empty(&query_id, &stale_query_regs);
+
+        let current_query_regs = regs_by_query.get_query(&query_id).unwrap();
+        assert!(Arc::ptr_eq(&current_query_regs, &new_query_regs));
+        assert_eq!(current_query_regs.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn remote_dyn_filter_register_uses_entry_to_merge_same_filter_subscribers() {
+        let regs_by_query = RemoteDynFilterRegistry::new();
+        let query_id = QueryId::new();
+        let first_region_id = RegionId::new(1024, 7);
+        let second_region_id = RegionId::new(1024, 8);
+        let regs = InitialDynFilterRegs::new(vec![InitialDynFilterReg::new("filter-1", vec![])]);
+
+        register_initial_dyn_filter_regs(&regs_by_query, &query_id, first_region_id, &regs);
+        register_initial_dyn_filter_regs(&regs_by_query, &query_id, second_region_id, &regs);
+
+        let query_regs = regs_by_query.get(&query_id).unwrap();
+        assert_eq!(query_regs.len(), 1);
+        let registered = query_regs.get(&RemoteDynFilterId::new("filter-1")).unwrap();
+        assert_eq!(registered.subscriber_regions.len(), 2);
+        assert!(registered.subscriber_regions.contains(&first_region_id));
+        assert!(registered.subscriber_regions.contains(&second_region_id));
+    }
+}

--- a/src/query/src/datafusion.rs
+++ b/src/query/src/datafusion.rs
@@ -64,7 +64,7 @@ use crate::metrics::{
     OnDone, QUERY_STAGE_ELAPSED, maybe_attach_region_watermark_metrics,
     should_collect_region_watermark_from_query_ctx,
 };
-use crate::physical_wrapper::PhysicalPlanWrapperRef;
+use crate::physical_wrapper::PhysicalPlanWrappersRef;
 use crate::planner::{DfLogicalPlanner, LogicalPlanner};
 use crate::query_engine::{DescribeResult, QueryEngineContext, QueryEngineState};
 use crate::{QueryEngine, metrics};
@@ -98,8 +98,12 @@ impl DatafusionQueryEngine {
         let physical_plan = self.create_physical_plan(&mut ctx, &plan).await?;
         let optimized_physical_plan = self.optimize_physical_plan(&mut ctx, physical_plan)?;
 
-        let physical_plan = if let Some(wrapper) = self.plugins.get::<PhysicalPlanWrapperRef>() {
-            wrapper.wrap(optimized_physical_plan, query_ctx)
+        let physical_plan = if let Some(wrappers) = self.plugins.get::<PhysicalPlanWrappersRef>() {
+            wrappers.wrap(
+                optimized_physical_plan,
+                query_ctx,
+                ctx.state().config_options(),
+            )
         } else {
             optimized_physical_plan
         };

--- a/src/query/src/dist_plan/merge_scan.rs
+++ b/src/query/src/dist_plan/merge_scan.rs
@@ -397,6 +397,13 @@ impl MergeScanExec {
                     })?;
                 let do_get_cost = do_get_start.elapsed();
 
+                if let Some(remote_dyn_filter_registry_lease) =
+                    remote_dyn_filter_registry_lease.as_ref()
+                {
+                    remote_dyn_filter_registry_lease
+                        .ensure_fanout_task(region_query_handler.clone());
+                }
+
                 ready_timer.stop();
 
                 let mut poll_duration = Duration::ZERO;

--- a/src/query/src/dist_plan/merge_scan.rs
+++ b/src/query/src/dist_plan/merge_scan.rs
@@ -85,6 +85,23 @@ fn acquire_remote_dyn_filter_registry_lease(
     )
 }
 
+fn query_context_for_remote_dyn_filter_region(
+    query_ctx: &QueryContextRef,
+    region_id: RegionId,
+    remote_dyn_filter_registry_lease: Option<&RemoteDynFilterRegistryLease>,
+    captured_dyn_filters: &[CapturedDynFilter],
+) -> session::context::QueryContext {
+    if let Some(remote_dyn_filter_registry_lease) = remote_dyn_filter_registry_lease {
+        register_dyn_filters_for_region(
+            remote_dyn_filter_registry_lease.registry(),
+            region_id,
+            captured_dyn_filters,
+        );
+    }
+
+    query_context_with_initial_dyn_filter_regs(query_ctx, region_id, captured_dyn_filters)
+}
+
 #[derive(Debug, Hash, PartialOrd, PartialEq, Eq, Clone)]
 pub struct MergeScanLogicalPlan {
     /// In logical plan phase it only contains one input
@@ -346,25 +363,16 @@ impl MergeScanExec {
                 .step_by(target_partition)
                 .copied()
             {
-                if let Some(remote_dyn_filter_registry_lease) =
-                    remote_dyn_filter_registry_lease.as_ref()
-                {
-                    register_dyn_filters_for_region(
-                        remote_dyn_filter_registry_lease.registry(),
-                        region_id,
-                        &captured_remote_dyn_filters,
-                    );
-                }
-
                 let region_span = tracing_context.attach(tracing::info_span!(
                     parent: &Span::current(),
                     "merge_scan_region",
                     region_id = %region_id,
                     partition = partition
                 ));
-                let region_query_ctx = query_context_with_initial_dyn_filter_regs(
+                let region_query_ctx = query_context_for_remote_dyn_filter_region(
                     &query_ctx,
                     region_id,
+                    remote_dyn_filter_registry_lease.as_ref(),
                     &captured_remote_dyn_filters,
                 );
                 let request = QueryRequest {
@@ -876,6 +884,7 @@ mod tests {
     use std::collections::BTreeSet;
 
     use async_trait::async_trait;
+    use common_query::request::INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY;
     use datafusion::config::ConfigOptions;
     use datafusion::execution::SessionStateBuilder;
     use datafusion::physical_plan::filter_pushdown::ChildFilterPushdownResult;
@@ -892,11 +901,52 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
-    use crate::dist_plan::DynFilterRegistryManager;
+    use crate::dist_plan::{DynFilterRegistryManager, Subscriber};
     use crate::region_query::RegionQueryHandler;
 
     fn test_query_id(value: u128) -> QueryId {
         QueryId::from(Uuid::from_u128(value))
+    }
+
+    #[test]
+    fn remote_dyn_filter_region_query_context_registers_before_do_get() {
+        let registry_manager = Arc::new(DynFilterRegistryManager::default());
+        let query_ctx = QueryContext::arc();
+        let query_id = query_ctx
+            .remote_query_id_value()
+            .expect("query context must have remote query id");
+        let lease = registry_manager.acquire_lease(query_id);
+        let region_id = RegionId::new(1024, 7);
+        let dyn_filter = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![Arc::new(Column::new("host", 0)) as Arc<_>],
+            physical_lit(true) as _,
+        )) as Arc<dyn datafusion_physical_expr::PhysicalExpr>;
+        let captured = capture_remote_dyn_filters_for_pushdown(
+            RemoteDynFilterProducerId::new(42),
+            vec![dyn_filter],
+        );
+        assert_eq!(captured.captured_dyn_filters.len(), 1);
+
+        let region_query_ctx = query_context_for_remote_dyn_filter_region(
+            &query_ctx,
+            region_id,
+            Some(&lease),
+            &captured.captured_dyn_filters,
+        );
+
+        let entries = lease.registry().entries();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].subscribers(), vec![Subscriber::new(region_id)]);
+        assert!(
+            !entries[0].fanout_started_for_test(),
+            "fanout must start only after do_get succeeds"
+        );
+        assert!(
+            region_query_ctx
+                .extension(INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY)
+                .is_some(),
+            "initial RDF registrations must be present in the do_get query context"
+        );
     }
 
     #[test]

--- a/src/query/src/dist_plan/remote_dyn_filter_registry.rs
+++ b/src/query/src/dist_plan/remote_dyn_filter_registry.rs
@@ -14,8 +14,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, RwLock, Weak};
+use std::sync::{Arc, Mutex, RwLock, Weak};
 use std::time::Duration;
 
 use api::v1::region::{RemoteDynFilterUnregister, RemoteDynFilterUpdate};
@@ -33,7 +32,8 @@ use crate::region_query::RegionQueryHandlerRef;
 
 const REMOTE_DYN_FILTER_UPDATE_PAYLOAD_MAX_BYTES: usize = 64 * 1024;
 const REMOTE_DYN_FILTER_RECONCILE_INTERVAL: Duration = Duration::from_secs(1);
-const REMOTE_DYN_FILTER_CONTROL_RPC_TIMEOUT: Duration = Duration::from_secs(30);
+/// Bound best-effort RDF control RPCs so one bad subscriber cannot stall fanout.
+const REMOTE_DYN_FILTER_CONTROL_RPC_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Region subscribed to a remote dynamic filter.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -73,10 +73,15 @@ pub struct DynFilterEntry {
     filter_id: FilterId,
     producer_filter: Weak<DynamicFilterPhysicalExpr>,
     subscribers: RwLock<HashSet<Subscriber>>,
-    last_sent_generation: AtomicU64,
-    unregistered: AtomicBool,
-    fanout_started: AtomicBool,
+    state: Mutex<DynFilterEntryState>,
     subscriber_changed: Notify,
+}
+
+#[derive(Debug, Default)]
+struct DynFilterEntryState {
+    last_sent_generation: u64,
+    unregistered: bool,
+    fanout_started: bool,
 }
 
 #[derive(Debug)]
@@ -90,9 +95,7 @@ impl DynFilterEntry {
             filter_id,
             producer_filter: Arc::downgrade(&producer_filter),
             subscribers: RwLock::new(HashSet::new()),
-            last_sent_generation: AtomicU64::new(0),
-            unregistered: AtomicBool::new(false),
-            fanout_started: AtomicBool::new(false),
+            state: Mutex::new(DynFilterEntryState::default()),
             subscriber_changed: Notify::new(),
         }
     }
@@ -115,43 +118,48 @@ impl DynFilterEntry {
     }
 
     fn mark_generation_sent(&self, generation: u64) -> bool {
-        let mut current = self.last_sent_generation.load(Ordering::SeqCst);
-        loop {
-            if generation <= current {
-                return false;
-            }
-
-            match self.last_sent_generation.compare_exchange(
-                current,
-                generation,
-                Ordering::SeqCst,
-                Ordering::SeqCst,
-            ) {
-                Ok(_) => return true,
-                Err(next) => current = next,
-            }
+        let mut state = self.state.lock().unwrap();
+        if generation <= state.last_sent_generation {
+            return false;
         }
+
+        state.last_sent_generation = generation;
+        true
     }
 
     fn try_mark_unregistered(&self) -> bool {
-        self.unregistered
-            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-            .is_ok()
+        let mut state = self.state.lock().unwrap();
+        if state.unregistered {
+            return false;
+        }
+
+        state.unregistered = true;
+        true
     }
 
     fn reactivate_for_new_subscriber(&self) {
-        self.last_sent_generation.store(0, Ordering::SeqCst);
-        self.unregistered.store(false, Ordering::SeqCst);
+        {
+            let mut state = self.state.lock().unwrap();
+            // Reset generation/unregister state so late subscribers get the current snapshot.
+            state.last_sent_generation = 0;
+            state.unregistered = false;
+        }
         self.subscriber_changed.notify_one();
     }
 
     fn mark_fanout_started(&self) -> bool {
-        !self.fanout_started.swap(true, Ordering::SeqCst)
+        let mut state = self.state.lock().unwrap();
+        if state.fanout_started {
+            return false;
+        }
+
+        state.fanout_started = true;
+        true
     }
 
     #[cfg(test)]
     pub(crate) fn fanout_started_for_test(&self) -> bool {
-        self.fanout_started.load(Ordering::SeqCst)
+        self.state.lock().unwrap().fanout_started
     }
 }
 
@@ -165,6 +173,7 @@ pub struct QueryDynFilterRegistry {
 
 impl QueryDynFilterRegistry {
     pub fn new(query_id: QueryId) -> Self {
+        // Close-only lifecycle signal; dropping the registry closes it for watchers.
         let (lifecycle_tx, _) = watch::channel(());
         Self {
             query_id,
@@ -260,6 +269,7 @@ impl QueryDynFilterRegistry {
             filter,
             is_complete,
             &mut lifecycle_rx,
+            REMOTE_DYN_FILTER_CONTROL_RPC_TIMEOUT,
         )
         .await;
     }
@@ -294,12 +304,12 @@ async fn run_entry_fanout(
     mut lifecycle_rx: watch::Receiver<()>,
 ) {
     let mut is_complete = false;
-    // `interval()` ticks immediately for the first tick. Start after one full interval so the
-    // reconcile branch remains a periodic fallback instead of an eager re-poll right after fanout.
+    // Start reconcile after one interval and skip missed ticks; it is only a coalescing fallback.
     let mut reconcile_interval = tokio::time::interval_at(
         tokio::time::Instant::now() + REMOTE_DYN_FILTER_RECONCILE_INTERVAL,
         REMOTE_DYN_FILTER_RECONCILE_INTERVAL,
     );
+    reconcile_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     loop {
         let Some(filter) = entry.upgrade_producer_filter() else {
@@ -314,6 +324,7 @@ async fn run_entry_fanout(
             &filter,
             is_complete,
             &mut lifecycle_rx,
+            REMOTE_DYN_FILTER_CONTROL_RPC_TIMEOUT,
         )
         .await
         {
@@ -359,11 +370,15 @@ async fn fanout_snapshot_for_query(
     filter: &DynamicFilterPhysicalExpr,
     is_complete: bool,
     lifecycle_rx: &mut watch::Receiver<()>,
+    control_rpc_timeout: Duration,
 ) -> bool {
     let Some((generation, current)) = current_stable_snapshot(filter, lifecycle_rx).await else {
         return true;
     };
 
+    // The entry-global watermark advances before best-effort fanout. A timed-out
+    // subscriber may miss this generation; later/complete snapshots supersede it,
+    // and RDF only prunes.
     if !is_complete && !entry.mark_generation_sent(generation) {
         return true;
     }
@@ -395,10 +410,12 @@ async fn fanout_snapshot_for_query(
         is_complete,
         payload,
         lifecycle_rx,
+        control_rpc_timeout,
     )
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn fanout_update_for_query(
     query_id: QueryId,
     region_query_handler: &RegionQueryHandlerRef,
@@ -407,6 +424,7 @@ async fn fanout_update_for_query(
     is_complete: bool,
     payload: Vec<u8>,
     lifecycle_rx: &mut watch::Receiver<()>,
+    control_rpc_timeout: Duration,
 ) -> bool {
     let query_id = query_id.to_string();
     let filter_id = entry.filter_id().to_string();
@@ -419,7 +437,7 @@ async fn fanout_update_for_query(
             is_complete,
         };
 
-        let Some(result) = await_control_rpc_or_lifecycle_close(
+        match await_control_rpc_or_lifecycle_close(
             lifecycle_rx,
             format!(
                 "update query_id={} filter_id={} region_id={}",
@@ -432,20 +450,23 @@ async fn fanout_update_for_query(
                 query_id.clone(),
                 update,
             ),
+            control_rpc_timeout,
         )
         .await
-        else {
-            return false;
-        };
-
-        if let Err(error) = result {
-            warn!(
-                error;
-                "Failed to fan out remote dynamic filter update, query_id={}, filter_id={}, region_id={}",
-                query_id,
-                filter_id,
-                subscriber.region_id()
-            );
+        {
+            ControlRpcResult::Ok(result) => {
+                if let Err(error) = result {
+                    warn!(
+                        error;
+                        "Failed to fan out remote dynamic filter update, query_id={}, filter_id={}, region_id={}",
+                        query_id,
+                        filter_id,
+                        subscriber.region_id()
+                    );
+                }
+            }
+            ControlRpcResult::TimedOut => {}
+            ControlRpcResult::LifecycleClosed => return false,
         }
     }
 
@@ -501,13 +522,20 @@ async fn unregister_entry_once_for_query(
     debug!("Remote dynamic filter producer unregistered subscribers");
 }
 
+enum ControlRpcResult<T> {
+    Ok(T),
+    TimedOut,
+    LifecycleClosed,
+}
+
 async fn await_control_rpc_or_lifecycle_close<T>(
     lifecycle_rx: &mut watch::Receiver<()>,
     operation: String,
     rpc: impl Future<Output = T>,
-) -> Option<T> {
+    control_rpc_timeout: Duration,
+) -> ControlRpcResult<T> {
     if lifecycle_rx.has_changed().is_err() {
-        return None;
+        return ControlRpcResult::LifecycleClosed;
     }
 
     tokio::select! {
@@ -516,12 +544,12 @@ async fn await_control_rpc_or_lifecycle_close<T>(
             if result.is_err() {
                 debug!("Cancelled remote dynamic filter control RPC after lifecycle close");
             }
-            None
+            ControlRpcResult::LifecycleClosed
         }
-        result = rpc => Some(result),
-        _ = tokio::time::sleep(REMOTE_DYN_FILTER_CONTROL_RPC_TIMEOUT) => {
+        result = rpc => ControlRpcResult::Ok(result),
+        _ = tokio::time::sleep(control_rpc_timeout) => {
             warn!("Timed out remote dynamic filter control RPC: {}", operation);
-            None
+            ControlRpcResult::TimedOut
         }
     }
 }
@@ -1263,7 +1291,7 @@ mod tests {
         lease.ensure_fanout_task(handler.clone() as RegionQueryHandlerRef);
         lease.ensure_fanout_task(handler.clone() as RegionQueryHandlerRef);
 
-        assert!(entry.fanout_started.load(Ordering::SeqCst));
+        assert!(entry.fanout_started_for_test());
         handler.wait_for_update_count(1).await;
         tokio::time::sleep(Duration::from_millis(50)).await;
         assert_eq!(handler.updates().len(), 1);
@@ -1437,6 +1465,96 @@ mod tests {
         assert_eq!(unregisters[0].region_id, subscriber.region_id());
         assert_eq!(unregisters[0].filter_id, filter_id.to_string());
         wait_for_registry_drop(registry_weak).await;
+    }
+
+    #[tokio::test]
+    async fn update_timeout_does_not_stop_fanout_for_other_subscribers() {
+        let query_id = test_query_id(9);
+        let registry = QueryDynFilterRegistry::new(query_id);
+        let filter = test_dyn_filter(&["host"]);
+        let filter_id = test_filter_id(1);
+        let entry = match registry.register_remote_dyn_filter(filter_id.clone(), filter.clone()) {
+            EntryRegistration::Inserted(entry) => entry,
+            other => panic!("unexpected registration result: {other:?}"),
+        };
+        let first_subscriber = Subscriber::new(RegionId::new(1024, 7));
+        let second_subscriber = Subscriber::new(RegionId::new(1024, 8));
+        assert_eq!(
+            registry.register_subscriber(&filter_id, first_subscriber.clone()),
+            SubscriberRegistration::Added
+        );
+        assert_eq!(
+            registry.register_subscriber(&filter_id, second_subscriber.clone()),
+            SubscriberRegistration::Added
+        );
+
+        let handler = Arc::new(RecordingRegionQueryHandler::default());
+        let handler_ref = handler.clone() as RegionQueryHandlerRef;
+        let mut lifecycle_rx = registry.lifecycle_tx.subscribe();
+        handler.block_next_update();
+        assert!(
+            fanout_snapshot_for_query(
+                query_id,
+                &handler_ref,
+                &entry,
+                filter.as_ref(),
+                false,
+                &mut lifecycle_rx,
+                Duration::from_millis(100),
+            )
+            .await
+        );
+
+        handler.wait_for_blocked_update().await;
+        // Fanout is serial and the blocked RPC stays blocked; the second update proves
+        // timeout continued to the next subscriber.
+        handler.wait_for_update_count(2).await;
+
+        let initial_updates = handler.updates();
+        assert_eq!(
+            initial_updates.len(),
+            2,
+            "the healthy subscriber must still receive the update after another subscriber times out"
+        );
+        assert!(
+            initial_updates
+                .iter()
+                .any(|update| update.region_id == first_subscriber.region_id())
+        );
+        assert!(
+            initial_updates
+                .iter()
+                .any(|update| update.region_id == second_subscriber.region_id())
+        );
+
+        filter.update(lit(false) as _).unwrap();
+        assert!(
+            fanout_snapshot_for_query(
+                query_id,
+                &handler_ref,
+                &entry,
+                filter.as_ref(),
+                false,
+                &mut lifecycle_rx,
+                Duration::from_millis(100),
+            )
+            .await
+        );
+        handler.wait_for_update_count(4).await;
+        let updates = handler.updates();
+        assert!(
+            updates[2..]
+                .iter()
+                .any(|update| update.region_id == first_subscriber.region_id())
+        );
+        assert!(
+            updates[2..]
+                .iter()
+                .any(|update| update.region_id == second_subscriber.region_id())
+        );
+
+        registry.unregister_all_once(&handler_ref).await;
+        handler.wait_for_unregister_count(1).await;
     }
 
     #[tokio::test]

--- a/src/query/src/dist_plan/remote_dyn_filter_registry.rs
+++ b/src/query/src/dist_plan/remote_dyn_filter_registry.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::future::Future;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, RwLock, Weak};
 use std::time::Duration;
 
@@ -32,8 +33,9 @@ use crate::region_query::RegionQueryHandlerRef;
 
 const REMOTE_DYN_FILTER_UPDATE_PAYLOAD_MAX_BYTES: usize = 64 * 1024;
 const REMOTE_DYN_FILTER_RECONCILE_INTERVAL: Duration = Duration::from_secs(1);
+const REMOTE_DYN_FILTER_CONTROL_RPC_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Routing metadata for a remote dynamic filter subscriber.
+/// Region subscribed to a remote dynamic filter.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Subscriber {
     region_id: RegionId,
@@ -65,14 +67,11 @@ pub enum SubscriberRegistration {
     MissingFilter,
 }
 
-/// A registered query-local remote dynamic filter entry.
-///
-/// The frontend query owns the strong DataFusion filter handle until the query finishes; the
-/// registry only keeps a weak reference for later updates.
+/// A registered query-local producer filter and its region subscribers.
 #[derive(Debug)]
 pub struct DynFilterEntry {
     filter_id: FilterId,
-    alive_dyn_filter: Weak<DynamicFilterPhysicalExpr>,
+    producer_filter: Weak<DynamicFilterPhysicalExpr>,
     subscribers: RwLock<HashSet<Subscriber>>,
     last_sent_generation: AtomicU64,
     unregistered: AtomicBool,
@@ -86,10 +85,10 @@ struct QueryDynFilterRegistryInner {
 }
 
 impl DynFilterEntry {
-    pub fn new(filter_id: FilterId, alive_dyn_filter: Arc<DynamicFilterPhysicalExpr>) -> Self {
+    pub fn new(filter_id: FilterId, producer_filter: Arc<DynamicFilterPhysicalExpr>) -> Self {
         Self {
             filter_id,
-            alive_dyn_filter: Arc::downgrade(&alive_dyn_filter),
+            producer_filter: Arc::downgrade(&producer_filter),
             subscribers: RwLock::new(HashSet::new()),
             last_sent_generation: AtomicU64::new(0),
             unregistered: AtomicBool::new(false),
@@ -102,8 +101,8 @@ impl DynFilterEntry {
         &self.filter_id
     }
 
-    pub fn upgrade_alive_dyn_filter(&self) -> Option<Arc<DynamicFilterPhysicalExpr>> {
-        self.alive_dyn_filter.upgrade()
+    pub fn upgrade_producer_filter(&self) -> Option<Arc<DynamicFilterPhysicalExpr>> {
+        self.producer_filter.upgrade()
     }
 
     pub fn subscribers(&self) -> Vec<Subscriber> {
@@ -149,27 +148,26 @@ impl DynFilterEntry {
     fn mark_fanout_started(&self) -> bool {
         !self.fanout_started.swap(true, Ordering::SeqCst)
     }
+
+    #[cfg(test)]
+    pub(crate) fn fanout_started_for_test(&self) -> bool {
+        self.fanout_started.load(Ordering::SeqCst)
+    }
 }
 
 /// Query-scoped registry that owns all remote dynamic filters for one query.
 #[derive(Debug)]
 pub struct QueryDynFilterRegistry {
     query_id: QueryId,
-    active_streams: AtomicUsize,
-    fanout_started: AtomicBool,
-    registry_changed: Notify,
-    lifecycle_tx: watch::Sender<bool>,
+    lifecycle_tx: watch::Sender<()>,
     inner: RwLock<QueryDynFilterRegistryInner>,
 }
 
 impl QueryDynFilterRegistry {
     pub fn new(query_id: QueryId) -> Self {
-        let (lifecycle_tx, _) = watch::channel(false);
+        let (lifecycle_tx, _) = watch::channel(());
         Self {
             query_id,
-            active_streams: AtomicUsize::new(0),
-            fanout_started: AtomicBool::new(false),
-            registry_changed: Notify::new(),
             lifecycle_tx,
             inner: RwLock::new(QueryDynFilterRegistryInner {
                 entries: HashMap::new(),
@@ -179,23 +177,6 @@ impl QueryDynFilterRegistry {
 
     pub fn query_id(&self) -> QueryId {
         self.query_id
-    }
-
-    fn acquire_stream(&self) {
-        if self.active_streams.fetch_add(1, Ordering::SeqCst) == 0 {
-            let _ = self.lifecycle_tx.send(false);
-        }
-    }
-
-    fn release_stream(&self) {
-        if self.active_streams.fetch_sub(1, Ordering::SeqCst) == 1 {
-            let _ = self.lifecycle_tx.send(true);
-            self.registry_changed.notify_one();
-        }
-    }
-
-    fn active_stream_count(&self) -> usize {
-        self.active_streams.load(Ordering::SeqCst)
     }
 
     pub fn entry_count(&self) -> usize {
@@ -219,16 +200,15 @@ impl QueryDynFilterRegistry {
     pub fn register_remote_dyn_filter(
         &self,
         filter_id: FilterId,
-        alive_dyn_filter: Arc<DynamicFilterPhysicalExpr>,
+        producer_filter: Arc<DynamicFilterPhysicalExpr>,
     ) -> EntryRegistration {
         let mut inner = self.inner.write().unwrap();
         if let Some(existing) = inner.entries.get(&filter_id) {
             return EntryRegistration::Existing(existing.clone());
         }
 
-        let entry = Arc::new(DynFilterEntry::new(filter_id.clone(), alive_dyn_filter));
+        let entry = Arc::new(DynFilterEntry::new(filter_id.clone(), producer_filter));
         inner.entries.insert(filter_id, entry.clone());
-        self.registry_changed.notify_one();
         EntryRegistration::Inserted(entry)
     }
 
@@ -242,9 +222,7 @@ impl QueryDynFilterRegistry {
         };
 
         if entry.register_subscriber(subscriber) {
-            // A newly added subscriber has not seen the latest snapshot yet. Reset the
-            // entry-level generation watermark so the next fanout tick resends the current
-            // snapshot to all subscribers; receivers treat duplicate generations idempotently.
+            // New subscribers need the current snapshot; existing subscribers may see a duplicate.
             entry.reactivate_for_new_subscriber();
             SubscriberRegistration::Added
         } else {
@@ -252,120 +230,21 @@ impl QueryDynFilterRegistry {
         }
     }
 
-    /// Starts one query-scoped producer fanout task if it has not already been started.
+    /// Starts missing producer fanout watchers for the registry's entries.
     ///
-    /// The supervisor starts one async watcher per registered source-side
-    /// [`DynamicFilterPhysicalExpr`]. Each watcher waits on DataFusion's
-    /// `wait_update()`/`wait_complete()` notifications and sends best-effort
-    /// update/unregister RPCs to subscribed datanodes. The supervisor exits once
-    /// all remote scan streams release their registry leases.
+    /// Watchers do not hold the registry alive; dropping the registry closes their lifecycle channel.
     pub fn ensure_fanout_task(self: &Arc<Self>, region_query_handler: RegionQueryHandlerRef) {
-        self.registry_changed.notify_one();
-        if self.fanout_started.swap(true, Ordering::SeqCst) {
-            return;
-        }
-
-        let registry = self.clone();
-        let _handle = spawn_global(async move {
-            registry.run_fanout(region_query_handler).await;
-        });
-    }
-
-    async fn run_fanout(self: Arc<Self>, region_query_handler: RegionQueryHandlerRef) {
-        let mut lifecycle_rx = self.lifecycle_tx.subscribe();
-
-        loop {
-            for entry in self.entries() {
-                self.ensure_entry_fanout_task(entry, region_query_handler.clone());
-            }
-
-            if *lifecycle_rx.borrow() || self.active_stream_count() == 0 {
-                break;
-            }
-
-            tokio::select! {
-                _ = self.registry_changed.notified() => {}
-                result = lifecycle_rx.changed() => {
-                    if result.is_err() || *lifecycle_rx.borrow() {
-                        break;
-                    }
-                }
-            }
-        }
-
-        self.unregister_all_once(&region_query_handler).await;
-    }
-
-    fn ensure_entry_fanout_task(
-        self: &Arc<Self>,
-        entry: Arc<DynFilterEntry>,
-        region_query_handler: RegionQueryHandlerRef,
-    ) {
-        if !entry.mark_fanout_started() {
-            return;
-        }
-
-        let registry = self.clone();
-        let _handle = spawn_global(async move {
-            registry.run_entry_fanout(entry, region_query_handler).await;
-        });
-    }
-
-    async fn run_entry_fanout(
-        self: Arc<Self>,
-        entry: Arc<DynFilterEntry>,
-        region_query_handler: RegionQueryHandlerRef,
-    ) {
-        let mut lifecycle_rx = self.lifecycle_tx.subscribe();
-        let mut is_complete = false;
-        let mut reconcile_interval = tokio::time::interval(REMOTE_DYN_FILTER_RECONCILE_INTERVAL);
-
-        loop {
-            if *lifecycle_rx.borrow() || self.active_stream_count() == 0 {
-                break;
-            }
-
-            let Some(filter) = entry.upgrade_alive_dyn_filter() else {
-                self.unregister_entry_once(&region_query_handler, &entry)
-                    .await;
-                return;
-            };
-
-            self.fanout_snapshot(&region_query_handler, &entry, &filter, is_complete)
-                .await;
-
-            if is_complete {
-                tokio::select! {
-                    _ = entry.subscriber_changed.notified() => {}
-                    result = lifecycle_rx.changed() => {
-                        if result.is_err() || *lifecycle_rx.borrow() {
-                            break;
-                        }
-                    }
-                }
-                continue;
-            }
-
-            tokio::select! {
-                _ = filter.wait_update() => {}
-                _ = filter.wait_complete() => {
-                    is_complete = true;
-                }
-                // `wait_update()` subscribes when called, so an update that happens between
-                // the post-send generation check and the wait call can be missed. This
-                // low-frequency reconcile tick bounds that race by periodically re-reading
-                // `snapshot_generation()` and coalescing to the latest snapshot.
-                _ = reconcile_interval.tick() => {}
-                _ = entry.subscriber_changed.notified() => {}
-                result = lifecycle_rx.changed() => {
-                    if result.is_err() || *lifecycle_rx.borrow() {
-                        break;
-                    }
-                }
-            }
+        for entry in self.entries() {
+            ensure_entry_fanout_task(
+                self.query_id,
+                entry,
+                region_query_handler.clone(),
+                self.lifecycle_tx.subscribe(),
+            );
         }
     }
 
+    #[cfg(test)]
     async fn fanout_snapshot(
         &self,
         region_query_handler: &RegionQueryHandlerRef,
@@ -373,115 +252,302 @@ impl QueryDynFilterRegistry {
         filter: &DynamicFilterPhysicalExpr,
         is_complete: bool,
     ) {
-        let Some((generation, current)) = current_stable_snapshot(filter).await else {
-            return;
-        };
-
-        if !is_complete && !entry.mark_generation_sent(generation) {
-            return;
-        }
-
-        if is_complete {
-            let _ = entry.mark_generation_sent(generation);
-        }
-
-        let payload = match DynFilterPayload::from_datafusion_expr(
-            &current,
-            REMOTE_DYN_FILTER_UPDATE_PAYLOAD_MAX_BYTES,
-        ) {
-            Ok(DynFilterPayload::Datafusion(payload)) => payload,
-            Ok(_) => {
-                warn!("Ignored unsupported remote dynamic filter producer payload");
-                return;
-            }
-            Err(error) => {
-                warn!(error; "Failed to encode remote dynamic filter producer snapshot");
-                return;
-            }
-        };
-
-        self.fanout_update(
+        let mut lifecycle_rx = self.lifecycle_tx.subscribe();
+        fanout_snapshot_for_query(
+            self.query_id,
             region_query_handler,
             entry,
-            generation,
+            filter,
             is_complete,
-            payload,
+            &mut lifecycle_rx,
         )
         .await;
     }
 
-    async fn fanout_update(
-        &self,
-        region_query_handler: &RegionQueryHandlerRef,
-        entry: &DynFilterEntry,
-        generation: u64,
-        is_complete: bool,
-        payload: Vec<u8>,
-    ) {
-        let query_id = self.query_id.to_string();
-        let filter_id = entry.filter_id().to_string();
-
-        for subscriber in entry.subscribers() {
-            let update = RemoteDynFilterUpdate {
-                filter_id: filter_id.clone(),
-                payload: payload.clone(),
-                generation,
-                is_complete,
-            };
-
-            if let Err(error) = region_query_handler
-                .handle_remote_dyn_filter_update(subscriber.region_id(), query_id.clone(), update)
-                .await
-            {
-                warn!(error; "Failed to fan out remote dynamic filter update");
-            }
-        }
-    }
-
+    #[cfg(test)]
     async fn unregister_all_once(&self, region_query_handler: &RegionQueryHandlerRef) {
         for entry in self.entries() {
-            self.unregister_entry_once(region_query_handler, &entry)
-                .await;
+            unregister_entry_once_for_query(region_query_handler, self.query_id, &entry).await;
+        }
+    }
+}
+
+fn ensure_entry_fanout_task(
+    query_id: QueryId,
+    entry: Arc<DynFilterEntry>,
+    region_query_handler: RegionQueryHandlerRef,
+    lifecycle_rx: watch::Receiver<()>,
+) {
+    if !entry.mark_fanout_started() {
+        return;
+    }
+
+    let _handle = spawn_global(async move {
+        run_entry_fanout(query_id, entry, region_query_handler, lifecycle_rx).await;
+    });
+}
+
+async fn run_entry_fanout(
+    query_id: QueryId,
+    entry: Arc<DynFilterEntry>,
+    region_query_handler: RegionQueryHandlerRef,
+    mut lifecycle_rx: watch::Receiver<()>,
+) {
+    let mut is_complete = false;
+    // `interval()` ticks immediately for the first tick. Start after one full interval so the
+    // reconcile branch remains a periodic fallback instead of an eager re-poll right after fanout.
+    let mut reconcile_interval = tokio::time::interval_at(
+        tokio::time::Instant::now() + REMOTE_DYN_FILTER_RECONCILE_INTERVAL,
+        REMOTE_DYN_FILTER_RECONCILE_INTERVAL,
+    );
+
+    loop {
+        let Some(filter) = entry.upgrade_producer_filter() else {
+            unregister_entry_once_for_query(&region_query_handler, query_id, &entry).await;
+            return;
+        };
+
+        if !fanout_snapshot_for_query(
+            query_id,
+            &region_query_handler,
+            &entry,
+            &filter,
+            is_complete,
+            &mut lifecycle_rx,
+        )
+        .await
+        {
+            break;
+        }
+
+        if is_complete {
+            tokio::select! {
+                _ = entry.subscriber_changed.notified() => {}
+                result = lifecycle_rx.changed() => {
+                    if result.is_err() {
+                        break;
+                    }
+                }
+            }
+            continue;
+        }
+
+        tokio::select! {
+            _ = filter.wait_update() => {}
+            _ = filter.wait_complete() => {
+                is_complete = true;
+            }
+            // `wait_update()` can miss an update sent while an RPC is in-flight.
+            // Re-read periodically to coalesce to the latest generation.
+            _ = reconcile_interval.tick() => {}
+            _ = entry.subscriber_changed.notified() => {}
+            result = lifecycle_rx.changed() => {
+                if result.is_err() {
+                    break;
+                }
+            }
         }
     }
 
-    async fn unregister_entry_once(
-        &self,
-        region_query_handler: &RegionQueryHandlerRef,
-        entry: &DynFilterEntry,
+    unregister_entry_once_for_query(&region_query_handler, query_id, &entry).await;
+}
+
+async fn fanout_snapshot_for_query(
+    query_id: QueryId,
+    region_query_handler: &RegionQueryHandlerRef,
+    entry: &DynFilterEntry,
+    filter: &DynamicFilterPhysicalExpr,
+    is_complete: bool,
+    lifecycle_rx: &mut watch::Receiver<()>,
+) -> bool {
+    let Some((generation, current)) = current_stable_snapshot(filter, lifecycle_rx).await else {
+        return true;
+    };
+
+    if !is_complete && !entry.mark_generation_sent(generation) {
+        return true;
+    }
+
+    if is_complete {
+        let _ = entry.mark_generation_sent(generation);
+    }
+
+    let payload = match DynFilterPayload::from_datafusion_expr(
+        &current,
+        REMOTE_DYN_FILTER_UPDATE_PAYLOAD_MAX_BYTES,
     ) {
-        if !entry.try_mark_unregistered() {
-            return;
+        Ok(DynFilterPayload::Datafusion(payload)) => payload,
+        Ok(_) => {
+            warn!("Ignored unsupported remote dynamic filter producer payload");
+            return true;
         }
+        Err(error) => {
+            warn!(error; "Failed to encode remote dynamic filter producer snapshot");
+            return true;
+        }
+    };
 
-        let query_id = self.query_id.to_string();
-        let filter_id = entry.filter_id().to_string();
+    fanout_update_for_query(
+        query_id,
+        region_query_handler,
+        entry,
+        generation,
+        is_complete,
+        payload,
+        lifecycle_rx,
+    )
+    .await
+}
 
-        for subscriber in entry.subscribers() {
-            let unregister = RemoteDynFilterUnregister {
-                filter_id: filter_id.clone(),
-            };
+async fn fanout_update_for_query(
+    query_id: QueryId,
+    region_query_handler: &RegionQueryHandlerRef,
+    entry: &DynFilterEntry,
+    generation: u64,
+    is_complete: bool,
+    payload: Vec<u8>,
+    lifecycle_rx: &mut watch::Receiver<()>,
+) -> bool {
+    let query_id = query_id.to_string();
+    let filter_id = entry.filter_id().to_string();
 
-            if let Err(error) = region_query_handler
-                .handle_remote_dyn_filter_unregister(
-                    subscriber.region_id(),
-                    query_id.clone(),
-                    unregister,
-                )
-                .await
-            {
-                warn!(error; "Failed to fan out remote dynamic filter unregister");
+    for subscriber in entry.subscribers() {
+        let update = RemoteDynFilterUpdate {
+            filter_id: filter_id.clone(),
+            payload: payload.clone(),
+            generation,
+            is_complete,
+        };
+
+        let Some(result) = await_control_rpc_or_lifecycle_close(
+            lifecycle_rx,
+            format!(
+                "update query_id={} filter_id={} region_id={}",
+                query_id,
+                filter_id,
+                subscriber.region_id()
+            ),
+            region_query_handler.handle_remote_dyn_filter_update(
+                subscriber.region_id(),
+                query_id.clone(),
+                update,
+            ),
+        )
+        .await
+        else {
+            return false;
+        };
+
+        if let Err(error) = result {
+            warn!(
+                error;
+                "Failed to fan out remote dynamic filter update, query_id={}, filter_id={}, region_id={}",
+                query_id,
+                filter_id,
+                subscriber.region_id()
+            );
+        }
+    }
+
+    true
+}
+
+async fn unregister_entry_once_for_query(
+    region_query_handler: &RegionQueryHandlerRef,
+    query_id: QueryId,
+    entry: &DynFilterEntry,
+) {
+    if !entry.try_mark_unregistered() {
+        return;
+    }
+
+    let query_id = query_id.to_string();
+    let filter_id = entry.filter_id().to_string();
+
+    for subscriber in entry.subscribers() {
+        let unregister = RemoteDynFilterUnregister {
+            filter_id: filter_id.clone(),
+        };
+
+        let Some(result) = await_control_rpc_timeout(
+            format!(
+                "unregister query_id={} filter_id={} region_id={}",
+                query_id,
+                filter_id,
+                subscriber.region_id()
+            ),
+            region_query_handler.handle_remote_dyn_filter_unregister(
+                subscriber.region_id(),
+                query_id.clone(),
+                unregister,
+            ),
+        )
+        .await
+        else {
+            continue;
+        };
+
+        if let Err(error) = result {
+            warn!(
+                error;
+                "Failed to fan out remote dynamic filter unregister, query_id={}, filter_id={}, region_id={}",
+                query_id,
+                filter_id,
+                subscriber.region_id()
+            );
+        }
+    }
+
+    debug!("Remote dynamic filter producer unregistered subscribers");
+}
+
+async fn await_control_rpc_or_lifecycle_close<T>(
+    lifecycle_rx: &mut watch::Receiver<()>,
+    operation: String,
+    rpc: impl Future<Output = T>,
+) -> Option<T> {
+    if lifecycle_rx.has_changed().is_err() {
+        return None;
+    }
+
+    tokio::select! {
+        biased;
+        result = lifecycle_rx.changed() => {
+            if result.is_err() {
+                debug!("Cancelled remote dynamic filter control RPC after lifecycle close");
             }
+            None
         }
+        result = rpc => Some(result),
+        _ = tokio::time::sleep(REMOTE_DYN_FILTER_CONTROL_RPC_TIMEOUT) => {
+            warn!("Timed out remote dynamic filter control RPC: {}", operation);
+            None
+        }
+    }
+}
 
-        debug!("Remote dynamic filter producer unregistered subscribers");
+async fn await_control_rpc_timeout<T>(
+    operation: String,
+    rpc: impl Future<Output = T>,
+) -> Option<T> {
+    tokio::select! {
+        result = rpc => Some(result),
+        _ = tokio::time::sleep(REMOTE_DYN_FILTER_CONTROL_RPC_TIMEOUT) => {
+            warn!("Timed out remote dynamic filter control RPC: {}", operation);
+            None
+        }
     }
 }
 
 async fn current_stable_snapshot(
     filter: &DynamicFilterPhysicalExpr,
+    lifecycle_rx: &mut watch::Receiver<()>,
 ) -> Option<(u64, Arc<dyn PhysicalExpr>)> {
     loop {
+        if lifecycle_rx.has_changed().is_err() {
+            return None;
+        }
+
         let before = filter.snapshot_generation();
         let current = match filter.current() {
             Ok(current) => current,
@@ -496,13 +562,21 @@ async fn current_stable_snapshot(
             return Some((after, current));
         }
 
-        tokio::task::yield_now().await;
+        tokio::select! {
+            biased;
+            result = lifecycle_rx.changed() => {
+                if result.is_err() {
+                    return None;
+                }
+            }
+            _ = tokio::task::yield_now() => {}
+        }
     }
 }
 
 /// Stream-scoped lease that keeps a query registry alive.
 ///
-/// Production code owns registries through this lease; the manager only keeps a weak index.
+/// Stream leases own registry lifecycle; the manager only keeps a weak index.
 #[derive(Debug)]
 pub struct RemoteDynFilterRegistryLease {
     registry_manager: Arc<DynFilterRegistryManager>,
@@ -517,7 +591,6 @@ impl RemoteDynFilterRegistryLease {
         registry_manager: Arc<DynFilterRegistryManager>,
         registry: Arc<QueryDynFilterRegistry>,
     ) -> Self {
-        registry.acquire_stream();
         Self {
             registry_manager,
             registry: Some(registry),
@@ -554,20 +627,18 @@ impl Drop for RemoteDynFilterRegistryLease {
         let query_id = registry.query_id();
         let registry_weak = Arc::downgrade(&registry);
 
-        registry.release_stream();
-
-        // Release this lease before pruning; concurrent drops must not observe each other's stream refs.
+        // Release this lease before pruning; concurrent drops must not observe each other's strong refs.
         drop(registry);
 
         let _ = self
             .registry_manager
-            .remove_if_inactive_registry(&query_id, &registry_weak);
+            .remove_if_dropped_registry(&query_id, &registry_weak);
     }
 }
 
 /// Query-engine manager for query-scoped remote dynamic filter registries.
 ///
-/// Weak index only; active streams own registries through [`RemoteDynFilterRegistryLease`].
+/// Weak index only; stream leases own registries through [`RemoteDynFilterRegistryLease`].
 #[derive(Debug, Default)]
 pub struct DynFilterRegistryManager {
     registries: RwLock<HashMap<QueryId, Weak<QueryDynFilterRegistry>>>,
@@ -595,10 +666,10 @@ impl DynFilterRegistryManager {
         self.registries.write().unwrap().remove(query_id)
     }
 
-    fn remove_if_inactive_registry(
+    fn remove_if_dropped_registry(
         &self,
         query_id: &QueryId,
-        registry_weak: &Weak<QueryDynFilterRegistry>,
+        dropped_registry: &Weak<QueryDynFilterRegistry>,
     ) -> Option<Weak<QueryDynFilterRegistry>> {
         let mut registries = self
             .registries
@@ -606,14 +677,8 @@ impl DynFilterRegistryManager {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         let current = registries.get(query_id)?;
 
-        // `ptr_eq` protects a newer registry for the same query id. In 03b the fanout
-        // task can briefly hold a strong `Arc`, so stream lifecycle uses active_streams
-        // instead of relying only on `Weak::upgrade().is_none()`.
-        let inactive = match current.upgrade() {
-            Some(registry) => registry.active_stream_count() == 0,
-            None => true,
-        };
-        if current.ptr_eq(registry_weak) && inactive {
+        // `ptr_eq` protects a newer registry for the same query id; `upgrade` ensures it is dead.
+        if current.ptr_eq(dropped_registry) && current.upgrade().is_none() {
             registries.remove(query_id)
         } else {
             None
@@ -758,6 +823,16 @@ mod tests {
             }
             panic!("timed out waiting for {expected} remote dyn filter unregisters");
         }
+    }
+
+    async fn wait_for_registry_drop(registry: Weak<QueryDynFilterRegistry>) {
+        for _ in 0..300 {
+            if registry.upgrade().is_none() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("timed out waiting for remote dyn filter registry drop");
     }
 
     #[async_trait]
@@ -1011,7 +1086,7 @@ mod tests {
 
         assert!(
             manager
-                .remove_if_inactive_registry(&query_id, &old_registry)
+                .remove_if_dropped_registry(&query_id, &old_registry)
                 .is_none(),
             "old registry cleanup must not remove the replacement weak entry"
         );
@@ -1120,18 +1195,22 @@ mod tests {
         let query_id = test_query_id(3);
         let manager = Arc::new(DynFilterRegistryManager::default());
         let lease = manager.acquire_lease(query_id);
-        let registry = manager.get(&query_id).unwrap();
+        let registry_weak = Arc::downgrade(lease.registry.as_ref().unwrap());
         let filter = test_dyn_filter(&["host"]);
         let filter_id = test_filter_id(1);
-        let _ = registry.register_remote_dyn_filter(filter_id.clone(), filter.clone());
+        let _ = lease
+            .registry()
+            .register_remote_dyn_filter(filter_id.clone(), filter.clone());
         let subscriber = Subscriber::new(RegionId::new(1024, 7));
         assert_eq!(
-            registry.register_subscriber(&filter_id, subscriber.clone()),
+            lease
+                .registry()
+                .register_subscriber(&filter_id, subscriber.clone()),
             SubscriberRegistration::Added
         );
 
         let handler = Arc::new(RecordingRegionQueryHandler::default());
-        registry.ensure_fanout_task(handler.clone() as RegionQueryHandlerRef);
+        lease.ensure_fanout_task(handler.clone() as RegionQueryHandlerRef);
 
         handler.wait_for_update_count(1).await;
         let initial_generation = handler.updates()[0].generation;
@@ -1153,6 +1232,137 @@ mod tests {
         let unregisters = handler.unregisters();
         assert_eq!(unregisters[0].region_id, subscriber.region_id());
         assert_eq!(unregisters[0].filter_id, filter_id.to_string());
+
+        wait_for_registry_drop(registry_weak).await;
+    }
+
+    #[tokio::test]
+    async fn repeated_ensure_fanout_task_keeps_single_watcher() {
+        let query_id = test_query_id(6);
+        let manager = Arc::new(DynFilterRegistryManager::default());
+        let lease = manager.acquire_lease(query_id);
+        let registry_weak = Arc::downgrade(lease.registry.as_ref().unwrap());
+        let filter = test_dyn_filter(&["host"]);
+        let filter_id = test_filter_id(1);
+        let entry = match lease
+            .registry()
+            .register_remote_dyn_filter(filter_id.clone(), filter.clone())
+        {
+            EntryRegistration::Inserted(entry) => entry,
+            other => panic!("unexpected registration result: {other:?}"),
+        };
+        let subscriber = Subscriber::new(RegionId::new(1024, 7));
+        assert_eq!(
+            lease
+                .registry()
+                .register_subscriber(&filter_id, subscriber.clone()),
+            SubscriberRegistration::Added
+        );
+
+        let handler = Arc::new(RecordingRegionQueryHandler::default());
+        lease.ensure_fanout_task(handler.clone() as RegionQueryHandlerRef);
+        lease.ensure_fanout_task(handler.clone() as RegionQueryHandlerRef);
+
+        assert!(entry.fanout_started.load(Ordering::SeqCst));
+        handler.wait_for_update_count(1).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(handler.updates().len(), 1);
+
+        filter.update(lit(false) as _).unwrap();
+        handler.wait_for_update_count(2).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(handler.updates().len(), 2);
+
+        drop(lease);
+        handler.wait_for_unregister_count(1).await;
+        wait_for_registry_drop(registry_weak).await;
+    }
+
+    #[tokio::test]
+    async fn fanout_task_resends_complete_snapshot_to_late_subscriber() {
+        let query_id = test_query_id(7);
+        let manager = Arc::new(DynFilterRegistryManager::default());
+        let lease = manager.acquire_lease(query_id);
+        let registry_weak = Arc::downgrade(lease.registry.as_ref().unwrap());
+        let filter = test_dyn_filter(&["host"]);
+        let filter_id = test_filter_id(1);
+        let _ = lease
+            .registry()
+            .register_remote_dyn_filter(filter_id.clone(), filter.clone());
+        let first_subscriber = Subscriber::new(RegionId::new(1024, 7));
+        assert_eq!(
+            lease
+                .registry()
+                .register_subscriber(&filter_id, first_subscriber.clone()),
+            SubscriberRegistration::Added
+        );
+
+        let handler = Arc::new(RecordingRegionQueryHandler::default());
+        lease.ensure_fanout_task(handler.clone() as RegionQueryHandlerRef);
+        handler.wait_for_update_count(1).await;
+
+        filter.mark_complete();
+        handler.wait_for_update_count(2).await;
+        assert!(handler.updates()[1].is_complete);
+
+        let late_subscriber = Subscriber::new(RegionId::new(1024, 8));
+        assert_eq!(
+            lease
+                .registry()
+                .register_subscriber(&filter_id, late_subscriber.clone()),
+            SubscriberRegistration::Added
+        );
+
+        handler.wait_for_update_count(4).await;
+        let updates = handler.updates();
+        assert!(
+            updates[2..].iter().any(
+                |update| update.region_id == first_subscriber.region_id() && update.is_complete
+            )
+        );
+        assert!(
+            updates[2..]
+                .iter()
+                .any(|update| update.region_id == late_subscriber.region_id()
+                    && update.is_complete)
+        );
+
+        drop(lease);
+        handler.wait_for_unregister_count(1).await;
+        wait_for_registry_drop(registry_weak).await;
+    }
+
+    #[tokio::test]
+    async fn fanout_task_unregisters_when_producer_filter_is_dropped() {
+        let query_id = test_query_id(8);
+        let manager = Arc::new(DynFilterRegistryManager::default());
+        let lease = manager.acquire_lease(query_id);
+        let registry_weak = Arc::downgrade(lease.registry.as_ref().unwrap());
+        let filter = test_dyn_filter(&["host"]);
+        let filter_id = test_filter_id(1);
+        let _ = lease
+            .registry()
+            .register_remote_dyn_filter(filter_id.clone(), filter.clone());
+        let subscriber = Subscriber::new(RegionId::new(1024, 7));
+        assert_eq!(
+            lease
+                .registry()
+                .register_subscriber(&filter_id, subscriber.clone()),
+            SubscriberRegistration::Added
+        );
+
+        let handler = Arc::new(RecordingRegionQueryHandler::default());
+        lease.ensure_fanout_task(handler.clone() as RegionQueryHandlerRef);
+        handler.wait_for_update_count(1).await;
+
+        drop(filter);
+        handler.wait_for_unregister_count(1).await;
+        let unregisters = handler.unregisters();
+        assert_eq!(unregisters[0].region_id, subscriber.region_id());
+        assert_eq!(unregisters[0].filter_id, filter_id.to_string());
+
+        drop(lease);
+        wait_for_registry_drop(registry_weak).await;
     }
 
     #[tokio::test]
@@ -1160,27 +1370,28 @@ mod tests {
         let query_id = test_query_id(4);
         let manager = Arc::new(DynFilterRegistryManager::default());
         let lease = manager.acquire_lease(query_id);
-        let registry = manager.get(&query_id).unwrap();
+        let registry_weak = Arc::downgrade(lease.registry.as_ref().unwrap());
         let filter = test_dyn_filter(&["host"]);
         let filter_id = test_filter_id(1);
-        let _ = registry.register_remote_dyn_filter(filter_id.clone(), filter.clone());
+        let _ = lease
+            .registry()
+            .register_remote_dyn_filter(filter_id.clone(), filter.clone());
         let subscriber = Subscriber::new(RegionId::new(1024, 7));
         assert_eq!(
-            registry.register_subscriber(&filter_id, subscriber.clone()),
+            lease
+                .registry()
+                .register_subscriber(&filter_id, subscriber.clone()),
             SubscriberRegistration::Added
         );
 
         let handler = Arc::new(RecordingRegionQueryHandler::default());
         handler.block_next_update();
-        registry.ensure_fanout_task(handler.clone() as RegionQueryHandlerRef);
+        lease.ensure_fanout_task(handler.clone() as RegionQueryHandlerRef);
 
         handler.wait_for_blocked_update().await;
         let initial_generation = handler.updates()[0].generation;
 
-        // Update while the first RPC is still in-flight. A pure `wait_update()` loop can
-        // subscribe after this update and miss the edge; the reconcile tick must still
-        // observe `snapshot_generation() > last_sent_generation` and fan out the latest
-        // snapshot.
+        // Update before the watcher can subscribe again; reconcile must catch it.
         filter.update(lit(false) as _).unwrap();
         handler.release_blocked_update();
 
@@ -1192,6 +1403,40 @@ mod tests {
 
         drop(lease);
         handler.wait_for_unregister_count(1).await;
+        wait_for_registry_drop(registry_weak).await;
+    }
+
+    #[tokio::test]
+    async fn fanout_task_unregisters_after_lifecycle_close_during_blocked_update() {
+        let query_id = test_query_id(5);
+        let manager = Arc::new(DynFilterRegistryManager::default());
+        let lease = manager.acquire_lease(query_id);
+        let registry_weak = Arc::downgrade(lease.registry.as_ref().unwrap());
+        let filter = test_dyn_filter(&["host"]);
+        let filter_id = test_filter_id(1);
+        let _ = lease
+            .registry()
+            .register_remote_dyn_filter(filter_id.clone(), filter.clone());
+        let subscriber = Subscriber::new(RegionId::new(1024, 7));
+        assert_eq!(
+            lease
+                .registry()
+                .register_subscriber(&filter_id, subscriber.clone()),
+            SubscriberRegistration::Added
+        );
+
+        let handler = Arc::new(RecordingRegionQueryHandler::default());
+        handler.block_next_update();
+        lease.ensure_fanout_task(handler.clone() as RegionQueryHandlerRef);
+
+        handler.wait_for_blocked_update().await;
+        drop(lease);
+
+        handler.wait_for_unregister_count(1).await;
+        let unregisters = handler.unregisters();
+        assert_eq!(unregisters[0].region_id, subscriber.region_id());
+        assert_eq!(unregisters[0].filter_id, filter_id.to_string());
+        wait_for_registry_drop(registry_weak).await;
     }
 
     #[tokio::test]

--- a/src/query/src/dist_plan/remote_dyn_filter_registry.rs
+++ b/src/query/src/dist_plan/remote_dyn_filter_registry.rs
@@ -13,13 +13,25 @@
 // limitations under the License.
 
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock, Weak};
+use std::time::Duration;
 
+use api::v1::region::{RemoteDynFilterUnregister, RemoteDynFilterUpdate};
+use common_query::request::DynFilterPayload;
+use common_runtime::spawn_global;
+use common_telemetry::{debug, warn};
+use datafusion_physical_expr::PhysicalExpr;
 use datafusion_physical_expr::expressions::DynamicFilterPhysicalExpr;
 use session::query_id::QueryId;
 use store_api::storage::RegionId;
+use tokio::sync::{Notify, watch};
 
 use crate::dist_plan::FilterId;
+use crate::region_query::RegionQueryHandlerRef;
+
+const REMOTE_DYN_FILTER_UPDATE_PAYLOAD_MAX_BYTES: usize = 64 * 1024;
+const REMOTE_DYN_FILTER_RECONCILE_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Routing metadata for a remote dynamic filter subscriber.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -62,6 +74,10 @@ pub struct DynFilterEntry {
     filter_id: FilterId,
     alive_dyn_filter: Weak<DynamicFilterPhysicalExpr>,
     subscribers: RwLock<HashSet<Subscriber>>,
+    last_sent_generation: AtomicU64,
+    unregistered: AtomicBool,
+    fanout_started: AtomicBool,
+    subscriber_changed: Notify,
 }
 
 #[derive(Debug)]
@@ -75,6 +91,10 @@ impl DynFilterEntry {
             filter_id,
             alive_dyn_filter: Arc::downgrade(&alive_dyn_filter),
             subscribers: RwLock::new(HashSet::new()),
+            last_sent_generation: AtomicU64::new(0),
+            unregistered: AtomicBool::new(false),
+            fanout_started: AtomicBool::new(false),
+            subscriber_changed: Notify::new(),
         }
     }
 
@@ -94,19 +114,63 @@ impl DynFilterEntry {
         let mut subscribers = self.subscribers.write().unwrap();
         subscribers.insert(subscriber)
     }
+
+    fn mark_generation_sent(&self, generation: u64) -> bool {
+        let mut current = self.last_sent_generation.load(Ordering::SeqCst);
+        loop {
+            if generation <= current {
+                return false;
+            }
+
+            match self.last_sent_generation.compare_exchange(
+                current,
+                generation,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            ) {
+                Ok(_) => return true,
+                Err(next) => current = next,
+            }
+        }
+    }
+
+    fn try_mark_unregistered(&self) -> bool {
+        self.unregistered
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+    }
+
+    fn reactivate_for_new_subscriber(&self) {
+        self.last_sent_generation.store(0, Ordering::SeqCst);
+        self.unregistered.store(false, Ordering::SeqCst);
+        self.subscriber_changed.notify_one();
+    }
+
+    fn mark_fanout_started(&self) -> bool {
+        !self.fanout_started.swap(true, Ordering::SeqCst)
+    }
 }
 
 /// Query-scoped registry that owns all remote dynamic filters for one query.
 #[derive(Debug)]
 pub struct QueryDynFilterRegistry {
     query_id: QueryId,
+    active_streams: AtomicUsize,
+    fanout_started: AtomicBool,
+    registry_changed: Notify,
+    lifecycle_tx: watch::Sender<bool>,
     inner: RwLock<QueryDynFilterRegistryInner>,
 }
 
 impl QueryDynFilterRegistry {
     pub fn new(query_id: QueryId) -> Self {
+        let (lifecycle_tx, _) = watch::channel(false);
         Self {
             query_id,
+            active_streams: AtomicUsize::new(0),
+            fanout_started: AtomicBool::new(false),
+            registry_changed: Notify::new(),
+            lifecycle_tx,
             inner: RwLock::new(QueryDynFilterRegistryInner {
                 entries: HashMap::new(),
             }),
@@ -115,6 +179,23 @@ impl QueryDynFilterRegistry {
 
     pub fn query_id(&self) -> QueryId {
         self.query_id
+    }
+
+    fn acquire_stream(&self) {
+        if self.active_streams.fetch_add(1, Ordering::SeqCst) == 0 {
+            let _ = self.lifecycle_tx.send(false);
+        }
+    }
+
+    fn release_stream(&self) {
+        if self.active_streams.fetch_sub(1, Ordering::SeqCst) == 1 {
+            let _ = self.lifecycle_tx.send(true);
+            self.registry_changed.notify_one();
+        }
+    }
+
+    fn active_stream_count(&self) -> usize {
+        self.active_streams.load(Ordering::SeqCst)
     }
 
     pub fn entry_count(&self) -> usize {
@@ -147,6 +228,7 @@ impl QueryDynFilterRegistry {
 
         let entry = Arc::new(DynFilterEntry::new(filter_id.clone(), alive_dyn_filter));
         inner.entries.insert(filter_id, entry.clone());
+        self.registry_changed.notify_one();
         EntryRegistration::Inserted(entry)
     }
 
@@ -160,10 +242,261 @@ impl QueryDynFilterRegistry {
         };
 
         if entry.register_subscriber(subscriber) {
+            // A newly added subscriber has not seen the latest snapshot yet. Reset the
+            // entry-level generation watermark so the next fanout tick resends the current
+            // snapshot to all subscribers; receivers treat duplicate generations idempotently.
+            entry.reactivate_for_new_subscriber();
             SubscriberRegistration::Added
         } else {
             SubscriberRegistration::Duplicate
         }
+    }
+
+    /// Starts one query-scoped producer fanout task if it has not already been started.
+    ///
+    /// The supervisor starts one async watcher per registered source-side
+    /// [`DynamicFilterPhysicalExpr`]. Each watcher waits on DataFusion's
+    /// `wait_update()`/`wait_complete()` notifications and sends best-effort
+    /// update/unregister RPCs to subscribed datanodes. The supervisor exits once
+    /// all remote scan streams release their registry leases.
+    pub fn ensure_fanout_task(self: &Arc<Self>, region_query_handler: RegionQueryHandlerRef) {
+        self.registry_changed.notify_one();
+        if self.fanout_started.swap(true, Ordering::SeqCst) {
+            return;
+        }
+
+        let registry = self.clone();
+        let _handle = spawn_global(async move {
+            registry.run_fanout(region_query_handler).await;
+        });
+    }
+
+    async fn run_fanout(self: Arc<Self>, region_query_handler: RegionQueryHandlerRef) {
+        let mut lifecycle_rx = self.lifecycle_tx.subscribe();
+
+        loop {
+            for entry in self.entries() {
+                self.ensure_entry_fanout_task(entry, region_query_handler.clone());
+            }
+
+            if *lifecycle_rx.borrow() || self.active_stream_count() == 0 {
+                break;
+            }
+
+            tokio::select! {
+                _ = self.registry_changed.notified() => {}
+                result = lifecycle_rx.changed() => {
+                    if result.is_err() || *lifecycle_rx.borrow() {
+                        break;
+                    }
+                }
+            }
+        }
+
+        self.unregister_all_once(&region_query_handler).await;
+    }
+
+    fn ensure_entry_fanout_task(
+        self: &Arc<Self>,
+        entry: Arc<DynFilterEntry>,
+        region_query_handler: RegionQueryHandlerRef,
+    ) {
+        if !entry.mark_fanout_started() {
+            return;
+        }
+
+        let registry = self.clone();
+        let _handle = spawn_global(async move {
+            registry.run_entry_fanout(entry, region_query_handler).await;
+        });
+    }
+
+    async fn run_entry_fanout(
+        self: Arc<Self>,
+        entry: Arc<DynFilterEntry>,
+        region_query_handler: RegionQueryHandlerRef,
+    ) {
+        let mut lifecycle_rx = self.lifecycle_tx.subscribe();
+        let mut is_complete = false;
+        let mut reconcile_interval = tokio::time::interval(REMOTE_DYN_FILTER_RECONCILE_INTERVAL);
+
+        loop {
+            if *lifecycle_rx.borrow() || self.active_stream_count() == 0 {
+                break;
+            }
+
+            let Some(filter) = entry.upgrade_alive_dyn_filter() else {
+                self.unregister_entry_once(&region_query_handler, &entry)
+                    .await;
+                return;
+            };
+
+            self.fanout_snapshot(&region_query_handler, &entry, &filter, is_complete)
+                .await;
+
+            if is_complete {
+                tokio::select! {
+                    _ = entry.subscriber_changed.notified() => {}
+                    result = lifecycle_rx.changed() => {
+                        if result.is_err() || *lifecycle_rx.borrow() {
+                            break;
+                        }
+                    }
+                }
+                continue;
+            }
+
+            tokio::select! {
+                _ = filter.wait_update() => {}
+                _ = filter.wait_complete() => {
+                    is_complete = true;
+                }
+                // `wait_update()` subscribes when called, so an update that happens between
+                // the post-send generation check and the wait call can be missed. This
+                // low-frequency reconcile tick bounds that race by periodically re-reading
+                // `snapshot_generation()` and coalescing to the latest snapshot.
+                _ = reconcile_interval.tick() => {}
+                _ = entry.subscriber_changed.notified() => {}
+                result = lifecycle_rx.changed() => {
+                    if result.is_err() || *lifecycle_rx.borrow() {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    async fn fanout_snapshot(
+        &self,
+        region_query_handler: &RegionQueryHandlerRef,
+        entry: &DynFilterEntry,
+        filter: &DynamicFilterPhysicalExpr,
+        is_complete: bool,
+    ) {
+        let Some((generation, current)) = current_stable_snapshot(filter).await else {
+            return;
+        };
+
+        if !is_complete && !entry.mark_generation_sent(generation) {
+            return;
+        }
+
+        if is_complete {
+            let _ = entry.mark_generation_sent(generation);
+        }
+
+        let payload = match DynFilterPayload::from_datafusion_expr(
+            &current,
+            REMOTE_DYN_FILTER_UPDATE_PAYLOAD_MAX_BYTES,
+        ) {
+            Ok(DynFilterPayload::Datafusion(payload)) => payload,
+            Ok(_) => {
+                warn!("Ignored unsupported remote dynamic filter producer payload");
+                return;
+            }
+            Err(error) => {
+                warn!(error; "Failed to encode remote dynamic filter producer snapshot");
+                return;
+            }
+        };
+
+        self.fanout_update(
+            region_query_handler,
+            entry,
+            generation,
+            is_complete,
+            payload,
+        )
+        .await;
+    }
+
+    async fn fanout_update(
+        &self,
+        region_query_handler: &RegionQueryHandlerRef,
+        entry: &DynFilterEntry,
+        generation: u64,
+        is_complete: bool,
+        payload: Vec<u8>,
+    ) {
+        let query_id = self.query_id.to_string();
+        let filter_id = entry.filter_id().to_string();
+
+        for subscriber in entry.subscribers() {
+            let update = RemoteDynFilterUpdate {
+                filter_id: filter_id.clone(),
+                payload: payload.clone(),
+                generation,
+                is_complete,
+            };
+
+            if let Err(error) = region_query_handler
+                .handle_remote_dyn_filter_update(subscriber.region_id(), query_id.clone(), update)
+                .await
+            {
+                warn!(error; "Failed to fan out remote dynamic filter update");
+            }
+        }
+    }
+
+    async fn unregister_all_once(&self, region_query_handler: &RegionQueryHandlerRef) {
+        for entry in self.entries() {
+            self.unregister_entry_once(region_query_handler, &entry)
+                .await;
+        }
+    }
+
+    async fn unregister_entry_once(
+        &self,
+        region_query_handler: &RegionQueryHandlerRef,
+        entry: &DynFilterEntry,
+    ) {
+        if !entry.try_mark_unregistered() {
+            return;
+        }
+
+        let query_id = self.query_id.to_string();
+        let filter_id = entry.filter_id().to_string();
+
+        for subscriber in entry.subscribers() {
+            let unregister = RemoteDynFilterUnregister {
+                filter_id: filter_id.clone(),
+            };
+
+            if let Err(error) = region_query_handler
+                .handle_remote_dyn_filter_unregister(
+                    subscriber.region_id(),
+                    query_id.clone(),
+                    unregister,
+                )
+                .await
+            {
+                warn!(error; "Failed to fan out remote dynamic filter unregister");
+            }
+        }
+
+        debug!("Remote dynamic filter producer unregistered subscribers");
+    }
+}
+
+async fn current_stable_snapshot(
+    filter: &DynamicFilterPhysicalExpr,
+) -> Option<(u64, Arc<dyn PhysicalExpr>)> {
+    loop {
+        let before = filter.snapshot_generation();
+        let current = match filter.current() {
+            Ok(current) => current,
+            Err(error) => {
+                warn!(error; "Failed to read remote dynamic filter producer snapshot");
+                return None;
+            }
+        };
+        let after = filter.snapshot_generation();
+
+        if before == after {
+            return Some((after, current));
+        }
+
+        tokio::task::yield_now().await;
     }
 }
 
@@ -184,6 +517,7 @@ impl RemoteDynFilterRegistryLease {
         registry_manager: Arc<DynFilterRegistryManager>,
         registry: Arc<QueryDynFilterRegistry>,
     ) -> Self {
+        registry.acquire_stream();
         Self {
             registry_manager,
             registry: Some(registry),
@@ -194,6 +528,13 @@ impl RemoteDynFilterRegistryLease {
         self.registry
             .as_deref()
             .expect("remote dyn filter registry lease must hold a registry")
+    }
+
+    pub fn ensure_fanout_task(&self, region_query_handler: RegionQueryHandlerRef) {
+        self.registry
+            .as_ref()
+            .expect("remote dyn filter registry lease must hold a registry")
+            .ensure_fanout_task(region_query_handler);
     }
 
     #[cfg(test)]
@@ -213,12 +554,14 @@ impl Drop for RemoteDynFilterRegistryLease {
         let query_id = registry.query_id();
         let registry_weak = Arc::downgrade(&registry);
 
-        // Release this lease before pruning; concurrent drops must not observe each other's strong refs.
+        registry.release_stream();
+
+        // Release this lease before pruning; concurrent drops must not observe each other's stream refs.
         drop(registry);
 
         let _ = self
             .registry_manager
-            .remove_if_dropped_registry(&query_id, &registry_weak);
+            .remove_if_inactive_registry(&query_id, &registry_weak);
     }
 }
 
@@ -252,10 +595,10 @@ impl DynFilterRegistryManager {
         self.registries.write().unwrap().remove(query_id)
     }
 
-    fn remove_if_dropped_registry(
+    fn remove_if_inactive_registry(
         &self,
         query_id: &QueryId,
-        dropped_registry: &Weak<QueryDynFilterRegistry>,
+        registry_weak: &Weak<QueryDynFilterRegistry>,
     ) -> Option<Weak<QueryDynFilterRegistry>> {
         let mut registries = self
             .registries
@@ -263,8 +606,14 @@ impl DynFilterRegistryManager {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         let current = registries.get(query_id)?;
 
-        // `ptr_eq` protects a newer registry for the same query id; `upgrade` ensures it is dead.
-        if current.ptr_eq(dropped_registry) && current.upgrade().is_none() {
+        // `ptr_eq` protects a newer registry for the same query id. In 03b the fanout
+        // task can briefly hold a strong `Arc`, so stream lifecycle uses active_streams
+        // instead of relying only on `Weak::upgrade().is_none()`.
+        let inactive = match current.upgrade() {
+            Some(registry) => registry.active_stream_count() == 0,
+            None => true,
+        };
+        if current.ptr_eq(registry_weak) && inactive {
             registries.remove(query_id)
         } else {
             None
@@ -326,14 +675,137 @@ impl DynFilterRegistryManager {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Barrier;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Barrier, Mutex};
     use std::thread;
+    use std::time::Duration;
 
+    use api::v1::region::{RemoteDynFilterUnregister, RemoteDynFilterUpdate};
+    use async_trait::async_trait;
+    use common_query::request::QueryRequest;
     use datafusion_physical_expr::expressions::{Column, lit};
+    use session::ReadPreference;
     use uuid::Uuid;
 
     use super::*;
     use crate::dist_plan::{FilterFingerprint, RemoteDynFilterProducerId};
+    use crate::error::Result as QueryResult;
+    use crate::region_query::RegionQueryHandler;
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct RecordedUpdate {
+        region_id: RegionId,
+        query_id: String,
+        filter_id: String,
+        generation: u64,
+        is_complete: bool,
+        payload: Vec<u8>,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct RecordedUnregister {
+        region_id: RegionId,
+        query_id: String,
+        filter_id: String,
+    }
+
+    #[derive(Default)]
+    struct RecordingRegionQueryHandler {
+        updates: Mutex<Vec<RecordedUpdate>>,
+        unregisters: Mutex<Vec<RecordedUnregister>>,
+        block_next_update: AtomicBool,
+        update_blocked: Notify,
+        release_update: Notify,
+    }
+
+    impl RecordingRegionQueryHandler {
+        fn updates(&self) -> Vec<RecordedUpdate> {
+            self.updates.lock().unwrap().clone()
+        }
+
+        fn unregisters(&self) -> Vec<RecordedUnregister> {
+            self.unregisters.lock().unwrap().clone()
+        }
+
+        fn block_next_update(&self) {
+            self.block_next_update.store(true, Ordering::SeqCst);
+        }
+
+        async fn wait_for_blocked_update(&self) {
+            self.update_blocked.notified().await;
+        }
+
+        fn release_blocked_update(&self) {
+            self.release_update.notify_one();
+        }
+
+        async fn wait_for_update_count(&self, expected: usize) {
+            for _ in 0..300 {
+                if self.updates().len() >= expected {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            panic!("timed out waiting for {expected} remote dyn filter updates");
+        }
+
+        async fn wait_for_unregister_count(&self, expected: usize) {
+            for _ in 0..300 {
+                if self.unregisters().len() >= expected {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            panic!("timed out waiting for {expected} remote dyn filter unregisters");
+        }
+    }
+
+    #[async_trait]
+    impl RegionQueryHandler for RecordingRegionQueryHandler {
+        async fn do_get(
+            &self,
+            _read_preference: ReadPreference,
+            _request: QueryRequest,
+        ) -> QueryResult<common_recordbatch::SendableRecordBatchStream> {
+            unreachable!("remote dyn filter registry tests should not execute remote queries")
+        }
+
+        async fn handle_remote_dyn_filter_update(
+            &self,
+            region_id: RegionId,
+            query_id: String,
+            update: RemoteDynFilterUpdate,
+        ) -> QueryResult<()> {
+            let should_block = self.block_next_update.swap(false, Ordering::SeqCst);
+            self.updates.lock().unwrap().push(RecordedUpdate {
+                region_id,
+                query_id,
+                filter_id: update.filter_id,
+                generation: update.generation,
+                is_complete: update.is_complete,
+                payload: update.payload,
+            });
+            if should_block {
+                self.update_blocked.notify_one();
+                self.release_update.notified().await;
+            }
+            Ok(())
+        }
+
+        async fn handle_remote_dyn_filter_unregister(
+            &self,
+            region_id: RegionId,
+            query_id: String,
+            unregister: RemoteDynFilterUnregister,
+        ) -> QueryResult<()> {
+            self.unregisters.lock().unwrap().push(RecordedUnregister {
+                region_id,
+                query_id,
+                filter_id: unregister.filter_id,
+            });
+            Ok(())
+        }
+    }
 
     fn test_query_id(value: u128) -> QueryId {
         QueryId::from(Uuid::from_u128(value))
@@ -539,7 +1011,7 @@ mod tests {
 
         assert!(
             manager
-                .remove_if_dropped_registry(&query_id, &old_registry)
+                .remove_if_inactive_registry(&query_id, &old_registry)
                 .is_none(),
             "old registry cleanup must not remove the replacement weak entry"
         );
@@ -574,5 +1046,177 @@ mod tests {
             SubscriberRegistration::Duplicate
         );
         assert_eq!(entry.subscribers().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn fanout_sends_changed_generations_to_subscribers() {
+        let query_id = test_query_id(1);
+        let registry = Arc::new(QueryDynFilterRegistry::new(query_id));
+        let filter = test_dyn_filter(&["host"]);
+        let filter_id = test_filter_id(1);
+        let entry = match registry.register_remote_dyn_filter(filter_id.clone(), filter.clone()) {
+            EntryRegistration::Inserted(entry) => entry,
+            other => panic!("unexpected registration result: {other:?}"),
+        };
+        let subscriber = Subscriber::new(RegionId::new(1024, 7));
+        assert_eq!(
+            registry.register_subscriber(&filter_id, subscriber.clone()),
+            SubscriberRegistration::Added
+        );
+
+        let handler = Arc::new(RecordingRegionQueryHandler::default());
+        let handler_ref = handler.clone() as RegionQueryHandlerRef;
+
+        registry
+            .fanout_snapshot(&handler_ref, &entry, filter.as_ref(), false)
+            .await;
+        let updates = handler.updates();
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].region_id, subscriber.region_id());
+        assert_eq!(updates[0].query_id, query_id.to_string());
+        assert_eq!(updates[0].filter_id, filter_id.to_string());
+        assert_eq!(updates[0].generation, filter.snapshot_generation());
+        assert!(!updates[0].is_complete);
+        assert!(!updates[0].payload.is_empty());
+
+        registry
+            .fanout_snapshot(&handler_ref, &entry, filter.as_ref(), false)
+            .await;
+        assert_eq!(handler.updates().len(), 1);
+
+        filter.update(lit(false) as _).unwrap();
+        registry
+            .fanout_snapshot(&handler_ref, &entry, filter.as_ref(), false)
+            .await;
+        let updates = handler.updates();
+        assert_eq!(updates.len(), 2);
+        assert_eq!(updates[1].generation, filter.snapshot_generation());
+
+        let second_subscriber = Subscriber::new(RegionId::new(1024, 8));
+        assert_eq!(
+            registry.register_subscriber(&filter_id, second_subscriber.clone()),
+            SubscriberRegistration::Added
+        );
+        registry
+            .fanout_snapshot(&handler_ref, &entry, filter.as_ref(), false)
+            .await;
+        let updates = handler.updates();
+        assert_eq!(updates.len(), 4);
+        assert!(
+            updates[2..]
+                .iter()
+                .any(|update| update.region_id == subscriber.region_id())
+        );
+        assert!(
+            updates[2..]
+                .iter()
+                .any(|update| update.region_id == second_subscriber.region_id())
+        );
+        assert_eq!(entry.subscribers().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn fanout_task_waits_for_dynamic_filter_notifications() {
+        let query_id = test_query_id(3);
+        let manager = Arc::new(DynFilterRegistryManager::default());
+        let lease = manager.acquire_lease(query_id);
+        let registry = manager.get(&query_id).unwrap();
+        let filter = test_dyn_filter(&["host"]);
+        let filter_id = test_filter_id(1);
+        let _ = registry.register_remote_dyn_filter(filter_id.clone(), filter.clone());
+        let subscriber = Subscriber::new(RegionId::new(1024, 7));
+        assert_eq!(
+            registry.register_subscriber(&filter_id, subscriber.clone()),
+            SubscriberRegistration::Added
+        );
+
+        let handler = Arc::new(RecordingRegionQueryHandler::default());
+        registry.ensure_fanout_task(handler.clone() as RegionQueryHandlerRef);
+
+        handler.wait_for_update_count(1).await;
+        let initial_generation = handler.updates()[0].generation;
+
+        filter.update(lit(false) as _).unwrap();
+        handler.wait_for_update_count(2).await;
+        let updates = handler.updates();
+        assert!(updates[1].generation > initial_generation);
+        assert_eq!(updates[1].region_id, subscriber.region_id());
+        assert_eq!(updates[1].filter_id, filter_id.to_string());
+
+        filter.mark_complete();
+        handler.wait_for_update_count(3).await;
+        let updates = handler.updates();
+        assert!(updates[2].is_complete);
+
+        drop(lease);
+        handler.wait_for_unregister_count(1).await;
+        let unregisters = handler.unregisters();
+        assert_eq!(unregisters[0].region_id, subscriber.region_id());
+        assert_eq!(unregisters[0].filter_id, filter_id.to_string());
+    }
+
+    #[tokio::test]
+    async fn reconcile_tick_catches_update_while_fanout_is_in_flight() {
+        let query_id = test_query_id(4);
+        let manager = Arc::new(DynFilterRegistryManager::default());
+        let lease = manager.acquire_lease(query_id);
+        let registry = manager.get(&query_id).unwrap();
+        let filter = test_dyn_filter(&["host"]);
+        let filter_id = test_filter_id(1);
+        let _ = registry.register_remote_dyn_filter(filter_id.clone(), filter.clone());
+        let subscriber = Subscriber::new(RegionId::new(1024, 7));
+        assert_eq!(
+            registry.register_subscriber(&filter_id, subscriber.clone()),
+            SubscriberRegistration::Added
+        );
+
+        let handler = Arc::new(RecordingRegionQueryHandler::default());
+        handler.block_next_update();
+        registry.ensure_fanout_task(handler.clone() as RegionQueryHandlerRef);
+
+        handler.wait_for_blocked_update().await;
+        let initial_generation = handler.updates()[0].generation;
+
+        // Update while the first RPC is still in-flight. A pure `wait_update()` loop can
+        // subscribe after this update and miss the edge; the reconcile tick must still
+        // observe `snapshot_generation() > last_sent_generation` and fan out the latest
+        // snapshot.
+        filter.update(lit(false) as _).unwrap();
+        handler.release_blocked_update();
+
+        handler.wait_for_update_count(2).await;
+        let updates = handler.updates();
+        assert!(updates[1].generation > initial_generation);
+        assert_eq!(updates[1].region_id, subscriber.region_id());
+        assert_eq!(updates[1].filter_id, filter_id.to_string());
+
+        drop(lease);
+        handler.wait_for_unregister_count(1).await;
+    }
+
+    #[tokio::test]
+    async fn unregister_fanout_is_idempotent() {
+        let query_id = test_query_id(2);
+        let registry = QueryDynFilterRegistry::new(query_id);
+        let filter = test_dyn_filter(&["host"]);
+        let filter_id = test_filter_id(1);
+        let _ = registry.register_remote_dyn_filter(filter_id.clone(), filter);
+        let subscriber = Subscriber::new(RegionId::new(1024, 7));
+        assert_eq!(
+            registry.register_subscriber(&filter_id, subscriber.clone()),
+            SubscriberRegistration::Added
+        );
+
+        let handler = Arc::new(RecordingRegionQueryHandler::default());
+        let handler_ref = handler.clone() as RegionQueryHandlerRef;
+
+        registry.unregister_all_once(&handler_ref).await;
+        registry.unregister_all_once(&handler_ref).await;
+
+        let unregisters = handler.unregisters();
+        assert_eq!(unregisters.len(), 1);
+        assert_eq!(unregisters[0].region_id, subscriber.region_id());
+        assert_eq!(unregisters[0].query_id, query_id.to_string());
+        assert_eq!(unregisters[0].filter_id, filter_id.to_string());
     }
 }

--- a/src/query/src/physical_wrapper.rs
+++ b/src/query/src/physical_wrapper.rs
@@ -12,15 +12,97 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
+use datafusion::config::ConfigOptions;
 use datafusion::physical_plan::ExecutionPlan;
 use session::context::QueryContextRef;
 
 /// wrap physical plan with additional layer
 /// e.g: metrics retrieving layer upon physical plan
 pub trait PhysicalPlanWrapper: Send + Sync + 'static {
-    fn wrap(&self, origin: Arc<dyn ExecutionPlan>, ctx: QueryContextRef) -> Arc<dyn ExecutionPlan>;
+    fn wrap(
+        &self,
+        origin: Arc<dyn ExecutionPlan>,
+        ctx: QueryContextRef,
+        config: &ConfigOptions,
+    ) -> Arc<dyn ExecutionPlan>;
 }
 
 pub type PhysicalPlanWrapperRef = Arc<dyn PhysicalPlanWrapper>;
+
+#[derive(Default)]
+pub struct PhysicalPlanWrappers {
+    wrappers: RwLock<Vec<PhysicalPlanWrapperRef>>,
+}
+
+impl PhysicalPlanWrappers {
+    pub fn push(&self, wrapper: PhysicalPlanWrapperRef) {
+        self.wrappers.write().unwrap().push(wrapper);
+    }
+
+    pub fn wrap(
+        &self,
+        origin: Arc<dyn ExecutionPlan>,
+        ctx: QueryContextRef,
+        config: &ConfigOptions,
+    ) -> Arc<dyn ExecutionPlan> {
+        let wrappers = self.wrappers.read().unwrap().clone();
+        wrappers.into_iter().fold(origin, |plan, wrapper| {
+            wrapper.wrap(plan, ctx.clone(), config)
+        })
+    }
+}
+
+pub type PhysicalPlanWrappersRef = Arc<PhysicalPlanWrappers>;
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use datafusion::arrow::datatypes::Schema;
+    use datafusion::config::ConfigOptions;
+    use datafusion::physical_plan::ExecutionPlan;
+    use datafusion::physical_plan::empty::EmptyExec;
+    use session::context::{QueryContextBuilder, QueryContextRef};
+
+    use super::{PhysicalPlanWrapper, PhysicalPlanWrappers};
+
+    struct RecordingWrapper {
+        marker: &'static str,
+        calls: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    impl PhysicalPlanWrapper for RecordingWrapper {
+        fn wrap(
+            &self,
+            origin: Arc<dyn ExecutionPlan>,
+            _ctx: QueryContextRef,
+            _config: &ConfigOptions,
+        ) -> Arc<dyn ExecutionPlan> {
+            self.calls.lock().unwrap().push(self.marker);
+            origin
+        }
+    }
+
+    #[test]
+    fn physical_plan_wrappers_apply_all_in_order() {
+        let wrappers = PhysicalPlanWrappers::default();
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        wrappers.push(Arc::new(RecordingWrapper {
+            marker: "first",
+            calls: calls.clone(),
+        }));
+        wrappers.push(Arc::new(RecordingWrapper {
+            marker: "second",
+            calls: calls.clone(),
+        }));
+
+        let plan = Arc::new(EmptyExec::new(Arc::new(Schema::empty()))) as Arc<dyn ExecutionPlan>;
+        let ctx = Arc::new(QueryContextBuilder::default().build());
+        let wrapped = wrappers.wrap(Arc::clone(&plan), ctx, &ConfigOptions::default());
+
+        assert!(Arc::ptr_eq(&plan, &wrapped));
+        assert_eq!(*calls.lock().unwrap(), vec!["first", "second"]);
+    }
+}

--- a/src/table/src/table/scan.rs
+++ b/src/table/src/table/scan.rs
@@ -40,7 +40,9 @@ use datafusion::physical_plan::{
 use datafusion_common::stats::Precision;
 use datafusion_common::{ColumnStatistics, DataFusionError, Statistics};
 use datafusion_physical_expr::expressions::Column;
-use datafusion_physical_expr::{EquivalenceProperties, Partitioning, PhysicalSortExpr};
+use datafusion_physical_expr::{
+    EquivalenceProperties, Partitioning, PhysicalExpr, PhysicalSortExpr,
+};
 use datatypes::arrow::datatypes::SchemaRef as ArrowSchemaRef;
 use datatypes::compute::SortOptions;
 use futures::{Stream, StreamExt};
@@ -339,6 +341,21 @@ impl RegionScanExec {
     pub fn set_explain_verbose(&mut self, explain_verbose: bool) {
         self.explain_verbose = explain_verbose;
     }
+
+    /// Adds dynamic filters directly to the underlying region scanner predicate.
+    ///
+    /// This is the same mutation path used by DataFusion child-filter pushdown. Remote dynamic
+    /// filter updates install their shared runtime wrapper through this method at scan build time
+    /// and later update the wrapper state out-of-band.
+    pub fn add_dyn_filters_to_predicate(
+        &self,
+        filter_exprs: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> Vec<bool> {
+        self.scanner
+            .lock()
+            .unwrap()
+            .add_dyn_filter_to_predicate(filter_exprs)
+    }
 }
 
 impl ExecutionPlan for RegionScanExec {
@@ -451,11 +468,7 @@ impl ExecutionPlan for RegionScanExec {
             .map(|f| f.filter)
             .collect::<Vec<_>>();
 
-        let supported = self
-            .scanner
-            .lock()
-            .unwrap()
-            .add_dyn_filter_to_predicate(parent_filters);
+        let supported = self.add_dyn_filters_to_predicate(parent_filters);
         // datafusion api require to clone self after mutate, even though we are only mutate inside mutex
         let new_self = Arc::new(self.clone());
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

- Tracking issue: #8127
- Depends on #8241 — FE producer fanout and payload encoding fallback.

This branch is based on the Task03b producer branch `feat/remote_dyn_filter_task03b_producer`.

Note: this PR is currently opened against `main` as requested, so it temporarily includes Task03b commits in the GitHub diff. Once Task03b is merged, this branch should be rebased and the PR diff will become Task04-only.

## What's changed and what's your intention?

This PR implements the datanode apply path for Remote Dynamic Filter (RDF).

Main changes:

- Add a DN-side remote dynamic filter registry keyed by `query_id + filter_id`.
- Register initial remote dynamic filter metadata when a remote read starts.
- Buffer early RDF updates until the receiver-side scan schema is available.
- Create DN-local `DynamicFilterPhysicalExpr` runtime filters and apply update generations with stale/idempotent/complete handling.
- Inject remote dynamic filters as `FilterExec` predicates, then reuse DataFusion `FilterPushdown` so eligible predicates can reach `RegionScanExec`.
- Add cleanup for stream-scoped registrations on EOF/drop and handle explicit RDF unregister RPCs.
- Support initial snapshot payloads from Task03b by converting them into pending DN updates and applying them when the runtime filter is created.
- Use a default-feature DataFusion `TaskContext` when decoding RDF payloads, because payloads may contain built-in scalar functions such as `struct(...) IN (...)`.
- Extend physical plan wrapper infrastructure to compose multiple wrappers instead of replacing the existing wrapper.

The remote dynamic filter remains an optimization only: missing/stale/oversized/decode-failed updates degrade to no extra pruning rather than affecting query correctness.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.

Validated locally:

```text
cargo test -p datanode remote_dyn_filter --lib
cargo test -p query dyn_filter --lib
cargo test -p common-query initial_dyn_filter --lib
cargo fmt --all -- --check
cargo check -p common-query -p query -p table -p datanode
cargo clippy -p datanode --lib --tests -- -D warnings
```
