### PR TITLE
feat(query): add experimental spill controls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11500,6 +11500,7 @@ dependencies = [
  "table",
  "tokio",
  "tokio-stream",
+ "toml 0.8.23",
  "tracing",
  "uuid",
 ]

--- a/config/config.md
+++ b/config/config.md
@@ -114,6 +114,11 @@
 | `query` | -- | -- | The query engine options. |
 | `query.parallelism` | Integer | `0` | Parallelism of the query engine.<br/>Default to 0, which means the number of CPU cores. |
 | `query.memory_pool_size` | String | `50%` | Memory pool size for query execution operators (aggregation, sorting, join).<br/>Supports absolute size (e.g., "2GB", "4GB") or percentage of system memory (e.g., "20%").<br/>Setting it to 0 disables the limit (unbounded, default behavior).<br/>When this limit is reached, queries will fail with ResourceExhausted error.<br/>NOTE: This does NOT limit memory used by table scans. |
+| `query.experimental_memory_pool_policy` | String | `greedy` | Experimental memory pool allocation policy:<br/>- "greedy" (default): preserves current greedy allocation behavior.<br/>- "fair": shares memory evenly among spillable operators.<br/>Only effective when `memory_pool_size` is bounded (>0). |
+| `query.experimental_spill_mode` | String | `default` | Spill mode:<br/>- "default": preserve DataFusion built-in OS temp directory (default).<br/>- "custom": explicitly configure spill path, quota, and compression.<br/>- "disabled": explicitly disable disk spilling.<br/>Set this to "custom" before using the path/quota/compression keys below. |
+| `query.experimental_spill_path` | String | Unset | Spill directory path. Ignored unless mode is "custom". |
+| `query.experimental_spill_max_temp_directory_size` | String | `100GiB` | Maximum total size of spill directory (default: "100GiB").<br/>Ignored unless mode is "custom". |
+| `query.experimental_spill_compression` | String | `uncompressed` | Compression for spilled data files: "uncompressed" (default), "lz4_frame", "zstd".<br/>Ignored unless mode is "custom". |
 | `storage` | -- | -- | The data storage options. |
 | `storage.data_home` | String | `./greptimedb_data` | The working home directory. |
 | `storage.type` | String | `File` | The storage type used to store the data.<br/>- `File`: the data is stored in the local file system.<br/>- `S3`: the data is stored in the S3 object storage.<br/>- `Gcs`: the data is stored in the Google Cloud Storage.<br/>- `Azblob`: the data is stored in the Azure Blob Storage.<br/>- `Oss`: the data is stored in the Aliyun OSS. |
@@ -317,6 +322,11 @@
 | `query.parallelism` | Integer | `0` | Parallelism of the query engine.<br/>Default to 0, which means the number of CPU cores. |
 | `query.allow_query_fallback` | Bool | `false` | Whether to allow query fallback when push down optimize fails.<br/>Default to false, meaning when push down optimize failed, return error msg |
 | `query.memory_pool_size` | String | `50%` | Memory pool size for query execution operators (aggregation, sorting, join).<br/>Supports absolute size (e.g., "4GB", "8GB") or percentage of system memory (e.g., "30%").<br/>Setting it to 0 disables the limit (unbounded, default behavior).<br/>When this limit is reached, queries will fail with ResourceExhausted error.<br/>NOTE: This does NOT limit memory used by table scans (only applies to datanodes). |
+| `query.experimental_memory_pool_policy` | String | `greedy` | Experimental memory pool allocation policy:<br/>- "greedy" (default): preserves current greedy allocation behavior.<br/>- "fair": shares memory evenly among spillable operators.<br/>Only effective when `memory_pool_size` is bounded (>0). |
+| `query.experimental_spill_mode` | String | `default` | Spill mode:<br/>- "default": preserve DataFusion built-in OS temp directory (default).<br/>- "custom": explicitly configure spill path, quota, and compression.<br/>- "disabled": explicitly disable disk spilling.<br/>Set this to "custom" before using the path/quota/compression keys below. |
+| `query.experimental_spill_path` | String | Unset | Spill directory path. Ignored unless mode is "custom". |
+| `query.experimental_spill_max_temp_directory_size` | String | `100GiB` | Maximum total size of spill directory (default: "100GiB").<br/>Ignored unless mode is "custom". |
+| `query.experimental_spill_compression` | String | `uncompressed` | Compression for spilled data files: "uncompressed" (default), "lz4_frame", "zstd".<br/>Ignored unless mode is "custom". |
 | `datanode` | -- | -- | Datanode options. |
 | `datanode.client` | -- | -- | Datanode client options. |
 | `datanode.client.connect_timeout` | String | `10s` | -- |
@@ -510,6 +520,11 @@
 | `query` | -- | -- | The query engine options. |
 | `query.parallelism` | Integer | `0` | Parallelism of the query engine.<br/>Default to 0, which means the number of CPU cores. |
 | `query.memory_pool_size` | String | `50%` | Memory pool size for query execution operators (aggregation, sorting, join).<br/>Supports absolute size (e.g., "2GB", "4GB") or percentage of system memory (e.g., "20%").<br/>Setting it to 0 disables the limit (unbounded, default behavior).<br/>When this limit is reached, queries will fail with ResourceExhausted error.<br/>NOTE: This does NOT limit memory used by table scans. |
+| `query.experimental_memory_pool_policy` | String | `greedy` | Experimental memory pool allocation policy:<br/>- "greedy" (default): preserves current greedy allocation behavior.<br/>- "fair": shares memory evenly among spillable operators.<br/>Only effective when `memory_pool_size` is bounded (>0). |
+| `query.experimental_spill_mode` | String | `default` | Spill mode:<br/>- "default": preserve DataFusion built-in OS temp directory (default).<br/>- "custom": explicitly configure spill path, quota, and compression.<br/>- "disabled": explicitly disable disk spilling.<br/>Set this to "custom" before using the path/quota/compression keys below. |
+| `query.experimental_spill_path` | String | Unset | Spill directory path. Ignored unless mode is "custom". |
+| `query.experimental_spill_max_temp_directory_size` | String | `100GiB` | Maximum total size of spill directory (default: "100GiB").<br/>Ignored unless mode is "custom". |
+| `query.experimental_spill_compression` | String | `uncompressed` | Compression for spilled data files: "uncompressed" (default), "lz4_frame", "zstd".<br/>Ignored unless mode is "custom". |
 | `storage` | -- | -- | The data storage options. |
 | `storage.data_home` | String | `./greptimedb_data` | The working home directory. |
 | `storage.type` | String | `File` | The storage type used to store the data.<br/>- `File`: the data is stored in the local file system.<br/>- `S3`: the data is stored in the S3 object storage.<br/>- `Gcs`: the data is stored in the Google Cloud Storage.<br/>- `Azblob`: the data is stored in the Azure Blob Storage.<br/>- `Oss`: the data is stored in the Aliyun OSS. |
@@ -680,5 +695,10 @@
 | `query` | -- | -- | -- |
 | `query.parallelism` | Integer | `1` | Parallelism of the query engine for query sent by flownode.<br/>Default to 1, so it won't use too much cpu or memory |
 | `query.memory_pool_size` | String | `50%` | Memory pool size for query execution operators (aggregation, sorting, join).<br/>Supports absolute size (e.g., "1GB", "2GB") or percentage of system memory (e.g., "20%").<br/>Setting it to 0 disables the limit (unbounded, default behavior).<br/>When this limit is reached, queries will fail with ResourceExhausted error.<br/>NOTE: This does NOT limit memory used by table scans. |
+| `query.experimental_memory_pool_policy` | String | `greedy` | Experimental memory pool allocation policy:<br/>- "greedy" (default): preserves current greedy allocation behavior.<br/>- "fair": shares memory evenly among spillable operators.<br/>Only effective when `memory_pool_size` is bounded (>0). |
+| `query.experimental_spill_mode` | String | `default` | Spill mode:<br/>- "default": preserve DataFusion built-in OS temp directory (default).<br/>- "custom": explicitly configure spill path, quota, and compression.<br/>- "disabled": explicitly disable disk spilling.<br/>Set this to "custom" before using the path/quota/compression keys below. |
+| `query.experimental_spill_path` | String | Unset | Spill directory path. Ignored unless mode is "custom". |
+| `query.experimental_spill_max_temp_directory_size` | String | `100GiB` | Maximum total size of spill directory (default: "100GiB").<br/>Ignored unless mode is "custom". |
+| `query.experimental_spill_compression` | String | `uncompressed` | Compression for spilled data files: "uncompressed" (default), "lz4_frame", "zstd".<br/>Ignored unless mode is "custom". |
 | `memory` | -- | -- | The memory options. |
 | `memory.enable_heap_profiling` | Bool | `true` | Whether to enable heap profiling activation during startup.<br/>When enabled, heap profiling will be activated if the `MALLOC_CONF` environment variable<br/>is set to "prof:true,prof_active:false". The official image adds this env variable.<br/>Default is true. |

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -274,6 +274,30 @@ parallelism = 0
 ## NOTE: This does NOT limit memory used by table scans.
 memory_pool_size = "50%"
 
