### PR TITLE
feat: add per-partition timings to merge scan partition metrics

### DIFF
--- a/src/query/src/dist_plan/merge_scan.rs
+++ b/src/query/src/dist_plan/merge_scan.rs
@@ -367,6 +367,12 @@ impl MergeScanExec {
             let mut ready_timer = metric.ready_time().timer();
             let mut first_consume_timer = Some(metric.first_consume_time().timer());
 
+            // Per-partition timings, mirroring the global timers above but scoped to this
+            // partition's stream so they can be surfaced in `EXPLAIN VERBOSE`.
+            let partition_start = Instant::now();
+            let mut partition_ready_time: Option<Duration> = None;
+            let mut partition_first_consume_time: Option<Duration> = None;
+
             for region_id in regions
                 .iter()
                 .skip(partition)
@@ -423,6 +429,9 @@ impl MergeScanExec {
                 }
 
                 ready_timer.stop();
+                if partition_ready_time.is_none() {
+                    partition_ready_time = Some(partition_start.elapsed());
+                }
 
                 let mut poll_duration = Duration::ZERO;
                 let mut poll_timer = Instant::now();
@@ -438,6 +447,7 @@ impl MergeScanExec {
                     metric.record_output_batch_rows(batch.num_rows());
                     if let Some(mut first_consume_timer) = first_consume_timer.take() {
                         first_consume_timer.stop();
+                        partition_first_consume_time = Some(partition_start.elapsed());
                     }
 
                     if let Some(metrics) = stream.metrics() {
@@ -448,6 +458,14 @@ impl MergeScanExec {
                     yield Ok(batch);
                     // reset poll timer
                     poll_timer = Instant::now();
+                }
+                // `first_consume_time` is the time until the first stream's first poll
+                // resolves, whether it yields a batch or is immediately exhausted. The
+                // `take()` guard ensures this only records once: on the first region whose
+                // stream produced no batch (the empty case the in-loop stop above misses).
+                if let Some(mut first_consume_timer) = first_consume_timer.take() {
+                    first_consume_timer.stop();
+                    partition_first_consume_time = Some(partition_start.elapsed());
                 }
                 let total_cost = region_start.elapsed();
 
@@ -502,9 +520,15 @@ impl MergeScanExec {
             }
 
             // Finish partition metrics and log results
+            let partition_finish_time = partition_start.elapsed();
             {
                 let mut partition_metrics_guard = partition_metrics_moved.lock().unwrap();
                 if let Some(partition_metrics) = partition_metrics_guard.get_mut(&partition) {
+                    partition_metrics.set_timings(
+                        partition_ready_time.unwrap_or_default(),
+                        partition_first_consume_time.unwrap_or_default(),
+                        partition_finish_time,
+                    );
                     partition_metrics.finish();
                 }
             }
@@ -648,6 +672,12 @@ struct PartitionMetrics {
     total_poll_duration: Duration,
     total_do_get_cost: Duration,
     total_regions: usize,
+    /// Time until this partition's scan is ready to emit data.
+    ready_time: Duration,
+    /// Time until this partition's first stream poll resolves (a batch or exhausted).
+    first_consume_time: Duration,
+    /// Time until this partition's scan finishes execution.
+    finish_time: Duration,
     explain_verbose: bool,
     finished: bool,
 }
@@ -660,6 +690,9 @@ impl PartitionMetrics {
             total_poll_duration: Duration::ZERO,
             total_do_get_cost: Duration::ZERO,
             total_regions: 0,
+            ready_time: Duration::ZERO,
+            first_consume_time: Duration::ZERO,
+            finish_time: Duration::ZERO,
             explain_verbose,
             finished: false,
         }
@@ -670,6 +703,18 @@ impl PartitionMetrics {
         self.total_do_get_cost += region_metrics.do_get_cost;
         self.total_regions += 1;
         self.region_metrics.push(region_metrics);
+    }
+
+    /// Set the per-partition timings captured during streaming.
+    fn set_timings(
+        &mut self,
+        ready_time: Duration,
+        first_consume_time: Duration,
+        finish_time: Duration,
+    ) {
+        self.ready_time = ready_time;
+        self.first_consume_time = first_consume_time;
+        self.finish_time = finish_time;
     }
 
     /// Finish the partition metrics and log the results.
@@ -685,19 +730,25 @@ impl PartitionMetrics {
     fn log_metrics(&self) {
         if self.explain_verbose {
             common_telemetry::info!(
-                "MergeScan partition {} finished: {} regions, total_poll_duration: {:?}, total_do_get_cost: {:?}",
+                "MergeScan partition {} finished: {} regions, total_poll_duration: {:?}, total_do_get_cost: {:?}, ready_time: {:?}, first_consume_time: {:?}, finish_time: {:?}",
                 self.partition,
                 self.total_regions,
                 self.total_poll_duration,
-                self.total_do_get_cost
+                self.total_do_get_cost,
+                self.ready_time,
+                self.first_consume_time,
+                self.finish_time
             );
         } else {
             common_telemetry::debug!(
-                "MergeScan partition {} finished: {} regions, total_poll_duration: {:?}, total_do_get_cost: {:?}",
+                "MergeScan partition {} finished: {} regions, total_poll_duration: {:?}, total_do_get_cost: {:?}, ready_time: {:?}, first_consume_time: {:?}, finish_time: {:?}",
                 self.partition,
                 self.total_regions,
                 self.total_poll_duration,
-                self.total_do_get_cost
+                self.total_do_get_cost,
+                self.ready_time,
+                self.first_consume_time,
+                self.finish_time
             );
         }
     }
@@ -832,11 +883,14 @@ impl DisplayAs for MergeScanExec {
                     }
                     write!(
                         f,
-                        "\"partition_{}\":{{\"regions\":{},\"total_poll_duration\":\"{:?}\",\"total_do_get_cost\":\"{:?}\",\"region_metrics\":[",
+                        "\"partition_{}\":{{\"regions\":{},\"total_poll_duration\":\"{:?}\",\"total_do_get_cost\":\"{:?}\",\"ready_time\":\"{:?}\",\"first_consume_time\":\"{:?}\",\"finish_time\":\"{:?}\",\"region_metrics\":[",
                         pm.partition,
                         pm.total_regions,
                         pm.total_poll_duration,
-                        pm.total_do_get_cost
+                        pm.total_do_get_cost,
+                        pm.ready_time,
+                        pm.first_consume_time,
+                        pm.finish_time
                     )?;
                     for (j, rm) in pm.region_metrics.iter().enumerate() {
                         if j > 0 {

--- a/src/query/src/dist_plan/merge_scan.rs
+++ b/src/query/src/dist_plan/merge_scan.rs
@@ -367,8 +367,7 @@ impl MergeScanExec {
             let mut ready_timer = metric.ready_time().timer();
             let mut first_consume_timer = Some(metric.first_consume_time().timer());
 
-            // Per-partition timings, mirroring the global timers above but scoped to this
-            // partition's stream so they can be surfaced in `EXPLAIN VERBOSE`.
+            // Per-partition timings, scoped to this partition's stream for `EXPLAIN VERBOSE`.
             let partition_start = Instant::now();
             let mut partition_ready_time: Option<Duration> = None;
             let mut partition_first_consume_time: Option<Duration> = None;
@@ -459,10 +458,8 @@ impl MergeScanExec {
                     // reset poll timer
                     poll_timer = Instant::now();
                 }
-                // `first_consume_time` is the time until the first stream's first poll
-                // resolves, whether it yields a batch or is immediately exhausted. The
-                // `take()` guard ensures this only records once: on the first region whose
-                // stream produced no batch (the empty case the in-loop stop above misses).
+                // Also stop on an exhausted stream that yielded no batch. The `take()`
+                // guard ensures it only records once, on the first such region.
                 if let Some(mut first_consume_timer) = first_consume_timer.take() {
                     first_consume_timer.stop();
                     partition_first_consume_time = Some(partition_start.elapsed());
@@ -517,6 +514,13 @@ impl MergeScanExec {
                 }
 
                 MERGE_SCAN_POLL_ELAPSED.observe(poll_duration.as_secs_f64());
+            }
+
+            // Stop the global timers for partitions with no region, otherwise they keep
+            // running until drop and inflate the shared metrics. No-op otherwise.
+            ready_timer.stop();
+            if let Some(mut first_consume_timer) = first_consume_timer.take() {
+                first_consume_timer.stop();
             }
 
             // Finish partition metrics and log results


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

`MergeScanMetric`'s `ready_time`, `first_consume_time`, and `finish_time` are built from the shared `ExecutionPlanMetricsSet`, so they are aggregated globally across all partitions and only visible via DataFusion's standard `EXPLAIN ANALYZE` output. This PR captures the same three timings **per partition** and surfaces them in `EXPLAIN VERBOSE`, matching the existing per-partition `poll_duration` / `do_get_cost` reporting.

Changes (all in `src/query/src/dist_plan/merge_scan.rs`):

- Capture per-partition `ready_time` / `first_consume_time` / `finish_time` in `to_stream` using an `Instant`-based `partition_start`, and store them on the partition's `PartitionMetrics` via a new `set_timings(...)`.
- Render the three timings in the `DisplayAs` *Verbose* JSON for each `"partition_N"`, and include them in the partition `log_metrics` lines.
- Fix `first_consume_time` semantics so it records the time until the first stream's first poll resolves — whether it yields a batch **or** is immediately exhausted (empty). Previously the timer was only stopped on the first consumed batch, so an empty first stream left it lingering until drop. This is now corrected for both the global and per-partition metrics via an `Option::take()`-guarded stop right after each region's drain loop (fires once, on the first empty stream).

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.