### PR TITLE
fix: surface DDL procedure id on timeout

### DIFF
--- a/src/common/meta/src/ddl_manager.rs
+++ b/src/common/meta/src/ddl_manager.rs
@@ -48,10 +48,10 @@ use crate::ddl::truncate_table::TruncateTableProcedure;
 use crate::ddl::undrop_table::UndropTableProcedure;
 use crate::ddl::{DdlContext, utils};
 use crate::error::{
-    self, CreateRepartitionProcedureSnafu, EmptyDdlTasksSnafu, ProcedureOutputSnafu,
-    RegisterProcedureLoaderSnafu, RegisterRepartitionProcedureLoaderSnafu, Result,
-    SubmitProcedureSnafu, TableInfoNotFoundSnafu, TableNotFoundSnafu, TableRouteNotFoundSnafu,
-    UnexpectedLogicalRouteTableSnafu, WaitProcedureSnafu,
+    self, CreateRepartitionProcedureSnafu, EmptyDdlTasksSnafu, ParseProcedureIdSnafu,
+    ProcedureOutputSnafu, RegisterProcedureLoaderSnafu, RegisterRepartitionProcedureLoaderSnafu,
+    Result, SubmitProcedureSnafu, TableInfoNotFoundSnafu, TableNotFoundSnafu,
+    TableRouteNotFoundSnafu, UnexpectedLogicalRouteTableSnafu, WaitProcedureSnafu,
 };
 use crate::key::table_info::TableInfoValue;
 use crate::key::table_name::TableNameKey;
