### PR TITLE
feat: add RDF bloom remote dynamic filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3642,7 +3642,6 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 [[package]]
 name = "datafusion"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "arrow 58.3.0",
  "arrow-schema 58.3.0",
@@ -3696,7 +3695,6 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3720,7 +3718,6 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3742,7 +3739,6 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -3766,7 +3762,6 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "futures",
  "log",
@@ -3776,7 +3771,6 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "arrow 58.3.0",
  "async-compression",
@@ -3810,7 +3804,6 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "arrow 58.3.0",
  "arrow-ipc 58.3.0",
@@ -3833,7 +3826,6 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3855,7 +3847,6 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3878,7 +3869,6 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3907,12 +3897,10 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 
 [[package]]
 name = "datafusion-execution"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "arrow 58.3.0",
  "arrow-buffer 58.3.0",
@@ -3934,7 +3922,6 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3956,7 +3943,6 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -3968,7 +3954,6 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "arrow 58.3.0",
  "arrow-buffer 58.3.0",
@@ -3999,7 +3984,6 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4020,7 +4004,6 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4032,7 +4015,6 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "arrow 58.3.0",
  "arrow-ord 58.3.0",
@@ -4056,7 +4038,6 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4071,7 +4052,6 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4088,7 +4068,6 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -4097,7 +4076,6 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -4107,7 +4085,6 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -4156,7 +4133,6 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4179,7 +4155,6 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4193,7 +4168,6 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4209,7 +4183,6 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4227,7 +4200,6 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4258,7 +4230,6 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -4285,7 +4256,6 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4295,7 +4265,6 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4311,7 +4280,6 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -4324,7 +4292,6 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "arrow 58.3.0",
  "bigdecimal 0.4.8",
@@ -4342,7 +4309,6 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=e8a127c28e8839964bb6aefdd909810dc11cd2c9#e8a127c28e8839964bb6aefdd909810dc11cd2c9"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -5937,7 +5903,6 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=5e358318890606a2961e12dcdf9674f6763cec3a#5e358318890606a2961e12dcdf9674f6763cec3a"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",

--- a/impl-note.md
+++ b/impl-note.md
@@ -1,0 +1,76 @@
+## 第 1 阶段实现备注
+
+本节记录 RDF Bloom 远程动态过滤第 1 阶段中，和原始预期或计划不同、后续实现需要知道的事项。
+
+### 和原计划不同的实现点
+
+- GreptimeDB 侧没有依赖 DataFusion 的 join-map trait。生产代码只使用 `HashTableLookupExpr` 的公开接口：`on_columns()`、`seeds()`、`visit_distinct_join_hashes(...)`。
+- 第 1 阶段最初只切了 `common-query` 内的 payload、probe、encoder 模型；后续又继续补上了 FE/DN typed payload wiring 和 initial snapshot Bloom 初始化。
+- 新增了 `DynFilterPayload::from_datafusion_expr_with_registered_children(...)`。Bloom 编码必须显式传入注册子表达式和输入 schema，不能只靠旧的 `from_datafusion_expr(...)`，否则无法安全生成 `join_key_child_indices` 和 `HashExpr` 兼容性指纹。
+- Bloom 转换比最初计划更保守：只有恰好一个 `HashTableLookupExpr` 作为正向 `AND` 合取项时才转换。`OR`、`NOT`、其他包装表达式、多 lookup、子表达式不匹配等情况都会回退。
+- 注册子表达式路径的回退逻辑改成 fail-open：遇到不安全 lookup 位置时，丢弃包含 lookup 的顶层 `AND` 合取项；如果整个表达式都不安全，则编码 `lit(true)`。这样避免 `NOT(lookup)` 被错误降级成 `NOT(true) == false`，从而产生 false negative。
+- Bloom payload 现在强制要求非空 `join_key_child_indices` 和非空 `residual_datafusion_physical_expr`。纯 lookup 场景的 residual 也必须编码成 `lit(true)`，不能用“空 residual 表示 true”的隐式约定。
+- `decode_expr_with_registered_children(...)` 会直接调用 `bloom.validate()`，因为 Bloom payload 可能来自 JSON 反序列化，不一定经过 proto 转换入口。
+- Encoder 最终没有收集全部 distinct hash 到 `Vec` 后再构建 Bloom；后续又按性能考虑去掉了“两次遍历”。现在通过 DataFusion 新增的 `HashTableLookupExpr::distinct_join_hash_count()` 先拿 distinct count 做 sizing，再单次调用 `visit_distinct_join_hashes(...)` 流式写入 bitset。
+- `JoinHashBloomProbeExpr` 的 eval 不再手写 `with_hashes` 路径；现在通过 DataFusion 自己的 `HashExpr` 计算 join hash，再用 Bloom bitset 做 membership probe，降低和 DataFusion hash 语义漂移的风险。
+- Bloom payload 新增 `hash_compat_fingerprint`（proto tag 14）。编码端用相同 seeds/children 在规范 `RecordBatch` 上直接评估 DataFusion `HashExpr`，再用本地稳定 digest 生成非零指纹；解码端本地重算，指纹为 0、重算失败或不匹配时直接返回 residual-only，不构造 Bloom probe。
+- 指纹 digest 不使用 `ahash`/`DefaultHasher`，而是写入固定 magic、seeds、child data type 稳定 tag 和 `HashExpr` 输出 hash 序列后再 finalize。这样能覆盖同版本不同平台的实际 hash 漂移检测，也避免 Int32/Int64 等值场景只看 hash 输出时不可区分的问题。
+- Initial snapshot 现在也会优先尝试 Bloom，而不再只等 gRPC update。这个决策牺牲了对“不认识 `JoinHashBloom` JSON variant 的老 DN”的滚动兼容；如果需要跨版本滚动升级，后续必须加 capability/version gate 或回退到 Datafusion-only initial snapshot。
+- gRPC update 采用“双写”：`typed_payload` 放完整 `DynFilterPayload`，deprecated legacy `payload` 继续放非空 Datafusion fallback。这样新 DN 优先读 typed，老 DN 忽略未知 tag 5 后仍能读 legacy bytes。
+- fanout 编码一开始误用过 `current.children()`；这是错的，因为当前表达式的 children 不是注册 children。Bloom 编码必须用 `DynamicFilterPhysicalExpr::children()` 的注册 children，否则 `join_key_child_indices` 映射会失败或退回 Datafusion。
+- fanout 的 generation watermark 改成“编码成功后再前进”；否则 Bloom/fallback 编码失败会跳过该 generation。为了避免 reconcile tick 对已发送 generation 反复做 Bloom 编码，又加了只读预检。
+- DN pending/runtime 状态从裸 `Vec<u8>` 改为保存 `DynFilterPayload`，runtime 显式保存注册 children，并统一走 `decode_expr_with_registered_children(...)`。这比从 runtime filter 现取 children 更清楚，也能支持 buffered Bloom snapshot/update。
+- `JoinHashBloomPayload::try_build_from_hashes(...)` 是安全构建入口；当前还保留了原始 `build_from_hashes(...)`，后续可以考虑改成私有或仅测试使用。
+- 集成测试里不能用小 build-side 数据来证明 Bloom 链路：DataFusion 默认会先生成 `InListExpr`（`IN (SET)`），不会经过 `HashTableLookupExpr`。Bloom FE→DN E2E 需要让 distinct key 数超过 `hash_join_inlist_pushdown_max_distinct_values`，并且用稀疏整数 key 避免 `ArrayMap`，这样才会走 `HashMap` lookup → `JoinHashBloom` typed payload → DN `bloom_probe`。
+- 现在的 FE→DN 集成测试证明的是 `JoinHashBloom` typed payload 能到 DN 并安装进 region `SeqScan` 的 `dyn_filters`，不是证明 Mito scan 已经逐行执行 Bloom。代码路径里 scan 只接受 `DynamicFilterPhysicalExpr` 包装并保存到 `Predicate::dyn_filters`；SST/memtable 侧主要把它交给 `PruningPredicate` 做统计剪枝。自定义 `bloom_probe` 对 `PruningPredicate` 来说是 unsupported，通常会被当成 `true` 保守跳过，剩下的 residual bounds 仍可用于剪枝。若要让 Bloom 在 DN 侧真正减少返回行，还需要在 scan/prefilter 路径增加对 dynamic filter current expr 的 batch-level evaluation。
+
+### 当前限制和后续注意事项
+
+- FE/DN wiring 阶段应优先使用 `from_datafusion_expr_with_registered_children(...)`。旧的 `from_datafusion_expr(...)` 仍会在表达式树内直接替换 `HashTableLookupExpr`，不适合任意包含 lookup 的非单调表达式。
+- Bloom sizing 当前是保守常量策略，不是最终 false-positive-rate 调优方案。
+- `compute_bloom_sizing(...)` 在某些 shrink-to-fit 情况下可能先给出超过硬上限的大小，再由 `try_build_from_hashes(...)` 回退；这是安全的，但后续可以简化。
+- 已补一个 FE→DN Bloom typed payload 集成测试，通过 `EXPLAIN ANALYZE VERBOSE` 中 region `SeqScan` 的 `dyn_filters` 包含 `bloom_probe` 验证 payload 安装链路。后续还需要补 Mito scan batch-level Bloom evaluation、多列、null key、typed payload 权威优先级、跨 FE/DN schema 对齐等测试。
+- 当前 fingerprint 只是 guardrail，不是跨版本稳定 hash 协议；它只检测规范样本上真实发生的本地 `HashExpr` 漂移。未覆盖值域（例如更多 null/NaN/复杂类型）仍可能需要后续扩展。
+- Fingerprint 规范 batch 覆盖常见标量 key 类型；unsupported key 类型会触发 encoder fallback 或 decoder residual-only。nullable 的 unsupported 非 key schema 列用 typed null array 填充，避免无关列禁用 Bloom。
+- `RemoteDynFilterUpdate.payload` 现在在 proto 里标了 deprecated，但过渡期仍必须写；因此 query/datanode 编译会出现 deprecated field warning，这是预期的兼容性代价，不应现在删除 legacy bytes。
+- 本地 target 盘一度打满；清理了当前 worktree 的 Rust incremental build cache 后，datanode targeted tests 才能链接运行。
+- 本阶段验证因为本地 path patch 会触发 `Cargo.lock` 归一化；验证后已回滚 `Cargo.lock`。`.cargo/config.toml` 仍是本地 scaffolding，不应提交。
+- DataFusion 依赖 lane 也新增了 `HashTableLookupExpr::distinct_join_hash_count()`；最终集成时需要确保 GreptimeDB 指向包含该 API 的 DataFusion commit。
+
+### 已验证命令
+
+- `cargo fmt --all -- --check`
+- `cargo check -p common-query --offline`
+- `cargo test -p common-query request --lib --offline`（最近一次 87 passed, 10 filtered）
+- `cargo test -p query remote_dyn_filter --lib --offline`（最近一次 46 passed, 415 filtered）
+- `cargo test -p datanode remote_dyn_filter --lib --offline`（最近一次 29 passed, 76 filtered）
+- `cargo check -p datanode --offline`（通过，仅依赖/legacy payload deprecation warnings）
+- `cargo test -p common-query dyn_filter --lib --offline`
+- DataFusion lane: `cargo test -p datafusion-physical-plan test_visit_distinct_join_hashes_hash_map --lib`
+- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test -p tests-integration test_remote_dyn_filter_bloom_typed_payload_e2e --lib -- --nocapture`（1 passed, 186 filtered）
+
+## 第 2 阶段修正备注
+
+### 和前一版预期不同的实现点
+
+- 旧备注里“集成测试通过 `SeqScan` 的 `dyn_filters` 包含 `bloom_probe` 验证链路”的判断已经不再适用。现在 Bloom exact 部分刻意不下推到 scan，而是通过 `non_pushdown(...)` 包装留在 DN 的 `FilterExec`；`SeqScan` 最多只接收 residual/no-op 的 `DynamicFilterPhysicalExpr` 作为统计剪枝提示。
+- DN 侧每个注册的 remote filter id 会创建两个运行时 wrapper：一个可下推的 pushdown wrapper，另一个 exact wrapper。即使初始 payload 是 `lit(true)` 或普通 Datafusion payload，也要保留 exact wrapper；否则后续 gRPC 更新变成 Bloom 时，计划里没有位置能执行行级过滤。
+- invalid update 不再做“防御性 fail-open 更新”。oversized payload、typed payload 解码失败且无 legacy fallback、payload 解码失败、`DynamicFilterPhysicalExpr::update(...)` 失败，都不修改现有 runtime filter，也不推进 generation。只有成功解码并接受的新 payload 才能更新 pushdown/exact 两个 wrapper。
+- `exact = lit(true)` 只表示“当前这个有效 payload 没有可执行的 exact Bloom 部分”，例如普通 Datafusion payload，或 Bloom payload 的 fingerprint 为空、不匹配、重算失败。它不是 invalid update 的替代状态。
+- `DynamicFilterPhysicalExpr::update(...)` 的两步更新理论上不是完全事务化：如果 pushdown 更新成功但 exact 更新失败，generation 不推进但 pushdown 已经变更。当前按用户选择不加 rollback 防御，因为该失败对本路径构造出的表达式基本不可达；继续加补偿逻辑反而会扩大复杂度。
+- 同 generation 的 `is_complete=true` 更新也必须先完成 payload 校验和解码，才能把 pushdown/exact wrapper 标记 complete。否则一个坏 payload 虽然不推进 generation，也可能提前关闭 runtime filter，和“invalid update 不改状态”的语义冲突。
+
+### 当前限制和后续注意事项
+
+- 现在的 Bloom 集成测试除计划形态外，还会解析 `EXPLAIN ANALYZE VERBOSE` 指标，要求至少一个带 `bloom_probe` 的 `non_pushdown` `FilterExec` 的 `output_rows` 小于其子 `SeqScan`，从而证明 Bloom exact 过滤发生在 scan 之外。
+- 这个 E2E 仍受异步 gRPC update 时序影响。当前 fixture 保持 build 侧 302 个 key（刚好超过 in-list 阈值、编码较快），把 probe 侧放大到 8192 个稀疏 SST key 并跨分区分布，让 Bloom update 有时间在 probe scan 完成前到达；不要简单增大 build 侧，否则反而可能延迟 Bloom 生成。
+
+### 本次补充验证命令
+
+- `cargo fmt --all -- --check`
+- `git diff --check`
+- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test -p datanode registrations --lib --offline`（最近一次 11 passed, 102 filtered）
+- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test -p datanode remote_dyn_filter --lib --offline`（最近一次 29 passed, 84 filtered）
+- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test -p common-query request --lib --offline`（最近一次 87 passed, 10 filtered）
+- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test -p query remote_dyn_filter --lib --offline`（最近一次 46 passed, 415 filtered）
+- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test -p tests-integration test_remote_dyn_filter_bloom_typed_payload_e2e --lib -- --nocapture`（最近一次 1 passed, 186 filtered）

--- a/src/client/src/region.rs
+++ b/src/client/src/region.rs
@@ -435,6 +435,7 @@ mod test {
                 payload: vec![1, 2, 3],
                 generation: 7,
                 is_complete: false,
+                typed_payload: None,
             },
         );
 