+## Experimental memory pool allocation policy:
+## - "greedy" (default): preserves current greedy allocation behavior.
+## - "fair": shares memory evenly among spillable operators.
+## Only effective when `memory_pool_size` is bounded (>0).
+#+ experimental_memory_pool_policy = "greedy"
+
+# --- Experimental: DataFusion spill-to-disk controls ---
+## Spill mode:
+## - "default": preserve DataFusion built-in OS temp directory (default).
+## - "custom": explicitly configure spill path, quota, and compression.
+## - "disabled": explicitly disable disk spilling.
+## Set this to "custom" before using the path/quota/compression keys below.
+#+ experimental_spill_mode = "default"
+## Spill directory path. Ignored unless mode is "custom".
+## @toml2docs:none-default
+#+ experimental_spill_path = "/path/to/spill"
+## Maximum total size of spill directory (default: "100GiB").
+## Ignored unless mode is "custom".
+#+ experimental_spill_max_temp_directory_size = "100GiB"
+## Compression for spilled data files: "uncompressed" (default), "lz4_frame", "zstd".
+## Ignored unless mode is "custom".
+#+ experimental_spill_compression = "uncompressed"
+# --- End spill-to-disk ---
+
 ## The data storage options.
 [storage]
 ## The working home directory.

--- a/config/flownode.example.toml
+++ b/config/flownode.example.toml
@@ -154,6 +154,30 @@ parallelism = 1
 ## NOTE: This does NOT limit memory used by table scans.
 memory_pool_size = "50%"
 
+## Experimental memory pool allocation policy:
+## - "greedy" (default): preserves current greedy allocation behavior.
+## - "fair": shares memory evenly among spillable operators.
+## Only effective when `memory_pool_size` is bounded (>0).
+#+ experimental_memory_pool_policy = "greedy"
+
+# --- Experimental: DataFusion spill-to-disk controls ---
+## Spill mode:
+## - "default": preserve DataFusion built-in OS temp directory (default).
+## - "custom": explicitly configure spill path, quota, and compression.
+## - "disabled": explicitly disable disk spilling.
+## Set this to "custom" before using the path/quota/compression keys below.
+#+ experimental_spill_mode = "default"
+## Spill directory path. Ignored unless mode is "custom".
+## @toml2docs:none-default
+#+ experimental_spill_path = "/path/to/spill"
+## Maximum total size of spill directory (default: "100GiB").
+## Ignored unless mode is "custom".
+#+ experimental_spill_max_temp_directory_size = "100GiB"
+## Compression for spilled data files: "uncompressed" (default), "lz4_frame", "zstd".
+## Ignored unless mode is "custom".
+#+ experimental_spill_compression = "uncompressed"
+# --- End spill-to-disk ---
+
 ## The memory options.
 [memory]
 ## Whether to enable heap profiling activation during startup.

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -275,6 +275,30 @@ allow_query_fallback = false
 ## NOTE: This does NOT limit memory used by table scans (only applies to datanodes).
 memory_pool_size = "50%"
 
+## Experimental memory pool allocation policy:
+## - "greedy" (default): preserves current greedy allocation behavior.
+## - "fair": shares memory evenly among spillable operators.
+## Only effective when `memory_pool_size` is bounded (>0).
+#+ experimental_memory_pool_policy = "greedy"
+
+# --- Experimental: DataFusion spill-to-disk controls ---
+## Spill mode:
+## - "default": preserve DataFusion built-in OS temp directory (default).
+## - "custom": explicitly configure spill path, quota, and compression.
+## - "disabled": explicitly disable disk spilling.
+## Set this to "custom" before using the path/quota/compression keys below.
+#+ experimental_spill_mode = "default"
+## Spill directory path. Ignored unless mode is "custom".
+## @toml2docs:none-default
+#+ experimental_spill_path = "/path/to/spill"
+## Maximum total size of spill directory (default: "100GiB").
+## Ignored unless mode is "custom".
+#+ experimental_spill_max_temp_directory_size = "100GiB"
+## Compression for spilled data files: "uncompressed" (default), "lz4_frame", "zstd".
+## Ignored unless mode is "custom".
+#+ experimental_spill_compression = "uncompressed"
+# --- End spill-to-disk ---
+
 ## Datanode options.
 [datanode]
 ## Datanode client options.

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -405,6 +405,30 @@ parallelism = 0
 ## NOTE: This does NOT limit memory used by table scans.
 memory_pool_size = "50%"
 
+## Experimental memory pool allocation policy:
+## - "greedy" (default): preserves current greedy allocation behavior.
+## - "fair": shares memory evenly among spillable operators.
+## Only effective when `memory_pool_size` is bounded (>0).
+#+ experimental_memory_pool_policy = "greedy"
+
+# --- Experimental: DataFusion spill-to-disk controls ---
+## Spill mode:
+## - "default": preserve DataFusion built-in OS temp directory (default).
+## - "custom": explicitly configure spill path, quota, and compression.
+## - "disabled": explicitly disable disk spilling.
+## Set this to "custom" before using the path/quota/compression keys below.
+#+ experimental_spill_mode = "default"
+## Spill directory path. Ignored unless mode is "custom".
+## @toml2docs:none-default
+#+ experimental_spill_path = "/path/to/spill"
+## Maximum total size of spill directory (default: "100GiB").
+## Ignored unless mode is "custom".
+#+ experimental_spill_max_temp_directory_size = "100GiB"
+## Compression for spilled data files: "uncompressed" (default), "lz4_frame", "zstd".
+## Ignored unless mode is "custom".
+#+ experimental_spill_compression = "uncompressed"
+# --- End spill-to-disk ---
+
 ## The data storage options.
 [storage]
 ## The working home directory.

--- a/src/cmd/tests/load_config_test.rs
+++ b/src/cmd/tests/load_config_test.rs
@@ -254,6 +254,7 @@ fn test_load_flownode_example_config() {
                 allow_query_fallback: false,
                 memory_pool_size: MemoryLimit::Percentage(50),
                 enable_per_region_metrics: false,
+                ..Default::default()
             },
             meta_client: Some(MetaClientOptions {
                 metasrv_addrs: vec!["127.0.0.1:3002".to_string()],

--- a/src/flow/src/adapter.rs
+++ b/src/flow/src/adapter.rs
@@ -130,6 +130,7 @@ impl Default for FlownodeOptions {
                 allow_query_fallback: false,
                 memory_pool_size: MemoryLimit::default(),
                 enable_per_region_metrics: false,
+                ..Default::default()
             },
             memory: MemoryOptions::default(),
         }

--- a/src/query/Cargo.toml
+++ b/src/query/Cargo.toml
@@ -97,3 +97,4 @@ session = { workspace = true, features = ["testing"] }
 store-api.workspace = true
 table = { workspace = true, features = ["testing"] }
 tokio-stream.workspace = true
+toml.workspace = true

--- a/src/query/src/options.rs
+++ b/src/query/src/options.rs
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 use common_base::memory_limit::MemoryLimit;
+use common_base::readable_size::ReadableSize;
 use serde::{Deserialize, Serialize};
 use store_api::storage::RegionId;
 use table::metadata::TableId;
@@ -31,6 +33,40 @@ pub const QUERY_ENABLE_REMOTE_DYNAMIC_FILTER_PUSHDOWN: &str =
 
 pub const FLOW_INCREMENTAL_MODE_MEMTABLE_ONLY: &str = "memtable_only";
 
+/// Query spill mode controlling disk manager behavior.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum QuerySpillMode {
+    /// Preserve DataFusion default disk manager behavior (OS temp directory).
+    Default,
+    /// Explicitly configure spill path, quota, and compression.
+    Custom,
+    /// Explicitly disable disk spilling; temporary file creation will error.
+    Disabled,
+}
+
+/// Compression for spilled data files.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum QuerySpillCompression {
+    /// No compression (default, matches DataFusion default).
+    Uncompressed,
+    /// LZ4 frame compression.
+    Lz4Frame,
+    /// Zstandard compression.
+    Zstd,
+}
+
+/// Memory pool allocation policy.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMemoryPoolPolicy {
+    /// Greedy memory allocation (default, preserves current behavior).
+    Greedy,
+    /// Fair memory allocation: share available memory evenly among operators.
+    Fair,
+}
+
 /// Query engine config
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default)]
@@ -46,6 +82,25 @@ pub struct QueryOptions {
     /// Whether to expose per-region query load metrics.
     #[serde(skip)]
     pub enable_per_region_metrics: bool,
+    /// Experimental: spill-to-disk mode.
+    /// - `default`: preserve DataFusion built-in OS temp directory behavior.
+    /// - `custom`: explicitly configure spill path, max directory size, and compression.
+    /// - `disabled`: explicitly disable disk spilling.
+    pub experimental_spill_mode: QuerySpillMode,
+    /// Experimental: spill directory path. Ignored unless `experimental_spill_mode` is
+    /// `"custom"`. When set, spill files are written into this directory.
+    pub experimental_spill_path: Option<PathBuf>,
+    /// Experimental: maximum total size of the spill directory (data written to spill files).
+    /// Ignored unless `experimental_spill_mode` is `"custom"`. Default: `100GiB`.
+    pub experimental_spill_max_temp_directory_size: ReadableSize,
+    /// Experimental: compression algorithm applied to spilled data.
+    /// Ignored unless `experimental_spill_mode` is `"custom"`. Default: `uncompressed`.
+    pub experimental_spill_compression: QuerySpillCompression,
+    /// Experimental: memory pool allocation policy.
+    /// - `greedy` (default): preserves current behavior.
+    /// - `fair`: share memory evenly among spillable operators.
+    /// Only effective when `memory_pool_size` is bounded (>0).
+    pub experimental_memory_pool_policy: QueryMemoryPoolPolicy,
 }
 
 #[allow(clippy::derivable_impls)]
