### PR TITLE
test: add recent sqlness compat cases

### DIFF
--- a/tests/compatibility/cases/column_default/case.toml
+++ b/tests/compatibility/cases/column_default/case.toml
@@ -1,0 +1,8 @@
+name = "column_default"
+reason = "Verify column DEFAULT metadata created by old binaries still works for inserts after upgrade."
+introduced_by = "PR #8376 follow-up"
+topologies = ["distributed"]
+from_range = ["*"]
+to_range = ["*"]
+features = ["table", "default"]
+owner = "query"

--- a/tests/compatibility/cases/column_default/setup.sql
+++ b/tests/compatibility/cases/column_default/setup.sql
@@ -1,0 +1,16 @@
+CREATE TABLE t_column_default(
+    ts TIMESTAMP TIME INDEX,
+    host STRING PRIMARY KEY,
+    val INT DEFAULT 42,
+    msg STRING DEFAULT 'hello',
+    score DOUBLE DEFAULT 1.5
+);
+
+INSERT INTO t_column_default (ts, host) VALUES
+('2024-02-03 00:00:00+0000', 'host_a'),
+('2024-02-03 00:01:00+0000', 'host_b');
+
+INSERT INTO t_column_default (ts, host, val, msg, score) VALUES
+('2024-02-03 00:02:00+0000', 'host_c', 100, 'override', 9.5);
+
+ADMIN FLUSH_TABLE('t_column_default');

--- a/tests/compatibility/cases/column_default/verify.result
+++ b/tests/compatibility/cases/column_default/verify.result
@@ -1,0 +1,41 @@
+SELECT ts, host, val, msg, score FROM t_column_default ORDER BY ts, host;
+
++---------------------+--------+-----+----------+-------+
+| ts                  | host   | val | msg      | score |
++---------------------+--------+-----+----------+-------+
+| 2024-02-03T00:00:00 | host_a | 42  | hello    | 1.5   |
+| 2024-02-03T00:01:00 | host_b | 42  | hello    | 1.5   |
+| 2024-02-03T00:02:00 | host_c | 100 | override | 9.5   |
++---------------------+--------+-----+----------+-------+
+
+INSERT INTO t_column_default (ts, host) VALUES
+('2024-02-03 00:03:00+0000', 'host_d');
+
+Affected Rows: 1
+
+SELECT ts, host, val, msg, score FROM t_column_default WHERE host = 'host_d';
+
++---------------------+--------+-----+-------+-------+
+| ts                  | host   | val | msg   | score |
++---------------------+--------+-----+-------+-------+
+| 2024-02-03T00:03:00 | host_d | 42  | hello | 1.5   |
++---------------------+--------+-----+-------+-------+
+
+SHOW CREATE TABLE t_column_default;
+
++------------------+-------------------------------------------------+
+| Table            | Create Table                                    |
++------------------+-------------------------------------------------+
+| t_column_default | CREATE TABLE IF NOT EXISTS "t_column_default" ( |
+|                  |   "ts" TIMESTAMP(3) NOT NULL,                   |
+|                  |   "host" STRING NULL,                           |
+|                  |   "val" INT NULL DEFAULT 42,                    |
+|                  |   "msg" STRING NULL DEFAULT 'hello',            |
+|                  |   "score" DOUBLE NULL DEFAULT 1.5,              |
+|                  |   TIME INDEX ("ts"),                            |
+|                  |   PRIMARY KEY ("host")                          |
+|                  | )                                               |
+|                  |                                                 |
+|                  | ENGINE=mito                                     |
+|                  |                                                 |
++------------------+-------------------------------------------------+

--- a/tests/compatibility/cases/column_default/verify.sql
+++ b/tests/compatibility/cases/column_default/verify.sql
@@ -1,0 +1,8 @@
+SELECT ts, host, val, msg, score FROM t_column_default ORDER BY ts, host;
+
+INSERT INTO t_column_default (ts, host) VALUES
+('2024-02-03 00:03:00+0000', 'host_d');
+
+SELECT ts, host, val, msg, score FROM t_column_default WHERE host = 'host_d';
+
+SHOW CREATE TABLE t_column_default;

