### PR TITLE
fix(flow): notify flow after source writes

### DIFF
--- a/src/operator/src/bulk_insert.rs
+++ b/src/operator/src/bulk_insert.rs
@@ -26,6 +26,9 @@ use bytes::Bytes;
 use common_base::AffectedRows;
 use common_grpc::FlightData;
 use common_grpc::flight::{FlightEncoder, FlightMessage};
+use common_meta::cache::TableFlownodeSetCacheRef;
+use common_meta::node_manager::NodeManagerRef;
+use common_meta::peer::Peer;
 use common_telemetry::error;
 use common_telemetry::tracing_context::TracingContext;
 use snafu::{OptionExt, ResultExt, ensure};
@@ -54,9 +57,12 @@ impl Inserter {
         }
 
         let body_size = raw_flight_data.data_body.len();
-        // TODO(yingwen): Fill record batch impure default values. Note that we should override `raw_flight_data` if we have to fill defaults.
-        // notify flownode to update dirty timestamps if flow is configured.
-        self.maybe_update_flow_dirty_window(table_info.clone(), record_batch.clone());
+
+        // Precompute the flow dirty-window notification before any source write
+        // so cache/timestamp errors fail before commit.
+        let dirty_task =
+            FlowDirtyWindowTask::new(&self.table_flownode_set_cache, &table_info, &record_batch)
+                .await?;
 
         metrics::BULK_REQUEST_MESSAGE_SIZE.observe(body_size as f64);
         metrics::BULK_REQUEST_ROWS
@@ -125,6 +131,7 @@ impl Inserter {
                 .context(error::RequestRegionSnafu)
                 .map(|r| r.affected_rows);
             if let Ok(rows) = result {
+                dirty_task.detach(self.node_manager.clone());
                 crate::metrics::DIST_INGEST_ROW_COUNT
                     .with_label_values(&[db_name.as_str()])
                     .inc_by(rows as u64);
@@ -240,79 +247,123 @@ impl Inserter {
             }
         }
 
-        let region_responses = futures::future::try_join_all(handles)
-            .await
-            .context(error::JoinTaskSnafu)?;
+        let region_responses = futures::future::join_all(handles).await;
         wait_all_datanode_timer.observe_duration();
         let mut rows_inserted: usize = 0;
-        for res in region_responses {
-            rows_inserted += res?.affected_rows;
+        let mut any_success = false;
+        let mut first_error = None;
+        for handle_result in region_responses {
+            match handle_result {
+                Ok(Ok(ref resp)) => {
+                    rows_inserted += resp.affected_rows;
+                    any_success = true;
+                }
+                Ok(Err(e)) => {
+                    first_error = first_error.or(Some(e));
+                }
+                Err(join_err) => {
+                    // Collect join errors instead of early-returning,
+                    // so we still check any_success and dispatch dirty below.
+                    first_error = first_error.or(Some(
+                        Err::<(), common_runtime::JoinError>(join_err)
+                            .context(error::JoinTaskSnafu)
+                            .unwrap_err(),
+                    ));
+                }
+            }
         }
+
+        if any_success {
+            dirty_task.detach(self.node_manager.clone());
+        }
+
+        if let Some(e) = first_error {
+            return Err(e);
+        }
+
         crate::metrics::DIST_INGEST_ROW_COUNT
             .with_label_values(&[db_name.as_str()])
             .inc_by(rows_inserted as u64);
         Ok(rows_inserted)
     }
+}
 
