### PR TITLE
chore: make OTLP trace ingest chunk size configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5500,7 +5500,6 @@ dependencies = [
  "humantime",
  "humantime-serde",
  "hyper-util",
- "itertools 0.14.0",
  "lazy_static",
  "log-query",
  "meta-client",

--- a/config/config.md
+++ b/config/config.md
@@ -73,7 +73,7 @@
 | `jaeger.enable` | Bool | `true` | Whether to enable Jaeger protocol in HTTP API. |
 | `otlp` | -- | -- | OpenTelemetry protocol options. |
 | `otlp.enable` | Bool | `true` | Whether to enable OpenTelemetry protocol in HTTP API. |
-| `otlp.trace_ingest_chunk_size` | Integer | `64` | Maximum spans per trace ingest chunk. Set to 0 to disable splitting. |
+| `otlp.trace_ingest_chunk_size` | Integer | `128` | Maximum spans per trace ingest chunk. Set to 0 to disable splitting. |
 | `prom_store` | -- | -- | Prometheus remote storage options |
 | `prom_store.enable` | Bool | `true` | Whether to enable Prometheus remote write and read in HTTP API. |
 | `prom_store.with_metric_engine` | Bool | `true` | Whether to store the data from Prometheus remote write in metric engine. |
@@ -305,7 +305,7 @@
 | `jaeger.enable` | Bool | `true` | Whether to enable Jaeger protocol in HTTP API. |
 | `otlp` | -- | -- | OpenTelemetry protocol options. |
 | `otlp.enable` | Bool | `true` | Whether to enable OpenTelemetry protocol in HTTP API. |
-| `otlp.trace_ingest_chunk_size` | Integer | `64` | Maximum spans per trace ingest chunk. Set to 0 to disable splitting. |
+| `otlp.trace_ingest_chunk_size` | Integer | `128` | Maximum spans per trace ingest chunk. Set to 0 to disable splitting. |
 | `prom_store` | -- | -- | Prometheus remote storage options |
 | `prom_store.enable` | Bool | `true` | Whether to enable Prometheus remote write and read in HTTP API. |
 | `prom_store.with_metric_engine` | Bool | `true` | Whether to store the data from Prometheus remote write in metric engine. |

--- a/config/config.md
+++ b/config/config.md
@@ -71,6 +71,9 @@
 | `influxdb.default_merge_mode` | String | `last_non_null` | Default merge mode for tables automatically created by InfluxDB protocol.<br/>Available values: "last_non_null", "last_row". |
 | `jaeger` | -- | -- | Jaeger protocol options. |
 | `jaeger.enable` | Bool | `true` | Whether to enable Jaeger protocol in HTTP API. |
+| `otlp` | -- | -- | OpenTelemetry protocol options. |
+| `otlp.enable` | Bool | `true` | Whether to enable OpenTelemetry protocol in HTTP API. |
+| `otlp.trace_ingest_chunk_size` | Integer | `64` | Maximum spans per trace ingest chunk. Set to 0 to disable splitting. |
 | `prom_store` | -- | -- | Prometheus remote storage options |
 | `prom_store.enable` | Bool | `true` | Whether to enable Prometheus remote write and read in HTTP API. |
 | `prom_store.with_metric_engine` | Bool | `true` | Whether to store the data from Prometheus remote write in metric engine. |
@@ -300,6 +303,9 @@
 | `influxdb.default_merge_mode` | String | `last_non_null` | Default merge mode for tables automatically created by InfluxDB protocol.<br/>Available values: "last_non_null", "last_row". |
 | `jaeger` | -- | -- | Jaeger protocol options. |
 | `jaeger.enable` | Bool | `true` | Whether to enable Jaeger protocol in HTTP API. |
+| `otlp` | -- | -- | OpenTelemetry protocol options. |
+| `otlp.enable` | Bool | `true` | Whether to enable OpenTelemetry protocol in HTTP API. |
+| `otlp.trace_ingest_chunk_size` | Integer | `64` | Maximum spans per trace ingest chunk. Set to 0 to disable splitting. |
 | `prom_store` | -- | -- | Prometheus remote storage options |
 | `prom_store.enable` | Bool | `true` | Whether to enable Prometheus remote write and read in HTTP API. |
 | `prom_store.with_metric_engine` | Bool | `true` | Whether to store the data from Prometheus remote write in metric engine. |

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -224,7 +224,7 @@ enable = true
 ## Whether to enable OpenTelemetry protocol in HTTP API.
 enable = true
 ## Maximum spans per trace ingest chunk. Set to 0 to disable splitting.
-trace_ingest_chunk_size = 64
+trace_ingest_chunk_size = 128
 
 ## Prometheus remote storage options
 [prom_store]

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -219,6 +219,13 @@ default_merge_mode = "last_non_null"
 ## Whether to enable Jaeger protocol in HTTP API.
 enable = true
 
+## OpenTelemetry protocol options.
+[otlp]
+## Whether to enable OpenTelemetry protocol in HTTP API.
+enable = true
+## Maximum spans per trace ingest chunk. Set to 0 to disable splitting.
+trace_ingest_chunk_size = 64
+
 ## Prometheus remote storage options
 [prom_store]
 ## Whether to enable Prometheus remote write and read in HTTP API.

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -186,6 +186,13 @@ default_merge_mode = "last_non_null"
 ## Whether to enable Jaeger protocol in HTTP API.
 enable = true
 
+## OpenTelemetry protocol options.
+[otlp]
+## Whether to enable OpenTelemetry protocol in HTTP API.
+enable = true
+## Maximum spans per trace ingest chunk. Set to 0 to disable splitting.
+trace_ingest_chunk_size = 64
+
 ## Prometheus remote storage options
 [prom_store]
 ## Whether to enable Prometheus remote write and read in HTTP API.

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -191,7 +191,7 @@ enable = true
 ## Whether to enable OpenTelemetry protocol in HTTP API.
 enable = true
 ## Maximum spans per trace ingest chunk. Set to 0 to disable splitting.
-trace_ingest_chunk_size = 64
+trace_ingest_chunk_size = 128
 
 ## Prometheus remote storage options
 [prom_store]

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -52,7 +52,6 @@ futures.workspace = true
 hostname.workspace = true
 humantime.workspace = true
 humantime-serde.workspace = true
-itertools.workspace = true
 lazy_static.workspace = true
 log-query.workspace = true
 meta-client.workspace = true

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -124,6 +124,7 @@ pub struct Instance {
     process_manager: ProcessManagerRef,
     slow_query_options: SlowQueryOptions,
     influxdb_default_merge_mode: InfluxdbMergeMode,
+    trace_ingest_chunk_size: usize,
     suspend: Arc<AtomicBool>,
 
     // cache for otlp metrics

--- a/src/frontend/src/instance/builder.rs
+++ b/src/frontend/src/instance/builder.rs
@@ -314,6 +314,7 @@ impl FrontendBuilder {
             otlp_metrics_table_legacy_cache: DashMap::new(),
             slow_query_options: self.options.slow_query.clone(),
             influxdb_default_merge_mode: self.options.influxdb.default_merge_mode,
+            trace_ingest_chunk_size: self.options.otlp.trace_ingest_chunk_size,
             suspend: Arc::new(AtomicBool::new(false)),
         })
     }