--- a/tests/compatibility/cases/information_schema_old_table/case.toml
+++ b/tests/compatibility/cases/information_schema_old_table/case.toml
@@ -1,0 +1,8 @@
+name = "information_schema_old_table"
+reason = "Verify current information_schema views expose table and column metadata for tables created by old binaries."
+introduced_by = "PR #8210"
+topologies = ["distributed"]
+from_range = ["*"]
+to_range = ["*"]
+features = ["information_schema", "table"]
+owner = "query"

--- a/tests/compatibility/cases/information_schema_old_table/setup.sql
+++ b/tests/compatibility/cases/information_schema_old_table/setup.sql
@@ -1,0 +1,12 @@
+CREATE TABLE t_information_schema_old_table(
+    ts TIMESTAMP TIME INDEX,
+    host STRING PRIMARY KEY,
+    val DOUBLE,
+    code INT
+);
+
+INSERT INTO t_information_schema_old_table VALUES
+('2024-02-09 00:00:00+0000', 'host_a', 1.0, 200),
+('2024-02-09 00:01:00+0000', 'host_b', 2.0, 500);
+
+ADMIN FLUSH_TABLE('t_information_schema_old_table');

--- a/tests/compatibility/cases/information_schema_old_table/verify.result
+++ b/tests/compatibility/cases/information_schema_old_table/verify.result
@@ -1,0 +1,34 @@
+SELECT table_schema, table_name, table_type, engine
+FROM information_schema.tables
+WHERE table_name = 't_information_schema_old_table'
+ORDER BY table_schema;
+
++------------------------------+--------------------------------+------------+--------+
+| table_schema                 | table_name                     | table_type | engine |
++------------------------------+--------------------------------+------------+--------+
+| information_schema_old_table | t_information_schema_old_table | BASE TABLE | mito   |
++------------------------------+--------------------------------+------------+--------+
+
+SELECT column_name, data_type, semantic_type
+FROM information_schema.columns
+WHERE table_name = 't_information_schema_old_table'
+ORDER BY table_schema, column_name;
+
++-------------+--------------+---------------+
+| column_name | data_type    | semantic_type |
++-------------+--------------+---------------+
+| code        | int          | FIELD         |
+| host        | string       | TAG           |
+| ts          | timestamp(3) | TIMESTAMP     |
+| val         | double       | FIELD         |
++-------------+--------------+---------------+
+
+SELECT count(*)
+FROM information_schema.table_semantics
+WHERE table_name = 't_information_schema_old_table';
+
++----------+
+| count(*) |
++----------+
+| 0        |
++----------+

--- a/tests/compatibility/cases/information_schema_old_table/verify.sql
+++ b/tests/compatibility/cases/information_schema_old_table/verify.sql
@@ -1,0 +1,13 @@
+SELECT table_schema, table_name, table_type, engine
+FROM information_schema.tables
+WHERE table_name = 't_information_schema_old_table'
+ORDER BY table_schema;
+
+SELECT column_name, data_type, semantic_type
+FROM information_schema.columns
+WHERE table_name = 't_information_schema_old_table'
+ORDER BY table_schema, column_name;
+
+SELECT count(*)
+FROM information_schema.table_semantics
+WHERE table_name = 't_information_schema_old_table';

--- a/tests/compatibility/cases/json2_compat/case.toml
+++ b/tests/compatibility/cases/json2_compat/case.toml
@@ -1,0 +1,8 @@
+name = "json2_compat"
+reason = "Verify JSON data written by v1.1.x JSON2 binaries remains readable after later JSON2 read/flush/compaction changes."
+introduced_by = "PR #7965"
+topologies = ["distributed"]
+from_range = [">=v1.1.0"]
+to_range = ["*"]
+features = ["json", "table"]
+owner = "query"

--- a/tests/compatibility/cases/json2_compat/setup.sql
+++ b/tests/compatibility/cases/json2_compat/setup.sql
@@ -1,0 +1,12 @@
+CREATE TABLE t_json2_compat(
+    ts TIMESTAMP TIME INDEX,
+    host STRING PRIMARY KEY,
+    j JSON
+);
+
+INSERT INTO t_json2_compat VALUES
+('2024-02-05 00:00:00+0000', 'host_a', parse_json('{"a": 10, "nested": {"b": "x"}, "flag": true}')),
+('2024-02-05 00:01:00+0000', 'host_b', parse_json('{"a": 20, "nested": {"b": "y"}, "flag": false}')),
+('2024-02-05 00:02:00+0000', 'host_c', parse_json('{"a": 30, "nested": {"b": "z"}, "flag": true}'));
+
+ADMIN FLUSH_TABLE('t_json2_compat');

