### PR TITLE
chore: client_ip error logs skip internal API

### DIFF
--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -119,6 +119,7 @@ pub mod test_helpers;
 
 pub const HTTP_API_VERSION: &str = "v1";
 pub const HTTP_API_PREFIX: &str = "/v1/";
+pub const HTTP_API_PREFIX_WITHOUT_TRAILING_SLASH: &str = "/v1";
 /// Default http body limit (64M).
 const DEFAULT_BODY_LIMIT: ReadableSize = ReadableSize::mb(64);
 

--- a/src/servers/src/http/client_ip.rs
+++ b/src/servers/src/http/client_ip.rs
@@ -21,8 +21,6 @@ use axum::middleware::Next;
 use axum::response::Response;
 use common_telemetry::warn;
 
-const HTTP_API_PREFIX_WITHOUT_TRAILING_SLASH: &str = "/v1";
-
 /// Middleware that logs HTTP error responses (4xx/5xx) with client IP address.
 ///
 /// Extracts client address from [`ConnectInfo`] if available.
@@ -63,7 +61,8 @@ pub async fn log_error_with_client_ip(req: Request<Body>, next: Next) -> Respons
 }
 
 fn is_public_http_api_path(path: &str) -> bool {
-    path == HTTP_API_PREFIX_WITHOUT_TRAILING_SLASH || path.starts_with(super::HTTP_API_PREFIX)
+    path == super::HTTP_API_PREFIX_WITHOUT_TRAILING_SLASH
+        || path.starts_with(super::HTTP_API_PREFIX)
 }
 
 #[cfg(test)]

--- a/src/servers/src/http/client_ip.rs
+++ b/src/servers/src/http/client_ip.rs
@@ -21,8 +21,6 @@ use axum::middleware::Next;
 use axum::response::Response;
 use common_telemetry::warn;
 
-use super::HTTP_API_PREFIX;
-
 /// Middleware that logs HTTP error responses (4xx/5xx) with client IP address.
 ///
 /// Extracts client address from [`ConnectInfo`] if available.
@@ -63,7 +61,7 @@ pub async fn log_error_with_client_ip(req: Request<Body>, next: Next) -> Respons
 }
 
 fn is_public_http_api_path(path: &str) -> bool {
-    path == HTTP_API_PREFIX.trim_end_matches('/') || path.starts_with(HTTP_API_PREFIX)
+    path == super::HTTP_API_PREFIX.trim_end_matches('/') || path.starts_with(super::HTTP_API_PREFIX)
 }
 
 #[cfg(test)]

--- a/src/servers/src/http/client_ip.rs
+++ b/src/servers/src/http/client_ip.rs
@@ -21,6 +21,8 @@ use axum::middleware::Next;
 use axum::response::Response;
 use common_telemetry::warn;
 
+const HTTP_API_PREFIX_WITHOUT_TRAILING_SLASH: &str = "/v1";
+
 /// Middleware that logs HTTP error responses (4xx/5xx) with client IP address.
 ///
 /// Extracts client address from [`ConnectInfo`] if available.
@@ -61,7 +63,7 @@ pub async fn log_error_with_client_ip(req: Request<Body>, next: Next) -> Respons
 }
 
 fn is_public_http_api_path(path: &str) -> bool {
-    path == super::HTTP_API_PREFIX.trim_end_matches('/') || path.starts_with(super::HTTP_API_PREFIX)
+    path == HTTP_API_PREFIX_WITHOUT_TRAILING_SLASH || path.starts_with(super::HTTP_API_PREFIX)
 }
 
 #[cfg(test)]

--- a/src/servers/src/http/client_ip.rs
+++ b/src/servers/src/http/client_ip.rs
@@ -21,20 +21,25 @@ use axum::middleware::Next;
 use axum::response::Response;
 use common_telemetry::warn;
 
+use super::HTTP_API_PREFIX;
+
 /// Middleware that logs HTTP error responses (4xx/5xx) with client IP address.
 ///
 /// Extracts client address from [`ConnectInfo`] if available.
 pub async fn log_error_with_client_ip(req: Request<Body>, next: Next) -> Response {
-    let request_info = req
-        .extensions()
-        .get::<ConnectInfo<SocketAddr>>()
-        .map(|c| c.0)
-        .map(|addr| {
-            let method = req.method().clone();
-            let uri = req.uri().clone();
-            let matched_path = req.extensions().get::<MatchedPath>().cloned();
-            (addr, method, uri, matched_path)
-        });
+    let request_info = if is_public_http_api_path(req.uri().path()) {
+        req.extensions()
+            .get::<ConnectInfo<SocketAddr>>()
+            .map(|c| c.0)
+            .map(|addr| {
+                let method = req.method().clone();
+                let uri = req.uri().clone();
+                let matched_path = req.extensions().get::<MatchedPath>().cloned();
+                (addr, method, uri, matched_path)
+            })
+    } else {
+        None
+    };
 
     let response = next.run(req).await;
 
@@ -57,6 +62,10 @@ pub async fn log_error_with_client_ip(req: Request<Body>, next: Next) -> Respons
     response
 }
 
+fn is_public_http_api_path(path: &str) -> bool {
+    path == HTTP_API_PREFIX.trim_end_matches('/') || path.starts_with(HTTP_API_PREFIX)
+}
+
 #[cfg(test)]
 mod tests {
     use axum::Router;
@@ -65,6 +74,19 @@ mod tests {
     use tower::ServiceExt;
 
     use super::*;
+
+    #[test]
+    fn test_public_http_api_path_matches_v1_prefix() {
+        assert!(is_public_http_api_path("/v1"));
+        assert!(is_public_http_api_path("/v1/sql"));
+        assert!(is_public_http_api_path("/v1/prometheus/api/v1/query"));
+
+        assert!(!is_public_http_api_path("/"));
+        assert!(!is_public_http_api_path("/health"));
+        assert!(!is_public_http_api_path("/status"));
+        assert!(!is_public_http_api_path("/metrics"));
+        assert!(!is_public_http_api_path("/v10/sql"));
+    }
 
     #[tokio::test]
     async fn test_middleware_passes_error_response() {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

As the title suggests, only log HTTP error for public APIs, which starts with `v1/`

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
