### PR TITLE
feat: decouple error retryability from status codes

### DIFF
--- a/src/auth/src/error.rs
+++ b/src/auth/src/error.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_error::ext::{BoxedError, ErrorExt, RetryHint};
+use common_error::ext::{BoxedError, ErrorExt, RetryHint, retry_hint_from_io_error};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use snafu::{Location, Snafu};
@@ -114,7 +114,7 @@ impl ErrorExt for Error {
 
     fn retry_hint(&self) -> RetryHint {
         match self {
-            Error::Io { .. } => RetryHint::Retryable,
+            Error::Io { error, .. } => retry_hint_from_io_error(error),
             Error::AuthBackend { source, .. } => source.retry_hint(),
             _ => RetryHint::NonRetryable,
         }

--- a/src/auth/src/error.rs
+++ b/src/auth/src/error.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_error::ext::{BoxedError, ErrorExt};
+use common_error::ext::{BoxedError, ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use snafu::{Location, Snafu};
@@ -110,6 +110,14 @@ impl ErrorExt for Error {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn retry_hint(&self) -> RetryHint {
+        match self {
+            Error::Io { .. } => RetryHint::Retryable,
+            Error::AuthBackend { source, .. } => source.retry_hint(),
+            _ => RetryHint::NonRetryable,
+        }
     }
 }
 

--- a/src/cli/src/data/export_v2/error.rs
+++ b/src/cli/src/data/export_v2/error.rs
@@ -14,9 +14,10 @@
 
 use std::any::Any;
 
-use common_error::ext::ErrorExt;
+use common_error::ext::{ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
+use object_store::error::retry_hint_from_opendal_error;
 use snafu::{Location, Snafu};
 
 #[derive(Snafu)]
@@ -242,5 +243,15 @@ impl ErrorExt for Error {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn retry_hint(&self) -> RetryHint {
+        match self {
+            Error::StorageOperation { error, .. } | Error::BuildObjectStore { error, .. } => {
+                retry_hint_from_opendal_error(error)
+            }
+            Error::Database { error, .. } => error.retry_hint(),
+            _ => RetryHint::NonRetryable,
+        }
     }
 }

--- a/src/cli/src/data/import_v2/error.rs
+++ b/src/cli/src/data/import_v2/error.rs
@@ -14,7 +14,7 @@
 
 use std::any::Any;
 
-use common_error::ext::{ErrorExt, RetryHint};
+use common_error::ext::{ErrorExt, RetryHint, retry_hint_from_io_error};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use snafu::{Location, Snafu};
@@ -230,7 +230,7 @@ impl ErrorExt for Error {
             Error::SnapshotStorage { error, .. } | Error::ChunkImportFailed { error, .. } => {
                 error.retry_hint()
             }
-            Error::ImportStateIo { .. } => RetryHint::Retryable,
+            Error::ImportStateIo { error, .. } => retry_hint_from_io_error(error),
             _ => RetryHint::NonRetryable,
         }
     }

--- a/src/cli/src/data/import_v2/error.rs
+++ b/src/cli/src/data/import_v2/error.rs
@@ -14,7 +14,7 @@
 
 use std::any::Any;
 
-use common_error::ext::ErrorExt;
+use common_error::ext::{ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use snafu::{Location, Snafu};
@@ -213,6 +213,25 @@ impl ErrorExt for Error {
             Error::ImportStateParse { .. } => StatusCode::Internal,
             Error::ImportStateIo { .. } => StatusCode::StorageUnavailable,
             Error::ImportStateLocked { .. } => StatusCode::IllegalState,
+        }
+    }
+
+    fn retry_hint(&self) -> RetryHint {
+        match self {
+            #[cfg(test)]
+            Error::TestTaskFailed { retryable, .. } => {
+                if *retryable {
+                    RetryHint::Retryable
+                } else {
+                    RetryHint::NonRetryable
+                }
+            }
+            Error::Database { error, .. } => error.retry_hint(),
+            Error::SnapshotStorage { error, .. } | Error::ChunkImportFailed { error, .. } => {
+                error.retry_hint()
+            }
+            Error::ImportStateIo { .. } => RetryHint::Retryable,
+            _ => RetryHint::NonRetryable,
         }
     }
 

--- a/src/client/src/database.rs
+++ b/src/client/src/database.rs
@@ -1012,7 +1012,7 @@ mod tests {
             code: StatusCode::Internal,
             msg: "blabla".to_string(),
             tonic_code: Code::Internal,
-            retry_hint: RetryHint::NonRetryable,
+            retry_hint: RetryHint::Retryable,
         }
         .build();
 
@@ -1020,7 +1020,8 @@ mod tests {
         let actual: Error = status.into();
 
         assert_eq!(expected.to_string(), actual.to_string());
-        assert_eq!(actual.retry_hint(), RetryHint::NonRetryable);
+        assert_eq!(actual.retry_hint(), RetryHint::Retryable);
+        assert!(actual.should_retry());
     }
 
     #[test]
@@ -1040,6 +1041,32 @@ mod tests {
         let actual: Error = status.into();
 
         assert_eq!(actual.retry_hint(), RetryHint::Retryable);
+        assert!(actual.should_retry());
+    }
+
+    #[test]
+    fn test_from_tonic_status_fallback_uses_status_code() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            GREPTIME_DB_HEADER_ERROR_CODE,
+            HeaderValue::from(StatusCode::InvalidArguments as u32),
+        );
+        let status =
+            Status::with_metadata(Code::Internal, "blabla", MetadataMap::from_headers(headers));
+
+        let actual: Error = status.into();
+
+        assert_eq!(actual.retry_hint(), RetryHint::NonRetryable);
+        assert!(!actual.should_retry());
+    }
+
+    #[test]
+    fn test_should_retry_preserves_transport_retry() {
+        let status = Status::new(Code::Unavailable, "blabla");
+        let actual: Error = status.into();
+
+        assert_eq!(actual.retry_hint(), RetryHint::Retryable);
+        assert!(actual.should_retry());
     }
 
     #[tokio::test]

--- a/src/client/src/database.rs
+++ b/src/client/src/database.rs
@@ -868,13 +868,17 @@ mod tests {
 
     use api::v1::auth_header::AuthScheme;
     use api::v1::{AuthHeader, Basic};
+    use common_error::ext::{ErrorExt, RetryHint};
     use common_error::status_code::StatusCode;
+    use common_error::{GREPTIME_DB_HEADER_ERROR_CODE, GREPTIME_DB_HEADER_ERROR_RETRY_HINT};
     use common_query::OutputData;
     use common_recordbatch::{OrderOption, RecordBatch, RecordBatchStream};
     use datatypes::prelude::{ConcreteDataType, VectorRef};
     use datatypes::schema::{ColumnSchema, Schema};
     use datatypes::vectors::Int32Vector;
     use futures_util::StreamExt;
+    use tonic::codegen::http::{HeaderMap, HeaderValue};
+    use tonic::metadata::MetadataMap;
     use tonic::{Code, Status};
 
     use super::*;
@@ -1008,6 +1012,7 @@ mod tests {
             code: StatusCode::Internal,
             msg: "blabla".to_string(),
             tonic_code: Code::Internal,
+            retry_hint: RetryHint::NonRetryable,
         }
         .build();
 
@@ -1015,6 +1020,26 @@ mod tests {
         let actual: Error = status.into();
 
         assert_eq!(expected.to_string(), actual.to_string());
+        assert_eq!(actual.retry_hint(), RetryHint::NonRetryable);
+    }
+
+    #[test]
+    fn test_from_tonic_status_with_retry_hint() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            GREPTIME_DB_HEADER_ERROR_CODE,
+            HeaderValue::from(StatusCode::Internal as u32),
+        );
+        headers.insert(
+            GREPTIME_DB_HEADER_ERROR_RETRY_HINT,
+            HeaderValue::from_static(RetryHint::Retryable.as_str()),
+        );
+        let status =
+            Status::with_metadata(Code::Internal, "blabla", MetadataMap::from_headers(headers));
+
+        let actual: Error = status.into();
+
+        assert_eq!(actual.retry_hint(), RetryHint::Retryable);
     }
 
     #[tokio::test]

--- a/src/client/src/database.rs
+++ b/src/client/src/database.rs
@@ -1012,7 +1012,7 @@ mod tests {
             code: StatusCode::Internal,
             msg: "blabla".to_string(),
             tonic_code: Code::Internal,
-            retry_hint: RetryHint::Retryable,
+            retry_hint: RetryHint::NonRetryable,
         }
         .build();
 
@@ -1020,8 +1020,8 @@ mod tests {
         let actual: Error = status.into();
 
         assert_eq!(expected.to_string(), actual.to_string());
-        assert_eq!(actual.retry_hint(), RetryHint::Retryable);
-        assert!(actual.should_retry());
+        assert_eq!(expected.retry_hint(), actual.retry_hint());
+        assert_eq!(expected.should_retry(), actual.should_retry());
     }
 
     #[test]
@@ -1065,7 +1065,6 @@ mod tests {
         let status = Status::new(Code::Unavailable, "blabla");
         let actual: Error = status.into();
 
-        assert_eq!(actual.retry_hint(), RetryHint::Retryable);
         assert!(actual.should_retry());
     }
 

