### PR TITLE
fix: collect lightweight query-load metrics

### DIFF
--- a/src/common/recordbatch/src/adapter.rs
+++ b/src/common/recordbatch/src/adapter.rs
@@ -287,11 +287,11 @@ impl RecordBatchStreamAdapter {
 
         match &self.metrics_2 {
             Metrics::Unresolved(df_plan) | Metrics::PartialResolved(df_plan, _) => {
-                let mut metric_collector = MetricCollector::new(self.explain_verbose);
-                accept(df_plan.as_ref(), &mut metric_collector).unwrap();
-                metric_collector.record_batch_metrics.query_load_region_id =
-                    self.query_load_region_id;
-                record_query_stats(counters, &metric_collector.record_batch_metrics);
+                let metrics = collect_lightweight_query_load_metrics(
+                    df_plan.as_ref(),
+                    self.query_load_region_id,
+                );
+                record_query_stats(counters, &metrics);
             }
             Metrics::Resolved(metrics) => record_query_stats(counters, metrics),
             Metrics::Unavailable => {}
@@ -330,6 +330,83 @@ fn record_query_stats(counters: &RegionQueryStatCounters, metrics: &RecordBatchM
     counters
         .query_scanned_bytes
         .fetch_add(region_scan_output_bytes(metrics) as u64, Ordering::Relaxed);
+}
+
+/// Collects the complete plan metrics used by terminal metrics and verbose analyze output.
+fn collect_full_metrics(
+    df_plan: &dyn ExecutionPlan,
+    explain_verbose: bool,
+    query_load_region_id: Option<u64>,
+) -> RecordBatchMetrics {
+    let mut metric_collector = MetricCollector::new(explain_verbose);
+    accept(df_plan, &mut metric_collector).unwrap();
+    metric_collector.record_batch_metrics.query_load_region_id = query_load_region_id;
+    metric_collector.record_batch_metrics
+}
+
+/// Collects the minimal metrics needed for query-load reporting before EOF.
+///
+/// This intentionally avoids [`MetricCollector`]'s full per-plan aggregation,
+/// sorting, and plan formatting work on the normal query hot path. The result
+/// is still enough for early-stop/cancellation paths to report per-region CPU
+/// time, scanned bytes, and physical-region attribution.
+fn collect_lightweight_query_load_metrics(
+    df_plan: &dyn ExecutionPlan,
+    query_load_region_id: Option<u64>,
+) -> RecordBatchMetrics {
+    let mut metrics = RecordBatchMetrics {
+        query_load_region_id,
+        ..Default::default()
+    };
+    collect_lightweight_query_load_metrics_inner(df_plan, 0, &mut metrics);
+    metrics
+}
+
+/// Recursively walks the physical plan and reads raw metric values without
+/// formatting plan nodes.
+fn collect_lightweight_query_load_metrics_inner(
+    df_plan: &dyn ExecutionPlan,
+    level: usize,
+    record_batch_metrics: &mut RecordBatchMetrics,
+) {
+    let is_region_scan = df_plan.name() == REGION_SCAN_EXEC_NAME;
+    let mut region_scan_output_bytes = None;
+
+    if let Some(metrics) = df_plan.metrics() {
+        for metric in metrics.iter() {
+            let value = metric.value();
+            match value {
+                MetricValue::ElapsedCompute(elapsed_compute) => {
+                    record_batch_metrics.elapsed_compute += elapsed_compute.value();
+                }
+                MetricValue::CurrentMemoryUsage(memory_usage) => {
+                    record_batch_metrics.memory_usage += memory_usage.value();
+                }
+                _ => {}
+            }
+
+            if is_region_scan && value.name() == "output_bytes" {
+                *region_scan_output_bytes.get_or_insert(0) += value.as_usize();
+            }
+        }
+    }
+
+    if let Some(output_bytes) = region_scan_output_bytes {
+        record_batch_metrics.plan_metrics.push(PlanMetrics {
+            plan: df_plan.name().to_string(),
+            plan_name: df_plan.name().to_string(),
+            level,
+            metrics: vec![("output_bytes".to_string(), output_bytes)],
+        });
+    }
+
+    for child in df_plan.children() {
+        collect_lightweight_query_load_metrics_inner(
+            child.as_ref(),
+            level + 1,
+            record_batch_metrics,
+        );
+    }
 }
 
 impl RecordBatchStream for RecordBatchStreamAdapter {
@@ -371,17 +448,30 @@ impl Stream for RecordBatchStreamAdapter {
             Poll::Pending => Poll::Pending,
             Poll::Ready(Some(df_record_batch)) => {
                 let df_record_batch = df_record_batch?;
-                if let Metrics::Unresolved(df_plan) | Metrics::PartialResolved(df_plan, _) =
+                // Verbose analyze streams need complete partial metrics. Normal
+                // queries only need query-load metrics before EOF so early
+                // stop/cancellation can still report per-region load.
+                if self.explain_verbose {
+                    if let Metrics::Unresolved(df_plan) | Metrics::PartialResolved(df_plan, _) =
+                        &self.metrics_2
+                    {
+                        let record_batch_metrics = collect_full_metrics(
+                            df_plan.as_ref(),
+                            self.explain_verbose,
+                            self.query_load_region_id,
+                        );
+                        self.metrics_2 =
+                            Metrics::PartialResolved(df_plan.clone(), record_batch_metrics);
+                    }
+                } else if let Metrics::Unresolved(df_plan) | Metrics::PartialResolved(df_plan, _) =
                     &self.metrics_2
                 {
-                    let mut metric_collector = MetricCollector::new(self.explain_verbose);
-                    accept(df_plan.as_ref(), &mut metric_collector).unwrap();
-                    metric_collector.record_batch_metrics.query_load_region_id =
-                        self.query_load_region_id;
-                    self.metrics_2 = Metrics::PartialResolved(
-                        df_plan.clone(),
-                        metric_collector.record_batch_metrics,
+                    let record_batch_metrics = collect_lightweight_query_load_metrics(
+                        df_plan.as_ref(),
+                        self.query_load_region_id,
                     );
+                    self.metrics_2 =
+                        Metrics::PartialResolved(df_plan.clone(), record_batch_metrics);
                 }
                 Poll::Ready(Some(Ok(RecordBatch::from_df_record_batch(
                     self.schema(),
@@ -392,11 +482,12 @@ impl Stream for RecordBatchStreamAdapter {
                 if let Metrics::Unresolved(df_plan) | Metrics::PartialResolved(df_plan, _) =
                     &self.metrics_2
                 {
-                    let mut metric_collector = MetricCollector::new(self.explain_verbose);
-                    accept(df_plan.as_ref(), &mut metric_collector).unwrap();
-                    metric_collector.record_batch_metrics.query_load_region_id =
-                        self.query_load_region_id;
-                    self.metrics_2 = Metrics::Resolved(metric_collector.record_batch_metrics);
+                    let record_batch_metrics = collect_full_metrics(
+                        df_plan.as_ref(),
+                        self.explain_verbose,
+                        self.query_load_region_id,
+                    );
+                    self.metrics_2 = Metrics::Resolved(record_batch_metrics);
                 }
                 Poll::Ready(None)
             }
@@ -800,21 +891,220 @@ fn convert_map_to_json_binary(
 
 #[cfg(test)]
 mod test {
+    use std::any::Any;
+    use std::time::Duration;
+
     use common_error::ext::BoxedError;
     use common_error::mock::MockError;
     use common_error::status_code::StatusCode;
+    use datafusion::execution::TaskContext;
+    use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
+    use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+    use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricBuilder, MetricsSet};
+    use datafusion::physical_plan::{DisplayAs, PlanProperties};
     use datatypes::arrow::array::{ArrayRef, MapArray, StringArray, StructArray};
     use datatypes::arrow::buffer::OffsetBuffer;
     use datatypes::arrow::datatypes::Field;
     use datatypes::prelude::ConcreteDataType;
     use datatypes::schema::ColumnSchema;
     use datatypes::vectors::Int32Vector;
+    use futures::StreamExt;
     use serde_json::json;
     use snafu::IntoError;
 
     use super::*;
     use crate::RecordBatches;
     use crate::error::Error;
+
+    #[derive(Debug)]
+    struct TestMetricsExec {
+        properties: Arc<PlanProperties>,
+        metrics: ExecutionPlanMetricsSet,
+    }
+
+    impl TestMetricsExec {
+        fn new(schema: DfSchemaRef) -> Self {
+            Self::with_output_bytes(schema, &[24])
+        }
+
+        fn with_output_bytes(schema: DfSchemaRef, output_bytes_by_partition: &[usize]) -> Self {
+            let metrics = ExecutionPlanMetricsSet::new();
+            let elapsed_compute = MetricBuilder::new(&metrics).elapsed_compute(0);
+            elapsed_compute.add_duration(Duration::from_nanos(42));
+            for (partition, output_bytes) in output_bytes_by_partition.iter().copied().enumerate() {
+                let metric = MetricBuilder::new(&metrics).output_bytes(partition);
+                metric.add(output_bytes);
+            }
+
+            Self {
+                properties: Arc::new(PlanProperties::new(
+                    EquivalenceProperties::new(schema),
+                    Partitioning::UnknownPartitioning(output_bytes_by_partition.len().max(1)),
+                    EmissionType::Incremental,
+                    Boundedness::Bounded,
+                )),
+                metrics,
+            }
+        }
+    }
+
+    impl DisplayAs for TestMetricsExec {
+        fn fmt_as(&self, _t: DisplayFormatType, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            panic!("non-verbose lightweight partial metrics must not format the plan")
+        }
+    }
+
+    impl ExecutionPlan for TestMetricsExec {
+        fn name(&self) -> &str {
+            REGION_SCAN_EXEC_NAME
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn properties(&self) -> &Arc<PlanProperties> {
+            &self.properties
+        }
+
+        fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+            vec![]
+        }
+
+        fn with_new_children(
+            self: Arc<Self>,
+            _children: Vec<Arc<dyn ExecutionPlan>>,
+        ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
+            Ok(self)
+        }
+
+        fn execute(
+            &self,
+            _partition: usize,
+            _context: Arc<TaskContext>,
+        ) -> datafusion_common::Result<DfSendableRecordBatchStream> {
+            unreachable!("the test passes a separate stream to RecordBatchStreamAdapter")
+        }
+
+        fn metrics(&self) -> Option<MetricsSet> {
+            Some(self.metrics.clone_inner())
+        }
+    }
+
+    #[test]
+    fn test_lightweight_query_load_metrics_sums_region_scan_output_bytes() {
+        let schema = Arc::new(Schema::new(vec![ColumnSchema::new(
+            "a",
+            ConcreteDataType::int32_datatype(),
+            false,
+        )]));
+        let plan = TestMetricsExec::with_output_bytes(schema.arrow_schema().clone(), &[24, 18]);
+
+        let metrics = collect_lightweight_query_load_metrics(&plan, Some(42));
+
+        assert_eq!(metrics.query_load_region_id, Some(42));
+        assert_eq!(region_scan_output_bytes(&metrics), 42);
+        assert_eq!(metrics.plan_metrics.len(), 1);
+        assert_eq!(
+            metrics.plan_metrics[0].metrics,
+            vec![("output_bytes".to_string(), 42)]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_record_batch_stream_adapter_collects_lightweight_partial_metrics() {
+        let schema = Arc::new(Schema::new(vec![ColumnSchema::new(
+            "a",
+            ConcreteDataType::int32_datatype(),
+            false,
+        )]));
+        let batch1 = RecordBatch::new(
+            schema.clone(),
+            vec![Arc::new(Int32Vector::from_slice([1])) as _],
+        )
+        .unwrap()
+        .into_df_record_batch();
+        let batch2 = RecordBatch::new(
+            schema.clone(),
+            vec![Arc::new(Int32Vector::from_slice([2])) as _],
+        )
+        .unwrap()
+        .into_df_record_batch();
+        let df_stream = Box::pin(
+            datafusion::physical_plan::stream::RecordBatchStreamAdapter::new(
+                schema.arrow_schema().clone(),
+                futures::stream::iter(vec![Ok(batch1), Ok(batch2)]),
+            ),
+        );
+        let plan = Arc::new(TestMetricsExec::new(schema.arrow_schema().clone()));
+
+        let mut adapter = RecordBatchStreamAdapter::try_new(df_stream).unwrap();
+        adapter.set_metrics2(plan);
+        adapter.set_query_load_region_id(Some(42));
+
+        assert!(adapter.metrics().is_none());
+        assert!(adapter.next().await.unwrap().is_ok());
+        let metrics = adapter
+            .metrics()
+            .expect("non-verbose queries need partial query-load metrics before EOF");
+        assert_eq!(metrics.elapsed_compute, 42);
+        assert_eq!(metrics.query_load_region_id, Some(42));
+        assert_eq!(region_scan_output_bytes(&metrics), 24);
+        assert_eq!(metrics.plan_metrics.len(), 1);
+        assert_eq!(metrics.plan_metrics[0].plan, REGION_SCAN_EXEC_NAME);
+        assert_eq!(metrics.plan_metrics[0].plan_name, REGION_SCAN_EXEC_NAME);
+        assert_eq!(
+            metrics.plan_metrics[0].metrics,
+            vec![("output_bytes".to_string(), 24)]
+        );
+    }
+
+    #[test]
+    fn test_record_batch_stream_adapter_refreshes_partial_query_stats_on_drop() {
+        let schema = Arc::new(Schema::new(vec![ColumnSchema::new(
+            "a",
+            ConcreteDataType::int32_datatype(),
+            false,
+        )]));
+        let df_stream = Box::pin(
+            datafusion::physical_plan::stream::RecordBatchStreamAdapter::new(
+                schema.arrow_schema().clone(),
+                futures::stream::empty::<datafusion::error::Result<DfRecordBatch>>(),
+            ),
+        );
+        let counters = RegionQueryStatCounters {
+            query_cpu_time: Arc::new(AtomicU64::new(10)),
+            query_scanned_bytes: Arc::new(AtomicU64::new(20)),
+        };
+        let stale_metrics = RecordBatchMetrics {
+            elapsed_compute: 1,
+            plan_metrics: vec![PlanMetrics {
+                plan: REGION_SCAN_EXEC_NAME.to_string(),
+                plan_name: REGION_SCAN_EXEC_NAME.to_string(),
+                level: 0,
+                metrics: vec![("output_bytes".to_string(), 2)],
+            }],
+            ..Default::default()
+        };
+        let adapter = RecordBatchStreamAdapter {
+            schema: schema.clone(),
+            stream: df_stream,
+            metrics: None,
+            metrics_2: Metrics::PartialResolved(
+                Arc::new(TestMetricsExec::new(schema.arrow_schema().clone())),
+                stale_metrics,
+            ),
+            query_load_region_id: None,
+            query_stat_counters: Some(counters.clone()),
+            explain_verbose: false,
+            span: Span::current(),
+        };
+
+        drop(adapter);
+
+        assert_eq!(counters.query_cpu_time.load(Ordering::Relaxed), 52);
+        assert_eq!(counters.query_scanned_bytes.load(Ordering::Relaxed), 44);
+    }
 
     #[tokio::test]
     async fn test_async_recordbatch_stream_adaptor() {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

- Preserves the per-region query-load behavior introduced by #8316 and #8355.
- Flamegraph attachment: [greptime-cpu.svg](https://gist.github.com/v0y4g3r/4f53564423a2900526c4cd0b73d28c45)

<details>
<summary>MetricCollector flamegraph</summary>

![greptime CPU flamegraph](https://gist.githubusercontent.com/v0y4g3r/4f53564423a2900526c4cd0b73d28c45/raw/2005fa809d97f95ea1e2c1beb8fbc7cb3a439666/greptime-cpu.svg)

</details>

## What's changed and what's your intention?

This PR reduces the CPU overhead from collecting query metrics on the normal query hot path.

Root cause from the attached flamegraph: ordinary query execution refreshed `RecordBatchStreamAdapter` partial metrics after every output batch by running the full `MetricCollector` visitor. The hottest related stacks were:

<img width="2250" height="1066" alt="image" src="https://github.com/user-attachments/assets/babc564e-7b6f-4a84-850e-8ade73f041b8" />


Changes in this PR:

- Split full metrics collection into `collect_full_metrics`, still used for `EXPLAIN ANALYZE VERBOSE` partial metrics and terminal EOF metrics.
- Add a lightweight query-load collector for normal per-batch partial metrics. It walks the plan and only reads raw values needed by query-load reporting (`elapsed_compute`, memory usage, `RegionScanExec.output_bytes`, and `query_load_region_id`) without invoking the full `MetricCollector` aggregation/sorting/display path.
- Keep early-stop/cancellation query-load reporting intact by continuing to expose lightweight partial metrics before EOF; this preserves the behavior needed by #8316 and #8355.
- Reuse already collected partial/resolved metrics in drop-time query stats recording before falling back to lightweight collection.
- Add tests for lightweight partial metrics and drop-time query stats reuse.

Compatibility:

- No API changes.
- No schema or data format changes.
- `EXPLAIN ANALYZE VERBOSE` keeps full partial metrics behavior.

Validation:

- `rtk cargo fmt -p common-recordbatch --check`
- `rtk cargo test -p common-recordbatch --lib`
- `rtk cargo test -p query query_load -- --test-threads=1 --nocapture`
- `rtk cargo check -p query`

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