@@ -56,6 +111,11 @@ impl Default for QueryOptions {
             allow_query_fallback: false,
             memory_pool_size: MemoryLimit::default(),
             enable_per_region_metrics: false,
+            experimental_spill_mode: QuerySpillMode::Default,
+            experimental_spill_path: None,
+            experimental_spill_max_temp_directory_size: ReadableSize::gb(100),
+            experimental_spill_compression: QuerySpillCompression::Uncompressed,
+            experimental_memory_pool_policy: QueryMemoryPoolPolicy::Greedy,
         }
     }
 }
@@ -554,5 +614,207 @@ mod flow_extension_tests {
             parsed.incremental_after_seqs,
             Some(HashMap::from([(1, 10)]))
         );
+    }
+}
+
+#[cfg(test)]
+mod query_options_tests {
+    use super::*;
+
+    #[test]
+    fn test_query_options_defaults() {
+        let opts = QueryOptions::default();
+        assert_eq!(opts.parallelism, 0);
+        assert!(!opts.allow_query_fallback);
+        assert!(opts.memory_pool_size.is_unlimited());
+        assert!(!opts.enable_per_region_metrics);
+        assert_eq!(opts.experimental_spill_mode, QuerySpillMode::Default);
+        assert_eq!(opts.experimental_spill_path, None);
+        assert_eq!(
+            opts.experimental_spill_max_temp_directory_size,
+            ReadableSize::gb(100)
+        );
+        assert_eq!(
+            opts.experimental_spill_compression,
+            QuerySpillCompression::Uncompressed
+        );
+        assert_eq!(
+            opts.experimental_memory_pool_policy,
+            QueryMemoryPoolPolicy::Greedy
+        );
+    }
+
+    #[test]
+    fn test_selected_defaults_parse() {
+        let toml_str = "";
+        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
+        let def = QueryOptions::default();
+        assert_eq!(opts, def);
+    }
+
+    #[test]
+    fn test_parse_experimental_spill_mode() {
+        let toml_str = r#"experimental_spill_mode = "custom""#;
+        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
+        assert_eq!(opts.experimental_spill_mode, QuerySpillMode::Custom);
+
+        let toml_str = r#"experimental_spill_mode = "disabled""#;
+        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
+        assert_eq!(opts.experimental_spill_mode, QuerySpillMode::Disabled);
+
+        let toml_str = r#"experimental_spill_mode = "default""#;
+        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
+        assert_eq!(opts.experimental_spill_mode, QuerySpillMode::Default);
+    }
+
+    #[test]
+    fn test_parse_invalid_spill_mode() {
+        let toml_str = r#"experimental_spill_mode = "invalid""#;
+        assert!(toml::from_str::<QueryOptions>(toml_str).is_err());
+    }
+
+    #[test]
+    fn test_parse_experimental_spill_compression() {
+        let toml_str = r#"experimental_spill_compression = "zstd""#;
+        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            opts.experimental_spill_compression,
+            QuerySpillCompression::Zstd
+        );
+
+        let toml_str = r#"experimental_spill_compression = "lz4_frame""#;
+        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            opts.experimental_spill_compression,
+            QuerySpillCompression::Lz4Frame
+        );
+    }
+
+    #[test]
+    fn test_parse_invalid_spill_compression() {
+        let toml_str = r#"experimental_spill_compression = "gzip""#;
+        assert!(toml::from_str::<QueryOptions>(toml_str).is_err());
+    }
+
+    #[test]
+    fn test_parse_experimental_memory_pool_policy() {
+        let toml_str = r#"experimental_memory_pool_policy = "fair""#;
+        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            opts.experimental_memory_pool_policy,
+            QueryMemoryPoolPolicy::Fair
+        );
+
+        let toml_str = r#"experimental_memory_pool_policy = "greedy""#;
+        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            opts.experimental_memory_pool_policy,
+            QueryMemoryPoolPolicy::Greedy
+        );
+    }
+
+    #[test]
+    fn test_parse_invalid_memory_pool_policy() {
+        let toml_str = r#"experimental_memory_pool_policy = "none""#;
+        assert!(toml::from_str::<QueryOptions>(toml_str).is_err());
+    }
+
+    #[test]
+    fn test_parse_experimental_spill_path_and_quota() {
+        let toml_str = r#"
+experimental_spill_path = "/tmp/spill"
+experimental_spill_max_temp_directory_size = "50GiB"
+"#;
+        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            opts.experimental_spill_path,
+            Some(PathBuf::from("/tmp/spill"))
+        );
+        assert_eq!(
+            opts.experimental_spill_max_temp_directory_size,
+            ReadableSize::gb(50)
+        );
+    }
+
+    #[test]
+    fn test_parse_experimental_spill_path_none_when_absent() {
+        let toml_str = r#"experimental_spill_mode = "custom""#;
+        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
+        assert_eq!(opts.experimental_spill_path, None);
+    }
+
+    /// Verify that `experimental_spill_compression` only takes effect
+    /// when paired with `experimental_spill_mode = "custom"`. This test
+    /// asserts the config can be parsed regardless, but the semantics
+    /// in `state.rs` enforce that compression is only applied in Custom mode.
+    #[test]
+    fn test_parse_experimental_spill_compression_without_custom_mode() {
+        let toml_str = r#"experimental_spill_compression = "zstd""#;
+        // Should parse fine, even though semantically compression
+        // is ignored unless mode is "custom".
+        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            opts.experimental_spill_compression,
+            QuerySpillCompression::Zstd
+        );
+        assert_eq!(opts.experimental_spill_mode, QuerySpillMode::Default);
+    }
+
+    #[test]
+    fn test_parse_experimental_spill_max_temp_directory_size_default() {
+        let toml_str = "";
+        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            opts.experimental_spill_max_temp_directory_size,
+            ReadableSize::gb(100)
+        );
+    }
+
+    #[test]
+    fn test_parse_experimental_spill_max_temp_directory_size_human_readable() {
+        let toml_str = r#"experimental_spill_max_temp_directory_size = "2GB""#;
+        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            opts.experimental_spill_max_temp_directory_size,
+            ReadableSize::gb(2)
+        );
+    }
+
+    #[test]
+    fn test_query_spill_mode_serde_roundtrip() {
+        let modes = [
+            QuerySpillMode::Default,
+            QuerySpillMode::Custom,
+            QuerySpillMode::Disabled,
+        ];
+        for mode in modes {
+            let json = serde_json::to_string(&mode).unwrap();
+            let roundtripped: QuerySpillMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(mode, roundtripped);
+        }
+    }
+
+    #[test]
+    fn test_query_spill_compression_serde_roundtrip() {
+        let compressions = [
+            QuerySpillCompression::Uncompressed,
+            QuerySpillCompression::Lz4Frame,
+            QuerySpillCompression::Zstd,
+        ];
+        for comp in compressions {
+            let json = serde_json::to_string(&comp).unwrap();
+            let roundtripped: QuerySpillCompression = serde_json::from_str(&json).unwrap();
+            assert_eq!(comp, roundtripped);
+        }
+    }
+
+    #[test]
+    fn test_query_memory_pool_policy_serde_roundtrip() {
+        let policies = [QueryMemoryPoolPolicy::Greedy, QueryMemoryPoolPolicy::Fair];
+        for policy in policies {
+            let json = serde_json::to_string(&policy).unwrap();
+            let roundtripped: QueryMemoryPoolPolicy = serde_json::from_str(&json).unwrap();
+            assert_eq!(policy, roundtripped);
+        }
     }
 }

--- a/src/query/src/options.rs
+++ b/src/query/src/options.rs
@@ -99,6 +99,7 @@ pub struct QueryOptions {
     /// Experimental: memory pool allocation policy.
     /// - `greedy` (default): preserves current behavior.
     /// - `fair`: share memory evenly among spillable operators.
+    ///
     /// Only effective when `memory_pool_size` is bounded (>0).
     pub experimental_memory_pool_policy: QueryMemoryPoolPolicy,
 }

--- a/src/query/src/query_engine/state.rs
+++ b/src/query/src/query_engine/state.rs
@@ -34,8 +34,9 @@ use datafusion::dataframe::DataFrame;
 use datafusion::error::Result as DfResult;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::execution::context::{QueryPlanner, SessionConfig, SessionContext, SessionState};
