### PR TITLE
feat: add remote dynamic filter metrics

### DIFF
--- a/src/common/query/src/request.rs
+++ b/src/common/query/src/request.rs
@@ -36,13 +36,14 @@ use store_api::storage::RegionId;
 
 /// Current wire-format version for remote dynamic filter payload updates.
 pub use self::initial_remote_dyn_filter_reg::{
-    INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY,
-    INITIAL_REMOTE_DYN_FILTER_REGS_MAX_TOTAL_PROTO_BYTES, InitialDynFilterReg,
+    INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY, InitialDynFilterReg,
     InitialDynFilterRegs, InitialDynFilterSnapshot,
 };
 use crate::error::{DynFilterPayloadTooLargeSnafu, Error as CommonQueryError};
 
 pub const DYN_FILTER_PROTOCOL_VERSION: u32 = 1;
+/// Shared raw protobuf byte budget for remote dynamic filter payloads.
+pub const REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES: usize = 512 * 1024;
 
 /// Serialized predicate payload for remote dynamic filter updates.
 ///

--- a/src/common/query/src/request/initial_remote_dyn_filter_reg.rs
+++ b/src/common/query/src/request/initial_remote_dyn_filter_reg.rs
@@ -22,17 +22,13 @@ use datafusion_common::Result as DataFusionResult;
 use serde::{Deserialize, Serialize};
 
 use crate::request::{
-    DynFilterPayload, decode_physical_expr_from_bytes, encode_physical_expr_to_bytes,
+    DynFilterPayload, REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES, decode_physical_expr_from_bytes,
+    encode_physical_expr_to_bytes,
 };
 
 pub const INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY: &str =
     "initial_remote_dyn_filter_registrations";
 pub const INITIAL_REMOTE_DYN_FILTER_REGS_MAX_COUNT: usize = 64;
