### PR TITLE
fix: spawn read operations on query runtime

### DIFF
--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -1781,7 +1781,14 @@ impl RegionServerInner {
         request: QueryRequest,
         query_ctx: QueryContextRef,
     ) -> Result<SendableRecordBatchStream> {
-        let mut stream = self.handle_read_inner(request, query_ctx).await?;
+        let inner = self.clone();
+        let mut stream = common_runtime::spawn_query(async move {
+            inner.handle_read_inner(request, query_ctx).await
+        })
+        .await
+        .context(RuntimeJoinSnafu {
+            request_type: "read",
+        })??;
         let schema = stream.schema();
         let output_ordering = stream.output_ordering().map(|ordering| ordering.to_vec());
 
@@ -1920,7 +1927,6 @@ impl RegionAttribute {
 
 #[cfg(test)]
 mod tests {
-
     use std::assert_matches;
     use std::collections::HashMap;
     use std::sync::Arc;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Fixes #8430

## What's changed and what's your intention?

This PR fixes datanode region reads running part of their query execution on the wrong runtime.

Before this change, `RegionServerInner::handle_read()` called `handle_read_inner()` directly from the request handling runtime. That meant `query_engine.execute()` and DataFusion `plan.execute()` could run on the datanode/global runtime. For multi-partition physical plans, DataFusion operators such as `CoalescePartitionsExec` may spawn internal producer tasks using the current Tokio runtime handle, so those query scan tasks could inherit `global-worker` instead of `query-worker`.

This change wraps `handle_read_inner()` in `common_runtime::spawn_query()` before building the output stream. As a result, `query_engine.execute()` / `plan.execute()` run on the query runtime, and the existing `QueryRuntimeStream` producer continues polling the returned stream on the query runtime.

User/developer impact:

- Region scan query execution is driven by the datanode query runtime.
- DataFusion internal tasks created while building/executing the physical stream inherit the query runtime instead of the global runtime.
- No API, wire format, schema, or persisted data format changes.

Validation:

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p datanode`

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
