### PR TITLE
ci: compare jsonbench insert results

### DIFF
--- a/.github/scripts/jsonbench-summary.py
+++ b/.github/scripts/jsonbench-summary.py
@@ -19,6 +19,7 @@ import ast
 import json
 import pathlib
 import re
+import statistics
 
 
 def read_number(result_dir, patterns):
@@ -106,6 +107,34 @@ def parse_query_rows(text):
     return rows
 
 
+def parse_load_data_stats(result_dir):
+    values = []
+    for path in sorted(result_dir.rglob("*.load_data")):
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            stripped = line.strip()
+            if not stripped.startswith("{"):
+                continue
+
+            try:
+                data = json.loads(stripped)
+            except json.JSONDecodeError:
+                continue
+
+            value = data.get("execution_time_ms")
+            if isinstance(value, (int, float)):
+                values.append(value / 1000)
+
+    if not values:
+        return {}
+
+    return {
+        "Max": max(values),
+        "Min": min(values),
+        "Avg": sum(values) / len(values),
+        "Median": statistics.median(values),
+    }
+
+
 def query_rows_to_map(query_rows):
     queries = {}
     for query_index, label, value in query_rows:
@@ -129,6 +158,33 @@ def format_delta(current, last):
 
     formatted = f"{percent:+.1f}"
     return formatted.rstrip("0").rstrip(".")
+
+
+def format_insert_table(stats, previous_stats):
+    rows = [("Indicator", "Value (s)", "Value Last (%)")]
+    for label, key in (
+        ("Max", "Max"),
+        ("Min", "Min"),
+        ("Avg", "Avg"),
+        ("Medium", "Median"),
+    ):
+        rows.append(
+            (
+                label,
+                format_duration(stats.get(key)),
+                format_delta(stats.get(key), previous_stats.get(key)),
+            )
+        )
+
+    widths = [max(len(row[column]) for row in rows) for column in range(3)]
+    separator = tuple("-" * width for width in widths)
+    rows.insert(1, separator)
+
+    return "\n".join(
+        f"| {indicator:<{widths[0]}} | {value:>{widths[1]}} | "
+        f"{delta:>{widths[2]}} |"
+        for indicator, value, delta in rows
+    )
 
 
 def format_query_table(query_rows, previous_query_rows):
@@ -175,20 +231,24 @@ def build_payload(result_dir, previous_result_dir, result, run_url):
     count = read_number(result_dir, ["*.count"])
     dataset = read_number(result_dir, ["*.dataset"])
     query_rows = parse_query_rows(read_runtime_text(result_dir))
+    insert_stats = parse_load_data_stats(result_dir)
     previous_query_rows = []
+    previous_insert_stats = {}
     if previous_result_dir and previous_result_dir.exists():
         previous_query_rows = parse_query_rows(read_runtime_text(previous_result_dir))
+        previous_insert_stats = parse_load_data_stats(previous_result_dir)
 
     summary = (
         f"Dataset: {format_dataset(dataset)}\n"
         f"Data size: {format_gb(data_size)}\n"
         f"Count: {count or 'N/A'}"
     )
-    table = format_query_table(query_rows, previous_query_rows)
+    insert_table = format_insert_table(insert_stats, previous_insert_stats)
+    query_table = format_query_table(query_rows, previous_query_rows)
     text = (
         "Nightly JSONBench has completed successfully.\n"
         f"<{run_url}|Workflow run>\n"
-        f"```{summary}\n\n{table}```"
+        f"```{summary}\n\nInsert:\n{insert_table}\n\n{query_table}```"
     )
     return {"text": text}
 

--- a/.github/scripts/jsonbench-summary.py
+++ b/.github/scripts/jsonbench-summary.py
@@ -166,7 +166,7 @@ def format_insert_table(stats, previous_stats):
         ("Max", "Max"),
         ("Min", "Min"),
         ("Avg", "Avg"),
-        ("Medium", "Median"),
+        ("Median", "Median"),
     ):
         rows.append(
             (

--- a/.github/workflows/nightly-jsonbench.yaml
+++ b/.github/workflows/nightly-jsonbench.yaml
@@ -195,6 +195,7 @@ jobs:
             ./JSONBench/greptimedb/*.count
             ./JSONBench/greptimedb/*.results_runtime
             ./JSONBench/greptimedb/*.query_results
+            ./JSONBench/greptimedb/*.load_data
           if-no-files-found: ignore
           retention-days: 7
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

report jsonbench data insert results, like this:

```text
Dataset: 10M
Data size: 1.35 GB
Count: 9999994

Insert:
| Indicator | Value (s) | Value Last (%) |
| --------- | --------- | -------------- |
| Max       |    34.871 |           +0.8 |
| Min       |     4.337 |             +1 |
| Avg       |    29.972 |           +0.9 |
| Medium    |    32.547 |           +1.2 |

| Query | Cold (s) | Cold Last (%) | Hot (s) | Hot Last (%) |
| ----- | -------- | ------------- | ------- | ------------ |
| Q1    |    0.260 |         -50.9 |   0.074 |         -6.3 |
| Q2    |    0.796 |         -41.3 |   0.549 |         +1.9 |
| Q3    |    0.250 |         +10.1 |   0.169 |         +2.4 |
| Q4    |    0.192 |          -7.7 |   0.159 |         -9.1 |
| Q5    |    0.193 |          -5.4 |   0.176 |          +15 |
```

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
