### PR TITLE
feat(json2): support JSON2 root reads in json_get

### DIFF
--- a/src/common/function/src/scalars/json/json_get.rs
+++ b/src/common/function/src/scalars/json/json_get.rs
@@ -26,6 +26,7 @@ use datafusion_common::arrow::datatypes::DataType;
 use datafusion_common::{DataFusionError, Result, ScalarValue, exec_datafusion_err, exec_err};
 use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, Signature, Volatility};
 use datatypes::arrow_array::{int_array_value_at_index, string_array_value_at_index};
+use datatypes::types::jsonb_to_string;
 use datatypes::vectors::json::array::JsonArray;
 use derive_more::Display;
 use serde_json::Value;
@@ -50,6 +51,7 @@ fn get_json_by_path(json: &[u8], path: &str) -> Option<Vec<u8>> {
 
 enum JsonResultValue<'a> {
     Jsonb(Vec<u8>),
+    JsonBytes(Vec<u8>),
     #[expect(unused)]
     JsonStructByColumn(&'a ArrayRef, usize),
     JsonStructByValue(&'a Value),
@@ -86,6 +88,14 @@ impl JsonGetResultBuilder for StringResultBuilder {
     fn append_value(&mut self, value: JsonResultValue<'_>) -> Result<()> {
         match value {
             JsonResultValue::Jsonb(value) => self.0.append_option(jsonb::to_str(&value).ok()),
+            JsonResultValue::JsonBytes(value) => {
+                let value = jsonb_to_string(&value).ok().or_else(|| {
+                    serde_json::from_slice::<Value>(&value)
+                        .ok()
+                        .map(|v| v.to_string())
+                });
+                self.0.append_option(value.as_deref())
+            }
             JsonResultValue::JsonStructByColumn(column, i) => {
                 if let Some(v) = string_array_value_at_index(column, i) {
                     self.0.append_value(v);
@@ -148,6 +158,12 @@ impl JsonGetResultBuilder for IntResultBuilder {
     fn append_value(&mut self, value: JsonResultValue<'_>) -> Result<()> {
         match value {
             JsonResultValue::Jsonb(value) => self.0.append_option(jsonb::to_i64(&value).ok()),
+            JsonResultValue::JsonBytes(value) => {
+                let value = jsonb::to_i64(&value)
+                    .ok()
+                    .or_else(|| serde_json::from_slice::<Value>(&value).ok()?.as_i64());
+                self.0.append_option(value)
+            }
             JsonResultValue::JsonStructByColumn(column, i) => {
                 self.0.append_option(int_array_value_at_index(column, i))
             }
@@ -199,6 +215,12 @@ impl JsonGetResultBuilder for FloatResultBuilder {
     fn append_value(&mut self, value: JsonResultValue<'_>) -> Result<()> {
         match value {
             JsonResultValue::Jsonb(value) => self.0.append_option(jsonb::to_f64(&value).ok()),
+            JsonResultValue::JsonBytes(value) => {
+                let value = jsonb::to_f64(&value)
+                    .ok()
+                    .or_else(|| serde_json::from_slice::<Value>(&value).ok()?.as_f64());
+                self.0.append_option(value)
+            }
             JsonResultValue::JsonStructByColumn(column, i) => {
                 let result = if column.data_type() == &DataType::Float64 {
                     column
@@ -258,6 +280,12 @@ impl JsonGetResultBuilder for BoolResultBuilder {
     fn append_value(&mut self, value: JsonResultValue<'_>) -> Result<()> {
         match value {
             JsonResultValue::Jsonb(value) => self.0.append_option(jsonb::to_bool(&value).ok()),
+            JsonResultValue::JsonBytes(value) => {
+                let value = jsonb::to_bool(&value)
+                    .ok()
+                    .or_else(|| serde_json::from_slice::<Value>(&value).ok()?.as_bool());
+                self.0.append_option(value)
+            }
             JsonResultValue::JsonStructByColumn(column, i) => {
                 let result = if column.data_type() == &DataType::Boolean {
                     column
@@ -319,14 +347,18 @@ fn jsonb_get(
     let size = jsons.len();
     for i in 0..size {
         let json = jsons.is_valid(i).then(|| jsons.value(i));
-        let result = match json {
-            Some(json) => get_json_by_path(json, path),
-            _ => None,
-        };
-        if let Some(v) = result {
-            builder.append_value(JsonResultValue::Jsonb(v))?;
-        } else {
-            builder.append_null();
+        match json {
+            Some(json) if path.is_empty() => {
+                builder.append_value(JsonResultValue::JsonBytes(json.to_vec()))?
+            }
+            Some(json) => {
+                if let Some(v) = get_json_by_path(json, path) {
+                    builder.append_value(JsonResultValue::Jsonb(v))?;
+                } else {
+                    builder.append_null();
+                }
+            }
+            _ => builder.append_null(),
         }
     }
     Ok(())
@@ -901,7 +933,7 @@ mod tests {
         let expects = [
             Some("a"),
             Some("d"),
-            None,
+            Some(r#"{"a":"g","b":"h","c":{"a":"g"}}"#),
             Some("foo"),
             Some("404"),
             Some("1.234"),
@@ -1034,7 +1066,7 @@ mod tests {
         let expects = [
             Some("a"),
             Some("d"),
-            None,
+            Some(r#"{"a":"g","b":"h","c":{"a":"g"}}"#),
             Some("foo"),
             Some("404"),
             Some("1.234"),

--- a/src/common/function/src/scalars/json/json_get.rs
+++ b/src/common/function/src/scalars/json/json_get.rs
@@ -26,7 +26,6 @@ use datafusion_common::arrow::datatypes::DataType;
 use datafusion_common::{DataFusionError, Result, ScalarValue, exec_datafusion_err, exec_err};
 use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, Signature, Volatility};
 use datatypes::arrow_array::{int_array_value_at_index, string_array_value_at_index};
-use datatypes::types::jsonb_to_string;
 use datatypes::vectors::json::array::JsonArray;
 use derive_more::Display;
 use serde_json::Value;
@@ -51,7 +50,6 @@ fn get_json_by_path(json: &[u8], path: &str) -> Option<Vec<u8>> {
 
 enum JsonResultValue<'a> {
     Jsonb(Vec<u8>),
-    JsonBytes(Vec<u8>),
     #[expect(unused)]
     JsonStructByColumn(&'a ArrayRef, usize),
     JsonStructByValue(&'a Value),
@@ -88,14 +86,6 @@ impl JsonGetResultBuilder for StringResultBuilder {
     fn append_value(&mut self, value: JsonResultValue<'_>) -> Result<()> {
         match value {
             JsonResultValue::Jsonb(value) => self.0.append_option(jsonb::to_str(&value).ok()),
-            JsonResultValue::JsonBytes(value) => {
-                let value = jsonb_to_string(&value).ok().or_else(|| {
-                    serde_json::from_slice::<Value>(&value)
-                        .ok()
-                        .map(|v| v.to_string())
-                });
-                self.0.append_option(value.as_deref())
-            }
             JsonResultValue::JsonStructByColumn(column, i) => {
                 if let Some(v) = string_array_value_at_index(column, i) {
                     self.0.append_value(v);
@@ -158,12 +148,6 @@ impl JsonGetResultBuilder for IntResultBuilder {
     fn append_value(&mut self, value: JsonResultValue<'_>) -> Result<()> {
         match value {
             JsonResultValue::Jsonb(value) => self.0.append_option(jsonb::to_i64(&value).ok()),
-            JsonResultValue::JsonBytes(value) => {
-                let value = jsonb::to_i64(&value)
-                    .ok()
-                    .or_else(|| serde_json::from_slice::<Value>(&value).ok()?.as_i64());
-                self.0.append_option(value)
-            }
             JsonResultValue::JsonStructByColumn(column, i) => {
                 self.0.append_option(int_array_value_at_index(column, i))
             }
@@ -215,12 +199,6 @@ impl JsonGetResultBuilder for FloatResultBuilder {
     fn append_value(&mut self, value: JsonResultValue<'_>) -> Result<()> {
         match value {
             JsonResultValue::Jsonb(value) => self.0.append_option(jsonb::to_f64(&value).ok()),
-            JsonResultValue::JsonBytes(value) => {
-                let value = jsonb::to_f64(&value)
-                    .ok()
-                    .or_else(|| serde_json::from_slice::<Value>(&value).ok()?.as_f64());
-                self.0.append_option(value)
-            }
             JsonResultValue::JsonStructByColumn(column, i) => {
                 let result = if column.data_type() == &DataType::Float64 {
                     column
@@ -280,12 +258,6 @@ impl JsonGetResultBuilder for BoolResultBuilder {
     fn append_value(&mut self, value: JsonResultValue<'_>) -> Result<()> {
         match value {
             JsonResultValue::Jsonb(value) => self.0.append_option(jsonb::to_bool(&value).ok()),
-            JsonResultValue::JsonBytes(value) => {
-                let value = jsonb::to_bool(&value)
-                    .ok()
-                    .or_else(|| serde_json::from_slice::<Value>(&value).ok()?.as_bool());
-                self.0.append_option(value)
-            }
             JsonResultValue::JsonStructByColumn(column, i) => {
                 let result = if column.data_type() == &DataType::Boolean {
                     column
@@ -348,9 +320,6 @@ fn jsonb_get(
     for i in 0..size {
         let json = jsons.is_valid(i).then(|| jsons.value(i));
         match json {
-            Some(json) if path.is_empty() => {
-                builder.append_value(JsonResultValue::JsonBytes(json.to_vec()))?
-            }
             Some(json) => {
                 if let Some(v) = get_json_by_path(json, path) {
                     builder.append_value(JsonResultValue::Jsonb(v))?;
@@ -933,7 +902,7 @@ mod tests {
         let expects = [
             Some("a"),
             Some("d"),
-            Some(r#"{"a":"g","b":"h","c":{"a":"g"}}"#),
+            None,
             Some("foo"),
             Some("404"),
             Some("1.234"),
@@ -1066,7 +1035,7 @@ mod tests {
         let expects = [
             Some("a"),
             Some("d"),
-            Some(r#"{"a":"g","b":"h","c":{"a":"g"}}"#),
+            None,
             Some("foo"),
             Some("404"),
             Some("1.234"),

--- a/src/datanode/src/lib.rs
+++ b/src/datanode/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 pub mod alive_keeper;
 pub mod config;
 pub mod datanode;

--- a/src/datatypes/src/types/json_type.rs
+++ b/src/datatypes/src/types/json_type.rs
@@ -391,11 +391,8 @@ impl DataType for JsonType {
     }
 
     fn as_arrow_type(&self) -> ArrowDataType {
-        match &self.format {
+        match self.format {
             JsonFormat::Jsonb => ArrowDataType::Binary,
-            JsonFormat::Json2(native_type) if native_type.as_ref() == &JsonNativeType::Variant => {
-                ArrowDataType::Binary
-            }
             JsonFormat::Json2(_) => self.as_struct_type().as_arrow_type(),
         }
     }
@@ -751,14 +748,6 @@ mod tests {
                 )])),
             )])),
             true,
-        );
-    }
-
-    #[test]
-    fn test_json2_variant_arrow_type() {
-        assert_eq!(
-            ArrowDataType::Binary,
-            JsonType::new_json2(JsonNativeType::Variant).as_arrow_type()
         );
     }
 

--- a/src/datatypes/src/types/json_type.rs
+++ b/src/datatypes/src/types/json_type.rs
@@ -391,8 +391,11 @@ impl DataType for JsonType {
     }
 
     fn as_arrow_type(&self) -> ArrowDataType {
-        match self.format {
+        match &self.format {
             JsonFormat::Jsonb => ArrowDataType::Binary,
+            JsonFormat::Json2(native_type) if native_type.as_ref() == &JsonNativeType::Variant => {
+                ArrowDataType::Binary
+            }
             JsonFormat::Json2(_) => self.as_struct_type().as_arrow_type(),
         }
     }
@@ -748,6 +751,14 @@ mod tests {
                 )])),
             )])),
             true,
+        );
+    }
+
+    #[test]
+    fn test_json2_variant_arrow_type() {
+        assert_eq!(
+            ArrowDataType::Binary,
+            JsonType::new_json2(JsonNativeType::Variant).as_arrow_type()
         );
     }
 

--- a/src/datatypes/src/vectors/json/array.rs
+++ b/src/datatypes/src/vectors/json/array.rs
@@ -65,16 +65,13 @@ impl JsonArray<'_> {
             }
             DataType::Struct(_) => {
                 let structs = array.as_struct();
-                let object = structs
-                    .fields()
-                    .iter()
-                    .zip(structs.columns())
-                    .map(|(field, column)| {
-                        JsonArray::from(column)
-                            .try_get_value(i)
-                            .map(|v| (field.name().clone(), v))
-                    })
-                    .collect::<Result<_>>()?;
+                let mut object = serde_json::Map::new();
+                for (field, column) in structs.fields().iter().zip(structs.columns()) {
+                    let value = JsonArray::from(column).try_get_value(i)?;
+                    if !value.is_null() {
+                        object.insert(field.name().clone(), value);
+                    }
+                }
                 Value::Object(object)
             }
             DataType::List(_) => {
@@ -113,6 +110,10 @@ impl JsonArray<'_> {
             self.inner.data_type(),
             expect
         );
+
+        if !matches!(expect, DataType::Struct(_)) {
+            return self.try_cast(expect);
+        }
 
         let struct_array = self.inner.as_struct_opt().context(AlignJsonArraySnafu {
             reason: "expect struct array",
@@ -411,7 +412,7 @@ mod test {
         );
         assert_eq!(
             JsonArray::from(&structs).try_get_value(1)?,
-            json!({"flag": null, "items": [2]})
+            json!({"items": [2]})
         );
 
         let unsupported: ArrayRef = Arc::new(Int32Array::from(vec![1]));
@@ -484,6 +485,20 @@ mod test {
             ]),
         )
         .test()?;
+
+        let root: ArrayRef = Arc::new(StructArray::from(vec![
+            (
+                Arc::new(Field::new("int", DataType::Int64, true)),
+                Arc::new(Int64Array::from(vec![Some(1)])) as ArrayRef,
+            ),
+            (
+                Arc::new(Field::new("missing", DataType::Int64, true)),
+                Arc::new(Int64Array::from(vec![None])) as ArrayRef,
+            ),
+        ]));
+        let aligned = JsonArray::from(&root).try_align(&DataType::Binary)?;
+        assert_eq!(aligned.data_type(), &DataType::Binary);
+        assert_eq!(binary_array_value(&aligned, 0), br#"{"int":1}"#);
 
         // Test simple json array alignment.
         TestCase::new(

--- a/src/datatypes/src/vectors/json/array.rs
+++ b/src/datatypes/src/vectors/json/array.rs
@@ -111,10 +111,6 @@ impl JsonArray<'_> {
             expect
         );
 
-        if !matches!(expect, DataType::Struct(_)) {
-            return self.try_cast(expect);
-        }
-
         let struct_array = self.inner.as_struct_opt().context(AlignJsonArraySnafu {
             reason: "expect struct array",
         })?;
@@ -170,6 +166,12 @@ impl JsonArray<'_> {
                     j += 1;
                 }
             }
+        }
+        if expect_fields.is_empty() {
+            return Ok(Arc::new(StructArray::new_empty_fields(
+                struct_array.len(),
+                struct_array.nulls().cloned(),
+            )));
         }
         if i < expect_fields.len() {
             for field in &expect_fields[i..] {
@@ -486,19 +488,15 @@ mod test {
         )
         .test()?;
 
-        let root: ArrayRef = Arc::new(StructArray::from(vec![
-            (
-                Arc::new(Field::new("int", DataType::Int64, true)),
-                Arc::new(Int64Array::from(vec![Some(1)])) as ArrayRef,
-            ),
-            (
-                Arc::new(Field::new("missing", DataType::Int64, true)),
-                Arc::new(Int64Array::from(vec![None])) as ArrayRef,
-            ),
-        ]));
-        let aligned = JsonArray::from(&root).try_align(&DataType::Binary)?;
-        assert_eq!(aligned.data_type(), &DataType::Binary);
-        assert_eq!(binary_array_value(&aligned, 0), br#"{"int":1}"#);
+        // Test aligning a non-empty json array to an empty struct schema.
+        let empty_fields = Fields::from(Vec::<Arc<Field>>::new());
+        let root_json: ArrayRef = Arc::new(StructArray::from(vec![(
+            Arc::new(Field::new("int", DataType::Int64, true)),
+            Arc::new(Int64Array::from(vec![Some(1), None])) as ArrayRef,
+        )]));
+        let aligned = JsonArray::from(&root_json).try_align(&DataType::Struct(empty_fields))?;
+        let expected = Arc::new(StructArray::new_empty_fields(2, None)) as ArrayRef;
+        assert_eq!(aligned.as_ref(), expected.as_ref());
 
         // Test simple json array alignment.
         TestCase::new(

--- a/src/datatypes/src/vectors/json/array.rs
+++ b/src/datatypes/src/vectors/json/array.rs
@@ -174,10 +174,11 @@ impl JsonArray<'_> {
             }
         }
 
-        let json_array = StructArray::try_new(
+        let json_array = StructArray::try_new_with_length(
             expect_fields.clone(),
             aligned,
             struct_array.nulls().cloned(),
+            struct_array.len(),
         )
         .map_err(|e| {
             AlignJsonArraySnafu {

--- a/src/datatypes/src/vectors/json/array.rs
+++ b/src/datatypes/src/vectors/json/array.rs
@@ -66,8 +66,8 @@ impl JsonArray<'_> {
             DataType::Struct(_) => {
                 let structs = array.as_struct();
                 let mut object = serde_json::Map::new();
-                for (field, column) in structs.fields().iter().zip(structs.columns()) {
-                    let value = JsonArray::from(column).try_get_value(i)?;
+                for (field, col) in structs.fields().iter().zip(structs.columns()) {
+                    let value = JsonArray::from(col).try_get_value(i)?;
                     if !value.is_null() {
                         object.insert(field.name().clone(), value);
                     }
@@ -167,12 +167,7 @@ impl JsonArray<'_> {
                 }
             }
         }
-        if expect_fields.is_empty() {
-            return Ok(Arc::new(StructArray::new_empty_fields(
-                struct_array.len(),
-                struct_array.nulls().cloned(),
-            )));
-        }
+
         if i < expect_fields.len() {
             for field in &expect_fields[i..] {
                 aligned.push(new_null_array(field.data_type(), struct_array.len()));

--- a/src/mito2/src/compaction.rs
+++ b/src/mito2/src/compaction.rs
@@ -47,7 +47,7 @@ use parquet::file::metadata::PageIndexPolicy;
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt};
 use store_api::metadata::RegionMetadataRef;
-use store_api::storage::RegionId;
+use store_api::storage::{JsonReadHint, RegionId};
 use task::MAX_PARALLEL_COMPACTION;
 use tokio::sync::mpsc::{self, Sender};
 
@@ -1060,7 +1060,12 @@ impl CompactionSstReaderBuilder<'_> {
                 }
             }
 
-            Some(json_type_hint)
+            Some(
+                json_type_hint
+                    .into_iter()
+                    .map(|(column, json_type)| (column, JsonReadHint::Paths(json_type)))
+                    .collect::<HashMap<_, _>>(),
+            )
         } else {
             None
         };

--- a/src/mito2/src/engine/scan_test.rs
+++ b/src/mito2/src/engine/scan_test.rs
@@ -34,7 +34,9 @@ use futures::TryStreamExt;
 use serde_json::json;
 use store_api::region_engine::{PrepareRequest, RegionEngine, RegionScanner};
 use store_api::region_request::RegionRequest;
-use store_api::storage::{ProjectionInput, RegionId, ScanRequest, TimeSeriesDistribution};
+use store_api::storage::{
+    JsonReadHint, ProjectionInput, RegionId, ScanRequest, TimeSeriesDistribution,
+};
 
 use crate::config::MitoConfig;
 use crate::error::Error;
@@ -105,13 +107,13 @@ async fn test_json_type_hint_pushdown_scanner_returns_batches() -> WhateverResul
         projection_input: Some(ProjectionInput::new(vec![1, 0])),
         json_type_hint: HashMap::from([(
             "field_0".to_string(),
-            JsonNativeType::Object(JsonObjectType::from([(
+            JsonReadHint::Paths(JsonNativeType::Object(JsonObjectType::from([(
                 "a".to_string(),
                 JsonNativeType::Object(JsonObjectType::from([(
                     "x".to_string(),
                     JsonNativeType::i64(),
                 )])),
-            )])),
+            )]))),
         )]),
         ..Default::default()
     };

--- a/src/mito2/src/engine/scan_test.rs
+++ b/src/mito2/src/engine/scan_test.rs
@@ -103,17 +103,18 @@ async fn test_json_type_hint_pushdown_scanner_returns_batches() -> WhateverResul
     // returns the JSON2 root column, while json_type_hint tells scan input construction which
     // nested physical path is needed.
 
+    let json_native_type = JsonNativeType::Object(JsonObjectType::from([(
+        "a".to_string(),
+        JsonNativeType::Object(JsonObjectType::from([(
+            "x".to_string(),
+            JsonNativeType::i64(),
+        )])),
+    )]));
     let request = ScanRequest {
         projection_input: Some(ProjectionInput::new(vec![1, 0])),
         json_type_hint: HashMap::from([(
             "field_0".to_string(),
-            JsonReadHint::Paths(JsonNativeType::Object(JsonObjectType::from([(
-                "a".to_string(),
-                JsonNativeType::Object(JsonObjectType::from([(
-                    "x".to_string(),
-                    JsonNativeType::i64(),
-                )])),
-            )]))),
+            JsonReadHint::Paths(json_native_type),
         )]),
         ..Default::default()
     };

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -44,7 +44,6 @@ use crate::error::{
 };
 use crate::manifest::action::{RegionEdit, RegionMetaAction, RegionMetaActionList};
 use crate::memtable::bulk::ENCODE_ROW_THRESHOLD;
-use crate::memtable::bulk::json_align::Json2Aligner;
 use crate::memtable::{BoxedRecordBatchIterator, EncodedRange, MemtableRanges, RangesOptions};
 use crate::metrics::{
     FLUSH_BYTES_TOTAL, FLUSH_ELAPSED, FLUSH_FAILURE_TOTAL, FLUSH_FILE_TOTAL, FLUSH_REQUESTS_TOTAL,
@@ -53,6 +52,7 @@ use crate::metrics::{
 use crate::read::FlatSource;
 use crate::read::flat_dedup::{FlatDedupIterator, FlatLastNonNull, FlatLastRow};
 use crate::read::flat_merge::FlatMergeIterator;
+use crate::read::json_schema::align::Json2Aligner;
 use crate::region::options::{IndexOptions, MergeMode, RegionOptions};
 use crate::region::version::{VersionControlData, VersionControlRef, VersionRef};
 use crate::region::{ManifestContextRef, RegionLeaderState, RegionRoleState, parse_partition_expr};

--- a/src/mito2/src/memtable/bulk.rs
+++ b/src/mito2/src/memtable/bulk.rs
@@ -16,7 +16,6 @@
 
 pub(crate) mod chunk_reader;
 pub mod context;
-pub(crate) mod json_align;
 pub mod part;
 pub mod part_reader;
 mod row_group_reader;
@@ -47,7 +46,6 @@ use tokio::sync::Semaphore;
 use crate::error::{Result, UnsupportedOperationSnafu};
 use crate::flush::WriteBufferManagerRef;
 use crate::memtable::bulk::context::BulkIterContext;
-use crate::memtable::bulk::json_align::Json2Aligner;
 use crate::memtable::bulk::part::{
     BulkPart, BulkPartEncodeMetrics, BulkPartEncoder, MultiBulkPart, UnorderedPart,
     should_prune_bulk_part,
@@ -61,6 +59,7 @@ use crate::memtable::{
 };
 use crate::read::flat_dedup::{FlatDedupIterator, FlatLastNonNull, FlatLastRow};
 use crate::read::flat_merge::FlatMergeIterator;
+use crate::read::json_schema::align::Json2Aligner;
 use crate::region::options::MergeMode;
 use crate::sst::parquet::flat_format::field_column_start;
 use crate::sst::parquet::{DEFAULT_READ_BATCH_SIZE, DEFAULT_ROW_GROUP_SIZE};

--- a/src/mito2/src/memtable/bulk/part.rs
+++ b/src/mito2/src/memtable/bulk/part.rs
@@ -60,10 +60,10 @@ use crate::error::{
     NewRecordBatchSnafu, Result,
 };
 use crate::memtable::bulk::context::{BulkIterContext, BulkIterContextRef};
-use crate::memtable::bulk::json_align::Json2Aligner;
 use crate::memtable::bulk::part_reader::EncodedBulkPartIter;
 use crate::memtable::time_series::{ValueBuilder, Values};
 use crate::memtable::{BoxedRecordBatchIterator, MemScanMetrics, MemtableStats};
+use crate::read::json_schema::align::Json2Aligner;
 use crate::sst::SeriesEstimator;
 use crate::sst::index::IndexOutput;
 use crate::sst::parquet::flat_format::primary_key_column_index;

--- a/src/mito2/src/read.rs
+++ b/src/mito2/src/read.rs
@@ -20,6 +20,7 @@ pub mod dedup;
 pub mod flat_dedup;
 pub mod flat_merge;
 pub mod flat_projection;
+pub(crate) mod json_schema;
 pub mod last_row;
 pub mod projection;
 pub(crate) mod prune;

--- a/src/mito2/src/read/compat.rs
+++ b/src/mito2/src/read/compat.rs
@@ -99,32 +99,8 @@ impl FlatCompatBatch {
         let actual = read_format.metadata();
         let format_projection = read_format.format_projection();
         let mut actual_schema = flat_projected_columns(actual, format_projection);
-
-        // The region manifest does not store the concrete types for json2 columns,
-        // so we recover them from the SST file's arrow schema, where the concrete
-        // types were known at write time. This patching allows the compat layer to
-        // properly align columns on the read path.
-        if read_format
-            .arrow_schema()
-            .fields()
-            .iter()
-            .any(is_structured_json_field)
-        {
-            for field in read_format.arrow_schema().fields() {
-                if is_structured_json_field(field)
-                    && let Some(col_id) = actual.column_by_name(field.name()).map(|x| x.column_id)
-                    && let Some(i) = actual_schema.iter().position(|x| x.0 == col_id)
-                {
-                    actual_schema[i].1 = ConcreteDataType::from_arrow_type(field.data_type());
-                }
-            }
-        }
-
-        let expect_schema = mapper.batch_schema();
-        // When a query only involves a json2 root column, no json type hint is
-        // propagated from the optimizer, so the expect schema carries an empty
-        // struct for that column. Patch it with the concrete type from the SST.
-        let expect_schema = Self::concretize_json2_root_types(expect_schema, &actual_schema);
+        let mut expect_schema = mapper.batch_schema().to_vec();
+        patch_json2_types_from_sst(read_format, &mut actual_schema, &mut expect_schema);
 
         if expect_schema == actual_schema {
             // Although the SST has a different schema, but the schema after projection is the same
@@ -147,37 +123,6 @@ impl FlatCompatBatch {
             arrow_schema: Arc::new(Schema::new(fields)),
             compat_pk,
         }))
-    }
-
-    /// Concretizes the types of json2 root columns in the expect schema using the
-    /// actual schema from the SST file.
-    fn concretize_json2_root_types(
-        expect_schema: &[(ColumnId, ConcreteDataType)],
-        actual_schema: &[(ColumnId, ConcreteDataType)],
-    ) -> Vec<(ColumnId, ConcreteDataType)> {
-        let actual_schema_index: HashMap<_, _> = actual_schema
-            .iter()
-            .map(|(column_id, data_type)| (*column_id, data_type))
-            .collect();
-
-        expect_schema
-            .iter()
-            .map(|(column_id, expect_data_type)| {
-                if let Some(actual_data_type) = actual_schema_index.get(column_id)
-                    && expect_data_type
-                        .as_json()
-                        .is_some_and(|json_type| json_type.is_json2())
-                    && matches!(
-                        expect_data_type.as_arrow_type(),
-                        datatypes::arrow::datatypes::DataType::Struct(fields) if fields.is_empty()
-                    )
-                {
-                    (*column_id, (*actual_data_type).clone())
-                } else {
-                    (*column_id, expect_data_type.clone())
-                }
-            })
-            .collect()
     }
 
     fn compute_index_and_fields(
@@ -340,6 +285,52 @@ impl FlatCompatBatch {
 
         // Handles primary keys.
         self.compat_pk.compat(compat_batch)
+    }
+}
+
+/// Patches the concrete types of json2 columns in both `actual_schema` and `expect_schema`
+/// using the arrow schema from the SST file, where the concrete types were known at write time.
+///
+/// The region manifest does not store concrete types for json2 columns, so we recover them
+/// from the SST's arrow schema for `actual_schema`.
+///
+/// `expect_schema` is only patched when a json2 column carries an empty struct type,
+/// which happens when a query reads a json2 root column without explicit type hints.
+fn patch_json2_types_from_sst(
+    read_format: &FlatReadFormat,
+    actual_schema: &mut [(ColumnId, ConcreteDataType)],
+    expect_schema: &mut [(ColumnId, ConcreteDataType)],
+) {
+    if !read_format
+        .arrow_schema()
+        .fields()
+        .iter()
+        .any(is_structured_json_field)
+    {
+        return;
+    }
+    let metadata = read_format.metadata();
+    for field in read_format.arrow_schema().fields() {
+        if !is_structured_json_field(field) {
+            continue;
+        }
+        let Some(col_id) = metadata.column_by_name(field.name()).map(|c| c.column_id) else {
+            continue;
+        };
+        let concrete_type = ConcreteDataType::from_arrow_type(field.data_type());
+
+        if let Some(i) = actual_schema.iter().position(|x| x.0 == col_id) {
+            actual_schema[i].1 = concrete_type.clone();
+        }
+        if let Some(i) = expect_schema.iter().position(|x| x.0 == col_id)
+            && expect_schema[i].1.as_json().is_some_and(|t| t.is_json2())
+            && matches!(
+                expect_schema[i].1.as_arrow_type(),
+                datatypes::arrow::datatypes::DataType::Struct(fields) if fields.is_empty()
+            )
+        {
+            expect_schema[i].1 = concrete_type;
+        }
     }
 }
 

--- a/src/mito2/src/read/compat.rs
+++ b/src/mito2/src/read/compat.rs
@@ -117,6 +117,7 @@ impl FlatCompatBatch {
         }
 
         let expect_schema = mapper.batch_schema();
+        let expect_schema = Self::resolve_json_root_schema(expect_schema, &actual_schema);
         if expect_schema == actual_schema {
             // Although the SST has a different schema, but the schema after projection is the same
             // as expected schema.
@@ -129,7 +130,7 @@ impl FlatCompatBatch {
         }
 
         let (index_or_defaults, fields) =
-            Self::compute_index_and_fields(&actual_schema, expect_schema, mapper.metadata())?;
+            Self::compute_index_and_fields(&actual_schema, &expect_schema, mapper.metadata())?;
 
         let compat_pk = FlatCompatPrimaryKey::new(mapper.metadata(), actual)?;
 
@@ -138,6 +139,35 @@ impl FlatCompatBatch {
             arrow_schema: Arc::new(Schema::new(fields)),
             compat_pk,
         }))
+    }
+
+    fn resolve_json_root_schema(
+        expect_schema: &[(ColumnId, ConcreteDataType)],
+        actual_schema: &[(ColumnId, ConcreteDataType)],
+    ) -> Vec<(ColumnId, ConcreteDataType)> {
+        let actual_schema_index: HashMap<_, _> = actual_schema
+            .iter()
+            .map(|(column_id, data_type)| (*column_id, data_type))
+            .collect();
+
+        expect_schema
+            .iter()
+            .map(|(column_id, expect_data_type)| {
+                if let Some(actual_data_type) = actual_schema_index.get(column_id)
+                    && expect_data_type
+                        .as_json()
+                        .is_some_and(|json_type| json_type.is_json2())
+                    && matches!(
+                        expect_data_type.as_arrow_type(),
+                        datatypes::arrow::datatypes::DataType::Struct(fields) if fields.is_empty()
+                    )
+                {
+                    (*column_id, (*actual_data_type).clone())
+                } else {
+                    (*column_id, expect_data_type.clone())
+                }
+            })
+            .collect()
     }
 
     fn compute_index_and_fields(

--- a/src/mito2/src/read/compat.rs
+++ b/src/mito2/src/read/compat.rs
@@ -99,6 +99,11 @@ impl FlatCompatBatch {
         let actual = read_format.metadata();
         let format_projection = read_format.format_projection();
         let mut actual_schema = flat_projected_columns(actual, format_projection);
+
+        // The region manifest does not store the concrete types for json2 columns,
+        // so we recover them from the SST file's arrow schema, where the concrete
+        // types were known at write time. This patching allows the compat layer to
+        // properly align columns on the read path.
         if read_format
             .arrow_schema()
             .fields()
@@ -107,9 +112,8 @@ impl FlatCompatBatch {
         {
             for field in read_format.arrow_schema().fields() {
                 if is_structured_json_field(field)
-                    && let Some(column_id) =
-                        actual.column_by_name(field.name()).map(|x| x.column_id)
-                    && let Some(i) = actual_schema.iter().position(|x| x.0 == column_id)
+                    && let Some(col_id) = actual.column_by_name(field.name()).map(|x| x.column_id)
+                    && let Some(i) = actual_schema.iter().position(|x| x.0 == col_id)
                 {
                     actual_schema[i].1 = ConcreteDataType::from_arrow_type(field.data_type());
                 }
@@ -117,7 +121,11 @@ impl FlatCompatBatch {
         }
 
         let expect_schema = mapper.batch_schema();
-        let expect_schema = Self::resolve_json_root_schema(expect_schema, &actual_schema);
+        // When a query only involves a json2 root column, no json type hint is
+        // propagated from the optimizer, so the expect schema carries an empty
+        // struct for that column. Patch it with the concrete type from the SST.
+        let expect_schema = Self::concretize_json2_root_types(expect_schema, &actual_schema);
+
         if expect_schema == actual_schema {
             // Although the SST has a different schema, but the schema after projection is the same
             // as expected schema.
@@ -141,7 +149,9 @@ impl FlatCompatBatch {
         }))
     }
 
-    fn resolve_json_root_schema(
+    /// Concretizes the types of json2 root columns in the expect schema using the
+    /// actual schema from the SST file.
+    fn concretize_json2_root_types(
         expect_schema: &[(ColumnId, ConcreteDataType)],
         actual_schema: &[(ColumnId, ConcreteDataType)],
     ) -> Vec<(ColumnId, ConcreteDataType)> {

--- a/src/mito2/src/read/flat_projection.rs
+++ b/src/mito2/src/read/flat_projection.rs
@@ -28,7 +28,6 @@ use datatypes::arrow::datatypes::{DataType as ArrowDataType, Field};
 use datatypes::extension::json::is_structured_json_field;
 use datatypes::prelude::{ConcreteDataType, DataType};
 use datatypes::schema::{Schema, SchemaRef};
-use datatypes::types::json_type::JsonNativeType;
 use datatypes::value::Value;
 use datatypes::vectors::Helper;
 use snafu::{OptionExt, ResultExt};
@@ -36,7 +35,7 @@ use store_api::metadata::{RegionMetadata, RegionMetadataRef};
 use store_api::storage::{ColumnId, JsonReadHint};
 
 use crate::cache::CacheStrategy;
-use crate::error::{InvalidRequestSnafu, RecordBatchSnafu, Result};
+use crate::error::{DataTypeMismatchSnafu, InvalidRequestSnafu, RecordBatchSnafu, Result};
 use crate::read::json_schema::{Json2OutputPlan, normalize_json2_output};
 use crate::read::projection::{read_column_ids_from_projection, repeated_vector_with_cache};
 use crate::read::read_columns::ReadColumns;
@@ -98,24 +97,6 @@ impl FlatProjectionMapper {
         read_cols: ReadColumns,
         json_type_hint: Option<&HashMap<String, JsonReadHint>>,
     ) -> Result<Self> {
-        Self::new_with_read_columns_and_json_root_types(
-            metadata,
-            projection,
-            read_cols,
-            json_type_hint,
-            None,
-        )
-    }
-
-    /// Returns a new mapper with output projection, explicit read columns, and
-    /// concrete JSON2 root types inferred from scan sources.
-    pub fn new_with_read_columns_and_json_root_types(
-        metadata: &RegionMetadataRef,
-        projection: Vec<usize>,
-        read_cols: ReadColumns,
-        json_type_hint: Option<&HashMap<String, JsonReadHint>>,
-        json_root_types: Option<&HashMap<String, JsonNativeType>>,
-    ) -> Result<Self> {
         // If the original projection is empty.
         let is_empty_projection = projection.is_empty();
 
@@ -136,9 +117,8 @@ impl FlatProjectionMapper {
 
             let mut schema = col.column_schema.clone();
             let json_read_hint = json_type_hint.and_then(|x| x.get(&schema.name));
-            let json_root_type = json_root_types.and_then(|x| x.get(&schema.name));
-            let json_output_plan =
-                Json2OutputPlan::new(&schema.data_type, json_read_hint, json_root_type);
+            let json_output_plan = Json2OutputPlan::new(&schema.data_type, json_read_hint)
+                .context(DataTypeMismatchSnafu)?;
             if let Some(concretized) = json_output_plan.planned_type() {
                 schema.data_type = concretized.clone();
             }
@@ -163,18 +143,23 @@ impl FlatProjectionMapper {
             && !json_type_hint.is_empty()
         {
             for (column_id, data_type) in batch_schema.iter_mut() {
-                if data_type
+                if !data_type
                     .as_json()
                     .is_some_and(|json_type| json_type.is_json2())
-                    && let Some(json_output_plan) =
-                        metadata.column_by_id(*column_id).and_then(|col| {
-                            let hint = json_type_hint.get(&col.column_schema.name)?;
-                            let root_json_type =
-                                json_root_types.and_then(|x| x.get(&col.column_schema.name));
-                            Some(Json2OutputPlan::new(data_type, Some(hint), root_json_type))
-                        })
-                    && let Some(concretized) = json_output_plan.planned_type()
                 {
+                    continue;
+                }
+
+                let Some(col) = metadata.column_by_id(*column_id) else {
+                    continue;
+                };
+                let Some(hint) = json_type_hint.get(&col.column_schema.name) else {
+                    continue;
+                };
+
+                let json_output_plan =
+                    Json2OutputPlan::new(data_type, Some(hint)).context(DataTypeMismatchSnafu)?;
+                if let Some(concretized) = json_output_plan.planned_type() {
                     *data_type = concretized.clone();
                 }
             }
@@ -586,7 +571,7 @@ mod tests {
     use datatypes::arrow::record_batch::RecordBatch as ArrowRecordBatch;
     use datatypes::types::json_type::{JsonNativeType, JsonObjectType};
     use store_api::metadata::{ColumnMetadata, RegionMetadataBuilder};
-    use store_api::storage::RegionId;
+    use store_api::storage::{JsonRootReadHint, RegionId};
 
     use super::*;
     use crate::cache::CacheStrategy;
@@ -677,7 +662,12 @@ mod tests {
         )
         .unwrap();
 
-        let hint = HashMap::from([("j".to_string(), JsonReadHint::Root)]);
+        let hint = HashMap::from([(
+            "j".to_string(),
+            JsonReadHint::Root(JsonRootReadHint::Inferred(
+                JsonNativeType::try_from(json_array.data_type()).unwrap(),
+            )),
+        )]);
         let mapper = FlatProjectionMapper::new_with_read_columns(
             &metadata,
             vec![0],

--- a/src/mito2/src/read/flat_projection.rs
+++ b/src/mito2/src/read/flat_projection.rs
@@ -72,6 +72,8 @@ pub struct FlatProjectionMapper {
     batch_indices: Vec<usize>,
     /// Precomputed Arrow schema for input batches.
     input_arrow_schema: datatypes::arrow::datatypes::SchemaRef,
+    /// Whether each output column is a JSON2 root read.
+    json_root_output_columns: Vec<bool>,
 }
 
 impl FlatProjectionMapper {
@@ -101,6 +103,7 @@ impl FlatProjectionMapper {
 
         // Output column schemas for the projection.
         let mut col_schemas = Vec::with_capacity(projection.len());
+        let mut json_root_output_columns = Vec::with_capacity(projection.len());
         // Column ids of the output projection without deduplication.
         let mut output_col_ids = Vec::with_capacity(projection.len());
         for idx in &projection {
@@ -114,13 +117,15 @@ impl FlatProjectionMapper {
             output_col_ids.push(col.column_id);
 
             let mut schema = col.column_schema.clone();
-            if let Some(concretized) = json_type_hint
-                .and_then(|x| x.get(&schema.name))
-                .map(json_read_hint_to_data_type)
-                && schema
-                    .data_type
-                    .as_json()
-                    .is_some_and(|json_type| json_type.is_json2())
+            let is_json2 = schema
+                .data_type
+                .as_json()
+                .is_some_and(|json_type| json_type.is_json2());
+            let json_read_hint = json_type_hint.and_then(|x| x.get(&schema.name));
+            json_root_output_columns
+                .push(is_json2 && matches!(json_read_hint, Some(JsonReadHint::Root)));
+            if is_json2
+                && let Some(concretized) = json_read_hint.and_then(json_read_hint_to_data_type)
             {
                 schema.data_type = concretized;
             }
@@ -150,7 +155,7 @@ impl FlatProjectionMapper {
                     && let Some(concretized) = metadata
                         .column_by_id(*column_id)
                         .and_then(|x| json_type_hint.get(&x.column_schema.name))
-                        .map(json_read_hint_to_data_type)
+                        .and_then(json_read_hint_to_data_type)
                 {
                     *data_type = concretized;
                 }
@@ -204,6 +209,7 @@ impl FlatProjectionMapper {
             is_empty_projection,
             batch_indices,
             input_arrow_schema,
+            json_root_output_columns,
         })
     }
 
@@ -293,6 +299,7 @@ impl FlatProjectionMapper {
         // Construct output record batch directly from Arrow arrays to avoid
         // Arrow -> Vector -> Arrow roundtrips in the hot path.
         let mut arrays = Vec::with_capacity(self.output_schema.num_columns());
+        let mut output_column_schemas = self.output_schema.column_schemas().to_vec();
         for (output_idx, index) in self.batch_indices.iter().enumerate() {
             let mut array = batch.column(*index).clone();
             // Cast dictionary values to the target type.
@@ -325,25 +332,32 @@ impl FlatProjectionMapper {
                 }
             }
 
-            let field = &self.output_schema.arrow_schema().fields()[output_idx];
-            let output_type = &self.output_schema.column_schemas()[output_idx].data_type;
-            if output_type
+            let output_type = &output_column_schemas[output_idx].data_type;
+            if self.json_root_output_columns[output_idx]
+                && output_type
+                    .as_json()
+                    .is_some_and(|json_type| json_type.is_json2())
+            {
+                let json_type =
+                    JsonNativeType::try_from(array.data_type()).context(DataTypesSnafu)?;
+                output_column_schemas[output_idx].data_type = ConcreteDataType::json2(json_type);
+            } else if output_type
                 .as_json()
                 .is_some_and(|json_type| json_type.is_json2())
             {
                 array = JsonArray::from(&array)
-                    .try_align(field.data_type())
+                    .try_align(&output_type.as_arrow_type())
                     .context(DataTypesSnafu)?;
             }
 
             arrays.push(array);
         }
 
-        let df_record_batch =
-            DfRecordBatch::try_new(self.output_schema.arrow_schema().clone(), arrays)
-                .context(NewDfRecordBatchSnafu)?;
+        let output_schema = Arc::new(Schema::new(output_column_schemas));
+        let df_record_batch = DfRecordBatch::try_new(output_schema.arrow_schema().clone(), arrays)
+            .context(NewDfRecordBatchSnafu)?;
         Ok(RecordBatch::from_df_record_batch(
-            self.output_schema.clone(),
+            output_schema,
             df_record_batch,
         ))
     }
@@ -373,10 +387,10 @@ impl FlatProjectionMapper {
     }
 }
 
-fn json_read_hint_to_data_type(hint: &JsonReadHint) -> ConcreteDataType {
+fn json_read_hint_to_data_type(hint: &JsonReadHint) -> Option<ConcreteDataType> {
     match hint {
-        JsonReadHint::Root => ConcreteDataType::json2(JsonNativeType::Variant),
-        JsonReadHint::Paths(json_type) => ConcreteDataType::json2(json_type.clone()),
+        JsonReadHint::Root => None,
+        JsonReadHint::Paths(json_type) => Some(ConcreteDataType::json2(json_type.clone())),
     }
 }
 
@@ -626,7 +640,7 @@ mod tests {
     }
 
     #[test]
-    fn test_json_type_hint_root_converts_struct_to_binary() {
+    fn test_json_type_hint_root_keeps_struct_schema() {
         let mut builder = RegionMetadataBuilder::new(RegionId::new(1024, 0));
         builder
             .push_column_metadata(ColumnMetadata {
@@ -667,14 +681,14 @@ mod tests {
                 json_array.data_type().clone(),
                 true,
             )])),
-            vec![json_array],
+            vec![json_array.clone()],
         )
         .unwrap();
 
         let converted = mapper.convert(&batch, &CacheStrategy::Disabled).unwrap();
         assert_eq!(
             converted.df_record_batch().schema().field(0).data_type(),
-            &ArrowDataType::Binary
+            json_array.data_type()
         );
     }
 }

--- a/src/mito2/src/read/flat_projection.rs
+++ b/src/mito2/src/read/flat_projection.rs
@@ -28,6 +28,7 @@ use datatypes::arrow::datatypes::{DataType as ArrowDataType, Field};
 use datatypes::extension::json::is_structured_json_field;
 use datatypes::prelude::{ConcreteDataType, DataType};
 use datatypes::schema::{Schema, SchemaRef};
+use datatypes::types::json_type::JsonNativeType;
 use datatypes::value::Value;
 use datatypes::vectors::Helper;
 use snafu::{OptionExt, ResultExt};
@@ -97,6 +98,24 @@ impl FlatProjectionMapper {
         read_cols: ReadColumns,
         json_type_hint: Option<&HashMap<String, JsonReadHint>>,
     ) -> Result<Self> {
+        Self::new_with_read_columns_and_json_root_types(
+            metadata,
+            projection,
+            read_cols,
+            json_type_hint,
+            None,
+        )
+    }
+
+    /// Returns a new mapper with output projection, explicit read columns, and
+    /// concrete JSON2 root types inferred from scan sources.
+    pub fn new_with_read_columns_and_json_root_types(
+        metadata: &RegionMetadataRef,
+        projection: Vec<usize>,
+        read_cols: ReadColumns,
+        json_type_hint: Option<&HashMap<String, JsonReadHint>>,
+        json_root_types: Option<&HashMap<String, JsonNativeType>>,
+    ) -> Result<Self> {
         // If the original projection is empty.
         let is_empty_projection = projection.is_empty();
 
@@ -117,7 +136,9 @@ impl FlatProjectionMapper {
 
             let mut schema = col.column_schema.clone();
             let json_read_hint = json_type_hint.and_then(|x| x.get(&schema.name));
-            let json_output_plan = Json2OutputPlan::new(&schema.data_type, json_read_hint);
+            let json_root_type = json_root_types.and_then(|x| x.get(&schema.name));
+            let json_output_plan =
+                Json2OutputPlan::new(&schema.data_type, json_read_hint, json_root_type);
             if let Some(concretized) = json_output_plan.planned_type() {
                 schema.data_type = concretized.clone();
             }
@@ -145,10 +166,13 @@ impl FlatProjectionMapper {
                 if data_type
                     .as_json()
                     .is_some_and(|json_type| json_type.is_json2())
-                    && let Some(json_output_plan) = metadata
-                        .column_by_id(*column_id)
-                        .and_then(|x| json_type_hint.get(&x.column_schema.name))
-                        .map(|hint| Json2OutputPlan::new(data_type, Some(hint)))
+                    && let Some(json_output_plan) =
+                        metadata.column_by_id(*column_id).and_then(|col| {
+                            let hint = json_type_hint.get(&col.column_schema.name)?;
+                            let root_json_type =
+                                json_root_types.and_then(|x| x.get(&col.column_schema.name));
+                            Some(Json2OutputPlan::new(data_type, Some(hint), root_json_type))
+                        })
                     && let Some(concretized) = json_output_plan.planned_type()
                 {
                     *data_type = concretized.clone();

--- a/src/mito2/src/read/flat_projection.rs
+++ b/src/mito2/src/read/flat_projection.rs
@@ -30,13 +30,15 @@ use datatypes::prelude::{ConcreteDataType, DataType};
 use datatypes::schema::{Schema, SchemaRef};
 use datatypes::value::Value;
 use datatypes::vectors::Helper;
+use datatypes::vectors::json::array::JsonArray;
 use snafu::{OptionExt, ResultExt};
 use store_api::metadata::{RegionMetadata, RegionMetadataRef};
 use store_api::storage::{ColumnId, JsonReadHint};
 
+use super::json_schema::Json2OutputPlan;
 use crate::cache::CacheStrategy;
 use crate::error::{DataTypeMismatchSnafu, InvalidRequestSnafu, RecordBatchSnafu, Result};
-use crate::read::json_schema::{Json2OutputPlan, normalize_json2_output};
+use crate::read::json_schema::planned_json2_output_type;
 use crate::read::projection::{read_column_ids_from_projection, repeated_vector_with_cache};
 use crate::read::read_columns::ReadColumns;
 use crate::sst::parquet::flat_format::sst_column_id_indices;
@@ -117,10 +119,14 @@ impl FlatProjectionMapper {
 
             let mut schema = col.column_schema.clone();
             let json_read_hint = json_type_hint.and_then(|x| x.get(&schema.name));
-            let json_output_plan = Json2OutputPlan::new(&schema.data_type, json_read_hint)
+
+            let json_output_plan = planned_json2_output_type(&schema.data_type, json_read_hint)
                 .context(DataTypeMismatchSnafu)?;
-            if let Some(concretized) = json_output_plan.planned_type() {
-                schema.data_type = concretized.clone();
+            match &json_output_plan {
+                Json2OutputPlan::AlignTo(data_type) => {
+                    schema.data_type = data_type.clone();
+                }
+                Json2OutputPlan::NonJson2 => {}
             }
             json_output_plans.push(json_output_plan);
             col_schemas.push(schema);
@@ -149,18 +155,17 @@ impl FlatProjectionMapper {
                 {
                     continue;
                 }
-
                 let Some(col) = metadata.column_by_id(*column_id) else {
                     continue;
                 };
                 let Some(hint) = json_type_hint.get(&col.column_schema.name) else {
                     continue;
                 };
-
-                let json_output_plan =
-                    Json2OutputPlan::new(data_type, Some(hint)).context(DataTypeMismatchSnafu)?;
-                if let Some(concretized) = json_output_plan.planned_type() {
-                    *data_type = concretized.clone();
+                if let Json2OutputPlan::AlignTo(concretized) =
+                    planned_json2_output_type(data_type, Some(hint))
+                        .context(DataTypeMismatchSnafu)?
+                {
+                    *data_type = concretized;
                 }
             }
         }
@@ -334,14 +339,15 @@ impl FlatProjectionMapper {
                     array = casted;
                 }
             }
-
-            array = normalize_json2_output(
-                array,
-                &mut output_column_schemas[output_idx].data_type,
-                &self.json_output_plans[output_idx],
-            )
-            .context(DataTypesSnafu)?;
-
+            let array = match &self.json_output_plans[output_idx] {
+                Json2OutputPlan::NonJson2 => array,
+                Json2OutputPlan::AlignTo(data_type) => {
+                    output_column_schemas[output_idx].data_type = data_type.clone();
+                    JsonArray::from(&array)
+                        .try_align(&data_type.as_arrow_type())
+                        .context(DataTypesSnafu)?
+                }
+            };
             arrays.push(array);
         }
 

--- a/src/mito2/src/read/flat_projection.rs
+++ b/src/mito2/src/read/flat_projection.rs
@@ -35,10 +35,9 @@ use snafu::{OptionExt, ResultExt};
 use store_api::metadata::{RegionMetadata, RegionMetadataRef};
 use store_api::storage::{ColumnId, JsonReadHint};
 
-use super::json_schema::Json2OutputPlan;
 use crate::cache::CacheStrategy;
 use crate::error::{DataTypeMismatchSnafu, InvalidRequestSnafu, RecordBatchSnafu, Result};
-use crate::read::json_schema::planned_json2_output_type;
+use crate::read::json_schema::{Json2OutputPlan, planned_json2_output_type};
 use crate::read::projection::{read_column_ids_from_projection, repeated_vector_with_cache};
 use crate::read::read_columns::ReadColumns;
 use crate::sst::parquet::flat_format::sst_column_id_indices;

--- a/src/mito2/src/read/flat_projection.rs
+++ b/src/mito2/src/read/flat_projection.rs
@@ -616,7 +616,7 @@ mod tests {
     }
 
     #[test]
-    fn test_json_type_hint_root_keeps_struct_schema() {
+    fn test_json2_root_read_keeps_struct_schema() {
         let mut builder = RegionMetadataBuilder::new(RegionId::new(1024, 0));
         builder
             .push_column_metadata(ColumnMetadata {
@@ -638,14 +638,6 @@ mod tests {
                 column_id: 1,
             });
         let metadata = Arc::new(builder.build().unwrap());
-        let hint = HashMap::from([("j".to_string(), JsonReadHint::Root)]);
-        let mapper = FlatProjectionMapper::new_with_read_columns(
-            &metadata,
-            vec![0],
-            ReadColumns::from_deduped_column_ids([0]),
-            Some(&hint),
-        )
-        .unwrap();
 
         let json_array = Arc::new(StructArray::from(vec![(
             Arc::new(Field::new("a", ArrowDataType::Int64, true)),
@@ -661,10 +653,28 @@ mod tests {
         )
         .unwrap();
 
+        let hint = HashMap::from([("j".to_string(), JsonReadHint::Root)]);
+        let mapper = FlatProjectionMapper::new_with_read_columns(
+            &metadata,
+            vec![0],
+            ReadColumns::from_deduped_column_ids([0]),
+            Some(&hint),
+        )
+        .unwrap();
+
         let converted = mapper.convert(&batch, &CacheStrategy::Disabled).unwrap();
         assert_eq!(
             converted.df_record_batch().schema().field(0).data_type(),
             json_array.data_type()
         );
+
+        let mapper = FlatProjectionMapper::new_with_read_columns(
+            &metadata,
+            vec![0],
+            ReadColumns::from_deduped_column_ids([0]),
+            None,
+        )
+        .unwrap();
+        assert!(mapper.convert(&batch, &CacheStrategy::Disabled).is_err());
     }
 }

--- a/src/mito2/src/read/flat_projection.rs
+++ b/src/mito2/src/read/flat_projection.rs
@@ -338,6 +338,8 @@ impl FlatProjectionMapper {
                     .as_json()
                     .is_some_and(|json_type| json_type.is_json2())
             {
+                // Root JSON2 reads don't have a concretized schema hint. Use the
+                // actual array type as the output type.
                 let json_type =
                     JsonNativeType::try_from(array.data_type()).context(DataTypesSnafu)?;
                 output_column_schemas[output_idx].data_type = ConcreteDataType::json2(json_type);

--- a/src/mito2/src/read/flat_projection.rs
+++ b/src/mito2/src/read/flat_projection.rs
@@ -34,7 +34,7 @@ use datatypes::vectors::Helper;
 use datatypes::vectors::json::array::JsonArray;
 use snafu::{OptionExt, ResultExt};
 use store_api::metadata::{RegionMetadata, RegionMetadataRef};
-use store_api::storage::ColumnId;
+use store_api::storage::{ColumnId, JsonReadHint};
 
 use crate::cache::CacheStrategy;
 use crate::error::{InvalidRequestSnafu, RecordBatchSnafu, Result};
@@ -94,7 +94,7 @@ impl FlatProjectionMapper {
         metadata: &RegionMetadataRef,
         projection: Vec<usize>,
         read_cols: ReadColumns,
-        json_type_hint: Option<&HashMap<String, JsonNativeType>>,
+        json_type_hint: Option<&HashMap<String, JsonReadHint>>,
     ) -> Result<Self> {
         // If the original projection is empty.
         let is_empty_projection = projection.is_empty();
@@ -116,8 +116,7 @@ impl FlatProjectionMapper {
             let mut schema = col.column_schema.clone();
             if let Some(concretized) = json_type_hint
                 .and_then(|x| x.get(&schema.name))
-                .cloned()
-                .map(ConcreteDataType::json2)
+                .map(json_read_hint_to_data_type)
                 && schema
                     .data_type
                     .as_json()
@@ -150,8 +149,8 @@ impl FlatProjectionMapper {
                     .is_some_and(|json_type| json_type.is_json2())
                     && let Some(concretized) = metadata
                         .column_by_id(*column_id)
-                        .and_then(|x| json_type_hint.get(&x.column_schema.name).cloned())
-                        .map(ConcreteDataType::json2)
+                        .and_then(|x| json_type_hint.get(&x.column_schema.name))
+                        .map(json_read_hint_to_data_type)
                 {
                     *data_type = concretized;
                 }
@@ -371,6 +370,13 @@ impl FlatProjectionMapper {
             columns.push(vector);
         }
         Ok(columns)
+    }
+}
+
+fn json_read_hint_to_data_type(hint: &JsonReadHint) -> ConcreteDataType {
+    match hint {
+        JsonReadHint::Root => ConcreteDataType::json2(JsonNativeType::Variant),
+        JsonReadHint::Paths(json_type) => ConcreteDataType::json2(json_type.clone()),
     }
 }
 
@@ -600,10 +606,10 @@ mod tests {
         let metadata = metadata_with_legacy_json();
         let hint = HashMap::from([(
             "j".to_string(),
-            JsonNativeType::Object(JsonObjectType::from([(
+            JsonReadHint::Paths(JsonNativeType::Object(JsonObjectType::from([(
                 "a".to_string(),
                 JsonNativeType::i64(),
-            )])),
+            )]))),
         )]);
         let mapper = FlatProjectionMapper::new_with_read_columns(
             &metadata,
@@ -620,7 +626,7 @@ mod tests {
     }
 
     #[test]
-    fn test_json_type_hint_variant_converts_struct_to_binary() {
+    fn test_json_type_hint_root_converts_struct_to_binary() {
         let mut builder = RegionMetadataBuilder::new(RegionId::new(1024, 0));
         builder
             .push_column_metadata(ColumnMetadata {
@@ -642,7 +648,7 @@ mod tests {
                 column_id: 1,
             });
         let metadata = Arc::new(builder.build().unwrap());
-        let hint = HashMap::from([("j".to_string(), JsonNativeType::Variant)]);
+        let hint = HashMap::from([("j".to_string(), JsonReadHint::Root)]);
         let mapper = FlatProjectionMapper::new_with_read_columns(
             &metadata,
             vec![0],

--- a/src/mito2/src/read/flat_projection.rs
+++ b/src/mito2/src/read/flat_projection.rs
@@ -327,7 +327,11 @@ impl FlatProjectionMapper {
             }
 
             let field = &self.output_schema.arrow_schema().fields()[output_idx];
-            if is_structured_json_field(field) {
+            let output_type = &self.output_schema.column_schemas()[output_idx].data_type;
+            if output_type
+                .as_json()
+                .is_some_and(|json_type| json_type.is_json2())
+            {
                 array = JsonArray::from(&array)
                     .try_align(field.data_type())
                     .context(DataTypesSnafu)?;
@@ -557,11 +561,15 @@ impl DfBatchAssembler {
 
 #[cfg(test)]
 mod tests {
+    use datatypes::arrow::array::{Array, ArrayRef, Int64Array, StructArray};
+    use datatypes::arrow::datatypes::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
+    use datatypes::arrow::record_batch::RecordBatch as ArrowRecordBatch;
     use datatypes::types::json_type::JsonObjectType;
     use store_api::metadata::{ColumnMetadata, RegionMetadataBuilder};
     use store_api::storage::RegionId;
 
     use super::*;
+    use crate::cache::CacheStrategy;
 
     fn metadata_with_legacy_json() -> RegionMetadataRef {
         let mut builder = RegionMetadataBuilder::new(RegionId::new(1024, 0));
@@ -608,6 +616,59 @@ mod tests {
         assert_eq!(
             mapper.batch_schema()[0],
             (0, ConcreteDataType::json_datatype())
+        );
+    }
+
+    #[test]
+    fn test_json_type_hint_variant_converts_struct_to_binary() {
+        let mut builder = RegionMetadataBuilder::new(RegionId::new(1024, 0));
+        builder
+            .push_column_metadata(ColumnMetadata {
+                column_schema: datatypes::schema::ColumnSchema::new(
+                    "j",
+                    ConcreteDataType::json2(JsonNativeType::Object(JsonObjectType::new())),
+                    true,
+                ),
+                semantic_type: SemanticType::Field,
+                column_id: 0,
+            })
+            .push_column_metadata(ColumnMetadata {
+                column_schema: datatypes::schema::ColumnSchema::new(
+                    "ts",
+                    ConcreteDataType::timestamp_millisecond_datatype(),
+                    false,
+                ),
+                semantic_type: SemanticType::Timestamp,
+                column_id: 1,
+            });
+        let metadata = Arc::new(builder.build().unwrap());
+        let hint = HashMap::from([("j".to_string(), JsonNativeType::Variant)]);
+        let mapper = FlatProjectionMapper::new_with_read_columns(
+            &metadata,
+            vec![0],
+            ReadColumns::from_deduped_column_ids([0]),
+            Some(&hint),
+        )
+        .unwrap();
+
+        let json_array = Arc::new(StructArray::from(vec![(
+            Arc::new(Field::new("a", ArrowDataType::Int64, true)),
+            Arc::new(Int64Array::from(vec![Some(1)])) as ArrayRef,
+        )])) as ArrayRef;
+        let batch = ArrowRecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![Field::new(
+                "j",
+                json_array.data_type().clone(),
+                true,
+            )])),
+            vec![json_array],
+        )
+        .unwrap();
+
+        let converted = mapper.convert(&batch, &CacheStrategy::Disabled).unwrap();
+        assert_eq!(
+            converted.df_record_batch().schema().field(0).data_type(),
+            &ArrowDataType::Binary
         );
     }
 }

--- a/src/mito2/src/read/flat_projection.rs
+++ b/src/mito2/src/read/flat_projection.rs
@@ -28,16 +28,15 @@ use datatypes::arrow::datatypes::{DataType as ArrowDataType, Field};
 use datatypes::extension::json::is_structured_json_field;
 use datatypes::prelude::{ConcreteDataType, DataType};
 use datatypes::schema::{Schema, SchemaRef};
-use datatypes::types::json_type::JsonNativeType;
 use datatypes::value::Value;
 use datatypes::vectors::Helper;
-use datatypes::vectors::json::array::JsonArray;
 use snafu::{OptionExt, ResultExt};
 use store_api::metadata::{RegionMetadata, RegionMetadataRef};
 use store_api::storage::{ColumnId, JsonReadHint};
 
 use crate::cache::CacheStrategy;
 use crate::error::{InvalidRequestSnafu, RecordBatchSnafu, Result};
+use crate::read::json_schema::{Json2OutputPlan, normalize_json2_output};
 use crate::read::projection::{read_column_ids_from_projection, repeated_vector_with_cache};
 use crate::read::read_columns::ReadColumns;
 use crate::sst::parquet::flat_format::sst_column_id_indices;
@@ -72,8 +71,8 @@ pub struct FlatProjectionMapper {
     batch_indices: Vec<usize>,
     /// Precomputed Arrow schema for input batches.
     input_arrow_schema: datatypes::arrow::datatypes::SchemaRef,
-    /// Whether each output column is a JSON2 root read.
-    json_root_output_columns: Vec<bool>,
+    /// JSON2 output handling plan for each output column.
+    json_output_plans: Vec<Json2OutputPlan>,
 }
 
 impl FlatProjectionMapper {
@@ -103,7 +102,7 @@ impl FlatProjectionMapper {
 
         // Output column schemas for the projection.
         let mut col_schemas = Vec::with_capacity(projection.len());
-        let mut json_root_output_columns = Vec::with_capacity(projection.len());
+        let mut json_output_plans = Vec::with_capacity(projection.len());
         // Column ids of the output projection without deduplication.
         let mut output_col_ids = Vec::with_capacity(projection.len());
         for idx in &projection {
@@ -117,18 +116,12 @@ impl FlatProjectionMapper {
             output_col_ids.push(col.column_id);
 
             let mut schema = col.column_schema.clone();
-            let is_json2 = schema
-                .data_type
-                .as_json()
-                .is_some_and(|json_type| json_type.is_json2());
             let json_read_hint = json_type_hint.and_then(|x| x.get(&schema.name));
-            json_root_output_columns
-                .push(is_json2 && matches!(json_read_hint, Some(JsonReadHint::Root)));
-            if is_json2
-                && let Some(concretized) = json_read_hint.and_then(json_read_hint_to_data_type)
-            {
-                schema.data_type = concretized;
+            let json_output_plan = Json2OutputPlan::new(&schema.data_type, json_read_hint);
+            if let Some(concretized) = json_output_plan.planned_type() {
+                schema.data_type = concretized.clone();
             }
+            json_output_plans.push(json_output_plan);
             col_schemas.push(schema);
         }
 
@@ -152,12 +145,13 @@ impl FlatProjectionMapper {
                 if data_type
                     .as_json()
                     .is_some_and(|json_type| json_type.is_json2())
-                    && let Some(concretized) = metadata
+                    && let Some(json_output_plan) = metadata
                         .column_by_id(*column_id)
                         .and_then(|x| json_type_hint.get(&x.column_schema.name))
-                        .and_then(json_read_hint_to_data_type)
+                        .map(|hint| Json2OutputPlan::new(data_type, Some(hint)))
+                    && let Some(concretized) = json_output_plan.planned_type()
                 {
-                    *data_type = concretized;
+                    *data_type = concretized.clone();
                 }
             }
         }
@@ -209,7 +203,7 @@ impl FlatProjectionMapper {
             is_empty_projection,
             batch_indices,
             input_arrow_schema,
-            json_root_output_columns,
+            json_output_plans,
         })
     }
 
@@ -332,25 +326,12 @@ impl FlatProjectionMapper {
                 }
             }
 
-            let output_type = &output_column_schemas[output_idx].data_type;
-            if self.json_root_output_columns[output_idx]
-                && output_type
-                    .as_json()
-                    .is_some_and(|json_type| json_type.is_json2())
-            {
-                // Root JSON2 reads don't have a concretized schema hint. Use the
-                // actual array type as the output type.
-                let json_type =
-                    JsonNativeType::try_from(array.data_type()).context(DataTypesSnafu)?;
-                output_column_schemas[output_idx].data_type = ConcreteDataType::json2(json_type);
-            } else if output_type
-                .as_json()
-                .is_some_and(|json_type| json_type.is_json2())
-            {
-                array = JsonArray::from(&array)
-                    .try_align(&output_type.as_arrow_type())
-                    .context(DataTypesSnafu)?;
-            }
+            array = normalize_json2_output(
+                array,
+                &mut output_column_schemas[output_idx].data_type,
+                &self.json_output_plans[output_idx],
+            )
+            .context(DataTypesSnafu)?;
 
             arrays.push(array);
         }
@@ -386,13 +367,6 @@ impl FlatProjectionMapper {
             columns.push(vector);
         }
         Ok(columns)
-    }
-}
-
-fn json_read_hint_to_data_type(hint: &JsonReadHint) -> Option<ConcreteDataType> {
-    match hint {
-        JsonReadHint::Root => None,
-        JsonReadHint::Paths(json_type) => Some(ConcreteDataType::json2(json_type.clone())),
     }
 }
 
@@ -586,7 +560,7 @@ mod tests {
     use datatypes::arrow::array::{Array, ArrayRef, Int64Array, StructArray};
     use datatypes::arrow::datatypes::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
     use datatypes::arrow::record_batch::RecordBatch as ArrowRecordBatch;
-    use datatypes::types::json_type::JsonObjectType;
+    use datatypes::types::json_type::{JsonNativeType, JsonObjectType};
     use store_api::metadata::{ColumnMetadata, RegionMetadataBuilder};
     use store_api::storage::RegionId;
 

--- a/src/mito2/src/read/flat_projection.rs
+++ b/src/mito2/src/read/flat_projection.rs
@@ -682,13 +682,14 @@ mod tests {
             json_array.data_type()
         );
 
-        let mapper = FlatProjectionMapper::new_with_read_columns(
-            &metadata,
-            vec![0],
-            ReadColumns::from_deduped_column_ids([0]),
-            None,
-        )
-        .unwrap();
-        assert!(mapper.convert(&batch, &CacheStrategy::Disabled).is_err());
+        assert!(
+            FlatProjectionMapper::new_with_read_columns(
+                &metadata,
+                vec![0],
+                ReadColumns::from_deduped_column_ids([0]),
+                None,
+            )
+            .is_err()
+        );
     }
 }

--- a/src/mito2/src/read/json_schema.rs
+++ b/src/mito2/src/read/json_schema.rs
@@ -36,10 +36,9 @@ use datatypes::types::json_type::JsonNativeType;
 use datatypes::vectors::json::array::JsonArray;
 use snafu::ResultExt;
 use store_api::metadata::RegionMetadata;
-use store_api::storage::{JsonReadHint, NestedPath};
+use store_api::storage::{JsonReadHint, JsonRootReadHint, NestedPath};
 
 use crate::error::{DataTypeMismatchSnafu, Result};
-use crate::read::json_schema::align::Json2Aligner;
 use crate::read::read_columns::{ReadColumns, merge_nested_paths};
 
 /// Applies JSON2 read hints to the nested paths in read columns.
@@ -94,39 +93,25 @@ fn collect_json_nested_paths(
     }
 }
 
-/// Builds an aligner for source schemas and returns merged root JSON2 types.
+/// Infers concrete schemas for JSON2 root read hints from an Arrow schema.
 ///
-/// This keeps root reads as root reads: callers still read the whole JSON2
-/// column, but they can use the returned concrete types to make merge-time
-/// schemas stable before batches reach `FlatMergeReader`.
-pub(crate) fn build_json2_root_aligner(
-    json_type_hint: &HashMap<String, JsonReadHint>,
-    source_schemas: Vec<ArrowSchemaRef>,
-) -> Result<Option<(Json2Aligner, HashMap<String, JsonNativeType>)>> {
-    if !has_json2_root_read_hint(json_type_hint) || source_schemas.is_empty() {
-        return Ok(None);
-    }
-
-    let aligner = Json2Aligner::try_new(source_schemas)?;
-    let root_types = root_json2_types_from_schema(json_type_hint, aligner.schema())?;
-    Ok(Some((aligner, root_types)))
-}
-
-/// Returns whether the hints contain at least one JSON2 root read.
-fn has_json2_root_read_hint(json_type_hint: &HashMap<String, JsonReadHint>) -> bool {
-    json_type_hint
-        .values()
-        .any(|hint| matches!(hint, JsonReadHint::Root))
-}
-
-
-fn root_json2_types_from_schema(
-    json_type_hint: &HashMap<String, JsonReadHint>,
+/// - `json_type_hint` contains query-driven JSON2 read hints. This function
+///   only updates entries whose hint is `JsonReadHint::Root(_)`; path hints and
+///   non-JSON2 entries are left unchanged.
+/// - `schema` is the merged source schema used by the read path. For each root
+///   read hint, this function looks up the field with the same column name,
+///   converts the field's Arrow type to `JsonNativeType`, and rewrites the hint
+///   to `JsonReadHint::Root(JsonRootReadHint::Inferred(...))`.
+///
+/// If a hinted root column is not present in `schema`, the hint is left as-is.
+/// If the field exists but its Arrow type cannot be converted to a JSON native
+/// type, this function returns a data type mismatch error.
+pub(crate) fn infer_json2_root_hints_from_schema(
+    json_type_hint: &mut HashMap<String, JsonReadHint>,
     schema: &ArrowSchemaRef,
-) -> Result<HashMap<String, JsonNativeType>> {
-    let mut root_types = HashMap::new();
+) -> Result<()> {
     for (col_name, hint) in json_type_hint {
-        if !matches!(hint, JsonReadHint::Root) {
+        if !matches!(hint, JsonReadHint::Root(_)) {
             continue;
         }
 
@@ -135,10 +120,10 @@ fn root_json2_types_from_schema(
         };
         let json_type =
             JsonNativeType::try_from(field.data_type()).context(DataTypeMismatchSnafu)?;
-        root_types.insert(col_name.clone(), json_type);
+        *hint = JsonReadHint::Root(JsonRootReadHint::Inferred(json_type));
     }
 
-    Ok(root_types)
+    Ok(())
 }
 
 /// JSON2 output handling plan for one projected column.
@@ -150,10 +135,9 @@ pub(crate) enum Json2OutputPlan {
     UnsupportedDirectProjection,
     /// Read the root JSON2 value.
     ///
-    /// If the plan has a concrete type, the read path aligns root arrays to it
-    /// before returning them. Otherwise the output type comes from the actual
-    /// array.
-    Root(Option<ConcreteDataType>),
+    /// The read path aligns root arrays to this concrete type before returning
+    /// them.
+    Root(ConcreteDataType),
     /// Align the array to the expected JSON2 type.
     Align(ConcreteDataType),
 }
@@ -165,24 +149,34 @@ impl Json2OutputPlan {
     /// while JSON2 root hints use [`Json2OutputPlan::Root`]. A missing hint on a
     /// JSON2 column means a direct projection such as `SELECT j`, which is not
     /// handled here yet.
+    ///
+    /// The caller must infer root read hints before building output plans.
+    /// `JsonReadHint::Root(JsonRootReadHint::Uninferred)` means the read path
+    /// has not inspected the source schemas yet, so this function cannot decide
+    /// the concrete output type for the root column.
     pub(crate) fn new(
         data_type: &ConcreteDataType,
         hint: Option<&JsonReadHint>,
-        root_json_type: Option<&JsonNativeType>,
-    ) -> Self {
+    ) -> DataTypeResult<Self> {
         if !is_json2_type(data_type) {
-            return Self::NonJson2;
+            return Ok(Self::NonJson2);
         }
 
-        match hint {
-            Some(JsonReadHint::Root) => {
-                Self::Root(root_json_type.cloned().map(ConcreteDataType::json2))
+        let plan = match hint {
+            Some(JsonReadHint::Root(JsonRootReadHint::Inferred(json_type))) => {
+                Self::Root(ConcreteDataType::json2(json_type.clone()))
             }
+            Some(JsonReadHint::Root(JsonRootReadHint::Uninferred)) => UnsupportedOperationSnafu {
+                op: "JSON2 root read schema must be inferred before building output plans",
+                vector_type: "Json2",
+            }
+            .fail()?,
             Some(JsonReadHint::Paths(json_type)) => {
                 Self::Align(ConcreteDataType::json2(json_type.clone()))
             }
             None => Self::UnsupportedDirectProjection,
-        }
+        };
+        Ok(plan)
     }
 
     /// Returns the planned concrete output type, if this plan has one before
@@ -190,8 +184,8 @@ impl Json2OutputPlan {
     pub(crate) fn planned_type(&self) -> Option<&ConcreteDataType> {
         match self {
             Self::Align(data_type) => Some(data_type),
-            Self::Root(Some(data_type)) => Some(data_type),
-            Self::NonJson2 | Self::UnsupportedDirectProjection | Self::Root(None) => None,
+            Self::Root(data_type) => Some(data_type),
+            Self::NonJson2 | Self::UnsupportedDirectProjection => None,
         }
     }
 }
@@ -204,10 +198,8 @@ impl Json2OutputPlan {
 /// - [`Json2OutputPlan::UnsupportedDirectProjection`] returns an error. Without
 ///   a read hint, aligning a direct JSON2 projection to the manifest's empty
 ///   JSON2 schema would silently drop all fields.
-/// - [`Json2OutputPlan::Root`] with a concrete type updates `output_type` to
-///   that type and aligns the array to it. [`Json2OutputPlan::Root`] without a
-///   concrete type keeps the array unchanged, but replaces `output_type` with
-///   the JSON2 type inferred from the actual Arrow array.
+/// - [`Json2OutputPlan::Root`] updates `output_type` to its concrete type and
+///   aligns the array to it.
 /// - [`Json2OutputPlan::Align`] updates `output_type` to the planned JSON2 type
 ///   and aligns the array to that type, filling missing fields with nulls.
 ///
@@ -231,14 +223,9 @@ pub(crate) fn normalize_json2_output(
             vector_type: "Json2",
         }
         .fail(),
-        Json2OutputPlan::Root(Some(data_type)) => {
+        Json2OutputPlan::Root(data_type) => {
             *output_type = data_type.clone();
             JsonArray::from(&array).try_align(&data_type.as_arrow_type())
-        }
-        Json2OutputPlan::Root(None) => {
-            let json_type = JsonNativeType::try_from(array.data_type())?;
-            *output_type = ConcreteDataType::json2(json_type);
-            Ok(array)
         }
         Json2OutputPlan::Align(data_type) => {
             *output_type = data_type.clone();
@@ -266,7 +253,7 @@ mod tests {
     fn test_json2_output_plan_rejects_unhinted_json2_projection() {
         let mut output_type =
             ConcreteDataType::json2(JsonNativeType::Object(JsonObjectType::new()));
-        let plan = Json2OutputPlan::new(&output_type, None, None);
+        let plan = Json2OutputPlan::new(&output_type, None).unwrap();
         assert!(matches!(plan, Json2OutputPlan::UnsupportedDirectProjection));
 
         let err = normalize_json2_output(Arc::new(NullArray::new(1)), &mut output_type, &plan)

--- a/src/mito2/src/read/json_schema.rs
+++ b/src/mito2/src/read/json_schema.rs
@@ -1,0 +1,168 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Helpers for JSON2 schema handling in the read path.
+//!
+//! JSON2 schemas used by reads are inferred from query expressions. For example,
+//! `json_get(j, "a.b")` gives us a concrete schema for the requested paths, so
+//! the reader can prune nested fields and align the output array to that schema.
+//!
+//! Root JSON2 reads are different: the query doesn't provide a concrete schema.
+//! They read the whole JSON2 column, and the output schema is whatever the
+//! actual array carries.
+
+use std::collections::HashMap;
+
+use datatypes::arrow::array::ArrayRef;
+use datatypes::error::Result as DataTypeResult;
+use datatypes::prelude::{ConcreteDataType, DataType};
+use datatypes::types::json_type::JsonNativeType;
+use datatypes::vectors::json::array::JsonArray;
+use store_api::metadata::RegionMetadata;
+use store_api::storage::{JsonReadHint, NestedPath};
+
+use crate::read::read_columns::{ReadColumns, merge_nested_paths};
+
+/// Applies JSON2 read hints to the nested paths in read columns.
+///
+/// [`JsonReadHint::Root`] is a read strategy: it reads the whole JSON2 column
+/// and therefore clears nested path pruning. [`JsonReadHint::Paths`] narrows the
+/// read to the leaves described by the hinted JSON type.
+pub(crate) fn apply_json_read_hints_to_read_columns(
+    read_cols: &mut ReadColumns,
+    json_type_hint: &HashMap<String, JsonReadHint>,
+    metadata: &RegionMetadata,
+) {
+    if json_type_hint.is_empty() {
+        return;
+    }
+
+    for read_col in &mut read_cols.cols {
+        let Some(col) = metadata.column_by_id(read_col.column_id) else {
+            continue;
+        };
+        let col_name = &col.column_schema.name;
+        let Some(json_type) = json_type_hint.get(col_name) else {
+            continue;
+        };
+
+        let JsonReadHint::Paths(json_type) = json_type else {
+            read_col.nested_paths.clear();
+            continue;
+        };
+
+        let mut paths = Vec::new();
+        let mut current = vec![col_name.clone()];
+        collect_json_nested_paths(json_type, &mut current, &mut paths);
+        merge_nested_paths(&mut read_col.nested_paths, paths)
+    }
+}
+
+fn collect_json_nested_paths(
+    json_type: &JsonNativeType,
+    current: &mut NestedPath,
+    paths: &mut Vec<NestedPath>,
+) {
+    match json_type {
+        JsonNativeType::Object(fields) if !fields.is_empty() => {
+            for (field, child) in fields {
+                current.push(field.clone());
+                collect_json_nested_paths(child, current, paths);
+                current.pop();
+            }
+        }
+        _ => paths.push(current.clone()),
+    }
+}
+
+/// JSON2 output handling plan for one projected column.
+#[derive(Debug, Clone)]
+pub(crate) enum Json2OutputPlan {
+    /// The column doesn't need JSON2 output handling.
+    None,
+    /// Read the root JSON2 value. The output type comes from the actual array.
+    Root,
+    /// Align the array to the expected JSON2 type.
+    Align(ConcreteDataType),
+}
+
+impl Json2OutputPlan {
+    /// Builds an output plan from a column type and its optional read hint.
+    pub(crate) fn new(data_type: &ConcreteDataType, hint: Option<&JsonReadHint>) -> Self {
+        if !is_json2_type(data_type) {
+            return Self::None;
+        }
+
+        match hint {
+            Some(JsonReadHint::Root) => Self::Root,
+            Some(JsonReadHint::Paths(json_type)) => {
+                Self::Align(ConcreteDataType::json2(json_type.clone()))
+            }
+            None => Self::Align(data_type.clone()),
+        }
+    }
+
+    /// Returns the planned concrete output type, if this plan has one before
+    /// reading actual data.
+    pub(crate) fn planned_type(&self) -> Option<&ConcreteDataType> {
+        match self {
+            Self::Align(data_type) => Some(data_type),
+            Self::None | Self::Root => None,
+        }
+    }
+}
+
+/// Normalizes one output array and its schema type according to its JSON2 read plan.
+///
+/// Behavior by plan:
+///
+/// - [`Json2OutputPlan::None`] returns the array unchanged.
+/// - [`Json2OutputPlan::Root`] keeps the array unchanged, but replaces
+///   `output_type` with the JSON2 type inferred from the actual Arrow array.
+///   Root reads don't have a query-inferred schema, so the actual array schema
+///   becomes the output schema.
+/// - [`Json2OutputPlan::Align`] updates `output_type` to the planned JSON2 type
+///   and aligns the array to that type, filling missing fields with nulls.
+///
+/// Parameters:
+///
+/// - `array`: the column data read from memtables or SSTs.
+/// - `output_type`: the type used in the returned record batch schema. This
+///   function updates it when the JSON2 plan determines a more precise type.
+/// - `plan`: whether the column is a non-JSON2 column, a root JSON2 read, or a
+///   path JSON2 read with a concrete schema.
+pub(crate) fn normalize_json2_output(
+    array: ArrayRef,
+    output_type: &mut ConcreteDataType,
+    plan: &Json2OutputPlan,
+) -> DataTypeResult<ArrayRef> {
+    match plan {
+        Json2OutputPlan::None => Ok(array),
+        Json2OutputPlan::Root => {
+            let json_type = JsonNativeType::try_from(array.data_type())?;
+            *output_type = ConcreteDataType::json2(json_type);
+            Ok(array)
+        }
+        Json2OutputPlan::Align(data_type) => {
+            *output_type = data_type.clone();
+            JsonArray::from(&array).try_align(&data_type.as_arrow_type())
+        }
+    }
+}
+
+fn is_json2_type(data_type: &ConcreteDataType) -> bool {
+    data_type
+        .as_json()
+        .is_some_and(|json_type| json_type.is_json2())
+}

--- a/src/mito2/src/read/json_schema.rs
+++ b/src/mito2/src/read/json_schema.rs
@@ -131,6 +131,14 @@ pub(crate) fn infer_json2_root_hints_from_schema(
     Ok(())
 }
 
+/// Returns the concrete JSON2 output type required by a read hint.
+pub(crate) fn planned_json2_output_type(
+    data_type: &ConcreteDataType,
+    hint: Option<&JsonReadHint>,
+) -> DataTypeResult<Option<ConcreteDataType>> {
+    todo!()
+}
+
 /// JSON2 output handling plan for one projected column.
 #[derive(Debug, Clone)]
 pub(crate) enum Json2OutputPlan {

--- a/src/mito2/src/read/json_schema.rs
+++ b/src/mito2/src/read/json_schema.rs
@@ -20,12 +20,14 @@
 //!
 //! Root JSON2 reads are different: the query doesn't provide a concrete schema.
 //! They read the whole JSON2 column, and the output schema is whatever the
-//! actual array carries.
+//! actual array carries. A projected JSON2 column without a read hint is not
+//! supported by this module yet; it must not be aligned to the manifest's empty
+//! JSON2 schema because that would silently drop fields.
 
 use std::collections::HashMap;
 
 use datatypes::arrow::array::ArrayRef;
-use datatypes::error::Result as DataTypeResult;
+use datatypes::error::{Result as DataTypeResult, UnsupportedOperationSnafu};
 use datatypes::prelude::{ConcreteDataType, DataType};
 use datatypes::types::json_type::JsonNativeType;
 use datatypes::vectors::json::array::JsonArray;
@@ -89,8 +91,10 @@ fn collect_json_nested_paths(
 /// JSON2 output handling plan for one projected column.
 #[derive(Debug, Clone)]
 pub(crate) enum Json2OutputPlan {
-    /// The column doesn't need JSON2 output handling.
-    None,
+    /// The column isn't JSON2 and doesn't need JSON2 output handling.
+    NonJson2,
+    /// The column is a direct JSON2 projection without a read hint.
+    UnsupportedDirectProjection,
     /// Read the root JSON2 value. The output type comes from the actual array.
     Root,
     /// Align the array to the expected JSON2 type.
@@ -99,9 +103,14 @@ pub(crate) enum Json2OutputPlan {
 
 impl Json2OutputPlan {
     /// Builds an output plan from a column type and its optional read hint.
+    ///
+    /// JSON2 path hints have a concrete schema and use [`Json2OutputPlan::Align`],
+    /// while JSON2 root hints use [`Json2OutputPlan::Root`]. A missing hint on a
+    /// JSON2 column means a direct projection such as `SELECT j`, which is not
+    /// handled here yet.
     pub(crate) fn new(data_type: &ConcreteDataType, hint: Option<&JsonReadHint>) -> Self {
         if !is_json2_type(data_type) {
-            return Self::None;
+            return Self::NonJson2;
         }
 
         match hint {
@@ -109,7 +118,7 @@ impl Json2OutputPlan {
             Some(JsonReadHint::Paths(json_type)) => {
                 Self::Align(ConcreteDataType::json2(json_type.clone()))
             }
-            None => Self::Align(data_type.clone()),
+            None => Self::UnsupportedDirectProjection,
         }
     }
 
@@ -118,7 +127,7 @@ impl Json2OutputPlan {
     pub(crate) fn planned_type(&self) -> Option<&ConcreteDataType> {
         match self {
             Self::Align(data_type) => Some(data_type),
-            Self::None | Self::Root => None,
+            Self::NonJson2 | Self::UnsupportedDirectProjection | Self::Root => None,
         }
     }
 }
@@ -127,7 +136,10 @@ impl Json2OutputPlan {
 ///
 /// Behavior by plan:
 ///
-/// - [`Json2OutputPlan::None`] returns the array unchanged.
+/// - [`Json2OutputPlan::NonJson2`] returns the array unchanged.
+/// - [`Json2OutputPlan::UnsupportedDirectProjection`] returns an error. Without
+///   a read hint, aligning a direct JSON2 projection to the manifest's empty
+///   JSON2 schema would silently drop all fields.
 /// - [`Json2OutputPlan::Root`] keeps the array unchanged, but replaces
 ///   `output_type` with the JSON2 type inferred from the actual Arrow array.
 ///   Root reads don't have a query-inferred schema, so the actual array schema
@@ -140,15 +152,21 @@ impl Json2OutputPlan {
 /// - `array`: the column data read from memtables or SSTs.
 /// - `output_type`: the type used in the returned record batch schema. This
 ///   function updates it when the JSON2 plan determines a more precise type.
-/// - `plan`: whether the column is a non-JSON2 column, a root JSON2 read, or a
-///   path JSON2 read with a concrete schema.
+/// - `plan`: whether the column is a non-JSON2 column, an unsupported direct
+///   JSON2 projection, a root JSON2 read, or a path JSON2 read with a concrete
+///   schema.
 pub(crate) fn normalize_json2_output(
     array: ArrayRef,
     output_type: &mut ConcreteDataType,
     plan: &Json2OutputPlan,
 ) -> DataTypeResult<ArrayRef> {
     match plan {
-        Json2OutputPlan::None => Ok(array),
+        Json2OutputPlan::NonJson2 => Ok(array),
+        Json2OutputPlan::UnsupportedDirectProjection => UnsupportedOperationSnafu {
+            op: "direct JSON2 column projection is not supported yet; use json_get(column, '') to read the root JSON2 value",
+            vector_type: "Json2",
+        }
+        .fail(),
         Json2OutputPlan::Root => {
             let json_type = JsonNativeType::try_from(array.data_type())?;
             *output_type = ConcreteDataType::json2(json_type);
@@ -165,4 +183,27 @@ fn is_json2_type(data_type: &ConcreteDataType) -> bool {
     data_type
         .as_json()
         .is_some_and(|json_type| json_type.is_json2())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use datatypes::arrow::array::NullArray;
+    use datatypes::types::json_type::JsonObjectType;
+
+    use super::*;
+
+    #[test]
+    fn test_json2_output_plan_rejects_unhinted_json2_projection() {
+        let mut output_type =
+            ConcreteDataType::json2(JsonNativeType::Object(JsonObjectType::new()));
+        let plan = Json2OutputPlan::new(&output_type, None);
+        assert!(matches!(plan, Json2OutputPlan::UnsupportedDirectProjection));
+
+        let err = normalize_json2_output(Arc::new(NullArray::new(1)), &mut output_type, &plan)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("use json_get(column, '')"));
+    }
 }

--- a/src/mito2/src/read/json_schema.rs
+++ b/src/mito2/src/read/json_schema.rs
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Helpers for JSON2 schema handling in the read path.
+//! JSON2 schema policy used by the read path.
 //!
 //! JSON2 schemas used by reads are inferred from query expressions. For example,
 //! `json_get(j, "a.b")` gives us a concrete schema for the requested paths, so
 //! the reader can prune nested fields and align the output array to that schema.
 //!
-//! Root JSON2 reads are different: the query doesn't provide a concrete schema.
-//! They read the whole JSON2 column, and the output schema is whatever the
-//! actual array carries. A projected JSON2 column without a read hint is not
-//! supported by this module yet; it must not be aligned to the manifest's empty
-//! JSON2 schema because that would silently drop fields.
+//! Root JSON2 reads are different: the query can only say that the whole JSON2
+//! column should be read, but it cannot provide a concrete root schema. The
+//! read path must infer the root schema from the merged source schemas before
+//! building output plans. The root read still reads the whole JSON2 column, but
+//! later stages use the inferred schema to keep batch schemas consistent.
 
 pub(crate) mod align;
 
@@ -43,9 +43,12 @@ use crate::read::read_columns::{ReadColumns, merge_nested_paths};
 
 /// Applies JSON2 read hints to the nested paths in read columns.
 ///
-/// [`JsonReadHint::Root`] is a read strategy: it reads the whole JSON2 column
-/// and therefore clears nested path pruning. [`JsonReadHint::Paths`] narrows the
-/// read to the leaves described by the hinted JSON type.
+/// Behavior by hint:
+///
+/// - [`JsonReadHint::Root`] reads the whole JSON2 column, so this function
+///   clears nested path pruning for that column.
+/// - [`JsonReadHint::Paths`] narrows the read to the leaf paths described by
+///   the hinted JSON type.
 pub(crate) fn apply_json_read_hints_to_read_columns(
     read_cols: &mut ReadColumns,
     json_type_hint: &HashMap<String, JsonReadHint>,
@@ -93,15 +96,17 @@ fn collect_json_nested_paths(
     }
 }
 
-/// Infers concrete schemas for JSON2 root read hints from an Arrow schema.
+/// Infers concrete schemas for uninferred JSON2 root read hints from an Arrow schema.
 ///
-/// - `json_type_hint` contains query-driven JSON2 read hints. This function
-///   only updates entries whose hint is `JsonReadHint::Root(_)`; path hints and
-///   non-JSON2 entries are left unchanged.
-/// - `schema` is the merged source schema used by the read path. For each root
-///   read hint, this function looks up the field with the same column name,
-///   converts the field's Arrow type to `JsonNativeType`, and rewrites the hint
-///   to `JsonReadHint::Root(JsonRootReadHint::Inferred(...))`.
+/// - `json_type_hint` contains JSON2 read hints produced by the query phase and
+///   refined by the read path. This function only updates entries whose hint is
+///   `JsonReadHint::Root(JsonRootReadHint::Uninferred)`. Path hints,
+///   already-inferred root hints, and non-JSON2 entries are left unchanged.
+/// - `schema` is the merged source schema used by the read path. For each
+///   uninferred root read hint, this function looks up the field with the same
+///   column name, converts the field's Arrow type to `JsonNativeType`, and
+///   rewrites the hint to
+///   `JsonReadHint::Root(JsonRootReadHint::Inferred(...))`.
 ///
 /// If a hinted root column is not present in `schema`, the hint is left as-is.
 /// If the field exists but its Arrow type cannot be converted to a JSON native
@@ -111,7 +116,7 @@ pub(crate) fn infer_json2_root_hints_from_schema(
     schema: &ArrowSchemaRef,
 ) -> Result<()> {
     for (col_name, hint) in json_type_hint {
-        if !matches!(hint, JsonReadHint::Root(_)) {
+        if !matches!(hint, JsonReadHint::Root(JsonRootReadHint::Uninferred)) {
             continue;
         }
 
@@ -131,29 +136,18 @@ pub(crate) fn infer_json2_root_hints_from_schema(
 pub(crate) enum Json2OutputPlan {
     /// The column isn't JSON2 and doesn't need JSON2 output handling.
     NonJson2,
-    /// The column is a direct JSON2 projection without a read hint.
-    UnsupportedDirectProjection,
-    /// Read the root JSON2 value.
-    ///
-    /// The read path aligns root arrays to this concrete type before returning
-    /// them.
-    Root(ConcreteDataType),
-    /// Align the array to the expected JSON2 type.
+    /// Align the array to the expected JSON2 output type.
     Align(ConcreteDataType),
 }
 
 impl Json2OutputPlan {
     /// Builds an output plan from a column type and its optional read hint.
     ///
-    /// JSON2 path hints have a concrete schema and use [`Json2OutputPlan::Align`],
-    /// while JSON2 root hints use [`Json2OutputPlan::Root`]. A missing hint on a
-    /// JSON2 column means a direct projection such as `SELECT j`, which is not
-    /// handled here yet.
-    ///
-    /// The caller must infer root read hints before building output plans.
-    /// `JsonReadHint::Root(JsonRootReadHint::Uninferred)` means the read path
-    /// has not inspected the source schemas yet, so this function cannot decide
-    /// the concrete output type for the root column.
+    /// Path hints and inferred root hints both carry a concrete JSON2 schema,
+    /// so they produce an [`Json2OutputPlan::Align`] plan. The caller must
+    /// infer root hints before calling this function; `Root(Uninferred)` cannot
+    /// produce an output type. A missing hint on a JSON2 column is treated as an
+    /// unsupported direct projection, such as `SELECT j`.
     pub(crate) fn new(
         data_type: &ConcreteDataType,
         hint: Option<&JsonReadHint>,
@@ -163,18 +157,20 @@ impl Json2OutputPlan {
         }
 
         let plan = match hint {
-            Some(JsonReadHint::Root(JsonRootReadHint::Inferred(json_type))) => {
-                Self::Root(ConcreteDataType::json2(json_type.clone()))
+            Some(JsonReadHint::Root(JsonRootReadHint::Inferred(json_type)))
+            | Some(JsonReadHint::Paths(json_type)) => {
+                Self::Align(ConcreteDataType::json2(json_type.clone()))
             }
             Some(JsonReadHint::Root(JsonRootReadHint::Uninferred)) => UnsupportedOperationSnafu {
                 op: "JSON2 root read schema must be inferred before building output plans",
                 vector_type: "Json2",
             }
             .fail()?,
-            Some(JsonReadHint::Paths(json_type)) => {
-                Self::Align(ConcreteDataType::json2(json_type.clone()))
+            None => UnsupportedOperationSnafu {
+                op: "direct JSON2 column projection is not supported yet; use json_get(column, '') to read the root JSON2 value",
+                vector_type: "Json2",
             }
-            None => Self::UnsupportedDirectProjection,
+            .fail()?,
         };
         Ok(plan)
     }
@@ -184,8 +180,7 @@ impl Json2OutputPlan {
     pub(crate) fn planned_type(&self) -> Option<&ConcreteDataType> {
         match self {
             Self::Align(data_type) => Some(data_type),
-            Self::Root(data_type) => Some(data_type),
-            Self::NonJson2 | Self::UnsupportedDirectProjection => None,
+            Self::NonJson2 => None,
         }
     }
 }
@@ -195,11 +190,6 @@ impl Json2OutputPlan {
 /// Behavior by plan:
 ///
 /// - [`Json2OutputPlan::NonJson2`] returns the array unchanged.
-/// - [`Json2OutputPlan::UnsupportedDirectProjection`] returns an error. Without
-///   a read hint, aligning a direct JSON2 projection to the manifest's empty
-///   JSON2 schema would silently drop all fields.
-/// - [`Json2OutputPlan::Root`] updates `output_type` to its concrete type and
-///   aligns the array to it.
 /// - [`Json2OutputPlan::Align`] updates `output_type` to the planned JSON2 type
 ///   and aligns the array to that type, filling missing fields with nulls.
 ///
@@ -208,9 +198,8 @@ impl Json2OutputPlan {
 /// - `array`: the column data read from memtables or SSTs.
 /// - `output_type`: the type used in the returned record batch schema. This
 ///   function updates it when the JSON2 plan determines a more precise type.
-/// - `plan`: whether the column is a non-JSON2 column, an unsupported direct
-///   JSON2 projection, a root JSON2 read, or a path JSON2 read with a concrete
-///   schema.
+/// - `plan`: whether the column is a non-JSON2 column or a JSON2 read with a
+///   concrete output schema.
 pub(crate) fn normalize_json2_output(
     array: ArrayRef,
     output_type: &mut ConcreteDataType,
@@ -218,15 +207,6 @@ pub(crate) fn normalize_json2_output(
 ) -> DataTypeResult<ArrayRef> {
     match plan {
         Json2OutputPlan::NonJson2 => Ok(array),
-        Json2OutputPlan::UnsupportedDirectProjection => UnsupportedOperationSnafu {
-            op: "direct JSON2 column projection is not supported yet; use json_get(column, '') to read the root JSON2 value",
-            vector_type: "Json2",
-        }
-        .fail(),
-        Json2OutputPlan::Root(data_type) => {
-            *output_type = data_type.clone();
-            JsonArray::from(&array).try_align(&data_type.as_arrow_type())
-        }
         Json2OutputPlan::Align(data_type) => {
             *output_type = data_type.clone();
             JsonArray::from(&array).try_align(&data_type.as_arrow_type())
@@ -242,21 +222,14 @@ fn is_json2_type(data_type: &ConcreteDataType) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
-    use datatypes::arrow::array::NullArray;
     use datatypes::types::json_type::JsonObjectType;
 
     use super::*;
 
     #[test]
     fn test_json2_output_plan_rejects_unhinted_json2_projection() {
-        let mut output_type =
-            ConcreteDataType::json2(JsonNativeType::Object(JsonObjectType::new()));
-        let plan = Json2OutputPlan::new(&output_type, None).unwrap();
-        assert!(matches!(plan, Json2OutputPlan::UnsupportedDirectProjection));
-
-        let err = normalize_json2_output(Arc::new(NullArray::new(1)), &mut output_type, &plan)
+        let output_type = ConcreteDataType::json2(JsonNativeType::Object(JsonObjectType::new()));
+        let err = Json2OutputPlan::new(&output_type, None)
             .unwrap_err()
             .to_string();
         assert!(err.contains("use json_get(column, '')"));

--- a/src/mito2/src/read/json_schema.rs
+++ b/src/mito2/src/read/json_schema.rs
@@ -134,7 +134,7 @@ pub(crate) fn planned_json2_output_type(
     data_type: &ConcreteDataType,
     hint: Option<&JsonReadHint>,
 ) -> DataTypeResult<Json2OutputPlan> {
-    if data_type
+    if !data_type
         .as_json()
         .is_some_and(|json_type| json_type.is_json2())
     {
@@ -142,21 +142,21 @@ pub(crate) fn planned_json2_output_type(
     }
 
     match hint {
-            Some(JsonReadHint::Root(JsonRootReadHint::Inferred(json_type)))
-            | Some(JsonReadHint::Paths(json_type)) => {
-                Ok(Json2OutputPlan::AlignTo(ConcreteDataType::json2(json_type.clone())))
-            }
-            Some(JsonReadHint::Root(JsonRootReadHint::Uninferred)) => UnsupportedOperationSnafu {
-                op: "JSON2 root read schema must be inferred",
-                vector_type: "Json2",
-            }
-            .fail(),
-            None => UnsupportedOperationSnafu {
-                op: "direct JSON2 column projection is not supported yet; use json_get(column, '') to read the root JSON2 value",
-                vector_type: "Json2",
-            }
-            .fail(),
+        Some(JsonReadHint::Root(JsonRootReadHint::Inferred(json_type)))
+        | Some(JsonReadHint::Paths(json_type)) => Ok(Json2OutputPlan::AlignTo(
+            ConcreteDataType::json2(json_type.clone()),
+        )),
+        Some(JsonReadHint::Root(JsonRootReadHint::Uninferred)) => UnsupportedOperationSnafu {
+            op: "JSON2 root read schema must be inferred",
+            vector_type: "Json2",
         }
+        .fail(),
+        None => UnsupportedOperationSnafu {
+            op: "direct JSON2 column projection is not supported yet; use json_get(column, '') to read the root JSON2 value",
+            vector_type: "Json2",
+        }
+        .fail(),
+    }
 }
 
 /// JSON2 output handling plan for one projected column.

--- a/src/mito2/src/read/json_schema.rs
+++ b/src/mito2/src/read/json_schema.rs
@@ -24,16 +24,22 @@
 //! supported by this module yet; it must not be aligned to the manifest's empty
 //! JSON2 schema because that would silently drop fields.
 
+pub(crate) mod align;
+
 use std::collections::HashMap;
 
 use datatypes::arrow::array::ArrayRef;
+use datatypes::arrow::datatypes::SchemaRef as ArrowSchemaRef;
 use datatypes::error::{Result as DataTypeResult, UnsupportedOperationSnafu};
 use datatypes::prelude::{ConcreteDataType, DataType};
 use datatypes::types::json_type::JsonNativeType;
 use datatypes::vectors::json::array::JsonArray;
+use snafu::ResultExt;
 use store_api::metadata::RegionMetadata;
 use store_api::storage::{JsonReadHint, NestedPath};
 
+use crate::error::{DataTypeMismatchSnafu, Result};
+use crate::read::json_schema::align::Json2Aligner;
 use crate::read::read_columns::{ReadColumns, merge_nested_paths};
 
 /// Applies JSON2 read hints to the nested paths in read columns.
@@ -88,6 +94,53 @@ fn collect_json_nested_paths(
     }
 }
 
+/// Builds an aligner for source schemas and returns merged root JSON2 types.
+///
+/// This keeps root reads as root reads: callers still read the whole JSON2
+/// column, but they can use the returned concrete types to make merge-time
+/// schemas stable before batches reach `FlatMergeReader`.
+pub(crate) fn build_json2_root_aligner(
+    json_type_hint: &HashMap<String, JsonReadHint>,
+    source_schemas: Vec<ArrowSchemaRef>,
+) -> Result<Option<(Json2Aligner, HashMap<String, JsonNativeType>)>> {
+    if !has_json2_root_read_hint(json_type_hint) || source_schemas.is_empty() {
+        return Ok(None);
+    }
+
+    let aligner = Json2Aligner::try_new(source_schemas)?;
+    let root_types = root_json2_types_from_schema(json_type_hint, aligner.schema())?;
+    Ok(Some((aligner, root_types)))
+}
+
+/// Returns whether the hints contain at least one JSON2 root read.
+fn has_json2_root_read_hint(json_type_hint: &HashMap<String, JsonReadHint>) -> bool {
+    json_type_hint
+        .values()
+        .any(|hint| matches!(hint, JsonReadHint::Root))
+}
+
+
+fn root_json2_types_from_schema(
+    json_type_hint: &HashMap<String, JsonReadHint>,
+    schema: &ArrowSchemaRef,
+) -> Result<HashMap<String, JsonNativeType>> {
+    let mut root_types = HashMap::new();
+    for (col_name, hint) in json_type_hint {
+        if !matches!(hint, JsonReadHint::Root) {
+            continue;
+        }
+
+        let Some((_, field)) = schema.column_with_name(col_name) else {
+            continue;
+        };
+        let json_type =
+            JsonNativeType::try_from(field.data_type()).context(DataTypeMismatchSnafu)?;
+        root_types.insert(col_name.clone(), json_type);
+    }
+
+    Ok(root_types)
+}
+
 /// JSON2 output handling plan for one projected column.
 #[derive(Debug, Clone)]
 pub(crate) enum Json2OutputPlan {
@@ -95,8 +148,12 @@ pub(crate) enum Json2OutputPlan {
     NonJson2,
     /// The column is a direct JSON2 projection without a read hint.
     UnsupportedDirectProjection,
-    /// Read the root JSON2 value. The output type comes from the actual array.
-    Root,
+    /// Read the root JSON2 value.
+    ///
+    /// If the plan has a concrete type, the read path aligns root arrays to it
+    /// before returning them. Otherwise the output type comes from the actual
+    /// array.
+    Root(Option<ConcreteDataType>),
     /// Align the array to the expected JSON2 type.
     Align(ConcreteDataType),
 }
@@ -108,13 +165,19 @@ impl Json2OutputPlan {
     /// while JSON2 root hints use [`Json2OutputPlan::Root`]. A missing hint on a
     /// JSON2 column means a direct projection such as `SELECT j`, which is not
     /// handled here yet.
-    pub(crate) fn new(data_type: &ConcreteDataType, hint: Option<&JsonReadHint>) -> Self {
+    pub(crate) fn new(
+        data_type: &ConcreteDataType,
+        hint: Option<&JsonReadHint>,
+        root_json_type: Option<&JsonNativeType>,
+    ) -> Self {
         if !is_json2_type(data_type) {
             return Self::NonJson2;
         }
 
         match hint {
-            Some(JsonReadHint::Root) => Self::Root,
+            Some(JsonReadHint::Root) => {
+                Self::Root(root_json_type.cloned().map(ConcreteDataType::json2))
+            }
             Some(JsonReadHint::Paths(json_type)) => {
                 Self::Align(ConcreteDataType::json2(json_type.clone()))
             }
@@ -127,7 +190,8 @@ impl Json2OutputPlan {
     pub(crate) fn planned_type(&self) -> Option<&ConcreteDataType> {
         match self {
             Self::Align(data_type) => Some(data_type),
-            Self::NonJson2 | Self::UnsupportedDirectProjection | Self::Root => None,
+            Self::Root(Some(data_type)) => Some(data_type),
+            Self::NonJson2 | Self::UnsupportedDirectProjection | Self::Root(None) => None,
         }
     }
 }
@@ -140,10 +204,10 @@ impl Json2OutputPlan {
 /// - [`Json2OutputPlan::UnsupportedDirectProjection`] returns an error. Without
 ///   a read hint, aligning a direct JSON2 projection to the manifest's empty
 ///   JSON2 schema would silently drop all fields.
-/// - [`Json2OutputPlan::Root`] keeps the array unchanged, but replaces
-///   `output_type` with the JSON2 type inferred from the actual Arrow array.
-///   Root reads don't have a query-inferred schema, so the actual array schema
-///   becomes the output schema.
+/// - [`Json2OutputPlan::Root`] with a concrete type updates `output_type` to
+///   that type and aligns the array to it. [`Json2OutputPlan::Root`] without a
+///   concrete type keeps the array unchanged, but replaces `output_type` with
+///   the JSON2 type inferred from the actual Arrow array.
 /// - [`Json2OutputPlan::Align`] updates `output_type` to the planned JSON2 type
 ///   and aligns the array to that type, filling missing fields with nulls.
 ///
@@ -167,7 +231,11 @@ pub(crate) fn normalize_json2_output(
             vector_type: "Json2",
         }
         .fail(),
-        Json2OutputPlan::Root => {
+        Json2OutputPlan::Root(Some(data_type)) => {
+            *output_type = data_type.clone();
+            JsonArray::from(&array).try_align(&data_type.as_arrow_type())
+        }
+        Json2OutputPlan::Root(None) => {
             let json_type = JsonNativeType::try_from(array.data_type())?;
             *output_type = ConcreteDataType::json2(json_type);
             Ok(array)
@@ -198,7 +266,7 @@ mod tests {
     fn test_json2_output_plan_rejects_unhinted_json2_projection() {
         let mut output_type =
             ConcreteDataType::json2(JsonNativeType::Object(JsonObjectType::new()));
-        let plan = Json2OutputPlan::new(&output_type, None);
+        let plan = Json2OutputPlan::new(&output_type, None, None);
         assert!(matches!(plan, Json2OutputPlan::UnsupportedDirectProjection));
 
         let err = normalize_json2_output(Arc::new(NullArray::new(1)), &mut output_type, &plan)

--- a/src/mito2/src/read/json_schema.rs
+++ b/src/mito2/src/read/json_schema.rs
@@ -28,12 +28,10 @@ pub(crate) mod align;
 
 use std::collections::HashMap;
 
-use datatypes::arrow::array::ArrayRef;
 use datatypes::arrow::datatypes::SchemaRef as ArrowSchemaRef;
 use datatypes::error::{Result as DataTypeResult, UnsupportedOperationSnafu};
-use datatypes::prelude::{ConcreteDataType, DataType};
+use datatypes::prelude::ConcreteDataType;
 use datatypes::types::json_type::JsonNativeType;
-use datatypes::vectors::json::array::JsonArray;
 use snafu::ResultExt;
 use store_api::metadata::RegionMetadata;
 use store_api::storage::{JsonReadHint, JsonRootReadHint, NestedPath};
@@ -135,111 +133,36 @@ pub(crate) fn infer_json2_root_hints_from_schema(
 pub(crate) fn planned_json2_output_type(
     data_type: &ConcreteDataType,
     hint: Option<&JsonReadHint>,
-) -> DataTypeResult<Option<ConcreteDataType>> {
-    todo!()
-}
+) -> DataTypeResult<Json2OutputPlan> {
+    if data_type
+        .as_json()
+        .is_some_and(|json_type| json_type.is_json2())
+    {
+        return Ok(Json2OutputPlan::NonJson2);
+    }
 
-/// JSON2 output handling plan for one projected column.
-#[derive(Debug, Clone)]
-pub(crate) enum Json2OutputPlan {
-    /// The column isn't JSON2 and doesn't need JSON2 output handling.
-    NonJson2,
-    /// Align the array to the expected JSON2 output type.
-    Align(ConcreteDataType),
-}
-
-impl Json2OutputPlan {
-    /// Builds an output plan from a column type and its optional read hint.
-    ///
-    /// Path hints and inferred root hints both carry a concrete JSON2 schema,
-    /// so they produce an [`Json2OutputPlan::Align`] plan. The caller must
-    /// infer root hints before calling this function; `Root(Uninferred)` cannot
-    /// produce an output type. A missing hint on a JSON2 column is treated as an
-    /// unsupported direct projection, such as `SELECT j`.
-    pub(crate) fn new(
-        data_type: &ConcreteDataType,
-        hint: Option<&JsonReadHint>,
-    ) -> DataTypeResult<Self> {
-        if !is_json2_type(data_type) {
-            return Ok(Self::NonJson2);
-        }
-
-        let plan = match hint {
+    match hint {
             Some(JsonReadHint::Root(JsonRootReadHint::Inferred(json_type)))
             | Some(JsonReadHint::Paths(json_type)) => {
-                Self::Align(ConcreteDataType::json2(json_type.clone()))
+                Ok(Json2OutputPlan::AlignTo(ConcreteDataType::json2(json_type.clone())))
             }
             Some(JsonReadHint::Root(JsonRootReadHint::Uninferred)) => UnsupportedOperationSnafu {
-                op: "JSON2 root read schema must be inferred before building output plans",
+                op: "JSON2 root read schema must be inferred",
                 vector_type: "Json2",
             }
-            .fail()?,
+            .fail(),
             None => UnsupportedOperationSnafu {
                 op: "direct JSON2 column projection is not supported yet; use json_get(column, '') to read the root JSON2 value",
                 vector_type: "Json2",
             }
-            .fail()?,
-        };
-        Ok(plan)
-    }
-
-    /// Returns the planned concrete output type, if this plan has one before
-    /// reading actual data.
-    pub(crate) fn planned_type(&self) -> Option<&ConcreteDataType> {
-        match self {
-            Self::Align(data_type) => Some(data_type),
-            Self::NonJson2 => None,
+            .fail(),
         }
-    }
 }
 
-/// Normalizes one output array and its schema type according to its JSON2 read plan.
-///
-/// Behavior by plan:
-///
-/// - [`Json2OutputPlan::NonJson2`] returns the array unchanged.
-/// - [`Json2OutputPlan::Align`] updates `output_type` to the planned JSON2 type
-///   and aligns the array to that type, filling missing fields with nulls.
-///
-/// Parameters:
-///
-/// - `array`: the column data read from memtables or SSTs.
-/// - `output_type`: the type used in the returned record batch schema. This
-///   function updates it when the JSON2 plan determines a more precise type.
-/// - `plan`: whether the column is a non-JSON2 column or a JSON2 read with a
-///   concrete output schema.
-pub(crate) fn normalize_json2_output(
-    array: ArrayRef,
-    output_type: &mut ConcreteDataType,
-    plan: &Json2OutputPlan,
-) -> DataTypeResult<ArrayRef> {
-    match plan {
-        Json2OutputPlan::NonJson2 => Ok(array),
-        Json2OutputPlan::Align(data_type) => {
-            *output_type = data_type.clone();
-            JsonArray::from(&array).try_align(&data_type.as_arrow_type())
-        }
-    }
-}
-
-fn is_json2_type(data_type: &ConcreteDataType) -> bool {
-    data_type
-        .as_json()
-        .is_some_and(|json_type| json_type.is_json2())
-}
-
-#[cfg(test)]
-mod tests {
-    use datatypes::types::json_type::JsonObjectType;
-
-    use super::*;
-
-    #[test]
-    fn test_json2_output_plan_rejects_unhinted_json2_projection() {
-        let output_type = ConcreteDataType::json2(JsonNativeType::Object(JsonObjectType::new()));
-        let err = Json2OutputPlan::new(&output_type, None)
-            .unwrap_err()
-            .to_string();
-        assert!(err.contains("use json_get(column, '')"));
-    }
+/// JSON2 output handling plan for one projected column.
+pub(crate) enum Json2OutputPlan {
+    /// The column isn't JSON2 and doesn't need JSON2 output handling.
+    NonJson2,
+    /// Align the array to the expected JSON2 output type.
+    AlignTo(ConcreteDataType),
 }

--- a/src/mito2/src/read/json_schema/align.rs
+++ b/src/mito2/src/read/json_schema/align.rs
@@ -30,9 +30,9 @@ use crate::memtable::BoxedRecordBatchIterator;
 
 /// Aligns concrete JSON2 Arrow types across record batches.
 ///
-/// JSON2 column concrete Arrow types are derived from data. Different memtable
-/// parts may therefore have different concrete types for the same JSON2 column.
-/// This helper merges those concrete types and aligns batches to the merged schema.
+/// JSON2 column concrete Arrow types are derived from data. Different sources
+/// may therefore have different concrete types for the same JSON2 column. This
+/// helper merges those concrete types and aligns batches to the merged schema.
 #[derive(Clone)]
 pub(crate) struct Json2Aligner {
     /// Schema after merging all JSON2 column concrete types.
@@ -308,96 +308,62 @@ mod tests {
             .downcast_ref::<StructArray>()
             .unwrap();
         let id_values = data_with_id
-            .column(0)
+            .column_by_name("id")
+            .unwrap()
             .as_any()
             .downcast_ref::<Int64Array>()
             .unwrap();
-        let missing_names = data_with_id.column(1);
-        assert_eq!(10, id_values.value(0));
-        assert_eq!(20, id_values.value(1));
-        assert!(missing_names.is_null(0));
-        assert!(missing_names.is_null(1));
+        let name_values = data_with_id
+            .column_by_name("name")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringViewArray>()
+            .unwrap();
+        assert_eq!(Some(10), id_values.value(0).into());
+        assert!(name_values.is_null(0));
 
         let data_with_name = aligned_with_name
             .column(1)
             .as_any()
             .downcast_ref::<StructArray>()
             .unwrap();
-        let missing_ids = data_with_name.column(0);
+        let id_values = data_with_name
+            .column_by_name("id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
         let name_values = data_with_name
-            .column(1)
+            .column_by_name("name")
+            .unwrap()
             .as_any()
             .downcast_ref::<StringViewArray>()
             .unwrap();
-        assert!(missing_ids.is_null(0));
-        assert!(missing_ids.is_null(1));
+        assert!(id_values.is_null(0));
         assert_eq!("alice", name_values.value(0));
-        assert_eq!("bob", name_values.value(1));
     }
 
-    #[test]
-    fn test_wrap_iter_aligns_each_batch() {
-        let id_fields = Fields::from(vec![id_field()]);
-        let name_fields = Fields::from(vec![name_field()]);
-        let schema_with_id = schema_with_json_field(json_field("data", id_fields.clone()));
-        let schema_with_name = schema_with_json_field(json_field("data", name_fields.clone()));
-
-        let batch_with_id = RecordBatch::try_new(
-            schema_with_id.clone(),
-            vec![
-                Arc::new(Int64Array::from_iter_values([1])) as ArrayRef,
-                struct_array(
-                    id_fields,
-                    vec![Arc::new(Int64Array::from_iter_values([10])) as ArrayRef],
-                ),
-            ],
-        )
-        .unwrap();
-        let batch_with_name = RecordBatch::try_new(
-            schema_with_name.clone(),
-            vec![
-                Arc::new(Int64Array::from_iter_values([2])) as ArrayRef,
-                struct_array(
-                    name_fields,
-                    vec![Arc::new(StringViewArray::from(vec![Some("alice")])) as ArrayRef],
-                ),
-            ],
-        )
-        .unwrap();
-
-        let aligner = Json2Aligner::try_new([schema_with_id, schema_with_name]).unwrap();
-        let iter: BoxedRecordBatchIterator =
-            Box::new(vec![Ok(batch_with_id), Ok(batch_with_name)].into_iter());
-        let aligned = aligner.wrap_iter(iter).collect::<Result<Vec<_>>>().unwrap();
-
-        assert_eq!(2, aligned.len());
-        assert!(Arc::ptr_eq(aligned[0].schema_ref(), aligner.schema()));
-        assert!(Arc::ptr_eq(aligned[1].schema_ref(), aligner.schema()));
-    }
-
-    fn json_field(name: &str, fields: Fields) -> Arc<Field> {
-        Arc::new(
-            Field::new(name, DataType::Struct(fields), true)
-                .with_extension_type(JsonExtensionType::new(Arc::new(JsonMetadata::default()))),
-        )
-    }
-
-    fn schema_with_json_field(json_field: Arc<Field>) -> SchemaRef {
+    fn schema_with_json_field(field: Field) -> SchemaRef {
         Arc::new(Schema::new(vec![
             Arc::new(Field::new("ts", DataType::Int64, false)),
-            json_field,
+            Arc::new(field),
         ]))
     }
 
-    fn id_field() -> Arc<Field> {
-        Arc::new(Field::new("id", DataType::Int64, true))
+    fn json_field(name: &str, fields: Fields) -> Field {
+        Field::new(name, DataType::Struct(fields), true)
+            .with_extension_type(JsonExtensionType::new(Arc::new(JsonMetadata::default())))
     }
 
-    fn name_field() -> Arc<Field> {
-        Arc::new(Field::new("name", DataType::Utf8View, true))
+    fn id_field() -> Field {
+        Field::new("id", DataType::Int64, true)
     }
 
-    fn struct_array(fields: Fields, columns: Vec<ArrayRef>) -> ArrayRef {
-        Arc::new(StructArray::new(fields, columns, None))
+    fn name_field() -> Field {
+        Field::new("name", DataType::Utf8View, true)
+    }
+
+    fn struct_array(fields: Fields, arrays: Vec<ArrayRef>) -> ArrayRef {
+        Arc::new(StructArray::new(fields, arrays, None))
     }
 }

--- a/src/mito2/src/read/json_schema/align.rs
+++ b/src/mito2/src/read/json_schema/align.rs
@@ -366,4 +366,38 @@ mod tests {
     fn struct_array(fields: Fields, arrays: Vec<ArrayRef>) -> ArrayRef {
         Arc::new(StructArray::new(fields, arrays, None))
     }
+
+    /// Verifies that `Json2Aligner` can align a projected batch where the JSON2
+    /// column is at a different index than in the full schema used to build the
+    /// aligner. Columns are matched by `PARQUET:field_id`, not positional index.
+    #[test]
+    fn test_align_batch_works_with_projected_batch() {
+        let id_fields = Fields::from(vec![id_field()]);
+        // Full schema: [ts(id=0), j(id=1)]
+        let full_schema = schema_with_json_field(json_field("j", id_fields.clone()));
+        let aligner = Json2Aligner::try_new([full_schema]).unwrap();
+        assert_eq!(aligner.json_columns.len(), 1);
+        assert_eq!(aligner.json_columns[0].0, 1); // column_id = 1
+
+        // Projected batch: only [j(id=1)], at index 0
+        let projected_schema = Arc::new(Schema::new(vec![
+            Arc::new(json_field("j", id_fields.clone())),
+        ]));
+        let batch = RecordBatch::try_new(
+            projected_schema,
+            vec![struct_array(
+                id_fields,
+                vec![Arc::new(Int64Array::from_iter_values([10, 20])) as ArrayRef],
+            )],
+        )
+        .unwrap();
+
+        // Should NOT panic — aligner finds j by column_id=1, not index
+        let aligned = aligner.align_batch(batch).unwrap();
+        assert_eq!(aligned.num_columns(), 1);
+        assert_eq!(
+            aligned.schema_ref().field(0).data_type(),
+            &aligner.json_columns[0].1
+        );
+    }
 }

--- a/src/mito2/src/read/range.rs
+++ b/src/mito2/src/read/range.rs
@@ -15,6 +15,7 @@
 //! Structs for partition ranges.
 
 use common_time::Timestamp;
+use datatypes::arrow::datatypes::SchemaRef;
 use smallvec::{SmallVec, smallvec};
 use store_api::region_engine::PartitionRange;
 use store_api::storage::TimeSeriesDistribution;
@@ -477,6 +478,11 @@ impl MemRangeBuilder {
     /// Returns the statistics of the memtable.
     pub(crate) fn stats(&self) -> &MemtableStats {
         &self.stats
+    }
+
+    /// Returns a cheap schema hint for record batches yielded by this range.
+    pub(crate) fn record_batch_schema_hint(&self) -> Option<SchemaRef> {
+        self.range.record_batch_schema_hint()
     }
 }
 

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -46,8 +46,8 @@ use snafu::ResultExt;
 use store_api::metadata::{RegionMetadata, RegionMetadataRef};
 use store_api::region_engine::{PartitionRange, RegionScannerRef};
 use store_api::storage::{
-    JsonReadHint, RegionId, ScanRequest, SequenceNumber, SequenceRange, TimeSeriesDistribution,
-    TimeSeriesRowSelector,
+    JsonReadHint, JsonRootReadHint, RegionId, ScanRequest, SequenceNumber, SequenceRange,
+    TimeSeriesDistribution, TimeSeriesRowSelector,
 };
 use table::predicate::{Predicate, build_time_range_predicate, extract_time_range_from_expr};
 use tokio::sync::{Semaphore, mpsc};
@@ -533,14 +533,18 @@ impl ScanRegion {
 
         let json_aligner = match json_type_hint.as_mut() {
             Some(json_type_hint)
-                if json_type_hint
-                    .values()
-                    .any(|hint| matches!(hint, JsonReadHint::Root(_))) =>
+                if json_type_hint.values().any(|hint| {
+                    matches!(hint, JsonReadHint::Root(JsonRootReadHint::Uninferred))
+                }) =>
             {
                 let source_schemas = self
                     .collect_source_arrow_schemas(&files, &mem_range_builders)
                     .await?;
                 if source_schemas.is_empty() {
+                    infer_json2_root_hints_from_schema(
+                        json_type_hint,
+                        self.version.metadata.schema.arrow_schema(),
+                    )?;
                     None
                 } else {
                     let aligner = Json2Aligner::try_new(source_schemas)?;
@@ -658,7 +662,8 @@ impl ScanRegion {
 
         for file in files {
             schemas.push(Arc::new(
-                self.collect_arrow_schema_from_parquet(file).await?,
+                self.collect_arrow_schema_from_parquet_metadata(file)
+                    .await?,
             ));
         }
 
@@ -671,7 +676,10 @@ impl ScanRegion {
         Ok(schemas)
     }
 
-    async fn collect_arrow_schema_from_parquet(&self, file: &FileHandle) -> Result<Schema> {
+    async fn collect_arrow_schema_from_parquet_metadata(
+        &self,
+        file: &FileHandle,
+    ) -> Result<Schema> {
         let file_path =
             file.file_path(self.access_layer.table_dir(), self.access_layer.path_type());
         let file_size = file.meta_ref().file_size;
@@ -682,6 +690,8 @@ impl ScanRegion {
             .read_parquet_metadata(
                 &file_path,
                 file_size,
+                // TODO: Report metadata cache metrics for this schema inference path.
+                // Dropping them here can hide cache misses when debugging scan latency.
                 &mut MetadataCacheMetrics::default(),
                 PageIndexPolicy::default(),
             )

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -46,7 +46,7 @@ use snafu::ResultExt;
 use store_api::metadata::{RegionMetadata, RegionMetadataRef};
 use store_api::region_engine::{PartitionRange, RegionScannerRef};
 use store_api::storage::{
-    RegionId, ScanRequest, SequenceNumber, SequenceRange, TimeSeriesDistribution,
+    JsonReadHint, RegionId, ScanRequest, SequenceNumber, SequenceRange, TimeSeriesDistribution,
     TimeSeriesRowSelector,
 };
 use table::predicate::{Predicate, build_time_range_predicate, extract_time_range_from_expr};
@@ -64,7 +64,9 @@ use crate::metrics::READ_SST_COUNT;
 use crate::read::compat::{self, FlatCompatBatch};
 use crate::read::flat_projection::FlatProjectionMapper;
 use crate::read::json_schema::align::Json2Aligner;
-use crate::read::json_schema::{apply_json_read_hints_to_read_columns, build_json2_root_aligner};
+use crate::read::json_schema::{
+    apply_json_read_hints_to_read_columns, infer_json2_root_hints_from_schema,
+};
 use crate::read::range::{FileRangeBuilder, MemRangeBuilder, RangeMeta, RowGroupIndex};
 use crate::read::range_cache::{ScanRequestFingerprint, implied_time_range_from_exprs};
 use crate::read::read_columns::{
@@ -518,36 +520,52 @@ impl ScanRegion {
             }));
         }
 
-        let json_type_hint = has_structured_json
-            .then_some(&self.request.json_type_hint)
-            .inspect(|json_type_hint| {
-                debug!(
-                    "Concretized JSON type: {{{}}}",
-                    json_type_hint
-                        .iter()
-                        .map(|(k, v)| format!("{}: {}", k, v))
-                        .join(", ")
-                );
-            });
+        let mut json_type_hint = has_structured_json.then(|| self.request.json_type_hint.clone());
+        if let Some(json_type_hint) = json_type_hint.as_mut() {
+            debug!(
+                "Concretized JSON type: {{{}}}",
+                json_type_hint
+                    .iter()
+                    .map(|(k, v)| format!("{}: {}", k, v))
+                    .join(", ")
+            );
+        }
 
-        let (json_aligner, json_root_types) = if let Some(json_type_hint) = json_type_hint {
-            let source_schemas = self
-                .collect_source_arrow_schemas(&files, &mem_range_builders)
-                .await?;
-            match build_json2_root_aligner(json_type_hint, source_schemas)? {
-                Some((aligner, root_types)) => (Some(aligner), Some(root_types)),
-                None => (None, None),
+        let json_aligner = match json_type_hint.as_mut() {
+            Some(json_type_hint)
+                if json_type_hint
+                    .values()
+                    .any(|hint| matches!(hint, JsonReadHint::Root(_))) =>
+            {
+                let source_schemas = self
+                    .collect_source_arrow_schemas(&files, &mem_range_builders)
+                    .await?;
+                if source_schemas.is_empty() {
+                    None
+                } else {
+                    let aligner = Json2Aligner::try_new(source_schemas)?;
+                    infer_json2_root_hints_from_schema(json_type_hint, aligner.schema())?;
+                    Some(aligner)
+                }
             }
-        } else {
-            (None, None)
+            _ => None,
         };
 
-        let mapper = FlatProjectionMapper::new_with_read_columns_and_json_root_types(
+        if let Some(json_type_hint) = json_type_hint.as_ref() {
+            debug!(
+                "Initialized JSON type hint: {{{}}}",
+                json_type_hint
+                    .iter()
+                    .map(|(k, v)| format!("{}: {}", k, v))
+                    .join(", ")
+            );
+        }
+
+        let mapper = FlatProjectionMapper::new_with_read_columns(
             &self.version.metadata,
             projection,
             read_cols,
-            json_type_hint,
-            json_root_types.as_ref(),
+            json_type_hint.as_ref(),
         )?;
 
         let region_id = self.region_id();
@@ -2003,7 +2021,8 @@ mod tests {
     use partition::expr::col as partition_col;
     use store_api::metadata::{ColumnMetadata, RegionMetadataBuilder};
     use store_api::storage::{
-        JsonReadHint, NestedPath, RegionId, TimeSeriesDistribution, TimeSeriesRowSelector,
+        JsonReadHint, JsonRootReadHint, NestedPath, RegionId, TimeSeriesDistribution,
+        TimeSeriesRowSelector,
     };
 
     use super::*;
@@ -2176,7 +2195,10 @@ mod tests {
             }
         );
 
-        let hint = HashMap::from([("j".to_string(), JsonReadHint::Root)]);
+        let hint = HashMap::from([(
+            "j".to_string(),
+            JsonReadHint::Root(JsonRootReadHint::Uninferred),
+        )]);
         let mut read_columns = ReadColumns {
             cols: vec![ReadColumn::new(1, vec![])],
         };

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -14,7 +14,7 @@
 
 //! Scans a region according to the scan request.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::fmt;
 use std::num::NonZeroU64;
 use std::sync::Arc;
@@ -34,7 +34,6 @@ use datafusion_expr::Expr;
 use datafusion_expr::utils::expr_to_columns;
 use datatypes::arrow::array::{ArrayRef, BooleanArray, UInt64Array};
 use datatypes::extension::json::is_structured_json_field;
-use datatypes::types::json_type::JsonNativeType;
 use datatypes::value::timestamp_to_scalar_value;
 use futures::StreamExt;
 use itertools::Itertools;
@@ -44,8 +43,8 @@ use snafu::ResultExt;
 use store_api::metadata::{RegionMetadata, RegionMetadataRef};
 use store_api::region_engine::{PartitionRange, RegionScannerRef};
 use store_api::storage::{
-    JsonReadHint, NestedPath, RegionId, ScanRequest, SequenceNumber, SequenceRange,
-    TimeSeriesDistribution, TimeSeriesRowSelector,
+    RegionId, ScanRequest, SequenceNumber, SequenceRange, TimeSeriesDistribution,
+    TimeSeriesRowSelector,
 };
 use table::predicate::{Predicate, build_time_range_predicate, extract_time_range_from_expr};
 use tokio::sync::{Semaphore, mpsc};
@@ -61,11 +60,11 @@ use crate::memtable::{MemtableRange, RangesOptions};
 use crate::metrics::READ_SST_COUNT;
 use crate::read::compat::{self, FlatCompatBatch};
 use crate::read::flat_projection::FlatProjectionMapper;
+use crate::read::json_schema::apply_json_read_hints_to_read_columns;
 use crate::read::range::{FileRangeBuilder, MemRangeBuilder, RangeMeta, RowGroupIndex};
 use crate::read::range_cache::{ScanRequestFingerprint, implied_time_range_from_exprs};
 use crate::read::read_columns::{
-    ReadColumns, merge, merge_nested_paths, read_columns_from_predicate,
-    read_columns_from_projection,
+    ReadColumns, merge, read_columns_from_predicate, read_columns_from_projection,
 };
 use crate::read::seq_scan::SeqScan;
 use crate::read::series_scan::SeriesScan;
@@ -440,7 +439,7 @@ impl ScanRegion {
             .iter()
             .any(is_structured_json_field);
         if has_structured_json {
-            narrow_read_columns_by_json_type_hint(
+            apply_json_read_hints_to_read_columns(
                 &mut read_cols,
                 &self.request.json_type_hint,
                 &self.version.metadata,
@@ -1421,53 +1420,6 @@ fn pre_filter_mode(append_mode: bool, merge_mode: MergeMode) -> PreFilterMode {
     }
 }
 
-fn narrow_read_columns_by_json_type_hint(
-    read_columns: &mut ReadColumns,
-    json_type_hint: &HashMap<String, JsonReadHint>,
-    metadata: &RegionMetadata,
-) {
-    if json_type_hint.is_empty() {
-        return;
-    }
-
-    for read_column in &mut read_columns.cols {
-        let Some(column) = metadata.column_by_id(read_column.column_id) else {
-            continue;
-        };
-        let column_name = &column.column_schema.name;
-        let Some(json_type) = json_type_hint.get(column_name) else {
-            continue;
-        };
-
-        let JsonReadHint::Paths(json_type) = json_type else {
-            read_column.nested_paths.clear();
-            continue;
-        };
-
-        let mut paths = Vec::new();
-        let mut current = vec![column_name.clone()];
-        collect_json_nested_paths(json_type, &mut current, &mut paths);
-        merge_nested_paths(&mut read_column.nested_paths, paths)
-    }
-}
-
-fn collect_json_nested_paths(
-    json_type: &JsonNativeType,
-    current: &mut NestedPath,
-    paths: &mut Vec<NestedPath>,
-) {
-    match json_type {
-        JsonNativeType::Object(fields) if !fields.is_empty() => {
-            for (field, child) in fields {
-                current.push(field.clone());
-                collect_json_nested_paths(child, current, paths);
-                current.pop();
-            }
-        }
-        _ => paths.push(current.clone()),
-    }
-}
-
 /// Output of [build_scan_fingerprint]: the cache fingerprint plus the derived
 /// implied time range used to decide whether the cache key can drop the time
 /// predicates for a given partition (see `build_range_cache_key`).
@@ -1957,6 +1909,7 @@ impl PredicateGroup {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     use common_time::timestamp::{TimeUnit, Timestamp};
@@ -1968,11 +1921,13 @@ mod tests {
     };
     use datatypes::prelude::ConcreteDataType;
     use datatypes::schema::ColumnSchema;
-    use datatypes::types::json_type::JsonObjectType;
+    use datatypes::types::json_type::{JsonNativeType, JsonObjectType};
     use datatypes::value::Value;
     use partition::expr::col as partition_col;
     use store_api::metadata::{ColumnMetadata, RegionMetadataBuilder};
-    use store_api::storage::{RegionId, TimeSeriesDistribution, TimeSeriesRowSelector};
+    use store_api::storage::{
+        JsonReadHint, NestedPath, RegionId, TimeSeriesDistribution, TimeSeriesRowSelector,
+    };
 
     use super::*;
     use crate::cache::CacheManager;
@@ -2119,7 +2074,7 @@ mod tests {
         let mut read_columns = ReadColumns {
             cols: vec![ReadColumn::new(1, vec![]), ReadColumn::new(0, vec![])],
         };
-        narrow_read_columns_by_json_type_hint(&mut read_columns, &hint, metadata.as_ref());
+        apply_json_read_hints_to_read_columns(&mut read_columns, &hint, metadata.as_ref());
         assert_eq!(
             read_columns,
             ReadColumns {
@@ -2136,7 +2091,7 @@ mod tests {
         let mut read_columns = ReadColumns {
             cols: vec![ReadColumn::new(0, vec![])],
         };
-        narrow_read_columns_by_json_type_hint(&mut read_columns, &hint, metadata.as_ref());
+        apply_json_read_hints_to_read_columns(&mut read_columns, &hint, metadata.as_ref());
         assert_eq!(
             read_columns,
             ReadColumns {
@@ -2148,7 +2103,7 @@ mod tests {
         let mut read_columns = ReadColumns {
             cols: vec![ReadColumn::new(1, vec![])],
         };
-        narrow_read_columns_by_json_type_hint(&mut read_columns, &hint, metadata.as_ref());
+        apply_json_read_hints_to_read_columns(&mut read_columns, &hint, metadata.as_ref());
         assert_eq!(
             read_columns,
             ReadColumns {

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -1442,6 +1442,9 @@ fn narrow_read_columns_by_json_type_hint(
         let mut paths = Vec::new();
         let mut current = vec![column_name.clone()];
         collect_json_nested_paths(json_type, &mut current, &mut paths);
+        if matches!(json_type, JsonNativeType::Variant) {
+            paths.clear();
+        }
         merge_nested_paths(&mut read_column.nested_paths, paths)
     }
 }
@@ -2136,6 +2139,18 @@ mod tests {
             read_columns,
             ReadColumns {
                 cols: vec![ReadColumn::new(0, vec![])]
+            }
+        );
+
+        let hint = HashMap::from([("j".to_string(), JsonNativeType::Variant)]);
+        let mut read_columns = ReadColumns {
+            cols: vec![ReadColumn::new(1, vec![])],
+        };
+        narrow_read_columns_by_json_type_hint(&mut read_columns, &hint, metadata.as_ref());
+        assert_eq!(
+            read_columns,
+            ReadColumns {
+                cols: vec![ReadColumn::new(1, vec![])]
             }
         );
         Ok(())

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -33,10 +33,13 @@ use datafusion_common::{Column, ScalarValue};
 use datafusion_expr::Expr;
 use datafusion_expr::utils::expr_to_columns;
 use datatypes::arrow::array::{ArrayRef, BooleanArray, UInt64Array};
+use datatypes::arrow::datatypes::{Schema, SchemaRef as ArrowSchemaRef};
 use datatypes::extension::json::is_structured_json_field;
 use datatypes::value::timestamp_to_scalar_value;
 use futures::StreamExt;
 use itertools::Itertools;
+use parquet::arrow::parquet_to_arrow_schema;
+use parquet::file::metadata::PageIndexPolicy;
 use partition::expr::PartitionExpr;
 use smallvec::SmallVec;
 use snafu::ResultExt;
@@ -53,14 +56,15 @@ use tokio_stream::wrappers::ReceiverStream;
 use crate::access_layer::AccessLayerRef;
 use crate::cache::CacheStrategy;
 use crate::config::DEFAULT_MAX_CONCURRENT_SCAN_FILES;
-use crate::error::{InvalidPartitionExprSnafu, Result};
+use crate::error::{InvalidPartitionExprSnafu, ParquetToArrowSchemaSnafu, Result};
 #[cfg(feature = "enterprise")]
 use crate::extension::{BoxedExtensionRange, BoxedExtensionRangeProvider};
 use crate::memtable::{MemtableRange, RangesOptions};
 use crate::metrics::READ_SST_COUNT;
 use crate::read::compat::{self, FlatCompatBatch};
 use crate::read::flat_projection::FlatProjectionMapper;
-use crate::read::json_schema::apply_json_read_hints_to_read_columns;
+use crate::read::json_schema::align::Json2Aligner;
+use crate::read::json_schema::{apply_json_read_hints_to_read_columns, build_json2_root_aligner};
 use crate::read::range::{FileRangeBuilder, MemRangeBuilder, RangeMeta, RowGroupIndex};
 use crate::read::range_cache::{ScanRequestFingerprint, implied_time_range_from_exprs};
 use crate::read::read_columns::{
@@ -84,7 +88,7 @@ use crate::sst::index::inverted_index::applier::builder::InvertedIndexApplierBui
 #[cfg(feature = "vector_index")]
 use crate::sst::index::vector_index::applier::{VectorIndexApplier, VectorIndexApplierRef};
 use crate::sst::parquet::file_range::PreFilterMode;
-use crate::sst::parquet::reader::ReaderMetrics;
+use crate::sst::parquet::reader::{MetadataCacheMetrics, ReaderMetrics};
 
 #[cfg(feature = "vector_index")]
 const VECTOR_INDEX_OVERFETCH_MULTIPLIER: usize = 2;
@@ -453,24 +457,6 @@ impl ScanRegion {
             .projection_indices()
             .map(|x| x.to_vec())
             .unwrap_or_else(|| (0..self.version.metadata.column_metadatas.len()).collect());
-        let json_type_hint = has_structured_json
-            .then_some(&self.request.json_type_hint)
-            .inspect(|json_type_hint| {
-                debug!(
-                    "Concretized JSON type: {{{}}}",
-                    json_type_hint
-                        .iter()
-                        .map(|(k, v)| format!("{}: {}", k, v))
-                        .join(", ")
-                );
-            });
-        let mapper = FlatProjectionMapper::new_with_read_columns(
-            &self.version.metadata,
-            projection,
-            read_cols,
-            json_type_hint,
-        )?;
-
         let ssts = &self.version.ssts;
         let mut files = Vec::new();
         if !self.request.skip_sst_files {
@@ -532,6 +518,38 @@ impl ScanRegion {
             }));
         }
 
+        let json_type_hint = has_structured_json
+            .then_some(&self.request.json_type_hint)
+            .inspect(|json_type_hint| {
+                debug!(
+                    "Concretized JSON type: {{{}}}",
+                    json_type_hint
+                        .iter()
+                        .map(|(k, v)| format!("{}: {}", k, v))
+                        .join(", ")
+                );
+            });
+
+        let (json_aligner, json_root_types) = if let Some(json_type_hint) = json_type_hint {
+            let source_schemas = self
+                .collect_source_arrow_schemas(&files, &mem_range_builders)
+                .await?;
+            match build_json2_root_aligner(json_type_hint, source_schemas)? {
+                Some((aligner, root_types)) => (Some(aligner), Some(root_types)),
+                None => (None, None),
+            }
+        } else {
+            (None, None)
+        };
+
+        let mapper = FlatProjectionMapper::new_with_read_columns_and_json_root_types(
+            &self.version.metadata,
+            projection,
+            read_cols,
+            json_type_hint,
+            json_root_types.as_ref(),
+        )?;
+
         let region_id = self.region_id();
         debug!(
             "Scan region {}, request: {:?}, time range: {:?}, memtables: {}, ssts_to_read: {}, append_mode: {}",
@@ -573,6 +591,7 @@ impl ScanRegion {
             .with_memtables(mem_range_builders)
             .with_files(files)
             .with_cache(self.cache_strategy)
+            .with_json_aligner(json_aligner)
             .with_inverted_index_appliers(inverted_index_appliers)
             .with_bloom_filter_index_appliers(bloom_filter_appliers)
             .with_fulltext_index_appliers(fulltext_index_appliers)
@@ -610,6 +629,54 @@ impl ScanRegion {
             input
         };
         Ok(input)
+    }
+
+    async fn collect_source_arrow_schemas(
+        &self,
+        files: &[FileHandle],
+        mem_range_builders: &[MemRangeBuilder],
+    ) -> Result<Vec<ArrowSchemaRef>> {
+        let mut schemas = Vec::with_capacity(files.len() + mem_range_builders.len());
+
+        for file in files {
+            schemas.push(Arc::new(
+                self.collect_arrow_schema_from_parquet(file).await?,
+            ));
+        }
+
+        schemas.extend(
+            mem_range_builders
+                .iter()
+                .filter_map(MemRangeBuilder::record_batch_schema_hint),
+        );
+
+        Ok(schemas)
+    }
+
+    async fn collect_arrow_schema_from_parquet(&self, file: &FileHandle) -> Result<Schema> {
+        let file_path =
+            file.file_path(self.access_layer.table_dir(), self.access_layer.path_type());
+        let file_size = file.meta_ref().file_size;
+        let parquet_metadata = self
+            .access_layer
+            .read_sst(file.clone())
+            .cache(self.cache_strategy.clone())
+            .read_parquet_metadata(
+                &file_path,
+                file_size,
+                &mut MetadataCacheMetrics::default(),
+                PageIndexPolicy::default(),
+            )
+            .await?
+            .0
+            .parquet_metadata();
+        let file_metadata = parquet_metadata.file_metadata();
+
+        parquet_to_arrow_schema(
+            file_metadata.schema_descr(),
+            file_metadata.key_value_metadata(),
+        )
+        .context(ParquetToArrowSchemaSnafu { file: file_path })
     }
 
     fn region_id(&self) -> RegionId {
@@ -802,6 +869,8 @@ pub struct ScanInput {
     pub(crate) files: Vec<FileHandle>,
     /// Cache.
     pub(crate) cache_strategy: CacheStrategy,
+    /// Aligns JSON2 memtable batches to the scan-time merged root schema.
+    pub(crate) json_aligner: Option<Json2Aligner>,
     /// Ignores file not found error.
     ignore_file_not_found: bool,
     /// Maximum number of SST files to scan concurrently.
@@ -852,6 +921,7 @@ impl ScanInput {
             memtables: Vec::new(),
             files: Vec::new(),
             cache_strategy: CacheStrategy::Disabled,
+            json_aligner: None,
             ignore_file_not_found: false,
             max_concurrent_scan_files: DEFAULT_MAX_CONCURRENT_SCAN_FILES,
             inverted_index_appliers: [None, None],
@@ -908,6 +978,13 @@ impl ScanInput {
     #[must_use]
     pub(crate) fn with_cache(mut self, cache: CacheStrategy) -> Self {
         self.cache_strategy = cache;
+        self
+    }
+
+    /// Sets the JSON2 aligner for memtable batches.
+    #[must_use]
+    pub(crate) fn with_json_aligner(mut self, aligner: Option<Json2Aligner>) -> Self {
+        self.json_aligner = aligner;
         self
     }
 

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -44,8 +44,8 @@ use snafu::ResultExt;
 use store_api::metadata::{RegionMetadata, RegionMetadataRef};
 use store_api::region_engine::{PartitionRange, RegionScannerRef};
 use store_api::storage::{
-    NestedPath, RegionId, ScanRequest, SequenceNumber, SequenceRange, TimeSeriesDistribution,
-    TimeSeriesRowSelector,
+    JsonReadHint, NestedPath, RegionId, ScanRequest, SequenceNumber, SequenceRange,
+    TimeSeriesDistribution, TimeSeriesRowSelector,
 };
 use table::predicate::{Predicate, build_time_range_predicate, extract_time_range_from_expr};
 use tokio::sync::{Semaphore, mpsc};
@@ -1423,7 +1423,7 @@ fn pre_filter_mode(append_mode: bool, merge_mode: MergeMode) -> PreFilterMode {
 
 fn narrow_read_columns_by_json_type_hint(
     read_columns: &mut ReadColumns,
-    json_type_hint: &HashMap<String, JsonNativeType>,
+    json_type_hint: &HashMap<String, JsonReadHint>,
     metadata: &RegionMetadata,
 ) {
     if json_type_hint.is_empty() {
@@ -1439,12 +1439,14 @@ fn narrow_read_columns_by_json_type_hint(
             continue;
         };
 
+        let JsonReadHint::Paths(json_type) = json_type else {
+            read_column.nested_paths.clear();
+            continue;
+        };
+
         let mut paths = Vec::new();
         let mut current = vec![column_name.clone()];
         collect_json_nested_paths(json_type, &mut current, &mut paths);
-        if matches!(json_type, JsonNativeType::Variant) {
-            paths.clear();
-        }
         merge_nested_paths(&mut read_column.nested_paths, paths)
     }
 }
@@ -2098,7 +2100,7 @@ mod tests {
         let metadata = json_projection_test_metadata()?;
         let hint = HashMap::from([(
             "j".to_string(),
-            JsonNativeType::Object(JsonObjectType::from([
+            JsonReadHint::Paths(JsonNativeType::Object(JsonObjectType::from([
                 ("a".to_string(), JsonNativeType::i64()),
                 (
                     "b".to_string(),
@@ -2107,7 +2109,7 @@ mod tests {
                         JsonNativeType::String,
                     )])),
                 ),
-            ])),
+            ]))),
         )]);
 
         fn nested_path(parts: &[&str]) -> NestedPath {
@@ -2142,7 +2144,7 @@ mod tests {
             }
         );
 
-        let hint = HashMap::from([("j".to_string(), JsonNativeType::Variant)]);
+        let hint = HashMap::from([("j".to_string(), JsonReadHint::Root)]);
         let mut read_columns = ReadColumns {
             cols: vec![ReadColumn::new(1, vec![])],
         };

--- a/src/mito2/src/read/scan_util.rs
+++ b/src/mito2/src/read/scan_util.rs
@@ -1218,7 +1218,10 @@ pub(crate) fn scan_flat_mem_ranges(
             let mut iter = range.build_record_batch_iter(Some(time_range), mem_scan_metrics.clone())?;
             part_metrics.inc_build_reader_cost(build_reader_start.elapsed());
 
-            while let Some(record_batch) = iter.next().transpose()? {
+            while let Some(mut record_batch) = iter.next().transpose()? {
+                if let Some(aligner) = &stream_ctx.input.json_aligner {
+                    record_batch = aligner.align_batch(record_batch)?;
+                }
                 yield record_batch;
             }
 

--- a/src/mito2/src/read/scan_util.rs
+++ b/src/mito2/src/read/scan_util.rs
@@ -1215,13 +1215,16 @@ pub(crate) fn scan_flat_mem_ranges(
         for range in ranges {
             let build_reader_start = Instant::now();
             let mem_scan_metrics = Some(MemScanMetrics::default());
-            let mut iter = range.build_record_batch_iter(Some(time_range), mem_scan_metrics.clone())?;
+            let iter = range.build_record_batch_iter(Some(time_range), mem_scan_metrics.clone())?;
+            let mut iter = if let Some(aligner) = &stream_ctx.input.json_aligner {
+                aligner.wrap_iter(iter)
+            } else {
+                iter
+            };
+
             part_metrics.inc_build_reader_cost(build_reader_start.elapsed());
 
-            while let Some(mut record_batch) = iter.next().transpose()? {
-                if let Some(aligner) = &stream_ctx.input.json_aligner {
-                    record_batch = aligner.align_batch(record_batch)?;
-                }
+            while let Some(record_batch) = iter.next().transpose()? {
                 yield record_batch;
             }
 

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -219,6 +219,8 @@ impl SeqScan {
             // that source may have duplicate rows.
             sources.pop().unwrap()
         } else {
+            // TODO: Currently although the json type hint for the qury is passed
+            // in, it is not concretized when read the whole column.
             let schema = mapper.input_arrow_schema(stream_ctx.input.compaction);
             let metrics_reporter = part_metrics.map(|m| m.merge_metrics_reporter());
             let reader =

--- a/src/mito2/src/sst/parquet/flat_format.rs
+++ b/src/mito2/src/sst/parquet/flat_format.rs
@@ -478,6 +478,10 @@ fn prune_field_by_nested_paths(field: &FieldRef, nested_paths: &[&[String]]) -> 
         return field.clone();
     };
 
+    if nested_paths.iter().any(|path| path.is_empty()) {
+        return field.clone();
+    }
+
     let pruned_fields = fields
         .iter()
         .filter_map(|field| {
@@ -1221,6 +1225,38 @@ mod tests {
             ),
         ]);
 
+        assert_eq!(schema, expected);
+    }
+
+    #[test]
+    fn test_prune_schema_by_root_nested_path() {
+        fn new_field(name: &str, data_type: ArrowDataType) -> FieldRef {
+            Arc::new(Field::new(name, data_type, true))
+        }
+
+        let mut schema = Schema::new([new_field(
+            "j",
+            ArrowDataType::Struct(
+                vec![new_field("a", ArrowDataType::Int64)]
+                    .into_iter()
+                    .collect(),
+            ),
+        )]);
+        let nested_paths = [vec![["j"].iter().map(|x| x.to_string()).collect()]];
+
+        prune_schema_by_nested_paths(
+            &mut schema,
+            nested_paths.iter().map(|paths| paths.as_slice()),
+        );
+
+        let expected = Schema::new([new_field(
+            "j",
+            ArrowDataType::Struct(
+                vec![new_field("a", ArrowDataType::Int64)]
+                    .into_iter()
+                    .collect(),
+            ),
+        )]);
         assert_eq!(schema, expected);
     }
 }

--- a/src/mito2/src/sst/parquet/flat_format.rs
+++ b/src/mito2/src/sst/parquet/flat_format.rs
@@ -1242,12 +1242,8 @@ mod tests {
                     .collect(),
             ),
         )]);
-        let nested_paths = [vec![["j"].iter().map(|x| x.to_string()).collect()]];
-
-        prune_schema_by_nested_paths(
-            &mut schema,
-            nested_paths.iter().map(|paths| paths.as_slice()),
-        );
+        let nested_paths: [&[Vec<String>]; 1] = [&[vec!["j".to_string()]]];
+        prune_schema_by_nested_paths(&mut schema, nested_paths);
 
         let expected = Schema::new([new_field(
             "j",

--- a/src/query/src/dummy_catalog.rs
+++ b/src/query/src/dummy_catalog.rs
@@ -31,14 +31,14 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion_common::DataFusionError;
 use datafusion_expr::{Expr, TableProviderFilterPushDown, TableType};
 use datatypes::arrow::datatypes::SchemaRef;
-use datatypes::types::json_type::JsonNativeType;
 use futures::stream::BoxStream;
 use session::context::{QueryContext, QueryContextRef};
 use snafu::ResultExt;
 use store_api::metadata::RegionMetadataRef;
 use store_api::region_engine::RegionEngineRef;
 use store_api::storage::{
-    RegionId, ScanRequest, TimeSeriesDistribution, TimeSeriesRowSelector, VectorSearchRequest,
+    JsonReadHint, RegionId, ScanRequest, TimeSeriesDistribution, TimeSeriesRowSelector,
+    VectorSearchRequest,
 };
 use table::TableRef;
 use table::metadata::{TableId, TableInfoRef};
@@ -287,7 +287,7 @@ impl DummyTableProvider {
         self.scan_request.lock().unwrap().memtable_max_sequence = Some(sequence);
     }
 
-    pub(crate) fn with_json_type_hint(&self, hint: HashMap<String, JsonNativeType>) {
+    pub(crate) fn with_json_type_hint(&self, hint: HashMap<String, JsonReadHint>) {
         self.scan_request.lock().unwrap().json_type_hint = hint;
     }
 

--- a/src/query/src/optimizer/json_type_concretize.rs
+++ b/src/query/src/optimizer/json_type_concretize.rs
@@ -22,6 +22,7 @@ use datafusion_common::{Result, plan_datafusion_err, plan_err};
 use datafusion_expr::{Expr, LogicalPlan};
 use datafusion_optimizer::{OptimizerConfig, OptimizerRule};
 use datatypes::types::json_type::{JsonNativeType, JsonObjectType};
+use store_api::storage::JsonReadHint;
 
 use crate::dummy_catalog::DummyTableProvider;
 
@@ -72,14 +73,14 @@ impl OptimizerRule for JsonTypeConcretizeRule {
     }
 }
 
-fn deduce_json_types(plan: &LogicalPlan) -> Result<HashMap<String, JsonNativeType>> {
-    let mut json_types = HashMap::<String, JsonNativeType>::new();
+fn deduce_json_types(plan: &LogicalPlan) -> Result<HashMap<String, JsonReadHint>> {
+    let mut json_types = HashMap::<String, JsonReadHint>::new();
 
     plan.apply(|plan| {
         for expr in plan.expressions() {
             expr.apply(|expr| {
-                if let Some((column, json_type)) = deduce_json_type(expr)? {
-                    json_types.entry(column).or_default().merge(&json_type);
+                if let Some((column, json_hint)) = deduce_json_type(expr)? {
+                    merge_json_read_hint(&mut json_types, column, json_hint);
                 }
                 Ok(TreeNodeRecursion::Continue)
             })?;
@@ -89,7 +90,30 @@ fn deduce_json_types(plan: &LogicalPlan) -> Result<HashMap<String, JsonNativeTyp
     Ok(json_types)
 }
 
-fn deduce_json_type(expr: &Expr) -> Result<Option<(String, JsonNativeType)>> {
+fn merge_json_read_hint(
+    json_types: &mut HashMap<String, JsonReadHint>,
+    column: String,
+    hint: JsonReadHint,
+) {
+    use std::collections::hash_map::Entry;
+
+    match json_types.entry(column) {
+        Entry::Vacant(entry) => {
+            entry.insert(hint);
+        }
+        Entry::Occupied(mut entry) => match (entry.get_mut(), hint) {
+            (existing @ JsonReadHint::Paths(_), JsonReadHint::Root) => {
+                *existing = JsonReadHint::Root;
+            }
+            (JsonReadHint::Root, _) => {}
+            (JsonReadHint::Paths(existing), JsonReadHint::Paths(incoming)) => {
+                existing.merge(&incoming);
+            }
+        },
+    }
+}
+
+fn deduce_json_type(expr: &Expr) -> Result<Option<(String, JsonReadHint)>> {
     let f = match expr {
         Expr::ScalarFunction(f) if f.name().eq_ignore_ascii_case(JsonGetWithType::NAME) => f,
         _ => return Ok(None),
@@ -127,12 +151,15 @@ fn deduce_json_type(expr: &Expr) -> Result<Option<(String, JsonNativeType)>> {
         JsonNativeType::try_from(&with_type).map_err(|e| plan_datafusion_err!("{e:?}"))?;
 
     if path.is_empty() {
-        return Ok(Some((column.name.clone(), JsonNativeType::Variant)));
+        return Ok(Some((column.name.clone(), JsonReadHint::Root)));
     }
 
     let mut split = path.rsplit(".");
     let Some(leaf) = split.next() else {
-        return Ok(Some((column.name.clone(), JsonNativeType::String)));
+        return Ok(Some((
+            column.name.clone(),
+            JsonReadHint::Paths(JsonNativeType::String),
+        )));
     };
 
     let mut object = JsonObjectType::new();
@@ -145,7 +172,7 @@ fn deduce_json_type(expr: &Expr) -> Result<Option<(String, JsonNativeType)>> {
         root = JsonNativeType::Object(object);
     }
 
-    Ok(Some((column.name.clone(), root)))
+    Ok(Some((column.name.clone(), JsonReadHint::Paths(root))))
 }
 
 #[cfg(test)]
@@ -215,7 +242,10 @@ mod tests {
 
         let request = provider.scan_request();
         assert_eq!(1, request.json_type_hint.len());
-        assert_eq!(Some(&expected), request.json_type_hint.get("k0"));
+        assert_eq!(
+            Some(&JsonReadHint::Paths(expected)),
+            request.json_type_hint.get("k0")
+        );
         Ok(())
     }
 
@@ -238,7 +268,7 @@ mod tests {
             JsonNativeType::Variant,
         )]));
         assert_eq!(
-            Some(&expected),
+            Some(&JsonReadHint::Paths(expected)),
             provider.scan_request().json_type_hint.get("k0")
         );
         Ok(())
@@ -258,7 +288,7 @@ mod tests {
     }
 
     #[test]
-    fn test_json_type_concretize_rule_empty_path_uses_variant() -> Result<()> {
+    fn test_json_type_concretize_rule_empty_path_uses_root() -> Result<()> {
         let exprs = vec![json_get_expr(
             Expr::Column(Column::new_unqualified("k0")),
             path_expr(""),
@@ -272,7 +302,35 @@ mod tests {
                 .transformed
         );
         assert_eq!(
-            Some(&JsonNativeType::Variant),
+            Some(&JsonReadHint::Root),
+            provider.scan_request().json_type_hint.get("k0")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_json_type_concretize_rule_root_overrides_paths() -> Result<()> {
+        let exprs = vec![
+            json_get_expr(
+                Expr::Column(Column::new_unqualified("k0")),
+                path_expr("a.b"),
+                None,
+            )?,
+            json_get_expr(
+                Expr::Column(Column::new_unqualified("k0")),
+                path_expr(""),
+                None,
+            )?,
+        ];
+        let (provider, plan) = build_plan(exprs)?;
+
+        assert!(
+            JsonTypeConcretizeRule
+                .rewrite(plan, &OptimizerContext::default())?
+                .transformed
+        );
+        assert_eq!(
+            Some(&JsonReadHint::Root),
             provider.scan_request().json_type_hint.get("k0")
         );
         Ok(())
@@ -327,7 +385,10 @@ mod tests {
             )])),
         )]));
 
-        assert_eq!(Some(("k0".to_string(), expected)), deduced);
+        assert_eq!(
+            Some(("k0".to_string(), JsonReadHint::Paths(expected))),
+            deduced
+        );
         Ok(())
     }
 }

--- a/src/query/src/optimizer/json_type_concretize.rs
+++ b/src/query/src/optimizer/json_type_concretize.rs
@@ -126,6 +126,10 @@ fn deduce_json_type(expr: &Expr) -> Result<Option<(String, JsonNativeType)>> {
     let with_type =
         JsonNativeType::try_from(&with_type).map_err(|e| plan_datafusion_err!("{e:?}"))?;
 
+    if path.is_empty() {
+        return Ok(Some((column.name.clone(), JsonNativeType::Variant)));
+    }
+
     let mut split = path.rsplit(".");
     let Some(leaf) = split.next() else {
         return Ok(Some((column.name.clone(), JsonNativeType::String)));
@@ -250,6 +254,27 @@ mod tests {
                 .transformed
         );
         assert!(provider.scan_request().json_type_hint.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_json_type_concretize_rule_empty_path_uses_variant() -> Result<()> {
+        let exprs = vec![json_get_expr(
+            Expr::Column(Column::new_unqualified("k0")),
+            path_expr(""),
+            None,
+        )?];
+        let (provider, plan) = build_plan(exprs)?;
+
+        assert!(
+            JsonTypeConcretizeRule
+                .rewrite(plan, &OptimizerContext::default())?
+                .transformed
+        );
+        assert_eq!(
+            Some(&JsonNativeType::Variant),
+            provider.scan_request().json_type_hint.get("k0")
+        );
         Ok(())
     }
 

--- a/src/query/src/optimizer/json_type_concretize.rs
+++ b/src/query/src/optimizer/json_type_concretize.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 
 use arrow_schema::DataType;
 use common_function::scalars::json::json_get::JsonGetWithType;
@@ -95,8 +96,6 @@ fn merge_json_read_hint(
     column: String,
     hint: JsonReadHint,
 ) {
-    use std::collections::hash_map::Entry;
-
     match json_types.entry(column) {
         Entry::Vacant(entry) => {
             entry.insert(hint);

--- a/src/query/src/optimizer/json_type_concretize.rs
+++ b/src/query/src/optimizer/json_type_concretize.rs
@@ -23,7 +23,7 @@ use datafusion_common::{Result, plan_datafusion_err, plan_err};
 use datafusion_expr::{Expr, LogicalPlan};
 use datafusion_optimizer::{OptimizerConfig, OptimizerRule};
 use datatypes::types::json_type::{JsonNativeType, JsonObjectType};
-use store_api::storage::JsonReadHint;
+use store_api::storage::{JsonReadHint, JsonRootReadHint};
 
 use crate::dummy_catalog::DummyTableProvider;
 
@@ -101,10 +101,10 @@ fn merge_json_read_hint(
             entry.insert(hint);
         }
         Entry::Occupied(mut entry) => match (entry.get_mut(), hint) {
-            (existing @ JsonReadHint::Paths(_), JsonReadHint::Root) => {
-                *existing = JsonReadHint::Root;
+            (existing @ JsonReadHint::Paths(_), JsonReadHint::Root(_)) => {
+                *existing = JsonReadHint::Root(JsonRootReadHint::Uninferred);
             }
-            (JsonReadHint::Root, _) => {}
+            (JsonReadHint::Root(_), _) => {}
             (JsonReadHint::Paths(existing), JsonReadHint::Paths(incoming)) => {
                 existing.merge(&incoming);
             }
@@ -150,7 +150,10 @@ fn deduce_json_type(expr: &Expr) -> Result<Option<(String, JsonReadHint)>> {
         JsonNativeType::try_from(&with_type).map_err(|e| plan_datafusion_err!("{e:?}"))?;
 
     if path.is_empty() {
-        return Ok(Some((column.name.clone(), JsonReadHint::Root)));
+        return Ok(Some((
+            column.name.clone(),
+            JsonReadHint::Root(JsonRootReadHint::Uninferred),
+        )));
     }
 
     let mut split = path.rsplit(".");
@@ -301,7 +304,7 @@ mod tests {
                 .transformed
         );
         assert_eq!(
-            Some(&JsonReadHint::Root),
+            Some(&JsonReadHint::Root(JsonRootReadHint::Uninferred)),
             provider.scan_request().json_type_hint.get("k0")
         );
         Ok(())
@@ -329,7 +332,7 @@ mod tests {
                 .transformed
         );
         assert_eq!(
-            Some(&JsonReadHint::Root),
+            Some(&JsonReadHint::Root(JsonRootReadHint::Uninferred)),
             provider.scan_request().json_type_hint.get("k0")
         );
         Ok(())

--- a/src/store-api/src/storage.rs
+++ b/src/store-api/src/storage.rs
@@ -30,7 +30,8 @@ pub use self::descriptors::*;
 pub use self::file::{FileId, FileRef, FileRefsManifest, GcReport, IndexVersion, ParseIdError};
 pub use self::projection::{NestedPath, ProjectionInput};
 pub use self::requests::{
-    JsonReadHint, ScanRequest, TimeSeriesDistribution, TimeSeriesRowSelector, VectorDistanceMetric,
-    VectorIndexEngine, VectorIndexEngineType, VectorSearchMatches, VectorSearchRequest,
+    JsonReadHint, JsonRootReadHint, ScanRequest, TimeSeriesDistribution, TimeSeriesRowSelector,
+    VectorDistanceMetric, VectorIndexEngine, VectorIndexEngineType, VectorSearchMatches,
+    VectorSearchRequest,
 };
 pub use self::types::{SequenceNumber, SequenceRange};

--- a/src/store-api/src/storage.rs
+++ b/src/store-api/src/storage.rs
@@ -30,7 +30,7 @@ pub use self::descriptors::*;
 pub use self::file::{FileId, FileRef, FileRefsManifest, GcReport, IndexVersion, ParseIdError};
 pub use self::projection::{NestedPath, ProjectionInput};
 pub use self::requests::{
-    ScanRequest, TimeSeriesDistribution, TimeSeriesRowSelector, VectorDistanceMetric,
+    JsonReadHint, ScanRequest, TimeSeriesDistribution, TimeSeriesRowSelector, VectorDistanceMetric,
     VectorIndexEngine, VectorIndexEngineType, VectorSearchMatches, VectorSearchRequest,
 };
 pub use self::types::{SequenceNumber, SequenceRange};

--- a/src/store-api/src/storage/requests.rs
+++ b/src/store-api/src/storage/requests.rs
@@ -96,6 +96,24 @@ pub enum TimeSeriesDistribution {
     PerSeries,
 }
 
+/// Query-driven hint for reading JSON2 columns.
+#[derive(Debug, Clone, PartialEq)]
+pub enum JsonReadHint {
+    /// Read the whole JSON2 root value.
+    Root,
+    /// Read and align the specified JSON2 subpaths.
+    Paths(JsonNativeType),
+}
+
+impl Display for JsonReadHint {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            JsonReadHint::Root => write!(f, "root"),
+            JsonReadHint::Paths(json_type) => write!(f, "{json_type}"),
+        }
+    }
+}
+
 #[derive(Default, Clone, Debug, PartialEq)]
 pub struct ScanRequest {
     /// Optional projection information for the scan. `None` reads all root
@@ -134,8 +152,8 @@ pub struct ScanRequest {
     /// Optional hint for KNN vector search. When set, the scan should use
     /// vector index to find the k nearest neighbors.
     pub vector_search: Option<VectorSearchRequest>,
-    /// Optional hint from query-driven JSON type concretization.
-    pub json_type_hint: HashMap<String, JsonNativeType>,
+    /// Optional hint from query-driven JSON2 root or subpath reads.
+    pub json_type_hint: HashMap<String, JsonReadHint>,
 }
 
 impl ScanRequest {
@@ -261,6 +279,7 @@ impl Display for ScanRequest {
 #[cfg(test)]
 mod tests {
     use datafusion_expr::{Operator, binary_expr, col, lit};
+    use datatypes::types::json_type::{JsonNativeType, JsonObjectType};
 
     use super::*;
 
@@ -338,5 +357,22 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(request.to_string(), "ScanRequest { skip_sst_files: true }");
+
+        let request = ScanRequest {
+            json_type_hint: HashMap::from([
+                ("j".to_string(), JsonReadHint::Root),
+                (
+                    "k".to_string(),
+                    JsonReadHint::Paths(JsonNativeType::Object(JsonObjectType::from([(
+                        "a".to_string(),
+                        JsonNativeType::String,
+                    )]))),
+                ),
+            ]),
+            ..Default::default()
+        };
+        let display = request.to_string();
+        assert!(display.contains("(j: root)"));
+        assert!(display.contains(r#"(k: {"a":"<String>"})"#));
     }
 }

--- a/src/store-api/src/storage/requests.rs
+++ b/src/store-api/src/storage/requests.rs
@@ -100,15 +100,35 @@ pub enum TimeSeriesDistribution {
 #[derive(Debug, Clone, PartialEq)]
 pub enum JsonReadHint {
     /// Read the whole JSON2 root value.
-    Root,
+    Root(JsonRootReadHint),
     /// Read and align the specified JSON2 subpaths.
     Paths(JsonNativeType),
+}
+
+/// Schema state for reading a whole JSON2 root value.
+///
+/// Unlike `json_get(j, 'a')`, a root read such as `json_get(j, '')` does not
+/// carry any JSON path that the query optimizer can use to infer a concrete
+/// JSON2 schema. The query phase can only mark the column as a root read. The
+/// storage read path initializes the concrete schema later by inspecting and
+/// merging the actual schemas from the scan sources, including SSTs and
+/// memtables.
+#[derive(Debug, Clone, PartialEq)]
+pub enum JsonRootReadHint {
+    /// The query asks for the root value, but the concrete root schema cannot
+    /// be inferred from the query expression.
+    Uninferred,
+    /// The concrete root schema inferred from the scan sources.
+    Inferred(JsonNativeType),
 }
 
 impl Display for JsonReadHint {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            JsonReadHint::Root => write!(f, "root"),
+            JsonReadHint::Root(JsonRootReadHint::Uninferred) => write!(f, "root"),
+            JsonReadHint::Root(JsonRootReadHint::Inferred(json_type)) => {
+                write!(f, "root({json_type})")
+            }
             JsonReadHint::Paths(json_type) => write!(f, "{json_type}"),
         }
     }
@@ -360,7 +380,10 @@ mod tests {
 
         let request = ScanRequest {
             json_type_hint: HashMap::from([
-                ("j".to_string(), JsonReadHint::Root),
+                (
+                    "j".to_string(),
+                    JsonReadHint::Root(JsonRootReadHint::Uninferred),
+                ),
                 (
                     "k".to_string(),
                     JsonReadHint::Paths(JsonNativeType::Object(JsonObjectType::from([(

--- a/tests/cases/standalone/common/types/json/json2.result
+++ b/tests/cases/standalone/common/types/json/json2.result
@@ -230,6 +230,57 @@ drop table json2_table;
 
 Affected Rows: 0
 
+create table json2_root_merge (
+    ts timestamp time index,
+    j  json2
+) with (
+    'sst_format' = 'flat',
+);
+
+Affected Rows: 0
+
+insert into json2_root_merge
+values (1, '{"a": {"b": 1}, "c": "sst1"}'),
+       (2, '{"a": {"b": 2}, "d": true}');
+
+Affected Rows: 2
+
+admin flush_table('json2_root_merge');
+
++---------------------------------------+
+| ADMIN flush_table('json2_root_merge') |
++---------------------------------------+
+| 0                                     |
++---------------------------------------+
+
+insert into json2_root_merge
+values (1, '{"a": {"b": 10}, "e": {"x": 1}}'),
+       (3, '{"a": {"x": false}, "c": "sst2"}');
+
+Affected Rows: 2
+
+admin flush_table('json2_root_merge');
+
++---------------------------------------+
+| ADMIN flush_table('json2_root_merge') |
++---------------------------------------+
+| 0                                     |
++---------------------------------------+
+
+insert into json2_root_merge
+values (2, '{"a": {"b": 20}, "f": [1, 2]}'),
+       (4, '{"z": "mem"}');
+
+Affected Rows: 2
+
+select json_get(j, '') from json2_root_merge order by ts;
+
+Error: 3001(EngineExecuteQuery), Invalid argument error: It is not possible to interleave arrays of different data types (Struct("a": Struct("b": Int64, "x": Boolean), "c": Utf8View, "d": Boolean, "e": Struct("x": Int64)) and Struct("a": Struct("b": Int64), "f": List(Int64), "z": Utf8View))
+
+drop table json2_root_merge;
+
+Affected Rows: 0
+
 create table json2_default_null_ok (
     ts timestamp time index,
     j json2(

--- a/tests/cases/standalone/common/types/json/json2.result
+++ b/tests/cases/standalone/common/types/json/json2.result
@@ -230,7 +230,7 @@ drop table json2_table;
 
 Affected Rows: 0
 
-create table json2_root_merge (
+create table json2_root_schema_merge (
     ts timestamp time index,
     j  json2
 ) with (
@@ -239,52 +239,52 @@ create table json2_root_merge (
 
 Affected Rows: 0
 
-insert into json2_root_merge
+insert into json2_root_schema_merge
 values (1, '{"a": {"b": 1}, "c": "sst1"}'),
        (2, '{"a": {"b": 2}, "d": true}');
 
 Affected Rows: 2
 
-admin flush_table('json2_root_merge');
+admin flush_table('json2_root_schema_merge');
 
-+---------------------------------------+
-| ADMIN flush_table('json2_root_merge') |
-+---------------------------------------+
-| 0                                     |
-+---------------------------------------+
++----------------------------------------------+
+| ADMIN flush_table('json2_root_schema_merge') |
++----------------------------------------------+
+| 0                                            |
++----------------------------------------------+
 
-insert into json2_root_merge
+insert into json2_root_schema_merge
 values (1, '{"a": {"b": 10}, "e": {"x": 1}}'),
        (3, '{"a": {"x": false}, "c": "sst2"}');
 
 Affected Rows: 2
 
-admin flush_table('json2_root_merge');
+admin flush_table('json2_root_schema_merge');
 
-+---------------------------------------+
-| ADMIN flush_table('json2_root_merge') |
-+---------------------------------------+
-| 0                                     |
-+---------------------------------------+
++----------------------------------------------+
+| ADMIN flush_table('json2_root_schema_merge') |
++----------------------------------------------+
+| 0                                            |
++----------------------------------------------+
 
-insert into json2_root_merge
+insert into json2_root_schema_merge
 values (2, '{"a": {"b": 20}, "f": [1, 2]}'),
        (4, '{"z": "mem"}');
 
 Affected Rows: 2
 
-select json_get(j, '') from json2_root_merge order by ts;
+select json_get(j, '') from json2_root_schema_merge order by ts;
 
-+---------------------------------------+
-| json_get(json2_root_merge.j,Utf8("")) |
-+---------------------------------------+
-| {"a":{"b":10},"e":{"x":1}}            |
-| {"a":{"b":20},"f":[1,2]}              |
-| {"a":{"x":false},"c":"sst2"}          |
-| {"z":"mem"}                           |
-+---------------------------------------+
++----------------------------------------------+
+| json_get(json2_root_schema_merge.j,Utf8("")) |
++----------------------------------------------+
+| {"a":{"b":10},"e":{"x":1}}                   |
+| {"a":{"b":20},"f":[1,2]}                     |
+| {"a":{"x":false},"c":"sst2"}                 |
+| {"z":"mem"}                                  |
++----------------------------------------------+
 
-drop table json2_root_merge;
+drop table json2_root_schema_merge;
 
 Affected Rows: 0
 

--- a/tests/cases/standalone/common/types/json/json2.result
+++ b/tests/cases/standalone/common/types/json/json2.result
@@ -275,7 +275,14 @@ Affected Rows: 2
 
 select json_get(j, '') from json2_root_merge order by ts;
 
-Error: 3001(EngineExecuteQuery), Invalid argument error: It is not possible to interleave arrays of different data types (Struct("a": Struct("b": Int64, "x": Boolean), "c": Utf8View, "d": Boolean, "e": Struct("x": Int64)) and Struct("a": Struct("b": Int64), "f": List(Int64), "z": Utf8View))
++---------------------------------------+
+| json_get(json2_root_merge.j,Utf8("")) |
++---------------------------------------+
+| {"a":{"b":10},"e":{"x":1}}            |
+| {"a":{"b":20},"f":[1,2]}              |
+| {"a":{"x":false},"c":"sst2"}          |
+| {"z":"mem"}                           |
++---------------------------------------+
 
 drop table json2_root_merge;
 

--- a/tests/cases/standalone/common/types/json/json2.result
+++ b/tests/cases/standalone/common/types/json/json2.result
@@ -150,8 +150,8 @@ select j.a, j.a.x from json2_table order by ts;
 |                                   |                                     |
 | {"b":"s7"}                        |                                     |
 | {"b":8}                           |                                     |
-| {"b":null,"x":true}               | true                                |
-| {"b":10,"x":null}                 | null                                |
+| {"x":true}                        | true                                |
+| {"b":10}                          |                                     |
 +-----------------------------------+-------------------------------------+
 
 select j.c, j.y from json2_table order by ts;

--- a/tests/cases/standalone/common/types/json/json2.result
+++ b/tests/cases/standalone/common/types/json/json2.result
@@ -284,6 +284,17 @@ select json_get(j, '') from json2_root_schema_merge order by ts;
 | {"z":"mem"}                                  |
 +----------------------------------------------+
 
+select json_get(j, ''), json_get(j, 'a.b') from json2_root_schema_merge order by ts;
+
++----------------------------------------------+-------------------------------------------------+
+| json_get(json2_root_schema_merge.j,Utf8("")) | json_get(json2_root_schema_merge.j,Utf8("a.b")) |
++----------------------------------------------+-------------------------------------------------+
+| {"a":{"b":10},"e":{"x":1}}                   | 10                                              |
+| {"a":{"b":20},"f":[1,2]}                     | 20                                              |
+| {"a":{"x":false},"c":"sst2"}                 |                                                 |
+| {"z":"mem"}                                  |                                                 |
++----------------------------------------------+-------------------------------------------------+
+
 drop table json2_root_schema_merge;
 
 Affected Rows: 0

--- a/tests/cases/standalone/common/types/json/json2.result
+++ b/tests/cases/standalone/common/types/json/json2.result
@@ -173,11 +173,37 @@ select j.c, j.y from json2_table order by ts;
 
 select j from json2_table order by ts;
 
-Error: 3001(EngineExecuteQuery), Failed to align JSON array, reason: Invalid argument error: use StructArray::try_new_with_length or StructArray::new_empty_fields to create a struct array with no fields so that the length can be set correctly
++----+
+| j  |
++----+
+| {} |
+| {} |
+| {} |
+| {} |
+| {} |
+| {} |
+| {} |
+| {} |
+| {} |
+| {} |
++----+
 
 select * from json2_table order by ts;
 
-Error: 3001(EngineExecuteQuery), Failed to align JSON array, reason: Invalid argument error: use StructArray::try_new_with_length or StructArray::new_empty_fields to create a struct array with no fields so that the length can be set correctly
++-------------------------+----+
+| ts                      | j  |
++-------------------------+----+
+| 1970-01-01T00:00:00.001 | {} |
+| 1970-01-01T00:00:00.002 | {} |
+| 1970-01-01T00:00:00.003 | {} |
+| 1970-01-01T00:00:00.004 | {} |
+| 1970-01-01T00:00:00.005 | {} |
+| 1970-01-01T00:00:00.006 | {} |
+| 1970-01-01T00:00:00.007 | {} |
+| 1970-01-01T00:00:00.008 | {} |
+| 1970-01-01T00:00:00.009 | {} |
+| 1970-01-01T00:00:00.010 | {} |
++-------------------------+----+
 
 select j.a.b + 1 from json2_table order by ts;
 

--- a/tests/cases/standalone/common/types/json/json2.result
+++ b/tests/cases/standalone/common/types/json/json2.result
@@ -173,37 +173,11 @@ select j.c, j.y from json2_table order by ts;
 
 select j from json2_table order by ts;
 
-+----+
-| j  |
-+----+
-| {} |
-| {} |
-| {} |
-| {} |
-| {} |
-| {} |
-| {} |
-| {} |
-| {} |
-| {} |
-+----+
+Error: 3001(EngineExecuteQuery), Unsupported operation: direct JSON2 column projection is not supported yet; use json_get(column, '') to read the root JSON2 value for vector: Json2
 
 select * from json2_table order by ts;
 
-+-------------------------+----+
-| ts                      | j  |
-+-------------------------+----+
-| 1970-01-01T00:00:00.001 | {} |
-| 1970-01-01T00:00:00.002 | {} |
-| 1970-01-01T00:00:00.003 | {} |
-| 1970-01-01T00:00:00.004 | {} |
-| 1970-01-01T00:00:00.005 | {} |
-| 1970-01-01T00:00:00.006 | {} |
-| 1970-01-01T00:00:00.007 | {} |
-| 1970-01-01T00:00:00.008 | {} |
-| 1970-01-01T00:00:00.009 | {} |
-| 1970-01-01T00:00:00.010 | {} |
-+-------------------------+----+
+Error: 3001(EngineExecuteQuery), Unsupported operation: direct JSON2 column projection is not supported yet; use json_get(column, '') to read the root JSON2 value for vector: Json2
 
 select j.a.b + 1 from json2_table order by ts;
 

--- a/tests/cases/standalone/common/types/json/json2.sql
+++ b/tests/cases/standalone/common/types/json/json2.sql
@@ -96,6 +96,8 @@ values (2, '{"a": {"b": 20}, "f": [1, 2]}'),
 
 select json_get(j, '') from json2_root_schema_merge order by ts;
 
+select json_get(j, ''), json_get(j, 'a.b') from json2_root_schema_merge order by ts;
+
 drop table json2_root_schema_merge;
 
 create table json2_default_null_ok (

--- a/tests/cases/standalone/common/types/json/json2.sql
+++ b/tests/cases/standalone/common/types/json/json2.sql
@@ -71,6 +71,33 @@ select j.d from json2_table order by ts;
 
 drop table json2_table;
 
+create table json2_root_merge (
+    ts timestamp time index,
+    j  json2
+) with (
+    'sst_format' = 'flat',
+);
+
+insert into json2_root_merge
+values (1, '{"a": {"b": 1}, "c": "sst1"}'),
+       (2, '{"a": {"b": 2}, "d": true}');
+
+admin flush_table('json2_root_merge');
+
+insert into json2_root_merge
+values (1, '{"a": {"b": 10}, "e": {"x": 1}}'),
+       (3, '{"a": {"x": false}, "c": "sst2"}');
+
+admin flush_table('json2_root_merge');
+
+insert into json2_root_merge
+values (2, '{"a": {"b": 20}, "f": [1, 2]}'),
+       (4, '{"z": "mem"}');
+
+select json_get(j, '') from json2_root_merge order by ts;
+
+drop table json2_root_merge;
+
 create table json2_default_null_ok (
     ts timestamp time index,
     j json2(

--- a/tests/cases/standalone/common/types/json/json2.sql
+++ b/tests/cases/standalone/common/types/json/json2.sql
@@ -71,32 +71,32 @@ select j.d from json2_table order by ts;
 
 drop table json2_table;
 
-create table json2_root_merge (
+create table json2_root_schema_merge (
     ts timestamp time index,
     j  json2
 ) with (
     'sst_format' = 'flat',
 );
 
-insert into json2_root_merge
+insert into json2_root_schema_merge
 values (1, '{"a": {"b": 1}, "c": "sst1"}'),
        (2, '{"a": {"b": 2}, "d": true}');
 
-admin flush_table('json2_root_merge');
+admin flush_table('json2_root_schema_merge');
 
-insert into json2_root_merge
+insert into json2_root_schema_merge
 values (1, '{"a": {"b": 10}, "e": {"x": 1}}'),
        (3, '{"a": {"x": false}, "c": "sst2"}');
 
-admin flush_table('json2_root_merge');
+admin flush_table('json2_root_schema_merge');
 
-insert into json2_root_merge
+insert into json2_root_schema_merge
 values (2, '{"a": {"b": 20}, "f": [1, 2]}'),
        (4, '{"z": "mem"}');
 
-select json_get(j, '') from json2_root_merge order by ts;
+select json_get(j, '') from json2_root_schema_merge order by ts;
 
-drop table json2_root_merge;
+drop table json2_root_schema_merge;
 
 create table json2_default_null_ok (
     ts timestamp time index,

--- a/tests/cases/standalone/common/types/json/json2_root_align.result
+++ b/tests/cases/standalone/common/types/json/json2_root_align.result
@@ -1,0 +1,41 @@
+create table json2_root_align (
+    ts timestamp time index,
+    col_x int64,
+    j json2
+) with (
+    'sst_format' = 'flat',
+);
+
+Affected Rows: 0
+
+-- SST data
+insert into json2_root_align values (1, 100, '{"a": 1}');
+
+Affected Rows: 1
+
+insert into json2_root_align values (2, 200, '{"a": 2}');
+
+Affected Rows: 1
+
+admin flush_table('json2_root_align');
+
++---------------------------------------+
+| ADMIN flush_table('json2_root_align') |
++---------------------------------------+
+| 0                                     |
++---------------------------------------+
+
+-- memtable data (unflushed)
+insert into json2_root_align values (3, 300, '{"b": 3}');
+
+Affected Rows: 1
+
+-- Root read: only the JSON2 column in projection
+select json_get(j, '') from json2_root_align order by ts;
+
+Error: 3001(EngineExecuteQuery), Failed to align JSON array, reason: expect struct array
+
+drop table json2_root_align;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/types/json/json2_root_align.sql
+++ b/tests/cases/standalone/common/types/json/json2_root_align.sql
@@ -1,0 +1,21 @@
+create table json2_root_align (
+    ts timestamp time index,
+    col_x int64,
+    j json2
+) with (
+    'sst_format' = 'flat',
+);
+
+-- SST data
+insert into json2_root_align values (1, 100, '{"a": 1}');
+insert into json2_root_align values (2, 200, '{"a": 2}');
+
+admin flush_table('json2_root_align');
+
+-- memtable data (unflushed)
+insert into json2_root_align values (3, 300, '{"b": 3}');
+
+-- Root read: only the JSON2 column in projection
+select json_get(j, '') from json2_root_align order by ts;
+
+drop table json2_root_align;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR supports JSON2 root reads such as `json_get(j, '')`.

Previously, JSON2 read schemas were inferred from query paths, but root reads
do not provide a concrete path schema. This PR introduces `JsonReadHint` and
`JsonRootReadHint` to distinguish root reads (`Root(Uninferred/Inferred)`)
from path reads (`Paths(JsonNativeType)`), so the read path can infer root
schemas from the actual data.

Key changes:

- **`store-api`**: Add `JsonReadHint` and `JsonRootReadHint` types.
  `Root(Uninferred)` marks a root read whose concrete schema will be inferred
  later from storage sources (SSTs + memtables).

- **`read/json_schema.rs`**: Centralize JSON2 read schema handling into a new
  module. It defines `Json2TypeOutputPlan`, `normalize_json2_output`,
  `apply_json_read_hints_to_read_columns`, and
  `infer_json2_root_hints_from_schema`. The `align` submodule (moved from
  `read/json_align.rs`) merges source schemas and aligns output batches.

- **`scan_region.rs`**: When root hints are `Uninferred`, collect source
  arrow schemas from all files and memtables, merge them via `Json2Aligner`,
  infer the concrete root schema, then build the projection mapper with the
  inferred hints. Fall back to the region metadata arrow schema when there
  are no sources.

- **`optimizer`**: `json_get(j, '')` now emits `JsonReadHint::Root` instead
  of `JsonNativeType::Variant`. `Root` hints take precedence over `Path`
  hints for the same column.

- **`read/compat.rs`**: Merge two-pass JSON2 schema patching into a single
  SST traversal, recovering both `actual_schema` and `expect_schema` types
  from the SST arrow schema.


 ### TODO

This PR only handles root reads through `json_get(j, "")`. Direct root-column projection such as `SELECT j FROM t` is still not supported by this change.

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
