### PR TITLE
fix(meta): configure heartbeat message size

### DIFF
--- a/src/meta-client/src/client/heartbeat.rs
+++ b/src/meta-client/src/client/heartbeat.rs
@@ -280,10 +280,16 @@ impl Inner {
             .get(addr)
             .context(error::CreateChannelSnafu)?;
 
+        let config = self.channel_manager.config();
+        let max_decoding_message_size = config.max_recv_message_size.as_bytes() as usize;
+        let max_encoding_message_size = config.max_send_message_size.as_bytes() as usize;
+
         Ok(HeartbeatClient::new(channel)
             .accept_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Gzip)
-            .send_compressed(CompressionEncoding::Zstd))
+            .send_compressed(CompressionEncoding::Zstd)
+            .max_decoding_message_size(max_decoding_message_size)
+            .max_encoding_message_size(max_encoding_message_size))
     }
 
     #[inline]

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -251,7 +251,15 @@ pub fn router(metasrv: Arc<Metasrv>) -> Router {
         // For quick network failures detection.
         .http2_keepalive_interval(Some(metasrv.options().grpc.http2_keep_alive_interval))
         .http2_keepalive_timeout(Some(metasrv.options().grpc.http2_keep_alive_timeout));
-    let router = add_compressed_service!(router, HeartbeatServer::from_arc(metasrv.clone()));
+    let grpc_config = metasrv.options().grpc.as_config();
+    let heartbeat_server = HeartbeatServer::from_arc(metasrv.clone())
+        .accept_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Zstd)
+        .send_compressed(CompressionEncoding::Gzip)
+        .send_compressed(CompressionEncoding::Zstd)
+        .max_decoding_message_size(grpc_config.max_recv_message_size)
+        .max_encoding_message_size(grpc_config.max_send_message_size);
+    let router = router.add_service(heartbeat_server);
     let router = add_compressed_service!(router, StoreServer::from_arc(metasrv.clone()));
     let router = add_compressed_service!(router, ClusterServer::from_arc(metasrv.clone()));
     let router = add_compressed_service!(router, ProcedureServiceServer::from_arc(metasrv.clone()));


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

N/A

## What's changed and what's your intention?

This PR configures the heartbeat gRPC message size limits to use GreptimeDB's existing gRPC max send/receive settings instead of tonic's default limit.

The heartbeat stream carries mailbox messages between metasrv and datanodes. Some control-plane replies, such as GC `GetFileRefs` / `GcRegions` replies, can be larger than tonic's default 4MiB message limit. When that happens, metasrv may fail to decode a heartbeat request and the waiting mailbox receiver observes the datanode channel as closed.

Changes:

- Configure `HeartbeatClient` with `max_decoding_message_size` and `max_encoding_message_size` from its `ChannelManager` config.
- Configure metasrv `HeartbeatServer` with `max_decoding_message_size` and `max_encoding_message_size` from `MetasrvOptions.grpc.as_config()`.
- Keep the existing compression settings unchanged.

This is backward-compatible and only makes the heartbeat service honor the same gRPC message-size configuration already used by other gRPC services/clients.

Validation:

- `cargo fmt --check`
- `cargo check -p meta-client -p meta-srv`
- `git diff --check`

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
