### PR TITLE
feat(json2): use Parquet Variant as the widest datatype for JSON2 subpath conflicts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2209,7 +2209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4452,6 +4452,7 @@ dependencies = [
  "num",
  "num-traits",
  "ordered-float 4.6.0",
+ "parquet",
  "paste",
  "regex",
  "serde",
@@ -6484,7 +6485,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -6555,7 +6556,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -6999,7 +7000,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8963,7 +8964,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10098,6 +10099,9 @@ dependencies = [
  "num-integer",
  "num-traits",
  "object_store",
+ "parquet-variant",
+ "parquet-variant-compute",
+ "parquet-variant-json",
  "paste",
  "seq-macro",
  "simdutf8",
@@ -10106,6 +10110,53 @@ dependencies = [
  "tokio",
  "twox-hash",
  "zstd",
+]
+
+[[package]]
+name = "parquet-variant"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c8db065291f088a2aad8ab831853eae1871c0d311c8d0b83bbc3b7e735d0fc"
+dependencies = [
+ "arrow 58.3.0",
+ "arrow-schema 58.3.0",
+ "chrono",
+ "half",
+ "indexmap 2.13.0",
+ "num-traits",
+ "simdutf8",
+ "uuid",
+]
+
+[[package]]
+name = "parquet-variant-compute"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a530e8d5b5e14efcb39c9a6ec55432ad11f6afb7dc4455a79be0dc615fe3cc31"
+dependencies = [
+ "arrow 58.3.0",
+ "arrow-schema 58.3.0",
+ "chrono",
+ "half",
+ "indexmap 2.13.0",
+ "parquet-variant",
+ "parquet-variant-json",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "parquet-variant-json"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00ed89908289f67caa2ca078f9ff9aacd6229a313ec92b12bf4f48f613dc2b97"
+dependencies = [
+ "arrow-schema 58.3.0",
+ "base64 0.22.1",
+ "chrono",
+ "parquet-variant",
+ "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -11135,7 +11186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck 0.4.1",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -11183,7 +11234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11196,7 +11247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11596,7 +11647,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12536,7 +12587,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12549,7 +12600,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12630,7 +12681,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13512,7 +13563,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13898,7 +13949,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -14504,7 +14555,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -16255,7 +16306,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,7 +193,7 @@ otel-arrow-rust = { git = "https://github.com/GreptimeTeam/otel-arrow", rev = "5
     "server",
 ] }
 parking_lot = "0.12"
-parquet = { version = "58.3", default-features = false, features = ["arrow", "async", "object_store"] }
+parquet = { version = "58.3", default-features = false, features = ["arrow", "async", "object_store", "variant_experimental"] }
 paste = "1.0"
 pin-project = "1.0"
 pretty_assertions = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,7 +193,12 @@ otel-arrow-rust = { git = "https://github.com/GreptimeTeam/otel-arrow", rev = "5
     "server",
 ] }
 parking_lot = "0.12"
-parquet = { version = "58.3", default-features = false, features = ["arrow", "async", "object_store", "variant_experimental"] }
+parquet = { version = "58.3", default-features = false, features = [
+    "arrow",
+    "async",
+    "object_store",
+    "variant_experimental",
+] }
 paste = "1.0"
 pin-project = "1.0"
 pretty_assertions = "1.4.0"

--- a/src/datatypes/Cargo.toml
+++ b/src/datatypes/Cargo.toml
@@ -27,6 +27,7 @@ jsonb.workspace = true
 num = "0.4"
 num-traits = "0.2"
 ordered-float.workspace = true
+parquet.workspace = true
 paste.workspace = true
 regex.workspace = true
 serde.workspace = true

--- a/src/datatypes/src/vectors/json/builder.rs
+++ b/src/datatypes/src/vectors/json/builder.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::any::Any;
-use std::str::from_utf8_unchecked;
 use std::sync::Arc;
 
 use arrow_schema::{DataType as ArrowDataType, Field, FieldRef, Fields};
@@ -57,43 +56,43 @@ impl JsonVectorBuilder {
 }
 
 fn build_json2_struct_vector(
-    values: &mut [JsonValue],
+    vals: &mut [JsonValue],
     native_type: &JsonNativeType,
 ) -> Result<VectorRef> {
     let json_type = JsonType::new_json2(native_type.clone());
-    for value in values.iter_mut() {
-        value.try_align(&json_type)?;
+    for val in vals.iter_mut() {
+        val.try_align(&json_type)?;
     }
 
-    let variants = values
+    let variants = vals
         .iter()
-        .map(|value| value.as_ref().into_variant())
+        .map(|val| val.as_ref().into_variant())
         .collect::<Vec<_>>();
-    let JsonNativeType::Object(object_type) = native_type else {
+
+    let JsonNativeType::Object(_) = native_type else {
         return InvalidVectorSnafu {
             msg: format!("expected json object type, got {native_type}"),
         }
         .fail();
     };
+
     let (_, array) = build_json_array("", &variants, native_type)?;
-    let struct_array = array
+    let json_struct_array = array
         .as_any()
         .downcast_ref::<StructArray>()
         .ok_or_else(|| {
             InvalidVectorSnafu {
-                msg: "expected JSON2 root to build a StructArray",
+                msg: format!(
+                    "expected JSON2 to be a StructArray, actual array type: {}",
+                    array.data_type()
+                ),
             }
             .build()
         })?
         .clone();
 
-    let fields = StructType::from(&Fields::from(
-        object_type
-            .iter()
-            .map(|(name, field_type)| Field::new(name, field_type.as_arrow_type(), true))
-            .collect::<Vec<_>>(),
-    ));
-    Ok(Arc::new(StructVector::try_new(fields, struct_array)?))
+    let fields = StructType::from(json_struct_array.fields());
+    Ok(Arc::new(StructVector::try_new(fields, json_struct_array)?))
 }
 
 fn build_json_array(
@@ -117,8 +116,12 @@ fn build_parquet_variant_array(
         .iter()
         .map(|val| match val {
             JsonVariantRef::Null => Ok(None),
-            // Safety: `val` must be valid UTF-8.
-            JsonVariantRef::Variant(val) => unsafe { Ok(Some(from_utf8_unchecked(val))) },
+            JsonVariantRef::Variant(val) => Ok(Some(from_utf8(val).map_err(|e| {
+                InvalidVectorSnafu {
+                    msg: format!("invalid UTF-8 in JSON variant payload: {e}"),
+                }
+                .build()
+            })?)),
             _ => InvalidVectorSnafu {
                 msg: format!("expected JSON variant payload, got {val:?}"),
             }
@@ -126,9 +129,9 @@ fn build_parquet_variant_array(
         })
         .collect::<Result<Vec<_>>>()?;
     let input: ArrayRef = Arc::new(StringArray::from(json_vals));
-    let array = json_to_variant(&input).map_err(|err| {
+    let array = json_to_variant(&input).map_err(|e| {
         InvalidVectorSnafu {
-            msg: format!("failed to encode JSON payload as parquet variant: {err}"),
+            msg: format!("failed to encode JSON payload as parquet variant: {e}"),
         }
         .build()
     })?;
@@ -143,18 +146,19 @@ fn build_json_object_array(
 ) -> Result<(FieldRef, ArrayRef)> {
     let mut fields = Vec::with_capacity(object_type.len());
     let mut arrays = Vec::with_capacity(object_type.len());
+    let mut field_vals = Vec::with_capacity(vals.len());
     for (field_name, field_type) in object_type {
-        let field_vals = vals
-            .iter()
-            .map(|value| match value {
+        field_vals.clear();
+        for value in vals {
+            let val = match value {
                 JsonVariantRef::Object(object) => object
                     .get(field_name.as_str())
                     .cloned()
                     .unwrap_or(JsonVariantRef::Null),
-                JsonVariantRef::Null => JsonVariantRef::Null,
                 _ => JsonVariantRef::Null,
-            })
-            .collect::<Vec<_>>();
+            };
+            field_vals.push(val);
+        }
         let (field, array) = build_json_array(field_name, &field_vals, field_type)?;
         fields.push(field);
         arrays.push(array);
@@ -172,45 +176,43 @@ fn build_json_object_array(
 
 fn build_plain_json_variant_array(
     name: &str,
-    values: &[JsonVariantRef<'_>],
+    vals: &[JsonVariantRef<'_>],
     native_type: &JsonNativeType,
 ) -> Result<(FieldRef, ArrayRef)> {
     let data_type = native_type.as_arrow_type();
     let field = Arc::new(Field::new(name, data_type.clone(), true));
     let array = match native_type {
-        JsonNativeType::Null => crate::arrow::array::new_null_array(&data_type, values.len()),
-        JsonNativeType::Bool => {
-            Arc::new(BooleanArray::from_iter(values.iter().map(
-                |value| match value {
-                    JsonVariantRef::Null => None,
-                    JsonVariantRef::Bool(value) => Some(*value),
-                    _ => None,
-                },
-            ))) as ArrayRef
-        }
+        JsonNativeType::Null => crate::arrow::array::new_null_array(&data_type, vals.len()),
+        JsonNativeType::Bool => Arc::new(BooleanArray::from_iter(vals.iter().map(
+            |value| match value {
+                JsonVariantRef::Null => None,
+                JsonVariantRef::Bool(value) => Some(*value),
+                _ => None,
+            },
+        ))) as ArrayRef,
         JsonNativeType::Number(JsonNumberType::U64) => Arc::new(UInt64Array::from_iter(
-            values.iter().map(|value| match value {
+            vals.iter().map(|value| match value {
                 JsonVariantRef::Null => None,
                 JsonVariantRef::Number(value) => json_number_as_u64(value),
                 _ => None,
             }),
         )) as ArrayRef,
         JsonNativeType::Number(JsonNumberType::I64) => Arc::new(Int64Array::from_iter(
-            values.iter().map(|value| match value {
+            vals.iter().map(|value| match value {
                 JsonVariantRef::Null => None,
                 JsonVariantRef::Number(value) => json_number_as_i64(value),
                 _ => None,
             }),
         )) as ArrayRef,
         JsonNativeType::Number(JsonNumberType::F64) => Arc::new(Float64Array::from_iter(
-            values.iter().map(|value| match value {
+            vals.iter().map(|value| match value {
                 JsonVariantRef::Null => None,
                 JsonVariantRef::Number(value) => Some(json_number_as_f64(value)),
                 _ => None,
             }),
         )) as ArrayRef,
         JsonNativeType::String => {
-            let values = values
+            let row_vals = vals
                 .iter()
                 .map(|value| match value {
                     JsonVariantRef::Null => Value::Null,
@@ -219,7 +221,7 @@ fn build_plain_json_variant_array(
                 })
                 .collect::<Vec<_>>();
             Helper::try_from_row_into_vector(
-                &values,
+                &row_vals,
                 &ConcreteDataType::from_arrow_type(&ArrowDataType::Utf8View),
             )?
             .to_arrow_array()
@@ -233,14 +235,14 @@ fn build_plain_json_variant_array(
 
 fn build_json_list_array(
     name: &str,
-    values: &[JsonVariantRef<'_>],
+    vals: &[JsonVariantRef<'_>],
     item_type: &JsonNativeType,
 ) -> Result<(FieldRef, ArrayRef)> {
-    let mut offsets = Vec::with_capacity(values.len() + 1);
-    let mut valid = Vec::with_capacity(values.len());
+    let mut offsets = Vec::with_capacity(vals.len() + 1);
+    let mut valid = Vec::with_capacity(vals.len());
     let mut flattened = Vec::new();
     offsets.push(0_i32);
-    for value in values {
+    for value in vals {
         match value {
             JsonVariantRef::Array(items) => {
                 flattened.extend(items.iter().cloned());
@@ -254,7 +256,13 @@ fn build_json_list_array(
                 .fail();
             }
         }
-        offsets.push(flattened.len() as i32);
+        let offset: i32 = flattened.len().try_into().map_err(|_| {
+            InvalidVectorSnafu {
+                msg: "flattened list length exceeds i32::MAX",
+            }
+            .build()
+        })?;
+        offsets.push(offset);
     }
 
     let (item_field, item_array) = build_json_array("item", &flattened, item_type)?;

--- a/src/datatypes/src/vectors/json/builder.rs
+++ b/src/datatypes/src/vectors/json/builder.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::str::from_utf8;
 use std::sync::Arc;
 
 use arrow_schema::{DataType as ArrowDataType, Field, FieldRef, Fields};

--- a/src/datatypes/src/vectors/json/builder.rs
+++ b/src/datatypes/src/vectors/json/builder.rs
@@ -13,14 +13,25 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::str::from_utf8_unchecked;
+use std::sync::Arc;
 
+use arrow_schema::{DataType as ArrowDataType, Field, FieldRef, Fields};
+use parquet::variant::json_to_variant;
+
+use crate::arrow::array::{
+    ArrayRef, BooleanArray, Float64Array, Int64Array, ListArray, StringArray, StructArray,
+    UInt64Array,
+};
+use crate::arrow::buffer::{NullBuffer, OffsetBuffer, ScalarBuffer};
 use crate::data_type::ConcreteDataType;
-use crate::error::{Result, TryFromValueSnafu, UnsupportedOperationSnafu};
-use crate::json::value::{JsonValue, JsonVariant};
+use crate::error::{InvalidVectorSnafu, Result, TryFromValueSnafu, UnsupportedOperationSnafu};
+use crate::json::value::{JsonNumber, JsonValue, JsonVariant, JsonVariantRef};
 use crate::prelude::{ValueRef, Vector, VectorRef};
-use crate::types::JsonType;
-use crate::types::json_type::{JsonFormat, JsonNativeType};
-use crate::vectors::{MutableVector, StructVectorBuilder};
+use crate::types::json_type::{JsonFormat, JsonNativeType, JsonNumberType, JsonObjectType};
+use crate::types::{JsonType, StructType};
+use crate::value::Value;
+use crate::vectors::{Helper, MutableVector, StructVector};
 
 #[derive(Clone)]
 pub(crate) struct JsonVectorBuilder {
@@ -41,19 +52,256 @@ impl JsonVectorBuilder {
     }
 
     fn try_build(&mut self) -> Result<VectorRef> {
-        let mut builder = StructVectorBuilder::with_type_and_capacity(
-            self.merged_type.as_struct_type(),
-            self.values.len(),
-        );
-        for value in self.values.iter_mut() {
-            value.try_align(&self.merged_type)?;
-            if value.is_null() {
-                builder.push_null();
-                continue;
-            }
-            builder.try_push_value_ref(&value.as_ref().as_value_ref())?;
+        build_json2_struct_vector(&mut self.values, self.merged_type.native_type())
+    }
+}
+
+fn build_json2_struct_vector(
+    values: &mut [JsonValue],
+    native_type: &JsonNativeType,
+) -> Result<VectorRef> {
+    let json_type = JsonType::new_json2(native_type.clone());
+    for value in values.iter_mut() {
+        value.try_align(&json_type)?;
+    }
+
+    let variants = values
+        .iter()
+        .map(|value| value.as_ref().into_variant())
+        .collect::<Vec<_>>();
+    let JsonNativeType::Object(object_type) = native_type else {
+        return InvalidVectorSnafu {
+            msg: format!("expected json object type, got {native_type}"),
         }
-        Ok(builder.to_vector())
+        .fail();
+    };
+    let (_, array) = build_json_array("", &variants, native_type)?;
+    let struct_array = array
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .ok_or_else(|| {
+            InvalidVectorSnafu {
+                msg: "expected JSON2 root to build a StructArray",
+            }
+            .build()
+        })?
+        .clone();
+
+    let fields = StructType::from(&Fields::from(
+        object_type
+            .iter()
+            .map(|(name, field_type)| Field::new(name, field_type.as_arrow_type(), true))
+            .collect::<Vec<_>>(),
+    ));
+    Ok(Arc::new(StructVector::try_new(fields, struct_array)?))
+}
+
+fn build_json_array(
+    name: &str,
+    vals: &[JsonVariantRef<'_>],
+    native_type: &JsonNativeType,
+) -> Result<(FieldRef, ArrayRef)> {
+    match native_type {
+        JsonNativeType::Variant => build_parquet_variant_array(name, vals),
+        JsonNativeType::Object(object_type) => build_json_object_array(name, vals, object_type),
+        JsonNativeType::Array(item_type) => build_json_list_array(name, vals, item_type),
+        _ => build_plain_json_variant_array(name, vals, native_type),
+    }
+}
+
+fn build_parquet_variant_array(
+    name: &str,
+    vals: &[JsonVariantRef<'_>],
+) -> Result<(FieldRef, ArrayRef)> {
+    let json_vals = vals
+        .iter()
+        .map(|val| match val {
+            JsonVariantRef::Null => Ok(None),
+            // Safety: `val` must be valid UTF-8.
+            JsonVariantRef::Variant(val) => unsafe { Ok(Some(from_utf8_unchecked(val))) },
+            _ => InvalidVectorSnafu {
+                msg: format!("expected JSON variant payload, got {val:?}"),
+            }
+            .fail(),
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let input: ArrayRef = Arc::new(StringArray::from(json_vals));
+    let array = json_to_variant(&input).map_err(|err| {
+        InvalidVectorSnafu {
+            msg: format!("failed to encode JSON payload as parquet variant: {err}"),
+        }
+        .build()
+    })?;
+    let field = Arc::new(array.field(name));
+    Ok((field, ArrayRef::from(array)))
+}
+
+fn build_json_object_array(
+    name: &str,
+    vals: &[JsonVariantRef<'_>],
+    object_type: &JsonObjectType,
+) -> Result<(FieldRef, ArrayRef)> {
+    let mut fields = Vec::with_capacity(object_type.len());
+    let mut arrays = Vec::with_capacity(object_type.len());
+    for (field_name, field_type) in object_type {
+        let field_vals = vals
+            .iter()
+            .map(|value| match value {
+                JsonVariantRef::Object(object) => object
+                    .get(field_name.as_str())
+                    .cloned()
+                    .unwrap_or(JsonVariantRef::Null),
+                JsonVariantRef::Null => JsonVariantRef::Null,
+                _ => JsonVariantRef::Null,
+            })
+            .collect::<Vec<_>>();
+        let (field, array) = build_json_array(field_name, &field_vals, field_type)?;
+        fields.push(field);
+        arrays.push(array);
+    }
+
+    let fields = Fields::from(fields);
+    let nulls = null_buffer(
+        vals.iter()
+            .map(|value| matches!(value, JsonVariantRef::Object(_))),
+    );
+    let array = StructArray::new(fields.clone(), arrays, nulls);
+    let field = Arc::new(Field::new(name, ArrowDataType::Struct(fields), true));
+    Ok((field, Arc::new(array)))
+}
+
+fn build_plain_json_variant_array(
+    name: &str,
+    values: &[JsonVariantRef<'_>],
+    native_type: &JsonNativeType,
+) -> Result<(FieldRef, ArrayRef)> {
+    let data_type = native_type.as_arrow_type();
+    let field = Arc::new(Field::new(name, data_type.clone(), true));
+    let array = match native_type {
+        JsonNativeType::Null => crate::arrow::array::new_null_array(&data_type, values.len()),
+        JsonNativeType::Bool => {
+            Arc::new(BooleanArray::from_iter(values.iter().map(
+                |value| match value {
+                    JsonVariantRef::Null => None,
+                    JsonVariantRef::Bool(value) => Some(*value),
+                    _ => None,
+                },
+            ))) as ArrayRef
+        }
+        JsonNativeType::Number(JsonNumberType::U64) => Arc::new(UInt64Array::from_iter(
+            values.iter().map(|value| match value {
+                JsonVariantRef::Null => None,
+                JsonVariantRef::Number(value) => json_number_as_u64(value),
+                _ => None,
+            }),
+        )) as ArrayRef,
+        JsonNativeType::Number(JsonNumberType::I64) => Arc::new(Int64Array::from_iter(
+            values.iter().map(|value| match value {
+                JsonVariantRef::Null => None,
+                JsonVariantRef::Number(value) => json_number_as_i64(value),
+                _ => None,
+            }),
+        )) as ArrayRef,
+        JsonNativeType::Number(JsonNumberType::F64) => Arc::new(Float64Array::from_iter(
+            values.iter().map(|value| match value {
+                JsonVariantRef::Null => None,
+                JsonVariantRef::Number(value) => Some(json_number_as_f64(value)),
+                _ => None,
+            }),
+        )) as ArrayRef,
+        JsonNativeType::String => {
+            let values = values
+                .iter()
+                .map(|value| match value {
+                    JsonVariantRef::Null => Value::Null,
+                    JsonVariantRef::String(value) => Value::String((*value).into()),
+                    _ => Value::Null,
+                })
+                .collect::<Vec<_>>();
+            Helper::try_from_row_into_vector(
+                &values,
+                &ConcreteDataType::from_arrow_type(&ArrowDataType::Utf8View),
+            )?
+            .to_arrow_array()
+        }
+        JsonNativeType::Array(_) | JsonNativeType::Object(_) | JsonNativeType::Variant => {
+            unreachable!("complex JSON native types are built by recursive builders")
+        }
+    };
+    Ok((field, array))
+}
+
+fn build_json_list_array(
+    name: &str,
+    values: &[JsonVariantRef<'_>],
+    item_type: &JsonNativeType,
+) -> Result<(FieldRef, ArrayRef)> {
+    let mut offsets = Vec::with_capacity(values.len() + 1);
+    let mut valid = Vec::with_capacity(values.len());
+    let mut flattened = Vec::new();
+    offsets.push(0_i32);
+    for value in values {
+        match value {
+            JsonVariantRef::Array(items) => {
+                flattened.extend(items.iter().cloned());
+                valid.push(true);
+            }
+            JsonVariantRef::Null => valid.push(false),
+            _ => {
+                return InvalidVectorSnafu {
+                    msg: format!("expected JSON array payload, got {value:?}"),
+                }
+                .fail();
+            }
+        }
+        offsets.push(flattened.len() as i32);
+    }
+
+    let (item_field, item_array) = build_json_array("item", &flattened, item_type)?;
+    let nulls = null_buffer(valid);
+    let array = ListArray::new(
+        item_field.clone(),
+        OffsetBuffer::new(ScalarBuffer::from(offsets)),
+        item_array,
+        nulls,
+    );
+    let field = Arc::new(Field::new(
+        name,
+        ArrowDataType::List(item_field.clone()),
+        true,
+    ));
+    Ok((field, Arc::new(array)))
+}
+
+fn null_buffer(valid: impl IntoIterator<Item = bool>) -> Option<NullBuffer> {
+    let valid = valid.into_iter().collect::<Vec<_>>();
+    valid
+        .iter()
+        .any(|valid| !*valid)
+        .then(|| NullBuffer::from(valid))
+}
+
+fn json_number_as_u64(value: &JsonNumber) -> Option<u64> {
+    match value {
+        JsonNumber::PosInt(value) => Some(*value),
+        JsonNumber::NegInt(value) => (*value >= 0).then_some(*value as u64),
+        JsonNumber::Float(_) => None,
+    }
+}
+
+fn json_number_as_i64(value: &JsonNumber) -> Option<i64> {
+    match value {
+        JsonNumber::PosInt(value) => (*value <= i64::MAX as u64).then_some(*value as i64),
+        JsonNumber::NegInt(value) => Some(*value),
+        JsonNumber::Float(_) => None,
+    }
+}
+
+fn json_number_as_f64(value: &JsonNumber) -> f64 {
+    match value {
+        JsonNumber::PosInt(value) => *value as f64,
+        JsonNumber::NegInt(value) => *value as f64,
+        JsonNumber::Float(value) => value.0,
     }
 }
 
@@ -124,9 +372,14 @@ impl MutableVector for JsonVectorBuilder {
 
 #[cfg(test)]
 mod tests {
-    use common_base::bytes::Bytes;
+    use parquet::arrow::ArrowWriter;
+    use parquet::basic::LogicalType;
+    use parquet::schema::types::Type;
+    use parquet::variant::{VariantArray, VariantType};
 
     use super::*;
+    use crate::arrow::array::Array;
+    use crate::arrow::record_batch::RecordBatch;
     use crate::data_type::ConcreteDataType;
     use crate::types::json_type::JsonObjectType;
     use crate::value::{StructValue, Value, ValueRef};
@@ -157,32 +410,95 @@ mod tests {
             ConcreteDataType::Json(merged_type.clone())
         );
 
-        let merged_struct_type = merged_type.as_struct_type();
         let vector = builder.to_vector();
         assert_eq!(vector.len(), 3);
+        let vector = vector.as_any().downcast_ref::<StructVector>().unwrap();
+        let array = vector.array();
+        assert!(array.is_valid(0));
+        assert!(array.is_null(1));
+        assert!(array.is_valid(2));
+
+        let payload_field = array
+            .fields()
+            .iter()
+            .find(|field| field.name() == "payload")
+            .unwrap();
+        assert!(payload_field.has_valid_extension_type::<VariantType>());
         assert_eq!(
-            vector.get(0),
-            Value::Struct(StructValue::new(
-                vec![
-                    Value::Null,
-                    Value::Int64(1),
-                    Value::Binary(Bytes::from(br#"{"name":"foo"}"#.to_vec())),
-                ],
-                merged_struct_type.clone(),
-            ))
+            payload_field.extension_type_name(),
+            Some("arrow.parquet.variant")
         );
-        assert_eq!(vector.get(1), Value::Null);
+        let payload = array.column_by_name("payload").unwrap();
+        let payload = VariantArray::try_new(payload.as_ref()).unwrap();
+        assert!(payload.is_valid(0));
+        assert!(payload.is_null(1));
+        assert!(payload.is_valid(2));
+
+        let root_array: ArrayRef = Arc::new(array.clone());
+        let schema = Arc::new(arrow_schema::Schema::new(vec![Field::new(
+            "j",
+            root_array.data_type().clone(),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![root_array]).unwrap();
+        let mut parquet_bytes = Vec::new();
+        let mut writer = ArrowWriter::try_new(&mut parquet_bytes, schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        let metadata = writer.close().unwrap();
+        let parquet_schema = metadata.file_metadata().schema_descr().root_schema();
+        assert!(has_variant_logical_type(parquet_schema, "payload"));
+
+        let mut nested_builder =
+            JsonVectorBuilder::new(JsonNativeType::Object(Default::default()), 2);
+        let first = parse_json_value(r#"{"items":[{"name":"foo"}],"name":"a"}"#);
+        let second = parse_json_value(r#"{"items":["raw"],"name":"b"}"#);
+        nested_builder.try_push_value_ref(&first.as_value_ref())?;
+        nested_builder.try_push_value_ref(&second.as_value_ref())?;
+
+        let nested_vector = nested_builder.to_vector();
+        let nested_vector = nested_vector
+            .as_any()
+            .downcast_ref::<StructVector>()
+            .unwrap();
+        let nested_array = nested_vector.array();
         assert_eq!(
-            vector.get(2),
-            Value::Struct(StructValue::new(
-                vec![
-                    Value::Boolean(true),
-                    Value::Int64(2),
-                    Value::Binary(Bytes::from(br#""raw""#.to_vec())),
-                ],
-                merged_struct_type,
-            ))
+            nested_array.column_by_name("name").unwrap().data_type(),
+            &ArrowDataType::Utf8View
         );
+        let items = nested_array.column_by_name("items").unwrap();
+        let items = items.as_any().downcast_ref::<ListArray>().unwrap();
+        let ArrowDataType::List(item_field) = items.data_type() else {
+            unreachable!();
+        };
+        assert!(item_field.has_valid_extension_type::<VariantType>());
+
+        let mut plain_nested_builder =
+            JsonVectorBuilder::new(JsonNativeType::Object(Default::default()), 2);
+        let first = parse_json_value(r#"{"items":[1,2],"payload":{"name":"foo"}}"#);
+        let second = parse_json_value(r#"{"items":[3],"payload":{"name":"bar"}}"#);
+        plain_nested_builder.try_push_value_ref(&first.as_value_ref())?;
+        plain_nested_builder.try_push_value_ref(&second.as_value_ref())?;
+
+        let plain_nested_vector = plain_nested_builder.to_vector();
+        let plain_nested_vector = plain_nested_vector
+            .as_any()
+            .downcast_ref::<StructVector>()
+            .unwrap();
+        let plain_nested_array = plain_nested_vector.array();
+        assert!(matches!(
+            plain_nested_array
+                .column_by_name("items")
+                .unwrap()
+                .data_type(),
+            ArrowDataType::List(_)
+        ));
+        assert!(matches!(
+            plain_nested_array
+                .column_by_name("payload")
+                .unwrap()
+                .data_type(),
+            ArrowDataType::Struct(_)
+        ));
 
         // A Null initial type represents an unknown JSON2 runtime type. The first
         // non-null value should set the concrete type instead of aligning all rows to Null.
@@ -235,5 +551,18 @@ mod tests {
         assert!(err.to_string().contains("expected json value"));
 
         Ok(())
+    }
+
+    fn has_variant_logical_type(parquet_type: &Type, field_name: &str) -> bool {
+        parquet_type.name() == field_name
+            && matches!(
+                parquet_type.get_basic_info().logical_type_ref(),
+                Some(LogicalType::Variant { .. })
+            )
+            || parquet_type.is_group()
+                && parquet_type
+                    .get_fields()
+                    .iter()
+                    .any(|field| has_variant_logical_type(field, field_name))
     }
 }

--- a/src/datatypes/src/vectors/json/builder.rs
+++ b/src/datatypes/src/vectors/json/builder.rs
@@ -20,8 +20,8 @@ use arrow_schema::{DataType as ArrowDataType, Field, FieldRef, Fields};
 use parquet::variant::json_to_variant;
 
 use crate::arrow::array::{
-    ArrayRef, BooleanArray, Float64Array, Int64Array, ListArray, StringArray, StructArray,
-    UInt64Array,
+    ArrayRef, BooleanArray, Float64Array, Int64Array, ListArray, StringArray, StringViewArray,
+    StructArray, UInt64Array, new_null_array,
 };
 use crate::arrow::buffer::{NullBuffer, OffsetBuffer, ScalarBuffer};
 use crate::data_type::ConcreteDataType;
@@ -30,8 +30,7 @@ use crate::json::value::{JsonNumber, JsonValue, JsonVariant, JsonVariantRef};
 use crate::prelude::{ValueRef, Vector, VectorRef};
 use crate::types::json_type::{JsonFormat, JsonNativeType, JsonNumberType, JsonObjectType};
 use crate::types::{JsonType, StructType};
-use crate::value::Value;
-use crate::vectors::{Helper, MutableVector, StructVector};
+use crate::vectors::{MutableVector, StructVector};
 
 #[derive(Clone)]
 pub(crate) struct JsonVectorBuilder {
@@ -53,264 +52,6 @@ impl JsonVectorBuilder {
 
     fn try_build(&mut self) -> Result<VectorRef> {
         build_json2_struct_vector(&mut self.values, self.merged_type.native_type())
-    }
-}
-
-fn build_json2_struct_vector(
-    vals: &mut [JsonValue],
-    native_type: &JsonNativeType,
-) -> Result<VectorRef> {
-    let json_type = JsonType::new_json2(native_type.clone());
-    for val in vals.iter_mut() {
-        val.try_align(&json_type)?;
-    }
-
-    let variants = vals
-        .iter()
-        .map(|val| val.as_ref().into_variant())
-        .collect::<Vec<_>>();
-
-    let JsonNativeType::Object(_) = native_type else {
-        return InvalidVectorSnafu {
-            msg: format!("expected json object type, got {native_type}"),
-        }
-        .fail();
-    };
-
-    let (_, array) = build_json_array("", &variants, native_type)?;
-    let json_struct_array = array
-        .as_any()
-        .downcast_ref::<StructArray>()
-        .ok_or_else(|| {
-            InvalidVectorSnafu {
-                msg: format!(
-                    "expected JSON2 to be a StructArray, actual array type: {}",
-                    array.data_type()
-                ),
-            }
-            .build()
-        })?
-        .clone();
-
-    let fields = StructType::from(json_struct_array.fields());
-    Ok(Arc::new(StructVector::try_new(fields, json_struct_array)?))
-}
-
-fn build_json_array(
-    name: &str,
-    vals: &[JsonVariantRef<'_>],
-    native_type: &JsonNativeType,
-) -> Result<(FieldRef, ArrayRef)> {
-    match native_type {
-        JsonNativeType::Variant => build_parquet_variant_array(name, vals),
-        JsonNativeType::Object(object_type) => build_json_object_array(name, vals, object_type),
-        JsonNativeType::Array(item_type) => build_json_list_array(name, vals, item_type),
-        _ => build_plain_json_variant_array(name, vals, native_type),
-    }
-}
-
-fn build_parquet_variant_array(
-    name: &str,
-    vals: &[JsonVariantRef<'_>],
-) -> Result<(FieldRef, ArrayRef)> {
-    let json_vals = vals
-        .iter()
-        .map(|val| match val {
-            JsonVariantRef::Null => Ok(None),
-            JsonVariantRef::Variant(val) => Ok(Some(from_utf8(val).map_err(|e| {
-                InvalidVectorSnafu {
-                    msg: format!("invalid UTF-8 in JSON variant payload: {e}"),
-                }
-                .build()
-            })?)),
-            _ => InvalidVectorSnafu {
-                msg: format!("expected JSON variant payload, got {val:?}"),
-            }
-            .fail(),
-        })
-        .collect::<Result<Vec<_>>>()?;
-    let input: ArrayRef = Arc::new(StringArray::from(json_vals));
-    let array = json_to_variant(&input).map_err(|e| {
-        InvalidVectorSnafu {
-            msg: format!("failed to encode JSON payload as parquet variant: {e}"),
-        }
-        .build()
-    })?;
-    let field = Arc::new(array.field(name));
-    Ok((field, ArrayRef::from(array)))
-}
-
-fn build_json_object_array(
-    name: &str,
-    vals: &[JsonVariantRef<'_>],
-    object_type: &JsonObjectType,
-) -> Result<(FieldRef, ArrayRef)> {
-    let mut fields = Vec::with_capacity(object_type.len());
-    let mut arrays = Vec::with_capacity(object_type.len());
-    let mut field_vals = Vec::with_capacity(vals.len());
-    for (field_name, field_type) in object_type {
-        field_vals.clear();
-        for value in vals {
-            let val = match value {
-                JsonVariantRef::Object(object) => object
-                    .get(field_name.as_str())
-                    .cloned()
-                    .unwrap_or(JsonVariantRef::Null),
-                _ => JsonVariantRef::Null,
-            };
-            field_vals.push(val);
-        }
-        let (field, array) = build_json_array(field_name, &field_vals, field_type)?;
-        fields.push(field);
-        arrays.push(array);
-    }
-
-    let fields = Fields::from(fields);
-    let nulls = null_buffer(
-        vals.iter()
-            .map(|value| matches!(value, JsonVariantRef::Object(_))),
-    );
-    let array = StructArray::new(fields.clone(), arrays, nulls);
-    let field = Arc::new(Field::new(name, ArrowDataType::Struct(fields), true));
-    Ok((field, Arc::new(array)))
-}
-
-fn build_plain_json_variant_array(
-    name: &str,
-    vals: &[JsonVariantRef<'_>],
-    native_type: &JsonNativeType,
-) -> Result<(FieldRef, ArrayRef)> {
-    let data_type = native_type.as_arrow_type();
-    let field = Arc::new(Field::new(name, data_type.clone(), true));
-    let array = match native_type {
-        JsonNativeType::Null => crate::arrow::array::new_null_array(&data_type, vals.len()),
-        JsonNativeType::Bool => Arc::new(BooleanArray::from_iter(vals.iter().map(
-            |value| match value {
-                JsonVariantRef::Null => None,
-                JsonVariantRef::Bool(value) => Some(*value),
-                _ => None,
-            },
-        ))) as ArrayRef,
-        JsonNativeType::Number(JsonNumberType::U64) => Arc::new(UInt64Array::from_iter(
-            vals.iter().map(|value| match value {
-                JsonVariantRef::Null => None,
-                JsonVariantRef::Number(value) => json_number_as_u64(value),
-                _ => None,
-            }),
-        )) as ArrayRef,
-        JsonNativeType::Number(JsonNumberType::I64) => Arc::new(Int64Array::from_iter(
-            vals.iter().map(|value| match value {
-                JsonVariantRef::Null => None,
-                JsonVariantRef::Number(value) => json_number_as_i64(value),
-                _ => None,
-            }),
-        )) as ArrayRef,
-        JsonNativeType::Number(JsonNumberType::F64) => Arc::new(Float64Array::from_iter(
-            vals.iter().map(|value| match value {
-                JsonVariantRef::Null => None,
-                JsonVariantRef::Number(value) => Some(json_number_as_f64(value)),
-                _ => None,
-            }),
-        )) as ArrayRef,
-        JsonNativeType::String => {
-            let row_vals = vals
-                .iter()
-                .map(|value| match value {
-                    JsonVariantRef::Null => Value::Null,
-                    JsonVariantRef::String(value) => Value::String((*value).into()),
-                    _ => Value::Null,
-                })
-                .collect::<Vec<_>>();
-            Helper::try_from_row_into_vector(
-                &row_vals,
-                &ConcreteDataType::from_arrow_type(&ArrowDataType::Utf8View),
-            )?
-            .to_arrow_array()
-        }
-        JsonNativeType::Array(_) | JsonNativeType::Object(_) | JsonNativeType::Variant => {
-            unreachable!("complex JSON native types are built by recursive builders")
-        }
-    };
-    Ok((field, array))
-}
-
-fn build_json_list_array(
-    name: &str,
-    vals: &[JsonVariantRef<'_>],
-    item_type: &JsonNativeType,
-) -> Result<(FieldRef, ArrayRef)> {
-    let mut offsets = Vec::with_capacity(vals.len() + 1);
-    let mut valid = Vec::with_capacity(vals.len());
-    let mut flattened = Vec::new();
-    offsets.push(0_i32);
-    for value in vals {
-        match value {
-            JsonVariantRef::Array(items) => {
-                flattened.extend(items.iter().cloned());
-                valid.push(true);
-            }
-            JsonVariantRef::Null => valid.push(false),
-            _ => {
-                return InvalidVectorSnafu {
-                    msg: format!("expected JSON array payload, got {value:?}"),
-                }
-                .fail();
-            }
-        }
-        let offset: i32 = flattened.len().try_into().map_err(|_| {
-            InvalidVectorSnafu {
-                msg: "flattened list length exceeds i32::MAX",
-            }
-            .build()
-        })?;
-        offsets.push(offset);
-    }
-
-    let (item_field, item_array) = build_json_array("item", &flattened, item_type)?;
-    let nulls = null_buffer(valid);
-    let array = ListArray::new(
-        item_field.clone(),
-        OffsetBuffer::new(ScalarBuffer::from(offsets)),
-        item_array,
-        nulls,
-    );
-    let field = Arc::new(Field::new(
-        name,
-        ArrowDataType::List(item_field.clone()),
-        true,
-    ));
-    Ok((field, Arc::new(array)))
-}
-
-fn null_buffer(valid: impl IntoIterator<Item = bool>) -> Option<NullBuffer> {
-    let valid = valid.into_iter().collect::<Vec<_>>();
-    valid
-        .iter()
-        .any(|valid| !*valid)
-        .then(|| NullBuffer::from(valid))
-}
-
-fn json_number_as_u64(value: &JsonNumber) -> Option<u64> {
-    match value {
-        JsonNumber::PosInt(value) => Some(*value),
-        JsonNumber::NegInt(value) => (*value >= 0).then_some(*value as u64),
-        JsonNumber::Float(_) => None,
-    }
-}
-
-fn json_number_as_i64(value: &JsonNumber) -> Option<i64> {
-    match value {
-        JsonNumber::PosInt(value) => (*value <= i64::MAX as u64).then_some(*value as i64),
-        JsonNumber::NegInt(value) => Some(*value),
-        JsonNumber::Float(_) => None,
-    }
-}
-
-fn json_number_as_f64(value: &JsonNumber) -> f64 {
-    match value {
-        JsonNumber::PosInt(value) => *value as f64,
-        JsonNumber::NegInt(value) => *value as f64,
-        JsonNumber::Float(value) => value.0,
     }
 }
 
@@ -376,6 +117,254 @@ impl MutableVector for JsonVectorBuilder {
             vector_type: "JsonVector",
         }
         .fail()
+    }
+}
+
+fn build_json2_struct_vector(
+    vals: &mut [JsonValue],
+    native_type: &JsonNativeType,
+) -> Result<VectorRef> {
+    let json_type = JsonType::new_json2(native_type.clone());
+    for val in vals.iter_mut() {
+        val.try_align(&json_type)?;
+    }
+
+    let variants = vals
+        .iter()
+        .map(|val| val.as_ref().into_variant())
+        .collect::<Vec<_>>();
+
+    let JsonNativeType::Object(_) = native_type else {
+        return InvalidVectorSnafu {
+            msg: format!("expected json object type, got {native_type}"),
+        }
+        .fail();
+    };
+
+    let (_, array) = build_json_array("", &variants, native_type)?;
+    let json_struct_array = array
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .ok_or_else(|| {
+            InvalidVectorSnafu {
+                msg: format!(
+                    "expected JSON2 to be a StructArray, actual array type: {}",
+                    array.data_type()
+                ),
+            }
+            .build()
+        })?
+        .clone();
+
+    let fields = StructType::from(json_struct_array.fields());
+    Ok(Arc::new(StructVector::try_new(fields, json_struct_array)?))
+}
+
+fn build_json_array(
+    name: &str,
+    vals: &[JsonVariantRef<'_>],
+    native_type: &JsonNativeType,
+) -> Result<(FieldRef, ArrayRef)> {
+    match native_type {
+        JsonNativeType::Variant => build_parquet_variant_array(name, vals),
+        JsonNativeType::Object(object_type) => build_json_object_array(name, vals, object_type),
+        JsonNativeType::Array(item_type) => build_json_list_array(name, vals, item_type),
+        _ => build_json_scalar_array(name, vals, native_type),
+    }
+}
+
+fn build_parquet_variant_array(
+    name: &str,
+    vals: &[JsonVariantRef<'_>],
+) -> Result<(FieldRef, ArrayRef)> {
+    let json_vals = vals
+        .iter()
+        .map(|val| match val {
+            JsonVariantRef::Null => Ok(None),
+            JsonVariantRef::Variant(val) => Ok(Some(from_utf8(val).map_err(|e| {
+                InvalidVectorSnafu {
+                    msg: format!("invalid UTF-8 in JSON variant payload: {e}"),
+                }
+                .build()
+            })?)),
+            _ => InvalidVectorSnafu {
+                msg: format!("expected JSON variant payload, got {val:?}"),
+            }
+            .fail(),
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let input: ArrayRef = Arc::new(StringArray::from(json_vals));
+    let array = json_to_variant(&input).map_err(|e| {
+        InvalidVectorSnafu {
+            msg: format!("failed to encode JSON payload as parquet variant: {e}"),
+        }
+        .build()
+    })?;
+    let field = Arc::new(array.field(name));
+    Ok((field, ArrayRef::from(array)))
+}
+
+fn build_json_object_array(
+    name: &str,
+    vals: &[JsonVariantRef<'_>],
+    object_type: &JsonObjectType,
+) -> Result<(FieldRef, ArrayRef)> {
+    let mut fields = Vec::with_capacity(object_type.len());
+    let mut arrays = Vec::with_capacity(object_type.len());
+    let mut field_vals = Vec::with_capacity(vals.len());
+    for (field_name, field_type) in object_type {
+        field_vals.clear();
+        for value in vals {
+            let val = match value {
+                JsonVariantRef::Object(object) => object
+                    .get(field_name.as_str())
+                    .cloned()
+                    .unwrap_or(JsonVariantRef::Null),
+                _ => JsonVariantRef::Null,
+            };
+            field_vals.push(val);
+        }
+        let (field, array) = build_json_array(field_name, &field_vals, field_type)?;
+        fields.push(field);
+        arrays.push(array);
+    }
+
+    let fields = Fields::from(fields);
+    let nulls = null_buffer(
+        vals.iter()
+            .map(|val| matches!(val, JsonVariantRef::Object(_))),
+    );
+    let array = StructArray::new(fields.clone(), arrays, nulls);
+    let field = Arc::new(Field::new(name, ArrowDataType::Struct(fields), true));
+    Ok((field, Arc::new(array)))
+}
+
+fn build_json_list_array(
+    name: &str,
+    vals: &[JsonVariantRef<'_>],
+    item_type: &JsonNativeType,
+) -> Result<(FieldRef, ArrayRef)> {
+    let mut offsets = Vec::with_capacity(vals.len() + 1);
+    let mut valid = Vec::with_capacity(vals.len());
+    let mut flattened = Vec::new();
+    offsets.push(0_i32);
+    for val in vals {
+        match val {
+            JsonVariantRef::Array(items) => {
+                flattened.extend(items.iter().cloned());
+                valid.push(true);
+            }
+            JsonVariantRef::Null => valid.push(false),
+            _ => {
+                return InvalidVectorSnafu {
+                    msg: format!("expected JSON array payload, got {val:?}"),
+                }
+                .fail();
+            }
+        }
+        let offset: i32 = flattened.len().try_into().map_err(|_| {
+            InvalidVectorSnafu {
+                msg: "flattened list length exceeds i32::MAX",
+            }
+            .build()
+        })?;
+        offsets.push(offset);
+    }
+
+    let (item_field, item_array) = build_json_array("item", &flattened, item_type)?;
+    let nulls = null_buffer(valid);
+    let offsets = OffsetBuffer::new(ScalarBuffer::from(offsets));
+    let array = ListArray::new(item_field.clone(), offsets, item_array, nulls);
+    let field = Arc::new(Field::new(
+        name,
+        ArrowDataType::List(item_field.clone()),
+        true,
+    ));
+    Ok((field, Arc::new(array)))
+}
+
+fn build_json_scalar_array(
+    name: &str,
+    vals: &[JsonVariantRef<'_>],
+    native_type: &JsonNativeType,
+) -> Result<(FieldRef, ArrayRef)> {
+    let data_type = native_type.as_arrow_type();
+    let field = Arc::new(Field::new(name, data_type.clone(), true));
+    let array = match native_type {
+        JsonNativeType::Null => new_null_array(&data_type, vals.len()),
+        JsonNativeType::Bool => {
+            Arc::new(BooleanArray::from_iter(vals.iter().map(|val| match val {
+                JsonVariantRef::Null => None,
+                JsonVariantRef::Bool(val) => Some(*val),
+                _ => None,
+            }))) as ArrayRef
+        }
+        JsonNativeType::Number(JsonNumberType::U64) => {
+            Arc::new(UInt64Array::from_iter(vals.iter().map(|val| match val {
+                JsonVariantRef::Null => None,
+                JsonVariantRef::Number(val) => json_number_as_u64(val),
+                _ => None,
+            }))) as ArrayRef
+        }
+        JsonNativeType::Number(JsonNumberType::I64) => {
+            Arc::new(Int64Array::from_iter(vals.iter().map(|val| match val {
+                JsonVariantRef::Null => None,
+                JsonVariantRef::Number(val) => json_number_as_i64(val),
+                _ => None,
+            }))) as ArrayRef
+        }
+        JsonNativeType::Number(JsonNumberType::F64) => {
+            Arc::new(Float64Array::from_iter(vals.iter().map(|val| match val {
+                JsonVariantRef::Null => None,
+                JsonVariantRef::Number(val) => Some(json_number_as_f64(val)),
+                _ => None,
+            }))) as ArrayRef
+        }
+        JsonNativeType::String => {
+            Arc::new(StringViewArray::from_iter(vals.iter().map(
+                |val| match val {
+                    JsonVariantRef::Null => None,
+                    JsonVariantRef::String(val) => Some(*val),
+                    _ => None,
+                },
+            ))) as ArrayRef
+        }
+        JsonNativeType::Array(_) | JsonNativeType::Object(_) | JsonNativeType::Variant => {
+            unreachable!("complex JSON native types are built by recursive builders")
+        }
+    };
+    Ok((field, array))
+}
+
+fn null_buffer(valid: impl IntoIterator<Item = bool>) -> Option<NullBuffer> {
+    let valid = valid.into_iter().collect::<Vec<_>>();
+    valid
+        .iter()
+        .any(|valid| !*valid)
+        .then(|| NullBuffer::from(valid))
+}
+
+fn json_number_as_u64(val: &JsonNumber) -> Option<u64> {
+    match val {
+        JsonNumber::PosInt(val) => Some(*val),
+        JsonNumber::NegInt(val) => (*val >= 0).then_some(*val as u64),
+        JsonNumber::Float(_) => None,
+    }
+}
+
+fn json_number_as_i64(val: &JsonNumber) -> Option<i64> {
+    match val {
+        JsonNumber::PosInt(val) => (*val <= i64::MAX as u64).then_some(*val as i64),
+        JsonNumber::NegInt(val) => Some(*val),
+        JsonNumber::Float(_) => None,
+    }
+}
+
+fn json_number_as_f64(val: &JsonNumber) -> f64 {
+    match val {
+        JsonNumber::PosInt(val) => *val as f64,
+        JsonNumber::NegInt(val) => *val as f64,
+        JsonNumber::Float(val) => val.0,
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
