### PR TITLE
feat: observe PromQL range query in-flight duplicates

### DIFF
--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -103,6 +103,7 @@ pub mod otlp;
 pub mod pprof;
 pub mod prom_store;
 pub mod prometheus;
+pub(crate) mod prometheus_query_frontend;
 pub mod result;
 mod timeout;
 pub mod utils;

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -69,6 +69,7 @@ use crate::error::{
     NotSupportedSnafu, ParseTimestampSnafu, Result, TableNotFoundSnafu, UnexpectedResultSnafu,
 };
 use crate::http::header::collect_plan_metrics;
+use crate::http::prometheus_query_frontend::{QueryFrontendKey, observe_range_query};
 use crate::prom_store::{FIELD_NAME_LABEL, METRIC_NAME_LABEL, is_database_selection_label};
 use crate::prometheus_handler::PrometheusHandlerRef;
 
@@ -451,12 +452,29 @@ async fn do_range_query(
     prom_query: &PromQuery,
     query_ctx: QueryContextRef,
 ) -> PrometheusJsonResponse {
+    let frontend_key = QueryFrontendKey::new(
+        query_ctx.get_db_string(),
+        query_ctx.read_preference().to_string(),
+        prom_query,
+    );
+    let mut in_flight_guard = observe_range_query(frontend_key);
+
     let result = handler.do_query(prom_query, query_ctx).await;
     let metric_name = match retrieve_metric_name_and_result_type(&prom_query.query) {
-        Err(err) => return PrometheusJsonResponse::error(err.status_code(), err.output_msg()),
+        Err(err) => {
+            in_flight_guard.mark_errored();
+            return PrometheusJsonResponse::error(err.status_code(), err.output_msg());
+        }
         Ok((metric_name, _)) => metric_name,
     };
-    PrometheusJsonResponse::from_query_result(result, metric_name, ValueType::Matrix).await
+    let response =
+        PrometheusJsonResponse::from_query_result(result, metric_name, ValueType::Matrix).await;
+    if response.status == "error" {
+        in_flight_guard.mark_errored();
+    } else {
+        in_flight_guard.mark_completed();
+    }
+    response
 }
 
 #[derive(Debug, Default, Serialize)]

