### PR TITLE
perf(json2): add JSON array align benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4447,6 +4447,7 @@ dependencies = [
  "common-macro",
  "common-telemetry",
  "common-time",
+ "criterion 0.7.0",
  "datafusion-common",
  "enum_dispatch",
  "jsonb",

--- a/src/datatypes/Cargo.toml
+++ b/src/datatypes/Cargo.toml
@@ -34,3 +34,10 @@ serde_json.workspace = true
 snafu.workspace = true
 sqlparser.workspace = true
 sqlparser_derive = "0.1"
+
+[dev-dependencies]
+criterion.workspace = true
+
+[[bench]]
+name = "json_array_align"
+harness = false

--- a/src/datatypes/benches/json_array_align.rs
+++ b/src/datatypes/benches/json_array_align.rs
@@ -1,0 +1,227 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::hint::black_box;
+use std::sync::Arc;
+
+use arrow::array::{Array, ArrayRef, AsArray, Int64Array, ListArray, StructArray};
+use arrow::buffer::OffsetBuffer;
+use arrow::datatypes::{DataType, Field, Fields};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use datatypes::vectors::json::array::JsonArray;
+
+const ROWS: usize = 8192;
+const MISSING_FIELDS: usize = 32;
+const ITEMS_PER_ROW: usize = 4;
+
+fn sorted_struct_type(mut fields: Vec<Field>) -> DataType {
+    fields.sort_by(|a, b| a.name().cmp(b.name()));
+    DataType::Struct(Fields::from(fields))
+}
+
+fn make_struct_input(rows: usize) -> ArrayRef {
+    Arc::new(StructArray::from(vec![(
+        Arc::new(Field::new("a_id", DataType::Int64, true)),
+        Arc::new(Int64Array::from_iter_values(0..rows as i64)) as ArrayRef,
+    )]))
+}
+
+fn make_expect_with_same_type_missing(missing_fields: usize) -> DataType {
+    let mut fields = vec![Field::new("a_id", DataType::Int64, true)];
+    fields.extend(
+        (0..missing_fields).map(|i| Field::new(format!("m_{i:03}"), DataType::Int64, true)),
+    );
+    sorted_struct_type(fields)
+}
+
+fn make_expect_with_mixed_missing(missing_fields: usize) -> DataType {
+    let mut fields = vec![Field::new("a_id", DataType::Int64, true)];
+    fields.extend((0..missing_fields).map(|i| {
+        let data_type = match i % 4 {
+            0 => DataType::Int64,
+            1 => DataType::Utf8,
+            2 => DataType::Boolean,
+            _ => DataType::Struct(Fields::from(vec![
+                Field::new("x", DataType::Int64, true),
+                Field::new("y", DataType::Utf8, true),
+            ])),
+        };
+        Field::new(format!("m_{i:03}"), data_type, true)
+    }));
+    sorted_struct_type(fields)
+}
+
+fn make_list_struct_input(rows: usize, items_per_row: usize) -> ArrayRef {
+    let values_len = rows * items_per_row;
+    let item_fields = Fields::from(vec![Field::new("a_id", DataType::Int64, true)]);
+    let item_type = DataType::Struct(item_fields.clone());
+    let values = Arc::new(StructArray::new(
+        item_fields,
+        vec![Arc::new(Int64Array::from_iter_values(0..values_len as i64)) as ArrayRef],
+        None,
+    ));
+    let offsets = OffsetBuffer::from_lengths(std::iter::repeat_n(items_per_row, rows));
+    let list = Arc::new(
+        ListArray::try_new(
+            Arc::new(Field::new_list_field(item_type.clone(), true)),
+            offsets,
+            values,
+            None,
+        )
+        .unwrap(),
+    ) as ArrayRef;
+
+    Arc::new(StructArray::from(vec![(
+        Arc::new(Field::new_list(
+            "items",
+            Field::new_list_field(item_type, true),
+            true,
+        )),
+        list,
+    )]))
+}
+
+fn make_list_struct_expect(missing_fields: usize) -> DataType {
+    let mut item_fields = vec![Field::new("a_id", DataType::Int64, true)];
+    item_fields.extend(
+        (0..missing_fields).map(|i| Field::new(format!("m_{i:03}"), DataType::Int64, true)),
+    );
+    item_fields.sort_by(|a, b| a.name().cmp(b.name()));
+
+    DataType::Struct(Fields::from(vec![Field::new_list(
+        "items",
+        Field::new_list_field(DataType::Struct(Fields::from(item_fields)), true),
+        true,
+    )]))
+}
+
+fn assert_struct_dataset(input: &ArrayRef, expect: &DataType, rows: usize, fields: usize) {
+    assert_eq!(input.len(), rows);
+    let DataType::Struct(expect_fields) = expect else {
+        panic!("expected struct type");
+    };
+    assert_eq!(expect_fields.len(), fields);
+}
+
+fn assert_list_struct_dataset(
+    input: &ArrayRef,
+    expect: &DataType,
+    rows: usize,
+    items_per_row: usize,
+    missing_fields: usize,
+) {
+    assert_eq!(input.len(), rows);
+    let input_struct = input.as_struct();
+    let list = input_struct.column(0).as_list::<i32>();
+    assert_eq!(list.len(), rows);
+    assert_eq!(list.values().len(), rows * items_per_row);
+
+    let DataType::Struct(expect_fields) = expect else {
+        panic!("expected struct type");
+    };
+    assert_eq!(expect_fields.len(), 1);
+    let DataType::List(item) = expect_fields[0].data_type() else {
+        panic!("expected list field");
+    };
+    let DataType::Struct(item_fields) = item.data_type() else {
+        panic!("expected struct list item");
+    };
+    assert_eq!(item_fields.len(), missing_fields + 1);
+}
+
+fn bench_json_array_align(c: &mut Criterion) {
+    let mut group = c.benchmark_group("json_array_align");
+
+    let input = make_struct_input(ROWS);
+    let expect = make_expect_with_same_type_missing(MISSING_FIELDS);
+    assert_struct_dataset(&input, &expect, ROWS, MISSING_FIELDS + 1);
+    group.bench_with_input(
+        BenchmarkId::new(
+            "missing_same_type",
+            format!("rows_{ROWS}_missing_{MISSING_FIELDS}"),
+        ),
+        &(&input, &expect),
+        |b, (input, expect)| {
+            b.iter(|| {
+                black_box(
+                    JsonArray::from(black_box(*input))
+                        .try_align(black_box(*expect))
+                        .unwrap(),
+                )
+            })
+        },
+    );
+
+    let input = make_struct_input(ROWS);
+    let expect = make_expect_with_mixed_missing(MISSING_FIELDS);
+    assert_struct_dataset(&input, &expect, ROWS, MISSING_FIELDS + 1);
+    group.bench_with_input(
+        BenchmarkId::new(
+            "missing_mixed_type",
+            format!("rows_{ROWS}_missing_{MISSING_FIELDS}"),
+        ),
+        &(&input, &expect),
+        |b, (input, expect)| {
+            b.iter(|| {
+                black_box(
+                    JsonArray::from(black_box(*input))
+                        .try_align(black_box(*expect))
+                        .unwrap(),
+                )
+            })
+        },
+    );
+
+    let input = make_list_struct_input(ROWS, ITEMS_PER_ROW);
+    let expect = make_list_struct_expect(MISSING_FIELDS);
+    assert_list_struct_dataset(&input, &expect, ROWS, ITEMS_PER_ROW, MISSING_FIELDS);
+    group.bench_with_input(
+        BenchmarkId::new(
+            "list_struct_missing",
+            format!("rows_{ROWS}_items_{ITEMS_PER_ROW}_missing_{MISSING_FIELDS}"),
+        ),
+        &(&input, &expect),
+        |b, (input, expect)| {
+            b.iter(|| {
+                black_box(
+                    JsonArray::from(black_box(*input))
+                        .try_align(black_box(*expect))
+                        .unwrap(),
+                )
+            })
+        },
+    );
+
+    let input = make_struct_input(ROWS);
+    let expect = input.data_type().clone();
+    assert_struct_dataset(&input, &expect, ROWS, 1);
+    group.bench_with_input(
+        BenchmarkId::new("already_aligned", format!("rows_{ROWS}")),
+        &(&input, &expect),
+        |b, (input, expect)| {
+            b.iter(|| {
+                black_box(
+                    JsonArray::from(black_box(*input))
+                        .try_align(black_box(*expect))
+                        .unwrap(),
+                )
+            })
+        },
+    );
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_json_array_align);
+criterion_main!(benches);

--- a/src/datatypes/src/vectors/json/array.rs
+++ b/src/datatypes/src/vectors/json/array.rs
@@ -361,6 +361,7 @@ impl<'a> From<&'a ArrayRef> for JsonArray<'a> {
 
 #[cfg(test)]
 mod test {
+    use arrow::buffer::OffsetBuffer;
     use arrow_array::types::Int64Type;
     use arrow_array::{
         BinaryArray, BooleanArray, Float64Array, Int32Array, Int64Array, ListArray, StringArray,
@@ -589,6 +590,61 @@ mod test {
                 ])),
                 Arc::new(StringArray::from(vec!["a", "b", "c"])),
             ]),
