### PR TITLE
test: add comment metadata compat case

### DIFF
--- a/tests/compatibility/cases/comment_on_old_objects/case.toml
+++ b/tests/compatibility/cases/comment_on_old_objects/case.toml
@@ -1,0 +1,8 @@
+name = "comment_on_old_objects"
+reason = "Verify COMMENT ON metadata can be applied after upgrade to tables, columns, and flows created by old binaries."
+introduced_by = "PR #8390"
+topologies = ["distributed"]
+from_range = ["*"]
+to_range = [">v1.1.1"]
+features = ["ddl", "flow", "information_schema", "metadata", "table"]
+owner = "flow"

--- a/tests/compatibility/cases/comment_on_old_objects/setup.sql
+++ b/tests/compatibility/cases/comment_on_old_objects/setup.sql
@@ -1,0 +1,24 @@
+CREATE TABLE compat_comment_table (
+  ts TIMESTAMP(3) TIME INDEX,
+  host STRING PRIMARY KEY,
+  val DOUBLE
+);
+
+CREATE TABLE compat_comment_flow_source (
+  ts TIMESTAMP(3) TIME INDEX,
+  host STRING,
+  val DOUBLE,
+  PRIMARY KEY(host)
+);
+
+CREATE TABLE compat_comment_flow_sink (
+  ts TIMESTAMP(3) TIME INDEX,
+  host STRING,
+  val DOUBLE,
+  PRIMARY KEY(host)
+);
+
+CREATE FLOW compat_comment_flow
+SINK TO compat_comment_flow_sink
+AS
+SELECT ts, host, val FROM compat_comment_flow_source;

--- a/tests/compatibility/cases/comment_on_old_objects/verify.result
+++ b/tests/compatibility/cases/comment_on_old_objects/verify.result
@@ -1,0 +1,45 @@
+COMMENT ON TABLE compat_comment_table IS 'upgraded table comment';
+
+Affected Rows: 0
+
+COMMENT ON COLUMN compat_comment_table.val IS 'upgraded value column comment';
+
+Affected Rows: 0
+
+COMMENT ON FLOW compat_comment_flow IS 'upgraded flow comment';
+
+Affected Rows: 0
+
+SELECT table_schema, table_name, table_comment
+FROM information_schema.tables
+WHERE table_name = 'compat_comment_table'
+ORDER BY table_schema, table_name;
+
++------------------------+----------------------+------------------------+
+| table_schema           | table_name           | table_comment          |
++------------------------+----------------------+------------------------+
+| comment_on_old_objects | compat_comment_table | upgraded table comment |
++------------------------+----------------------+------------------------+
+
+SELECT table_schema, table_name, column_name, column_comment
+FROM information_schema.columns
+WHERE table_name = 'compat_comment_table'
+  AND column_name = 'val'
+ORDER BY table_schema, table_name, column_name;
+
++------------------------+----------------------+-------------+-------------------------------+
+| table_schema           | table_name           | column_name | column_comment                |
++------------------------+----------------------+-------------+-------------------------------+
+| comment_on_old_objects | compat_comment_table | val         | upgraded value column comment |
++------------------------+----------------------+-------------+-------------------------------+
+
+SELECT flow_name, comment
+FROM information_schema.flows
+WHERE flow_name = 'compat_comment_flow'
+ORDER BY flow_name;
+
++---------------------+-----------------------+
+| flow_name           | comment               |
++---------------------+-----------------------+
+| compat_comment_flow | upgraded flow comment |
++---------------------+-----------------------+

--- a/tests/compatibility/cases/comment_on_old_objects/verify.sql
+++ b/tests/compatibility/cases/comment_on_old_objects/verify.sql
@@ -1,0 +1,21 @@
+COMMENT ON TABLE compat_comment_table IS 'upgraded table comment';
+
+COMMENT ON COLUMN compat_comment_table.val IS 'upgraded value column comment';
+
+COMMENT ON FLOW compat_comment_flow IS 'upgraded flow comment';
+
+SELECT table_schema, table_name, table_comment
+FROM information_schema.tables
+WHERE table_name = 'compat_comment_table'
+ORDER BY table_schema, table_name;
+
+SELECT table_schema, table_name, column_name, column_comment
+FROM information_schema.columns
+WHERE table_name = 'compat_comment_table'
+  AND column_name = 'val'
+ORDER BY table_schema, table_name, column_name;
+
+SELECT flow_name, comment
+FROM information_schema.flows
+WHERE flow_name = 'compat_comment_flow'
+ORDER BY flow_name;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up to #8390.

## What's changed and what's your intention?

This PR adds a distributed sqlness compatibility smoke case for applying comment metadata to objects created by old binaries.

The new `comment_on_old_objects` case verifies this upgrade path:

1. Start an old distributed cluster (`v1.0.0` / `v1.1.0`).
2. Create table metadata and flow metadata without comments.
3. Restart the preserved state with the current binary.
4. Run `COMMENT ON TABLE`, `COMMENT ON COLUMN`, and `COMMENT ON FLOW` against those old objects.
5. Verify the new comments are immediately visible through `information_schema.tables`, `information_schema.columns`, and `information_schema.flows`.

This is intentionally an upgrade smoke test for comment metadata on old objects. It does not try to reproduce the original stale-cache or concurrent-locking race from #8390.

Validation performed locally:

```text
cargo run -p sqlness-runner -- compat --dry-run --from-version v1.0.0 --to-bins-dir /mnt/nvme_rust/rust-targets/compat_framework_retry/debug --test-filter 'comment_on_old_objects'
cargo run -p sqlness-runner -- compat --dry-run --from-version v1.1.0 --to-bins-dir /mnt/nvme_rust/rust-targets/compat_framework_retry/debug --test-filter 'comment_on_old_objects'
cargo run -p sqlness-runner -- compat --from-version v1.0.0 --to-bins-dir /mnt/nvme_rust/rust-targets/compat_framework_retry/debug --test-filter 'comment_on_old_objects' --preserve-state
cargo run -p sqlness-runner -- compat --from-version v1.1.0 --to-bins-dir /mnt/nvme_rust/rust-targets/compat_framework_retry/debug --test-filter 'comment_on_old_objects' --preserve-state
git diff --check
```

Both `v1.0.0 -> current` and `v1.1.0 -> current` distributed compat runs passed.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments. (not applicable, test-only)
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