@@ -205,6 +205,27 @@ pub struct DdlOptions {
     ///
     /// Note: The value of `wait` is independent of the `timeout` option. If a procedure ignores the `timeout` and `wait` is set to true, the operation returns until the procedure completes.
     pub wait: bool,
+    /// The caller-generated procedure id for this DDL, if present.
+    pub procedure_id: Option<ProcedureId>,
+}
+
+fn requested_ddl_procedure_id(query_context: &QueryContext) -> Result<Option<ProcedureId>> {
+    crate::rpc::ddl::ddl_procedure_id(query_context)
+        .map(|procedure_id| {
+            ProcedureId::parse_str(procedure_id)
+                .with_context(|_| ParseProcedureIdSnafu { key: procedure_id })
+        })
+        .transpose()
+}
+
+fn procedure_with_id(
+    procedure: BoxedProcedure,
+    procedure_id: Option<ProcedureId>,
+) -> ProcedureWithId {
+    match procedure_id {
+        Some(id) => ProcedureWithId { id, procedure },
+        None => ProcedureWithId::with_random_id(procedure),
+    }
 }
 
 impl DdlManager {
@@ -304,6 +325,7 @@ impl DdlManager {
         repartition: Repartition,
         wait: bool,
         timeout: Duration,
+        procedure_id: Option<ProcedureId>,
     ) -> Result<(ProcedureId, Option<Output>)> {
         let context = self.create_context();
 
@@ -341,7 +363,7 @@ impl DdlManager {
                 Some(timeout),
             )
             .context(CreateRepartitionProcedureSnafu)?;
-        let procedure_with_id = ProcedureWithId::with_random_id(Box::new(procedure));
+        let procedure_with_id = procedure_with_id(Box::new(procedure), procedure_id);
         if wait {
             self.execute_procedure_and_wait(procedure_with_id).await
         } else {
@@ -377,6 +399,7 @@ impl DdlManager {
                     repartition,
                     ddl_options.wait,
                     ddl_options.timeout,
+                    ddl_options.procedure_id,
                 )
                 .await;
         }
@@ -384,7 +407,7 @@ impl DdlManager {
         let context = self.create_context();
         let procedure = AlterTableProcedure::new(table_id, alter_table_task, context)?;
 
-        let procedure_with_id = ProcedureWithId::with_random_id(Box::new(procedure));
+        let procedure_with_id = procedure_with_id(Box::new(procedure), ddl_options.procedure_id);
 
         self.execute_procedure_and_wait(procedure_with_id).await
     }
@@ -395,6 +418,7 @@ impl DdlManager {
         &self,
         create_table_task: CreateTableTask,
         query_context: QueryContext,
+        procedure_id: Option<ProcedureId>,
     ) -> Result<(ProcedureId, Option<Output>)> {
         let context = self.create_context();
 
@@ -404,7 +428,7 @@ impl DdlManager {
             context,
         )?;
 
-        let procedure_with_id = ProcedureWithId::with_random_id(Box::new(procedure));
+        let procedure_with_id = procedure_with_id(Box::new(procedure), procedure_id);
 
         self.execute_procedure_and_wait(procedure_with_id).await
     }
@@ -414,12 +438,13 @@ impl DdlManager {
     pub async fn submit_create_view_task(
         &self,
         create_view_task: CreateViewTask,
+        procedure_id: Option<ProcedureId>,
     ) -> Result<(ProcedureId, Option<Output>)> {
         let context = self.create_context();
 
         let procedure = CreateViewProcedure::new(create_view_task, context);
 
-        let procedure_with_id = ProcedureWithId::with_random_id(Box::new(procedure));
+        let procedure_with_id = procedure_with_id(Box::new(procedure), procedure_id);
 
         self.execute_procedure_and_wait(procedure_with_id).await
     }
@@ -430,13 +455,14 @@ impl DdlManager {
         &self,
         create_table_tasks: Vec<CreateTableTask>,
         physical_table_id: TableId,
+        procedure_id: Option<ProcedureId>,
     ) -> Result<(ProcedureId, Option<Output>)> {
         let context = self.create_context();
 
         let procedure =
             CreateLogicalTablesProcedure::new(create_table_tasks, physical_table_id, context);
 
-        let procedure_with_id = ProcedureWithId::with_random_id(Box::new(procedure));
+        let procedure_with_id = procedure_with_id(Box::new(procedure), procedure_id);
 
         self.execute_procedure_and_wait(procedure_with_id).await
     }
@@ -447,13 +473,14 @@ impl DdlManager {
         &self,
         alter_table_tasks: Vec<AlterTableTask>,
         physical_table_id: TableId,
+        procedure_id: Option<ProcedureId>,
     ) -> Result<(ProcedureId, Option<Output>)> {
         let context = self.create_context();
 
         let procedure =
             AlterLogicalTablesProcedure::new(alter_table_tasks, physical_table_id, context);
 
-        let procedure_with_id = ProcedureWithId::with_random_id(Box::new(procedure));
+        let procedure_with_id = procedure_with_id(Box::new(procedure), procedure_id);
 
         self.execute_procedure_and_wait(procedure_with_id).await
     }
@@ -463,12 +490,13 @@ impl DdlManager {
     pub async fn submit_drop_table_task(
         &self,
         drop_table_task: DropTableTask,
+        procedure_id: Option<ProcedureId>,
     ) -> Result<(ProcedureId, Option<Output>)> {
         let context = self.create_context();
 
         let procedure = DropTableProcedure::new(drop_table_task, context);
 
-        let procedure_with_id = ProcedureWithId::with_random_id(Box::new(procedure));
+        let procedure_with_id = procedure_with_id(Box::new(procedure), procedure_id);
 
         self.execute_procedure_and_wait(procedure_with_id).await
     }
@@ -478,10 +506,11 @@ impl DdlManager {
     pub async fn submit_undrop_table_task(
         &self,
         undrop_table_task: UndropTableTask,
+        procedure_id: Option<ProcedureId>,
     ) -> Result<(ProcedureId, Option<Output>)> {
         let context = self.create_context();
         let procedure = UndropTableProcedure::new(undrop_table_task, context);
-        let procedure_with_id = ProcedureWithId::with_random_id(Box::new(procedure));
+        let procedure_with_id = procedure_with_id(Box::new(procedure), procedure_id);
 
         self.execute_procedure_and_wait(procedure_with_id).await
     }
@@ -491,10 +520,11 @@ impl DdlManager {
     pub async fn submit_purge_dropped_table_task(
         &self,
         purge_dropped_table_task: PurgeDroppedTableTask,
+        procedure_id: Option<ProcedureId>,
     ) -> Result<(ProcedureId, Option<Output>)> {
         let context = self.create_context();
         let procedure = PurgeDroppedTableProcedure::new(purge_dropped_table_task, context);
-        let procedure_with_id = ProcedureWithId::with_random_id(Box::new(procedure));
+        let procedure_with_id = procedure_with_id(Box::new(procedure), procedure_id);
 
         self.execute_procedure_and_wait(procedure_with_id).await
     }
@@ -509,11 +539,12 @@ impl DdlManager {
             create_if_not_exists,
             options,
         }: CreateDatabaseTask,
+        procedure_id: Option<ProcedureId>,
     ) -> Result<(ProcedureId, Option<Output>)> {
         let context = self.create_context();
         let procedure =
             CreateDatabaseProcedure::new(catalog, schema, create_if_not_exists, options, context);
-        let procedure_with_id = ProcedureWithId::with_random_id(Box::new(procedure));
+        let procedure_with_id = procedure_with_id(Box::new(procedure), procedure_id);
 
         self.execute_procedure_and_wait(procedure_with_id).await
     }
@@ -527,10 +558,11 @@ impl DdlManager {
             schema,
             drop_if_exists,
         }: DropDatabaseTask,
+        procedure_id: Option<ProcedureId>,
     ) -> Result<(ProcedureId, Option<Output>)> {
         let context = self.create_context();
         let procedure = DropDatabaseProcedure::new(catalog, schema, drop_if_exists, context);
-        let procedure_with_id = ProcedureWithId::with_random_id(Box::new(procedure));
+        let procedure_with_id = procedure_with_id(Box::new(procedure), procedure_id);
 
         self.execute_procedure_and_wait(procedure_with_id).await
     }
@@ -538,10 +570,11 @@ impl DdlManager {
     pub async fn submit_alter_database(
         &self,
         alter_database_task: AlterDatabaseTask,
+        procedure_id: Option<ProcedureId>,
     ) -> Result<(ProcedureId, Option<Output>)> {
         let context = self.create_context();
         let procedure = AlterDatabaseProcedure::new(alter_database_task, context)?;
-        let procedure_with_id = ProcedureWithId::with_random_id(Box::new(procedure));
+        let procedure_with_id = procedure_with_id(Box::new(procedure), procedure_id);
 
         self.execute_procedure_and_wait(procedure_with_id).await
     }
@@ -552,10 +585,11 @@ impl DdlManager {
         &self,
         create_flow: CreateFlowTask,
         query_context: QueryContext,
+        procedure_id: Option<ProcedureId>,
     ) -> Result<(ProcedureId, Option<Output>)> {
         let context = self.create_context();
         let procedure = CreateFlowProcedure::new(create_flow, query_context, context);
-        let procedure_with_id = ProcedureWithId::with_random_id(Box::new(procedure));
+        let procedure_with_id = procedure_with_id(Box::new(procedure), procedure_id);
 
         self.execute_procedure_and_wait(procedure_with_id).await
     }
@@ -565,10 +599,11 @@ impl DdlManager {
     pub async fn submit_drop_flow_task(
         &self,
         drop_flow: DropFlowTask,
+        procedure_id: Option<ProcedureId>,
     ) -> Result<(ProcedureId, Option<Output>)> {
         let context = self.create_context();
         let procedure = DropFlowProcedure::new(drop_flow, context);
-        let procedure_with_id = ProcedureWithId::with_random_id(Box::new(procedure));
+        let procedure_with_id = procedure_with_id(Box::new(procedure), procedure_id);
 
         self.execute_procedure_and_wait(procedure_with_id).await
     }
@@ -578,10 +613,11 @@ impl DdlManager {
     pub async fn submit_drop_view_task(
         &self,
         drop_view: DropViewTask,
+        procedure_id: Option<ProcedureId>,
     ) -> Result<(ProcedureId, Option<Output>)> {
         let context = self.create_context();
         let procedure = DropViewProcedure::new(drop_view, context);
-        let procedure_with_id = ProcedureWithId::with_random_id(Box::new(procedure));
+        let procedure_with_id = procedure_with_id(Box::new(procedure), procedure_id);
 
         self.execute_procedure_and_wait(procedure_with_id).await
     }
@@ -592,11 +628,12 @@ impl DdlManager {
         &self,
         truncate_table_task: TruncateTableTask,
         table_info_value: DeserializedValueWithBytes<TableInfoValue>,
+        procedure_id: Option<ProcedureId>,
     ) -> Result<(ProcedureId, Option<Output>)> {
         let context = self.create_context();
         let procedure = TruncateTableProcedure::new(truncate_table_task, table_info_value, context);
 
-        let procedure_with_id = ProcedureWithId::with_random_id(Box::new(procedure));
+        let procedure_with_id = procedure_with_id(Box::new(procedure), procedure_id);
 
         self.execute_procedure_and_wait(procedure_with_id).await
     }
@@ -606,6 +643,7 @@ impl DdlManager {
     pub async fn submit_comment_on_task(
         &self,
         mut comment_on_task: CommentOnTask,
+        procedure_id: Option<ProcedureId>,
     ) -> Result<(ProcedureId, Option<Output>)> {
         let context = self.create_context();
         comment_on_task
@@ -615,7 +653,7 @@ impl DdlManager {
             )
             .await?;
         let procedure = CommentOnProcedure::new(comment_on_task, context);
-        let procedure_with_id = ProcedureWithId::with_random_id(Box::new(procedure));
+        let procedure_with_id = procedure_with_id(Box::new(procedure), procedure_id);
 
         self.execute_procedure_and_wait(procedure_with_id).await
     }
@@ -663,54 +701,77 @@ impl DdlManager {
             .map(TracingContext::from_w3c)
             .unwrap_or_else(TracingContext::from_current_span)
             .attach(tracing::info_span!("DdlManager::submit_ddl_task"));
+        let procedure_id = requested_ddl_procedure_id(&request.query_context)?;
         let ddl_options = DdlOptions {
             wait: request.wait,
             timeout: request.timeout,
+            procedure_id,
         };
         async move {
             debug!("Submitting Ddl task: {:?}", request.task);
             match request.task {
                 CreateTable(create_table_task) => {
-                    handle_create_table_task(self, create_table_task, request.query_context).await
+                    handle_create_table_task(
+                        self,
+                        create_table_task,
+                        request.query_context,
+                        procedure_id,
+                    )
+                    .await
                 }
-                DropTable(drop_table_task) => handle_drop_table_task(self, drop_table_task).await,
+                DropTable(drop_table_task) => {
+                    handle_drop_table_task(self, drop_table_task, procedure_id).await
+                }
                 UndropTable(undrop_table_task) => {
-                    handle_undrop_table_task(self, undrop_table_task).await
+                    handle_undrop_table_task(self, undrop_table_task, procedure_id).await
                 }
                 PurgeDroppedTable(purge_dropped_table_task) => {
-                    handle_purge_dropped_table_task(self, purge_dropped_table_task).await
+                    handle_purge_dropped_table_task(self, purge_dropped_table_task, procedure_id)
+                        .await
                 }
                 AlterTable(alter_table_task) => {
                     handle_alter_table_task(self, alter_table_task, ddl_options).await
                 }
                 TruncateTable(truncate_table_task) => {
-                    handle_truncate_table_task(self, truncate_table_task).await
+                    handle_truncate_table_task(self, truncate_table_task, procedure_id).await
                 }
                 CreateLogicalTables(create_table_tasks) => {
-                    handle_create_logical_table_tasks(self, create_table_tasks).await
+                    handle_create_logical_table_tasks(self, create_table_tasks, procedure_id).await
                 }
                 AlterLogicalTables(alter_table_tasks) => {
-                    handle_alter_logical_table_tasks(self, alter_table_tasks).await
+                    handle_alter_logical_table_tasks(self, alter_table_tasks, procedure_id).await
                 }
                 DropLogicalTables(_) => todo!(),
                 CreateDatabase(create_database_task) => {
-                    handle_create_database_task(self, create_database_task).await
+                    handle_create_database_task(self, create_database_task, procedure_id).await
                 }
                 DropDatabase(drop_database_task) => {
-                    handle_drop_database_task(self, drop_database_task).await
+                    handle_drop_database_task(self, drop_database_task, procedure_id).await
                 }
                 AlterDatabase(alter_database_task) => {
-                    handle_alter_database_task(self, alter_database_task).await
+                    handle_alter_database_task(self, alter_database_task, procedure_id).await
                 }
                 CreateFlow(create_flow_task) => {
-                    handle_create_flow_task(self, create_flow_task, request.query_context).await
+                    handle_create_flow_task(
+                        self,
+                        create_flow_task,
+                        request.query_context,
+                        procedure_id,
+                    )
+                    .await
                 }
-                DropFlow(drop_flow_task) => handle_drop_flow_task(self, drop_flow_task).await,
+                DropFlow(drop_flow_task) => {
+                    handle_drop_flow_task(self, drop_flow_task, procedure_id).await
+                }
                 CreateView(create_view_task) => {
-                    handle_create_view_task(self, create_view_task).await
+                    handle_create_view_task(self, create_view_task, procedure_id).await
                 }
-                DropView(drop_view_task) => handle_drop_view_task(self, drop_view_task).await,
-                CommentOn(comment_on_task) => handle_comment_on_task(self, comment_on_task).await,
+                DropView(drop_view_task) => {
+                    handle_drop_view_task(self, drop_view_task, procedure_id).await
+                }
+                CommentOn(comment_on_task) => {
+                    handle_comment_on_task(self, comment_on_task, procedure_id).await
+                }
                 #[cfg(feature = "enterprise")]
                 CreateTrigger(create_trigger_task) => {
                     handle_create_trigger_task(self, create_trigger_task, request.query_context)
@@ -730,6 +791,7 @@ impl DdlManager {
 async fn handle_truncate_table_task(
     ddl_manager: &DdlManager,
     truncate_table_task: TruncateTableTask,
+    procedure_id: Option<ProcedureId>,
 ) -> Result<SubmitDdlTaskResponse> {
     let table_id = truncate_table_task.table_id;
     let table_metadata_manager = &ddl_manager.table_metadata_manager();
@@ -754,7 +816,7 @@ async fn handle_truncate_table_task(
     );
 
     let (id, _) = ddl_manager
-        .submit_truncate_table_task(truncate_table_task, table_info_value)
+        .submit_truncate_table_task(truncate_table_task, table_info_value, procedure_id)
         .await?;
 
     info!("Table: {table_id} is truncated via procedure_id {id:?}");
@@ -815,9 +877,12 @@ async fn handle_alter_table_task(
 async fn handle_drop_table_task(
     ddl_manager: &DdlManager,
     drop_table_task: DropTableTask,
+    procedure_id: Option<ProcedureId>,
 ) -> Result<SubmitDdlTaskResponse> {
     let table_id = drop_table_task.table_id;
-    let (id, _) = ddl_manager.submit_drop_table_task(drop_table_task).await?;
+    let (id, _) = ddl_manager
+        .submit_drop_table_task(drop_table_task, procedure_id)
+        .await?;
 
     info!("Table: {table_id} is dropped via procedure_id {id:?}");
 
@@ -830,10 +895,11 @@ async fn handle_drop_table_task(
 async fn handle_undrop_table_task(
     ddl_manager: &DdlManager,
     undrop_table_task: UndropTableTask,
+    procedure_id: Option<ProcedureId>,
 ) -> Result<SubmitDdlTaskResponse> {
     let table_id = undrop_table_task.table_id;
     let (id, _) = ddl_manager
-        .submit_undrop_table_task(undrop_table_task)
+        .submit_undrop_table_task(undrop_table_task, procedure_id)
         .await?;
 
     info!("Table: {table_id} is undropped via procedure_id {id:?}");
@@ -847,9 +913,10 @@ async fn handle_undrop_table_task(
 async fn handle_purge_dropped_table_task(
     ddl_manager: &DdlManager,
     purge_dropped_table_task: PurgeDroppedTableTask,
+    procedure_id: Option<ProcedureId>,
 ) -> Result<SubmitDdlTaskResponse> {
     let (id, _) = ddl_manager
-        .submit_purge_dropped_table_task(purge_dropped_table_task)
+        .submit_purge_dropped_table_task(purge_dropped_table_task, procedure_id)
         .await?;
 
     info!("Dropped table is purged via procedure_id {id:?}");
@@ -864,9 +931,10 @@ async fn handle_create_table_task(
     ddl_manager: &DdlManager,
     create_table_task: CreateTableTask,
     query_context: QueryContext,
+    procedure_id: Option<ProcedureId>,
 ) -> Result<SubmitDdlTaskResponse> {
     let (id, output) = ddl_manager
-        .submit_create_table_task(create_table_task, query_context)
+        .submit_create_table_task(create_table_task, query_context, procedure_id)
         .await?;
 
     let procedure_id = id.to_string();
@@ -889,6 +957,7 @@ async fn handle_create_table_task(
 async fn handle_create_logical_table_tasks(
     ddl_manager: &DdlManager,
     create_table_tasks: Vec<CreateTableTask>,
+    procedure_id: Option<ProcedureId>,
 ) -> Result<SubmitDdlTaskResponse> {
     ensure!(
         !create_table_tasks.is_empty(),
@@ -904,7 +973,7 @@ async fn handle_create_logical_table_tasks(
     let num_logical_tables = create_table_tasks.len();
 
     let (id, output) = ddl_manager
-        .submit_create_logical_table_tasks(create_table_tasks, physical_table_id)
+        .submit_create_logical_table_tasks(create_table_tasks, physical_table_id, procedure_id)
         .await?;
 
     info!(
@@ -933,9 +1002,10 @@ async fn handle_create_logical_table_tasks(
 async fn handle_create_database_task(
     ddl_manager: &DdlManager,
     create_database_task: CreateDatabaseTask,
+    procedure_id: Option<ProcedureId>,
 ) -> Result<SubmitDdlTaskResponse> {
     let (id, _) = ddl_manager
-        .submit_create_database(create_database_task.clone())
+        .submit_create_database(create_database_task.clone(), procedure_id)
         .await?;
 
     let procedure_id = id.to_string();
@@ -953,9 +1023,10 @@ async fn handle_create_database_task(
 async fn handle_drop_database_task(
     ddl_manager: &DdlManager,
     drop_database_task: DropDatabaseTask,
+    procedure_id: Option<ProcedureId>,
 ) -> Result<SubmitDdlTaskResponse> {
     let (id, _) = ddl_manager
-        .submit_drop_database(drop_database_task.clone())
+        .submit_drop_database(drop_database_task.clone(), procedure_id)
         .await?;
 
     let procedure_id = id.to_string();
@@ -973,9 +1044,10 @@ async fn handle_drop_database_task(
 async fn handle_alter_database_task(
     ddl_manager: &DdlManager,
     alter_database_task: AlterDatabaseTask,
+    procedure_id: Option<ProcedureId>,
 ) -> Result<SubmitDdlTaskResponse> {
     let (id, _) = ddl_manager
-        .submit_alter_database(alter_database_task.clone())
+        .submit_alter_database(alter_database_task.clone(), procedure_id)
         .await?;
 
     let procedure_id = id.to_string();
@@ -994,9 +1066,10 @@ async fn handle_alter_database_task(
 async fn handle_drop_flow_task(
     ddl_manager: &DdlManager,
     drop_flow_task: DropFlowTask,
+    procedure_id: Option<ProcedureId>,
 ) -> Result<SubmitDdlTaskResponse> {
     let (id, _) = ddl_manager
-        .submit_drop_flow_task(drop_flow_task.clone())
+        .submit_drop_flow_task(drop_flow_task.clone(), procedure_id)
         .await?;
 
     let procedure_id = id.to_string();
@@ -1038,9 +1111,10 @@ async fn handle_drop_trigger_task(
 async fn handle_drop_view_task(
     ddl_manager: &DdlManager,
     drop_view_task: DropViewTask,
+    procedure_id: Option<ProcedureId>,
 ) -> Result<SubmitDdlTaskResponse> {
     let (id, _) = ddl_manager
-        .submit_drop_view_task(drop_view_task.clone())
+        .submit_drop_view_task(drop_view_task.clone(), procedure_id)
         .await?;
 
     let procedure_id = id.to_string();
@@ -1060,9 +1134,10 @@ async fn handle_create_flow_task(
     ddl_manager: &DdlManager,
     create_flow_task: CreateFlowTask,
     query_context: QueryContext,
+    procedure_id: Option<ProcedureId>,
 ) -> Result<SubmitDdlTaskResponse> {
     let (id, output) = ddl_manager
-        .submit_create_flow_task(create_flow_task.clone(), query_context)
+        .submit_create_flow_task(create_flow_task.clone(), query_context, procedure_id)
         .await?;
 
     let procedure_id = id.to_string();
@@ -1119,6 +1194,7 @@ async fn handle_create_trigger_task(
 async fn handle_alter_logical_table_tasks(
     ddl_manager: &DdlManager,
     alter_table_tasks: Vec<AlterTableTask>,
+    procedure_id: Option<ProcedureId>,
 ) -> Result<SubmitDdlTaskResponse> {
     ensure!(
         !alter_table_tasks.is_empty(),
@@ -1138,7 +1214,7 @@ async fn handle_alter_logical_table_tasks(
     let num_logical_tables = alter_table_tasks.len();
 
     let (id, _) = ddl_manager
-        .submit_alter_logical_table_tasks(alter_table_tasks, physical_table_id)
+        .submit_alter_logical_table_tasks(alter_table_tasks, physical_table_id, procedure_id)
         .await?;
 
     info!(
@@ -1157,9 +1233,10 @@ async fn handle_alter_logical_table_tasks(
 async fn handle_create_view_task(
     ddl_manager: &DdlManager,
     create_view_task: CreateViewTask,
+    procedure_id: Option<ProcedureId>,
 ) -> Result<SubmitDdlTaskResponse> {
     let (id, output) = ddl_manager
-        .submit_create_view_task(create_view_task)
+        .submit_create_view_task(create_view_task, procedure_id)
         .await?;
 
     let procedure_id = id.to_string();
@@ -1182,9 +1259,10 @@ async fn handle_create_view_task(
 async fn handle_comment_on_task(
     ddl_manager: &DdlManager,
     comment_on_task: CommentOnTask,
+    procedure_id: Option<ProcedureId>,
 ) -> Result<SubmitDdlTaskResponse> {
     let (id, _) = ddl_manager
-        .submit_comment_on_task(comment_on_task.clone())
+        .submit_comment_on_task(comment_on_task.clone(), procedure_id)
         .await?;
 
     let procedure_id = id.to_string();
@@ -1207,11 +1285,14 @@ mod tests {
     use common_error::ext::BoxedError;
     use common_procedure::local::LocalManager;
     use common_procedure::test_util::InMemoryPoisonStore;
-    use common_procedure::{BoxedProcedure, ProcedureManagerRef};
+    use common_procedure::{
+        BoxedProcedure, Context, LockKey, PoisonKeys, Procedure, ProcedureId, ProcedureManagerRef,
+        Result as ProcedureResult, Status,
+    };
     use store_api::storage::TableId;
     use table::table_name::TableName;
 
-    use super::DdlManager;
+    use super::{DdlManager, procedure_with_id, requested_ddl_procedure_id};
     use crate::cache_invalidator::DummyCacheInvalidator;
     use crate::ddl::alter_table::AlterTableProcedure;
     use crate::ddl::create_table::CreateTableProcedure;
@@ -1228,6 +1309,7 @@ mod tests {
     use crate::peer::Peer;
     use crate::region_keeper::MemoryRegionKeeper;
     use crate::region_registry::LeaderRegionRegistry;
+    use crate::rpc::ddl::QueryContext;
     use crate::sequence::SequenceBuilder;
     use crate::state_store::KvStateStore;
     use crate::wal_provider::WalProvider;
@@ -1272,6 +1354,68 @@ mod tests {
         ) -> std::result::Result<(), BoxedError> {
             Ok(())
         }
+    }
+
+    struct NoopProcedure;
+
+    #[async_trait::async_trait]
+    impl Procedure for NoopProcedure {
+        fn type_name(&self) -> &str {
+            "NoopProcedure"
+        }
+
+        async fn execute(&mut self, _ctx: &Context) -> ProcedureResult<Status> {
+            Ok(Status::Done { output: None })
+        }
+
+        fn dump(&self) -> ProcedureResult<String> {
+            Ok(String::new())
+        }
+
+        fn lock_key(&self) -> LockKey {
+            LockKey::single_exclusive("noop_procedure")
+        }
+
+        fn poison_keys(&self) -> PoisonKeys {
+            PoisonKeys::default()
+        }
+    }
+
+    #[test]
+    fn test_requested_ddl_procedure_id_parses_query_context_extension() {
+        let expected = ProcedureId::random();
+        let mut query_context = QueryContext::default();
+        query_context.extensions.insert(
+            crate::rpc::ddl::DDL_PROCEDURE_ID_EXTENSION_KEY.to_string(),
+            expected.to_string(),
+        );
+
+        assert_eq!(
+            requested_ddl_procedure_id(&query_context).unwrap(),
+            Some(expected)
+        );
+    }
+
+    #[test]
+    fn test_requested_ddl_procedure_id_rejects_invalid_extension() {
+        let mut query_context = QueryContext::default();
+        query_context.extensions.insert(
+            crate::rpc::ddl::DDL_PROCEDURE_ID_EXTENSION_KEY.to_string(),
+            "not-a-procedure-id".to_string(),
+        );
+
+        let err = requested_ddl_procedure_id(&query_context).unwrap_err();
+
+        assert!(err.to_string().contains("Failed to parse procedure id"));
+    }
+
+    #[test]
+    fn test_procedure_with_id_uses_requested_id() {
+        let expected = ProcedureId::random();
+
+        let procedure = procedure_with_id(Box::new(NoopProcedure), Some(expected));
+
+        assert_eq!(procedure.id, expected);
     }
 
     #[test]

--- a/src/common/meta/src/rpc/ddl.rs
+++ b/src/common/meta/src/rpc/ddl.rs
@@ -30,9 +30,9 @@ use api::v1::meta::{
     CreateViewTask as PbCreateViewTask, DdlTaskRequest as PbDdlTaskRequest,
     DdlTaskResponse as PbDdlTaskResponse, DropDatabaseTask as PbDropDatabaseTask,
     DropFlowTask as PbDropFlowTask, DropTableTask as PbDropTableTask,
-    DropTableTasks as PbDropTableTasks, DropViewTask as PbDropViewTask, Partition, ProcedureId,
-    PurgeDroppedTableTask as PbPurgeDroppedTableTask, TruncateTableTask as PbTruncateTableTask,
-    UndropTableTask as PbUndropTableTask,
+    DropTableTasks as PbDropTableTasks, DropViewTask as PbDropViewTask, Partition,
+    ProcedureId as PbProcedureId, PurgeDroppedTableTask as PbPurgeDroppedTableTask,
+    TruncateTableTask as PbTruncateTableTask, UndropTableTask as PbUndropTableTask,
 };
 use api::v1::{
     AlterDatabaseExpr, AlterTableExpr, CommentObjectType as PbCommentObjectType, CommentOnExpr,
@@ -44,6 +44,7 @@ use base64::Engine as _;
 use base64::engine::general_purpose;
 use common_catalog::{format_full_flow_name, format_full_table_name};
 use common_error::ext::BoxedError;
+use common_procedure::ProcedureId as CommonProcedureId;
 use common_time::{DatabaseTimeToLive, Timestamp};
 use prost::Message;
 use serde::{Deserialize, Serialize};
@@ -66,6 +67,27 @@ use crate::key::table_name::{TableNameKey, TableNameManager};
 
 /// Reserved query-context extension key for the frontend peer address that submitted a DDL request.
 pub const ORIGIN_FRONTEND_ADDR_EXTENSION_KEY: &str = "__greptime_origin_frontend.addr";
+
+/// Reserved query-context extension key for the caller-generated DDL procedure id.
+pub const DDL_PROCEDURE_ID_EXTENSION_KEY: &str = "__greptime_ddl.procedure_id";
+
+/// Injects a fresh DDL procedure id into the query context and returns it.
+pub fn inject_ddl_procedure_id(query_context: &mut QueryContext) -> String {
+    let procedure_id = CommonProcedureId::random().to_string();
+    query_context.extensions.insert(
+        DDL_PROCEDURE_ID_EXTENSION_KEY.to_string(),
+        procedure_id.clone(),
+    );
+    procedure_id
+}
+
+/// Returns the caller-generated DDL procedure id from the query context.
+pub fn ddl_procedure_id(query_context: &QueryContext) -> Option<&str> {
+    query_context
+        .extensions
+        .get(DDL_PROCEDURE_ID_EXTENSION_KEY)
+        .map(String::as_str)
+}
 
 /// DDL tasks
 #[derive(Debug, Clone)]
@@ -428,7 +450,7 @@ impl TryFrom<PbDdlTaskResponse> for SubmitDdlTaskResponse {
 impl From<SubmitDdlTaskResponse> for PbDdlTaskResponse {
     fn from(val: SubmitDdlTaskResponse) -> Self {
         Self {
-            pid: Some(ProcedureId { key: val.key }),
+            pid: Some(PbProcedureId { key: val.key }),
             table_ids: val
                 .table_ids
                 .into_iter()

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -351,8 +351,9 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Canceling statement due to statement timeout"))]
+    #[snafu(display("{msg}"))]
     StatementTimeout {
+        msg: String,
         #[snafu(implicit)]
         location: Location,
     },
@@ -365,6 +366,19 @@ pub enum Error {
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+pub(crate) fn statement_timeout_message(ddl_procedure_ids: &[String]) -> String {
+    match ddl_procedure_ids {
+        [] => "Canceling statement due to statement timeout".to_string(),
+        [procedure_id] => format!(
+            "Canceling statement due to statement timeout. The DDL request may still be running. Procedure ID: {procedure_id}. Please use this procedure id to query the final status"
+        ),
+        procedure_ids => format!(
+            "Canceling statement due to statement timeout. Some DDL procedures may still be running. Procedure IDs: {}. Please use these procedure ids to query the final status",
+            procedure_ids.join(", ")
+        ),
+    }
+}
 
 impl ErrorExt for Error {
     fn status_code(&self) -> StatusCode {
@@ -487,6 +501,36 @@ impl ErrorExt for Error {
 
             _ => RetryHint::NonRetryable,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::statement_timeout_message;
+
+    #[test]
+    fn test_statement_timeout_message_without_ddl_procedure_ids() {
+        assert_eq!(
+            statement_timeout_message(&[]),
+            "Canceling statement due to statement timeout"
+        );
+    }
+
+    #[test]
+    fn test_statement_timeout_message_with_single_ddl_procedure_id() {
+        let message = statement_timeout_message(&["procedure-1".to_string()]);
+
+        assert!(message.contains("DDL request may still be running"));
+        assert!(message.contains("Procedure ID: procedure-1"));
+    }
+
+    #[test]
+    fn test_statement_timeout_message_with_multiple_ddl_procedure_ids() {
+        let message =
+            statement_timeout_message(&["procedure-1".to_string(), "procedure-2".to_string()]);
+
+        assert!(message.contains("DDL procedures may still be running"));
+        assert!(message.contains("Procedure IDs: procedure-1, procedure-2"));
     }
 }
 

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -97,7 +97,7 @@ use tracing::Span;
 use crate::error::{
     self, Error, ExecLogicalPlanSnafu, ExecutePromqlSnafu, ExternalSnafu, InvalidSqlSnafu,
     ParseSqlSnafu, PermissionSnafu, PlanStatementSnafu, Result, SqlExecInterceptedSnafu,
-    StatementTimeoutSnafu, TableOperationSnafu,
+    StatementTimeoutSnafu, TableOperationSnafu, statement_timeout_message,
 };
 use crate::service_config::InfluxdbMergeMode;
 use crate::stream_wrapper::CancellableStreamWrapper;
@@ -247,6 +247,7 @@ impl Instance {
 
     async fn query_statement(&self, stmt: Statement, query_ctx: QueryContextRef) -> Result<Output> {
         check_permission(self.plugins.clone(), &stmt, &query_ctx)?;
+        query_ctx.clear_ddl_procedure_ids();
 
         let query_interceptor = self.plugins.get::<SqlQueryInterceptorRef<Error>>();
         let query_interceptor = query_interceptor.as_ref();
@@ -299,10 +300,10 @@ impl Instance {
                 let start = tokio::time::Instant::now();
                 let output = tokio::time::timeout(
                     timeout,
-                    self.exec_statement(stmt, query_ctx, query_interceptor),
+                    self.exec_statement(stmt, query_ctx.clone(), query_interceptor),
                 )
                 .await
-                .map_err(|_| StatementTimeoutSnafu.build())??;
+                .map_err(|_| statement_timeout_error(&query_ctx))??;
                 // compute remaining timeout
                 let remaining_timeout = timeout.checked_sub(start.elapsed()).unwrap_or_default();
                 attach_timeout(output, remaining_timeout)
@@ -532,6 +533,21 @@ fn derive_timeout(stmt: &Statement, query_ctx: &QueryContextRef) -> Option<Durat
     }
 }
 
+fn statement_timeout_error(query_ctx: &QueryContextRef) -> Error {
+    let ddl_procedure_ids = query_ctx.ddl_procedure_ids();
+    StatementTimeoutSnafu {
+        msg: statement_timeout_message(&ddl_procedure_ids),
+    }
+    .build()
+}
+
+fn plain_statement_timeout_error() -> Error {
+    StatementTimeoutSnafu {
+        msg: statement_timeout_message(&[]),
+    }
+    .build()
+}
+
 /// Derives timeout for plan execution.
 fn derive_timeout_for_plan(plan: &LogicalPlan, query_ctx: &QueryContextRef) -> Option<Duration> {
     let query_timeout = query_ctx.query_timeout()?;
@@ -547,7 +563,7 @@ fn derive_timeout_for_plan(plan: &LogicalPlan, query_ctx: &QueryContextRef) -> O
 
 fn attach_timeout(output: Output, mut timeout: Duration) -> Result<Output> {
     if timeout.is_zero() {
-        return StatementTimeoutSnafu.fail();
+        return Err(plain_statement_timeout_error());
     }
 
     let output = match output.data {
@@ -722,9 +738,9 @@ impl Instance {
         match timeout {
             Some(timeout) => {
                 let start = tokio::time::Instant::now();
-                let output = tokio::time::timeout(timeout, self.exec_plan(plan, query_ctx))
+                let output = tokio::time::timeout(timeout, self.exec_plan(plan, query_ctx.clone()))
                     .await
-                    .map_err(|_| StatementTimeoutSnafu.build())??;
+                    .map_err(|_| statement_timeout_error(&query_ctx))??;
                 let remaining_timeout = timeout.checked_sub(start.elapsed()).unwrap_or_default();
                 attach_timeout(output, remaining_timeout)
             }

--- a/src/operator/src/statement/comment.rs
+++ b/src/operator/src/statement/comment.rs
@@ -28,7 +28,7 @@ use crate::error::{
     self, ExecuteDdlSnafu, ExternalSnafu, InvalidSqlSnafu, Result, TableMetadataManagerSnafu,
 };
 use crate::statement::StatementExecutor;
-use crate::utils::to_meta_query_context;
+use crate::utils::to_meta_query_context_with_ddl_procedure_id;
 
 impl StatementExecutor {
     /// Adds a comment to a database object (table, column, or flow).
@@ -53,7 +53,7 @@ impl StatementExecutor {
         let cache_idents = comment_on_task.cache_idents();
 
         let request = SubmitDdlTaskRequest::new(
-            to_meta_query_context(query_ctx),
+            to_meta_query_context_with_ddl_procedure_id(query_ctx),
             DdlTask::new_comment_on(comment_on_task),
         );
 
@@ -87,7 +87,7 @@ impl StatementExecutor {
         let cache_idents = comment_on_task.cache_idents();
 
         let request = SubmitDdlTaskRequest::new(
-            to_meta_query_context(query_ctx),
+            to_meta_query_context_with_ddl_procedure_id(query_ctx),
             DdlTask::new_comment_on(comment_on_task),
         );
 

--- a/src/operator/src/statement/ddl.rs
+++ b/src/operator/src/statement/ddl.rs
@@ -109,7 +109,9 @@ use crate::error::{
 use crate::expr_helper::{self, RepartitionRequest, RepartitionSource};
 use crate::statement::StatementExecutor;
 use crate::statement::show::create_partitions_stmt;
-use crate::utils::{to_meta_query_context, to_meta_query_context_with_origin_frontend};
+use crate::utils::{
+    to_meta_query_context_with_ddl_procedure_id, to_meta_query_context_with_origin_frontend,
+};
 
 #[derive(Debug, Clone, Copy)]
 struct DdlSubmitOptions {
@@ -697,7 +699,7 @@ impl StatementExecutor {
         .context(error::InvalidExprSnafu)?;
 
         let request = SubmitDdlTaskRequest::new(
-            to_meta_query_context(query_context),
+            to_meta_query_context_with_ddl_procedure_id(query_context),
             DdlTask::new_create_trigger(task),
         );
 
@@ -761,7 +763,7 @@ impl StatementExecutor {
         })
         .context(error::InvalidExprSnafu)?;
         let request = SubmitDdlTaskRequest::new(
-            to_meta_query_context(query_context),
+            to_meta_query_context_with_ddl_procedure_id(query_context),
             DdlTask::new_create_flow(task),
         );
 
@@ -1074,7 +1076,7 @@ impl StatementExecutor {
         };
 
         let request = SubmitDdlTaskRequest::new(
-            to_meta_query_context(ctx),
+            to_meta_query_context_with_ddl_procedure_id(ctx),
             DdlTask::new_create_view(expr, view_info.clone()),
         );
 
@@ -1160,7 +1162,7 @@ impl StatementExecutor {
         query_context: QueryContextRef,
     ) -> Result<SubmitDdlTaskResponse> {
         let request = SubmitDdlTaskRequest::new(
-            to_meta_query_context(query_context),
+            to_meta_query_context_with_ddl_procedure_id(query_context),
             DdlTask::new_drop_flow(expr),
         );
 
@@ -1195,7 +1197,7 @@ impl StatementExecutor {
         query_context: QueryContextRef,
     ) -> Result<SubmitDdlTaskResponse> {
         let request = SubmitDdlTaskRequest::new(
-            to_meta_query_context(query_context),
+            to_meta_query_context_with_ddl_procedure_id(query_context),
             DdlTask::new_drop_trigger(expr),
         );
 
@@ -1263,7 +1265,7 @@ impl StatementExecutor {
         query_context: QueryContextRef,
     ) -> Result<SubmitDdlTaskResponse> {
         let request = SubmitDdlTaskRequest::new(
-            to_meta_query_context(query_context),
+            to_meta_query_context_with_ddl_procedure_id(query_context),
             DdlTask::new_drop_view(expr),
         );
 
@@ -1727,7 +1729,7 @@ impl StatementExecutor {
             ..Default::default()
         };
         let mut req = SubmitDdlTaskRequest::new(
-            to_meta_query_context(query_context.clone()),
+            to_meta_query_context_with_ddl_procedure_id(query_context.clone()),
             DdlTask::new_alter_table(AlterTableExpr {
                 catalog_name: request.catalog_name.clone(),
                 schema_name: request.schema_name.clone(),
@@ -1839,7 +1841,7 @@ impl StatementExecutor {
         let (req, invalidate_keys) = if physical_table_id == table_id {
             // This is physical table
             let req = SubmitDdlTaskRequest::new(
-                to_meta_query_context(query_context),
+                to_meta_query_context_with_ddl_procedure_id(query_context),
                 DdlTask::new_alter_table(expr),
             );
 
@@ -1852,7 +1854,7 @@ impl StatementExecutor {
         } else {
             // This is logical table
             let req = SubmitDdlTaskRequest::new(
-                to_meta_query_context(query_context),
+                to_meta_query_context_with_ddl_procedure_id(query_context),
                 DdlTask::new_alter_logical_tables(vec![expr]),
             );
 
@@ -2005,7 +2007,7 @@ impl StatementExecutor {
         query_context: QueryContextRef,
     ) -> Result<SubmitDdlTaskResponse> {
         let request = SubmitDdlTaskRequest::new(
-            to_meta_query_context(query_context),
+            to_meta_query_context_with_ddl_procedure_id(query_context),
             DdlTask::new_alter_logical_tables(tables_data),
         );
 
@@ -2023,7 +2025,7 @@ impl StatementExecutor {
         query_context: QueryContextRef,
     ) -> Result<SubmitDdlTaskResponse> {
         let request = SubmitDdlTaskRequest::new(
-            to_meta_query_context(query_context),
+            to_meta_query_context_with_ddl_procedure_id(query_context),
             DdlTask::new_drop_table(
                 table_name.catalog_name.clone(),
                 table_name.schema_name.clone(),
@@ -2047,7 +2049,7 @@ impl StatementExecutor {
         query_context: QueryContextRef,
     ) -> Result<SubmitDdlTaskResponse> {
         let request = SubmitDdlTaskRequest::new(
-            to_meta_query_context(query_context),
+            to_meta_query_context_with_ddl_procedure_id(query_context),
             DdlTask::new_drop_database(catalog, schema, drop_if_exists),
         );
 
@@ -2063,7 +2065,7 @@ impl StatementExecutor {
         query_context: QueryContextRef,
     ) -> Result<SubmitDdlTaskResponse> {
         let request = SubmitDdlTaskRequest::new(
-            to_meta_query_context(query_context),
+            to_meta_query_context_with_ddl_procedure_id(query_context),
             DdlTask::new_alter_database(alter_expr),
         );
 
@@ -2081,7 +2083,7 @@ impl StatementExecutor {
         query_context: QueryContextRef,
     ) -> Result<SubmitDdlTaskResponse> {
         let request = SubmitDdlTaskRequest::new(
-            to_meta_query_context(query_context),
+            to_meta_query_context_with_ddl_procedure_id(query_context),
             DdlTask::new_truncate_table(
                 table_name.catalog_name.clone(),
                 table_name.schema_name.clone(),
@@ -2153,7 +2155,7 @@ impl StatementExecutor {
         query_context: QueryContextRef,
     ) -> Result<SubmitDdlTaskResponse> {
         let request = SubmitDdlTaskRequest::new(
-            to_meta_query_context(query_context),
+            to_meta_query_context_with_ddl_procedure_id(query_context),
             DdlTask::new_create_database(catalog, database, create_if_not_exists, options),
         );
 

--- a/src/operator/src/utils.rs
+++ b/src/operator/src/utils.rs
@@ -34,11 +34,20 @@ pub fn to_meta_query_context(
     }
 }
 
+pub fn to_meta_query_context_with_ddl_procedure_id(
+    query_context: QueryContextRef,
+) -> common_meta::rpc::ddl::QueryContext {
+    let mut meta_query_context = to_meta_query_context(query_context.clone());
+    let procedure_id = common_meta::rpc::ddl::inject_ddl_procedure_id(&mut meta_query_context);
+    query_context.push_ddl_procedure_id(procedure_id);
+    meta_query_context
+}
+
 pub fn to_meta_query_context_with_origin_frontend(
     query_context: QueryContextRef,
     origin_frontend_addr: &str,
 ) -> common_meta::rpc::ddl::QueryContext {
-    let mut meta_query_context = to_meta_query_context(query_context);
+    let mut meta_query_context = to_meta_query_context_with_ddl_procedure_id(query_context);
     meta_query_context.extensions.insert(
         common_meta::rpc::ddl::ORIGIN_FRONTEND_ADDR_EXTENSION_KEY.to_string(),
         origin_frontend_addr.to_string(),
@@ -69,13 +78,15 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::{Arc, RwLock};
 
-    use common_meta::rpc::ddl::ORIGIN_FRONTEND_ADDR_EXTENSION_KEY;
+    use common_meta::rpc::ddl::{
+        DDL_PROCEDURE_ID_EXTENSION_KEY, ORIGIN_FRONTEND_ADDR_EXTENSION_KEY,
+    };
     use common_time::Timezone;
     use session::context::QueryContextBuilder;
 
     use super::{
-        to_meta_query_context, to_meta_query_context_with_origin_frontend,
-        try_to_session_query_context,
+        to_meta_query_context, to_meta_query_context_with_ddl_procedure_id,
+        to_meta_query_context_with_origin_frontend, try_to_session_query_context,
     };
 
     #[test]
@@ -112,7 +123,8 @@ mod tests {
                 .build(),
         );
 
-        let meta_ctx = to_meta_query_context_with_origin_frontend(session_ctx, "127.0.0.1:4000");
+        let meta_ctx =
+            to_meta_query_context_with_origin_frontend(session_ctx.clone(), "127.0.0.1:4000");
 
         assert_eq!(
             meta_ctx
@@ -121,5 +133,33 @@ mod tests {
                 .map(String::as_str),
             Some("127.0.0.1:4000")
         );
+        assert!(
+            meta_ctx
+                .extensions
+                .contains_key(DDL_PROCEDURE_ID_EXTENSION_KEY)
+        );
+        assert_eq!(session_ctx.ddl_procedure_ids().len(), 1);
+    }
+
+    #[test]
+    fn test_meta_query_context_with_ddl_procedure_id_records_generated_id() {
+        let session_ctx = Arc::new(
+            QueryContextBuilder::default()
+                .set_extension(
+                    DDL_PROCEDURE_ID_EXTENSION_KEY.to_string(),
+                    "spoofed".to_string(),
+                )
+                .build(),
+        );
+
+        let meta_ctx = to_meta_query_context_with_ddl_procedure_id(session_ctx.clone());
+        let procedure_id = meta_ctx
+            .extensions
+            .get(DDL_PROCEDURE_ID_EXTENSION_KEY)
+            .cloned()
+            .unwrap();
+
+        assert_ne!("spoofed", procedure_id);
+        assert_eq!(session_ctx.ddl_procedure_ids(), vec![procedure_id]);
     }
 }

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -91,6 +91,7 @@ pub struct QueryContext {
 #[derive(Debug, Builder, Clone, Default)]
 pub struct QueryContextMutableFields {
     warning: Option<String>,
+    ddl_procedure_ids: Vec<String>,
     // TODO: remove this when format is supported in datafusion
     explain_format: Option<String>,
     /// Explain options to control the verbose analyze output.
@@ -400,6 +401,30 @@ impl QueryContext {
 
     pub fn set_warning(&self, msg: String) {
         self.mutable_query_context_data.write().unwrap().warning = Some(msg);
+    }
+
+    pub fn push_ddl_procedure_id(&self, procedure_id: String) {
+        self.mutable_query_context_data
+            .write()
+            .unwrap()
+            .ddl_procedure_ids
+            .push(procedure_id);
+    }
+
+    pub fn ddl_procedure_ids(&self) -> Vec<String> {
+        self.mutable_query_context_data
+            .read()
+            .unwrap()
+            .ddl_procedure_ids
+            .clone()
+    }
+
+    pub fn clear_ddl_procedure_ids(&self) {
+        self.mutable_query_context_data
+            .write()
+            .unwrap()
+            .ddl_procedure_ids
+            .clear();
     }
 
     pub fn explain_format(&self) -> Option<String> {
@@ -827,5 +852,24 @@ mod test {
             restored.remote_query_id_value().unwrap().to_string(),
             query_id
         );
+    }
+
+    #[test]
+    fn test_query_context_tracks_ddl_procedure_ids_for_current_statement() {
+        let ctx = QueryContext::arc();
+
+        assert!(ctx.ddl_procedure_ids().is_empty());
+
+        ctx.push_ddl_procedure_id("procedure-1".to_string());
+        ctx.push_ddl_procedure_id("procedure-2".to_string());
+
+        assert_eq!(
+            ctx.ddl_procedure_ids(),
+            vec!["procedure-1".to_string(), "procedure-2".to_string()]
+        );
+
+        ctx.clear_ddl_procedure_ids();
+
+        assert!(ctx.ddl_procedure_ids().is_empty());
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Fixes https://github.com/GreptimeTeam/greptimedb/issues/8418

## What's changed and what's your intention?

This PR makes synchronous DDL timeouts recoverable by surfacing the DDL procedure id that was generated before submitting the DDL request to metasrv.

Currently, a `wait = true` DDL can be submitted to metasrv and continue running after the frontend-side wait is cancelled by a statement timeout. If the timeout happens after metasrv accepts the procedure but before the response reaches the client, the client may only see a timeout and lose the procedure id needed to query the final procedure state.

The change keeps the existing wire format unchanged and uses `QueryContext.extensions` to carry a reserved frontend-generated DDL procedure id:

- The operator generates a fresh DDL procedure id for each `SubmitDdlTaskRequest` and injects it into the meta `QueryContext`.
- The session `QueryContext` records the generated id for the current statement, including statements that submit multiple DDL procedures.
- `DdlManager` reads the optional requested id from the query context and uses it when constructing `ProcedureWithId`, falling back to a random id when no id is provided.
- Frontend statement timeout errors include the recorded DDL procedure id or ids, so users can query the final procedure status after a timeout.

This PR does not add or change protobuf fields, persisted metadata formats, or public SQL syntax. The reserved extension key is internal to the DDL submission path.

Verified on Linux with the repository-pinned toolchain `nightly-2026-03-21`:

```bash
cargo +nightly-2026-03-21 test -p common-meta test_requested_ddl_procedure_id
cargo +nightly-2026-03-21 test -p common-meta test_procedure_with_id_uses_requested_id
cargo +nightly-2026-03-21 test -p session test_query_context_tracks_ddl_procedure_ids_for_current_statement
cargo +nightly-2026-03-21 test -p operator test_meta_query_context_with_ddl_procedure_id
cargo +nightly-2026-03-21 test -p operator test_meta_query_context_with_origin_frontend_overrides_reserved_key
cargo +nightly-2026-03-21 test -p frontend test_statement_timeout_message
```

Also verified related crates:

```bash
cargo +nightly-2026-03-21 test -p common-meta
cargo +nightly-2026-03-21 test -p session
cargo +nightly-2026-03-21 test -p operator
cargo +nightly-2026-03-21 test -p frontend
```

Formatting and whitespace checks:

```bash
cargo +nightly-2026-03-21 fmt --all -- --check
git diff --check
```

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
