### PR TITLE
refactor: try best to make sure hook is called on manifest update

### DIFF
--- a/src/mito2/src/engine/region_hook.rs
+++ b/src/mito2/src/engine/region_hook.rs
@@ -146,6 +146,11 @@ impl PendingManifestHook {
     /// version wins. Used when a sequence of writes (e.g. staging-exit followed
     /// by metadata backfill) should notify the hook exactly once.
     pub(crate) fn merge(self, other: PendingManifestHook) -> PendingManifestHook {
+        debug_assert_eq!(
+            self.region_id, other.region_id,
+            "Cannot merge pending hooks of different regions: {:?} and {:?}",
+            self.region_id, other.region_id
+        );
         PendingManifestHook {
             region_id: self.region_id,
             action_list: match (self.action_list, other.action_list) {

--- a/src/mito2/src/engine/region_hook.rs
+++ b/src/mito2/src/engine/region_hook.rs
@@ -62,39 +62,17 @@
 //! `on_sst_files_written` is invoked at the SST write site (flush task or compaction task),
 //! immediately after SST files are written but **before** the manifest is committed.
 //!
-//! `on_manifest_updated` is funneled through a single method,
-//! [`ManifestContext::update_locked`], which is the **only** place in the crate
-//! that calls the low-level [`RegionManifestManager::update`] and turns each
-//! successful write into a [`PendingManifestHook`]. Callers fire the receipt
-//! **after** releasing the manifest write lock (the hook must never run under
-//! the lock — it may read the manifest or send region requests that acquire it).
+//! `on_manifest_updated` is funneled through [`ManifestContext::update_locked`],
+//! the sole caller of the low-level [`RegionManifestManager::update`], which
+//! packages each successful write into a [`PendingManifestHook`]. The caller
+//! owns the write lock, drops it, and *then* fires the receipt — the hook must
+//! never run under the lock. [`ManifestContext::update_manifest`] is the common
+//! case: it acquires the lock, delegates to `update_locked`, and fires the
+//! receipt in one go. Multi-step sequences (staging-exit, role-state backfill)
+//! call `update_locked` directly under their own held guard.
 //!
-//! There are two usage patterns, both producing/firing a [`PendingManifestHook`]:
-//! - [`ManifestContext::update_manifest`] (and its typed variants such as
-//!   `update_manifest_for_compaction`): acquire the lock, update, release the
-//!   lock, and fire the receipt in one go. Used by flush, compaction, alter,
-//!   truncate, region edit, copy region, index build, and enter-staging.
-//! - [`ManifestContext::update_locked`] / [`MitoRegion::exit_staging_on_success`]:
-//!   for multi-step sequences that must hold the lock across several operations.
-//!   They take a caller-owned `&mut` write guard and return the receipt so the
-//!   caller fires it after dropping the lock (see `set_role_state_gracefully`
-//!   and `handle_apply_staging_manifest_request`).
-//!
-//! Non-logical writes intentionally do **not** fire the hook: GC and staging
-//! bookkeeping call the manager's own methods directly (e.g. `clear_deleted_files`,
-//! `clear_staging_manifest_and_dir`, `unset_staging_manifest`) under a
-//! caller-owned lock guard, rather than going through `update_locked`.
-//!
-//! The funnel is a convention reinforced by two structural aids:
-//! - [`ManifestContext::update_locked`] is the single place that calls the
-//!   low-level [`RegionManifestManager::update`] and packages the result as a
-//!   [`PendingManifestHook`]; all logical write paths route through it.
-//! - [`PendingManifestHook`] is `#[must_use]`, so a receipt that nobody fires
-//!   is a compile warning.
-//!
-//! Lock scope stays caller-owned: each call site acquires the write guard,
-//! performs whatever reads/validations/writes it needs, drops the guard, and
-//! *then* fires the receipt. The hook therefore never runs under the lock.
+//! Non-logical writes (GC, staging bookkeeping) call the manager's own methods
+//! directly and intentionally do not fire the hook.
 //!
 //! ## Future work
 //!
@@ -104,6 +82,8 @@
 //! [`on_sst_files_written`]: RegionHook::on_sst_files_written
 //! [`on_manifest_updated`]: RegionHook::on_manifest_updated
 //! [`RegionManifestManager::update`]: crate::manifest::manager::RegionManifestManager::update
+//! [`ManifestContext::update_locked`]: crate::region::ManifestContext::update_locked
+//! [`ManifestContext::update_manifest`]: crate::region::ManifestContext::update_manifest
 
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -117,22 +97,11 @@ use crate::manifest::action::RegionMetaActionList;
 use crate::sst::file::FileMeta;
 use crate::sst::parquet::SstInfo;
 
-/// A deferred [`RegionHook::on_manifest_updated`] notification produced after a
-/// manifest write succeeds.
+/// A deferred [`RegionHook::on_manifest_updated`] notification produced by a
+/// logical manifest write via [`ManifestContext::update_locked`](crate::region::ManifestContext::update_locked).
 ///
-/// **Invariant:** [`fire`](Self::fire) **must** be called *after* the manifest
-/// write lock is released. The receipt is `#[must_use]`, so forgetting to fire
-/// it produces a compile warning.
-///
-/// This type exists to make manifest-update + hook-notification a single,
-/// hard-to-miss step: every logical manifest write goes through
-/// [`ManifestContext::update_locked`](crate::region::ManifestContext::update_locked),
-/// which returns a `PendingManifestHook`. The caller is then responsible for
-/// dropping the lock and firing the receipt. Callers that don't need to hold
-/// the lock themselves should use
-/// [`ManifestContext::update_manifest`](crate::region::ManifestContext::update_manifest)
-/// instead, which acquires the lock, updates, releases the lock, and fires the
-/// receipt in one go.
+/// Must be [`fire`](Self::fire)d **after** the manifest write lock is released
+/// (the hook may read the manifest). `#[must_use]` so a forgotten receipt warns.
 #[must_use = "the region hook must be fired after releasing the manifest write lock"]
 pub(crate) struct PendingManifestHook {
     region_id: RegionId,

--- a/src/mito2/src/engine/region_hook.rs
+++ b/src/mito2/src/engine/region_hook.rs
@@ -62,10 +62,39 @@
 //! `on_sst_files_written` is invoked at the SST write site (flush task or compaction task),
 //! immediately after SST files are written but **before** the manifest is committed.
 //!
-//! `on_manifest_updated` is centralized in [`ManifestContext::update_manifest_with_state_check`],
-//! so it automatically covers all manifest write paths that go through `ManifestContext`.
-//! The sole exception is [`MitoRegion::exit_staging_on_success`], which returns the hook
-//! payload to the caller so the hook can be invoked after dropping the manifest write lock.
+//! `on_manifest_updated` is funneled through a single method,
+//! [`ManifestContext::update_locked`], which is the **only** place in the crate
+//! that calls the low-level [`RegionManifestManager::update`] and turns each
+//! successful write into a [`PendingManifestHook`]. Callers fire the receipt
+//! **after** releasing the manifest write lock (the hook must never run under
+//! the lock — it may read the manifest or send region requests that acquire it).
+//!
+//! There are two usage patterns, both producing/firing a [`PendingManifestHook`]:
+//! - [`ManifestContext::update_manifest`] (and its typed variants such as
+//!   `update_manifest_for_compaction`): acquire the lock, update, release the
+//!   lock, and fire the receipt in one go. Used by flush, compaction, alter,
+//!   truncate, region edit, copy region, index build, and enter-staging.
+//! - [`ManifestContext::update_locked`] / [`MitoRegion::exit_staging_on_success`]:
+//!   for multi-step sequences that must hold the lock across several operations.
+//!   They take a caller-owned `&mut` write guard and return the receipt so the
+//!   caller fires it after dropping the lock (see `set_role_state_gracefully`
+//!   and `handle_apply_staging_manifest_request`).
+//!
+//! Non-logical writes intentionally do **not** fire the hook: GC and staging
+//! bookkeeping call the manager's own methods directly (e.g. `clear_deleted_files`,
+//! `clear_staging_manifest_and_dir`, `unset_staging_manifest`) under a
+//! caller-owned lock guard, rather than going through `update_locked`.
+//!
+//! The funnel is a convention reinforced by two structural aids:
+//! - [`ManifestContext::update_locked`] is the single place that calls the
+//!   low-level [`RegionManifestManager::update`] and packages the result as a
+//!   [`PendingManifestHook`]; all logical write paths route through it.
+//! - [`PendingManifestHook`] is `#[must_use]`, so a receipt that nobody fires
+//!   is a compile warning.
+//!
+//! Lock scope stays caller-owned: each call site acquires the write guard,
+//! performs whatever reads/validations/writes it needs, drops the guard, and
+//! *then* fires the receipt. The hook therefore never runs under the lock.
 //!
 //! ## Future work
 //!
@@ -74,6 +103,7 @@
 //!
 //! [`on_sst_files_written`]: RegionHook::on_sst_files_written
 //! [`on_manifest_updated`]: RegionHook::on_manifest_updated
+//! [`RegionManifestManager::update`]: crate::manifest::manager::RegionManifestManager::update
 
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -86,6 +116,82 @@ use store_api::storage::RegionId;
 use crate::manifest::action::RegionMetaActionList;
 use crate::sst::file::FileMeta;
 use crate::sst::parquet::SstInfo;
+
+/// A deferred [`RegionHook::on_manifest_updated`] notification produced after a
+/// manifest write succeeds.
+///
+/// **Invariant:** [`fire`](Self::fire) **must** be called *after* the manifest
+/// write lock is released. The receipt is `#[must_use]`, so forgetting to fire
+/// it produces a compile warning.
+///
+/// This type exists to make manifest-update + hook-notification a single,
+/// hard-to-miss step: every logical manifest write goes through
+/// [`ManifestContext::update_locked`](crate::region::ManifestContext::update_locked),
+/// which returns a `PendingManifestHook`. The caller is then responsible for
+/// dropping the lock and firing the receipt. Callers that don't need to hold
+/// the lock themselves should use
+/// [`ManifestContext::update_manifest`](crate::region::ManifestContext::update_manifest)
+/// instead, which acquires the lock, updates, releases the lock, and fires the
+/// receipt in one go.
+#[must_use = "the region hook must be fired after releasing the manifest write lock"]
+pub(crate) struct PendingManifestHook {
+    region_id: RegionId,
+    /// `None` when no hook is registered (fire becomes a no-op).
+    action_list: Option<RegionMetaActionList>,
+    version: ManifestVersion,
+    hook: Option<RegionHookRef>,
+}
+
+impl PendingManifestHook {
+    pub(crate) fn new(
+        region_id: RegionId,
+        action_list: Option<RegionMetaActionList>,
+        version: ManifestVersion,
+        hook: Option<RegionHookRef>,
+    ) -> Self {
+        Self {
+            region_id,
+            action_list,
+            version,
+            hook,
+        }
+    }
+
+    /// The manifest version produced by the write.
+    pub(crate) fn version(&self) -> ManifestVersion {
+        self.version
+    }
+
+    /// Fires the hook if one is registered. Safe to call unconditionally: it is
+    /// a no-op when no hook is registered.
+    pub(crate) async fn fire(self) {
+        if let (Some(hook), Some(action_list)) = (self.hook, self.action_list) {
+            hook.on_manifest_updated(self.region_id, &action_list, self.version)
+                .await;
+        }
+    }
+
+    /// Merges two pending notifications into one so consumers observe a single
+    /// `on_manifest_updated` call covering all actions. The combined action list
+    /// keeps `self`'s actions followed by `other`'s, and the *later* manifest
+    /// version wins. Used when a sequence of writes (e.g. staging-exit followed
+    /// by metadata backfill) should notify the hook exactly once.
+    pub(crate) fn merge(self, other: PendingManifestHook) -> PendingManifestHook {
+        PendingManifestHook {
+            region_id: self.region_id,
+            action_list: match (self.action_list, other.action_list) {
+                (Some(mut a), Some(b)) => {
+                    a.actions.extend(b.actions);
+                    Some(a)
+                }
+                (a, None) => a,
+                (None, b) => b,
+            },
+            version: self.version.max(other.version),
+            hook: self.hook.or(other.hook),
+        }
+    }
+}
 
 /// Information about a single SST data file written during flush or compaction.
 pub struct SstFileInfo<'a> {

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -560,8 +560,6 @@ impl MitoRegion {
                     append_mode: None,
                 });
                 let action_list = RegionMetaActionList::with_action(action);
-                // Route through `update_locked` so this write also produces a
-                // `PendingManifestHook` instead of bypassing the funnel.
                 match self
                     .manifest_ctx
                     .update_locked(&mut manager, action_list, false)
@@ -584,9 +582,8 @@ impl MitoRegion {
 
         drop(manager);
 
-        // Merge both payloads into a single hook invocation so consumers see
-        // the complete set of actions and the latest manifest version. Then fire
-        // it now that the manifest write lock has been released.
+        // Merge both payloads so consumers see the complete set of actions in
+        // one notification. The lock is released, so it's safe to fire.
         let merged = match (hook_payload, backfill_hook_payload) {
             (Some(staging), Some(backfill)) => Some(staging.merge(backfill)),
             (Some(payload), None) => Some(payload),
@@ -815,9 +812,8 @@ impl MitoRegion {
     /// Returns `Ok(Some(pending))` when staging manifests were merged, or
     /// `Ok(None)` when there were no staged manifests to merge.
     ///
-    /// **Important:** the returned [`PendingManifestHook`] must be
-    /// [`fire`](PendingManifestHook::fire)d **after** the caller drops the
-    /// manifest write lock, to avoid deadlocking if the hook reads the manifest.
+    /// **Important:** [`fire`](PendingManifestHook::fire) the receipt only after
+    /// dropping the lock — the hook may read the manifest and deadlock otherwise.
     pub(crate) async fn exit_staging_on_success(
         &self,
         manager: &mut RwLockWriteGuard<'_, RegionManifestManager>,
@@ -887,9 +883,6 @@ impl MitoRegion {
 
         // Submit merged actions using the manifest manager's update method.
         // Pass `false` so it saves to normal directory, not staging.
-        //
-        // `update_locked` is the single funnel that turns this write into a
-        // `PendingManifestHook`; the caller fires it after dropping the lock.
         let pending = self
             .manifest_ctx
             .update_locked(manager, merged_actions, false)
@@ -979,15 +972,9 @@ impl MitoRegion {
 /// Context to update the region manifest.
 #[derive(Debug)]
 pub(crate) struct ManifestContext {
-    /// Manager to maintain manifest for this region.
-    ///
-    /// Logical manifest writes must go through [`update_locked`](Self::update_locked)
-    /// (or one of the [`update_manifest`](Self::update_manifest) variants), which
-    /// return a [`PendingManifestHook`] so [`RegionHook::on_manifest_updated`] is
-    /// always fired. The caller owns the write-lock guard and fires the receipt
-    /// after dropping it, so the hook never runs under the lock.
-    ///
-    /// [`RegionHook::on_manifest_updated`]: crate::engine::region_hook::RegionHook::on_manifest_updated
+    /// Manager to maintain manifest for this region. Logical writes go through
+    /// [`update_locked`](Self::update_locked) (or an [`update_manifest`](Self::update_manifest)
+    /// variant) so they produce a [`PendingManifestHook`].
     pub(crate) manifest_manager: tokio::sync::RwLock<RegionManifestManager>,
     /// The state of the region. The region checks the state before updating
     /// manifest.
@@ -1170,27 +1157,15 @@ impl ManifestContext {
         .await
     }
 
-    /// Performs a manifest write **while the caller already holds the manifest
-    /// write lock**, and returns a [`PendingManifestHook`] that the caller must
-    /// [`fire`](PendingManifestHook::fire) **after** dropping the lock.
+    /// Performs a manifest write under a caller-held write lock and returns a
+    /// [`PendingManifestHook`] to [`fire`](PendingManifestHook::fire) after
+    /// dropping the lock. This is the sole caller of
+    /// [`RegionManifestManager::update`], so it is the funnel through which all
+    /// logical manifest writes notify the hook.
     ///
-    /// This is the *only* method inside the crate that calls
-    /// [`RegionManifestManager::update`]. It is the funnel through which all
-    /// logical manifest writes produce a hook notification, so that a manifest
-    /// update can never silently skip `on_manifest_updated`.
-    ///
-    /// Callers that do **not** need to hold the lock for a multi-step sequence
-    /// should call [`ManifestContext::update_manifest`] (or one of its typed
-    /// variants) instead — those acquire the lock, delegate here, and fire the
-    /// receipt in one shot.
-    ///
-    /// # Validation is the caller's responsibility
-    ///
-    /// This method does **not** perform state checks or edit-applicability
-    /// validation: those are path-specific and must be done by the caller while
-    /// still holding the lock (see `update_manifest_with_state_check` for the
-    /// standard pattern, and `MitoRegion::exit_staging_on_success` for the
-    /// staging pattern).
+    /// Does not validate state or edit applicability — the caller must do so
+    /// while still holding the lock (see `update_manifest_with_state_check`
+    /// and `MitoRegion::exit_staging_on_success`).
     pub(crate) async fn update_locked(
         &self,
         manager: &mut RegionManifestManager,
@@ -1198,8 +1173,8 @@ impl ManifestContext {
         is_staging: bool,
     ) -> Result<PendingManifestHook> {
         let region_id = manager.manifest().metadata.region_id;
-        // Clone the action list up-front so the hook still sees what was written
-        // after `action_list` is moved into `manager.update`.
+        // Clone before `action_list` is moved into `update` so the hook still
+        // sees what was written.
         let action_list_for_hook = self.hook.as_ref().map(|_| action_list.clone());
         let version = manager
             .update(action_list, is_staging)
@@ -1279,10 +1254,7 @@ impl ManifestContext {
             }
         }
 
-        // If a region hook is registered, clone the action list before it is consumed
-        // so we can pass a reference to the hook after a successful update.
-        // `update_locked` is the single funnel that turns a manifest write into a
-        // `PendingManifestHook`; we fire it below after releasing the lock.
+        // `update_locked` returns a `PendingManifestHook` we fire after releasing the lock.
         let region_id = manifest.metadata.region_id;
         let pending = self
             .update_locked(&mut manager, action_list, is_staging)

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -45,7 +45,7 @@ use tokio::sync::RwLockWriteGuard;
 pub use utils::*;
 
 use crate::access_layer::AccessLayerRef;
-use crate::engine::region_hook::RegionHookRef;
+use crate::engine::region_hook::{PendingManifestHook, RegionHookRef};
 use crate::error::{
     FlushableRegionStateSnafu, InvalidPartitionExprSnafu, RegionNotFoundSnafu, RegionStateSnafu,
     RegionTruncatedSnafu, Result, UnexpectedSnafu, UpdateManifestSnafu,
@@ -442,7 +442,7 @@ impl MitoRegion {
             self.manifest_ctx.manifest_manager.write().await;
         let current_state = self.state();
 
-        let hook_payload: Option<(RegionMetaActionList, ManifestVersion)> = match state {
+        let hook_payload: Option<PendingManifestHook> = match state {
             SettableRegionRoleState::Leader => {
                 // Exit staging mode and return to normal writable leader
                 // Only allowed from staging state
@@ -547,7 +547,7 @@ impl MitoRegion {
         };
 
         // Hack(zhongzc): If we have just become leader (writable), persist any backfilled metadata.
-        let mut backfill_hook_payload: Option<(RegionMetaActionList, ManifestVersion)> = None;
+        let mut backfill_hook_payload: Option<PendingManifestHook> = None;
         if self.state() == RegionRoleState::Leader(RegionLeaderState::Writable) {
             // Persist backfilled metadata if manifest is missing fields (e.g., partition_expr)
             let manifest_meta = &manager.manifest().metadata;
@@ -560,17 +560,20 @@ impl MitoRegion {
                     append_mode: None,
                 });
                 let action_list = RegionMetaActionList::with_action(action);
-                let hook = self.manifest_ctx.hook();
-                let al_for_hook = hook.as_ref().map(|_| action_list.clone());
-                let result = manager.update(action_list, false).await;
-
-                match result {
-                    Ok(version) => {
+                // Route through `update_locked` so this write also produces a
+                // `PendingManifestHook` instead of bypassing the funnel.
+                match self
+                    .manifest_ctx
+                    .update_locked(&mut manager, action_list, false)
+                    .await
+                {
+                    Ok(pending) => {
                         info!(
                             "Successfully persisted backfilled metadata for region {}, version: {}",
-                            self.region_id, version
+                            self.region_id,
+                            pending.version()
                         );
-                        backfill_hook_payload = al_for_hook.map(|al| (al, version));
+                        backfill_hook_payload = Some(pending);
                     }
                     Err(e) => {
                         warn!(e; "Failed to persist backfilled metadata for region {}", self.region_id);
@@ -582,24 +585,17 @@ impl MitoRegion {
         drop(manager);
 
         // Merge both payloads into a single hook invocation so consumers see
-        // the complete set of actions and the latest manifest version.
+        // the complete set of actions and the latest manifest version. Then fire
+        // it now that the manifest write lock has been released.
         let merged = match (hook_payload, backfill_hook_payload) {
-            (Some((al, _v)), Some((backfill_al, backfill_v))) => {
-                // Combine action lists; use the later version (backfill happens after staging merge).
-                let mut combined = al;
-                combined.actions.extend(backfill_al.actions);
-                Some((combined, backfill_v))
-            }
+            (Some(staging), Some(backfill)) => Some(staging.merge(backfill)),
             (Some(payload), None) => Some(payload),
             (None, Some(payload)) => Some(payload),
             (None, None) => None,
         };
 
-        if let Some((action_list, version)) = merged
-            && let Some(hook) = self.manifest_ctx.hook()
-        {
-            hook.on_manifest_updated(self.region_id, &action_list, version)
-                .await;
+        if let Some(pending) = merged {
+            pending.fire().await;
         }
 
         Ok(())
@@ -816,15 +812,16 @@ impl MitoRegion {
     /// Merges staged manifest actions into the live manifest and exits staging mode.
     ///
     /// The caller must hold the manifest write lock and pass it via `manager`.
-    /// Returns `Ok(Some(action_list, version))` when staging manifests were merged,
-    /// or `Ok(None)` when there were no staged manifests to merge.
+    /// Returns `Ok(Some(pending))` when staging manifests were merged, or
+    /// `Ok(None)` when there were no staged manifests to merge.
     ///
-    /// **Important:** the returned hook payload must be invoked **after** the caller
-    /// drops the manifest write lock, to avoid deadlocking if the hook reads the manifest.
+    /// **Important:** the returned [`PendingManifestHook`] must be
+    /// [`fire`](PendingManifestHook::fire)d **after** the caller drops the
+    /// manifest write lock, to avoid deadlocking if the hook reads the manifest.
     pub(crate) async fn exit_staging_on_success(
         &self,
         manager: &mut RwLockWriteGuard<'_, RegionManifestManager>,
-    ) -> Result<Option<(RegionMetaActionList, ManifestVersion)>> {
+    ) -> Result<Option<PendingManifestHook>> {
         let current_state = self.manifest_ctx.current_state();
         ensure!(
             current_state == RegionRoleState::Leader(RegionLeaderState::Staging),
@@ -891,11 +888,13 @@ impl MitoRegion {
         // Submit merged actions using the manifest manager's update method.
         // Pass `false` so it saves to normal directory, not staging.
         //
-        // Clone the action list before it is consumed so we can return it to
-        // the caller for hook invocation after the lock is dropped.
-        let hook = self.manifest_ctx.hook();
-        let action_list_for_hook = hook.as_ref().map(|_| merged_actions.clone());
-        let new_version = manager.update(merged_actions, false).await?;
+        // `update_locked` is the single funnel that turns this write into a
+        // `PendingManifestHook`; the caller fires it after dropping the lock.
+        let pending = self
+            .manifest_ctx
+            .update_locked(manager, merged_actions, false)
+            .await?;
+        let new_version = pending.version();
         info!(
             "Successfully submitted merged staged manifests for region {}, new version: {}",
             self.region_id, new_version
@@ -920,8 +919,7 @@ impl MitoRegion {
         self.exit_staging()?;
 
         // Return the hook payload; the caller invokes the hook after dropping the lock.
-        let hook_payload = action_list_for_hook.map(|action_list| (action_list, new_version));
-        Ok(hook_payload)
+        Ok(Some(pending))
     }
 
     /// Returns the partition expression string for this region.
@@ -982,6 +980,14 @@ impl MitoRegion {
 #[derive(Debug)]
 pub(crate) struct ManifestContext {
     /// Manager to maintain manifest for this region.
+    ///
+    /// Logical manifest writes must go through [`update_locked`](Self::update_locked)
+    /// (or one of the [`update_manifest`](Self::update_manifest) variants), which
+    /// return a [`PendingManifestHook`] so [`RegionHook::on_manifest_updated`] is
+    /// always fired. The caller owns the write-lock guard and fires the receipt
+    /// after dropping it, so the hook never runs under the lock.
+    ///
+    /// [`RegionHook::on_manifest_updated`]: crate::engine::region_hook::RegionHook::on_manifest_updated
     pub(crate) manifest_manager: tokio::sync::RwLock<RegionManifestManager>,
     /// The state of the region. The region checks the state before updating
     /// manifest.
@@ -1164,6 +1170,50 @@ impl ManifestContext {
         .await
     }
 
+    /// Performs a manifest write **while the caller already holds the manifest
+    /// write lock**, and returns a [`PendingManifestHook`] that the caller must
+    /// [`fire`](PendingManifestHook::fire) **after** dropping the lock.
+    ///
+    /// This is the *only* method inside the crate that calls
+    /// [`RegionManifestManager::update`]. It is the funnel through which all
+    /// logical manifest writes produce a hook notification, so that a manifest
+    /// update can never silently skip `on_manifest_updated`.
+    ///
+    /// Callers that do **not** need to hold the lock for a multi-step sequence
+    /// should call [`ManifestContext::update_manifest`] (or one of its typed
+    /// variants) instead — those acquire the lock, delegate here, and fire the
+    /// receipt in one shot.
+    ///
+    /// # Validation is the caller's responsibility
+    ///
+    /// This method does **not** perform state checks or edit-applicability
+    /// validation: those are path-specific and must be done by the caller while
+    /// still holding the lock (see `update_manifest_with_state_check` for the
+    /// standard pattern, and `MitoRegion::exit_staging_on_success` for the
+    /// staging pattern).
+    pub(crate) async fn update_locked(
+        &self,
+        manager: &mut RegionManifestManager,
+        action_list: RegionMetaActionList,
+        is_staging: bool,
+    ) -> Result<PendingManifestHook> {
+        let region_id = manager.manifest().metadata.region_id;
+        // Clone the action list up-front so the hook still sees what was written
+        // after `action_list` is moved into `manager.update`.
+        let action_list_for_hook = self.hook.as_ref().map(|_| action_list.clone());
+        let version = manager
+            .update(action_list, is_staging)
+            .await
+            .inspect_err(|e| error!(e; "Failed to update manifest, region_id: {}", region_id))?;
+
+        Ok(PendingManifestHook::new(
+            region_id,
+            action_list_for_hook,
+            version,
+            self.hook.clone(),
+        ))
+    }
+
     async fn update_manifest_with_state_check(
         &self,
         action_list: RegionMetaActionList,
@@ -1231,13 +1281,13 @@ impl ManifestContext {
 
         // If a region hook is registered, clone the action list before it is consumed
         // so we can pass a reference to the hook after a successful update.
-        let hook = self.hook.clone();
-        let action_list_for_hook = hook.as_ref().map(|_| action_list.clone());
+        // `update_locked` is the single funnel that turns a manifest write into a
+        // `PendingManifestHook`; we fire it below after releasing the lock.
         let region_id = manifest.metadata.region_id;
-        let version = manager
-            .update(action_list, is_staging)
-            .await
-            .inspect_err(|e| error!(e; "Failed to update manifest, region_id: {}", region_id))?;
+        let pending = self
+            .update_locked(&mut manager, action_list, is_staging)
+            .await?;
+        let version = pending.version();
 
         // Drop the write lock before invoking the hook. Hook implementations may
         // read the manifest or send region requests that acquire this lock;
@@ -1251,12 +1301,7 @@ impl ManifestContext {
             );
         }
 
-        if let Some(hook) = hook
-            && let Some(action_list) = action_list_for_hook
-        {
-            hook.on_manifest_updated(region_id, &action_list, version)
-                .await;
-        }
+        pending.fire().await;
 
         Ok(version)
     }

--- a/src/mito2/src/worker/handle_apply_staging.rs
+++ b/src/mito2/src/worker/handle_apply_staging.rs
@@ -159,13 +159,9 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                         return;
                     }
                 };
-                // Drop the write lock before invoking the hook to avoid deadlock.
                 drop(manager);
-                if let Some((action_list, version)) = hook_payload
-                    && let Some(hook) = region.manifest_ctx.hook()
-                {
-                    hook.on_manifest_updated(region.region_id, &action_list, version)
-                        .await;
+                if let Some(pending) = hook_payload {
+                    pending.fire().await;
                 }
                 sender.send(Ok(0));
             } else {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Follow up of #8145 , this patch attempts to refactor how we call the manifest update hook from various update call sites. This is designed to prevent miss of hook call.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
