### PR TITLE
test(cli): add minio export-import v2 e2e

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -884,6 +884,38 @@ jobs:
         working-directory: tests-integration/fixtures
         run: ../../.github/scripts/pull-test-deps-images.sh && docker compose up -d --wait
 
+      - name: Build GreptimeDB standalone
+        run: cargo build --bin greptime --features "dashboard,pg_kvbackend,mysql_kvbackend,vector_index"
+
+      - name: Start GreptimeDB standalone
+        run: |
+          ./target/debug/greptime standalone start > greptimedb.log 2>&1 &
+          greptime_pid=$!
+          echo "Waiting for GreptimeDB..."
+          for i in {1..60}; do
+            if curl -sf http://localhost:4000/health > /dev/null; then
+              echo "GreptimeDB is ready"
+              exit 0
+            fi
+            if ! kill -0 "${greptime_pid}" 2>/dev/null; then
+              cat greptimedb.log
+              exit 1
+            fi
+            sleep 1
+          done
+          cat greptimedb.log
+          exit 1
+
+      - name: Run export/import v2 E2E tests
+        run: cargo test -p cli data::export_v2::tests --lib -- --ignored --test-threads=1
+        env:
+          GREPTIME_ADDR: 127.0.0.1:4000
+          GT_S3_BUCKET: greptime
+          GT_S3_ACCESS_KEY_ID: superpower_ci_user
+          GT_S3_ACCESS_KEY: superpower_password
+          GT_S3_REGION: us-west-2
+          GT_S3_ENDPOINT_URL: http://127.0.0.1:9000
+
       - name: Run nextest cases
         run: cargo nextest run --workspace -F dashboard -F pg_kvbackend -F mysql_kvbackend -F vector_index
         env:

--- a/src/cli/src/data/export_v2/tests.rs
+++ b/src/cli/src/data/export_v2/tests.rs
@@ -571,16 +571,7 @@ async fn export_import_v2_minio_roundtrip_e2e() -> Result<()> {
         "GT_MINIO_ACCESS_KEY",
         "GT_MINIO_ENDPOINT_URL",
     ];