--- a/tests/compatibility/cases/json2_compat/verify.result
+++ b/tests/compatibility/cases/json2_compat/verify.result
@@ -1,0 +1,52 @@
+SELECT host, json_to_string(j)
+FROM t_json2_compat
+ORDER BY host;
+
++--------+------------------------------------------+
+| host   | json_to_string(t_json2_compat.j)         |
++--------+------------------------------------------+
+| host_a | {"a":10,"flag":true,"nested":{"b":"x"}}  |
+| host_b | {"a":20,"flag":false,"nested":{"b":"y"}} |
+| host_c | {"a":30,"flag":true,"nested":{"b":"z"}}  |
++--------+------------------------------------------+
+
+SELECT host, json_get_int(j, 'a') AS a
+FROM t_json2_compat
+WHERE json_get_int(j, 'a') >= 20
+ORDER BY host;
+
++--------+----+
+| host   | a  |
++--------+----+
+| host_b | 20 |
+| host_c | 30 |
++--------+----+
+
+SELECT host, json_get_string(j, 'nested.b') AS nested_b
+FROM t_json2_compat
+WHERE json_get_bool(j, 'flag') = true
+ORDER BY host;
+
++--------+----------+
+| host   | nested_b |
++--------+----------+
+| host_a | x        |
+| host_c | z        |
++--------+----------+
+
+SHOW CREATE TABLE t_json2_compat;
+
++----------------+-----------------------------------------------+
+| Table          | Create Table                                  |
++----------------+-----------------------------------------------+
+| t_json2_compat | CREATE TABLE IF NOT EXISTS "t_json2_compat" ( |
+|                |   "ts" TIMESTAMP(3) NOT NULL,                 |
+|                |   "host" STRING NULL,                         |
+|                |   "j" JSON NULL,                              |
+|                |   TIME INDEX ("ts"),                          |
+|                |   PRIMARY KEY ("host")                        |
+|                | )                                             |
+|                |                                               |
+|                | ENGINE=mito                                   |
+|                |                                               |
++----------------+-----------------------------------------------+

--- a/tests/compatibility/cases/json2_compat/verify.sql
+++ b/tests/compatibility/cases/json2_compat/verify.sql
@@ -1,0 +1,15 @@
+SELECT host, json_to_string(j)
+FROM t_json2_compat
+ORDER BY host;
+
+SELECT host, json_get_int(j, 'a') AS a
+FROM t_json2_compat
+WHERE json_get_int(j, 'a') >= 20
+ORDER BY host;
+
+SELECT host, json_get_string(j, 'nested.b') AS nested_b
+FROM t_json2_compat
+WHERE json_get_bool(j, 'flag') = true
+ORDER BY host;
+
+SHOW CREATE TABLE t_json2_compat;

--- a/tests/compatibility/cases/last_row_append_mode/case.toml
+++ b/tests/compatibility/cases/last_row_append_mode/case.toml
@@ -1,0 +1,8 @@
+name = "last_row_append_mode"
+reason = "Verify a table created with merge_mode='last_row' by old binaries can switch to append_mode after upgrade."
+introduced_by = "PR #8065"
+topologies = ["distributed"]
+from_range = ["*"]
+to_range = ["*"]
+features = ["table", "merge", "append_mode"]
+owner = "storage"

--- a/tests/compatibility/cases/last_row_append_mode/setup.sql
+++ b/tests/compatibility/cases/last_row_append_mode/setup.sql
@@ -1,0 +1,18 @@
+CREATE TABLE t_last_row_append_mode(
+    host STRING,
+    ts TIMESTAMP TIME INDEX,
+    cpu DOUBLE,
+    PRIMARY KEY(host)
+)
+ENGINE=mito
+WITH('merge_mode'='last_row');
+
+INSERT INTO t_last_row_append_mode VALUES
+('host1', 0, 1.0),
+('host2', 1, 2.0);
+
+INSERT INTO t_last_row_append_mode VALUES
+('host1', 0, 10.0),
+('host2', 1, 20.0);
+
+ADMIN FLUSH_TABLE('t_last_row_append_mode');