+use datafusion::execution::disk_manager::{DiskManagerBuilder, DiskManagerMode};
 use datafusion::execution::memory_pool::{
-    GreedyMemoryPool, MemoryConsumer, MemoryLimit, MemoryPool, MemoryReservation,
+    FairSpillPool, GreedyMemoryPool, MemoryConsumer, MemoryLimit, MemoryPool, MemoryReservation,
     TrackConsumersPool,
 };
 use datafusion::execution::runtime_env::{RuntimeEnv, RuntimeEnvBuilder};
@@ -44,6 +45,7 @@ use datafusion::physical_optimizer::optimizer::PhysicalOptimizer;
 use datafusion::physical_optimizer::sanity_checker::SanityCheckPlan;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_planner::{DefaultPhysicalPlanner, ExtensionPlanner, PhysicalPlanner};
+use datafusion_common::config::SpillCompression;
 use datafusion_expr::{AggregateUDF, LogicalPlan as DfLogicalPlan, WindowUDF};
 use datafusion_optimizer::Analyzer;
 use datafusion_optimizer::analyzer::function_rewrite::ApplyFunctionRewrites;
@@ -76,7 +78,9 @@ use crate::optimizer::string_normalization::StringNormalizationRule;
 use crate::optimizer::transcribe_atat::TranscribeAtatRule;
 use crate::optimizer::type_conversion::TypeConversionRule;
 use crate::optimizer::windowed_sort::WindowedSortPhysicalRule;
-use crate::options::QueryOptions as QueryOptionsNew;
+use crate::options::{
+    QueryMemoryPoolPolicy, QueryOptions as QueryOptionsNew, QuerySpillCompression, QuerySpillMode,
+};
 use crate::query_engine::DefaultSerializer;
 use crate::query_engine::options::QueryOptions;
 use crate::range_select::planner::RangeSelectPlanner;
