### PR TITLE
feat(mito): add adaptive metric value encoding

### DIFF
--- a/src/cmd/src/bin/query_perf_fixture.rs
+++ b/src/cmd/src/bin/query_perf_fixture.rs
@@ -601,6 +601,9 @@ async fn main() {
             write_buffer_size: DEFAULT_WRITE_BUFFER_SIZE,
             row_group_size: scenario.layout.row_group_size,
             max_file_size: None,
+            parquet: Default::default(),
+            parquet_write_operation: Default::default(),
+            metric_value_encoding_mode: Default::default(),
         };
         let infos = match format {
             FormatType::Flat => writer.write_all_flat(source, Some(sequence), &opts).await,

--- a/src/common/meta/src/ddl/create_table.rs
+++ b/src/common/meta/src/ddl/create_table.rs
@@ -27,6 +27,10 @@ use common_telemetry::info;
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt};
 use store_api::metadata::ColumnMetadata;
+use store_api::metric_engine_consts::{METRIC_ENGINE_NAME, PHYSICAL_TABLE_METADATA_KEY};
+use store_api::mito_engine_options::{
+    EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING, METRIC_ENGINE_VALUE_ENCODING_AUTO,
+};
 use strum::AsRefStr;
 use table::metadata::{TableId, TableInfo};
 use table::table_name::TableName;
@@ -77,6 +81,37 @@ fn build_executor_from_create_table_data(
     Ok(executor)
 }
 
+/// Normalizes new submissions only; recovered procedures retain their original options for compatibility.
+fn normalize_new_physical_metric_table_value_encoding(
+    mut task: CreateTableTask,
+) -> CreateTableTask {
+    let create_table = &mut task.create_table;
+    if create_table.engine != METRIC_ENGINE_NAME
+        || !create_table
+            .table_options
+            .contains_key(PHYSICAL_TABLE_METADATA_KEY)
+    {
+        return task;
+    }
+
+    // The create expression is canonical when its options disagree with TableInfo.
+    let value_encoding = create_table
+        .table_options
+        .get(EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING)
+        .cloned()
+        .unwrap_or_else(|| METRIC_ENGINE_VALUE_ENCODING_AUTO.to_string());
+    create_table.table_options.insert(
+        EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING.to_string(),
+        value_encoding.clone(),
+    );
+    task.table_info.meta.options.extra_options.insert(
+        EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING.to_string(),
+        value_encoding,
+    );
+
+    task
+}
+
 impl CreateTableProcedure {
     pub const TYPE_NAME: &'static str = "metasrv-procedure::CreateTable";
 
@@ -89,6 +124,7 @@ impl CreateTableProcedure {
         query_context: QueryContext,
         context: DdlContext,
     ) -> Result<Self> {
+        let task = normalize_new_physical_metric_table_value_encoding(task);
         let executor = build_executor_from_create_table_data(&task.create_table)?;
 
         Ok(Self {

--- a/src/common/meta/src/ddl/tests/create_table.rs
+++ b/src/common/meta/src/ddl/tests/create_table.rs
@@ -30,7 +30,13 @@ use common_wal::options::{KafkaWalOptions, WalOptions};
 use datatypes::prelude::ConcreteDataType;
 use datatypes::schema::ColumnSchema;
 use store_api::metadata::ColumnMetadata;
-use store_api::metric_engine_consts::TABLE_COLUMN_METADATA_EXTENSION_KEY;
+use store_api::metric_engine_consts::{
+    LOGICAL_TABLE_METADATA_KEY, METRIC_ENGINE_NAME, PHYSICAL_TABLE_METADATA_KEY,
+    TABLE_COLUMN_METADATA_EXTENSION_KEY,
+};
+use store_api::mito_engine_options::{
+    EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING, METRIC_ENGINE_VALUE_ENCODING_AUTO,
+};
 use store_api::region_engine::RegionRole;
 use store_api::storage::RegionId;
 use tokio::sync::mpsc;
@@ -44,8 +50,12 @@ use crate::ddl::test_util::datanode_handler::{
     DatanodeWatcher, NaiveDatanodeHandler, RetryErrorDatanodeHandler,
     UnexpectedErrorDatanodeHandler,
 };
-use crate::ddl::test_util::{assert_column_name, get_raw_table_info, put_datanode_address};
+use crate::ddl::test_util::{
+    assert_column_name, get_raw_table_info, put_datanode_address, test_create_logical_table_task,
+    test_create_physical_table_task,
+};
 use crate::error::{Error, Result};
+use crate::key::datanode_table::DatanodeTableKey;
 use crate::key::table_route::TableRouteValue;
 use crate::kv_backend::memory::MemoryKvBackend;
 use crate::rpc::ddl::CreateTableTask;
@@ -171,6 +181,229 @@ pub(crate) fn test_create_table_task(name: &str) -> CreateTableTask {
         partitions: vec![Partition::default()],
         table_info,
     }
+}
+
+fn test_physical_metric_table_task(name: &str) -> CreateTableTask {
+    let mut task = test_create_physical_table_task(name);
+    task.create_table
+        .table_options
+        .insert(PHYSICAL_TABLE_METADATA_KEY.to_string(), String::new());
+    task.table_info
+        .meta
+        .options
+        .extra_options
+        .insert(PHYSICAL_TABLE_METADATA_KEY.to_string(), String::new());
+    task
+}
+
+#[test]
+fn test_new_physical_metric_table_defaults_value_encoding_in_task_and_template() {
+    let task = test_physical_metric_table_task("physical");
+    let context = new_ddl_context(Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler)));
+
+    let procedure = CreateTableProcedure::new(task, context).unwrap();
+
+    assert_eq!(
+        procedure
+            .data
+            .task
+            .create_table
+            .table_options
+            .get(EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING),
+        Some(&METRIC_ENGINE_VALUE_ENCODING_AUTO.to_string())
+    );
+    assert_eq!(
+        procedure
+            .data
+            .task
+            .table_info
+            .meta
+            .options
+            .extra_options
+            .get(EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING),
+        Some(&METRIC_ENGINE_VALUE_ENCODING_AUTO.to_string())
+    );
+    assert_eq!(
+        procedure
+            .executor
+            .builder()
+            .template()
+            .options
+            .get(EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING),
+        Some(&METRIC_ENGINE_VALUE_ENCODING_AUTO.to_string())
+    );
+}
+
+#[test]
+fn test_new_physical_metric_table_expression_value_encoding_wins() {
+    let mut task = test_physical_metric_table_task("physical");
+    task.create_table.table_options.insert(
+        EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING.to_string(),
+        "plain".to_string(),
+    );
+    task.table_info.meta.options.extra_options.insert(
+        EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING.to_string(),
+        "mismatched".to_string(),
+    );
+    let context = new_ddl_context(Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler)));
+
+    let procedure = CreateTableProcedure::new(task, context).unwrap();
+
+    assert_eq!(
+        procedure
+            .data
+            .task
+            .create_table
+            .table_options
+            .get(EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING),
+        Some(&"plain".to_string())
+    );
+    assert_eq!(
+        procedure
+            .data
+            .task
+            .table_info
+            .meta
+            .options
+            .extra_options
+            .get(EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING),
+        Some(&"plain".to_string())
+    );
+}
+
+#[test]
+fn test_value_encoding_normalization_only_applies_to_physical_metric_tables() {
+    let logical_task = test_create_logical_table_task("logical");
+    assert_eq!(logical_task.create_table.engine, METRIC_ENGINE_NAME);
+    assert!(
+        logical_task
+            .create_table
+            .table_options
+            .contains_key(LOGICAL_TABLE_METADATA_KEY)
+    );
+
+    let mut non_metric_task = test_create_table_task("non_metric");
+    non_metric_task
+        .create_table
+        .table_options
+        .insert(PHYSICAL_TABLE_METADATA_KEY.to_string(), String::new());
+
+    for task in [logical_task, non_metric_task] {
+        let context = new_ddl_context(Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler)));
+        let procedure = CreateTableProcedure::new(task, context).unwrap();
+        assert!(
+            !procedure
+                .data
+                .task
+                .create_table
+                .table_options
+                .contains_key(EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING)
+        );
+        assert!(
+            !procedure
+                .data
+                .task
+                .table_info
+                .meta
+                .options
+                .extra_options
+                .contains_key(EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING)
+        );
+    }
+}
+
+#[test]
+fn test_recover_legacy_physical_metric_table_keeps_missing_value_encoding() {
+    let task = test_physical_metric_table_task("legacy_physical");
+    let data = CreateTableData::new(task, Default::default());
+    let json = serde_json::to_string(&data).unwrap();
+    let context = new_ddl_context(Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler)));
+
+    let procedure = CreateTableProcedure::from_json(&json, context).unwrap();
+
+    assert!(
+        !procedure
+            .data
+            .task
+            .create_table
+            .table_options
+            .contains_key(EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING)
+    );
+    assert!(
+        !procedure
+            .data
+            .task
+            .table_info
+            .meta
+            .options
+            .extra_options
+            .contains_key(EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING)
+    );
+    assert!(
+        !procedure
+            .executor
+            .builder()
+            .template()
+            .options
+            .contains_key(EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING)
+    );
+}
+
+#[test]
+fn test_recover_new_physical_metric_table_retains_value_encoding() {
+    let task = test_physical_metric_table_task("physical");
+    let context = new_ddl_context(Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler)));
+    let procedure = CreateTableProcedure::new(task, context.clone()).unwrap();
+    let json = procedure.dump().unwrap();
+
+    let mut recovered = CreateTableProcedure::from_json(&json, context).unwrap();
+    recovered.recover().unwrap();
+
+    assert_eq!(
+        recovered
+            .data
+            .task
+            .create_table
+            .table_options
+            .get(EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING),
+        Some(&METRIC_ENGINE_VALUE_ENCODING_AUTO.to_string())
+    );
+    assert_eq!(
+        recovered
+            .data
+            .task
+            .table_info
+            .meta
+            .options
+            .extra_options
+            .get(EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING),
+        Some(&METRIC_ENGINE_VALUE_ENCODING_AUTO.to_string())
+    );
+}
+
+#[tokio::test]
+async fn test_physical_metric_table_persists_default_value_encoding_in_region_options() {
+    let node_manager = Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler));
+    let context = new_ddl_context(node_manager);
+    let task = test_physical_metric_table_task("physical");
+    let mut procedure = CreateTableProcedure::new(task, context.clone()).unwrap();
+
+    execute_procedure_until_done(&mut procedure).await;
+
+    let datanode_table = context
+        .table_metadata_manager
+        .datanode_table_manager()
+        .get(&DatanodeTableKey::new(0, procedure.table_id()))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        datanode_table
+            .region_info
+            .region_options
+            .get(EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING),
+        Some(&METRIC_ENGINE_VALUE_ENCODING_AUTO.to_string())
+    );
 }
 
 #[tokio::test]

--- a/src/metric-engine/src/engine/create.rs
+++ b/src/metric-engine/src/engine/create.rs
@@ -42,7 +42,7 @@ use store_api::storage::consts::ReservedColumnId;
 
 use crate::engine::MetricEngineInner;
 use crate::engine::create::extract_new_columns::extract_new_columns;
