### PR TITLE
test: add auto flush interval compat case

### DIFF
--- a/tests/compatibility/cases/alter_auto_flush_interval_old_table/case.toml
+++ b/tests/compatibility/cases/alter_auto_flush_interval_old_table/case.toml
@@ -1,0 +1,8 @@
+name = "alter_auto_flush_interval_old_table"
+reason = "Verify current ALTER TABLE SET auto_flush_interval works on tables created by old binaries."
+introduced_by = "PR #8403"
+topologies = ["distributed"]
+from_range = ["*"]
+to_range = [">v1.1.1"]
+features = ["table", "metadata", "alter", "auto_flush_interval"]
+owner = "storage"

--- a/tests/compatibility/cases/alter_auto_flush_interval_old_table/setup.sql
+++ b/tests/compatibility/cases/alter_auto_flush_interval_old_table/setup.sql
@@ -1,0 +1,12 @@
+CREATE TABLE t_alter_auto_flush_interval_old_table (
+  host STRING,
+  ts TIMESTAMP TIME INDEX,
+  cpu DOUBLE,
+  PRIMARY KEY(host)
+) ENGINE=mito;
+
+INSERT INTO t_alter_auto_flush_interval_old_table VALUES
+  ('host1', '2026-07-07 00:00:00+0000', 1.0),
+  ('host2', '2026-07-07 00:01:00+0000', 2.0);
+
+ADMIN FLUSH_TABLE('t_alter_auto_flush_interval_old_table');

--- a/tests/compatibility/cases/alter_auto_flush_interval_old_table/verify.result
+++ b/tests/compatibility/cases/alter_auto_flush_interval_old_table/verify.result
@@ -1,0 +1,111 @@
+SELECT host, ts, cpu
+FROM t_alter_auto_flush_interval_old_table
+ORDER BY host, ts;
+
++-------+---------------------+-----+
+| host  | ts                  | cpu |
++-------+---------------------+-----+
+| host1 | 2026-07-07T00:00:00 | 1.0 |
+| host2 | 2026-07-07T00:01:00 | 2.0 |
++-------+---------------------+-----+
+
+SHOW CREATE TABLE t_alter_auto_flush_interval_old_table;
+
++---------------------------------------+----------------------------------------------------------------------+
+| Table                                 | Create Table                                                         |
++---------------------------------------+----------------------------------------------------------------------+
+| t_alter_auto_flush_interval_old_table | CREATE TABLE IF NOT EXISTS "t_alter_auto_flush_interval_old_table" ( |
+|                                       |   "host" STRING NULL,                                                |
+|                                       |   "ts" TIMESTAMP(3) NOT NULL,                                        |
+|                                       |   "cpu" DOUBLE NULL,                                                 |
+|                                       |   TIME INDEX ("ts"),                                                 |
+|                                       |   PRIMARY KEY ("host")                                               |
+|                                       | )                                                                    |
+|                                       |                                                                      |
+|                                       | ENGINE=mito                                                          |
+|                                       |                                                                      |
++---------------------------------------+----------------------------------------------------------------------+
+
+ALTER TABLE t_alter_auto_flush_interval_old_table SET 'auto_flush_interval' = '5m';
+
+Affected Rows: 0
+
+SHOW CREATE TABLE t_alter_auto_flush_interval_old_table;
+
++---------------------------------------+----------------------------------------------------------------------+
+| Table                                 | Create Table                                                         |
++---------------------------------------+----------------------------------------------------------------------+
+| t_alter_auto_flush_interval_old_table | CREATE TABLE IF NOT EXISTS "t_alter_auto_flush_interval_old_table" ( |
+|                                       |   "host" STRING NULL,                                                |
+|                                       |   "ts" TIMESTAMP(3) NOT NULL,                                        |
+|                                       |   "cpu" DOUBLE NULL,                                                 |
+|                                       |   TIME INDEX ("ts"),                                                 |
+|                                       |   PRIMARY KEY ("host")                                               |
+|                                       | )                                                                    |
+|                                       |                                                                      |
+|                                       | ENGINE=mito                                                          |
+|                                       | WITH(                                                                |
+|                                       |   auto_flush_interval = '5m'                                         |
+|                                       | )                                                                    |
++---------------------------------------+----------------------------------------------------------------------+
+
+INSERT INTO t_alter_auto_flush_interval_old_table VALUES
+  ('host3', '2026-07-07 00:02:00+0000', 3.0);
+
+Affected Rows: 1
+
+SELECT host, ts, cpu
+FROM t_alter_auto_flush_interval_old_table
+ORDER BY host, ts;
+
++-------+---------------------+-----+
+| host  | ts                  | cpu |
++-------+---------------------+-----+
+| host1 | 2026-07-07T00:00:00 | 1.0 |
+| host2 | 2026-07-07T00:01:00 | 2.0 |
+| host3 | 2026-07-07T00:02:00 | 3.0 |
++-------+---------------------+-----+
+
+ALTER TABLE t_alter_auto_flush_interval_old_table SET 'auto_flush_interval' = '10m';
+
+Affected Rows: 0
+
+SHOW CREATE TABLE t_alter_auto_flush_interval_old_table;
+
++---------------------------------------+----------------------------------------------------------------------+
+| Table                                 | Create Table                                                         |
++---------------------------------------+----------------------------------------------------------------------+
+| t_alter_auto_flush_interval_old_table | CREATE TABLE IF NOT EXISTS "t_alter_auto_flush_interval_old_table" ( |
+|                                       |   "host" STRING NULL,                                                |
+|                                       |   "ts" TIMESTAMP(3) NOT NULL,                                        |
+|                                       |   "cpu" DOUBLE NULL,                                                 |
+|                                       |   TIME INDEX ("ts"),                                                 |
+|                                       |   PRIMARY KEY ("host")                                               |
+|                                       | )                                                                    |
+|                                       |                                                                      |
+|                                       | ENGINE=mito                                                          |
+|                                       | WITH(                                                                |
+|                                       |   auto_flush_interval = '10m'                                        |
+|                                       | )                                                                    |
++---------------------------------------+----------------------------------------------------------------------+
+
+ALTER TABLE t_alter_auto_flush_interval_old_table SET 'auto_flush_interval' = NULL;
+
+Affected Rows: 0
+
+SHOW CREATE TABLE t_alter_auto_flush_interval_old_table;
+
++---------------------------------------+----------------------------------------------------------------------+
+| Table                                 | Create Table                                                         |
++---------------------------------------+----------------------------------------------------------------------+
+| t_alter_auto_flush_interval_old_table | CREATE TABLE IF NOT EXISTS "t_alter_auto_flush_interval_old_table" ( |
+|                                       |   "host" STRING NULL,                                                |
+|                                       |   "ts" TIMESTAMP(3) NOT NULL,                                        |
+|                                       |   "cpu" DOUBLE NULL,                                                 |
+|                                       |   TIME INDEX ("ts"),                                                 |
+|                                       |   PRIMARY KEY ("host")                                               |
+|                                       | )                                                                    |
+|                                       |                                                                      |
+|                                       | ENGINE=mito                                                          |
+|                                       |                                                                      |
++---------------------------------------+----------------------------------------------------------------------+

