### PR TITLE
feat: accept x-greptime-pipeline-name header on /events/logs

### DIFF
--- a/src/servers/src/http/event.rs
+++ b/src/servers/src/http/event.rs
@@ -54,7 +54,10 @@ use crate::error::{
     status_code_to_http_status,
 };
 use crate::http::HttpResponse;
-use crate::http::header::constants::GREPTIME_PIPELINE_PARAMS_HEADER;
+use crate::http::header::constants::{
+    GREPTIME_LOG_PIPELINE_NAME_HEADER_NAME, GREPTIME_PIPELINE_NAME_HEADER_NAME,
+    GREPTIME_PIPELINE_PARAMS_HEADER,
+};
 use crate::http::header::{
     CONTENT_TYPE_NDJSON_STR, CONTENT_TYPE_NDJSON_SUBTYPE_STR, CONTENT_TYPE_PROTOBUF_STR,
 };
@@ -693,6 +696,28 @@ pub(crate) fn extract_pipeline_params_map_from_headers(
     )
 }
 
+/// Extracts the pipeline name from the request headers.
+///
+/// Both `x-greptime-pipeline-name` and the deprecated `x-greptime-log-pipeline-name`
+/// are accepted, matching the headers already honored by the OTLP/Elasticsearch/Splunk
+/// log ingestion endpoints. Empty header values are ignored so that they fall back to
+/// the `pipeline_name` query parameter.
+fn pipeline_name_from_headers(headers: &HeaderMap) -> Option<String> {
+    [
+        GREPTIME_LOG_PIPELINE_NAME_HEADER_NAME,
+        GREPTIME_PIPELINE_NAME_HEADER_NAME,
+    ]
+    .iter()
+    .find_map(|name| {
+        headers
+            .get(*name)
+            .and_then(|value| value.to_str().ok())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToString::to_string)
+    })
+}
+
 #[axum_macros::debug_handler]
 pub async fn log_ingester(
     State(log_state): State<LogState>,
@@ -720,9 +745,14 @@ pub async fn log_ingester(
 
     let ignore_errors = query_params.ignore_errors.unwrap_or(false);
 
-    let pipeline_name = query_params.pipeline_name.context(InvalidParameterSnafu {
-        reason: "pipeline_name is required",
-    })?;
+    // A pipeline name supplied via header takes precedence over the query parameter,
+    // consistent with how other pipeline options (e.g. `x-greptime-pipeline-params`)
+    // outrank their query-parameter counterparts.
+    let pipeline_name = pipeline_name_from_headers(&headers)
+        .or(query_params.pipeline_name)
+        .context(InvalidParameterSnafu {
+            reason: "pipeline_name is required",
+        })?;
     let skip_error = query_params.skip_error.unwrap_or(false);
     let version = to_pipeline_version(query_params.version.as_deref()).context(PipelineSnafu)?;
     let pipeline = PipelineDefinition::from_name(

--- a/src/servers/src/http/event.rs
+++ b/src/servers/src/http/event.rs
@@ -700,12 +700,13 @@ pub(crate) fn extract_pipeline_params_map_from_headers(
 ///
 /// Both `x-greptime-pipeline-name` and the deprecated `x-greptime-log-pipeline-name`
 /// are accepted, matching the headers already honored by the OTLP/Elasticsearch/Splunk
-/// log ingestion endpoints. Empty header values are ignored so that they fall back to
-/// the `pipeline_name` query parameter.
+/// log ingestion endpoints. If both are present, the non-deprecated
+/// `x-greptime-pipeline-name` takes precedence. Empty header values are ignored so that
+/// they fall back to the `pipeline_name` query parameter.
 fn pipeline_name_from_headers(headers: &HeaderMap) -> Option<String> {
     [
-        GREPTIME_LOG_PIPELINE_NAME_HEADER_NAME,
         GREPTIME_PIPELINE_NAME_HEADER_NAME,
+        GREPTIME_LOG_PIPELINE_NAME_HEADER_NAME,
     ]
     .iter()
     .find_map(|name| {

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -3018,9 +3018,29 @@ transform:
     )
     .await;
 
-    // 4. missing pipeline name in both header and query param is rejected.
+    // 4. when both headers are present, the non-deprecated
+    //    `x-greptime-pipeline-name` wins over the deprecated
+    //    `x-greptime-log-pipeline-name`.
     let res = client
         .post("/v1/events/logs?db=public&table=logs4")
+        .header("Content-Type", "application/json")
+        .header("x-greptime-pipeline-name", "test")
+        .header("x-greptime-log-pipeline-name", "does_not_exist")
+        .body(data_body)
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+    validate_data(
+        "pipeline_name_header_non_deprecated_priority",
+        &client,
+        "select message from logs4",
+        "[[\"hello header\"]]",
+    )
+    .await;
+
+    // 5. missing pipeline name in both header and query param is rejected.
+    let res = client
+        .post("/v1/events/logs?db=public&table=logs5")
         .header("Content-Type", "application/json")
         .body(data_body)
         .send()

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -127,6 +127,7 @@ macro_rules! http_tests {
 
                 test_pipeline_api,
                 test_test_pipeline_api,
+                test_pipeline_name_in_header,
                 test_plain_text_ingestion,
                 test_pipeline_auto_transform,
                 test_pipeline_auto_transform_with_select,
@@ -2920,6 +2921,111 @@ transform:
         .await;
     // todo(shuiyisong): refactor http error handling
     assert_ne!(res.status(), StatusCode::OK);
+
+    guard.remove_all().await;
+}
+
+pub async fn test_pipeline_name_in_header(store_type: StorageType) {
+    common_telemetry::init_default_ut_logging();
+    let (app, mut guard) =
+        setup_test_http_app_with_frontend(store_type, "test_pipeline_name_in_header").await;
+
+    let client = TestClient::new(app).await;
+
+    let pipeline_body = r#"
+processors:
+  - date:
+      field: time
+      formats:
+        - "%Y-%m-%d %H:%M:%S%.3f"
+      ignore_missing: true
+transform:
+  - field: message
+    type: string
+  - field: time
+    type: time
+    index: timestamp
+"#;
+
+    // create pipeline named `test`
+    let res = client
+        .post("/v1/events/pipelines/test")
+        .header("Content-Type", "application/x-yaml")
+        .body(pipeline_body)
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let data_body = r#"
+[
+  {
+    "time": "2024-05-25 20:16:37.217",
+    "message": "hello header"
+  }
+]
+"#;
+
+    // 1. pipeline name provided via the `x-greptime-pipeline-name` header,
+    //    without the `pipeline_name` query parameter.
+    let res = client
+        .post("/v1/events/logs?db=public&table=logs1")
+        .header("Content-Type", "application/json")
+        .header("x-greptime-pipeline-name", "test")
+        .body(data_body)
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+    validate_data(
+        "pipeline_name_header",
+        &client,
+        "select message from logs1",
+        "[[\"hello header\"]]",
+    )
+    .await;
+
+    // 2. the deprecated `x-greptime-log-pipeline-name` header is also accepted.
+    let res = client
+        .post("/v1/events/logs?db=public&table=logs2")
+        .header("Content-Type", "application/json")
+        .header("x-greptime-log-pipeline-name", "test")
+        .body(data_body)
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+    validate_data(
+        "pipeline_name_log_header",
+        &client,
+        "select message from logs2",
+        "[[\"hello header\"]]",
+    )
+    .await;
+
+    // 3. the header takes precedence over the query parameter. A bogus
+    //    `pipeline_name` query param is overridden by the valid header.
+    let res = client
+        .post("/v1/events/logs?db=public&table=logs3&pipeline_name=does_not_exist")
+        .header("Content-Type", "application/json")
+        .header("x-greptime-pipeline-name", "test")
+        .body(data_body)
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+    validate_data(
+        "pipeline_name_header_priority",
+        &client,
+        "select message from logs3",
+        "[[\"hello header\"]]",
+    )
+    .await;
+
+    // 4. missing pipeline name in both header and query param is rejected.
+    let res = client
+        .post("/v1/events/logs?db=public&table=logs4")
+        .header("Content-Type", "application/json")
+        .body(data_body)
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
 
     guard.remove_all().await;
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Closes #6095

## What's changed and what's your intention?

The `/v1/events/logs` (and its alias `/v1/logs/ingest`) endpoint previously
resolved the pipeline name **only** from the `pipeline_name` query parameter.
Meanwhile the OTLP, Elasticsearch and Splunk log-ingestion endpoints already
accept the pipeline name via the `x-greptime-pipeline-name` HTTP header. As
noted in #6095, this inconsistency is unfriendly to users who set the header
expecting it to work everywhere.

This PR makes `log_ingester` also honor the header:

- Added a small helper `pipeline_name_from_headers` that reads the pipeline
  name from `x-greptime-pipeline-name` (and the deprecated
  `x-greptime-log-pipeline-name`), mirroring the header list already used by
  the `PipelineInfo` extractor. Empty/whitespace-only values are ignored so
  they fall back to the query parameter.
- `log_ingester` now resolves the pipeline name as
  `header → query parameter`. The header takes precedence, consistent with the
  existing convention in this codebase where pipeline options such as
  `x-greptime-pipeline-params` outrank their query-parameter counterparts
  (see the existing `test_pipeline_skip_error` comment "header has a higher
  priority than params").

When neither the header nor the query parameter is provided, the behavior is
unchanged: the request is rejected with `pipeline_name is required`.

### Tests

Added integration test `test_pipeline_name_in_header` in
`tests-integration/tests/http.rs` covering:
1. ingestion driven solely by the `x-greptime-pipeline-name` header (no query param);
2. the deprecated `x-greptime-log-pipeline-name` header;
3. header taking precedence over a bogus `pipeline_name` query param;
4. missing name in both header and query param still returns `400 BAD_REQUEST`.

Verified locally (File storage backend):

```
test integration_http_file_test::test_pipeline_name_in_header ... ok
test result: ok. 6 passed; 0 failed; 0 ignored
```

`cargo fmt --all -- --check` and `cargo clippy -p servers --lib` are clean.

### Compatibility

No API or data compatibility break. The header is purely additive; existing
query-parameter-based callers are unaffected.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