--- a/src/servers/src/http/prometheus_query_frontend.rs
+++ b/src/servers/src/http/prometheus_query_frontend.rs
@@ -1,0 +1,280 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Observe-only PromQL HTTP query frontend instrumentation.
+//!
+//! This module intentionally does not cache, coalesce, normalize, or replay
+//! query responses. It only observes identical in-flight `query_range` work so
+//! a future query frontend can be built without changing current behavior.
+
+use std::collections::HashMap;
+
+use lazy_static::lazy_static;
+use parking_lot::Mutex;
+use query::parser::PromQuery;
+
+const OUTCOME_FIRST_IN_FLIGHT: &str = "first_in_flight";
+const OUTCOME_DUPLICATE_IN_FLIGHT: &str = "duplicate_in_flight";
+const OUTCOME_COMPLETED: &str = "completed";
+const OUTCOME_ERRORED: &str = "errored";
+const OUTCOME_CANCELLED: &str = "cancelled";
+
+lazy_static! {
+    static ref IN_FLIGHT_REGISTRY: Mutex<InFlightRegistry> =
+        Mutex::new(InFlightRegistry::default());
+}
+
+/// Exact observe-only key for PromQL range queries.
+///
+/// The full query is kept only in memory for equality/collision checks. Metrics
+/// and logs must not include it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct QueryFrontendKey {
+    db: String,
+    read_preference: String,
+    query: String,
+    start: String,
+    end: String,
+    step: String,
+    lookback: String,
+}
+
+impl QueryFrontendKey {
+    pub(crate) fn new(db: String, read_preference: String, prom_query: &PromQuery) -> Self {
+        Self {
+            db,
+            read_preference,
+            query: prom_query.query.clone(),
+            start: prom_query.start.clone(),
+            end: prom_query.end.clone(),
+            step: prom_query.step.clone(),
+            lookback: prom_query.lookback.clone(),
+        }
+    }
+
+    #[cfg(test)]
+    fn for_test(
+        db: &str,
+        read_preference: &str,
+        query: &str,
+        start: &str,
+        end: &str,
+        step: &str,
+        lookback: &str,
+    ) -> Self {
+        Self {
+            db: db.to_string(),
+            read_preference: read_preference.to_string(),
+            query: query.to_string(),
+            start: start.to_string(),
+            end: end.to_string(),
+            step: step.to_string(),
+            lookback: lookback.to_string(),
+        }
+    }
+
+    fn db(&self) -> &str {
+        &self.db
+    }
+}
+
+#[derive(Default)]
+struct InFlightRegistry {
+    in_flight: HashMap<QueryFrontendKey, usize>,
+}
+
+impl InFlightRegistry {
+    fn enter(&mut self, key: QueryFrontendKey) -> bool {
+        if let Some(count) = self.in_flight.get_mut(&key) {
+            *count += 1;
+            true
+        } else {
+            self.in_flight.insert(key, 1);
+            false
+        }
+    }
+
+    fn exit(&mut self, key: &QueryFrontendKey) {
+        if let Some(count) = self.in_flight.get_mut(key) {
+            if *count > 1 {
+                *count -= 1;
+            } else {
+                self.in_flight.remove(key);
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn active_count(&self, key: &QueryFrontendKey) -> usize {
+        self.in_flight.get(key).copied().unwrap_or(0)
+    }
+
+    #[cfg(test)]
+    fn is_empty(&self) -> bool {
+        self.in_flight.is_empty()
+    }
+}
+
+/// RAII guard for an observed in-flight range query.
+///
+/// Dropping the guard removes its entry even if later response conversion exits
+/// early. The guard does not affect execution of the query.
+pub(crate) struct InFlightGuard {
+    key: QueryFrontendKey,
+    completed: bool,
+    errored: bool,
+}
+
+impl InFlightGuard {
+    pub(crate) fn mark_completed(&mut self) {
+        self.completed = true;
+    }
+
+    pub(crate) fn mark_errored(&mut self) {
+        self.errored = true;
+    }
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        IN_FLIGHT_REGISTRY.lock().exit(&self.key);
+        let outcome = if self.errored {
+            OUTCOME_ERRORED
+        } else if self.completed {
+            OUTCOME_COMPLETED
+        } else {
+            OUTCOME_CANCELLED
+        };
+        observe(self.key.db(), outcome);
+    }
+}
+
+pub(crate) fn observe_range_query(key: QueryFrontendKey) -> InFlightGuard {
+    let duplicate = IN_FLIGHT_REGISTRY.lock().enter(key.clone());
+    let outcome = if duplicate {
+        OUTCOME_DUPLICATE_IN_FLIGHT
+    } else {
+        OUTCOME_FIRST_IN_FLIGHT
+    };
+    observe(key.db(), outcome);
+    InFlightGuard {
+        key,
+        completed: false,
+        errored: false,
+    }
+}
+
+fn observe(db: &str, outcome: &str) {
+    crate::metrics::METRIC_HTTP_PROMETHEUS_QUERY_FRONTEND_OBSERVATIONS
+        .with_label_values(&[db, outcome])
+        .inc();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn key_equality_and_difference_are_exact() {
+        let base = QueryFrontendKey::for_test("db", "LEADER", "up", "1", "2", "5s", "5m");
+        assert_eq!(
+            base,
+            QueryFrontendKey::for_test("db", "LEADER", "up", "1", "2", "5s", "5m")
+        );
+        assert_ne!(
+            base,
+            QueryFrontendKey::for_test("other", "LEADER", "up", "1", "2", "5s", "5m")
+        );
+        assert_ne!(
+            base,
+            QueryFrontendKey::for_test("db", "FOLLOWER", "up", "1", "2", "5s", "5m")
+        );
+        assert_ne!(
+            base,
+            QueryFrontendKey::for_test("db", "LEADER", "rate(up[5m])", "1", "2", "5s", "5m")
+        );
+        assert_ne!(
+            base,
+            QueryFrontendKey::for_test("db", "LEADER", "up", "0", "2", "5s", "5m")
+        );
+        assert_ne!(
+            base,
+            QueryFrontendKey::for_test("db", "LEADER", "up", "1", "3", "5s", "5m")
+        );
+        assert_ne!(
+            base,
+            QueryFrontendKey::for_test("db", "LEADER", "up", "1", "2", "10s", "5m")
+        );
+        assert_ne!(
+            base,
+            QueryFrontendKey::for_test("db", "LEADER", "up", "1", "2", "5s", "1m")
+        );
+    }
+
+    #[test]
+    fn registry_tracks_duplicate_enter_and_exit() {
+        let key = QueryFrontendKey::for_test("db", "LEADER", "up", "1", "2", "5s", "5m");
+        let mut registry = InFlightRegistry::default();
+
+        assert!(!registry.enter(key.clone()));
+        assert_eq!(1, registry.active_count(&key));
+
+        assert!(registry.enter(key.clone()));
+        assert_eq!(2, registry.active_count(&key));
+
+        registry.exit(&key);
+        assert_eq!(1, registry.active_count(&key));
+
+        registry.exit(&key);
+        assert_eq!(0, registry.active_count(&key));
+        assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn guard_removes_entry_on_drop() {
+        let key = QueryFrontendKey::for_test("guard_db", "LEADER", "up", "1", "2", "5s", "5m");
+        {
+            let _guard = observe_range_query(key.clone());
+            assert_eq!(1, IN_FLIGHT_REGISTRY.lock().active_count(&key));
+        }
+        assert_eq!(0, IN_FLIGHT_REGISTRY.lock().active_count(&key));
+    }
+
+    #[test]
+    fn guard_removes_entry_after_mark_errored() {
+        let key =
+            QueryFrontendKey::for_test("guard_error_db", "LEADER", "up", "1", "2", "5s", "5m");
+        {
+            let mut guard = observe_range_query(key.clone());
+            guard.mark_errored();
+            assert_eq!(1, IN_FLIGHT_REGISTRY.lock().active_count(&key));
+        }
+        assert_eq!(0, IN_FLIGHT_REGISTRY.lock().active_count(&key));
+    }
+
+    #[test]
+    fn duplicate_guards_exit_independently() {
+        let key =
+            QueryFrontendKey::for_test("duplicate_guard_db", "LEADER", "up", "1", "2", "5s", "5m");
+        let first_guard = observe_range_query(key.clone());
+        let second_guard = observe_range_query(key.clone());
+        assert_eq!(2, IN_FLIGHT_REGISTRY.lock().active_count(&key));
+
+        drop(first_guard);
+        assert_eq!(1, IN_FLIGHT_REGISTRY.lock().active_count(&key));
+
+        drop(second_guard);
+        assert_eq!(0, IN_FLIGHT_REGISTRY.lock().active_count(&key));
+    }
+}

--- a/src/servers/src/metrics.rs
+++ b/src/servers/src/metrics.rs
@@ -198,6 +198,12 @@ lazy_static! {
         &[METRIC_DB_LABEL, METRIC_METHOD_LABEL]
     )
     .unwrap();
+    pub static ref METRIC_HTTP_PROMETHEUS_QUERY_FRONTEND_OBSERVATIONS: IntCounterVec = register_int_counter_vec!(
+        "greptime_servers_http_prometheus_query_frontend_observations_total",
+        "servers http prometheus query frontend observe-only in-flight lifecycle observations. Entry outcomes are first_in_flight/duplicate_in_flight; exit outcomes are completed/errored/cancelled",
+        &[METRIC_DB_LABEL, METRIC_RESULT_LABEL]
+    )
+    .unwrap();
     pub static ref METRIC_HTTP_OPENTELEMETRY_METRICS_ELAPSED: HistogramVec =
         register_histogram_vec!(
             "greptime_servers_http_otlp_metrics_elapsed",


### PR DESCRIPTION
## Summary

- Add observe-only in-flight tracking for Prometheus HTTP `query_range` requests.
- Emit low-cardinality query-frontend observation metrics for first/duplicate/completed/errored/cancelled in-flight work.
- Include read preference in the exact observation key so leader/follower requests are not treated as interchangeable.

This is Phase 0 only. It intentionally does **not** cache responses, coalesce requests, replay/stale results, or rewrite `start`/`end`/`step`/`lookback`.

## Validation

- `cargo fmt --check --package servers`
- `cargo test -p servers prometheus_query_frontend --lib`
  - 5 passed
- `cargo check -p servers`
- `cargo clippy -p servers --lib -- -D warnings`

Local standalone smoke was run with a local-only workload script (not included in this PR) and non-empty query results:

| scenario | requests | concurrency | first | duplicate | duplicate ratio | errors | points |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| identical | 20 | 1 | 20 | 0 | 0.0% | 0 | 47,480 |
| identical | 100 | 50 | 1 | 99 | 99.0% | 0 | 237,400 |
| identical | 500 | 100 | 1 | 499 | 99.8% | 0 | 1,187,000 |
| shifted | 100 | 50 | 100 | 0 | 0.0% | 0 | 240,210 |
| mixed | 100 | 50 | 51 | 49 | 49.0% | 0 | 238,813 |