--- a/tests/compatibility/cases/last_row_append_mode/verify.result
+++ b/tests/compatibility/cases/last_row_append_mode/verify.result
@@ -1,0 +1,52 @@
+SELECT host, ts, cpu
+FROM t_last_row_append_mode
+ORDER BY host, ts, cpu;
+
++-------+-------------------------+------+
+| host  | ts                      | cpu  |
++-------+-------------------------+------+
+| host1 | 1970-01-01T00:00:00     | 10.0 |
+| host2 | 1970-01-01T00:00:00.001 | 20.0 |
++-------+-------------------------+------+
+
+ALTER TABLE t_last_row_append_mode SET 'append_mode' = 'true';
+
+Affected Rows: 0
+
+SHOW CREATE TABLE t_last_row_append_mode;
+
++------------------------+-------------------------------------------------------+
+| Table                  | Create Table                                          |
++------------------------+-------------------------------------------------------+
+| t_last_row_append_mode | CREATE TABLE IF NOT EXISTS "t_last_row_append_mode" ( |
+|                        |   "host" STRING NULL,                                 |
+|                        |   "ts" TIMESTAMP(3) NOT NULL,                         |
+|                        |   "cpu" DOUBLE NULL,                                  |
+|                        |   TIME INDEX ("ts"),                                  |
+|                        |   PRIMARY KEY ("host")                                |
+|                        | )                                                     |
+|                        |                                                       |
+|                        | ENGINE=mito                                           |
+|                        | WITH(                                                 |
+|                        |   append_mode = 'true'                                |
+|                        | )                                                     |
++------------------------+-------------------------------------------------------+
+
+INSERT INTO t_last_row_append_mode VALUES
+('host1', 0, 100.0),
+('host2', 1, 200.0);
+
+Affected Rows: 2
+
+SELECT host, ts, cpu
+FROM t_last_row_append_mode
+ORDER BY host, ts, cpu;
+
++-------+-------------------------+-------+
+| host  | ts                      | cpu   |
++-------+-------------------------+-------+
+| host1 | 1970-01-01T00:00:00     | 10.0  |
+| host1 | 1970-01-01T00:00:00     | 100.0 |
+| host2 | 1970-01-01T00:00:00.001 | 20.0  |
+| host2 | 1970-01-01T00:00:00.001 | 200.0 |
++-------+-------------------------+-------+

--- a/tests/compatibility/cases/last_row_append_mode/verify.sql
+++ b/tests/compatibility/cases/last_row_append_mode/verify.sql
@@ -1,0 +1,15 @@
+SELECT host, ts, cpu
+FROM t_last_row_append_mode
+ORDER BY host, ts, cpu;
+
+ALTER TABLE t_last_row_append_mode SET 'append_mode' = 'true';
+
+SHOW CREATE TABLE t_last_row_append_mode;
+
+INSERT INTO t_last_row_append_mode VALUES
+('host1', 0, 100.0),
+('host2', 1, 200.0);
+
+SELECT host, ts, cpu
+FROM t_last_row_append_mode
+ORDER BY host, ts, cpu;

--- a/tests/compatibility/cases/last_row_merge/case.toml
+++ b/tests/compatibility/cases/last_row_merge/case.toml
@@ -1,0 +1,8 @@
+name = "last_row_merge"
+reason = "Verify data written with merge_mode='last_row' by old binaries is still merged correctly by newer binaries."
+introduced_by = "PR #8065"
+topologies = ["distributed"]
+from_range = ["*"]
+to_range = ["*"]
+features = ["table", "merge"]
+owner = "query"

--- a/tests/compatibility/cases/last_row_merge/setup.sql
+++ b/tests/compatibility/cases/last_row_merge/setup.sql
@@ -1,0 +1,19 @@
+CREATE TABLE t_last_row_merge(
+    host STRING,
+    ts TIMESTAMP TIME INDEX,
+    cpu DOUBLE,
+    memory DOUBLE,
+    PRIMARY KEY(host)
+)
+ENGINE=mito
+WITH('merge_mode'='last_row');
+
+INSERT INTO t_last_row_merge VALUES
+('host1', 0, 0, NULL),
+('host2', 1, NULL, 1);
+
+INSERT INTO t_last_row_merge VALUES
+('host1', 0, NULL, 10),
+('host2', 1, 11, NULL);
+
+ADMIN FLUSH_TABLE('t_last_row_merge');

