### PR TITLE
test: add flow scheduled now compat case

### DIFF
--- a/tests/compatibility/cases/flow_scheduled_now_dist_plan/case.toml
+++ b/tests/compatibility/cases/flow_scheduled_now_dist_plan/case.toml
@@ -1,0 +1,8 @@
+name = "flow_scheduled_now_dist_plan"
+reason = "Verify flow metadata containing now()/current_timestamp() created by old binaries binds scheduled logical time after upgrade."
+introduced_by = "PR #8389"
+topologies = ["distributed"]
+from_range = ["<=v1.1.1"]
+to_range = [">v1.1.1"]
+features = ["flow", "table"]
+owner = "flow"

--- a/tests/compatibility/cases/flow_scheduled_now_dist_plan/setup.sql
+++ b/tests/compatibility/cases/flow_scheduled_now_dist_plan/setup.sql
@@ -1,0 +1,19 @@
+CREATE TABLE compat_flow_now_input (
+  ts TIMESTAMP(3) TIME INDEX,
+  v DOUBLE,
+  PRIMARY KEY(v)
+);
+
+CREATE FLOW compat_flow_scheduled_now
+SINK TO compat_flow_now_sink
+EVAL INTERVAL '1s'
+AS
+SELECT
+  date_bin(INTERVAL '1 second', ts) AS window_start,
+  count(v) AS value_count,
+  now() AS create_time,
+  current_timestamp() AS cur_ts
+FROM compat_flow_now_input
+WHERE ts >= date_trunc('second', now()) - INTERVAL '1 second'
+  AND ts <  date_trunc('second', current_timestamp())
+GROUP BY date_bin(INTERVAL '1 second', ts);

--- a/tests/compatibility/cases/flow_scheduled_now_dist_plan/verify.result
+++ b/tests/compatibility/cases/flow_scheduled_now_dist_plan/verify.result
@@ -1,0 +1,81 @@
+SELECT flow_name, source_table_names
+FROM information_schema.flows
+WHERE flow_name = 'compat_flow_scheduled_now';
+
++---------------------------+-------------------------------------------------------------+
+| flow_name                 | source_table_names                                          |
++---------------------------+-------------------------------------------------------------+
+| compat_flow_scheduled_now | greptime.flow_scheduled_now_dist_plan.compat_flow_now_input |
++---------------------------+-------------------------------------------------------------+
+
+SHOW CREATE FLOW compat_flow_scheduled_now;
+
++---------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Flow                      | Create Flow                                                                                                                                                                                                                                                                                                                      |
++---------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| compat_flow_scheduled_now | CREATE FLOW IF NOT EXISTS compat_flow_scheduled_now                                                                                                                                                                                                                                                                              |
+|                           | SINK TO flow_scheduled_now_dist_plan.compat_flow_now_sink                                                                                                                                                                                                                                                                        |
+|                           | EVAL INTERVAL '1 s'                                                                                                                                                                                                                                                                                                              |
+|                           | AS SELECT date_bin(INTERVAL '1 second', ts) AS window_start, count(v) AS value_count, now() AS create_time, current_timestamp() AS cur_ts FROM compat_flow_now_input WHERE ts >= date_trunc('second', now()) - INTERVAL '1 second' AND ts < date_trunc('second', current_timestamp()) GROUP BY date_bin(INTERVAL '1 second', ts) |
++---------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+SHOW CREATE TABLE compat_flow_now_sink;
+
++----------------------+-----------------------------------------------------+
+| Table                | Create Table                                        |
++----------------------+-----------------------------------------------------+
+| compat_flow_now_sink | CREATE TABLE IF NOT EXISTS "compat_flow_now_sink" ( |
+|                      |   "window_start" TIMESTAMP(3) NOT NULL,             |
+|                      |   "value_count" BIGINT NULL,                        |
+|                      |   "create_time" TIMESTAMP(9) NULL,                  |
+|                      |   "cur_ts" TIMESTAMP(9) NULL,                       |
+|                      |   "update_at" TIMESTAMP(3) NULL,                    |
+|                      |   TIME INDEX ("window_start")                       |
+|                      | )                                                   |
+|                      |                                                     |
+|                      | ENGINE=mito                                         |
+|                      | WITH(                                               |
+|                      |   'comment' = 'Auto created table by flow engine'   |
+|                      | )                                                   |
++----------------------+-----------------------------------------------------+
+
+INSERT INTO compat_flow_now_input VALUES
+  (date_trunc('second', now()) - INTERVAL '1 second', 0.0),
+  (date_trunc('second', now()), 1.0),
+  (date_trunc('second', now()) + INTERVAL '1 second', 2.0),
+  (date_trunc('second', now()) + INTERVAL '2 seconds', 3.0),
+  (date_trunc('second', now()) + INTERVAL '3 seconds', 4.0),
+  (date_trunc('second', now()) + INTERVAL '4 seconds', 5.0),
+  (date_trunc('second', now()) + INTERVAL '5 seconds', 6.0),
+  (date_trunc('second', now()) + INTERVAL '6 seconds', 7.0),
+  (date_trunc('second', now()) + INTERVAL '7 seconds', 8.0);
+
+Affected Rows: 9
+
+-- SQLNESS SLEEP 4s
+SELECT
+  count(DISTINCT window_start) >= 1 AS has_selected_window,
+  min(value_count) AS min_value_count,
+  max(value_count) AS max_value_count,
+  bool_and(create_time = date_trunc('second', create_time)) AS all_create_time_at_second_boundary,
+  bool_and(cur_ts = create_time) AS cur_ts_equals_create_time,
+  bool_and(window_start = create_time - INTERVAL '1 second') AS all_windows_match_scheduled_previous_second
+FROM compat_flow_now_sink
+WHERE value_count > 0;
+
++---------------------+-----------------+-----------------+------------------------------------+---------------------------+---------------------------------------------+
+| has_selected_window | min_value_count | max_value_count | all_create_time_at_second_boundary | cur_ts_equals_create_time | all_windows_match_scheduled_previous_second |
++---------------------+-----------------+-----------------+------------------------------------+---------------------------+---------------------------------------------+
+| true                | 1               | 1               | true                               | true                      | true                                        |
++---------------------+-----------------+-----------------+------------------------------------+---------------------------+---------------------------------------------+
+
+SELECT
+  bool_and(value_count = 1) AS all_value_count_equals_one
+FROM compat_flow_now_sink
+WHERE value_count > 0;
+
++----------------------------+
+| all_value_count_equals_one |
++----------------------------+
+| true                       |
++----------------------------+

