### PR TITLE
test: choose compat runner cli args by version

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1020,7 +1020,7 @@ jobs:
       artifact-name: bins
 
   compat:
-    if: ${{ github.repository == 'GreptimeTeam/greptimedb' && (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'pull_request' && github.event.action == 'ready_for_review')) }}
+    if: ${{ github.repository == 'GreptimeTeam/greptimedb' && (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'pull_request' && (github.event.action == 'ready_for_review' || (github.event.action == 'opened' && github.event.pull_request.draft == false)))) }}
     name: Compatibility Test (recent releases)
     needs: build
     runs-on: ubuntu-latest

--- a/tests/runner/src/env/bare.rs
+++ b/tests/runner/src/env/bare.rs
@@ -30,6 +30,7 @@ use tokio::sync::Mutex as TokioMutex;
 
 use crate::client::MultiProtocolClient;
 use crate::cmd::bare::ServerAddr;
+use crate::cmd::compat_case::try_infer_version;
 use crate::formatter::{ErrorFormatter, MysqlFormatter, OutputFormatter, PostgresqlFormatter};
 use crate::protocol_interceptor::{MYSQL, PROTOCOL_KEY};
 use crate::server_mode::{GrpcArgStyle, ServerMode};
@@ -100,9 +101,8 @@ pub struct Env {
     store_config: StoreConfig,
     /// Extra command line arguments when starting GreptimeDB binaries.
     extra_args: Vec<String>,
-    /// Cache for the detected gRPC argument style per (bins_dir, mode_name).
-    /// Avoids running `--help` on every server start.
-    grpc_arg_style_cache: Arc<Mutex<HashMap<(PathBuf, String), GrpcArgStyle>>>,
+    /// Cache for the inferred gRPC argument style per `bins_dir`.
+    grpc_arg_style_cache: Arc<Mutex<HashMap<PathBuf, GrpcArgStyle>>>,
 }
 
 #[async_trait]
@@ -276,10 +276,9 @@ impl Env {
         let _ = process.wait();
     }
 
-    /// Detect which gRPC argument style the binary at `bins_dir` supports for
-    /// the given server mode.  Caches the result keyed by `(bins_dir, mode_name)`.
-    fn detect_grpc_arg_style(&self, bins_dir: &Path, mode_name: &str) -> GrpcArgStyle {
-        let cache_key = (bins_dir.to_path_buf(), mode_name.to_string());
+    /// Infers which gRPC argument style to use for the binary at `bins_dir`.
+    fn infer_grpc_arg_style(&self, bins_dir: &Path) -> GrpcArgStyle {
+        let cache_key = bins_dir.to_path_buf();
 
         // Fast path: already cached.
         {
@@ -289,36 +288,8 @@ impl Env {
             }
         }
 
-        let binary_path = bins_dir.join(PROGRAM);
-        let output = Command::new(&binary_path)
-            .args([mode_name, "start", "--help"])
-            .output()
-            .unwrap_or_else(|e| {
-                panic!(
-                    "Failed to run '{} {} start --help': {e}",
-                    binary_path.display(),
-                    mode_name,
-                );
-            });
-
-        let help_text = format!(
-            "{}\n{}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-
-        let style = if let Some(style) = GrpcArgStyle::detect_from_help(&help_text) {
-            style
-        } else {
-            let help_preview = help_text.chars().take(1000).collect::<String>();
-            panic!(
-                "Could not detect gRPC argument style from '{} {} start --help'.\n\
-                 Help output (first 1000 chars):\n{}",
-                binary_path.display(),
-                mode_name,
-                help_preview
-            );
-        };
+        let version = try_infer_version(bins_dir);
+        let style = GrpcArgStyle::for_version(version.as_ref());
 
         // Insert into cache (may race with another thread, but both detect
         // the same value, so it's harmless).
@@ -375,8 +346,7 @@ impl Env {
             .open(&stdout_file_name)
             .unwrap();
 
-        let mode_name = mode.name();
-        let arg_style = self.detect_grpc_arg_style(&bins_dir, mode_name);
+        let arg_style = self.infer_grpc_arg_style(&bins_dir);
         let args = mode.get_args(&self.sqlness_home, self, db_ctx, id, arg_style);
         let check_ip_addrs = mode.check_addrs();
 

--- a/tests/runner/src/env/bare.rs
+++ b/tests/runner/src/env/bare.rs
@@ -32,7 +32,7 @@ use crate::client::MultiProtocolClient;
 use crate::cmd::bare::ServerAddr;
 use crate::formatter::{ErrorFormatter, MysqlFormatter, OutputFormatter, PostgresqlFormatter};
 use crate::protocol_interceptor::{MYSQL, PROTOCOL_KEY};
-use crate::server_mode::ServerMode;
+use crate::server_mode::{GrpcArgStyle, ServerMode};
 use crate::util;
 use crate::util::{PROGRAM, get_workspace_root, maybe_pull_binary};
 
@@ -100,6 +100,9 @@ pub struct Env {
     store_config: StoreConfig,
     /// Extra command line arguments when starting GreptimeDB binaries.
     extra_args: Vec<String>,
+    /// Cache for the detected gRPC argument style per (bins_dir, mode_name).
+    /// Avoids running `--help` on every server start.
+    grpc_arg_style_cache: Arc<Mutex<HashMap<(PathBuf, String), GrpcArgStyle>>>,
 }
 
 #[async_trait]
@@ -149,6 +152,7 @@ impl Env {
             )]))),
             store_config,
             extra_args,