-/// Raw encoded registration byte budget for initial remote dynamic filter registrations.
-///
-/// Counts proto payload bytes before JSON/base64 expansion, not the final extension size.
-pub const INITIAL_REMOTE_DYN_FILTER_REGS_MAX_TOTAL_PROTO_BYTES: usize = 64 * 1024;
-
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InitialDynFilterRegs {
     #[serde(rename = "registrations")]
@@ -58,7 +54,7 @@ impl InitialDynFilterRegs {
     pub fn validate_default_bounds(&self) -> Result<(), String> {
         self.validate_bounds(
             INITIAL_REMOTE_DYN_FILTER_REGS_MAX_COUNT,
-            INITIAL_REMOTE_DYN_FILTER_REGS_MAX_TOTAL_PROTO_BYTES,
+            REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES,
         )
     }
 

--- a/src/common/query/src/request/initial_remote_dyn_filter_reg.rs
+++ b/src/common/query/src/request/initial_remote_dyn_filter_reg.rs
@@ -29,6 +29,9 @@ use crate::request::{
 pub const INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY: &str =
     "initial_remote_dyn_filter_registrations";
 pub const INITIAL_REMOTE_DYN_FILTER_REGS_MAX_COUNT: usize = 64;
+
+// Initial registration validation uses the shared remote dynamic filter payload budget.
+// It counts raw protobuf payload bytes before JSON/base64 expansion, not the final extension size.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InitialDynFilterRegs {
     #[serde(rename = "registrations")]

--- a/src/datanode/src/metrics.rs
+++ b/src/datanode/src/metrics.rs
@@ -91,4 +91,38 @@ lazy_static! {
         &[REGION_REQUEST_TYPE]
     )
     .unwrap();
+
+    /// Remote dynamic filter update apply outcomes, labeled with the outcome.
+    pub static ref REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL: IntCounterVec = register_int_counter_vec!(
+        "greptime_datanode_remote_dyn_filter_update_apply_total",
+        "remote dynamic filter update apply outcomes",
+        &["result"]
+    )
+    .unwrap();
+
+    /// Remote dynamic filter update drops, labeled with drop reason.
+    pub static ref REMOTE_DYN_FILTER_UPDATE_DROP_TOTAL: IntCounterVec = register_int_counter_vec!(
+        "greptime_datanode_remote_dyn_filter_update_drop_total",
+        "remote dynamic filter update drops by reason",
+        &["reason"]
+    )
+    .unwrap();
+
+    /// Current count of remote dynamic filter runtime registry entries.
+    pub static ref REMOTE_DYN_FILTER_RUNTIME_REGISTRY_ENTRIES: IntGauge = register_int_gauge!(
+        "greptime_datanode_remote_dyn_filter_runtime_registry_entries",
+        "current remote dynamic filter registry entry count",
+    )
+    .unwrap();
+
+    /// Remote dynamic filter payload bytes received.
+    pub static ref REMOTE_DYN_FILTER_PAYLOAD_BYTES: Histogram = register_histogram!(
+        "greptime_datanode_remote_dyn_filter_payload_bytes",
+        "remote dynamic filter payload bytes received",
+        vec![
+            128.0, 256.0, 512.0, 1024.0, 2048.0, 4096.0, 8192.0, 16384.0, 32768.0,
+            65536.0, 131072.0, 262144.0, 524288.0,
+        ]
+    )
+    .unwrap();
 }

--- a/src/datanode/src/metrics.rs
+++ b/src/datanode/src/metrics.rs
@@ -92,10 +92,10 @@ lazy_static! {
     )
     .unwrap();
 
-    /// Remote dynamic filter update apply outcomes, labeled with the outcome.
-    pub static ref REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL: IntCounterVec = register_int_counter_vec!(
-        "greptime_datanode_remote_dyn_filter_update_apply_total",
-        "remote dynamic filter update apply outcomes",
+    /// Remote dynamic filter update processing outcomes, labeled with the outcome.
+    pub static ref REMOTE_DYN_FILTER_UPDATE_OUTCOME_TOTAL: IntCounterVec = register_int_counter_vec!(
+        "greptime_datanode_remote_dyn_filter_update_outcome_total",
+        "remote dynamic filter update processing outcomes",
         &["result"]
     )
     .unwrap();

--- a/src/datanode/src/metrics.rs
+++ b/src/datanode/src/metrics.rs
@@ -108,17 +108,25 @@ lazy_static! {
     )
     .unwrap();
 
-    /// Current count of remote dynamic filter runtime registry entries.
-    pub static ref REMOTE_DYN_FILTER_RUNTIME_REGISTRY_ENTRIES: IntGauge = register_int_gauge!(
-        "greptime_datanode_remote_dyn_filter_runtime_registry_entries",
+    /// Remote dynamic filter unregister outcomes, labeled with the outcome.
+    pub static ref REMOTE_DYN_FILTER_UNREGISTER_TOTAL: IntCounterVec = register_int_counter_vec!(
+        "greptime_datanode_remote_dyn_filter_unregister_total",
+        "remote dynamic filter unregister outcomes",
+        &["result"]
+    )
+    .unwrap();
+
+    /// Current count of remote dynamic filter registry entries.
+    pub static ref REMOTE_DYN_FILTER_REGISTRY_ENTRIES: IntGauge = register_int_gauge!(
+        "greptime_datanode_remote_dyn_filter_registry_entries",
         "current remote dynamic filter registry entry count",
     )
     .unwrap();
 
-    /// Remote dynamic filter payload bytes received.
+    /// Remote dynamic filter accepted update payload bytes received.
     pub static ref REMOTE_DYN_FILTER_PAYLOAD_BYTES: Histogram = register_histogram!(
         "greptime_datanode_remote_dyn_filter_payload_bytes",
-        "remote dynamic filter payload bytes received",
+        "remote dynamic filter accepted update payload bytes received",
         vec![
             128.0, 256.0, 512.0, 1024.0, 2048.0, 4096.0, 8192.0, 16384.0, 32768.0,
             65536.0, 131072.0, 262144.0, 524288.0,

--- a/src/datanode/src/region_server/registrations.rs
+++ b/src/datanode/src/region_server/registrations.rs
@@ -33,8 +33,9 @@ use session::query_id::QueryId;
 use store_api::storage::RegionId;
 
 use crate::metrics::{
-    REMOTE_DYN_FILTER_PAYLOAD_BYTES, REMOTE_DYN_FILTER_RUNTIME_REGISTRY_ENTRIES,
-    REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL, REMOTE_DYN_FILTER_UPDATE_DROP_TOTAL,
+    REMOTE_DYN_FILTER_PAYLOAD_BYTES, REMOTE_DYN_FILTER_REGISTRY_ENTRIES,
+    REMOTE_DYN_FILTER_UNREGISTER_TOTAL, REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL,
+    REMOTE_DYN_FILTER_UPDATE_DROP_TOTAL,
 };
 
 type QueryRemoteDynFilterRegs = HashMap<RemoteDynFilterId, RegisteredDynFilter>;
@@ -139,6 +140,23 @@ impl RemoteDynFilterUpdateOutcome {
                 | Self::DecodeFailed
         )
     }
+}
+
+fn record_update_outcome(outcome: RemoteDynFilterUpdateOutcome) {
+    REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
+        .with_label_values(&[outcome.as_str()])
+        .inc();
+    if outcome.is_drop() {
+        REMOTE_DYN_FILTER_UPDATE_DROP_TOTAL
+            .with_label_values(&[outcome.as_str()])
+            .inc();
+    }
+}
+
+fn record_unregister_outcome(outcome: RemoteDynFilterUpdateOutcome) {
+    REMOTE_DYN_FILTER_UNREGISTER_TOTAL
+        .with_label_values(&[outcome.as_str()])
+        .inc();
 }
 
 #[derive(Debug, Clone)]
@@ -484,7 +502,7 @@ pub(super) fn register_initial_dyn_filter_regs(
                     PendingDynFilterUpdate::from_initial_reg(reg),
                     region_id,
                 ));
-                REMOTE_DYN_FILTER_RUNTIME_REGISTRY_ENTRIES.inc();
+                REMOTE_DYN_FILTER_REGISTRY_ENTRIES.inc();
                 registered_filter_ids.push(filter_id);
             }
         }
@@ -532,12 +550,7 @@ pub(super) fn apply_remote_dyn_filter_update(
             REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES
         );
         let outcome = RemoteDynFilterUpdateOutcome::PayloadTooLarge;
-        REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
-            .with_label_values(&[outcome.as_str()])
-            .inc();
-        REMOTE_DYN_FILTER_UPDATE_DROP_TOTAL
-            .with_label_values(&[outcome.as_str()])
-            .inc();
+        record_update_outcome(outcome);
         return outcome;
     }
 
@@ -549,12 +562,7 @@ pub(super) fn apply_remote_dyn_filter_update(
             query_id, filter_id
         );
         let outcome = RemoteDynFilterUpdateOutcome::MissingRegistration;
-        REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
-            .with_label_values(&[outcome.as_str()])
-            .inc();
-        REMOTE_DYN_FILTER_UPDATE_DROP_TOTAL
-            .with_label_values(&[outcome.as_str()])
-            .inc();
+        record_update_outcome(outcome);
         return outcome;
     };
 
@@ -565,24 +573,12 @@ pub(super) fn apply_remote_dyn_filter_update(
             query_id, filter_id
         );
         let outcome = RemoteDynFilterUpdateOutcome::MissingRegistration;
-        REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
-            .with_label_values(&[outcome.as_str()])
-            .inc();
-        REMOTE_DYN_FILTER_UPDATE_DROP_TOTAL
-            .with_label_values(&[outcome.as_str()])
-            .inc();
+        record_update_outcome(outcome);
         return outcome;
     };
 
     let outcome = registered.apply_or_buffer_update(payload, generation, is_complete);