--- a/tests/compatibility/cases/last_row_merge/verify.result
+++ b/tests/compatibility/cases/last_row_merge/verify.result
@@ -1,0 +1,41 @@
+SELECT host, ts, cpu, memory
+FROM t_last_row_merge
+ORDER BY host, ts;
+
++-------+-------------------------+------+--------+
+| host  | ts                      | cpu  | memory |
++-------+-------------------------+------+--------+
+| host1 | 1970-01-01T00:00:00     |      | 10.0   |
+| host2 | 1970-01-01T00:00:00.001 | 11.0 |        |
++-------+-------------------------+------+--------+
+
+SELECT host, cpu, memory
+FROM t_last_row_merge
+WHERE memory IS NULL
+ORDER BY host;
+
++-------+------+--------+
+| host  | cpu  | memory |
++-------+------+--------+
+| host2 | 11.0 |        |
++-------+------+--------+
+
+SHOW CREATE TABLE t_last_row_merge;
+
++------------------+-------------------------------------------------+
+| Table            | Create Table                                    |
++------------------+-------------------------------------------------+
+| t_last_row_merge | CREATE TABLE IF NOT EXISTS "t_last_row_merge" ( |
+|                  |   "host" STRING NULL,                           |
+|                  |   "ts" TIMESTAMP(3) NOT NULL,                   |
+|                  |   "cpu" DOUBLE NULL,                            |
+|                  |   "memory" DOUBLE NULL,                         |
+|                  |   TIME INDEX ("ts"),                            |
+|                  |   PRIMARY KEY ("host")                          |
+|                  | )                                               |
+|                  |                                                 |
+|                  | ENGINE=mito                                     |
+|                  | WITH(                                           |
+|                  |   merge_mode = 'last_row'                       |
+|                  | )                                               |
++------------------+-------------------------------------------------+

--- a/tests/compatibility/cases/last_row_merge/verify.sql
+++ b/tests/compatibility/cases/last_row_merge/verify.sql
@@ -1,0 +1,10 @@
+SELECT host, ts, cpu, memory
+FROM t_last_row_merge
+ORDER BY host, ts;
+
+SELECT host, cpu, memory
+FROM t_last_row_merge
+WHERE memory IS NULL
+ORDER BY host;
+
+SHOW CREATE TABLE t_last_row_merge;

--- a/tests/compatibility/cases/legacy_json_non_object/case.toml
+++ b/tests/compatibility/cases/legacy_json_non_object/case.toml
@@ -1,0 +1,8 @@
+name = "legacy_json_non_object"
+reason = "Verify non-object JSON values written by old JSONB binaries remain readable after JSON2 non-object write rejection changes."
+introduced_by = "PR #8381"
+topologies = ["distributed"]
+from_range = ["<=v1.1.0"]
+to_range = [">=v1.2.0"]
+features = ["json", "table"]
+owner = "query"

--- a/tests/compatibility/cases/legacy_json_non_object/setup.sql
+++ b/tests/compatibility/cases/legacy_json_non_object/setup.sql
@@ -1,0 +1,15 @@
+CREATE TABLE t_legacy_json_non_object(
+    ts TIMESTAMP TIME INDEX,
+    kind STRING PRIMARY KEY,
+    j JSON
+);
+
+INSERT INTO t_legacy_json_non_object VALUES
+('2024-02-06 00:00:00+0000', 'array', parse_json('[1, 2, 3]')),
+('2024-02-06 00:01:00+0000', 'string', parse_json('"hello"')),
+('2024-02-06 00:02:00+0000', 'int', parse_json('42')),
+('2024-02-06 00:03:00+0000', 'bool', parse_json('true')),
+('2024-02-06 00:04:00+0000', 'null', parse_json('null')),
+('2024-02-06 00:05:00+0000', 'object', parse_json('{"a": 10, "msg": "object"}'));
+
+ADMIN FLUSH_TABLE('t_legacy_json_non_object');

