### PR TITLE
fix: pin tonic below 0.14.5 to avoid max connection age panic (#8265)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -250,7 +250,9 @@ tokio-rustls = { version = "0.26.2", default-features = false }
 tokio-stream = "0.1"
 tokio-util = { version = "0.7", features = ["io-util", "compat"] }
 toml = "0.8.8"
-tonic = { version = "0.14", features = ["tls-aws-lc", "gzip", "zstd"] }
+# Pin below 0.14.5 to avoid the `connection_timeout_future` "async fn resumed after
+# completion" panic (greptimedb#8265 / grpc-rust#2522). Remove once tonic ships a fix.
+tonic = { version = "0.14, <0.14.5", features = ["tls-aws-lc", "gzip", "zstd"] }
 tower = "0.5"
 tower-http = "0.6"
 tracing = "0.1"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Closes #8265. Upstream: hyperium/tonic#2522, fix PR hyperium/tonic#2588 (unmerged — author declined the CLA).

## What's changed and what's your intention?

Pin `tonic` to `>=0.14.0, <0.14.5` in the workspace `Cargo.toml`.

tonic 0.14.5 introduced a regression in `connection_timeout_future` / `serve_connection`: when `max_connection_age` is configured **without** `max_connection_age_grace`, the timeout future returns `GracefulShutdown` and completes, then the `select!` loop re-polls the already-completed future, triggering an `` `async fn` resumed after completion `` panic. This is the cause of the flaky `grpc::network::tests::test_grpc_max_connection_age` failures.

Older tonic (≤ 0.14.4) resets the timer to `pending` after firing graceful shutdown, so the completed future is never re-polled and `GOAWAY` is still sent correctly. Pinning below 0.14.5 keeps the graceful `max_connection_age` behavior (and the existing `GOAWAY` test) intact while avoiding the panic.

The committed `Cargo.lock` already resolves `tonic 0.14.2`, which satisfies the new constraint, so `cargo check --locked` stays green with no lock change. Remove this pin once tonic ships a fix upstream.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.