### PR TITLE
fix(mito): collect index apply metrics in pruner verbose mode

### DIFF
--- a/src/mito2/src/read/pruner.rs
+++ b/src/mito2/src/read/pruner.rs
@@ -31,7 +31,7 @@ use crate::error::{PruneFileSnafu, Result};
 use crate::metrics::PRUNER_ACTIVE_BUILDERS;
 use crate::read::range::{FileRangeBuilder, RowGroupIndex};
 use crate::read::scan_region::StreamContext;
-use crate::read::scan_util::{FileScanMetrics, PartitionMetrics};
+use crate::read::scan_util::{FileScanMetrics, PartitionMetrics, new_filter_metrics};
 use crate::sst::parquet::file_range::{FileRange, PreFilterMode};
 use crate::sst::parquet::reader::ReaderMetrics;
 
@@ -447,7 +447,14 @@ impl Pruner {
             // Do the actual pruning (outside lock)
             let file = &inner.stream_ctx.input.files[file_index];
             pruned_files.push(file.file_id().file_id());
-            let mut metrics = ReaderMetrics::default();
+            let explain_verbose = partition_metrics
+                .as_ref()
+                .map(|m| m.explain_verbose())
+                .unwrap_or(false);
+            let mut metrics = ReaderMetrics {
+                filter_metrics: new_filter_metrics(explain_verbose),
+                ..Default::default()
+            };
             let result = inner
                 .stream_ctx
                 .input

--- a/src/mito2/src/read/scan_util.rs
+++ b/src/mito2/src/read/scan_util.rs
@@ -1426,7 +1426,7 @@ mod split_tests {
 
 /// Creates a new [ReaderFilterMetrics] with optional apply metrics initialized
 /// based on the `explain_verbose` flag.
-fn new_filter_metrics(explain_verbose: bool) -> ReaderFilterMetrics {
+pub(crate) fn new_filter_metrics(explain_verbose: bool) -> ReaderFilterMetrics {
     if explain_verbose {
         ReaderFilterMetrics {
             inverted_index_apply_metrics: Some(InvertedIndexApplyMetrics::default()),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

In `EXPLAIN ANALYZE VERBOSE`, mito2 reports per-index "apply metrics" (inverted / bloom / fulltext index apply timings, blob reads, cache hits). These live in `ReaderFilterMetrics` as `Option<...ApplyMetrics>` fields, and the index appliers only record into them when the option is `Some(...)` — i.e. when verbose collection was explicitly enabled on the `ReaderMetrics` before pruning.

The regular (non-pruner) scan path enables this in `scan_flat_file_ranges` via `filter_metrics: new_filter_metrics(part_metrics.explain_verbose())`. The pruner's worker loop, however, prunes files with a plain `ReaderMetrics::default()`, so those options stay `None`. As a result, even in verbose mode the appliers skipped recording, and the index apply metrics never reached the partition-level `ScanMetricsSet` that `EXPLAIN ANALYZE VERBOSE` prints for files pruned through the worker/prefetch path.

This PR fixes it by:

- Making `new_filter_metrics` `pub(crate)` so the pruner module can reuse the same verbose-enabling helper as the normal scan path.
- In `Pruner::worker_loop`, deriving `explain_verbose` from the request's `partition_metrics` and building the `ReaderMetrics` with `filter_metrics: new_filter_metrics(explain_verbose)` before calling `prune_file`.

Once the apply-metric options are `Some`, the appliers record into them, and the existing `part_metrics.merge_reader_metrics(&metrics, ..)` call folds them into the partition metrics automatically. The direct fallback path (`prune_file_directly`) was already unaffected since it uses the caller's already-verbose metrics.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.