-    fn maybe_update_flow_dirty_window(&self, table_info: TableInfoRef, record_batch: RecordBatch) {
+/// Precompute the flow dirty-window notification before any source write.
+/// `new()` extracts timestamps and resolves flownode peers so cache/timestamp
+/// failures happen before commit. `detach()` does fire-and-forget best-effort
+/// dispatch only after the relevant success boundary.
+struct FlowDirtyWindowTask {
+    table_id: u32,
+    timestamps: Vec<i64>,
+    peers: Vec<Peer>,
+}
+
+impl FlowDirtyWindowTask {
+    async fn new(
+        cache: &TableFlownodeSetCacheRef,
+        table_info: &TableInfoRef,
+        record_batch: &RecordBatch,
+    ) -> error::Result<Self> {
         let table_id = table_info.table_id();
-        let table_flownode_set_cache = self.table_flownode_set_cache.clone();
-        let node_manager = self.node_manager.clone();
-        common_runtime::spawn_global(async move {
-            let result = table_flownode_set_cache
-                .get(table_id)
-                .await
-                .context(error::RequestInsertsSnafu);
-            let flownodes = match result {
-                Ok(flownodes) => flownodes.unwrap_or_default(),
-                Err(e) => {
-                    error!(e; "Failed to get flownodes for table id: {}", table_id);
-                    return;
-                }
-            };
+        let flownodes = cache
+            .get(table_id)
+            .await
+            .context(error::RequestInsertsSnafu)?
+            .unwrap_or_default();
+        let peers: Vec<Peer> = flownodes
+            .values()
+            .cloned()
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
 
-            let peers: HashSet<_> = flownodes.values().cloned().collect();
-            if peers.is_empty() {
-                return;
-            }
-
-            let Ok(timestamps) = extract_timestamps(
-                &record_batch,
-                &table_info
+        let timestamps = if peers.is_empty() {
+            vec![]
+        } else {
+            extract_timestamps(
+                record_batch,
+                table_info
                     .meta
                     .schema
                     .timestamp_column()
                     .as_ref()
                     .unwrap()
-                    .name,
-            )
-            .inspect_err(|e| {
-                error!(e; "Failed to extract timestamps from record batch");
-            }) else {
-                return;
-            };
+                    .name
+                    .as_str(),
+            )?
+        };
 
-            for peer in peers {
-                let node_manager = node_manager.clone();
-                let timestamps = timestamps.clone();
-                common_runtime::spawn_global(async move {
-                    if let Err(e) = node_manager
-                        .flownode(&peer)
-                        .await
-                        .handle_mark_window_dirty(DirtyWindowRequests {
-                            requests: vec![DirtyWindowRequest {
-                                table_id,
-                                timestamps,
-                            }],
-                        })
-                        .await
-                        .context(error::RequestInsertsSnafu)
-                    {
-                        error!(e; "Failed to mark timestamps as dirty, table: {}", table_id);
-                    }
-                });
-            }
-        });
+        Ok(Self {
+            table_id,
+            timestamps,
+            peers,
+        })
+    }
+
+    fn detach(self, node_manager: NodeManagerRef) {
+        if self.peers.is_empty() || self.timestamps.is_empty() {
+            return;
+        }
+        for peer in self.peers {
+            let timestamps = self.timestamps.clone();
+            let node_manager = node_manager.clone();
+            let table_id = self.table_id;
+            common_runtime::spawn_global(async move {
+                let result = node_manager
+                    .flownode(&peer)
+                    .await
+                    .handle_mark_window_dirty(DirtyWindowRequests {
+                        requests: vec![DirtyWindowRequest {
+                            table_id,
+                            timestamps,
+                        }],
+                    })
+                    .await;
+                if let Err(e) = result {
+                    error!(e; "Failed to mark timestamps as dirty, table: {}", table_id);
+                }
+            });
+        }
     }
 }
 
@@ -333,4 +384,267 @@ fn extract_timestamps(rb: &RecordBatch, timestamp_index_name: &str) -> error::Re
             }
         })?;
     Ok(primitive.iter().flatten().collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use api::v1::flow::FlowResponse;
+    use arrow::array::{Int64Array, TimestampMillisecondArray};
+    use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+    use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
+    use common_meta::cache::new_table_flownode_set_cache;
+    use common_meta::ddl::test_util::datanode_handler::NaiveDatanodeHandler;
+    use common_meta::instruction::{CacheIdent, CreateFlow};
+    use common_meta::node_manager::{DatanodeManager, DatanodeRef, FlownodeManager, FlownodeRef};
+    use common_meta::peer::Peer;
+    use common_meta::test_util::MockDatanodeManager;
+    use moka::future::Cache;
+    use tokio::sync::mpsc;
+
+    use super::*;
+    use crate::tests::prepare_mocked_backend;
+
+    /// Combined mock for DatanodeManager + FlownodeManager (same as in insert.rs tests).
+    struct CombinedNodeManager<D: DatanodeManager, F: FlownodeManager> {
+        datanode_mgr: D,
+        flownode_mgr: F,
+    }
+
+    #[async_trait::async_trait]
+    impl<D: DatanodeManager + Send + Sync, F: FlownodeManager + Send + Sync> DatanodeManager
+        for CombinedNodeManager<D, F>
+    {
+        async fn datanode(&self, peer: &Peer) -> DatanodeRef {
+            self.datanode_mgr.datanode(peer).await
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl<D: DatanodeManager + Send + Sync, F: FlownodeManager + Send + Sync> FlownodeManager
+        for CombinedNodeManager<D, F>
+    {
+        async fn flownode(&self, peer: &Peer) -> FlownodeRef {
+            self.flownode_mgr.flownode(peer).await
+        }
+    }
+
+    /// A `MockFlownodeHandler` that records flownode calls through a channel.
+    #[derive(Clone)]
+    struct RecordingFlownodeHandler {
+        tx: mpsc::UnboundedSender<()>,
+    }
+
+    #[async_trait::async_trait]
+    impl common_meta::test_util::MockFlownodeHandler for RecordingFlownodeHandler {
+        async fn handle_inserts(
+            &self,
+            _peer: &Peer,
+            _requests: api::v1::region::InsertRequests,
+        ) -> common_meta::error::Result<FlowResponse> {
+            let _ = self.tx.send(());
+            Ok(FlowResponse::default())
+        }
+
+        async fn handle_mark_window_dirty(
+            &self,
+            _peer: &Peer,
+            _req: api::v1::flow::DirtyWindowRequests,
+        ) -> common_meta::error::Result<FlowResponse> {
+            let _ = self.tx.send(());
+            Ok(FlowResponse::default())
+        }
+    }
+
+    /// Populates the flownode set cache so that `table_id` resolves to `peers`.
+    async fn populate_flownode_cache(
+        cache: &TableFlownodeSetCacheRef,
+        table_id: u32,
+        peers: Vec<Peer>,
+    ) {
+        let ident = vec![CacheIdent::CreateFlow(CreateFlow {
+            flow_id: 1,
+            source_table_ids: vec![table_id],
+            partition_to_peer_mapping: peers
+                .into_iter()
+                .enumerate()
+                .map(|(i, p)| (i as u32, p))
+                .collect(),
+        })];
+        cache.invalidate(&ident).await.unwrap();
+    }
+
+    /// Create a `RecordBatch` with a single timestamp column and a value column.
+    fn make_record_batch(ts_millis: &[i64]) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "ts",
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                false,
+            ),
+            Field::new("val", DataType::Int64, true),
+        ]));
+        let ts_array = Arc::new(TimestampMillisecondArray::from(
+            ts_millis.iter().map(|&ts| Some(ts)).collect::<Vec<_>>(),
+        ));
+        let val_array = Arc::new(Int64Array::from(vec![42i64; ts_millis.len()]));
+        RecordBatch::try_new(schema, vec![ts_array, val_array]).unwrap()
+    }
+
+    /// Create a `TableInfoRef` with a timestamp column named "ts".
+    fn make_table_info_ref(table_id: u32) -> TableInfoRef {
+        let col_schemas = vec![
+            datatypes::schema::ColumnSchema::new(
+                "ts",
+                datatypes::data_type::ConcreteDataType::timestamp_millisecond_datatype(),
+                false,
+            )
+            .with_time_index(true),
+            datatypes::schema::ColumnSchema::new(
+                "val",
+                datatypes::data_type::ConcreteDataType::int64_datatype(),
+                true,
+            ),
+        ];
+        let schema = Arc::new(
+            datatypes::schema::SchemaBuilder::try_from(col_schemas)
+                .unwrap()
+                .build()
+                .unwrap(),
+        );
+        let meta = table::metadata::TableMetaBuilder::empty()
+            .schema(schema)
+            .primary_key_indices(vec![])
+            .value_indices(vec![1])
+            .engine("mito")
+            .next_column_id(2)
+            .options(Default::default())
+            .created_on(Default::default())
+            .build()
+            .unwrap();
+        Arc::new(
+            table::metadata::TableInfoBuilder::default()
+                .table_id(table_id)
+                .table_version(0)
+                .name("test_table")
+                .schema_name(DEFAULT_SCHEMA_NAME)
+                .catalog_name(DEFAULT_CATALOG_NAME)
+                .desc(None)
+                .table_type(table::metadata::TableType::Base)
+                .meta(meta)
+                .build()
+                .unwrap(),
+        )
+    }
+
+    // --- Flow dirty-window ordering tests ---
+
+    /// Verifies that `FlowDirtyWindowTask::detach` sends dirty-window requests
+    /// to the flownode via the node manager.
+    #[tokio::test]
+    async fn test_flow_dirty_window_task_detach_sends_dirty() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        let kv_backend = prepare_mocked_backend().await;
+        let cache = Arc::new(new_table_flownode_set_cache(
+            String::new(),
+            Cache::new(100),
+            kv_backend,
+        ));
+        // Populate cache so table 1 has flownode peer (id=1)
+        populate_flownode_cache(&cache, 1, vec![Peer::empty(1)]).await;
+
+        let flownode_mgr =
+            common_meta::test_util::MockFlownodeManager::new(RecordingFlownodeHandler {
+                tx: tx.clone(),
+            });
+        let datanode_mgr = MockDatanodeManager::new(NaiveDatanodeHandler);
+        let node_manager: NodeManagerRef = Arc::new(CombinedNodeManager {
+            datanode_mgr,
+            flownode_mgr,
+        });
+
+        let record_batch = make_record_batch(&[1000, 2000, 3000]);
+        let table_info = make_table_info_ref(1);
+
+        // Precompute the task — should extract timestamps and find flownode peers
+        let task = FlowDirtyWindowTask::new(&cache, &table_info, &record_batch)
+            .await
+            .unwrap();
+
+        assert!(!task.timestamps.is_empty(), "should extract timestamps");
+        assert!(!task.peers.is_empty(), "should find flownode peers");
+
+        // Detach should spawn flownode calls
+        task.detach(node_manager);
+
+        // Wait for the spawned task to actually send
+        tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+            .await
+            .expect("flownode handle_mark_window_dirty should be called after detach");
+    }
+
+    /// Verifies that `FlowDirtyWindowTask` with no flownode peers is a no-op on detach.
+    #[tokio::test]
+    async fn test_flow_dirty_window_task_no_peers_noop() {
+        let kv_backend = prepare_mocked_backend().await;
+        let cache = Arc::new(new_table_flownode_set_cache(
+            String::new(),
+            Cache::new(100),
+            kv_backend,
+        ));
+        // Don't populate cache — no flownode peers
+
+        let record_batch = make_record_batch(&[1000, 2000]);
+        let table_info = make_table_info_ref(1);
+
+        let task = FlowDirtyWindowTask::new(&cache, &table_info, &record_batch)
+            .await
+            .unwrap();
+
+        // No peers found — timestamps should be empty
+        assert!(task.timestamps.is_empty());
+        assert!(task.peers.is_empty());
+
+        // Detach should be a no-op (no flownode calls spawned)
+        // We use MockDatanodeManager (flownode() is unimplemented!) but
+        // detach returns early when peers is empty, so it's safe.
+        let datanode_mgr = MockDatanodeManager::new(NaiveDatanodeHandler);
+        task.detach(Arc::new(datanode_mgr));
+    }
+
+    /// Verifies that `extract_timestamps` correctly extracts all timestamp
+    /// values from a record batch.
+    #[test]
+    fn test_extract_timestamps() {
+        let rb = make_record_batch(&[1000, 2000, 3000, 1000]);
+        let timestamps = extract_timestamps(&rb, "ts").unwrap();
+        assert_eq!(timestamps, vec![1000, 2000, 3000, 1000]);
+    }
+
+    /// Verifies that `extract_timestamps` returns an empty vec for an empty batch.
+    #[test]
+    fn test_extract_timestamps_empty() {
+        let rb = make_record_batch(&[]);
+        let timestamps = extract_timestamps(&rb, "ts").unwrap();
+        assert!(timestamps.is_empty());
+    }
+
+    // ── Note on bulk insert ordering guarantees ──
+    //
+    // Full `handle_bulk_insert` ordering tests (blocking datanode, asserting
+    // no dirty before release, multi-region partial failure) require heavy
+    // integration setup: TableRef, FlightData, partition manager with real
+    // region routes, etc. The structural guarantees are enforced by the code:
+    //
+    // - Single-region: dirty_task.detach() is only called inside
+    //   `if let Ok(rows) = result { ... }`, after datanode write completes.
+    // - Multi-region: dirty_task.detach() is only called after
+    //   `join_all(handles).await` completes and `any_success` is computed.
+    //   Join errors are collected (not early-returned) before dirty dispatch.
+    //
+    // The isolated `FlowDirtyWindowTask` tests above verify that:
+    // - `new()` extracts timestamps and resolves flownode peers (precompute)
+    // - `detach()` spawns flownode dirty-window calls (best-effort dispatch)
 }