-    if outcome.is_drop() {
-        REMOTE_DYN_FILTER_UPDATE_DROP_TOTAL
-            .with_label_values(&[outcome.as_str()])
-            .inc();
-    }
-    REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
-        .with_label_values(&[outcome.as_str()])
-        .inc();
+    record_update_outcome(outcome);
 
     outcome
 }
@@ -598,9 +594,7 @@ pub(super) fn unregister_remote_dyn_filter(
             query_id, filter_id
         );
         let outcome = RemoteDynFilterUpdateOutcome::MissingRegistration;
-        REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
-            .with_label_values(&[outcome.as_str()])
-            .inc();
+        record_unregister_outcome(outcome);
         return outcome;
     };
 
@@ -612,12 +606,10 @@ pub(super) fn unregister_remote_dyn_filter(
                 query_id, filter_id
             );
             let outcome = RemoteDynFilterUpdateOutcome::MissingRegistration;
-            REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
-                .with_label_values(&[outcome.as_str()])
-                .inc();
+            record_unregister_outcome(outcome);
             return outcome;
         };
-        REMOTE_DYN_FILTER_RUNTIME_REGISTRY_ENTRIES.dec();
+        REMOTE_DYN_FILTER_REGISTRY_ENTRIES.dec();
         let should_remove_query = locked.is_empty();
         (registered, should_remove_query)
     };
@@ -628,9 +620,7 @@ pub(super) fn unregister_remote_dyn_filter(
     }
 
     let outcome = RemoteDynFilterUpdateOutcome::Applied;
-    REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
-        .with_label_values(&[outcome.as_str()])
-        .inc();
+    record_unregister_outcome(outcome);
 
     outcome
 }
@@ -660,7 +650,7 @@ pub(super) fn remove_initial_dyn_filter_regs(
                 .unwrap_or(false);
 
             if should_remove_filter && let Some(registered) = locked.remove(filter_id) {
-                REMOTE_DYN_FILTER_RUNTIME_REGISTRY_ENTRIES.dec();
+                REMOTE_DYN_FILTER_REGISTRY_ENTRIES.dec();
                 removed_filters.push(registered);
             }
         }

--- a/src/datanode/src/region_server/registrations.rs
+++ b/src/datanode/src/region_server/registrations.rs
@@ -32,7 +32,9 @@ use session::context::QueryContextRef;
 use session::query_id::QueryId;
 use store_api::storage::RegionId;
 
-pub(super) const REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES: usize = 64 * 1024;
+use crate::metrics;
+
+pub(super) const REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES: usize = 512 * 1024;
 
 type QueryRemoteDynFilterRegs = HashMap<RemoteDynFilterId, RegisteredDynFilter>;
 
@@ -110,6 +112,21 @@ pub(super) enum RemoteDynFilterUpdateOutcome {
     AlreadyComplete,
     PayloadTooLarge,
     DecodeFailed,
+}
+
+impl RemoteDynFilterUpdateOutcome {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::MissingRegistration => "missing_registration",
+            Self::Buffered => "buffered",
+            Self::Applied => "applied",
+            Self::Idempotent => "idempotent",
+            Self::Stale => "stale",
+            Self::AlreadyComplete => "already_complete",
+            Self::PayloadTooLarge => "payload_too_large",
+            Self::DecodeFailed => "decode_failed",
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -455,6 +472,7 @@ pub(super) fn register_initial_dyn_filter_regs(
                     PendingDynFilterUpdate::from_initial_reg(reg),
                     region_id,
                 ));
+                metrics::REMOTE_DYN_FILTER_RUNTIME_REGISTRY_ENTRIES.inc();
                 registered_filter_ids.push(filter_id);
             }
         }
@@ -501,15 +519,31 @@ pub(super) fn apply_remote_dyn_filter_update(
             payload.len(),
             REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES
         );
-        return RemoteDynFilterUpdateOutcome::PayloadTooLarge;
+        let outcome = RemoteDynFilterUpdateOutcome::PayloadTooLarge;
+        metrics::REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
+            .with_label_values(&[outcome.as_str()])
+            .inc();
+        metrics::REMOTE_DYN_FILTER_UPDATE_DROP_TOTAL
+            .with_label_values(&[outcome.as_str()])
+            .inc();
+        return outcome;
     }
+
+    metrics::REMOTE_DYN_FILTER_PAYLOAD_BYTES.observe(payload.len() as f64);
 
     let Some(query_regs) = regs_by_query.get_query(query_id) else {
         warn!(
             "Ignored remote dynamic filter update without query registration, query_id: {}, filter_id: {}",
             query_id, filter_id
         );
-        return RemoteDynFilterUpdateOutcome::MissingRegistration;
+        let outcome = RemoteDynFilterUpdateOutcome::MissingRegistration;
+        metrics::REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
+            .with_label_values(&[outcome.as_str()])
+            .inc();
+        metrics::REMOTE_DYN_FILTER_UPDATE_DROP_TOTAL
+            .with_label_values(&[outcome.as_str()])
+            .inc();
+        return outcome;
     };
 
     let mut query_regs = query_regs.lock().unwrap();
@@ -518,10 +552,34 @@ pub(super) fn apply_remote_dyn_filter_update(
             "Ignored remote dynamic filter update without filter registration, query_id: {}, filter_id: {}",
             query_id, filter_id
         );
-        return RemoteDynFilterUpdateOutcome::MissingRegistration;
+        let outcome = RemoteDynFilterUpdateOutcome::MissingRegistration;
+        metrics::REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
+            .with_label_values(&[outcome.as_str()])
+            .inc();
+        metrics::REMOTE_DYN_FILTER_UPDATE_DROP_TOTAL
+            .with_label_values(&[outcome.as_str()])
+            .inc();
+        return outcome;
     };
 