--- a/tests/compatibility/cases/flow_scheduled_now_dist_plan/verify.sql
+++ b/tests/compatibility/cases/flow_scheduled_now_dist_plan/verify.sql
@@ -1,0 +1,34 @@
+SELECT flow_name, source_table_names
+FROM information_schema.flows
+WHERE flow_name = 'compat_flow_scheduled_now';
+
+SHOW CREATE FLOW compat_flow_scheduled_now;
+
+SHOW CREATE TABLE compat_flow_now_sink;
+
+INSERT INTO compat_flow_now_input VALUES
+  (date_trunc('second', now()) - INTERVAL '1 second', 0.0),
+  (date_trunc('second', now()), 1.0),
+  (date_trunc('second', now()) + INTERVAL '1 second', 2.0),
+  (date_trunc('second', now()) + INTERVAL '2 seconds', 3.0),
+  (date_trunc('second', now()) + INTERVAL '3 seconds', 4.0),
+  (date_trunc('second', now()) + INTERVAL '4 seconds', 5.0),
+  (date_trunc('second', now()) + INTERVAL '5 seconds', 6.0),
+  (date_trunc('second', now()) + INTERVAL '6 seconds', 7.0),
+  (date_trunc('second', now()) + INTERVAL '7 seconds', 8.0);
+
+-- SQLNESS SLEEP 4s
+SELECT
+  count(DISTINCT window_start) >= 1 AS has_selected_window,
+  min(value_count) AS min_value_count,
+  max(value_count) AS max_value_count,
+  bool_and(create_time = date_trunc('second', create_time)) AS all_create_time_at_second_boundary,
+  bool_and(cur_ts = create_time) AS cur_ts_equals_create_time,
+  bool_and(window_start = create_time - INTERVAL '1 second') AS all_windows_match_scheduled_previous_second
+FROM compat_flow_now_sink
+WHERE value_count > 0;
+
+SELECT
+  bool_and(value_count = 1) AS all_value_count_equals_one
+FROM compat_flow_now_sink
+WHERE value_count > 0;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up to #8389 and #8395.

## What's changed and what's your intention?

This PR adds a sqlness compatibility case for scheduled flow `now()` / `current_timestamp()` binding in distributed plans.

The new case `flow_scheduled_now_dist_plan` verifies this upgrade path:

1. Start an old distributed cluster (`v1.0.0` / `v1.1.0`).
2. Create flow metadata containing `now()` and `current_timestamp()` in a distributed-plan-sensitive filter and projection.
3. Restart the preserved state with the current binary.
4. Insert rows around the scheduled second boundary.
5. Verify current flow execution binds both `now()` and `current_timestamp()` to the scheduled logical time instead of wall-clock time.

The case checks semantic invariants instead of exact timestamps:

- the flow emits at least one selected window;
- `create_time` is aligned to a second boundary;
- `current_timestamp()` equals `now()`;
- the selected `window_start` is exactly `create_time - 1s`;
- each selected window has `value_count = 1`.

Validation performed locally:

```text
cargo build --bin greptime -j 1
cargo run -p sqlness-runner -- compat --dry-run --from-version v1.0.0 --to-bins-dir /mnt/nvme_rust/rust-targets/compat_framework_retry/debug --test-filter 'flow_scheduled_now_dist_plan'
cargo run -p sqlness-runner -- compat --dry-run --from-version v1.1.0 --to-bins-dir /mnt/nvme_rust/rust-targets/compat_framework_retry/debug --test-filter 'flow_scheduled_now_dist_plan'
cargo run -p sqlness-runner -- compat --from-version v1.0.0 --to-bins-dir /mnt/nvme_rust/rust-targets/compat_framework_retry/debug --test-filter 'flow_scheduled_now_dist_plan' --preserve-state
cargo run -p sqlness-runner -- compat --from-version v1.1.0 --to-bins-dir /mnt/nvme_rust/rust-targets/compat_framework_retry/debug --test-filter 'flow_scheduled_now_dist_plan' --preserve-state
git diff --check
```

Both `v1.0.0 -> current` and `v1.1.0 -> current` distributed compat runs passed.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments. (not applicable, test-only)
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