+        )
+        .test()?;
+
+        // Test list item alignment. The outer struct has 3 rows, while the list values
+        // contain 4 struct items. Missing item fields must use the values length.
+        let input_item_fields = Fields::from(vec![Field::new("id", DataType::Int64, true)]);
+        let expected_item_fields = Fields::from(vec![
+            Field::new("id", DataType::Int64, true),
+            Field::new("name", DataType::Utf8, true),
+        ]);
+        let input_item_type = DataType::Struct(input_item_fields.clone());
+        let expected_item_type = DataType::Struct(expected_item_fields.clone());
+        let offsets = OffsetBuffer::from_lengths([2, 0, 2]);
+        TestCase::new(
+            StructArray::from(vec![(
+                Arc::new(Field::new_list(
+                    "items",
+                    Field::new_list_field(input_item_type.clone(), true),
+                    true,
+                )),
+                Arc::new(
+                    ListArray::try_new(
+                        Arc::new(Field::new_list_field(input_item_type, true)),
+                        offsets.clone(),
+                        Arc::new(StructArray::new(
+                            input_item_fields,
+                            vec![Arc::new(Int64Array::from(vec![1, 2, 3, 4])) as ArrayRef],
+                            None,
+                        )),
+                        None,
+                    )
+                    .unwrap(),
+                ) as ArrayRef,
+            )]),
+            Fields::from(vec![Field::new_list(
+                "items",
+                Field::new_list_field(expected_item_type.clone(), true),
+                true,
+            )]),
+            Ok(vec![Arc::new(
+                ListArray::try_new(
+                    Arc::new(Field::new_list_field(expected_item_type, true)),
+                    offsets,
+                    Arc::new(StructArray::new(
+                        expected_item_fields,
+                        vec![
+                            Arc::new(Int64Array::from(vec![1, 2, 3, 4])) as ArrayRef,
+                            Arc::new(StringArray::new_null(4)),
+                        ],
+                        None,
+                    )),
+                    None,
+                )
+                .unwrap(),
+            )]),
         )
         .test()?;
 