--- a/src/client/src/region.rs
+++ b/src/client/src/region.rs
@@ -427,6 +427,7 @@ mod test {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_build_remote_dyn_filter_request_sets_header_and_body() {
         let request = build_remote_dyn_filter_update_request(
             "query-1",

--- a/src/common/query/src/request.rs
+++ b/src/common/query/src/request.rs
@@ -14,17 +14,18 @@
 
 mod base64_serde;
 mod initial_remote_dyn_filter_reg;
+mod join_hash_bloom;
 
 use std::sync::Arc;
 
 use api::v1::region::RegionRequestHeader;
 use datafusion::execution::TaskContext;
-use datafusion::physical_expr::expressions::{Column, InListExpr, lit};
+use datafusion::physical_expr::expressions::{BinaryExpr, Column, InListExpr, lit};
 use datafusion::physical_plan::PhysicalExpr;
 use datafusion::physical_plan::joins::HashTableLookupExpr;
 use datafusion_common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
 use datafusion_common::{DataFusionError, Result as DataFusionResult};
-use datafusion_expr::LogicalPlan;
+use datafusion_expr::{LogicalPlan, Operator};
 use datafusion_proto::physical_plan::DefaultPhysicalExtensionCodec;
 use datafusion_proto::physical_plan::from_proto::parse_physical_expr;
 use datafusion_proto::physical_plan::to_proto::serialize_physical_expr;
@@ -39,6 +40,12 @@ pub use self::initial_remote_dyn_filter_reg::{
     INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY,
     INITIAL_REMOTE_DYN_FILTER_REGS_MAX_TOTAL_PROTO_BYTES, InitialDynFilterReg,
     InitialDynFilterRegs, InitialDynFilterSnapshot,
+};
+pub use self::join_hash_bloom::{
+    BLOOM_ENCODER_BITS_PER_HASH, BLOOM_ENCODER_MAX_NUM_BITS_BUDGET, BLOOM_ENCODER_MIN_NUM_BITS,
+    BLOOM_ENCODER_NUM_PROBES, BLOOM_PROTO_ENVELOPE_OVERHEAD_ESTIMATE, BloomHashAlgorithm,
+    JOIN_HASH_BLOOM_VERSION, JoinHashBloomPayload, JoinHashBloomProbeExpr, JoinHashKind,
+    MAX_BLOOM_NUM_PROBES, MAX_BLOOM_RESIDUAL_BYTES,
 };
 use crate::error::{DynFilterPayloadTooLargeSnafu, Error as CommonQueryError};
 
@@ -60,9 +67,19 @@ pub enum DynFilterPayload {
     /// A serialized DataFusion [`PhysicalExpr`] encoded as a protobuf
     /// [`PhysicalExprNode`].
     Datafusion(#[serde(with = "base64_serde::bytes")] Vec<u8>),
+    /// A join-hash Bloom filter over DataFusion `u64` join hashes.
+    JoinHashBloom(JoinHashBloomPayload),
 }
 
 impl DynFilterPayload {
+    /// Validates payload-level invariants that can be checked without a receiver schema.
+    pub fn validate(&self) -> DataFusionResult<()> {
+        match self {
+            Self::Datafusion(_) => Ok(()),
+            Self::JoinHashBloom(bloom) => bloom.validate(),
+        }
+    }
+
     /// Encodes a DataFusion physical expression into a bounded dynamic filter payload.
     ///
     /// Runtime-only hash lookup predicates are degraded to `true` before encoding so
@@ -84,6 +101,39 @@ impl DynFilterPayload {
         }
     }
 
+    /// Encodes a DataFusion physical expression into a bounded dynamic filter payload
+    /// with registered children context, attempting Bloom conversion for eligible
+    /// `HashTableLookupExpr` conjuncts.
+    ///
+    /// When the expression is a flattened AND conjunction containing exactly one
+    /// `HashTableLookupExpr` as a positive conjunct, the encoder attempts to build a
+    /// Bloom payload with a hash-compat fingerprint.  If Bloom conversion is infeasible
+    /// (ArrayMap, child mismatch, budget exceeded, unsupported structure, fingerprint error),
+    /// it falls back to a fail-open `Datafusion` payload that drops unsafe lookup-containing
+    /// conjuncts rather than replacing nested lookups in-place.
+    pub fn from_datafusion_expr_with_registered_children(
+        expr: &Arc<dyn PhysicalExpr>,
+        registered_children: &[Arc<dyn PhysicalExpr>],
+        max_payload_bytes: usize,
+        input_schema: &datafusion::arrow::datatypes::Schema,
+    ) -> DataFusionResult<Self> {
+        match try_encode_bloom_payload(expr, registered_children, max_payload_bytes, input_schema) {
+            Ok(bloom) => Ok(Self::JoinHashBloom(bloom)),
+            Err(_fallback) => {
+                encode_fail_open_remote_dyn_filter_expr(expr, max_payload_bytes, false)
+                    .map(Self::Datafusion)
+                    .or_else(|error| match error {
+                        CommonQueryError::DynFilterPayloadTooLarge { .. } => {
+                            encode_fail_open_remote_dyn_filter_expr(expr, max_payload_bytes, true)
+                                .map(Self::Datafusion)
+                        }
+                        error => Err(error),
+                    })
+                    .map_err(DataFusionError::from)
+            }
+        }
+    }
+
     /// Decodes a DataFusion dynamic filter payload against the provided input schema.
     ///
     /// The decoded expression is validated to ensure column indexes stay within the receiver-side
@@ -95,7 +145,12 @@ impl DynFilterPayload {
         input_schema: &datafusion::arrow::datatypes::Schema,
         max_payload_bytes: usize,
     ) -> DataFusionResult<Arc<dyn PhysicalExpr>> {
-        let Self::Datafusion(bytes) = self;
+        let Self::Datafusion(bytes) = self else {
+            return Err(DataFusionError::Plan(
+                "DynFilterPayload::decode_datafusion_expr called on non-Datafusion payload"
+                    .to_string(),
+            ));
+        };
         validate_payload_size(bytes.len(), max_payload_bytes).map_err(DataFusionError::from)?;
         let codec = DefaultPhysicalExtensionCodec {};
         let proto = PhysicalExprNode::decode(bytes.as_slice()).map_err(|e| {
@@ -106,6 +161,171 @@ impl DynFilterPayload {
         validate_supported_payload_expr(&expr)?;
         validate_decoded_payload_expr(&expr, input_schema)?;
         Ok(expr)
+    }
+
+    /// Decodes this payload into a DataFusion physical expression using
+    /// the registered dynamic-filter children for context.
+    ///
+    /// - `Datafusion` variant delegates to [`Self::decode_datafusion_expr`].
+    /// - `JoinHashBloom` variant validates payload budget, checks join key child index
+    ///   range, recomputes the hash-compat fingerprint, and returns
+    ///   `residual_expr AND JoinHashBloomProbeExpr` only when fingerprints match.
+    ///   If the fingerprint is zero (not computed), cannot be recomputed, or mismatches, returns
+    ///   residual-only fail-open.
+    pub fn decode_expr_with_registered_children(
+        &self,
+        task_ctx: &TaskContext,
+        input_schema: &datafusion::arrow::datatypes::Schema,
+        registered_children: &[Arc<dyn PhysicalExpr>],
+        max_payload_bytes: usize,
+    ) -> DataFusionResult<Arc<dyn PhysicalExpr>> {
+        match self {
+            Self::Datafusion(_) => {
+                self.decode_datafusion_expr(task_ctx, input_schema, max_payload_bytes)
+            }
+            Self::JoinHashBloom(bloom) => {
+                bloom.validate()?;
+
+                // Validate the encoded proto budget
+                let encoded_bytes = self.encoded_payload_bytes();
+                validate_payload_size(encoded_bytes, max_payload_bytes)
+                    .map_err(DataFusionError::from)?;
+
+                // Validate join key child indices are in range
+                let num_registered = registered_children.len();
+                for &child_index in &bloom.join_key_child_indices {
+                    if child_index as usize >= num_registered {
+                        return Err(DataFusionError::Plan(format!(
+                            "JoinHashBloomPayload: join key child index {} out of range (registered children: {})",
+                            child_index, num_registered
+                        )));
+                    }
+                }
+
+                // Decode residual DataFusion expression
+                let residual_expr = decode_physical_expr_from_bytes(
+                    &bloom.residual_datafusion_physical_expr,
+                    task_ctx,
+                    input_schema,
+                    max_payload_bytes,
+                )?;
+
+                // Ensure residual is Boolean-typed
+                let residual_dt = residual_expr.data_type(input_schema)?;
+                if residual_dt != datafusion::arrow::datatypes::DataType::Boolean {
+                    return Err(DataFusionError::Plan(format!(
+                        "JoinHashBloomPayload: residual expression has type {:?}, expected Boolean",
+                        residual_dt
+                    )));
+                }
+
+                // Select probe children from registered_children by join-key child index
+                let probe_children: Vec<Arc<dyn PhysicalExpr>> = bloom
+                    .join_key_child_indices
+                    .iter()
+                    .map(|&child_index| Arc::clone(&registered_children[child_index as usize]))
+                    .collect();
+
+                // Recompute hash compat fingerprint for cross-platform drift detection.
+                // A missing/zero fingerprint, mismatch, or recompute error must fail open
+                // to residual-only rather than risk Bloom false negatives.
+                if bloom.hash_compat_fingerprint == 0 {
+                    return Ok(residual_expr);
+                }
+                match crate::request::join_hash_bloom::compute_hash_compat_fingerprint(
+                    &probe_children,
+                    input_schema,
+                    (
+                        bloom.df_seed0,
+                        bloom.df_seed1,
+                        bloom.df_seed2,
+                        bloom.df_seed3,
+                    ),
+                ) {
+                    Ok(local_fp) if local_fp == bloom.hash_compat_fingerprint => {
+                        // Fingerprint matches — construct probe expression below.
+                    }
+                    _ => {
+                        // Fingerprint mismatch or recompute error — fail open.
+                        return Ok(residual_expr);
+                    }
+                }
+
+                let probe_expr = Arc::new(JoinHashBloomProbeExpr::try_new(
+                    probe_children,
+                    Arc::new(bloom.clone()),
+                )?) as Arc<dyn PhysicalExpr>;
+
+                // Return residual AND probe
+                Ok(Arc::new(BinaryExpr::new(
+                    residual_expr,
+                    Operator::And,
+                    probe_expr,
+                )))
+            }
+        }
+    }
+
+    /// Returns the proto-encoded byte size of this payload for budget tracking.
+    ///
+    /// - `Datafusion`: length of the raw protobuf bytes.
+    /// - `JoinHashBloom`: `encoded_len()` of the whole typed
+    ///   `RemoteDynFilterPayload` proto that carries the Bloom payload,
+    ///   conservatively computed by converting to proto and measuring.
+    pub fn encoded_payload_bytes(&self) -> usize {
+        match self {
+            Self::Datafusion(bytes) => bytes.len(),
+            Self::JoinHashBloom(_bloom) => {
+                use prost::Message;
+                let proto = self.to_region_proto_payload();
+                proto.encoded_len()
+            }
+        }
+    }
+
+    /// Converts this payload to the corresponding gRPC
+    /// `RemoteDynFilterPayload` proto.
+    pub fn to_region_proto_payload(&self) -> api::v1::region::RemoteDynFilterPayload {
+        match self {
+            Self::Datafusion(bytes) => api::v1::region::RemoteDynFilterPayload {
+                kind: Some(
+                    api::v1::region::remote_dyn_filter_payload::Kind::DatafusionPhysicalExpr(
+                        bytes.clone(),
+                    ),
+                ),
+            },
+            Self::JoinHashBloom(bloom) => api::v1::region::RemoteDynFilterPayload {
+                kind: Some(
+                    api::v1::region::remote_dyn_filter_payload::Kind::JoinHashBloom(
+                        bloom.to_proto(),
+                    ),
+                ),
+            },
+        }
+    }
+
+    /// Constructs a `DynFilterPayload` from a gRPC
+    /// `RemoteDynFilterPayload` proto.
+    ///
+    /// Rejects missing `kind` and unknown / unspecified enum values
+    /// (hash kind / bloom algorithm) via the payload's own validation.
+    pub fn from_region_proto_payload(
+        payload: api::v1::region::RemoteDynFilterPayload,
+    ) -> DataFusionResult<Self> {
+        let kind = payload.kind.ok_or_else(|| {
+            DataFusionError::Plan("RemoteDynFilterPayload::kind is missing".to_string())
+        })?;
+
+        match kind {
+            api::v1::region::remote_dyn_filter_payload::Kind::DatafusionPhysicalExpr(bytes) => {
+                Ok(Self::Datafusion(bytes))
+            }
+            api::v1::region::remote_dyn_filter_payload::Kind::JoinHashBloom(bloom) => {
+                let model = JoinHashBloomPayload::from_proto(&bloom)?;
+                model.validate()?;
+                Ok(Self::JoinHashBloom(model))
+            }
+        }
     }
 }
 
@@ -131,6 +351,18 @@ fn encode_remote_dyn_filter_expr(
     Ok(bytes)
 }
 
+fn encode_fail_open_remote_dyn_filter_expr(
+    expr: &Arc<dyn PhysicalExpr>,
+    max_payload_bytes: usize,
+    bounds_only: bool,
+) -> Result<Vec<u8>, CommonQueryError> {
+    let expr = fail_open_remote_dyn_filter_expr(Arc::clone(expr), bounds_only)
+        .map_err(CommonQueryError::from)?;
+    let bytes = encode_physical_expr_to_bytes(&expr).map_err(CommonQueryError::from)?;
+    validate_payload_size(bytes.len(), max_payload_bytes)?;
+    Ok(bytes)
+}
+
 fn portable_remote_dyn_filter_expr(
     expr: Arc<dyn PhysicalExpr>,
     bounds_only: bool,
@@ -145,6 +377,269 @@ fn portable_remote_dyn_filter_expr(
         }
     })
     .map(|transformed| transformed.data)
+}
+
+/// Builds a fail-open DataFusion fallback expression for the registered-children
+/// encoder path.
+///
+/// Unlike [`portable_remote_dyn_filter_expr`], this does **not** replace nested
+/// `HashTableLookupExpr` nodes in-place. Replacing a lookup under non-monotone
+/// contexts such as `NOT(lookup)` would turn the subtree into `false` and could
+/// create false negatives. Instead, any top-level AND conjunct containing a
+/// lookup is dropped entirely; if the whole expression is unsafe, the fallback
+/// is `lit(true)`.
+fn fail_open_remote_dyn_filter_expr(
+    expr: Arc<dyn PhysicalExpr>,
+    bounds_only: bool,
+) -> DataFusionResult<Arc<dyn PhysicalExpr>> {
+    let conjuncts = flatten_and_conjuncts(&expr);
+    let mut saw_lookup = false;
+    let mut safe_conjuncts = Vec::with_capacity(conjuncts.len());
+
+    for conjunct in conjuncts {
+        if contains_hashtable_lookup(&conjunct) {
+            saw_lookup = true;
+            continue;
+        }
+
+        let conjunct = if bounds_only {
+            portable_remote_dyn_filter_expr(conjunct, true)?
+        } else {
+            conjunct
+        };
+        safe_conjuncts.push(conjunct);
+    }
+
+    if !saw_lookup {
+        return portable_remote_dyn_filter_expr(expr, bounds_only);
+    }
+
+    Ok(rebuild_and_conjuncts(safe_conjuncts))
+}
+
+fn rebuild_and_conjuncts(mut conjuncts: Vec<Arc<dyn PhysicalExpr>>) -> Arc<dyn PhysicalExpr> {
+    let Some(first) = conjuncts.pop() else {
+        return lit(true);
+    };
+
+    conjuncts.into_iter().rev().fold(first, |right, left| {
+        Arc::new(BinaryExpr::new(left, Operator::And, right)) as Arc<dyn PhysicalExpr>
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Bloom encoder helpers
+// ---------------------------------------------------------------------------
+
+/// Flattens a physical expression that is a top-level chain of AND
+/// (`BinaryExpr` with `Operator::And`) into a vector of conjuncts.
+fn flatten_and_conjuncts(expr: &Arc<dyn PhysicalExpr>) -> Vec<Arc<dyn PhysicalExpr>> {
+    let mut conjuncts = Vec::new();
+    let mut stack = vec![Arc::clone(expr)];
+    while let Some(node) = stack.pop() {
+        if let Some(and) = node.as_any().downcast_ref::<BinaryExpr>() {
+            if *and.op() == Operator::And {
+                stack.push(Arc::clone(and.right()));
+                stack.push(Arc::clone(and.left()));
+                continue;
+            }
+        }
+        conjuncts.push(node);
+    }
+    conjuncts
+}
+
+/// Returns the single `HashTableLookupExpr` that is a direct AND conjunct, if
+/// exactly one exists and every other conjunct is lookup-free.
+fn extract_safe_single_lookup(conjuncts: &[Arc<dyn PhysicalExpr>]) -> Option<usize> {
+    let mut lookup_idx: Option<usize> = None;
+    for (i, conj) in conjuncts.iter().enumerate() {
+        if conj.as_any().is::<HashTableLookupExpr>() {
+            if lookup_idx.is_some() {
+                return None;
+            }
+            lookup_idx = Some(i);
+            continue;
+        }
+        if contains_hashtable_lookup(conj) {
+            return None;
+        }
+    }
+    lookup_idx
+}
+
+fn contains_hashtable_lookup(expr: &Arc<dyn PhysicalExpr>) -> bool {
+    let mut found = false;
+    let apply_result = expr.apply(|node| {
+        if node.as_any().is::<HashTableLookupExpr>() {
+            found = true;
+            Ok(TreeNodeRecursion::Stop)
+        } else {
+            Ok(TreeNodeRecursion::Continue)
+        }
+    });
+    apply_result.is_err() || found
+}
+
+fn map_on_columns_to_join_key_child_indices(
+    lookup: &HashTableLookupExpr,
+    registered_children: &[Arc<dyn PhysicalExpr>],
+) -> Option<Vec<u32>> {
+    let on_columns = lookup.on_columns();
+    let mut join_key_child_indices = Vec::with_capacity(on_columns.len());
+    for on_col in on_columns {
+        let mut found = None;
+        for (idx, reg_child) in registered_children.iter().enumerate() {
+            if on_col == reg_child {
+                if found.is_some() {
+                    return None;
+                }
+                found = Some(idx as u32);
+            }
+        }
+        match found {
+            Some(child_index) => join_key_child_indices.push(child_index),
+            None => return None,
+        }
+    }
+    let mut seen = std::collections::HashSet::with_capacity(join_key_child_indices.len());
+    for &child_index in &join_key_child_indices {
+        if !seen.insert(child_index) {
+            return None;
+        }
+    }
+    Some(join_key_child_indices)
+}
+
+fn build_residual_expr(
+    original_expr: &Arc<dyn PhysicalExpr>,
+    lookup_conjunct: &Arc<dyn PhysicalExpr>,
+) -> DataFusionResult<Arc<dyn PhysicalExpr>> {
+    if Arc::ptr_eq(original_expr, lookup_conjunct) {
+        return Ok(lit(true));
+    }
+    original_expr
+        .clone()
+        .transform_up(|node| {
+            if Arc::ptr_eq(&node, lookup_conjunct) || node.as_any().is::<HashTableLookupExpr>() {
+                Ok(Transformed::yes(lit(true)))
+            } else {
+                Ok(Transformed::no(node))
+            }
+        })
+        .map(|t| t.data)
+}
+
+fn try_encode_bloom_payload(
+    expr: &Arc<dyn PhysicalExpr>,
+    registered_children: &[Arc<dyn PhysicalExpr>],
+    max_payload_bytes: usize,
+    input_schema: &datafusion::arrow::datatypes::Schema,
+) -> DataFusionResult<JoinHashBloomPayload> {
+    // 1. Flatten AND conjuncts
+    let conjuncts = flatten_and_conjuncts(expr);
+
+    // 2. Extract exactly one safe HashTableLookupExpr conjunct index
+    let Some(lookup_idx) = extract_safe_single_lookup(&conjuncts) else {
+        return Err(DataFusionError::Plan(
+            "Bloom encoder: no single safe HashTableLookupExpr conjunct".to_string(),
+        ));
+    };
+
+    let lookup_dyn = Arc::clone(&conjuncts[lookup_idx]);
+    let lookup = lookup_dyn
+        .as_any()
+        .downcast_ref::<HashTableLookupExpr>()
+        .expect("already checked above");
+
+    // 3. Map on_columns to join key child indices
+    let Some(join_key_child_indices) =
+        map_on_columns_to_join_key_child_indices(lookup, registered_children)
+    else {
+        return Err(DataFusionError::Plan(
+            "Bloom encoder: cannot map on_columns to registered children".to_string(),
+        ));
+    };
+
+    // 3.5 Compute hash compat fingerprint using the selected probe children
+    let seeds = lookup.seeds();
+    let probe_children: Vec<Arc<dyn PhysicalExpr>> = join_key_child_indices
+        .iter()
+        .map(|&child_index| Arc::clone(&registered_children[child_index as usize]))
+        .collect();
+    let hash_compat_fingerprint = crate::request::join_hash_bloom::compute_hash_compat_fingerprint(
+        &probe_children,
+        input_schema,
+        seeds,
+    )
+    .map_err(|e| {
+        DataFusionError::Plan(format!(
+            "Bloom encoder: cannot compute hash compat fingerprint: {e}"
+        ))
+    })?;
+
+    // 4. Get distinct hash count
+    let distinct_count = lookup.distinct_join_hash_count().ok_or_else(|| {
+        DataFusionError::Plan(
+            "Bloom encoder: HashTableLookupExpr uses ArrayMap, falling back".to_string(),
+        )
+    })? as u64;
+
+    // 5. Build residual expression
+    let residual_expr = build_residual_expr(expr, &lookup_dyn)?;
+    let residual_bytes = encode_physical_expr_to_bytes(&residual_expr)?;
+
+    // 6. Compute Bloom sizing
+    let Some((num_bits, num_probes)) = JoinHashBloomPayload::compute_bloom_sizing(
+        distinct_count,
+        residual_bytes.len(),
+        max_payload_bytes,
+    ) else {
+        return Err(DataFusionError::Plan(
+            "Bloom encoder: payload budget too small for Bloom".to_string(),
+        ));
+    };
+
+    // 7. Build the Bloom payload
+    let mut payload = JoinHashBloomPayload::try_build_from_hashes(
+        std::iter::empty(),
+        num_bits,
+        num_probes,
+        seeds,
+        join_key_child_indices,
+        residual_bytes,
+    )?;
+
+    let mut inserted_count = 0u64;
+    let ok = lookup.visit_distinct_join_hashes(&mut |h| {
+        payload.insert_join_hash(h);
+        inserted_count = inserted_count.saturating_add(1);
+    })?;
+    if !ok {
+        return Err(DataFusionError::Plan(
+            "Bloom encoder: HashTableLookupExpr uses ArrayMap, falling back".to_string(),
+        ));
+    }
+    if inserted_count != distinct_count {
+        return Err(DataFusionError::Plan(format!(
+            "Bloom encoder: distinct hash count changed during encoding (counted {}, inserted {})",
+            distinct_count, inserted_count
+        )));
+    }
+    payload.distinct_hash_count = inserted_count;
+    payload.hash_compat_fingerprint = hash_compat_fingerprint;
+    payload.validate()?;
+
+    // 8. Final budget check
+    let encoded_len = DynFilterPayload::JoinHashBloom(payload.clone()).encoded_payload_bytes();
+    if encoded_len > max_payload_bytes {
+        return Err(DataFusionError::Plan(format!(
+            "Bloom encoder: final proto encoded payload {} bytes exceeds budget {}",
+            encoded_len, max_payload_bytes
+        )));
+    }
+
+    Ok(payload)
 }
 
 pub(crate) fn decode_physical_expr_from_bytes(
@@ -196,11 +691,6 @@ fn validate_supported_payload_expr(expr: &Arc<dyn PhysicalExpr>) -> DataFusionRe
 }
 
 /// Validates decoded dynamic filter physical expressions against the receiver-side schema.
-///
-/// Rejects out-of-bounds column indexes and, as a defensive check, rejects columns whose
-/// name disagrees with the corresponding schema field. DataFusion physical `Column` is
-/// index-authoritative, so a name mismatch usually indicates a coordinator/receiver
-/// schema inconsistency that should be surfaced loudly.
 fn validate_decoded_payload_expr(
     expr: &Arc<dyn PhysicalExpr>,
     input_schema: &datafusion::arrow::datatypes::Schema,
@@ -233,28 +723,17 @@ fn validate_decoded_payload_expr(
 }
 
 /// A remote dynamic filter update sent from a query coordinator to region servers.
-///
-/// `generation` is monotonic within a `query_id`/`filter_id` pair and matches the
-/// gRPC field name used by `RemoteDynFilterUpdate`. Receivers use it to ignore
-/// stale updates while `is_complete` marks the final payload for the filter.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DynFilterUpdate {
-    /// Protocol version used by this update payload.
     pub protocol_version: u32,
-    /// Internal query identifier that owns this dynamic filter lifecycle.
     pub query_id: String,
-    /// Identifier of the dynamic filter within the query.
     pub filter_id: String,
-    /// Monotonic update generation for this filter.
     pub generation: u64,
-    /// Whether this update completes the dynamic filter stream.
     pub is_complete: bool,
-    /// Serialized predicate payload carried by this update.
     pub payload: DynFilterPayload,
 }
 
 impl DynFilterUpdate {
-    /// Creates a dynamic filter update with the current protocol version.
     pub fn new(
         query_id: String,
         filter_id: String,
@@ -276,13 +755,8 @@ impl DynFilterUpdate {
 /// The query request to be handled by the RegionServer (Datanode).
 #[derive(Clone, Debug)]
 pub struct QueryRequest {
-    /// The header of this request. Often to store some context of the query. None means all to defaults.
     pub header: Option<RegionRequestHeader>,
-
-    /// The id of the region to be queried.
     pub region_id: RegionId,
-
-    /// The form of the query: a logical plan.
     pub plan: LogicalPlan,
 }
 
@@ -292,14 +766,31 @@ mod tests {
 
     use base64::Engine;
     use base64::prelude::BASE64_STANDARD;
+    use datafusion::arrow::array::{BooleanArray, Int32Array};
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
-    use datafusion::physical_expr::expressions::{BinaryExpr, Column, InListExpr, lit};
+    use datafusion::arrow::record_batch::RecordBatch;
+    use datafusion::physical_expr::expressions::{BinaryExpr, Column, InListExpr, NotExpr, lit};
     use datafusion::physical_plan::expressions::col;
-    use datafusion::physical_plan::joins::join_hash_map::JoinHashMapU32;
+    use datafusion::physical_plan::joins::join_hash_map::{JoinHashMapType, JoinHashMapU32};
     use datafusion::physical_plan::joins::{HashTableLookupExpr, Map, SeededRandomState};
+    use datafusion_common::DataFusionError;
     use datafusion_expr::Operator;
 
     use super::*;
+
+    fn make_lookup_expr(col: Arc<dyn PhysicalExpr>, hashes: Vec<u64>) -> Arc<dyn PhysicalExpr> {
+        let mut hash_map = JoinHashMapU32::with_capacity(hashes.len().max(1));
+        hash_map.update_from_iter(Box::new(hashes.iter().enumerate()), 0);
+        let map = Arc::new(Map::HashMap(Box::new(hash_map)));
+        Arc::new(HashTableLookupExpr::new(
+            vec![col],
+            SeededRandomState::with_seeds(1, 2, 3, 4),
+            map,
+            "lookup".to_string(),
+        ))
+    }
+
+    // ── Basic tests ──────────────────────────────────────────
 
     #[test]
     fn dyn_filter_update_sets_protocol_version() {
@@ -310,7 +801,6 @@ mod tests {
             false,
             DynFilterPayload::Datafusion(vec![1, 2, 3]),
         );
-
         assert_eq!(update.protocol_version, DYN_FILTER_PROTOCOL_VERSION);
         assert!(!update.is_complete);
         assert!(
@@ -536,6 +1026,662 @@ mod tests {
             error.downcast_ref::<CommonQueryError>(),
             Some(CommonQueryError::DynFilterPayloadTooLarge { .. })
         ));
+    }
+
+    // ── Encoder + decoder with fingerprint ───────────────────
+
+    #[test]
+    fn encoder_bounds_and_lookup_creates_bloom_with_nonzero_fingerprint() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("val", DataType::Float64, false),
+        ]));
+        let id_col = col("id", &schema).unwrap();
+        let val_col = col("val", &schema).unwrap();
+
+        let lower_bound: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            Arc::clone(&id_col),
+            Operator::GtEq,
+            lit(10i32),
+        ));
+        let lookup = make_lookup_expr(Arc::clone(&id_col), vec![10, 20, 30]);
+        let expr: Arc<dyn PhysicalExpr> =
+            Arc::new(BinaryExpr::new(lower_bound, Operator::And, lookup));
+
+        let registered: Vec<Arc<dyn PhysicalExpr>> =
+            vec![Arc::clone(&id_col), Arc::clone(&val_col)];
+
+        let payload = DynFilterPayload::from_datafusion_expr_with_registered_children(
+            &expr,
+            &registered,
+            4096,
+            &schema,
+        )
+        .unwrap();
+
+        match &payload {
+            DynFilterPayload::JoinHashBloom(bloom) => {
+                assert!(!bloom.residual_datafusion_physical_expr.is_empty());
+                assert_eq!(bloom.join_key_child_indices, vec![0]);
+                assert_eq!(bloom.distinct_hash_count, 3);
+                assert!(
+                    bloom.hash_compat_fingerprint != 0,
+                    "expected nonzero fingerprint, got {}",
+                    bloom.hash_compat_fingerprint
+                );
+                for &h in &[10u64, 20, 30] {
+                    assert!(bloom.contains_join_hash(h));
+                }
+            }
+            _ => panic!("expected JoinHashBloom, got {:?}", payload),
+        }
+    }
+
+    #[test]
+    fn encoder_lookup_only_creates_bloom_with_lit_true_residual() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let id_col = col("id", &schema).unwrap();
+
+        let lookup = make_lookup_expr(Arc::clone(&id_col), vec![42, 99]);
+        let expr: Arc<dyn PhysicalExpr> = lookup;
+
+        let registered: Vec<Arc<dyn PhysicalExpr>> = vec![Arc::clone(&id_col)];
+
+        let payload = DynFilterPayload::from_datafusion_expr_with_registered_children(
+            &expr,
+            &registered,
+            4096,
+            &schema,
+        )
+        .unwrap();
+
+        match payload {
+            DynFilterPayload::JoinHashBloom(bloom) => {
+                assert!(!bloom.residual_datafusion_physical_expr.is_empty());
+                assert_eq!(bloom.distinct_hash_count, 2);
+                assert_ne!(bloom.hash_compat_fingerprint, 0);
+            }
+            DynFilterPayload::Datafusion(_) => panic!("expected JoinHashBloom payload"),
+        }
+    }
+
+    #[test]
+    fn encoder_preserves_on_columns_order() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+            Field::new("c", DataType::Int32, false),
+        ]));
+        let col_a = col("a", &schema).unwrap();
+        let col_b = col("b", &schema).unwrap();
+        let col_c = col("c", &schema).unwrap();
+
+        let mut hash_map = JoinHashMapU32::with_capacity(10);
+        let hashes: Vec<u64> = vec![1, 2, 3];
+        hash_map.update_from_iter(Box::new(hashes.iter().enumerate()), 0);
+        let map = Arc::new(Map::HashMap(Box::new(hash_map)));
+        let lookup: Arc<dyn PhysicalExpr> = Arc::new(HashTableLookupExpr::new(
+            vec![Arc::clone(&col_a), Arc::clone(&col_c)],
+            SeededRandomState::with_seeds(0, 0, 0, 0),
+            map,
+            "lookup".to_string(),
+        ));
+
+        let residual_bound: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            Arc::clone(&col_b),
+            Operator::GtEq,
+            lit(0i32),
+        ));
+        let expr: Arc<dyn PhysicalExpr> =
+            Arc::new(BinaryExpr::new(residual_bound, Operator::And, lookup));
+
+        let registered: Vec<Arc<dyn PhysicalExpr>> =
+            vec![Arc::clone(&col_a), Arc::clone(&col_b), Arc::clone(&col_c)];
+
+        let payload = DynFilterPayload::from_datafusion_expr_with_registered_children(
+            &expr,
+            &registered,
+            4096,
+            &schema,
+        )
+        .unwrap();
+
+        match payload {
+            DynFilterPayload::JoinHashBloom(bloom) => {
+                assert_eq!(bloom.join_key_child_indices, vec![0, 2]);
+            }
+            DynFilterPayload::Datafusion(_) => panic!("expected JoinHashBloom payload"),
+        }
+    }
+
+    #[test]
+    fn decode_with_matching_fingerprint_uses_probe_expr() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let id_col = col("id", &schema).unwrap();
+        let lookup = make_lookup_expr(Arc::clone(&id_col), vec![10, 20, 30]);
+        let expr: Arc<dyn PhysicalExpr> = lookup;
+
+        let registered: Vec<Arc<dyn PhysicalExpr>> = vec![Arc::clone(&id_col)];
+
+        let payload = DynFilterPayload::from_datafusion_expr_with_registered_children(
+            &expr,
+            &registered,
+            4096,
+            &schema,
+        )
+        .unwrap();
+
+        let decoded = payload
+            .decode_expr_with_registered_children(
+                &TaskContext::default(),
+                &schema,
+                &registered,
+                4096,
+            )
+            .unwrap();
+
+        assert!(
+            contains_expr::<JoinHashBloomProbeExpr>(&decoded),
+            "expected bloom_probe in decoded expression, got: {}",
+            decoded
+        );
+    }
+
+    #[test]
+    fn decode_with_corrupted_fingerprint_returns_residual_only() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let id_col = col("id", &schema).unwrap();
+        let lookup = make_lookup_expr(Arc::clone(&id_col), vec![10, 20, 30]);
+        let expr: Arc<dyn PhysicalExpr> = lookup;
+
+        let registered: Vec<Arc<dyn PhysicalExpr>> = vec![Arc::clone(&id_col)];
+
+        let payload = DynFilterPayload::from_datafusion_expr_with_registered_children(
+            &expr,
+            &registered,
+            4096,
+            &schema,
+        )
+        .unwrap();
+
+        // Corrupt the fingerprint
+        let corrupted = match &payload {
+            DynFilterPayload::JoinHashBloom(bloom) => {
+                let mut b = bloom.clone();
+                b.hash_compat_fingerprint = b.hash_compat_fingerprint.wrapping_add(1);
+                DynFilterPayload::JoinHashBloom(b)
+            }
+            _ => panic!(),
+        };
+
+        let decoded = corrupted
+            .decode_expr_with_registered_children(
+                &TaskContext::default(),
+                &schema,
+                &registered,
+                4096,
+            )
+            .unwrap();
+
+        assert!(
+            !contains_expr::<JoinHashBloomProbeExpr>(&decoded),
+            "expected no bloom_probe after fingerprint corruption, got: {}",
+            decoded
+        );
+    }
+
+    #[test]
+    fn decode_with_zero_fingerprint_returns_residual_only() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let id_col: Arc<dyn PhysicalExpr> =
+            Arc::new(Column::new_with_schema("id", &schema).unwrap());
+        let registered: Vec<Arc<dyn PhysicalExpr>> = vec![Arc::clone(&id_col)];
+
+        // Manually construct a Bloom payload with zero fingerprint (old-format compatible)
+        let residual_bytes =
+            encode_physical_expr_to_bytes(&(lit(true) as Arc<dyn PhysicalExpr>)).unwrap();
+        let bloom = JoinHashBloomPayload::build_from_hashes(
+            vec![10u64, 20],
+            64,
+            2,
+            (0, 0, 0, 0),
+            vec![0],
+            residual_bytes,
+        );
+        let payload = DynFilterPayload::JoinHashBloom(bloom);
+        let decoded = payload
+            .decode_expr_with_registered_children(
+                &TaskContext::default(),
+                &schema,
+                &registered,
+                4096,
+            )
+            .unwrap();
+        assert!(
+            !contains_expr::<JoinHashBloomProbeExpr>(&decoded),
+            "zero fingerprint should fail open to residual-only, got: {}",
+            decoded
+        );
+    }
+
+    #[test]
+    fn decode_fingerprint_recompute_error_returns_residual_only() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "amount",
+            DataType::Decimal128(10, 2),
+            false,
+        )]));
+        let amount_col: Arc<dyn PhysicalExpr> =
+            Arc::new(Column::new_with_schema("amount", &schema).unwrap());
+        let registered: Vec<Arc<dyn PhysicalExpr>> = vec![Arc::clone(&amount_col)];
+
+        let residual_bytes =
+            encode_physical_expr_to_bytes(&(lit(true) as Arc<dyn PhysicalExpr>)).unwrap();
+        let mut bloom = JoinHashBloomPayload::build_from_hashes(
+            vec![10u64, 20],
+            64,
+            2,
+            (0, 0, 0, 0),
+            vec![0],
+            residual_bytes,
+        );
+        bloom.hash_compat_fingerprint = 42;
+
+        let decoded = DynFilterPayload::JoinHashBloom(bloom)
+            .decode_expr_with_registered_children(
+                &TaskContext::default(),
+                &schema,
+                &registered,
+                4096,
+            )
+            .unwrap();
+
+        assert!(
+            !contains_expr::<JoinHashBloomProbeExpr>(&decoded),
+            "fingerprint recompute error should fail open to residual-only, got: {}",
+            decoded
+        );
+    }
+
+    #[test]
+    fn encoder_allows_unsupported_non_key_schema_column_for_fingerprint() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("unused_decimal", DataType::Decimal128(10, 2), true),
+        ]));
+        let id_col = col("id", &schema).unwrap();
+        let lookup = make_lookup_expr(Arc::clone(&id_col), vec![10, 20]);
+        let expr: Arc<dyn PhysicalExpr> = lookup;
+        let registered: Vec<Arc<dyn PhysicalExpr>> = vec![Arc::clone(&id_col)];
+
+        let payload = DynFilterPayload::from_datafusion_expr_with_registered_children(
+            &expr,
+            &registered,
+            4096,
+            &schema,
+        )
+        .unwrap();
+
+        match payload {
+            DynFilterPayload::JoinHashBloom(bloom) => assert_ne!(bloom.hash_compat_fingerprint, 0),
+            DynFilterPayload::Datafusion(_) => {
+                panic!("unused unsupported schema column should not disable Bloom")
+            }
+        }
+    }
+
+    #[test]
+    fn join_hash_bloom_region_proto_roundtrip_preserves_fingerprint() {
+        let mut bloom = JoinHashBloomPayload::build_from_hashes(
+            vec![1u64, 2, 3],
+            128,
+            3,
+            (1, 2, 3, 4),
+            vec![0],
+            vec![1, 2, 3],
+        );
+        bloom.hash_compat_fingerprint = 0xfeed_beef_dead_beef;
+        let payload = DynFilterPayload::JoinHashBloom(bloom.clone());
+
+        let proto = payload.to_region_proto_payload();
+        let decoded = DynFilterPayload::from_region_proto_payload(proto).unwrap();
+
+        assert_eq!(decoded, DynFilterPayload::JoinHashBloom(bloom));
+    }
+
+    #[test]
+    fn encoder_falls_back_on_child_mismatch() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let id_col = col("id", &schema).unwrap();
+
+        let lookup = make_lookup_expr(Arc::clone(&id_col), vec![1, 2]);
+        let expr: Arc<dyn PhysicalExpr> = lookup;
+
+        let other_col: Arc<dyn PhysicalExpr> = Arc::new(Column::new("other", 0));
+        let registered: Vec<Arc<dyn PhysicalExpr>> = vec![Arc::clone(&other_col)];
+
+        let payload = DynFilterPayload::from_datafusion_expr_with_registered_children(
+            &expr,
+            &registered,
+            4096,
+            &schema,
+        )
+        .unwrap();
+
+        match payload {
+            DynFilterPayload::Datafusion(_) => {}
+            DynFilterPayload::JoinHashBloom(_) => panic!("expected Datafusion fallback"),
+        }
+    }
+
+    #[test]
+    fn encoder_falls_back_on_multiple_lookups() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let id_col = col("id", &schema).unwrap();
+
+        let lookup1 = make_lookup_expr(Arc::clone(&id_col), vec![1]);
+        let lookup2 = make_lookup_expr(Arc::clone(&id_col), vec![2]);
+
+        let expr: Arc<dyn PhysicalExpr> =
+            Arc::new(BinaryExpr::new(lookup1, Operator::And, lookup2));
+
+        let registered: Vec<Arc<dyn PhysicalExpr>> = vec![Arc::clone(&id_col)];
+
+        let payload = DynFilterPayload::from_datafusion_expr_with_registered_children(
+            &expr,
+            &registered,
+            4096,
+            &schema,
+        )
+        .unwrap();
+
+        match payload {
+            DynFilterPayload::Datafusion(_) => {}
+            DynFilterPayload::JoinHashBloom(_) => {
+                panic!("expected Datafusion fallback for multiple lookups")
+            }
+        }
+    }
+
+    #[test]
+    fn encoder_falls_back_on_lookup_under_or() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let id_col = col("id", &schema).unwrap();
+
+        let lower_bound: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            Arc::clone(&id_col),
+            Operator::GtEq,
+            lit(10i32),
+        ));
+        let lookup = make_lookup_expr(Arc::clone(&id_col), vec![1, 2]);
+
+        let expr: Arc<dyn PhysicalExpr> =
+            Arc::new(BinaryExpr::new(lower_bound, Operator::Or, lookup));
+
+        let registered: Vec<Arc<dyn PhysicalExpr>> = vec![Arc::clone(&id_col)];
+
+        let payload = DynFilterPayload::from_datafusion_expr_with_registered_children(
+            &expr,
+            &registered,
+            4096,
+            &schema,
+        )
+        .unwrap();
+
+        match payload {
+            DynFilterPayload::Datafusion(_) => {}
+            DynFilterPayload::JoinHashBloom(_) => {
+                panic!("expected Datafusion fallback for OR context")
+            }
+        }
+    }
+
+    #[test]
+    fn encoder_fail_open_fallback_for_not_lookup_is_true() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let id_col = col("id", &schema).unwrap();
+
+        let lookup = make_lookup_expr(Arc::clone(&id_col), vec![1, 2]);
+        let expr: Arc<dyn PhysicalExpr> = Arc::new(NotExpr::new(lookup));
+
+        let registered: Vec<Arc<dyn PhysicalExpr>> = vec![Arc::clone(&id_col)];
+        let payload = DynFilterPayload::from_datafusion_expr_with_registered_children(
+            &expr,
+            &registered,
+            4096,
+            &schema,
+        )
+        .unwrap();
+
+        let DynFilterPayload::Datafusion(bytes) = payload else {
+            panic!("expected Datafusion fail-open fallback for NOT lookup");
+        };
+        let decoded = DynFilterPayload::Datafusion(bytes)
+            .decode_datafusion_expr(&TaskContext::default(), &schema, 4096)
+            .unwrap();
+
+        assert!(!contains_expr::<HashTableLookupExpr>(&decoded));
+        assert!(!decoded.to_string().contains("NOT"));
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
+        let result = decoded
+            .evaluate(&batch)
+            .unwrap()
+            .into_array(batch.num_rows())
+            .unwrap();
+        let bools = result.as_any().downcast_ref::<BooleanArray>().unwrap();
+        assert!(bools.iter().all(|value| value == Some(true)));
+    }
+
+    #[test]
+    fn encoder_fail_open_fallback_preserves_bounds_around_not_lookup() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let id_col = col("id", &schema).unwrap();
+
+        let lower_bound: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            Arc::clone(&id_col),
+            Operator::GtEq,
+            lit(10i32),
+        ));
+        let lookup = make_lookup_expr(Arc::clone(&id_col), vec![1, 2]);
+        let not_lookup: Arc<dyn PhysicalExpr> = Arc::new(NotExpr::new(lookup));
+        let expr: Arc<dyn PhysicalExpr> =
+            Arc::new(BinaryExpr::new(lower_bound, Operator::And, not_lookup));
+
+        let registered: Vec<Arc<dyn PhysicalExpr>> = vec![Arc::clone(&id_col)];
+        let payload = DynFilterPayload::from_datafusion_expr_with_registered_children(
+            &expr,
+            &registered,
+            4096,
+            &schema,
+        )
+        .unwrap();
+
+        let DynFilterPayload::Datafusion(bytes) = payload else {
+            panic!("expected Datafusion fail-open fallback for bounds AND NOT lookup");
+        };
+        let decoded = DynFilterPayload::Datafusion(bytes)
+            .decode_datafusion_expr(&TaskContext::default(), &schema, 4096)
+            .unwrap();
+
+        assert!(!contains_expr::<HashTableLookupExpr>(&decoded));
+        assert!(!decoded.to_string().contains("NOT"));
+        assert!(decoded.to_string().contains(">="));
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(vec![5, 10, 15]))],
+        )
+        .unwrap();
+        let result = decoded
+            .evaluate(&batch)
+            .unwrap()
+            .into_array(batch.num_rows())
+            .unwrap();
+        let bools = result.as_any().downcast_ref::<BooleanArray>().unwrap();
+        assert_eq!(bools.value(0), false);
+        assert_eq!(bools.value(1), true);
+        assert_eq!(bools.value(2), true);
+    }
+
+    #[test]
+    fn encoder_flattens_nested_and_lookup() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let id_col = col("id", &schema).unwrap();
+
+        let inner_lookup = make_lookup_expr(Arc::clone(&id_col), vec![1]);
+        let upper_bound: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            Arc::clone(&id_col),
+            Operator::LtEq,
+            lit(100i32),
+        ));
+        let inner_expr: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            Arc::clone(&upper_bound),
+            Operator::And,
+            inner_lookup,
+        ));
+        let lower_bound: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            Arc::clone(&id_col),
+            Operator::GtEq,
+            lit(10i32),
+        ));
+        let expr: Arc<dyn PhysicalExpr> =
+            Arc::new(BinaryExpr::new(lower_bound, Operator::And, inner_expr));
+
+        let registered: Vec<Arc<dyn PhysicalExpr>> = vec![Arc::clone(&id_col)];
+
+        let payload = DynFilterPayload::from_datafusion_expr_with_registered_children(
+            &expr,
+            &registered,
+            4096,
+            &schema,
+        )
+        .unwrap();
+
+        match payload {
+            DynFilterPayload::JoinHashBloom(bloom) => assert_eq!(bloom.distinct_hash_count, 1),
+            DynFilterPayload::Datafusion(_) => panic!("expected JoinHashBloom"),
+        }
+    }
+
+    #[test]
+    fn encoder_no_false_negatives_for_lookup_hashes() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let id_col = col("id", &schema).unwrap();
+
+        let inserted_hashes = vec![10u64, 20, 30, 10, 30];
+        let lookup = make_lookup_expr(Arc::clone(&id_col), inserted_hashes);
+        let expr: Arc<dyn PhysicalExpr> = lookup;
+
+        let registered: Vec<Arc<dyn PhysicalExpr>> = vec![Arc::clone(&id_col)];
+
+        let payload = DynFilterPayload::from_datafusion_expr_with_registered_children(
+            &expr,
+            &registered,
+            4096,
+            &schema,
+        )
+        .unwrap();
+
+        match payload {
+            DynFilterPayload::JoinHashBloom(bloom) => {
+                assert_eq!(bloom.distinct_hash_count, 3);
+                for &h in &[10u64, 20, 30] {
+                    assert!(
+                        bloom.contains_join_hash(h),
+                        "hash {h} should be in the Bloom filter"
+                    );
+                }
+            }
+            DynFilterPayload::Datafusion(_) => panic!("expected JoinHashBloom"),
+        }
+    }
+
+    #[test]
+    fn encoder_falls_back_on_oversized_bloom_budget() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let id_col = col("id", &schema).unwrap();
+
+        let lookup = make_lookup_expr(Arc::clone(&id_col), vec![1, 2, 3]);
+        let expr: Arc<dyn PhysicalExpr> = lookup;
+
+        let registered: Vec<Arc<dyn PhysicalExpr>> = vec![Arc::clone(&id_col)];
+
+        let payload = DynFilterPayload::from_datafusion_expr_with_registered_children(
+            &expr,
+            &registered,
+            50,
+            &schema,
+        )
+        .unwrap();
+
+        match payload {
+            DynFilterPayload::Datafusion(bytes) => assert!(!bytes.is_empty()),
+            DynFilterPayload::JoinHashBloom(_) => {
+                panic!("expected Datafusion fallback for tiny budget")
+            }
+        }
+    }
+
+    #[test]
+    fn fingerprint_sensitive_to_seeds() {
+        let schema = Schema::new(vec![Field::new("id", DataType::Int32, false)]);
+        let id_col = col("id", &schema).unwrap();
+        let children: Vec<Arc<dyn PhysicalExpr>> = vec![Arc::clone(&id_col)];
+
+        let fp1 =
+            join_hash_bloom::compute_hash_compat_fingerprint(&children, &schema, (0, 0, 0, 0))
+                .unwrap();
+        let fp2 =
+            join_hash_bloom::compute_hash_compat_fingerprint(&children, &schema, (99, 99, 99, 99))
+                .unwrap();
+        assert_ne!(fp1, fp2, "fingerprints should differ for different seeds");
+    }
+
+    #[test]
+    fn fingerprint_sensitive_to_child_order() {
+        let schema = Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+        ]);
+        let col_a = col("a", &schema).unwrap();
+        let col_b = col("b", &schema).unwrap();
+
+        let fp_ab = join_hash_bloom::compute_hash_compat_fingerprint(
+            &[Arc::clone(&col_a), Arc::clone(&col_b)],
+            &schema,
+            (1, 2, 3, 4),
+        )
+        .unwrap();
+        let fp_ba = join_hash_bloom::compute_hash_compat_fingerprint(
+            &[Arc::clone(&col_b), Arc::clone(&col_a)],
+            &schema,
+            (1, 2, 3, 4),
+        )
+        .unwrap();
+
+        assert_ne!(fp_ab, fp_ba, "fingerprint should differ for child order");
+    }
+
+    #[test]
+    fn fingerprint_sensitive_to_key_type() {
+        let schema_i32 = Schema::new(vec![Field::new("id", DataType::Int32, false)]);
+        let schema_i64 = Schema::new(vec![Field::new("id", DataType::Int64, false)]);
+        let col_i32 = col("id", &schema_i32).unwrap();
+        let col_i64 = col("id", &schema_i64).unwrap();
+
+        let fp_i32 =
+            join_hash_bloom::compute_hash_compat_fingerprint(&[col_i32], &schema_i32, (1, 2, 3, 4))
+                .unwrap();
+        let fp_i64 =
+            join_hash_bloom::compute_hash_compat_fingerprint(&[col_i64], &schema_i64, (1, 2, 3, 4))
+                .unwrap();
+
+        assert_ne!(fp_i32, fp_i64, "fingerprint should differ for key type");
     }
 
     fn contains_expr<T: 'static>(expr: &Arc<dyn PhysicalExpr>) -> bool {