--- a/tests/compatibility/cases/alter_auto_flush_interval_old_table/verify.sql
+++ b/tests/compatibility/cases/alter_auto_flush_interval_old_table/verify.sql
@@ -1,0 +1,24 @@
+SELECT host, ts, cpu
+FROM t_alter_auto_flush_interval_old_table
+ORDER BY host, ts;
+
+SHOW CREATE TABLE t_alter_auto_flush_interval_old_table;
+
+ALTER TABLE t_alter_auto_flush_interval_old_table SET 'auto_flush_interval' = '5m';
+
+SHOW CREATE TABLE t_alter_auto_flush_interval_old_table;
+
+INSERT INTO t_alter_auto_flush_interval_old_table VALUES
+  ('host3', '2026-07-07 00:02:00+0000', 3.0);
+
+SELECT host, ts, cpu
+FROM t_alter_auto_flush_interval_old_table
+ORDER BY host, ts;
+
+ALTER TABLE t_alter_auto_flush_interval_old_table SET 'auto_flush_interval' = '10m';
+
+SHOW CREATE TABLE t_alter_auto_flush_interval_old_table;
+
+ALTER TABLE t_alter_auto_flush_interval_old_table SET 'auto_flush_interval' = NULL;
+
+SHOW CREATE TABLE t_alter_auto_flush_interval_old_table;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up to #8403.

## What's changed and what's your intention?

This PR adds a distributed sqlness compatibility case for altering `auto_flush_interval` on tables created by old binaries.

The new `alter_auto_flush_interval_old_table` case verifies this upgrade path:

1. Start an old distributed cluster (`v1.0.0` / `v1.1.0`).
2. Create a normal Mito table without `auto_flush_interval`, insert rows, and flush it.
3. Restart the preserved state with the current binary.
4. Verify the old table is readable and initially has no table-level `auto_flush_interval` override.
5. Run `ALTER TABLE ... SET 'auto_flush_interval' = '5m'` and verify `SHOW CREATE TABLE` exposes the option.
6. Insert another row to confirm the altered old table remains writable/readable.
7. Update the option to `10m`, then clear it with `SET 'auto_flush_interval' = NULL`, verifying `SHOW CREATE TABLE` each time.

This intentionally does not require old binaries to support create-time `auto_flush_interval`; the compat target is current ALTER behavior over ordinary old table metadata.

Validation performed locally:

```text
cargo build --bin greptime -j 1
cargo run -p sqlness-runner -- compat --dry-run --from-version v1.0.0 --to-bins-dir /mnt/nvme_rust/rust-targets/compat_framework_retry/debug --test-filter 'alter_auto_flush_interval_old_table'
cargo run -p sqlness-runner -- compat --dry-run --from-version v1.1.0 --to-bins-dir /mnt/nvme_rust/rust-targets/compat_framework_retry/debug --test-filter 'alter_auto_flush_interval_old_table'
cargo run -p sqlness-runner -- compat --from-version v1.0.0 --to-bins-dir /mnt/nvme_rust/rust-targets/compat_framework_retry/debug --test-filter 'alter_auto_flush_interval_old_table' --preserve-state
cargo run -p sqlness-runner -- compat --from-version v1.1.0 --to-bins-dir /mnt/nvme_rust/rust-targets/compat_framework_retry/debug --test-filter 'alter_auto_flush_interval_old_table' --preserve-state
git diff --check
```

Both `v1.0.0 -> current` and `v1.1.0 -> current` distributed compat runs passed.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments. (not applicable, test-only)
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
