### PR TITLE
feat: propagate RDF initial snapshot completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3642,7 +3642,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 [[package]]
 name = "datafusion"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "arrow 58.3.0",
  "arrow-schema 58.3.0",
@@ -3696,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3720,7 +3720,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3742,7 +3742,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -3766,7 +3766,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "futures",
  "log",
@@ -3776,7 +3776,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "arrow 58.3.0",
  "async-compression",
@@ -3810,7 +3810,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "arrow 58.3.0",
  "arrow-ipc 58.3.0",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3855,7 +3855,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3878,7 +3878,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3907,12 +3907,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 
 [[package]]
 name = "datafusion-execution"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "arrow 58.3.0",
  "arrow-buffer 58.3.0",
@@ -3934,7 +3934,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3956,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -3968,7 +3968,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "arrow 58.3.0",
  "arrow-buffer 58.3.0",
@@ -3999,7 +3999,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4020,7 +4020,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "arrow 58.3.0",
  "arrow-ord 58.3.0",
@@ -4056,7 +4056,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4071,7 +4071,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4088,7 +4088,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -4097,7 +4097,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -4107,7 +4107,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -4156,7 +4156,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4179,7 +4179,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4193,7 +4193,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4209,7 +4209,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4227,7 +4227,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4258,7 +4258,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -4285,7 +4285,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4295,7 +4295,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4311,7 +4311,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -4324,7 +4324,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "arrow 58.3.0",
  "bigdecimal 0.4.8",
@@ -4342,7 +4342,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=96cff4fd0fcedd217151ad18e4ef4956b401f78f#96cff4fd0fcedd217151ad18e4ef4956b401f78f"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -341,21 +341,21 @@ git = "https://github.com/GreptimeTeam/greptime-meter.git"
 rev = "5618e779cf2bb4755b499c630fba4c35e91898cb"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "e8a127c28e8839964bb6aefdd909810dc11cd2c9" }
-datafusion-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "e8a127c28e8839964bb6aefdd909810dc11cd2c9" }
-datafusion-datasource = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "e8a127c28e8839964bb6aefdd909810dc11cd2c9" }
-datafusion-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "e8a127c28e8839964bb6aefdd909810dc11cd2c9" }
-datafusion-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "e8a127c28e8839964bb6aefdd909810dc11cd2c9" }
-datafusion-functions = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "e8a127c28e8839964bb6aefdd909810dc11cd2c9" }
-datafusion-functions-aggregate-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "e8a127c28e8839964bb6aefdd909810dc11cd2c9" }
-datafusion-functions-window-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "e8a127c28e8839964bb6aefdd909810dc11cd2c9" }
-datafusion-optimizer = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "e8a127c28e8839964bb6aefdd909810dc11cd2c9" }
-datafusion-physical-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "e8a127c28e8839964bb6aefdd909810dc11cd2c9" }
-datafusion-physical-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "e8a127c28e8839964bb6aefdd909810dc11cd2c9" }
-datafusion-physical-plan = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "e8a127c28e8839964bb6aefdd909810dc11cd2c9" }
-datafusion-proto = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "e8a127c28e8839964bb6aefdd909810dc11cd2c9" }
-datafusion-sql = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "e8a127c28e8839964bb6aefdd909810dc11cd2c9" }
-datafusion-substrait = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "e8a127c28e8839964bb6aefdd909810dc11cd2c9" }
+datafusion = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "96cff4fd0fcedd217151ad18e4ef4956b401f78f" }
+datafusion-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "96cff4fd0fcedd217151ad18e4ef4956b401f78f" }
+datafusion-datasource = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "96cff4fd0fcedd217151ad18e4ef4956b401f78f" }
+datafusion-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "96cff4fd0fcedd217151ad18e4ef4956b401f78f" }
+datafusion-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "96cff4fd0fcedd217151ad18e4ef4956b401f78f" }
+datafusion-functions = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "96cff4fd0fcedd217151ad18e4ef4956b401f78f" }
+datafusion-functions-aggregate-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "96cff4fd0fcedd217151ad18e4ef4956b401f78f" }
+datafusion-functions-window-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "96cff4fd0fcedd217151ad18e4ef4956b401f78f" }
+datafusion-optimizer = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "96cff4fd0fcedd217151ad18e4ef4956b401f78f" }
+datafusion-physical-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "96cff4fd0fcedd217151ad18e4ef4956b401f78f" }
+datafusion-physical-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "96cff4fd0fcedd217151ad18e4ef4956b401f78f" }
+datafusion-physical-plan = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "96cff4fd0fcedd217151ad18e4ef4956b401f78f" }
+datafusion-proto = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "96cff4fd0fcedd217151ad18e4ef4956b401f78f" }
+datafusion-sql = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "96cff4fd0fcedd217151ad18e4ef4956b401f78f" }
+datafusion-substrait = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "96cff4fd0fcedd217151ad18e4ef4956b401f78f" }
 sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "2aefa08a8d69c96eec2d6d6703598a009bba6e4c" }                           # on branch v0.61.x
 
 [profile.release]

--- a/src/query/src/dist_plan/dyn_filter_bridge.rs
+++ b/src/query/src/dist_plan/dyn_filter_bridge.rs
@@ -178,8 +178,7 @@ fn initial_snapshot(
         }
     };
 
-    // Current DataFusion exposes `wait_complete()`, but no non-blocking completion getter.
-    let is_complete = false;
+    let is_complete = alive_dyn_filter.is_complete();
     Some(InitialDynFilterSnapshot::new(
         payload,
         generation,
@@ -481,6 +480,31 @@ mod tests {
             snapshot.payload,
             DynFilterPayload::Datafusion(ref bytes) if !bytes.is_empty()
         ));
+    }
+
+    #[test]
+    fn capture_remote_dyn_filters_for_pushdown_attaches_complete_initial_snapshot() {
+        let dyn_filter = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![Arc::new(Column::new("host", 1)) as Arc<_>],
+            lit(true) as _,
+        ));
+        dyn_filter.update(lit(false) as _).unwrap();
+        dyn_filter.mark_complete();
+        let parent_filters = vec![dyn_filter as Arc<dyn datafusion::physical_plan::PhysicalExpr>];
+
+        let pushdown = capture_remote_dyn_filters_for_pushdown(
+            test_remote_dyn_filter_producer_id(42),
+            parent_filters,
+        );
+
+        assert_eq!(pushdown.pushed_down, vec![true]);
+        let snapshot = pushdown.captured_dyn_filters[0]
+            .initial_registration
+            .initial_snapshot
+            .as_ref()
+            .unwrap();
+        assert_eq!(snapshot.generation, 2);
+        assert!(snapshot.is_complete);
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Depends on GreptimeTeam/datafusion#8.

## What's changed and what's your intention?

This PR propagates the completion state of remote dynamic filter initial snapshots.

- Updates the DataFusion fork pin from `e8a127c28e8839964bb6aefdd909810dc11cd2c9` to `96cff4fd0fcedd217151ad18e4ef4956b401f78f`, which includes `DynamicFilterPhysicalExpr::is_complete()` from GreptimeTeam/datafusion#8.
- Uses `alive_dyn_filter.is_complete()` when building `InitialDynFilterSnapshot` instead of hardcoding `is_complete = false`.
- Adds a unit test covering a captured remote dynamic filter whose initial snapshot is already complete.

This should land after GreptimeTeam/datafusion#8 is merged, or after we decide it is acceptable to pin GreptimeDB to that DataFusion commit directly.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