--- a/tests/compatibility/cases/legacy_json_non_object/verify.result
+++ b/tests/compatibility/cases/legacy_json_non_object/verify.result
@@ -1,0 +1,60 @@
+SELECT kind, json_to_string(j) FROM t_legacy_json_non_object ORDER BY kind;
+
++--------+--------------------------------------------+
+| kind   | json_to_string(t_legacy_json_non_object.j) |
++--------+--------------------------------------------+
+| array  | [1,2,3]                                    |
+| bool   | true                                       |
+| int    | 42                                         |
+| null   | null                                       |
+| object | {"a":10,"msg":"object"}                    |
+| string | "hello"                                    |
++--------+--------------------------------------------+
+
+SELECT kind FROM t_legacy_json_non_object WHERE json_is_array(j) ORDER BY kind;
+
++-------+
+| kind  |
++-------+
+| array |
++-------+
+
+SELECT kind FROM t_legacy_json_non_object WHERE json_is_string(j) ORDER BY kind;
+
++--------+
+| kind   |
++--------+
+| string |
++--------+
+
+SELECT kind FROM t_legacy_json_non_object WHERE json_is_int(j) ORDER BY kind;
+
++------+
+| kind |
++------+
+| int  |
++------+
+
+SELECT kind FROM t_legacy_json_non_object WHERE json_is_bool(j) ORDER BY kind;
+
++------+
+| kind |
++------+
+| bool |
++------+
+
+SELECT kind FROM t_legacy_json_non_object WHERE json_is_null(j) ORDER BY kind;
+
++------+
+| kind |
++------+
+| null |
++------+
+
+SELECT kind FROM t_legacy_json_non_object WHERE json_is_object(j) ORDER BY kind;
+
++--------+
+| kind   |
++--------+
+| object |
++--------+

--- a/tests/compatibility/cases/legacy_json_non_object/verify.sql
+++ b/tests/compatibility/cases/legacy_json_non_object/verify.sql
@@ -1,0 +1,13 @@
+SELECT kind, json_to_string(j) FROM t_legacy_json_non_object ORDER BY kind;
+
+SELECT kind FROM t_legacy_json_non_object WHERE json_is_array(j) ORDER BY kind;
+
+SELECT kind FROM t_legacy_json_non_object WHERE json_is_string(j) ORDER BY kind;
+
+SELECT kind FROM t_legacy_json_non_object WHERE json_is_int(j) ORDER BY kind;
+
+SELECT kind FROM t_legacy_json_non_object WHERE json_is_bool(j) ORDER BY kind;
+
+SELECT kind FROM t_legacy_json_non_object WHERE json_is_null(j) ORDER BY kind;
+
+SELECT kind FROM t_legacy_json_non_object WHERE json_is_object(j) ORDER BY kind;

--- a/tests/compatibility/cases/prefiltered_read/case.toml
+++ b/tests/compatibility/cases/prefiltered_read/case.toml
@@ -1,0 +1,8 @@
+name = "prefiltered_read"
+reason = "Verify newer read-path prefiltering returns correct rows from SSTs written by old binaries."
+introduced_by = "PR #7972"
+topologies = ["distributed"]
+from_range = ["*"]
+to_range = ["*"]
+features = ["table", "read", "prefilter"]
+owner = "storage"

--- a/tests/compatibility/cases/prefiltered_read/setup.sql
+++ b/tests/compatibility/cases/prefiltered_read/setup.sql
@@ -1,0 +1,17 @@
+CREATE TABLE t_prefiltered_read(
+    ts TIMESTAMP TIME INDEX,
+    host STRING PRIMARY KEY,
+    site STRING,
+    val INT,
+    cpu_load DOUBLE,
+    active BOOLEAN
+);
+
+INSERT INTO t_prefiltered_read VALUES
+('2024-02-04 00:00:00+0000', 'host_a', 'us-east', 1, 0.10, true),
+('2024-02-04 00:01:00+0000', 'host_b', 'us-east', 5, 0.50, false),
+('2024-02-04 00:02:00+0000', 'host_c', 'eu-west', 8, 0.80, true),
+('2024-02-04 00:03:00+0000', 'host_d', 'eu-west', 13, 1.30, false),
+('2024-02-04 00:04:00+0000', 'host_e', 'ap-south', 21, 2.10, true);
+
+ADMIN FLUSH_TABLE('t_prefiltered_read');