-    registered.apply_or_buffer_update(payload, generation, is_complete)
+    let outcome = registered.apply_or_buffer_update(payload, generation, is_complete);
+    match outcome {
+        RemoteDynFilterUpdateOutcome::PayloadTooLarge
+        | RemoteDynFilterUpdateOutcome::DecodeFailed
+        | RemoteDynFilterUpdateOutcome::MissingRegistration
+        | RemoteDynFilterUpdateOutcome::Stale
+        | RemoteDynFilterUpdateOutcome::AlreadyComplete => {
+            metrics::REMOTE_DYN_FILTER_UPDATE_DROP_TOTAL
+                .with_label_values(&[outcome.as_str()])
+                .inc();
+        }
+        _ => {}
+    }
+    metrics::REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
+        .with_label_values(&[outcome.as_str()])
+        .inc();
+
+    outcome
 }
 
 pub(super) fn unregister_remote_dyn_filter(
@@ -534,7 +592,11 @@ pub(super) fn unregister_remote_dyn_filter(
             "Ignored remote dynamic filter unregister without query registration, query_id: {}, filter_id: {}",
             query_id, filter_id
         );
-        return RemoteDynFilterUpdateOutcome::MissingRegistration;
+        let outcome = RemoteDynFilterUpdateOutcome::MissingRegistration;
+        metrics::REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
+            .with_label_values(&[outcome.as_str()])
+            .inc();
+        return outcome;
     };
 
     let (registered, should_remove_query) = {
@@ -544,8 +606,13 @@ pub(super) fn unregister_remote_dyn_filter(
                 "Ignored remote dynamic filter unregister without filter registration, query_id: {}, filter_id: {}",
                 query_id, filter_id
             );
-            return RemoteDynFilterUpdateOutcome::MissingRegistration;
+            let outcome = RemoteDynFilterUpdateOutcome::MissingRegistration;
+            metrics::REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
+                .with_label_values(&[outcome.as_str()])
+                .inc();
+            return outcome;
         };
+        metrics::REMOTE_DYN_FILTER_RUNTIME_REGISTRY_ENTRIES.dec();
         let should_remove_query = locked.is_empty();
         (registered, should_remove_query)
     };
@@ -555,7 +622,12 @@ pub(super) fn unregister_remote_dyn_filter(
         regs_by_query.remove_query_if_empty(query_id, &query_regs);
     }
 
-    RemoteDynFilterUpdateOutcome::Applied
+    let outcome = RemoteDynFilterUpdateOutcome::Applied;
+    metrics::REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
+        .with_label_values(&[outcome.as_str()])
+        .inc();
+
+    outcome
 }
 
 pub(super) fn remove_initial_dyn_filter_regs(
@@ -583,6 +655,7 @@ pub(super) fn remove_initial_dyn_filter_regs(
                 .unwrap_or(false);
 
             if should_remove_filter && let Some(registered) = locked.remove(filter_id) {
+                metrics::REMOTE_DYN_FILTER_RUNTIME_REGISTRY_ENTRIES.dec();
                 removed_filters.push(registered);
             }
         }

--- a/src/datanode/src/region_server/registrations.rs
+++ b/src/datanode/src/region_server/registrations.rs
@@ -34,8 +34,8 @@ use store_api::storage::RegionId;
 
 use crate::metrics::{
     REMOTE_DYN_FILTER_PAYLOAD_BYTES, REMOTE_DYN_FILTER_REGISTRY_ENTRIES,
-    REMOTE_DYN_FILTER_UNREGISTER_TOTAL, REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL,
-    REMOTE_DYN_FILTER_UPDATE_DROP_TOTAL,
+    REMOTE_DYN_FILTER_UNREGISTER_TOTAL, REMOTE_DYN_FILTER_UPDATE_DROP_TOTAL,
+    REMOTE_DYN_FILTER_UPDATE_OUTCOME_TOTAL,
 };
 
 type QueryRemoteDynFilterRegs = HashMap<RemoteDynFilterId, RegisteredDynFilter>;
@@ -143,7 +143,7 @@ impl RemoteDynFilterUpdateOutcome {
 }
 
 fn record_update_outcome(outcome: RemoteDynFilterUpdateOutcome) {
-    REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
+    REMOTE_DYN_FILTER_UPDATE_OUTCOME_TOTAL
         .with_label_values(&[outcome.as_str()])
         .inc();
     if outcome.is_drop() {

--- a/src/datanode/src/region_server/registrations.rs
+++ b/src/datanode/src/region_server/registrations.rs
@@ -32,7 +32,10 @@ use session::context::QueryContextRef;
 use session::query_id::QueryId;
 use store_api::storage::RegionId;
 
-use crate::metrics;
+use crate::metrics::{
+    REMOTE_DYN_FILTER_PAYLOAD_BYTES, REMOTE_DYN_FILTER_RUNTIME_REGISTRY_ENTRIES,
+    REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL, REMOTE_DYN_FILTER_UPDATE_DROP_TOTAL,
+};
 
 type QueryRemoteDynFilterRegs = HashMap<RemoteDynFilterId, RegisteredDynFilter>;
 
@@ -481,7 +484,7 @@ pub(super) fn register_initial_dyn_filter_regs(
                     PendingDynFilterUpdate::from_initial_reg(reg),
                     region_id,
                 ));
-                metrics::REMOTE_DYN_FILTER_RUNTIME_REGISTRY_ENTRIES.inc();
+                REMOTE_DYN_FILTER_RUNTIME_REGISTRY_ENTRIES.inc();
                 registered_filter_ids.push(filter_id);
             }
         }
@@ -529,16 +532,16 @@ pub(super) fn apply_remote_dyn_filter_update(
             REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES
         );
         let outcome = RemoteDynFilterUpdateOutcome::PayloadTooLarge;
