### PR TITLE
ci: add cargo.lock changeset size check

### DIFF
--- a/.github/workflows/cargo-lock-check.yml
+++ b/.github/workflows/cargo-lock-check.yml
@@ -1,0 +1,80 @@
+name: Cargo.lock Diff Check
+
+# Non-blocking check that warns when Cargo.lock has a large diff, to help
+# catch accidental dependency updates. This job always succeeds; it only
+# posts/updates a PR comment when the threshold is exceeded.
+on:
+    pull_request:
+        paths:
+            - "Cargo.lock"
+
+jobs:
+    check-cargo-lock:
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        permissions:
+            pull-requests: write
+            contents: read
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+
+            - name: Compute Cargo.lock diff size
+              id: diff
+              env:
+                  BASE_SHA: ${{ github.event.pull_request.base.sha }}
+                  HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+              run: |
+                  set -euo pipefail
+
+                  # Make sure the base commit is available locally (it may be absent
+                  # from a shallow/fetched history).
+                  git fetch origin "${BASE_SHA}" --depth=1 2>/dev/null || true
+
+                  # `base...head` diffs from the merge-base of the PR, i.e. exactly
+                  # what this PR changes in Cargo.lock. --numstat prints
+                  # "<added> <deleted> <path>".
+                  NUMSTAT="$(git diff "${BASE_SHA}...${HEAD_SHA}" -- Cargo.lock --numstat || true)"
+                  echo "::group::Cargo.lock numstat"
+                  echo "${NUMSTAT}"
+                  echo "::endgroup::"
+
+                  ADDED="$(awk '{print $1}' <<<"${NUMSTAT}")"
+                  DELETED="$(awk '{print $2}' <<<"${NUMSTAT}")"
+                  ADDED="${ADDED:-0}"
+                  DELETED="${DELETED:-0}"
+
+                  TOTAL=$((ADDED + DELETED))
+
+                  {
+                    echo "added=${ADDED}"
+                    echo "deleted=${DELETED}"
+                    echo "total=${TOTAL}"
+                  } >> "${GITHUB_OUTPUT}"
+                  echo "Computed Cargo.lock diff: +${ADDED} -${DELETED} (${TOTAL} lines)"
+
+            - name: Warn when Cargo.lock diff exceeds 500 lines
+              if: ${{ fromJSON(steps.diff.outputs.total) > 500 }}
+              uses: marocchino/sticky-pull-request-comment@v2
+              with:
+                  header: cargo-lock-diff-warning
+                  recreate: true
+                  message: |
+                      ⚠️ **Large `Cargo.lock` diff detected** (${{ steps.diff.outputs.total }} lines changed: +${{ steps.diff.outputs.added }} -${{ steps.diff.outputs.deleted }})
+
+                      This is a **non-blocking** check — it will not fail CI. It exists to help catch
+                      accidental `Cargo.lock` updates, which can pull in unintended dependency changes.
+
+                      Please double-check that this change is intentional:
+                      - If unintended, restore `Cargo.lock` to the base version.
+                      - If intended (e.g. a deliberate dependency bump), you can ignore this warning.
+
+            - name: Hide resolved warning
+              if: ${{ fromJSON(steps.diff.outputs.total) <= 500 }}
+              uses: marocchino/sticky-pull-request-comment@v2
+              with:
+                  header: cargo-lock-diff-warning
+                  hide: true
+                  hide_classify: RESOLVED

--- a/.github/workflows/cargo-lock-check.yml
+++ b/.github/workflows/cargo-lock-check.yml
@@ -27,7 +27,7 @@ jobs:
                   BASE_SHA: ${{ github.event.pull_request.base.sha }}
                   HEAD_SHA: ${{ github.event.pull_request.head.sha }}
               run: |
-                  set -euo pipefail
+                  set -eo pipefail
 
                   # Make sure the base commit is available locally (it may be absent
                   # from a shallow/fetched history).
@@ -36,9 +36,9 @@ jobs:
                   # `base...head` diffs from the merge-base of the PR, i.e. exactly
                   # what this PR changes in Cargo.lock. --numstat prints
                   # "<added> <deleted> <path>".
-                  NUMSTAT="$(git diff "${BASE_SHA}...${HEAD_SHA}" -- Cargo.lock --numstat || true)"
+                  NUMSTAT="$(git diff --numstat "${BASE_SHA}...${HEAD_SHA}" -- Cargo.lock || true)"
                   echo "::group::Cargo.lock numstat"
-                  echo "${NUMSTAT}"
+                  echo "${NUMSTAT}" >&2
                   echo "::endgroup::"
 
                   ADDED="$(awk '{print $1}' <<<"${NUMSTAT}")"
@@ -56,7 +56,7 @@ jobs:
                   echo "Computed Cargo.lock diff: +${ADDED} -${DELETED} (${TOTAL} lines)"
 
             - name: Warn when Cargo.lock diff exceeds 500 lines
-              if: ${{ fromJSON(steps.diff.outputs.total) > 500 }}
+              if: ${{ fromJSON(steps.diff.outputs.total || '0') > 500 }}
               uses: marocchino/sticky-pull-request-comment@v2
               with:
                   header: cargo-lock-diff-warning
@@ -72,7 +72,7 @@ jobs:
                       - If intended (e.g. a deliberate dependency bump), you can ignore this warning.
 
             - name: Hide resolved warning
-              if: ${{ fromJSON(steps.diff.outputs.total) <= 500 }}
+              if: ${{ fromJSON(steps.diff.outputs.total || '0') <= 500 }}
               uses: marocchino/sticky-pull-request-comment@v2
               with:
                   header: cargo-lock-diff-warning


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Will create a comment when cargo.lock changeset is longer than 500 lines

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
