### PR TITLE
test: redact dynamic filter in order_by sqlness

### DIFF
--- a/tests/cases/standalone/common/order/order_by.result
+++ b/tests/cases/standalone/common/order/order_by.result
@@ -289,6 +289,7 @@ select tag from t where num > 6 order by ts;
 -- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
 -- SQLNESS REPLACE num_ranges=\d+ num_ranges=REDACTED
 -- SQLNESS REPLACE ,\sfilter=\[[^]]+\] 
+-- SQLNESS REPLACE DynamicFilter\s\[[^\]]*\] DynamicFilter [ REDACTED ]
 explain analyze select tag from t where num > 6 order by ts desc limit 2;
 
 +-+-+-+
@@ -299,14 +300,14 @@ explain analyze select tag from t where num > 6 order by ts desc limit 2;
 |_|_|_SortExec: TopK(fetch=2), expr=[ts@1 DESC], preserve_partitioning=[true] REDACTED
 |_|_|_MergeScanExec: REDACTED
 |_|_|_|
-| 1_| 0_|_FilterExec: DynamicFilter [ true ] REDACTED
+| 1_| 0_|_FilterExec: DynamicFilter [ REDACTED ] REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
 |_|_|_SortPreservingMergeExec: [ts@1 DESC], fetch=2 REDACTED
 |_|_|_SortExec: TopK(fetch=2), expr=[ts@1 DESC], preserve_partitioning=[true] REDACTED
 |_|_|_FilterExec: num@2 > 6, projection=[tag@0, ts@1] REDACTED
 |_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0} REDACTED
 |_|_|_|
-| 1_| 1_|_FilterExec: DynamicFilter [ true ] REDACTED
+| 1_| 1_|_FilterExec: DynamicFilter [ REDACTED ] REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
 |_|_|_SortPreservingMergeExec: [ts@1 DESC], fetch=2 REDACTED
 |_|_|_SortExec: TopK(fetch=2), expr=[ts@1 DESC], preserve_partitioning=[true] REDACTED

--- a/tests/cases/standalone/common/order/order_by.sql
+++ b/tests/cases/standalone/common/order/order_by.sql
@@ -96,6 +96,7 @@ select tag from t where num > 6 order by ts;
 -- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
 -- SQLNESS REPLACE num_ranges=\d+ num_ranges=REDACTED
 -- SQLNESS REPLACE ,\sfilter=\[[^]]+\] 
+-- SQLNESS REPLACE DynamicFilter\s\[[^\]]*\] DynamicFilter [ REDACTED ]
 explain analyze select tag from t where num > 6 order by ts desc limit 2;
 
 drop table t;
@@ -121,4 +122,3 @@ SELECT c1, c3 FROM test ORDER BY c3, c1;
 SELECT c2 FROM test ORDER BY ts;
 
 drop table test;
-


### PR DESCRIPTION
## Summary
- Redact DynamicFilter contents in order_by sqlness output.
- Update the expected result to use the redacted DynamicFilter text.

## Tests
- Not run; skipped per request because compiling sqlness was too slow.
