### PR TITLE
chore: declare GreptimeDB Enterprise License for enterprise-gated sources

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -46,6 +46,10 @@ jobs:
         with:
           persist-credentials: false
       - uses: korandoru/hawkeye@v5
+      - name: Check enterprise license header
+        uses: korandoru/hawkeye@v5
+        with:
+          config: licenserc-enterprise.toml
 
   check:
     if: ${{ github.repository == 'GreptimeTeam/greptimedb' }}

--- a/LICENSE-ENTERPRISE
+++ b/LICENSE-ENTERPRISE
@@ -21,11 +21,12 @@ Copyright (c) 2023-2026 GrepTime Inc.
 With regard to the GreptimeDB Enterprise Software:
 
 This software and associated documentation files (the "Software") may only be
-used if you (and any entity that you represent) have agreed to, and are in
-compliance with, the applicable GreptimeDB Enterprise Terms, available at
-https://greptime.com/legal/enterprise-terms (the "Enterprise Terms"), or other
-agreement governing the use of the Software, as agreed by you and GrepTime, and
-otherwise have a valid GreptimeDB Enterprise License.
+used if you (and any entity that you represent) have entered into, and are in
+compliance with, a separate written commercial agreement with GrepTime Inc.
+governing the use of the Software (the "Enterprise Agreement"), and otherwise
+have a valid GreptimeDB Enterprise License. The terms of each Enterprise
+Agreement are negotiated and executed individually; to obtain one, contact
+GrepTime Inc. at https://greptime.com/contactus.
 
 Subject to the foregoing sentence, you are free to modify this Software and
 publish patches to the Software. You agree that GrepTime and/or its licensors

--- a/LICENSE-ENTERPRISE
+++ b/LICENSE-ENTERPRISE
@@ -1,0 +1,55 @@
+START NOTE
+GreptimeDB is an open-core project. The core of GreptimeDB is permissively
+licensed under the Apache License, Version 2.0. Certain peripheral features are
+commercially licensed and governed by this Enterprise License.
+
+For the avoidance of doubt, this license does NOT apply to the core of
+GreptimeDB as defined by its license in the repository root file "/LICENSE"
+(as opposed to this file "/LICENSE-ENTERPRISE"). The core can be used and run
+without infringing the license and licensed materials described below.
+
+Source files governed by this Enterprise License carry an explicit Enterprise
+License header and are gated behind the `enterprise` Cargo feature; they are not
+compiled into the default open-source build.
+END NOTE
+
+START OF LICENSE
+GreptimeDB Enterprise License (the "Enterprise License" or "EE License")
+
+Copyright (c) 2023-2026 GrepTime Inc.
+
+With regard to the GreptimeDB Enterprise Software:
+
+This software and associated documentation files (the "Software") may only be
+used if you (and any entity that you represent) have agreed to, and are in
+compliance with, the applicable GreptimeDB Enterprise Terms, available at
+https://greptime.com/legal/enterprise-terms (the "Enterprise Terms"), or other
+agreement governing the use of the Software, as agreed by you and GrepTime, and
+otherwise have a valid GreptimeDB Enterprise License.
+
+Subject to the foregoing sentence, you are free to modify this Software and
+publish patches to the Software. You agree that GrepTime and/or its licensors
+(as applicable) retain all right, title and interest in and to all such
+modifications and/or patches, and all such modifications and/or patches may only
+be used, copied, modified, displayed, distributed, or otherwise exploited with a
+valid GreptimeDB Enterprise License. Notwithstanding the foregoing, you may copy
+and modify the Software for development and testing purposes, without requiring a
+subscription. You agree that GrepTime Inc. and/or its licensors (as applicable)
+retain all right, title and interest in and to all such modifications. You are
+not granted any other rights beyond what is expressly stated herein. Subject to
+the foregoing, it is forbidden to copy, merge, publish, distribute, sublicense,
+and/or sell the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+For all third party components incorporated into the GreptimeDB Software, those
+components are licensed under the original license provided by the owner of the
+applicable component.
+
+END OF LICENSE

--- a/README.md
+++ b/README.md
@@ -227,7 +227,13 @@ We invite you to engage and contribute!
 
 ## License
 