+            grpc_arg_style_cache: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -272,6 +276,60 @@ impl Env {
         let _ = process.wait();
     }
 
+    /// Detect which gRPC argument style the binary at `bins_dir` supports for
+    /// the given server mode.  Caches the result keyed by `(bins_dir, mode_name)`.
+    fn detect_grpc_arg_style(&self, bins_dir: &Path, mode_name: &str) -> GrpcArgStyle {
+        let cache_key = (bins_dir.to_path_buf(), mode_name.to_string());
+
+        // Fast path: already cached.
+        {
+            let cache = self.grpc_arg_style_cache.lock().unwrap();
+            if let Some(style) = cache.get(&cache_key) {
+                return *style;
+            }
+        }
+
+        let binary_path = bins_dir.join(PROGRAM);
+        let output = Command::new(&binary_path)
+            .args([mode_name, "start", "--help"])
+            .output()
+            .unwrap_or_else(|e| {
+                panic!(
+                    "Failed to run '{} {} start --help': {e}",
+                    binary_path.display(),
+                    mode_name,
+                );
+            });
+
+        let help_text = format!(
+            "{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let style = if let Some(style) = GrpcArgStyle::detect_from_help(&help_text) {
+            style
+        } else {
+            let help_preview = help_text.chars().take(1000).collect::<String>();
+            panic!(
+                "Could not detect gRPC argument style from '{} {} start --help'.\n\
+                 Help output (first 1000 chars):\n{}",
+                binary_path.display(),
+                mode_name,
+                help_preview
+            );
+        };
+
+        // Insert into cache (may race with another thread, but both detect
+        // the same value, so it's harmless).
+        {
+            let mut cache = self.grpc_arg_style_cache.lock().unwrap();
+            cache.entry(cache_key).or_insert(style);
+        }
+
+        style
+    }
+
     async fn start_server(
         &self,
         mode: ServerMode,
@@ -317,7 +375,9 @@ impl Env {
             .open(&stdout_file_name)
             .unwrap();
 
-        let args = mode.get_args(&self.sqlness_home, self, db_ctx, id);
+        let mode_name = mode.name();
+        let arg_style = self.detect_grpc_arg_style(&bins_dir, mode_name);
+        let args = mode.get_args(&self.sqlness_home, self, db_ctx, id, arg_style);
         let check_ip_addrs = mode.check_addrs();
 
         for check_ip_addr in &check_ip_addrs {

--- a/tests/runner/src/server_mode.rs
+++ b/tests/runner/src/server_mode.rs
@@ -25,11 +25,48 @@ use crate::util;
 
 const DEFAULT_LOG_LEVEL: &str = "--log-level=debug,hyper=warn,tower=warn,datafusion=warn,reqwest=warn,sqlparser=warn,h2=info,opendal=info";
 
-// Use the legacy `rpc-*` aliases when spawning GreptimeDB so the same runner can
-// start older release binaries that predate the `grpc-*` CLI rename. Current
-// binaries keep these aliases for compatibility.
-const RPC_BIND_ADDR_ARG: &str = "--rpc-bind-addr";
-const RPC_SERVER_ADDR_ARG: &str = "--rpc-server-addr";
+/// Which set of gRPC CLI argument names to use when spawning a GreptimeDB binary.
+///
+/// Newer binaries (≥ current development) accept `--grpc-bind-addr` and
+/// `--grpc-server-addr`.  Older release binaries (e.g. v1.0.0) only recognise
+/// `--rpc-bind-addr` and `--rpc-server-addr`.  The runner auto-detects the
+/// correct style by inspecting `<binary> <mode> start --help` output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum GrpcArgStyle {
+    /// Current-style: `--grpc-bind-addr` / `--grpc-server-addr`
+    Grpc,
+    /// Legacy-style: `--rpc-bind-addr` / `--rpc-server-addr`
+    Rpc,
+}
+
+impl GrpcArgStyle {
+    /// Detects the preferred argument style from command help output.
+    pub fn detect_from_help(help: &str) -> Option<Self> {
+        if help.contains("--grpc-bind-addr") {
+            Some(GrpcArgStyle::Grpc)
+        } else if help.contains("--rpc-bind-addr") {
+            Some(GrpcArgStyle::Rpc)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the CLI flag name for the gRPC bind address.
+    pub fn bind_addr_arg(self) -> &'static str {
+        match self {
+            GrpcArgStyle::Grpc => "--grpc-bind-addr",
+            GrpcArgStyle::Rpc => "--rpc-bind-addr",
+        }
+    }
+
+    /// Returns the CLI flag name for the gRPC server (advertised) address.
+    pub fn server_addr_arg(self) -> &'static str {
+        match self {
+            GrpcArgStyle::Grpc => "--grpc-server-addr",
+            GrpcArgStyle::Rpc => "--rpc-server-addr",
+        }
+    }
+}
 
 static USED_PORTS: OnceLock<Mutex<HashSet<u16>>> = OnceLock::new();
 
@@ -336,6 +373,7 @@ impl ServerMode {
         env: &Env,
         db_ctx: &GreptimeDBContext,
         id: usize,
+        arg_style: GrpcArgStyle,
     ) -> Vec<String> {
         let mut args = env
             .extra_args()
@@ -361,7 +399,7 @@ impl ServerMode {
                     "-c".to_string(),
                     self.generate_config_file(sqlness_home, db_ctx, id),
                     format!("--http-addr={http_addr}"),
-                    format!("{RPC_BIND_ADDR_ARG}={rpc_bind_addr}"),
+                    format!("{}={rpc_bind_addr}", arg_style.bind_addr_arg()),
                     format!("--mysql-addr={mysql_addr}"),
                     format!("--postgres-addr={postgres_addr}"),
                 ]);
@@ -376,10 +414,10 @@ impl ServerMode {
                 args.extend([
                     format!("--metasrv-addrs={metasrv_addr}"),
                     format!("--http-addr={http_addr}"),
-                    format!("{RPC_BIND_ADDR_ARG}={rpc_bind_addr}"),
+                    format!("{}={rpc_bind_addr}", arg_style.bind_addr_arg()),
                     // since sqlness run on local, bind addr is the same as server addr
                     // this is needed so that `cluster_info`'s server addr column can be correct
-                    format!("{RPC_SERVER_ADDR_ARG}={rpc_bind_addr}"),
+                    format!("{}={rpc_bind_addr}", arg_style.server_addr_arg()),
                     format!("--mysql-addr={mysql_addr}"),
                     format!("--postgres-addr={postgres_addr}"),
                     format!(
@@ -397,9 +435,9 @@ impl ServerMode {
                 http_addr,
             } => {
                 args.extend([
-                    RPC_BIND_ADDR_ARG.to_string(),
+                    arg_style.bind_addr_arg().to_string(),
                     rpc_bind_addr.clone(),
-                    RPC_SERVER_ADDR_ARG.to_string(),
+                    arg_style.server_addr_arg().to_string(),
                     rpc_server_addr.clone(),
                     "--enable-region-failover".to_string(),
                     "false".to_string(),
@@ -482,8 +520,8 @@ impl ServerMode {
                     db_ctx.time()
                 ));
                 args.extend([
-                    format!("{RPC_BIND_ADDR_ARG}={rpc_bind_addr}"),
-                    format!("{RPC_SERVER_ADDR_ARG}={rpc_server_addr}"),
+                    format!("{}={rpc_bind_addr}", arg_style.bind_addr_arg()),
+                    format!("{}={rpc_server_addr}", arg_style.server_addr_arg()),
                     format!("--http-addr={http_addr}"),
                     format!("--data-home={}", data_home.display()),
                     format!("--log-dir={}/logs", data_home.display()),
@@ -501,8 +539,8 @@ impl ServerMode {
                 node_id,
             } => {
                 args.extend([
-                    format!("{RPC_BIND_ADDR_ARG}={rpc_bind_addr}"),
-                    format!("{RPC_SERVER_ADDR_ARG}={rpc_server_addr}"),
+                    format!("{}={rpc_bind_addr}", arg_style.bind_addr_arg()),
+                    format!("{}={rpc_server_addr}", arg_style.server_addr_arg()),
                     format!("--node-id={node_id}"),
                     format!(
                         "--log-dir={}/greptimedb-{}-flownode/logs",
@@ -553,35 +591,43 @@ mod tests {
             .any(|arg| arg == name || arg.starts_with(&format!("{name}=")))
     }
 
-    fn assert_uses_rpc_cli_aliases(args: &[String], expect_server_addr: bool) {
-        assert!(has_arg(args, RPC_BIND_ADDR_ARG), "args: {args:?}");
+    fn assert_uses_style(args: &[String], style: GrpcArgStyle, expect_server_addr: bool) {
+        let bind = style.bind_addr_arg();
+        let server = style.server_addr_arg();
+        let other_bind = match style {
+            GrpcArgStyle::Grpc => "--rpc-bind-addr",
+            GrpcArgStyle::Rpc => "--grpc-bind-addr",
+        };
+        let other_server = match style {
+            GrpcArgStyle::Grpc => "--rpc-server-addr",
+            GrpcArgStyle::Rpc => "--grpc-server-addr",
+        };
+
+        assert!(has_arg(args, bind), "missing {bind} in args: {args:?}");
         assert!(
-            !args.iter().any(|arg| arg.contains("--grpc-bind-addr")),
-            "args: {args:?}"
+            !args.iter().any(|arg| arg.contains(other_bind)),
+            "unexpected {other_bind} in args: {args:?}"
         );
 
         if expect_server_addr {
-            assert!(has_arg(args, RPC_SERVER_ADDR_ARG), "args: {args:?}");
+            assert!(has_arg(args, server), "missing {server} in args: {args:?}");
             assert!(
-                !args.iter().any(|arg| arg.contains("--grpc-server-addr")),
-                "args: {args:?}"
+                !args.iter().any(|arg| arg.contains(other_server)),
+                "unexpected {other_server} in args: {args:?}"
             );
         }
     }
 
-    #[test]
-    fn test_get_args_uses_legacy_rpc_cli_aliases() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let (env, db_ctx) = test_env(temp_dir.path());
-
+    fn test_all_modes(env: &Env, db_ctx: &GreptimeDBContext, temp_dir: &Path, style: GrpcArgStyle) {
         let standalone = ServerMode::Standalone {
             http_addr: "127.0.0.1:4000".to_string(),
             rpc_bind_addr: "127.0.0.1:4001".to_string(),
             mysql_addr: "127.0.0.1:4002".to_string(),
             postgres_addr: "127.0.0.1:4003".to_string(),
         };
-        assert_uses_rpc_cli_aliases(
-            &standalone.get_args(temp_dir.path(), &env, &db_ctx, 0),
+        assert_uses_style(
+            &standalone.get_args(temp_dir, env, db_ctx, 0, style),
+            style,
             false,
         );
 
@@ -592,14 +638,22 @@ mod tests {
             postgres_addr: "127.0.0.1:4103".to_string(),
             metasrv_addr: "127.0.0.1:4001".to_string(),
         };
-        assert_uses_rpc_cli_aliases(&frontend.get_args(temp_dir.path(), &env, &db_ctx, 0), true);
+        assert_uses_style(
+            &frontend.get_args(temp_dir, env, db_ctx, 0, style),
+            style,
+            true,
+        );
 
         let metasrv = ServerMode::Metasrv {
             rpc_bind_addr: "127.0.0.1:4201".to_string(),
             rpc_server_addr: "127.0.0.1:4201".to_string(),
             http_addr: "127.0.0.1:4200".to_string(),
         };
-        assert_uses_rpc_cli_aliases(&metasrv.get_args(temp_dir.path(), &env, &db_ctx, 0), true);
+        assert_uses_style(
+            &metasrv.get_args(temp_dir, env, db_ctx, 0, style),
+            style,
+            true,
+        );
 
         let datanode = ServerMode::Datanode {
             rpc_bind_addr: "127.0.0.1:4301".to_string(),
@@ -608,7 +662,11 @@ mod tests {
             metasrv_addr: "127.0.0.1:4001".to_string(),
             node_id: 0,
         };
-        assert_uses_rpc_cli_aliases(&datanode.get_args(temp_dir.path(), &env, &db_ctx, 0), true);
+        assert_uses_style(
+            &datanode.get_args(temp_dir, env, db_ctx, 0, style),
+            style,
+            true,
+        );
 
         let flownode = ServerMode::Flownode {
             rpc_bind_addr: "127.0.0.1:4401".to_string(),
@@ -617,6 +675,51 @@ mod tests {
             metasrv_addr: "127.0.0.1:4001".to_string(),
             node_id: 0,
         };
-        assert_uses_rpc_cli_aliases(&flownode.get_args(temp_dir.path(), &env, &db_ctx, 0), true);
+        assert_uses_style(
+            &flownode.get_args(temp_dir, env, db_ctx, 0, style),
+            style,
+            true,
+        );
+    }
+
+    #[test]
+    fn test_get_args_with_grpc_style() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let (env, db_ctx) = test_env(temp_dir.path());
+        test_all_modes(&env, &db_ctx, temp_dir.path(), GrpcArgStyle::Grpc);
+    }
+
+    #[test]
+    fn test_get_args_with_rpc_style() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let (env, db_ctx) = test_env(temp_dir.path());
+        test_all_modes(&env, &db_ctx, temp_dir.path(), GrpcArgStyle::Rpc);
+    }
+
+    #[test]
+    fn test_detect_arg_style_from_help_prefers_grpc() {
+        let help = "Usage: greptime metasrv start --grpc-bind-addr <ADDR> --rpc-bind-addr <ADDR>";
+
+        assert_eq!(
+            GrpcArgStyle::detect_from_help(help),
+            Some(GrpcArgStyle::Grpc)
+        );
+    }
+
+    #[test]
+    fn test_detect_arg_style_from_help_falls_back_to_rpc() {
+        let help = "Usage: greptime metasrv start --rpc-bind-addr <ADDR>";
+
+        assert_eq!(
+            GrpcArgStyle::detect_from_help(help),
+            Some(GrpcArgStyle::Rpc)
+        );
+    }
+
+    #[test]
+    fn test_detect_arg_style_from_help_rejects_unknown() {
+        let help = "Usage: greptime metasrv start --http-addr <ADDR>";
+
+        assert_eq!(GrpcArgStyle::detect_from_help(help), None);
     }
 }

--- a/tests/runner/src/server_mode.rs
+++ b/tests/runner/src/server_mode.rs
@@ -20,6 +20,7 @@ use serde::Serialize;
 use tinytemplate::TinyTemplate;
 
 use crate::cmd::bare::ServerAddr;
+use crate::cmd::compat_case::Version;
 use crate::env::bare::{Env, GreptimeDBContext, ServiceProvider};
 use crate::util;
 
@@ -27,10 +28,10 @@ const DEFAULT_LOG_LEVEL: &str = "--log-level=debug,hyper=warn,tower=warn,datafus
 
 /// Which set of gRPC CLI argument names to use when spawning a GreptimeDB binary.
 ///
-/// Newer binaries (≥ current development) accept `--grpc-bind-addr` and
-/// `--grpc-server-addr`.  Older release binaries (e.g. v1.0.0) only recognise
-/// `--rpc-bind-addr` and `--rpc-server-addr`.  The runner auto-detects the
-/// correct style by inspecting `<binary> <mode> start --help` output.
+/// The CLI rename from `rpc-*` to `grpc-*` landed before v1.1.0.  Older release
+/// binaries (e.g. v1.0.0) only recognise `--rpc-bind-addr` and
+/// `--rpc-server-addr`; v1.1.0+ and current binaries use `--grpc-*` names while
+/// keeping the old names as hidden aliases.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum GrpcArgStyle {
     /// Current-style: `--grpc-bind-addr` / `--grpc-server-addr`
@@ -40,14 +41,21 @@ pub enum GrpcArgStyle {
 }
 
 impl GrpcArgStyle {
-    /// Detects the preferred argument style from command help output.
-    pub fn detect_from_help(help: &str) -> Option<Self> {
-        if help.contains("--grpc-bind-addr") {
-            Some(GrpcArgStyle::Grpc)
-        } else if help.contains("--rpc-bind-addr") {
-            Some(GrpcArgStyle::Rpc)
+    /// Chooses the argument style from an inferred GreptimeDB binary version.
+    ///
+    /// Unknown versions are treated as current/development binaries and use the
+    /// official `grpc-*` names.
+    pub(crate) fn for_version(version: Option<&Version>) -> Self {
+        const GRPC_ARG_RENAME_VERSION: Version = Version {
+            major: 1,
+            minor: 1,
+            patch: 0,
+        };
+
+        if version.is_some_and(|version| version < &GRPC_ARG_RENAME_VERSION) {
+            GrpcArgStyle::Rpc
         } else {
-            None
+            GrpcArgStyle::Grpc
         }
     }
 
@@ -697,29 +705,25 @@ mod tests {
     }
 
     #[test]
-    fn test_detect_arg_style_from_help_prefers_grpc() {
-        let help = "Usage: greptime metasrv start --grpc-bind-addr <ADDR> --rpc-bind-addr <ADDR>";
-
-        assert_eq!(
-            GrpcArgStyle::detect_from_help(help),
-            Some(GrpcArgStyle::Grpc)
-        );
+    fn test_arg_style_for_unknown_version_defaults_to_grpc() {
+        assert_eq!(GrpcArgStyle::for_version(None), GrpcArgStyle::Grpc);
     }
 
     #[test]
-    fn test_detect_arg_style_from_help_falls_back_to_rpc() {
-        let help = "Usage: greptime metasrv start --rpc-bind-addr <ADDR>";
+    fn test_arg_style_for_legacy_versions_uses_rpc() {
+        let v1_0_0 = Version::parse("v1.0.0").unwrap();
+        let v1_0_9 = Version::parse("v1.0.9").unwrap();
 
-        assert_eq!(
-            GrpcArgStyle::detect_from_help(help),
-            Some(GrpcArgStyle::Rpc)
-        );
+        assert_eq!(GrpcArgStyle::for_version(Some(&v1_0_0)), GrpcArgStyle::Rpc);
+        assert_eq!(GrpcArgStyle::for_version(Some(&v1_0_9)), GrpcArgStyle::Rpc);
     }
 
     #[test]
-    fn test_detect_arg_style_from_help_rejects_unknown() {
-        let help = "Usage: greptime metasrv start --http-addr <ADDR>";
+    fn test_arg_style_for_current_versions_uses_grpc() {
+        let v1_1_0 = Version::parse("v1.1.0").unwrap();
+        let v1_2_0 = Version::parse("v1.2.0").unwrap();
 
-        assert_eq!(GrpcArgStyle::detect_from_help(help), None);
+        assert_eq!(GrpcArgStyle::for_version(Some(&v1_1_0)), GrpcArgStyle::Grpc);
+        assert_eq!(GrpcArgStyle::for_version(Some(&v1_2_0)), GrpcArgStyle::Grpc);
     }
 }

--- a/tests/runner/src/server_mode.rs
+++ b/tests/runner/src/server_mode.rs
@@ -29,7 +29,7 @@ const DEFAULT_LOG_LEVEL: &str = "--log-level=debug,hyper=warn,tower=warn,datafus
 /// Which set of gRPC CLI argument names to use when spawning a GreptimeDB binary.
 ///
 /// The CLI rename from `rpc-*` to `grpc-*` landed before v1.1.0.  Older release
-/// binaries (e.g. v1.0.0) only recognise `--rpc-bind-addr` and
+/// binaries (e.g. v1.0.0) only recognize `--rpc-bind-addr` and
 /// `--rpc-server-addr`; v1.1.0+ and current binaries use `--grpc-*` names while
 /// keeping the old names as hidden aliases.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/tests/runner/src/server_mode.rs
+++ b/tests/runner/src/server_mode.rs
@@ -25,6 +25,12 @@ use crate::util;
 
 const DEFAULT_LOG_LEVEL: &str = "--log-level=debug,hyper=warn,tower=warn,datafusion=warn,reqwest=warn,sqlparser=warn,h2=info,opendal=info";
 
+// Use the legacy `rpc-*` aliases when spawning GreptimeDB so the same runner can
+// start older release binaries that predate the `grpc-*` CLI rename. Current
+// binaries keep these aliases for compatibility.
+const RPC_BIND_ADDR_ARG: &str = "--rpc-bind-addr";
+const RPC_SERVER_ADDR_ARG: &str = "--rpc-server-addr";
+
 static USED_PORTS: OnceLock<Mutex<HashSet<u16>>> = OnceLock::new();
 
 fn get_used_ports() -> &'static Mutex<HashSet<u16>> {
@@ -355,7 +361,7 @@ impl ServerMode {
                     "-c".to_string(),
                     self.generate_config_file(sqlness_home, db_ctx, id),
                     format!("--http-addr={http_addr}"),
-                    format!("--grpc-bind-addr={rpc_bind_addr}"),
+                    format!("{RPC_BIND_ADDR_ARG}={rpc_bind_addr}"),
                     format!("--mysql-addr={mysql_addr}"),
                     format!("--postgres-addr={postgres_addr}"),
                 ]);
@@ -370,10 +376,10 @@ impl ServerMode {
                 args.extend([
                     format!("--metasrv-addrs={metasrv_addr}"),
                     format!("--http-addr={http_addr}"),
-                    format!("--grpc-bind-addr={rpc_bind_addr}"),
+                    format!("{RPC_BIND_ADDR_ARG}={rpc_bind_addr}"),
                     // since sqlness run on local, bind addr is the same as server addr
                     // this is needed so that `cluster_info`'s server addr column can be correct
-                    format!("--grpc-server-addr={rpc_bind_addr}"),
+                    format!("{RPC_SERVER_ADDR_ARG}={rpc_bind_addr}"),
                     format!("--mysql-addr={mysql_addr}"),
                     format!("--postgres-addr={postgres_addr}"),
                     format!(
@@ -391,9 +397,9 @@ impl ServerMode {
                 http_addr,
             } => {
                 args.extend([
-                    "--grpc-bind-addr".to_string(),
+                    RPC_BIND_ADDR_ARG.to_string(),
                     rpc_bind_addr.clone(),
-                    "--grpc-server-addr".to_string(),
+                    RPC_SERVER_ADDR_ARG.to_string(),
                     rpc_server_addr.clone(),
                     "--enable-region-failover".to_string(),
                     "false".to_string(),
@@ -476,8 +482,8 @@ impl ServerMode {
                     db_ctx.time()
                 ));
                 args.extend([
-                    format!("--grpc-bind-addr={rpc_bind_addr}"),
-                    format!("--grpc-server-addr={rpc_server_addr}"),
+                    format!("{RPC_BIND_ADDR_ARG}={rpc_bind_addr}"),
+                    format!("{RPC_SERVER_ADDR_ARG}={rpc_server_addr}"),
                     format!("--http-addr={http_addr}"),
                     format!("--data-home={}", data_home.display()),
                     format!("--log-dir={}/logs", data_home.display()),
@@ -495,8 +501,8 @@ impl ServerMode {
                 node_id,
             } => {
                 args.extend([
-                    format!("--grpc-bind-addr={rpc_bind_addr}"),
-                    format!("--grpc-server-addr={rpc_server_addr}"),
+                    format!("{RPC_BIND_ADDR_ARG}={rpc_bind_addr}"),
+                    format!("{RPC_SERVER_ADDR_ARG}={rpc_server_addr}"),
                     format!("--node-id={node_id}"),
                     format!(
                         "--log-dir={}/greptimedb-{}-flownode/logs",
@@ -510,5 +516,107 @@ impl ServerMode {
         }
 
         args
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::env::bare::{StoreConfig, WalConfig};
+
+    fn test_env(sqlness_home: &Path) -> (Env, GreptimeDBContext) {
+        let store_config = StoreConfig {
+            store_addrs: vec!["127.0.0.1:2379".to_string()],
+            setup_etcd: true,
+            setup_pg: None,
+            setup_mysql: None,
+            enable_flat_format: false,
+        };
+        let env = Env::new(
+            sqlness_home.to_path_buf(),
+            ServerAddr::default(),
+            WalConfig::RaftEngine,
+            false,
+            Some(PathBuf::from(".")),
+            store_config.clone(),
+            vec![],
+        );
+        let db_ctx = GreptimeDBContext::new(WalConfig::RaftEngine, store_config);
+
+        (env, db_ctx)
+    }
+
+    fn has_arg(args: &[String], name: &str) -> bool {
+        args.iter()
+            .any(|arg| arg == name || arg.starts_with(&format!("{name}=")))
+    }
+
+    fn assert_uses_rpc_cli_aliases(args: &[String], expect_server_addr: bool) {
+        assert!(has_arg(args, RPC_BIND_ADDR_ARG), "args: {args:?}");
+        assert!(
+            !args.iter().any(|arg| arg.contains("--grpc-bind-addr")),
+            "args: {args:?}"
+        );
+
+        if expect_server_addr {
+            assert!(has_arg(args, RPC_SERVER_ADDR_ARG), "args: {args:?}");
+            assert!(
+                !args.iter().any(|arg| arg.contains("--grpc-server-addr")),
+                "args: {args:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_get_args_uses_legacy_rpc_cli_aliases() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let (env, db_ctx) = test_env(temp_dir.path());
+
+        let standalone = ServerMode::Standalone {
+            http_addr: "127.0.0.1:4000".to_string(),
+            rpc_bind_addr: "127.0.0.1:4001".to_string(),
+            mysql_addr: "127.0.0.1:4002".to_string(),
+            postgres_addr: "127.0.0.1:4003".to_string(),
+        };
+        assert_uses_rpc_cli_aliases(
+            &standalone.get_args(temp_dir.path(), &env, &db_ctx, 0),
+            false,
+        );
+
+        let frontend = ServerMode::Frontend {
+            http_addr: "127.0.0.1:4100".to_string(),
+            rpc_bind_addr: "127.0.0.1:4101".to_string(),
+            mysql_addr: "127.0.0.1:4102".to_string(),
+            postgres_addr: "127.0.0.1:4103".to_string(),
+            metasrv_addr: "127.0.0.1:4001".to_string(),
+        };
+        assert_uses_rpc_cli_aliases(&frontend.get_args(temp_dir.path(), &env, &db_ctx, 0), true);
+
+        let metasrv = ServerMode::Metasrv {
+            rpc_bind_addr: "127.0.0.1:4201".to_string(),
+            rpc_server_addr: "127.0.0.1:4201".to_string(),
+            http_addr: "127.0.0.1:4200".to_string(),
+        };
+        assert_uses_rpc_cli_aliases(&metasrv.get_args(temp_dir.path(), &env, &db_ctx, 0), true);
+
+        let datanode = ServerMode::Datanode {
+            rpc_bind_addr: "127.0.0.1:4301".to_string(),
+            rpc_server_addr: "127.0.0.1:4301".to_string(),
+            http_addr: "127.0.0.1:4300".to_string(),
+            metasrv_addr: "127.0.0.1:4001".to_string(),
+            node_id: 0,
+        };
+        assert_uses_rpc_cli_aliases(&datanode.get_args(temp_dir.path(), &env, &db_ctx, 0), true);
+
+        let flownode = ServerMode::Flownode {
+            rpc_bind_addr: "127.0.0.1:4401".to_string(),
+            rpc_server_addr: "127.0.0.1:4401".to_string(),
+            http_addr: "127.0.0.1:4400".to_string(),
+            metasrv_addr: "127.0.0.1:4001".to_string(),
+            node_id: 0,
+        };
+        assert_uses_rpc_cli_aliases(&flownode.get_args(temp_dir.path(), &env, &db_ctx, 0), true);
     }
 }

--- a/tests/runner/src/server_mode.rs
+++ b/tests/runner/src/server_mode.rs
@@ -595,8 +595,9 @@ mod tests {
     }
 
     fn has_arg(args: &[String], name: &str) -> bool {
+        let prefix = format!("{name}=");
         args.iter()
-            .any(|arg| arg == name || arg.starts_with(&format!("{name}=")))
+            .any(|arg| arg == name || arg.starts_with(&prefix))
     }
 
     fn assert_uses_style(args: &[String], style: GrpcArgStyle, expect_server_addr: bool) {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up to #8370.

Failed merge queue job: https://github.com/GreptimeTeam/greptimedb/actions/runs/28358349753/job/84009569504

## What's changed and what's your intention?

This PR fixes the sqlness compatibility runner startup args for old release binaries without changing the default current-binary CLI style.

PR #8370 added `v1.0.0` to the recent-release compatibility window, but the merge queue compat job failed before running cases because the `v1.0.0` metasrv binary does not accept the newer `--grpc-bind-addr` option name:

```text
error: unexpected argument '--grpc-bind-addr' found
tip: a similar argument exists: '--rpc-bind-addr'
```

The runner now chooses the gRPC CLI argument style from the GreptimeDB binary version inferred by `<binary> --version`:

- use legacy args for versions before `v1.1.0`: `--rpc-bind-addr` / `--rpc-server-addr`
- use current official args for `v1.1.0+`, current/development, or unknown versions: `--grpc-bind-addr` / `--grpc-server-addr`
- cache the inferred style per `bins_dir`

This keeps normal/current sqlness runs on the official `grpc-*` names while allowing compat runs to start older binaries such as `v1.0.0`.

This PR also lets the compat job run once when a PR is opened directly as ready/non-draft, in addition to the existing draft-to-ready, merge queue, schedule, and manual triggers.

Tests cover both generated arg styles and version-based style selection.

Validation:

- `cargo fmt --package sqlness-runner`
- `cargo test -p sqlness-runner`
- `cargo test -p cmd test_parse_grpc_cli_aliases`
- `cargo check -p sqlness-runner`
- `python3 -m py_compile .github/scripts/run-compat.py`
- `git diff --check`

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
