### PR TITLE
ci: check kafka readiness before fuzz tests

### DIFF
--- a/.github/scripts/wait-kafka-ready.sh
+++ b/.github/scripts/wait-kafka-ready.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+GT_KAFKA_NAMESPACE="${GT_KAFKA_NAMESPACE:-kafka-cluster}"
+GT_KAFKA_CLIENT_NAMESPACE="${GT_KAFKA_CLIENT_NAMESPACE:-my-greptimedb}"
+GT_KAFKA_BOOTSTRAP_SERVERS="${GT_KAFKA_BOOTSTRAP_SERVERS:-kafka.kafka-cluster.svc.cluster.local:9092}"
+GT_KAFKA_IMAGE="${GT_KAFKA_IMAGE:-docker.io/greptime/kafka:3.9.0-debian-12-r1}"
+GT_KAFKA_READY_TIMEOUT_SECS="${GT_KAFKA_READY_TIMEOUT_SECS:-120}"
+GT_KAFKA_READY_INTERVAL_SECS="${GT_KAFKA_READY_INTERVAL_SECS:-5}"
+GT_KAFKA_POD_LABEL="${GT_KAFKA_POD_LABEL:-app.kubernetes.io/instance=kafka}"
+
+log() {
+  printf '[wait-kafka-ready] %s\n' "$*"
+}
+
+run_client_probe() {
+  local pod_name="kafka-readiness-${RANDOM}-${RANDOM}"
+
+  kubectl run "${pod_name}" \
+    --namespace "${GT_KAFKA_CLIENT_NAMESPACE}" \
+    --image "${GT_KAFKA_IMAGE}" \
+    --restart=Never \
+    --rm \
+    --attach \
+    --quiet \
+    --env "GT_KAFKA_BOOTSTRAP_SERVERS=${GT_KAFKA_BOOTSTRAP_SERVERS}" \
+    --command -- bash -euo pipefail -c '
+      if command -v kafka-broker-api-versions.sh >/dev/null 2>&1; then
+        kafka_tool="kafka-broker-api-versions.sh"
+      elif [ -x /opt/bitnami/kafka/bin/kafka-broker-api-versions.sh ]; then
+        kafka_tool="/opt/bitnami/kafka/bin/kafka-broker-api-versions.sh"
+      else
+        echo "kafka-broker-api-versions.sh not found" >&2
+        exit 1
+      fi
+
+      "${kafka_tool}" --bootstrap-server "${GT_KAFKA_BOOTSTRAP_SERVERS}" >/tmp/kafka-ready.out
+      cat /tmp/kafka-ready.out
+    '
+}
+
+log "wait for Kafka pods in namespace ${GT_KAFKA_NAMESPACE}"
+kubectl wait \
+  --for=condition=Ready \
+  pod -l "${GT_KAFKA_POD_LABEL}" \
+  --timeout="${GT_KAFKA_READY_TIMEOUT_SECS}s" \
+  -n "${GT_KAFKA_NAMESPACE}"
+
+deadline=$((SECONDS + GT_KAFKA_READY_TIMEOUT_SECS))
+attempt=1
+
+while [ "${SECONDS}" -le "${deadline}" ]; do
+  log "probe Kafka from namespace ${GT_KAFKA_CLIENT_NAMESPACE}, attempt ${attempt}"
+  if run_client_probe; then
+    log "Kafka is ready at ${GT_KAFKA_BOOTSTRAP_SERVERS}"
+    exit 0
+  fi
+
+  log "Kafka probe failed; retrying in ${GT_KAFKA_READY_INTERVAL_SECS}s"
+  sleep "${GT_KAFKA_READY_INTERVAL_SECS}"
+  attempt=$((attempt + 1))
+done
+
+log "timed out waiting for Kafka bootstrap ${GT_KAFKA_BOOTSTRAP_SERVERS}"
+kubectl get pods -o wide -n "${GT_KAFKA_NAMESPACE}" || true
+kubectl get pods -o wide -n "${GT_KAFKA_CLIENT_NAMESPACE}" || true
+exit 1

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -457,6 +457,11 @@ jobs:
         name: Port forward Kafka WAL helper
         run: |
           kubectl port-forward service/kafka-wal-helper 8080:8080 -n kafka-cluster&
+      - if: matrix.mode.kafka
+        name: Check Kafka readiness
+        shell: bash
+        run: |
+          .github/scripts/wait-kafka-ready.sh
       - name: Fuzz Test
         uses: ./.github/actions/fuzz-test
         env:
@@ -648,6 +653,11 @@ jobs:
       - name: Port forward (mysql)
         run: |
           kubectl port-forward service/my-greptimedb-frontend 4002:4002 -n my-greptimedb&
+      - if: matrix.mode.kafka
+        name: Check Kafka readiness
+        shell: bash
+        run: |
+          .github/scripts/wait-kafka-ready.sh
       - name: Fuzz Test
         uses: ./.github/actions/fuzz-test
         env:


### PR DESCRIPTION
Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)

I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR adds a Kafka readiness probe before distributed fuzz tests that use Kafka WAL.

Previously, the workflow only waited for Kafka pods to become `Ready`. In a failed fuzz run, the GreptimeDB datanode could discover the Kafka WAL topic leader but repeatedly timed out connecting to the broker endpoint from the GreptimeDB namespace. Pod readiness alone did not verify that Kafka was reachable from the actual client namespace.

This change adds `.github/scripts/wait-kafka-ready.sh`, which:

- waits for Kafka pods to be ready;
- starts a temporary Kafka client pod in the GreptimeDB namespace;
- runs `kafka-broker-api-versions.sh` against the configured bootstrap server;
- retries until Kafka is reachable or times out;
- dumps Kafka and client namespace pod status on failure.

The develop workflow now runs this readiness check before fuzz tests in both distributed fuzz jobs when `matrix.mode.kafka` is enabled.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