-        metrics::REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
+        REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
             .with_label_values(&[outcome.as_str()])
             .inc();
-        metrics::REMOTE_DYN_FILTER_UPDATE_DROP_TOTAL
+        REMOTE_DYN_FILTER_UPDATE_DROP_TOTAL
             .with_label_values(&[outcome.as_str()])
             .inc();
         return outcome;
     }
 
-    metrics::REMOTE_DYN_FILTER_PAYLOAD_BYTES.observe(payload.len() as f64);
+    REMOTE_DYN_FILTER_PAYLOAD_BYTES.observe(payload.len() as f64);
 
     let Some(query_regs) = regs_by_query.get_query(query_id) else {
         warn!(
@@ -546,10 +549,10 @@ pub(super) fn apply_remote_dyn_filter_update(
             query_id, filter_id
         );
         let outcome = RemoteDynFilterUpdateOutcome::MissingRegistration;
-        metrics::REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
+        REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
             .with_label_values(&[outcome.as_str()])
             .inc();
-        metrics::REMOTE_DYN_FILTER_UPDATE_DROP_TOTAL
+        REMOTE_DYN_FILTER_UPDATE_DROP_TOTAL
             .with_label_values(&[outcome.as_str()])
             .inc();
         return outcome;
@@ -562,10 +565,10 @@ pub(super) fn apply_remote_dyn_filter_update(
             query_id, filter_id
         );
         let outcome = RemoteDynFilterUpdateOutcome::MissingRegistration;
-        metrics::REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
+        REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
             .with_label_values(&[outcome.as_str()])
             .inc();
-        metrics::REMOTE_DYN_FILTER_UPDATE_DROP_TOTAL
+        REMOTE_DYN_FILTER_UPDATE_DROP_TOTAL
             .with_label_values(&[outcome.as_str()])
             .inc();
         return outcome;
@@ -573,11 +576,11 @@ pub(super) fn apply_remote_dyn_filter_update(
 
     let outcome = registered.apply_or_buffer_update(payload, generation, is_complete);
     if outcome.is_drop() {
-        metrics::REMOTE_DYN_FILTER_UPDATE_DROP_TOTAL
+        REMOTE_DYN_FILTER_UPDATE_DROP_TOTAL
             .with_label_values(&[outcome.as_str()])
             .inc();
     }
-    metrics::REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
+    REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
         .with_label_values(&[outcome.as_str()])
         .inc();
 
@@ -595,7 +598,7 @@ pub(super) fn unregister_remote_dyn_filter(
             query_id, filter_id
         );
         let outcome = RemoteDynFilterUpdateOutcome::MissingRegistration;
-        metrics::REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
+        REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
             .with_label_values(&[outcome.as_str()])
             .inc();
         return outcome;
@@ -609,12 +612,12 @@ pub(super) fn unregister_remote_dyn_filter(
                 query_id, filter_id
             );
             let outcome = RemoteDynFilterUpdateOutcome::MissingRegistration;
-            metrics::REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
+            REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
                 .with_label_values(&[outcome.as_str()])
                 .inc();
             return outcome;
         };
-        metrics::REMOTE_DYN_FILTER_RUNTIME_REGISTRY_ENTRIES.dec();
+        REMOTE_DYN_FILTER_RUNTIME_REGISTRY_ENTRIES.dec();
         let should_remove_query = locked.is_empty();
         (registered, should_remove_query)
     };
@@ -625,7 +628,7 @@ pub(super) fn unregister_remote_dyn_filter(
     }
 
     let outcome = RemoteDynFilterUpdateOutcome::Applied;
-    metrics::REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
+    REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
         .with_label_values(&[outcome.as_str()])
         .inc();
 
@@ -657,7 +660,7 @@ pub(super) fn remove_initial_dyn_filter_regs(
                 .unwrap_or(false);
 
             if should_remove_filter && let Some(registered) = locked.remove(filter_id) {
-                metrics::REMOTE_DYN_FILTER_RUNTIME_REGISTRY_ENTRIES.dec();
+                REMOTE_DYN_FILTER_RUNTIME_REGISTRY_ENTRIES.dec();
                 removed_filters.push(registered);
             }
         }

--- a/src/datanode/src/region_server/registrations.rs
+++ b/src/datanode/src/region_server/registrations.rs
@@ -19,7 +19,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 
 use common_query::request::{
     DynFilterPayload, INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY, InitialDynFilterReg,
-    InitialDynFilterRegs,
+    InitialDynFilterRegs, REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES,
 };
 use common_telemetry::warn;
 use dashmap::DashMap;
@@ -33,8 +33,6 @@ use session::query_id::QueryId;
 use store_api::storage::RegionId;
 
 use crate::metrics;
-
-pub(super) const REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES: usize = 512 * 1024;
 
 type QueryRemoteDynFilterRegs = HashMap<RemoteDynFilterId, RegisteredDynFilter>;
 
@@ -126,6 +124,17 @@ impl RemoteDynFilterUpdateOutcome {
             Self::PayloadTooLarge => "payload_too_large",
             Self::DecodeFailed => "decode_failed",
         }
+    }
+
+    fn is_drop(&self) -> bool {
+        matches!(
+            self,
+            Self::MissingRegistration
+                | Self::Stale
+                | Self::AlreadyComplete
+                | Self::PayloadTooLarge
+                | Self::DecodeFailed
+        )
     }
 }
 
@@ -563,17 +572,10 @@ pub(super) fn apply_remote_dyn_filter_update(
     };
 
     let outcome = registered.apply_or_buffer_update(payload, generation, is_complete);