@@ -119,16 +123,7 @@ impl QueryEngineState {
     ) -> Self {
         let total_memory = get_total_memory_bytes().max(0) as u64;
         let memory_pool_size = options.memory_pool_size.resolve(total_memory) as usize;
-        let runtime_env = if memory_pool_size > 0 {
-            Arc::new(
-                RuntimeEnvBuilder::new()
-                    .with_memory_pool(Arc::new(MetricsMemoryPool::new(memory_pool_size)))
-                    .build()
-                    .expect("Failed to build RuntimeEnv"),
-            )
-        } else {
-            Arc::new(RuntimeEnv::default())
-        };
+        let runtime_env = build_runtime_env(&options, memory_pool_size);
         let mut session_config = SessionConfig::new().with_create_default_catalog_and_schema(false);
         if options.parallelism > 0 {
             session_config = session_config.with_target_partitions(options.parallelism);
@@ -140,6 +135,15 @@ impl QueryEngineState {
                 .insert(DistPlannerOptions {
                     allow_query_fallback: true,
                 });
+        }
+
+        // Set spill compression on session config only when spill mode is
+        // Custom. In Default/Disabled modes, DataFusion's own default
+        // (Uncompressed) is preserved—setting compression when spill is not
+        // explicitly configured would be misleading.
+        if options.experimental_spill_mode == QuerySpillMode::Custom {
+            session_config.options_mut().execution.spill_compression =
+                spill_compression_from_options(options.experimental_spill_compression);
         }
 
         // todo(hl): This serves as a workaround for https://github.com/GreptimeTeam/greptimedb/issues/5659
@@ -536,26 +540,37 @@ impl DfQueryPlanner {
     }
 }
 
-/// A wrapper around TrackConsumersPool that records metrics.
+/// A wrapper around a memory pool that records metrics.
 ///
 /// This wrapper intercepts all memory pool operations and updates
 /// Prometheus metrics for monitoring query memory usage and rejections.
+///
+/// The inner pool is always wrapped with `TrackConsumersPool` to preserve
+/// top-consumer error context on rejection, regardless of whether the
+/// underlying pool is greedy or fair.
 #[derive(Debug)]
 struct MetricsMemoryPool {
-    inner: Arc<TrackConsumersPool<GreedyMemoryPool>>,
+    inner: Arc<dyn MemoryPool>,
 }
 
 impl MetricsMemoryPool {
     // Number of top memory consumers to report in OOM error messages
     const TOP_CONSUMERS_TO_REPORT: usize = 5;
 
-    fn new(limit: usize) -> Self {
-        Self {
-            inner: Arc::new(TrackConsumersPool::new(
-                GreedyMemoryPool::new(limit),
-                NonZeroUsize::new(Self::TOP_CONSUMERS_TO_REPORT).unwrap(),
-            )),
-        }
+    /// Create a new metrics-wrapped memory pool with the given size limit and
+    /// allocation policy. Both greedy and fair pools are wrapped in
+    /// [`TrackConsumersPool`] to preserve top-consumer error context on rejection.
+    fn new(limit: usize, policy: QueryMemoryPoolPolicy) -> Self {
+        let top_n = NonZeroUsize::new(Self::TOP_CONSUMERS_TO_REPORT).unwrap();
+        let inner: Arc<dyn MemoryPool> = match policy {
+            QueryMemoryPoolPolicy::Greedy => {
+                Arc::new(TrackConsumersPool::new(GreedyMemoryPool::new(limit), top_n))
+            }
+            QueryMemoryPoolPolicy::Fair => {
+                Arc::new(TrackConsumersPool::new(FairSpillPool::new(limit), top_n))
+            }
+        };
+        Self { inner }
     }
 
     #[inline]
@@ -603,6 +618,80 @@ impl MemoryPool for MetricsMemoryPool {
     fn memory_limit(&self) -> MemoryLimit {
         self.inner.memory_limit()
     }
+}
+
+/// Map [`QuerySpillCompression`] to DataFusion's [`SpillCompression`].
+///
+/// This conversion is intentionally not a `From` impl because the
+/// semantics depend on the spill mode; callers should only invoke
+/// this when `experimental_spill_mode == Custom`.
+fn spill_compression_from_options(comp: QuerySpillCompression) -> SpillCompression {
+    match comp {
+        QuerySpillCompression::Uncompressed => SpillCompression::Uncompressed,
+        QuerySpillCompression::Lz4Frame => SpillCompression::Lz4Frame,
+        QuerySpillCompression::Zstd => SpillCompression::Zstd,
+    }
+}
+
+/// Build an [`Arc<RuntimeEnv>`] from query options and resolved memory pool size.
+///
+/// # Spill mode behavior
+///
+/// - `Default`: preserves DataFusion built-in behavior. No custom disk manager
+///   builder is attached. A bounded metrics memory pool is attached only when
+///   `memory_pool_size > 0`.
+/// - `Custom`: attaches a [`DiskManagerBuilder`] with an optional explicit
+///   directory and max temp directory size.
+/// - `Disabled`: explicitly uses [`DiskManagerMode::Disabled`]; temporary file
+///   creation will error.
+///
+/// # Panics
+///
+/// Panics if `RuntimeEnvBuilder::build()` fails (e.g., cannot create the
+/// configured spill directory). The panic message includes the spill mode,
+/// path, and quota for diagnostics.
+fn build_runtime_env(options: &QueryOptionsNew, memory_pool_size: usize) -> Arc<RuntimeEnv> {
+    let mut builder = RuntimeEnvBuilder::new();
+
+    // Attach the bounded metrics memory pool only when limit is set (>0).
+    // When unbounded (0), use the builder default / UnboundedMemoryPool.
+    if memory_pool_size > 0 {
+        let pool =
+            MetricsMemoryPool::new(memory_pool_size, options.experimental_memory_pool_policy);
+        builder = builder.with_memory_pool(Arc::new(pool));
+    }
+
+    match options.experimental_spill_mode {
+        QuerySpillMode::Default => {
+            // No custom disk manager builder; preserve DataFusion default OS temp dir.
+        }
+        QuerySpillMode::Disabled => {
+            let dm_builder = DiskManagerBuilder::default().with_mode(DiskManagerMode::Disabled);
+            builder = builder.with_disk_manager_builder(dm_builder);
+        }
+        QuerySpillMode::Custom => {
+            let mut dm_builder = DiskManagerBuilder::default();
+            if let Some(ref path) = options.experimental_spill_path {
+                dm_builder = dm_builder.with_mode(DiskManagerMode::Directories(vec![path.clone()]));
+            }
+            dm_builder = dm_builder.with_max_temp_directory_size(
+                options
+                    .experimental_spill_max_temp_directory_size
+                    .as_bytes(),
+            );
+            builder = builder.with_disk_manager_builder(dm_builder);
+        }
+    }
+
+    builder.build().map(Arc::new).unwrap_or_else(|e| {
+        panic!(
+            "Failed to build DataFusion RuntimeEnv: {e}\
+             (spill_mode={:?}, spill_path={:?}, spill_max_temp_directory_size={})",
+            options.experimental_spill_mode,
+            options.experimental_spill_path,
+            options.experimental_spill_max_temp_directory_size,
+        )
+    })
 }
 
 #[cfg(test)]
@@ -688,5 +777,718 @@ mod tests {
             second.registry().query_id(),
             second_query_ctx.remote_query_id_value().unwrap()
         );
+    }
+
+    // --- spill / memory pool tests ---
+
+    /// Default mode: unbounded memory, OS temp dir disk manager.
+    #[test]
+    fn test_build_runtime_env_default_mode_unbounded() {
+        let opts = QueryOptions::default();
+        let env = build_runtime_env(&opts, 0);
+        // Default mode + unbounded pool: no custom disk manager override,
+        // so tmp files should be enabled (DataFusion default).
+        assert!(env.disk_manager.tmp_files_enabled());
+    }
+
+    /// Default mode with bounded memory: pool is attached but disk manager
+    /// remains default.
+    #[test]
+    fn test_build_runtime_env_default_mode_bounded() {
+        let mut opts = QueryOptions::default();
+        opts.memory_pool_size = common_base::memory_limit::MemoryLimit::Size(
+            common_base::readable_size::ReadableSize::mb(128),
+        );
+        let env = build_runtime_env(&opts, 128 * 1024 * 1024);
+        // Bounded pool is attached
+        assert!(env.memory_pool.reserved() == 0);
+        // Disk manager remains default (OS temp dir)
+        assert!(env.disk_manager.tmp_files_enabled());
+    }
+
+    /// Custom mode with explicit path: disk manager is configured with the
+    /// custom directory and the directory actually gets created.
+    #[test]
+    fn test_build_runtime_env_custom_mode_with_path() {
+        // Use a temp directory managed manually so we don't need the `tempfile` crate.
+        let spill_dir = std::env::temp_dir().join(format!("df_spill_test_{}", std::process::id()));
+        // Clean up if exists from a previous run
+        let _ = std::fs::remove_dir_all(&spill_dir);
+        let mut opts = QueryOptions::default();
+        opts.experimental_spill_mode = QuerySpillMode::Custom;
+        opts.experimental_spill_path = Some(spill_dir.clone());
+        opts.experimental_spill_max_temp_directory_size =
+            common_base::readable_size::ReadableSize::gb(1);
+        let env = build_runtime_env(&opts, 0);
+
+        assert!(env.disk_manager.tmp_files_enabled());
+        // Creating a temp file should succeed
+        let tmp_file = env.disk_manager.create_tmp_file("test spill");
+        assert!(tmp_file.is_ok());
+        // The directory should have been created
+        assert!(spill_dir.exists());
+
+        // Cleanup
+        let _ = std::fs::remove_dir_all(&spill_dir);
+    }
+
+    /// Disabled mode: tmp files are disabled; creating a temp file returns an error.
+    #[test]
+    fn test_build_runtime_env_disabled_mode() {
+        let mut opts = QueryOptions::default();
+        opts.experimental_spill_mode = QuerySpillMode::Disabled;
+        let env = build_runtime_env(&opts, 0);
+
+        assert!(!env.disk_manager.tmp_files_enabled());
+        let result = env.disk_manager.create_tmp_file("test spill");
+        assert!(result.is_err());
+        assert!(format!("{}", result.unwrap_err()).contains("DiskManager is disabled"));
+    }
+
+    /// MetricsMemoryPool defaults to greedy with TrackConsumersPool wrapping.
+    #[test]
+    fn test_metrics_memory_pool_default_greedy() {
+        let pool = MetricsMemoryPool::new(1024, QueryMemoryPoolPolicy::Greedy);
+        assert!(matches!(pool.memory_limit(), MemoryLimit::Finite(1024)));
+        // Smoke test: register a consumer and grow
+        let pool: Arc<dyn MemoryPool> = Arc::new(pool);
+        let consumer = MemoryConsumer::new("test");
+        let reservation = consumer.register(&pool);
+        pool.try_grow(&reservation, 128).unwrap();
+        assert!(pool.reserved() > 0);
+    }
+
+    /// MetricsMemoryPool with fair policy: still wrapped in TrackConsumersPool.
+    #[test]
+    fn test_metrics_memory_pool_fair() {
+        let pool = MetricsMemoryPool::new(1024, QueryMemoryPoolPolicy::Fair);
+        assert!(matches!(pool.memory_limit(), MemoryLimit::Finite(1024)));
+        let pool: Arc<dyn MemoryPool> = Arc::new(pool);
+        let consumer = MemoryConsumer::new("test fair");
+        let reservation = consumer.register(&pool);
+        pool.try_grow(&reservation, 128).unwrap();
+        assert!(pool.reserved() > 0);
+    }
+
+    /// Bounded fair pool rejects over-limit growth.
+    #[test]
+    fn test_metrics_memory_pool_fair_rejects_over_limit() {
+        let pool = MetricsMemoryPool::new(200, QueryMemoryPoolPolicy::Fair);
+        let pool: Arc<dyn MemoryPool> = Arc::new(pool);
+        let consumer = MemoryConsumer::new("test fair oom");
+        let reservation = consumer.register(&pool);
+        let result = pool.try_grow(&reservation, 201);
+        assert!(result.is_err(), "expected error but got Ok");
+    }
+
+    /// Bounded greedy pool rejects over-limit growth.
+    #[test]
+    fn test_metrics_memory_pool_greedy_rejects_over_limit() {
+        let pool = MetricsMemoryPool::new(200, QueryMemoryPoolPolicy::Greedy);
+        let pool: Arc<dyn MemoryPool> = Arc::new(pool);
+        let consumer = MemoryConsumer::new("test greedy oom");
+        let reservation = consumer.register(&pool);
+        let result = pool.try_grow(&reservation, 201);
+        assert!(result.is_err(), "expected error but got Ok");
+    }
+
+    // --- end-to-end spill smoke test ---
+
+    /// Builds a runtime with custom spill configuration and a bounded memory
+    /// pool, then runs sort queries that probe spill-to-disk behaviour:
+    ///
+    /// - Phase 1: a pool too small to sort in-memory → OOM (proves pool active).
+    /// - Phase 2: a pool large enough for merge chunks but still much smaller
+    ///   than the total data.  Executes the physical plan directly so we can
+    ///   walk the plan tree afterwards and sum `spill_count` / `spilled_rows` /
+    ///   `spilled_bytes` on `SortExec` nodes.  All three must be > 0.
+    ///
+    /// Also checks the custom spill-path directory was initialised, pool
+    /// reserved returns to 0, and output is correctly sorted.
+    #[tokio::test]
+    async fn test_sort_spill_smoke_with_custom_runtime() {
+        // ---- shared imports (in-function to avoid polluting the module) ----
+        use arrow::array::Int32Array;
+        use arrow::datatypes::{DataType, Field, Schema};
+        use arrow::record_batch::RecordBatch;
+        use datafusion::datasource::MemTable;
+        use datafusion::physical_plan::collect as df_collect;
+
+        // ---- setup: spill directory ----
+        let spill_dir =
+            std::env::temp_dir().join(format!("greptime_spill_smoke_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&spill_dir);
+
+        // ---- shared options ----
+        let mut opts = QueryOptions::default();
+        opts.experimental_spill_mode = QuerySpillMode::Custom;
+        opts.experimental_spill_path = Some(spill_dir.clone());
+        opts.experimental_spill_max_temp_directory_size =
+            common_base::readable_size::ReadableSize::gb(1);
+        opts.experimental_memory_pool_policy = QueryMemoryPoolPolicy::Greedy;
+
+        // ---- shared session config ----
+        let session_config = SessionConfig::new()
+            .with_target_partitions(1)
+            .with_sort_in_place_threshold_bytes(0)
+            .with_sort_spill_reservation_bytes(64 * 1024);
+
+        // ---- data: 200 K rows Int32×2, split into 40 batches of 5 K ----
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("val", DataType::Int32, false),
+        ]));
+        let n_rows: i32 = 200_000;
+        let batch_size: i32 = 5_000;
+        let partitions = 1usize;
+
+        let mut table_partitions: Vec<Vec<RecordBatch>> = Vec::with_capacity(partitions);
+        for _ in 0..partitions {
+            let mut batches = Vec::new();
+            let mut row_offset: i32 = 0;
+            while row_offset < n_rows {
+                let chunk_end = (row_offset + batch_size).min(n_rows);
+                let chunk_len = (chunk_end - row_offset) as usize;
+                let mut id_builder = Int32Array::builder(chunk_len);
+                let mut val_builder = Int32Array::builder(chunk_len);
+                for i in row_offset..chunk_end {
+                    id_builder.append_value(i);
+                    val_builder.append_value(n_rows - 1 - i);
+                }
+                batches.push(
+                    RecordBatch::try_new(
+                        Arc::clone(&schema),
+                        vec![
+                            Arc::new(id_builder.finish()),
+                            Arc::new(val_builder.finish()),
+                        ],
+                    )
+                    .unwrap(),
+                );
+                row_offset = chunk_end;
+            }
+            table_partitions.push(batches);
+        }
+
+        // ---- helper: build a SessionContext from options + data ----
+        fn build_ctx(
+            session_config: &SessionConfig,
+            runtime: &Arc<RuntimeEnv>,
+            schema: &Arc<Schema>,
+            partitions: &[Vec<RecordBatch>],
+        ) -> SessionContext {
+            let session_state = SessionStateBuilder::new()
+                .with_config(session_config.clone())
+                .with_runtime_env(Arc::clone(runtime))
+                .with_default_features()
+                .build();
+            let ctx = SessionContext::new_with_state(session_state);
+            let table = MemTable::try_new(Arc::clone(schema), partitions.to_vec()).unwrap();
+            ctx.register_table("t", Arc::new(table)).unwrap();
+            ctx
+        }
+
+        // ---- Phase 1: 64 KB pool → OOM (proves pool is active) ----
+        {
+            let mem_limit: usize = 64 * 1024;
+            let runtime = build_runtime_env(&opts, mem_limit);
+            let ctx = build_ctx(&session_config, &runtime, &schema, &table_partitions);
+            let result = ctx
+                .sql("SELECT * FROM t ORDER BY val ASC")
+                .await
+                .unwrap()
+                .collect()
+                .await;
+            assert!(
+                result.is_err(),
+                "64 KB pool should be too small for 200K rows, but query succeeded"
+            );
+            let err_msg = format!("{}", result.unwrap_err());
+            assert!(
+                err_msg.contains("Resources exhausted") || err_msg.contains("Memory Exhausted"),
+                "error should mention resource exhaustion: {err_msg}"
+            );
+            assert_eq!(runtime.memory_pool.reserved(), 0);
+        }
+
+        // ---- Phase 2: 512 KB pool → spilling to disk ----
+        {
+            let mem_limit: usize = 512 * 1024; // 512 KB pool, 64 KB reserved for merge
+
+            let runtime = build_runtime_env(&opts, mem_limit);
+            assert_eq!(runtime.memory_pool.reserved(), 0);
+            let ctx = build_ctx(&session_config, &runtime, &schema, &table_partitions);
+
+            // Execute via direct physical-plan path so we can inspect metrics.
+            let df = ctx
+                .sql("SELECT val FROM t ORDER BY val ASC")
+                .await
+                .expect("planning ORDER BY");
+            let plan = df
+                .create_physical_plan()
+                .await
+                .expect("creating physical plan");
+            let task_ctx = ctx.task_ctx();
+
+            let batches = df_collect(Arc::clone(&plan), task_ctx)
+                .await
+                .expect("executing ORDER BY");
+
+            // ---- spill metrics on SortExec nodes ----
+            let (spill_count, spilled_rows, spilled_bytes, _sort_elapsed_ns) =
+                sum_sort_spill_metrics(&plan);
+            assert!(
+                spill_count > 0,
+                "expected SortExec spill_count > 0 (pool={} KB, reservation=64 KB), got 0",
+                mem_limit / 1024,
+            );
+            assert!(
+                spilled_rows > 0,
+                "expected SortExec spilled_rows > 0, got 0 \
+                 (spill_count={spill_count}, spilled_bytes={spilled_bytes})",
+            );
+            assert!(
+                spilled_bytes > 0,
+                "expected SortExec spilled_bytes > 0, got 0 \
+                 (spill_count={spill_count}, spilled_rows={spilled_rows})",
+            );
+
+            // ---- correctness: row count & sorted order ----
+            let vals: Vec<i32> = batches
+                .iter()
+                .flat_map(|b| {
+                    let col = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+                    (0..b.num_rows()).map(move |i| col.value(i))
+                })
+                .collect();
+            assert_eq!(vals.len(), n_rows as usize);
+            for w in vals.windows(2) {
+                assert!(w[0] <= w[1], "sort order violation: {} > {}", w[0], w[1]);
+            }
+
+            // ---- spill-path directory was initialised ----
+            assert!(
+                std::fs::read_dir(&spill_dir)
+                    .ok()
+                    .map(|mut entries| entries.any(|e| {
+                        e.as_ref()
+                            .map(|de| de.file_name().to_string_lossy().starts_with("datafusion-"))
+                            .unwrap_or(false)
+                    }))
+                    .unwrap_or(false),
+                "Expected 'datafusion-*' directory in spill path {:?} \
+                 (DiskManager should create it on build).",
+                spill_dir,
+            );
+
+            // Memory pool fully released.
+            assert_eq!(runtime.memory_pool.reserved(), 0);
+        }
+
+        // ---- cleanup ----
+        let _ = std::fs::remove_dir_all(&spill_dir);
+    }
+
+    /// Manual local benchmark for spill-to-disk experiments.
+    ///
+    /// This is ignored by default and intended for local tuning only. Example:
+    ///
+    /// ```text
+    /// GT_SPILL_BENCH_ROWS=1000000 \
+    /// GT_SPILL_BENCH_PAYLOAD_MODE=metric \
+    /// GT_SPILL_BENCH_PAYLOAD_BYTES=256 \
+    /// GT_SPILL_BENCH_REPEATS=2 \
+    /// GT_SPILL_BENCH_SPILL_MB_LIST=64,128,256,384,512 \
+    /// GT_SPILL_BENCH_INMEM_MB=2048 \
+    /// GT_SPILL_BENCH_CASES=spill-fair-uncompressed \
+    /// cargo test --release -p query -- bench_sort_spill_local --ignored --nocapture --test-threads=1
+    /// ```
+    #[tokio::test]
+    #[ignore]
+    async fn bench_sort_spill_local() {
+        use std::time::Instant;
+
+        use arrow::array::{Int32Array, StringBuilder};
+        use arrow::datatypes::{DataType, Field, Schema};
+        use arrow::record_batch::RecordBatch;
+        use datafusion::datasource::MemTable;
+        use datafusion::physical_plan::collect as df_collect;
+
+        fn env_usize(name: &str, default: usize) -> usize {
+            std::env::var(name)
+                .ok()
+                .and_then(|value| value.parse().ok())
+                .unwrap_or(default)
+        }
+
+        fn env_usize_list(name: &str, default: Vec<usize>) -> Vec<usize> {
+            std::env::var(name)
+                .ok()
+                .map(|value| {
+                    value
+                        .split(',')
+                        .filter_map(|item| {
+                            let item = item.trim();
+                            if item.is_empty() {
+                                None
+                            } else {
+                                Some(item.parse::<usize>().unwrap())
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .filter(|values| !values.is_empty())
+                .unwrap_or(default)
+        }
+
+        fn mix64(mut value: u64) -> u64 {
+            value = value.wrapping_add(0x9e3779b97f4a7c15);
+            value = (value ^ (value >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
+            value = (value ^ (value >> 27)).wrapping_mul(0x94d049bb133111eb);
+            value ^ (value >> 31)
+        }
+
+        fn write_payload(buf: &mut String, mode: &str, row: usize, target_len: usize) {
+            use std::fmt::Write;
+
+            buf.clear();
+            match mode {
+                "repeat" => {
+                    buf.extend(std::iter::repeat_n('x', target_len));
+                }
+                "metric" => {
+                    let h1 = mix64(row as u64);
+                    let h2 = mix64((row as u64) ^ 0x517cc1b727220a95);
+                    write!(
+                        buf,
+                        "metric=cpu_usage,host=host-{:06},region=region-{},service=svc-{},pod=pod-{:08x},instance={:016x}",
+                        row % 1_000_000,
+                        row % 32,
+                        row % 4096,
+                        h1 as u32,
+                        h2,
+                    )
+                    .unwrap();
+                    let mut tag = 0;
+                    while buf.len() < target_len {
+                        let hash = mix64((row as u64).wrapping_add(tag));
+                        write!(buf, ",tag{}={:016x}", tag, hash).unwrap();
+                        tag += 1;
+                    }
+                    buf.truncate(target_len);
+                }
+                "random" => {
+                    let mut tag = 0;
+                    while buf.len() < target_len {
+                        let hash = mix64((row as u64).wrapping_add(tag));
+                        write!(buf, "{:016x}", hash).unwrap();
+                        tag += 1;
+                    }
+                    buf.truncate(target_len);
+                }
+                other => panic!("unsupported GT_SPILL_BENCH_PAYLOAD_MODE: {other}"),
+            }
+        }
+
+        fn memory_limit_label(limit: usize) -> String {
+            if limit == 0 {
+                "unlimited".to_string()
+            } else {
+                format!("{}MiB", limit / 1024 / 1024)
+            }
+        }
+
+        fn env_string_list(name: &str) -> Vec<String> {
+            std::env::var(name)
+                .ok()
+                .map(|value| {
+                    value
+                        .split(',')
+                        .map(str::trim)
+                        .filter(|item| !item.is_empty())
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default()
+        }
+
+        let n_rows = env_usize("GT_SPILL_BENCH_ROWS", 300_000);
+        let batch_size = env_usize("GT_SPILL_BENCH_BATCH_SIZE", 10_000);
+        let payload_bytes = env_usize("GT_SPILL_BENCH_PAYLOAD_BYTES", 128);
+        let payload_mode =
+            std::env::var("GT_SPILL_BENCH_PAYLOAD_MODE").unwrap_or_else(|_| "repeat".to_string());
+        let repeats = env_usize("GT_SPILL_BENCH_REPEATS", 3);
+        let spill_mb = env_usize("GT_SPILL_BENCH_SPILL_MB", 16);
+        let spill_mb_list = env_usize_list("GT_SPILL_BENCH_SPILL_MB_LIST", vec![spill_mb]);
+        let in_memory_mb = env_usize("GT_SPILL_BENCH_INMEM_MB", 256);
+        let sort_reservation_mb = env_usize("GT_SPILL_BENCH_SORT_RESERVATION_MB", 1);
+        let case_filter = env_string_list("GT_SPILL_BENCH_CASES");
+        let in_memory_limit = in_memory_mb * 1024 * 1024;
+        let sort_reservation = sort_reservation_mb * 1024 * 1024;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("val", DataType::Int32, false),
+            Field::new("payload", DataType::Utf8, false),
+        ]));
+
+        let mut batches = Vec::new();
+        let mut row_offset = 0usize;
+        let mut payload = String::with_capacity(payload_bytes + 128);
+        while row_offset < n_rows {
+            let chunk_end = (row_offset + batch_size).min(n_rows);
+            let chunk_len = chunk_end - row_offset;
+            let mut id_builder = Int32Array::builder(chunk_len);
+            let mut val_builder = Int32Array::builder(chunk_len);
+            let mut payload_builder = StringBuilder::new();
+            for i in row_offset..chunk_end {
+                id_builder.append_value(i as i32);
+                val_builder.append_value((n_rows - 1 - i) as i32);
+                write_payload(&mut payload, payload_mode.as_str(), i, payload_bytes);
+                payload_builder.append_value(payload.as_str());
+            }
+            batches.push(
+                RecordBatch::try_new(
+                    Arc::clone(&schema),
+                    vec![
+                        Arc::new(id_builder.finish()),
+                        Arc::new(val_builder.finish()),
+                        Arc::new(payload_builder.finish()),
+                    ],
+                )
+                .unwrap(),
+            );
+            row_offset = chunk_end;
+        }
+        let table_partitions = vec![batches];
+
+        fn build_ctx(
+            mut session_config: SessionConfig,
+            opts: &QueryOptions,
+            runtime: &Arc<RuntimeEnv>,
+            schema: &Arc<Schema>,
+            partitions: &[Vec<RecordBatch>],
+        ) -> SessionContext {
+            if opts.experimental_spill_mode == QuerySpillMode::Custom {
+                session_config.options_mut().execution.spill_compression =
+                    spill_compression_from_options(opts.experimental_spill_compression);
+            }
+            let session_state = SessionStateBuilder::new()
+                .with_config(session_config)
+                .with_runtime_env(Arc::clone(runtime))
+                .with_default_features()
+                .build();
+            let ctx = SessionContext::new_with_state(session_state);
+            let table = MemTable::try_new(Arc::clone(schema), partitions.to_vec()).unwrap();
+            ctx.register_table("t", Arc::new(table)).unwrap();
+            ctx
+        }
+
+        #[derive(Clone, Copy)]
+        struct Case {
+            name: &'static str,
+            mode: QuerySpillMode,
+            compression: QuerySpillCompression,
+            policy: QueryMemoryPoolPolicy,
+            mem_limit: usize,
+        }
+
+        let mut cases = Vec::new();
+        for spill_mb in &spill_mb_list {
+            let mem_limit = spill_mb * 1024 * 1024;
+            cases.extend([
+                Case {
+                    name: "disabled-same-limit",
+                    mode: QuerySpillMode::Disabled,
+                    compression: QuerySpillCompression::Uncompressed,
+                    policy: QueryMemoryPoolPolicy::Greedy,
+                    mem_limit,
+                },
+                Case {
+                    name: "spill-greedy-uncompressed",
+                    mode: QuerySpillMode::Custom,
+                    compression: QuerySpillCompression::Uncompressed,
+                    policy: QueryMemoryPoolPolicy::Greedy,
+                    mem_limit,
+                },
+                Case {
+                    name: "spill-greedy-lz4",
+                    mode: QuerySpillMode::Custom,
+                    compression: QuerySpillCompression::Lz4Frame,
+                    policy: QueryMemoryPoolPolicy::Greedy,
+                    mem_limit,
+                },
+                Case {
+                    name: "spill-greedy-zstd",
+                    mode: QuerySpillMode::Custom,
+                    compression: QuerySpillCompression::Zstd,
+                    policy: QueryMemoryPoolPolicy::Greedy,
+                    mem_limit,
+                },
+                Case {
+                    name: "spill-fair-uncompressed",
+                    mode: QuerySpillMode::Custom,
+                    compression: QuerySpillCompression::Uncompressed,
+                    policy: QueryMemoryPoolPolicy::Fair,
+                    mem_limit,
+                },
+            ]);
+        }
+        cases.extend([
+            Case {
+                name: "bounded-inmem-greedy-uncompressed",
+                mode: QuerySpillMode::Custom,
+                compression: QuerySpillCompression::Uncompressed,
+                policy: QueryMemoryPoolPolicy::Greedy,
+                mem_limit: in_memory_limit,
+            },
+            Case {
+                name: "unlimited-greedy-uncompressed",
+                mode: QuerySpillMode::Custom,
+                compression: QuerySpillCompression::Uncompressed,
+                policy: QueryMemoryPoolPolicy::Greedy,
+                mem_limit: 0,
+            },
+        ]);
+
+        if !case_filter.is_empty() {
+            cases.retain(|case| case_filter.iter().any(|name| name == case.name));
+            assert!(
+                !cases.is_empty(),
+                "GT_SPILL_BENCH_CASES did not match any benchmark cases: {:?}",
+                case_filter
+            );
+        }
+
+        let base_spill_dir =
+            std::env::temp_dir().join(format!("greptime_spill_bench_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base_spill_dir);
+
+        println!(
+            "BENCH_DATA rows={} batch_size={} payload_mode={} payload_bytes={} raw_payload_mb={:.1} repeats={} spill_mb_list={:?} in_memory_mb={} sort_reservation_mb={} cases={:?}",
+            n_rows,
+            batch_size,
+            payload_mode,
+            payload_bytes,
+            n_rows as f64 * payload_bytes as f64 / (1024.0 * 1024.0),
+            repeats,
+            spill_mb_list,
+            in_memory_mb,
+            sort_reservation_mb,
+            case_filter,
+        );
+        println!(
+            "BENCH_COLUMNS name,memory_limit,iter,status,elapsed_ms,sort_elapsed_ms,spill_count,spilled_rows,spilled_bytes,memory_reserved,error"
+        );
+
+        for case in cases {
+            for iter in 0..repeats {
+                let spill_dir = base_spill_dir.join(format!("{}-{}", case.name, iter));
+                let _ = std::fs::remove_dir_all(&spill_dir);
+                std::fs::create_dir_all(&spill_dir).unwrap();
+
+                let mut opts = QueryOptions::default();
+                opts.experimental_spill_mode = case.mode;
+                opts.experimental_spill_path = Some(spill_dir.clone());
+                opts.experimental_spill_max_temp_directory_size =
+                    common_base::readable_size::ReadableSize::gb(8);
+                opts.experimental_spill_compression = case.compression;
+                opts.experimental_memory_pool_policy = case.policy;
+
+                let runtime = build_runtime_env(&opts, case.mem_limit);
+                let session_config = SessionConfig::new()
+                    .with_target_partitions(1)
+                    .with_sort_in_place_threshold_bytes(0)
+                    .with_sort_spill_reservation_bytes(sort_reservation);
+                let ctx = build_ctx(session_config, &opts, &runtime, &schema, &table_partitions);
+
+                let started = Instant::now();
+                let result = async {
+                    let df = ctx
+                        .sql("SELECT val, payload FROM t ORDER BY val ASC")
+                        .await?;
+                    let plan = df.create_physical_plan().await?;
+                    let batches = df_collect(Arc::clone(&plan), ctx.task_ctx()).await?;
+                    let (spill_count, spilled_rows, spilled_bytes, sort_elapsed_ns) =
+                        sum_sort_spill_metrics(&plan);
+                    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+                    assert_eq!(rows, n_rows);
+                    Ok::<_, datafusion_common::DataFusionError>((
+                        spill_count,
+                        spilled_rows,
+                        spilled_bytes,
+                        sort_elapsed_ns,
+                    ))
+                }
+                .await;
+                let elapsed = started.elapsed();
+                let mem_label = memory_limit_label(case.mem_limit);
+                match result {
+                    Ok((spill_count, spilled_rows, spilled_bytes, sort_elapsed_ns)) => println!(
+                        "BENCH_RESULT {},{},{},ok,{:.3},{:.3},{},{},{},{},",
+                        case.name,
+                        mem_label,
+                        iter,
+                        elapsed.as_secs_f64() * 1000.0,
+                        sort_elapsed_ns as f64 / 1_000_000.0,
+                        spill_count,
+                        spilled_rows,
+                        spilled_bytes,
+                        runtime.memory_pool.reserved(),
+                    ),
+                    Err(e) => println!(
+                        "BENCH_RESULT {},{},{},err,{:.3},0,0,0,0,{},{}",
+                        case.name,
+                        mem_label,
+                        iter,
+                        elapsed.as_secs_f64() * 1000.0,
+                        runtime.memory_pool.reserved(),
+                        format!("{e}").replace('\n', " "),
+                    ),
+                }
+                assert_eq!(runtime.memory_pool.reserved(), 0);
+            }
+        }
+
+        let _ = std::fs::remove_dir_all(&base_spill_dir);
+    }
+
+    /// Walk a physical plan tree, summing spill metrics and `elapsed_compute`
+    /// for every node whose name starts with `"SortExec"`.
+    fn sum_sort_spill_metrics(plan: &Arc<dyn ExecutionPlan>) -> (usize, usize, usize, usize) {
+        let mut spill_count = 0usize;
+        let mut spilled_rows = 0usize;
+        let mut spilled_bytes = 0usize;
+        let mut elapsed_compute_ns = 0usize;
+
+        fn walk(
+            plan: &Arc<dyn ExecutionPlan>,
+            sc: &mut usize,
+            sr: &mut usize,
+            sb: &mut usize,
+            elapsed: &mut usize,
+        ) {
+            let name = plan.name();
+            if name.starts_with("SortExec") {
+                if let Some(m) = plan.metrics() {
+                    *sc += m.spill_count().unwrap_or(0);
+                    *sr += m.spilled_rows().unwrap_or(0);
+                    *sb += m.spilled_bytes().unwrap_or(0);
+                    *elapsed += m.elapsed_compute().unwrap_or(0);
+                }
+            }
+            for child in plan.children() {
+                walk(child, sc, sr, sb, elapsed);
+            }
+        }
+
+        walk(
+            plan,
+            &mut spill_count,
+            &mut spilled_rows,
+            &mut spilled_bytes,
+            &mut elapsed_compute_ns,
+        );
+        (spill_count, spilled_rows, spilled_bytes, elapsed_compute_ns)
     }
 }

--- a/src/query/src/query_engine/state.rs
+++ b/src/query/src/query_engine/state.rs
@@ -795,10 +795,12 @@ mod tests {
     /// remains default.
     #[test]
     fn test_build_runtime_env_default_mode_bounded() {
-        let mut opts = QueryOptions::default();
-        opts.memory_pool_size = common_base::memory_limit::MemoryLimit::Size(
-            common_base::readable_size::ReadableSize::mb(128),
-        );
+        let opts = QueryOptions {
+            memory_pool_size: common_base::memory_limit::MemoryLimit::Size(
+                common_base::readable_size::ReadableSize::mb(128),
+            ),
+            ..Default::default()
+        };
         let env = build_runtime_env(&opts, 128 * 1024 * 1024);
         // Bounded pool is attached
         assert!(env.memory_pool.reserved() == 0);
@@ -814,11 +816,13 @@ mod tests {
         let spill_dir = std::env::temp_dir().join(format!("df_spill_test_{}", std::process::id()));
         // Clean up if exists from a previous run
         let _ = std::fs::remove_dir_all(&spill_dir);
-        let mut opts = QueryOptions::default();
-        opts.experimental_spill_mode = QuerySpillMode::Custom;
-        opts.experimental_spill_path = Some(spill_dir.clone());
-        opts.experimental_spill_max_temp_directory_size =
-            common_base::readable_size::ReadableSize::gb(1);
+        let opts = QueryOptions {
+            experimental_spill_mode: QuerySpillMode::Custom,
+            experimental_spill_path: Some(spill_dir.clone()),
+            experimental_spill_max_temp_directory_size:
+                common_base::readable_size::ReadableSize::gb(1),
+            ..Default::default()
+        };
         let env = build_runtime_env(&opts, 0);
 
         assert!(env.disk_manager.tmp_files_enabled());
@@ -835,8 +839,10 @@ mod tests {
     /// Disabled mode: tmp files are disabled; creating a temp file returns an error.
     #[test]
     fn test_build_runtime_env_disabled_mode() {
-        let mut opts = QueryOptions::default();
-        opts.experimental_spill_mode = QuerySpillMode::Disabled;
+        let opts = QueryOptions {
+            experimental_spill_mode: QuerySpillMode::Disabled,
+            ..Default::default()
+        };
         let env = build_runtime_env(&opts, 0);
 
         assert!(!env.disk_manager.tmp_files_enabled());
@@ -920,12 +926,14 @@ mod tests {
         let _ = std::fs::remove_dir_all(&spill_dir);
 
         // ---- shared options ----
-        let mut opts = QueryOptions::default();
-        opts.experimental_spill_mode = QuerySpillMode::Custom;
-        opts.experimental_spill_path = Some(spill_dir.clone());
-        opts.experimental_spill_max_temp_directory_size =
-            common_base::readable_size::ReadableSize::gb(1);
-        opts.experimental_memory_pool_policy = QueryMemoryPoolPolicy::Greedy;
+        let opts = QueryOptions {
+            experimental_spill_mode: QuerySpillMode::Custom,
+            experimental_spill_path: Some(spill_dir.clone()),
+            experimental_spill_max_temp_directory_size:
+                common_base::readable_size::ReadableSize::gb(1),
+            experimental_memory_pool_policy: QueryMemoryPoolPolicy::Greedy,
+            ..Default::default()
+        };
 
         // ---- shared session config ----
         let session_config = SessionConfig::new()
@@ -1105,6 +1113,7 @@ mod tests {
     /// ```
     #[tokio::test]
     #[ignore]
+    #[allow(clippy::print_stdout)]
     async fn bench_sort_spill_local() {
         use std::time::Instant;
 
@@ -1387,13 +1396,15 @@ mod tests {
                 let _ = std::fs::remove_dir_all(&spill_dir);
                 std::fs::create_dir_all(&spill_dir).unwrap();
 
-                let mut opts = QueryOptions::default();
-                opts.experimental_spill_mode = case.mode;
-                opts.experimental_spill_path = Some(spill_dir.clone());
-                opts.experimental_spill_max_temp_directory_size =
-                    common_base::readable_size::ReadableSize::gb(8);
-                opts.experimental_spill_compression = case.compression;
-                opts.experimental_memory_pool_policy = case.policy;
+                let opts = QueryOptions {
+                    experimental_spill_mode: case.mode,
+                    experimental_spill_path: Some(spill_dir.clone()),
+                    experimental_spill_max_temp_directory_size:
+                        common_base::readable_size::ReadableSize::gb(8),
+                    experimental_spill_compression: case.compression,
+                    experimental_memory_pool_policy: case.policy,
+                    ..Default::default()
+                };
 
                 let runtime = build_runtime_env(&opts, case.mem_limit);
                 let session_config = SessionConfig::new()
@@ -1469,13 +1480,13 @@ mod tests {
             elapsed: &mut usize,
         ) {
             let name = plan.name();
-            if name.starts_with("SortExec") {
-                if let Some(m) = plan.metrics() {
-                    *sc += m.spill_count().unwrap_or(0);
-                    *sr += m.spilled_rows().unwrap_or(0);
-                    *sb += m.spilled_bytes().unwrap_or(0);
-                    *elapsed += m.elapsed_compute().unwrap_or(0);
-                }
+            if name.starts_with("SortExec")
+                && let Some(m) = plan.metrics()
+            {
+                *sc += m.spill_count().unwrap_or(0);
+                *sr += m.spilled_rows().unwrap_or(0);
+                *sb += m.spilled_bytes().unwrap_or(0);
+                *elapsed += m.elapsed_compute().unwrap_or(0);
             }
             for child in plan.children() {
                 walk(child, sc, sr, sb, elapsed);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

N/A

## What's changed and what's your intention?

This PR adds experimental query spill controls for DataFusion runtime construction while preserving the existing default behavior.

Changes included:

- Add query config options:
  - `experimental_spill_mode = default | custom | disabled`
  - `experimental_spill_path`
  - `experimental_spill_max_temp_directory_size`
  - `experimental_spill_compression = uncompressed | lz4_frame | zstd`
  - `experimental_memory_pool_policy = greedy | fair`
- Wire the options into the query engine's `RuntimeEnv` creation:
  - `default` keeps DataFusion's current default disk manager behavior.
  - `custom` applies the configured temp path, quota, and compression.
  - `disabled` explicitly disables temp files/spill.
  - bounded query memory can choose either greedy or fair memory pool policy.
- Document the experimental options in the example config files and regenerate `config/config.md`.
- Add config serde coverage and a direct `SortExec` smoke test that verifies custom spill produces spill metrics.

Compatibility:

- Defaults are backward compatible: existing deployments continue to use the previous runtime behavior unless the experimental options are explicitly configured.
- No persisted format, schema, or wire format changes are introduced.

Validation run locally:

- `cargo fmt -p query`
- `cargo test -p query -- test_sort_spill_smoke_with_custom_runtime`
- `cargo clippy -p query --lib --tests -- -D warnings`
- `git diff --check`
- pre-push hooks passed when pushing `exp/spill-to-disk`

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