--- a/tests/compatibility/cases/prefiltered_read/verify.result
+++ b/tests/compatibility/cases/prefiltered_read/verify.result
@@ -1,0 +1,42 @@
+SELECT host, site, val, cpu_load, active
+FROM t_prefiltered_read
+WHERE val >= 5 AND val <= 13
+ORDER BY host;
+
++--------+---------+-----+----------+--------+
+| host   | site    | val | cpu_load | active |
++--------+---------+-----+----------+--------+
+| host_b | us-east | 5   | 0.5      | false  |
+| host_c | eu-west | 8   | 0.8      | true   |
+| host_d | eu-west | 13  | 1.3      | false  |
++--------+---------+-----+----------+--------+
+
+SELECT host, val
+FROM t_prefiltered_read
+WHERE site = 'eu-west' AND active = true
+ORDER BY host;
+
++--------+-----+
+| host   | val |
++--------+-----+
+| host_c | 8   |
++--------+-----+
+
+SELECT count(*) FROM t_prefiltered_read WHERE cpu_load > 0.40 AND host != 'host_e';
+
++----------+
+| count(*) |
++----------+
+| 3        |
++----------+
+
+SELECT host
+FROM t_prefiltered_read
+WHERE site IN ('us-east', 'ap-south') AND val > 10
+ORDER BY host;
+
++--------+
+| host   |
++--------+
+| host_e |
++--------+

--- a/tests/compatibility/cases/prefiltered_read/verify.sql
+++ b/tests/compatibility/cases/prefiltered_read/verify.sql
@@ -1,0 +1,16 @@
+SELECT host, site, val, cpu_load, active
+FROM t_prefiltered_read
+WHERE val >= 5 AND val <= 13
+ORDER BY host;
+
+SELECT host, val
+FROM t_prefiltered_read
+WHERE site = 'eu-west' AND active = true
+ORDER BY host;
+
+SELECT count(*) FROM t_prefiltered_read WHERE cpu_load > 0.40 AND host != 'host_e';
+
+SELECT host
+FROM t_prefiltered_read
+WHERE site IN ('us-east', 'ap-south') AND val > 10
+ORDER BY host;

--- a/tests/compatibility/cases/table_ttl/case.toml
+++ b/tests/compatibility/cases/table_ttl/case.toml
@@ -1,0 +1,8 @@
+name = "table_ttl"
+reason = "Verify table TTL metadata created by old binaries is preserved and can be changed after upgrade."
+introduced_by = "PR #8352"
+topologies = ["distributed"]
+from_range = ["*"]
+to_range = ["*"]
+features = ["table", "ttl"]
+owner = "storage"

--- a/tests/compatibility/cases/table_ttl/setup.sql
+++ b/tests/compatibility/cases/table_ttl/setup.sql
@@ -1,0 +1,12 @@
+CREATE TABLE t_table_ttl(
+    ts TIMESTAMP TIME INDEX,
+    host STRING PRIMARY KEY,
+    val INT
+)
+WITH('ttl'='7d');
+
+INSERT INTO t_table_ttl VALUES
+('2099-02-08 00:00:00+0000', 'host_a', 1),
+('2099-02-08 00:01:00+0000', 'host_b', 2);
+
+ADMIN FLUSH_TABLE('t_table_ttl');