--- a/src/client/src/database.rs
+++ b/src/client/src/database.rs
@@ -1045,7 +1045,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_tonic_status_fallback_uses_status_code() {
+    fn test_from_tonic_status_fallback() {
         let mut headers = HeaderMap::new();
         headers.insert(
             GREPTIME_DB_HEADER_ERROR_CODE,

--- a/src/client/src/error.rs
+++ b/src/client/src/error.rs
@@ -181,7 +181,7 @@ impl ErrorExt for Error {
             | Error::CreateChannel { source, .. }
             | Error::CreateTlsChannel { source, .. } => source.retry_hint(),
             Error::ConvertSchema { source, .. } => source.retry_hint(),
-            _ => RetryHint::NonRetryable,
+            _ => RetryHint::from_status_code(self.status_code()),
         }
     }
 }
@@ -210,7 +210,8 @@ impl Error {
     }
 
     pub fn should_retry(&self) -> bool {
-        self.is_connection_error()
+        self.retry_hint().is_retryable()
+            || self.is_connection_error()
             || matches!(
                 self.tonic_code(),
                 Some(Code::Cancelled) | Some(Code::DeadlineExceeded)

--- a/src/client/src/error.rs
+++ b/src/client/src/error.rs
@@ -15,7 +15,7 @@
 use std::any::Any;
 
 use common_error::define_from_tonic_status;
-use common_error::ext::{BoxedError, ErrorExt};
+use common_error::ext::{BoxedError, ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use snafu::{Location, Snafu};
@@ -130,6 +130,7 @@ pub enum Error {
         code: StatusCode,
         msg: String,
         tonic_code: Code,
+        retry_hint: RetryHint,
         #[snafu(implicit)]
         location: Location,
     },
@@ -167,6 +168,21 @@ impl ErrorExt for Error {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn retry_hint(&self) -> RetryHint {
+        match self {
+            Error::Tonic { retry_hint, .. } => *retry_hint,
+            Error::FlightGet { source, .. }
+            | Error::RegionServer { source, .. }
+            | Error::FlowServer { source, .. }
+            | Error::External { source, .. } => source.retry_hint(),
+            Error::ConvertFlightData { source, .. }
+            | Error::CreateChannel { source, .. }
+            | Error::CreateTlsChannel { source, .. } => source.retry_hint(),
+            Error::ConvertSchema { source, .. } => source.retry_hint(),
+            _ => RetryHint::NonRetryable,
+        }
     }
 }
 

--- a/src/client/src/error.rs
+++ b/src/client/src/error.rs
@@ -181,7 +181,7 @@ impl ErrorExt for Error {
             | Error::CreateChannel { source, .. }
             | Error::CreateTlsChannel { source, .. } => source.retry_hint(),
             Error::ConvertSchema { source, .. } => source.retry_hint(),
-            _ => RetryHint::from_status_code(self.status_code()),
+            _ => RetryHint::NonRetryable,
         }
     }
 }

--- a/src/common/datasource/src/error.rs
+++ b/src/common/datasource/src/error.rs
@@ -15,7 +15,7 @@
 use std::any::Any;
 
 use arrow_schema::ArrowError;
-use common_error::ext::{ErrorExt, RetryHint};
+use common_error::ext::{ErrorExt, RetryHint, retry_hint_from_io_error};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use datafusion::parquet::errors::ParquetError;
@@ -260,7 +260,8 @@ impl ErrorExt for Error {
             | ListObjects { error, .. }
             | ReadObject { error, .. }
             | WriteObject { error, .. } => retry_hint_from_opendal_error(error),
-            AsyncWrite { .. } | WriteParquet { .. } => RetryHint::Retryable,
+            AsyncWrite { error, .. } => retry_hint_from_io_error(error),
+            WriteParquet { .. } => RetryHint::Retryable,
             _ => RetryHint::NonRetryable,
         }
     }

--- a/src/common/datasource/src/error.rs
+++ b/src/common/datasource/src/error.rs
@@ -15,10 +15,11 @@
 use std::any::Any;
 
 use arrow_schema::ArrowError;
-use common_error::ext::ErrorExt;
+use common_error::ext::{ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use datafusion::parquet::errors::ParquetError;
+use object_store::error::retry_hint_from_opendal_error;
 use snafu::{Location, Snafu};
 use url::ParseError;
 
@@ -249,5 +250,18 @@ impl ErrorExt for Error {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn retry_hint(&self) -> RetryHint {
+        use Error::*;
+
+        match self {
+            BuildBackend { error, .. }
+            | ListObjects { error, .. }
+            | ReadObject { error, .. }
+            | WriteObject { error, .. } => retry_hint_from_opendal_error(error),
+            AsyncWrite { .. } | WriteParquet { .. } => RetryHint::Retryable,
+            _ => RetryHint::NonRetryable,
+        }
     }
 }

--- a/src/common/error/src/ext.rs
+++ b/src/common/error/src/ext.rs
@@ -14,17 +14,62 @@
 
 use std::any::Any;
 use std::fmt::{Debug, Formatter};
+use std::str::FromStr;
 use std::sync::Arc;
 
 use snafu::{FromString, Snafu};
 
 use crate::status_code::StatusCode;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetryHint {
+    Retryable,
+    NonRetryable,
+}
+
+const RETRY_HINT_RETRYABLE: &str = "retryable";
+const RETRY_HINT_NON_RETRYABLE: &str = "non_retryable";
+
+impl RetryHint {
+    pub fn is_retryable(self) -> bool {
+        matches!(self, RetryHint::Retryable)
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            RetryHint::Retryable => RETRY_HINT_RETRYABLE,
+            RetryHint::NonRetryable => RETRY_HINT_NON_RETRYABLE,
+        }
+    }
+}
+
+impl FromStr for RetryHint {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            RETRY_HINT_RETRYABLE => Ok(RetryHint::Retryable),
+            RETRY_HINT_NON_RETRYABLE => Ok(RetryHint::NonRetryable),
+            _ => Err(()),
+        }
+    }
+}
+
 /// Extension to [`Error`](std::error::Error) in std.
 pub trait ErrorExt: StackError {
     /// Map this error to [StatusCode].
     fn status_code(&self) -> StatusCode {
         StatusCode::Unknown
+    }
+
+    /// Returns the retry hint for this error.
+    fn retry_hint(&self) -> RetryHint {
+        RetryHint::NonRetryable
+    }
+
+    /// Returns true if this error is retryable.
+    fn is_retryable(&self) -> bool {
+        self.retry_hint().is_retryable()
     }
 
     /// Returns the error as [Any](std::any::Any) so that it can be
@@ -192,6 +237,10 @@ impl std::error::Error for BoxedError {
 impl crate::ext::ErrorExt for BoxedError {
     fn status_code(&self) -> crate::status_code::StatusCode {
         self.inner.status_code()
+    }
+
+    fn retry_hint(&self) -> RetryHint {
+        self.inner.retry_hint()
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/src/common/error/src/ext.rs
+++ b/src/common/error/src/ext.rs
@@ -36,10 +36,13 @@ impl RetryHint {
     }
 
     pub fn from_status_code(status_code: StatusCode) -> Self {
-        if status_code.is_retryable() {
-            RetryHint::Retryable
-        } else {
-            RetryHint::NonRetryable
+        match status_code {
+            StatusCode::StorageUnavailable
+            | StatusCode::RuntimeResourcesExhausted
+            | StatusCode::RegionNotReady
+            | StatusCode::TableUnavailable
+            | StatusCode::RegionBusy => RetryHint::Retryable,
+            _ => RetryHint::NonRetryable,
         }
     }
 

--- a/src/common/error/src/ext.rs
+++ b/src/common/error/src/ext.rs
@@ -14,6 +14,7 @@
 
 use std::any::Any;
 use std::fmt::{Debug, Formatter};
+use std::io::ErrorKind;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -21,9 +22,18 @@ use snafu::{FromString, Snafu};
 
 use crate::status_code::StatusCode;
 
+/// Describes whether an error instance is safe and useful to retry.
+///
+/// This is intentionally separate from [`StatusCode`]: status code describes the
+/// error category exposed to users, while retry hint describes retry policy for
+/// this specific error instance.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RetryHint {
+    /// The operation may succeed if retried later.
     Retryable,
+    /// Retrying the same operation is not expected to help.
+    ///
+    /// This is the default for errors that do not explicitly opt in to retry.
     NonRetryable,
 }
 
@@ -55,6 +65,62 @@ impl FromStr for RetryHint {
     }
 }
 
+/// Converts a [`std::io::Error`] into a conservative [`RetryHint`].
+///
+/// This helper classifies known transient I/O conditions as retryable and treats
+/// request, permission, filesystem-capacity, and data-shape errors as
+/// non-retryable. `std::io::ErrorKind` is non-exhaustive, so future or
+/// unclassified kinds are considered non-retryable until reviewed explicitly.
+pub fn retry_hint_from_io_error(error: &std::io::Error) -> RetryHint {
+    match error.kind() {
+        ErrorKind::ConnectionRefused
+        | ErrorKind::ConnectionReset
+        | ErrorKind::HostUnreachable
+        | ErrorKind::NetworkUnreachable
+        | ErrorKind::ConnectionAborted
+        | ErrorKind::NotConnected
+        | ErrorKind::NetworkDown
+        | ErrorKind::BrokenPipe
+        | ErrorKind::WouldBlock
+        | ErrorKind::StaleNetworkFileHandle
+        | ErrorKind::TimedOut
+        | ErrorKind::ResourceBusy
+        | ErrorKind::Interrupted => RetryHint::Retryable,
+
+        ErrorKind::NotFound
+        | ErrorKind::PermissionDenied
+        | ErrorKind::AddrInUse
+        | ErrorKind::AddrNotAvailable
+        | ErrorKind::AlreadyExists
+        | ErrorKind::NotADirectory
+        | ErrorKind::IsADirectory
+        | ErrorKind::DirectoryNotEmpty
+        | ErrorKind::ReadOnlyFilesystem
+        | ErrorKind::InvalidInput
+        | ErrorKind::InvalidData
+        | ErrorKind::WriteZero
+        | ErrorKind::StorageFull
+        | ErrorKind::NotSeekable
+        | ErrorKind::QuotaExceeded
+        | ErrorKind::FileTooLarge
+        | ErrorKind::ExecutableFileBusy
+        | ErrorKind::Deadlock
+        | ErrorKind::CrossesDevices
+        | ErrorKind::TooManyLinks
+        | ErrorKind::InvalidFilename
+        | ErrorKind::ArgumentListTooLong
+        | ErrorKind::Unsupported
+        | ErrorKind::UnexpectedEof
+        | ErrorKind::OutOfMemory
+        | ErrorKind::Other => RetryHint::NonRetryable,
+
+        unclassified_or_future_kind => {
+            let _ = unclassified_or_future_kind;
+            RetryHint::NonRetryable
+        }
+    }
+}
+
 /// Extension to [`Error`](std::error::Error) in std.
 pub trait ErrorExt: StackError {
     /// Map this error to [StatusCode].
@@ -62,12 +128,19 @@ pub trait ErrorExt: StackError {
         StatusCode::Unknown
     }
 
-    /// Returns the retry hint for this error.
+    /// Returns the retry hint for this error instance.
+    ///
+    /// Implementations should return [`RetryHint::Retryable`] only when retrying the
+    /// same operation may succeed without changing the request. The default is
+    /// [`RetryHint::NonRetryable`] to avoid accidental retry loops.
     fn retry_hint(&self) -> RetryHint {
         RetryHint::NonRetryable
     }
 
-    /// Returns true if this error is retryable.
+    /// Returns whether this error instance is marked retryable.
+    ///
+    /// This is derived from [`Self::retry_hint`]. Transport-level retries, such as a
+    /// gRPC `Unavailable`, may still be handled separately by client code.
     fn is_retryable(&self) -> bool {
         self.retry_hint().is_retryable()
     }

--- a/src/common/error/src/ext.rs
+++ b/src/common/error/src/ext.rs
@@ -35,17 +35,6 @@ impl RetryHint {
         matches!(self, RetryHint::Retryable)
     }
 
-    pub fn from_status_code(status_code: StatusCode) -> Self {
-        match status_code {
-            StatusCode::StorageUnavailable
-            | StatusCode::RuntimeResourcesExhausted
-            | StatusCode::RegionNotReady
-            | StatusCode::TableUnavailable
-            | StatusCode::RegionBusy => RetryHint::Retryable,
-            _ => RetryHint::NonRetryable,
-        }
-    }
-
     pub fn as_str(self) -> &'static str {
         match self {
             RetryHint::Retryable => RETRY_HINT_RETRYABLE,
@@ -75,7 +64,7 @@ pub trait ErrorExt: StackError {
 
     /// Returns the retry hint for this error.
     fn retry_hint(&self) -> RetryHint {
-        RetryHint::from_status_code(self.status_code())
+        RetryHint::NonRetryable
     }
 
     /// Returns true if this error is retryable.

--- a/src/common/error/src/ext.rs
+++ b/src/common/error/src/ext.rs
@@ -87,37 +87,7 @@ pub fn retry_hint_from_io_error(error: &std::io::Error) -> RetryHint {
         | ErrorKind::ResourceBusy
         | ErrorKind::Interrupted => RetryHint::Retryable,
 
-        ErrorKind::NotFound
-        | ErrorKind::PermissionDenied
-        | ErrorKind::AddrInUse
-        | ErrorKind::AddrNotAvailable
-        | ErrorKind::AlreadyExists
-        | ErrorKind::NotADirectory
-        | ErrorKind::IsADirectory
-        | ErrorKind::DirectoryNotEmpty
-        | ErrorKind::ReadOnlyFilesystem
-        | ErrorKind::InvalidInput
-        | ErrorKind::InvalidData
-        | ErrorKind::WriteZero
-        | ErrorKind::StorageFull
-        | ErrorKind::NotSeekable
-        | ErrorKind::QuotaExceeded
-        | ErrorKind::FileTooLarge
-        | ErrorKind::ExecutableFileBusy
-        | ErrorKind::Deadlock
-        | ErrorKind::CrossesDevices
-        | ErrorKind::TooManyLinks
-        | ErrorKind::InvalidFilename
-        | ErrorKind::ArgumentListTooLong
-        | ErrorKind::Unsupported
-        | ErrorKind::UnexpectedEof
-        | ErrorKind::OutOfMemory
-        | ErrorKind::Other => RetryHint::NonRetryable,
-
-        unclassified_or_future_kind => {
-            let _ = unclassified_or_future_kind;
-            RetryHint::NonRetryable
-        }
+        _ => RetryHint::NonRetryable,
     }
 }
 

--- a/src/common/error/src/ext.rs
+++ b/src/common/error/src/ext.rs
@@ -35,6 +35,14 @@ impl RetryHint {
         matches!(self, RetryHint::Retryable)
     }
 
+    pub fn from_status_code(status_code: StatusCode) -> Self {
+        if status_code.is_retryable() {
+            RetryHint::Retryable
+        } else {
+            RetryHint::NonRetryable
+        }
+    }
+
     pub fn as_str(self) -> &'static str {
         match self {
             RetryHint::Retryable => RETRY_HINT_RETRYABLE,
@@ -64,7 +72,7 @@ pub trait ErrorExt: StackError {
 
     /// Returns the retry hint for this error.
     fn retry_hint(&self) -> RetryHint {
-        RetryHint::NonRetryable
+        RetryHint::from_status_code(self.status_code())
     }
 
     /// Returns true if this error is retryable.

--- a/src/common/error/src/lib.rs
+++ b/src/common/error/src/lib.rs
@@ -27,6 +27,7 @@ use crate::status_code::StatusCode;
 // please define in `src/servers/src/http/header.rs`.
 pub const GREPTIME_DB_HEADER_ERROR_CODE: &str = "x-greptime-err-code";
 pub const GREPTIME_DB_HEADER_ERROR_MSG: &str = "x-greptime-err-msg";
+pub const GREPTIME_DB_HEADER_ERROR_RETRY_HINT: &str = "x-greptime-err-retry-hint";
 
 /// Create a http header map from error code and message.
 /// using `GREPTIME_DB_HEADER_ERROR_CODE` and `GREPTIME_DB_HEADER_ERROR_MSG` as keys.

--- a/src/common/error/src/status_code.rs
+++ b/src/common/error/src/status_code.rs
@@ -139,12 +139,12 @@ impl StatusCode {
         match self {
             StatusCode::StorageUnavailable
             | StatusCode::RuntimeResourcesExhausted
-            | StatusCode::Internal
             | StatusCode::RegionNotReady
             | StatusCode::TableUnavailable
             | StatusCode::RegionBusy => true,
 
             StatusCode::Success
+            | StatusCode::Internal
             | StatusCode::Unknown
             | StatusCode::Unsupported
             | StatusCode::IllegalState

--- a/src/common/error/src/status_code.rs
+++ b/src/common/error/src/status_code.rs
@@ -134,54 +134,6 @@ impl StatusCode {
         Self::Success as u32 == code
     }
 
-    /// Returns `true` if the error with this code is retryable.
-    pub fn is_retryable(&self) -> bool {
-        match self {
-            StatusCode::StorageUnavailable
-            | StatusCode::RuntimeResourcesExhausted
-            | StatusCode::RegionNotReady
-            | StatusCode::TableUnavailable
-            | StatusCode::RegionBusy => true,
-
-            StatusCode::Success
-            | StatusCode::Internal
-            | StatusCode::Unknown
-            | StatusCode::Unsupported
-            | StatusCode::IllegalState
-            | StatusCode::Unexpected
-            | StatusCode::InvalidArguments
-            | StatusCode::Cancelled
-            | StatusCode::DeadlineExceeded
-            | StatusCode::InvalidSyntax
-            | StatusCode::DatabaseAlreadyExists
-            | StatusCode::PlanQuery
-            | StatusCode::EngineExecuteQuery
-            | StatusCode::TableAlreadyExists
-            | StatusCode::TableNotFound
-            | StatusCode::RegionAlreadyExists
-            | StatusCode::RegionNotFound
-            | StatusCode::FlowAlreadyExists
-            | StatusCode::FlowNotFound
-            | StatusCode::TriggerAlreadyExists
-            | StatusCode::TriggerNotFound
-            | StatusCode::RegionReadonly
-            | StatusCode::TableColumnNotFound
-            | StatusCode::TableColumnExists
-            | StatusCode::DatabaseNotFound
-            | StatusCode::RateLimited
-            | StatusCode::UserNotFound
-            | StatusCode::UnsupportedPasswordType
-            | StatusCode::UserPasswordMismatch
-            | StatusCode::AuthHeaderNotFound
-            | StatusCode::InvalidAuthHeader
-            | StatusCode::AccessDenied
-            | StatusCode::PermissionDenied
-            | StatusCode::RequestOutdated
-            | StatusCode::External
-            | StatusCode::Suspended => false,
-        }
-    }
-
     /// Returns `true` if we should print an error log for an error with
     /// this status code.
     pub fn should_log_error(&self) -> bool {
@@ -273,7 +225,7 @@ macro_rules! define_from_tonic_status {
                     .unwrap_or_else(|| e.message().to_string());
                 let retry_hint = metadata_value(&e, $crate::GREPTIME_DB_HEADER_ERROR_RETRY_HINT)
                     .and_then(|s| s.parse().ok())
-                    .unwrap_or_else(|| $crate::ext::RetryHint::from_status_code(code));
+                    .unwrap_or($crate::ext::RetryHint::NonRetryable);
 
                 // TODO(LFC): Make the error variant defined automatically.
                 Self::$Variant {

--- a/src/common/error/src/status_code.rs
+++ b/src/common/error/src/status_code.rs
@@ -271,12 +271,16 @@ macro_rules! define_from_tonic_status {
 
                 let msg = metadata_value(&e, $crate::GREPTIME_DB_HEADER_ERROR_MSG)
                     .unwrap_or_else(|| e.message().to_string());
+                let retry_hint = metadata_value(&e, $crate::GREPTIME_DB_HEADER_ERROR_RETRY_HINT)
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or($crate::ext::RetryHint::NonRetryable);
 
                 // TODO(LFC): Make the error variant defined automatically.
                 Self::$Variant {
                     code,
                     msg,
                     tonic_code: e.code(),
+                    retry_hint,
                     location: location!(),
                 }
             }
@@ -291,11 +295,13 @@ macro_rules! define_into_tonic_status {
             fn from(err: $Error) -> Self {
                 use tonic::codegen::http::{HeaderMap, HeaderValue};
                 use tonic::metadata::MetadataMap;
-                use $crate::GREPTIME_DB_HEADER_ERROR_CODE;
+                use $crate::{
+                    GREPTIME_DB_HEADER_ERROR_CODE, GREPTIME_DB_HEADER_ERROR_RETRY_HINT,
+                };
 
                 common_telemetry::error!(err; "Failed to handle request");
 
-                let mut headers = HeaderMap::<HeaderValue>::with_capacity(2);
+                let mut headers = HeaderMap::<HeaderValue>::with_capacity(3);
 
                 // If either of the status_code or error msg cannot convert to valid HTTP header value
                 // (which is a very rare case), just ignore. Client will use Tonic status code and message.
@@ -303,6 +309,10 @@ macro_rules! define_into_tonic_status {
                 headers.insert(
                     GREPTIME_DB_HEADER_ERROR_CODE,
                     HeaderValue::from(status_code as u32),
+                );
+                headers.insert(
+                    GREPTIME_DB_HEADER_ERROR_RETRY_HINT,
+                    HeaderValue::from_static(err.retry_hint().as_str()),
                 );
                 let root_error = err.output_msg();
 

--- a/src/common/error/src/status_code.rs
+++ b/src/common/error/src/status_code.rs
@@ -273,7 +273,7 @@ macro_rules! define_from_tonic_status {
                     .unwrap_or_else(|| e.message().to_string());
                 let retry_hint = metadata_value(&e, $crate::GREPTIME_DB_HEADER_ERROR_RETRY_HINT)
                     .and_then(|s| s.parse().ok())
-                    .unwrap_or($crate::ext::RetryHint::NonRetryable);
+                    .unwrap_or_else(|| $crate::ext::RetryHint::from_status_code(code));
 
                 // TODO(LFC): Make the error variant defined automatically.
                 Self::$Variant {

--- a/src/common/error/tests/ext.rs
+++ b/src/common/error/tests/ext.rs
@@ -14,9 +14,13 @@
 
 use std::any::Any;
 use std::fmt::{Display, Formatter};
+use std::io::{Error as IoError, ErrorKind};
 use std::str::FromStr;
 
-use common_error::ext::{BoxedError, ErrorExt, PlainError, RetryHint, StackError, WhateverResult};
+use common_error::ext::{
+    BoxedError, ErrorExt, PlainError, RetryHint, StackError, WhateverResult,
+    retry_hint_from_io_error,
+};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use snafu::{Location, ResultExt, Snafu};
@@ -74,7 +78,7 @@ fn test_into_whatever_error() {
         normalize_path(&whatever.to_string()),
         // The location points to the `NormalSnafu` context in `normal_error()`.
         format!(
-            r#"0: A normal error with "display" attribute, message "blabla", at {}:57:22
+            r#"0: A normal error with "display" attribute, message "blabla", at {}:61:22
 1: PlainError {{ msg: "<root cause>", status_code: Unexpected }}"#,
             normalize_path(file!())
         )
@@ -85,7 +89,7 @@ fn test_into_whatever_error() {
         normalize_path(&whatever.to_string()),
         // The location points to the transparent `?` return in `transparent_error()`.
         format!(
-            r#"0: <transparent>, at {}:62:5
+            r#"0: <transparent>, at {}:66:5
 1: PlainError {{ msg: "<root cause>", status_code: Unexpected }}"#,
             normalize_path(file!())
         )
@@ -129,7 +133,7 @@ fn test_debug_format() {
         normalize_path(&debug_output),
         // The location points to the `NormalSnafu` context in `normal_error()`.
         format!(
-            r#"0: A normal error with "display" attribute, message "blabla", at {}:57:22
+            r#"0: A normal error with "display" attribute, message "blabla", at {}:61:22
 1: PlainError {{ msg: "<root cause>", status_code: Unexpected }}"#,
             normalize_path(file!())
         )
@@ -141,7 +145,7 @@ fn test_debug_format() {
         normalize_path(&debug_output),
         // The location points to the transparent `?` return in `transparent_error()`.
         format!(
-            r#"0: <transparent>, at {}:62:5
+            r#"0: <transparent>, at {}:66:5
 1: PlainError {{ msg: "<root cause>", status_code: Unexpected }}"#,
             normalize_path(file!())
         )
@@ -189,6 +193,72 @@ fn test_boxed_error_retry_hint() {
 
     assert_eq!(err.retry_hint(), RetryHint::Retryable);
     assert!(err.is_retryable());
+}
+
+#[test]
+fn test_retry_hint_from_io_error() {
+    let retryable_kinds = [
+        ErrorKind::ConnectionRefused,
+        ErrorKind::ConnectionReset,
+        ErrorKind::HostUnreachable,
+        ErrorKind::NetworkUnreachable,
+        ErrorKind::ConnectionAborted,
+        ErrorKind::NotConnected,
+        ErrorKind::NetworkDown,
+        ErrorKind::BrokenPipe,
+        ErrorKind::WouldBlock,
+        ErrorKind::StaleNetworkFileHandle,
+        ErrorKind::TimedOut,
+        ErrorKind::ResourceBusy,
+        ErrorKind::Interrupted,
+    ];
+
+    for kind in retryable_kinds {
+        let error = IoError::from(kind);
+        assert_eq!(
+            retry_hint_from_io_error(&error),
+            RetryHint::Retryable,
+            "{kind:?}"
+        );
+    }
+
+    let non_retryable_kinds = [
+        ErrorKind::NotFound,
+        ErrorKind::PermissionDenied,
+        ErrorKind::AddrInUse,
+        ErrorKind::AddrNotAvailable,
+        ErrorKind::AlreadyExists,
+        ErrorKind::NotADirectory,
+        ErrorKind::IsADirectory,
+        ErrorKind::DirectoryNotEmpty,
+        ErrorKind::ReadOnlyFilesystem,
+        ErrorKind::InvalidInput,
+        ErrorKind::InvalidData,
+        ErrorKind::WriteZero,
+        ErrorKind::StorageFull,
+        ErrorKind::NotSeekable,
+        ErrorKind::QuotaExceeded,
+        ErrorKind::FileTooLarge,
+        ErrorKind::ExecutableFileBusy,
+        ErrorKind::Deadlock,
+        ErrorKind::CrossesDevices,
+        ErrorKind::TooManyLinks,
+        ErrorKind::InvalidFilename,
+        ErrorKind::ArgumentListTooLong,
+        ErrorKind::Unsupported,
+        ErrorKind::UnexpectedEof,
+        ErrorKind::OutOfMemory,
+        ErrorKind::Other,
+    ];
+
+    for kind in non_retryable_kinds {
+        let error = IoError::from(kind);
+        assert_eq!(
+            retry_hint_from_io_error(&error),
+            RetryHint::NonRetryable,
+            "{kind:?}"
+        );
+    }
 }
 
 #[derive(Debug)]

--- a/src/common/error/tests/ext.rs
+++ b/src/common/error/tests/ext.rs
@@ -162,15 +162,6 @@ fn test_retry_hint_helpers() {
     assert!(RetryHint::Retryable.is_retryable());
     assert!(!RetryHint::NonRetryable.is_retryable());
 
-    assert_eq!(
-        RetryHint::from_status_code(StatusCode::Internal),
-        RetryHint::Retryable
-    );
-    assert_eq!(
-        RetryHint::from_status_code(StatusCode::InvalidArguments),
-        RetryHint::NonRetryable
-    );
-
     assert_eq!(RetryHint::Retryable.as_str(), "retryable");
     assert_eq!(RetryHint::NonRetryable.as_str(), "non_retryable");
 

--- a/src/common/error/tests/ext.rs
+++ b/src/common/error/tests/ext.rs
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
 
-use common_error::ext::{ErrorExt, PlainError, StackError, WhateverResult};
+use common_error::ext::{BoxedError, ErrorExt, PlainError, RetryHint, StackError, WhateverResult};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use snafu::{Location, ResultExt, Snafu};
@@ -70,8 +72,9 @@ fn test_into_whatever_error() {
     let whatever = f(normal_error).unwrap_err();
     assert_eq!(
         normalize_path(&whatever.to_string()),
+        // The location points to the `NormalSnafu` context in `normal_error()`.
         format!(
-            r#"0: A normal error with "display" attribute, message "blabla", at {}:55:22
+            r#"0: A normal error with "display" attribute, message "blabla", at {}:57:22
 1: PlainError {{ msg: "<root cause>", status_code: Unexpected }}"#,
             normalize_path(file!())
         )
@@ -80,8 +83,9 @@ fn test_into_whatever_error() {
     let whatever = f(transparent_error).unwrap_err();
     assert_eq!(
         normalize_path(&whatever.to_string()),
+        // The location points to the transparent `?` return in `transparent_error()`.
         format!(
-            r#"0: <transparent>, at {}:60:5
+            r#"0: <transparent>, at {}:62:5
 1: PlainError {{ msg: "<root cause>", status_code: Unexpected }}"#,
             normalize_path(file!())
         )
@@ -123,8 +127,9 @@ fn test_debug_format() {
 
     assert_eq!(
         normalize_path(&debug_output),
+        // The location points to the `NormalSnafu` context in `normal_error()`.
         format!(
-            r#"0: A normal error with "display" attribute, message "blabla", at {}:55:22
+            r#"0: A normal error with "display" attribute, message "blabla", at {}:57:22
 1: PlainError {{ msg: "<root cause>", status_code: Unexpected }}"#,
             normalize_path(file!())
         )
@@ -134,8 +139,9 @@ fn test_debug_format() {
     let debug_output = format!("{:?}", result.unwrap_err());
     assert_eq!(
         normalize_path(&debug_output),
+        // The location points to the transparent `?` return in `transparent_error()`.
         format!(
-            r#"0: <transparent>, at {}:60:5
+            r#"0: <transparent>, at {}:62:5
 1: PlainError {{ msg: "<root cause>", status_code: Unexpected }}"#,
             normalize_path(file!())
         )
@@ -149,4 +155,69 @@ fn test_transparent_flag() {
 
     let result = transparent_error();
     assert!(result.unwrap_err().transparent());
+}
+
+#[test]
+fn test_retry_hint_helpers() {
+    assert!(RetryHint::Retryable.is_retryable());
+    assert!(!RetryHint::NonRetryable.is_retryable());
+
+    assert_eq!(RetryHint::Retryable.as_str(), "retryable");
+    assert_eq!(RetryHint::NonRetryable.as_str(), "non_retryable");
+
+    assert_eq!(
+        RetryHint::from_str("retryable").unwrap(),
+        RetryHint::Retryable
+    );
+    assert_eq!(
+        RetryHint::from_str("non_retryable").unwrap(),
+        RetryHint::NonRetryable
+    );
+    assert!(RetryHint::from_str("unknown").is_err());
+}
+
+#[test]
+fn test_retry_hint_default() {
+    let err = normal_error().unwrap_err();
+    assert_eq!(err.retry_hint(), RetryHint::NonRetryable);
+    assert!(!err.is_retryable());
+}
+
+#[test]
+fn test_boxed_error_retry_hint() {
+    let err = BoxedError::new(RetryableError);
+
+    assert_eq!(err.retry_hint(), RetryHint::Retryable);
+    assert!(err.is_retryable());
+}
+
+#[derive(Debug)]
+struct RetryableError;
+
+impl Display for RetryableError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "retryable error")
+    }
+}
+
+impl std::error::Error for RetryableError {}
+
+impl StackError for RetryableError {
+    fn debug_fmt(&self, layer: usize, buf: &mut Vec<String>) {
+        buf.push(format!("{}: retryable error", layer))
+    }
+
+    fn next(&self) -> Option<&dyn StackError> {
+        None
+    }
+}
+
+impl ErrorExt for RetryableError {
+    fn retry_hint(&self) -> RetryHint {
+        RetryHint::Retryable
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }

--- a/src/common/error/tests/ext.rs
+++ b/src/common/error/tests/ext.rs
@@ -162,6 +162,15 @@ fn test_retry_hint_helpers() {
     assert!(RetryHint::Retryable.is_retryable());
     assert!(!RetryHint::NonRetryable.is_retryable());
 
+    assert_eq!(
+        RetryHint::from_status_code(StatusCode::Internal),
+        RetryHint::Retryable
+    );
+    assert_eq!(
+        RetryHint::from_status_code(StatusCode::InvalidArguments),
+        RetryHint::NonRetryable
+    );
+
     assert_eq!(RetryHint::Retryable.as_str(), "retryable");
     assert_eq!(RetryHint::NonRetryable.as_str(), "non_retryable");
 

--- a/src/common/frontend/src/error.rs
+++ b/src/common/frontend/src/error.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_error::ext::{BoxedError, ErrorExt};
+use common_error::ext::{BoxedError, ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use snafu::{Location, Snafu};
@@ -74,5 +74,16 @@ impl ErrorExt for Error {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn retry_hint(&self) -> RetryHint {
+        use Error::*;
+
+        match self {
+            External { source, .. } => source.retry_hint(),
+            Meta { source, .. } => source.retry_hint(),
+            CreateChannel { source, .. } => source.retry_hint(),
+            _ => RetryHint::NonRetryable,
+        }
     }
 }

--- a/src/common/grpc/src/error.rs
+++ b/src/common/grpc/src/error.rs
@@ -15,7 +15,7 @@
 use std::any::Any;
 use std::io;
 
-use common_error::ext::ErrorExt;
+use common_error::ext::{ErrorExt, RetryHint, retry_hint_from_io_error};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use datatypes::arrow::error::ArrowError;
@@ -132,5 +132,21 @@ impl ErrorExt for Error {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn retry_hint(&self) -> RetryHint {
+        match self {
+            Error::CreateChannel { .. } => RetryHint::Retryable,
+            Error::Arrow { error, .. } => retry_hint_from_arrow_error(error),
+            Error::FileWatch { source, .. } => source.retry_hint(),
+            _ => RetryHint::NonRetryable,
+        }
+    }
+}
+
+fn retry_hint_from_arrow_error(error: &ArrowError) -> RetryHint {
+    match error {
+        ArrowError::IoError(_, error) => retry_hint_from_io_error(error),
+        _ => RetryHint::NonRetryable,
     }
 }

--- a/src/common/mem-prof/src/jemalloc/error.rs
+++ b/src/common/mem-prof/src/jemalloc/error.rs
@@ -15,7 +15,7 @@
 use std::any::Any;
 use std::path::PathBuf;
 
-use common_error::ext::{BoxedError, ErrorExt, RetryHint};
+use common_error::ext::{BoxedError, ErrorExt, RetryHint, retry_hint_from_io_error};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use snafu::{Location, Snafu};
@@ -103,7 +103,8 @@ impl ErrorExt for Error {
 
     fn retry_hint(&self) -> RetryHint {
         match self {
-            Error::OpenTempFile { .. } | Error::DumpProfileData { .. } => RetryHint::Retryable,
+            Error::OpenTempFile { error, .. } => retry_hint_from_io_error(error),
+            Error::DumpProfileData { .. } => RetryHint::Retryable,
             _ => RetryHint::NonRetryable,
         }
     }

--- a/src/common/mem-prof/src/jemalloc/error.rs
+++ b/src/common/mem-prof/src/jemalloc/error.rs
@@ -15,7 +15,7 @@
 use std::any::Any;
 use std::path::PathBuf;
 
-use common_error::ext::{BoxedError, ErrorExt};
+use common_error::ext::{BoxedError, ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use snafu::{Location, Snafu};
@@ -98,6 +98,13 @@ impl ErrorExt for Error {
             Error::ReadProfActive { .. } => StatusCode::Internal,
             Error::ReadGdump { .. } => StatusCode::Internal,
             Error::UpdateGdump { .. } => StatusCode::Internal,
+        }
+    }
+
+    fn retry_hint(&self) -> RetryHint {
+        match self {
+            Error::OpenTempFile { .. } | Error::DumpProfileData { .. } => RetryHint::Retryable,
+            _ => RetryHint::NonRetryable,
         }
     }
 

--- a/src/common/memory-manager/src/error.rs
+++ b/src/common/memory-manager/src/error.rs
@@ -15,7 +15,7 @@
 use std::any::Any;
 use std::time::Duration;
 
-use common_error::ext::ErrorExt;
+use common_error::ext::{ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use snafu::Snafu;
@@ -59,5 +59,14 @@ impl ErrorExt for Error {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn retry_hint(&self) -> RetryHint {
+        match self {
+            Error::MemoryLimitExceeded { .. } | Error::MemoryAcquireTimeout { .. } => {
+                RetryHint::Retryable
+            }
+            _ => RetryHint::NonRetryable,
+        }
     }
 }

--- a/src/common/meta/src/error.rs
+++ b/src/common/meta/src/error.rs
@@ -19,6 +19,7 @@ use common_error::ext::{BoxedError, ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use common_procedure::ProcedureId;
+use common_wal::kafka::rskafka_client_error_to_retry_hint;
 use object_store::error::retry_hint_from_opendal_error;
 use serde_json::error::Error as JsonError;
 use snafu::{Location, Snafu};
@@ -1282,6 +1283,12 @@ impl ErrorExt for Error {
             WriteObject { error, .. } | ReadObject { error, .. } => {
                 retry_hint_from_opendal_error(error)
             }
+            BuildKafkaClient { error, .. }
+            | BuildKafkaCtrlClient { error, .. }
+            | KafkaPartitionClient { error, .. }
+            | KafkaGetOffset { error, .. }
+            | ProduceRecord { error, .. }
+            | CreateKafkaWalTopic { error, .. } => rskafka_client_error_to_retry_hint(error),
             SubmitProcedure { source, .. }
             | QueryProcedure { source, .. }
             | WaitProcedure { source, .. }

--- a/src/common/meta/src/error.rs
+++ b/src/common/meta/src/error.rs
@@ -19,6 +19,8 @@ use common_error::ext::{BoxedError, ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use common_procedure::ProcedureId;
+use common_wal::options::WalOptions;
+use object_store::error::retry_hint_from_opendal_error;
 use serde_json::error::Error as JsonError;
 use snafu::{Location, Snafu};
 use store_api::storage::RegionId;
@@ -1272,7 +1274,12 @@ impl ErrorExt for Error {
         use Error::*;
 
         match self {
-            RetryLater { .. } | GetLatestCacheRetryExceeded { .. } => RetryHint::Retryable,
+            RetryLater { .. } | GetLatestCacheRetryExceeded { .. } | NoLeader { .. } => {
+                RetryHint::Retryable
+            }
+            WriteObject { error, .. } | ReadObject { error, .. } => {
+                retry_hint_from_opendal_error(error)
+            }
             SubmitProcedure { source, .. }
             | QueryProcedure { source, .. }
             | WaitProcedure { source, .. }
@@ -1291,7 +1298,7 @@ impl ErrorExt for Error {
             ConvertAlterTableRequest { source, .. } => source.retry_hint(),
             ConvertColumnDef { source, .. } => source.retry_hint(),
             GetCache { source, .. } => source.retry_hint(),
-            _ => RetryHint::from_status_code(self.status_code()),
+            _ => RetryHint::NonRetryable,
         }
     }
 }

--- a/src/common/meta/src/error.rs
+++ b/src/common/meta/src/error.rs
@@ -15,7 +15,7 @@
 use std::str::Utf8Error;
 use std::sync::Arc;
 
-use common_error::ext::{BoxedError, ErrorExt};
+use common_error::ext::{BoxedError, ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use common_procedure::ProcedureId;
@@ -1267,6 +1267,33 @@ impl ErrorExt for Error {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
+
+    fn retry_hint(&self) -> RetryHint {
+        use Error::*;
+
+        match self {
+            RetryLater { .. } | GetLatestCacheRetryExceeded { .. } => RetryHint::Retryable,
+            SubmitProcedure { source, .. }
+            | QueryProcedure { source, .. }
+            | WaitProcedure { source, .. }
+            | StartProcedureManager { source, .. }
+            | StopProcedureManager { source, .. }
+            | RegisterProcedureLoader { source, .. }
+            | PutPoison { source, .. }
+            | ProcedureStateReceiver { source, .. } => source.retry_hint(),
+            External { source, .. }
+            | ResponseExceededSizeLimit { source, .. }
+            | OperateDatanode { source, .. }
+            | AbortProcedure { source, .. }
+            | RegisterRepartitionProcedureLoader { source, .. }
+            | CreateRepartitionProcedure { source, .. } => source.retry_hint(),
+            Table { source, .. } => source.retry_hint(),
+            ConvertAlterTableRequest { source, .. } => source.retry_hint(),
+            ConvertColumnDef { source, .. } => source.retry_hint(),
+            GetCache { source, .. } => source.retry_hint(),
+            _ => RetryHint::NonRetryable,
+        }
+    }
 }
 
 impl Error {
@@ -1334,5 +1361,46 @@ impl Error {
             Error::ResponseExceededSizeLimit { .. } => true,
             _ => false,
         }
+    }
+}
+
+#[cfg(test)]
+mod retry_hint_tests {
+    use std::sync::Arc;
+
+    use common_error::mock::MockError;
+
+    use super::*;
+
+    #[test]
+    fn test_retry_later_hint_is_retryable() {
+        let err = Error::retry_later(MockError::new(StatusCode::Internal));
+
+        assert_eq!(err.retry_hint(), RetryHint::Retryable);
+    }
+
+    #[test]
+    fn test_latest_cache_retry_exceeded_hint_is_retryable() {
+        let err = GetLatestCacheRetryExceededSnafu { attempts: 3_usize }.build();
+
+        assert_eq!(err.retry_hint(), RetryHint::Retryable);
+    }
+
+    #[test]
+    fn test_get_cache_forwards_retry_hint() {
+        let source = Arc::new(Error::retry_later(MockError::new(StatusCode::Internal)));
+        let err = Error::GetCache { source };
+
+        assert_eq!(err.retry_hint(), RetryHint::Retryable);
+    }
+
+    #[test]
+    fn test_default_hint_is_non_retryable() {
+        let err = UnexpectedSnafu {
+            err_msg: "mock error",
+        }
+        .build();
+
+        assert_eq!(err.retry_hint(), RetryHint::NonRetryable);
     }
 }

--- a/src/common/meta/src/error.rs
+++ b/src/common/meta/src/error.rs
@@ -19,7 +19,6 @@ use common_error::ext::{BoxedError, ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use common_procedure::ProcedureId;
-use common_wal::options::WalOptions;
 use object_store::error::retry_hint_from_opendal_error;
 use serde_json::error::Error as JsonError;
 use snafu::{Location, Snafu};

--- a/src/common/meta/src/error.rs
+++ b/src/common/meta/src/error.rs
@@ -1273,9 +1273,13 @@ impl ErrorExt for Error {
         use Error::*;
 
         match self {
-            RetryLater { .. } | GetLatestCacheRetryExceeded { .. } | NoLeader { .. } => {
-                RetryHint::Retryable
-            }
+            RetryLater { .. }
+            | GetLatestCacheRetryExceeded { .. }
+            | NoLeader { .. }
+            | ElectionNoLeader { .. }
+            | ElectionLeaderLeaseExpired { .. }
+            | ElectionLeaderLeaseChanged { .. }
+            | RegionOperatingRace { .. } => RetryHint::Retryable,
             WriteObject { error, .. } | ReadObject { error, .. } => {
                 retry_hint_from_opendal_error(error)
             }

--- a/src/common/meta/src/error.rs
+++ b/src/common/meta/src/error.rs
@@ -1278,8 +1278,7 @@ impl ErrorExt for Error {
             | NoLeader { .. }
             | ElectionNoLeader { .. }
             | ElectionLeaderLeaseExpired { .. }
-            | ElectionLeaderLeaseChanged { .. }
-            | RegionOperatingRace { .. } => RetryHint::Retryable,
+            | ElectionLeaderLeaseChanged { .. } => RetryHint::Retryable,
             WriteObject { error, .. } | ReadObject { error, .. } => {
                 retry_hint_from_opendal_error(error)
             }

--- a/src/common/meta/src/error.rs
+++ b/src/common/meta/src/error.rs
@@ -1291,7 +1291,7 @@ impl ErrorExt for Error {
             ConvertAlterTableRequest { source, .. } => source.retry_hint(),
             ConvertColumnDef { source, .. } => source.retry_hint(),
             GetCache { source, .. } => source.retry_hint(),
-            _ => RetryHint::NonRetryable,
+            _ => RetryHint::from_status_code(self.status_code()),
         }
     }
 }

--- a/src/common/procedure/src/error.rs
+++ b/src/common/procedure/src/error.rs
@@ -311,7 +311,7 @@ impl ErrorExt for Error {
             Error::RetryTimesExceeded { .. } | Error::RollbackTimesExceeded { .. } => {
                 RetryHint::NonRetryable
             }
-            _ => RetryHint::from_status_code(self.status_code()),
+            _ => RetryHint::NonRetryable,
         }
     }
 }

--- a/src/common/procedure/src/error.rs
+++ b/src/common/procedure/src/error.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use common_error::ext::{BoxedError, ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
+use object_store::error::retry_hint_from_opendal_error;
 use snafu::{Location, Snafu};
 
 use crate::PoisonKey;
@@ -308,6 +309,7 @@ impl ErrorExt for Error {
             Error::ProcedureExec { source, .. } => source.retry_hint(),
             Error::StartRemoveOutdatedMetaTask { source, .. }
             | Error::StopRemoveOutdatedMetaTask { source, .. } => source.retry_hint(),
+            Error::DeleteState { error, .. } => retry_hint_from_opendal_error(error),
             Error::RetryTimesExceeded { .. } | Error::RollbackTimesExceeded { .. } => {
                 RetryHint::NonRetryable
             }

--- a/src/common/procedure/src/error.rs
+++ b/src/common/procedure/src/error.rs
@@ -362,6 +362,7 @@ impl Error {
             || matches!(self, Error::RetryLater { clean_poisons, .. } if *clean_poisons)
     }
 
+    #[cfg(test)]
     /// Creates a new [Error::RetryLater] or [Error::External] error from source `err` according
     /// to its [RetryHint].
     pub fn from_error_ext<E: ErrorExt + Send + Sync + 'static>(err: E) -> Self {

--- a/src/common/procedure/src/error.rs
+++ b/src/common/procedure/src/error.rs
@@ -311,7 +311,7 @@ impl ErrorExt for Error {
             Error::RetryTimesExceeded { .. } | Error::RollbackTimesExceeded { .. } => {
                 RetryHint::NonRetryable
             }
-            _ => RetryHint::NonRetryable,
+            _ => RetryHint::from_status_code(self.status_code()),
         }
     }
 }
@@ -361,9 +361,9 @@ impl Error {
     }
 
     /// Creates a new [Error::RetryLater] or [Error::External] error from source `err` according
-    /// to its [StatusCode].
+    /// to its [RetryHint].
     pub fn from_error_ext<E: ErrorExt + Send + Sync + 'static>(err: E) -> Self {
-        if err.status_code().is_retryable() {
+        if err.retry_hint().is_retryable() {
             Error::retry_later(err)
         } else {
             Error::external(err)
@@ -410,5 +410,19 @@ mod tests {
         };
 
         assert_eq!(err.retry_hint(), RetryHint::NonRetryable);
+    }
+
+    #[test]
+    fn test_from_error_ext_uses_retry_hint() {
+        let err = Error::from_error_ext(Error::retry_later(MockError::new(
+            StatusCode::InvalidArguments,
+        )));
+        assert!(err.is_retry_later());
+
+        let err = Error::from_error_ext(MockError::new(StatusCode::InvalidArguments));
+        assert!(!err.is_retry_later());
+
+        let err = Error::from_error_ext(MockError::new(StatusCode::Internal));
+        assert!(err.is_retry_later());
     }
 }

--- a/src/common/procedure/src/error.rs
+++ b/src/common/procedure/src/error.rs
@@ -423,6 +423,6 @@ mod tests {
         assert!(!err.is_retry_later());
 
         let err = Error::from_error_ext(MockError::new(StatusCode::Internal));
-        assert!(err.is_retry_later());
+        assert!(!err.is_retry_later());
     }
 }

--- a/src/common/procedure/src/error.rs
+++ b/src/common/procedure/src/error.rs
@@ -15,7 +15,7 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use common_error::ext::{BoxedError, ErrorExt};
+use common_error::ext::{BoxedError, ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use snafu::{Location, Snafu};
@@ -293,6 +293,27 @@ impl ErrorExt for Error {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
+    fn retry_hint(&self) -> RetryHint {
+        match self {
+            Error::RetryLater { .. } => RetryHint::Retryable,
+            Error::External { source, .. }
+            | Error::PutState { source, .. }
+            | Error::DeleteStates { source, .. }
+            | Error::ListState { source, .. }
+            | Error::PutPoison { source, .. }
+            | Error::DeletePoison { source, .. }
+            | Error::GetPoison { source, .. }
+            | Error::CheckStatus { source, .. } => source.retry_hint(),
+            Error::ProcedureExec { source, .. } => source.retry_hint(),
+            Error::StartRemoveOutdatedMetaTask { source, .. }
+            | Error::StopRemoveOutdatedMetaTask { source, .. } => source.retry_hint(),
+            Error::RetryTimesExceeded { .. } | Error::RollbackTimesExceeded { .. } => {
+                RetryHint::NonRetryable
+            }
+            _ => RetryHint::NonRetryable,
+        }
+    }
 }
 
 impl Error {
@@ -347,5 +368,47 @@ impl Error {
         } else {
             Error::external(err)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use common_error::mock::MockError;
+
+    use super::*;
+
+    #[test]
+    fn test_retry_later_hint_is_retryable() {
+        let err = Error::retry_later(MockError::new(StatusCode::Internal));
+
+        assert_eq!(err.retry_hint(), RetryHint::Retryable);
+    }
+
+    #[test]
+    fn test_external_forwards_retry_hint() {
+        let source = Error::retry_later(MockError::new(StatusCode::Internal));
+        let err = Error::external(source);
+
+        assert_eq!(err.retry_hint(), RetryHint::Retryable);
+    }
+
+    #[test]
+    fn test_retry_exceeded_hint_is_non_retryable() {
+        let source = Arc::new(Error::retry_later(MockError::new(StatusCode::Internal)));
+        let err = Error::RetryTimesExceeded {
+            source: source.clone(),
+            procedure_id: ProcedureId::random(),
+        };
+
+        assert_eq!(err.retry_hint(), RetryHint::NonRetryable);
+
+        let err = Error::RollbackTimesExceeded {
+            source,
+            procedure_id: ProcedureId::random(),
+        };
+
+        assert_eq!(err.retry_hint(), RetryHint::NonRetryable);
     }
 }

--- a/src/common/recordbatch/src/error.rs
+++ b/src/common/recordbatch/src/error.rs
@@ -15,7 +15,7 @@
 //! Error of record batch.
 use std::any::Any;
 
-use common_error::ext::{BoxedError, ErrorExt};
+use common_error::ext::{BoxedError, ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use datafusion_common::ScalarValue;
@@ -229,5 +229,16 @@ impl ErrorExt for Error {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn retry_hint(&self) -> RetryHint {
+        match self {
+            Error::ExceedMemoryLimit { .. } => RetryHint::Retryable,
+            Error::External { source, .. } => source.retry_hint(),
+            Error::SchemaConversion { source, .. } | Error::CastVector { source, .. } => {
+                source.retry_hint()
+            }
+            _ => RetryHint::NonRetryable,
+        }
     }
 }

--- a/src/common/wal/src/kafka.rs
+++ b/src/common/wal/src/kafka.rs
@@ -1,0 +1,96 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_error::ext::RetryHint;
+
+/// Maps an rskafka client error to a conservative retry hint.
+///
+/// rskafka already retries most transient Kafka/network errors internally. This helper only
+/// marks errors retryable when rskafka has exhausted its own retry loop or returns an explicit
+/// client timeout.
+pub fn rskafka_client_error_to_retry_hint(error: &rskafka::client::error::Error) -> RetryHint {
+    use rskafka::client::error::Error;
+
+    match error {
+        Error::RetryFailed(_)
+        | Error::Timeout
+        | Error::Connection(rskafka::ConnectionError::RetryFailed(_)) => RetryHint::Retryable,
+        _ => RetryHint::NonRetryable,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use common_error::ext::RetryHint;
+    use rskafka::BackoffError;
+    use rskafka::client::error::{Error as KafkaClientError, ProtocolError, RequestContext};
+
+    use super::*;
+
+    fn retry_failed_error() -> KafkaClientError {
+        KafkaClientError::RetryFailed(BackoffError::DeadlineExceded {
+            deadline: Duration::from_secs(1),
+            source: Box::new(std::io::Error::other("retry failed")),
+        })
+    }
+
+    #[test]
+    fn test_retry_failed_hint_is_retryable() {
+        assert_eq!(
+            rskafka_client_error_to_retry_hint(&retry_failed_error()),
+            RetryHint::Retryable
+        );
+    }
+
+    #[test]
+    fn test_timeout_hint_is_retryable() {
+        assert_eq!(
+            rskafka_client_error_to_retry_hint(&KafkaClientError::Timeout),
+            RetryHint::Retryable
+        );
+    }
+
+    #[test]
+    fn test_connection_retry_failed_hint_is_retryable() {
+        let err = KafkaClientError::Connection(rskafka::ConnectionError::RetryFailed(
+            BackoffError::DeadlineExceded {
+                deadline: Duration::from_secs(1),
+                source: Box::new(std::io::Error::other("retry failed")),
+            },
+        ));
+
+        assert_eq!(
+            rskafka_client_error_to_retry_hint(&err),
+            RetryHint::Retryable
+        );
+    }
+
+    #[test]
+    fn test_raw_protocol_error_hint_is_non_retryable() {
+        let err = KafkaClientError::ServerError {
+            protocol_error: ProtocolError::NetworkException,
+            error_message: None,
+            request: RequestContext::Topic("test_topic".to_string()),
+            response: None,
+            is_virtual: false,
+        };
+
+        assert_eq!(
+            rskafka_client_error_to_retry_hint(&err),
+            RetryHint::NonRetryable
+        );
+    }
+}

--- a/src/common/wal/src/lib.rs
+++ b/src/common/wal/src/lib.rs
@@ -21,6 +21,7 @@ use tokio::net;
 
 pub mod config;
 pub mod error;
+pub mod kafka;
 pub mod options;
 #[cfg(any(test, feature = "testing"))]
 pub mod test_util;

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -538,7 +538,7 @@ impl ErrorExt for Error {
             BuildMetricEngine { source, .. } => source.retry_hint(),
             ListStorageSsts { source, .. } => source.retry_hint(),
             ObjectStore { source, .. } => source.retry_hint(),
-            _ => RetryHint::from_status_code(self.status_code()),
+            _ => RetryHint::NonRetryable,
         }
     }
 }

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -538,7 +538,7 @@ impl ErrorExt for Error {
             BuildMetricEngine { source, .. } => source.retry_hint(),
             ListStorageSsts { source, .. } => source.retry_hint(),
             ObjectStore { source, .. } => source.retry_hint(),
-            _ => RetryHint::NonRetryable,
+            _ => RetryHint::from_status_code(self.status_code()),
         }
     }
 }

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -16,7 +16,7 @@ use std::any::Any;
 use std::sync::Arc;
 
 use common_error::define_into_tonic_status;
-use common_error::ext::{BoxedError, ErrorExt};
+use common_error::ext::{BoxedError, ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use common_runtime::JoinError;
@@ -506,6 +506,69 @@ impl ErrorExt for Error {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
+    fn retry_hint(&self) -> RetryHint {
+        use Error::*;
+
+        match self {
+            RegionBusy { .. }
+            | RegionNotReady { .. }
+            | ConcurrentQueryLimiterClosed { .. }
+            | ConcurrentQueryLimiterTimeout { .. } => RetryHint::Retryable,
+            NewPlanDecoder { source, .. } | ExecuteLogicalPlan { source, .. } => {
+                source.retry_hint()
+            }
+            HandleHeartbeatResponse { source, .. } | GetMetadata { source, .. } => {
+                source.retry_hint()
+            }
+            DecodeLogicalPlan { source, .. } => source.retry_hint(),
+            Delete { source, .. } => source.retry_hint(),
+            AsyncTaskExecute { source, .. } => source.retry_hint(),
+            StartServer { source, .. } | ShutdownServer { source, .. } => source.retry_hint(),
+            OpenLogStore { source, .. } => source.retry_hint(),
+            MetaClientInit { source, .. } => source.retry_hint(),
+            HandleRegionRequest { source, .. }
+            | GetRegionMetadata { source, .. }
+            | HandleBatchOpenRequest { source, .. }
+            | HandleBatchDdlRequest { source, .. }
+            | StopRegionEngine { source, .. } => source.retry_hint(),
+            FindLogicalRegions { source, .. } => source.retry_hint(),
+            BuildMitoEngine { source, .. } => source.retry_hint(),
+            GcMitoEngine { source, .. } => source.retry_hint(),
+            BuildMetricEngine { source, .. } => source.retry_hint(),
+            ListStorageSsts { source, .. } => source.retry_hint(),
+            ObjectStore { source, .. } => source.retry_hint(),
+            _ => RetryHint::NonRetryable,
+        }
+    }
 }
 
 define_into_tonic_status!(Error);
+
+#[cfg(test)]
+mod tests {
+    use common_error::ext::RetryHint;
+
+    use super::*;
+
+    #[test]
+    fn test_region_state_hints_are_retryable() {
+        let region_id = RegionId::new(1024, 1);
+
+        let err = RegionBusySnafu { region_id }.build();
+        assert_eq!(err.retry_hint(), RetryHint::Retryable);
+
+        let err = RegionNotReadySnafu { region_id }.build();
+        assert_eq!(err.retry_hint(), RetryHint::Retryable);
+    }
+
+    #[test]
+    fn test_default_hint_is_non_retryable() {
+        let err = UnexpectedSnafu {
+            violated: "mock error",
+        }
+        .build();
+
+        assert_eq!(err.retry_hint(), RetryHint::NonRetryable);
+    }
+}

--- a/src/file-engine/src/error.rs
+++ b/src/file-engine/src/error.rs
@@ -14,11 +14,12 @@
 
 use std::any::Any;
 
-use common_error::ext::ErrorExt;
+use common_error::ext::{ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use datafusion::arrow::error::ArrowError;
 use datafusion::error::DataFusionError;
+use object_store::error::retry_hint_from_opendal_error;
 use serde_json::error::Error as JsonError;
 use snafu::{Location, Snafu};
 use store_api::storage::RegionId;
@@ -233,6 +234,19 @@ impl ErrorExt for Error {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn retry_hint(&self) -> RetryHint {
+        use Error::*;
+
+        match self {
+            BuildBackend { source, .. } | ParseFileFormat { source, .. } => source.retry_hint(),
+            CheckObject { error, .. }
+            | StoreRegionManifest { error, .. }
+            | LoadRegionManifest { error, .. }
+            | DeleteRegionManifest { error, .. } => retry_hint_from_opendal_error(error),
+            _ => RetryHint::NonRetryable,
+        }
     }
 }
 

--- a/src/file-engine/src/error.rs
+++ b/src/file-engine/src/error.rs
@@ -249,4 +249,3 @@ impl ErrorExt for Error {
         }
     }
 }
-

--- a/src/file-engine/src/error.rs
+++ b/src/file-engine/src/error.rs
@@ -250,8 +250,3 @@ impl ErrorExt for Error {
     }
 }
 
-impl From<Error> for common_procedure::Error {
-    fn from(e: Error) -> common_procedure::Error {
-        common_procedure::Error::from_error_ext(e)
-    }
-}

--- a/src/flow/src/error.rs
+++ b/src/flow/src/error.rs
@@ -19,11 +19,14 @@ use std::any::Any;
 use api::v1::CreateTableExpr;
 use arrow_schema::ArrowError;
 use common_error::ext::BoxedError;
-use common_error::{define_into_tonic_status, from_err_code_msg_to_header};
+use common_error::{
+    GREPTIME_DB_HEADER_ERROR_RETRY_HINT, define_into_tonic_status, from_err_code_msg_to_header,
+};
 use common_macro::stack_trace_debug;
 use common_telemetry::common_error::ext::ErrorExt;
 use common_telemetry::common_error::status_code::StatusCode;
 use snafu::{Location, ResultExt, Snafu};
+use tonic::codegen::http::HeaderValue;
 use tonic::metadata::MetadataMap;
 
 use crate::FlowId;
@@ -308,7 +311,11 @@ pub fn to_status_with_last_err(err: impl ErrorExt) -> tonic::Status {
     let msg = err.to_string();
     let last_err_msg = common_error::ext::StackError::last(&err).to_string();
     let code = err.status_code() as u32;
-    let header = from_err_code_msg_to_header(code, &last_err_msg);
+    let mut header = from_err_code_msg_to_header(code, &last_err_msg);
+    header.insert(
+        GREPTIME_DB_HEADER_ERROR_RETRY_HINT,
+        HeaderValue::from_static(err.retry_hint().as_str()),
+    );
 
     tonic::Status::with_metadata(
         tonic::Code::InvalidArgument,

--- a/src/flow/src/error.rs
+++ b/src/flow/src/error.rs
@@ -18,7 +18,7 @@ use std::any::Any;
 
 use api::v1::CreateTableExpr;
 use arrow_schema::ArrowError;
-use common_error::ext::BoxedError;
+use common_error::ext::{BoxedError, RetryHint};
 use common_error::{
     GREPTIME_DB_HEADER_ERROR_RETRY_HINT, define_into_tonic_status, from_err_code_msg_to_header,
 };
@@ -372,6 +372,35 @@ impl ErrorExt for Error {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn retry_hint(&self) -> RetryHint {
+        match self {
+            Self::FlowNotRecovered { .. } | Self::NoAvailableFrontend { .. } => {
+                RetryHint::Retryable
+            }
+
+            Self::InsertIntoFlow { source, .. }
+            | Self::CreateFlow { source, .. }
+            | Self::CreateSinkTable { source, .. }
+            | Self::External { source, .. } => source.retry_hint(),
+
+            Self::Time { source, .. } => source.retry_hint(),
+            Self::TableNotFoundMeta { source, .. } | Self::ListFlows { source, .. } => {
+                source.retry_hint()
+            }
+            Self::Datatypes { source, .. } => source.retry_hint(),
+            Self::StartServer { source, .. } | Self::ShutdownServer { source, .. } => {
+                source.retry_hint()
+            }
+            Self::MetaClientInit { source, .. } => source.retry_hint(),
+            Self::InvalidRequest { source, .. } => source.retry_hint(),
+            Self::SubstraitEncodeLogicalPlan { source, .. } => source.retry_hint(),
+            Self::ConvertColumnSchema { source, .. } => source.retry_hint(),
+            Self::InvalidClientConfig { source, .. } => source.retry_hint(),
+
+            _ => RetryHint::NonRetryable,
+        }
     }
 }
 

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -16,7 +16,7 @@ use std::any::Any;
 
 use common_datasource::file_format::Format;
 use common_error::define_into_tonic_status;
-use common_error::ext::{BoxedError, ErrorExt};
+use common_error::ext::{BoxedError, ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use common_query::error::datafusion_status_code;
@@ -447,6 +447,46 @@ impl ErrorExt for Error {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn retry_hint(&self) -> RetryHint {
+        match self {
+            Error::InvalidateTableCache { source, .. }
+            | Error::HandleHeartbeatResponse { source, .. }
+            | Error::RequestQuery { source, .. } => source.retry_hint(),
+
+            Error::External { source, .. }
+            | Error::SqlExecIntercepted { source, .. }
+            | Error::InitPlugin { source, .. } => source.retry_hint(),
+
+            Error::StartServer { source, .. }
+            | Error::ShutdownServer { source, .. }
+            | Error::InvokeRegionServer { source, .. }
+            | Error::ExecutePromql { source, .. }
+            | Error::PromStoreRemoteQueryPlan { source, .. }
+            | Error::PrometheusMetricNamesQueryPlan { source, .. } => source.retry_hint(),
+
+            Error::ParseSql { source, .. } => source.retry_hint(),
+            Error::Catalog { source, .. } => source.retry_hint(),
+            Error::CreateMetaHeartbeatStream { source, .. } => source.retry_hint(),
+            Error::FindRegionPeer { source, .. } => source.retry_hint(),
+            Error::Table { source, .. } => source.retry_hint(),
+            Error::CollectRecordbatch { source, .. } => source.retry_hint(),
+            Error::PlanStatement { source, .. }
+            | Error::ReadTable { source, .. }
+            | Error::ExecLogicalPlan { source, .. }
+            | Error::DescribeStatement { source, .. } => source.retry_hint(),
+            Error::PrometheusLabelValuesQueryPlan { source, .. } => source.retry_hint(),
+            Error::Insert { source, .. } => source.retry_hint(),
+            Error::Permission { source, .. } => source.retry_hint(),
+            Error::TableOperation { source, .. } => source.retry_hint(),
+            Error::IllegalAuthConfig { source, .. } => source.retry_hint(),
+            Error::TomlFormat { source, .. } => source.retry_hint(),
+            Error::InvalidTlsConfig { error, .. } => error.retry_hint(),
+            Error::SubstraitDecodeLogicalPlan { source, .. } => source.retry_hint(),
+
+            _ => RetryHint::NonRetryable,
+        }
     }
 }
 

--- a/src/frontend/src/instance/otlp.rs
+++ b/src/frontend/src/instance/otlp.rs
@@ -543,7 +543,12 @@ impl Instance {
             | StatusCode::TableColumnNotFound => ChunkFailureReaction::RetryPerSpan,
             StatusCode::DatabaseNotFound => ChunkFailureReaction::DiscardChunk,
             StatusCode::Cancelled | StatusCode::DeadlineExceeded => ChunkFailureReaction::Propagate,
-            _ if status.is_retryable() => ChunkFailureReaction::Propagate,
+            StatusCode::StorageUnavailable
+            | StatusCode::RuntimeResourcesExhausted
+            | StatusCode::Internal
+            | StatusCode::RegionNotReady
+            | StatusCode::TableUnavailable
+            | StatusCode::RegionBusy => ChunkFailureReaction::Propagate,
             _ => ChunkFailureReaction::DiscardChunk,
         }
     }

--- a/src/log-store/src/error.rs
+++ b/src/log-store/src/error.rs
@@ -18,6 +18,7 @@ use common_error::ext::{ErrorExt, RetryHint, retry_hint_from_io_error};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use common_runtime::error::Error as RuntimeError;
+use common_wal::kafka::rskafka_client_error_to_retry_hint;
 use object_store::error::retry_hint_from_opendal_error;
 use serde_json::error::Error as JsonError;
 use snafu::{Location, Snafu};
@@ -320,13 +321,6 @@ fn rskafka_client_error_to_status_code(error: &rskafka::client::error::Error) ->
         | rskafka::client::error::Error::RetryFailed(_) => StatusCode::Internal,
         rskafka::client::error::Error::Timeout => StatusCode::StorageUnavailable,
         _ => StatusCode::Internal,
-    }
-}
-
-fn rskafka_client_error_to_retry_hint(error: &rskafka::client::error::Error) -> RetryHint {
-    match error {
-        rskafka::client::error::Error::Timeout => RetryHint::Retryable,
-        _ => RetryHint::NonRetryable,
     }
 }
 

--- a/src/log-store/src/error.rs
+++ b/src/log-store/src/error.rs
@@ -14,7 +14,7 @@
 
 use std::any::Any;
 
-use common_error::ext::{ErrorExt, RetryHint};
+use common_error::ext::{ErrorExt, RetryHint, retry_hint_from_io_error};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use common_runtime::error::Error as RuntimeError;
@@ -391,9 +391,8 @@ impl ErrorExt for Error {
             CreateWriter { error, .. } | WriteIndex { error, .. } | ReadIndex { error, .. } => {
                 retry_hint_from_opendal_error(error)
             }
-            Io { .. } | FetchEntry { .. } | RaftEngine { .. } | AddEntryLogBatch { .. } => {
-                RetryHint::Retryable
-            }
+            Io { error, .. } => retry_hint_from_io_error(error),
+            FetchEntry { .. } | RaftEngine { .. } | AddEntryLogBatch { .. } => RetryHint::Retryable,
             ProduceRecord { error, .. } => match error {
                 rskafka::client::producer::Error::Client(error) => {
                     rskafka_client_error_to_retry_hint(error)

--- a/src/log-store/src/error.rs
+++ b/src/log-store/src/error.rs
@@ -14,10 +14,11 @@
 
 use std::any::Any;
 
-use common_error::ext::ErrorExt;
+use common_error::ext::{ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use common_runtime::error::Error as RuntimeError;
+use object_store::error::retry_hint_from_opendal_error;
 use serde_json::error::Error as JsonError;
 use snafu::{Location, Snafu};
 use store_api::storage::RegionId;
@@ -322,6 +323,13 @@ fn rskafka_client_error_to_status_code(error: &rskafka::client::error::Error) ->
     }
 }
 
+fn rskafka_client_error_to_retry_hint(error: &rskafka::client::error::Error) -> RetryHint {
+    match error {
+        rskafka::client::error::Error::Timeout => RetryHint::Retryable,
+        _ => RetryHint::NonRetryable,
+    }
+}
+
 impl ErrorExt for Error {
     fn as_any(&self) -> &dyn Any {
         self
@@ -373,6 +381,33 @@ impl ErrorExt for Error {
             | BatchProduce { error, .. }
             | GetOffset { error, .. }
             | ConsumeRecord { error, .. } => rskafka_client_error_to_status_code(error),
+        }
+    }
+
+    fn retry_hint(&self) -> RetryHint {
+        use Error::*;
+
+        match self {
+            CreateWriter { error, .. } | WriteIndex { error, .. } | ReadIndex { error, .. } => {
+                retry_hint_from_opendal_error(error)
+            }
+            Io { .. } | FetchEntry { .. } | RaftEngine { .. } | AddEntryLogBatch { .. } => {
+                RetryHint::Retryable
+            }
+            ProduceRecord { error, .. } => match error {
+                rskafka::client::producer::Error::Client(error) => {
+                    rskafka_client_error_to_retry_hint(error)
+                }
+                rskafka::client::producer::Error::Aggregator(_)
+                | rskafka::client::producer::Error::FlushError(_)
+                | rskafka::client::producer::Error::TooLarge => RetryHint::NonRetryable,
+            },
+            BuildClient { error, .. }
+            | BuildPartitionClient { error, .. }
+            | BatchProduce { error, .. }
+            | GetOffset { error, .. }
+            | ConsumeRecord { error, .. } => rskafka_client_error_to_retry_hint(error),
+            _ => RetryHint::NonRetryable,
         }
     }
 }

--- a/src/meta-client/src/error.rs
+++ b/src/meta-client/src/error.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use common_error::define_from_tonic_status;
-use common_error::ext::ErrorExt;
+use common_error::ext::{ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use snafu::{Location, Snafu};
@@ -34,6 +34,7 @@ pub enum Error {
         code: StatusCode,
         msg: String,
         tonic_code: tonic::Code,
+        retry_hint: RetryHint,
         #[snafu(implicit)]
         location: Location,
     },
@@ -156,6 +157,17 @@ impl ErrorExt for Error {
             | Error::GetFlowStat { source, .. } => source.status_code(),
         }
     }
+
+    fn retry_hint(&self) -> RetryHint {
+        match self {
+            Error::MetaServer { retry_hint, .. } => *retry_hint,
+            Error::InvalidResponseHeader { source, .. }
+            | Error::ConvertMetaRequest { source, .. }
+            | Error::ConvertMetaResponse { source, .. }
+            | Error::GetFlowStat { source, .. } => source.retry_hint(),
+            _ => RetryHint::NonRetryable,
+        }
+    }
 }
 
 impl Error {
@@ -171,3 +183,44 @@ impl Error {
 }
 
 define_from_tonic_status!(Error, MetaServer);
+
+#[cfg(test)]
+mod tests {
+    use common_error::ext::{ErrorExt, RetryHint};
+    use common_error::{GREPTIME_DB_HEADER_ERROR_CODE, GREPTIME_DB_HEADER_ERROR_RETRY_HINT};
+    use tonic::codegen::http::{HeaderMap, HeaderValue};
+    use tonic::metadata::MetadataMap;
+
+    use super::*;
+
+    #[test]
+    fn test_from_tonic_status_defaults_to_non_retryable() {
+        let status = tonic::Status::new(tonic::Code::Internal, "blabla");
+
+        let err: Error = status.into();
+
+        assert_eq!(err.retry_hint(), RetryHint::NonRetryable);
+    }
+
+    #[test]
+    fn test_from_tonic_status_with_retry_hint() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            GREPTIME_DB_HEADER_ERROR_CODE,
+            HeaderValue::from(StatusCode::Internal as u32),
+        );
+        headers.insert(
+            GREPTIME_DB_HEADER_ERROR_RETRY_HINT,
+            HeaderValue::from_static(RetryHint::Retryable.as_str()),
+        );
+        let status = tonic::Status::with_metadata(
+            tonic::Code::Internal,
+            "blabla",
+            MetadataMap::from_headers(headers),
+        );
+
+        let err: Error = status.into();
+
+        assert_eq!(err.retry_hint(), RetryHint::Retryable);
+    }
+}

--- a/src/meta-client/src/error.rs
+++ b/src/meta-client/src/error.rs
@@ -165,7 +165,7 @@ impl ErrorExt for Error {
             | Error::ConvertMetaRequest { source, .. }
             | Error::ConvertMetaResponse { source, .. }
             | Error::GetFlowStat { source, .. } => source.retry_hint(),
-            _ => RetryHint::NonRetryable,
+            _ => RetryHint::from_status_code(self.status_code()),
         }
     }
 }
@@ -194,8 +194,26 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_from_tonic_status_defaults_to_non_retryable() {
+    fn test_from_tonic_status_fallbacks_to_status_code() {
         let status = tonic::Status::new(tonic::Code::Internal, "blabla");
+
+        let err: Error = status.into();
+
+        assert_eq!(err.retry_hint(), RetryHint::Retryable);
+    }
+
+    #[test]
+    fn test_from_tonic_status_fallback_can_be_non_retryable() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            GREPTIME_DB_HEADER_ERROR_CODE,
+            HeaderValue::from(StatusCode::InvalidArguments as u32),
+        );
+        let status = tonic::Status::with_metadata(
+            tonic::Code::Internal,
+            "blabla",
+            MetadataMap::from_headers(headers),
+        );
 
         let err: Error = status.into();
 

--- a/src/meta-client/src/error.rs
+++ b/src/meta-client/src/error.rs
@@ -165,6 +165,7 @@ impl ErrorExt for Error {
             | Error::ConvertMetaRequest { source, .. }
             | Error::ConvertMetaResponse { source, .. }
             | Error::GetFlowStat { source, .. } => source.retry_hint(),
+            Error::CreateChannel { source, .. } => source.retry_hint(),
             _ => RetryHint::NonRetryable,
         }
     }

--- a/src/meta-client/src/error.rs
+++ b/src/meta-client/src/error.rs
@@ -165,7 +165,7 @@ impl ErrorExt for Error {
             | Error::ConvertMetaRequest { source, .. }
             | Error::ConvertMetaResponse { source, .. }
             | Error::GetFlowStat { source, .. } => source.retry_hint(),
-            _ => RetryHint::from_status_code(self.status_code()),
+            _ => RetryHint::NonRetryable,
         }
     }
 }

--- a/src/meta-client/src/error.rs
+++ b/src/meta-client/src/error.rs
@@ -199,7 +199,7 @@ mod tests {
 
         let err: Error = status.into();
 
-        assert_eq!(err.retry_hint(), RetryHint::Retryable);
+        assert_eq!(err.retry_hint(), RetryHint::NonRetryable);
     }
 
     #[test]

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -1304,8 +1304,7 @@ impl ErrorExt for Error {
             | Error::NoLeader { .. }
             | Error::LeaderLeaseExpired { .. }
             | Error::LeaderLeaseChanged { .. }
-            | Error::PeerUnavailable { .. }
-            | Error::RegionOperatingRace { .. } => RetryHint::Retryable,
+            | Error::PeerUnavailable { .. } => RetryHint::Retryable,
 
             Error::AllocateRegions { source, .. } | Error::DeallocateRegions { source, .. }
                 if source.retry_hint().is_retryable() =>

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use common_error::define_into_tonic_status;
-use common_error::ext::{BoxedError, ErrorExt};
+use common_error::ext::{BoxedError, ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use common_meta::DatanodeId;
@@ -1124,24 +1124,7 @@ pub enum Error {
 impl Error {
     /// Returns `true` if the error is retryable.
     pub fn is_retryable(&self) -> bool {
-        matches!(
-            self,
-            Error::RetryLater { .. }
-                | Error::RetryLaterWithSource { .. }
-                | Error::MailboxTimeout { .. }
-        ) || matches!(
-            self,
-            Error::AllocateRegions { source, .. } if source.is_retry_later()
-        ) || matches!(
-            self,
-            Error::DeallocateRegions { source, .. } if source.is_retry_later()
-        ) || matches!(
-            self,
-            Error::DeleteRecords { error, .. }
-                | Error::BuildPartitionClient { error, .. }
-                | Error::GetOffset { error, .. }
-                if Self::is_retryable_kafka_client_error(error)
-        )
+        self.retry_hint().is_retryable()
     }
 
     /// Returns `true` if the Kafka client has exhausted its internal retry.
@@ -1311,6 +1294,29 @@ impl ErrorExt for Error {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
+
+    fn retry_hint(&self) -> RetryHint {
+        if matches!(
+            self,
+            Error::RetryLater { .. }
+                | Error::RetryLaterWithSource { .. }
+                | Error::MailboxTimeout { .. }
+        ) || matches!(
+            self,
+            Error::AllocateRegions { source, .. } | Error::DeallocateRegions { source, .. }
+                if source.retry_hint().is_retryable()
+        ) || matches!(
+            self,
+            Error::DeleteRecords { error, .. }
+                | Error::BuildPartitionClient { error, .. }
+                | Error::GetOffset { error, .. }
+                if Self::is_retryable_kafka_client_error(error)
+        ) {
+            RetryHint::Retryable
+        } else {
+            RetryHint::NonRetryable
+        }
+    }
 }
 
 // for form tonic
@@ -1338,6 +1344,7 @@ pub(crate) fn match_for_io_error(err_status: &tonic::Status) -> Option<&std::io:
 mod tests {
     use std::time::Duration;
 
+    use common_error::ext::ErrorExt;
     use common_error::mock::MockError;
     use common_error::status_code::StatusCode;
     use rskafka::BackoffError;
@@ -1363,6 +1370,7 @@ mod tests {
             .unwrap_err();
 
         assert!(err.is_retryable());
+        assert!(err.retry_hint().is_retryable());
     }
 
     #[test]
@@ -1376,6 +1384,7 @@ mod tests {
             .unwrap_err();
 
         assert!(!err.is_retryable());
+        assert!(!err.retry_hint().is_retryable());
     }
 
     #[test]
@@ -1402,6 +1411,9 @@ mod tests {
         assert!(delete_records_err.is_retryable());
         assert!(build_partition_client_err.is_retryable());
         assert!(get_offset_err.is_retryable());
+        assert!(delete_records_err.retry_hint().is_retryable());
+        assert!(build_partition_client_err.retry_hint().is_retryable());
+        assert!(get_offset_err.retry_hint().is_retryable());
     }
 
     #[test]
@@ -1428,5 +1440,8 @@ mod tests {
         assert!(!delete_records_err.is_retryable());
         assert!(!build_partition_client_err.is_retryable());
         assert!(!get_offset_err.is_retryable());
+        assert!(!delete_records_err.retry_hint().is_retryable());
+        assert!(!build_partition_client_err.retry_hint().is_retryable());
+        assert!(!get_offset_err.retry_hint().is_retryable());
     }
 }

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -1300,7 +1300,12 @@ impl ErrorExt for Error {
             Error::RetryLater { .. }
             | Error::RetryLaterWithSource { .. }
             | Error::MailboxTimeout { .. }
-            | Error::NoEnoughAvailableNode { .. } => RetryHint::Retryable,
+            | Error::NoEnoughAvailableNode { .. }
+            | Error::NoLeader { .. }
+            | Error::LeaderLeaseExpired { .. }
+            | Error::LeaderLeaseChanged { .. }
+            | Error::PeerUnavailable { .. }
+            | Error::RegionOperatingRace { .. } => RetryHint::Retryable,
 
             Error::AllocateRegions { source, .. } | Error::DeallocateRegions { source, .. }
                 if source.retry_hint().is_retryable() =>

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -1296,25 +1296,33 @@ impl ErrorExt for Error {
     }
 
     fn retry_hint(&self) -> RetryHint {
-        if matches!(
-            self,
+        match self {
             Error::RetryLater { .. }
-                | Error::RetryLaterWithSource { .. }
-                | Error::MailboxTimeout { .. }
-        ) || matches!(
-            self,
+            | Error::RetryLaterWithSource { .. }
+            | Error::MailboxTimeout { .. } => RetryHint::Retryable,
+
             Error::AllocateRegions { source, .. } | Error::DeallocateRegions { source, .. }
-                if source.retry_hint().is_retryable()
-        ) || matches!(
-            self,
+                if source.retry_hint().is_retryable() =>
+            {
+                RetryHint::Retryable
+            }
+
             Error::DeleteRecords { error, .. }
-                | Error::BuildPartitionClient { error, .. }
-                | Error::GetOffset { error, .. }
-                if Self::is_retryable_kafka_client_error(error)
-        ) {
-            RetryHint::Retryable
-        } else {
-            RetryHint::NonRetryable
+            | Error::BuildPartitionClient { error, .. }
+            | Error::GetOffset { error, .. }
+                if Self::is_retryable_kafka_client_error(error) =>
+            {
+                RetryHint::Retryable
+            }
+
+            Error::DeleteRecords { .. }
+            | Error::BuildPartitionClient { .. }
+            | Error::GetOffset { .. }
+            | Error::PusherNotFound { .. }
+            | Error::PushMessage { .. }
+            | Error::ExceededDeadline { .. } => RetryHint::NonRetryable,
+
+            _ => RetryHint::from_status_code(self.status_code()),
         }
     }
 }

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -1299,7 +1299,8 @@ impl ErrorExt for Error {
         match self {
             Error::RetryLater { .. }
             | Error::RetryLaterWithSource { .. }
-            | Error::MailboxTimeout { .. } => RetryHint::Retryable,
+            | Error::MailboxTimeout { .. }
+            | Error::NoEnoughAvailableNode { .. } => RetryHint::Retryable,
 
             Error::AllocateRegions { source, .. } | Error::DeallocateRegions { source, .. }
                 if source.retry_hint().is_retryable() =>
@@ -1322,7 +1323,7 @@ impl ErrorExt for Error {
             | Error::PushMessage { .. }
             | Error::ExceededDeadline { .. } => RetryHint::NonRetryable,
 
-            _ => RetryHint::from_status_code(self.status_code()),
+            _ => RetryHint::NonRetryable,
         }
     }
 }

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -19,6 +19,7 @@ use common_macro::stack_trace_debug;
 use common_meta::DatanodeId;
 use common_procedure::ProcedureId;
 use common_runtime::JoinError;
+use common_wal::kafka::rskafka_client_error_to_retry_hint;
 use snafu::{Location, Snafu};
 use store_api::storage::RegionId;
 use table::metadata::TableId;
@@ -1126,11 +1127,6 @@ impl Error {
     pub fn is_retryable(&self) -> bool {
         self.retry_hint().is_retryable()
     }
-
-    /// Returns `true` if the Kafka client has exhausted its internal retry.
-    fn is_retryable_kafka_client_error(err: &rskafka::client::error::Error) -> bool {
-        matches!(err, rskafka::client::error::Error::RetryFailed(_))
-    }
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -1314,16 +1310,9 @@ impl ErrorExt for Error {
 
             Error::DeleteRecords { error, .. }
             | Error::BuildPartitionClient { error, .. }
-            | Error::GetOffset { error, .. }
-                if Self::is_retryable_kafka_client_error(error) =>
-            {
-                RetryHint::Retryable
-            }
+            | Error::GetOffset { error, .. } => rskafka_client_error_to_retry_hint(error),
 
-            Error::DeleteRecords { .. }
-            | Error::BuildPartitionClient { .. }
-            | Error::GetOffset { .. }
-            | Error::PusherNotFound { .. }
+            Error::PusherNotFound { .. }
             | Error::PushMessage { .. }
             | Error::ExceededDeadline { .. } => RetryHint::NonRetryable,
 
@@ -1431,20 +1420,21 @@ mod tests {
 
     #[test]
     fn test_kafka_non_retry_failed_errors_are_not_retryable() {
-        let delete_records_err = Err::<(), _>(KafkaClientError::Timeout)
+        let delete_records_err = Err::<(), _>(KafkaClientError::InvalidResponse("invalid".into()))
             .context(DeleteRecordsSnafu {
                 topic: "test_topic",
                 partition: 0,
                 offset: 1024u64,
             })
             .unwrap_err();
-        let build_partition_client_err = Err::<(), _>(KafkaClientError::Timeout)
-            .context(BuildPartitionClientSnafu {
-                topic: "test_topic",
-                partition: 0,
-            })
-            .unwrap_err();
-        let get_offset_err = Err::<(), _>(KafkaClientError::Timeout)
+        let build_partition_client_err =
+            Err::<(), _>(KafkaClientError::InvalidResponse("invalid".into()))
+                .context(BuildPartitionClientSnafu {
+                    topic: "test_topic",
+                    partition: 0,
+                })
+                .unwrap_err();
+        let get_offset_err = Err::<(), _>(KafkaClientError::InvalidResponse("invalid".into()))
             .context(GetOffsetSnafu {
                 topic: "test_topic",
             })

--- a/src/metric-engine/src/error.rs
+++ b/src/metric-engine/src/error.rs
@@ -15,7 +15,7 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use common_error::ext::{BoxedError, ErrorExt};
+use common_error::ext::{BoxedError, ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use datatypes::prelude::ConcreteDataType;
@@ -463,5 +463,31 @@ impl ErrorExt for Error {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn retry_hint(&self) -> RetryHint {
+        use Error::*;
+
+        match self {
+            CreateMitoRegion { source, .. }
+            | OpenMitoRegion { source, .. }
+            | BatchOpenMitoRegion { source, .. }
+            | BatchCatchupMitoRegion { source, .. }
+            | CloseMitoRegion { source, .. }
+            | MitoReadOperation { source, .. }
+            | MitoWriteOperation { source, .. }
+            | MitoFlushOperation { source, .. }
+            | MitoSyncOperation { source, .. }
+            | MitoEnterStagingOperation { source, .. }
+            | MitoCopyRegionFromOperation { source, .. }
+            | MitoEditRegion { source, .. } => source.retry_hint(),
+
+            EncodePrimaryKey { source, .. } => source.retry_hint(),
+            CollectRecordBatchStream { source, .. } => source.retry_hint(),
+            StartRepeatedTask { source, .. } => source.retry_hint(),
+            CacheGet { source, .. } => source.retry_hint(),
+
+            _ => RetryHint::NonRetryable,
+        }
     }
 }

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -16,7 +16,7 @@ use std::any::Any;
 use std::sync::Arc;
 
 use common_datasource::compression::CompressionType;
-use common_error::ext::{BoxedError, ErrorExt};
+use common_error::ext::{BoxedError, ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use common_memory_manager;
@@ -26,6 +26,7 @@ use common_time::timestamp::TimeUnit;
 use datatypes::arrow::error::ArrowError;
 use datatypes::prelude::ConcreteDataType;
 use object_store::ErrorKind;
+use object_store::error::retry_hint_from_opendal_error;
 use partition::error::Error as PartitionError;
 use prost::DecodeError;
 use snafu::{Location, Snafu};
@@ -1497,5 +1498,81 @@ impl ErrorExt for Error {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn retry_hint(&self) -> RetryHint {
+        use Error::*;
+
+        match self {
+            ReadParquet { .. }
+            | WriteParquet { .. }
+            | RejectWrite { .. }
+            | Download { .. }
+            | Upload { .. }
+            | RegionState { .. }
+            | UpdateManifest { .. }
+            | RegionStopped { .. }
+            | RegionBusy { .. }
+            | FlushableRegionState { .. } => RetryHint::Retryable,
+
+            OpenDal { error, .. }
+            | DeleteSsts { error, .. }
+            | DeleteIndex { error, .. }
+            | DeleteIndexes { error, .. } => retry_hint_from_opendal_error(error),
+
+            WriteWal { source, .. }
+            | ReadWal { source, .. }
+            | DeleteWal { source, .. }
+            | FetchManifests { source, .. }
+            | External { source, .. } => source.retry_hint(),
+
+            OpenRegion { source, .. }
+            | WriteGroup { source, .. }
+            | FlushRegion { source, .. }
+            | BuildIndexAsync { source, .. }
+            | CompactRegion { source, .. }
+            | EditRegion { source, .. }
+            | ScanSeries { source, .. }
+            | PruneFile { source, .. } => source.retry_hint(),
+
+            DataTypeMismatch { source, .. }
+            | ConvertVector { source, .. }
+            | ConvertValue { source, .. }
+            | IndexOptions { source, .. }
+            | CastVector { source, .. } => source.retry_hint(),
+
+            BuildIndexApplier { source, .. }
+            | PushIndexValue { source, .. }
+            | ApplyInvertedIndex { source, .. }
+            | IndexFinish { source, .. } => source.retry_hint(),
+
+            ApplyBloomFilterIndex { source, .. }
+            | PushBloomFilterValue { source, .. }
+            | BloomFilterFinish { source, .. } => source.retry_hint(),
+
+            PuffinReadBlob { source, .. }
+            | PuffinAddBlob { source, .. }
+            | PuffinInitStager { source, .. }
+            | PuffinBuildReader { source, .. }
+            | PuffinPurgeStager { source, .. } => source.retry_hint(),
+
+            CreateFulltextCreator { source, .. }
+            | FulltextPushText { source, .. }
+            | FulltextFinish { source, .. }
+            | ApplyFulltextIndex { source, .. } => source.retry_hint(),
+
+            InvalidRegionRequest { source, .. } => source.retry_hint(),
+            InvalidPartitionExpr { source, .. } => source.retry_hint(),
+            RecordBatch { source, .. } => source.retry_hint(),
+            GetSchemaMetadata { source, .. } => source.retry_hint(),
+            CompactionMemoryExhausted { source, .. } => source.retry_hint(),
+            ConvertBulkWalEntry { source, .. } => source.retry_hint(),
+            Encode { source, .. } | Decode { source, .. } => source.retry_hint(),
+
+            #[cfg(feature = "enterprise")]
+            ScanExternalRange { source, .. } => source.retry_hint(),
+
+            _ => RetryHint::NonRetryable,
+        }
     }
 }

--- a/src/object-store/src/error.rs
+++ b/src/object-store/src/error.rs
@@ -15,7 +15,7 @@
 use std::any::Any;
 
 use common_macro::stack_trace_debug;
-use common_telemetry::common_error::ext::ErrorExt;
+use common_telemetry::common_error::ext::{ErrorExt, RetryHint};
 use common_telemetry::common_error::status_code::StatusCode;
 use snafu::{Location, Snafu};
 
@@ -56,6 +56,15 @@ pub enum Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// Converts an `opendal::Error` into a `RetryHint`.
+pub fn retry_hint_from_opendal_error(error: &opendal::Error) -> RetryHint {
+    if error.is_temporary() {
+        RetryHint::Retryable
+    } else {
+        RetryHint::NonRetryable
+    }
+}
+
 impl ErrorExt for Error {
     fn status_code(&self) -> StatusCode {
         use Error::*;
@@ -68,5 +77,12 @@ impl ErrorExt for Error {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn retry_hint(&self) -> RetryHint {
+        match self {
+            Error::InitBackend { error, .. } => retry_hint_from_opendal_error(error),
+            _ => RetryHint::NonRetryable,
+        }
     }
 }

--- a/src/operator/src/error.rs
+++ b/src/operator/src/error.rs
@@ -16,13 +16,14 @@ use std::any::Any;
 
 use common_datasource::file_format::Format;
 use common_error::define_into_tonic_status;
-use common_error::ext::{BoxedError, ErrorExt};
+use common_error::ext::{BoxedError, ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use common_query::error::Error as QueryResult;
 use datafusion::parquet;
 use datafusion_common::DataFusionError;
 use datatypes::arrow::error::ArrowError;
+use object_store::error::retry_hint_from_opendal_error;
 use snafu::{Location, Snafu};
 use table::metadata::TableType;
 
@@ -1061,6 +1062,67 @@ impl ErrorExt for Error {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn retry_hint(&self) -> RetryHint {
+        match self {
+            Error::ReadObject { error, .. } => retry_hint_from_opendal_error(error),
+            Error::ReadParquetMetadata { .. } => RetryHint::Retryable,
+            Error::InvalidateTableCache { source, .. }
+            | Error::ExecuteDdl { source, .. }
+            | Error::RequestInserts { source, .. }
+            | Error::RequestDeletes { source, .. }
+            | Error::RequestRegion { source, .. }
+            | Error::FindViewInfo { source, .. }
+            | Error::TableMetadataManager { source, .. } => source.retry_hint(),
+
+            Error::ParseFileFormat { source, .. }
+            | Error::InferSchema { source, .. }
+            | Error::ListObjects { source, .. }
+            | Error::ParseUrl { source, .. }
+            | Error::BuildBackend { source, .. }
+            | Error::ReadOrc { source, .. } => source.retry_hint(),
+
+            Error::ExtractTableNames { source, .. }
+            | Error::ExecuteStatement { source, .. }
+            | Error::PlanStatement { source, .. }
+            | Error::ParseQuery { source, .. }
+            | Error::ExecLogicalPlan { source, .. }
+            | Error::DescribeStatement { source, .. } => source.retry_hint(),
+
+            Error::FindTablePartitionRule { source, .. }
+            | Error::SplitInsert { source, .. }
+            | Error::SplitDelete { source, .. }
+            | Error::FindRegionLeader { source, .. } => source.retry_hint(),
+
+            Error::BuildCreateExprOnInsertion { source, .. }
+            | Error::FindNewColumnsOnInsertion { source, .. }
+            | Error::AlterExprToRequest { source, .. } => source.retry_hint(),
+
+            Error::ConvertColumnDefaultConstraint { source, .. }
+            | Error::IntoVectors { source, .. }
+            | Error::ColumnDefaultValue { source, .. } => source.retry_hint(),
+
+            Error::ColumnDataType { source, .. }
+            | Error::InvalidColumnDef { source, .. }
+            | Error::ColumnOptions { source, .. } => source.retry_hint(),
+
+            Error::Table { source, .. }
+            | Error::Insert { source, .. }
+            | Error::MissingTimeIndexColumn { source, .. } => source.retry_hint(),
+
+            Error::Cast { source, .. } => source.retry_hint(),
+            Error::ParseSql { source, .. } => source.retry_hint(),
+            Error::Catalog { source, .. } => source.retry_hint(),
+            Error::SubstraitCodec { source, .. } => source.retry_hint(),
+            Error::External { source, .. } => source.retry_hint(),
+            Error::BuildRecordBatch { source, .. } => source.retry_hint(),
+            Error::DecodeFlightData { source, .. } => source.retry_hint(),
+            Error::SqlCommon { source, .. } => source.retry_hint(),
+            #[cfg(feature = "enterprise")]
+            Error::TriggerQuerier { source, .. } => source.retry_hint(),
+            _ => RetryHint::NonRetryable,
+        }
     }
 }
 

--- a/src/operator/src/error.rs
+++ b/src/operator/src/error.rs
@@ -1119,6 +1119,11 @@ impl ErrorExt for Error {
             Error::BuildRecordBatch { source, .. } => source.retry_hint(),
             Error::DecodeFlightData { source, .. } => source.retry_hint(),
             Error::SqlCommon { source, .. } => source.retry_hint(),
+            Error::ConvertSchema { source, .. } => source.retry_hint(),
+            Error::WriteStreamToFile { source, .. } => source.retry_hint(),
+            Error::PrepareFileTable { source, .. } | Error::InferFileTableSchema { source, .. } => {
+                source.retry_hint()
+            }
             #[cfg(feature = "enterprise")]
             Error::TriggerQuerier { source, .. } => source.retry_hint(),
             _ => RetryHint::NonRetryable,

--- a/src/partition/src/error.rs
+++ b/src/partition/src/error.rs
@@ -14,7 +14,7 @@
 
 use std::any::Any;
 
-use common_error::ext::ErrorExt;
+use common_error::ext::{ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use datafusion_common::ScalarValue;
@@ -282,6 +282,17 @@ impl ErrorExt for Error {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn retry_hint(&self) -> RetryHint {
+        match self {
+            Error::GetCache { .. } | Error::FindLeader { .. } => RetryHint::Retryable,
+            Error::TableRouteManager { source, .. }
+            | Error::GetPartitionInfo { source, .. }
+            | Error::UnexpectedLogicalRouteTable { source, .. } => source.retry_hint(),
+            Error::ConvertToVector { source, .. } => source.retry_hint(),
+            _ => RetryHint::NonRetryable,
+        }
     }
 }
 

--- a/src/query/src/error.rs
+++ b/src/query/src/error.rs
@@ -15,7 +15,7 @@
 use std::any::Any;
 use std::time::{Duration, TryFromFloatSecsError};
 
-use common_error::ext::{BoxedError, ErrorExt};
+use common_error::ext::{BoxedError, ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use common_query::error::datafusion_status_code;
@@ -461,6 +461,30 @@ impl ErrorExt for Error {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn retry_hint(&self) -> RetryHint {
+        use Error::*;
+
+        match self {
+            BuildBackend { .. } | ListObjects { .. } | GetRegionMetadata { .. } => {
+                RetryHint::Retryable
+            }
+            ParseFileFormat { source, .. } | InferSchema { source, .. } => source.retry_hint(),
+            Catalog { source, .. } => source.retry_hint(),
+            CreateRecordBatch { source, .. } => source.retry_hint(),
+            PartitionRuleManager { source, .. } => source.retry_hint(),
+            QueryExecution { source, .. } | QueryPlan { source, .. } => source.retry_hint(),
+            Sql { source, .. } => source.retry_hint(),
+            ConvertSqlType { source, .. } | ConvertSqlValue { source, .. } => source.retry_hint(),
+            RegionQuery { source, .. } => source.retry_hint(),
+            TableMutation { source, .. } => source.retry_hint(),
+            GetFulltextOptions { source, .. }
+            | GetSkippingIndexOptions { source, .. }
+            | GetVectorIndexOptions { source, .. }
+            | Datatypes { source, .. } => source.retry_hint(),
+            _ => RetryHint::NonRetryable,
+        }
     }
 }
 

--- a/src/query/src/error.rs
+++ b/src/query/src/error.rs
@@ -467,9 +467,8 @@ impl ErrorExt for Error {
         use Error::*;
 
         match self {
-            BuildBackend { .. } | ListObjects { .. } | GetRegionMetadata { .. } => {
-                RetryHint::Retryable
-            }
+            BuildBackend { source, .. } | ListObjects { source, .. } => source.retry_hint(),
+            GetRegionMetadata { .. } => RetryHint::Retryable,
             ParseFileFormat { source, .. } | InferSchema { source, .. } => source.retry_hint(),
             Catalog { source, .. } => source.retry_hint(),
             CreateRecordBatch { source, .. } => source.retry_hint(),

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -23,7 +23,7 @@ use axum::{Json, http};
 use base64::DecodeError;
 use common_base::readable_size::ReadableSize;
 use common_error::define_into_tonic_status;
-use common_error::ext::{BoxedError, ErrorExt};
+use common_error::ext::{BoxedError, ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use common_telemetry::{error, warn};
@@ -850,6 +850,44 @@ impl ErrorExt for Error {
             Partition { source, .. } => source.status_code(),
             MetricEngine { source, .. } => source.status_code(),
             SubmitBatch { source, .. } => source.status_code(),
+        }
+    }
+
+    fn retry_hint(&self) -> RetryHint {
+        use Error::*;
+        match self {
+            ExecuteQuery { source, .. }
+            | ExecutePlan { source, .. }
+            | ExecuteGrpcQuery { source, .. }
+            | ExecuteGrpcRequest { source, .. }
+            | CheckDatabaseValidity { source, .. }
+            | DescribeStatement { source } => source.retry_hint(),
+
+            Pipeline { source, .. } => source.retry_hint(),
+            CommonMeta { source, .. } => source.retry_hint(),
+            Catalog { source, .. } => source.retry_hint(),
+            RowWriter { source, .. } => source.retry_hint(),
+            Auth { source, .. } => source.retry_hint(),
+
+            #[cfg(feature = "mem-prof")]
+            DumpProfileData { source, .. } => source.retry_hint(),
+
+            ParsePromQL { source, .. } => source.retry_hint(),
+            Other { source, .. } => source.retry_hint(),
+
+            #[cfg(feature = "pprof")]
+            DumpPprof { source, .. } => source.retry_hint(),
+
+            ConvertScalarValue { source, .. } => source.retry_hint(),
+            ConvertSqlValue { source, .. } => source.retry_hint(),
+            GreptimeProto { source, .. } => source.retry_hint(),
+            Partition { source, .. } => source.retry_hint(),
+            MetricEngine { source, .. } => source.retry_hint(),
+            SubmitBatch { source, .. } => source.retry_hint(),
+
+            TooManyConcurrentRequests { .. } => RetryHint::Retryable,
+
+            _ => RetryHint::NonRetryable,
         }
     }
 

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -885,6 +885,9 @@ impl ErrorExt for Error {
             MetricEngine { source, .. } => source.retry_hint(),
             SubmitBatch { source, .. } => source.retry_hint(),
 
+            MemoryLimitExceeded { source, .. } => source.retry_hint(),
+            CollectRecordbatch { source, .. } => source.retry_hint(),
+
             TooManyConcurrentRequests { .. } => RetryHint::Retryable,
 
             _ => RetryHint::NonRetryable,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Prepare for https://github.com/GreptimeTeam/greptimedb/issues/8207

## What's changed and what's your intention?

This PR introduces structured retry hints for GreptimeDB errors as a preparation step for the later structured instruction reply work in #8207.

The main intention is to decouple retryability from `StatusCode`. Previously, whether an error was retryable was inferred from coarse-grained status codes such as `StorageUnavailable`, `RegionNotReady`, or `RegionBusy`. This made retry behavior too implicit and sometimes too broad. After this PR, retryability is controlled by `RetryHint`, allowing each error variant to express retry semantics more precisely.

Main changes:

- Add `RetryHint::{Retryable, NonRetryable}` to `common-error`.
- Add `ErrorExt::retry_hint()` and make `ErrorExt::is_retryable()` derive from retry hints.
- Propagate retry hints through `BoxedError`.
- Propagate retry hints through gRPC metadata using `x-greptime-err-retry-hint`.
- Add explicit `retry_hint()` implementations across core crates, including:
  - `common-procedure`
  - `common-meta`
  - `meta-srv`
  - `datanode`
  - `client`
  - `meta-client`
  - storage/query/operator/mito/log-store related errors
- Add a centralized OpenDAL/object-store retry hint conversion helper.
- Remove status-code based retry fallback:
  - remove `RetryHint::from_status_code()`
  - remove `StatusCode::is_retryable()`
  - avoid deriving retryability from status code by default
- Keep transport-level retry handling separate from error-level retry hints.

With this change, `StatusCode` continues to describe the error category, while `RetryHint` describes whether the specific error instance should be considered retryable. This gives errors finer-grained control and avoids overloading status codes with retry policy semantics.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
