### PR TITLE
ci: gate releases on compat and query regression

### DIFF
--- a/.github/actions/publish-github-release/action.yml
+++ b/.github/actions/publish-github-release/action.yml
@@ -18,7 +18,7 @@ runs:
       uses: actions/download-artifact@v4
 
     - name: Create git tag for release
-      if: ${{ github.event_name != 'push' }} # Meaning this is a scheduled or manual workflow.
+      if: ${{ github.event_name != 'push' && github.ref_type != 'tag' }} # Scheduled and manual branch workflows need a new tag.
       shell: bash
       run: |
         git tag ${{ inputs.version }}

--- a/.github/scripts/create-version.sh
+++ b/.github/scripts/create-version.sh
@@ -2,12 +2,27 @@
 
 set -e
 
-# - If it's a tag push release, the version is the tag name(${{ github.ref_name }});
+# - If it's a tag push release or manual dispatch on a tag with REUSE_EXISTING_RELEASE_TAG=true, the version is the tag name(${{ github.ref_name }});
 # - If it's a scheduled release, the version is '${{ env.NEXT_RELEASE_VERSION }}-nightly-$buildTime', like 'v0.2.0-nightly-20230313';
-# - If it's a manual release, the version is '${{ env.NEXT_RELEASE_VERSION }}-$(git rev-parse --short HEAD)-YYYYMMDDSS', like 'v0.2.0-e5b243c-2023071245';
+# - If it's a manual non-tag release, the version is '${{ env.NEXT_RELEASE_VERSION }}-$(git rev-parse --short HEAD)-YYYYMMDDSS', like 'v0.2.0-e5b243c-2023071245';
 # - If it's a nightly build, the version is 'nightly-YYYYMMDD-$(git rev-parse --short HEAD)', like 'nightly-20230712-e5b243c'.
 # create_version ${GIHUB_EVENT_NAME} ${NEXT_RELEASE_VERSION} ${NIGHTLY_RELEASE_PREFIX}
 function create_version() {
+  validate_formal_tag() {
+    if [ -z "$GITHUB_REF_NAME" ]; then
+      echo "GITHUB_REF_NAME is empty in formal tag release" >&2
+      exit 1
+    fi
+
+    CARGO_VERSION=$(grep '^version = ' Cargo.toml | cut -d '"' -f 2 | head -n 1)
+    EXPECTED_REF_NAME="v${CARGO_VERSION}"
+    if [ "$GITHUB_REF_NAME" != "$EXPECTED_REF_NAME" ]; then
+      echo "Error: GITHUB_REF_NAME '$GITHUB_REF_NAME' does not match Cargo.toml version 'v${CARGO_VERSION}'" >&2
+      echo "Expected tag name: '$EXPECTED_REF_NAME'" >&2
+      exit 1
+    fi
+  }
+
   # Read from environment variables.
   if [ -z "$GITHUB_EVENT_NAME" ]; then
       echo "GITHUB_EVENT_NAME is empty" >&2
@@ -23,6 +38,13 @@ function create_version() {
   if [ -z "$NIGHTLY_RELEASE_PREFIX" ]; then
       echo "NIGHTLY_RELEASE_PREFIX is empty" >&2
       exit 1
+  fi
+
+  if [ "$GITHUB_EVENT_NAME" = workflow_dispatch ] && [ "${GITHUB_REF_TYPE:-}" = tag ] && \
+    [ "${REUSE_EXISTING_RELEASE_TAG:-}" = true ]; then
+    validate_formal_tag
+    echo "$GITHUB_REF_NAME"
+    exit 0
   fi
 
   # Reuse $NEXT_RELEASE_VERSION to identify whether it's a nightly build.
@@ -45,21 +67,7 @@ function create_version() {
 
   # Note: Only output 'version=xxx' to stdout when everything is ok, so that it can be used in GitHub Actions Outputs.
   if [ "$GITHUB_EVENT_NAME" = push ]; then
-    if [ -z "$GITHUB_REF_NAME" ]; then
-      echo "GITHUB_REF_NAME is empty in push event" >&2
-      exit 1
-    fi
-    
-    # For tag releases, ensure GITHUB_REF_NAME matches the version in Cargo.toml
-    CARGO_VERSION=$(grep '^version = ' Cargo.toml | cut -d '"' -f 2 | head -n 1)
-    EXPECTED_REF_NAME="v${CARGO_VERSION}"
-    
-    if [ "$GITHUB_REF_NAME" != "$EXPECTED_REF_NAME" ]; then
-      echo "Error: GITHUB_REF_NAME '$GITHUB_REF_NAME' does not match Cargo.toml version 'v${CARGO_VERSION}'" >&2
-      echo "Expected tag name: '$EXPECTED_REF_NAME'" >&2
-      exit 1
-    fi
-    
+    validate_formal_tag
     echo "$GITHUB_REF_NAME"
   elif [ "$GITHUB_EVENT_NAME" = workflow_dispatch ]; then
     echo "$NEXT_RELEASE_VERSION-$(git rev-parse --short HEAD)-$(date "+%Y%m%d-%s")"
@@ -73,6 +81,7 @@ function create_version() {
 
 # You can run as following examples:
 #  GITHUB_EVENT_NAME=push NEXT_RELEASE_VERSION=v0.4.0 NIGHTLY_RELEASE_PREFIX=nightly GITHUB_REF_NAME=v0.3.0 ./create-version.sh
+#  GITHUB_EVENT_NAME=workflow_dispatch GITHUB_REF_TYPE=tag REUSE_EXISTING_RELEASE_TAG=true GITHUB_REF_NAME=v0.3.0 NEXT_RELEASE_VERSION=v0.4.0 NIGHTLY_RELEASE_PREFIX=nightly ./create-version.sh
 #  GITHUB_EVENT_NAME=workflow_dispatch NEXT_RELEASE_VERSION=v0.4.0 NIGHTLY_RELEASE_PREFIX=nightly ./create-version.sh
 #  GITHUB_EVENT_NAME=schedule NEXT_RELEASE_VERSION=v0.4.0 NIGHTLY_RELEASE_PREFIX=nightly ./create-version.sh
 #  GITHUB_EVENT_NAME=schedule NEXT_RELEASE_VERSION=nightly NIGHTLY_RELEASE_PREFIX=nightly ./create-version.sh

--- a/.github/workflows/query-regression.yml
+++ b/.github/workflows/query-regression.yml
@@ -1,6 +1,41 @@
 name: Query Regression
 
 on:
+  workflow_call:
+    inputs:
+      case:
+        description: Query perf case path(s) in candidate checkout, or all
+        required: false
+        type: string
+        default: all
+      allow_large_fixture:
+        description: Pass --allow-large-fixture to runner
+        required: false
+        type: boolean
+        default: true
+      http_timeout:
+        description: Runner HTTP timeout seconds
+        required: false
+        type: string
+        default: "300"
+      base_ref:
+        description: Base ref/sha to build
+        required: true
+        type: string
+      candidate_ref:
+        description: Candidate ref/sha to build; reusable release calls must provide an immutable full SHA
+        required: true
+        type: string
+      cargo_profile:
+        description: Cargo profile to build base and candidate binaries with
+        required: false
+        type: string
+        default: nightly
+      runner:
+        description: Self-hosted runner label or ARC runner scale set for this query regression run
+        required: false
+        type: string
+        default: perf-regression-8-cores
   workflow_dispatch:
     inputs:
       case:
@@ -48,12 +83,12 @@ permissions:
 jobs:
   query-regression:
     if: >-
-      ${{ github.event_name == 'workflow_dispatch' ||
+      ${{ github.event_name != 'pull_request' ||
            (github.event_name == 'pull_request' &&
             !github.event.pull_request.draft &&
             contains(github.event.pull_request.labels.*.name, 'query-regression') &&
             (github.event.action != 'labeled' || github.event.label.name == 'query-regression')) }}
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner || 'perf-regression-8-cores' }}
+    runs-on: ${{ github.event_name != 'pull_request' && inputs.runner || 'perf-regression-8-cores' }}
     timeout-minutes: 180
     concurrency:
       group: query-regression-persistent-cache-v1
@@ -75,7 +110,7 @@ jobs:
       RUSTFLAGS: -D warnings -C link-arg=-fuse-ld=mold
       QUERY_REGRESSION_CACHE_EPOCH: "1"
       BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || inputs.base_ref }}
-      CANDIDATE_REF: ${{ github.event_name == 'workflow_dispatch' && (inputs.candidate_ref || github.ref) || '' }}
+      CANDIDATE_REF: ${{ github.event_name != 'pull_request' && (inputs.candidate_ref || github.ref) || '' }}
       EVENT_MERGE_SHA: ${{ github.event_name == 'pull_request' && github.sha || '' }}
       EVENT_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
       EVENT_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
@@ -88,17 +123,12 @@ jobs:
           path: src
           persist-credentials: false
 
-      - name: Preserve trusted query regression scripts
-        run: |
-          mkdir -p query-regression-trusted-scripts
-          cp src/.github/scripts/query-regression-pr-metadata.py \
-            query-regression-trusted-scripts/query-regression-pr-metadata.py
-          cp src/.github/scripts/query-regression-summary.py \
-            query-regression-trusted-scripts/query-regression-summary.py
-
       - name: Resolve immutable candidate and build base
         working-directory: src
         shell: bash
+        env:
+          CALLER_WORKFLOW_REF: ${{ github.workflow_ref }}
+          DEFINING_WORKFLOW_REF: ${{ job.workflow_ref }}
         run: |
           set -euo pipefail
 
@@ -111,6 +141,11 @@ jobs:
           is_full_sha() {
             [[ "$1" =~ ^[[:xdigit:]]{40}$ ]]
           }
+
+          is_reusable_call=false
+          if [[ "${CALLER_WORKFLOW_REF}" != "${DEFINING_WORKFLOW_REF}" ]]; then
+            is_reusable_call=true
+          fi
 
           fetch_with_retry() {
             local ref="$1"
@@ -172,11 +207,23 @@ jobs:
               || fail_closed "Event merge SHA has no non-head parent for the base build."
             VERIFIED_CANDIDATE_SHA="${fetched_sha,,}"
           else
+            if [[ "${is_reusable_call}" == true ]] && ! is_full_sha "${CANDIDATE_REF}"; then
+              printf 'Reusable calls require CANDIDATE_REF to be an immutable full SHA, got: %s\n' \
+                "${CANDIDATE_REF}" >&2
+              exit 1
+            fi
             if ! fetch_with_retry "${CANDIDATE_REF}" 1; then
               printf 'Could not fetch candidate ref %s.\n' "${CANDIDATE_REF}" >&2
               exit 1
             fi
-            VERIFIED_CANDIDATE_SHA="$(git rev-parse --verify FETCH_HEAD)"
+            fetched_sha="$(git rev-parse --verify FETCH_HEAD)"
+            if { [[ "${is_reusable_call}" == true ]] || is_full_sha "${CANDIDATE_REF}"; } && \
+              [[ "${fetched_sha,,}" != "${CANDIDATE_REF,,}" ]]; then
+              printf 'FETCH_HEAD %s does not match immutable candidate SHA %s.\n' \
+                "${fetched_sha}" "${CANDIDATE_REF}" >&2
+              exit 1
+            fi
+            VERIFIED_CANDIDATE_SHA="${fetched_sha}"
             VERIFIED_BASE_SHA="${initially_checked_out_base_sha}"
           fi
 
@@ -196,6 +243,21 @@ jobs:
             "${VERIFIED_CANDIDATE_SHA,,}" "${VERIFIED_BASE_SHA,,}" >> "${GITHUB_STEP_SUMMARY}"
           git reset --hard "${VERIFIED_BASE_SHA}"
           git clean -ffdx
+
+      - name: Preserve trusted query regression scripts
+        working-directory: src
+        shell: bash
+        run: |
+          set -euo pipefail
+          helper_ref="${VERIFIED_CANDIDATE_SHA}"
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            helper_ref="${VERIFIED_BASE_SHA}"
+          fi
+          mkdir -p "${GITHUB_WORKSPACE}/query-regression-trusted-scripts"
+          git show "${helper_ref}:.github/scripts/query-regression-pr-metadata.py" \
+            > "${GITHUB_WORKSPACE}/query-regression-trusted-scripts/query-regression-pr-metadata.py"
+          git show "${helper_ref}:.github/scripts/query-regression-summary.py" \
+            > "${GITHUB_WORKSPACE}/query-regression-trusted-scripts/query-regression-summary.py"
 
       - name: Verify runner image tools
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 # There are two kinds of formal release:
 # 1. The tag('v*.*.*') push release: the release workflow will be triggered by the tag push event.
 # 2. The scheduled release(the version will be '${{ env.NEXT_RELEASE_VERSION }}-nightly-YYYYMMDD'): the release workflow will be triggered by the schedule event.
+# A failed tag push release can be manually dispatched on the same tag to recover it without changing the formal release version.
 on:
   push:
     tags:
@@ -11,7 +12,7 @@ on:
     # At 00:00 on Monday.
     - cron: '0 0 * * 1'
   workflow_dispatch: # Allows you to run this workflow manually.
-    # Notes: The GitHub Actions ONLY support 10 inputs, and it's already used up.
+    # Notes: The GitHub Actions ONLY support 10 inputs; this final input is the tenth.
     inputs:
       linux_amd64_runner:
         type: choice
@@ -74,6 +75,16 @@ on:
         description: Build and push images to DockerHub and ACR
         required: false
         default: false
+      release_validation:
+        type: choice
+        description: Manual policy for accepted perf regressions or runner failures; automatic releases always run all validation
+        required: true
+        default: all
+        options:
+          - all
+          - skip-compat
+          - skip-query-regression
+          - skip-all
 
 # Use env variables to control all the release process.
 env:
@@ -121,9 +132,9 @@ jobs:
           ./scripts/check-builder-rust-version.sh
 
       # The create-version will create a global variable named 'version' in the global workflows.
-      # - If it's a tag push release, the version is the tag name(${{ github.ref_name }});
+      # - If it's a tag push release or manual dispatch on a tag with REUSE_EXISTING_RELEASE_TAG=true, the version is the tag name(${{ github.ref_name }});
       # - If it's a scheduled release, the version is '${{ env.NEXT_RELEASE_VERSION }}-nightly-$buildTime', like v0.2.0-nightly-20230313;
-      # - If it's a manual release, the version is '${{ env.NEXT_RELEASE_VERSION }}-<short-git-sha>-YYYYMMDDSS', like v0.2.0-e5b243c-2023071245;
+      # - If it's a manual non-tag release, the version is '${{ env.NEXT_RELEASE_VERSION }}-<short-git-sha>-YYYYMMDDSS', like v0.2.0-e5b243c-2023071245;
       - name: Create version
         id: create-version
         run: |
@@ -131,6 +142,8 @@ jobs:
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
+          GITHUB_REF_TYPE: ${{ github.ref_type }}
+          REUSE_EXISTING_RELEASE_TAG: "true"
           NIGHTLY_RELEASE_PREFIX: ${{ env.NIGHTLY_RELEASE_PREFIX }}
 
       - name: Check version
@@ -139,7 +152,7 @@ jobs:
           ./.github/scripts/check-version.sh "${{ steps.create-version.outputs.version }}"
 
       - name: Allocate linux-amd64 runner
-        if: ${{ inputs.build_linux_artifacts || github.event_name == 'push' || github.event_name == 'schedule' }}
+        if: ${{ inputs.build_linux_artifacts || inputs.publish_github_release || inputs.release_images || github.event_name == 'push' || github.event_name == 'schedule' }}
         uses: ./.github/actions/start-runner
         id: start-linux-amd64-runner
         with:
@@ -153,7 +166,7 @@ jobs:
           subnet-id: ${{ vars.EC2_RUNNER_SUBNET_ID }}
 
       - name: Allocate linux-arm64 runner
-        if: ${{ inputs.build_linux_artifacts || github.event_name == 'push' || github.event_name == 'schedule' }}
+        if: ${{ inputs.build_linux_artifacts || inputs.publish_github_release || inputs.release_images || github.event_name == 'push' || github.event_name == 'schedule' }}
         uses: ./.github/actions/start-runner
         id: start-linux-arm64-runner
         with:
@@ -168,7 +181,7 @@ jobs:
 
   build-linux-amd64-artifacts:
     name: Build linux-amd64 artifacts
-    if: ${{ inputs.build_linux_artifacts || github.event_name == 'push' || github.event_name == 'schedule' }}
+    if: ${{ inputs.build_linux_artifacts || inputs.publish_github_release || inputs.release_images || github.event_name == 'push' || github.event_name == 'schedule' }}
     needs: [
       allocate-runners,
     ]
@@ -190,7 +203,7 @@ jobs:
 
   build-linux-arm64-artifacts:
     name: Build linux-arm64 artifacts
-    if: ${{ inputs.build_linux_artifacts || github.event_name == 'push' || github.event_name == 'schedule' }}
+    if: ${{ inputs.build_linux_artifacts || inputs.publish_github_release || inputs.release_images || github.event_name == 'push' || github.event_name == 'schedule' }}
     needs: [
       allocate-runners,
     ]
@@ -292,13 +305,186 @@ jobs:
         run: |
           echo "build-windows-result=success" >> $Env:GITHUB_OUTPUT
 
+  prepare-release-validation:
+    name: Prepare release validation
+    if: ${{ inputs.publish_github_release || inputs.release_images || github.event_name == 'push' || github.event_name == 'schedule' }}
+    needs: [
+      allocate-runners,
+    ]
+    runs-on: ubuntu-latest
+    outputs:
+      previous-release-tag: ${{ steps.refs.outputs.previous-release-tag }}
+      candidate-ref: ${{ steps.refs.outputs.candidate-ref }}
+      validation-policy: ${{ steps.refs.outputs.validation-policy }}
+      run-compat: ${{ steps.refs.outputs.run-compat }}
+      run-query-regression: ${{ steps.refs.outputs.run-query-regression }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve release validation refs
+        id: refs
+        shell: bash
+        env:
+          REQUESTED_VALIDATION_POLICY: ${{ inputs.release_validation }}
+        run: |
+          set -euo pipefail
+          base_commit="${GITHUB_SHA}"
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            base_commit="${GITHUB_SHA}^"
+          fi
+          previous_release_tag="$(git tag --merged "${base_commit}" --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)"
+          if [[ -z "${previous_release_tag}" ]]; then
+            previous_release_tag="main"
+          fi
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            validation_policy="${REQUESTED_VALIDATION_POLICY}"
+          else
+            validation_policy="all"
+          fi
+          case "${validation_policy}" in
+            all)
+              run_compat=true
+              run_query_regression=true
+              ;;
+            skip-compat)
+              run_compat=false
+              run_query_regression=true
+              ;;
+            skip-query-regression)
+              run_compat=true
+              run_query_regression=false
+              ;;
+            skip-all)
+              run_compat=false
+              run_query_regression=false
+              ;;
+            *)
+              printf 'Unsupported release validation policy: %s\n' "${validation_policy}" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "previous-release-tag=${previous_release_tag}" >> "${GITHUB_OUTPUT}"
+          echo "candidate-ref=${GITHUB_SHA}" >> "${GITHUB_OUTPUT}"
+          echo "validation-policy=${validation_policy}" >> "${GITHUB_OUTPUT}"
+          echo "run-compat=${run_compat}" >> "${GITHUB_OUTPUT}"
+          echo "run-query-regression=${run_query_regression}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "## Release validation policy"
+            echo "- Effective policy: \`${validation_policy}\`"
+            echo "- Actor: \`${GITHUB_ACTOR}\`"
+            echo "- Triggering actor: \`${GITHUB_TRIGGERING_ACTOR}\`"
+            echo "- Event: \`${GITHUB_EVENT_NAME}\`"
+            echo "- Candidate SHA: \`${GITHUB_SHA}\`"
+            echo "- Baseline: \`${previous_release_tag}\`"
+            if [[ "${validation_policy}" != "all" ]]; then
+              echo "- ⚠️ Validation bypassed: compatibility=${run_compat}, query-regression=${run_query_regression}"
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  compat-release:
+    name: Compatibility release test
+    if: ${{ needs.prepare-release-validation.outputs.run-compat == 'true' }}
+    needs: [
+      allocate-runners,
+      build-linux-amd64-artifacts,
+      prepare-release-validation,
+    ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-compat
+          cache-all-crates: "true"
+          save-if: false
+
+      - name: Download release greptime artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: greptime-linux-amd64-${{ needs.allocate-runners.outputs.version }}
+          path: .
+
+      - name: Prepare release greptime binary
+        shell: bash
+        run: |
+          artifact_dir="greptime-linux-amd64-${{ needs.allocate-runners.outputs.version }}"
+          tar -xzf "${artifact_dir}.tar.gz"
+          mkdir -p ./bins
+          cp "${artifact_dir}/greptime" ./bins/greptime
+          chmod +x ./bins/greptime
+          ./bins/greptime --version
+
+      - name: Build release compatibility runner
+        shell: bash
+        run: |
+          cargo build --profile "${CARGO_PROFILE}" -p sqlness-runner --bin sqlness-runner
+          cp "target/${CARGO_PROFILE}/sqlness-runner" ./bins/sqlness-runner
+
+      - name: Run release compatibility test
+        run: python3 .github/scripts/run-compat.py --preserve-state
+
+      - name: Upload compatibility failure logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-compat-failure-logs
+          path: /tmp/sqlness-compat*
+          if-no-files-found: ignore
+
+  query-regression-release:
+    name: Query regression release test
+    if: ${{ needs.prepare-release-validation.outputs.run-query-regression == 'true' }}
+    needs: [
+      allocate-runners,
+      prepare-release-validation,
+    ]
+    uses: ./.github/workflows/query-regression.yml
+    secrets: inherit
+    with:
+      case: all
+      base_ref: ${{ needs.prepare-release-validation.outputs.previous-release-tag }}
+      candidate_ref: ${{ needs.prepare-release-validation.outputs.candidate-ref }}
+      cargo_profile: nightly
+      runner: perf-regression-8-cores
+
   release-images-to-dockerhub:
     name: Build and push images to DockerHub
-    if: ${{ inputs.release_images || github.event_name == 'push' || github.event_name == 'schedule' }}
+    if: |
+      always() &&
+      (inputs.release_images || github.event_name == 'push' || github.event_name == 'schedule') &&
+      needs.allocate-runners.result == 'success' &&
+      needs.build-linux-amd64-artifacts.result == 'success' &&
+      needs.build-linux-arm64-artifacts.result == 'success' &&
+      needs.prepare-release-validation.result == 'success' &&
+      (needs.compat-release.result == 'success' ||
+       (needs.prepare-release-validation.outputs.run-compat == 'false' && needs.compat-release.result == 'skipped')) &&
+      (needs.query-regression-release.result == 'success' ||
+       (needs.prepare-release-validation.outputs.run-query-regression == 'false' && needs.query-regression-release.result == 'skipped'))
     needs: [
       allocate-runners,
       build-linux-amd64-artifacts,
       build-linux-arm64-artifacts,
+      prepare-release-validation,
+      compat-release,
+      query-regression-release,
     ]
     runs-on: ubuntu-latest
     outputs:
@@ -374,11 +560,20 @@ jobs:
       always() &&
       (inputs.publish_github_release || github.event_name == 'push' || github.event_name == 'schedule') &&
       needs.allocate-runners.result == 'success' &&
-      (needs.build-linux-amd64-artifacts.result == 'success' || needs.build-linux-amd64-artifacts.result == 'skipped') &&
-      (needs.build-linux-arm64-artifacts.result == 'success' || needs.build-linux-arm64-artifacts.result == 'skipped') &&
+      needs.prepare-release-validation.result == 'success' &&
+      (needs.compat-release.result == 'success' ||
+       (needs.prepare-release-validation.outputs.run-compat == 'false' && needs.compat-release.result == 'skipped')) &&
+      (needs.query-regression-release.result == 'success' ||
+       (needs.prepare-release-validation.outputs.run-query-regression == 'false' && needs.query-regression-release.result == 'skipped')) &&
+      needs.build-linux-amd64-artifacts.result == 'success' &&
+      needs.build-linux-arm64-artifacts.result == 'success' &&
       (needs.build-macos-artifacts.result == 'success' || needs.build-macos-artifacts.result == 'skipped') &&
       (needs.build-windows-artifacts.result == 'success' || needs.build-windows-artifacts.result == 'skipped') &&
-      (needs.release-images-to-dockerhub.result == 'success' || needs.release-images-to-dockerhub.result == 'skipped')
+      (needs.release-images-to-dockerhub.result == 'success' ||
+       (github.event_name == 'workflow_dispatch' && inputs.release_images == false &&
+        needs.release-images-to-dockerhub.result == 'skipped')) &&
+      (github.event_name != 'workflow_dispatch' || github.ref_type != 'tag' ||
+       needs.allocate-runners.outputs.is-current-version-latest == 'true')
     needs: [ # The job have to wait for all the artifacts are built.
       allocate-runners,
       build-linux-amd64-artifacts,
@@ -386,6 +581,9 @@ jobs:
       build-macos-artifacts,
       build-windows-artifacts,
       release-images-to-dockerhub,
+      prepare-release-validation,
+      compat-release,
+      query-regression-release,
     ]
     runs-on: ubuntu-latest
     steps:
@@ -456,7 +654,7 @@ jobs:
 
   bump-downstream-repo-versions:
     name: Bump downstream repo versions
-    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref_type == 'tag') }}
     needs: [allocate-runners, publish-github-release]
     runs-on: ubuntu-latest
     # Permission reference: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up to the recent compatibility CI and query-regression workflow work.