--- a/tests/compatibility/cases/table_ttl/verify.result
+++ b/tests/compatibility/cases/table_ttl/verify.result
@@ -1,0 +1,65 @@
+SELECT ts, host, val FROM t_table_ttl ORDER BY ts, host;
+
++---------------------+--------+-----+
+| ts                  | host   | val |
++---------------------+--------+-----+
+| 2099-02-08T00:00:00 | host_a | 1   |
+| 2099-02-08T00:01:00 | host_b | 2   |
++---------------------+--------+-----+
+
+SHOW CREATE TABLE t_table_ttl;
+
++-------------+--------------------------------------------+
+| Table       | Create Table                               |
++-------------+--------------------------------------------+
+| t_table_ttl | CREATE TABLE IF NOT EXISTS "t_table_ttl" ( |
+|             |   "ts" TIMESTAMP(3) NOT NULL,              |
+|             |   "host" STRING NULL,                      |
+|             |   "val" INT NULL,                          |
+|             |   TIME INDEX ("ts"),                       |
+|             |   PRIMARY KEY ("host")                     |
+|             | )                                          |
+|             |                                            |
+|             | ENGINE=mito                                |
+|             | WITH(                                      |
+|             |   ttl = '7days'                            |
+|             | )                                          |
++-------------+--------------------------------------------+
+
+ALTER TABLE t_table_ttl SET 'ttl' = '30d';
+
+Affected Rows: 0
+
+SHOW CREATE TABLE t_table_ttl;
+
++-------------+--------------------------------------------+
+| Table       | Create Table                               |
++-------------+--------------------------------------------+
+| t_table_ttl | CREATE TABLE IF NOT EXISTS "t_table_ttl" ( |
+|             |   "ts" TIMESTAMP(3) NOT NULL,              |
+|             |   "host" STRING NULL,                      |
+|             |   "val" INT NULL,                          |
+|             |   TIME INDEX ("ts"),                       |
+|             |   PRIMARY KEY ("host")                     |
+|             | )                                          |
+|             |                                            |
+|             | ENGINE=mito                                |
+|             | WITH(                                      |
+|             |   ttl = '30days'                           |
+|             | )                                          |
++-------------+--------------------------------------------+
+
+INSERT INTO t_table_ttl VALUES
+('2099-02-08 00:02:00+0000', 'host_c', 3);
+
+Affected Rows: 1
+
+SELECT ts, host, val FROM t_table_ttl ORDER BY ts, host;
+
++---------------------+--------+-----+
+| ts                  | host   | val |
++---------------------+--------+-----+
+| 2099-02-08T00:00:00 | host_a | 1   |
+| 2099-02-08T00:01:00 | host_b | 2   |
+| 2099-02-08T00:02:00 | host_c | 3   |
++---------------------+--------+-----+

--- a/tests/compatibility/cases/table_ttl/verify.sql
+++ b/tests/compatibility/cases/table_ttl/verify.sql
@@ -1,0 +1,12 @@
+SELECT ts, host, val FROM t_table_ttl ORDER BY ts, host;
+
+SHOW CREATE TABLE t_table_ttl;
+
+ALTER TABLE t_table_ttl SET 'ttl' = '30d';
+
+SHOW CREATE TABLE t_table_ttl;
+
+INSERT INTO t_table_ttl VALUES
+('2099-02-08 00:02:00+0000', 'host_c', 3);
+
+SELECT ts, host, val FROM t_table_ttl ORDER BY ts, host;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up to #8334, #8370, and #8376.

Note: #8394 tracks `ALTER TABLE SET auto_flush_interval` support separately; this PR intentionally does not add an `auto_flush_interval` compat case.

## What's changed and what's your intention?

This PR adds more sqlness compatibility cases focused on recent feature/read-path coverage:

- `column_default`: verifies DEFAULT metadata created by old binaries still works for reads and new inserts after upgrade.
- `legacy_json_non_object`: verifies legacy non-object JSON values remain readable after JSON2 non-object write rejection changes.
- `prefiltered_read`: verifies current read-path predicate/prefilter logic returns correct rows from SSTs written by old binaries.
- `json2_compat`: verifies JSON data written by v1.1.x JSON2 binaries remains readable/filterable by current binaries.
- `last_row_merge`: verifies `merge_mode='last_row'` semantics and metadata survive upgrade.
- `table_ttl`: verifies TTL metadata survives upgrade and can still be changed after upgrade.
- `information_schema_old_table`: verifies current `information_schema.tables` and `information_schema.columns` expose metadata for tables created by old binaries.
- `last_row_append_mode`: verifies a table created with `merge_mode='last_row'` by old binaries can switch to `append_mode` after upgrade.

Validation performed locally:

```text
cargo run -p sqlness-runner -- compat --from-version v1.0.0 --to-bins-dir /mnt/nvme_rust/rust-targets/compat_framework_retry/debug --test-filter 'column_default|legacy_json_non_object|prefiltered_read|json2_compat|last_row_merge|table_ttl|information_schema_old_table|last_row_append_mode' --preserve-state
```

- `json2_compat` is skipped for v1.0.0 by version range; the other 7 cases passed.

```text
cargo run -p sqlness-runner -- compat --from-version v1.1.0 --to-bins-dir /mnt/nvme_rust/rust-targets/compat_framework_retry/debug --test-filter 'column_default|legacy_json_non_object|prefiltered_read|json2_compat|last_row_merge|table_ttl|information_schema_old_table|last_row_append_mode' --preserve-state
```

- All 8 cases passed.

Also ran:

```text
git diff --check
```

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments. (not applicable, test-only)
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
