### PR TITLE
fix(flow): convert streaming expiration to milliseconds

### DIFF
--- a/src/flow/src/adapter.rs
+++ b/src/flow/src/adapter.rs
@@ -77,6 +77,13 @@ use crate::FrontendInvoker;
 use crate::error::Error;
 
 fn expire_after_secs_to_millis(expire_after_secs: i64) -> Result<repr::Duration, Error> {
+    ensure!(
+        expire_after_secs >= 0,
+        InvalidQuerySnafu {
+            reason: format!("EXPIRE AFTER must be non-negative, got {expire_after_secs} seconds"),
+        }
+    );
+
     expire_after_secs
         .checked_mul(1_000)
         .with_context(|| InvalidQuerySnafu {

--- a/src/flow/src/adapter.rs
+++ b/src/flow/src/adapter.rs
@@ -76,6 +76,16 @@ pub(crate) mod table_source;
 use crate::FrontendInvoker;
 use crate::error::Error;
 
+fn expire_after_secs_to_millis(expire_after_secs: i64) -> Result<repr::Duration, Error> {
+    expire_after_secs
+        .checked_mul(1_000)
+        .with_context(|| InvalidQuerySnafu {
+            reason: format!(
+                "EXPIRE AFTER value {expire_after_secs} seconds cannot be represented in milliseconds"
+            ),
+        })
+}
+
 // `GREPTIME_TIMESTAMP` is not used to distinguish when table is created automatically by flow
 pub const AUTO_CREATED_PLACEHOLDER_TS_COL: &str = "__ts_placeholder";
 
@@ -740,7 +750,7 @@ impl StreamingEngine {
             source_table_ids,
             create_if_not_exists,
             or_replace,
-            expire_after,
+            expire_after: expire_after_secs,
             eval_interval: _,
             comment,
             sql,
@@ -748,6 +758,9 @@ impl StreamingEngine {
             query_ctx,
             ..
         } = args;
+        let expire_after = expire_after_secs
+            .map(expire_after_secs_to_millis)
+            .transpose()?;
 
         let mut node_ctx = self.node_context.write().await;
         // assign global id to source and sink table

--- a/src/flow/src/adapter/refill.rs
+++ b/src/flow/src/adapter/refill.rs
@@ -85,7 +85,10 @@ impl StreamingEngine {
                 }
             }
 
-            let expire_after = info.expire_after();
+            let expire_after = info
+                .expire_after()
+                .map(super::expire_after_secs_to_millis)
+                .transpose()?;
             // TODO(discord9): better way to get last point
             let now = self.tick_manager.tick();
             let plan = self

--- a/src/flow/src/adapter/tests.rs
+++ b/src/flow/src/adapter/tests.rs
@@ -65,6 +65,7 @@ fn mock_harness_flow_node_manager() {}
 #[test]
 fn test_expire_after_secs_to_millis() {
     assert_eq!(expire_after_secs_to_millis(300).unwrap(), 300_000);
+    assert_eq!(expire_after_secs_to_millis(0).unwrap(), 0);
 
     let max_secs = i64::MAX / 1_000;
     assert_eq!(
@@ -74,11 +75,11 @@ fn test_expire_after_secs_to_millis() {
 }
 
 #[test]
-fn test_expire_after_secs_to_millis_overflow() {
-    let overflow_values = [i64::MAX / 1_000 + 1, i64::MIN / 1_000 - 1];
+fn test_expire_after_secs_to_millis_invalid() {
+    let invalid_values = [i64::MAX / 1_000 + 1, -1];
 
-    for overflow_secs in overflow_values {
-        let error = expire_after_secs_to_millis(overflow_secs).unwrap_err();
+    for invalid_secs in invalid_values {
+        let error = expire_after_secs_to_millis(invalid_secs).unwrap_err();
         assert!(matches!(error, Error::InvalidQuery { .. }));
     }
 }

--- a/src/flow/src/adapter/tests.rs
+++ b/src/flow/src/adapter/tests.rs
@@ -61,3 +61,24 @@ pub fn new_test_table_info_with_name<I: IntoIterator<Item = u32>>(
 ///
 /// containing several default table info and schema
 fn mock_harness_flow_node_manager() {}
+
+#[test]
+fn test_expire_after_secs_to_millis() {
+    assert_eq!(expire_after_secs_to_millis(300).unwrap(), 300_000);
+
+    let max_secs = i64::MAX / 1_000;
+    assert_eq!(
+        expire_after_secs_to_millis(max_secs).unwrap(),
+        max_secs * 1_000
+    );
+}
+
+#[test]
+fn test_expire_after_secs_to_millis_overflow() {
+    let overflow_values = [i64::MAX / 1_000 + 1, i64::MIN / 1_000 - 1];
+
+    for overflow_secs in overflow_values {
+        let error = expire_after_secs_to_millis(overflow_secs).unwrap_err();
+        assert!(matches!(error, Error::InvalidQuery { .. }));
+    }
+}

--- a/src/flow/src/engine.rs
+++ b/src/flow/src/engine.rs
@@ -34,6 +34,7 @@ pub struct CreateFlowArgs {
     pub source_table_ids: Vec<TableId>,
     pub create_if_not_exists: bool,
     pub or_replace: bool,
+    /// Duration in seconds.
     pub expire_after: Option<i64>,
     pub eval_interval: Option<i64>,
     pub comment: Option<String>,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

`EXPIRE AFTER` is stored in seconds, while the streaming flow runtime uses millisecond timestamps and durations. Passing the value through unchanged caused the streaming state to expire and refill scan ranges to be limited 1000 times earlier than configured.

This PR converts the value to milliseconds at the streaming flow creation and refill boundaries, rejects conversion overflow, documents the input unit, and adds unit tests.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