--- a/src/common/query/src/request.rs
+++ b/src/common/query/src/request.rs
@@ -455,12 +455,12 @@ fn flatten_and_conjuncts(expr: &Arc<dyn PhysicalExpr>) -> Vec<Arc<dyn PhysicalEx
     let mut conjuncts = Vec::new();
     let mut stack = vec![Arc::clone(expr)];
     while let Some(node) = stack.pop() {
-        if let Some(and) = node.as_any().downcast_ref::<BinaryExpr>() {
-            if *and.op() == Operator::And {
-                stack.push(Arc::clone(and.right()));
-                stack.push(Arc::clone(and.left()));
-                continue;
-            }
+        if let Some(and) = node.as_any().downcast_ref::<BinaryExpr>()
+            && *and.op() == Operator::And
+        {
+            stack.push(Arc::clone(and.right()));
+            stack.push(Arc::clone(and.left()));
+            continue;
         }
         conjuncts.push(node);
     }
@@ -1562,9 +1562,9 @@ mod tests {
             .into_array(batch.num_rows())
             .unwrap();
         let bools = result.as_any().downcast_ref::<BooleanArray>().unwrap();
-        assert_eq!(bools.value(0), false);
-        assert_eq!(bools.value(1), true);
-        assert_eq!(bools.value(2), true);
+        assert!(!bools.value(0));
+        assert!(bools.value(1));
+        assert!(bools.value(2));
     }
 
     #[test]

--- a/src/common/query/src/request.rs
+++ b/src/common/query/src/request.rs
@@ -163,15 +163,12 @@ impl DynFilterPayload {
         Ok(expr)
     }
 
-    /// Decodes this payload into a DataFusion physical expression using
+    /// Decodes this payload into a single DataFusion physical expression using
     /// the registered dynamic-filter children for context.
     ///
-    /// - `Datafusion` variant delegates to [`Self::decode_datafusion_expr`].
-    /// - `JoinHashBloom` variant validates payload budget, checks join key child index
-    ///   range, recomputes the hash-compat fingerprint, and returns
-    ///   `residual_expr AND JoinHashBloomProbeExpr` only when fingerprints match.
-    ///   If the fingerprint is zero (not computed), cannot be recomputed, or mismatches, returns
-    ///   residual-only fail-open.
+    /// This is a convenience wrapper around [`Self::decode_placement_aware`] that
+    /// combines pushdown and exact expressions with AND for callers that do not
+    /// need placement-aware splitting (e.g. legacy tests or single-filter usage).
     pub fn decode_expr_with_registered_children(
         &self,
         task_ctx: &TaskContext,
@@ -179,19 +176,48 @@ impl DynFilterPayload {
         registered_children: &[Arc<dyn PhysicalExpr>],
         max_payload_bytes: usize,
     ) -> DataFusionResult<Arc<dyn PhysicalExpr>> {
+        let decoded = self.decode_placement_aware(
+            task_ctx,
+            input_schema,
+            registered_children,
+            max_payload_bytes,
+        )?;
+        match decoded.exact_expr {
+            Some(exact) => Ok(Arc::new(BinaryExpr::new(
+                decoded.pushdown_expr,
+                Operator::And,
+                exact,
+            ))),
+            None => Ok(decoded.pushdown_expr),
+        }
+    }
+
+    /// Decodes this payload into placement-aware parts.
+    ///
+    /// See [`DecodedDynFilterExprs`] for semantics.
+    pub fn decode_placement_aware(
+        &self,
+        task_ctx: &TaskContext,
+        input_schema: &datafusion::arrow::datatypes::Schema,
+        registered_children: &[Arc<dyn PhysicalExpr>],
+        max_payload_bytes: usize,
+    ) -> DataFusionResult<DecodedDynFilterExprs> {
         match self {
             Self::Datafusion(_) => {
-                self.decode_datafusion_expr(task_ctx, input_schema, max_payload_bytes)
+                let pushdown_expr =
+                    self.decode_datafusion_expr(task_ctx, input_schema, max_payload_bytes)?;
+                Ok(DecodedDynFilterExprs {
+                    pushdown_expr,
+                    exact_expr: None,
+                })
             }
             Self::JoinHashBloom(bloom) => {
                 bloom.validate()?;
 
-                // Validate the encoded proto budget
                 let encoded_bytes = self.encoded_payload_bytes();
                 validate_payload_size(encoded_bytes, max_payload_bytes)
                     .map_err(DataFusionError::from)?;
 
-                // Validate join key child indices are in range
                 let num_registered = registered_children.len();
                 for &child_index in &bloom.join_key_child_indices {
                     if child_index as usize >= num_registered {
@@ -226,42 +252,34 @@ impl DynFilterPayload {
                     .map(|&child_index| Arc::clone(&registered_children[child_index as usize]))
                     .collect();
 
-                // Recompute hash compat fingerprint for cross-platform drift detection.
-                // A missing/zero fingerprint, mismatch, or recompute error must fail open
-                // to residual-only rather than risk Bloom false negatives.
-                if bloom.hash_compat_fingerprint == 0 {
-                    return Ok(residual_expr);
-                }
-                match crate::request::join_hash_bloom::compute_hash_compat_fingerprint(
-                    &probe_children,
-                    input_schema,
-                    (
-                        bloom.df_seed0,
-                        bloom.df_seed1,
-                        bloom.df_seed2,
-                        bloom.df_seed3,
-                    ),
-                ) {
-                    Ok(local_fp) if local_fp == bloom.hash_compat_fingerprint => {
-                        // Fingerprint matches — construct probe expression below.
+                // Recompute fingerprint; zero/mismatch/recompute-error yields lit(true) exact.
+                let exact_expr: Arc<dyn PhysicalExpr> = if bloom.hash_compat_fingerprint == 0 {
+                    lit(true)
+                } else {
+                    match crate::request::join_hash_bloom::compute_hash_compat_fingerprint(
+                        &probe_children,
+                        input_schema,
+                        (
+                            bloom.df_seed0,
+                            bloom.df_seed1,
+                            bloom.df_seed2,
+                            bloom.df_seed3,
+                        ),
+                    ) {
+                        Ok(local_fp) if local_fp == bloom.hash_compat_fingerprint => {
+                            Arc::new(JoinHashBloomProbeExpr::try_new(
+                                probe_children,
+                                Arc::new(bloom.clone()),
+                            )?) as Arc<dyn PhysicalExpr>
+                        }
+                        _ => lit(true),
                     }
-                    _ => {
-                        // Fingerprint mismatch or recompute error — fail open.
-                        return Ok(residual_expr);
-                    }
-                }
+                };
 
-                let probe_expr = Arc::new(JoinHashBloomProbeExpr::try_new(
-                    probe_children,
-                    Arc::new(bloom.clone()),
-                )?) as Arc<dyn PhysicalExpr>;
-
-                // Return residual AND probe
-                Ok(Arc::new(BinaryExpr::new(
-                    residual_expr,
-                    Operator::And,
-                    probe_expr,
-                )))
+                Ok(DecodedDynFilterExprs {
+                    pushdown_expr: residual_expr,
+                    exact_expr: Some(exact_expr),
+                })
             }
         }
     }
@@ -720,6 +738,27 @@ fn validate_decoded_payload_expr(
     })?;
 
     Ok(())
+}
+
+/// Placement-aware decoded dynamic filter expressions.
+///
+/// Splits a decoded payload so DataNode can install the `pushdown_expr` into a
+/// normal [`DynamicFilterPhysicalExpr`] that Mito scan can push down, while the
+/// optional `exact_expr` is wrapped in a non-pushdown marker that stays in
+/// [`FilterExec`] for row-level evaluation only.
+///
+/// - `Datafusion` payload: `pushdown_expr = decode_datafusion_expr(...)`,
+///   `exact_expr = None`.
+/// - `JoinHashBloom` payload: `pushdown_expr = residual_expr`,
+///   `exact_expr = Some(bloom_probe_expr)` when fingerprint matches;
+///   `exact_expr = Some(lit(true))` on zero/mismatch/recompute error
+///   (valid-payload degradation that disables exact Bloom safely).
+///
+/// [`DynamicFilterPhysicalExpr`]: datafusion::physical_plan::expressions::DynamicFilterPhysicalExpr
+#[derive(Debug, Clone)]
+pub struct DecodedDynFilterExprs {
+    pub pushdown_expr: Arc<dyn PhysicalExpr>,
+    pub exact_expr: Option<Arc<dyn PhysicalExpr>>,
 }
 
 /// A remote dynamic filter update sent from a query coordinator to region servers.

--- a/src/common/query/src/request.rs
+++ b/src/common/query/src/request.rs
@@ -1696,14 +1696,17 @@ mod tests {
             (1, 2, 3, 4),
         )
         .unwrap();
-        let fp_ba = join_hash_bloom::compute_hash_compat_fingerprint(
+        let fp_reversed = join_hash_bloom::compute_hash_compat_fingerprint(
             &[Arc::clone(&col_b), Arc::clone(&col_a)],
             &schema,
             (1, 2, 3, 4),
         )
         .unwrap();
 
-        assert_ne!(fp_ab, fp_ba, "fingerprint should differ for child order");
+        assert_ne!(
+            fp_ab, fp_reversed,
+            "fingerprint should differ for child order"
+        );
     }
 
     #[test]

--- a/src/common/query/src/request/initial_remote_dyn_filter_reg.rs
+++ b/src/common/query/src/request/initial_remote_dyn_filter_reg.rs
@@ -91,6 +91,15 @@ impl InitialDynFilterRegs {
                     reg.filter_id
                 ));
             }
+
+            if let Some(snapshot) = &reg.initial_snapshot {
+                snapshot.payload.validate().map_err(|err| {
+                    format!(
+                        "InitialDynFilterRegs contains invalid initial snapshot for filter_id '{}': {}",
+                        reg.filter_id, err
+                    )
+                })?;
+            }
         }
 
         Ok(())
@@ -199,9 +208,7 @@ impl InitialDynFilterSnapshot {
     }
 
     pub fn encoded_payload_bytes(&self) -> usize {
-        match &self.payload {
-            DynFilterPayload::Datafusion(bytes) => bytes.len(),
-        }
+        self.payload.encoded_payload_bytes()
     }
 }
 
@@ -215,6 +222,7 @@ mod tests {
     use datafusion_common::DataFusionError;
 
     use super::*;
+    use crate::request::join_hash_bloom::{BloomHashAlgorithm, JoinHashBloomPayload, JoinHashKind};
 
     #[test]
     fn initial_dyn_filter_regs_json_round_trip() {
@@ -393,5 +401,172 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(err, DataFusionError::Plan(_)));
+    }
+
+    #[test]
+    fn initial_dyn_filter_snapshot_bloom_encoded_payload_bytes_counts_full_proto() {
+        let bitset = vec![0u8; 128];
+        let bloom = JoinHashBloomPayload {
+            version: 1,
+            hash_kind: JoinHashKind::DatafusionJoinHashU64,
+            df_seed0: 0,
+            df_seed1: 0,
+            df_seed2: 0,
+            df_seed3: 0,
+            num_bits: 1024,
+            num_probes: 2,
+            distinct_hash_count: 42,
+            bitset: bitset.clone(),
+            join_key_child_indices: vec![0],
+            residual_datafusion_physical_expr: vec![1, 2, 3],
+            bloom_hash_algorithm: BloomHashAlgorithm::Splitmix64DoubleHashV1,
+            hash_compat_fingerprint: 0,
+        };
+
+        let snapshot =
+            InitialDynFilterSnapshot::new(DynFilterPayload::JoinHashBloom(bloom.clone()), 2, false);
+
+        let encoded_bytes = snapshot.encoded_payload_bytes();
+
+        // Should be more than bitset + residual alone (includes proto overhead)
+        assert!(
+            encoded_bytes > bitset.len() + bloom.residual_datafusion_physical_expr.len(),
+            "expected > {}, got {encoded_bytes}",
+            bitset.len() + bloom.residual_datafusion_physical_expr.len()
+        );
+    }
+
+    #[test]
+    fn initial_dyn_filter_snapshot_bloom_json_roundtrip() {
+        let bloom = JoinHashBloomPayload {
+            version: 1,
+            hash_kind: JoinHashKind::DatafusionJoinHashU64,
+            df_seed0: 0,
+            df_seed1: 0,
+            df_seed2: 0,
+            df_seed3: 0,
+            num_bits: 1024,
+            num_probes: 2,
+            distinct_hash_count: 42,
+            bitset: vec![0u8; 128],
+            join_key_child_indices: vec![0],
+            residual_datafusion_physical_expr: vec![1, 2, 3],
+            bloom_hash_algorithm: BloomHashAlgorithm::Splitmix64DoubleHashV1,
+            hash_compat_fingerprint: 0,
+        };
+
+        let snapshot =
+            InitialDynFilterSnapshot::new(DynFilterPayload::JoinHashBloom(bloom.clone()), 5, true);
+
+        let json = serde_json::to_string(&snapshot).unwrap();
+        let decoded: InitialDynFilterSnapshot = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(decoded.generation, 5);
+        assert!(decoded.is_complete);
+        assert_eq!(decoded.payload, DynFilterPayload::JoinHashBloom(bloom));
+    }
+
+    #[test]
+    fn initial_dyn_filter_reg_encoded_registration_bytes_include_bloom_snapshot() {
+        let bloom = JoinHashBloomPayload {
+            version: 1,
+            hash_kind: JoinHashKind::DatafusionJoinHashU64,
+            df_seed0: 0,
+            df_seed1: 0,
+            df_seed2: 0,
+            df_seed3: 0,
+            num_bits: 64,
+            num_probes: 2,
+            distinct_hash_count: 10,
+            bitset: vec![0u8; 8],
+            join_key_child_indices: vec![0],
+            residual_datafusion_physical_expr: vec![1],
+            bloom_hash_algorithm: BloomHashAlgorithm::Splitmix64DoubleHashV1,
+            hash_compat_fingerprint: 0,
+        };
+
+        let snapshot =
+            InitialDynFilterSnapshot::new(DynFilterPayload::JoinHashBloom(bloom), 2, false);
+
+        let reg = InitialDynFilterReg::new("filter-bloom", vec![vec![1, 2, 3]])
+            .with_initial_snapshot(snapshot);
+
+        let child_bytes = reg.encoded_child_expr_bytes();
+        let total_bytes = reg.encoded_registration_bytes();
+
+        assert_eq!(child_bytes, 3);
+        // The Bloom payload proto encoded size should be > 0
+        assert!(
+            total_bytes > child_bytes,
+            "expected total_bytes > {child_bytes}, got {total_bytes}"
+        );
+    }
+
+    #[test]
+    fn initial_dyn_filter_regs_json_round_trip_with_bloom_snapshot() {
+        let bloom = JoinHashBloomPayload {
+            version: 1,
+            hash_kind: JoinHashKind::DatafusionJoinHashU64,
+            df_seed0: 0,
+            df_seed1: 0,
+            df_seed2: 0,
+            df_seed3: 0,
+            num_bits: 256,
+            num_probes: 2,
+            distinct_hash_count: 42,
+            bitset: vec![0u8; 32],
+            join_key_child_indices: vec![0],
+            residual_datafusion_physical_expr: vec![4, 5, 6],
+            bloom_hash_algorithm: BloomHashAlgorithm::Splitmix64DoubleHashV1,
+            hash_compat_fingerprint: 0,
+        };
+
+        let regs = InitialDynFilterRegs::new(vec![
+            InitialDynFilterReg::new("filter-bloom", vec![vec![1, 2, 3]]).with_initial_snapshot(
+                InitialDynFilterSnapshot::new(DynFilterPayload::JoinHashBloom(bloom), 7, true),
+            ),
+        ]);
+
+        let encoded = regs.to_extension_value().unwrap();
+        let json: serde_json::Value = serde_json::from_str(&encoded).unwrap();
+        let decoded = InitialDynFilterRegs::from_extension_value(&encoded).unwrap();
+
+        assert_eq!(
+            json["registrations"][0]["initial_snapshot"]["payload"]["kind"],
+            "join_hash_bloom"
+        );
+        assert_eq!(decoded, regs);
+    }
+
+    #[test]
+    fn initial_dyn_filter_regs_from_extension_rejects_invalid_bloom_snapshot() {
+        let bloom = JoinHashBloomPayload {
+            version: 1,
+            hash_kind: JoinHashKind::DatafusionJoinHashU64,
+            df_seed0: 0,
+            df_seed1: 0,
+            df_seed2: 0,
+            df_seed3: 0,
+            num_bits: 256,
+            num_probes: 2,
+            distinct_hash_count: 42,
+            bitset: vec![0u8; 32],
+            join_key_child_indices: vec![],
+            residual_datafusion_physical_expr: vec![4, 5, 6],
+            bloom_hash_algorithm: BloomHashAlgorithm::Splitmix64DoubleHashV1,
+            hash_compat_fingerprint: 0,
+        };
+
+        let regs = InitialDynFilterRegs::new(vec![
+            InitialDynFilterReg::new("filter-bloom", vec![vec![1, 2, 3]]).with_initial_snapshot(
+                InitialDynFilterSnapshot::new(DynFilterPayload::JoinHashBloom(bloom), 7, true),
+            ),
+        ]);
+
+        let encoded = serde_json::to_string(&regs).unwrap();
+        let err = InitialDynFilterRegs::from_extension_value(&encoded).unwrap_err();
+
+        assert!(err.to_string().contains("invalid initial snapshot"));
+        assert!(err.to_string().contains("join_key_child_indices is empty"));
     }
 }