--- a/src/datatypes/src/vectors/json/array.rs
+++ b/src/datatypes/src/vectors/json/array.rs
@@ -56,10 +56,13 @@ impl NullArrayCache {
     }
 
     fn get(&mut self, data_type: &DataType) -> ArrayRef {
-        self.arrays
-            .entry(data_type.clone())
-            .or_insert_with(|| new_null_array(data_type, self.len))
-            .clone()
+        if let Some(array) = self.arrays.get(data_type) {
+            array.clone()
+        } else {
+            let array = new_null_array(data_type, self.len);
+            self.arrays.insert(data_type.clone(), array.clone());
+            array
+        }
     }
 }
 

--- a/src/datatypes/src/vectors/json/array.rs
+++ b/src/datatypes/src/vectors/json/array.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::cmp::Ordering;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow::compute;
@@ -39,6 +40,27 @@ use crate::json::value::{decode_json_variant, encode_serde_json_as_jsonb};
 
 pub struct JsonArray<'a> {
     inner: &'a ArrayRef,
+}
+
+struct NullArrayCache {
+    len: usize,
+    arrays: HashMap<DataType, ArrayRef>,
+}
+
+impl NullArrayCache {
+    fn new(len: usize) -> Self {
+        Self {
+            len,
+            arrays: HashMap::new(),
+        }
+    }
+
+    fn get(&mut self, data_type: &DataType) -> ArrayRef {
+        self.arrays
+            .entry(data_type.clone())
+            .or_insert_with(|| new_null_array(data_type, self.len))
+            .clone()
+    }
 }
 
 impl JsonArray<'_> {