## What's changed and what's your intention?

This PR makes the release workflow run compatibility and query performance regression validation before publishing artifacts externally.

The release workflow now:

- prepares immutable validation refs for release checks;
- runs the SQL compatibility test against the built linux-amd64 release artifact;
- reuses the persistent-cache query regression workflow through `workflow_call`;
- gates DockerHub image publishing and GitHub release publishing on validation results;
- triggers linux artifact builds automatically for manual `publish_github_release` / `release_images` runs.

Automatic tag and scheduled releases always run all validation. Manual dispatches have one auditable `release_validation` policy with these options:

- `all`
- `skip-compat`
- `skip-query-regression`
- `skip-all`

Publishing only accepts a skipped validation job when that exact check was explicitly disabled by the selected policy. Failed, cancelled, and unexpectedly skipped validation still block publishing. The effective policy, actors, event, candidate SHA, and baseline are written to the workflow summary.

For compatibility validation, the job uses the linux-amd64 release artifact as the candidate `greptime` binary, builds `sqlness-runner`, then runs:

```text
python3 .github/scripts/run-compat.py --preserve-state
```

For query regression validation, reusable calls must pass an immutable full candidate SHA. The existing fail-closed candidate resolver verifies that exact SHA while preserving the latest persistent cache, pinned runner image, and PR merge identity checks. Trusted helper scripts come from the verified base SHA for PRs and the verified candidate SHA for non-PR runs.

If an automatic formal-tag release fails validation, it can be manually dispatched on the same tag with an explicit skip policy. The retry reuses and validates the existing tag, does not recreate it, blocks retries of older-than-latest formal tags, and runs the normal downstream version bumps after publishing.

Validation performed:

```text
git diff --check
bash -n .github/scripts/create-version.sh
uv run python -m py_compile .github/scripts/run-compat.py .github/scripts/query-regression-run.py .github/scripts/query-regression-summary.py .github/scripts/query-regression-pr-metadata.py
```

Focused shell checks cover push tags, manual exact-tag recovery, manual non-tag versions, shared dev/nightly behavior without release opt-in, and invalid tags. `actionlint` was not available locally.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments. (not applicable, workflow-only)
- [x] I have added the necessary unit tests and integration tests. (workflow/shell validation)
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
