### PR TITLE
feat(json2): encode json2 variant payloads as jsonb

### DIFF
--- a/src/datatypes/src/error.rs
+++ b/src/datatypes/src/error.rs
@@ -264,13 +264,6 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Invalid json value, {}", msg))]
-    InvalidJsonValue {
-        msg: String,
-        #[snafu(implicit)]
-        location: Location,
-    },
-
     #[snafu(display("Failed to merge JSON datatype: {reason}"))]
     MergeJsonDatatype {
         reason: String,
@@ -329,7 +322,6 @@ impl ErrorExt for Error {
             | InvalidVector { .. }
             | InvalidFulltextOption { .. }
             | InvalidSkippingIndexOption { .. }
-            | InvalidJsonValue { .. }
             | MergeJsonDatatype { .. } => StatusCode::InvalidArguments,
 
             ValueExceedsPrecision { .. }

--- a/src/datatypes/src/error.rs
+++ b/src/datatypes/src/error.rs
@@ -234,18 +234,21 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+
     #[snafu(display("Invalid fulltext option: {}", msg))]
     InvalidFulltextOption {
         msg: String,
         #[snafu(implicit)]
         location: Location,
     },
+
     #[snafu(display("Invalid skipping index option: {}", msg))]
     InvalidSkippingIndexOption {
         msg: String,
         #[snafu(implicit)]
         location: Location,
     },
+
     #[snafu(display("Inconsistent struct field count {field_len} and item count {item_len}"))]
     InconsistentStructFieldsAndItems {
         field_len: usize,
@@ -253,9 +256,17 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+
     #[snafu(display("Failed to process JSONB value"))]
     InvalidJsonb {
         error: jsonb::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Invalid json value, {}", msg))]
+    InvalidJsonValue {
+        msg: String,
         #[snafu(implicit)]
         location: Location,
     },
@@ -318,6 +329,7 @@ impl ErrorExt for Error {
             | InvalidVector { .. }
             | InvalidFulltextOption { .. }
             | InvalidSkippingIndexOption { .. }
+            | InvalidJsonValue { .. }
             | MergeJsonDatatype { .. } => StatusCode::InvalidArguments,
 
             ValueExceedsPrecision { .. }

--- a/src/datatypes/src/json/value.rs
+++ b/src/datatypes/src/json/value.rs
@@ -25,7 +25,7 @@ use snafu::{OptionExt, ensure};
 
 use crate::Result;
 use crate::data_type::ConcreteDataType;
-use crate::error::{AlignJsonValueSnafu, InvalidJsonValueSnafu, InvalidJsonbSnafu};
+use crate::error::{AlignJsonValueSnafu, InvalidJsonSnafu, InvalidJsonbSnafu};
 use crate::types::json_type::{JsonNativeType, JsonNumberType};
 use crate::types::{JsonType, StructField, StructType};
 use crate::value::{ListValue, ListValueRef, StructValue, StructValueRef, Value, ValueRef};
@@ -559,10 +559,10 @@ impl TryFrom<JsonValue> for serde_json::Value {
 }
 
 pub(crate) fn encode_json_variant(value: JsonVariant) -> Result<Vec<u8>> {
-    if let JsonVariant::Variant(bytes) = &value {
-        return Ok(bytes.clone());
+    match value {
+        JsonVariant::Variant(bytes) => Ok(bytes),
+        value => jsonb::Value::try_from(value).map(|value| value.to_vec()),
     }
-    jsonb::Value::try_from(value).map(|value| value.to_vec())
 }
 
 pub(crate) fn decode_json_variant(
@@ -596,7 +596,6 @@ impl TryFrom<JsonVariant> for jsonb::Value<'static> {
                     .map(|(key, value)| jsonb::Value::try_from(value).map(|value| (key, value)))
                     .collect::<Result<_>>()?,
             ),
-            // This branch should be unreachable.
             JsonVariant::Variant(value) => {
                 let value = decode_json_variant(&value)
                     .map_err(|error| InvalidJsonbSnafu { error }.build())?;
@@ -616,8 +615,8 @@ impl TryFrom<JsonNumber> for jsonb::Number {
             JsonNumber::Float(value) => {
                 ensure!(
                     !value.0.is_nan(),
-                    InvalidJsonValueSnafu {
-                        msg: "NaN is not a valid JSON number"
+                    InvalidJsonSnafu {
+                        value: "NaN is not a valid JSON number"
                     }
                 );
                 jsonb::Number::Float64(value.0)
@@ -1054,7 +1053,7 @@ mod tests {
             .unwrap_err();
         assert_eq!(
             err.to_string(),
-            "Invalid json value, NaN is not a valid JSON number"
+            "Invalid JSON: NaN is not a valid JSON number"
         );
 
         Ok(())

--- a/src/datatypes/src/json/value.rs
+++ b/src/datatypes/src/json/value.rs
@@ -283,13 +283,10 @@ impl Display for JsonVariant {
                         .join(", ")
                 )
             }
-            Self::Variant(x) => {
-                let result: serde_json::Result<serde_json::Value> = serde_json::from_slice(x);
-                match result {
-                    Ok(v) => write!(f, "{v}"),
-                    Err(_) => write!(f, "{x:?}"),
-                }
-            }
+            Self::Variant(x) => match decode_json_variant(x) {
+                Ok(v) => write!(f, "{v}"),
+                Err(_) => write!(f, "{x:?}"),
+            },
         }
     }
 }
@@ -486,9 +483,7 @@ impl JsonValue {
                 (v, JsonNativeType::Variant) => {
                     let json: serde_json::Value =
                         JsonValue::new(v).try_into().context(SerializeSnafu)?;
-                    serde_json::to_vec(&json)
-                        .map(JsonVariant::Variant)
-                        .context(SerializeSnafu)?
+                    JsonVariant::Variant(encode_json_variant(json))
                 }
 
                 (value, expected) => {
@@ -555,11 +550,26 @@ impl TryFrom<JsonValue> for serde_json::Value {
                     }
                     serde_json::Value::Object(map)
                 }
-                JsonVariant::Variant(x) => serde_json::from_slice(&x)?,
+                JsonVariant::Variant(x) => decode_json_variant(&x).map_err(|err| {
+                    serde_json::Error::io(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        err.to_string(),
+                    ))
+                })?,
             })
         }
         helper(v.json_variant)
     }
+}
+
+pub(crate) fn encode_json_variant(value: serde_json::Value) -> Vec<u8> {
+    jsonb::Value::from(value).to_vec()
+}
+
+pub(crate) fn decode_json_variant(
+    bytes: &[u8],
+) -> std::result::Result<serde_json::Value, jsonb::Error> {
+    jsonb::from_slice(bytes).map(Into::into)
 }
 
 impl Clone for JsonValue {
@@ -890,6 +900,10 @@ mod tests {
     use super::*;
     use crate::types::json_type::JsonObjectType;
 
+    fn jsonb_bytes(json: &str) -> Vec<u8> {
+        jsonb::parse_value(json.as_bytes()).unwrap().to_vec()
+    }
+
     #[test]
     fn test_align_json_value() -> Result<()> {
         fn parse_json_value(json: &str) -> JsonValue {
@@ -935,7 +949,7 @@ mod tests {
                         ("note".to_string(), JsonVariant::Null),
                         (
                             "payload".to_string(),
-                            JsonVariant::Variant(br#"{"k":"v"}"#.to_vec()),
+                            JsonVariant::Variant(jsonb_bytes(r#"{"k":"v"}"#)),
                         ),
                     ]))]),
                 ),
@@ -964,7 +978,9 @@ mod tests {
         value.try_align(&JsonType::new_json2(JsonNativeType::Variant))?;
         assert_eq!(
             value,
-            JsonValue::from(JsonVariant::Variant(br#"{"foo":[1,true,null]}"#.to_vec()))
+            JsonValue::from(JsonVariant::Variant(jsonb_bytes(
+                r#"{"foo":[1,true,null]}"#
+            )))
         );
 
         // Incompatible scalar alignment should fail instead of coercing the value.

--- a/src/datatypes/src/json/value.rs
+++ b/src/datatypes/src/json/value.rs
@@ -25,7 +25,7 @@ use snafu::{OptionExt, ResultExt, ensure};
 
 use crate::Result;
 use crate::data_type::ConcreteDataType;
-use crate::error::{AlignJsonValueSnafu, InvalidJsonbSnafu};
+use crate::error::{AlignJsonValueSnafu, InvalidJsonValueSnafu, InvalidJsonbSnafu};
 use crate::types::json_type::{JsonNativeType, JsonNumberType};
 use crate::types::{JsonType, StructField, StructType};
 use crate::value::{ListValue, ListValueRef, StructValue, StructValueRef, Value, ValueRef};
@@ -546,12 +546,9 @@ impl TryFrom<JsonValue> for serde_json::Value {
                     }
                     serde_json::Value::Object(map)
                 }
-                JsonVariant::Variant(x) => decode_json_variant(&x).map_err(|err| {
-                    serde_json::Error::io(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        err.to_string(),
-                    ))
-                })?,
+                JsonVariant::Variant(x) => {
+                    decode_json_variant(&x).map_err(|e| InvalidJsonbSnafu { error: e }.build())?
+                }
             })
         }
         helper(v.json_variant)
@@ -559,17 +556,20 @@ impl TryFrom<JsonValue> for serde_json::Value {
 }
 
 pub(crate) fn encode_json_variant(value: JsonVariant) -> Result<Vec<u8>> {
+    if let JsonVariant::Variant(bytes) = &value {
+        return Ok(bytes.clone());
+    }
     jsonb::Value::try_from(value).map(|value| value.to_vec())
-}
-
-pub(crate) fn encode_serde_json_as_jsonb(value: serde_json::Value) -> Vec<u8> {
-    jsonb::Value::from(value).to_vec()
 }
 
 pub(crate) fn decode_json_variant(
     bytes: &[u8],
 ) -> std::result::Result<serde_json::Value, jsonb::Error> {
     jsonb::from_slice(bytes).map(Into::into)
+}
+
+pub(crate) fn encode_serde_json_as_jsonb(value: serde_json::Value) -> Vec<u8> {
+    jsonb::Value::from(value).to_vec()
 }
 
 impl TryFrom<JsonVariant> for jsonb::Value<'static> {
@@ -579,10 +579,7 @@ impl TryFrom<JsonVariant> for jsonb::Value<'static> {
         Ok(match value {
             JsonVariant::Null => jsonb::Value::Null,
             JsonVariant::Bool(value) => jsonb::Value::Bool(value),
-            JsonVariant::Number(value) => match value {
-                JsonNumber::Float(value) if value.0.is_nan() => jsonb::Value::String("NaN".into()),
-                value => jsonb::Value::Number(value.into()),
-            },
+            JsonVariant::Number(value) => jsonb::Value::Number(value.try_into()?),
             JsonVariant::String(value) => jsonb::Value::String(value.into()),
             JsonVariant::Array(values) => jsonb::Value::Array(
                 values
@@ -596,6 +593,7 @@ impl TryFrom<JsonVariant> for jsonb::Value<'static> {
                     .map(|(key, value)| jsonb::Value::try_from(value).map(|value| (key, value)))
                     .collect::<Result<_>>()?,
             ),
+            // This branch should be unreachable.
             JsonVariant::Variant(value) => {
                 let value = decode_json_variant(&value)
                     .map_err(|error| InvalidJsonbSnafu { error }.build())?;
@@ -605,16 +603,23 @@ impl TryFrom<JsonVariant> for jsonb::Value<'static> {
     }
 }
 
-impl From<JsonNumber> for jsonb::Number {
-    fn from(value: JsonNumber) -> Self {
-        match value {
+impl TryFrom<JsonNumber> for jsonb::Number {
+    type Error = crate::Error;
+
+    fn try_from(value: JsonNumber) -> Result<Self> {
+        Ok(match value {
             JsonNumber::PosInt(value) => jsonb::Number::UInt64(value),
             JsonNumber::NegInt(value) => jsonb::Number::Int64(value),
             JsonNumber::Float(value) => {
-                debug_assert!(!value.0.is_nan());
+                ensure!(
+                    !value.0.is_nan(),
+                    InvalidJsonValueSnafu {
+                        msg: "NaN is not a valid JSON number"
+                    }
+                );
                 jsonb::Number::Float64(value.0)
             }
-        }
+        })
     }
 }
 
@@ -1038,6 +1043,15 @@ mod tests {
         assert_eq!(
             err.to_string(),
             r#"Failed to align JSON value, reason: unable to align 'hello' of type "<String>" to type "<Bool>""#
+        );
+
+        let mut value = JsonValue::from(f64::NAN);
+        let err = value
+            .try_align(&JsonType::new_json2(JsonNativeType::Variant))
+            .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Failed to align JSON value, reason: NaN is not a valid JSON number"
         );
 
         Ok(())

--- a/src/datatypes/src/json/value.rs
+++ b/src/datatypes/src/json/value.rs
@@ -25,7 +25,7 @@ use snafu::{OptionExt, ResultExt, ensure};
 
 use crate::Result;
 use crate::data_type::ConcreteDataType;
-use crate::error::{AlignJsonValueSnafu, SerializeSnafu};
+use crate::error::{AlignJsonValueSnafu, InvalidJsonbSnafu};
 use crate::types::json_type::{JsonNativeType, JsonNumberType};
 use crate::types::{JsonType, StructField, StructType};
 use crate::value::{ListValue, ListValueRef, StructValue, StructValueRef, Value, ValueRef};
@@ -480,11 +480,7 @@ impl JsonValue {
                     JsonVariant::Object(object)
                 }
 
-                (v, JsonNativeType::Variant) => {
-                    let json: serde_json::Value =
-                        JsonValue::new(v).try_into().context(SerializeSnafu)?;
-                    JsonVariant::Variant(encode_json_variant(json))
-                }
+                (v, JsonNativeType::Variant) => JsonVariant::Variant(encode_json_variant(v)?),
 
                 (value, expected) => {
                     return AlignJsonValueSnafu {
@@ -562,7 +558,11 @@ impl TryFrom<JsonValue> for serde_json::Value {
     }
 }
 
-pub(crate) fn encode_json_variant(value: serde_json::Value) -> Vec<u8> {
+pub(crate) fn encode_json_variant(value: JsonVariant) -> Result<Vec<u8>> {
+    jsonb::Value::try_from(value).map(|value| value.to_vec())
+}
+
+pub(crate) fn encode_serde_json_as_jsonb(value: serde_json::Value) -> Vec<u8> {
     jsonb::Value::from(value).to_vec()
 }
 
@@ -570,6 +570,52 @@ pub(crate) fn decode_json_variant(
     bytes: &[u8],
 ) -> std::result::Result<serde_json::Value, jsonb::Error> {
     jsonb::from_slice(bytes).map(Into::into)
+}
+
+impl TryFrom<JsonVariant> for jsonb::Value<'static> {
+    type Error = crate::Error;
+
+    fn try_from(value: JsonVariant) -> Result<Self> {
+        Ok(match value {
+            JsonVariant::Null => jsonb::Value::Null,
+            JsonVariant::Bool(value) => jsonb::Value::Bool(value),
+            JsonVariant::Number(value) => match value {
+                JsonNumber::Float(value) if value.0.is_nan() => jsonb::Value::String("NaN".into()),
+                value => jsonb::Value::Number(value.into()),
+            },
+            JsonVariant::String(value) => jsonb::Value::String(value.into()),
+            JsonVariant::Array(values) => jsonb::Value::Array(
+                values
+                    .into_iter()
+                    .map(jsonb::Value::try_from)
+                    .collect::<Result<_>>()?,
+            ),
+            JsonVariant::Object(values) => jsonb::Value::Object(
+                values
+                    .into_iter()
+                    .map(|(key, value)| jsonb::Value::try_from(value).map(|value| (key, value)))
+                    .collect::<Result<_>>()?,
+            ),
+            JsonVariant::Variant(value) => {
+                let value = decode_json_variant(&value)
+                    .map_err(|error| InvalidJsonbSnafu { error }.build())?;
+                jsonb::Value::from(value)
+            }
+        })
+    }
+}
+
+impl From<JsonNumber> for jsonb::Number {
+    fn from(value: JsonNumber) -> Self {
+        match value {
+            JsonNumber::PosInt(value) => jsonb::Number::UInt64(value),
+            JsonNumber::NegInt(value) => jsonb::Number::Int64(value),
+            JsonNumber::Float(value) => {
+                debug_assert!(!value.0.is_nan());
+                jsonb::Number::Float64(value.0)
+            }
+        }
+    }
 }
 
 impl Clone for JsonValue {
@@ -901,7 +947,8 @@ mod tests {
     use crate::types::json_type::JsonObjectType;
 
     fn jsonb_bytes(json: &str) -> Vec<u8> {
-        jsonb::parse_value(json.as_bytes()).unwrap().to_vec()
+        let value: serde_json::Value = serde_json::from_str(json).unwrap();
+        encode_json_variant(value.into()).unwrap()
     }
 
     #[test]

--- a/src/datatypes/src/json/value.rs
+++ b/src/datatypes/src/json/value.rs
@@ -1054,7 +1054,7 @@ mod tests {
             .unwrap_err();
         assert_eq!(
             err.to_string(),
-            "Failed to align JSON value, reason: NaN is not a valid JSON number"
+            "Invalid json value, NaN is not a valid JSON number"
         );
 
         Ok(())

--- a/src/datatypes/src/json/value.rs
+++ b/src/datatypes/src/json/value.rs
@@ -21,7 +21,7 @@ use num_traits::ToPrimitive;
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 use serde_json::Number;
-use snafu::{OptionExt, ResultExt, ensure};
+use snafu::{OptionExt, ensure};
 
 use crate::Result;
 use crate::data_type::ConcreteDataType;
@@ -546,9 +546,12 @@ impl TryFrom<JsonValue> for serde_json::Value {
                     }
                     serde_json::Value::Object(map)
                 }
-                JsonVariant::Variant(x) => {
-                    decode_json_variant(&x).map_err(|e| InvalidJsonbSnafu { error: e }.build())?
-                }
+                JsonVariant::Variant(x) => decode_json_variant(&x).map_err(|err| {
+                    serde_json::Error::io(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        err.to_string(),
+                    ))
+                })?,
             })
         }
         helper(v.json_variant)

--- a/src/datatypes/src/vectors/json/array.rs
+++ b/src/datatypes/src/vectors/json/array.rs
@@ -35,7 +35,7 @@ use crate::error::{
     AlignJsonArraySnafu, ArrowComputeSnafu, CastTypeSnafu, InvalidJsonSnafu, InvalidJsonbSnafu,
     Result,
 };
-use crate::json::value::{decode_json_variant, encode_json_variant};
+use crate::json::value::{decode_json_variant, encode_serde_json_as_jsonb};
 
 pub struct JsonArray<'a> {
     inner: &'a ArrayRef,
@@ -229,7 +229,7 @@ impl JsonArray<'_> {
             if value.is_null() {
                 encoded.push(None);
             } else {
-                let bytes = encode_json_variant(value);
+                let bytes = encode_serde_json_as_jsonb(value);
                 total_bytes += bytes.len();
                 encoded.push(Some(bytes));
             }

--- a/src/datatypes/src/vectors/json/array.rs
+++ b/src/datatypes/src/vectors/json/array.rs
@@ -32,9 +32,10 @@ use crate::arrow_array::{
     MutableBinaryArray, StringViewArray, binary_array_value, string_array_value,
 };
 use crate::error::{
-    AlignJsonArraySnafu, ArrowComputeSnafu, CastTypeSnafu, DeserializeSnafu, InvalidJsonSnafu,
-    Result, SerializeSnafu,
+    AlignJsonArraySnafu, ArrowComputeSnafu, CastTypeSnafu, InvalidJsonSnafu, InvalidJsonbSnafu,
+    Result,
 };
+use crate::json::value::{decode_json_variant, encode_json_variant};
 
 pub struct JsonArray<'a> {
     inner: &'a ArrayRef,
@@ -59,9 +60,7 @@ impl JsonArray<'_> {
             }
             DataType::Binary | DataType::LargeBinary | DataType::BinaryView => {
                 let bytes = binary_array_value(array, i);
-                serde_json::from_slice(bytes).with_context(|_| DeserializeSnafu {
-                    json: String::from_utf8_lossy(bytes),
-                })?
+                decode_json_variant(bytes).map_err(|error| InvalidJsonbSnafu { error }.build())?
             }
             DataType::Struct(_) => {
                 let structs = array.as_struct();
@@ -230,7 +229,7 @@ impl JsonArray<'_> {
             if value.is_null() {
                 encoded.push(None);
             } else {
-                let bytes = serde_json::to_vec(&value).context(SerializeSnafu)?;
+                let bytes = encode_json_variant(value);
                 total_bytes += bytes.len();
                 encoded.push(Some(bytes));
             }
@@ -368,10 +367,12 @@ mod test {
         assert_eq!(JsonArray::from(&strings).try_get_value(0)?, json!("hello"));
         assert_eq!(JsonArray::from(&strings).try_get_value(1)?, Value::Null);
 
-        let binaries: ArrayRef = Arc::new(BinaryArray::from(vec![
-            br#"{"nested":[1,null,"x"]}"#.as_slice(),
-            b"null".as_slice(),
-        ]));
+        let nested = jsonb::parse_value(br#"{"nested":[1,null,"x"]}"#)
+            .unwrap()
+            .to_vec();
+        let null = jsonb::parse_value(b"null").unwrap().to_vec();
+        let binaries: ArrayRef =
+            Arc::new(BinaryArray::from(vec![nested.as_slice(), null.as_slice()]));
         assert_eq!(
             JsonArray::from(&binaries).try_get_value(0)?,
             json!({"nested": [1, null, "x"]})

--- a/src/datatypes/src/vectors/json/builder.rs
+++ b/src/datatypes/src/vectors/json/builder.rs
@@ -128,7 +128,6 @@ mod tests {
 
     use super::*;
     use crate::data_type::ConcreteDataType;
-    use crate::json::value::encode_json_variant;
     use crate::types::json_type::JsonObjectType;
     use crate::value::{StructValue, Value, ValueRef};
 
@@ -140,8 +139,7 @@ mod tests {
         }
 
         fn jsonb_bytes(json: &str) -> Bytes {
-            let value: serde_json::Value = serde_json::from_str(json).unwrap();
-            Bytes::from(encode_json_variant(value))
+            Bytes::from(jsonb::parse_value(json.as_bytes()).unwrap().to_vec())
         }
 
         // Object inputs should merge into a superset schema, preserve null rows,

--- a/src/datatypes/src/vectors/json/builder.rs
+++ b/src/datatypes/src/vectors/json/builder.rs
@@ -128,6 +128,7 @@ mod tests {
 
     use super::*;
     use crate::data_type::ConcreteDataType;
+    use crate::json::value::encode_json_variant;
     use crate::types::json_type::JsonObjectType;
     use crate::value::{StructValue, Value, ValueRef};
 
@@ -136,6 +137,11 @@ mod tests {
         fn parse_json_value(json: &str) -> Value {
             let value: serde_json::Value = serde_json::from_str(json).unwrap();
             Value::Json(Box::new(value.into()))
+        }
+
+        fn jsonb_bytes(json: &str) -> Bytes {
+            let value: serde_json::Value = serde_json::from_str(json).unwrap();
+            Bytes::from(encode_json_variant(value))
         }
 
         // Object inputs should merge into a superset schema, preserve null rows,
@@ -166,7 +172,7 @@ mod tests {
                 vec![
                     Value::Null,
                     Value::Int64(1),
-                    Value::Binary(Bytes::from(br#"{"name":"foo"}"#.to_vec())),
+                    Value::Binary(jsonb_bytes(r#"{"name":"foo"}"#)),
                 ],
                 merged_struct_type.clone(),
             ))
@@ -178,7 +184,7 @@ mod tests {
                 vec![
                     Value::Boolean(true),
                     Value::Int64(2),
-                    Value::Binary(Bytes::from(br#""raw""#.to_vec())),
+                    Value::Binary(jsonb_bytes(r#""raw""#)),
                 ],
                 merged_struct_type,
             ))


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This pr encode JSON2 `Variant` payloads as JSONB binary instead of serde JSON bytes.

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
