### PR TITLE
fix: compare all LoggingOptions fields in PartialEq

### DIFF
--- a/src/cmd/tests/load_config_test.rs
+++ b/src/cmd/tests/load_config_test.rs
@@ -108,6 +108,7 @@ fn test_load_datanode_example_config() {
                 level: Some("info".to_string()),
                 dir: format!("{}/{}", DEFAULT_DATA_HOME, DEFAULT_LOGGING_DIR),
                 otlp_endpoint: Some(DEFAULT_OTLP_HTTP_ENDPOINT.to_string()),
+                otlp_export_protocol: Some(common_telemetry::logging::OtlpExportProtocol::Http),
                 tracing_sample_ratio: Some(Default::default()),
                 ..Default::default()
             },
@@ -147,6 +148,7 @@ fn test_load_frontend_example_config() {
                 level: Some("info".to_string()),
                 dir: format!("{}/{}", DEFAULT_DATA_HOME, DEFAULT_LOGGING_DIR),
                 otlp_endpoint: Some(DEFAULT_OTLP_HTTP_ENDPOINT.to_string()),
+                otlp_export_protocol: Some(common_telemetry::logging::OtlpExportProtocol::Http),
                 tracing_sample_ratio: Some(Default::default()),
                 ..Default::default()
             },
@@ -197,6 +199,7 @@ fn test_load_metasrv_example_config() {
                 dir: format!("{}/{}", DEFAULT_DATA_HOME, DEFAULT_LOGGING_DIR),
                 level: Some("info".to_string()),
                 otlp_endpoint: Some(DEFAULT_OTLP_HTTP_ENDPOINT.to_string()),
+                otlp_export_protocol: Some(common_telemetry::logging::OtlpExportProtocol::Http),
                 tracing_sample_ratio: Some(Default::default()),
                 ..Default::default()
             },
@@ -314,6 +317,7 @@ fn test_load_standalone_example_config() {
                 level: Some("info".to_string()),
                 dir: format!("{}/{}", DEFAULT_DATA_HOME, DEFAULT_LOGGING_DIR),
                 otlp_endpoint: Some(DEFAULT_OTLP_HTTP_ENDPOINT.to_string()),
+                otlp_export_protocol: Some(common_telemetry::logging::OtlpExportProtocol::Http),
                 tracing_sample_ratio: Some(Default::default()),
                 ..Default::default()
             },

--- a/src/common/telemetry/src/logging.rs
+++ b/src/common/telemetry/src/logging.rs
@@ -237,7 +237,7 @@ enum TraceState {
 }
 
 /// The logging options that used to initialize the logger.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct LoggingOptions {
     /// The directory to store log files. If not set, logs will be written to stdout.
@@ -340,20 +340,6 @@ pub enum LogFormat {
     #[default]
     Text,
 }
-
-impl PartialEq for LoggingOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.dir == other.dir
-            && self.level == other.level
-            && self.enable_otlp_tracing == other.enable_otlp_tracing
-            && self.otlp_endpoint == other.otlp_endpoint
-            && self.tracing_sample_ratio == other.tracing_sample_ratio
-            && self.append_stdout == other.append_stdout
-            && self.enable_per_region_metrics == other.enable_per_region_metrics
-    }
-}
-
-impl Eq for LoggingOptions {}
 
 #[derive(Clone, Debug)]
 struct TraceContext {
@@ -873,5 +859,28 @@ mod tests {
         let http_json = r#""http""#;
         let protocol: OtlpExportProtocol = serde_json::from_str(http_json).unwrap();
         assert_eq!(protocol, OtlpExportProtocol::Http);
+    }
+
+    #[test]
+    fn test_logging_options_partial_eq_all_fields() {
+        let base = LoggingOptions::default();
+
+        let mut log_format = base.clone();
+        log_format.log_format = LogFormat::Json;
+        assert_ne!(base, log_format);
+
+        let mut max_log_files = base.clone();
+        max_log_files.max_log_files += 1;
+        assert_ne!(base, max_log_files);
+
+        let mut otlp_export_protocol = base.clone();
+        otlp_export_protocol.otlp_export_protocol = Some(OtlpExportProtocol::Http);
+        assert_ne!(base, otlp_export_protocol);
+
+        let mut otlp_headers = base.clone();
+        otlp_headers
+            .otlp_headers
+            .insert("key".to_string(), "value".to_string());
+        assert_ne!(base, otlp_headers);
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## What's changed and what's your intention?

The hand-written `impl PartialEq for LoggingOptions` only compared 7 of the struct's 11 fields, silently omitting four real fields:

- `log_format`
- `max_log_files`
- `otlp_export_protocol`
- `otlp_headers`

As a result, two `LoggingOptions` that differ only in those fields compared as equal. This masks config-parsing regressions: the config round-trip test in `src/cmd/tests/load_config_test.rs` asserts with `assert_eq!`, so a bug that mis-parses any of these four fields would still pass CI unnoticed.

### Fix

Replace the manual `PartialEq` impl with `#[derive(PartialEq)]` on the struct, so the comparison always covers every field (and stays correct as fields are added). Every field implements `PartialEq` (`String`, `Option<_>`, `usize`, `bool`, `HashMap`, `LogFormat` derives it, `OtlpExportProtocol` derives it, and `TracingSampleOptions` has a manual `PartialEq`), so the derive compiles.

I also removed the manual `impl Eq for LoggingOptions {}`. `Eq` cannot be derived here (`TracingSampleOptions` transitively contains an `f64`), and it turned out to be unused: `LoggingOptions` is never used as a `HashMap`/`HashSet` key, no code has a `T: Eq` bound over it, and its only container `GreptimeOptions<T>` (see `src/cmd/src/options.rs`) derives just `PartialEq`, not `Eq`. So dropping `Eq` is safe rather than keeping a redundant impl.

### Test

Added `test_logging_options_partial_eq_all_fields` in `logging.rs`, which starts from `LoggingOptions::default()` and asserts that mutating each of the four previously-ignored fields makes the value `!=` the default. This test fails on `main` (the old impl reports equality) and passes after the fix.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