--- a/src/frontend/src/instance/otlp.rs
+++ b/src/frontend/src/instance/otlp.rs
@@ -26,7 +26,6 @@ use common_error::ext::{BoxedError, ErrorExt};
 use common_error::status_code::StatusCode;
 use common_query::prelude::GREPTIME_PHYSICAL_TABLE;
 use common_telemetry::{tracing, warn};
-use itertools::Itertools;
 use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
 use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
 use otel_arrow_rust::proto::opentelemetry::collector::metrics::v1::ExportMetricsServiceRequest;
@@ -845,12 +844,12 @@ fn chunk_owned<T>(items: Vec<T>, chunk_size: usize) -> Vec<Vec<T>> {
         return vec![items];
     }
 
-    items
-        .into_iter()
-        .chunks(chunk_size)
-        .into_iter()
-        .map(|chunk| chunk.collect::<Vec<_>>())
-        .collect()
+    let mut chunks = Vec::with_capacity(items.len().div_ceil(chunk_size));
+    let mut iter = items.into_iter();
+    while iter.len() > 0 {
+        chunks.push(iter.by_ref().take(chunk_size).collect());
+    }
+    chunks
 }
 
 /// Preserve the original alter failure status so chunk retry behavior stays correct.

--- a/src/frontend/src/instance/otlp.rs
+++ b/src/frontend/src/instance/otlp.rs
@@ -63,7 +63,6 @@ use crate::metrics::{
 pub mod trace_semconv;
 pub mod trace_types;
 
-const TRACE_INGEST_CHUNK_SIZE: usize = 64;
 const TRACE_FAILURE_MESSAGE_LIMIT: usize = 4;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -311,13 +310,7 @@ impl Instance {
         };
 
         for group in groups {
-            let chunks = group
-                .spans
-                .into_iter()
-                .chunks(TRACE_INGEST_CHUNK_SIZE)
-                .into_iter()
-                .map(|chunk| chunk.collect::<Vec<_>>())
-                .collect::<Vec<_>>();
+            let chunks = chunk_owned(group.spans, self.trace_ingest_chunk_size);
             for chunk in chunks {
                 self.ingest_trace_chunk(&ingest_ctx, chunk, main_ctx.clone(), &mut ingest_state)
                     .await?;
@@ -843,6 +836,23 @@ impl Instance {
     }
 }
 
+fn chunk_owned<T>(items: Vec<T>, chunk_size: usize) -> Vec<Vec<T>> {
+    if items.is_empty() {
+        return Vec::new();
+    }
+
+    if chunk_size == 0 {
+        return vec![items];
+    }
+
+    items
+        .into_iter()
+        .chunks(chunk_size)
+        .into_iter()
+        .map(|chunk| chunk.collect::<Vec<_>>())
+        .collect()
+}
+
 /// Preserve the original alter failure status so chunk retry behavior stays correct.
 fn wrap_trace_alter_failure<E>(err: E) -> servers::error::Error
 where
@@ -898,8 +908,20 @@ mod tests {
     use common_error::status_code::StatusCode;
     use servers::query_handler::TraceIngestOutcome;
 
-    use super::{ChunkFailureReaction, Instance, wrap_trace_alter_failure};
+    use super::{ChunkFailureReaction, Instance, chunk_owned, wrap_trace_alter_failure};
     use crate::metrics::OTLP_TRACES_FAILURE_COUNT;
+
+    #[test]
+    fn test_chunk_owned() {
+        let chunks = chunk_owned(vec![1, 2, 3], 2);
+        assert_eq!(chunks.iter().map(Vec::len).collect::<Vec<_>>(), vec![2, 1]);
+
+        let chunks = chunk_owned(vec![1, 2, 3], 0);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].len(), 3);
+
+        assert!(chunk_owned::<i32>(Vec::new(), 0).is_empty());
+    }
 
     #[test]
     fn test_classify_trace_chunk_failure() {

--- a/src/frontend/src/service_config/otlp.rs
+++ b/src/frontend/src/service_config/otlp.rs
@@ -14,7 +14,7 @@
 
 use serde::{Deserialize, Serialize};
 
-const DEFAULT_TRACE_INGEST_CHUNK_SIZE: usize = 64;
+const DEFAULT_TRACE_INGEST_CHUNK_SIZE: usize = 128;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default)]