--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -398,41 +398,67 @@ impl Inserter {
             instant_requests,
         } = requests;
 
-        // Mirror requests for source table to flownode asynchronously
-        let flow_mirror_task = FlowMirrorTask::new(
+        // Instant TTL requests are not committed to source storage; mirror
+        // them to flownodes. Build the task here so cache errors fail before
+        // any work, but defer detach until after all normal mirror precomputes
+        // succeed. If a normal precompute fails later, we must not have sent
+        // side effects for instant requests either.
+        let instant_mirror = FlowMirrorTask::new(
             &self.table_flownode_set_cache,
-            normal_requests
-                .requests
-                .iter()
-                .chain(instant_requests.requests.iter()),
+            instant_requests.requests.iter(),
         )
         .await?;
-        flow_mirror_task.detach(self.node_manager.clone())?;
 
-        // Write requests to datanode and wait for response
-        let write_tasks = self
-            .group_requests_by_peer(normal_requests)
-            .await?
-            .into_iter()
-            .map(|(peer, inserts)| {
-                let node_manager = self.node_manager.clone();
-                let request = request_factory.build_insert(inserts);
-                common_runtime::spawn_global(async move {
-                    node_manager
-                        .datanode(&peer)
-                        .await
-                        .handle(request)
-                        .await
-                        .context(RequestInsertsSnafu)
-                })
-            });
-        let results = future::try_join_all(write_tasks)
-            .await
-            .context(JoinTaskSnafu)?;
-        let affected_rows = results
-            .into_iter()
-            .map(|resp| resp.map(|r| r.affected_rows))
-            .sum::<Result<AffectedRows>>()?;
+        // Normal requests: group by datanode peer first, then prebuild all
+        // mirror tasks BEFORE spawning any datanode write. This avoids the
+        // race where a later group's cache lookup fails but an earlier group's
+        // write has already committed.
+        let grouped = self.group_requests_by_peer(normal_requests).await?;
+        let mut per_peer: Vec<(Peer, RegionInsertRequests, FlowMirrorTask)> =
+            Vec::with_capacity(grouped.len());
+        for (peer, inserts) in grouped {
+            let mirror =
+                FlowMirrorTask::new(&self.table_flownode_set_cache, inserts.requests.iter())
+                    .await?;
+            per_peer.push((peer, inserts, mirror));
+        }
+
+        // All precompute succeeded. Now detach instant mirror (no source write
+        // barrier — instant TTL rows are never written to datanode storage).
+        instant_mirror.detach(self.node_manager.clone())?;
+
+        // All mirrors precomputed; now spawn writes. Each spawned task
+        // detaches its group's mirror only after its datanode returns Ok.
+        let mut write_tasks = Vec::with_capacity(per_peer.len());
+        for (peer, inserts, mirror) in per_peer {
+            let node_manager = self.node_manager.clone();
+            let request = request_factory.build_insert(inserts);
+            write_tasks.push(common_runtime::spawn_global(async move {
+                let result = node_manager
+                    .datanode(&peer)
+                    .await
+                    .handle(request)
+                    .await
+                    .context(RequestInsertsSnafu);
+                if result.is_ok() {
+                    let _ = mirror.detach(node_manager);
+                }
+                result.map(|r| r.affected_rows)
+            }));
+        }
+
+        let results = future::join_all(write_tasks).await;
+        let mut affected_rows: AffectedRows = 0;
+        let mut first_error = None;
+        for result in results {
+            match result.context(JoinTaskSnafu)? {
+                Ok(rows) => affected_rows += rows,
+                Err(e) => first_error = first_error.or(Some(e)),
+            }
+        }
+        if let Some(e) = first_error {
+            return Err(e);
+        }
         crate::metrics::DIST_INGEST_ROW_COUNT
             .with_label_values(&[ctx.get_db_string().as_str()])
             .inc_by(affected_rows as u64);
@@ -1334,22 +1360,118 @@ impl FlowMirrorTask {
 mod tests {
     use std::sync::Arc;
 
+    use api::v1::flow::FlowResponse;
     use api::v1::helper::{field_column_schema, time_index_column_schema};
+    use api::v1::region::{InsertRequest as RegionInsertRequest, RegionRequest};
     use api::v1::{RowInsertRequest, Rows, Value};
     use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
     use common_meta::cache::new_table_flownode_set_cache;
     use common_meta::ddl::test_util::datanode_handler::NaiveDatanodeHandler;
+    use common_meta::instruction::{CacheIdent, CreateFlow};
+    use common_meta::node_manager::{DatanodeManager, DatanodeRef, FlownodeManager, FlownodeRef};
+    use common_meta::peer::Peer;
     use common_meta::test_util::MockDatanodeManager;
     use datatypes::data_type::ConcreteDataType;
     use datatypes::schema::ColumnSchema;
     use moka::future::Cache;
     use session::context::QueryContext;
+    use store_api::storage::RegionId;
     use table::TableRef;
     use table::dist_table::DummyDataSource;
-    use table::metadata::{TableInfoBuilder, TableMetaBuilder, TableType};
+    use table::metadata::{TableInfoBuilder, TableInfoRef, TableMetaBuilder, TableType};
+    use tokio::sync::mpsc;
 
     use super::*;
     use crate::tests::{create_partition_rule_manager, prepare_mocked_backend};
+
+    /// A combined `DatanodeManager` + `FlownodeManager` that implements
+    /// `NodeManager` by delegating to separate inner managers.
+    struct CombinedNodeManager<D: DatanodeManager, F: FlownodeManager> {
+        datanode_mgr: D,
+        flownode_mgr: F,
+    }
+
+    #[async_trait::async_trait]
+    impl<D: DatanodeManager + Send + Sync, F: FlownodeManager + Send + Sync> DatanodeManager
+        for CombinedNodeManager<D, F>
+    {
+        async fn datanode(&self, peer: &Peer) -> DatanodeRef {
+            self.datanode_mgr.datanode(peer).await
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl<D: DatanodeManager + Send + Sync, F: FlownodeManager + Send + Sync> FlownodeManager
+        for CombinedNodeManager<D, F>
+    {
+        async fn flownode(&self, peer: &Peer) -> FlownodeRef {
+            self.flownode_mgr.flownode(peer).await
+        }
+    }
+
+    /// A `MockFlownodeHandler` that records flownode calls through a channel.
+    #[derive(Clone)]
+    struct RecordingFlownodeHandler {
+        tx: mpsc::UnboundedSender<()>,
+    }
+
+    #[async_trait::async_trait]
+    impl common_meta::test_util::MockFlownodeHandler for RecordingFlownodeHandler {
+        async fn handle_inserts(
+            &self,
+            _peer: &Peer,
+            _requests: api::v1::region::InsertRequests,
+        ) -> common_meta::error::Result<FlowResponse> {
+            let _ = self.tx.send(());
+            Ok(FlowResponse::default())
+        }
+
+        async fn handle_mark_window_dirty(
+            &self,
+            _peer: &Peer,
+            _req: api::v1::flow::DirtyWindowRequests,
+        ) -> common_meta::error::Result<FlowResponse> {
+            let _ = self.tx.send(());
+            Ok(FlowResponse::default())
+        }
+    }
+
+    /// Populates the flownode set cache so that `table_id` resolves to `peers`.
+    async fn populate_flownode_cache(
+        cache: &TableFlownodeSetCacheRef,
+        table_id: u32,
+        peers: Vec<Peer>,
+    ) {
+        let ident = vec![CacheIdent::CreateFlow(CreateFlow {
+            flow_id: 1,
+            source_table_ids: vec![table_id],
+            partition_to_peer_mapping: peers
+                .into_iter()
+                .enumerate()
+                .map(|(i, p)| (i as u32, p))
+                .collect(),
+        })];
+        cache.invalidate(&ident).await.unwrap();
+    }
+
+    /// Builds a minimal `RegionInsertRequest` with a single row (no real data).
+    fn make_region_insert_req(region_id: RegionId) -> RegionInsertRequest {
+        RegionInsertRequest {
+            region_id: region_id.as_u64(),
+            rows: Some(api::v1::Rows {
+                schema: vec![time_index_column_schema(
+                    "ts",
+                    api::v1::ColumnDataType::TimestampMillisecond,
+                )],
+                rows: vec![api::v1::Row {
+                    values: vec![Value {
+                        value_data: Some(api::v1::value::ValueData::TimeMillisecondValue(1000)),
+                    }],
+                }],
+            }),
+            partition_expr_version: None,
+        }
+    }
 
     fn make_table_ref_with_schema(ts_name: &str, field_name: &str) -> TableRef {
         let schema = datatypes::schema::SchemaBuilder::try_from_columns(vec![
@@ -1593,5 +1715,576 @@ mod tests {
             Some("last_row"),
             table_options.get(MERGE_MODE_KEY).map(String::as_str)
         );
+    }
+
+    use api::region::RegionResponse;
+    use common_meta::error as meta_error;
+    use common_meta::node_manager::Datanode;
+    use common_query::request::QueryRequest;
+    use common_recordbatch::SendableRecordBatchStream;
+    use tokio::sync::oneshot;
+
+    /// Builds a `TableInfoRef` for `table_id` with a `ts` timestamp column.
+    fn make_table_info(table_id: u32) -> TableInfoRef {
+        let column_schemas = vec![
+            ColumnSchema::new(
+                "ts",
+                ConcreteDataType::timestamp_millisecond_datatype(),
+                false,
+            )
+            .with_time_index(true),
+        ];
+        let schema = Arc::new(
+            datatypes::schema::SchemaBuilder::try_from(column_schemas)
+                .unwrap()
+                .build()
+                .unwrap(),
+        );
+        let meta = TableMetaBuilder::empty()
+            .schema(schema)
+            .primary_key_indices(vec![])
+            .value_indices(vec![])
+            .engine("mito")
+            .next_column_id(1)
+            .options(Default::default())
+            .created_on(Default::default())
+            .build()
+            .unwrap();
+        Arc::new(
+            TableInfoBuilder::default()
+                .table_id(table_id)
+                .table_version(0)
+                .name("test_table")
+                .schema_name(DEFAULT_SCHEMA_NAME)
+                .catalog_name(DEFAULT_CATALOG_NAME)
+                .desc(None)
+                .table_type(TableType::Base)
+                .meta(meta)
+                .build()
+                .unwrap(),
+        )
+    }
+
+    // ── Blocking datanode manager for ordering tests ──
+
+    /// A `Datanode` that sends on `entered_tx` when `handle()` is called,
+    /// then blocks until its `release_rx` fires, and returns a pre-set result.
+    struct BlockingDatanode {
+        entered_tx: mpsc::UnboundedSender<()>,
+        release_rx: std::sync::Mutex<Option<oneshot::Receiver<()>>>,
+        result: std::sync::Mutex<Option<meta_error::Result<RegionResponse>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl Datanode for BlockingDatanode {
+        async fn handle(&self, _request: RegionRequest) -> meta_error::Result<RegionResponse> {
+            let _ = self.entered_tx.send(());
+            let rx = self.release_rx.lock().unwrap().take().unwrap();
+            rx.await.unwrap();
+            self.result.lock().unwrap().take().unwrap()
+        }
+
+        async fn handle_query(
+            &self,
+            _request: QueryRequest,
+        ) -> meta_error::Result<SendableRecordBatchStream> {
+            unimplemented!("not needed for insert tests")
+        }
+    }
+
+    /// A `DatanodeManager` that creates `BlockingDatanode` instances from
+    /// pre-set slots. Each slot is a `(oneshot::Receiver, Result<RegionResponse>)`.
+    #[allow(clippy::type_complexity)]
+    struct BlockingDatanodeManager {
+        entered_tx: mpsc::UnboundedSender<()>,
+        slots:
+            Arc<std::sync::Mutex<Vec<(oneshot::Receiver<()>, meta_error::Result<RegionResponse>)>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl DatanodeManager for BlockingDatanodeManager {
+        async fn datanode(&self, _peer: &Peer) -> DatanodeRef {
+            let (rx, result) = self
+                .slots
+                .lock()
+                .unwrap()
+                .pop()
+                .expect("too many datanode calls");
+            Arc::new(BlockingDatanode {
+                entered_tx: self.entered_tx.clone(),
+                release_rx: std::sync::Mutex::new(Some(rx)),
+                result: std::sync::Mutex::new(Some(result)),
+            })
+        }
+    }
+
+    // ── Flow mirror ordering tests ──
+
+    /// Normal insert success ordering: datanode blocks; assert no mirror before
+    /// release; release datanode; assert mirror arrives after success.
+    #[tokio::test]
+    async fn test_normal_insert_success_ordering() {
+        let (flownode_tx, mut flownode_rx) = mpsc::unbounded_channel::<()>();
+        let (entered_tx, mut entered_rx) = mpsc::unbounded_channel::<()>();
+        let (rel_tx, rel_rx) = oneshot::channel();
+
+        let kv_backend = prepare_mocked_backend().await;
+        let cache = Arc::new(new_table_flownode_set_cache(
+            String::new(),
+            Cache::new(100),
+            kv_backend.clone(),
+        ));
+        populate_flownode_cache(&cache, 1, vec![Peer::new(1, "")]).await;
+
+        let flownode_mgr =
+            common_meta::test_util::MockFlownodeManager::new(RecordingFlownodeHandler {
+                tx: flownode_tx,
+            });
+        let datanode_mgr = BlockingDatanodeManager {
+            entered_tx,
+            slots: Arc::new(std::sync::Mutex::new(vec![(
+                rel_rx,
+                Ok(RegionResponse::new(1)),
+            )])),
+        };
+        let node_manager: NodeManagerRef = Arc::new(CombinedNodeManager {
+            datanode_mgr,
+            flownode_mgr,
+        });
+
+        let partition_manager = create_partition_rule_manager(kv_backend).await;
+        let inserter = Inserter::new(
+            catalog::memory::MemoryCatalogManager::new(),
+            partition_manager,
+            node_manager,
+            cache,
+            true,
+        );
+
+        let table_info = make_table_info(1);
+        let mut table_infos = ahash::HashMap::new();
+        table_infos.insert(table_info.table_id(), table_info);
+
+        let normal_requests = RegionInsertRequests {
+            requests: vec![make_region_insert_req(RegionId::new(1, 1))],
+        };
+        let instant_requests = RegionInsertRequests { requests: vec![] };
+        let ctx = Arc::new(QueryContext::with(
+            DEFAULT_CATALOG_NAME,
+            DEFAULT_SCHEMA_NAME,
+        ));
+
+        let do_req = inserter.do_request(
+            InstantAndNormalInsertRequests {
+                normal_requests,
+                instant_requests,
+            },
+            &table_infos,
+            &ctx,
+        );
+        tokio::pin!(do_req);
+
+        // Interleave: wait for datanode to be entered
+        tokio::select! {
+            r = &mut do_req => panic!("do_req completed too early: {:?}", r),
+            e = entered_rx.recv() => assert!(e.is_some(), "datanode should be entered"),
+        }
+
+        // Assert no flownode mirror has been dispatched yet
+        let premature =
+            tokio::time::timeout(std::time::Duration::from_millis(200), flownode_rx.recv()).await;
+        assert!(
+            premature.is_err() || premature.unwrap().is_none(),
+            "flownode mirror must NOT be dispatched before datanode returns"
+        );
+
+        // Release the datanode
+        rel_tx.send(()).unwrap();
+
+        // Now await completion
+        let result = do_req.await;
+        assert!(result.is_ok(), "insert should succeed: {:?}", result.err());
+
+        // Flownode mirror should now arrive
+        tokio::time::timeout(std::time::Duration::from_secs(5), flownode_rx.recv())
+            .await
+            .expect("flownode mirror should be dispatched after datanode success");
+    }
+
+    /// Normal insert datanode failure: datanode returns error, assert no mirror.
+    #[tokio::test]
+    async fn test_normal_insert_datanode_failure_no_mirror() {
+        let (flownode_tx, mut flownode_rx) = mpsc::unbounded_channel::<()>();
+        let (entered_tx, mut entered_rx) = mpsc::unbounded_channel::<()>();
+        let (rel_tx, rel_rx) = oneshot::channel();
+
+        let kv_backend = prepare_mocked_backend().await;
+        let cache = Arc::new(new_table_flownode_set_cache(
+            String::new(),
+            Cache::new(100),
+            kv_backend.clone(),
+        ));
+        populate_flownode_cache(&cache, 1, vec![Peer::new(1, "")]).await;
+
+        let err = meta_error::UnexpectedSnafu {
+            err_msg: "mock datanode error",
+        }
+        .build();
+
+        let flownode_mgr =
+            common_meta::test_util::MockFlownodeManager::new(RecordingFlownodeHandler {
+                tx: flownode_tx,
+            });
+        let datanode_mgr = BlockingDatanodeManager {
+            entered_tx,
+            slots: Arc::new(std::sync::Mutex::new(vec![(rel_rx, Err(err))])),
+        };
+        let node_manager: NodeManagerRef = Arc::new(CombinedNodeManager {
+            datanode_mgr,
+            flownode_mgr,
+        });
+
+        let partition_manager = create_partition_rule_manager(kv_backend).await;
+        let inserter = Inserter::new(
+            catalog::memory::MemoryCatalogManager::new(),
+            partition_manager,
+            node_manager,
+            cache,
+            true,
+        );
+
+        let table_info = make_table_info(1);
+        let mut table_infos = ahash::HashMap::new();
+        table_infos.insert(table_info.table_id(), table_info);
+
+        let normal_requests = RegionInsertRequests {
+            requests: vec![make_region_insert_req(RegionId::new(1, 1))],
+        };
+        let instant_requests = RegionInsertRequests { requests: vec![] };
+        let ctx = Arc::new(QueryContext::with(
+            DEFAULT_CATALOG_NAME,
+            DEFAULT_SCHEMA_NAME,
+        ));
+
+        let do_req = inserter.do_request(
+            InstantAndNormalInsertRequests {
+                normal_requests,
+                instant_requests,
+            },
+            &table_infos,
+            &ctx,
+        );
+        tokio::pin!(do_req);
+
+        // Wait for datanode to be entered
+        tokio::select! {
+            r = &mut do_req => panic!("do_req completed too early: {:?}", r),
+            e = entered_rx.recv() => assert!(e.is_some(), "datanode should be entered"),
+        }
+
+        // Release — the datanode returns error
+        rel_tx.send(()).unwrap();
+
+        let result = do_req.await;
+        assert!(result.is_err(), "insert should fail on datanode error");
+
+        // No flownode mirror should have been dispatched
+        let premature =
+            tokio::time::timeout(std::time::Duration::from_millis(200), flownode_rx.recv()).await;
+        assert!(
+            premature.is_err() || premature.unwrap().is_none(),
+            "flownode mirror must NOT be dispatched on datanode failure"
+        );
+    }
+
+    /// Normal insert with two datanode peers: one succeeds, one fails.
+    /// Only the successful peer's rows are mirrored; final result is error.
+    #[tokio::test]
+    async fn test_normal_insert_partial_peer_success() {
+        let (flownode_tx, mut flownode_rx) = mpsc::unbounded_channel::<()>();
+        let (entered_tx, mut entered_rx) = mpsc::unbounded_channel::<()>();
+
+        let (rel1_tx, rel1_rx) = oneshot::channel();
+        let (rel2_tx, rel2_rx) = oneshot::channel();
+        let err = meta_error::UnexpectedSnafu {
+            err_msg: "mock datanode error",
+        }
+        .build();
+
+        let kv_backend = prepare_mocked_backend().await;
+        let cache = Arc::new(new_table_flownode_set_cache(
+            String::new(),
+            Cache::new(100),
+            kv_backend.clone(),
+        ));
+        populate_flownode_cache(&cache, 1, vec![Peer::new(1, ""), Peer::new(3, "")]).await;
+
+        let flownode_mgr =
+            common_meta::test_util::MockFlownodeManager::new(RecordingFlownodeHandler {
+                tx: flownode_tx,
+            });
+        let datanode_mgr = BlockingDatanodeManager {
+            entered_tx,
+            slots: Arc::new(std::sync::Mutex::new(vec![
+                (rel1_rx, Ok(RegionResponse::new(1))),
+                (rel2_rx, Err(err)),
+            ])),
+        };
+        let node_manager: NodeManagerRef = Arc::new(CombinedNodeManager {
+            datanode_mgr,
+            flownode_mgr,
+        });
+
+        let partition_manager = create_partition_rule_manager(kv_backend).await;
+        let inserter = Inserter::new(
+            catalog::memory::MemoryCatalogManager::new(),
+            partition_manager,
+            node_manager,
+            cache,
+            true,
+        );
+
+        let table_info = make_table_info(1);
+        let mut table_infos = ahash::HashMap::new();
+        table_infos.insert(table_info.table_id(), table_info);
+
+        let normal_requests = RegionInsertRequests {
+            requests: vec![
+                make_region_insert_req(RegionId::new(1, 1)),
+                make_region_insert_req(RegionId::new(1, 3)),
+            ],
+        };
+        let instant_requests = RegionInsertRequests { requests: vec![] };
+        let ctx = Arc::new(QueryContext::with(
+            DEFAULT_CATALOG_NAME,
+            DEFAULT_SCHEMA_NAME,
+        ));
+
+        let do_req = inserter.do_request(
+            InstantAndNormalInsertRequests {
+                normal_requests,
+                instant_requests,
+            },
+            &table_infos,
+            &ctx,
+        );
+        tokio::pin!(do_req);
+
+        // Wait for BOTH datanodes to be entered
+        tokio::select! {
+            r = &mut do_req => panic!("do_req completed too early: {:?}", r),
+            e = entered_rx.recv() => assert!(e.is_some(), "datanode 1 should be entered"),
+        }
+        tokio::select! {
+            r = &mut do_req => panic!("do_req completed too early: {:?}", r),
+            e = entered_rx.recv() => assert!(e.is_some(), "datanode 2 should be entered"),
+        }
+
+        // Release both
+        rel1_tx.send(()).unwrap();
+        rel2_tx.send(()).unwrap();
+
+        let result = do_req.await;
+        assert!(result.is_err(), "insert should fail when one peer fails");
+
+        // The successful peer's mirror should arrive (one per flownode peer
+        // in the cache — we have 2 flownode peers)
+        let mut mirror_count = 0;
+        for _ in 0..2 {
+            tokio::time::timeout(std::time::Duration::from_secs(5), flownode_rx.recv())
+                .await
+                .expect("successful peer's mirror should be dispatched");
+            mirror_count += 1;
+        }
+
+        // No additional mirror for the failed peer
+        let premature =
+            tokio::time::timeout(std::time::Duration::from_millis(200), flownode_rx.recv()).await;
+        assert!(
+            premature.is_err() || premature.unwrap().is_none(),
+            "failed peer's mirror must NOT be dispatched (got {} mirrors from success)",
+            mirror_count
+        );
+    }
+
+    /// Instant-only insert: datanode is never called; mirror is dispatched
+    /// without any source write barrier.
+    #[tokio::test]
+    async fn test_instant_only_insert_no_datanode_write() {
+        let (flownode_tx, mut flownode_rx) = mpsc::unbounded_channel::<()>();
+        let (entered_tx, _entered_rx) = mpsc::unbounded_channel::<()>();
+
+        let kv_backend = prepare_mocked_backend().await;
+        let cache = Arc::new(new_table_flownode_set_cache(
+            String::new(),
+            Cache::new(100),
+            kv_backend.clone(),
+        ));
+        populate_flownode_cache(&cache, 1, vec![Peer::new(1, "")]).await;
+
+        let flownode_mgr =
+            common_meta::test_util::MockFlownodeManager::new(RecordingFlownodeHandler {
+                tx: flownode_tx,
+            });
+        let datanode_mgr = BlockingDatanodeManager {
+            entered_tx,
+            slots: Arc::new(std::sync::Mutex::new(vec![])),
+        };
+        let node_manager: NodeManagerRef = Arc::new(CombinedNodeManager {
+            datanode_mgr,
+            flownode_mgr,
+        });
+
+        let partition_manager = create_partition_rule_manager(kv_backend).await;
+        let inserter = Inserter::new(
+            catalog::memory::MemoryCatalogManager::new(),
+            partition_manager,
+            node_manager,
+            cache,
+            true,
+        );
+
+        let table_info = make_table_info(1);
+        let mut table_infos = ahash::HashMap::new();
+        table_infos.insert(table_info.table_id(), table_info);
+
+        let normal_requests = RegionInsertRequests { requests: vec![] };
+        let instant_requests = RegionInsertRequests {
+            requests: vec![make_region_insert_req(RegionId::new(1, 1))],
+        };
+        let ctx = Arc::new(QueryContext::with(
+            DEFAULT_CATALOG_NAME,
+            DEFAULT_SCHEMA_NAME,
+        ));
+
+        let result = inserter
+            .do_request(
+                InstantAndNormalInsertRequests {
+                    normal_requests,
+                    instant_requests,
+                },
+                &table_infos,
+                &ctx,
+            )
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "instant-only insert should succeed: {:?}",
+            result.err()
+        );
+
+        // Mirror should be dispatched (no datanode barrier)
+        tokio::time::timeout(std::time::Duration::from_secs(5), flownode_rx.recv())
+            .await
+            .expect("instant mirror should be dispatched without datanode write");
+    }
+
+    /// Mixed instant+normal insert: instant mirror dispatched immediately
+    /// (no source barrier), normal mirror waits for datanode success.
+    #[tokio::test]
+    async fn test_mixed_instant_normal_insert() {
+        let (flownode_tx, mut flownode_rx) = mpsc::unbounded_channel::<()>();
+        let (entered_tx, mut entered_rx) = mpsc::unbounded_channel::<()>();
+        let (rel_tx, rel_rx) = oneshot::channel();
+
+        let kv_backend = prepare_mocked_backend().await;
+        let cache = Arc::new(new_table_flownode_set_cache(
+            String::new(),
+            Cache::new(100),
+            kv_backend.clone(),
+        ));
+        populate_flownode_cache(&cache, 1, vec![Peer::new(1, "")]).await;
+
+        let flownode_mgr =
+            common_meta::test_util::MockFlownodeManager::new(RecordingFlownodeHandler {
+                tx: flownode_tx,
+            });
+        let datanode_mgr = BlockingDatanodeManager {
+            entered_tx,
+            slots: Arc::new(std::sync::Mutex::new(vec![(
+                rel_rx,
+                Ok(RegionResponse::new(1)),
+            )])),
+        };
+        let node_manager: NodeManagerRef = Arc::new(CombinedNodeManager {
+            datanode_mgr,
+            flownode_mgr,
+        });
+
+        let partition_manager = create_partition_rule_manager(kv_backend).await;
+        let inserter = Inserter::new(
+            catalog::memory::MemoryCatalogManager::new(),
+            partition_manager,
+            node_manager,
+            cache,
+            true,
+        );
+
+        let table_info = make_table_info(1);
+        let mut table_infos = ahash::HashMap::new();
+        table_infos.insert(table_info.table_id(), table_info);
+
+        let normal_requests = RegionInsertRequests {
+            requests: vec![make_region_insert_req(RegionId::new(1, 1))],
+        };
+        let instant_requests = RegionInsertRequests {
+            requests: vec![make_region_insert_req(RegionId::new(1, 2))],
+        };
+        let ctx = Arc::new(QueryContext::with(
+            DEFAULT_CATALOG_NAME,
+            DEFAULT_SCHEMA_NAME,
+        ));
+
+        let do_req = inserter.do_request(
+            InstantAndNormalInsertRequests {
+                normal_requests,
+                instant_requests,
+            },
+            &table_infos,
+            &ctx,
+        );
+        tokio::pin!(do_req);
+
+        // Drive do_req forward. The instant mirror detach happens first
+        // (after all precompute but before spawning normal writes).
+        // The flownode channel will receive the instant mirror signal.
+        // Then the normal datanode will be entered and block.
+        //
+        // Use select to interleave: we need both the inst mirror AND
+        // the datanode-entered signal.
+        tokio::select! {
+            r = &mut do_req => panic!("do_req completed too early: {:?}", r),
+            msg = flownode_rx.recv() => assert!(msg.is_some(), "instant mirror should be dispatched"),
+        };
+
+        // Now wait for normal datanode to be entered
+        tokio::select! {
+            r = &mut do_req => panic!("do_req completed too early: {:?}", r),
+            e = entered_rx.recv() => assert!(e.is_some(), "datanode should be entered"),
+        }
+
+        // Normal mirror must NOT have arrived yet
+        let premature =
+            tokio::time::timeout(std::time::Duration::from_millis(200), flownode_rx.recv()).await;
+        assert!(
+            premature.is_err() || premature.unwrap().is_none(),
+            "normal mirror must NOT arrive before datanode completes"
+        );
+
+        // Release
+        rel_tx.send(()).unwrap();
+
+        let result = do_req.await;
+        assert!(
+            result.is_ok(),
+            "mixed insert should succeed: {:?}",
+            result.err()
+        );
+
+        // Normal mirror should now arrive
+        tokio::time::timeout(std::time::Duration::from_secs(5), flownode_rx.recv())
+            .await
+            .expect("normal mirror should arrive after datanode success");
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Related to #8409.

## What's changed and what's your intention?

**Draft status:** this PR is not merge-ready. The change fixed the original 100k rows/s 2-minute sinkstress mismatch, but a longer 100k rows/s 5-minute validation still exposed a remaining Flow correctness gap. Keeping this as a draft while investigating the residual race.

This PR fixes one Flow dirty/mirror notification ordering race in the frontend/operator write path.

Previously, normal inserts mirrored source rows to Flow before the corresponding datanode write had succeeded, and bulk inserts marked Flow dirty windows before source writes completed. Under high write pressure, Flow could consume a dirty window while the source rows were not yet visible, clear/advance the dirty state, and miss rows that became visible afterward.

The fix changes the write paths to notify Flow only after source write success:

- normal insert:
  - precomputes all per-peer Flow mirror tasks before spawning any datanode write;
  - delays instant-TTL mirror dispatch until normal mirror precompute succeeds;
  - dispatches each normal peer's mirror only after that peer's datanode write returns `Ok`;
  - preserves partial-success behavior by mirroring successful peers even when another peer fails and the final response is an error.
- bulk insert:
  - precomputes dirty-window notification metadata before source writes, so timestamp/cache errors happen before commit;
  - dispatches dirty notifications only after the successful write boundary;
  - waits for all multi-region write attempts, marks dirty if any region succeeded, then returns the first error if any attempt failed.

Flow notification RPCs remain best-effort/fire-and-forget after source commit, so a committed source write is not reported as failed only because Flow notification fails.

Validation performed:

- `cargo fmt -p operator -- --check`
- `cargo test -p operator`
- `cargo clippy -p operator --all-targets -- -D warnings`
- `git diff --check`
- pre-push hook completed successfully

Live validation with frontend built from this PR and flownode built from #8409:

- 100k rows/s for 2 minutes inserted `12,002,000` rows with 0 client errors.
- After source/flow/sink flushes, source and sink both reported `12,002,000` rows.
- Key/window diff reported 0 mismatched keys and 0 extra sink keys.

Remaining failure under investigation:

- Continuing the same setup at 100k rows/s for 5 minutes inserted another `22,123,000` rows with 0 client errors.
- After source/flow/sink flushes, source reported `34,125,000` rows while sink reported `34,102,000` rows, lagging by `23,000`.
- Key/window diff showed `23,000` mismatched keys, each lagging by exactly 1 row (`max_abs_lag = 1`, no sink extra keys).
- Inserting one sentinel row in the same window and retrying `ADMIN FLUSH_FLOW` repaired the lag, ending at `34,125,001 = 34,125,001`.

Limitations:

- This PR currently addresses only the source-write-before-notify ordering issue. It may still leave a race between asynchronous/best-effort Flow notification delivery and `ADMIN FLUSH_FLOW`/dirty-window/checkpoint handling.
- Bulk insert has focused helper tests for precompute/dispatch behavior. Full `handle_bulk_insert` partial-failure integration tests would require heavier table/FlightData/partition setup and can be added later if needed.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
