### PR TITLE
fix: record catalog and schema in slow queries

### DIFF
--- a/src/catalog/src/process_manager.rs
+++ b/src/catalog/src/process_manager.rs
@@ -307,6 +307,8 @@ impl Debug for CancellableProcess {
 pub struct SlowQueryTimer {
     start: Instant,
     stmt: QueryStatement,
+    catalog_name: String,
+    schema_name: String,
     threshold: Duration,
     sample_ratio: f64,
     record_type: SlowQueriesRecordType,
@@ -316,6 +318,8 @@ pub struct SlowQueryTimer {
 impl SlowQueryTimer {
     pub fn new(
         stmt: QueryStatement,
+        catalog_name: String,
+        schema_name: String,
         threshold: Duration,
         sample_ratio: f64,
         record_type: SlowQueriesRecordType,
@@ -324,6 +328,8 @@ impl SlowQueryTimer {
         Self {
             start: Instant::now(),
             stmt,
+            catalog_name,
+            schema_name,
             threshold,
             sample_ratio,
             record_type,
@@ -338,6 +344,8 @@ impl SlowQueryTimer {
             cost: elapsed.as_millis() as u64,
             threshold: self.threshold.as_millis() as u64,
             query: "".to_string(),
+            catalog_name: self.catalog_name.clone(),
+            schema_name: self.schema_name.clone(),
 
             // The following fields are only used for PromQL queries.
             is_promql: false,
@@ -388,6 +396,8 @@ impl SlowQueryTimer {
                     cost = slow_query_event.cost,
                     threshold = slow_query_event.threshold,
                     query = slow_query_event.query,
+                    catalog_name = slow_query_event.catalog_name,
+                    schema_name = slow_query_event.schema_name,
                     is_promql = slow_query_event.is_promql,
                     promql_range = slow_query_event.promql_range,
                     promql_step = slow_query_event.promql_step,

--- a/src/catalog/src/process_manager.rs
+++ b/src/catalog/src/process_manager.rs
@@ -307,7 +307,6 @@ impl Debug for CancellableProcess {
 pub struct SlowQueryTimer {
     start: Instant,
     stmt: QueryStatement,
-    catalog_name: String,
     schema_name: String,
     threshold: Duration,
     sample_ratio: f64,
@@ -318,7 +317,6 @@ pub struct SlowQueryTimer {
 impl SlowQueryTimer {
     pub fn new(
         stmt: QueryStatement,
-        catalog_name: String,
         schema_name: String,
         threshold: Duration,
         sample_ratio: f64,
@@ -328,7 +326,6 @@ impl SlowQueryTimer {
         Self {
             start: Instant::now(),
             stmt,
-            catalog_name,
             schema_name,
             threshold,
             sample_ratio,
@@ -344,7 +341,6 @@ impl SlowQueryTimer {
             cost: elapsed.as_millis() as u64,
             threshold: self.threshold.as_millis() as u64,
             query: "".to_string(),
-            catalog_name: self.catalog_name.clone(),
             schema_name: self.schema_name.clone(),
 
             // The following fields are only used for PromQL queries.
@@ -396,7 +392,6 @@ impl SlowQueryTimer {
                     cost = slow_query_event.cost,
                     threshold = slow_query_event.threshold,
                     query = slow_query_event.query,
-                    catalog_name = slow_query_event.catalog_name,
                     schema_name = slow_query_event.schema_name,
                     is_promql = slow_query_event.is_promql,
                     promql_range = slow_query_event.promql_range,

--- a/src/common/frontend/src/slow_query_event.rs
+++ b/src/common/frontend/src/slow_query_event.rs
@@ -24,6 +24,8 @@ pub const SLOW_QUERY_TABLE_NAME: &str = "slow_queries";
 pub const SLOW_QUERY_TABLE_COST_COLUMN_NAME: &str = "cost";
 pub const SLOW_QUERY_TABLE_THRESHOLD_COLUMN_NAME: &str = "threshold";
 pub const SLOW_QUERY_TABLE_QUERY_COLUMN_NAME: &str = "query";
+pub const SLOW_QUERY_TABLE_CATALOG_NAME_COLUMN_NAME: &str = "catalog_name";
+pub const SLOW_QUERY_TABLE_SCHEMA_NAME_COLUMN_NAME: &str = "schema_name";
 pub const SLOW_QUERY_TABLE_TIMESTAMP_COLUMN_NAME: &str = "timestamp";
 pub const SLOW_QUERY_TABLE_IS_PROMQL_COLUMN_NAME: &str = "is_promql";
 pub const SLOW_QUERY_TABLE_PROMQL_START_COLUMN_NAME: &str = "promql_start";
@@ -38,6 +40,8 @@ pub struct SlowQueryEvent {
     pub cost: u64,
     pub threshold: u64,
     pub query: String,
+    pub catalog_name: String,
+    pub schema_name: String,
     pub is_promql: bool,
     pub promql_range: Option<u64>,
     pub promql_step: Option<u64>,
@@ -104,6 +108,18 @@ impl Event for SlowQueryEvent {
                 semantic_type: SemanticType::Field.into(),
                 ..Default::default()
             },
+            ColumnSchema {
+                column_name: SLOW_QUERY_TABLE_CATALOG_NAME_COLUMN_NAME.to_string(),
+                datatype: ColumnDataType::String.into(),
+                semantic_type: SemanticType::Field.into(),
+                ..Default::default()
+            },
+            ColumnSchema {
+                column_name: SLOW_QUERY_TABLE_SCHEMA_NAME_COLUMN_NAME.to_string(),
+                datatype: ColumnDataType::String.into(),
+                semantic_type: SemanticType::Field.into(),
+                ..Default::default()
+            },
         ]
     }
 
@@ -118,11 +134,69 @@ impl Event for SlowQueryEvent {
                 ValueData::U64Value(self.promql_step.unwrap_or(0)).into(),
                 ValueData::TimestampMillisecondValue(self.promql_start.unwrap_or(0)).into(),
                 ValueData::TimestampMillisecondValue(self.promql_end.unwrap_or(0)).into(),
+                ValueData::StringValue(self.catalog_name.to_string()).into(),
+                ValueData::StringValue(self.schema_name.to_string()).into(),
             ],
         }])
     }
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use api::v1::value::ValueData;
+    use common_event_recorder::Event;
+
+    use super::*;
+
+    #[test]
+    fn slow_query_event_includes_catalog_and_schema() {
+        let event = SlowQueryEvent {
+            cost: 100,
+            threshold: 10,
+            query: "SELECT * FROM numbers".to_string(),
+            catalog_name: "greptime".to_string(),
+            schema_name: "public".to_string(),
+            is_promql: false,
+            promql_range: None,
+            promql_step: None,
+            promql_start: None,
+            promql_end: None,
+        };
+
+        let schema = event.extra_schema();
+        let column_names = schema
+            .iter()
+            .map(|column| column.column_name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            column_names,
+            vec![
+                SLOW_QUERY_TABLE_COST_COLUMN_NAME,
+                SLOW_QUERY_TABLE_THRESHOLD_COLUMN_NAME,
+                SLOW_QUERY_TABLE_QUERY_COLUMN_NAME,
+                SLOW_QUERY_TABLE_IS_PROMQL_COLUMN_NAME,
+                SLOW_QUERY_TABLE_PROMQL_RANGE_COLUMN_NAME,
+                SLOW_QUERY_TABLE_PROMQL_STEP_COLUMN_NAME,
+                SLOW_QUERY_TABLE_PROMQL_START_COLUMN_NAME,
+                SLOW_QUERY_TABLE_PROMQL_END_COLUMN_NAME,
+                SLOW_QUERY_TABLE_CATALOG_NAME_COLUMN_NAME,
+                SLOW_QUERY_TABLE_SCHEMA_NAME_COLUMN_NAME,
+            ]
+        );
+
+        let rows = event.extra_rows().unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].values[8].value_data,
+            Some(ValueData::StringValue("greptime".to_string()))
+        );
+        assert_eq!(
+            rows[0].values[9].value_data,
+            Some(ValueData::StringValue("public".to_string()))
+        );
     }
 }

--- a/src/common/frontend/src/slow_query_event.rs
+++ b/src/common/frontend/src/slow_query_event.rs
@@ -24,7 +24,6 @@ pub const SLOW_QUERY_TABLE_NAME: &str = "slow_queries";
 pub const SLOW_QUERY_TABLE_COST_COLUMN_NAME: &str = "cost";
 pub const SLOW_QUERY_TABLE_THRESHOLD_COLUMN_NAME: &str = "threshold";
 pub const SLOW_QUERY_TABLE_QUERY_COLUMN_NAME: &str = "query";
-pub const SLOW_QUERY_TABLE_CATALOG_NAME_COLUMN_NAME: &str = "catalog_name";
 pub const SLOW_QUERY_TABLE_SCHEMA_NAME_COLUMN_NAME: &str = "schema_name";
 pub const SLOW_QUERY_TABLE_TIMESTAMP_COLUMN_NAME: &str = "timestamp";
 pub const SLOW_QUERY_TABLE_IS_PROMQL_COLUMN_NAME: &str = "is_promql";
@@ -40,7 +39,6 @@ pub struct SlowQueryEvent {
     pub cost: u64,
     pub threshold: u64,
     pub query: String,
-    pub catalog_name: String,
     pub schema_name: String,
     pub is_promql: bool,
     pub promql_range: Option<u64>,
@@ -109,15 +107,9 @@ impl Event for SlowQueryEvent {
                 ..Default::default()
             },
             ColumnSchema {
-                column_name: SLOW_QUERY_TABLE_CATALOG_NAME_COLUMN_NAME.to_string(),
-                datatype: ColumnDataType::String.into(),
-                semantic_type: SemanticType::Field.into(),
-                ..Default::default()
-            },
-            ColumnSchema {
                 column_name: SLOW_QUERY_TABLE_SCHEMA_NAME_COLUMN_NAME.to_string(),
                 datatype: ColumnDataType::String.into(),
-                semantic_type: SemanticType::Field.into(),
+                semantic_type: SemanticType::Tag.into(),
                 ..Default::default()
             },
         ]
@@ -134,7 +126,6 @@ impl Event for SlowQueryEvent {
                 ValueData::U64Value(self.promql_step.unwrap_or(0)).into(),
                 ValueData::TimestampMillisecondValue(self.promql_start.unwrap_or(0)).into(),
                 ValueData::TimestampMillisecondValue(self.promql_end.unwrap_or(0)).into(),
-                ValueData::StringValue(self.catalog_name.clone()).into(),
                 ValueData::StringValue(self.schema_name.clone()).into(),
             ],
         }])
@@ -153,12 +144,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn slow_query_event_includes_catalog_and_schema() {
+    fn slow_query_event_includes_schema() {
         let event = SlowQueryEvent {
             cost: 100,
             threshold: 10,
             query: "SELECT * FROM numbers".to_string(),
-            catalog_name: "greptime".to_string(),
             schema_name: "public".to_string(),
             is_promql: false,
             promql_range: None,
@@ -183,19 +173,15 @@ mod tests {
                 SLOW_QUERY_TABLE_PROMQL_STEP_COLUMN_NAME,
                 SLOW_QUERY_TABLE_PROMQL_START_COLUMN_NAME,
                 SLOW_QUERY_TABLE_PROMQL_END_COLUMN_NAME,
-                SLOW_QUERY_TABLE_CATALOG_NAME_COLUMN_NAME,
                 SLOW_QUERY_TABLE_SCHEMA_NAME_COLUMN_NAME,
             ]
         );
+        assert_eq!(schema[8].semantic_type, SemanticType::Tag as i32);
 
         let rows = event.extra_rows().unwrap();
         assert_eq!(rows.len(), 1);
         assert_eq!(
             rows[0].values[8].value_data,
-            Some(ValueData::StringValue("greptime".to_string()))
-        );
-        assert_eq!(
-            rows[0].values[9].value_data,
             Some(ValueData::StringValue("public".to_string()))
         );
     }

--- a/src/common/frontend/src/slow_query_event.rs
+++ b/src/common/frontend/src/slow_query_event.rs
@@ -134,8 +134,8 @@ impl Event for SlowQueryEvent {
                 ValueData::U64Value(self.promql_step.unwrap_or(0)).into(),
                 ValueData::TimestampMillisecondValue(self.promql_start.unwrap_or(0)).into(),
                 ValueData::TimestampMillisecondValue(self.promql_end.unwrap_or(0)).into(),
-                ValueData::StringValue(self.catalog_name.to_string()).into(),
-                ValueData::StringValue(self.schema_name.to_string()).into(),
+                ValueData::StringValue(self.catalog_name.clone()).into(),
+                ValueData::StringValue(self.schema_name.clone()).into(),
             ],
         }])
     }

--- a/src/common/frontend/src/slow_query_event.rs
+++ b/src/common/frontend/src/slow_query_event.rs
@@ -109,7 +109,7 @@ impl Event for SlowQueryEvent {
             ColumnSchema {
                 column_name: SLOW_QUERY_TABLE_SCHEMA_NAME_COLUMN_NAME.to_string(),
                 datatype: ColumnDataType::String.into(),
-                semantic_type: SemanticType::Tag.into(),
+                semantic_type: SemanticType::Field.into(),
                 ..Default::default()
             },
         ]
@@ -176,7 +176,7 @@ mod tests {
                 SLOW_QUERY_TABLE_SCHEMA_NAME_COLUMN_NAME,
             ]
         );
-        assert_eq!(schema[8].semantic_type, SemanticType::Tag as i32);
+        assert_eq!(schema[8].semantic_type, SemanticType::Field as i32);
 
         let rows = event.extra_rows().unwrap();
         assert_eq!(rows.len(), 1);

--- a/src/common/meta/src/ddl/alter_logical_tables.rs
+++ b/src/common/meta/src/ddl/alter_logical_tables.rs
@@ -58,13 +58,13 @@ pub struct AlterLogicalTablesProcedure {
 fn build_validator_from_alter_table_data<'a>(
     data: &'a AlterTablesData,
 ) -> AlterLogicalTableValidator<'a> {
-    let phsycial_table_id = data.physical_table_id;
+    let physical_table_id = data.physical_table_id;
     let alters = data
         .tasks
         .iter()
         .map(|task| &task.alter_table)
         .collect::<Vec<_>>();
-    AlterLogicalTableValidator::new(phsycial_table_id, alters)
+    AlterLogicalTableValidator::new(physical_table_id, alters)
 }
 
 /// Builds the executor from the [`AlterTablesData`].

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -214,7 +214,6 @@ impl Instance {
                     .map(|event_recorder| {
                         SlowQueryTimer::new(
                             CatalogQueryStatement::Sql(stmt.clone()),
-                            catalog_name.clone(),
                             schema_name.clone(),
                             self.slow_query_options.threshold,
                             self.slow_query_options.sample_ratio,
@@ -676,7 +675,6 @@ impl Instance {
                     .map(|event_recorder| {
                         SlowQueryTimer::new(
                             CatalogQueryStatement::Plan(query.clone()),
-                            catalog_name.clone(),
                             schema_name.clone(),
                             self.slow_query_options.threshold,
                             self.slow_query_options.sample_ratio,
@@ -916,7 +914,6 @@ impl PrometheusHandler for Instance {
             .map(|event_recorder| {
                 SlowQueryTimer::new(
                     query_statement,
-                    query_ctx.current_catalog().to_string(),
                     query_ctx.current_schema(),
                     self.slow_query_options.threshold,
                     self.slow_query_options.sample_ratio,

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -204,6 +204,8 @@ impl Instance {
 
         let is_readonly_stmt = stmt.is_readonly();
         if should_track_statement_process(&stmt) {
+            let catalog_name = query_ctx.current_catalog().to_string();
+            let schema_name = query_ctx.current_schema();
             let slow_query_timer = if is_readonly_stmt {
                 self.slow_query_options
                     .enable
@@ -212,6 +214,8 @@ impl Instance {
                     .map(|event_recorder| {
                         SlowQueryTimer::new(
                             CatalogQueryStatement::Sql(stmt.clone()),
+                            catalog_name.clone(),
+                            schema_name.clone(),
                             self.slow_query_options.threshold,
                             self.slow_query_options.sample_ratio,
                             self.slow_query_options.record_type,
@@ -223,8 +227,8 @@ impl Instance {
             };
 
             let ticket = self.process_manager.register_query(
-                query_ctx.current_catalog().to_string(),
-                vec![query_ctx.current_schema()],
+                catalog_name,
+                vec![schema_name],
                 stmt.to_string(),
                 query_ctx.conn_info().to_string(),
                 Some(query_ctx.process_id()),
@@ -662,6 +666,8 @@ impl Instance {
 
         let plan_is_readonly = is_readonly_plan(&plan);
         let result = if should_track_plan_process(stmt.as_ref(), &plan) {
+            let catalog_name = query_ctx.current_catalog().to_string();
+            let schema_name = query_ctx.current_schema();
             let slow_query_timer = if plan_is_readonly {
                 self.slow_query_options
                     .enable
@@ -670,6 +676,8 @@ impl Instance {
                     .map(|event_recorder| {
                         SlowQueryTimer::new(
                             CatalogQueryStatement::Plan(query.clone()),
+                            catalog_name.clone(),
+                            schema_name.clone(),
                             self.slow_query_options.threshold,
                             self.slow_query_options.sample_ratio,
                             self.slow_query_options.record_type,
@@ -681,8 +689,8 @@ impl Instance {
             };
 
             let ticket = self.process_manager.register_query(
-                query_ctx.current_catalog().to_string(),
-                vec![query_ctx.current_schema()],
+                catalog_name,
+                vec![schema_name],
                 query,
                 query_ctx.conn_info().to_string(),
                 Some(query_ctx.process_id()),
@@ -908,6 +916,8 @@ impl PrometheusHandler for Instance {
             .map(|event_recorder| {
                 SlowQueryTimer::new(
                     query_statement,
+                    query_ctx.current_catalog().to_string(),
+                    query_ctx.current_schema(),
                     self.slow_query_options.threshold,
                     self.slow_query_options.sample_ratio,
                     self.slow_query_options.record_type,

--- a/tests-integration/tests/sql.rs
+++ b/tests-integration/tests/sql.rs
@@ -17,10 +17,13 @@ use std::time::Duration;
 
 use auth::user_provider_from_option;
 use chrono::{DateTime, NaiveDate, NaiveDateTime, SecondsFormat, Utc};
-use common_catalog::consts::DEFAULT_PRIVATE_SCHEMA_NAME;
+use common_catalog::consts::{
+    DEFAULT_CATALOG_NAME, DEFAULT_PRIVATE_SCHEMA_NAME, DEFAULT_SCHEMA_NAME,
+};
 use common_frontend::slow_query_event::{
-    SLOW_QUERY_TABLE_COST_COLUMN_NAME, SLOW_QUERY_TABLE_IS_PROMQL_COLUMN_NAME,
-    SLOW_QUERY_TABLE_NAME, SLOW_QUERY_TABLE_QUERY_COLUMN_NAME,
+    SLOW_QUERY_TABLE_CATALOG_NAME_COLUMN_NAME, SLOW_QUERY_TABLE_COST_COLUMN_NAME,
+    SLOW_QUERY_TABLE_IS_PROMQL_COLUMN_NAME, SLOW_QUERY_TABLE_NAME,
+    SLOW_QUERY_TABLE_QUERY_COLUMN_NAME, SLOW_QUERY_TABLE_SCHEMA_NAME_COLUMN_NAME,
     SLOW_QUERY_TABLE_THRESHOLD_COLUMN_NAME,
 };
 use sqlx::mysql::{MySqlConnection, MySqlDatabaseError, MySqlPoolOptions};
@@ -720,10 +723,12 @@ pub async fn test_mysql_slow_query(store_type: StorageType) {
 
     let table = format!("{}.{}", DEFAULT_PRIVATE_SCHEMA_NAME, SLOW_QUERY_TABLE_NAME);
     let query = format!(
-        "SELECT {}, {}, {}, {} FROM {table} WHERE {} = ?",
+        "SELECT {}, {}, {}, {}, {}, {} FROM {table} WHERE {} = ?",
         SLOW_QUERY_TABLE_COST_COLUMN_NAME,
         SLOW_QUERY_TABLE_THRESHOLD_COLUMN_NAME,
         SLOW_QUERY_TABLE_QUERY_COLUMN_NAME,
+        SLOW_QUERY_TABLE_CATALOG_NAME_COLUMN_NAME,
+        SLOW_QUERY_TABLE_SCHEMA_NAME_COLUMN_NAME,
         SLOW_QUERY_TABLE_IS_PROMQL_COLUMN_NAME,
         SLOW_QUERY_TABLE_QUERY_COLUMN_NAME,
     );
@@ -747,10 +752,14 @@ pub async fn test_mysql_slow_query(store_type: StorageType) {
     let cost: u64 = row.get(0);
     let threshold: u64 = row.get(1);
     let query: String = row.get(2);
-    let is_promql: bool = row.get(3);
+    let catalog_name: String = row.get(3);
+    let schema_name: String = row.get(4);
+    let is_promql: bool = row.get(5);
 
     assert!(cost > 0 && threshold > 0 && cost > threshold);
     assert_eq!(query, slow_query);
+    assert_eq!(catalog_name, DEFAULT_CATALOG_NAME);
+    assert_eq!(schema_name, DEFAULT_SCHEMA_NAME);
     assert!(!is_promql);
 
     let _ = fe_mysql_server.shutdown().await;
@@ -847,10 +856,12 @@ pub async fn test_postgres_slow_query(store_type: StorageType) {
 
     let table = format!("{}.{}", DEFAULT_PRIVATE_SCHEMA_NAME, SLOW_QUERY_TABLE_NAME);
     let query = format!(
-        "SELECT {}, {}, {}, {} FROM {table} WHERE {} = $1",
+        "SELECT {}, {}, {}, {}, {}, {} FROM {table} WHERE {} = $1",
         SLOW_QUERY_TABLE_COST_COLUMN_NAME,
         SLOW_QUERY_TABLE_THRESHOLD_COLUMN_NAME,
         SLOW_QUERY_TABLE_QUERY_COLUMN_NAME,
+        SLOW_QUERY_TABLE_CATALOG_NAME_COLUMN_NAME,
+        SLOW_QUERY_TABLE_SCHEMA_NAME_COLUMN_NAME,
         SLOW_QUERY_TABLE_IS_PROMQL_COLUMN_NAME,
         SLOW_QUERY_TABLE_QUERY_COLUMN_NAME,
     );
@@ -873,10 +884,14 @@ pub async fn test_postgres_slow_query(store_type: StorageType) {
     let cost: Decimal = row.get(0);
     let threshold: Decimal = row.get(1);
     let query: String = row.get(2);
-    let is_promql: bool = row.get(3);
+    let catalog_name: String = row.get(3);
+    let schema_name: String = row.get(4);
+    let is_promql: bool = row.get(5);
 
     assert!(cost > 0.into() && threshold > 0.into() && cost > threshold);
     assert_eq!(query, slow_query);
+    assert_eq!(catalog_name, DEFAULT_CATALOG_NAME);
+    assert_eq!(schema_name, DEFAULT_SCHEMA_NAME);
     assert!(!is_promql);
 
     let _ = fe_pg_server.shutdown().await;

--- a/tests-integration/tests/sql.rs
+++ b/tests-integration/tests/sql.rs
@@ -17,14 +17,11 @@ use std::time::Duration;
 
 use auth::user_provider_from_option;
 use chrono::{DateTime, NaiveDate, NaiveDateTime, SecondsFormat, Utc};
-use common_catalog::consts::{
-    DEFAULT_CATALOG_NAME, DEFAULT_PRIVATE_SCHEMA_NAME, DEFAULT_SCHEMA_NAME,
-};
+use common_catalog::consts::{DEFAULT_PRIVATE_SCHEMA_NAME, DEFAULT_SCHEMA_NAME};
 use common_frontend::slow_query_event::{
-    SLOW_QUERY_TABLE_CATALOG_NAME_COLUMN_NAME, SLOW_QUERY_TABLE_COST_COLUMN_NAME,
-    SLOW_QUERY_TABLE_IS_PROMQL_COLUMN_NAME, SLOW_QUERY_TABLE_NAME,
-    SLOW_QUERY_TABLE_QUERY_COLUMN_NAME, SLOW_QUERY_TABLE_SCHEMA_NAME_COLUMN_NAME,
-    SLOW_QUERY_TABLE_THRESHOLD_COLUMN_NAME,
+    SLOW_QUERY_TABLE_COST_COLUMN_NAME, SLOW_QUERY_TABLE_IS_PROMQL_COLUMN_NAME,
+    SLOW_QUERY_TABLE_NAME, SLOW_QUERY_TABLE_QUERY_COLUMN_NAME,
+    SLOW_QUERY_TABLE_SCHEMA_NAME_COLUMN_NAME, SLOW_QUERY_TABLE_THRESHOLD_COLUMN_NAME,
 };
 use sqlx::mysql::{MySqlConnection, MySqlDatabaseError, MySqlPoolOptions};
 use sqlx::postgres::{PgDatabaseError, PgPoolOptions};
@@ -723,11 +720,10 @@ pub async fn test_mysql_slow_query(store_type: StorageType) {
 
     let table = format!("{}.{}", DEFAULT_PRIVATE_SCHEMA_NAME, SLOW_QUERY_TABLE_NAME);
     let query = format!(
-        "SELECT {}, {}, {}, {}, {}, {} FROM {table} WHERE {} = ?",
+        "SELECT {}, {}, {}, {}, {} FROM {table} WHERE {} = ?",
         SLOW_QUERY_TABLE_COST_COLUMN_NAME,
         SLOW_QUERY_TABLE_THRESHOLD_COLUMN_NAME,
         SLOW_QUERY_TABLE_QUERY_COLUMN_NAME,
-        SLOW_QUERY_TABLE_CATALOG_NAME_COLUMN_NAME,
         SLOW_QUERY_TABLE_SCHEMA_NAME_COLUMN_NAME,
         SLOW_QUERY_TABLE_IS_PROMQL_COLUMN_NAME,
         SLOW_QUERY_TABLE_QUERY_COLUMN_NAME,
@@ -752,13 +748,11 @@ pub async fn test_mysql_slow_query(store_type: StorageType) {
     let cost: u64 = row.get(0);
     let threshold: u64 = row.get(1);
     let query: String = row.get(2);
-    let catalog_name: String = row.get(3);
-    let schema_name: String = row.get(4);
-    let is_promql: bool = row.get(5);
+    let schema_name: String = row.get(3);
+    let is_promql: bool = row.get(4);
 
     assert!(cost > 0 && threshold > 0 && cost > threshold);
     assert_eq!(query, slow_query);
-    assert_eq!(catalog_name, DEFAULT_CATALOG_NAME);
     assert_eq!(schema_name, DEFAULT_SCHEMA_NAME);
     assert!(!is_promql);
 
@@ -856,11 +850,10 @@ pub async fn test_postgres_slow_query(store_type: StorageType) {
 
     let table = format!("{}.{}", DEFAULT_PRIVATE_SCHEMA_NAME, SLOW_QUERY_TABLE_NAME);
     let query = format!(
-        "SELECT {}, {}, {}, {}, {}, {} FROM {table} WHERE {} = $1",
+        "SELECT {}, {}, {}, {}, {} FROM {table} WHERE {} = $1",
         SLOW_QUERY_TABLE_COST_COLUMN_NAME,
         SLOW_QUERY_TABLE_THRESHOLD_COLUMN_NAME,
         SLOW_QUERY_TABLE_QUERY_COLUMN_NAME,
-        SLOW_QUERY_TABLE_CATALOG_NAME_COLUMN_NAME,
         SLOW_QUERY_TABLE_SCHEMA_NAME_COLUMN_NAME,
         SLOW_QUERY_TABLE_IS_PROMQL_COLUMN_NAME,
         SLOW_QUERY_TABLE_QUERY_COLUMN_NAME,
@@ -884,13 +877,11 @@ pub async fn test_postgres_slow_query(store_type: StorageType) {
     let cost: Decimal = row.get(0);
     let threshold: Decimal = row.get(1);
     let query: String = row.get(2);
-    let catalog_name: String = row.get(3);
-    let schema_name: String = row.get(4);
-    let is_promql: bool = row.get(5);
+    let schema_name: String = row.get(3);
+    let is_promql: bool = row.get(4);
 
     assert!(cost > 0.into() && threshold > 0.into() && cost > threshold);
     assert_eq!(query, slow_query);
-    assert_eq!(catalog_name, DEFAULT_CATALOG_NAME);
     assert_eq!(schema_name, DEFAULT_SCHEMA_NAME);
     assert!(!is_promql);
 


### PR DESCRIPTION
## Summary
- Add catalog and schema fields to slow query events and the `slow_queries` system table rows.
- Capture query context in `SlowQueryTimer` for SQL, logical plan, and PromQL slow query paths.
- Keep new columns appended after existing slow-query fields and cover them in MySQL/PostgreSQL integration assertions.

## Test Plan
- `make fmt`
- `make clippy`
- `cargo nextest run`
- `make check`
- `cargo test -p tests-integration slow_query`

## Notes
- `make check-udeps` was attempted but could not run because `cargo-udeps` is not installed in this environment.