-    match outcome {
-        RemoteDynFilterUpdateOutcome::PayloadTooLarge
-        | RemoteDynFilterUpdateOutcome::DecodeFailed
-        | RemoteDynFilterUpdateOutcome::MissingRegistration
-        | RemoteDynFilterUpdateOutcome::Stale
-        | RemoteDynFilterUpdateOutcome::AlreadyComplete => {
-            metrics::REMOTE_DYN_FILTER_UPDATE_DROP_TOTAL
-                .with_label_values(&[outcome.as_str()])
-                .inc();
-        }
-        _ => {}
+    if outcome.is_drop() {
+        metrics::REMOTE_DYN_FILTER_UPDATE_DROP_TOTAL
+            .with_label_values(&[outcome.as_str()])
+            .inc();
     }
     metrics::REMOTE_DYN_FILTER_UPDATE_APPLY_TOTAL
         .with_label_values(&[outcome.as_str()])

--- a/src/datanode/src/region_server/remote_dyn_filter.rs
+++ b/src/datanode/src/region_server/remote_dyn_filter.rs
@@ -352,6 +352,7 @@ mod tests {
     use common_query::request::{
         DynFilterPayload, INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY,
         InitialDynFilterReg, InitialDynFilterRegs, InitialDynFilterSnapshot,
+        REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES,
     };
     use common_recordbatch::RecordBatches;
     use datafusion::arrow::datatypes::Schema as ArrowSchema;
@@ -370,9 +371,7 @@ mod tests {
     use store_api::storage::RegionId;
 
     use super::*;
-    use crate::region_server::registrations::{
-        REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES, RemoteDynFilterRegistry,
-    };
+    use crate::region_server::registrations::RemoteDynFilterRegistry;
     use crate::tests::mock_region_server;
 
     #[derive(Debug, Clone)]

--- a/src/query/src/dist_plan/dyn_filter_bridge.rs
+++ b/src/query/src/dist_plan/dyn_filter_bridge.rs
@@ -16,9 +16,8 @@ use std::any::Any;
 use std::sync::Arc;
 
 use common_query::request::{
-    DynFilterPayload, INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY,
-    INITIAL_REMOTE_DYN_FILTER_REGS_MAX_TOTAL_PROTO_BYTES, InitialDynFilterReg,
-    InitialDynFilterRegs, InitialDynFilterSnapshot,
+    DynFilterPayload, INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY, InitialDynFilterReg,
+    InitialDynFilterRegs, InitialDynFilterSnapshot, REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES,
 };
 use datafusion_common::Result;
 use datafusion_physical_expr::PhysicalExpr;
@@ -169,7 +168,7 @@ fn initial_snapshot(
 
     let payload = match DynFilterPayload::from_datafusion_expr(
         &current,
-        INITIAL_REMOTE_DYN_FILTER_REGS_MAX_TOTAL_PROTO_BYTES,
+        REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES,
     ) {
         Ok(payload) => payload,
         Err(error) => {
@@ -485,10 +484,11 @@ mod tests {
 
     #[test]
     fn capture_remote_dyn_filters_for_pushdown_rejects_oversized_snapshots() {
+        let oversized_total_snapshot_bytes = REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES * 3 / 5;
         let parent_filters = vec![
-            test_dyn_filter_with_snapshot_payload("host", 0, 40 * 1024)
+            test_dyn_filter_with_snapshot_payload("host", 0, oversized_total_snapshot_bytes)
                 as Arc<dyn datafusion::physical_plan::PhysicalExpr>,
-            test_dyn_filter_with_snapshot_payload("pod", 1, 40 * 1024)
+            test_dyn_filter_with_snapshot_payload("pod", 1, oversized_total_snapshot_bytes)
                 as Arc<dyn datafusion::physical_plan::PhysicalExpr>,
         ];
 

--- a/src/query/src/dist_plan/remote_dyn_filter_registry.rs
+++ b/src/query/src/dist_plan/remote_dyn_filter_registry.rs
@@ -28,7 +28,10 @@ use store_api::storage::RegionId;
 use tokio::sync::{Notify, watch};
 
 use crate::dist_plan::FilterId;
-use crate::metrics;
+use crate::metrics::{
+    REMOTE_DYN_FILTER_ENCODE_TOTAL, REMOTE_DYN_FILTER_PAYLOAD_BYTES,
+    REMOTE_DYN_FILTER_UPDATE_RPC_TOTAL,
+};
 use crate::region_query::RegionQueryHandlerRef;
 
 const REMOTE_DYN_FILTER_RECONCILE_INTERVAL: Duration = Duration::from_secs(1);
@@ -391,21 +394,21 @@ async fn fanout_snapshot_for_query(
         match DynFilterPayload::from_datafusion_expr(&current, REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES)
         {
             Ok(DynFilterPayload::Datafusion(payload)) => {
-                metrics::REMOTE_DYN_FILTER_ENCODE_TOTAL
+                REMOTE_DYN_FILTER_ENCODE_TOTAL
                     .with_label_values(&["success"])
                     .inc();
-                metrics::REMOTE_DYN_FILTER_PAYLOAD_BYTES.observe(payload.len() as f64);
+                REMOTE_DYN_FILTER_PAYLOAD_BYTES.observe(payload.len() as f64);
                 payload
             }
             Ok(_) => {
-                metrics::REMOTE_DYN_FILTER_ENCODE_TOTAL
+                REMOTE_DYN_FILTER_ENCODE_TOTAL
                     .with_label_values(&["unsupported"])
                     .inc();
                 warn!("Ignored unsupported remote dynamic filter producer payload");
                 return true;
             }
             Err(error) => {
-                metrics::REMOTE_DYN_FILTER_ENCODE_TOTAL
+                REMOTE_DYN_FILTER_ENCODE_TOTAL
                     .with_label_values(&["error"])
                     .inc();
                 warn!(error; "Failed to encode remote dynamic filter producer snapshot");
@@ -467,7 +470,7 @@ async fn fanout_update_for_query(
         {
             ControlRpcResult::Ok(result) => {
                 if let Err(error) = result {
-                    metrics::REMOTE_DYN_FILTER_UPDATE_RPC_TOTAL
+                    REMOTE_DYN_FILTER_UPDATE_RPC_TOTAL
                         .with_label_values(&["error"])
                         .inc();
                     warn!(
@@ -478,18 +481,18 @@ async fn fanout_update_for_query(
                         subscriber.region_id()
                     );
                 } else {
-                    metrics::REMOTE_DYN_FILTER_UPDATE_RPC_TOTAL
+                    REMOTE_DYN_FILTER_UPDATE_RPC_TOTAL
                         .with_label_values(&["success"])
                         .inc();
                 }
             }
             ControlRpcResult::TimedOut => {
-                metrics::REMOTE_DYN_FILTER_UPDATE_RPC_TOTAL
+                REMOTE_DYN_FILTER_UPDATE_RPC_TOTAL
                     .with_label_values(&["timeout"])
                     .inc();
             }
             ControlRpcResult::LifecycleClosed => {
-                metrics::REMOTE_DYN_FILTER_UPDATE_RPC_TOTAL
+                REMOTE_DYN_FILTER_UPDATE_RPC_TOTAL
                     .with_label_values(&["cancelled"])
                     .inc();
                 return false;

--- a/src/query/src/dist_plan/remote_dyn_filter_registry.rs
+++ b/src/query/src/dist_plan/remote_dyn_filter_registry.rs
@@ -28,9 +28,10 @@ use store_api::storage::RegionId;
 use tokio::sync::{Notify, watch};
 
 use crate::dist_plan::FilterId;
+use crate::metrics;
 use crate::region_query::RegionQueryHandlerRef;
 
-const REMOTE_DYN_FILTER_UPDATE_PAYLOAD_MAX_BYTES: usize = 64 * 1024;
+const REMOTE_DYN_FILTER_UPDATE_PAYLOAD_MAX_BYTES: usize = 512 * 1024;
 const REMOTE_DYN_FILTER_RECONCILE_INTERVAL: Duration = Duration::from_secs(1);
 /// Bound best-effort RDF control RPCs so one bad subscriber cannot stall fanout.
 const REMOTE_DYN_FILTER_CONTROL_RPC_TIMEOUT: Duration = Duration::from_secs(10);
@@ -391,12 +392,24 @@ async fn fanout_snapshot_for_query(
         &current,
         REMOTE_DYN_FILTER_UPDATE_PAYLOAD_MAX_BYTES,
     ) {
-        Ok(DynFilterPayload::Datafusion(payload)) => payload,
+        Ok(DynFilterPayload::Datafusion(payload)) => {
+            metrics::REMOTE_DYN_FILTER_ENCODE_TOTAL
+                .with_label_values(&["success"])
+                .inc();
+            metrics::REMOTE_DYN_FILTER_PAYLOAD_BYTES.observe(payload.len() as f64);
+            payload
+        }
         Ok(_) => {
+            metrics::REMOTE_DYN_FILTER_ENCODE_TOTAL
+                .with_label_values(&["unsupported"])
+                .inc();
             warn!("Ignored unsupported remote dynamic filter producer payload");
             return true;
         }
         Err(error) => {
+            metrics::REMOTE_DYN_FILTER_ENCODE_TOTAL
+                .with_label_values(&["error"])
+                .inc();
             warn!(error; "Failed to encode remote dynamic filter producer snapshot");
             return true;
         }
@@ -456,6 +469,9 @@ async fn fanout_update_for_query(
         {
             ControlRpcResult::Ok(result) => {
                 if let Err(error) = result {
+                    metrics::REMOTE_DYN_FILTER_UPDATE_RPC_TOTAL
+                        .with_label_values(&["error"])
+                        .inc();
                     warn!(
                         error;
                         "Failed to fan out remote dynamic filter update, query_id={}, filter_id={}, region_id={}",
@@ -463,10 +479,23 @@ async fn fanout_update_for_query(
                         filter_id,
                         subscriber.region_id()
                     );
+                } else {
+                    metrics::REMOTE_DYN_FILTER_UPDATE_RPC_TOTAL
+                        .with_label_values(&["success"])
+                        .inc();
                 }
             }
-            ControlRpcResult::TimedOut => {}
-            ControlRpcResult::LifecycleClosed => return false,
+            ControlRpcResult::TimedOut => {
+                metrics::REMOTE_DYN_FILTER_UPDATE_RPC_TOTAL
+                    .with_label_values(&["timeout"])
+                    .inc();
+            }
+            ControlRpcResult::LifecycleClosed => {
+                metrics::REMOTE_DYN_FILTER_UPDATE_RPC_TOTAL
+                    .with_label_values(&["cancelled"])
+                    .inc();
+                return false;
+            }
         }
     }
 

--- a/src/query/src/dist_plan/remote_dyn_filter_registry.rs
+++ b/src/query/src/dist_plan/remote_dyn_filter_registry.rs
@@ -18,7 +18,7 @@ use std::sync::{Arc, Mutex, RwLock, Weak};
 use std::time::Duration;
 
 use api::v1::region::{RemoteDynFilterUnregister, RemoteDynFilterUpdate};
-use common_query::request::DynFilterPayload;
+use common_query::request::{DynFilterPayload, REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES};
 use common_runtime::spawn_global;
 use common_telemetry::{debug, warn};
 use datafusion_physical_expr::PhysicalExpr;
@@ -31,7 +31,6 @@ use crate::dist_plan::FilterId;
 use crate::metrics;
 use crate::region_query::RegionQueryHandlerRef;
 
-const REMOTE_DYN_FILTER_UPDATE_PAYLOAD_MAX_BYTES: usize = 512 * 1024;
 const REMOTE_DYN_FILTER_RECONCILE_INTERVAL: Duration = Duration::from_secs(1);
 /// Bound best-effort RDF control RPCs so one bad subscriber cannot stall fanout.
 const REMOTE_DYN_FILTER_CONTROL_RPC_TIMEOUT: Duration = Duration::from_secs(10);
@@ -388,32 +387,31 @@ async fn fanout_snapshot_for_query(
         let _ = entry.mark_generation_sent(generation);
     }
 
-    let payload = match DynFilterPayload::from_datafusion_expr(
-        &current,
-        REMOTE_DYN_FILTER_UPDATE_PAYLOAD_MAX_BYTES,
-    ) {
-        Ok(DynFilterPayload::Datafusion(payload)) => {
-            metrics::REMOTE_DYN_FILTER_ENCODE_TOTAL
-                .with_label_values(&["success"])
-                .inc();
-            metrics::REMOTE_DYN_FILTER_PAYLOAD_BYTES.observe(payload.len() as f64);
-            payload
-        }
-        Ok(_) => {
-            metrics::REMOTE_DYN_FILTER_ENCODE_TOTAL
-                .with_label_values(&["unsupported"])
-                .inc();
-            warn!("Ignored unsupported remote dynamic filter producer payload");
-            return true;
-        }
-        Err(error) => {
-            metrics::REMOTE_DYN_FILTER_ENCODE_TOTAL
-                .with_label_values(&["error"])
-                .inc();
-            warn!(error; "Failed to encode remote dynamic filter producer snapshot");
-            return true;
-        }
-    };
+    let payload =
+        match DynFilterPayload::from_datafusion_expr(&current, REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES)
+        {
+            Ok(DynFilterPayload::Datafusion(payload)) => {
+                metrics::REMOTE_DYN_FILTER_ENCODE_TOTAL
+                    .with_label_values(&["success"])
+                    .inc();
+                metrics::REMOTE_DYN_FILTER_PAYLOAD_BYTES.observe(payload.len() as f64);
+                payload
+            }
+            Ok(_) => {
+                metrics::REMOTE_DYN_FILTER_ENCODE_TOTAL
+                    .with_label_values(&["unsupported"])
+                    .inc();
+                warn!("Ignored unsupported remote dynamic filter producer payload");
+                return true;
+            }
+            Err(error) => {
+                metrics::REMOTE_DYN_FILTER_ENCODE_TOTAL
+                    .with_label_values(&["error"])
+                    .inc();
+                warn!(error; "Failed to encode remote dynamic filter producer snapshot");
+                return true;
+            }
+        };
 
     fanout_update_for_query(
         query_id,

--- a/src/query/src/metrics.rs
+++ b/src/query/src/metrics.rs
@@ -99,6 +99,33 @@ lazy_static! {
         "total number of query memory allocations rejected"
     )
     .unwrap();
+
+    /// Remote dynamic filter fanout RPC results, labeled with status.
+    pub static ref REMOTE_DYN_FILTER_UPDATE_RPC_TOTAL: IntCounterVec = register_int_counter_vec!(
+        "greptime_query_remote_dyn_filter_update_rpc_total",
+        "remote dynamic filter fanout RPC results",
+        &["status"]
+    )
+    .unwrap();
+
+    /// Remote dynamic filter fanout payload bytes.
+    pub static ref REMOTE_DYN_FILTER_PAYLOAD_BYTES: Histogram = register_histogram!(
+        "greptime_query_remote_dyn_filter_payload_bytes",
+        "remote dynamic filter fanout payload bytes",
+        vec![
+            128.0, 256.0, 512.0, 1024.0, 2048.0, 4096.0, 8192.0, 16384.0, 32768.0,
+            65536.0, 131072.0, 262144.0, 524288.0,
+        ]
+    )
+    .unwrap();
+
+    /// Remote dynamic filter encode results, labeled with result.
+    pub static ref REMOTE_DYN_FILTER_ENCODE_TOTAL: IntCounterVec = register_int_counter_vec!(
+        "greptime_query_remote_dyn_filter_encode_total",
+        "remote dynamic filter encode results",
+        &["result"]
+    )
+    .unwrap();
 }
 
 /// A stream to call the callback once a RecordBatch stream is done.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up for remote dynamic filter tracking: #8127

## What's changed and what's your intention?

This PR improves remote dynamic filter observability and reconciles the payload budget used by frontend fanout, initial registrations, and datanode validation.

- Add frontend/query metrics for remote dynamic filter update fanout:
  - `greptime_query_remote_dyn_filter_update_rpc_total{status}`
  - `greptime_query_remote_dyn_filter_payload_bytes`
  - `greptime_query_remote_dyn_filter_encode_total{result}`
- Add datanode metrics for remote dynamic filter update processing and state:
  - `greptime_datanode_remote_dyn_filter_update_outcome_total{result}`
  - `greptime_datanode_remote_dyn_filter_update_drop_total{reason}`
  - `greptime_datanode_remote_dyn_filter_unregister_total{result}`
  - `greptime_datanode_remote_dyn_filter_registry_entries`
  - `greptime_datanode_remote_dyn_filter_payload_bytes`
- Use one shared RDF payload budget constant, `common_query::request::REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES`, set to 512KiB.
- Apply that shared budget consistently to update fanout encoding, initial snapshot encoding/registration validation, and datanode payload validation/decoding.

The 512KiB cap remains bounded and is intended for low-frequency RDF control-plane updates. In the target join cases, the producer typically sends one stable/final update after the build side is ready. Oversized payloads still fail safely as an optimization fallback and are visible through drop metrics.

No query correctness depends on remote dynamic filters; failures continue to degrade to no remote RDF optimization.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p common-query initial_remote_dyn_filter --lib`
- `cargo test -p datanode remote_dyn_filter --lib`
- `cargo test -p query remote_dyn_filter --lib`