@@ -125,6 +147,7 @@ impl JsonArray<'_> {
             .fail();
         };
         let mut aligned = Vec::with_capacity(expect_fields.len());
+        let mut null_arrays = NullArrayCache::new(struct_array.len());
 
         // Compare the fields in the JSON array and the to-be-aligned schema, amending with null
         // arrays on the way. It's very important to note that fields in the JSON array and those
@@ -161,7 +184,7 @@ impl JsonArray<'_> {
                     j += 1;
                 }
                 Ordering::Less => {
-                    aligned.push(new_null_array(expect_field.data_type(), struct_array.len()));
+                    aligned.push(null_arrays.get(expect_field.data_type()));
                     i += 1;
                 }
                 Ordering::Greater => {
@@ -171,7 +194,7 @@ impl JsonArray<'_> {
         }
         if i < expect_fields.len() {
             for field in &expect_fields[i..] {
-                aligned.push(new_null_array(field.data_type(), struct_array.len()));
+                aligned.push(null_arrays.get(field.data_type()));
             }
         }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

`new_null_array` takes a noticeable portion of CPU time during JSON2 `try_align`. This PR adds a local null array cache in `JsonArray::try_align()` to reuse null arrays with the same type and length.

It also adds a benchmark for JSON array alignment.

### Benchmark

```bash
cargo bench -p datatypes --bench json_array_align
```

Results:

- missing_same_type: ~94.9% faster
- missing_mixed_type: ~87.0% faster
- list_struct_missing: ~97.5% faster
- already_aligned: no significant change

```text
➜ cargo bench -p datatypes --bench json_array_align
    Finished `bench` profile [optimized + debuginfo] target(s) in 5.66s
     Running benches/json_array_align.rs (target/release/deps/json_array_align-de808223a9a05355)
json_array_align/missing_same_type/rows_8192_missing_32
                        time:   [1.0135 µs 1.0142 µs 1.0150 µs]
                        change: [−94.916% −94.906% −94.896%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low severe
  4 (4.00%) high mild
  2 (2.00%) high severe
json_array_align/missing_mixed_type/rows_8192_missing_32
                        time:   [2.7737 µs 2.7750 µs 2.7765 µs]
                        change: [−87.053% −87.016% −86.991%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  1 (1.00%) high mild
  11 (11.00%) high severe
json_array_align/list_struct_missing/rows_8192_items_4_missing_32
                        time:   [1.7476 µs 1.7482 µs 1.7489 µs]
                        change: [−97.516% −97.514% −97.512%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
json_array_align/already_aligned/rows_8192
                        time:   [10.001 ns 10.005 ns 10.009 ns]
                        change: [−1.5568% −0.2631% +0.4839%] (p = 0.77 > 0.05)
                        No change in performance detected.
Found 16 outliers among 100 measurements (16.00%)
  3 (3.00%) low severe
  2 (2.00%) low mild
  3 (3.00%) high mild
  8 (8.00%) high severe
```

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
