### PR TITLE
feat: support structured instruction reply errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2339,6 +2339,7 @@ version = "1.1.0"
 dependencies = [
  "common-macro",
  "http 1.3.1",
+ "serde",
  "snafu 0.8.6",
  "strum 0.27.1",
  "tonic 0.14.2",

--- a/src/common/error/Cargo.toml
+++ b/src/common/error/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 
 [dependencies]
 http.workspace = true
+serde.workspace = true
 snafu.workspace = true
 strum.workspace = true
 tonic.workspace = true

--- a/src/common/error/src/ext.rs
+++ b/src/common/error/src/ext.rs
@@ -18,6 +18,7 @@ use std::io::ErrorKind;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use serde::{Deserialize, Deserializer, Serializer};
 use snafu::{FromString, Snafu};
 
 use crate::status_code::StatusCode;
@@ -50,6 +51,22 @@ impl RetryHint {
             RetryHint::Retryable => RETRY_HINT_RETRYABLE,
             RetryHint::NonRetryable => RETRY_HINT_NON_RETRYABLE,
         }
+    }
+
+    pub fn serialize_as_str<S>(hint: &Self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(hint.as_str())
+    }
+
+    pub fn deserialize_from_str<'de, D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let hint = String::deserialize(deserializer)?;
+        hint.parse::<RetryHint>()
+            .map_err(|_| serde::de::Error::custom(format!("unknown retry hint: {hint}")))
     }
 }
 

--- a/src/common/error/src/status_code.rs
+++ b/src/common/error/src/status_code.rs
@@ -14,6 +14,7 @@
 
 use std::fmt;
 
+use serde::{Deserialize, Deserializer, Serializer};
 use strum::{AsRefStr, EnumIter, EnumString, FromRepr};
 use tonic::Code;
 
@@ -185,6 +186,22 @@ impl StatusCode {
 
     pub fn from_u32(value: u32) -> Option<Self> {
         StatusCode::from_repr(value as usize)
+    }
+
+    pub fn serialize_as_u32<S>(code: &Self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u32(*code as u32)
+    }
+
+    pub fn deserialize_from_u32<'de, D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let code = u32::deserialize(deserializer)?;
+        StatusCode::from_u32(code)
+            .ok_or_else(|| serde::de::Error::custom(format!("unknown status code: {code}")))
     }
 }
 

--- a/src/common/meta/src/error.rs
+++ b/src/common/meta/src/error.rs
@@ -27,12 +27,22 @@ use store_api::storage::RegionId;
 use table::metadata::TableId;
 
 use crate::DatanodeId;
