### PR TITLE
chore(ci): stabilize remote wal fuzz tests

### DIFF
--- a/.github/actions/setup-greptimedb-cluster/with-remote-wal.yaml
+++ b/.github/actions/setup-greptimedb-cluster/with-remote-wal.yaml
@@ -11,6 +11,8 @@ meta:
     [wal]
     provider = "kafka"
     broker_endpoints = ["kafka.kafka-cluster.svc.cluster.local:9092"]
+    connect_timeout = "10s"
+    timeout = "10s"
     num_topics = 3
     auto_prune_interval = "30s"
     trigger_flush_threshold = 100
@@ -27,6 +29,8 @@ datanode:
     [wal]
     provider = "kafka"
     broker_endpoints = ["kafka.kafka-cluster.svc.cluster.local:9092"]
+    connect_timeout = "10s"
+    timeout = "10s"
     overwrite_entry_start_id = true
 frontend:
   configData: |-


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR stabilizes Remote WAL fuzz tests by increasing the Kafka client `connect_timeout` and request `timeout` from the default 3s to 10s in the CI test deployment.

The Remote WAL fuzz tests run GreptimeDB, Kafka, etcd, and MinIO in a kind cluster on GitHub Actions. Kafka pods can become Ready before DNS, broker listeners, or partition leader connections are fully stable. A 3s Kafka client deadline is too aggressive in this CI environment and can make fuzz tests fail before exercising the target logic.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
