### PR TITLE
chore: add Renovate config with 14-day dependency cooldown

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,7 +13,9 @@
     {
       "description": "Allow our own forks/internal crates to update immediately",
       "matchSourceUrls": [
-        "https://github.com/GreptimeTeam/**"
+        "https://github.com/GreptimeTeam/**",
+        "git+https://github.com/GreptimeTeam/**",
+        "git@github.com:GreptimeTeam/**"
       ],
       "minimumReleaseAge": null
     }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:best-practices",
+    ":dependencyDashboard"
+  ],
+  "minimumReleaseAge": "14 days",
+  "internalChecksFilter": "strict",
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": null
+  },
+  "packageRules": [
+    {
+      "description": "Allow our own forks/internal crates to update immediately",
+      "matchSourceUrls": [
+        "https://github.com/GreptimeTeam/**"
+      ],
+      "minimumReleaseAge": null
+    }
+  ]
+}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Inspired by [rust-lang/rfcs#3923](https://github.com/rust-lang/rfcs/pull/3923) (Cargo minimum publish age), which is accepted but not yet implemented in Cargo. This achieves the same goal today at the bot layer.

## What's changed and what's your intention?

Add a Renovate configuration (`.github/renovate.json`) that enforces a dependency-update cooldown, leaving a detection window for supply-chain attacks (typosquats, hijacked publishes) that are usually caught and yanked within days.

- `minimumReleaseAge: "14 days"` — a release must be 14 days old before Renovate proposes the bump.
- `internalChecksFilter: "strict"` — versions still inside the cooldown are suppressed rather than raised as "pending" PRs; suppressed updates remain visible on the dependency dashboard.
- `vulnerabilityAlerts.minimumReleaseAge: null` — security fixes bypass the cooldown and are raised immediately, so CVEs are not delayed by 14 days.
- GreptimeTeam-sourced crates (e.g. our DataFusion fork) update immediately, since the cooldown is only meant to guard third-party registry releases.

Newly added dependencies are unaffected: Renovate only acts on upgrades of existing deps, not first-time `cargo add`.

**Prerequisite:** this file only takes effect once the Renovate GitHub App is installed and authorized for the GreptimeTeam org / this repo. If it is not onboarded yet, the config sits dormant until an org owner enables it.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
