### PR TITLE
chore: pin datafusion to merged branch commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3644,7 +3644,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 [[package]]
 name = "datafusion"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "arrow 58.3.0",
  "arrow-schema 58.3.0",
@@ -3698,7 +3698,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3722,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3744,7 +3744,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -3768,7 +3768,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "futures",
  "log",
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "arrow 58.3.0",
  "async-compression",
@@ -3812,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "arrow 58.3.0",
  "arrow-ipc 58.3.0",
@@ -3835,7 +3835,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3857,7 +3857,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3880,7 +3880,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3909,12 +3909,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 
 [[package]]
 name = "datafusion-execution"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "arrow 58.3.0",
  "arrow-buffer 58.3.0",
@@ -3936,7 +3936,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3958,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -3970,7 +3970,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "arrow 58.3.0",
  "arrow-buffer 58.3.0",
@@ -4001,7 +4001,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4022,7 +4022,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4034,7 +4034,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "arrow 58.3.0",
  "arrow-ord 58.3.0",
@@ -4058,7 +4058,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4073,7 +4073,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4090,7 +4090,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -4099,7 +4099,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -4109,7 +4109,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -4158,7 +4158,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4181,7 +4181,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4195,7 +4195,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4211,7 +4211,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4229,7 +4229,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4260,7 +4260,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -4287,7 +4287,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4297,7 +4297,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4313,7 +4313,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -4326,7 +4326,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "arrow 58.3.0",
  "bigdecimal 0.4.8",
@@ -4344,7 +4344,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=fe8422ed266dc8a527c06699057c20875a465173#fe8422ed266dc8a527c06699057c20875a465173"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=25e823d9ceefc2e538dee93f58c1a5c9e05e8182#25e823d9ceefc2e538dee93f58c1a5c9e05e8182"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -341,21 +341,21 @@ git = "https://github.com/GreptimeTeam/greptime-meter.git"
 rev = "5618e779cf2bb4755b499c630fba4c35e91898cb"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "fe8422ed266dc8a527c06699057c20875a465173" }
-datafusion-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "fe8422ed266dc8a527c06699057c20875a465173" }
-datafusion-datasource = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "fe8422ed266dc8a527c06699057c20875a465173" }
-datafusion-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "fe8422ed266dc8a527c06699057c20875a465173" }
-datafusion-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "fe8422ed266dc8a527c06699057c20875a465173" }
-datafusion-functions = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "fe8422ed266dc8a527c06699057c20875a465173" }
-datafusion-functions-aggregate-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "fe8422ed266dc8a527c06699057c20875a465173" }
-datafusion-functions-window-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "fe8422ed266dc8a527c06699057c20875a465173" }
-datafusion-optimizer = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "fe8422ed266dc8a527c06699057c20875a465173" }
-datafusion-physical-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "fe8422ed266dc8a527c06699057c20875a465173" }
-datafusion-physical-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "fe8422ed266dc8a527c06699057c20875a465173" }
-datafusion-physical-plan = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "fe8422ed266dc8a527c06699057c20875a465173" }
-datafusion-proto = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "fe8422ed266dc8a527c06699057c20875a465173" }
-datafusion-sql = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "fe8422ed266dc8a527c06699057c20875a465173" }
-datafusion-substrait = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "fe8422ed266dc8a527c06699057c20875a465173" }
+datafusion = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "25e823d9ceefc2e538dee93f58c1a5c9e05e8182" }
+datafusion-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "25e823d9ceefc2e538dee93f58c1a5c9e05e8182" }
+datafusion-datasource = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "25e823d9ceefc2e538dee93f58c1a5c9e05e8182" }
+datafusion-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "25e823d9ceefc2e538dee93f58c1a5c9e05e8182" }
+datafusion-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "25e823d9ceefc2e538dee93f58c1a5c9e05e8182" }
+datafusion-functions = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "25e823d9ceefc2e538dee93f58c1a5c9e05e8182" }
+datafusion-functions-aggregate-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "25e823d9ceefc2e538dee93f58c1a5c9e05e8182" }
+datafusion-functions-window-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "25e823d9ceefc2e538dee93f58c1a5c9e05e8182" }
+datafusion-optimizer = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "25e823d9ceefc2e538dee93f58c1a5c9e05e8182" }
+datafusion-physical-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "25e823d9ceefc2e538dee93f58c1a5c9e05e8182" }
+datafusion-physical-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "25e823d9ceefc2e538dee93f58c1a5c9e05e8182" }
+datafusion-physical-plan = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "25e823d9ceefc2e538dee93f58c1a5c9e05e8182" }
+datafusion-proto = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "25e823d9ceefc2e538dee93f58c1a5c9e05e8182" }
+datafusion-sql = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "25e823d9ceefc2e538dee93f58c1a5c9e05e8182" }
+datafusion-substrait = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "25e823d9ceefc2e538dee93f58c1a5c9e05e8182" }
 sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "2aefa08a8d69c96eec2d6d6703598a009bba6e4c" }                           # on branch v0.61.x
 
 [profile.release]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Fixes follow-up from #8407.
Related DataFusion PR: https://github.com/GreptimeTeam/datafusion/pull/11

## What's changed and what's your intention?

Update the GreptimeDB DataFusion dependency pin from the DataFusion PR head commit `fe8422ed266dc8a527c06699057c20875a465173` to the commit that is actually on `GreptimeTeam/datafusion` branch `greptimedb-53.1.0-function-signature-exec-error`: `25e823d9ceefc2e538dee93f58c1a5c9e05e8182`.

This keeps GreptimeDB pinned to the merged DataFusion branch commit instead of a PR-head commit.

Validated locally:

- `cargo fmt --all -- --check`
- `cargo metadata --locked --no-deps --format-version 1`
- `git diff --check`

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