--- a/src/common/query/src/request/join_hash_bloom.rs
+++ b/src/common/query/src/request/join_hash_bloom.rs
@@ -1,0 +1,1801 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Join-hash Bloom filter payload model for remote dynamic filter updates.
+//!
+//! The Bloom payload carries a bitset over DataFusion join-hash `u64` values
+//! along with the hash seeds, join key child indices, and a residual
+//! DataFusion expression where runtime `HashTableLookupExpr` nodes have been
+//! replaced by `lit(true)`. Receivers combine the residual expression with a
+//! Bloom probe expression via `AND` to obtain the final predicate.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use datafusion_common::{DataFusionError, Result as DataFusionResult};
+use serde::{Deserialize, Serialize};
+
+use super::base64_serde;
+
+/// Current wire-format version for join-hash Bloom payloads.
+pub const JOIN_HASH_BLOOM_VERSION: u32 = 1;
+
+/// Upper bound on the number of Bloom hash probes per lookup key.
+/// Keeps probe cost bounded and prevents obviously misconfigured payloads.
+pub const MAX_BLOOM_NUM_PROBES: u32 = 64;
+
+/// Upper bound on the residual DataFusion expression bytes carried in a
+/// Bloom payload. The residual is an optional safety net; oversized
+/// residuals indicate a producer-side budget violation.
+pub const MAX_BLOOM_RESIDUAL_BYTES: usize = 8192;
+
+/// Conservative estimate of proto envelope overhead for a Bloom payload
+/// when wrapped inside `RemoteDynFilterPayload`.  Used during encoding to
+/// avoid overshooting the payload budget.
+pub const BLOOM_PROTO_ENVELOPE_OVERHEAD_ESTIMATE: usize = 256;
+
+/// Default number of Bloom hash probes used by the encoder.
+pub const BLOOM_ENCODER_NUM_PROBES: u32 = 5;
+
+/// Bits allocated per distinct hash in the Bloom filter.
+pub const BLOOM_ENCODER_BITS_PER_HASH: u64 = 10;
+
+/// Minimum Bloom size in bits.
+pub const BLOOM_ENCODER_MIN_NUM_BITS: u64 = 64;
+
+/// Largest `num_bits` the encoder will ever allocate (hard OOM guard).
+pub const BLOOM_ENCODER_MAX_NUM_BITS_BUDGET: u64 = 256 * 1024; // 256 KiB = 32 KiB bytes
+
+/// Identifies the join-hash scheme used to produce the hash values stored
+/// in the Bloom filter.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum JoinHashKind {
+    /// Sentinel / unknown.
+    Unspecified = 0,
+    /// DataFusion `create_hashes(..., HASH_JOIN_SEED)` producing `u64` hashes.
+    DatafusionJoinHashU64 = 1,
+}
+
+impl JoinHashKind {
+    pub fn to_proto(&self) -> i32 {
+        use api::v1::region::JoinHashKind as Proto;
+        match self {
+            Self::Unspecified => Proto::Unspecified as i32,
+            Self::DatafusionJoinHashU64 => Proto::DatafusionJoinHashU64 as i32,
+        }
+    }
+
+    pub fn from_proto_i32(value: i32) -> Option<Self> {
+        let proto =
+            <api::v1::region::JoinHashKind as std::convert::TryFrom<i32>>::try_from(value).ok()?;
+        Some(match proto {
+            api::v1::region::JoinHashKind::Unspecified => Self::Unspecified,
+            api::v1::region::JoinHashKind::DatafusionJoinHashU64 => Self::DatafusionJoinHashU64,
+        })
+    }
+}
+
+/// The hash algorithm used for Bloom bucket probing (SplitMix64
+/// double-hashing).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum BloomHashAlgorithm {
+    /// Sentinel / unknown.
+    Unspecified = 0,
+    /// SplitMix64-based double-hashing (v1).
+    Splitmix64DoubleHashV1 = 1,
+}
+
+impl BloomHashAlgorithm {
+    pub fn to_proto(&self) -> i32 {
+        use api::v1::region::BloomHashAlgorithm as Proto;
+        match self {
+            Self::Unspecified => Proto::Unspecified as i32,
+            Self::Splitmix64DoubleHashV1 => Proto::Splitmix64DoubleHashV1 as i32,
+        }
+    }
+
+    pub fn from_proto_i32(value: i32) -> Option<Self> {
+        let proto =
+            <api::v1::region::BloomHashAlgorithm as std::convert::TryFrom<i32>>::try_from(value)
+                .ok()?;
+        Some(match proto {
+            api::v1::region::BloomHashAlgorithm::Unspecified => Self::Unspecified,
+            api::v1::region::BloomHashAlgorithm::Splitmix64DoubleHashV1 => {
+                Self::Splitmix64DoubleHashV1
+            }
+        })
+    }
+}
+
+/// Serialized Bloom filter payload for remote dynamic filter updates.
+///
+/// Carries a Bloom bitset over DataFusion join-hash `u64` values together
+/// with the parameters needed to reconstruct the probe-side hash computation
+/// and a residual DataFusion expression with `HashTableLookupExpr` replaced
+/// by `lit(true)`.
+///
+/// Byte fields are base64-encoded in JSON to keep the wire representation
+/// compact and safe.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct JoinHashBloomPayload {
+    pub version: u32,
+    pub hash_kind: JoinHashKind,
+    pub df_seed0: u64,
+    pub df_seed1: u64,
+    pub df_seed2: u64,
+    pub df_seed3: u64,
+    pub num_bits: u64,
+    pub num_probes: u32,
+    pub distinct_hash_count: u64,
+    #[serde(with = "base64_serde::bytes")]
+    pub bitset: Vec<u8>,
+    pub join_key_child_indices: Vec<u32>,
+    #[serde(with = "base64_serde::bytes")]
+    pub residual_datafusion_physical_expr: Vec<u8>,
+    pub bloom_hash_algorithm: BloomHashAlgorithm,
+    /// Cross-platform hash-compatibility fingerprint.
+    ///
+    /// Computed deterministically by running a `HashExpr` over a canonical
+    /// `RecordBatch` built from `input_schema`.  Zero means "not computed".
+    pub hash_compat_fingerprint: u64,
+}
+
+impl JoinHashBloomPayload {
+    /// Fail-closed validation of payload invariants.
+    ///
+    /// Rejects:
+    /// - unsupported version
+    /// - unsupported hash kind or bloom algorithm
+    /// - `num_bits == 0`
+    /// - `num_bits` not representable as `usize`
+    /// - `num_probes == 0` or exceeding [`MAX_BLOOM_NUM_PROBES`]
+    /// - bitset length not equal to `ceil(num_bits / 8)`
+    /// - empty or duplicate join key child indices
+    /// - empty residual expression or residual expression exceeding
+    ///   [`MAX_BLOOM_RESIDUAL_BYTES`]
+    pub fn validate(&self) -> DataFusionResult<()> {
+        if self.version != JOIN_HASH_BLOOM_VERSION {
+            return Err(DataFusionError::Plan(format!(
+                "JoinHashBloomPayload: unsupported version {} (expected {})",
+                self.version, JOIN_HASH_BLOOM_VERSION
+            )));
+        }
+
+        if self.hash_kind != JoinHashKind::DatafusionJoinHashU64 {
+            return Err(DataFusionError::Plan(format!(
+                "JoinHashBloomPayload: unsupported hash_kind {:?}",
+                self.hash_kind
+            )));
+        }
+
+        if self.bloom_hash_algorithm != BloomHashAlgorithm::Splitmix64DoubleHashV1 {
+            return Err(DataFusionError::Plan(format!(
+                "JoinHashBloomPayload: unsupported bloom_hash_algorithm {:?}",
+                self.bloom_hash_algorithm
+            )));
+        }
+
+        if self.num_bits == 0 {
+            return Err(DataFusionError::Plan(
+                "JoinHashBloomPayload: num_bits is zero".to_string(),
+            ));
+        }
+
+        if self.num_bits > usize::MAX as u64 {
+            return Err(DataFusionError::Plan(format!(
+                "JoinHashBloomPayload: num_bits {} exceeds usize::MAX",
+                self.num_bits
+            )));
+        }
+
+        if self.num_probes == 0 {
+            return Err(DataFusionError::Plan(
+                "JoinHashBloomPayload: num_probes is zero".to_string(),
+            ));
+        }
+
+        if self.num_probes > MAX_BLOOM_NUM_PROBES {
+            return Err(DataFusionError::Plan(format!(
+                "JoinHashBloomPayload: num_probes {} exceeds limit {}",
+                self.num_probes, MAX_BLOOM_NUM_PROBES
+            )));
+        }
+
+        let expected_bitset_len = num_bits_ceil_bytes(self.num_bits as usize);
+        if self.bitset.len() != expected_bitset_len {
+            return Err(DataFusionError::Plan(format!(
+                "JoinHashBloomPayload: bitset length {} does not match ceil(num_bits {}/8) = {}",
+                self.bitset.len(),
+                self.num_bits,
+                expected_bitset_len
+            )));
+        }
+
+        if self.join_key_child_indices.is_empty() {
+            return Err(DataFusionError::Plan(
+                "JoinHashBloomPayload: join_key_child_indices is empty".to_string(),
+            ));
+        }
+
+        let mut seen = HashSet::with_capacity(self.join_key_child_indices.len());
+        for &child_index in &self.join_key_child_indices {
+            if !seen.insert(child_index) {
+                return Err(DataFusionError::Plan(format!(
+                    "JoinHashBloomPayload: duplicate join key child index {}",
+                    child_index
+                )));
+            }
+        }
+
+        if self.residual_datafusion_physical_expr.is_empty() {
+            return Err(DataFusionError::Plan(
+                "JoinHashBloomPayload: residual expression is empty".to_string(),
+            ));
+        }
+
+        if self.residual_datafusion_physical_expr.len() > MAX_BLOOM_RESIDUAL_BYTES {
+            return Err(DataFusionError::Plan(format!(
+                "JoinHashBloomPayload: residual expression {} bytes exceeds budget {}",
+                self.residual_datafusion_physical_expr.len(),
+                MAX_BLOOM_RESIDUAL_BYTES
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Converts this model to the corresponding proto `JoinHashBloomPayload`.
+    pub fn to_proto(&self) -> api::v1::region::JoinHashBloomPayload {
+        api::v1::region::JoinHashBloomPayload {
+            version: self.version,
+            hash_kind: self.hash_kind.to_proto(),
+            df_seed0: self.df_seed0,
+            df_seed1: self.df_seed1,
+            df_seed2: self.df_seed2,
+            df_seed3: self.df_seed3,
+            num_bits: self.num_bits,
+            num_probes: self.num_probes,
+            distinct_hash_count: self.distinct_hash_count,
+            bitset: self.bitset.clone(),
+            join_key_child_indices: self.join_key_child_indices.clone(),
+            residual_datafusion_physical_expr: self.residual_datafusion_physical_expr.clone(),
+            bloom_hash_algorithm: self.bloom_hash_algorithm.to_proto(),
+            hash_compat_fingerprint: self.hash_compat_fingerprint,
+        }
+    }
+
+    /// Constructs this model from a proto `JoinHashBloomPayload`.
+    ///
+    /// Does *not* validate — call [`Self::validate`] separately.
+    pub fn from_proto(payload: &api::v1::region::JoinHashBloomPayload) -> DataFusionResult<Self> {
+        let hash_kind = JoinHashKind::from_proto_i32(payload.hash_kind).ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "JoinHashBloomPayload: unknown hash_kind value {}",
+                payload.hash_kind
+            ))
+        })?;
+
+        let bloom_hash_algorithm = BloomHashAlgorithm::from_proto_i32(payload.bloom_hash_algorithm)
+            .ok_or_else(|| {
+                DataFusionError::Plan(format!(
+                    "JoinHashBloomPayload: unknown bloom_hash_algorithm value {}",
+                    payload.bloom_hash_algorithm
+                ))
+            })?;
+
+        Ok(Self {
+            version: payload.version,
+            hash_kind,
+            df_seed0: payload.df_seed0,
+            df_seed1: payload.df_seed1,
+            df_seed2: payload.df_seed2,
+            df_seed3: payload.df_seed3,
+            num_bits: payload.num_bits,
+            num_probes: payload.num_probes,
+            distinct_hash_count: payload.distinct_hash_count,
+            bitset: payload.bitset.clone(),
+            join_key_child_indices: payload.join_key_child_indices.clone(),
+            residual_datafusion_physical_expr: payload.residual_datafusion_physical_expr.clone(),
+            bloom_hash_algorithm,
+            hash_compat_fingerprint: payload.hash_compat_fingerprint,
+        })
+    }
+
+    /// Returns the expected bitset byte length for `num_bits`, i.e.
+    /// `ceil(num_bits / 8)`.
+    pub fn expected_bitset_bytes(&self) -> usize {
+        num_bits_ceil_bytes(self.num_bits as usize)
+    }
+
+    /// Tests whether the given join hash is a member of this Bloom filter.
+    ///
+    /// Uses SplitMix64 double-hashing to derive the probe sequence.
+    /// This is deterministic and false-negative-free for any hash that was
+    /// previously inserted into the bitset with the same parameters.
+    #[inline]
+    pub fn contains_join_hash(&self, hash: u64) -> bool {
+        bloom_contains(
+            hash,
+            &self.bitset,
+            self.num_bits,
+            self.num_probes,
+            self.bloom_hash_algorithm,
+        )
+    }
+
+    /// Inserts a join hash into this Bloom filter's bitset in-place.
+    ///
+    /// This is used during encoding to build the bitset from distinct join hashes.
+    #[inline]
+    pub fn insert_join_hash(&mut self, hash: u64) {
+        bloom_insert(
+            hash,
+            &mut self.bitset,
+            self.num_bits,
+            self.num_probes,
+            self.bloom_hash_algorithm,
+        )
+    }
+
+    /// Builds a new Bloom payload from distinct join hashes.
+    ///
+    /// Allocates a fresh zeroed bitset of the correct size and inserts every
+    /// hash. The returned payload passes [`Self::validate`] when `num_bits`,
+    /// `num_probes`, and the other required fields are set correctly.
+    ///
+    /// The `hash_compat_fingerprint` is left at zero; the encoder should set it
+    /// after construction via [`Self::hash_compat_fingerprint`].
+    pub fn build_from_hashes(
+        hashes: impl IntoIterator<Item = u64>,
+        num_bits: u64,
+        num_probes: u32,
+        seeds: (u64, u64, u64, u64),
+        join_key_child_indices: Vec<u32>,
+        residual_datafusion_physical_expr: Vec<u8>,
+    ) -> Self {
+        let bitset_len = num_bits_ceil_bytes(num_bits as usize);
+        let mut bitset = vec![0u8; bitset_len];
+        let distinct = bloom_insert_many(
+            hashes,
+            &mut bitset,
+            num_bits,
+            num_probes,
+            BloomHashAlgorithm::Splitmix64DoubleHashV1,
+        );
+        Self {
+            version: JOIN_HASH_BLOOM_VERSION,
+            hash_kind: JoinHashKind::DatafusionJoinHashU64,
+            df_seed0: seeds.0,
+            df_seed1: seeds.1,
+            df_seed2: seeds.2,
+            df_seed3: seeds.3,
+            num_bits,
+            num_probes,
+            distinct_hash_count: distinct,
+            bitset,
+            join_key_child_indices,
+            residual_datafusion_physical_expr,
+            bloom_hash_algorithm: BloomHashAlgorithm::Splitmix64DoubleHashV1,
+            hash_compat_fingerprint: 0,
+        }
+    }
+
+    /// Fallible builder: validates parameters before allocation and insertion.
+    ///
+    /// Checks `num_bits`, `num_probes`, join key child indices, and residual before
+    /// allocating the bitset.  The returned payload is already validated via
+    /// [`Self::validate`].
+    pub fn try_build_from_hashes(
+        hashes: impl IntoIterator<Item = u64>,
+        num_bits: u64,
+        num_probes: u32,
+        seeds: (u64, u64, u64, u64),
+        join_key_child_indices: Vec<u32>,
+        residual_datafusion_physical_expr: Vec<u8>,
+    ) -> DataFusionResult<Self> {
+        // --- validate before allocating ---
+
+        if num_bits == 0 {
+            return Err(DataFusionError::Plan(
+                "JoinHashBloomPayload: try_build_from_hashes num_bits is zero".to_string(),
+            ));
+        }
+        if num_bits > BLOOM_ENCODER_MAX_NUM_BITS_BUDGET {
+            return Err(DataFusionError::Plan(format!(
+                "JoinHashBloomPayload: try_build_from_hashes num_bits {} exceeds budget {}",
+                num_bits, BLOOM_ENCODER_MAX_NUM_BITS_BUDGET
+            )));
+        }
+        if num_bits > usize::MAX as u64 {
+            return Err(DataFusionError::Plan(format!(
+                "JoinHashBloomPayload: try_build_from_hashes num_bits {} exceeds usize::MAX",
+                num_bits
+            )));
+        }
+        if num_probes == 0 {
+            return Err(DataFusionError::Plan(
+                "JoinHashBloomPayload: try_build_from_hashes num_probes is zero".to_string(),
+            ));
+        }
+        if num_probes > MAX_BLOOM_NUM_PROBES {
+            return Err(DataFusionError::Plan(format!(
+                "JoinHashBloomPayload: try_build_from_hashes num_probes {} exceeds limit {}",
+                num_probes, MAX_BLOOM_NUM_PROBES
+            )));
+        }
+        if join_key_child_indices.is_empty() {
+            return Err(DataFusionError::Plan(
+                "JoinHashBloomPayload: try_build_from_hashes join_key_child_indices is empty"
+                    .to_string(),
+            ));
+        }
+        if residual_datafusion_physical_expr.is_empty() {
+            return Err(DataFusionError::Plan(
+                "JoinHashBloomPayload: try_build_from_hashes residual expression is empty"
+                    .to_string(),
+            ));
+        }
+
+        // --- allocate and build ---
+
+        let payload = Self::build_from_hashes(
+            hashes,
+            num_bits,
+            num_probes,
+            seeds,
+            join_key_child_indices,
+            residual_datafusion_physical_expr,
+        );
+
+        payload.validate()?;
+
+        Ok(payload)
+    }
+
+    /// Compute a Bloom size recommendation given a number of distinct hashes
+    /// and a payload byte budget.
+    ///
+    /// Returns `None` if the budget is too small to accommodate even the
+    /// minimum Bloom, the residual, and proto envelope overhead.
+    pub fn compute_bloom_sizing(
+        distinct_hash_count: u64,
+        residual_bytes_len: usize,
+        max_payload_bytes: usize,
+    ) -> Option<(u64, u32)> {
+        let num_bits = std::cmp::max(
+            BLOOM_ENCODER_MIN_NUM_BITS,
+            distinct_hash_count.saturating_mul(BLOOM_ENCODER_BITS_PER_HASH),
+        );
+        let num_probes = BLOOM_ENCODER_NUM_PROBES;
+
+        let bitset_bytes = num_bits_ceil_bytes(num_bits as usize);
+
+        // Quick budget check: residual + bitset + envelope overhead must fit
+        let estimated_total = residual_bytes_len
+            .saturating_add(bitset_bytes)
+            .saturating_add(BLOOM_PROTO_ENVELOPE_OVERHEAD_ESTIMATE);
+
+        if estimated_total > max_payload_bytes {
+            // Shrink num_bits to fit, trading off false-positive rate
+            let available_for_bitset = max_payload_bytes
+                .saturating_sub(residual_bytes_len)
+                .saturating_sub(BLOOM_PROTO_ENVELOPE_OVERHEAD_ESTIMATE);
+            let max_bits = (available_for_bitset as u64).saturating_mul(8);
+            if max_bits < BLOOM_ENCODER_MIN_NUM_BITS {
+                return None;
+            }
+            Some((max_bits, num_probes))
+        } else if num_bits > BLOOM_ENCODER_MAX_NUM_BITS_BUDGET {
+            // Cap at hard budget even if there is room
+            Some((BLOOM_ENCODER_MAX_NUM_BITS_BUDGET, num_probes))
+        } else {
+            Some((num_bits, num_probes))
+        }
+    }
+}
+
+/// DataFusion [`PhysicalExpr`] that probes a join-hash Bloom filter against
+/// probe-side columns.
+///
+/// Owns the child expressions selected by the payload's `join_key_child_indices` and
+/// an immutable, already-validated [`JoinHashBloomPayload`].
+///
+/// During evaluation, a DataFusion [`HashExpr`](datafusion::physical_plan::joins::HashExpr)
+/// computes the join-hash `u64` values from the serialized seeds, and the
+/// Bloom bitset is probed for each row. The result is a non-nullable
+/// `BooleanArray` with false-positive-only semantics.
+#[derive(Clone, Debug, Eq)]
+pub struct JoinHashBloomProbeExpr {
+    children: Vec<Arc<dyn datafusion::physical_plan::PhysicalExpr>>,
+    bloom: Arc<JoinHashBloomPayload>,
+}
+
+impl JoinHashBloomProbeExpr {
+    /// Creates a new probe expression **without validation**.
+    ///
+    /// This constructor panics via `try_new` if the arguments are invalid.
+    /// Prefer [`Self::try_new`] in production code paths.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the bloom payload fails validation, children are empty, or
+    /// `children.len()` does not match `bloom.join_key_child_indices.len()`.
+    pub fn new(
+        children: Vec<Arc<dyn datafusion::physical_plan::PhysicalExpr>>,
+        bloom: Arc<JoinHashBloomPayload>,
+    ) -> Self {
+        Self::try_new(children, bloom)
+            .expect("JoinHashBloomProbeExpr::new called with invalid state")
+    }
+
+    /// Fallible constructor that validates the bloom payload and
+    /// children against the payload's `join_key_child_indices`.
+    ///
+    /// Errors:
+    /// - bloom payload validation fails (version, bitset len, num_bits, etc.)
+    /// - `children` is empty
+    /// - `children.len() != bloom.join_key_child_indices.len()`
+    pub fn try_new(
+        children: Vec<Arc<dyn datafusion::physical_plan::PhysicalExpr>>,
+        bloom: Arc<JoinHashBloomPayload>,
+    ) -> DataFusionResult<Self> {
+        bloom.validate()?;
+
+        if children.is_empty() {
+            return Err(DataFusionError::Plan(
+                "JoinHashBloomProbeExpr: children is empty".to_string(),
+            ));
+        }
+
+        if children.len() != bloom.join_key_child_indices.len() {
+            return Err(DataFusionError::Plan(format!(
+                "JoinHashBloomProbeExpr: children.len() {} != bloom.join_key_child_indices.len() {}",
+                children.len(),
+                bloom.join_key_child_indices.len()
+            )));
+        }
+
+        Ok(Self { children, bloom })
+    }
+
+    /// Runtime validation guard for [`Self::evaluate`].
+    ///
+    /// Catches stale / mutated payloads that may have bypassed construction-time
+    /// checks. This is a defense-in-depth measure.
+    fn guard(&self) -> DataFusionResult<()> {
+        if self.children.is_empty() {
+            return Err(DataFusionError::Plan(
+                "JoinHashBloomProbeExpr::evaluate: children is empty".to_string(),
+            ));
+        }
+        if self.children.len() != self.bloom.join_key_child_indices.len() {
+            return Err(DataFusionError::Plan(format!(
+                "JoinHashBloomProbeExpr::evaluate: children.len() {} != bloom.join_key_child_indices.len() {}",
+                self.children.len(),
+                self.bloom.join_key_child_indices.len()
+            )));
+        }
+        // Re-validate the bloom payload to catch invalid bitset lengths,
+        // zero num_bits / num_probes, etc. before indexing into the bitset.
+        self.bloom.validate()?;
+        Ok(())
+    }
+
+    /// Returns a reference to the underlying Bloom payload.
+    pub fn bloom_payload(&self) -> &JoinHashBloomPayload {
+        &self.bloom
+    }
+}
+
+impl std::hash::Hash for JoinHashBloomProbeExpr {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        for child in &self.children {
+            child.dyn_hash(state);
+        }
+        self.bloom.hash(state);
+    }
+}
+
+impl PartialEq for JoinHashBloomProbeExpr {
+    fn eq(&self, other: &Self) -> bool {
+        self.children == other.children && self.bloom == other.bloom
+    }
+}
+
+impl std::fmt::Display for JoinHashBloomProbeExpr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let cols = self
+            .children
+            .iter()
+            .map(|e| e.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let seeds = (
+            self.bloom.df_seed0,
+            self.bloom.df_seed1,
+            self.bloom.df_seed2,
+            self.bloom.df_seed3,
+        );
+        write!(f, "bloom_probe({cols}, seeds={seeds:?})")
+    }
+}
+
+impl datafusion::physical_plan::PhysicalExpr for JoinHashBloomProbeExpr {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn data_type(
+        &self,
+        _input_schema: &datafusion::arrow::datatypes::Schema,
+    ) -> datafusion_common::Result<datafusion::arrow::datatypes::DataType> {
+        Ok(datafusion::arrow::datatypes::DataType::Boolean)
+    }
+
+    fn nullable(
+        &self,
+        _input_schema: &datafusion::arrow::datatypes::Schema,
+    ) -> datafusion_common::Result<bool> {
+        Ok(false)
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn datafusion::physical_plan::PhysicalExpr>> {
+        self.children.iter().collect()
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn datafusion::physical_plan::PhysicalExpr>>,
+    ) -> datafusion_common::Result<Arc<dyn datafusion::physical_plan::PhysicalExpr>> {
+        if children.len() != self.children.len() {
+            return Err(datafusion_common::DataFusionError::Plan(format!(
+                "JoinHashBloomProbeExpr::with_new_children: expected {} children, got {}",
+                self.children.len(),
+                children.len()
+            )));
+        }
+        Ok(Arc::new(Self {
+            children,
+            bloom: Arc::clone(&self.bloom),
+        }))
+    }
+
+    fn evaluate(
+        &self,
+        batch: &datafusion::arrow::record_batch::RecordBatch,
+    ) -> datafusion_common::Result<datafusion_expr::ColumnarValue> {
+        // Runtime guard: reject invalid/stale payload before probing
+        self.guard()?;
+
+        let num_rows = batch.num_rows();
+        let seeds = (
+            self.bloom.df_seed0,
+            self.bloom.df_seed1,
+            self.bloom.df_seed2,
+            self.bloom.df_seed3,
+        );
+        let hash_expr = datafusion::physical_plan::joins::HashExpr::new(
+            self.children.clone(),
+            datafusion::physical_plan::joins::SeededRandomState::with_seeds(
+                seeds.0, seeds.1, seeds.2, seeds.3,
+            ),
+            "join_hash_bloom_probe_hash".to_string(),
+        );
+        let hashes = datafusion::physical_plan::PhysicalExpr::evaluate(&hash_expr, batch)?
+            .into_array(num_rows)
+            .map_err(DataFusionError::from)?;
+        let hashes = hashes
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::UInt64Array>()
+            .ok_or_else(|| {
+                DataFusionError::Plan(
+                    "JoinHashBloomProbeExpr: HashExpr did not return UInt64Array".to_string(),
+                )
+            })?;
+
+        let num_bits = self.bloom.num_bits;
+        let num_probes = self.bloom.num_probes;
+        let bitset: &[u8] = &self.bloom.bitset; // borrow, don't clone
+
+        let bools: Vec<bool> = hashes
+            .iter()
+            .map(|hash| {
+                hash.is_some_and(|h| {
+                    bloom_contains(
+                        h,
+                        bitset,
+                        num_bits,
+                        num_probes,
+                        BloomHashAlgorithm::Splitmix64DoubleHashV1,
+                    )
+                })
+            })
+            .collect();
+
+        let array = datafusion::arrow::array::BooleanArray::from(bools);
+        Ok(datafusion_expr::ColumnarValue::Array(Arc::new(array)))
+    }
+
+    fn fmt_sql(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self}")
+    }
+}
+
+/// `ceil(n / 8)` without floating point.
+#[inline]
+fn num_bits_ceil_bytes(num_bits: usize) -> usize {
+    (num_bits / 8) + usize::from(num_bits % 8 != 0)
+}
+
+// ---------------------------------------------------------------------------
+// SplitMix64 double-hash Bloom helpers
+// ---------------------------------------------------------------------------
+
+/// SplitMix64 — a fast, high-quality 64-bit mixing function.
+///
+/// Each round avalanches all input bits. This is the same SplitMix64 used by
+/// many hash-table and Bloom filter implementations.
+#[inline]
+fn splitmix64(mut x: u64) -> u64 {
+    x = x.wrapping_add(0x9e3779b97f4a7c15);
+    x = (x ^ (x >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
+    x = (x ^ (x >> 27)).wrapping_mul(0x94d049bb133111eb);
+    x ^ (x >> 31)
+}
+
+/// Returns the bit position for the k-th probe of the given hash using
+/// SplitMix64 double-hashing.
+///
+/// - `h1 = splitmix64(hash)`
+/// - `delta = splitmix64(h1)`
+/// - `bit = (h1 + k * delta) % num_bits`
+#[inline]
+fn bloom_bit_index(hash: u64, k: u32, num_bits: u64) -> u64 {
+    let h1 = splitmix64(hash);
+    let delta = splitmix64(h1);
+    h1.wrapping_add((k as u64).wrapping_mul(delta)) % num_bits
+}
+
+/// Returns `true` if `hash` is present in the Bloom filter.
+///
+/// `bitset` is a byte slice of length `ceil(num_bits / 8)`. Bit 0 of each
+/// byte is the least-significant bit.
+fn bloom_contains(
+    hash: u64,
+    bitset: &[u8],
+    num_bits: u64,
+    num_probes: u32,
+    _algorithm: BloomHashAlgorithm,
+) -> bool {
+    for k in 0..num_probes {
+        let bit = bloom_bit_index(hash, k, num_bits);
+        let byte_idx = (bit >> 3) as usize;
+        let bit_mask = 1u8 << (bit & 7);
+        if bitset[byte_idx] & bit_mask == 0 {
+            return false;
+        }
+    }
+    true
+}
+
+/// Sets the bits for `hash` in the Bloom filter.
+fn bloom_insert(
+    hash: u64,
+    bitset: &mut [u8],
+    num_bits: u64,
+    num_probes: u32,
+    _algorithm: BloomHashAlgorithm,
+) {
+    for k in 0..num_probes {
+        let bit = bloom_bit_index(hash, k, num_bits);
+        let byte_idx = (bit >> 3) as usize;
+        let bit_mask = 1u8 << (bit & 7);
+        bitset[byte_idx] |= bit_mask;
+    }
+}
+
+/// Inserts many hashes and returns the number of *distinct* hashes inserted.
+fn bloom_insert_many(
+    hashes: impl IntoIterator<Item = u64>,
+    bitset: &mut [u8],
+    num_bits: u64,
+    num_probes: u32,
+    algorithm: BloomHashAlgorithm,
+) -> u64 {
+    let mut distinct = 0u64;
+    let mut seen = std::collections::HashSet::new();
+    for hash in hashes {
+        if seen.insert(hash) {
+            distinct += 1;
+            bloom_insert(hash, bitset, num_bits, num_probes, algorithm);
+        }
+    }
+    distinct
+}
+
+/// Compute a deterministic cross-platform hash-compatibility fingerprint.
+///
+/// Evaluates a DataFusion `HashExpr` with the given children and seeds over a
+/// canonical `RecordBatch` built from `input_schema`, then digests the output
+/// `UInt64Array` with FNV-1a (over little-endian bytes) finalized with
+/// SplitMix64. The digest also includes deterministic tags for the seeds and
+/// child output data types, because DataFusion may intentionally hash equal
+/// values of different integer widths to the same `u64`. The canonical batch
+/// has fixed-size rows with column-index-dependent values so child order is
+/// reflected in the `HashExpr` output sequence.
+///
+/// Returns `Ok(nonzero_u64)` on success or `Err(DataFusionError::Plan)` for
+/// unsupported input types.
+pub(crate) fn compute_hash_compat_fingerprint(
+    children: &[Arc<dyn datafusion::physical_plan::PhysicalExpr>],
+    input_schema: &datafusion::arrow::datatypes::Schema,
+    seeds: (u64, u64, u64, u64),
+) -> DataFusionResult<u64> {
+    use datafusion::physical_expr::PhysicalExpr;
+    use datafusion::physical_plan::joins::{HashExpr, SeededRandomState};
+
+    if children.is_empty() {
+        return Err(DataFusionError::Plan(
+            "fingerprint: empty children list".to_string(),
+        ));
+    }
+
+    let mut fnv: u64 = 0xcbf29ce484222325;
+    digest_bytes(&mut fnv, b"greptimedb-join-hash-bloom-compat-v1");
+    digest_u64(&mut fnv, seeds.0);
+    digest_u64(&mut fnv, seeds.1);
+    digest_u64(&mut fnv, seeds.2);
+    digest_u64(&mut fnv, seeds.3);
+    digest_u64(&mut fnv, children.len() as u64);
+    for child in children {
+        let data_type = child.data_type(input_schema)?;
+        digest_data_type(&mut fnv, &data_type)?;
+    }
+
+    // Build canonical batch — 3 rows with column-index-distinct values.
+    // Unsupported non-key columns are represented as typed null arrays in
+    // `build_canonical_batch`; unsupported key child types fail above.
+    let batch = build_canonical_batch(input_schema)?;
+    let hash_expr = HashExpr::new(
+        children.to_vec(),
+        SeededRandomState::with_seeds(seeds.0, seeds.1, seeds.2, seeds.3),
+        "join_hash_bloom_hash_compat".to_string(),
+    );
+
+    let result = hash_expr.evaluate(&batch)?;
+    let array = result
+        .into_array(batch.num_rows())
+        .map_err(|e| DataFusionError::Plan(format!("fingerprint: cannot convert to array: {e}")))?;
+    let hashes = array
+        .as_any()
+        .downcast_ref::<datafusion::arrow::array::UInt64Array>()
+        .ok_or_else(|| {
+            DataFusionError::Plan("fingerprint: HashExpr did not produce UInt64Array".to_string())
+        })?;
+
+    // FNV-1a over little-endian bytes of each u64 hash, with a null marker for
+    // completeness even though HashExpr normally returns a non-null UInt64Array.
+    for h in hashes.iter() {
+        match h {
+            Some(h) => {
+                digest_u8(&mut fnv, 1);
+                digest_u64(&mut fnv, h);
+            }
+            None => {
+                digest_u8(&mut fnv, 0);
+            }
+        }
+    }
+
+    // Finalize with SplitMix64 to avalanche bits; prevent accidental zero output
+    let mut fp = splitmix64(fnv);
+    if fp == 0 {
+        fp = 1;
+    }
+    Ok(fp)
+}
+
+fn digest_u8(state: &mut u64, value: u8) {
+    *state ^= value as u64;
+    *state = state.wrapping_mul(0x100000001b3);
+}
+
+fn digest_u64(state: &mut u64, value: u64) {
+    digest_bytes(state, &value.to_le_bytes());
+}
+
+fn digest_bytes(state: &mut u64, bytes: &[u8]) {
+    digest_u64_lenless(state, bytes.len() as u64);
+    for &byte in bytes {
+        digest_u8(state, byte);
+    }
+}
+
+fn digest_u64_lenless(state: &mut u64, value: u64) {
+    for byte in value.to_le_bytes() {
+        digest_u8(state, byte);
+    }
+}
+
+fn digest_data_type(
+    state: &mut u64,
+    data_type: &datafusion::arrow::datatypes::DataType,
+) -> DataFusionResult<()> {
+    use datafusion::arrow::datatypes::DataType;
+
+    match data_type {
+        DataType::Boolean => digest_u64(state, 1),
+        DataType::Int8 => digest_u64(state, 2),
+        DataType::Int16 => digest_u64(state, 3),
+        DataType::Int32 => digest_u64(state, 4),
+        DataType::Int64 => digest_u64(state, 5),
+        DataType::UInt8 => digest_u64(state, 6),
+        DataType::UInt16 => digest_u64(state, 7),
+        DataType::UInt32 => digest_u64(state, 8),
+        DataType::UInt64 => digest_u64(state, 9),
+        DataType::Float32 => digest_u64(state, 10),
+        DataType::Float64 => digest_u64(state, 11),
+        DataType::Utf8 => digest_u64(state, 12),
+        DataType::LargeUtf8 => digest_u64(state, 13),
+        DataType::Binary => digest_u64(state, 14),
+        DataType::LargeBinary => digest_u64(state, 15),
+        DataType::Date32 => digest_u64(state, 16),
+        DataType::Date64 => digest_u64(state, 17),
+        DataType::Timestamp(unit, timezone) => {
+            digest_u64(state, 18);
+            digest_time_unit(state, unit);
+            match timezone {
+                Some(timezone) => {
+                    digest_u8(state, 1);
+                    digest_bytes(state, timezone.as_bytes());
+                }
+                None => digest_u8(state, 0),
+            }
+        }
+        other => {
+            return Err(DataFusionError::Plan(format!(
+                "fingerprint: unsupported child data type {other:?}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn digest_time_unit(state: &mut u64, unit: &datafusion::arrow::datatypes::TimeUnit) {
+    use datafusion::arrow::datatypes::TimeUnit;
+
+    let tag = match unit {
+        TimeUnit::Second => 1,
+        TimeUnit::Millisecond => 2,
+        TimeUnit::Microsecond => 3,
+        TimeUnit::Nanosecond => 4,
+    };
+    digest_u64(state, tag);
+}
+
+/// Canonical batch with 3 rows. Each column gets column-index-distinct scalar values
+/// so the fingerprint is sensitive to column types and ordering.
+fn build_canonical_batch(
+    schema: &datafusion::arrow::datatypes::Schema,
+) -> DataFusionResult<datafusion::arrow::record_batch::RecordBatch> {
+    use datafusion::arrow::array::{
+        ArrayRef, BinaryArray, BooleanArray, Date32Array, Date64Array, Float32Array, Float64Array,
+        Int8Array, Int16Array, Int32Array, Int64Array, LargeBinaryArray, LargeStringArray,
+        StringArray, TimestampMicrosecondArray, TimestampMillisecondArray,
+        TimestampNanosecondArray, TimestampSecondArray, UInt8Array, UInt16Array, UInt32Array,
+        UInt64Array, new_null_array,
+    };
+    use datafusion::arrow::datatypes::{DataType, TimeUnit};
+
+    let column_values: Vec<ArrayRef> = schema
+        .fields()
+        .iter()
+        .enumerate()
+        .map(|(col_idx, field)| {
+            let idx = col_idx as i64;
+            Ok(match field.data_type() {
+                DataType::Boolean => Arc::new(BooleanArray::from(vec![
+                    idx % 2 == 0,
+                    idx % 3 != 0,
+                    idx % 2 != 0,
+                ])) as ArrayRef,
+                DataType::Int8 => Arc::new(Int8Array::from(vec![
+                    (idx + 1) as i8,
+                    (idx + 2) as i8,
+                    (idx + 3) as i8,
+                ])),
+                DataType::Int16 => Arc::new(Int16Array::from(vec![
+                    (idx + 1) as i16,
+                    (idx + 2) as i16,
+                    (idx + 3) as i16,
+                ])),
+                DataType::Int32 => Arc::new(Int32Array::from(vec![
+                    (idx + 1) as i32,
+                    (idx + 2) as i32,
+                    (idx + 3) as i32,
+                ])),
+                DataType::Int64 => Arc::new(Int64Array::from(vec![idx + 1, idx + 2, idx + 3])),
+                DataType::UInt8 => Arc::new(UInt8Array::from(vec![
+                    (idx + 1) as u8,
+                    (idx + 2) as u8,
+                    (idx + 3) as u8,
+                ])),
+                DataType::UInt16 => Arc::new(UInt16Array::from(vec![
+                    (idx + 1) as u16,
+                    (idx + 2) as u16,
+                    (idx + 3) as u16,
+                ])),
+                DataType::UInt32 => Arc::new(UInt32Array::from(vec![
+                    (idx + 1) as u32,
+                    (idx + 2) as u32,
+                    (idx + 3) as u32,
+                ])),
+                DataType::UInt64 => Arc::new(UInt64Array::from(vec![
+                    (idx + 1) as u64,
+                    (idx + 2) as u64,
+                    (idx + 3) as u64,
+                ])),
+                DataType::Float32 => Arc::new(Float32Array::from(vec![
+                    (idx + 1) as f32,
+                    (idx + 2) as f32,
+                    (idx + 3) as f32,
+                ])),
+                DataType::Float64 => Arc::new(Float64Array::from(vec![
+                    (idx + 1) as f64,
+                    (idx + 2) as f64,
+                    (idx + 3) as f64,
+                ])),
+                DataType::Utf8 => Arc::new(StringArray::from(vec![
+                    format!("c{idx}_0"),
+                    format!("c{idx}_1"),
+                    format!("c{idx}_2"),
+                ])),
+                DataType::LargeUtf8 => Arc::new(LargeStringArray::from(vec![
+                    format!("c{idx}_0"),
+                    format!("c{idx}_1"),
+                    format!("c{idx}_2"),
+                ])),
+                DataType::Binary => {
+                    let v0: Vec<u8> = format!("b{idx}_0").into_bytes();
+                    let v1: Vec<u8> = format!("b{idx}_1").into_bytes();
+                    let v2: Vec<u8> = format!("b{idx}_2").into_bytes();
+                    Arc::new(BinaryArray::from_iter_values([&v0[..], &v1[..], &v2[..]]))
+                }
+                DataType::LargeBinary => {
+                    let v0: Vec<u8> = format!("b{idx}_0").into_bytes();
+                    let v1: Vec<u8> = format!("b{idx}_1").into_bytes();
+                    let v2: Vec<u8> = format!("b{idx}_2").into_bytes();
+                    Arc::new(LargeBinaryArray::from_iter_values([
+                        &v0[..],
+                        &v1[..],
+                        &v2[..],
+                    ]))
+                }
+                DataType::Date32 => Arc::new(Date32Array::from(vec![
+                    (idx + 1) as i32,
+                    (idx + 2) as i32,
+                    (idx + 3) as i32,
+                ])),
+                DataType::Date64 => Arc::new(Date64Array::from(vec![idx + 1, idx + 2, idx + 3])),
+                DataType::Timestamp(TimeUnit::Second, _) => {
+                    Arc::new(TimestampSecondArray::from(vec![idx + 1, idx + 2, idx + 3]))
+                }
+                DataType::Timestamp(TimeUnit::Millisecond, _) => {
+                    Arc::new(TimestampMillisecondArray::from(vec![
+                        idx + 1,
+                        idx + 2,
+                        idx + 3,
+                    ]))
+                }
+                DataType::Timestamp(TimeUnit::Microsecond, _) => {
+                    Arc::new(TimestampMicrosecondArray::from(vec![
+                        idx + 1,
+                        idx + 2,
+                        idx + 3,
+                    ]))
+                }
+                DataType::Timestamp(TimeUnit::Nanosecond, _) => {
+                    Arc::new(TimestampNanosecondArray::from(vec![
+                        idx + 1,
+                        idx + 2,
+                        idx + 3,
+                    ]))
+                }
+                other => new_null_array(other, 3),
+            })
+        })
+        .collect::<DataFusionResult<Vec<_>>>()?;
+
+    let batch = datafusion::arrow::record_batch::RecordBatch::try_new(
+        Arc::new(schema.clone()),
+        column_values,
+    )
+    .map_err(|e| {
+        DataFusionError::Plan(format!("fingerprint: failed to build canonical batch: {e}"))
+    })?;
+
+    Ok(batch)
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion_common::DataFusionError;
+
+    use super::*;
+
+    fn minimal_valid_payload() -> JoinHashBloomPayload {
+        JoinHashBloomPayload {
+            version: JOIN_HASH_BLOOM_VERSION,
+            hash_kind: JoinHashKind::DatafusionJoinHashU64,
+            df_seed0: 4,
+            df_seed1: 5,
+            df_seed2: 6,
+            df_seed3: 7,
+            num_bits: 1024,
+            num_probes: 3,
+            distinct_hash_count: 100,
+            bitset: vec![0u8; 128],
+            join_key_child_indices: vec![0, 1],
+            residual_datafusion_physical_expr: vec![1, 2, 3],
+            bloom_hash_algorithm: BloomHashAlgorithm::Splitmix64DoubleHashV1,
+            hash_compat_fingerprint: 0,
+        }
+    }
+
+    #[test]
+    fn validate_accepts_valid_payload() {
+        minimal_valid_payload().validate().unwrap();
+    }
+
+    #[test]
+    fn validate_rejects_unsupported_version() {
+        let mut p = minimal_valid_payload();
+        p.version = 99;
+        let err = p.validate().unwrap_err();
+        assert!(err.to_string().contains("unsupported version 99"));
+    }
+
+    #[test]
+    fn validate_rejects_unspecified_hash_kind() {
+        let mut p = minimal_valid_payload();
+        p.hash_kind = JoinHashKind::Unspecified;
+        let err = p.validate().unwrap_err();
+        assert!(err.to_string().contains("unsupported hash_kind"));
+    }
+
+    #[test]
+    fn validate_rejects_unspecified_bloom_algorithm() {
+        let mut p = minimal_valid_payload();
+        p.bloom_hash_algorithm = BloomHashAlgorithm::Unspecified;
+        let err = p.validate().unwrap_err();
+        assert!(err.to_string().contains("unsupported bloom_hash_algorithm"));
+    }
+
+    #[test]
+    fn validate_rejects_zero_num_bits() {
+        let mut p = minimal_valid_payload();
+        p.num_bits = 0;
+        let err = p.validate().unwrap_err();
+        assert!(err.to_string().contains("num_bits is zero"));
+    }
+
+    #[test]
+    fn validate_accepts_num_bits_at_usize_max() {
+        let mut p = minimal_valid_payload();
+        p.num_bits = usize::MAX as u64;
+        // bitset must match: ceil(usize::MAX / 8) — but that's huge and would OOM.
+        // On 64-bit platforms, usize::MAX == u64::MAX and the check
+        // `num_bits > usize::MAX` is always false, so we only verify
+        // the validation path does not panic on a passing value.
+        // The `> usize::MAX` branch is only reachable on 32-bit targets.
+        if cfg!(target_pointer_width = "64") {
+            // On 64-bit we cannot construct a bitset of size ceil(u64::MAX/8),
+            // but we can verify that smaller valid sizes still pass.
+            p.num_bits = 1024;
+            p.bitset = vec![0u8; 128];
+            p.validate().unwrap();
+        }
+    }
+
+    #[test]
+    fn validate_rejects_zero_num_probes() {
+        let mut p = minimal_valid_payload();
+        p.num_probes = 0;
+        let err = p.validate().unwrap_err();
+        assert!(err.to_string().contains("num_probes is zero"));
+    }
+
+    #[test]
+    fn validate_rejects_excessive_num_probes() {
+        let mut p = minimal_valid_payload();
+        p.num_probes = MAX_BLOOM_NUM_PROBES + 1;
+        let err = p.validate().unwrap_err();
+        assert!(err.to_string().contains("exceeds limit"));
+    }
+
+    #[test]
+    fn validate_rejects_wrong_bitset_length() {
+        let mut p = minimal_valid_payload();
+        p.bitset = vec![0u8; 127]; // should be 128 for num_bits=1024
+        let err = p.validate().unwrap_err();
+        assert!(err.to_string().contains("bitset length"));
+    }
+
+    #[test]
+    fn validate_rejects_duplicate_join_key_child_indices() {
+        let mut p = minimal_valid_payload();
+        p.join_key_child_indices = vec![0, 1, 0];
+        let err = p.validate().unwrap_err();
+        assert!(err.to_string().contains("duplicate join key child index 0"));
+    }
+
+    #[test]
+    fn validate_rejects_oversized_residual() {
+        let mut p = minimal_valid_payload();
+        p.residual_datafusion_physical_expr = vec![0u8; MAX_BLOOM_RESIDUAL_BYTES + 1];
+        let err = p.validate().unwrap_err();
+        assert!(err.to_string().contains("exceeds budget"));
+    }
+
+    #[test]
+    fn validate_rejects_empty_join_key_child_indices() {
+        let mut p = minimal_valid_payload();
+        p.join_key_child_indices = vec![];
+        let err = p.validate().unwrap_err();
+        assert!(err.to_string().contains("join_key_child_indices is empty"));
+    }
+
+    #[test]
+    fn validate_rejects_empty_residual() {
+        let mut p = minimal_valid_payload();
+        p.residual_datafusion_physical_expr = vec![];
+        let err = p.validate().unwrap_err();
+        assert!(err.to_string().contains("residual expression is empty"));
+    }
+
+    #[test]
+    fn validate_num_bits_exactly_divisible_by_8() {
+        let mut p = minimal_valid_payload();
+        p.num_bits = 1024;
+        p.bitset = vec![0u8; 128];
+        p.validate().unwrap();
+    }
+
+    #[test]
+    fn validate_num_bits_not_divisible_by_8() {
+        let mut p = minimal_valid_payload();
+        p.num_bits = 1025;
+        p.bitset = vec![0u8; 129]; // ceil(1025/8) = 129
+        p.validate().unwrap();
+
+        p.bitset = vec![0u8; 128];
+        let err = p.validate().unwrap_err();
+        assert!(err.to_string().contains("bitset length"));
+    }
+
+    #[test]
+    fn from_proto_rejects_unknown_hash_kind() {
+        let proto = api::v1::region::JoinHashBloomPayload {
+            hash_kind: 999,
+            ..Default::default()
+        };
+        let err = JoinHashBloomPayload::from_proto(&proto).unwrap_err();
+        assert!(matches!(err, DataFusionError::Plan(_)));
+        assert!(err.to_string().contains("unknown hash_kind"));
+    }
+
+    #[test]
+    fn from_proto_rejects_unknown_bloom_algorithm() {
+        let proto = api::v1::region::JoinHashBloomPayload {
+            version: JOIN_HASH_BLOOM_VERSION,
+            hash_kind: api::v1::region::JoinHashKind::DatafusionJoinHashU64 as i32,
+            bloom_hash_algorithm: 999,
+            hash_compat_fingerprint: 0,
+            ..Default::default()
+        };
+        let err = JoinHashBloomPayload::from_proto(&proto).unwrap_err();
+        assert!(matches!(err, DataFusionError::Plan(_)));
+        assert!(err.to_string().contains("unknown bloom_hash_algorithm"));
+    }
+
+    #[test]
+    fn proto_roundtrip_preserves_fields() {
+        let original = minimal_valid_payload();
+        let proto = original.to_proto();
+        let decoded = JoinHashBloomPayload::from_proto(&proto).unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn json_serde_roundtrip_uses_base64() {
+        let original = minimal_valid_payload();
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: JoinHashBloomPayload = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, original);
+
+        // Verify bitset and residual are base64-encoded (not raw bytes)
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let bitset_str = value["bitset"].as_str().unwrap();
+        let residual_str = value["residual_datafusion_physical_expr"].as_str().unwrap();
+        // Should be valid base64
+        use base64::Engine;
+        use base64::prelude::BASE64_STANDARD;
+        BASE64_STANDARD.decode(bitset_str).unwrap();
+        BASE64_STANDARD.decode(residual_str).unwrap();
+        // And should not be raw byte arrays
+        assert!(!bitset_str.starts_with('['));
+    }
+
+    #[test]
+    fn json_rejects_invalid_base64_in_bitset() {
+        let err = serde_json::from_str::<JoinHashBloomPayload>(
+            r#"{"version":1,"hash_kind":"DatafusionJoinHashU64","df_seed0":0,"df_seed1":0,"df_seed2":0,"df_seed3":0,"num_bits":8,"num_probes":1,"distinct_hash_count":0,"bitset":"!!!not.base64!!!","join_key_child_indices":[],"residual_datafusion_physical_expr":"","bloom_hash_algorithm":"Splitmix64DoubleHashV1"}"#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("invalid base64"));
+    }
+
+    #[test]
+    fn expected_bitset_bytes_computes_ceil_division() {
+        let p = JoinHashBloomPayload {
+            num_bits: 1024,
+            bitset: vec![0u8; 128],
+            ..minimal_valid_payload()
+        };
+        assert_eq!(p.expected_bitset_bytes(), 128);
+
+        let p2 = JoinHashBloomPayload {
+            num_bits: 1025,
+            bitset: vec![0u8; 129],
+            ..p
+        };
+        assert_eq!(p2.expected_bitset_bytes(), 129);
+    }
+
+    #[test]
+    fn num_bits_ceil_bytes_does_not_overflow() {
+        assert_eq!(num_bits_ceil_bytes(usize::MAX), (usize::MAX / 8) + 1);
+    }
+
+    // ── Bloom bitset / SplitMix64 tests ──────────────────────────
+
+    #[test]
+    fn bloom_insert_contains_no_false_negatives() {
+        let hashes: Vec<u64> = (0..100).map(|i| i * 7 + 13).collect();
+        let payload = JoinHashBloomPayload::build_from_hashes(
+            hashes.clone(),
+            1024,
+            3,
+            (1, 2, 3, 4),
+            vec![0],
+            vec![1],
+        );
+
+        // Every inserted hash must be found
+        for &h in &hashes {
+            assert!(
+                payload.contains_join_hash(h),
+                "hash {} should be in the Bloom filter",
+                h
+            );
+        }
+
+        // Hash not inserted should usually be absent (may have false positives)
+        // but we can at least verify the method doesn't crash
+        let _ = payload.contains_join_hash(u64::MAX);
+    }
+
+    #[test]
+    fn bloom_roundtrip_no_false_negatives_after_json() {
+        let hashes = vec![42u64, 12345, 98765];
+        let payload = JoinHashBloomPayload::build_from_hashes(
+            hashes.clone(),
+            256,
+            2,
+            (0, 0, 0, 0),
+            vec![0],
+            vec![1],
+        );
+
+        let json = serde_json::to_string(&payload).unwrap();
+        let decoded: JoinHashBloomPayload = serde_json::from_str(&json).unwrap();
+
+        for &h in &hashes {
+            assert!(decoded.contains_join_hash(h));
+        }
+    }
+
+    #[test]
+    fn bloom_roundtrip_no_false_negatives_after_proto() {
+        let hashes = vec![42u64, 12345, 98765];
+        let payload = JoinHashBloomPayload::build_from_hashes(
+            hashes.clone(),
+            256,
+            2,
+            (0, 0, 0, 0),
+            vec![0],
+            vec![1],
+        );
+
+        let proto = payload.to_proto();
+        let decoded = JoinHashBloomPayload::from_proto(&proto).unwrap();
+
+        for &h in &hashes {
+            assert!(decoded.contains_join_hash(h));
+        }
+    }
+
+    #[test]
+    fn build_from_hashes_counts_distinct() {
+        let hashes = vec![1u64, 2, 3, 2, 1]; // 3 distinct
+        let payload =
+            JoinHashBloomPayload::build_from_hashes(hashes, 256, 2, (0, 0, 0, 0), vec![0], vec![1]);
+        assert_eq!(payload.distinct_hash_count, 3);
+    }
+
+    #[test]
+    fn splitmix64_is_deterministic() {
+        let h1 = splitmix64(42);
+        let h2 = splitmix64(42);
+        assert_eq!(h1, h2);
+
+        let h3 = splitmix64(43);
+        assert_ne!(h1, h3);
+    }
+
+    // ── JoinHashBloomProbeExpr tests ────────────────────────────
+
+    use datafusion::arrow::array::Array;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::physical_plan::PhysicalExpr;
+
+    #[test]
+    fn probe_expr_evaluates_non_null_boolean_array() {
+        let schema = Schema::new(vec![Field::new("id", DataType::Int32, false)]);
+        let col: Arc<dyn PhysicalExpr> =
+            Arc::new(datafusion::physical_expr::expressions::Column::new("id", 0));
+
+        // Build a Bloom with some sample hashes
+        let hashes = vec![100u64, 200, 300];
+        let bloom = Arc::new(JoinHashBloomPayload::build_from_hashes(
+            hashes,
+            512,
+            2,
+            (1, 2, 3, 4),
+            vec![0],
+            vec![1],
+        ));
+
+        let probe = JoinHashBloomProbeExpr::new(vec![Arc::clone(&col)], bloom);
+
+        // Create a batch with some values
+        let batch = datafusion::arrow::record_batch::RecordBatch::try_new(
+            Arc::new(schema.clone()),
+            vec![Arc::new(datafusion::arrow::array::Int32Array::from(vec![
+                10, 20, 30, 40, 50,
+            ]))],
+        )
+        .unwrap();
+
+        let result = probe.evaluate(&batch).unwrap();
+        match result {
+            datafusion_expr::ColumnarValue::Array(arr) => {
+                let bool_arr = arr
+                    .as_any()
+                    .downcast_ref::<datafusion::arrow::array::BooleanArray>()
+                    .unwrap();
+                assert_eq!(bool_arr.len(), 5);
+                // No nulls
+                assert_eq!(bool_arr.null_count(), 0);
+                // All should be boolean (either true or false)
+                for i in 0..5 {
+                    assert!(!bool_arr.is_null(i));
+                }
+            }
+            _ => panic!("expected array result"),
+        }
+    }
+
+    #[test]
+    fn probe_expr_uses_datafusion_hash_expr_hashes_without_false_negatives() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let col: Arc<dyn PhysicalExpr> =
+            Arc::new(datafusion::physical_expr::expressions::Column::new("id", 0));
+        let seeds = (1, 2, 3, 4);
+        let batch = datafusion::arrow::record_batch::RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(datafusion::arrow::array::Int32Array::from(vec![
+                10, 20, 30, 40, 50,
+            ]))],
+        )
+        .unwrap();
+
+        let hash_expr = datafusion::physical_plan::joins::HashExpr::new(
+            vec![Arc::clone(&col)],
+            datafusion::physical_plan::joins::SeededRandomState::with_seeds(
+                seeds.0, seeds.1, seeds.2, seeds.3,
+            ),
+            "test_hash".to_string(),
+        );
+        let hashes = hash_expr
+            .evaluate(&batch)
+            .unwrap()
+            .into_array(batch.num_rows())
+            .unwrap();
+        let hashes = hashes
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::UInt64Array>()
+            .unwrap();
+        let inserted_hashes = hashes.iter().map(|hash| hash.unwrap()).collect::<Vec<_>>();
+
+        let bloom = Arc::new(JoinHashBloomPayload::build_from_hashes(
+            inserted_hashes,
+            512,
+            2,
+            seeds,
+            vec![0],
+            vec![1],
+        ));
+        let probe = JoinHashBloomProbeExpr::new(vec![Arc::clone(&col)], bloom);
+
+        let result = probe.evaluate(&batch).unwrap();
+        let datafusion_expr::ColumnarValue::Array(arr) = result else {
+            panic!("expected array result");
+        };
+        let bool_arr = arr
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::BooleanArray>()
+            .unwrap();
+
+        assert_eq!(bool_arr.len(), batch.num_rows());
+        assert!(bool_arr.iter().all(|value| value == Some(true)));
+    }
+
+    #[test]
+    fn probe_expr_message_borrows_all_data() {
+        // Sanity check that Debug and Display work
+        let col: Arc<dyn PhysicalExpr> =
+            Arc::new(datafusion::physical_expr::expressions::Column::new("id", 0));
+        let bloom = Arc::new(JoinHashBloomPayload::build_from_hashes(
+            vec![1u64],
+            64,
+            2,
+            (0, 0, 0, 0),
+            vec![0],
+            vec![1],
+        ));
+        let probe = JoinHashBloomProbeExpr::new(vec![Arc::clone(&col)], bloom);
+        let debug_str = format!("{probe:?}");
+        assert!(debug_str.contains("JoinHashBloomProbeExpr"));
+        let display_str = format!("{probe}");
+        assert!(display_str.contains("bloom_probe"));
+    }
+
+    #[test]
+    fn probe_expr_equality_and_hash() {
+        let col: Arc<dyn PhysicalExpr> =
+            Arc::new(datafusion::physical_expr::expressions::Column::new("id", 0));
+        let bloom1 = Arc::new(JoinHashBloomPayload::build_from_hashes(
+            vec![1u64],
+            64,
+            2,
+            (0, 0, 0, 0),
+            vec![0],
+            vec![1],
+        ));
+        let bloom2 = Arc::new(JoinHashBloomPayload::build_from_hashes(
+            vec![1u64],
+            64,
+            2,
+            (0, 0, 0, 0),
+            vec![0],
+            vec![1],
+        ));
+
+        let probe1 = JoinHashBloomProbeExpr::new(vec![Arc::clone(&col)], bloom1);
+        let probe2 = JoinHashBloomProbeExpr::new(vec![Arc::clone(&col)], bloom2);
+
+        assert_eq!(probe1, probe2);
+    }
+
+    #[test]
+    fn probe_expr_children_and_with_new_children() {
+        let col_a: Arc<dyn PhysicalExpr> =
+            Arc::new(datafusion::physical_expr::expressions::Column::new("a", 0));
+        let col_b: Arc<dyn PhysicalExpr> =
+            Arc::new(datafusion::physical_expr::expressions::Column::new("b", 1));
+        let bloom = Arc::new(JoinHashBloomPayload::build_from_hashes(
+            vec![1u64],
+            64,
+            2,
+            (0, 0, 0, 0),
+            vec![0, 1],
+            vec![1],
+        ));
+
+        let probe = Arc::new(JoinHashBloomProbeExpr::new(
+            vec![Arc::clone(&col_a), Arc::clone(&col_b)],
+            bloom,
+        ));
+
+        let children = probe.children();
+        assert_eq!(children.len(), 2);
+
+        // with_new_children with correct count succeeds
+        let new_probe = Arc::clone(&probe)
+            .with_new_children(vec![Arc::clone(&col_b), Arc::clone(&col_a)])
+            .unwrap();
+        assert_eq!(new_probe.children().len(), 2);
+
+        // with_new_children with wrong count fails
+        let err = Arc::clone(&probe)
+            .with_new_children(vec![Arc::clone(&col_a)])
+            .unwrap_err();
+        assert!(err.to_string().contains("expected 2 children"));
+    }
+
+    // ── Hardening tests ──────────────────────────────────────
+
+    #[test]
+    fn try_new_rejects_empty_children() {
+        let bloom = Arc::new(JoinHashBloomPayload::build_from_hashes(
+            vec![1u64],
+            64,
+            2,
+            (0, 0, 0, 0),
+            vec![0],
+            vec![1],
+        ));
+        let err = JoinHashBloomProbeExpr::try_new(vec![], bloom).unwrap_err();
+        assert!(matches!(err, DataFusionError::Plan(_)));
+        assert!(err.to_string().contains("children is empty"));
+    }
+
+    #[test]
+    fn try_new_rejects_child_count_mismatch() {
+        let col: Arc<dyn PhysicalExpr> =
+            Arc::new(datafusion::physical_expr::expressions::Column::new("a", 0));
+        let bloom = Arc::new(JoinHashBloomPayload::build_from_hashes(
+            vec![1u64],
+            64,
+            2,
+            (0, 0, 0, 0),
+            vec![0, 1],
+            vec![1], // 2 join key child indices
+        ));
+        let err = JoinHashBloomProbeExpr::try_new(vec![Arc::clone(&col)], bloom).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("bloom.join_key_child_indices.len()")
+        );
+    }
+
+    #[test]
+    fn try_new_rejects_invalid_bloom_payload() {
+        let col: Arc<dyn PhysicalExpr> =
+            Arc::new(datafusion::physical_expr::expressions::Column::new("a", 0));
+        let mut bloom = JoinHashBloomPayload::build_from_hashes(
+            vec![1u64],
+            64,
+            2,
+            (0, 0, 0, 0),
+            vec![0],
+            vec![1],
+        );
+        // Corrupt: set num_bits = 0
+        bloom.num_bits = 0;
+        let err =
+            JoinHashBloomProbeExpr::try_new(vec![Arc::clone(&col)], Arc::new(bloom)).unwrap_err();
+        assert!(err.to_string().contains("num_bits is zero"));
+    }
+
+    #[test]
+    #[should_panic(expected = "new called with invalid state")]
+    fn new_panics_on_invalid_payload() {
+        let col: Arc<dyn PhysicalExpr> =
+            Arc::new(datafusion::physical_expr::expressions::Column::new("id", 0));
+        let mut bloom = JoinHashBloomPayload::build_from_hashes(
+            vec![1u64, 2, 3],
+            64,
+            2,
+            (0, 0, 0, 0),
+            vec![0],
+            vec![1],
+        );
+        bloom.num_bits = 0; // invalid
+        let corrupted = Arc::new(bloom);
+        // This should panic via try_new in new()
+        let _bad = JoinHashBloomProbeExpr::new(vec![Arc::clone(&col)], corrupted);
+    }
+
+    #[test]
+    fn try_new_rejects_invalid_payload_does_not_panic() {
+        let col: Arc<dyn PhysicalExpr> =
+            Arc::new(datafusion::physical_expr::expressions::Column::new("id", 0));
+        let mut bloom = JoinHashBloomPayload::build_from_hashes(
+            vec![1u64, 2, 3],
+            64,
+            2,
+            (0, 0, 0, 0),
+            vec![0],
+            vec![1],
+        );
+        bloom.num_bits = 0; // invalid
+        let corrupted = Arc::new(bloom);
+        let err = JoinHashBloomProbeExpr::try_new(vec![Arc::clone(&col)], corrupted).unwrap_err();
+        assert!(matches!(err, DataFusionError::Plan(_)));
+        assert!(err.to_string().contains("num_bits is zero"));
+    }
+
+    #[test]
+    fn evaluate_with_invalid_bitset_length_errors_not_panics() {
+        let schema = Schema::new(vec![Field::new("id", DataType::Int32, false)]);
+        let col: Arc<dyn PhysicalExpr> =
+            Arc::new(datafusion::physical_expr::expressions::Column::new("id", 0));
+
+        // Build a bloom with wrong bitset length
+        let mut bloom = JoinHashBloomPayload::build_from_hashes(
+            vec![10u64, 20, 30],
+            64,
+            2,
+            (0, 0, 0, 0),
+            vec![0],
+            vec![1],
+        );
+        bloom.num_bits = 128; // 128 bits need 16 bytes, but bitset has 8
+        // bitset is still 8 bytes (wrong)
+        let bloom_arc = Arc::new(bloom);
+
+        let err = JoinHashBloomProbeExpr::try_new(vec![Arc::clone(&col)], bloom_arc).unwrap_err();
+        assert!(err.to_string().contains("bitset length"));
+    }
+
+    #[test]
+    fn evaluate_with_zero_num_probes_errors_not_panics() {
+        let col: Arc<dyn PhysicalExpr> =
+            Arc::new(datafusion::physical_expr::expressions::Column::new("id", 0));
+        let mut bloom = JoinHashBloomPayload::build_from_hashes(
+            vec![10u64],
+            64,
+            2,
+            (0, 0, 0, 0),
+            vec![0],
+            vec![1],
+        );
+        bloom.num_probes = 0;
+        let err =
+            JoinHashBloomProbeExpr::try_new(vec![Arc::clone(&col)], Arc::new(bloom)).unwrap_err();
+        assert!(err.to_string().contains("num_probes is zero"));
+    }
+
+    #[test]
+    fn evaluate_with_zero_num_bits_errors_not_panics() {
+        let col: Arc<dyn PhysicalExpr> =
+            Arc::new(datafusion::physical_expr::expressions::Column::new("id", 0));
+        let mut bloom = JoinHashBloomPayload::build_from_hashes(
+            vec![10u64],
+            64,
+            2,
+            (0, 0, 0, 0),
+            vec![0],
+            vec![1],
+        );
+        bloom.num_bits = 0;
+        let err =
+            JoinHashBloomProbeExpr::try_new(vec![Arc::clone(&col)], Arc::new(bloom)).unwrap_err();
+        assert!(err.to_string().contains("num_bits is zero"));
+    }
+}

--- a/src/common/query/src/request/join_hash_bloom.rs
+++ b/src/common/query/src/request/join_hash_bloom.rs
@@ -695,8 +695,7 @@ impl datafusion::physical_plan::PhysicalExpr for JoinHashBloomProbeExpr {
             "join_hash_bloom_probe_hash".to_string(),
         );
         let hashes = datafusion::physical_plan::PhysicalExpr::evaluate(&hash_expr, batch)?
-            .into_array(num_rows)
-            .map_err(DataFusionError::from)?;
+            .into_array(num_rows)?;
         let hashes = hashes
             .as_any()
             .downcast_ref::<datafusion::arrow::array::UInt64Array>()
@@ -737,7 +736,7 @@ impl datafusion::physical_plan::PhysicalExpr for JoinHashBloomProbeExpr {
 /// `ceil(n / 8)` without floating point.
 #[inline]
 fn num_bits_ceil_bytes(num_bits: usize) -> usize {
-    (num_bits / 8) + usize::from(num_bits % 8 != 0)
+    (num_bits / 8) + usize::from(!num_bits.is_multiple_of(8))
 }
 
 // ---------------------------------------------------------------------------
@@ -1742,7 +1741,6 @@ mod tests {
 
     #[test]
     fn evaluate_with_invalid_bitset_length_errors_not_panics() {
-        let schema = Schema::new(vec![Field::new("id", DataType::Int32, false)]);
         let col: Arc<dyn PhysicalExpr> =
             Arc::new(datafusion::physical_expr::expressions::Column::new("id", 0));
 

--- a/src/datanode/src/region_server/registrations.rs
+++ b/src/datanode/src/region_server/registrations.rs
@@ -18,21 +18,99 @@ use std::fmt::{Display, Formatter};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use common_query::request::{
-    DynFilterPayload, INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY, InitialDynFilterReg,
-    InitialDynFilterRegs,
+    DecodedDynFilterExprs, DynFilterPayload, INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY,
+    InitialDynFilterReg, InitialDynFilterRegs,
 };
 use common_telemetry::warn;
 use dashmap::DashMap;
-use datafusion::arrow::datatypes::{Schema, SchemaRef};
+use datafusion::arrow::datatypes::{DataType, Schema, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::execution::{SessionStateBuilder, TaskContext};
 use datafusion::physical_plan::PhysicalExpr;
 use datafusion::physical_plan::expressions::{DynamicFilterPhysicalExpr, lit};
 use datafusion_common::Result as DataFusionResult;
+use datafusion_expr::ColumnarValue;
 use session::context::QueryContextRef;
 use session::query_id::QueryId;
 use store_api::storage::RegionId;
 
 pub(super) const REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES: usize = 64 * 1024;
+
+/// A [`PhysicalExpr`] wrapper that prevents Mito scan from downcasting the
+/// inner expression as a [`DynamicFilterPhysicalExpr`].
+///
+/// Mito scan pushes filters into its predicate by downcasting each
+/// `PhysicalExpr` to `DynamicFilterPhysicalExpr`.  This wrapper ensures
+/// the inner exact filter (e.g. a Bloom probe) stays in the [`FilterExec`]
+/// for row-level evaluation only, while the separately-constructed pushdown
+/// `DynamicFilterPhysicalExpr` is pushed into scan for pruning.
+///
+/// [`PhysicalExpr`]: datafusion::physical_plan::PhysicalExpr
+/// [`DynamicFilterPhysicalExpr`]: datafusion::physical_plan::expressions::DynamicFilterPhysicalExpr
+#[derive(Debug, Clone)]
+struct NonPushdownDynFilterExpr {
+    inner: Arc<dyn PhysicalExpr>,
+}
+
+impl NonPushdownDynFilterExpr {
+    fn new(inner: Arc<dyn PhysicalExpr>) -> Self {
+        Self { inner }
+    }
+}
+
+impl Display for NonPushdownDynFilterExpr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "non_pushdown({})", self.inner)
+    }
+}
+
+impl std::hash::Hash for NonPushdownDynFilterExpr {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.inner.dyn_hash(state);
+    }
+}
+
+impl PartialEq for NonPushdownDynFilterExpr {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner.dyn_eq(other.inner.as_any())
+    }
+}
+
+impl Eq for NonPushdownDynFilterExpr {}
+
+impl PhysicalExpr for NonPushdownDynFilterExpr {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn data_type(&self, input_schema: &Schema) -> DataFusionResult<DataType> {
+        self.inner.data_type(input_schema)
+    }
+
+    fn nullable(&self, input_schema: &Schema) -> DataFusionResult<bool> {
+        self.inner.nullable(input_schema)
+    }
+
+    fn evaluate(&self, batch: &RecordBatch) -> DataFusionResult<ColumnarValue> {
+        self.inner.evaluate(batch)
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn PhysicalExpr>> {
+        self.inner.children()
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> DataFusionResult<Arc<dyn PhysicalExpr>> {
+        let new_inner = self.inner.clone().with_new_children(children)?;
+        Ok(Arc::new(Self { inner: new_inner }))
+    }
+
+    fn fmt_sql(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "non_pushdown({})", self.inner)
+    }
+}
 
 type QueryRemoteDynFilterRegs = HashMap<RemoteDynFilterId, RegisteredDynFilter>;
 
@@ -139,7 +217,8 @@ struct RemoteDynFilterEpochState {
 
 #[derive(Debug)]
 struct RemoteDynFilterState {
-    filter: Arc<DynamicFilterPhysicalExpr>,
+    pushdown_filter: Arc<DynamicFilterPhysicalExpr>,
+    exact_filter: Arc<DynamicFilterPhysicalExpr>,
     input_schema: SchemaRef,
     registered_children: Vec<Arc<dyn PhysicalExpr>>,
     epoch: Mutex<RemoteDynFilterEpochState>,
@@ -147,12 +226,14 @@ struct RemoteDynFilterState {
 
 impl RemoteDynFilterState {
     fn new(
-        filter: Arc<DynamicFilterPhysicalExpr>,
+        pushdown_filter: Arc<DynamicFilterPhysicalExpr>,
+        exact_filter: Arc<DynamicFilterPhysicalExpr>,
         input_schema: SchemaRef,
         registered_children: Vec<Arc<dyn PhysicalExpr>>,
     ) -> Self {
         Self {
-            filter,
+            pushdown_filter,
+            exact_filter,
             input_schema,
             registered_children,
             epoch: Mutex::new(RemoteDynFilterEpochState {
@@ -162,8 +243,33 @@ impl RemoteDynFilterState {
         }
     }
 
-    fn filter(&self) -> Arc<DynamicFilterPhysicalExpr> {
-        self.filter.clone()
+    fn pushdown_filter(&self) -> Arc<DynamicFilterPhysicalExpr> {
+        self.pushdown_filter.clone()
+    }
+
+    fn exact_filter(&self) -> Arc<DynamicFilterPhysicalExpr> {
+        self.exact_filter.clone()
+    }
+
+    fn decode_update_payload(
+        &self,
+        payload: &DynFilterPayload,
+    ) -> std::result::Result<DecodedDynFilterExprs, RemoteDynFilterUpdateOutcome> {
+        if !validate_update_payload_size(payload) {
+            return Err(RemoteDynFilterUpdateOutcome::PayloadTooLarge);
+        }
+
+        payload
+            .decode_placement_aware(
+                remote_dyn_filter_task_context(),
+                self.input_schema.as_ref(),
+                &self.registered_children,
+                REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES,
+            )
+            .map_err(|error| {
+                warn!(error; "Failed to decode remote dynamic filter update payload");
+                RemoteDynFilterUpdateOutcome::DecodeFailed
+            })
     }
 
     fn apply_update(
@@ -172,10 +278,6 @@ impl RemoteDynFilterState {
         generation: u64,
         is_complete: bool,
     ) -> RemoteDynFilterUpdateOutcome {
-        if !validate_update_payload_size(payload) {
-            return RemoteDynFilterUpdateOutcome::PayloadTooLarge;
-        }
-
         let mut epoch = self.epoch.lock().unwrap();
         if let Some(current_generation) = epoch.generation {
             if generation < current_generation {
@@ -184,7 +286,11 @@ impl RemoteDynFilterState {
 
             if generation == current_generation {
                 if is_complete && !epoch.is_complete {
-                    self.filter.mark_complete();
+                    if let Err(outcome) = self.decode_update_payload(payload) {
+                        return outcome;
+                    }
+                    self.pushdown_filter.mark_complete();
+                    self.exact_filter.mark_complete();
                     epoch.is_complete = true;
                     return RemoteDynFilterUpdateOutcome::Applied;
                 }
@@ -196,27 +302,29 @@ impl RemoteDynFilterState {
             return RemoteDynFilterUpdateOutcome::AlreadyComplete;
         }
 
-        let expr = match payload.decode_expr_with_registered_children(
-            remote_dyn_filter_task_context(),
-            self.input_schema.as_ref(),
-            &self.registered_children,
-            REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES,
-        ) {
-            Ok(expr) => expr,
-            Err(error) => {
-                warn!(error; "Failed to decode remote dynamic filter update payload");
-                return RemoteDynFilterUpdateOutcome::DecodeFailed;
-            }
+        // Decode placement-aware parts before mutating state
+        let decoded = match self.decode_update_payload(payload) {
+            Ok(decoded) => decoded,
+            Err(outcome) => return outcome,
         };
 
-        if let Err(error) = self.filter.update(expr) {
-            warn!(error; "Failed to apply remote dynamic filter update");
+        // Update pushdown wrapper first, then exact wrapper second.
+        // Generation is only advanced after both succeed.
+        if let Err(error) = self.pushdown_filter.update(decoded.pushdown_expr) {
+            warn!(error; "Failed to apply pushdown remote dynamic filter update");
+            return RemoteDynFilterUpdateOutcome::DecodeFailed;
+        }
+
+        let exact_expr = decoded.exact_expr.unwrap_or_else(|| lit(true));
+        if let Err(error) = self.exact_filter.update(exact_expr) {
+            warn!(error; "Failed to apply exact remote dynamic filter update");
             return RemoteDynFilterUpdateOutcome::DecodeFailed;
         }
 
         epoch.generation = Some(generation);
         if is_complete {
-            self.filter.mark_complete();
+            self.pushdown_filter.mark_complete();
+            self.exact_filter.mark_complete();
             epoch.is_complete = true;
         }
 
@@ -290,10 +398,6 @@ impl RegisteredDynFilter {
         generation: u64,
         is_complete: bool,
     ) -> RemoteDynFilterUpdateOutcome {
-        if !validate_update_payload_size(payload) {
-            return RemoteDynFilterUpdateOutcome::PayloadTooLarge;
-        }
-
         if let Some(pending) = self.pending_update.as_mut() {
             if generation < pending.generation {
                 return RemoteDynFilterUpdateOutcome::Stale;
@@ -307,6 +411,10 @@ impl RegisteredDynFilter {
             if pending.is_complete {
                 return RemoteDynFilterUpdateOutcome::AlreadyComplete;
             }
+        }
+
+        if !validate_update_payload_size(payload) {
+            return RemoteDynFilterUpdateOutcome::PayloadTooLarge;
         }
 
         self.pending_update = Some(PendingDynFilterUpdate {
@@ -345,7 +453,7 @@ impl RegisteredDynFilter {
         )
     }
 
-    fn dyn_filter(&mut self, input_schema: &Schema) -> Option<Arc<dyn PhysicalExpr>> {
+    fn dyn_filters(&mut self, input_schema: &Schema) -> Option<Vec<Arc<dyn PhysicalExpr>>> {
         let children = match self.decode_children(input_schema) {
             Ok(children) => children,
             Err(error) => {
@@ -357,9 +465,13 @@ impl RegisteredDynFilter {
         let runtime = match &self.runtime {
             Some(runtime) => runtime.clone(),
             None => {
-                let filter = Arc::new(DynamicFilterPhysicalExpr::new(children.clone(), lit(true)));
+                let pushdown_filter =
+                    Arc::new(DynamicFilterPhysicalExpr::new(children.clone(), lit(true)));
+                let exact_filter =
+                    Arc::new(DynamicFilterPhysicalExpr::new(children.clone(), lit(true)));
                 let runtime = Arc::new(RemoteDynFilterState::new(
-                    filter,
+                    pushdown_filter,
+                    exact_filter,
                     Arc::new(input_schema.clone()),
                     children.clone(),
                 ));
@@ -381,18 +493,37 @@ impl RegisteredDynFilter {
             }
         };
 
-        match runtime.filter().with_new_children(children) {
-            Ok(expr) => Some(expr),
+        let pushdown_expr = match runtime
+            .pushdown_filter()
+            .with_new_children(children.clone())
+        {
+            Ok(expr) => expr,
             Err(error) => {
-                warn!(error; "Failed to remap remote dynamic filter children for scan");
-                None
+                warn!(error; "Failed to remap pushdown dyn filter children for scan");
+                return None;
             }
-        }
+        };
+
+        let exact_inner = match runtime.exact_filter().with_new_children(children) {
+            Ok(expr) => expr,
+            Err(error) => {
+                warn!(error; "Failed to remap exact dyn filter children for scan");
+                return None;
+            }
+        };
+
+        // Wrap the exact filter in a non-pushdown marker so Mito scan cannot
+        // downcast it as DynamicFilterPhysicalExpr and push it into scan.
+        let exact_non_pushdown: Arc<dyn PhysicalExpr> =
+            Arc::new(NonPushdownDynFilterExpr::new(exact_inner));
+
+        Some(vec![pushdown_expr, exact_non_pushdown])
     }
 
     fn deactivate(&self) {
         if let Some(runtime) = &self.runtime {
-            runtime.filter.mark_complete();
+            runtime.pushdown_filter.mark_complete();
+            runtime.exact_filter.mark_complete();
         }
     }
 }
@@ -490,8 +621,9 @@ pub(super) fn remote_dyn_filter_exprs_for_initial_regs(
         .filter_map(|reg| {
             let filter_id = RemoteDynFilterId::new(reg.filter_id.clone());
             let registered = query_regs.get_mut(&filter_id)?;
-            registered.dyn_filter(input_schema)
+            registered.dyn_filters(input_schema)
         })
+        .flatten()
         .collect()
 }
 
@@ -626,6 +758,14 @@ fn remote_dyn_filter_task_context() -> &'static TaskContext {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use common_query::request::InitialDynFilterSnapshot;
+    use datafusion::arrow::datatypes::{DataType, Field};
+    use datafusion::physical_expr::expressions::{Column, lit};
+    use datafusion::physical_plan::joins::join_hash_map::{JoinHashMapType, JoinHashMapU32};
+    use datafusion::physical_plan::joins::{HashTableLookupExpr, Map, SeededRandomState};
+
     use super::*;
 
     #[test]
@@ -681,5 +821,452 @@ mod tests {
         assert_eq!(registered.subscriber_regions.len(), 2);
         assert!(registered.subscriber_regions.contains(&first_region_id));
         assert!(registered.subscriber_regions.contains(&second_region_id));
+    }
+
+    // ── NonPushdownDynFilterExpr tests ──────────────────────────────
+
+    fn empty_arrow_schema() -> ::datafusion::arrow::datatypes::Schema {
+        ::datafusion::arrow::datatypes::Schema::empty()
+    }
+
+    #[test]
+    fn non_pushdown_wrapper_hides_dynamic_filter_and_delegates() {
+        let inner =
+            Arc::new(DynamicFilterPhysicalExpr::new(vec![], lit(true))) as Arc<dyn PhysicalExpr>;
+        let wrapper: Arc<dyn PhysicalExpr> = Arc::new(NonPushdownDynFilterExpr::new(inner));
+
+        let any = Arc::clone(&wrapper) as Arc<dyn std::any::Any + Send + Sync>;
+        assert!(any.downcast_ref::<DynamicFilterPhysicalExpr>().is_none());
+        assert!(any.downcast_ref::<NonPushdownDynFilterExpr>().is_some());
+
+        let schema = empty_arrow_schema();
+        assert_eq!(wrapper.data_type(&schema).unwrap(), DataType::Boolean);
+        assert!(!wrapper.nullable(&schema).unwrap());
+        assert_eq!(wrapper.children().len(), 0);
+
+        let display = format!("{}", wrapper);
+        assert!(
+            display.starts_with("non_pushdown("),
+            "expected non_pushdown prefix, got: {display}"
+        );
+    }
+
+    // ── dyn_filters returns two exprs for Datafusion payload ───────
+
+    fn test_remote_query_id() -> QueryId {
+        QueryId::new()
+    }
+
+    #[test]
+    fn dyn_filters_returns_two_exprs_for_datafusion_initial_snapshot() {
+        let regs_by_query = RemoteDynFilterRegistry::new();
+        let query_id = test_remote_query_id();
+        let region_id = RegionId::new(1024, 7);
+
+        let payload = DynFilterPayload::from_datafusion_expr(&lit(true), 1024).unwrap();
+        let regs = InitialDynFilterRegs::new(vec![
+            InitialDynFilterReg::new("filter-df", vec![])
+                .with_initial_snapshot(InitialDynFilterSnapshot::new(payload, 1, false)),
+        ]);
+
+        register_initial_dyn_filter_regs(&regs_by_query, &query_id, region_id, &regs);
+        let exprs = remote_dyn_filter_exprs_for_initial_regs(
+            &regs_by_query,
+            &query_id,
+            &regs,
+            &empty_arrow_schema(),
+        );
+
+        // Two exprs: pushdown (DynamicFilterPhysicalExpr) + exact non-pushdown
+        assert_eq!(exprs.len(), 2);
+
+        let _ = pushdown_dyn_filter(&exprs[0]);
+        let _ = exact_dyn_filter(&exprs[1]);
+    }
+
+    // ── Bloom placement-aware decode test ───────────────────────────
+
+    fn one_column_arrow_schema() -> ::datafusion::arrow::datatypes::Schema {
+        ::datafusion::arrow::datatypes::Schema::new(vec![Field::new("id", DataType::Int32, false)])
+    }
+
+    fn test_lookup_expr(child: Arc<dyn PhysicalExpr>, hashes: Vec<u64>) -> Arc<dyn PhysicalExpr> {
+        let mut hash_map = JoinHashMapU32::with_capacity(hashes.len().max(1));
+        hash_map.update_from_iter(Box::new(hashes.iter().enumerate()), 0);
+        let map = Arc::new(Map::HashMap(Box::new(hash_map)));
+        Arc::new(HashTableLookupExpr::new(
+            vec![child],
+            SeededRandomState::with_seeds(1, 2, 3, 4),
+            map,
+            "lookup".to_string(),
+        ))
+    }
+
+    fn pushdown_dyn_filter(expr: &Arc<dyn PhysicalExpr>) -> Arc<DynamicFilterPhysicalExpr> {
+        let any = Arc::clone(expr) as Arc<dyn std::any::Any + Send + Sync>;
+        any.downcast::<DynamicFilterPhysicalExpr>()
+            .expect("pushdown must be DynamicFilterPhysicalExpr")
+    }
+
+    fn exact_dyn_filter(expr: &Arc<dyn PhysicalExpr>) -> Arc<DynamicFilterPhysicalExpr> {
+        let any = Arc::clone(expr) as Arc<dyn std::any::Any + Send + Sync>;
+        assert!(any.downcast_ref::<DynamicFilterPhysicalExpr>().is_none());
+        let wrapper = any
+            .downcast_ref::<NonPushdownDynFilterExpr>()
+            .expect("exact must be NonPushdownDynFilterExpr");
+        let inner = Arc::clone(&wrapper.inner) as Arc<dyn std::any::Any + Send + Sync>;
+        inner
+            .downcast::<DynamicFilterPhysicalExpr>()
+            .expect("exact wrapper must contain DynamicFilterPhysicalExpr")
+    }
+
+    #[test]
+    fn bloom_dyn_filters_pushdown_is_dynamic_filter_and_exact_contains_bloom_probe() {
+        let regs_by_query = RemoteDynFilterRegistry::new();
+        let query_id = test_remote_query_id();
+        let region_id = RegionId::new(1024, 7);
+        let schema = one_column_arrow_schema();
+        let id_col = Arc::new(Column::new("id", 0)) as Arc<dyn PhysicalExpr>;
+        let children = vec![Arc::clone(&id_col)];
+        let lookup = test_lookup_expr(Arc::clone(&id_col), vec![10, 20, 30]);
+
+        let payload = DynFilterPayload::from_datafusion_expr_with_registered_children(
+            &lookup,
+            &children,
+            REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES,
+            &schema,
+        )
+        .unwrap();
+        assert!(matches!(payload, DynFilterPayload::JoinHashBloom(_)));
+
+        let reg = InitialDynFilterReg::from_filter_id_and_children("filter-bloom", &children)
+            .unwrap()
+            .with_initial_snapshot(InitialDynFilterSnapshot::new(payload, 1, false));
+        let regs = InitialDynFilterRegs::new(vec![reg]);
+
+        register_initial_dyn_filter_regs(&regs_by_query, &query_id, region_id, &regs);
+        let exprs =
+            remote_dyn_filter_exprs_for_initial_regs(&regs_by_query, &query_id, &regs, &schema);
+
+        assert_eq!(exprs.len(), 2);
+
+        // Pushdown wrapper: DynamicFilterPhysicalExpr with residual (lit(true) for lookup-only)
+        let pushdown = pushdown_dyn_filter(&exprs[0]);
+        let pushdown_current = format!("{}", pushdown.current().unwrap());
+        assert!(
+            pushdown_current.contains("true"),
+            "pushdown should be residual (lit(true) for lookup-only), got: {pushdown_current}"
+        );
+
+        // Exact wrapper: NonPushdownDynFilterExpr containing bloom_probe
+        let _ = exact_dyn_filter(&exprs[1]);
+        let exact_display = format!("{}", exprs[1]);
+        assert!(
+            exact_display.contains("bloom_probe"),
+            "exact wrapper display must contain bloom_probe, got: {exact_display}"
+        );
+        assert!(
+            exact_display.contains("non_pushdown("),
+            "exact wrapper display must have non_pushdown prefix, got: {exact_display}"
+        );
+    }
+
+    #[test]
+    fn datafusion_update_after_bloom_clears_exact_to_true() {
+        let regs_by_query = RemoteDynFilterRegistry::new();
+        let query_id = test_remote_query_id();
+        let region_id = RegionId::new(1024, 7);
+        let schema = one_column_arrow_schema();
+        let id_col = Arc::new(Column::new("id", 0)) as Arc<dyn PhysicalExpr>;
+        let children = vec![Arc::clone(&id_col)];
+        let lookup = test_lookup_expr(Arc::clone(&id_col), vec![10, 20, 30]);
+
+        let bloom_payload = DynFilterPayload::from_datafusion_expr_with_registered_children(
+            &lookup,
+            &children,
+            REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES,
+            &schema,
+        )
+        .unwrap();
+        assert!(matches!(bloom_payload, DynFilterPayload::JoinHashBloom(_)));
+
+        let reg = InitialDynFilterReg::from_filter_id_and_children("filter-x", &children)
+            .unwrap()
+            .with_initial_snapshot(InitialDynFilterSnapshot::new(bloom_payload, 1, false));
+        let regs = InitialDynFilterRegs::new(vec![reg]);
+
+        register_initial_dyn_filter_regs(&regs_by_query, &query_id, region_id, &regs);
+
+        // Install wrappers
+        let exprs =
+            remote_dyn_filter_exprs_for_initial_regs(&regs_by_query, &query_id, &regs, &schema);
+        assert_eq!(exprs.len(), 2);
+
+        let pushdown = pushdown_dyn_filter(&exprs[0]);
+        let exact_dynamic = exact_dyn_filter(&exprs[1]);
+
+        // Assert bloom is installed
+        let exact_display = format!("{}", exprs[1]);
+        assert!(
+            exact_display.contains("bloom_probe"),
+            "pre-update: exact should contain bloom_probe"
+        );
+
+        // Now send a Datafusion payload update (higher generation)
+        let df_payload = DynFilterPayload::from_datafusion_expr(&lit(true), 1024).unwrap();
+        let outcome = apply_remote_dyn_filter_update(
+            &regs_by_query,
+            &query_id,
+            &RemoteDynFilterId::new("filter-x"),
+            &df_payload,
+            2, // higher generation
+            false,
+        );
+        assert_eq!(outcome, RemoteDynFilterUpdateOutcome::Applied);
+
+        // Pushdown should now be the Datafusion expression
+        let pushdown_current = format!("{}", pushdown.current().unwrap());
+        assert!(
+            pushdown_current.contains("true"),
+            "post-DF-update: pushdown should be true, got: {pushdown_current}"
+        );
+
+        // Re-fetch exprs to check exact was cleared to true
+        let exprs_after =
+            remote_dyn_filter_exprs_for_initial_regs(&regs_by_query, &query_id, &regs, &schema);
+        assert_eq!(exprs_after.len(), 2);
+        let exact_after_display = format!("{}", exprs_after[1]);
+        assert!(
+            !exact_after_display.contains("bloom_probe"),
+            "post-DF-update: exact must NOT contain bloom_probe, got: {exact_after_display}"
+        );
+        assert_eq!(format!("{}", exact_dynamic.current().unwrap()), "true");
+    }
+
+    #[test]
+    fn oversized_update_after_bloom_does_not_mutate_state() {
+        let regs_by_query = RemoteDynFilterRegistry::new();
+        let query_id = test_remote_query_id();
+        let region_id = RegionId::new(1024, 7);
+        let schema = one_column_arrow_schema();
+        let id_col = Arc::new(Column::new("id", 0)) as Arc<dyn PhysicalExpr>;
+        let children = vec![Arc::clone(&id_col)];
+        let lookup = test_lookup_expr(Arc::clone(&id_col), vec![10, 20, 30]);
+
+        let bloom_payload = DynFilterPayload::from_datafusion_expr_with_registered_children(
+            &lookup,
+            &children,
+            REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES,
+            &schema,
+        )
+        .unwrap();
+        let reg = InitialDynFilterReg::from_filter_id_and_children("filter-oversized", &children)
+            .unwrap()
+            .with_initial_snapshot(InitialDynFilterSnapshot::new(
+                bloom_payload.clone(),
+                1,
+                false,
+            ));
+        let regs = InitialDynFilterRegs::new(vec![reg]);
+
+        register_initial_dyn_filter_regs(&regs_by_query, &query_id, region_id, &regs);
+        let exprs =
+            remote_dyn_filter_exprs_for_initial_regs(&regs_by_query, &query_id, &regs, &schema);
+        assert_eq!(exprs.len(), 2);
+
+        let exact_dynamic = exact_dyn_filter(&exprs[1]);
+        let pre_oversized = format!("{}", exact_dynamic.current().unwrap());
+        assert!(
+            pre_oversized.contains("bloom_probe"),
+            "pre-oversized: exact should contain bloom_probe, got: {pre_oversized}"
+        );
+
+        // Send oversized update — must NOT mutate state
+        let oversized =
+            DynFilterPayload::Datafusion(vec![0; REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES + 1]);
+        let outcome = apply_remote_dyn_filter_update(
+            &regs_by_query,
+            &query_id,
+            &RemoteDynFilterId::new("filter-oversized"),
+            &oversized,
+            2,
+            false,
+        );
+        assert_eq!(outcome, RemoteDynFilterUpdateOutcome::PayloadTooLarge);
+
+        // Exact should still contain bloom_probe (not cleared)
+        let post_oversized = format!("{}", exact_dynamic.current().unwrap());
+        assert!(
+            post_oversized.contains("bloom_probe"),
+            "post-oversized: exact must still contain bloom_probe, got: {post_oversized}"
+        );
+
+        // The oversized generation must not become the runtime watermark.
+        let valid_gen1_outcome = apply_remote_dyn_filter_update(
+            &regs_by_query,
+            &query_id,
+            &RemoteDynFilterId::new("filter-oversized"),
+            &bloom_payload,
+            1, // same as installed
+            false,
+        );
+        assert_eq!(valid_gen1_outcome, RemoteDynFilterUpdateOutcome::Idempotent);
+
+        let stale_outcome = apply_remote_dyn_filter_update(
+            &regs_by_query,
+            &query_id,
+            &RemoteDynFilterId::new("filter-oversized"),
+            &bloom_payload,
+            0,
+            false,
+        );
+        assert_eq!(stale_outcome, RemoteDynFilterUpdateOutcome::Stale);
+    }
+
+    #[test]
+    fn decode_failed_update_does_not_mutate_state() {
+        let regs_by_query = RemoteDynFilterRegistry::new();
+        let query_id = test_remote_query_id();
+        let region_id = RegionId::new(1024, 7);
+        let schema = one_column_arrow_schema();
+        let id_col = Arc::new(Column::new("id", 0)) as Arc<dyn PhysicalExpr>;
+        let children = vec![Arc::clone(&id_col)];
+        let lookup = test_lookup_expr(Arc::clone(&id_col), vec![10, 20, 30]);
+
+        let bloom_payload = DynFilterPayload::from_datafusion_expr_with_registered_children(
+            &lookup,
+            &children,
+            REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES,
+            &schema,
+        )
+        .unwrap();
+        let reg = InitialDynFilterReg::from_filter_id_and_children("filter-decode-fail", &children)
+            .unwrap()
+            .with_initial_snapshot(InitialDynFilterSnapshot::new(
+                bloom_payload.clone(),
+                1,
+                false,
+            ));
+        let regs = InitialDynFilterRegs::new(vec![reg]);
+
+        register_initial_dyn_filter_regs(&regs_by_query, &query_id, region_id, &regs);
+        let exprs =
+            remote_dyn_filter_exprs_for_initial_regs(&regs_by_query, &query_id, &regs, &schema);
+        assert_eq!(exprs.len(), 2);
+
+        let exact_dynamic = exact_dyn_filter(&exprs[1]);
+        assert!(format!("{}", exact_dynamic.current().unwrap()).contains("bloom_probe"));
+
+        // Send an undecodable Datafusion payload (garbage bytes)
+        let garbage = DynFilterPayload::Datafusion(vec![0, 1, 2, 3]);
+        let outcome = apply_remote_dyn_filter_update(
+            &regs_by_query,
+            &query_id,
+            &RemoteDynFilterId::new("filter-decode-fail"),
+            &garbage,
+            2,
+            false,
+        );
+        assert_eq!(outcome, RemoteDynFilterUpdateOutcome::DecodeFailed);
+
+        // Exact should NOT be cleared — state is unchanged
+        assert!(format!("{}", exact_dynamic.current().unwrap()).contains("bloom_probe"));
+    }
+
+    #[test]
+    fn same_generation_invalid_complete_update_does_not_mark_complete() {
+        let regs_by_query = RemoteDynFilterRegistry::new();
+        let query_id = test_remote_query_id();
+        let region_id = RegionId::new(1024, 7);
+        let schema = one_column_arrow_schema();
+        let id_col = Arc::new(Column::new("id", 0)) as Arc<dyn PhysicalExpr>;
+        let children = vec![Arc::clone(&id_col)];
+        let lookup = test_lookup_expr(Arc::clone(&id_col), vec![10, 20, 30]);
+
+        let bloom_payload = DynFilterPayload::from_datafusion_expr_with_registered_children(
+            &lookup,
+            &children,
+            REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES,
+            &schema,
+        )
+        .unwrap();
+        let reg = InitialDynFilterReg::from_filter_id_and_children("filter-complete", &children)
+            .unwrap()
+            .with_initial_snapshot(InitialDynFilterSnapshot::new(
+                bloom_payload.clone(),
+                1,
+                false,
+            ));
+        let regs = InitialDynFilterRegs::new(vec![reg]);
+
+        register_initial_dyn_filter_regs(&regs_by_query, &query_id, region_id, &regs);
+        let exprs =
+            remote_dyn_filter_exprs_for_initial_regs(&regs_by_query, &query_id, &regs, &schema);
+        assert_eq!(exprs.len(), 2);
+
+        let pushdown = pushdown_dyn_filter(&exprs[0]);
+        let exact_dynamic = exact_dyn_filter(&exprs[1]);
+        assert!(!pushdown.is_complete());
+        assert!(!exact_dynamic.is_complete());
+        assert!(format!("{}", exact_dynamic.current().unwrap()).contains("bloom_probe"));
+
+        let garbage = DynFilterPayload::Datafusion(vec![0, 1, 2, 3]);
+        let outcome = apply_remote_dyn_filter_update(
+            &regs_by_query,
+            &query_id,
+            &RemoteDynFilterId::new("filter-complete"),
+            &garbage,
+            1,
+            true,
+        );
+        assert_eq!(outcome, RemoteDynFilterUpdateOutcome::DecodeFailed);
+
+        assert!(!pushdown.is_complete());
+        assert!(!exact_dynamic.is_complete());
+        assert!(format!("{}", exact_dynamic.current().unwrap()).contains("bloom_probe"));
+
+        let valid_outcome = apply_remote_dyn_filter_update(
+            &regs_by_query,
+            &query_id,
+            &RemoteDynFilterId::new("filter-complete"),
+            &bloom_payload,
+            2,
+            false,
+        );
+        assert_eq!(valid_outcome, RemoteDynFilterUpdateOutcome::Applied);
+        assert!(!pushdown.is_complete());
+        assert!(!exact_dynamic.is_complete());
+    }
+
+    #[test]
+    fn deactivate_marks_both_pushdown_and_exact_filters_complete() {
+        let regs_by_query = RemoteDynFilterRegistry::new();
+        let query_id = test_remote_query_id();
+        let region_id = RegionId::new(1024, 7);
+        let regs = InitialDynFilterRegs::new(vec![InitialDynFilterReg::new("filter-d", vec![])]);
+
+        register_initial_dyn_filter_regs(&regs_by_query, &query_id, region_id, &regs);
+        let exprs = remote_dyn_filter_exprs_for_initial_regs(
+            &regs_by_query,
+            &query_id,
+            &regs,
+            &empty_arrow_schema(),
+        );
+        assert_eq!(exprs.len(), 2);
+
+        let pushdown = pushdown_dyn_filter(&exprs[0]);
+        let exact_dynamic = exact_dyn_filter(&exprs[1]);
+
+        // Deactivate (via drop of RegisteredDynFilter)
+        let _ = unregister_remote_dyn_filter(
+            &regs_by_query,
+            &query_id,
+            &RemoteDynFilterId::new("filter-d"),
+        );
+
+        // After deactivation, the filter registration should be gone.
+        assert!(regs_by_query.get_query(&query_id).is_none());
+        assert!(pushdown.is_complete());
+        assert!(exact_dynamic.is_complete());
     }
 }

--- a/src/datanode/src/region_server/registrations.rs
+++ b/src/datanode/src/region_server/registrations.rs
@@ -114,7 +114,7 @@ pub(super) enum RemoteDynFilterUpdateOutcome {
 
 #[derive(Debug, Clone)]
 struct PendingDynFilterUpdate {
-    payload: Vec<u8>,
+    payload: DynFilterPayload,
     generation: u64,
     is_complete: bool,
 }
@@ -122,14 +122,12 @@ struct PendingDynFilterUpdate {
 impl PendingDynFilterUpdate {
     fn from_initial_reg(reg: &InitialDynFilterReg) -> Option<Self> {
         let snapshot = reg.initial_snapshot.as_ref()?;
-        match &snapshot.payload {
-            DynFilterPayload::Datafusion(payload) => Some(Self {
-                payload: payload.clone(),
-                generation: snapshot.generation,
-                is_complete: snapshot.is_complete,
-            }),
-            _ => None,
-        }
+        // Accept any payload variant for pending; FE may send non-Datafusion in the future.
+        Some(Self {
+            payload: snapshot.payload.clone(),
+            generation: snapshot.generation,
+            is_complete: snapshot.is_complete,
+        })
     }
 }
 
@@ -143,14 +141,20 @@ struct RemoteDynFilterEpochState {
 struct RemoteDynFilterState {
     filter: Arc<DynamicFilterPhysicalExpr>,
     input_schema: SchemaRef,
+    registered_children: Vec<Arc<dyn PhysicalExpr>>,
     epoch: Mutex<RemoteDynFilterEpochState>,
 }
 
 impl RemoteDynFilterState {
-    fn new(filter: Arc<DynamicFilterPhysicalExpr>, input_schema: SchemaRef) -> Self {
+    fn new(
+        filter: Arc<DynamicFilterPhysicalExpr>,
+        input_schema: SchemaRef,
+        registered_children: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> Self {
         Self {
             filter,
             input_schema,
+            registered_children,
             epoch: Mutex::new(RemoteDynFilterEpochState {
                 generation: None,
                 is_complete: false,
@@ -164,7 +168,7 @@ impl RemoteDynFilterState {
 
     fn apply_update(
         &self,
-        payload: &[u8],
+        payload: &DynFilterPayload,
         generation: u64,
         is_complete: bool,
     ) -> RemoteDynFilterUpdateOutcome {
@@ -192,7 +196,12 @@ impl RemoteDynFilterState {
             return RemoteDynFilterUpdateOutcome::AlreadyComplete;
         }
 
-        let expr = match decode_update_payload(payload, self.input_schema.as_ref()) {
+        let expr = match payload.decode_expr_with_registered_children(
+            remote_dyn_filter_task_context(),
+            self.input_schema.as_ref(),
+            &self.registered_children,
+            REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES,
+        ) {
             Ok(expr) => expr,
             Err(error) => {
                 warn!(error; "Failed to decode remote dynamic filter update payload");
@@ -277,7 +286,7 @@ impl RegisteredDynFilter {
 
     fn buffer_update(
         &mut self,
-        payload: &[u8],
+        payload: &DynFilterPayload,
         generation: u64,
         is_complete: bool,
     ) -> RemoteDynFilterUpdateOutcome {
@@ -301,7 +310,7 @@ impl RegisteredDynFilter {
         }
 
         self.pending_update = Some(PendingDynFilterUpdate {
-            payload: payload.to_vec(),
+            payload: payload.clone(),
             generation,
             is_complete,
         });
@@ -310,7 +319,7 @@ impl RegisteredDynFilter {
 
     fn apply_or_buffer_update(
         &mut self,
-        payload: &[u8],
+        payload: &DynFilterPayload,
         generation: u64,
         is_complete: bool,
     ) -> RemoteDynFilterUpdateOutcome {
@@ -352,6 +361,7 @@ impl RegisteredDynFilter {
                 let runtime = Arc::new(RemoteDynFilterState::new(
                     filter,
                     Arc::new(input_schema.clone()),
+                    children.clone(),
                 ));
                 if let Some(pending) = self.pending_update.take() {
                     let outcome = runtime.apply_update(
@@ -489,7 +499,7 @@ pub(super) fn apply_remote_dyn_filter_update(
     regs_by_query: &RemoteDynFilterRegistry,
     query_id: &QueryId,
     filter_id: &RemoteDynFilterId,
-    payload: &[u8],
+    payload: &DynFilterPayload,
     generation: u64,
     is_complete: bool,
 ) -> RemoteDynFilterUpdateOutcome {
@@ -498,7 +508,7 @@ pub(super) fn apply_remote_dyn_filter_update(
             "Ignored oversized remote dynamic filter update, query_id: {}, filter_id: {}, payload_size: {}, max_payload_size: {}",
             query_id,
             filter_id,
-            payload.len(),
+            payload.encoded_payload_bytes(),
             REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES
         );
         return RemoteDynFilterUpdateOutcome::PayloadTooLarge;
@@ -597,15 +607,8 @@ pub(super) fn remove_initial_dyn_filter_regs(
     }
 }
 
-fn decode_update_payload(
-    payload: &[u8],
-    input_schema: &Schema,
-) -> DataFusionResult<Arc<dyn PhysicalExpr>> {
-    DynFilterPayload::Datafusion(payload.to_vec()).decode_datafusion_expr(
-        remote_dyn_filter_task_context(),
-        input_schema,
-        REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES,
-    )
+fn validate_update_payload_size(payload: &DynFilterPayload) -> bool {
+    payload.encoded_payload_bytes() <= REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES
 }
 
 fn remote_dyn_filter_task_context() -> &'static TaskContext {
@@ -619,10 +622,6 @@ fn remote_dyn_filter_task_context() -> &'static TaskContext {
         let session_state = SessionStateBuilder::new().with_default_features().build();
         TaskContext::from(&session_state)
     })
-}
-
-fn validate_update_payload_size(payload: &[u8]) -> bool {
-    payload.len() <= REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES
 }
 
 #[cfg(test)]

--- a/src/datanode/src/region_server/remote_dyn_filter.rs
+++ b/src/datanode/src/region_server/remote_dyn_filter.rs
@@ -196,8 +196,11 @@ impl RegionServer {
                 }
                 Err(_error) => {
                     warn!(_error; "Failed to decode typed remote dyn filter payload with no legacy fallback");
-                    let outcome = RemoteDynFilterUpdateOutcome::DecodeFailed;
-                    self.log_remote_dyn_filter_update_outcome(query_id, &filter_id, outcome);
+                    self.log_remote_dyn_filter_update_outcome(
+                        query_id,
+                        &filter_id,
+                        RemoteDynFilterUpdateOutcome::DecodeFailed,
+                    );
                     return Ok(RegionResponse::new(0));
                 }
             }
@@ -942,8 +945,11 @@ mod tests {
             &empty_arrow_schema(),
         );
 
-        assert_eq!(exprs.len(), 1);
+        // Two exprs: pushdown DynamicFilterPhysicalExpr + non-pushdown exact wrapper
+        assert_eq!(exprs.len(), 2);
         assert_eq!(format!("{}", exprs[0]), "DynamicFilter [ false ]");
+        // Exact wrapper display
+        assert!(format!("{}", exprs[1]).contains("non_pushdown"));
     }
 
     #[test]
@@ -977,11 +983,41 @@ mod tests {
         let exprs =
             remote_dyn_filter_exprs_for_initial_regs(&regs_by_query, &query_id, &regs, &schema);
 
-        assert_eq!(exprs.len(), 1);
+        // Two exprs: pushdown DynamicFilterPhysicalExpr (residual, lit(true)) +
+        // non-pushdown exact wrapper (bloom_probe)
+        assert_eq!(exprs.len(), 2);
+        let pushdown_display = format!("{}", exprs[0]);
+        let exact_display = format!("{}", exprs[1]);
         assert!(
-            format!("{}", exprs[0]).contains("bloom_probe"),
-            "expected Bloom initial snapshot to initialize runtime filter, got {}",
-            exprs[0]
+            exact_display.contains("bloom_probe"),
+            "expected exact non-pushdown expr to contain bloom_probe, got: {exact_display}"
+        );
+        assert!(
+            exact_display.starts_with("non_pushdown("),
+            "expected exact non-pushdown wrapper display, got: {exact_display}"
+        );
+        // Pushdown wrapper should be the residual (lit(true) for lookup-only)
+        assert!(
+            pushdown_display.contains("DynamicFilter"),
+            "expected pushdown expr to be a DynamicFilter, got: {pushdown_display}"
+        );
+
+        // The exact wrapper must NOT be downcastable as DynamicFilterPhysicalExpr
+        let exact_any = exprs[1].clone() as Arc<dyn std::any::Any + Send + Sync>;
+        assert!(
+            exact_any
+                .downcast_ref::<DynamicFilterPhysicalExpr>()
+                .is_none(),
+            "exact non-pushdown wrapper must not downcast as DynamicFilterPhysicalExpr"
+        );
+
+        // The pushdown wrapper must be downcastable as DynamicFilterPhysicalExpr
+        let pushdown_any = exprs[0].clone() as Arc<dyn std::any::Any + Send + Sync>;
+        assert!(
+            pushdown_any
+                .downcast_ref::<DynamicFilterPhysicalExpr>()
+                .is_some(),
+            "pushdown wrapper must downcast as DynamicFilterPhysicalExpr"
         );
     }
 
@@ -997,14 +1033,15 @@ mod tests {
             &initial_regs,
             &empty_arrow_schema(),
         );
-        assert_eq!(1, exprs.len());
+        // Now returns two exprs: pushdown (DynamicFilterPhysicalExpr) + exact (non-pushdown)
+        assert_eq!(2, exprs.len());
         let expr = exprs.into_iter().next().unwrap();
         let expr = expr as Arc<dyn std::any::Any + Send + Sync>;
         expr.downcast::<DynamicFilterPhysicalExpr>().unwrap()
     }
 
     #[test]
-    fn test_remote_dyn_filter_rejects_oversized_payload_before_buffering() {
+    fn test_remote_dyn_filter_oversized_payload_rejected_without_mutation() {
         let regs_by_query = RemoteDynFilterRegistry::new();
         let query_id = test_remote_query_id();
         let filter_id = RemoteDynFilterId::new("filter-1");
@@ -1022,7 +1059,8 @@ mod tests {
         );
         assert_eq!(outcome, RemoteDynFilterUpdateOutcome::PayloadTooLarge);
 
-        // The rejected generation must not become the pending generation.
+        // The oversized generation must NOT install any watermark — a lower
+        // generation can still buffer because no previous generation was recorded.
         let outcome = apply_remote_dyn_filter_update(
             &regs_by_query,
             &query_id,

--- a/src/datanode/src/region_server/remote_dyn_filter.rs
+++ b/src/datanode/src/region_server/remote_dyn_filter.rs
@@ -171,6 +171,7 @@ impl RegionServer {
         }
     }
 
+    #[allow(deprecated)]
     async fn handle_remote_dyn_filter_update(
         &self,
         query_id: &QueryId,
@@ -363,6 +364,7 @@ impl Stream for RemoteDynFilterGuardedStream {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use std::assert_matches;
     use std::collections::{HashMap, HashSet};

--- a/src/datanode/src/region_server/remote_dyn_filter.rs
+++ b/src/datanode/src/region_server/remote_dyn_filter.rs
@@ -20,6 +20,7 @@ use api::region::RegionResponse;
 use api::v1::region::RemoteDynFilterRequest;
 use api::v1::region::remote_dyn_filter_request::Action;
 use common_base::Plugins;
+use common_query::request::DynFilterPayload;
 use common_recordbatch::adapter::RecordBatchMetrics;
 use common_recordbatch::{OrderOption, RecordBatch, RecordBatchStream, SendableRecordBatchStream};
 use common_telemetry::{debug, warn};
@@ -179,16 +180,36 @@ impl RegionServer {
             return error::MissingRequiredFieldSnafu { name: "filter_id" }.fail();
         }
 
-        if request.payload.is_empty() {
+        if request.payload.is_empty() && request.typed_payload.is_none() {
             return error::MissingRequiredFieldSnafu { name: "payload" }.fail();
         }
 
         let filter_id = RemoteDynFilterId::new(request.filter_id.clone());
+
+        // Prefer typed payload if available; fall back to legacy payload.
+        let dyn_filter_payload = if let Some(ref typed_proto) = request.typed_payload {
+            match DynFilterPayload::from_region_proto_payload(typed_proto.clone()) {
+                Ok(typed) => typed,
+                Err(error) if !request.payload.is_empty() => {
+                    warn!(error; "Failed to decode typed remote dyn filter payload, falling back to legacy Datafusion payload");
+                    DynFilterPayload::Datafusion(request.payload.clone())
+                }
+                Err(_error) => {
+                    warn!(_error; "Failed to decode typed remote dyn filter payload with no legacy fallback");
+                    let outcome = RemoteDynFilterUpdateOutcome::DecodeFailed;
+                    self.log_remote_dyn_filter_update_outcome(query_id, &filter_id, outcome);
+                    return Ok(RegionResponse::new(0));
+                }
+            }
+        } else {
+            DynFilterPayload::Datafusion(request.payload.clone())
+        };
+
         let outcome = apply_remote_dyn_filter_update(
             &self.inner.initial_remote_dyn_filter_registrations,
             query_id,
             &filter_id,
-            &request.payload,
+            &dyn_filter_payload,
             request.generation,
             request.is_complete,
         );
@@ -354,9 +375,15 @@ mod tests {
         InitialDynFilterReg, InitialDynFilterRegs, InitialDynFilterSnapshot,
     };
     use common_recordbatch::RecordBatches;
-    use datafusion::arrow::datatypes::Schema as ArrowSchema;
+    use datafusion::arrow::datatypes::{
+        DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
+    };
     use datafusion::physical_plan::PhysicalExpr;
-    use datafusion::physical_plan::expressions::{DynamicFilterPhysicalExpr, lit as physical_lit};
+    use datafusion::physical_plan::expressions::{
+        Column, DynamicFilterPhysicalExpr, lit as physical_lit,
+    };
+    use datafusion::physical_plan::joins::join_hash_map::{JoinHashMapType, JoinHashMapU32};
+    use datafusion::physical_plan::joins::{HashTableLookupExpr, Map, SeededRandomState};
     use datafusion_common::DFSchema;
     use datafusion_expr::EmptyRelation;
     use datatypes::prelude::{ConcreteDataType, VectorRef};
@@ -730,6 +757,7 @@ mod tests {
                         payload: vec![1],
                         generation: 1,
                         is_complete: false,
+                        typed_payload: None,
                     },
                 )),
             })
@@ -755,6 +783,7 @@ mod tests {
                         payload: Vec::new(),
                         generation: 1,
                         is_complete: false,
+                        typed_payload: None,
                     },
                 )),
             })
@@ -773,8 +802,14 @@ mod tests {
         let query_id = test_remote_query_id();
         let filter_id = RemoteDynFilterId::new("filter-1");
 
-        let outcome =
-            apply_remote_dyn_filter_update(&regs_by_query, &query_id, &filter_id, &[1], 1, false);
+        let outcome = apply_remote_dyn_filter_update(
+            &regs_by_query,
+            &query_id,
+            &filter_id,
+            &test_datafusion_payload(vec![1]),
+            1,
+            false,
+        );
         assert_eq!(outcome, RemoteDynFilterUpdateOutcome::MissingRegistration);
 
         let outcome = unregister_remote_dyn_filter(&regs_by_query, &query_id, &filter_id);
@@ -799,34 +834,65 @@ mod tests {
         );
 
         // First update with generation 1: should be Buffered (no runtime installed yet)
-        let outcome =
-            apply_remote_dyn_filter_update(&regs_by_query, &query_id, &filter_id, &[1], 1, false);
+        let outcome = apply_remote_dyn_filter_update(
+            &regs_by_query,
+            &query_id,
+            &filter_id,
+            &test_datafusion_payload(vec![1]),
+            1,
+            false,
+        );
         assert_eq!(outcome, RemoteDynFilterUpdateOutcome::Buffered);
 
         // Update with generation 0: should be Stale (older than pending generation 1)
-        let outcome =
-            apply_remote_dyn_filter_update(&regs_by_query, &query_id, &filter_id, &[2], 0, false);
+        let outcome = apply_remote_dyn_filter_update(
+            &regs_by_query,
+            &query_id,
+            &filter_id,
+            &test_datafusion_payload(vec![2]),
+            0,
+            false,
+        );
         assert_eq!(outcome, RemoteDynFilterUpdateOutcome::Stale);
 
         // Update with generation 1 again: should be Idempotent (same generation)
-        let outcome =
-            apply_remote_dyn_filter_update(&regs_by_query, &query_id, &filter_id, &[3], 1, false);
+        let outcome = apply_remote_dyn_filter_update(
+            &regs_by_query,
+            &query_id,
+            &filter_id,
+            &test_datafusion_payload(vec![3]),
+            1,
+            false,
+        );
         assert_eq!(outcome, RemoteDynFilterUpdateOutcome::Idempotent);
     }
 
-    fn datafusion_payload_bytes(expr: Arc<dyn PhysicalExpr>) -> Vec<u8> {
-        match DynFilterPayload::from_datafusion_expr(&expr, REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES)
-            .unwrap()
-        {
-            DynFilterPayload::Datafusion(bytes) => bytes,
-            _ => unreachable!(
-                "DynFilterPayload::from_datafusion_expr only returns datafusion payloads"
-            ),
-        }
+    fn datafusion_payload_bytes(expr: Arc<dyn PhysicalExpr>) -> DynFilterPayload {
+        DynFilterPayload::from_datafusion_expr(&expr, REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES).unwrap()
+    }
+
+    fn test_datafusion_payload(bytes: Vec<u8>) -> DynFilterPayload {
+        DynFilterPayload::Datafusion(bytes)
+    }
+
+    fn test_lookup_expr(child: Arc<dyn PhysicalExpr>, hashes: Vec<u64>) -> Arc<dyn PhysicalExpr> {
+        let mut hash_map = JoinHashMapU32::with_capacity(hashes.len().max(1));
+        hash_map.update_from_iter(Box::new(hashes.iter().enumerate()), 0);
+        let map = Arc::new(Map::HashMap(Box::new(hash_map)));
+        Arc::new(HashTableLookupExpr::new(
+            vec![child],
+            SeededRandomState::with_seeds(1, 2, 3, 4),
+            map,
+            "lookup".to_string(),
+        ))
     }
 
     fn empty_arrow_schema() -> ArrowSchema {
         ArrowSchema::empty()
+    }
+
+    fn one_column_arrow_schema() -> ArrowSchema {
+        ArrowSchema::new(vec![ArrowField::new("id", ArrowDataType::Int32, false)])
     }
 
     fn register_empty_remote_dyn_filter(
@@ -857,7 +923,7 @@ mod tests {
     fn initial_remote_dyn_filter_snapshot_initializes_runtime_filter() {
         let regs_by_query = RemoteDynFilterRegistry::new();
         let query_id = test_remote_query_id();
-        let payload = DynFilterPayload::Datafusion(datafusion_payload_bytes(physical_lit(false)));
+        let payload = datafusion_payload_bytes(physical_lit(false));
         let regs = InitialDynFilterRegs::new(vec![
             InitialDynFilterReg::new("filter-1", vec![])
                 .with_initial_snapshot(InitialDynFilterSnapshot::new(payload, 7, false)),
@@ -878,6 +944,45 @@ mod tests {
 
         assert_eq!(exprs.len(), 1);
         assert_eq!(format!("{}", exprs[0]), "DynamicFilter [ false ]");
+    }
+
+    #[test]
+    fn bloom_initial_remote_dyn_filter_snapshot_initializes_runtime_filter() {
+        let regs_by_query = RemoteDynFilterRegistry::new();
+        let query_id = test_remote_query_id();
+        let schema = one_column_arrow_schema();
+        let id_col = Arc::new(Column::new("id", 0)) as Arc<dyn PhysicalExpr>;
+        let children = vec![Arc::clone(&id_col)];
+        let lookup = test_lookup_expr(Arc::clone(&id_col), vec![10, 20, 30]);
+        let payload = DynFilterPayload::from_datafusion_expr_with_registered_children(
+            &lookup,
+            &children,
+            REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES,
+            &schema,
+        )
+        .unwrap();
+        assert!(matches!(payload, DynFilterPayload::JoinHashBloom(_)));
+
+        let reg = InitialDynFilterReg::from_filter_id_and_children("filter-1", &children)
+            .unwrap()
+            .with_initial_snapshot(InitialDynFilterSnapshot::new(payload, 7, false));
+        let regs = InitialDynFilterRegs::new(vec![reg]);
+
+        register_initial_dyn_filter_regs(
+            &regs_by_query,
+            &query_id,
+            test_remote_dyn_filter_region_id(),
+            &regs,
+        );
+        let exprs =
+            remote_dyn_filter_exprs_for_initial_regs(&regs_by_query, &query_id, &regs, &schema);
+
+        assert_eq!(exprs.len(), 1);
+        assert!(
+            format!("{}", exprs[0]).contains("bloom_probe"),
+            "expected Bloom initial snapshot to initialize runtime filter, got {}",
+            exprs[0]
+        );
     }
 
     fn only_remote_dyn_filter(
@@ -905,7 +1010,8 @@ mod tests {
         let filter_id = RemoteDynFilterId::new("filter-1");
         register_empty_remote_dyn_filter(&regs_by_query, &query_id);
 
-        let oversized = vec![0; REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES + 1];
+        let oversized =
+            DynFilterPayload::Datafusion(vec![0; REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES + 1]);
         let outcome = apply_remote_dyn_filter_update(
             &regs_by_query,
             &query_id,
@@ -917,8 +1023,14 @@ mod tests {
         assert_eq!(outcome, RemoteDynFilterUpdateOutcome::PayloadTooLarge);
 
         // The rejected generation must not become the pending generation.
-        let outcome =
-            apply_remote_dyn_filter_update(&regs_by_query, &query_id, &filter_id, &[1], 0, false);
+        let outcome = apply_remote_dyn_filter_update(
+            &regs_by_query,
+            &query_id,
+            &filter_id,
+            &test_datafusion_payload(vec![1]),
+            0,
+            false,
+        );
         assert_eq!(outcome, RemoteDynFilterUpdateOutcome::Buffered);
     }
 

--- a/src/query/src/dist_plan/dyn_filter_bridge.rs
+++ b/src/query/src/dist_plan/dyn_filter_bridge.rs
@@ -15,6 +15,7 @@
 use std::any::Any;
 use std::sync::Arc;
 
+use arrow_schema::Schema as ArrowSchema;
 use common_query::request::{
     DynFilterPayload, INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY,
     INITIAL_REMOTE_DYN_FILTER_REGS_MAX_TOTAL_PROTO_BYTES, InitialDynFilterReg,
@@ -34,6 +35,7 @@ pub(crate) struct CapturedDynFilter {
     filter_id: FilterId,
     initial_registration: InitialDynFilterReg,
     pub(crate) alive_dyn_filter: Arc<DynamicFilterPhysicalExpr>,
+    pub(crate) input_schema: arrow_schema::SchemaRef,
 }
 
 #[derive(Debug, Clone)]
@@ -46,6 +48,7 @@ pub(crate) struct RemoteDynFilterPushdown {
 pub(crate) fn capture_remote_dyn_filters_for_pushdown(
     remote_dyn_filter_producer_id: RemoteDynFilterProducerId,
     parent_filters: Vec<Arc<dyn datafusion::physical_plan::PhysicalExpr>>,
+    input_schema: &ArrowSchema,
 ) -> RemoteDynFilterPushdown {
     let mut pushed_down = Vec::with_capacity(parent_filters.len());
     let mut captured_dyn_filters = Vec::new();
@@ -60,6 +63,7 @@ pub(crate) fn capture_remote_dyn_filters_for_pushdown(
             remote_dyn_filter_producer_id,
             producer_local_ordinal,
             alive_dyn_filter,
+            input_schema,
         ) {
             Ok(captured_dyn_filter) => {
                 pushed_down.push(true);
@@ -103,6 +107,7 @@ pub(crate) fn register_dyn_filters_for_region(
         let _ = registry.register_remote_dyn_filter(
             captured_dyn_filter.filter_id.clone(),
             captured_dyn_filter.alive_dyn_filter.clone(),
+            captured_dyn_filter.input_schema.clone(),
         );
         let _ = registry
             .register_subscriber(&captured_dyn_filter.filter_id, Subscriber::new(region_id));
@@ -113,6 +118,7 @@ fn build_captured_dyn_filter(
     remote_dyn_filter_producer_id: RemoteDynFilterProducerId,
     producer_local_ordinal: usize,
     alive_dyn_filter: Arc<DynamicFilterPhysicalExpr>,
+    input_schema: &ArrowSchema,
 ) -> Result<CapturedDynFilter> {
     let children = alive_dyn_filter
         .children()
@@ -129,8 +135,14 @@ fn build_captured_dyn_filter(
 
     Ok(CapturedDynFilter {
         filter_id,
-        initial_registration: attach_initial_snapshot(initial_registration, &alive_dyn_filter),
+        initial_registration: attach_initial_snapshot(
+            initial_registration,
+            &alive_dyn_filter,
+            &children,
+            input_schema,
+        ),
         alive_dyn_filter,
+        input_schema: Arc::new(input_schema.clone()),
     })
 }
 
@@ -147,8 +159,12 @@ fn validate_initial_registrations_for_pushdown(
 fn attach_initial_snapshot(
     initial_registration: InitialDynFilterReg,
     alive_dyn_filter: &DynamicFilterPhysicalExpr,
+    registered_children: &[Arc<dyn PhysicalExpr>],
+    input_schema: &ArrowSchema,
 ) -> InitialDynFilterReg {
-    let Some(initial_snapshot) = initial_snapshot(alive_dyn_filter) else {
+    let Some(initial_snapshot) =
+        initial_snapshot(alive_dyn_filter, registered_children, input_schema)
+    else {
         return initial_registration;
     };
 
@@ -157,6 +173,8 @@ fn attach_initial_snapshot(
 
 fn initial_snapshot(
     alive_dyn_filter: &DynamicFilterPhysicalExpr,
+    registered_children: &[Arc<dyn PhysicalExpr>],
+    input_schema: &ArrowSchema,
 ) -> Option<InitialDynFilterSnapshot> {
     let generation = alive_dyn_filter.snapshot_generation();
     let current = match alive_dyn_filter.current() {
@@ -167,9 +185,11 @@ fn initial_snapshot(
         }
     };
 
-    let payload = match DynFilterPayload::from_datafusion_expr(
+    let payload = match DynFilterPayload::from_datafusion_expr_with_registered_children(
         &current,
+        registered_children,
         INITIAL_REMOTE_DYN_FILTER_REGS_MAX_TOTAL_PROTO_BYTES,
+        input_schema,
     ) {
         Ok(payload) => payload,
         Err(error) => {
@@ -233,6 +253,8 @@ mod tests {
     use std::hash::{Hash, Hasher};
 
     use datafusion::execution::TaskContext;
+    use datafusion::physical_plan::joins::join_hash_map::{JoinHashMapType, JoinHashMapU32};
+    use datafusion::physical_plan::joins::{HashTableLookupExpr, Map, SeededRandomState};
     use datafusion_common::ScalarValue;
     use datafusion_expr::ColumnarValue;
     use datafusion_physical_expr::expressions::{Column, lit};
@@ -314,6 +336,15 @@ mod tests {
         RemoteDynFilterProducerId::new(value)
     }
 
+    fn test_arrow_schema() -> ArrowSchema {
+        ArrowSchema::new(vec![
+            arrow_schema::Field::new("service", arrow_schema::DataType::Utf8, true),
+            arrow_schema::Field::new("host", arrow_schema::DataType::Utf8, true),
+            arrow_schema::Field::new("zone", arrow_schema::DataType::Utf8, true),
+            arrow_schema::Field::new("pod", arrow_schema::DataType::Utf8, true),
+        ])
+    }
+
     fn test_captured_dyn_filter(
         remote_dyn_filter_producer_id: RemoteDynFilterProducerId,
         producer_local_ordinal: usize,
@@ -327,6 +358,7 @@ mod tests {
                 vec![Arc::new(Column::new(column_name, column_index)) as Arc<_>],
                 lit(true) as _,
             )),
+            &test_arrow_schema(),
         )
         .unwrap()
     }
@@ -346,6 +378,18 @@ mod tests {
         dyn_filter
     }
 
+    fn test_lookup_expr(child: Arc<dyn PhysicalExpr>, hashes: Vec<u64>) -> Arc<dyn PhysicalExpr> {
+        let mut hash_map = JoinHashMapU32::with_capacity(hashes.len().max(1));
+        hash_map.update_from_iter(Box::new(hashes.iter().enumerate()), 0);
+        let map = Arc::new(Map::HashMap(Box::new(hash_map)));
+        Arc::new(HashTableLookupExpr::new(
+            vec![child],
+            SeededRandomState::with_seeds(1, 2, 3, 4),
+            map,
+            "lookup".to_string(),
+        ))
+    }
+
     #[test]
     fn capture_remote_dyn_filters_for_pushdown_preserves_parent_filter_ordinals() {
         let parent_filters = vec![
@@ -362,9 +406,12 @@ mod tests {
         ];
 
         let remote_dyn_filter_producer_id = test_remote_dyn_filter_producer_id(42);
-        let captured =
-            capture_remote_dyn_filters_for_pushdown(remote_dyn_filter_producer_id, parent_filters)
-                .captured_dyn_filters;
+        let captured = capture_remote_dyn_filters_for_pushdown(
+            remote_dyn_filter_producer_id,
+            parent_filters,
+            &test_arrow_schema(),
+        )
+        .captured_dyn_filters;
 
         assert_eq!(captured.len(), 2);
         assert_eq!(
@@ -391,8 +438,11 @@ mod tests {
         ];
 
         let remote_dyn_filter_producer_id = test_remote_dyn_filter_producer_id(42);
-        let pushdown =
-            capture_remote_dyn_filters_for_pushdown(remote_dyn_filter_producer_id, parent_filters);
+        let pushdown = capture_remote_dyn_filters_for_pushdown(
+            remote_dyn_filter_producer_id,
+            parent_filters,
+            &test_arrow_schema(),
+        );
 
         assert_eq!(pushdown.pushed_down, vec![false, true, false]);
         assert_eq!(pushdown.captured_dyn_filters.len(), 1);
@@ -408,12 +458,15 @@ mod tests {
                 .producer_ordinal(),
             1
         );
-        assert!(
-            pushdown.captured_dyn_filters[0]
-                .initial_registration
-                .initial_snapshot
-                .is_some()
-        );
+        let snapshot = pushdown.captured_dyn_filters[0]
+            .initial_registration
+            .initial_snapshot
+            .as_ref()
+            .unwrap();
+        assert!(matches!(
+            snapshot.payload,
+            DynFilterPayload::Datafusion(ref bytes) if !bytes.is_empty()
+        ));
     }
 
     #[test]
@@ -427,6 +480,7 @@ mod tests {
         let pushdown = capture_remote_dyn_filters_for_pushdown(
             test_remote_dyn_filter_producer_id(42),
             parent_filters,
+            &test_arrow_schema(),
         );
 
         assert_eq!(pushdown.pushed_down, vec![false]);
@@ -444,6 +498,7 @@ mod tests {
         let pushdown = capture_remote_dyn_filters_for_pushdown(
             test_remote_dyn_filter_producer_id(42),
             parent_filters,
+            &test_arrow_schema(),
         );
 
         assert_eq!(pushdown.pushed_down, vec![true]);
@@ -467,6 +522,7 @@ mod tests {
         let pushdown = capture_remote_dyn_filters_for_pushdown(
             test_remote_dyn_filter_producer_id(42),
             parent_filters,
+            &test_arrow_schema(),
         );
 
         assert_eq!(pushdown.pushed_down, vec![true]);
@@ -484,6 +540,40 @@ mod tests {
     }
 
     #[test]
+    fn capture_remote_dyn_filters_for_pushdown_can_attach_bloom_initial_snapshot() {
+        let host = Arc::new(Column::new("host", 1)) as Arc<dyn PhysicalExpr>;
+        let dyn_filter = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![Arc::clone(&host)],
+            lit(true) as _,
+        ));
+        dyn_filter
+            .update(test_lookup_expr(Arc::clone(&host), vec![10, 20, 30]))
+            .unwrap();
+        let parent_filters = vec![dyn_filter as Arc<dyn datafusion::physical_plan::PhysicalExpr>];
+
+        let pushdown = capture_remote_dyn_filters_for_pushdown(
+            test_remote_dyn_filter_producer_id(42),
+            parent_filters,
+            &test_arrow_schema(),
+        );
+
+        assert_eq!(pushdown.pushed_down, vec![true]);
+        let snapshot = pushdown.captured_dyn_filters[0]
+            .initial_registration
+            .initial_snapshot
+            .as_ref()
+            .unwrap();
+        match &snapshot.payload {
+            DynFilterPayload::JoinHashBloom(bloom) => {
+                assert_eq!(bloom.join_key_child_indices, vec![0]);
+                assert_eq!(bloom.distinct_hash_count, 3);
+                assert_ne!(bloom.hash_compat_fingerprint, 0);
+            }
+            other => panic!("expected Bloom initial snapshot, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn capture_remote_dyn_filters_for_pushdown_rejects_oversized_snapshots() {
         let parent_filters = vec![
             test_dyn_filter_with_snapshot_payload("host", 0, 40 * 1024)
@@ -495,6 +585,7 @@ mod tests {
         let pushdown = capture_remote_dyn_filters_for_pushdown(
             test_remote_dyn_filter_producer_id(42),
             parent_filters,
+            &test_arrow_schema(),
         );
 
         assert_eq!(pushdown.pushed_down, vec![false, false]);
@@ -515,6 +606,7 @@ mod tests {
         let pushdown = capture_remote_dyn_filters_for_pushdown(
             test_remote_dyn_filter_producer_id(42),
             parent_filters,
+            &test_arrow_schema(),
         );
 
         assert!(pushdown.captured_dyn_filters.is_empty());
@@ -537,6 +629,7 @@ mod tests {
         let pushdown = capture_remote_dyn_filters_for_pushdown(
             test_remote_dyn_filter_producer_id(42),
             parent_filters,
+            &test_arrow_schema(),
         );
 
         assert!(pushdown.captured_dyn_filters.is_empty());

--- a/src/query/src/dist_plan/merge_scan.rs
+++ b/src/query/src/dist_plan/merge_scan.rs
@@ -832,8 +832,11 @@ impl ExecutionPlan for MergeScanExec {
                 updated_node: Some(new_self),
             });
         };
-        let remote_dyn_filter_pushdown =
-            capture_remote_dyn_filters_for_pushdown(remote_dyn_filter_producer_id, parent_filters);
+        let remote_dyn_filter_pushdown = capture_remote_dyn_filters_for_pushdown(
+            remote_dyn_filter_producer_id,
+            parent_filters,
+            self.arrow_schema.as_ref(),
+        );
         *self.captured_remote_dyn_filters.lock().unwrap() =
             remote_dyn_filter_pushdown.captured_dyn_filters;
         let new_self = Arc::new(self.clone());
@@ -1022,6 +1025,11 @@ mod tests {
         let captured = capture_remote_dyn_filters_for_pushdown(
             RemoteDynFilterProducerId::new(42),
             vec![dyn_filter],
+            &ArrowSchema::new(vec![arrow_schema::Field::new(
+                "host",
+                arrow_schema::DataType::Utf8,
+                true,
+            )]),
         );
         assert_eq!(captured.captured_dyn_filters.len(), 1);
 

--- a/src/query/src/dist_plan/remote_dyn_filter_registry.rs
+++ b/src/query/src/dist_plan/remote_dyn_filter_registry.rs
@@ -18,11 +18,12 @@ use std::sync::{Arc, Mutex, RwLock, Weak};
 use std::time::Duration;
 
 use api::v1::region::{RemoteDynFilterUnregister, RemoteDynFilterUpdate};
+use arrow_schema::SchemaRef as ArrowSchemaRef;
 use common_query::request::DynFilterPayload;
 use common_runtime::spawn_global;
 use common_telemetry::{debug, warn};
 use datafusion_physical_expr::PhysicalExpr;
-use datafusion_physical_expr::expressions::DynamicFilterPhysicalExpr;
+use datafusion_physical_expr::expressions::{DynamicFilterPhysicalExpr, lit as physical_lit};
 use session::query_id::QueryId;
 use store_api::storage::RegionId;
 use tokio::sync::{Notify, watch};
@@ -75,6 +76,7 @@ pub struct DynFilterEntry {
     subscribers: RwLock<HashSet<Subscriber>>,
     state: Mutex<DynFilterEntryState>,
     subscriber_changed: Notify,
+    input_schema: ArrowSchemaRef,
 }
 
 #[derive(Debug, Default)]
@@ -90,13 +92,18 @@ struct QueryDynFilterRegistryInner {
 }
 
 impl DynFilterEntry {
-    pub fn new(filter_id: FilterId, producer_filter: Arc<DynamicFilterPhysicalExpr>) -> Self {
+    pub fn new(
+        filter_id: FilterId,
+        producer_filter: Arc<DynamicFilterPhysicalExpr>,
+        input_schema: ArrowSchemaRef,
+    ) -> Self {
         Self {
             filter_id,
             producer_filter: Arc::downgrade(&producer_filter),
             subscribers: RwLock::new(HashSet::new()),
             state: Mutex::new(DynFilterEntryState::default()),
             subscriber_changed: Notify::new(),
+            input_schema,
         }
     }
 
@@ -125,6 +132,14 @@ impl DynFilterEntry {
 
         state.last_sent_generation = generation;
         true
+    }
+
+    fn should_send_generation(&self, generation: u64, is_complete: bool) -> bool {
+        if is_complete {
+            return true;
+        }
+
+        generation > self.state.lock().unwrap().last_sent_generation
     }
 
     fn try_mark_unregistered(&self) -> bool {
@@ -210,13 +225,18 @@ impl QueryDynFilterRegistry {
         &self,
         filter_id: FilterId,
         producer_filter: Arc<DynamicFilterPhysicalExpr>,
+        input_schema: ArrowSchemaRef,
     ) -> EntryRegistration {
         let mut inner = self.inner.write().unwrap();
         if let Some(existing) = inner.entries.get(&filter_id) {
             return EntryRegistration::Existing(existing.clone());
         }
 
-        let entry = Arc::new(DynFilterEntry::new(filter_id.clone(), producer_filter));
+        let entry = Arc::new(DynFilterEntry::new(
+            filter_id.clone(),
+            producer_filter,
+            input_schema,
+        ));
         inner.entries.insert(filter_id, entry.clone());
         EntryRegistration::Inserted(entry)
     }
@@ -363,6 +383,87 @@ async fn run_entry_fanout(
     unregister_entry_once_for_query(&region_query_handler, query_id, &entry).await;
 }
 
+/// Encoded payload pair for a fanout update.
+#[derive(Debug, Clone)]
+struct EncodedRemoteDynFilterUpdate {
+    typed_payload: DynFilterPayload,
+    legacy_payload: Vec<u8>,
+}
+
+fn encode_remote_dyn_filter_update(
+    current: &Arc<dyn PhysicalExpr>,
+    filter: &DynamicFilterPhysicalExpr,
+    entry: &DynFilterEntry,
+) -> Option<EncodedRemoteDynFilterUpdate> {
+    let children = filter.children().into_iter().cloned().collect::<Vec<_>>();
+
+    let typed = match DynFilterPayload::from_datafusion_expr_with_registered_children(
+        current,
+        &children,
+        REMOTE_DYN_FILTER_UPDATE_PAYLOAD_MAX_BYTES,
+        entry.input_schema.as_ref(),
+    ) {
+        Ok(typed) => typed,
+        Err(error) => {
+            warn!(error; "Failed to encode typed remote dynamic filter update");
+            return None;
+        }
+    };
+
+    let legacy_payload = match &typed {
+        DynFilterPayload::Datafusion(bytes) => bytes.clone(),
+        DynFilterPayload::JoinHashBloom(_) => {
+            // Build a safe legacy fallback for old DNs that cannot parse JoinHashBloom.
+            // Try Datafusion encoding first; if that fails, use lit(true).
+            match DynFilterPayload::from_datafusion_expr(
+                current,
+                REMOTE_DYN_FILTER_UPDATE_PAYLOAD_MAX_BYTES,
+            ) {
+                Ok(DynFilterPayload::Datafusion(bytes)) => bytes,
+                Ok(_) => {
+                    // Unsupported variant from from_datafusion_expr — fallback to lit(true).
+                    match DynFilterPayload::from_datafusion_expr(
+                        &(physical_lit(true) as Arc<dyn PhysicalExpr>),
+                        REMOTE_DYN_FILTER_UPDATE_PAYLOAD_MAX_BYTES,
+                    ) {
+                        Ok(DynFilterPayload::Datafusion(bytes)) => bytes,
+                        _ => {
+                            warn!("Failed to encode legacy fallback payload for old DNs");
+                            return None;
+                        }
+                    }
+                }
+                Err(_) => {
+                    match DynFilterPayload::from_datafusion_expr(
+                        &(physical_lit(true) as Arc<dyn PhysicalExpr>),
+                        REMOTE_DYN_FILTER_UPDATE_PAYLOAD_MAX_BYTES,
+                    ) {
+                        Ok(DynFilterPayload::Datafusion(bytes)) => bytes,
+                        _ => {
+                            warn!("Failed to encode legacy fallback payload for old DNs");
+                            return None;
+                        }
+                    }
+                }
+            }
+        }
+        _ => {
+            warn!("Unsupported DynFilterPayload variant for fanout");
+            return None;
+        }
+    };
+
+    if legacy_payload.is_empty() {
+        warn!("Failed to encode non-empty legacy remote dynamic filter payload for old DNs");
+        return None;
+    }
+
+    Some(EncodedRemoteDynFilterUpdate {
+        typed_payload: typed,
+        legacy_payload,
+    })
+}
+
 async fn fanout_snapshot_for_query(
     query_id: QueryId,
     region_query_handler: &RegionQueryHandlerRef,
@@ -376,9 +477,17 @@ async fn fanout_snapshot_for_query(
         return true;
     };
 
-    // The entry-global watermark advances before best-effort fanout. A timed-out
-    // subscriber may miss this generation; later/complete snapshots supersede it,
-    // and RDF only prunes.
+    if !entry.should_send_generation(generation, is_complete) {
+        return true;
+    }
+
+    let Some(encoded) = encode_remote_dyn_filter_update(&current, filter, entry) else {
+        // Failed to encode; do not advance watermark.
+        return true;
+    };
+
+    // Advance watermark after encoding succeeds, so a failed encode doesn't
+    // skip a generation.
     if !is_complete && !entry.mark_generation_sent(generation) {
         return true;
     }
@@ -387,28 +496,13 @@ async fn fanout_snapshot_for_query(
         let _ = entry.mark_generation_sent(generation);
     }
 
-    let payload = match DynFilterPayload::from_datafusion_expr(
-        &current,
-        REMOTE_DYN_FILTER_UPDATE_PAYLOAD_MAX_BYTES,
-    ) {
-        Ok(DynFilterPayload::Datafusion(payload)) => payload,
-        Ok(_) => {
-            warn!("Ignored unsupported remote dynamic filter producer payload");
-            return true;
-        }
-        Err(error) => {
-            warn!(error; "Failed to encode remote dynamic filter producer snapshot");
-            return true;
-        }
-    };
-
     fanout_update_for_query(
         query_id,
         region_query_handler,
         entry,
         generation,
         is_complete,
-        payload,
+        encoded,
         lifecycle_rx,
         control_rpc_timeout,
     )
@@ -422,7 +516,7 @@ async fn fanout_update_for_query(
     entry: &DynFilterEntry,
     generation: u64,
     is_complete: bool,
-    payload: Vec<u8>,
+    encoded: EncodedRemoteDynFilterUpdate,
     lifecycle_rx: &mut watch::Receiver<()>,
     control_rpc_timeout: Duration,
 ) -> bool {
@@ -432,9 +526,10 @@ async fn fanout_update_for_query(
     for subscriber in entry.subscribers() {
         let update = RemoteDynFilterUpdate {
             filter_id: filter_id.clone(),
-            payload: payload.clone(),
+            payload: encoded.legacy_payload.clone(),
             generation,
             is_complete,
+            typed_payload: Some(encoded.typed_payload.to_region_proto_payload()),
         };
 
         match await_control_rpc_or_lifecycle_close(
@@ -773,9 +868,13 @@ mod tests {
     use std::thread;
     use std::time::Duration;
 
-    use api::v1::region::{RemoteDynFilterUnregister, RemoteDynFilterUpdate};
+    use api::v1::region::{
+        RemoteDynFilterPayload, RemoteDynFilterUnregister, RemoteDynFilterUpdate,
+    };
     use async_trait::async_trait;
     use common_query::request::QueryRequest;
+    use datafusion::physical_plan::joins::join_hash_map::{JoinHashMapType, JoinHashMapU32};
+    use datafusion::physical_plan::joins::{HashTableLookupExpr, Map, SeededRandomState};
     use datafusion_physical_expr::expressions::{Column, lit};
     use session::ReadPreference;
     use uuid::Uuid;
@@ -793,6 +892,7 @@ mod tests {
         generation: u64,
         is_complete: bool,
         payload: Vec<u8>,
+        typed_payload: Option<RemoteDynFilterPayload>,
     }
 
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -887,6 +987,7 @@ mod tests {
                 generation: update.generation,
                 is_complete: update.is_complete,
                 payload: update.payload,
+                typed_payload: update.typed_payload,
             });
             if should_block {
                 self.update_blocked.notify_one();
@@ -930,6 +1031,31 @@ mod tests {
             .collect();
 
         Arc::new(DynamicFilterPhysicalExpr::new(children, lit(true) as _))
+    }
+
+    fn test_lookup_expr(child: Arc<dyn PhysicalExpr>, hashes: Vec<u64>) -> Arc<dyn PhysicalExpr> {
+        let mut hash_map = JoinHashMapU32::with_capacity(hashes.len().max(1));
+        hash_map.update_from_iter(Box::new(hashes.iter().enumerate()), 0);
+        let map = Arc::new(Map::HashMap(Box::new(hash_map)));
+        Arc::new(HashTableLookupExpr::new(
+            vec![child],
+            SeededRandomState::with_seeds(1, 2, 3, 4),
+            map,
+            "lookup".to_string(),
+        ))
+    }
+
+    fn test_arrow_schema(names: &[&str]) -> ArrowSchemaRef {
+        Arc::new(arrow_schema::Schema::new(
+            names
+                .iter()
+                .map(|name| arrow_schema::Field::new(*name, arrow_schema::DataType::Utf8, true))
+                .collect::<Vec<_>>(),
+        ))
+    }
+
+    fn test_entry_schema() -> ArrowSchemaRef {
+        test_arrow_schema(&["host"])
     }
 
     #[test]
@@ -1131,7 +1257,11 @@ mod tests {
         let registry = QueryDynFilterRegistry::new(test_query_id(1));
         let filter = test_dyn_filter(&["host"]);
         let filter_id = test_filter_id(1);
-        let entry = match registry.register_remote_dyn_filter(filter_id.clone(), filter.clone()) {
+        let entry = match registry.register_remote_dyn_filter(
+            filter_id.clone(),
+            filter.clone(),
+            test_entry_schema(),
+        ) {
             EntryRegistration::Inserted(entry) => entry,
             other => panic!("unexpected registration result: {other:?}"),
         };
@@ -1157,7 +1287,11 @@ mod tests {
         let registry = Arc::new(QueryDynFilterRegistry::new(query_id));
         let filter = test_dyn_filter(&["host"]);
         let filter_id = test_filter_id(1);
-        let entry = match registry.register_remote_dyn_filter(filter_id.clone(), filter.clone()) {
+        let entry = match registry.register_remote_dyn_filter(
+            filter_id.clone(),
+            filter.clone(),
+            test_entry_schema(),
+        ) {
             EntryRegistration::Inserted(entry) => entry,
             other => panic!("unexpected registration result: {other:?}"),
         };
@@ -1181,6 +1315,7 @@ mod tests {
         assert_eq!(updates[0].generation, filter.snapshot_generation());
         assert!(!updates[0].is_complete);
         assert!(!updates[0].payload.is_empty());
+        assert!(updates[0].typed_payload.is_some());
 
         registry
             .fanout_snapshot(&handler_ref, &entry, filter.as_ref(), false)
@@ -1219,6 +1354,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fanout_sends_join_hash_bloom_typed_payload_with_legacy_fallback() {
+        let query_id = test_query_id(10);
+        let registry = Arc::new(QueryDynFilterRegistry::new(query_id));
+        let filter = test_dyn_filter(&["host"]);
+        let filter_id = test_filter_id(1);
+        let entry = match registry.register_remote_dyn_filter(
+            filter_id.clone(),
+            filter.clone(),
+            test_entry_schema(),
+        ) {
+            EntryRegistration::Inserted(entry) => entry,
+            other => panic!("unexpected registration result: {other:?}"),
+        };
+        let subscriber = Subscriber::new(RegionId::new(1024, 7));
+        assert_eq!(
+            registry.register_subscriber(&filter_id, subscriber.clone()),
+            SubscriberRegistration::Added
+        );
+
+        let host = Arc::new(Column::new("host", 0)) as Arc<dyn PhysicalExpr>;
+        filter
+            .update(test_lookup_expr(Arc::clone(&host), vec![10, 20, 30]))
+            .unwrap();
+
+        let handler = Arc::new(RecordingRegionQueryHandler::default());
+        let handler_ref = handler.clone() as RegionQueryHandlerRef;
+        registry
+            .fanout_snapshot(&handler_ref, &entry, filter.as_ref(), false)
+            .await;
+
+        let updates = handler.updates();
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].region_id, subscriber.region_id());
+        assert!(
+            !updates[0].payload.is_empty(),
+            "legacy fallback payload must stay non-empty for old DNs"
+        );
+
+        let typed = updates[0]
+            .typed_payload
+            .clone()
+            .expect("typed payload must be populated");
+        let typed = DynFilterPayload::from_region_proto_payload(typed).unwrap();
+        match typed {
+            DynFilterPayload::JoinHashBloom(bloom) => {
+                assert_eq!(bloom.join_key_child_indices, vec![0]);
+                assert_eq!(bloom.distinct_hash_count, 3);
+                assert_ne!(bloom.hash_compat_fingerprint, 0);
+            }
+            other => panic!("expected JoinHashBloom typed payload, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
     async fn fanout_task_waits_for_dynamic_filter_notifications() {
         let query_id = test_query_id(3);
         let manager = Arc::new(DynFilterRegistryManager::default());
@@ -1226,9 +1415,11 @@ mod tests {
         let registry_weak = Arc::downgrade(lease.registry.as_ref().unwrap());
         let filter = test_dyn_filter(&["host"]);
         let filter_id = test_filter_id(1);
-        let _ = lease
-            .registry()
-            .register_remote_dyn_filter(filter_id.clone(), filter.clone());
+        let _ = lease.registry().register_remote_dyn_filter(
+            filter_id.clone(),
+            filter.clone(),
+            test_entry_schema(),
+        );
         let subscriber = Subscriber::new(RegionId::new(1024, 7));
         assert_eq!(
             lease
@@ -1272,10 +1463,11 @@ mod tests {
         let registry_weak = Arc::downgrade(lease.registry.as_ref().unwrap());
         let filter = test_dyn_filter(&["host"]);
         let filter_id = test_filter_id(1);
-        let entry = match lease
-            .registry()
-            .register_remote_dyn_filter(filter_id.clone(), filter.clone())
-        {
+        let entry = match lease.registry().register_remote_dyn_filter(
+            filter_id.clone(),
+            filter.clone(),
+            test_entry_schema(),
+        ) {
             EntryRegistration::Inserted(entry) => entry,
             other => panic!("unexpected registration result: {other:?}"),
         };
@@ -1314,9 +1506,11 @@ mod tests {
         let registry_weak = Arc::downgrade(lease.registry.as_ref().unwrap());
         let filter = test_dyn_filter(&["host"]);
         let filter_id = test_filter_id(1);
-        let _ = lease
-            .registry()
-            .register_remote_dyn_filter(filter_id.clone(), filter.clone());
+        let _ = lease.registry().register_remote_dyn_filter(
+            filter_id.clone(),
+            filter.clone(),
+            test_entry_schema(),
+        );
         let first_subscriber = Subscriber::new(RegionId::new(1024, 7));
         assert_eq!(
             lease
@@ -1368,9 +1562,11 @@ mod tests {
         let registry_weak = Arc::downgrade(lease.registry.as_ref().unwrap());
         let filter = test_dyn_filter(&["host"]);
         let filter_id = test_filter_id(1);
-        let _ = lease
-            .registry()
-            .register_remote_dyn_filter(filter_id.clone(), filter.clone());
+        let _ = lease.registry().register_remote_dyn_filter(
+            filter_id.clone(),
+            filter.clone(),
+            test_entry_schema(),
+        );
         let subscriber = Subscriber::new(RegionId::new(1024, 7));
         assert_eq!(
             lease
@@ -1401,9 +1597,11 @@ mod tests {
         let registry_weak = Arc::downgrade(lease.registry.as_ref().unwrap());
         let filter = test_dyn_filter(&["host"]);
         let filter_id = test_filter_id(1);
-        let _ = lease
-            .registry()
-            .register_remote_dyn_filter(filter_id.clone(), filter.clone());
+        let _ = lease.registry().register_remote_dyn_filter(
+            filter_id.clone(),
+            filter.clone(),
+            test_entry_schema(),
+        );
         let subscriber = Subscriber::new(RegionId::new(1024, 7));
         assert_eq!(
             lease
@@ -1442,9 +1640,11 @@ mod tests {
         let registry_weak = Arc::downgrade(lease.registry.as_ref().unwrap());
         let filter = test_dyn_filter(&["host"]);
         let filter_id = test_filter_id(1);
-        let _ = lease
-            .registry()
-            .register_remote_dyn_filter(filter_id.clone(), filter.clone());
+        let _ = lease.registry().register_remote_dyn_filter(
+            filter_id.clone(),
+            filter.clone(),
+            test_entry_schema(),
+        );
         let subscriber = Subscriber::new(RegionId::new(1024, 7));
         assert_eq!(
             lease
@@ -1473,7 +1673,11 @@ mod tests {
         let registry = QueryDynFilterRegistry::new(query_id);
         let filter = test_dyn_filter(&["host"]);
         let filter_id = test_filter_id(1);
-        let entry = match registry.register_remote_dyn_filter(filter_id.clone(), filter.clone()) {
+        let entry = match registry.register_remote_dyn_filter(
+            filter_id.clone(),
+            filter.clone(),
+            test_entry_schema(),
+        ) {
             EntryRegistration::Inserted(entry) => entry,
             other => panic!("unexpected registration result: {other:?}"),
         };
@@ -1563,7 +1767,7 @@ mod tests {
         let registry = QueryDynFilterRegistry::new(query_id);
         let filter = test_dyn_filter(&["host"]);
         let filter_id = test_filter_id(1);
-        let _ = registry.register_remote_dyn_filter(filter_id.clone(), filter);
+        let _ = registry.register_remote_dyn_filter(filter_id.clone(), filter, test_entry_schema());
         let subscriber = Subscriber::new(RegionId::new(1024, 7));
         assert_eq!(
             registry.register_subscriber(&filter_id, subscriber.clone()),

--- a/src/query/src/dist_plan/remote_dyn_filter_registry.rs
+++ b/src/query/src/dist_plan/remote_dyn_filter_registry.rs
@@ -510,6 +510,7 @@ async fn fanout_snapshot_for_query(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[allow(deprecated)]
 async fn fanout_update_for_query(
     query_id: QueryId,
     region_query_handler: &RegionQueryHandlerRef,
@@ -973,6 +974,7 @@ mod tests {
             unreachable!("remote dyn filter registry tests should not execute remote queries")
         }
 
+        #[allow(deprecated)]
         async fn handle_remote_dyn_filter_update(
             &self,
             region_id: RegionId,

--- a/tests-integration/src/tests/remote_dyn_filter_test.rs
+++ b/tests-integration/src/tests/remote_dyn_filter_test.rs
@@ -385,6 +385,95 @@ async fn prepare_remote_dyn_filter_large_tables(frontend: &Arc<Instance>) {
     .await;
 }
 
+async fn prepare_remote_dyn_filter_bloom_tables(frontend: &Arc<Instance>) {
+    // Probe table: 8192 sparse keys spread across 4 partitions. Build table:
+    // 302 keys distributed across the full probe key range. Keeping the build
+    // side small makes the Bloom update arrive quickly, while the larger
+    // flushed probe-side SST scan gives the non-pushdown FilterExec enough
+    // rows to show the Bloom filtering effect in EXPLAIN ANALYZE metrics.
+    execute_sql(
+        frontend,
+        r#"
+        CREATE TABLE rdf_bloom_probe(
+            k INT,
+            ts TIMESTAMP,
+            v DOUBLE,
+            TIME INDEX (ts),
+            PRIMARY KEY(k)
+        )
+        PARTITION ON COLUMNS (k) (
+            k < 2097152,
+            k >= 2097152 AND k < 4194304,
+            k >= 4194304 AND k < 6291456,
+            k >= 6291456
+        )
+        engine=mito
+        "#,
+    )
+    .await;
+
+    execute_sql(
+        frontend,
+        r#"
+        CREATE TABLE rdf_bloom_build(
+            k INT,
+            ts TIMESTAMP,
+            TIME INDEX (ts),
+            PRIMARY KEY(k)
+        ) engine=mito
+        "#,
+    )
+    .await;
+
+    const PROBE_COUNT: usize = 8192;
+    const BUILD_COUNT: usize = 302;
+
+    let probe_values = (0..PROBE_COUNT)
+        .map(|i| {
+            let k = i * 1024;
+            format!("({k}, {k}, {}.0)", k * 10)
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    let insert_probe_sql = format!("INSERT INTO rdf_bloom_probe(k, ts, v) VALUES {probe_values}");
+    execute_sql(frontend, &insert_probe_sql).await;
+
+    // Flush so the scan reads from SST files, giving the async Bloom
+    // gRPC update more time to arrive before the scan finishes.
+    execute_sql(frontend, "ADMIN FLUSH_TABLE('rdf_bloom_probe')").await;
+
+    // Write a few extra probe-only rows into memtable after flush.
+    // These are probe keys that do NOT appear in the build side,
+    // so the Bloom filter must reject them. This increases the gap
+    // between scan volume and join output, making the filtering effect
+    // easier to observe in metrics.
+    let extra_start = PROBE_COUNT;
+    let extra_end = extra_start + 8;
+    let extra_probe_values = (extra_start..extra_end)
+        .map(|i| {
+            let k = i * 1024;
+            format!("({k}, {k}, {}.0)", k * 10)
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    if !extra_probe_values.is_empty() {
+        let extra_sql =
+            format!("INSERT INTO rdf_bloom_probe(k, ts, v) VALUES {extra_probe_values}");
+        execute_sql(frontend, &extra_sql).await;
+    }
+
+    let build_values = (0..BUILD_COUNT)
+        .map(|i| {
+            let probe_index = i * (PROBE_COUNT - 1) / (BUILD_COUNT - 1);
+            let k = probe_index * 1024;
+            format!("({k}, {k})")
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    let insert_build_sql = format!("INSERT INTO rdf_bloom_build(k, ts) VALUES {build_values}");
+    execute_sql(frontend, &insert_build_sql).await;
+}
+
 async fn insert_remote_dyn_filter_large_probe_range(
     frontend: &Arc<Instance>,
     start: usize,
@@ -432,6 +521,14 @@ fn remote_dyn_filter_large_join_sql() -> &'static str {
     FROM rdf_large_build b
     JOIN rdf_large_probe p ON p.k = b.k
     ORDER BY p.k
+    "#
+}
+
+fn remote_dyn_filter_bloom_join_sql() -> &'static str {
+    r#"
+    SELECT COUNT(*) AS cnt
+    FROM rdf_bloom_build b
+    JOIN rdf_bloom_probe p ON p.k = b.k
     "#
 }
 
@@ -505,5 +602,125 @@ fn assert_seq_scan_has_dyn_filter(explain: &str) {
     assert!(
         has_dyn_filter,
         "expected at least one region SeqScan line with dyn_filters in:\n{explain}"
+    );
+}
+
+fn assert_seq_scan_dyn_filter_not_contains(explain: &str, needle: &str) {
+    let seq_scan_dyn_filter_lines = explain
+        .lines()
+        .filter(|line| line.contains("SeqScan: region=") && line.contains("\"dyn_filters\""))
+        .collect::<Vec<_>>();
+
+    assert!(
+        seq_scan_dyn_filter_lines
+            .iter()
+            .all(|line| !line.contains(needle)),
+        "expected no region SeqScan dyn_filters line to contain {needle:?}; actual SeqScan dyn_filters lines:\n{}\n\nfull explain:\n{explain}",
+        seq_scan_dyn_filter_lines.join("\n")
+    );
+}
+
+/// Extracts the value of a named metric from an explain metrics line.
+///
+/// The line is expected to contain `metrics=[..., metric_name: value, ...]`.
+/// Returns `None` if the metric name is not found or the value cannot be
+/// parsed as `usize`.
+fn parse_metric_value(line: &str, metric_name: &str) -> Option<usize> {
+    let metrics_segment = line.split("metrics=[").nth(1)?;
+    // The metrics block ends with `]` (potentially followed by extra output).
+    let metrics_body = metrics_segment.split(']').next()?;
+    let prefix = format!("{}: ", metric_name);
+    for part in metrics_body.split(", ") {
+        if let Some(val_str) = part.strip_prefix(&prefix) {
+            return val_str.trim().parse::<usize>().ok();
+        }
+    }
+    None
+}
+
+/// Pairs each `FilterExec` line carrying `bloom_probe` with the next region
+/// `SeqScan` line under it, returning `(filter_output_rows, scan_output_rows)`.
+fn bloom_filter_exec_scan_row_pairs(explain: &str) -> Vec<(usize, usize)> {
+    let mut pending_bloom_filter_rows = None;
+    let mut pairs = Vec::new();
+
+    for line in explain.lines() {
+        if line.contains("FilterExec")
+            && line.contains("non_pushdown(")
+            && line.contains("bloom_probe")
+        {
+            pending_bloom_filter_rows = parse_metric_value(line, "output_rows");
+            continue;
+        }
+
+        if line.contains("SeqScan: region=")
+            && let Some(filter_rows) = pending_bloom_filter_rows.take()
+            && let Some(scan_rows) = parse_metric_value(line, "output_rows")
+        {
+            pairs.push((filter_rows, scan_rows));
+        }
+    }
+
+    pairs
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_remote_dyn_filter_bloom_typed_payload_e2e() {
+    common_telemetry::init_default_ut_logging();
+
+    let distributed =
+        tests::create_distributed_instance("test_remote_dyn_filter_bloom_typed_payload_e2e").await;
+    let frontend = distributed.frontend();
+
+    prepare_remote_dyn_filter_bloom_tables(&frontend).await;
+
+    let join_sql = remote_dyn_filter_bloom_join_sql();
+    let result = output_to_pretty_string(
+        execute_sql_with_query_parallelism_one(&frontend, join_sql, true).await,
+    )
+    .await;
+    // 302 build keys distributed across the 8192 probe keys → 302 join rows.
+    assert_eq!(
+        result,
+        r#"+-----+
+| cnt |
++-----+
+| 302 |
++-----+"#
+    );
+
+    let explain_sql = format!("EXPLAIN ANALYZE VERBOSE {join_sql}");
+    let explain = output_to_pretty_string(
+        execute_sql_with_query_parallelism_one(&frontend, &explain_sql, true).await,
+    )
+    .await;
+
+    // ── Plan-shape invariants ──────────────────────────────────────
+    assert_contains(&explain, "HashJoinExec: mode=CollectLeft");
+    assert_contains(&explain, "MergeScanExec");
+    assert_contains(&explain, "FilterExec");
+    assert_contains(&explain, "non_pushdown(");
+    // The exact Bloom probe must never leak into SeqScan dyn_filters
+    // (it stays in the non-pushdown FilterExec wrapper).
+    assert_seq_scan_dyn_filter_not_contains(&explain, "bloom_probe");
+
+    // ── Bloom filtering-effect assertions ──────────────────────────
+    //
+    // The Bloom gRPC update is asynchronous per region.  The explain may show
+    // some region FilterExec nodes already carrying `bloom_probe`, while other
+    // regions still carry the initial `true` exact wrapper.  For regions where
+    // Bloom arrived, the FilterExec output must be smaller than the underlying
+    // SeqScan output, proving row-level filtering outside scan.
+    let bloom_pairs = bloom_filter_exec_scan_row_pairs(&explain);
+    assert!(
+        !bloom_pairs.is_empty(),
+        "expected at least one non-pushdown FilterExec with bloom_probe in:\n{explain}"
+    );
+    assert!(
+        bloom_pairs
+            .iter()
+            .any(|(filter_rows, scan_rows)| filter_rows < scan_rows),
+        "expected at least one Bloom FilterExec to reduce rows; pairs={bloom_pairs:?};\
+         explain:\n{explain}"
     );
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Depends on greptime-proto branch/commit carrying the typed remote dynamic filter payload.

## What's changed and what's your intention?

This PR adds RDF Bloom remote dynamic filter support and keeps Bloom exact filtering correct on DataNodes.

- Add typed `DynFilterPayload::JoinHashBloom` encoding/decoding, Bloom probe expression, and a hash compatibility fingerprint guard.
- Fan out typed remote dynamic filter payloads while preserving legacy DataFusion bytes for compatibility.
- Decode remote dynamic filters placement-aware on DataNodes:
  - residual/bounds go into scan `dyn_filters` as best-effort pruning hints;
  - Bloom exact probes are wrapped with `non_pushdown(...)` and retained in `FilterExec` for row-level filtering.
- Ensure invalid remote filter updates do not mutate runtime filters or advance generation/watermark, including same-generation complete updates.
- Add unit and integration coverage, including an E2E that verifies `FilterExec` with `bloom_probe` reduces rows while `SeqScan dyn_filters` does not contain `bloom_probe`.

Limitations / notes:

- Scan `dyn_filters` are pruning-only and must not be treated as exact row filtering.
- Bloom exact filtering intentionally stays in `FilterExec`; pushing it into scan exactly would require a separate scan-level row-filter/runtime-filter contract.
- The exact/pushdown update path intentionally does not implement rollback for the theoretical case where pushdown update succeeds and exact update fails; this was accepted as a pragmatic first pass.

Validation run locally:

- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test -p datanode registrations --lib --offline`
- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test -p datanode remote_dyn_filter --lib --offline`
- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test -p common-query request --lib --offline`
- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test -p query remote_dyn_filter --lib --offline`
- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test -p tests-integration test_remote_dyn_filter_bloom_typed_payload_e2e --lib -- --nocapture`
- pre-push clippy hook passed after scoped legacy-payload deprecation allows.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
