### PR TITLE
fix: redact Kafka SASL password in debug output

### DIFF
--- a/src/common/wal/src/config.rs
+++ b/src/common/wal/src/config.rs
@@ -268,4 +268,26 @@ mod tests {
         };
         assert_eq!(datanode_wal_config, DatanodeWalConfig::Kafka(expected));
     }
+
+    #[test]
+    fn test_kafka_wal_config_debug_redacts_password() {
+        let config = MetasrvWalConfig::Kafka(MetasrvKafkaConfig {
+            connection: KafkaConnectionConfig {
+                sasl: Some(KafkaClientSasl {
+                    config: KafkaClientSaslConfig::Plain {
+                        username: "greptime".to_string(),
+                        password: "kafka-secret".to_string(),
+                    },
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let debug = format!("{config:#?}");
+
+        assert!(debug.contains("greptime"));
+        assert!(debug.contains("<REDACTED>"));
+        assert!(!debug.contains("kafka-secret"));
+    }
 }

--- a/src/common/wal/src/config/kafka/common.rs
+++ b/src/common/wal/src/config/kafka/common.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
 use std::io::Cursor;
 use std::sync::Arc;
 use std::time::Duration;
@@ -63,7 +64,7 @@ pub struct KafkaClientSasl {
     pub config: KafkaClientSaslConfig,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "SCREAMING-KEBAB-CASE")]
 pub enum KafkaClientSaslConfig {
     Plain {
@@ -80,6 +81,28 @@ pub enum KafkaClientSaslConfig {
         username: String,
         password: String,
     },
+}
+
+impl fmt::Debug for KafkaClientSaslConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            KafkaClientSaslConfig::Plain { username, .. } => f
+                .debug_struct("Plain")
+                .field("username", username)
+                .field("password", &"<REDACTED>")
+                .finish(),
+            KafkaClientSaslConfig::ScramSha256 { username, .. } => f
+                .debug_struct("ScramSha256")
+                .field("username", username)
+                .field("password", &"<REDACTED>")
+                .finish(),
+            KafkaClientSaslConfig::ScramSha512 { username, .. } => f
+                .debug_struct("ScramSha512")
+                .field("username", username)
+                .field("password", &"<REDACTED>")
+                .finish(),
+        }
+    }
 }
 
 impl KafkaClientSaslConfig {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)


## What's changed and what's your intention?

This PR prevents Kafka SASL passwords from being exposed through debug-formatted WAL configuration logs.

- Add a custom `Debug` implementation for `KafkaClientSaslConfig` that preserves usernames and redacts password fields as `<REDACTED>`.
- Cover `MetasrvWalConfig` debug output with a regression test to ensure configured Kafka passwords are not printed.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.

Test plan:

- `rtk cargo test -p common-wal`