-use crate::engine::options::{PhysicalRegionOptions, set_data_region_options};
+use crate::engine::options::{PhysicalRegionOptions, set_data_region_options_for_create};
 use crate::error::{
     ColumnTypeMismatchSnafu, ConflictRegionOptionSnafu, CreateMitoRegionSnafu,
     InternalColumnOccupiedSnafu, InvalidMetadataSnafu, MissingRegionOptionSnafu,
@@ -554,7 +554,7 @@ impl MetricEngineInner {
         data_region_request.primary_key = primary_key;
 
         // set data region options
-        set_data_region_options(
+        set_data_region_options_for_create(
             &mut data_region_request.options,
             self.config.sparse_primary_key_encoding,
         );

--- a/src/metric-engine/src/engine/open.rs
+++ b/src/metric-engine/src/engine/open.rs
@@ -27,7 +27,7 @@ use store_api::storage::RegionId;
 
 use crate::engine::MetricEngineInner;
 use crate::engine::create::region_options_for_metadata_region;
-use crate::engine::options::{PhysicalRegionOptions, set_data_region_options};
+use crate::engine::options::{PhysicalRegionOptions, set_data_region_options_for_open};
 use crate::error::{
     BatchOpenMitoRegionSnafu, NoOpenRegionResultSnafu, OpenMitoRegionSnafu,
     PhysicalRegionNotFoundSnafu, Result,
@@ -226,7 +226,7 @@ impl MetricEngineInner {
         };
 
         let mut data_region_options = request.options;
-        set_data_region_options(
+        set_data_region_options_for_open(
             &mut data_region_options,
             self.config.sparse_primary_key_encoding,
         );

--- a/src/metric-engine/src/engine/options.rs
+++ b/src/metric-engine/src/engine/options.rs
@@ -26,7 +26,7 @@ use store_api::metric_engine_consts::{
 };
 use store_api::mito_engine_options::{
     COMPACTION_TYPE, COMPACTION_TYPE_TWCS, EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING,
-    TWCS_TIME_WINDOW,
+    METRIC_ENGINE_VALUE_ENCODING_AUTO, TWCS_TIME_WINDOW,
 };
 
 /// Prefix for legacy `memtable.partition_tree.*` option keys. These keys are
@@ -112,7 +112,7 @@ fn set_data_region_options_inner(
     {
         options.insert(
             EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING.to_string(),
-            "auto".to_string(),
+            METRIC_ENGINE_VALUE_ENCODING_AUTO.to_string(),
         );
     }
 }
@@ -276,7 +276,7 @@ mod tests {
         assert_eq!(options.get(TWCS_TIME_WINDOW), Some(&"1d".to_string()));
         assert_eq!(
             options.get(EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING),
-            Some(&"auto".to_string())
+            Some(&METRIC_ENGINE_VALUE_ENCODING_AUTO.to_string())
         );
     }
 

--- a/src/metric-engine/src/engine/options.rs
+++ b/src/metric-engine/src/engine/options.rs
@@ -24,7 +24,10 @@ use store_api::metric_engine_consts::{
     METRIC_ENGINE_INDEX_SKIPPING_INDEX_GRANULARITY_OPTION_DEFAULT, METRIC_ENGINE_INDEX_TYPE_OPTION,
     PRIMARY_KEY_ENCODING,
 };
-use store_api::mito_engine_options::{COMPACTION_TYPE, COMPACTION_TYPE_TWCS, TWCS_TIME_WINDOW};
+use store_api::mito_engine_options::{
+    COMPACTION_TYPE, COMPACTION_TYPE_TWCS, EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING,
+    TWCS_TIME_WINDOW,
+};
 
 /// Prefix for legacy `memtable.partition_tree.*` option keys. These keys are
 /// silently dropped by the metric engine; the partition tree memtable is gone.
@@ -60,9 +63,10 @@ pub enum IndexOptions {
 }
 
 /// Sets data region specific options.
-pub fn set_data_region_options(
+fn set_data_region_options_inner(
     options: &mut HashMap<String, String>,
     sparse_primary_key_encoding_if_absent: bool,
+    insert_value_encoding_default: bool,
 ) {
     options.remove(METRIC_ENGINE_INDEX_TYPE_OPTION);
     options.remove(METRIC_ENGINE_INDEX_SKIPPING_INDEX_GRANULARITY_OPTION);
@@ -102,6 +106,40 @@ pub fn set_data_region_options(
             DEFAULT_DATA_REGION_COMPACTION_TIME_WINDOW.to_string(),
         );
     }
+
+    if insert_value_encoding_default
+        && !options.contains_key(EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING)
+    {
+        options.insert(
+            EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING.to_string(),
+            "auto".to_string(),
+        );
+    }
+}
+
+/// Sets data region specific options when creating a physical data region.
+pub fn set_data_region_options_for_create(
+    options: &mut HashMap<String, String>,
+    sparse_primary_key_encoding_if_absent: bool,
+) {
+    set_data_region_options_inner(options, sparse_primary_key_encoding_if_absent, true);
+}
+
+/// Sets data region specific options when opening a physical data region.
+pub fn set_data_region_options_for_open(
+    options: &mut HashMap<String, String>,
+    sparse_primary_key_encoding_if_absent: bool,
+) {
+    set_data_region_options_inner(options, sparse_primary_key_encoding_if_absent, false);
+}
+
+/// Sets data region specific options.
+#[allow(dead_code)]
+pub fn set_data_region_options(
+    options: &mut HashMap<String, String>,
+    sparse_primary_key_encoding_if_absent: bool,
+) {
+    set_data_region_options_for_create(options, sparse_primary_key_encoding_if_absent);
 }
 
 impl TryFrom<&HashMap<String, String>> for PhysicalRegionOptions {
@@ -236,6 +274,33 @@ mod tests {
             Some(&COMPACTION_TYPE_TWCS.to_string())
         );
         assert_eq!(options.get(TWCS_TIME_WINDOW), Some(&"1d".to_string()));
+        assert_eq!(
+            options.get(EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING),
+            Some(&"auto".to_string())
+        );
+    }
+
+    #[test]
+    fn test_set_data_region_options_for_open_preserves_missing_value_encoding() {
+        let mut options = HashMap::new();
+        set_data_region_options_for_open(&mut options, false);
+
+        assert!(!options.contains_key(EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING));
+    }
+
+    #[test]
+    fn test_set_data_region_options_for_create_preserves_user_value_encoding() {
+        let mut options = HashMap::new();
+        options.insert(
+            EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING.to_string(),
+            "plain".to_string(),
+        );
+        set_data_region_options_for_create(&mut options, false);
+
+        assert_eq!(
+            options.get(EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING),
+            Some(&"plain".to_string())
+        );
     }
 
     #[test]

--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -44,6 +44,7 @@ use crate::sst::index::intermediate::IntermediateManager;
 use crate::sst::index::puffin_manager::{PuffinManagerFactory, SstPuffinManager};
 use crate::sst::location::{self, region_dir_from_table_dir};
 use crate::sst::parquet::reader::ParquetReaderBuilder;
+use crate::sst::parquet::value_encoding::ParquetWriteOperation;
 use crate::sst::parquet::writer::ParquetWriter;
 use crate::sst::parquet::{SstInfo, WriteOptions};
 use crate::sst::{DEFAULT_WRITE_BUFFER_SIZE, DEFAULT_WRITE_CONCURRENCY, FormatType};
@@ -340,6 +341,11 @@ impl AccessLayer {
         let region_id = request.metadata.region_id;
         let region_metadata = request.metadata.clone();
         let cache_manager = request.cache_manager.clone();
+        let mut effective_write_opts = write_opts.clone();
+        effective_write_opts.parquet_write_operation = match request.op_type {
+            OperationType::Flush => ParquetWriteOperation::Flush,
+            OperationType::Compact => ParquetWriteOperation::Compaction,
+        };
 
         let sst_info = if let Some(write_cache) = cache_manager.write_cache() {
             // Write to the write cache.
@@ -353,7 +359,7 @@ impl AccessLayer {
                         ),
                         remote_store: self.object_store.clone(),
                     },
-                    write_opts,
+                    &effective_write_opts,
                     metrics,
                 )
                 .await?
@@ -364,7 +370,7 @@ impl AccessLayer {
             let indexer_builder = IndexerBuilderImpl {
                 build_type: request.op_type.into(),
                 metadata: request.metadata.clone(),
-                row_group_size: write_opts.row_group_size,
+                row_group_size: effective_write_opts.row_group_size,
                 puffin_manager: self
                     .puffin_manager_factory
                     .build(store, path_provider.clone()),
@@ -397,13 +403,13 @@ impl AccessLayer {
                         .write_all_flat_as_primary_key(
                             request.source,
                             request.max_sequence,
-                            write_opts,
+                            &effective_write_opts,
                         )
                         .await?
                 }
                 FormatType::Flat => {
                     writer
-                        .write_all_flat(request.source, request.max_sequence, write_opts)
+                        .write_all_flat(request.source, request.max_sequence, &effective_write_opts)
                         .await?
                 }
             }

--- a/src/mito2/src/compaction/compactor.rs
+++ b/src/mito2/src/compaction/compactor.rs
@@ -591,6 +591,9 @@ where
             let write_opts = WriteOptions {
                 write_buffer_size: compaction_region.engine_config.sst_write_buffer_size,
                 max_file_size: picker_output.max_file_size,
+                metric_value_encoding_mode: compaction_region
+                    .region_options
+                    .experimental_metric_engine_value_encoding,
                 ..Default::default()
             };
             let merger = self.merger.clone();

--- a/src/mito2/src/compaction/window.rs
+++ b/src/mito2/src/compaction/window.rs
@@ -254,6 +254,7 @@ mod tests {
                 merge_mode: None,
                 sst_format: None,
                 primary_key_encoding: None,
+                experimental_metric_engine_value_encoding: Default::default(),
             },
             compaction_time_window: None,
         }

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -424,12 +424,12 @@ impl RegionFlushTask {
 
         let mut write_opts = WriteOptions {
             write_buffer_size: self.engine_config.sst_write_buffer_size,
+            metric_value_encoding_mode: version.options.experimental_metric_engine_value_encoding,
             ..Default::default()
         };
         if let Some(row_group_size) = self.row_group_size {
             write_opts.row_group_size = row_group_size;
         }
-
         let DoFlushMemtablesResult {
             file_metas,
             flushed_bytes,

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -441,6 +441,9 @@ impl MemtableBuilderProvider {
             Some(MemtableOptions::Bulk(config)) => Arc::new(
                 BulkMemtableBuilder::new(self.write_buffer_manager.clone(), !dedup, merge_mode)
                     .with_config(config.clone())
+                    .with_metric_value_encoding_mode(
+                        options.experimental_metric_engine_value_encoding,
+                    )
                     .with_compact_dispatcher(self.compact_dispatcher.clone()),
             ),
             Some(MemtableOptions::TimeSeries) => Arc::new(TimeSeriesMemtableBuilder::new(
@@ -464,6 +467,8 @@ impl MemtableBuilderProvider {
             merge_mode,
         )
         .with_compact_dispatcher(self.compact_dispatcher.clone());
+        builder = builder
+            .with_metric_value_encoding_mode(options.experimental_metric_engine_value_encoding);
 
         if let Some(MemtableOptions::Bulk(config)) = &options.memtable {
             builder = builder.with_config(config.clone());

--- a/src/mito2/src/memtable/bulk.rs
+++ b/src/mito2/src/memtable/bulk.rs
@@ -693,6 +693,7 @@ impl BulkMemtable {
     }
 
     /// Creates a new BulkMemtable with MetricEngine value encoding mode.
+    #[allow(clippy::too_many_arguments)]
     pub fn new_with_metric_value_encoding_mode(
         id: MemtableId,
         config: BulkMemtableConfig,

--- a/src/mito2/src/memtable/bulk.rs
+++ b/src/mito2/src/memtable/bulk.rs
@@ -63,6 +63,7 @@ use crate::read::flat_dedup::{FlatDedupIterator, FlatLastNonNull, FlatLastRow};
 use crate::read::flat_merge::FlatMergeIterator;
 use crate::region::options::MergeMode;
 use crate::sst::parquet::flat_format::field_column_start;
+use crate::sst::parquet::value_encoding::MetricValueEncodingMode;
 use crate::sst::parquet::{DEFAULT_READ_BATCH_SIZE, DEFAULT_ROW_GROUP_SIZE};
 
 /// Default merge threshold for triggering compaction.
@@ -393,6 +394,8 @@ pub struct BulkMemtable {
     append_mode: bool,
     /// Mode to handle duplicate rows while merging
     merge_mode: MergeMode,
+    /// MetricEngine greptime_value Parquet encoding mode.
+    metric_value_encoding_mode: MetricValueEncodingMode,
 }
 
 impl std::fmt::Debug for BulkMemtable {
@@ -635,6 +638,7 @@ impl Memtable for BulkMemtable {
             compact_dispatcher: self.compact_dispatcher.clone(),
             append_mode: self.append_mode,
             merge_mode: self.merge_mode,
+            metric_value_encoding_mode: self.metric_value_encoding_mode,
         })
     }
 
@@ -657,6 +661,7 @@ impl Memtable for BulkMemtable {
                 &self.metadata,
                 !self.append_mode,
                 self.merge_mode,
+                self.metric_value_encoding_mode,
             )?;
         }
 
@@ -675,6 +680,29 @@ impl BulkMemtable {
         append_mode: bool,
         merge_mode: MergeMode,
     ) -> Self {
+        Self::new_with_metric_value_encoding_mode(
+            id,
+            config,
+            metadata,
+            write_buffer_manager,
+            compact_dispatcher,
+            append_mode,
+            merge_mode,
+            MetricValueEncodingMode::Disabled,
+        )
+    }
+
+    /// Creates a new BulkMemtable with MetricEngine value encoding mode.
+    pub fn new_with_metric_value_encoding_mode(
+        id: MemtableId,
+        config: BulkMemtableConfig,
+        metadata: RegionMetadataRef,
+        write_buffer_manager: Option<WriteBufferManagerRef>,
+        compact_dispatcher: Option<Arc<CompactDispatcher>>,
+        append_mode: bool,
+        merge_mode: MergeMode,
+        metric_value_encoding_mode: MetricValueEncodingMode,
+    ) -> Self {
         let config = config.sanitize();
         let region_id = metadata.region_id;
         Self {
@@ -691,6 +719,7 @@ impl BulkMemtable {
             compact_dispatcher,
             append_mode,
             merge_mode,
+            metric_value_encoding_mode,
         }
     }
 
@@ -756,6 +785,7 @@ impl BulkMemtable {
                 compactor: self.compactor.clone(),
                 append_mode: self.append_mode,
                 merge_mode: self.merge_mode,
+                metric_value_encoding_mode: self.metric_value_encoding_mode,
             };
 
             dispatcher.dispatch_compact(task);
@@ -1079,6 +1109,7 @@ impl MemtableCompactor {
         metadata: &RegionMetadataRef,
         dedup: bool,
         merge_mode: MergeMode,
+        metric_value_encoding_mode: MetricValueEncodingMode,
     ) -> Result<()> {
         let start = Instant::now();
 
@@ -1117,6 +1148,7 @@ impl MemtableCompactor {
                     metadata,
                     dedup,
                     merge_mode,
+                    metric_value_encoding_mode,
                     encode_row_threshold,
                     encode_bytes_threshold,
                 )
@@ -1150,6 +1182,7 @@ impl MemtableCompactor {
         metadata: &RegionMetadataRef,
         dedup: bool,
         merge_mode: MergeMode,
+        metric_value_encoding_mode: MetricValueEncodingMode,
         encode_row_threshold: usize,
         encode_bytes_threshold: usize,
     ) -> Result<Option<MergedPart>> {
@@ -1230,7 +1263,11 @@ impl MemtableCompactor {
         if estimated_total_rows > encode_row_threshold
             || estimated_total_bytes > encode_bytes_threshold
         {
-            let encoder = BulkPartEncoder::new(metadata.clone(), DEFAULT_ROW_GROUP_SIZE)?;
+            let encoder = BulkPartEncoder::new_with_metric_value_encoding_mode(
+                metadata.clone(),
+                DEFAULT_ROW_GROUP_SIZE,
+                metric_value_encoding_mode,
+            )?;
             let mut metrics = BulkPartEncodeMetrics::default();
             let encoded_part = encoder.encode_record_batch_iter(
                 boxed_iter,
@@ -1291,6 +1328,8 @@ struct MemCompactTask {
     append_mode: bool,
     /// Mode to handle duplicate rows while merging
     merge_mode: MergeMode,
+    /// MetricEngine greptime_value Parquet encoding mode.
+    metric_value_encoding_mode: MetricValueEncodingMode,
 }
 
 impl MemCompactTask {
@@ -1308,6 +1347,7 @@ impl MemCompactTask {
                 &self.metadata,
                 !self.append_mode,
                 self.merge_mode,
+                self.metric_value_encoding_mode,
             )?;
         }
 
@@ -1355,6 +1395,7 @@ pub struct BulkMemtableBuilder {
     compact_dispatcher: Option<Arc<CompactDispatcher>>,
     append_mode: bool,
     merge_mode: MergeMode,
+    metric_value_encoding_mode: MetricValueEncodingMode,
 }
 
 impl BulkMemtableBuilder {
@@ -1370,12 +1411,19 @@ impl BulkMemtableBuilder {
             compact_dispatcher: None,
             append_mode,
             merge_mode,
+            metric_value_encoding_mode: MetricValueEncodingMode::Disabled,
         }
     }
 
     /// Sets the bulk memtable config.
     pub fn with_config(mut self, config: BulkMemtableConfig) -> Self {
         self.config = config;
+        self
+    }
+
+    /// Sets MetricEngine greptime_value Parquet encoding mode.
+    pub fn with_metric_value_encoding_mode(mut self, mode: MetricValueEncodingMode) -> Self {
+        self.metric_value_encoding_mode = mode;
         self
     }
 
@@ -1393,7 +1441,7 @@ impl BulkMemtableBuilder {
 
 impl MemtableBuilder for BulkMemtableBuilder {
     fn build(&self, id: MemtableId, metadata: &RegionMetadataRef) -> MemtableRef {
-        Arc::new(BulkMemtable::new(
+        Arc::new(BulkMemtable::new_with_metric_value_encoding_mode(
             id,
             self.config.clone(),
             metadata.clone(),
@@ -1401,6 +1449,7 @@ impl MemtableBuilder for BulkMemtableBuilder {
             self.compact_dispatcher.clone(),
             self.append_mode,
             self.merge_mode,
+            self.metric_value_encoding_mode,
         ))
     }
 

--- a/src/mito2/src/memtable/bulk/part.rs
+++ b/src/mito2/src/memtable/bulk/part.rs
@@ -44,8 +44,7 @@ use datatypes::vectors::Helper;
 use mito_codec::key_values::{KeyValue, KeyValues};
 use mito_codec::row_converter::{PrimaryKeyCodec, SortField, build_primary_key_codec_with_fields};
 use parquet::arrow::ArrowWriter;
-use parquet::basic::{Compression, ZstdLevel};
-use parquet::file::metadata::ParquetMetaData;
+use parquet::file::metadata::{KeyValue as ParquetKeyValue, ParquetMetaData};
 use parquet::file::properties::WriterProperties;
 use smallvec::SmallVec;
 use snafu::{OptionExt, ResultExt};
@@ -68,6 +67,10 @@ use crate::sst::SeriesEstimator;
 use crate::sst::index::IndexOutput;
 use crate::sst::parquet::flat_format::primary_key_column_index;
 use crate::sst::parquet::format::{PrimaryKeyArray, PrimaryKeyArrayBuilder};
+use crate::sst::parquet::value_encoding::{
+    MetricValueEncodingMode, ParquetWriteOptions, metric_engine_value_column_encoding,
+    metric_value_encoding_plan_for_batch, parquet_options_for_plan, sst_writer_properties,
+};
 use crate::sst::parquet::{PARQUET_METADATA_KEY, SstInfo};
 
 const INIT_DICT_VALUE_CAPACITY: usize = 8;
@@ -1134,32 +1137,59 @@ pub struct BulkPartEncodeMetrics {
 
 pub struct BulkPartEncoder {
     metadata: RegionMetadataRef,
-    writer_props: Option<WriterProperties>,
+    key_value_meta: ParquetKeyValue,
+    row_group_size: usize,
+    metric_value_encoding_mode: MetricValueEncodingMode,
 }
 
 impl BulkPartEncoder {
     pub fn new(metadata: RegionMetadataRef, row_group_size: usize) -> Result<BulkPartEncoder> {
+        Self::new_with_metric_value_encoding_mode(
+            metadata,
+            row_group_size,
+            MetricValueEncodingMode::Disabled,
+        )
+    }
+
+    pub fn new_with_metric_value_encoding_mode(
+        metadata: RegionMetadataRef,
+        row_group_size: usize,
+        metric_value_encoding_mode: MetricValueEncodingMode,
+    ) -> Result<BulkPartEncoder> {
         // TODO(yingwen): Skip arrow schema if needed.
         let json = metadata.to_json().context(InvalidMetadataSnafu)?;
-        let key_value_meta =
-            parquet::file::metadata::KeyValue::new(PARQUET_METADATA_KEY.to_string(), json);
-
-        // TODO(yingwen): Do we need compression?
-        let writer_props = Some(
-            WriterProperties::builder()
-                .set_key_value_metadata(Some(vec![key_value_meta]))
-                .set_write_batch_size(row_group_size)
-                .set_max_row_group_row_count(Some(row_group_size))
-                .set_compression(Compression::ZSTD(ZstdLevel::default()))
-                .set_column_index_truncate_length(None)
-                .set_statistics_truncate_length(None)
-                .build(),
-        );
+        let key_value_meta = ParquetKeyValue::new(PARQUET_METADATA_KEY.to_string(), json);
 
         Ok(Self {
             metadata,
-            writer_props,
+            key_value_meta,
+            row_group_size,
+            metric_value_encoding_mode,
         })
+    }
+
+    fn writer_props(&self, parquet_options: ParquetWriteOptions) -> Option<WriterProperties> {
+        Some(sst_writer_properties(
+            self.key_value_meta.clone(),
+            self.row_group_size,
+            &parquet_options,
+            |builder| builder.set_write_batch_size(self.row_group_size),
+        ))
+    }
+
+    fn initial_parquet_options(&self) -> (ParquetWriteOptions, bool) {
+        let mut parquet_options = ParquetWriteOptions::default();
+        if let Some(plan) =
+            metric_engine_value_column_encoding(&self.metadata, self.metric_value_encoding_mode)
+        {
+            parquet_options = parquet_options.overlay(parquet_options_for_plan(plan));
+            (parquet_options, false)
+        } else {
+            (
+                parquet_options,
+                self.metric_value_encoding_mode == MetricValueEncodingMode::Auto,
+            )
+        }
     }
 }
 
@@ -1167,7 +1197,7 @@ impl BulkPartEncoder {
     /// Encodes [BoxedRecordBatchIterator] into [EncodedBulkPart] with min/max timestamps.
     pub fn encode_record_batch_iter(
         &self,
-        iter: BoxedRecordBatchIterator,
+        mut iter: BoxedRecordBatchIterator,
         arrow_schema: SchemaRef,
         min_timestamp: i64,
         max_timestamp: i64,
@@ -1175,21 +1205,59 @@ impl BulkPartEncoder {
         metrics: &mut BulkPartEncodeMetrics,
     ) -> Result<Option<EncodedBulkPart>> {
         let mut buf = Vec::with_capacity(4096);
-        let mut writer =
-            ArrowWriter::try_new(&mut buf, arrow_schema.clone(), self.writer_props.clone())
-                .context(EncodeMemtableSnafu)?;
+        let (mut parquet_options, sample_metric_value_encoding) = self.initial_parquet_options();
         let mut total_rows = 0;
         let mut series_estimator = SeriesEstimator::default();
 
-        // Process each batch from the iterator
+        // Find the first non-empty batch before opening ArrowWriter so `auto` can decide
+        // writer properties without unbounded buffering.
         let mut iter_start = Instant::now();
+        let first_batch = loop {
+            let Some(batch_result) = iter.next() else {
+                metrics.iter_cost += iter_start.elapsed();
+                return Ok(None);
+            };
+            metrics.iter_cost += iter_start.elapsed();
+            let batch = batch_result?;
+            if batch.num_rows() == 0 {
+                iter_start = Instant::now();
+                continue;
+            }
+            break batch;
+        };
+
+        if sample_metric_value_encoding {
+            if let Some(plan) = metric_value_encoding_plan_for_batch(
+                &self.metadata,
+                self.metric_value_encoding_mode,
+                &first_batch,
+            ) {
+                parquet_options = parquet_options.overlay(parquet_options_for_plan(plan));
+            }
+        }
+        let mut writer = ArrowWriter::try_new(
+            &mut buf,
+            arrow_schema.clone(),
+            self.writer_props(parquet_options),
+        )
+        .context(EncodeMemtableSnafu)?;
+
+        let write_start = Instant::now();
+        series_estimator.update_flat(&first_batch);
+        metrics.raw_size += record_batch_estimated_size(&first_batch);
+        writer.write(&first_batch).context(EncodeMemtableSnafu)?;
+        metrics.write_cost += write_start.elapsed();
+        total_rows += first_batch.num_rows();
+
+        // Process remaining batches from the iterator.
+        iter_start = Instant::now();
         for batch_result in iter {
             metrics.iter_cost += iter_start.elapsed();
             let batch = batch_result?;
             if batch.num_rows() == 0 {
+                iter_start = Instant::now();
                 continue;
             }
-
             series_estimator.update_flat(&batch);
             metrics.raw_size += record_batch_estimated_size(&batch);
             let write_start = Instant::now();
@@ -1199,10 +1267,6 @@ impl BulkPartEncoder {
             iter_start = Instant::now();
         }
         metrics.iter_cost += iter_start.elapsed();
-
-        if total_rows == 0 {
-            return Ok(None);
-        }
 
         let close_start = Instant::now();
         let file_metadata = writer.close().context(EncodeMemtableSnafu)?;
@@ -1237,11 +1301,24 @@ impl BulkPartEncoder {
 
         let mut buf = Vec::with_capacity(4096);
         let arrow_schema = part.batch.schema();
+        let (mut parquet_options, sample_metric_value_encoding) = self.initial_parquet_options();
+        if sample_metric_value_encoding
+            && let Some(plan) = metric_value_encoding_plan_for_batch(
+                &self.metadata,
+                self.metric_value_encoding_mode,
+                &part.batch,
+            )
+        {
+            parquet_options = parquet_options.overlay(parquet_options_for_plan(plan));
+        }
 
         let file_metadata = {
-            let mut writer =
-                ArrowWriter::try_new(&mut buf, arrow_schema.clone(), self.writer_props.clone())
-                    .context(EncodeMemtableSnafu)?;
+            let mut writer = ArrowWriter::try_new(
+                &mut buf,
+                arrow_schema.clone(),
+                self.writer_props(parquet_options),
+            )
+            .context(EncodeMemtableSnafu)?;
             writer.write(&part.batch).context(EncodeMemtableSnafu)?;
             writer.finish().context(EncodeMemtableSnafu)?
         };

--- a/src/mito2/src/memtable/bulk/part.rs
+++ b/src/mito2/src/memtable/bulk/part.rs
@@ -1226,14 +1226,14 @@ impl BulkPartEncoder {
             break batch;
         };
 
-        if sample_metric_value_encoding {
-            if let Some(plan) = metric_value_encoding_plan_for_batch(
+        if sample_metric_value_encoding
+            && let Some(plan) = metric_value_encoding_plan_for_batch(
                 &self.metadata,
                 self.metric_value_encoding_mode,
                 &first_batch,
-            ) {
-                parquet_options = parquet_options.overlay(parquet_options_for_plan(plan));
-            }
+            )
+        {
+            parquet_options = parquet_options.overlay(parquet_options_for_plan(plan));
         }
         let mut writer = ArrowWriter::try_new(
             &mut buf,

--- a/src/mito2/src/region/options.rs
+++ b/src/mito2/src/region/options.rs
@@ -39,6 +39,7 @@ use strum::EnumString;
 use crate::error::{InvalidRegionOptionsSnafu, JsonOptionsSnafu, Result};
 use crate::memtable::bulk::BulkMemtableConfig;
 use crate::sst::FormatType;
+use crate::sst::parquet::value_encoding::MetricValueEncodingMode;
 
 const DEFAULT_INDEX_SEGMENT_ROW_COUNT: usize = 1024;
 const COMPACTION_TWCS_PREFIX: &str = "compaction.twcs.";
@@ -107,6 +108,8 @@ pub struct RegionOptions {
     /// Internal primary key encoding override used by metric-engine.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub primary_key_encoding: Option<PrimaryKeyEncoding>,
+    /// Experimental metric engine greptime_value Parquet encoding mode.
+    pub experimental_metric_engine_value_encoding: MetricValueEncodingMode,
 }
 
 impl RegionOptions {
@@ -256,6 +259,8 @@ impl RegionOptions {
             merge_mode: options.merge_mode,
             sst_format,
             primary_key_encoding,
+            experimental_metric_engine_value_encoding: options
+                .experimental_metric_engine_value_encoding,
         };
         opts.validate()?;
 
@@ -365,6 +370,7 @@ struct RegionOptionsWithoutEnum {
     merge_mode: Option<MergeMode>,
     #[serde_as(as = "NoneAsEmptyString")]
     sst_format: Option<FormatType>,
+    experimental_metric_engine_value_encoding: MetricValueEncodingMode,
 }
 
 impl Default for RegionOptionsWithoutEnum {
@@ -377,6 +383,8 @@ impl Default for RegionOptionsWithoutEnum {
             append_mode: options.append_mode,
             merge_mode: options.merge_mode,
             sst_format: options.sst_format,
+            experimental_metric_engine_value_encoding: options
+                .experimental_metric_engine_value_encoding,
         }
     }
 }
@@ -535,6 +543,33 @@ mod tests {
         let map = make_map(&[]);
         let options = RegionOptions::try_from_options(RegionId::new(0, 0), &map).unwrap();
         assert_eq!(RegionOptions::default(), options);
+        assert_eq!(
+            MetricValueEncodingMode::Disabled,
+            options.experimental_metric_engine_value_encoding
+        );
+    }
+
+    #[test]
+    fn test_metric_value_encoding_modes() {
+        for (raw, expected) in [
+            ("disabled", MetricValueEncodingMode::Disabled),
+            ("auto", MetricValueEncodingMode::Auto),
+            ("plain", MetricValueEncodingMode::Plain),
+            (
+                "byte_stream_split",
+                MetricValueEncodingMode::ByteStreamSplit,
+            ),
+        ] {
+            let map = make_map(&[("experimental_metric_engine_value_encoding", raw)]);
+            let options = RegionOptions::try_from_options(RegionId::new(0, 0), &map).unwrap();
+            assert_eq!(expected, options.experimental_metric_engine_value_encoding);
+        }
+    }
+
+    #[test]
+    fn test_invalid_metric_value_encoding_mode() {
+        let map = make_map(&[("experimental_metric_engine_value_encoding", "bss")]);
+        assert!(RegionOptions::try_from_options(RegionId::new(0, 0), &map).is_err());
     }
 
     #[test]
@@ -898,6 +933,7 @@ mod tests {
             merge_mode: Some(MergeMode::LastNonNull),
             sst_format: Some(FormatType::Flat),
             primary_key_encoding: None,
+            experimental_metric_engine_value_encoding: MetricValueEncodingMode::Disabled,
         };
         assert_eq!(expect, options);
     }
@@ -928,6 +964,7 @@ mod tests {
             merge_mode: Some(MergeMode::LastNonNull),
             sst_format: None,
             primary_key_encoding: None,
+            experimental_metric_engine_value_encoding: MetricValueEncodingMode::Disabled,
         };
         let region_options_json_str = serde_json::to_string(&options).unwrap();
         let got: RegionOptions = serde_json::from_str(&region_options_json_str).unwrap();
@@ -985,6 +1022,7 @@ mod tests {
             merge_mode: Some(MergeMode::LastNonNull),
             sst_format: None,
             primary_key_encoding: None,
+            experimental_metric_engine_value_encoding: MetricValueEncodingMode::Disabled,
         };
         assert_eq!(options, got);
     }

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -121,14 +121,15 @@ mod tests {
     use common_function::function_factory::ScalarFunctionFactory;
     use common_function::scalars::matches::MatchesFunction;
     use common_function::scalars::matches_term::MatchesTermFunction;
+    use common_query::prelude::greptime_value;
     use common_time::Timestamp;
     use datafusion_common::{Column, ScalarValue};
     use datafusion_expr::expr::ScalarFunction;
     use datafusion_expr::{BinaryExpr, Expr, Literal, Operator, col, lit};
     use datatypes::arrow;
     use datatypes::arrow::array::{
-        ArrayRef, BinaryDictionaryBuilder, RecordBatch, StringArray, StringDictionaryBuilder,
-        TimestampMillisecondArray, UInt8Array, UInt64Array,
+        ArrayRef, BinaryDictionaryBuilder, Float64Array, RecordBatch, StringArray,
+        StringDictionaryBuilder, TimestampMillisecondArray, UInt8Array, UInt32Array, UInt64Array,
     };
     use datatypes::arrow::datatypes::{DataType, Field, Schema, UInt32Type};
     use datatypes::arrow::util::pretty::pretty_format_batches;
@@ -141,7 +142,11 @@ mod tests {
     use parquet::file::properties::WriterProperties;
     use store_api::codec::PrimaryKeyEncoding;
     use store_api::metadata::{ColumnMetadata, RegionMetadata, RegionMetadataBuilder};
+    use store_api::metric_engine_consts::{
+        DATA_SCHEMA_TABLE_ID_COLUMN_NAME, DATA_SCHEMA_TSID_COLUMN_NAME, METRIC_DATA_REGION_GROUP,
+    };
     use store_api::region_request::PathType;
+    use store_api::storage::consts::ReservedColumnId;
     use store_api::storage::{ColumnSchema, RegionId};
     use table::predicate::Predicate;
     use tokio_util::compat::FuturesAsyncWriteCompatExt;
@@ -1287,6 +1292,323 @@ mod tests {
             .await
             .unwrap()
             .remove(0)
+    }
+
+    fn metric_data_region_metadata() -> Arc<RegionMetadata> {
+        let mut builder = RegionMetadataBuilder::new(RegionId::with_group_and_seq(
+            1,
+            METRIC_DATA_REGION_GROUP,
+            1,
+        ));
+        builder
+            .push_column_metadata(ColumnMetadata {
+                column_schema: ColumnSchema::new(
+                    DATA_SCHEMA_TABLE_ID_COLUMN_NAME,
+                    ConcreteDataType::uint32_datatype(),
+                    false,
+                ),
+                semantic_type: SemanticType::Tag,
+                column_id: ReservedColumnId::table_id(),
+            })
+            .push_column_metadata(ColumnMetadata {
+                column_schema: ColumnSchema::new(
+                    DATA_SCHEMA_TSID_COLUMN_NAME,
+                    ConcreteDataType::uint64_datatype(),
+                    false,
+                ),
+                semantic_type: SemanticType::Tag,
+                column_id: ReservedColumnId::tsid(),
+            })
+            .push_column_metadata(ColumnMetadata {
+                column_schema: ColumnSchema::new(
+                    greptime_value(),
+                    ConcreteDataType::float64_datatype(),
+                    false,
+                ),
+                semantic_type: SemanticType::Field,
+                column_id: 1,
+            })
+            .push_column_metadata(ColumnMetadata {
+                column_schema: ColumnSchema::new(
+                    "ts",
+                    ConcreteDataType::timestamp_millisecond_datatype(),
+                    false,
+                ),
+                semantic_type: SemanticType::Timestamp,
+                column_id: 0,
+            })
+            .primary_key(vec![ReservedColumnId::table_id(), ReservedColumnId::tsid()]);
+        Arc::new(builder.build().unwrap())
+    }
+
+    fn metric_value_record_batch(metadata: &RegionMetadata) -> RecordBatch {
+        const ROWS: usize = 1_024;
+
+        metric_value_record_batch_with_values(
+            metadata,
+            &(0..ROWS).map(|value| value as f64).collect::<Vec<_>>(),
+            0,
+        )
+    }
+
+    fn metric_value_record_batch_with_values(
+        metadata: &RegionMetadata,
+        values: &[f64],
+        timestamp_start: i64,
+    ) -> RecordBatch {
+        metric_value_record_batch_with_values_and_primary_key_size(
+            metadata,
+            values,
+            timestamp_start,
+            None,
+        )
+    }
+
+    fn metric_value_record_batch_with_values_and_primary_key_size(
+        metadata: &RegionMetadata,
+        values: &[f64],
+        timestamp_start: i64,
+        primary_key_size: Option<usize>,
+    ) -> RecordBatch {
+        let rows = values.len();
+
+        let schema = to_flat_sst_arrow_schema(metadata, &FlatSchemaOptions::default());
+        let mut primary_key = BinaryDictionaryBuilder::<UInt32Type>::new();
+        for row in 0..rows {
+            if let Some(primary_key_size) = primary_key_size {
+                let mut state = row as u64 + 1;
+                let primary_key_value = (0..primary_key_size)
+                    .map(|_| {
+                        state ^= state << 13;
+                        state ^= state >> 7;
+                        state ^= state << 17;
+                        state as u8
+                    })
+                    .collect::<Vec<_>>();
+                primary_key.append(&primary_key_value).unwrap();
+            } else {
+                primary_key.append(b"metric-series").unwrap();
+            }
+        }
+
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(UInt32Array::from_value(1, rows)) as ArrayRef,
+                Arc::new(UInt64Array::from_value(1, rows)) as ArrayRef,
+                Arc::new(Float64Array::from(values.to_vec())) as ArrayRef,
+                Arc::new(TimestampMillisecondArray::from_iter_values(
+                    (0..rows).map(|value| timestamp_start + value as i64),
+                )) as ArrayRef,
+                Arc::new(primary_key.finish()) as ArrayRef,
+                Arc::new(UInt64Array::from_value(1, rows)) as ArrayRef,
+                Arc::new(UInt8Array::from_value(OpType::Put as u8, rows)) as ArrayRef,
+            ],
+        )
+        .unwrap()
+    }
+
+    async fn write_metric_value_sst_with_auto_encoding(
+        operation: value_encoding::ParquetWriteOperation,
+    ) -> SstInfo {
+        let mut env = TestEnv::new().await;
+        let object_store = env.init_object_store_manager();
+        let metadata = metric_data_region_metadata();
+        let mut metrics = Metrics::new(match operation {
+            value_encoding::ParquetWriteOperation::Flush => WriteType::Flush,
+            value_encoding::ParquetWriteOperation::Compaction => WriteType::Compaction,
+            value_encoding::ParquetWriteOperation::Other => unreachable!(),
+        });
+        let mut writer = ParquetWriter::new_with_object_store(
+            object_store,
+            metadata.clone(),
+            IndexConfig::default(),
+            NoopIndexBuilder,
+            RegionFilePathFactory::new(FILE_DIR.to_string(), PathType::Bare),
+            &mut metrics,
+        )
+        .await;
+        let write_opts = WriteOptions {
+            row_group_size: 1_024,
+            parquet_write_operation: operation,
+            metric_value_encoding_mode: value_encoding::MetricValueEncodingMode::Auto,
+            ..Default::default()
+        };
+
+        writer
+            .write_all_flat(
+                new_flat_source_from_record_batches(vec![metric_value_record_batch(&metadata)]),
+                None,
+                &write_opts,
+            )
+            .await
+            .unwrap()
+            .remove(0)
+    }
+
+    fn assert_metric_value_uses_byte_stream_split(
+        operation: value_encoding::ParquetWriteOperation,
+        info: &SstInfo,
+    ) {
+        let metadata = info.file_metadata.as_ref().unwrap_or_else(|| {
+            panic!(
+                "operation {operation:?}, file {:?}: missing Parquet file metadata",
+                info.file_id
+            )
+        });
+        let value_chunks = metadata
+            .row_groups()
+            .iter()
+            .flat_map(|row_group| {
+                (0..row_group.num_columns()).map(move |index| row_group.column(index))
+            })
+            .filter(|chunk| {
+                chunk.column_path().parts().len() == 1
+                    && chunk.column_path().parts()[0] == greptime_value()
+            });
+
+        let mut found = false;
+        for chunk in value_chunks {
+            found = true;
+            let encodings = chunk.encodings().collect::<Vec<_>>();
+            assert!(
+                encodings.contains(&Encoding::BYTE_STREAM_SPLIT),
+                "operation {operation:?}, file {:?}: {} column lacks BYTE_STREAM_SPLIT; encodings: {encodings:?}",
+                info.file_id,
+                greptime_value(),
+            );
+            assert!(
+                !encodings.contains(&Encoding::RLE_DICTIONARY),
+                "operation {operation:?}, file {:?}: {} column uses dictionary encoding; encodings: {encodings:?}",
+                info.file_id,
+                greptime_value(),
+            );
+        }
+        assert!(
+            found,
+            "operation {operation:?}, file {:?}: {} column chunk not found",
+            info.file_id,
+            greptime_value(),
+        );
+    }
+
+    fn assert_metric_value_uses_dictionary_plain(
+        operation: value_encoding::ParquetWriteOperation,
+        info: &SstInfo,
+    ) {
+        let metadata = info.file_metadata.as_ref().unwrap_or_else(|| {
+            panic!(
+                "operation {operation:?}, file {:?}: missing Parquet file metadata",
+                info.file_id
+            )
+        });
+        let value_chunks = metadata
+            .row_groups()
+            .iter()
+            .flat_map(|row_group| {
+                (0..row_group.num_columns()).map(move |index| row_group.column(index))
+            })
+            .filter(|chunk| {
+                chunk.column_path().parts().len() == 1
+                    && chunk.column_path().parts()[0] == greptime_value()
+            });
+
+        let mut found = false;
+        for chunk in value_chunks {
+            found = true;
+            let encodings = chunk.encodings().collect::<Vec<_>>();
+            assert!(
+                !encodings.contains(&Encoding::BYTE_STREAM_SPLIT),
+                "operation {operation:?}, file {:?}: {} column uses BYTE_STREAM_SPLIT; encodings: {encodings:?}",
+                info.file_id,
+                greptime_value(),
+            );
+            assert!(
+                encodings.contains(&Encoding::RLE_DICTIONARY),
+                "operation {operation:?}, file {:?}: {} column lacks dictionary encoding; encodings: {encodings:?}",
+                info.file_id,
+                greptime_value(),
+            );
+        }
+        assert!(
+            found,
+            "operation {operation:?}, file {:?}: {} column chunk not found",
+            info.file_id,
+            greptime_value(),
+        );
+    }
+
+    #[tokio::test]
+    async fn test_auto_metric_value_encoding_uses_byte_stream_split_for_flush_and_compaction() {
+        for operation in [
+            value_encoding::ParquetWriteOperation::Flush,
+            value_encoding::ParquetWriteOperation::Compaction,
+        ] {
+            let info = write_metric_value_sst_with_auto_encoding(operation).await;
+            assert_metric_value_uses_byte_stream_split(operation, &info);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_auto_metric_value_encoding_reselects_after_rollover() {
+        const ROWS: usize = 1_024;
+
+        let mut env = TestEnv::new().await;
+        let object_store = env.init_object_store_manager();
+        let metadata = metric_data_region_metadata();
+        let mut metrics = Metrics::new(WriteType::Compaction);
+        let mut writer = ParquetWriter::new_with_object_store(
+            object_store,
+            metadata.clone(),
+            IndexConfig::default(),
+            NoopIndexBuilder,
+            RegionFilePathFactory::new(FILE_DIR.to_string(), PathType::Bare),
+            &mut metrics,
+        )
+        .await;
+        let write_opts = WriteOptions {
+            row_group_size: 64,
+            max_file_size: Some(1),
+            parquet: value_encoding::ParquetWriteOptions::default().with_column_options(
+                greptime_value(),
+                value_encoding::ParquetColumnWriteOptions::default()
+                    .with_encoding(Encoding::BYTE_STREAM_SPLIT)
+                    .with_dictionary_enabled(false),
+            ),
+            parquet_write_operation: value_encoding::ParquetWriteOperation::Other,
+            metric_value_encoding_mode: value_encoding::MetricValueEncodingMode::Auto,
+            ..Default::default()
+        };
+        let ssts = writer
+            .write_all_flat(
+                new_flat_source_from_record_batches(vec![
+                    metric_value_record_batch_with_values_and_primary_key_size(
+                        &metadata,
+                        &(0..ROWS).map(|value| value as f64).collect::<Vec<_>>(),
+                        0,
+                        Some(12 * 1024),
+                    ),
+                    metric_value_record_batch_with_values(
+                        &metadata,
+                        &vec![42.0; ROWS],
+                        ROWS as i64,
+                    ),
+                ]),
+                None,
+                &write_opts,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(2, ssts.len(), "expected one SST for each input batch");
+        assert_metric_value_uses_byte_stream_split(
+            value_encoding::ParquetWriteOperation::Other,
+            &ssts[0],
+        );
+        assert_metric_value_uses_dictionary_plain(
+            value_encoding::ParquetWriteOperation::Other,
+            &ssts[1],
+        );
     }
 
     /// Helper function to create FileHandle from SstInfo.

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -36,6 +36,7 @@ pub mod reader;
 pub mod row_group;
 pub mod row_selection;
 pub(crate) mod stats;
+pub mod value_encoding;
 pub mod writer;
 
 /// Key of metadata in parquet SST.
@@ -65,6 +66,12 @@ pub struct WriteOptions {
     /// Note: This is not a hard limit as we can only observe the file size when
     /// ArrowWrite writes to underlying writers.
     pub max_file_size: Option<usize>,
+    /// Generic Parquet column write overrides.
+    pub parquet: value_encoding::ParquetWriteOptions,
+    /// Operation kind for built-in Parquet write policy.
+    pub parquet_write_operation: value_encoding::ParquetWriteOperation,
+    /// Metric value encoding mode from persisted region options.
+    pub metric_value_encoding_mode: value_encoding::MetricValueEncodingMode,
 }
 
 impl Default for WriteOptions {
@@ -73,6 +80,9 @@ impl Default for WriteOptions {
             write_buffer_size: DEFAULT_WRITE_BUFFER_SIZE,
             row_group_size: DEFAULT_ROW_GROUP_SIZE,
             max_file_size: None,
+            parquet: Default::default(),
+            parquet_write_operation: Default::default(),
+            metric_value_encoding_mode: Default::default(),
         }
     }
 }

--- a/src/mito2/src/sst/parquet/value_encoding.rs
+++ b/src/mito2/src/sst/parquet/value_encoding.rs
@@ -304,7 +304,13 @@ pub fn parquet_options_for_plan(plan: MetricValueEncodingPlan) -> ParquetWriteOp
                     .with_encoding(Encoding::BYTE_STREAM_SPLIT)
                     .with_dictionary_enabled(false),
             ),
-        MetricValueEncodingDecision::DictionaryPlain => ParquetWriteOptions::default(),
+        MetricValueEncodingDecision::DictionaryPlain => ParquetWriteOptions::default()
+            .with_column_options(
+                greptime_value(),
+                ParquetColumnWriteOptions::default()
+                    .with_encoding(Encoding::PLAIN)
+                    .with_dictionary_enabled(true),
+            ),
     }
 }
 
@@ -352,4 +358,29 @@ pub fn sst_writer_properties_with_metadata(
         parquet_options,
     ))
     .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dictionary_plain_plan_overrides_byte_stream_split_option() {
+        let byte_stream_split = parquet_options_for_plan(MetricValueEncodingPlan {
+            decision: MetricValueEncodingDecision::ByteStreamSplit,
+        });
+        let dictionary_plain = parquet_options_for_plan(MetricValueEncodingPlan {
+            decision: MetricValueEncodingDecision::DictionaryPlain,
+        });
+
+        let options = byte_stream_split.overlay(dictionary_plain);
+        assert_eq!(
+            options.column_options.get(greptime_value()),
+            Some(
+                &ParquetColumnWriteOptions::default()
+                    .with_encoding(Encoding::PLAIN)
+                    .with_dictionary_enabled(true),
+            ),
+        );
+    }
 }

--- a/src/mito2/src/sst/parquet/value_encoding.rs
+++ b/src/mito2/src/sst/parquet/value_encoding.rs
@@ -14,7 +14,7 @@
 
 //! Parquet per-column write overrides and MetricEngine value encoding policy.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use common_query::prelude::greptime_value;
 use datatypes::arrow::array::{Array, Float32Array, Float64Array};
@@ -149,7 +149,10 @@ impl MetricValueEncodingProfileBuilder {
                 run = 1;
             }
         }
-        let distinct = self.samples.iter().copied().collect::<HashSet<_>>().len();
+        let mut distinct_samples = self.samples.clone();
+        distinct_samples.sort_unstable();
+        distinct_samples.dedup();
+        let distinct = distinct_samples.len();
         Some(MetricValueEncodingProfile {
             valid_count,
             adjacent_equal_ratio: if valid_count > 1 {
@@ -215,9 +218,7 @@ pub fn metric_value_encoding_plan_for_batch(
     if mode != MetricValueEncodingMode::Auto {
         return metric_engine_value_column_encoding(metadata, mode);
     }
-    if metric_engine_value_column_encoding(metadata, MetricValueEncodingMode::Plain).is_none() {
-        return None;
-    }
+    metric_engine_value_column_encoding(metadata, MetricValueEncodingMode::Plain)?;
     let mut builder = MetricValueEncodingProfileBuilder::default();
     builder.update_batch(batch);
     builder.finish().map(|profile| decide_profile(&profile))

--- a/src/mito2/src/sst/parquet/value_encoding.rs
+++ b/src/mito2/src/sst/parquet/value_encoding.rs
@@ -1,0 +1,354 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Parquet per-column write overrides and MetricEngine value encoding policy.
+
+use std::collections::{HashMap, HashSet};
+
+use common_query::prelude::greptime_value;
+use datatypes::arrow::array::{Array, Float32Array, Float64Array};
+use datatypes::arrow::datatypes::DataType;
+use datatypes::arrow::record_batch::RecordBatch;
+use datatypes::prelude::ConcreteDataType;
+use parquet::basic::{Compression, Encoding, ZstdLevel};
+use parquet::file::metadata::KeyValue;
+use parquet::file::properties::{WriterProperties, WriterPropertiesBuilder};
+use parquet::schema::types::ColumnPath;
+use serde::{Deserialize, Serialize};
+use store_api::metadata::RegionMetadataRef;
+use store_api::metric_engine_consts::{
+    DATA_SCHEMA_TABLE_ID_COLUMN_NAME, DATA_SCHEMA_TSID_COLUMN_NAME, METRIC_DATA_REGION_GROUP,
+};
+use strum::EnumString;
+
+/// Operation kind for generic Parquet write policy.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ParquetWriteOperation {
+    /// Memtable flush.
+    Flush,
+    /// Compaction/rewrite.
+    Compaction,
+    /// Other write path.
+    #[default]
+    Other,
+}
+
+const MAX_PROFILE_SAMPLES: usize = 65_536;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, EnumString)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum MetricValueEncodingMode {
+    #[default]
+    Disabled,
+    Auto,
+    Plain,
+    ByteStreamSplit,
+}
+
+impl MetricValueEncodingMode {
+    pub fn is_auto(self) -> bool {
+        matches!(self, Self::Auto)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MetricValueEncodingDecision {
+    DictionaryPlain,
+    ByteStreamSplit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MetricValueEncodingPlan {
+    pub decision: MetricValueEncodingDecision,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MetricValueEncodingProfile {
+    pub valid_count: usize,
+    pub adjacent_equal_ratio: f64,
+    pub distinct_ratio: f64,
+    pub max_run: usize,
+}
+
+#[derive(Debug, Default)]
+pub struct MetricValueEncodingProfileBuilder {
+    samples: Vec<u64>,
+    unsupported: bool,
+}
+
+impl MetricValueEncodingProfileBuilder {
+    pub fn update_batch(&mut self, batch: &RecordBatch) {
+        if self.samples.len() >= MAX_PROFILE_SAMPLES || self.unsupported {
+            return;
+        }
+        let Some(array) = batch.column_by_name(greptime_value()) else {
+            self.unsupported = true;
+            return;
+        };
+        match array.data_type() {
+            DataType::Float32 => {
+                let array = array.as_any().downcast_ref::<Float32Array>().unwrap();
+                for i in 0..array.len() {
+                    if array.is_valid(i) {
+                        self.samples.push(array.value(i).to_bits() as u64);
+                        if self.samples.len() >= MAX_PROFILE_SAMPLES {
+                            break;
+                        }
+                    }
+                }
+            }
+            DataType::Float64 => {
+                let array = array.as_any().downcast_ref::<Float64Array>().unwrap();
+                for i in 0..array.len() {
+                    if array.is_valid(i) {
+                        self.samples.push(array.value(i).to_bits());
+                        if self.samples.len() >= MAX_PROFILE_SAMPLES {
+                            break;
+                        }
+                    }
+                }
+            }
+            _ => self.unsupported = true,
+        }
+    }
+
+    pub fn finish(&self) -> Option<MetricValueEncodingProfile> {
+        if self.unsupported {
+            return None;
+        }
+        let valid_count = self.samples.len();
+        if valid_count == 0 {
+            return Some(MetricValueEncodingProfile {
+                valid_count,
+                adjacent_equal_ratio: 0.0,
+                distinct_ratio: 0.0,
+                max_run: 0,
+            });
+        }
+        let mut adjacent_equal = 0usize;
+        let mut max_run = 1usize;
+        let mut run = 1usize;
+        for pair in self.samples.windows(2) {
+            if pair[0] == pair[1] {
+                adjacent_equal += 1;
+                run += 1;
+                max_run = max_run.max(run);
+            } else {
+                run = 1;
+            }
+        }
+        let distinct = self.samples.iter().copied().collect::<HashSet<_>>().len();
+        Some(MetricValueEncodingProfile {
+            valid_count,
+            adjacent_equal_ratio: if valid_count > 1 {
+                adjacent_equal as f64 / (valid_count - 1) as f64
+            } else {
+                0.0
+            },
+            distinct_ratio: distinct as f64 / valid_count as f64,
+            max_run,
+        })
+    }
+}
+
+pub fn decide_profile(profile: &MetricValueEncodingProfile) -> MetricValueEncodingPlan {
+    let decision = if profile.valid_count < 2
+        || profile.adjacent_equal_ratio >= 0.20
+        || profile.distinct_ratio <= 0.20
+    {
+        MetricValueEncodingDecision::DictionaryPlain
+    } else {
+        MetricValueEncodingDecision::ByteStreamSplit
+    };
+    MetricValueEncodingPlan { decision }
+}
+
+pub fn metric_engine_value_column_encoding(
+    metadata: &RegionMetadataRef,
+    mode: MetricValueEncodingMode,
+) -> Option<MetricValueEncodingPlan> {
+    if mode == MetricValueEncodingMode::Disabled
+        || metadata.region_id.region_group() != METRIC_DATA_REGION_GROUP
+        || metadata
+            .column_by_name(DATA_SCHEMA_TABLE_ID_COLUMN_NAME)
+            .is_none()
+        || metadata
+            .column_by_name(DATA_SCHEMA_TSID_COLUMN_NAME)
+            .is_none()
+    {
+        return None;
+    }
+    let value_column = metadata.column_by_name(greptime_value())?;
+    let data_type = &value_column.column_schema.data_type;
+    if data_type != &ConcreteDataType::float32_datatype()
+        && data_type != &ConcreteDataType::float64_datatype()
+    {
+        return None;
+    }
+    match mode {
+        MetricValueEncodingMode::Disabled => None,
+        MetricValueEncodingMode::Plain => Some(default_plan()),
+        MetricValueEncodingMode::ByteStreamSplit => Some(MetricValueEncodingPlan {
+            decision: MetricValueEncodingDecision::ByteStreamSplit,
+        }),
+        MetricValueEncodingMode::Auto => None,
+    }
+}
+
+pub fn metric_value_encoding_plan_for_batch(
+    metadata: &RegionMetadataRef,
+    mode: MetricValueEncodingMode,
+    batch: &RecordBatch,
+) -> Option<MetricValueEncodingPlan> {
+    if mode != MetricValueEncodingMode::Auto {
+        return metric_engine_value_column_encoding(metadata, mode);
+    }
+    if metric_engine_value_column_encoding(metadata, MetricValueEncodingMode::Plain).is_none() {
+        return None;
+    }
+    let mut builder = MetricValueEncodingProfileBuilder::default();
+    builder.update_batch(batch);
+    builder.finish().map(|profile| decide_profile(&profile))
+}
+
+pub fn default_plan() -> MetricValueEncodingPlan {
+    MetricValueEncodingPlan {
+        decision: MetricValueEncodingDecision::DictionaryPlain,
+    }
+}
+
+/// Per-column Parquet write options.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ParquetColumnWriteOptions {
+    /// Optional column encoding override.
+    pub encoding: Option<Encoding>,
+    /// Optional dictionary setting override.
+    pub dictionary_enabled: Option<bool>,
+}
+
+impl ParquetColumnWriteOptions {
+    /// Overrides the column encoding.
+    pub fn with_encoding(mut self, encoding: Encoding) -> Self {
+        self.encoding = Some(encoding);
+        self
+    }
+
+    /// Overrides whether dictionary encoding is enabled.
+    pub fn with_dictionary_enabled(mut self, enabled: bool) -> Self {
+        self.dictionary_enabled = Some(enabled);
+        self
+    }
+}
+
+/// Generic Parquet write options shared by SST writers.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ParquetWriteOptions {
+    /// Column path/name to Parquet write overrides.
+    pub column_options: HashMap<String, ParquetColumnWriteOptions>,
+}
+
+impl ParquetWriteOptions {
+    /// Adds/updates an override for a top-level column name.
+    pub fn with_column_options(
+        mut self,
+        column: impl Into<String>,
+        options: ParquetColumnWriteOptions,
+    ) -> Self {
+        self.column_options.insert(column.into(), options);
+        self
+    }
+
+    /// Overlays another set of overrides. Overrides from `other` win on conflicts.
+    pub fn overlay(mut self, other: ParquetWriteOptions) -> Self {
+        self.column_options.extend(other.column_options);
+        self
+    }
+
+    /// Applies generic column overrides to an existing builder.
+    pub fn apply_to_builder(
+        &self,
+        mut builder: WriterPropertiesBuilder,
+    ) -> WriterPropertiesBuilder {
+        for (column, options) in &self.column_options {
+            let column_path = ColumnPath::new(vec![column.clone()]);
+            if let Some(encoding) = options.encoding {
+                builder = builder.set_column_encoding(column_path.clone(), encoding);
+            }
+            if let Some(enabled) = options.dictionary_enabled {
+                builder = builder.set_column_dictionary_enabled(column_path, enabled);
+            }
+        }
+        builder
+    }
+}
+
+pub fn parquet_options_for_plan(plan: MetricValueEncodingPlan) -> ParquetWriteOptions {
+    match plan.decision {
+        MetricValueEncodingDecision::ByteStreamSplit => ParquetWriteOptions::default()
+            .with_column_options(
+                greptime_value(),
+                ParquetColumnWriteOptions::default()
+                    .with_encoding(Encoding::BYTE_STREAM_SPLIT)
+                    .with_dictionary_enabled(false),
+            ),
+        MetricValueEncodingDecision::DictionaryPlain => ParquetWriteOptions::default(),
+    }
+}
+
+/// Builds the default Mito SST Parquet writer properties and applies generic overrides.
+pub fn sst_writer_properties_builder_with_metadata(
+    key_value_meta: Option<Vec<KeyValue>>,
+    row_group_size: usize,
+    parquet_options: &ParquetWriteOptions,
+) -> WriterPropertiesBuilder {
+    let builder = WriterProperties::builder()
+        .set_key_value_metadata(key_value_meta)
+        .set_compression(Compression::ZSTD(ZstdLevel::default()))
+        .set_encoding(Encoding::PLAIN)
+        .set_max_row_group_row_count(Some(row_group_size))
+        .set_column_index_truncate_length(None)
+        .set_statistics_truncate_length(None);
+    parquet_options.apply_to_builder(builder)
+}
+
+/// Builds the default Mito SST Parquet writer properties and applies generic overrides.
+pub fn sst_writer_properties(
+    key_value_meta: KeyValue,
+    row_group_size: usize,
+    parquet_options: &ParquetWriteOptions,
+    customize: impl FnOnce(WriterPropertiesBuilder) -> WriterPropertiesBuilder,
+) -> WriterProperties {
+    customize(sst_writer_properties_builder_with_metadata(
+        Some(vec![key_value_meta]),
+        row_group_size,
+        parquet_options,
+    ))
+    .build()
+}
+
+/// Builds the default Mito SST Parquet writer properties with optional metadata.
+pub fn sst_writer_properties_with_metadata(
+    key_value_meta: Option<Vec<KeyValue>>,
+    row_group_size: usize,
+    parquet_options: &ParquetWriteOptions,
+    customize: impl FnOnce(WriterPropertiesBuilder) -> WriterPropertiesBuilder,
+) -> WriterProperties {
+    customize(sst_writer_properties_builder_with_metadata(
+        key_value_meta,
+        row_group_size,
+        parquet_options,
+    ))
+    .build()
+}

--- a/src/mito2/src/sst/parquet/writer.rs
+++ b/src/mito2/src/sst/parquet/writer.rs
@@ -352,8 +352,6 @@ where
         {
             sample_metric_value_encoding = true;
         }
-        let mut buffered = Vec::with_capacity(1);
-
         while let Some(next_batch) = self
             .next_flat_batch(&mut source, converter)
             .await
@@ -371,18 +369,15 @@ where
                                 parquet_options.overlay(parquet_options_for_plan(plan));
                         }
                         sample_metric_value_encoding = false;
-                        buffered.push((record_batch, arrow_batch));
-                        for (record_batch, arrow_batch) in buffered.drain(..) {
-                            self.write_processed_flat_batch(
-                                record_batch,
-                                arrow_batch,
-                                opts,
-                                &parquet_options,
-                                &mut results,
-                                &mut stats,
-                            )
-                            .await?;
-                        }
+                        self.write_processed_flat_batch(
+                            record_batch,
+                            arrow_batch,
+                            opts,
+                            &parquet_options,
+                            &mut results,
+                            &mut stats,
+                        )
+                        .await?;
                         continue;
                     }
                     self.write_processed_flat_batch(
@@ -402,18 +397,6 @@ where
                     return Err(e);
                 }
             }
-        }
-
-        for (record_batch, arrow_batch) in buffered.drain(..) {
-            self.write_processed_flat_batch(
-                record_batch,
-                arrow_batch,
-                opts,
-                &parquet_options,
-                &mut results,
-                &mut stats,
-            )
-            .await?;
         }
 
         self.finish_current_file(&mut results, &mut stats).await?;

--- a/src/mito2/src/sst/parquet/writer.rs
+++ b/src/mito2/src/sst/parquet/writer.rs
@@ -35,9 +35,9 @@ use datatypes::arrow::record_batch::RecordBatch;
 use datatypes::extension::json::is_structured_json_field;
 use object_store::{FuturesAsyncWriter, ObjectStore};
 use parquet::arrow::AsyncArrowWriter;
-use parquet::basic::{Compression, Encoding, ZstdLevel};
+use parquet::basic::{Compression, Encoding};
 use parquet::file::metadata::KeyValue;
-use parquet::file::properties::{WriterProperties, WriterPropertiesBuilder};
+use parquet::file::properties::WriterPropertiesBuilder;
 use parquet::schema::types::ColumnPath;
 use smallvec::smallvec;
 use snafu::ResultExt;
@@ -57,6 +57,10 @@ use crate::sst::file::RegionFileId;
 use crate::sst::index::{IndexOutput, Indexer, IndexerBuilder};
 use crate::sst::parquet::flat_format::{FlatWriteFormat, time_index_column_index};
 use crate::sst::parquet::format::PrimaryKeyWriteFormat;
+use crate::sst::parquet::value_encoding::{
+    ParquetWriteOperation, ParquetWriteOptions, metric_engine_value_column_encoding,
+    metric_value_encoding_plan_for_batch, parquet_options_for_plan, sst_writer_properties,
+};
 use crate::sst::parquet::{PARQUET_METADATA_KEY, SstInfo, WriteOptions};
 use crate::sst::{
     DEFAULT_WRITE_BUFFER_SIZE, DEFAULT_WRITE_CONCURRENCY, FlatSchemaOptions, SeriesEstimator,
@@ -201,7 +205,7 @@ where
     ) -> Result<()> {
         // maybe_init_writer will re-create a new file.
         if let Some(mut current_writer) = mem::take(&mut self.writer) {
-            let mut stats = mem::take(stats);
+            let mut stats = stats.take_file_stats();
             // At least one row has been written.
             assert!(stats.num_rows > 0);
 
@@ -337,30 +341,59 @@ where
     ) -> Result<SstInfoArray> {
         let mut results = smallvec![];
         let mut stats = SourceStats::default();
+        let mut parquet_options = opts.parquet.clone();
+        let mut sample_metric_value_encoding = false;
+        if let Some(plan) =
+            metric_engine_value_column_encoding(&self.metadata, opts.metric_value_encoding_mode)
+        {
+            parquet_options = parquet_options.overlay(parquet_options_for_plan(plan));
+        } else if opts.metric_value_encoding_mode.is_auto()
+            && opts.parquet_write_operation == ParquetWriteOperation::Flush
+        {
+            sample_metric_value_encoding = true;
+        }
+        let mut buffered = Vec::with_capacity(1);
 
-        while let Some(record_batch) = self
-            .write_next_flat_batch(&mut source, converter, opts)
+        while let Some(next_batch) = self
+            .next_flat_batch(&mut source, converter)
             .await
             .transpose()
         {
-            match record_batch {
-                Ok(batch) => {
-                    stats.update_flat(&batch)?;
-                    if matches!(self.index_config.build_mode, IndexBuildMode::Sync) {
-                        let start = Instant::now();
-                        // safety: self.current_indexer must be set when first batch has been written.
-                        self.current_indexer
-                            .as_mut()
-                            .unwrap()
-                            .update_flat(&batch)
-                            .await;
-                        self.metrics.update_index += start.elapsed();
+            match next_batch {
+                Ok((record_batch, arrow_batch)) => {
+                    if self.writer.is_none() && sample_metric_value_encoding {
+                        if let Some(plan) = metric_value_encoding_plan_for_batch(
+                            &self.metadata,
+                            opts.metric_value_encoding_mode,
+                            &arrow_batch,
+                        ) {
+                            parquet_options =
+                                parquet_options.overlay(parquet_options_for_plan(plan));
+                        }
+                        sample_metric_value_encoding = false;
+                        buffered.push((record_batch, arrow_batch));
+                        for (record_batch, arrow_batch) in buffered.drain(..) {
+                            self.write_processed_flat_batch(
+                                record_batch,
+                                arrow_batch,
+                                opts,
+                                &parquet_options,
+                                &mut results,
+                                &mut stats,
+                            )
+                            .await?;
+                        }
+                        continue;
                     }
-                    if let Some(max_file_size) = opts.max_file_size
-                        && self.bytes_written.load(Ordering::Relaxed) > max_file_size
-                    {
-                        self.finish_current_file(&mut results, &mut stats).await?;
-                    }
+                    self.write_processed_flat_batch(
+                        record_batch,
+                        arrow_batch,
+                        opts,
+                        &parquet_options,
+                        &mut results,
+                        &mut stats,
+                    )
+                    .await?;
                 }
                 Err(e) => {
                     if let Some(indexer) = &mut self.current_indexer {
@@ -369,6 +402,18 @@ where
                     return Err(e);
                 }
             }
+        }
+
+        for (record_batch, arrow_batch) in buffered.drain(..) {
+            self.write_processed_flat_batch(
+                record_batch,
+                arrow_batch,
+                opts,
+                &parquet_options,
+                &mut results,
+                &mut stats,
+            )
+            .await?;
         }
 
         self.finish_current_file(&mut results, &mut stats).await?;
@@ -400,12 +445,11 @@ where
             .set_column_compression(op_type_col, Compression::UNCOMPRESSED)
     }
 
-    async fn write_next_flat_batch(
+    async fn next_flat_batch(
         &mut self,
         source: &mut FlatSource,
         converter: &FlatBatchConverter,
-        opts: &WriteOptions,
-    ) -> Result<Option<RecordBatch>> {
+    ) -> Result<Option<(RecordBatch, RecordBatch)>> {
         let start = Instant::now();
         let Some(record_batch) = source.next_batch().await? else {
             return Ok(None);
@@ -413,22 +457,65 @@ where
         self.metrics.iter_source += start.elapsed();
 
         let arrow_batch = converter.convert_batch(&record_batch)?;
+        Ok(Some((record_batch, arrow_batch)))
+    }
 
+    async fn write_processed_flat_batch(
+        &mut self,
+        record_batch: RecordBatch,
+        arrow_batch: RecordBatch,
+        opts: &WriteOptions,
+        parquet_options: &ParquetWriteOptions,
+        results: &mut SstInfoArray,
+        stats: &mut SourceStats,
+    ) -> Result<()> {
+        self.write_arrow_batch(
+            &arrow_batch,
+            arrow_batch.schema_ref(),
+            opts,
+            parquet_options,
+        )
+        .await?;
+        stats.update_flat(&record_batch)?;
+        if matches!(self.index_config.build_mode, IndexBuildMode::Sync) {
+            let start = Instant::now();
+            self.current_indexer
+                .as_mut()
+                .unwrap()
+                .update_flat(&record_batch)
+                .await;
+            self.metrics.update_index += start.elapsed();
+        }
+        if let Some(max_file_size) = opts.max_file_size
+            && self.bytes_written.load(Ordering::Relaxed) > max_file_size
+        {
+            self.finish_current_file(results, stats).await?;
+        }
+        Ok(())
+    }
+
+    async fn write_arrow_batch(
+        &mut self,
+        arrow_batch: &RecordBatch,
+        schema: &SchemaRef,
+        opts: &WriteOptions,
+        parquet_options: &ParquetWriteOptions,
+    ) -> Result<()> {
         let start = Instant::now();
-        self.maybe_init_writer(arrow_batch.schema_ref(), opts)
+        self.maybe_init_writer(schema, opts, parquet_options)
             .await?
-            .write(&arrow_batch)
+            .write(arrow_batch)
             .await
             .context(WriteParquetSnafu)?;
         self.metrics.write_batch += start.elapsed();
-        // Return original flat batch for stats/indexer which use flat layout.
-        Ok(Some(record_batch))
+        Ok(())
     }
 
     async fn maybe_init_writer(
         &mut self,
         schema: &SchemaRef,
         opts: &WriteOptions,
+        parquet_options: &ParquetWriteOptions,
     ) -> Result<&mut AsyncArrowWriter<SizeAwareWriter<F::Writer>>> {
         if let Some(ref mut w) = self.writer {
             Ok(w)
@@ -437,16 +524,12 @@ where
             let key_value_meta = KeyValue::new(PARQUET_METADATA_KEY.to_string(), json);
 
             // TODO(yingwen): Find and set proper column encoding for internal columns: op type and tsid.
-            let props_builder = WriterProperties::builder()
-                .set_key_value_metadata(Some(vec![key_value_meta]))
-                .set_compression(Compression::ZSTD(ZstdLevel::default()))
-                .set_encoding(Encoding::PLAIN)
-                .set_max_row_group_row_count(Some(opts.row_group_size))
-                .set_column_index_truncate_length(None)
-                .set_statistics_truncate_length(None);
-
-            let props_builder = Self::customize_column_config(props_builder, &self.metadata);
-            let writer_props = props_builder.build();
+            let writer_props = sst_writer_properties(
+                key_value_meta,
+                opts.row_group_size,
+                parquet_options,
+                |props_builder| Self::customize_column_config(props_builder, &self.metadata),
+            );
 
             let sst_file_path = self.path_provider.build_sst_file_path(RegionFileId::new(
                 self.metadata.region_id,
@@ -481,6 +564,14 @@ struct SourceStats {
 }
 
 impl SourceStats {
+    fn take_file_stats(&mut self) -> Self {
+        Self {
+            num_rows: mem::take(&mut self.num_rows),
+            time_range: mem::take(&mut self.time_range),
+            series_estimator: mem::take(&mut self.series_estimator),
+        }
+    }
+
     fn update_flat(&mut self, record_batch: &RecordBatch) -> Result<()> {
         if record_batch.num_rows() == 0 {
             return Ok(());

--- a/src/mito2/src/sst/parquet/writer.rs
+++ b/src/mito2/src/sst/parquet/writer.rs
@@ -58,8 +58,8 @@ use crate::sst::index::{IndexOutput, Indexer, IndexerBuilder};
 use crate::sst::parquet::flat_format::{FlatWriteFormat, time_index_column_index};
 use crate::sst::parquet::format::PrimaryKeyWriteFormat;
 use crate::sst::parquet::value_encoding::{
-    ParquetWriteOperation, ParquetWriteOptions, metric_engine_value_column_encoding,
-    metric_value_encoding_plan_for_batch, parquet_options_for_plan, sst_writer_properties,
+    ParquetWriteOptions, metric_engine_value_column_encoding, metric_value_encoding_plan_for_batch,
+    parquet_options_for_plan, sst_writer_properties,
 };
 use crate::sst::parquet::{PARQUET_METADATA_KEY, SstInfo, WriteOptions};
 use crate::sst::{
@@ -341,17 +341,18 @@ where
     ) -> Result<SstInfoArray> {
         let mut results = smallvec![];
         let mut stats = SourceStats::default();
-        let mut parquet_options = opts.parquet.clone();
-        let mut sample_metric_value_encoding = false;
+        let mut base_parquet_options = opts.parquet.clone();
         if let Some(plan) =
             metric_engine_value_column_encoding(&self.metadata, opts.metric_value_encoding_mode)
         {
-            parquet_options = parquet_options.overlay(parquet_options_for_plan(plan));
-        } else if opts.metric_value_encoding_mode.is_auto()
-            && opts.parquet_write_operation == ParquetWriteOperation::Flush
-        {
-            sample_metric_value_encoding = true;
+            base_parquet_options = base_parquet_options.overlay(parquet_options_for_plan(plan));
         }
+        let sample_metric_value_encoding = opts.metric_value_encoding_mode.is_auto()
+            && metric_engine_value_column_encoding(
+                &self.metadata,
+                crate::sst::parquet::value_encoding::MetricValueEncodingMode::Plain,
+            )
+            .is_some();
         while let Some(next_batch) = self
             .next_flat_batch(&mut source, converter)
             .await
@@ -359,7 +360,11 @@ where
         {
             match next_batch {
                 Ok((record_batch, arrow_batch)) => {
+                    let mut parquet_options = base_parquet_options.clone();
                     if self.writer.is_none() && sample_metric_value_encoding {
+                        // The first batch of each output file selects that file's encoding.
+                        // Empty or all-NULL batches deliberately keep the default plain plan
+                        // rather than buffering later rows or changing their write order.
                         if let Some(plan) = metric_value_encoding_plan_for_batch(
                             &self.metadata,
                             opts.metric_value_encoding_mode,
@@ -368,17 +373,6 @@ where
                             parquet_options =
                                 parquet_options.overlay(parquet_options_for_plan(plan));
                         }
-                        sample_metric_value_encoding = false;
-                        self.write_processed_flat_batch(
-                            record_batch,
-                            arrow_batch,
-                            opts,
-                            &parquet_options,
-                            &mut results,
-                            &mut stats,
-                        )
-                        .await?;
-                        continue;
                     }
                     self.write_processed_flat_batch(
                         record_batch,

--- a/src/store-api/src/mito_engine_options.rs
+++ b/src/store-api/src/mito_engine_options.rs
@@ -66,6 +66,9 @@ pub const MEMTABLE_PARTITION_TREE_FORK_DICTIONARY_BYTES: &str =
 pub const SKIP_WAL_KEY: &str = "skip_wal";
 /// Option key for sst format.
 pub const SST_FORMAT_KEY: &str = "sst_format";
+/// Option key for experimental metric engine greptime_value Parquet encoding.
+pub const EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING: &str =
+    "experimental_metric_engine_value_encoding";
 // Note: Adding new options here should also check if this option should be removed in [metric_engine::engine::create::region_options_for_metadata_region].
 
 /// Returns true if the `key` is a valid option key for the mito engine.
@@ -96,6 +99,7 @@ pub fn is_mito_engine_option_key(key: &str) -> bool {
         APPEND_MODE_KEY,
         MERGE_MODE_KEY,
         SST_FORMAT_KEY,
+        EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING,
     ]
     .contains(&key)
 }

--- a/src/store-api/src/mito_engine_options.rs
+++ b/src/store-api/src/mito_engine_options.rs
@@ -69,6 +69,8 @@ pub const SST_FORMAT_KEY: &str = "sst_format";
 /// Option key for experimental metric engine greptime_value Parquet encoding.
 pub const EXPERIMENTAL_METRIC_ENGINE_VALUE_ENCODING: &str =
     "experimental_metric_engine_value_encoding";
+/// Value encoding default for newly submitted physical metric tables.
+pub const METRIC_ENGINE_VALUE_ENCODING_AUTO: &str = "auto";
 // Note: Adding new options here should also check if this option should be removed in [metric_engine::engine::create::region_options_for_metadata_region].
 
 /// Returns true if the `key` is a valid option key for the mito engine.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Related perf-regression/value-distribution harness work: #8444.

## What's changed and what's your intention?

This PR adds an experimental adaptive Parquet encoding mode for the MetricEngine physical `greptime_value` column.

Summary:

- Add Mito region option `experimental_metric_engine_value_encoding` with modes:
  - `disabled` (default for existing/missing options)
  - `auto`
  - `plain`
  - `byte_stream_split`
- Default newly-created MetricEngine physical data regions to `auto` when the user does not specify the option; opening existing regions preserves missing options as `disabled`.
- Keep metadata regions from inheriting the value-encoding option.
- Apply the policy only to MetricEngine physical data regions with MetricEngine marker columns and a Float32/Float64 `greptime_value` column.
- Implement the current Auto heuristic:
  - sample up to 65,536 non-null Float32/Float64 values by raw bits;
  - choose dictionary/plain when `valid_count < 2`, `adjacent_equal_ratio >= 0.20`, or `distinct_ratio <= 0.20`;
  - otherwise choose `BYTE_STREAM_SPLIT` and disable dictionary for `greptime_value`.
- Apply encoding decisions before Parquet writers are opened across normal flush and bulk/flat pre-encoded SST paths.
- Avoid cold sampling during compaction Auto; explicit `byte_stream_split` still applies during compaction.

Known no-dictionary gap:

- This PR intentionally keeps the Auto heuristic binary: dictionary/plain vs `BYTE_STREAM_SPLIT`.
- Synthetic mixed-distribution experiments show a possible third `no_dictionary/plain` branch can improve latency for some patterns, especially mixed signal + repeated values (`mixed-every-*`).
- That tuning is deliberately deferred. We should add broader value-distribution coverage and regression criteria first, then decide whether `no_dictionary` should become part of Auto.
- The expected place to build that evidence is #8444 and follow-up benchmark work, not this plumbing/OSS-migration PR.

Performance/regression plan:

- This PR does not add new perf-regression scenarios directly.
- Value-distribution perf-regression coverage is expected to build on #8444 after it lands/rebases.
- Benchmark evidence can be refreshed after that instead of duplicating perf-regress harness changes here.

Compatibility:

- Existing regions with the option missing keep current behavior (`disabled`).
- Mixed Parquet encodings across SSTs remain reader-compatible.
- New MetricEngine data regions may write `greptime_value` with byte-stream-split when Auto detects a high-distinct signal-like distribution.

Validation:

- `cargo fmt -p mito2 -p metric-engine -p store-api -p cmd`
- `cargo test -p mito2 value_encoding --lib`
- `cargo test -p metric-engine engine::options --lib`
- `cargo check -p mito2 --lib`
- `git diff --check`

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