--- a/src/frontend/src/service_config/otlp.rs
+++ b/src/frontend/src/service_config/otlp.rs
@@ -14,14 +14,22 @@
 
 use serde::{Deserialize, Serialize};
 
+const DEFAULT_TRACE_INGEST_CHUNK_SIZE: usize = 64;
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
 pub struct OtlpOptions {
     pub enable: bool,
+    /// Maximum spans per trace ingest chunk. Set to 0 to disable splitting.
+    pub trace_ingest_chunk_size: usize,
 }
 
 impl Default for OtlpOptions {
     fn default() -> Self {
-        Self { enable: true }
+        Self {
+            enable: true,
+            trace_ingest_chunk_size: DEFAULT_TRACE_INGEST_CHUNK_SIZE,
+        }
     }
 }
 
@@ -33,5 +41,20 @@ mod tests {
     fn test_otlp_options() {
         let default = OtlpOptions::default();
         assert!(default.enable);
+        assert_eq!(
+            default.trace_ingest_chunk_size,
+            DEFAULT_TRACE_INGEST_CHUNK_SIZE
+        );
+
+        let options: OtlpOptions = toml::from_str("enable = false").unwrap();
+        assert!(!options.enable);
+        assert_eq!(
+            options.trace_ingest_chunk_size,
+            DEFAULT_TRACE_INGEST_CHUNK_SIZE
+        );
+
+        let options: OtlpOptions = toml::from_str("trace_ingest_chunk_size = 0").unwrap();
+        assert!(options.enable);
+        assert_eq!(options.trace_ingest_chunk_size, 0);
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This pull request adds a frontend OTLP config option for trace ingest chunk sizing, replacing the hard-coded trace split size with `otlp.trace_ingest_chunk_size`.

The default chunk size is `128` spans, and setting it to `0` disables splitting so trace groups are ingested as-is. The change updates the frontend and standalone example TOMLs, generated config docs, and the frontend OTLP config defaults/tests.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