-GreptimeDB is licensed under the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0.txt).
+GreptimeDB is an open-core project. Its core is licensed under the
+[Apache License 2.0](https://apache.org/licenses/LICENSE-2.0.txt).
+
+A small set of peripheral, enterprise-only features are gated behind the
+`enterprise` Cargo feature (not built by default) and are governed by the
+separate [GreptimeDB Enterprise License](LICENSE-ENTERPRISE). Source files under
+that license carry an explicit Enterprise License header.
 
 ## Commercial Support
 

--- a/licenserc-enterprise.toml
+++ b/licenserc-enterprise.toml
@@ -1,0 +1,30 @@
+# License-header config for GreptimeDB Enterprise Edition source files.
+#
+# These files are commercially licensed under the GreptimeDB Enterprise License
+# (see /LICENSE-ENTERPRISE), NOT Apache-2.0. They are kept out of the main
+# Apache-2.0 header check in `licenserc.toml` (listed under its `excludes`) and
+# are instead enforced here. Run with:
+#
+#     hawkeye check  --config licenserc-enterprise.toml
+#     hawkeye format --config licenserc-enterprise.toml   # to apply/fix headers
+
+headerPath = "licenses/enterprise-header.txt"
+
+# Only the enterprise-gated sources. Keep this list in sync with the
+# "# enterprise" block in `licenserc.toml`'s `excludes`.
+includes = [
+    "src/common/meta/src/rpc/ddl/trigger.rs",
+    "src/operator/src/expr_helper/trigger.rs",
+    "src/sql/src/statements/alter/trigger.rs",
+    "src/sql/src/statements/create/trigger.rs",
+    "src/sql/src/statements/show/trigger.rs",
+    "src/sql/src/statements/drop/trigger.rs",
+    "src/sql/src/parsers/alter_parser/trigger.rs",
+    "src/sql/src/parsers/create_parser/trigger.rs",
+    "src/sql/src/parsers/show_parser/trigger.rs",
+    "src/mito2/src/extension.rs",
+]
+
+[properties]
+inceptionYear = 2023
+copyrightOwner = "GrepTime Inc."

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -26,7 +26,9 @@ excludes = [
     "src/common/base/src/secrets.rs",
     "src/servers/src/repeated_field.rs",
     "src/servers/src/http/test_helpers.rs",
-    # enterprise
+    # enterprise: Apache-2.0 header is NOT applied to these. They are governed by
+    # the GreptimeDB Enterprise License and checked via `licenserc-enterprise.toml`.
+    # Keep this list in sync with that file's `includes`.
     "src/common/meta/src/rpc/ddl/trigger.rs",
     "src/operator/src/expr_helper/trigger.rs",
     "src/sql/src/statements/alter/trigger.rs",

--- a/licenses/README.md
+++ b/licenses/README.md
@@ -1,0 +1,36 @@
+# Licensing
+
+GreptimeDB is an open-core project with a dual-license layout.
+
+| Scope | License | Where it's declared |
+| --- | --- | --- |
+| Core (default build) | Apache-2.0 | [`/LICENSE`](../LICENSE); per-file Apache header enforced by [`/licenserc.toml`](../licenserc.toml) |
+| Enterprise features | GreptimeDB Enterprise License | [`/LICENSE-ENTERPRISE`](../LICENSE-ENTERPRISE); per-file Enterprise header enforced by [`/licenserc-enterprise.toml`](../licenserc-enterprise.toml) |
+
+Enterprise sources are gated behind the `enterprise` Cargo feature and are **not**
+compiled into the default open-source build. Each one carries an explicit
+Enterprise License header generated from [`enterprise-header.txt`](enterprise-header.txt).
+
+## How it's enforced
+
+CI (`license-header-check` in `.github/workflows/develop.yml`) runs
+[hawkeye](https://github.com/korandoru/hawkeye) twice:
+
+1. Default config — applies the Apache-2.0 header to all sources, **excluding**
+   the enterprise files.
+2. `licenserc-enterprise.toml` — applies the Enterprise header to **only** the
+   enterprise files.
+
+The two file lists are complementary and must stay in sync:
+
+- `licenserc.toml` `excludes` — the `# enterprise` block.
+- `licenserc-enterprise.toml` `includes`.
+
+## Adding a new enterprise file
+
+1. Add its path to **both** lists above.
+2. Apply the header: `hawkeye format --config licenserc-enterprise.toml`.
+3. Verify: `hawkeye check --config licenserc-enterprise.toml`.
+
+Do not put an Apache-2.0 header on an enterprise file, and do not leave an
+enterprise file without a header — CI fails in both cases.

--- a/licenses/enterprise-header.txt
+++ b/licenses/enterprise-header.txt
@@ -1,0 +1,10 @@
+Copyright 2023-2026 GrepTime Inc.
+
+This file is part of the GreptimeDB Enterprise Edition and is licensed under
+the GreptimeDB Enterprise License. You may not use this file except in
+compliance with that license. A copy of the license is available at the root
+of this repository in the file LICENSE-ENTERPRISE.
+
+Unless required by applicable law or agreed to in writing, this software is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied.

--- a/src/common/meta/src/rpc/ddl/trigger.rs
+++ b/src/common/meta/src/rpc/ddl/trigger.rs
@@ -1,3 +1,14 @@
+// Copyright 2023-2026 GrepTime Inc.
+//
+// This file is part of the GreptimeDB Enterprise Edition and is licensed under
+// the GreptimeDB Enterprise License. You may not use this file except in
+// compliance with that license. A copy of the license is available at the root
+// of this repository in the file LICENSE-ENTERPRISE.
+//
+// Unless required by applicable law or agreed to in writing, this software is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied.
+
 use std::collections::HashMap;
 use std::time::Duration;
 

--- a/src/mito2/src/extension.rs
+++ b/src/mito2/src/extension.rs
@@ -1,3 +1,14 @@
+// Copyright 2023-2026 GrepTime Inc.
+//
+// This file is part of the GreptimeDB Enterprise Edition and is licensed under
+// the GreptimeDB Enterprise License. You may not use this file except in
+// compliance with that license. A copy of the license is available at the root
+// of this repository in the file LICENSE-ENTERPRISE.
+//
+// Unless required by applicable law or agreed to in writing, this software is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied.
+
 use std::fmt::Debug;
 use std::sync::Arc;
 

--- a/src/operator/src/expr_helper/trigger.rs
+++ b/src/operator/src/expr_helper/trigger.rs
@@ -1,3 +1,14 @@
+// Copyright 2023-2026 GrepTime Inc.
+//
+// This file is part of the GreptimeDB Enterprise Edition and is licensed under
+// the GreptimeDB Enterprise License. You may not use this file except in
+// compliance with that license. A copy of the license is available at the root
+// of this repository in the file LICENSE-ENTERPRISE.
+//
+// Unless required by applicable law or agreed to in writing, this software is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied.
+
 use api::v1::notify_channel::ChannelType as PbChannelType;
 use api::v1::{
     CreateTriggerExpr as PbCreateTriggerExpr, NotifyChannel as PbNotifyChannel,

--- a/src/sql/src/parsers/alter_parser/trigger.rs
+++ b/src/sql/src/parsers/alter_parser/trigger.rs
@@ -1,3 +1,14 @@
+// Copyright 2023-2026 GrepTime Inc.
+//
+// This file is part of the GreptimeDB Enterprise Edition and is licensed under
+// the GreptimeDB Enterprise License. You may not use this file except in
+// compliance with that license. A copy of the license is available at the root
+// of this repository in the file LICENSE-ENTERPRISE.
+//
+// Unless required by applicable law or agreed to in writing, this software is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied.
+
 use snafu::{ResultExt, ensure};
 use sqlparser::ast::Ident;
 use sqlparser::parser::Parser;

--- a/src/sql/src/parsers/create_parser/trigger.rs
+++ b/src/sql/src/parsers/create_parser/trigger.rs
@@ -1,3 +1,14 @@
+// Copyright 2023-2026 GrepTime Inc.
+//
+// This file is part of the GreptimeDB Enterprise Edition and is licensed under
+// the GreptimeDB Enterprise License. You may not use this file except in
+// compliance with that license. A copy of the license is available at the root
+// of this repository in the file LICENSE-ENTERPRISE.
+//
+// Unless required by applicable law or agreed to in writing, this software is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied.
+
 use std::time::Duration;
 
 use snafu::{OptionExt, ResultExt, ensure};

--- a/src/sql/src/parsers/show_parser/trigger.rs
+++ b/src/sql/src/parsers/show_parser/trigger.rs
@@ -1,3 +1,14 @@
+// Copyright 2023-2026 GrepTime Inc.
+//
+// This file is part of the GreptimeDB Enterprise Edition and is licensed under
+// the GreptimeDB Enterprise License. You may not use this file except in
+// compliance with that license. A copy of the license is available at the root
+// of this repository in the file LICENSE-ENTERPRISE.
+//
+// Unless required by applicable law or agreed to in writing, this software is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied.
+
 use snafu::{ResultExt, ensure};
 
 use crate::error::{self, Result};

--- a/src/sql/src/statements/alter/trigger.rs
+++ b/src/sql/src/statements/alter/trigger.rs
@@ -1,3 +1,14 @@
+// Copyright 2023-2026 GrepTime Inc.
+//
+// This file is part of the GreptimeDB Enterprise Edition and is licensed under
+// the GreptimeDB Enterprise License. You may not use this file except in
+// compliance with that license. A copy of the license is available at the root
+// of this repository in the file LICENSE-ENTERPRISE.
+//
+// Unless required by applicable law or agreed to in writing, this software is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied.
+
 use std::fmt::{Display, Formatter};
 
 use serde::Serialize;

--- a/src/sql/src/statements/create/trigger.rs
+++ b/src/sql/src/statements/create/trigger.rs
@@ -1,3 +1,14 @@
+// Copyright 2023-2026 GrepTime Inc.
+//
+// This file is part of the GreptimeDB Enterprise Edition and is licensed under
+// the GreptimeDB Enterprise License. You may not use this file except in
+// compliance with that license. A copy of the license is available at the root
+// of this repository in the file LICENSE-ENTERPRISE.
+//
+// Unless required by applicable law or agreed to in writing, this software is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied.
+
 use std::fmt::{Display, Formatter};
 use std::ops::ControlFlow;
 use std::time::Duration;

--- a/src/sql/src/statements/drop/trigger.rs
+++ b/src/sql/src/statements/drop/trigger.rs
@@ -1,3 +1,14 @@
+// Copyright 2023-2026 GrepTime Inc.
+//
+// This file is part of the GreptimeDB Enterprise Edition and is licensed under
+// the GreptimeDB Enterprise License. You may not use this file except in
+// compliance with that license. A copy of the license is available at the root
+// of this repository in the file LICENSE-ENTERPRISE.
+//
+// Unless required by applicable law or agreed to in writing, this software is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied.
+
 use std::fmt::Display;
 
 use serde::Serialize;

--- a/src/sql/src/statements/show/trigger.rs
+++ b/src/sql/src/statements/show/trigger.rs
@@ -1,3 +1,14 @@
+// Copyright 2023-2026 GrepTime Inc.
+//
+// This file is part of the GreptimeDB Enterprise Edition and is licensed under
+// the GreptimeDB Enterprise License. You may not use this file except in
+// compliance with that license. A copy of the license is available at the root
+// of this repository in the file LICENSE-ENTERPRISE.
+//
+// Unless required by applicable law or agreed to in writing, this software is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied.
+
 use std::fmt::{self, Display};
 
 use serde::Serialize;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The `enterprise`-feature-gated sources (the trigger DDL/statement/parser files and `mito2`'s extension module) were excluded from the Apache-2.0 license-header check in `licenserc.toml`, but carried **no license header of their own** — leaving them in an undeclared "all rights reserved" gray area.

This PR declares a dedicated **GreptimeDB Enterprise License** for those files and enforces it, following an open-core split (the core stays Apache-2.0):

- **`LICENSE-ENTERPRISE`** — the Enterprise License text. A leading NOTE makes the open-core boundary explicit: it does **not** apply to the core, which remains under `/LICENSE` (Apache-2.0).
- **Per-file headers** — each enterprise source now carries an explicit Enterprise License header, generated from `licenses/enterprise-header.txt`.
- **Enforcement** — `licenserc-enterprise.toml` is a second hawkeye config that applies the Enterprise header to *only* those files; CI's `license-header-check` job now runs hawkeye twice (Apache for the core, Enterprise for the gated files). The two file lists are complementary and documented to stay in sync.
- **Docs** — `licenses/README.md` explains the dual-license layout and how to add a new enterprise file; the README License section now describes the open-core model.

No code logic changes — headers, license files, CI, and docs only. The enterprise sources remain gated behind the `enterprise` Cargo feature and are not built by default.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.