+use crate::instruction::InstructionError;
 use crate::peer::Peer;
 
 #[derive(Snafu)]
 #[snafu(visibility(pub))]
 #[stack_trace_debug]
 pub enum Error {
+    #[snafu(display("Instruction error, code: {:?}, message: {}", code, message))]
+    Instruction {
+        code: StatusCode,
+        message: String,
+        retry_hint: RetryHint,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Empty key is not allowed"))]
     EmptyKey {
         #[snafu(implicit)]
@@ -1116,6 +1126,8 @@ impl ErrorExt for Error {
     fn status_code(&self) -> StatusCode {
         use Error::*;
         match self {
+            Instruction { code, .. } => *code,
+
             IllegalServerState { .. }
             | EtcdTxnOpResponse { .. }
             | EtcdFailed { .. }
@@ -1274,6 +1286,8 @@ impl ErrorExt for Error {
         use Error::*;
 
         match self {
+            Instruction { retry_hint, .. } => *retry_hint,
+
             RetryLater { .. }
             | GetLatestCacheRetryExceeded { .. }
             | NoLeader { .. }
@@ -1309,6 +1323,17 @@ impl ErrorExt for Error {
             GetCache { source, .. } => source.retry_hint(),
             _ => RetryHint::NonRetryable,
         }
+    }
+}
+
+impl From<InstructionError> for Error {
+    fn from(error: InstructionError) -> Self {
+        InstructionSnafu {
+            code: error.code,
+            message: error.message,
+            retry_hint: error.retry_hint,
+        }
+        .build()
     }
 }
 
@@ -1407,6 +1432,17 @@ mod retry_hint_tests {
         let source = Arc::new(Error::retry_later(MockError::new(StatusCode::Internal)));
         let err = Error::GetCache { source };
 
+        assert_eq!(err.retry_hint(), RetryHint::Retryable);
+    }
+
+    #[test]
+    fn test_instruction_error_forwards_status_code_and_retry_hint() {
+        let instruction_error =
+            InstructionError::new(StatusCode::RegionBusy, "region busy", RetryHint::Retryable);
+
+        let err = Error::from(instruction_error);
+
+        assert_eq!(err.status_code(), StatusCode::RegionBusy);
         assert_eq!(err.retry_hint(), RetryHint::Retryable);
     }
 

--- a/src/common/meta/src/error.rs
+++ b/src/common/meta/src/error.rs
@@ -27,22 +27,12 @@ use store_api::storage::RegionId;
 use table::metadata::TableId;
 
 use crate::DatanodeId;
-use crate::instruction::InstructionError;
 use crate::peer::Peer;
 
 #[derive(Snafu)]
 #[snafu(visibility(pub))]
 #[stack_trace_debug]
 pub enum Error {
-    #[snafu(display("Instruction error, code: {:?}, message: {}", code, message))]
-    Instruction {
-        code: StatusCode,
-        message: String,
-        retry_hint: RetryHint,
-        #[snafu(implicit)]
-        location: Location,
-    },
-
     #[snafu(display("Empty key is not allowed"))]
     EmptyKey {
         #[snafu(implicit)]
@@ -1126,8 +1116,6 @@ impl ErrorExt for Error {
     fn status_code(&self) -> StatusCode {
         use Error::*;
         match self {
-            Instruction { code, .. } => *code,
-
             IllegalServerState { .. }
             | EtcdTxnOpResponse { .. }
             | EtcdFailed { .. }
@@ -1286,8 +1274,6 @@ impl ErrorExt for Error {
         use Error::*;
 
         match self {
-            Instruction { retry_hint, .. } => *retry_hint,
-
             RetryLater { .. }
             | GetLatestCacheRetryExceeded { .. }
             | NoLeader { .. }
@@ -1323,17 +1309,6 @@ impl ErrorExt for Error {
             GetCache { source, .. } => source.retry_hint(),
             _ => RetryHint::NonRetryable,
         }
-    }
-}
-
-impl From<InstructionError> for Error {
-    fn from(error: InstructionError) -> Self {
-        InstructionSnafu {
-            code: error.code,
-            message: error.message,
-            retry_hint: error.retry_hint,
-        }
-        .build()
     }
 }
 
@@ -1432,17 +1407,6 @@ mod retry_hint_tests {
         let source = Arc::new(Error::retry_later(MockError::new(StatusCode::Internal)));
         let err = Error::GetCache { source };
 
-        assert_eq!(err.retry_hint(), RetryHint::Retryable);
-    }
-
-    #[test]
-    fn test_instruction_error_forwards_status_code_and_retry_hint() {
-        let instruction_error =
-            InstructionError::new(StatusCode::RegionBusy, "region busy", RetryHint::Retryable);
-
-        let err = Error::from(instruction_error);
-
-        assert_eq!(err.status_code(), StatusCode::RegionBusy);
         assert_eq!(err.retry_hint(), RetryHint::Retryable);
     }
 

--- a/src/common/meta/src/instruction.rs
+++ b/src/common/meta/src/instruction.rs
@@ -16,6 +16,8 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::{Display, Formatter};
 use std::time::Duration;
 
+use common_error::ext::{ErrorExt, RetryHint};
+use common_error::status_code::StatusCode;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use store_api::region_engine::SyncRegionFromRequest;
 use store_api::region_request::{RegionFlushReason, RegionRequirements};
@@ -30,6 +32,83 @@ use crate::key::{FlowId, FlowPartitionId};
 use crate::peer::Peer;
 use crate::wal_provider::{RegionWalOptions, region_wal_options_serde};
 use crate::{DatanodeId, FlownodeId};
+
+/// A structured error returned by instruction replies.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub struct InstructionError {
+    /// Numeric status code aligned with [`StatusCode`].
+    #[serde(
+        serialize_with = "StatusCode::serialize_as_u32",
+        deserialize_with = "StatusCode::deserialize_from_u32"
+    )]
+    pub code: StatusCode,
+    /// User-facing error message aligned with [`ErrorExt::output_msg`].
+    pub message: String,
+    /// Retry hint serialized as a string.
+    #[serde(
+        serialize_with = "RetryHint::serialize_as_str",
+        deserialize_with = "RetryHint::deserialize_from_str"
+    )]
+    pub retry_hint: RetryHint,
+}
+
+impl InstructionError {
+    pub fn new(code: StatusCode, message: impl Into<String>, retry_hint: RetryHint) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            retry_hint,
+        }
+    }
+
+    pub fn from_error<E: ErrorExt>(error: &E) -> Self {
+        Self {
+            code: error.status_code(),
+            message: error.output_msg(),
+            retry_hint: error.retry_hint(),
+        }
+    }
+}
+
+pub type InstructionResult<T> = std::result::Result<T, InstructionError>;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum HandleInstructionResults<'a> {
+    AllSuccessful,
+    AllRetryable(Vec<(usize, &'a InstructionError)>),
+    PartialRetryable {
+        retryable_errors: Vec<(usize, &'a InstructionError)>,
+        non_retryable_errors: Vec<(usize, &'a InstructionError)>,
+    },
+    AllNonRetryable(Vec<(usize, &'a InstructionError)>),
+}
+
+pub fn handle_instruction_results<T>(
+    results: &[InstructionResult<T>],
+) -> HandleInstructionResults<'_> {
+    let mut retryable_errors = Vec::new();
+    let mut non_retryable_errors = Vec::new();
+
+    for (index, result) in results.iter().enumerate() {
+        if let Err(error) = result {
+            if error.retry_hint.is_retryable() {
+                retryable_errors.push((index, error));
+            } else {
+                non_retryable_errors.push((index, error));
+            }
+        }
+    }
+
+    match (retryable_errors.is_empty(), non_retryable_errors.is_empty()) {
+        (true, true) => HandleInstructionResults::AllSuccessful,
+        (false, true) => HandleInstructionResults::AllRetryable(retryable_errors),
+        (true, false) => HandleInstructionResults::AllNonRetryable(non_retryable_errors),
+        (false, false) => HandleInstructionResults::PartialRetryable {
+            retryable_errors,
+            non_retryable_errors,
+        },
+    }
+}
 
 #[derive(Eq, Hash, PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct RegionIdent {
@@ -1130,10 +1209,128 @@ impl InstructionReply {
 mod tests {
     use std::collections::HashSet;
 
+    use common_error::mock::MockError;
     use common_wal::options::WalOptions;
     use store_api::storage::{FileId, FileRef};
 
     use super::*;
+
+    #[test]
+    fn test_instruction_error_serde() {
+        let error = InstructionError::new(
+            StatusCode::RegionNotFound,
+            "region not found",
+            RetryHint::Retryable,
+        );
+
+        let serialized = serde_json::to_string(&error).unwrap();
+        assert_eq!(
+            r#"{"code":4005,"message":"region not found","retry_hint":"retryable"}"#,
+            serialized
+        );
+
+        let deserialized: InstructionError = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(error, deserialized);
+
+        assert!(
+            serde_json::from_str::<InstructionError>(
+                r#"{"code":999999,"message":"unknown","retry_hint":"retryable"}"#
+            )
+            .is_err()
+        );
+        assert!(
+            serde_json::from_str::<InstructionError>(
+                r#"{"code":4005,"message":"unknown","retry_hint":"unknown"}"#
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn test_instruction_error_from_error() {
+        let error = MockError::new(StatusCode::RegionNotFound);
+
+        let instruction_error = InstructionError::from_error(&error);
+
+        assert_eq!(StatusCode::RegionNotFound, instruction_error.code);
+        assert_eq!("RegionNotFound", instruction_error.message);
+        assert_eq!(RetryHint::NonRetryable, instruction_error.retry_hint);
+    }
+
+    #[test]
+    fn test_instruction_result_serde() {
+        let success: InstructionResult<bool> = Ok(true);
+        let serialized = serde_json::to_string(&success).unwrap();
+        assert_eq!(r#"{"Ok":true}"#, serialized);
+        let deserialized: InstructionResult<bool> = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(success, deserialized);
+
+        let failure: InstructionResult<bool> = Err(InstructionError::new(
+            StatusCode::RegionBusy,
+            "region busy",
+            RetryHint::Retryable,
+        ));
+        let serialized = serde_json::to_string(&failure).unwrap();
+        assert_eq!(
+            r#"{"Err":{"code":4009,"message":"region busy","retry_hint":"retryable"}}"#,
+            serialized
+        );
+        let deserialized: InstructionResult<bool> = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(failure, deserialized);
+    }
+
+    #[test]
+    fn test_handle_instruction_results() {
+        let retryable =
+            InstructionError::new(StatusCode::RegionBusy, "region busy", RetryHint::Retryable);
+        let non_retryable = InstructionError::new(
+            StatusCode::InvalidArguments,
+            "invalid arguments",
+            RetryHint::NonRetryable,
+        );
+
+        let all_successful: Vec<InstructionResult<()>> = vec![Ok(()), Ok(())];
+        assert_eq!(
+            HandleInstructionResults::AllSuccessful,
+            handle_instruction_results(&all_successful)
+        );
+
+        let all_retryable = vec![Err(retryable.clone())];
+        match handle_instruction_results::<()>(&all_retryable) {
+            HandleInstructionResults::AllRetryable(errors) => {
+                assert_eq!(1, errors.len());
+                assert_eq!(0, errors[0].0);
+                assert_eq!(&retryable, errors[0].1);
+            }
+            result => panic!("expect all retryable, got {result:?}"),
+        }
+
+        let all_non_retryable = vec![Err(non_retryable.clone())];
+        match handle_instruction_results::<()>(&all_non_retryable) {
+            HandleInstructionResults::AllNonRetryable(errors) => {
+                assert_eq!(1, errors.len());
+                assert_eq!(0, errors[0].0);
+                assert_eq!(&non_retryable, errors[0].1);
+            }
+            result => panic!("expect all non-retryable, got {result:?}"),
+        }
+
+        let mixed = vec![Ok(()), Err(retryable.clone()), Err(non_retryable.clone())];
+        match handle_instruction_results(&mixed) {
+            HandleInstructionResults::PartialRetryable {
+                retryable_errors,
+                non_retryable_errors,
+            } => {
+                assert_eq!(1, retryable_errors.len());
+                assert_eq!(1, retryable_errors[0].0);
+                assert_eq!(&retryable, retryable_errors[0].1);
+                assert_eq!(1, non_retryable_errors.len());
+                assert_eq!(2, non_retryable_errors[0].0);
+                assert_eq!(&non_retryable, non_retryable_errors[0].1);
+            }
+            result => panic!("expect partial retryable, got {result:?}"),
+        }
+    }
 
     #[test]
     fn test_serialize_instruction() {

--- a/src/common/meta/src/instruction.rs
+++ b/src/common/meta/src/instruction.rs
@@ -34,7 +34,7 @@ use crate::wal_provider::{RegionWalOptions, region_wal_options_serde};
 use crate::{DatanodeId, FlownodeId};
 
 /// A structured error returned by instruction replies.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[derive(Debug, Serialize, PartialEq, Eq, Clone)]
 pub struct InstructionError {
     /// Numeric status code aligned with [`StatusCode`].
     #[serde(
@@ -52,6 +52,39 @@ pub struct InstructionError {
     pub retry_hint: RetryHint,
 }
 
+impl<'de> Deserialize<'de> for InstructionError {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Compat {
+            Structured {
+                #[serde(deserialize_with = "StatusCode::deserialize_from_u32")]
+                code: StatusCode,
+                message: String,
+                #[serde(deserialize_with = "RetryHint::deserialize_from_str")]
+                retry_hint: RetryHint,
+            },
+            Legacy(String),
+        }
+
+        match Compat::deserialize(deserializer)? {
+            Compat::Structured {
+                code,
+                message,
+                retry_hint,
+            } => Ok(Self {
+                code,
+                message,
+                retry_hint,
+            }),
+            Compat::Legacy(message) => Ok(Self::legacy_internal_retryable(message)),
+        }
+    }
+}
+
 impl InstructionError {
     pub fn new(code: StatusCode, message: impl Into<String>, retry_hint: RetryHint) -> Self {
         Self {
@@ -61,12 +94,28 @@ impl InstructionError {
         }
     }
 
+    pub fn legacy_internal_retryable(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::Internal, message, RetryHint::Retryable)
+    }
+
     pub fn from_error<E: ErrorExt>(error: &E) -> Self {
         Self {
             code: error.status_code(),
             message: error.output_msg(),
             retry_hint: error.retry_hint(),
         }
+    }
+}
+
+impl Display for InstructionError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "InstructionError(code={}, retry_hint={}, message={})",
+            self.code as u32,
+            self.retry_hint.as_str(),
+            self.message
+        )
     }
 }
 
@@ -148,7 +197,7 @@ pub struct DowngradeRegionReply {
     /// Indicates whether the region exists.
     pub exists: bool,
     /// Return error if any during the operation.
-    pub error: Option<String>,
+    pub error: Option<InstructionError>,
 }
 
 impl Display for DowngradeRegionReply {
@@ -164,7 +213,7 @@ impl Display for DowngradeRegionReply {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct SimpleReply {
     pub result: bool,
-    pub error: Option<String>,
+    pub error: Option<InstructionError>,
 }
 
 /// Reply for flush region operations with support for batch results.
@@ -173,7 +222,7 @@ pub struct FlushRegionReply {
     /// Results for each region that was attempted to be flushed.
     /// For single region flushes, this will contain one result.
     /// For batch flushes, this contains results for all attempted regions.
-    pub results: Vec<(RegionId, Result<(), String>)>,
+    pub results: Vec<(RegionId, InstructionResult<()>)>,
     /// Overall success: true if all regions were flushed successfully.
     pub overall_success: bool,
 }
@@ -188,7 +237,7 @@ impl FlushRegionReply {
     }
 
     /// Create a failed single region reply.
-    pub fn error_single(region_id: RegionId, error: String) -> Self {
+    pub fn error_single(region_id: RegionId, error: InstructionError) -> Self {
         Self {
             results: vec![(region_id, Err(error))],
             overall_success: false,
@@ -196,7 +245,7 @@ impl FlushRegionReply {
     }
 
     /// Create a batch reply from individual results.
-    pub fn from_results(results: Vec<(RegionId, Result<(), String>)>) -> Self {
+    pub fn from_results(results: Vec<(RegionId, InstructionResult<()>)>) -> Self {
         let overall_success = results.iter().all(|(_, result)| result.is_ok());
         Self {
             results,
@@ -224,7 +273,9 @@ impl FlushRegionReply {
                 .collect();
             SimpleReply {
                 result: false,
-                error: Some(errors.join("; ")),
+                error: Some(InstructionError::legacy_internal_retryable(
+                    errors.join("; "),
+                )),
             }
         }
     }
@@ -597,7 +648,7 @@ pub struct GetFileRefsReply {
     /// Whether the operation was successful.
     pub success: bool,
     /// Error message if any.
-    pub error: Option<String>,
+    pub error: Option<InstructionError>,
 }
 
 impl Display for GetFileRefsReply {
@@ -615,7 +666,7 @@ impl Display for GetFileRefsReply {
 /// Reply for GC instruction.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GcRegionsReply {
-    pub result: Result<GcReport, String>,
+    pub result: InstructionResult<GcReport>,
 }
 
 impl Display for GcRegionsReply {
@@ -911,7 +962,7 @@ pub struct UpgradeRegionReply {
     /// Indicates whether the region exists.
     pub exists: bool,
     /// Returns error if any.
-    pub error: Option<String>,
+    pub error: Option<InstructionError>,
 }
 
 impl Display for UpgradeRegionReply {
@@ -998,7 +1049,7 @@ pub struct EnterStagingRegionReply {
     /// Indicates whether the region exists.
     pub exists: bool,
     /// Return error if any during the operation.
-    pub error: Option<String>,
+    pub error: Option<InstructionError>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
@@ -1022,7 +1073,7 @@ pub struct SyncRegionReply {
     /// Indicates whether the region exists.
     pub exists: bool,
     /// Return error message if any during the operation.
-    pub error: Option<String>,
+    pub error: Option<InstructionError>,
 }
 
 /// Reply for a batch of region sync requests.
@@ -1044,7 +1095,7 @@ pub struct RemapManifestReply {
     /// A map from region IDs to their corresponding remapped manifest paths.
     pub manifest_paths: HashMap<RegionId, String>,
     /// Return error if any during the operation.
-    pub error: Option<String>,
+    pub error: Option<InstructionError>,
 }
 
 impl Display for RemapManifestReply {
@@ -1076,7 +1127,7 @@ pub struct ApplyStagingManifestReply {
     /// Indicates whether the region exists.
     pub exists: bool,
     /// Return error if any during the operation.
-    pub error: Option<String>,
+    pub error: Option<InstructionError>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
@@ -1713,7 +1764,10 @@ mod tests {
         assert!(success_reply.results[0].1.is_ok());
 
         // Failed single region reply
-        let error_reply = FlushRegionReply::error_single(region_id, "test error".to_string());
+        let error_reply = FlushRegionReply::error_single(
+            region_id,
+            InstructionError::legacy_internal_retryable("test error"),
+        );
         assert!(!error_reply.overall_success);
         assert_eq!(error_reply.results.len(), 1);
         assert_eq!(error_reply.results[0].0, region_id);
@@ -1723,7 +1777,10 @@ mod tests {
         let region_id2 = RegionId::new(1024, 2);
         let results = vec![
             (region_id, Ok(())),
-            (region_id2, Err("flush failed".to_string())),
+            (
+                region_id2,
+                Err(InstructionError::legacy_internal_retryable("flush failed")),
+            ),
         ];
         let batch_reply = FlushRegionReply::from_results(results);
         assert!(!batch_reply.overall_success);
@@ -1733,7 +1790,7 @@ mod tests {
         let simple_reply = batch_reply.to_simple_reply();
         assert!(!simple_reply.result);
         assert!(simple_reply.error.is_some());
-        assert!(simple_reply.error.unwrap().contains("flush failed"));
+        assert!(simple_reply.error.unwrap().message.contains("flush failed"));
     }
 
     #[test]

--- a/src/common/meta/src/instruction.rs
+++ b/src/common/meta/src/instruction.rs
@@ -121,44 +121,6 @@ impl Display for InstructionError {
 
 pub type InstructionResult<T> = std::result::Result<T, InstructionError>;
 
-#[derive(Debug, PartialEq, Eq)]
-pub enum HandleInstructionResults<'a> {
-    AllSuccessful,
-    AllRetryable(Vec<(usize, &'a InstructionError)>),
-    PartialRetryable {
-        retryable_errors: Vec<(usize, &'a InstructionError)>,
-        non_retryable_errors: Vec<(usize, &'a InstructionError)>,
-    },
-    AllNonRetryable(Vec<(usize, &'a InstructionError)>),
-}
-
-pub fn handle_instruction_results<T>(
-    results: &[InstructionResult<T>],
-) -> HandleInstructionResults<'_> {
-    let mut retryable_errors = Vec::new();
-    let mut non_retryable_errors = Vec::new();
-
-    for (index, result) in results.iter().enumerate() {
-        if let Err(error) = result {
-            if error.retry_hint.is_retryable() {
-                retryable_errors.push((index, error));
-            } else {
-                non_retryable_errors.push((index, error));
-            }
-        }
-    }
-
-    match (retryable_errors.is_empty(), non_retryable_errors.is_empty()) {
-        (true, true) => HandleInstructionResults::AllSuccessful,
-        (false, true) => HandleInstructionResults::AllRetryable(retryable_errors),
-        (true, false) => HandleInstructionResults::AllNonRetryable(non_retryable_errors),
-        (false, false) => HandleInstructionResults::PartialRetryable {
-            retryable_errors,
-            non_retryable_errors,
-        },
-    }
-}
-
 #[derive(Eq, Hash, PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct RegionIdent {
     pub datanode_id: DatanodeId,
@@ -1328,59 +1290,6 @@ mod tests {
         );
         let deserialized: InstructionResult<bool> = serde_json::from_str(&serialized).unwrap();
         assert_eq!(failure, deserialized);
-    }
-
-    #[test]
-    fn test_handle_instruction_results() {
-        let retryable =
-            InstructionError::new(StatusCode::RegionBusy, "region busy", RetryHint::Retryable);
-        let non_retryable = InstructionError::new(
-            StatusCode::InvalidArguments,
-            "invalid arguments",
-            RetryHint::NonRetryable,
-        );
-
-        let all_successful: Vec<InstructionResult<()>> = vec![Ok(()), Ok(())];
-        assert_eq!(
-            HandleInstructionResults::AllSuccessful,
-            handle_instruction_results(&all_successful)
-        );
-
-        let all_retryable = vec![Err(retryable.clone())];
-        match handle_instruction_results::<()>(&all_retryable) {
-            HandleInstructionResults::AllRetryable(errors) => {
-                assert_eq!(1, errors.len());
-                assert_eq!(0, errors[0].0);
-                assert_eq!(&retryable, errors[0].1);
-            }
-            result => panic!("expect all retryable, got {result:?}"),
-        }
-
-        let all_non_retryable = vec![Err(non_retryable.clone())];
-        match handle_instruction_results::<()>(&all_non_retryable) {
-            HandleInstructionResults::AllNonRetryable(errors) => {
-                assert_eq!(1, errors.len());
-                assert_eq!(0, errors[0].0);
-                assert_eq!(&non_retryable, errors[0].1);
-            }
-            result => panic!("expect all non-retryable, got {result:?}"),
-        }
-
-        let mixed = vec![Ok(()), Err(retryable.clone()), Err(non_retryable.clone())];
-        match handle_instruction_results(&mixed) {
-            HandleInstructionResults::PartialRetryable {
-                retryable_errors,
-                non_retryable_errors,
-            } => {
-                assert_eq!(1, retryable_errors.len());
-                assert_eq!(1, retryable_errors[0].0);
-                assert_eq!(&retryable, retryable_errors[0].1);
-                assert_eq!(1, non_retryable_errors.len());
-                assert_eq!(2, non_retryable_errors[0].0);
-                assert_eq!(&non_retryable, non_retryable_errors[0].1);
-            }
-            result => panic!("expect partial retryable, got {result:?}"),
-        }
     }
 
     #[test]

--- a/src/datanode/src/heartbeat/handler/apply_staging_manifest.rs
+++ b/src/datanode/src/heartbeat/handler/apply_staging_manifest.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 use common_meta::instruction::{
-    ApplyStagingManifest, ApplyStagingManifestReply, ApplyStagingManifestsReply, InstructionReply,
+    ApplyStagingManifest, ApplyStagingManifestReply, ApplyStagingManifestsReply, InstructionError,
+    InstructionReply,
 };
 use common_telemetry::{error, warn};
 use futures::future::join_all;
@@ -76,7 +77,9 @@ impl ApplyStagingManifestsHandler {
                 region_id,
                 exists: true,
                 ready: false,
-                error: Some("Region is not leader".into()),
+                error: Some(InstructionError::legacy_internal_retryable(
+                    "Region is not leader",
+                )),
             };
         }
 
@@ -104,7 +107,7 @@ impl ApplyStagingManifestsHandler {
                     region_id,
                     exists: true,
                     ready: false,
-                    error: Some(format!("{err:?}")),
+                    error: Some(InstructionError::from_error(&err)),
                 }
             }
         }

--- a/src/datanode/src/heartbeat/handler/close_region.rs
+++ b/src/datanode/src/heartbeat/handler/close_region.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use common_meta::RegionIdent;
-use common_meta::instruction::{InstructionReply, SimpleReply};
+use common_meta::instruction::{InstructionError, InstructionReply, SimpleReply};
 use common_telemetry::warn;
 use futures::future::join_all;
 use store_api::region_request::{RegionCloseRequest, RegionRequest};
@@ -69,7 +69,9 @@ impl InstructionHandler for CloseRegionsHandler {
 
         Some(InstructionReply::CloseRegions(SimpleReply {
             result: false,
-            error: Some(errors.join("; ")),
+            error: Some(InstructionError::legacy_internal_retryable(
+                errors.join("; "),
+            )),
         }))
     }
 }

--- a/src/datanode/src/heartbeat/handler/downgrade_region.rs
+++ b/src/datanode/src/heartbeat/handler/downgrade_region.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 use common_meta::instruction::{
-    DowngradeRegion, DowngradeRegionReply, DowngradeRegionsReply, InstructionReply,
+    DowngradeRegion, DowngradeRegionReply, DowngradeRegionsReply, InstructionError,
+    InstructionReply,
 };
 use common_telemetry::tracing::info;
 use common_telemetry::{error, warn};
@@ -89,7 +90,7 @@ impl DowngradeRegionsHandler {
                     last_entry_id: None,
                     metadata_last_entry_id: None,
                     exists: true,
-                    error: Some(format!("{err:?}")),
+                    error: Some(InstructionError::from_error(&err)),
                 };
             }
             Err(err) => {
@@ -99,7 +100,7 @@ impl DowngradeRegionsHandler {
                     last_entry_id: None,
                     metadata_last_entry_id: None,
                     exists: true,
-                    error: Some(format!("{err:?}")),
+                    error: Some(InstructionError::from_error(&err)),
                 };
             }
         }
@@ -135,10 +136,10 @@ impl DowngradeRegionsHandler {
                 last_entry_id: None,
                 metadata_last_entry_id: None,
                 exists: true,
-                error: Some(format!(
+                error: Some(InstructionError::legacy_internal_retryable(format!(
                     "Flush region timeout, region: {region_id}, timeout: {:?}",
                     flush_timeout
-                )),
+                ))),
             },
             WaitResult::Finish(Ok(_)) => ctx.downgrade_to_follower_gracefully(region_id).await,
             WaitResult::Finish(Err(err)) => DowngradeRegionReply {
@@ -146,7 +147,7 @@ impl DowngradeRegionsHandler {
                 last_entry_id: None,
                 metadata_last_entry_id: None,
                 exists: true,
-                error: Some(format!("{err:?}")),
+                error: Some(InstructionError::from_error(&err)),
             },
         }
     }
@@ -204,7 +205,7 @@ impl HandlerContext {
                     last_entry_id: None,
                     metadata_last_entry_id: None,
                     exists: true,
-                    error: Some(format!("{err:?}")),
+                    error: Some(InstructionError::from_error(&err)),
                 }
             }
             Err(err) => {
@@ -214,7 +215,7 @@ impl HandlerContext {
                     last_entry_id: None,
                     metadata_last_entry_id: None,
                     exists: true,
-                    error: Some(format!("{err:?}")),
+                    error: Some(InstructionError::from_error(&err)),
                 }
             }
         }
@@ -352,7 +353,7 @@ mod tests {
 
         let reply = &reply.unwrap().expect_downgrade_regions_reply()[0];
         assert!(reply.exists);
-        assert!(reply.error.as_ref().unwrap().contains("timeout"));
+        assert!(reply.error.as_ref().unwrap().message.contains("timeout"));
         assert!(reply.last_entry_id.is_none());
     }
 
@@ -392,7 +393,7 @@ mod tests {
 
             let reply = &reply.unwrap().expect_downgrade_regions_reply()[0];
             assert!(reply.exists);
-            assert!(reply.error.as_ref().unwrap().contains("timeout"));
+            assert!(reply.error.as_ref().unwrap().message.contains("timeout"));
             assert!(reply.last_entry_id.is_none());
         }
         let timer = Instant::now();
@@ -455,7 +456,7 @@ mod tests {
                 .await;
             let reply = &reply.unwrap().expect_downgrade_regions_reply()[0];
             assert!(reply.exists);
-            assert!(reply.error.as_ref().unwrap().contains("timeout"));
+            assert!(reply.error.as_ref().unwrap().message.contains("timeout"));
             assert!(reply.last_entry_id.is_none());
         }
         let timer = Instant::now();
@@ -472,7 +473,14 @@ mod tests {
         assert!(timer.elapsed().as_millis() < 300);
         let reply = &reply.unwrap().expect_downgrade_regions_reply()[0];
         assert!(reply.exists);
-        assert!(reply.error.as_ref().unwrap().contains("flush failed"));
+        assert!(
+            reply
+                .error
+                .as_ref()
+                .unwrap()
+                .message
+                .contains("flush failed")
+        );
         assert!(reply.last_entry_id.is_none());
     }
 
@@ -537,6 +545,7 @@ mod tests {
                 .error
                 .as_ref()
                 .unwrap()
+                .message
                 .contains("Failed to set region to readonly")
         );
         assert!(reply.last_entry_id.is_none());

--- a/src/datanode/src/heartbeat/handler/enter_staging.rs
+++ b/src/datanode/src/heartbeat/handler/enter_staging.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use common_meta::instruction::{
-    EnterStagingRegion, EnterStagingRegionReply, EnterStagingRegionsReply, InstructionReply,
-    StagingPartitionDirective as InstructionStagingPartitionDirective,
+    EnterStagingRegion, EnterStagingRegionReply, EnterStagingRegionsReply, InstructionError,
+    InstructionReply, StagingPartitionDirective as InstructionStagingPartitionDirective,
 };
 use common_telemetry::{error, warn};
 use futures::future::join_all;
@@ -70,7 +70,9 @@ impl EnterStagingRegionsHandler {
                 region_id,
                 ready: false,
                 exists: true,
-                error: Some("Region is not writable".into()),
+                error: Some(InstructionError::legacy_internal_retryable(
+                    "Region is not writable",
+                )),
             };
         }
 
@@ -107,7 +109,7 @@ impl EnterStagingRegionsHandler {
                     region_id,
                     ready: false,
                     exists: true,
-                    error: Some(format!("{err:?}")),
+                    error: Some(InstructionError::from_error(&err)),
                 }
             }
         }

--- a/src/datanode/src/heartbeat/handler/file_ref.rs
+++ b/src/datanode/src/heartbeat/handler/file_ref.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use common_error::ext::ErrorExt;
-use common_meta::instruction::{GetFileRefs, GetFileRefsReply, InstructionReply};
+use common_meta::instruction::{GetFileRefs, GetFileRefsReply, InstructionError, InstructionReply};
 use store_api::storage::FileRefsManifest;
 
 use crate::heartbeat::handler::{HandlerContext, InstructionHandler};
@@ -36,7 +36,9 @@ impl InstructionHandler for GetFileRefsHandler {
             return Some(InstructionReply::GetFileRefs(GetFileRefsReply {
                 file_refs_manifest: FileRefsManifest::default(),
                 success: false,
-                error: Some("MitoEngine not found".to_string()),
+                error: Some(InstructionError::legacy_internal_retryable(
+                    "MitoEngine not found",
+                )),
             }));
         };
         match mito_engine
@@ -54,7 +56,11 @@ impl InstructionHandler for GetFileRefsHandler {
             Err(e) => Some(InstructionReply::GetFileRefs(GetFileRefsReply {
                 file_refs_manifest: FileRefsManifest::default(),
                 success: false,
-                error: Some(format!("Failed to get file refs: {}", e.output_msg())),
+                error: Some(InstructionError::new(
+                    e.status_code(),
+                    format!("Failed to get file refs: {}", e.output_msg()),
+                    e.retry_hint(),
+                )),
             })),
         }
     }

--- a/src/datanode/src/heartbeat/handler/flush_region.rs
+++ b/src/datanode/src/heartbeat/handler/flush_region.rs
@@ -15,7 +15,8 @@
 use std::time::Instant;
 
 use common_meta::instruction::{
-    FlushErrorStrategy, FlushRegionReply, FlushRegions, FlushStrategy, InstructionReply,
+    FlushErrorStrategy, FlushRegionReply, FlushRegions, FlushStrategy, InstructionError,
+    InstructionReply,
 };
 use common_telemetry::{debug, warn};
 use store_api::region_request::{RegionFlushReason, RegionFlushRequest, RegionRequest};
@@ -124,9 +125,7 @@ impl HandlerContext {
             match &result {
                 Ok(_) => results.push((region_id, Ok(()))),
                 Err(err) => {
-                    // Convert error::Error to String for FlushRegionReply compatibility
-                    let error_string = err.to_string();
-                    results.push((region_id, Err(error_string)));
+                    results.push((region_id, Err(InstructionError::from_error(err))));
 
                     // For fail-fast strategy, abort on first error
                     if matches!(error_strategy, FlushErrorStrategy::FailFast) {

--- a/src/datanode/src/heartbeat/handler/gc_worker.rs
+++ b/src/datanode/src/heartbeat/handler/gc_worker.rs
@@ -118,9 +118,11 @@ impl InstructionHandler for GcRegionsHandler {
         if register_result.is_busy() {
             warn!("Another gc task is running for the region: {target_region_id}");
             return Some(InstructionReply::GcRegions(GcRegionsReply {
-                result: Err(format!(
-                    "Another gc task is running for the region: {target_region_id}"
-                )),
+                result: Err(
+                    common_meta::instruction::InstructionError::legacy_internal_retryable(format!(
+                        "Another gc task is running for the region: {target_region_id}"
+                    )),
+                ),
             }));
         }
         let mut watcher = register_result.into_watcher();
@@ -130,7 +132,7 @@ impl InstructionHandler for GcRegionsHandler {
                 result: Ok(report),
             })),
             Err(err) => Some(InstructionReply::GcRegions(GcRegionsReply {
-                result: Err(format!("{err:?}")),
+                result: Err(common_meta::instruction::InstructionError::from_error(&err)),
             })),
         }
     }

--- a/src/datanode/src/heartbeat/handler/open_region.rs
+++ b/src/datanode/src/heartbeat/handler/open_region.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_meta::instruction::{InstructionReply, OpenRegion, SimpleReply};
+use common_meta::instruction::{InstructionError, InstructionReply, OpenRegion, SimpleReply};
 use common_meta::wal_provider::serialize_wal_options;
 use common_telemetry::info;
 use store_api::path_utils::table_dir;
@@ -73,7 +73,7 @@ impl InstructionHandler for OpenRegionsHandler {
             Err(error) => {
                 return Some(InstructionReply::OpenRegions(SimpleReply {
                     result: false,
-                    error: Some(error),
+                    error: Some(InstructionError::legacy_internal_retryable(error)),
                 }));
             }
         };
@@ -83,7 +83,7 @@ impl InstructionHandler for OpenRegionsHandler {
             .handle_batch_open_requests(self.open_region_parallelism, requests, false)
             .await;
         let success = result.is_ok();
-        let error = result.as_ref().map_err(|e| format!("{e:?}")).err();
+        let error = result.as_ref().map_err(InstructionError::from_error).err();
 
         Some(InstructionReply::OpenRegions(SimpleReply {
             result: success,

--- a/src/datanode/src/heartbeat/handler/remap_manifest.rs
+++ b/src/datanode/src/heartbeat/handler/remap_manifest.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_meta::instruction::{InstructionReply, RemapManifest, RemapManifestReply};
+use common_meta::instruction::{
+    InstructionError, InstructionReply, RemapManifest, RemapManifestReply,
+};
 use common_telemetry::{error, info, warn};
 use store_api::region_engine::RemapManifestsRequest;
 
@@ -54,7 +56,9 @@ impl InstructionHandler for RemapManifestHandler {
             return Some(InstructionReply::RemapManifest(RemapManifestReply {
                 exists: true,
                 manifest_paths: Default::default(),
-                error: Some("Region is not leader".into()),
+                error: Some(InstructionError::legacy_internal_retryable(
+                    "Region is not leader",
+                )),
             }));
         }
 
@@ -82,7 +86,7 @@ impl InstructionHandler for RemapManifestHandler {
                 InstructionReply::RemapManifest(RemapManifestReply {
                     exists: true,
                     manifest_paths: Default::default(),
-                    error: Some(format!("{e:?}")),
+                    error: Some(InstructionError::from_error(&e)),
                 })
             }
         };

--- a/src/datanode/src/heartbeat/handler/sync_region.rs
+++ b/src/datanode/src/heartbeat/handler/sync_region.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_meta::instruction::{InstructionReply, SyncRegion, SyncRegionReply, SyncRegionsReply};
+use common_meta::instruction::{
+    InstructionError, InstructionReply, SyncRegion, SyncRegionReply, SyncRegionsReply,
+};
 use common_telemetry::{debug, error, info, warn};
 use futures::future::join_all;
 
@@ -68,7 +70,9 @@ impl SyncRegionHandler {
                 region_id,
                 ready: false,
                 exists: true,
-                error: Some("Region is not writable".into()),
+                error: Some(InstructionError::legacy_internal_retryable(
+                    "Region is not writable",
+                )),
             };
         }
 
@@ -88,7 +92,7 @@ impl SyncRegionHandler {
                     region_id,
                     ready: false,
                     exists: true,
-                    error: Some(format!("{:?}", e)),
+                    error: Some(InstructionError::from_error(&e)),
                 }
             }
         }

--- a/src/datanode/src/heartbeat/handler/upgrade_region.rs
+++ b/src/datanode/src/heartbeat/handler/upgrade_region.rs
@@ -15,7 +15,7 @@
 use common_error::ext::{BoxedError, ErrorExt};
 use common_error::status_code::StatusCode;
 use common_meta::instruction::{
-    InstructionReply, UpgradeRegion, UpgradeRegionReply, UpgradeRegionsReply,
+    InstructionError, InstructionReply, UpgradeRegion, UpgradeRegionReply, UpgradeRegionsReply,
 };
 use common_telemetry::{debug, info, warn};
 use store_api::region_request::{RegionCatchupRequest, ReplayCheckpoint};
@@ -59,14 +59,14 @@ impl UpgradeRegionsHandler {
                                 region_id,
                                 ready: false,
                                 exists: false,
-                                error: Some(format!("{err:?}")),
+                                error: Some(InstructionError::from_error(&err)),
                             }
                         } else {
                             UpgradeRegionReply {
                                 region_id,
                                 ready: false,
                                 exists: true,
-                                error: Some(format!("{err:?}")),
+                                error: Some(InstructionError::from_error(&err)),
                             }
                         }
                     }
@@ -78,7 +78,7 @@ impl UpgradeRegionsHandler {
                     region_id: *region_id,
                     ready: false,
                     exists: true,
-                    error: Some(format!("{err:?}")),
+                    error: Some(InstructionError::from_error(&err)),
                 })
                 .collect::<Vec<_>>(),
         }
@@ -458,6 +458,6 @@ mod tests {
         assert!(!reply.ready);
         assert!(reply.exists);
         assert!(reply.error.is_some());
-        assert!(reply.error.as_ref().unwrap().contains("mock_error"));
+        assert!(reply.error.as_ref().unwrap().message.contains("mock_error"));
     }
 }

--- a/src/meta-srv/src/gc/procedure.rs
+++ b/src/meta-srv/src/gc/procedure.rs
@@ -44,6 +44,7 @@ use crate::gc::util::table_route_to_region;
 use crate::gc::{Peer2Regions, Region2Peers};
 use crate::handler::HeartbeatMailbox;
 use crate::metrics::{METRIC_META_GC_DATANODE_CALLS_TOTAL, METRIC_META_GC_FAILED_REGIONS_TOTAL};
+use crate::procedure::utils::instruction_error_result;
 use crate::service::mailbox::{Channel, MailboxReceiver, MailboxRef};
 
 async fn send_get_file_refs_inner(
@@ -158,13 +159,13 @@ async fn recv_gc_regions_reply(
                 e; "Datanode {} reported error during GC for regions {:?}",
                 peer, gc_regions
             );
-            error::UnexpectedSnafu {
-                violated: format!(
+            instruction_error_result(
+                &e,
+                format!(
                     "Datanode {} reported error during GC for regions {:?}: {}",
                     peer, gc_regions, e
                 ),
-            }
-            .fail()
+            )
         }
     }
 }
@@ -670,13 +671,24 @@ impl BatchGcProcedure {
                 METRIC_META_GC_DATANODE_CALLS_TOTAL
                     .with_label_values(&["get_file_refs", "error"])
                     .inc();
-                let err = error::UnexpectedSnafu {
-                    violated: format!(
-                        "Failed to get file references from datanode {}: {:?}",
-                        peer, reply.error
-                    ),
-                }
-                .build();
+                let err = if let Some(error) = &reply.error {
+                    instruction_error_result::<()>(
+                        error,
+                        format!(
+                            "Failed to get file references from datanode {}: {:?}",
+                            peer, error
+                        ),
+                    )
+                    .unwrap_err()
+                } else {
+                    error::UnexpectedSnafu {
+                        violated: format!(
+                            "Failed to get file references from datanode {}: {:?}",
+                            peer, reply.error
+                        ),
+                    }
+                    .build()
+                };
                 record_get_file_refs_error(err);
                 continue;
             }

--- a/src/meta-srv/src/gc/procedure.rs
+++ b/src/meta-srv/src/gc/procedure.rs
@@ -44,7 +44,7 @@ use crate::gc::util::table_route_to_region;
 use crate::gc::{Peer2Regions, Region2Peers};
 use crate::handler::HeartbeatMailbox;
 use crate::metrics::{METRIC_META_GC_DATANODE_CALLS_TOTAL, METRIC_META_GC_FAILED_REGIONS_TOTAL};
-use crate::procedure::utils::instruction_error_result;
+use crate::procedure::utils::{instruction_error_result, instruction_to_error};
 use crate::service::mailbox::{Channel, MailboxReceiver, MailboxRef};
 
 async fn send_get_file_refs_inner(
@@ -672,14 +672,13 @@ impl BatchGcProcedure {
                     .with_label_values(&["get_file_refs", "error"])
                     .inc();
                 let err = if let Some(error) = &reply.error {
-                    instruction_error_result::<()>(
+                    instruction_to_error(
                         error,
                         format!(
                             "Failed to get file references from datanode {}: {:?}",
                             peer, error
                         ),
                     )
-                    .unwrap_err()
                 } else {
                     error::UnexpectedSnafu {
                         violated: format!(

--- a/src/meta-srv/src/procedure/region_migration.rs
+++ b/src/meta-srv/src/procedure/region_migration.rs
@@ -1502,7 +1502,13 @@ mod tests {
                 "Should be throwing a retryable error",
                 Some(mock_datanode_reply(
                     to_peer_id,
-                    Arc::new(|id| Ok(new_open_region_reply(id, false, None))),
+                    Arc::new(|id| {
+                        Ok(new_open_region_reply(
+                            id,
+                            false,
+                            Some("mock retryable open region error".to_string()),
+                        ))
+                    }),
                 )),
                 Assertion::error(|error| assert!(error.is_retryable(), "err: {error:?}")),
             ),

--- a/src/meta-srv/src/procedure/region_migration/close_downgraded_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/close_downgraded_region.rs
@@ -28,6 +28,7 @@ use crate::error::{self, Result};
 use crate::handler::HeartbeatMailbox;
 use crate::procedure::region_migration::migration_end::RegionMigrationEnd;
 use crate::procedure::region_migration::{Context, State};
+use crate::procedure::utils::instruction_error_result;
 use crate::service::mailbox::Channel;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -131,10 +132,18 @@ impl CloseDowngradedRegion {
 
                 if result {
                     Ok(())
+                } else if let Some(error) = error {
+                    instruction_error_result(
+                        &error,
+                        format!(
+                            "Failed to close downgraded leader region: {region_ids:?} on datanode {:?}, error: {error:?}",
+                            downgrade_leader_datanode,
+                        ),
+                    )
                 } else {
                     error::UnexpectedSnafu {
                         violated: format!(
-                            "Failed to close downgraded leader region: {region_ids:?} on datanode {:?}, error: {error:?}",
+                            "Failed to close downgraded leader region: {region_ids:?} on datanode {:?}",
                             downgrade_leader_datanode,
                         ),
                     }

--- a/src/meta-srv/src/procedure/region_migration/downgrade_leader_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/downgrade_leader_region.rs
@@ -35,6 +35,7 @@ use crate::handler::HeartbeatMailbox;
 use crate::procedure::region_migration::update_metadata::UpdateMetadata;
 use crate::procedure::region_migration::upgrade_candidate_region::UpgradeCandidateRegion;
 use crate::procedure::region_migration::{Context, State};
+use crate::procedure::utils::instruction_error_result;
 use crate::service::mailbox::Channel;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -146,14 +147,17 @@ impl DowngradeLeaderRegion {
             error,
         } = reply;
 
-        if error.is_some() {
-            return error::RetryLaterSnafu {
-                reason: format!(
+        if let Some(error) = error {
+            return instruction_error_result(
+                error,
+                format!(
                     "Failed to downgrade the region {} on datanode {:?}, error: {:?}, elapsed: {:?}",
-                    region_id, leader, error, now.elapsed()
+                    region_id,
+                    leader,
+                    error,
+                    now.elapsed()
                 ),
-            }
-            .fail();
+            );
         }
 
         if !exists {

--- a/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
@@ -35,6 +35,7 @@ use crate::error::{self, Result};
 use crate::handler::HeartbeatMailbox;
 use crate::procedure::region_migration::flush_leader_region::PreFlushRegion;
 use crate::procedure::region_migration::{Context, RegionMigrationTriggerReason, State};
+use crate::procedure::utils::instruction_error_result;
 use crate::service::mailbox::Channel;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -192,10 +193,19 @@ impl OpenCandidateRegion {
 
                 if result {
                     Ok(())
-                } else {
-                    error::RetryLaterSnafu {
-                        reason: format!(
+                } else if let Some(error) = error {
+                    instruction_error_result(
+                        &error,
+                        format!(
                             "Region {region_ids:?} is not opened by datanode {:?}, error: {error:?}, elapsed: {:?}",
+                            candidate,
+                            now.elapsed()
+                        ),
+                    )
+                } else {
+                    error::UnexpectedSnafu {
+                        violated: format!(
+                            "Region {region_ids:?} is not opened by datanode {:?}, but error is absent, elapsed: {:?}",
                             candidate,
                             now.elapsed()
                         ),
@@ -222,7 +232,10 @@ mod tests {
     use std::collections::HashMap;
 
     use common_catalog::consts::MITO2_ENGINE;
+    use common_error::ext::RetryHint;
+    use common_error::status_code::StatusCode;
     use common_meta::DatanodeId;
+    use common_meta::instruction::InstructionError;
     use common_meta::key::table_route::TableRouteValue;
     use common_meta::key::test_utils::new_test_table_info;
     use common_meta::peer::Peer;
@@ -234,7 +247,8 @@ mod tests {
     use crate::procedure::region_migration::test_util::{self, TestingEnv, new_procedure_context};
     use crate::procedure::region_migration::{ContextFactory, PersistentContext};
     use crate::procedure::test_util::{
-        new_close_region_reply, new_open_region_reply, send_mock_reply,
+        new_close_region_reply, new_open_region_reply, new_open_region_reply_with_error,
+        send_mock_reply,
     };
 
     fn new_persistent_context() -> PersistentContext {
@@ -477,6 +491,79 @@ mod tests {
         assert_matches!(err, Error::RetryLater { .. });
         assert!(err.is_retryable());
         assert!(format!("{err:?}").contains("test mocked"));
+    }
+
+    #[tokio::test]
+    async fn test_open_candidate_region_non_retryable_instruction_error() {
+        let state = OpenCandidateRegion;
+        let persistent_context = new_persistent_context();
+        let region_id = persistent_context.region_ids[0];
+        let to_peer_id = persistent_context.to_peer.id;
+        let mut env = TestingEnv::new();
+
+        let mut ctx = env.context_factory().new_context(persistent_context);
+        let mailbox_ctx = env.mailbox_context();
+        let mailbox = mailbox_ctx.mailbox().clone();
+
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+
+        mailbox_ctx
+            .insert_heartbeat_response_receiver(Channel::Datanode(to_peer_id), tx)
+            .await;
+
+        send_mock_reply(mailbox, rx, |id| {
+            Ok(new_open_region_reply_with_error(
+                id,
+                false,
+                Some(InstructionError {
+                    code: StatusCode::Internal,
+                    message: "non retryable mocked".to_string(),
+                    retry_hint: RetryHint::NonRetryable,
+                }),
+            ))
+        });
+
+        let open_instruction = new_mock_open_instruction(to_peer_id, region_id);
+        let err = state
+            .open_candidate_region(&mut ctx, open_instruction)
+            .await
+            .unwrap_err();
+
+        assert_matches!(err, Error::Unexpected { .. });
+        assert!(!err.is_retryable());
+        assert!(format!("{err:?}").contains("non retryable mocked"));
+    }
+
+    #[tokio::test]
+    async fn test_open_candidate_region_false_without_error_is_unexpected() {
+        let state = OpenCandidateRegion;
+        let persistent_context = new_persistent_context();
+        let region_id = persistent_context.region_ids[0];
+        let to_peer_id = persistent_context.to_peer.id;
+        let mut env = TestingEnv::new();
+
+        let mut ctx = env.context_factory().new_context(persistent_context);
+        let mailbox_ctx = env.mailbox_context();
+        let mailbox = mailbox_ctx.mailbox().clone();
+
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+
+        mailbox_ctx
+            .insert_heartbeat_response_receiver(Channel::Datanode(to_peer_id), tx)
+            .await;
+
+        send_mock_reply(mailbox, rx, |id| {
+            Ok(new_open_region_reply_with_error(id, false, None))
+        });
+
+        let open_instruction = new_mock_open_instruction(to_peer_id, region_id);
+        let err = state
+            .open_candidate_region(&mut ctx, open_instruction)
+            .await
+            .unwrap_err();
+
+        assert_matches!(err, Error::Unexpected { .. });
+        assert!(!err.is_retryable());
     }
 
     #[tokio::test]

--- a/src/meta-srv/src/procedure/region_migration/upgrade_candidate_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/upgrade_candidate_region.rs
@@ -35,6 +35,7 @@ use crate::error::{self, Result};
 use crate::handler::HeartbeatMailbox;
 use crate::procedure::region_migration::update_metadata::UpdateMetadata;
 use crate::procedure::region_migration::{Context, State};
+use crate::procedure::utils::instruction_error_result;
 use crate::service::mailbox::Channel;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -179,17 +180,17 @@ impl UpgradeCandidateRegion {
         now: &Instant,
     ) -> Result<()> {
         let candidate = &ctx.persistent_ctx.to_peer;
-        if error.is_some() {
-            return error::RetryLaterSnafu {
-                reason: format!(
+        if let Some(error) = error {
+            return instruction_error_result(
+                error,
+                format!(
                     "Failed to upgrade the region {} on datanode {:?}, error: {:?}, elapsed: {:?}",
                     region_id,
                     candidate,
                     error,
                     now.elapsed()
                 ),
-            }
-            .fail();
+            );
         }
 
         ensure!(

--- a/src/meta-srv/src/procedure/repartition/group/apply_staging_manifest.rs
+++ b/src/meta-srv/src/procedure/repartition/group/apply_staging_manifest.rs
@@ -38,6 +38,7 @@ use crate::procedure::repartition::group::utils::{
 };
 use crate::procedure::repartition::group::{Context, State};
 use crate::procedure::repartition::plan::TargetRegionDescriptor;
+use crate::procedure::utils::instruction_error_result;
 use crate::service::mailbox::{Channel, MailboxRef};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -374,16 +375,16 @@ impl ApplyStagingManifest {
             }
         );
 
-        if error.is_some() {
-            return error::RetryLaterSnafu {
-                reason: format!(
+        if let Some(error) = error {
+            return instruction_error_result(
+                error,
+                format!(
                     "Failed to apply staging manifest on datanode {:?}, error: {:?}, elapsed: {:?}",
                     peer,
                     error,
                     now.elapsed()
                 ),
-            }
-            .fail();
+            );
         }
 
         ensure!(

--- a/src/meta-srv/src/procedure/repartition/group/enter_staging_region.rs
+++ b/src/meta-srv/src/procedure/repartition/group/enter_staging_region.rs
@@ -39,7 +39,7 @@ use crate::procedure::repartition::group::utils::{
 };
 use crate::procedure::repartition::group::{Context, GroupId, GroupPrepareResult, State};
 use crate::procedure::repartition::plan::TargetRegionDescriptor;
-use crate::procedure::utils::{self, ErrorStrategy};
+use crate::procedure::utils::{self, ErrorStrategy, instruction_error_result};
 use crate::service::mailbox::{Channel, MailboxRef};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -358,14 +358,17 @@ impl EnterStagingRegion {
             }
         );
 
-        if error.is_some() {
-            return error::RetryLaterSnafu {
-                reason: format!(
+        if let Some(error) = error {
+            return instruction_error_result(
+                error,
+                format!(
                     "Failed to enter staging region {} on datanode {:?}, error: {:?}, elapsed: {:?}",
-                    region_id, peer, error, now.elapsed()
+                    region_id,
+                    peer,
+                    error,
+                    now.elapsed()
                 ),
-            }
-            .fail();
+            );
         }
 
         ensure!(

--- a/src/meta-srv/src/procedure/repartition/group/remap_manifest.rs
+++ b/src/meta-srv/src/procedure/repartition/group/remap_manifest.rs
@@ -31,6 +31,7 @@ use crate::handler::HeartbeatMailbox;
 use crate::procedure::repartition::group::apply_staging_manifest::ApplyStagingManifest;
 use crate::procedure::repartition::group::{Context, State};
 use crate::procedure::repartition::plan::{SourceRegionDescriptor, TargetRegionDescriptor};
+use crate::procedure::utils::instruction_error_result;
 use crate::service::mailbox::{Channel, MailboxRef};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -226,16 +227,16 @@ impl RemapManifest {
             }
         );
 
-        if error.is_some() {
-            return error::RetryLaterSnafu {
-                reason: format!(
+        if let Some(error) = error {
+            return instruction_error_result(
+                &error,
+                format!(
                     "Failed to remap manifest on datanode {:?}, error: {:?}, elapsed: {:?}",
                     peer,
                     error,
                     now.elapsed()
                 ),
-            }
-            .fail();
+            );
         }
 
         Ok(manifest_paths)

--- a/src/meta-srv/src/procedure/repartition/group/sync_region.rs
+++ b/src/meta-srv/src/procedure/repartition/group/sync_region.rs
@@ -37,7 +37,7 @@ use crate::procedure::repartition::group::utils::{
     HandleMultipleResult, group_region_routes_by_peer, handle_multiple_results,
 };
 use crate::procedure::repartition::group::{Context, State};
-use crate::procedure::utils::ErrorStrategy;
+use crate::procedure::utils::{ErrorStrategy, instruction_error_result};
 use crate::service::mailbox::{Channel, MailboxRef};
 
 const DEFAULT_SYNC_REGION_PARALLELISM: usize = 3;
@@ -318,16 +318,16 @@ impl SyncRegion {
         );
 
         if let Some(error) = error {
-            return error::RetryLaterSnafu {
-                reason: format!(
+            return instruction_error_result(
+                error,
+                format!(
                     "Failed to sync region {} on datanode {:?}, error: {:?}, elapsed: {:?}",
                     region_id,
                     peer,
                     error,
                     now.elapsed()
                 ),
-            }
-            .fail();
+            );
         }
 
         ensure!(

--- a/src/meta-srv/src/procedure/test_util.rs
+++ b/src/meta-srv/src/procedure/test_util.rs
@@ -18,8 +18,8 @@ use api::v1::meta::mailbox_message::Payload;
 use api::v1::meta::{HeartbeatResponse, MailboxMessage};
 use common_meta::instruction::{
     DowngradeRegionReply, DowngradeRegionsReply, EnterStagingRegionReply, EnterStagingRegionsReply,
-    FlushRegionReply, InstructionReply, SimpleReply, SyncRegionReply, SyncRegionsReply,
-    UpgradeRegionReply, UpgradeRegionsReply,
+    FlushRegionReply, InstructionError, InstructionReply, SimpleReply, SyncRegionReply,
+    SyncRegionsReply, UpgradeRegionReply, UpgradeRegionsReply,
 };
 use common_meta::key::TableMetadataManagerRef;
 use common_meta::key::table_route::TableRouteValue;
@@ -41,6 +41,10 @@ use tokio::sync::mpsc::{Receiver, Sender};
 use crate::error::Result;
 use crate::handler::{HeartbeatMailbox, Pusher, Pushers};
 use crate::service::mailbox::{Channel, MailboxRef};
+
+fn legacy_instruction_error(error: Option<String>) -> Option<InstructionError> {
+    error.map(InstructionError::legacy_internal_retryable)
+}
 
 pub type MockHeartbeatReceiver = Receiver<std::result::Result<HeartbeatResponse, tonic::Status>>;
 
@@ -100,7 +104,7 @@ pub fn new_open_region_reply(id: u64, result: bool, error: Option<String>) -> Ma
         payload: Some(Payload::Json(
             serde_json::to_string(&InstructionReply::OpenRegions(SimpleReply {
                 result,
-                error,
+                error: legacy_instruction_error(error),
             }))
             .unwrap(),
         )),
@@ -115,7 +119,10 @@ pub fn new_flush_region_reply(id: u64, result: bool, error: Option<String>) -> M
     let flush_reply = if result {
         FlushRegionReply::success_single(region_id)
     } else {
-        FlushRegionReply::error_single(region_id, error.unwrap_or("Test error".to_string()))
+        FlushRegionReply::error_single(
+            region_id,
+            InstructionError::legacy_internal_retryable(error.unwrap_or("Test error".to_string())),
+        )
     };
 
     MailboxMessage {
@@ -141,7 +148,10 @@ pub fn new_flush_region_reply_for_region(
     let flush_reply = if result {
         FlushRegionReply::success_single(region_id)
     } else {
-        FlushRegionReply::error_single(region_id, error.unwrap_or("Test error".to_string()))
+        FlushRegionReply::error_single(
+            region_id,
+            InstructionError::legacy_internal_retryable(error.unwrap_or("Test error".to_string())),
+        )
     };
 
     MailboxMessage {
@@ -196,7 +206,7 @@ pub fn new_downgrade_region_reply(
                     last_entry_id,
                     metadata_last_entry_id: None,
                     exists: exist,
-                    error,
+                    error: legacy_instruction_error(error),
                 }]),
             ))
             .unwrap(),
@@ -224,7 +234,7 @@ pub fn new_upgrade_region_reply(
                     region_id: RegionId::new(0, 0),
                     ready,
                     exists,
-                    error,
+                    error: legacy_instruction_error(error),
                 }),
             ))
             .unwrap(),
@@ -253,7 +263,7 @@ pub fn new_enter_staging_region_reply(
                     region_id,
                     ready,
                     exists,
-                    error,
+                    error: legacy_instruction_error(error),
                 }]),
             ))
             .unwrap(),
@@ -282,7 +292,7 @@ pub fn new_sync_region_reply(
                     region_id,
                     ready,
                     exists,
-                    error,
+                    error: legacy_instruction_error(error),
                 },
             ])))
             .unwrap(),

--- a/src/meta-srv/src/procedure/test_util.rs
+++ b/src/meta-srv/src/procedure/test_util.rs
@@ -95,6 +95,15 @@ pub fn send_mock_reply(
 
 /// Generates a [InstructionReply::OpenRegion] reply.
 pub fn new_open_region_reply(id: u64, result: bool, error: Option<String>) -> MailboxMessage {
+    new_open_region_reply_with_error(id, result, legacy_instruction_error(error))
+}
+
+/// Generates a [InstructionReply::OpenRegion] reply with a structured error.
+pub fn new_open_region_reply_with_error(
+    id: u64,
+    result: bool,
+    error: Option<InstructionError>,
+) -> MailboxMessage {
     MailboxMessage {
         id,
         subject: "mock".to_string(),
@@ -104,7 +113,7 @@ pub fn new_open_region_reply(id: u64, result: bool, error: Option<String>) -> Ma
         payload: Some(Payload::Json(
             serde_json::to_string(&InstructionReply::OpenRegions(SimpleReply {
                 result,
-                error: legacy_instruction_error(error),
+                error,
             }))
             .unwrap(),
         )),

--- a/src/meta-srv/src/procedure/utils.rs
+++ b/src/meta-srv/src/procedure/utils.rs
@@ -15,7 +15,9 @@
 use std::time::Duration;
 
 use api::v1::meta::MailboxMessage;
-use common_meta::instruction::{FlushErrorStrategy, FlushRegions, Instruction, InstructionReply};
+use common_meta::instruction::{
+    FlushErrorStrategy, FlushRegions, Instruction, InstructionError, InstructionReply,
+};
 use common_meta::peer::Peer;
 use common_telemetry::tracing_context::TracingContext;
 use common_telemetry::{info, warn};
@@ -33,11 +35,44 @@ pub(crate) enum ErrorStrategy {
     Retry,
 }
 
+#[derive(Debug, Default)]
+struct FlushRegionErrors {
+    retryable: Vec<String>,
+    non_retryable: Vec<String>,
+}
+
+impl FlushRegionErrors {
+    fn is_empty(&self) -> bool {
+        self.retryable.is_empty() && self.non_retryable.is_empty()
+    }
+
+    fn format_all(&self) -> String {
+        self.retryable
+            .iter()
+            .chain(self.non_retryable.iter())
+            .cloned()
+            .collect::<Vec<_>>()
+            .join("; ")
+    }
+
+    fn format_non_retryable(&self) -> String {
+        self.non_retryable.join("; ")
+    }
+}
+
+pub(crate) fn instruction_error_result<T>(error: &InstructionError, reason: String) -> Result<T> {
+    if error.retry_hint.is_retryable() {
+        error::RetryLaterSnafu { reason }.fail()
+    } else {
+        error::UnexpectedSnafu { violated: reason }.fail()
+    }
+}
+
 fn handle_flush_region_reply(
     reply: &InstructionReply,
     region_ids: &[RegionId],
     msg: &MailboxMessage,
-) -> Result<(bool, Option<String>)> {
+) -> Result<(bool, Option<FlushRegionErrors>)> {
     let result = match reply {
         InstructionReply::FlushRegions(flush_reply) => {
             if flush_reply.results.len() != region_ids.len() {
@@ -54,20 +89,21 @@ fn handle_flush_region_reply(
 
             match flush_reply.overall_success {
                 true => (true, None),
-                false => (
-                    false,
-                    Some(
-                        flush_reply
-                            .results
-                            .iter()
-                            .filter_map(|(region_id, result)| match result {
-                                Ok(_) => None,
-                                Err(e) => Some(format!("{}: {:?}", region_id, e)),
-                            })
-                            .collect::<Vec<String>>()
-                            .join("; "),
-                    ),
-                ),
+                false => {
+                    let mut errors = FlushRegionErrors::default();
+                    for (region_id, result) in &flush_reply.results {
+                        let Err(error) = result else {
+                            continue;
+                        };
+                        let message = format!("{}: {:?}", region_id, error);
+                        if error.retry_hint.is_retryable() {
+                            errors.retryable.push(message);
+                        } else {
+                            errors.non_retryable.push(message);
+                        }
+                    }
+                    (false, (!errors.is_empty()).then_some(errors))
+                }
             }
         }
         _ => {
@@ -162,16 +198,29 @@ pub(crate) async fn flush_region(
                     ErrorStrategy::Ignore => {
                         warn!(
                             "Failed to flush regions {:?}, the datanode({}) error is ignored: {}",
-                            region_ids, datanode, error
+                            region_ids,
+                            datanode,
+                            error.format_all()
                         );
                     }
                     ErrorStrategy::Retry => {
+                        if !error.non_retryable.is_empty() {
+                            return error::UnexpectedSnafu {
+                                violated: format!(
+                                    "Failed to flush regions {:?}, the datanode({}) reported non-retryable errors: {}",
+                                    region_ids,
+                                    datanode,
+                                    error.format_non_retryable(),
+                                ),
+                            }
+                            .fail();
+                        }
                         return error::RetryLaterSnafu {
                             reason: format!(
                                 "Failed to flush regions {:?}, the datanode({}) error is retried: {}",
                                 region_ids,
                                 datanode,
-                                error,
+                                error.format_all(),
                             ),
                         }
                         .fail()?;

--- a/src/meta-srv/src/procedure/utils.rs
+++ b/src/meta-srv/src/procedure/utils.rs
@@ -60,12 +60,16 @@ impl FlushRegionErrors {
     }
 }
 
-pub(crate) fn instruction_error_result<T>(error: &InstructionError, reason: String) -> Result<T> {
+pub(crate) fn instruction_to_error(error: &InstructionError, reason: String) -> Error {
     if error.retry_hint.is_retryable() {
-        error::RetryLaterSnafu { reason }.fail()
+        error::RetryLaterSnafu { reason }.build()
     } else {
-        error::UnexpectedSnafu { violated: reason }.fail()
+        error::UnexpectedSnafu { violated: reason }.build()
     }
+}
+
+pub(crate) fn instruction_error_result<T>(error: &InstructionError, reason: String) -> Result<T> {
+    Err(instruction_to_error(error, reason))
 }
 
 fn handle_flush_region_reply(


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
close #8207
## What's changed and what's your intention?

This PR introduces structured instruction reply errors and updates procedure-side handling to respect retry hints from instruction errors.

Main changes:

- Add `InstructionError` / `InstructionResult` as structured instruction error representation.
- Add serde helpers for `StatusCode` and `RetryHint` so instruction errors can carry machine-readable error code and retry semantics.
- Refactor datanode instruction replies to return structured errors instead of plain strings.
- Keep legacy string error compatibility by mapping old string errors to `Internal + Retryable`.
- Update metasrv procedures to respect `InstructionError.retry_hint`:
  - retryable instruction errors return retryable procedure errors;
  - non-retryable instruction errors fail fast.
- Preserve existing whole-operation retry behavior; partial retry is intentionally not introduced because these operations are idempotent.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
