### PR TITLE
test: add ssts limit compat case

### DIFF
--- a/tests/compatibility/cases/ssts_limit_old_manifest/case.toml
+++ b/tests/compatibility/cases/ssts_limit_old_manifest/case.toml
@@ -1,0 +1,8 @@
+name = "ssts_limit_old_manifest"
+reason = "Verify distributed information_schema.ssts_manifest LIMIT queries over SSTs written by old binaries obey a global limit."
+introduced_by = "PR #8412"
+topologies = ["distributed"]
+from_range = ["*"]
+to_range = [">v1.1.1"]
+features = ["information_schema", "sst", "metadata", "table", "query"]
+owner = "query"

--- a/tests/compatibility/cases/ssts_limit_old_manifest/setup.sql
+++ b/tests/compatibility/cases/ssts_limit_old_manifest/setup.sql
@@ -1,0 +1,17 @@
+CREATE TABLE ssts_limit_old_manifest_table (
+  a INT PRIMARY KEY,
+  b STRING,
+  ts TIMESTAMP TIME INDEX
+)
+PARTITION ON COLUMNS (a) (
+  a < 1000,
+  a >= 1000 AND a < 2000,
+  a >= 2000
+);
+
+INSERT INTO ssts_limit_old_manifest_table VALUES
+  (500, 'a', '2026-07-06 00:00:00+0000'),
+  (1500, 'b', '2026-07-06 00:01:00+0000'),
+  (2500, 'c', '2026-07-06 00:02:00+0000');
+
+ADMIN FLUSH_TABLE('ssts_limit_old_manifest_table');

--- a/tests/compatibility/cases/ssts_limit_old_manifest/verify.result
+++ b/tests/compatibility/cases/ssts_limit_old_manifest/verify.result
@@ -1,0 +1,35 @@
+SELECT COUNT(DISTINCT node_id) > 1 AS has_multi_datanodes
+FROM information_schema.ssts_manifest;
+
++---------------------+
+| has_multi_datanodes |
++---------------------+
+| true                |
++---------------------+
+
+SELECT COUNT(*) AS limited_rows
+FROM (
+  SELECT region_id
+  FROM information_schema.ssts_manifest
+  LIMIT 1
+);
+
++--------------+
+| limited_rows |
++--------------+
+| 1            |
++--------------+
+
+SELECT COUNT(*) AS filtered_limited_rows
+FROM (
+  SELECT region_id
+  FROM information_schema.ssts_manifest
+  WHERE region_id > 0
+  LIMIT 1
+);
+
++-----------------------+
+| filtered_limited_rows |
++-----------------------+
+| 1                     |
++-----------------------+

--- a/tests/compatibility/cases/ssts_limit_old_manifest/verify.sql
+++ b/tests/compatibility/cases/ssts_limit_old_manifest/verify.sql
@@ -1,0 +1,17 @@
+SELECT COUNT(DISTINCT node_id) > 1 AS has_multi_datanodes
+FROM information_schema.ssts_manifest;
+
+SELECT COUNT(*) AS limited_rows
+FROM (
+  SELECT region_id
+  FROM information_schema.ssts_manifest
+  LIMIT 1
+);
+
+SELECT COUNT(*) AS filtered_limited_rows
+FROM (
+  SELECT region_id
+  FROM information_schema.ssts_manifest
+  WHERE region_id > 0
+  LIMIT 1
+);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up to #8412.

## What's changed and what's your intention?

This PR adds a distributed sqlness compatibility case for `information_schema.ssts_manifest` queries with `LIMIT` over SST state written by old binaries.

The new `ssts_limit_old_manifest` case verifies this upgrade path:

1. Start an old distributed cluster (`v1.0.0` / `v1.1.0`).
2. Create a partitioned table, insert one row per partition, and flush it to produce SST manifest rows.
3. Restart the preserved state with the current binary.
4. Query `information_schema.ssts_manifest` from the current binary.
5. Verify distributed inspect streams still apply a global `LIMIT 1`, including the filtered shape from #8412.

The case checks deterministic aggregate wrappers rather than raw manifest rows:

- the manifest spans multiple datanodes;
- an unfiltered `LIMIT 1` returns exactly one row;
- a filtered `WHERE region_id > 0 LIMIT 1` returns exactly one row.

Validation performed locally:

```text
cargo build --bin greptime -j 1
cargo run -p sqlness-runner -- compat --dry-run --from-version v1.0.0 --to-bins-dir /mnt/nvme_rust/rust-targets/compat_framework_retry/debug --test-filter 'ssts_limit_old_manifest'
cargo run -p sqlness-runner -- compat --dry-run --from-version v1.1.0 --to-bins-dir /mnt/nvme_rust/rust-targets/compat_framework_retry/debug --test-filter 'ssts_limit_old_manifest'
cargo run -p sqlness-runner -- compat --from-version v1.0.0 --to-bins-dir /mnt/nvme_rust/rust-targets/compat_framework_retry/debug --test-filter 'ssts_limit_old_manifest' --preserve-state
cargo run -p sqlness-runner -- compat --from-version v1.1.0 --to-bins-dir /mnt/nvme_rust/rust-targets/compat_framework_retry/debug --test-filter 'ssts_limit_old_manifest' --preserve-state
git diff --check
```

Both `v1.0.0 -> current` and `v1.1.0 -> current` distributed compat runs passed.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments. (not applicable, test-only)
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