-    let missing_env = required_env
-        .iter()
-        .filter(|key| env::var(key).is_err())
-        .copied()
-        .collect::<Vec<_>>();
-    if !missing_env.is_empty() {
-        eprintln!(
-            "skipping export_import_v2_minio_roundtrip_e2e; missing env vars: {}",
-            missing_env.join(", ")
-        );
+    if required_env.iter().any(|key| env::var(key).is_err()) {
         return Ok(());
     }
 
@@ -746,13 +737,8 @@ async fn export_import_v2_minio_roundtrip_e2e() -> Result<()> {
     ];
     append_common_storage_args(&mut delete_args);
     let delete_cmd = ExportDeleteCommand::parse_from(delete_args);
-    match delete_cmd.build().await {
-        Ok(delete) => {
-            if let Err(err) = delete.do_work().await {
-                eprintln!("best-effort failed to delete snapshot {snapshot_uri}: {err}");
-            }
-        }
-        Err(err) => eprintln!("best-effort failed to build delete for {snapshot_uri}: {err}"),
+    if let Ok(delete) = delete_cmd.build().await {
+        let _ = delete.do_work().await;
     }
 
     database_client

--- a/src/cli/src/data/export_v2/tests.rs
+++ b/src/cli/src/data/export_v2/tests.rs
@@ -566,21 +566,21 @@ async fn export_import_v2_data_roundtrip_e2e() -> Result<()> {
 #[ignore]
 async fn export_import_v2_minio_roundtrip_e2e() -> Result<()> {
     let required_env = [
-        "GT_MINIO_BUCKET",
-        "GT_MINIO_ACCESS_KEY_ID",
-        "GT_MINIO_ACCESS_KEY",
-        "GT_MINIO_ENDPOINT_URL",
+        "GT_S3_BUCKET",
+        "GT_S3_ACCESS_KEY_ID",
+        "GT_S3_ACCESS_KEY",
+        "GT_S3_ENDPOINT_URL",
     ];
     if required_env.iter().any(|key| env::var(key).is_err()) {
         return Ok(());
     }
 
     let conn = TestConnection::from_env();
-    let bucket = env::var("GT_MINIO_BUCKET").expect("checked above");
-    let access_key_id = env::var("GT_MINIO_ACCESS_KEY_ID").expect("checked above");
-    let secret_access_key = env::var("GT_MINIO_ACCESS_KEY").expect("checked above");
-    let endpoint = env::var("GT_MINIO_ENDPOINT_URL").expect("checked above");
-    let region = env::var("GT_MINIO_REGION").unwrap_or_else(|_| "us-west-2".to_string());
+    let bucket = env::var("GT_S3_BUCKET").expect("checked above");
+    let access_key_id = env::var("GT_S3_ACCESS_KEY_ID").expect("checked above");
+    let secret_access_key = env::var("GT_S3_ACCESS_KEY").expect("checked above");
+    let endpoint = env::var("GT_S3_ENDPOINT_URL").expect("checked above");
+    let region = env::var("GT_S3_REGION").unwrap_or_else(|_| "us-west-2".to_string());
     let schema = "test_db_minio_roundtrip";
     let snapshot_uri = format!(
         "s3://{}/export-import-v2-e2e/{}",

--- a/src/cli/src/data/export_v2/tests.rs
+++ b/src/cli/src/data/export_v2/tests.rs
@@ -584,9 +584,7 @@ async fn export_import_v2_minio_roundtrip_e2e() -> Result<()> {
         return Ok(());
     }
 
-    let addr = env::var("GREPTIME_ADDR").unwrap_or_else(|_| "127.0.0.1:4000".to_string());
-    let catalog = env::var("GREPTIME_CATALOG").unwrap_or_else(|_| "greptime".to_string());
-    let auth_basic = env::var("GREPTIME_AUTH_BASIC").ok();
+    let conn = TestConnection::from_env();
     let bucket = env::var("GT_MINIO_BUCKET").expect("checked above");
     let access_key_id = env::var("GT_MINIO_ACCESS_KEY_ID").expect("checked above");
     let secret_access_key = env::var("GT_MINIO_ACCESS_KEY").expect("checked above");
@@ -613,15 +611,15 @@ async fn export_import_v2_minio_roundtrip_e2e() -> Result<()> {
         ]);
     };
     let append_auth_args = |args: &mut Vec<String>| {
-        if let Some(auth) = &auth_basic {
+        if let Some(auth) = &conn.auth_basic {
             args.extend(["--auth-basic".to_string(), auth.clone()]);
         }
     };
 
     let database_client = DatabaseClient::new(
-        addr.clone(),
-        catalog.clone(),
-        auth_basic.clone(),
+        conn.addr.clone(),
+        conn.catalog.clone(),
+        conn.auth_basic.clone(),
         Duration::from_secs(60),
         None,
         false,
@@ -658,11 +656,11 @@ async fn export_import_v2_minio_roundtrip_e2e() -> Result<()> {
     let mut export_args = vec![
         "export-v2-create".to_string(),
         "--addr".to_string(),
-        addr.clone(),
+        conn.addr.clone(),
         "--to".to_string(),
         snapshot_uri.clone(),
         "--catalog".to_string(),
-        catalog.clone(),
+        conn.catalog.clone(),
         "--schemas".to_string(),
         schema.to_string(),
         "--start-time".to_string(),
@@ -712,11 +710,11 @@ async fn export_import_v2_minio_roundtrip_e2e() -> Result<()> {
     let mut import_args = vec![
         "import-v2".to_string(),
         "--addr".to_string(),
-        addr.clone(),
+        conn.addr.clone(),
         "--from".to_string(),
         snapshot_uri.clone(),
         "--catalog".to_string(),
-        catalog.clone(),
+        conn.catalog.clone(),
         "--schemas".to_string(),
         schema.to_string(),
         "--task-parallelism".to_string(),

--- a/src/cli/src/data/export_v2/tests.rs
+++ b/src/cli/src/data/export_v2/tests.rs
@@ -22,7 +22,7 @@ use snafu::ResultExt;
 use tempfile::tempdir;
 use url::Url;
 
-use super::command::{ExportCreateCommand, ExportVerifyCommand};
+use super::command::{ExportCreateCommand, ExportDeleteCommand, ExportVerifyCommand};
 use crate::common::ObjectStoreConfig;
 use crate::data::export_v2::manifest::ChunkStatus;
 use crate::data::import_v2::ImportV2Command;
@@ -554,6 +554,208 @@ async fn export_import_v2_data_roundtrip_e2e() -> Result<()> {
 
     let actual_rows = query_count(&database_client, schema, "metrics").await?;
     assert_eq!(actual_rows, expected_rows);
+
+    database_client
+        .sql_in_public(&format!("DROP DATABASE IF EXISTS {schema}"))
+        .await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore]
+async fn export_import_v2_minio_roundtrip_e2e() -> Result<()> {
+    let required_env = [
+        "GT_MINIO_BUCKET",
+        "GT_MINIO_ACCESS_KEY_ID",
+        "GT_MINIO_ACCESS_KEY",
+        "GT_MINIO_ENDPOINT_URL",
+    ];
+    let missing_env = required_env
+        .iter()
+        .filter(|key| env::var(key).is_err())
+        .copied()
+        .collect::<Vec<_>>();
+    if !missing_env.is_empty() {
+        eprintln!(
+            "skipping export_import_v2_minio_roundtrip_e2e; missing env vars: {}",
+            missing_env.join(", ")
+        );
+        return Ok(());
+    }
+
+    let addr = env::var("GREPTIME_ADDR").unwrap_or_else(|_| "127.0.0.1:4000".to_string());
+    let catalog = env::var("GREPTIME_CATALOG").unwrap_or_else(|_| "greptime".to_string());
+    let auth_basic = env::var("GREPTIME_AUTH_BASIC").ok();
+    let bucket = env::var("GT_MINIO_BUCKET").expect("checked above");
+    let access_key_id = env::var("GT_MINIO_ACCESS_KEY_ID").expect("checked above");
+    let secret_access_key = env::var("GT_MINIO_ACCESS_KEY").expect("checked above");
+    let endpoint = env::var("GT_MINIO_ENDPOINT_URL").expect("checked above");
+    let region = env::var("GT_MINIO_REGION").unwrap_or_else(|_| "us-west-2".to_string());
+    let schema = "test_db_minio_roundtrip";
+    let snapshot_uri = format!(
+        "s3://{}/export-import-v2-e2e/{}",
+        bucket,
+        uuid::Uuid::new_v4()
+    );
+
+    let append_common_storage_args = |args: &mut Vec<String>| {
+        args.extend([
+            "--s3".to_string(),
+            "--s3-region".to_string(),
+            region.clone(),
+            "--s3-access-key-id".to_string(),
+            access_key_id.clone(),
+            "--s3-secret-access-key".to_string(),
+            secret_access_key.clone(),
+            "--s3-endpoint".to_string(),
+            endpoint.clone(),
+        ]);
+    };
+    let append_auth_args = |args: &mut Vec<String>| {
+        if let Some(auth) = &auth_basic {
+            args.extend(["--auth-basic".to_string(), auth.clone()]);
+        }
+    };
+
+    let database_client = DatabaseClient::new(
+        addr.clone(),
+        catalog.clone(),
+        auth_basic.clone(),
+        Duration::from_secs(60),
+        None,
+        false,
+    );
+
+    database_client
+        .sql_in_public(&format!("DROP DATABASE IF EXISTS {schema}"))
+        .await?;
+    database_client
+        .sql_in_public(&format!("CREATE DATABASE {schema}"))
+        .await?;
+    database_client
+        .sql(
+            "CREATE TABLE metrics (\
+                ts TIMESTAMP TIME INDEX, \
+                host STRING PRIMARY KEY, \
+                cpu DOUBLE \
+            ) ENGINE=mito",
+            schema,
+        )
+        .await?;
+    database_client
+        .sql(
+            "INSERT INTO metrics (ts, host, cpu) VALUES \
+             ('2025-01-01T00:00:00Z', 'minio-h1', 1.0), \
+             ('2025-01-01T01:00:00Z', 'minio-h2', 2.0)",
+            schema,
+        )
+        .await?;
+
+    let expected_rows = query_count(&database_client, schema, "metrics").await?;
+    assert_eq!(expected_rows, 2);
+
+    let mut export_args = vec![
+        "export-v2-create".to_string(),
+        "--addr".to_string(),
+        addr.clone(),
+        "--to".to_string(),
+        snapshot_uri.clone(),
+        "--catalog".to_string(),
+        catalog.clone(),
+        "--schemas".to_string(),
+        schema.to_string(),
+        "--start-time".to_string(),
+        "2025-01-01T00:00:00Z".to_string(),
+        "--end-time".to_string(),
+        "2025-01-01T02:00:00Z".to_string(),
+        "--chunk-time-window".to_string(),
+        "1h".to_string(),
+        "--chunk-parallelism".to_string(),
+        "2".to_string(),
+        "--progress".to_string(),
+        "never".to_string(),
+    ];
+    append_auth_args(&mut export_args);
+    append_common_storage_args(&mut export_args);
+    let export_cmd = ExportCreateCommand::parse_from(export_args);
+    export_cmd
+        .build()
+        .await
+        .context(OtherSnafu)?
+        .do_work()
+        .await
+        .context(OtherSnafu)?;
+
+    let mut verify_args = vec![
+        "export-v2-verify".to_string(),
+        "--snapshot".to_string(),
+        snapshot_uri.clone(),
+    ];
+    append_common_storage_args(&mut verify_args);
+    let verify_cmd = ExportVerifyCommand::parse_from(verify_args);
+    verify_cmd
+        .build()
+        .await
+        .context(OtherSnafu)?
+        .do_work()
+        .await
+        .context(OtherSnafu)?;
+
+    database_client
+        .sql_in_public(&format!("DROP DATABASE IF EXISTS {schema}"))
+        .await?;
+
+    let import_state_dir = tempdir().context(FileIoSnafu)?;
+    let import_state_path = import_state_dir.path().join("import-state.json");
+    let import_state_path = import_state_path.to_string_lossy().into_owned();
+    let mut import_args = vec![
+        "import-v2".to_string(),
+        "--addr".to_string(),
+        addr.clone(),
+        "--from".to_string(),
+        snapshot_uri.clone(),
+        "--catalog".to_string(),
+        catalog.clone(),
+        "--schemas".to_string(),
+        schema.to_string(),
+        "--task-parallelism".to_string(),
+        "2".to_string(),
+        "--state-path".to_string(),
+        import_state_path,
+        "--progress".to_string(),
+        "never".to_string(),
+    ];
+    append_auth_args(&mut import_args);
+    append_common_storage_args(&mut import_args);
+    let import_cmd = ImportV2Command::parse_from(import_args);
+    import_cmd
+        .build()
+        .await
+        .context(OtherSnafu)?
+        .do_work()
+        .await
+        .context(OtherSnafu)?;
+
+    let actual_rows = query_count(&database_client, schema, "metrics").await?;
+    assert_eq!(actual_rows, expected_rows);
+
+    let mut delete_args = vec![
+        "export-v2-delete".to_string(),
+        "--snapshot".to_string(),
+        snapshot_uri.clone(),
+        "--no-confirm".to_string(),
+    ];
+    append_common_storage_args(&mut delete_args);
+    let delete_cmd = ExportDeleteCommand::parse_from(delete_args);
+    match delete_cmd.build().await {
+        Ok(delete) => {
+            if let Err(err) = delete.do_work().await {
+                eprintln!("best-effort failed to delete snapshot {snapshot_uri}: {err}");
+            }
+        }
+        Err(err) => eprintln!("best-effort failed to build delete for {snapshot_uri}: {err}"),
+    }
 
     database_client
         .sql_in_public(&format!("DROP DATABASE IF EXISTS {schema}"))

--- a/src/cli/src/data/export_v2/tests.rs
+++ b/src/cli/src/data/export_v2/tests.rs
@@ -117,6 +117,25 @@ async fn query_hosts(database_client: &DatabaseClient, schema: &str) -> Result<V
         .collect()
 }
 
+async fn delete_snapshot(snapshot_uri: &str, common_storage_args: Vec<String>) -> Result<()> {
+    let mut delete_args = vec![
+        "export-v2-delete".to_string(),
+        "--snapshot".to_string(),
+        snapshot_uri.to_string(),
+        "--no-confirm".to_string(),
+    ];
+    delete_args.extend(common_storage_args);
+
+    let delete_cmd = ExportDeleteCommand::parse_from(delete_args);
+    delete_cmd
+        .build()
+        .await
+        .context(OtherSnafu)?
+        .do_work()
+        .await
+        .context(OtherSnafu)
+}
+
 async fn schema_exists(database_client: &DatabaseClient, schema: &str) -> Result<bool> {
     let rows = database_client
         .sql_in_public("SHOW DATABASES")
@@ -588,8 +607,8 @@ async fn export_import_v2_minio_roundtrip_e2e() -> Result<()> {
         uuid::Uuid::new_v4()
     );
 
-    let append_common_storage_args = |args: &mut Vec<String>| {
-        args.extend([
+    let common_storage_args = || {
+        vec![
             "--s3".to_string(),
             "--s3-region".to_string(),
             region.clone(),
@@ -599,7 +618,10 @@ async fn export_import_v2_minio_roundtrip_e2e() -> Result<()> {
             secret_access_key.clone(),
             "--s3-endpoint".to_string(),
             endpoint.clone(),
-        ]);
+        ]
+    };
+    let append_common_storage_args = |args: &mut Vec<String>| {
+        args.extend(common_storage_args());
     };
     let append_auth_args = |args: &mut Vec<String>| {
         if let Some(auth) = &conn.auth_basic {
@@ -676,74 +698,85 @@ async fn export_import_v2_minio_roundtrip_e2e() -> Result<()> {
         .await
         .context(OtherSnafu)?;
 
-    let mut verify_args = vec![
-        "export-v2-verify".to_string(),
-        "--snapshot".to_string(),
-        snapshot_uri.clone(),
-    ];
-    append_common_storage_args(&mut verify_args);
-    let verify_cmd = ExportVerifyCommand::parse_from(verify_args);
-    verify_cmd
-        .build()
-        .await
-        .context(OtherSnafu)?
-        .do_work()
-        .await
-        .context(OtherSnafu)?;
+    let roundtrip_result: Result<()> = async {
+        let mut verify_args = vec![
+            "export-v2-verify".to_string(),
+            "--snapshot".to_string(),
+            snapshot_uri.clone(),
+        ];
+        append_common_storage_args(&mut verify_args);
+        let verify_cmd = ExportVerifyCommand::parse_from(verify_args);
+        verify_cmd
+            .build()
+            .await
+            .context(OtherSnafu)?
+            .do_work()
+            .await
+            .context(OtherSnafu)?;
 
-    database_client
-        .sql_in_public(&format!("DROP DATABASE IF EXISTS {schema}"))
-        .await?;
+        database_client
+            .sql_in_public(&format!("DROP DATABASE IF EXISTS {schema}"))
+            .await?;
 
-    let import_state_dir = tempdir().context(FileIoSnafu)?;
-    let import_state_path = import_state_dir.path().join("import-state.json");
-    let import_state_path = import_state_path.to_string_lossy().into_owned();
-    let mut import_args = vec![
-        "import-v2".to_string(),
-        "--addr".to_string(),
-        conn.addr.clone(),
-        "--from".to_string(),
-        snapshot_uri.clone(),
-        "--catalog".to_string(),
-        conn.catalog.clone(),
-        "--schemas".to_string(),
-        schema.to_string(),
-        "--task-parallelism".to_string(),
-        "2".to_string(),
-        "--state-path".to_string(),
-        import_state_path,
-        "--progress".to_string(),
-        "never".to_string(),
-    ];
-    append_auth_args(&mut import_args);
-    append_common_storage_args(&mut import_args);
-    let import_cmd = ImportV2Command::parse_from(import_args);
-    import_cmd
-        .build()
-        .await
-        .context(OtherSnafu)?
-        .do_work()
-        .await
-        .context(OtherSnafu)?;
+        let import_state_dir = tempdir().context(FileIoSnafu)?;
+        let import_state_path = import_state_dir.path().join("import-state.json");
+        let import_state_path = import_state_path.to_string_lossy().into_owned();
+        let mut import_args = vec![
+            "import-v2".to_string(),
+            "--addr".to_string(),
+            conn.addr.clone(),
+            "--from".to_string(),
+            snapshot_uri.clone(),
+            "--catalog".to_string(),
+            conn.catalog.clone(),
+            "--schemas".to_string(),
+            schema.to_string(),
+            "--task-parallelism".to_string(),
+            "2".to_string(),
+            "--state-path".to_string(),
+            import_state_path,
+            "--progress".to_string(),
+            "never".to_string(),
+        ];
+        append_auth_args(&mut import_args);
+        append_common_storage_args(&mut import_args);
+        let import_cmd = ImportV2Command::parse_from(import_args);
+        import_cmd
+            .build()
+            .await
+            .context(OtherSnafu)?
+            .do_work()
+            .await
+            .context(OtherSnafu)?;
 
-    let actual_rows = query_count(&database_client, schema, "metrics").await?;
-    assert_eq!(actual_rows, expected_rows);
+        let actual_rows = query_count(&database_client, schema, "metrics").await?;
+        if actual_rows != expected_rows {
+            return InvalidArgumentsSnafu {
+                msg: format!("expected {expected_rows} rows, got {actual_rows}"),
+            }
+            .fail();
+        }
 
-    let mut delete_args = vec![
-        "export-v2-delete".to_string(),
-        "--snapshot".to_string(),
-        snapshot_uri.clone(),
-        "--no-confirm".to_string(),
-    ];
-    append_common_storage_args(&mut delete_args);
-    let delete_cmd = ExportDeleteCommand::parse_from(delete_args);
-    delete_cmd
-        .build()
-        .await
-        .context(OtherSnafu)?
-        .do_work()
-        .await
-        .context(OtherSnafu)?;
+        let hosts = query_hosts(&database_client, schema).await?;
+        let expected_hosts = vec!["minio-h1".to_string(), "minio-h2".to_string()];
+        if hosts != expected_hosts {
+            return InvalidArgumentsSnafu {
+                msg: format!("expected hosts {expected_hosts:?}, got {hosts:?}"),
+            }
+            .fail();
+        }
+
+        Ok(())
+    }
+    .await;
+
+    let cleanup_result = delete_snapshot(&snapshot_uri, common_storage_args()).await;
+    match (roundtrip_result, cleanup_result) {
+        (Ok(()), Ok(())) => {}
+        (Ok(()), Err(err)) => return Err(err),
+        (Err(err), Ok(())) => return Err(err),
+        (Err(err), Err(_cleanup_err)) => return Err(err),
+    }
 
     database_client
         .sql_in_public(&format!("DROP DATABASE IF EXISTS {schema}"))

--- a/src/cli/src/data/export_v2/tests.rs
+++ b/src/cli/src/data/export_v2/tests.rs
@@ -737,9 +737,13 @@ async fn export_import_v2_minio_roundtrip_e2e() -> Result<()> {
     ];
     append_common_storage_args(&mut delete_args);
     let delete_cmd = ExportDeleteCommand::parse_from(delete_args);
-    if let Ok(delete) = delete_cmd.build().await {
-        let _ = delete.do_work().await;
-    }
+    delete_cmd
+        .build()
+        .await
+        .context(OtherSnafu)?
+        .do_work()
+        .await
+        .context(OtherSnafu)?;
 
     database_client
         .sql_in_public(&format!("DROP DATABASE IF EXISTS {schema}"))


### PR DESCRIPTION
## Summary

- add a MinIO/S3-compatible export/import-v2 roundtrip E2E using the existing `GT_S3_*` test environment convention
- run all ignored export/import-v2 E2E tests serially in CI after starting the MinIO fixture and a GreptimeDB standalone server
- keep the live E2E tests `#[ignore]` so normal unit/nextest runs remain stable; CI invokes them explicitly with `--ignored --test-threads=1`

## Stack

Stacked on #8313 (`feat/import-v2-negative-e2e`). Review this PR against `feat/import-v2-negative-e2e`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p cli data::export_v2::tests::export_import_v2_minio_roundtrip_e2e --lib -- --exact`
- `cargo test -p cli data::export_v2::tests --lib -- --ignored --test-threads=1` with local MinIO fixture and GreptimeDB standalone: 8 passed
- `cargo clippy -p cli --lib --tests -- -D warnings`
- `cargo build --bin greptime --features "dashboard,pg_kvbackend,mysql_kvbackend,vector_index"`
- `git diff --check`

Refs #7786
