### PR TITLE
feat(cli): allow overriding import-v2 state path

### DIFF
--- a/src/cli/src/data/import_v2/command.rs
+++ b/src/cli/src/data/import_v2/command.rs
@@ -15,6 +15,7 @@
 //! Import V2 CLI command.
 
 use std::collections::HashSet;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -74,6 +75,12 @@ pub struct ImportV2Command {
     /// Number of import data tasks to run concurrently on the client (1..=64).
     #[clap(long, default_value = "1", value_parser = parse_task_parallelism)]
     task_parallelism: usize,
+
+    /// Override the import resume state file path.
+    ///
+    /// Defaults to a stable path under `~/.greptime/import_state`.
+    #[clap(long)]
+    state_path: Option<PathBuf>,
 
     /// Basic authentication (user:password).
     #[clap(long)]
@@ -137,12 +144,33 @@ impl ImportV2Command {
             dry_run: self.dry_run,
             progress: self.progress,
             task_parallelism: self.task_parallelism,
+            state_path: self.state_path.clone(),
             snapshot_uri: self.from.clone(),
             storage_config: self.storage.clone(),
             storage: Box::new(storage),
             database_client,
         }))
     }
+}
+
+/// Resolves the import resume state file path. When `override_path` is set it is
+/// used verbatim; otherwise the stable default under `~/.greptime/import_state`
+/// is derived from the import identity.
+fn resolve_state_path(
+    override_path: Option<&Path>,
+    snapshot_id: &str,
+    target_addr: &str,
+    catalog: &str,
+    schemas: &[String],
+) -> Result<PathBuf> {
+    if let Some(path) = override_path {
+        return Ok(path.to_path_buf());
+    }
+    default_state_path(snapshot_id, target_addr, catalog, schemas).context(
+        ImportStatePathUnavailableSnafu {
+            snapshot_id: snapshot_id.to_string(),
+        },
+    )
 }
 
 fn parse_task_parallelism(value: &str) -> std::result::Result<usize, String> {
@@ -163,6 +191,7 @@ pub struct Import {
     dry_run: bool,
     progress: ProgressMode,
     task_parallelism: usize,
+    state_path: Option<PathBuf>,
     snapshot_uri: String,
     storage_config: ObjectStoreConfig,
     storage: Box<dyn SnapshotStorage>,
@@ -241,15 +270,13 @@ impl Import {
         }
 
         let mut resume_session = if !data_tasks.is_empty() {
-            let state_path = default_state_path(
+            let state_path = resolve_state_path(
+                self.state_path.as_deref(),
                 &manifest.snapshot_id.to_string(),
                 self.database_client.addr(),
                 &self.catalog,
                 &schemas_to_import,
-            )
-            .context(ImportStatePathUnavailableSnafu {
-                snapshot_id: manifest.snapshot_id.to_string(),
-            })?;
+            )?;
             Some(
                 prepare_import_resume(ImportResumeConfig {
                     snapshot_id: manifest.snapshot_id.to_string(),
@@ -768,6 +795,53 @@ mod tests {
             parse_command(&["--task-parallelism", "64"]).task_parallelism,
             64
         );
+    }
+
+    #[test]
+    fn test_state_path_defaults_to_none() {
+        assert_eq!(parse_command(&[]).state_path, None);
+    }
+
+    #[test]
+    fn test_state_path_parses_explicit_value() {
+        assert_eq!(
+            parse_command(&["--state-path", "/tmp/import_state.json"]).state_path,
+            Some(PathBuf::from("/tmp/import_state.json"))
+        );
+    }
+
+    #[test]
+    fn test_resolve_state_path_prefers_override() {
+        let override_path = PathBuf::from("/tmp/custom_import_state.json");
+        let resolved = resolve_state_path(
+            Some(override_path.as_path()),
+            "snapshot-1",
+            "127.0.0.1:4000",
+            "greptime",
+            &["public".to_string()],
+        )
+        .unwrap();
+        assert_eq!(resolved, override_path);
+    }
+
+    #[test]
+    fn test_resolve_state_path_uses_default_when_absent() {
+        let resolved = resolve_state_path(
+            None,
+            "snapshot-1",
+            "127.0.0.1:4000",
+            "greptime",
+            &["public".to_string()],
+        )
+        .unwrap();
+        let expected = default_state_path(
+            "snapshot-1",
+            "127.0.0.1:4000",
+            "greptime",
+            &["public".to_string()],
+        )
+        .unwrap();
+        assert_eq!(resolved, expected);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add import-v2 `--state-path <PATH>` to override the resume state file path.
- Keep the existing default `~/.greptime/import_state`-based state path behavior when the option is omitted.
- Continue to avoid touching resume state for dry-run, schema-only, and no-data-task imports.

## Stack

Dependency #8300 has merged; this PR is now rebased onto `main`.

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p cli data::import_v2::command --lib`
- [x] `cargo test -p cli data::import_v2::coordinator --lib`
- [x] `cargo clippy -p cli --lib -- -D warnings`
- [x] `git diff --check`

## Review Notes

- Local independent code review: approved before rebase.
- Release-manager verification: passed before rebase.
- Rebase verification onto latest `main`: passed.
