### PR TITLE
feat: use scan output bytes for read costing

### DIFF
--- a/src/common/recordbatch/src/adapter.rs
+++ b/src/common/recordbatch/src/adapter.rs
@@ -366,6 +366,7 @@ impl ExecutionPlanVisitor for MetricCollector {
         let Some(metric) = plan.metrics() else {
             self.record_batch_metrics.plan_metrics.push(PlanMetrics {
                 plan: plan.name().to_string(),
+                plan_name: plan.name().to_string(),
                 level: self.current_level,
                 metrics: vec![],
             });
@@ -380,6 +381,7 @@ impl ExecutionPlanVisitor for MetricCollector {
             .timestamps_removed();
         let mut plan_metric = PlanMetrics {
             plan: one_line(plan, self.verbose).to_string(),
+            plan_name: plan.name().to_string(),
             level: self.current_level,
             metrics: Vec::with_capacity(metric.iter().size_hint().0),
         };
@@ -519,6 +521,9 @@ impl Display for RecordBatchMetrics {
 pub struct PlanMetrics {
     /// The plan name
     pub plan: String,
+    /// The stable execution plan name.
+    #[serde(default)]
+    pub plan_name: String,
     /// The level of the plan, starts from 0
     pub level: usize,
     /// An ordered key-value list of metrics.
@@ -914,6 +919,22 @@ mod test {
         assert!(metrics.region_watermarks.is_empty());
         assert_eq!(metrics.elapsed_compute, 12);
         assert_eq!(metrics.memory_usage, 34);
+    }
+
+    #[test]
+    fn test_plan_metrics_deserializes_without_plan_name() {
+        let metrics: RecordBatchMetrics = serde_json::from_value(json!({
+            "elapsed_compute": 12,
+            "memory_usage": 34,
+            "plan_metrics": [{
+                "plan": "SeqScan: region=1",
+                "level": 0,
+                "metrics": []
+            }]
+        }))
+        .unwrap();
+
+        assert_eq!(metrics.plan_metrics[0].plan_name, "");
     }
 
     #[test]

--- a/src/query/src/dist_plan/merge_scan.rs
+++ b/src/query/src/dist_plan/merge_scan.rs
@@ -840,7 +840,7 @@ fn scan_output_bytes(metrics: &RecordBatchMetrics) -> Option<usize> {
     metrics
         .plan_metrics
         .iter()
-        .filter(|pm| pm.plan.starts_with(REGION_SCAN_EXEC_NAME))
+        .filter(|pm| pm.plan_name == REGION_SCAN_EXEC_NAME)
         .flat_map(|pm| &pm.metrics)
         .find(|(name, _)| name == "output_bytes")
         .map(|(_, value)| *value)
@@ -899,6 +899,7 @@ mod tests {
 
     use async_trait::async_trait;
     use common_query::request::INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY;
+    use common_recordbatch::adapter::{PlanMetrics, RecordBatchMetrics};
     use datafusion::config::ConfigOptions;
     use datafusion::execution::SessionStateBuilder;
     use datafusion::physical_plan::filter_pushdown::ChildFilterPushdownResult;
@@ -1139,5 +1140,20 @@ mod tests {
 
         assert_eq!(exec.captured_remote_dyn_filters().len(), 1);
         assert!(matches!(propagation.filters.as_slice(), [PushedDown::No]));
+    }
+
+    #[test]
+    fn scan_output_bytes_uses_plan_name() {
+        let metrics = RecordBatchMetrics {
+            plan_metrics: vec![PlanMetrics {
+                plan: "SeqScan: region=1".to_string(),
+                plan_name: REGION_SCAN_EXEC_NAME.to_string(),
+                level: 0,
+                metrics: vec![("output_bytes".to_string(), 42)],
+            }],
+            ..Default::default()
+        };
+
+        assert_eq!(scan_output_bytes(&metrics), Some(42));
     }
 }

--- a/src/query/src/dist_plan/merge_scan.rs
+++ b/src/query/src/dist_plan/merge_scan.rs
@@ -472,19 +472,18 @@ impl MergeScanExec {
 
                 // process metrics after all data is drained.
                 if let Some(metrics) = stream.metrics() {
-                    if let Some(output_bytes) = scan_output_bytes(&metrics) {
-                        let (c, s) = parse_catalog_and_schema_from_db_string(&dbname);
-                        let value = read_meter!(
-                            c,
-                            s,
-                            ReadItem {
-                                cpu_time: metrics.elapsed_compute as u64,
-                                table_scan: output_bytes as u64,
-                            },
-                            current_channel as u8
-                        );
-                        metric.record_greptime_exec_cost(value as usize);
-                    }
+                    let output_bytes = scan_output_bytes(&metrics);
+                    let (c, s) = parse_catalog_and_schema_from_db_string(&dbname);
+                    let value = read_meter!(
+                        c,
+                        s,
+                        ReadItem {
+                            cpu_time: metrics.elapsed_compute as u64,
+                            table_scan: output_bytes as u64,
+                        },
+                        current_channel as u8
+                    );
+                    metric.record_greptime_exec_cost(value as usize);
 
                     // record metrics from sub sgates
                     let mut sub_stage_metrics = sub_stage_metrics_moved.lock().unwrap();
@@ -835,15 +834,15 @@ impl DisplayAs for MergeScanExec {
     }
 }
 
-/// Extract the `output_bytes` metric from the [`RegionScanExec`] plan node, if present.
-fn scan_output_bytes(metrics: &RecordBatchMetrics) -> Option<usize> {
+/// Extract total `output_bytes` from [`RegionScanExec`] plan nodes.
+fn scan_output_bytes(metrics: &RecordBatchMetrics) -> usize {
     metrics
         .plan_metrics
         .iter()
         .filter(|pm| pm.plan_name == REGION_SCAN_EXEC_NAME)
         .flat_map(|pm| &pm.metrics)
-        .find(|(name, _)| name == "output_bytes")
-        .map(|(_, value)| *value)
+        .filter_map(|(name, value)| (name == "output_bytes").then_some(*value))
+        .sum()
 }
 
 #[derive(Debug, Clone)]
@@ -1154,6 +1153,44 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(scan_output_bytes(&metrics), Some(42));
+        assert_eq!(scan_output_bytes(&metrics), 42);
+    }
+
+    #[test]
+    fn scan_output_bytes_defaults_to_zero_without_region_scan() {
+        let metrics = RecordBatchMetrics {
+            plan_metrics: vec![PlanMetrics {
+                plan: "ProjectionExec".to_string(),
+                plan_name: "ProjectionExec".to_string(),
+                level: 0,
+                metrics: vec![("output_bytes".to_string(), 42)],
+            }],
+            ..Default::default()
+        };
+
+        assert_eq!(scan_output_bytes(&metrics), 0);
+    }
+
+    #[test]
+    fn scan_output_bytes_sums_multiple_region_scans() {
+        let metrics = RecordBatchMetrics {
+            plan_metrics: vec![
+                PlanMetrics {
+                    plan: "RegionScanExec: region=1".to_string(),
+                    plan_name: REGION_SCAN_EXEC_NAME.to_string(),
+                    level: 0,
+                    metrics: vec![("output_bytes".to_string(), 42)],
+                },
+                PlanMetrics {
+                    plan: "RegionScanExec: region=2".to_string(),
+                    plan_name: REGION_SCAN_EXEC_NAME.to_string(),
+                    level: 0,
+                    metrics: vec![("output_bytes".to_string(), 18)],
+                },
+            ],
+            ..Default::default()
+        };
+
+        assert_eq!(scan_output_bytes(&metrics), 60);
     }
 }

--- a/src/query/src/dist_plan/merge_scan.rs
+++ b/src/query/src/dist_plan/merge_scan.rs
@@ -47,6 +47,7 @@ use meter_core::data::ReadItem;
 use meter_macros::read_meter;
 use session::context::QueryContextRef;
 use store_api::storage::RegionId;
+use table::table::scan::REGION_SCAN_EXEC_NAME;
 use table::table_name::TableName;
 use tokio::time::Instant;
 use tracing::{Instrument, Span};
@@ -471,17 +472,19 @@ impl MergeScanExec {
 
                 // process metrics after all data is drained.
                 if let Some(metrics) = stream.metrics() {
-                    let (c, s) = parse_catalog_and_schema_from_db_string(&dbname);
-                    let value = read_meter!(
-                        c,
-                        s,
-                        ReadItem {
-                            cpu_time: metrics.elapsed_compute as u64,
-                            table_scan: metrics.memory_usage as u64
-                        },
-                        current_channel as u8
-                    );
-                    metric.record_greptime_exec_cost(value as usize);
+                    if let Some(output_bytes) = scan_output_bytes(&metrics) {
+                        let (c, s) = parse_catalog_and_schema_from_db_string(&dbname);
+                        let value = read_meter!(
+                            c,
+                            s,
+                            ReadItem {
+                                cpu_time: metrics.elapsed_compute as u64,
+                                table_scan: output_bytes as u64,
+                            },
+                            current_channel as u8
+                        );
+                        metric.record_greptime_exec_cost(value as usize);
+                    }
 
                     // record metrics from sub sgates
                     let mut sub_stage_metrics = sub_stage_metrics_moved.lock().unwrap();
@@ -830,6 +833,17 @@ impl DisplayAs for MergeScanExec {
 
         Ok(())
     }
+}
+
+/// Extract the `output_bytes` metric from the [`RegionScanExec`] plan node, if present.
+fn scan_output_bytes(metrics: &RecordBatchMetrics) -> Option<usize> {
+    metrics
+        .plan_metrics
+        .iter()
+        .filter(|pm| pm.plan.starts_with(REGION_SCAN_EXEC_NAME))
+        .flat_map(|pm| &pm.metrics)
+        .find(|(name, _)| name == "output_bytes")
+        .map(|(_, value)| *value)
 }
 
 #[derive(Debug, Clone)]

--- a/src/table/src/table/metrics.rs
+++ b/src/table/src/table/metrics.rs
@@ -29,6 +29,8 @@ pub struct StreamMetrics {
     mem_used: Gauge,
     /// Number of rows in output
     output_rows: Count,
+    /// Number of bytes in output
+    output_bytes: Count,
     /// Elapsed time used to `poll` the stream
     poll_elapsed: Time,
     /// Elapsed time used to `.await`ing the stream
@@ -45,6 +47,7 @@ impl StreamMetrics {
             end_time: MetricBuilder::new(metrics).end_timestamp(partition),
             mem_used: MetricBuilder::new(metrics).mem_used(partition),
             output_rows: MetricBuilder::new(metrics).output_rows(partition),
+            output_bytes: MetricBuilder::new(metrics).output_bytes(partition),
             poll_elapsed: MetricBuilder::new(metrics).subset_time("elapsed_poll", partition),
             await_elapsed: MetricBuilder::new(metrics).subset_time("elapsed_await", partition),
         }
@@ -56,6 +59,10 @@ impl StreamMetrics {
 
     pub fn record_output(&self, num_rows: usize) {
         self.output_rows.add(num_rows);
+    }
+
+    pub fn record_output_bytes(&self, num_bytes: usize) {
+        self.output_bytes.add(num_bytes);
     }
 
     /// Record the end time of the query

--- a/src/table/src/table/metrics.rs
+++ b/src/table/src/table/metrics.rs
@@ -15,7 +15,7 @@
 use std::time::Duration;
 
 use datafusion::physical_plan::metrics::{
-    Count, ExecutionPlanMetricsSet, Gauge, MetricBuilder, ScopedTimerGuard, Time, Timestamp,
+    Count, ExecutionPlanMetricsSet, MetricBuilder, ScopedTimerGuard, Time, Timestamp,
 };
 
 /// This metrics struct is used to record and hold metrics like memory usage
@@ -25,8 +25,6 @@ use datafusion::physical_plan::metrics::{
 pub struct StreamMetrics {
     /// Timestamp when the stream finished
     end_time: Timestamp,
-    /// Used memory in bytes
-    mem_used: Gauge,
     /// Number of rows in output
     output_rows: Count,
     /// Number of bytes in output
@@ -45,16 +43,11 @@ impl StreamMetrics {
 
         Self {
             end_time: MetricBuilder::new(metrics).end_timestamp(partition),
-            mem_used: MetricBuilder::new(metrics).mem_used(partition),
             output_rows: MetricBuilder::new(metrics).output_rows(partition),
             output_bytes: MetricBuilder::new(metrics).output_bytes(partition),
             poll_elapsed: MetricBuilder::new(metrics).subset_time("elapsed_poll", partition),
             await_elapsed: MetricBuilder::new(metrics).subset_time("elapsed_await", partition),
         }
-    }
-
-    pub fn record_mem_usage(&self, mem_used: usize) {
-        self.mem_used.add(mem_used);
     }
 
     pub fn record_output(&self, num_rows: usize) {

--- a/src/table/src/table/metrics.rs
+++ b/src/table/src/table/metrics.rs
@@ -36,7 +36,7 @@ pub struct StreamMetrics {
 }
 
 impl StreamMetrics {
-    /// Create a new MemoryUsageMetrics structure, and set `start_time` to now
+    /// Create a new [`StreamMetrics`] structure, and set `start_time` to now.
     pub fn new(metrics: &ExecutionPlanMetricsSet, partition: usize) -> Self {
         let start_time = MetricBuilder::new(metrics).start_timestamp(partition);
         start_time.record();

--- a/src/table/src/table/scan.rs
+++ b/src/table/src/table/scan.rs
@@ -52,6 +52,9 @@ use store_api::storage::{ScanRequest, TimeSeriesDistribution};
 
 use crate::table::metrics::StreamMetrics;
 
+/// The name of [`RegionScanExec`] plan node.
+pub const REGION_SCAN_EXEC_NAME: &str = "RegionScanExec";
+
 /// A plan to read multiple partitions from a region of a table.
 #[derive(Clone)]
 pub struct RegionScanExec {
@@ -436,7 +439,7 @@ impl ExecutionPlan for RegionScanExec {
     }
 
     fn name(&self) -> &str {
-        "RegionScanExec"
+        REGION_SCAN_EXEC_NAME
     }
 
     fn handle_child_pushdown_result(
@@ -506,8 +509,9 @@ impl Stream for StreamWithMetricWrapper {
                     Ok(record_batch) => {
                         // we don't record elapsed time here
                         // since it's calling storage api involving I/O ops
-                        this.metric
-                            .record_mem_usage(record_batch.buffer_memory_size());
+                        let batch_bytes = record_batch.buffer_memory_size();
+                        this.metric.record_mem_usage(batch_bytes);
+                        this.metric.record_output_bytes(batch_bytes);
                         this.metric.record_output(record_batch.num_rows());
                         Poll::Ready(Some(Ok(record_batch.into_df_record_batch())))
                     }

--- a/src/table/src/table/scan.rs
+++ b/src/table/src/table/scan.rs
@@ -510,7 +510,6 @@ impl Stream for StreamWithMetricWrapper {
                         // we don't record elapsed time here
                         // since it's calling storage api involving I/O ops
                         let batch_bytes = record_batch.buffer_memory_size();
-                        this.metric.record_mem_usage(batch_bytes);
                         this.metric.record_output_bytes(batch_bytes);
                         this.metric.record_output(record_batch.num_rows());
                         Poll::Ready(Some(Ok(record_batch.into_df_record_batch())))


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR makes read-cost accounting use scan output bytes instead of aggregated plan memory usage.

- Add an `output_bytes` counter to `RegionScanExec` stream metrics so datanodes can expose scan output volume through `RecordBatchMetrics.plan_metrics`.
- Use the `RegionScanExec` `output_bytes` metric as the `table_scan` input for `read_meter!`, avoiding double-counting bytes that pass through multiple operators.
- Remove the misleading scan `mem_used` gauge because it accumulated batch sizes with gauge semantics.
- Add `PlanMetrics.plan_name` with serde defaulting so metric extraction can use stable `ExecutionPlan::name()` values instead of formatted explain text.

Compatibility:

- Old serialized metrics without `plan_name` still deserialize because the field has `#[serde(default)]`.
- Older readers should ignore the extra JSON field when reading new metrics.
- No schema or persisted data changes are introduced.

Test plan:

- `cargo test -p common-recordbatch test_plan_metrics_deserializes_without_plan_name`
- `cargo test -p query scan_output_bytes_uses_plan_name`

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.