### PR TITLE
ci: increase Kafka resource requests

### DIFF
--- a/.github/actions/setup-greptimedb-cluster/with-remote-wal-logical-prune.yaml
+++ b/.github/actions/setup-greptimedb-cluster/with-remote-wal-logical-prune.yaml
@@ -3,6 +3,7 @@ logging:
   format: "json"
   filters:
   - log_store=debug
+  - rskafka=debug
 meta:
   configData: |-
     [runtime]

--- a/.github/actions/setup-greptimedb-cluster/with-remote-wal.yaml
+++ b/.github/actions/setup-greptimedb-cluster/with-remote-wal.yaml
@@ -3,6 +3,7 @@ logging:
   format: "json"
   filters:
   - log_store=debug
+  - rskafka=debug
 meta:
   configData: |-
     [runtime]

--- a/.github/actions/setup-kafka-cluster/action.yml
+++ b/.github/actions/setup-kafka-cluster/action.yml
@@ -16,8 +16,8 @@ runs:
       helm upgrade \
         --install kafka oci://registry-1.docker.io/bitnamicharts/kafka \
         --set controller.replicaCount=${{ inputs.controller-replicas }} \
-        --set controller.resources.requests.cpu=50m \
-        --set controller.resources.requests.memory=128Mi \
+        --set controller.resources.requests.cpu=500m \
+        --set controller.resources.requests.memory=512Mi \
         --set controller.resources.limits.cpu=2000m \
         --set controller.resources.limits.memory=2Gi \
         --set listeners.controller.protocol=PLAINTEXT \


### PR DESCRIPTION
Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)

I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR increases the Kafka controller resource requests used by the CI Kafka cluster setup action:

- CPU request: `50m` -> `500m`
- Memory request: `128Mi` -> `512Mi`

The Kafka limits remain unchanged at `2000m` CPU and `2Gi` memory.

The intention is to reduce Kafka instability in distributed fuzz tests that use Remote WAL. Recent fuzz failures showed Kafka KRaft/controller instability symptoms such as heartbeat timeouts, broker fencing, controller election churn, and transient DNS/connectivity failures to Kafka broker/controller pods. Raising resource requests should give Kafka a more reliable CPU/memory baseline in CI while preserving the existing upper limits.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
