### PR TITLE
fix(flow): recover stale incremental reads

### DIFF
--- a/src/flow/src/batching_mode.rs
+++ b/src/flow/src/batching_mode.rs
@@ -22,6 +22,7 @@ use session::ReadPreference;
 
 mod checkpoint;
 pub(crate) mod engine;
+mod error_chain;
 mod eval_schedule;
 pub(crate) mod frontend_client;
 mod state;

--- a/src/flow/src/batching_mode/engine.rs
+++ b/src/flow/src/batching_mode/engine.rs
@@ -20,7 +20,8 @@ use std::time::Duration;
 
 use api::v1::flow::DirtyWindowRequests;
 use catalog::CatalogManagerRef;
-use common_error::ext::BoxedError;
+use common_error::ext::{BoxedError, ErrorExt};
+use common_error::status_code::StatusCode;
 use common_meta::ddl::create_flow::{FLOW_EXPERIMENTAL_ENABLE_INCREMENTAL_READ_KEY, FlowType};
 use common_meta::key::TableMetadataManagerRef;
 use common_meta::key::flow::FlowMetadataManagerRef;
@@ -44,6 +45,7 @@ use table::table_reference::TableReference;
 use tokio::sync::{RwLock, oneshot};
 
 use crate::batching_mode::BatchingModeOptions;
+use crate::batching_mode::error_chain::error_chain_contains_any;
 use crate::batching_mode::eval_schedule::EvalSchedule;
 use crate::batching_mode::frontend_client::FrontendClient;
 use crate::batching_mode::task::{BatchingTask, TaskArgs};
@@ -56,6 +58,8 @@ use crate::error::{
 };
 use crate::metrics::METRIC_FLOW_BATCHING_ENGINE_BULK_MARK_TIME_WINDOW;
 use crate::{CreateFlowArgs, Error, FlowId, TableName};
+
+const FLUSH_FLOW_REQUEST_OUTDATED_MAX_RETRIES: usize = 3;
 
 /// Batching mode Engine, responsible for driving all the batching mode tasks
 ///
@@ -894,27 +898,32 @@ impl BatchingEngine {
         let task = self.runtime.read().await.tasks.get(&flow_id).cloned();
         let task = task.with_context(|| FlowNotFoundSnafu { id: flow_id })?;
 
-        let time_window_size = task
-            .config
-            .time_window_expr
-            .as_ref()
-            .and_then(|expr| *expr.time_window_size());
-
-        let cur_dirty_window_cnt = time_window_size.map(|time_window_size| {
-            task.state
-                .read()
-                .unwrap()
-                .dirty_time_windows
-                .effective_count(&time_window_size)
-        });
-
-        let res = task
-            .execute_once_serialized(
-                &self.query_engine,
-                &self.frontend_client,
-                cur_dirty_window_cnt,
-            )
-            .await?;
+        let mut attempt = 0;
+        let res = loop {
+            match task
+                .execute_once_serialized_for_flush(&self.query_engine, &self.frontend_client)
+                .await
+            {
+                Ok(res) => break res,
+                Err(err)
+                    if should_retry_flush_error(&err)
+                        && attempt < FLUSH_FLOW_REQUEST_OUTDATED_MAX_RETRIES =>
+                {
+                    attempt += 1;
+                    warn!(
+                        "Flush flow {flow_id} hit retryable stale source state, retrying ({attempt}/{FLUSH_FLOW_REQUEST_OUTDATED_MAX_RETRIES}): {err}"
+                    );
+                }
+                Err(err) => {
+                    if should_retry_flush_error(&err) {
+                        warn!(
+                            "Flush flow {flow_id} exhausted retryable stale retries ({FLUSH_FLOW_REQUEST_OUTDATED_MAX_RETRIES}), returning last error: {err}"
+                        );
+                    }
+                    return Err(err);
+                }
+            }
+        };
 
         let affected_rows = res.map(|(r, _)| r).unwrap_or_default();
         debug!(
@@ -938,6 +947,21 @@ impl BatchingEngine {
         notify_flow_shutdown(flow_id, removed_shutdown_tx, "rolled back");
         abort_flow_task(flow_id, removed_task, "rolled back");
     }
+}
+
+fn should_retry_flush_error(err: &Error) -> bool {
+    err.status_code() == StatusCode::RequestOutdated
+        || error_chain_contains_any(
+            err,
+            &[
+                "stale_cursor",
+                "fallback_full_recompute",
+                "incremental query stale",
+                "stale_snapshot_fence",
+                "rebind_snapshot_fence",
+                "snapshot upper bound stale",
+            ],
+        )
 }
 
 fn notify_flow_shutdown(flow_id: FlowId, tx: Option<oneshot::Sender<()>>, action: &str) -> bool {
@@ -1007,12 +1031,17 @@ impl FlowEngine for BatchingEngine {
 
 #[cfg(test)]
 mod tests {
+    use std::fmt;
+
     use catalog::memory::new_memory_catalog_manager;
+    use common_error::ext::StackError;
+    use common_error::mock::MockError;
     use common_meta::key::TableMetadataManager;
     use common_meta::key::flow::FlowMetadataManager;
     use common_meta::kv_backend::memory::MemoryKvBackend;
     use query::options::QueryOptions;
     use session::context::QueryContext;
+    use snafu::ResultExt;
 
     use super::*;
     use crate::test_utils::create_test_query_engine;
@@ -1074,6 +1103,87 @@ mod tests {
         assert!(BatchingEngine::table_options_enable_append_mode(
             &HashMap::from([(APPEND_MODE_KEY.to_string(), "TRUE".to_string())])
         ));
+    }
+
+    fn flow_error_with_status(status_code: StatusCode) -> Error {
+        Err::<(), _>(BoxedError::new(MockError::new(status_code)))
+            .context(ExternalSnafu)
+            .unwrap_err()
+    }
+
+    #[derive(Debug)]
+    struct MarkerSourceError(&'static str);
+
+    impl fmt::Display for MarkerSourceError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "{}", self.0)
+        }
+    }
+
+    impl std::error::Error for MarkerSourceError {}
+
+    #[derive(Debug)]
+    struct WrappedMarkerError {
+        source: MarkerSourceError,
+    }
+
+    impl fmt::Display for WrappedMarkerError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "External error")
+        }
+    }
+
+    impl std::error::Error for WrappedMarkerError {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            Some(&self.source)
+        }
+    }
+
+    impl ErrorExt for WrappedMarkerError {
+        fn status_code(&self) -> StatusCode {
+            StatusCode::Unexpected
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    impl StackError for WrappedMarkerError {
+        fn debug_fmt(&self, _: usize, _: &mut Vec<String>) {}
+
+        fn next(&self) -> Option<&dyn StackError> {
+            None
+        }
+    }
+
+    fn external_error_with_source_marker(marker: &'static str) -> Error {
+        Err::<(), _>(BoxedError::new(WrappedMarkerError {
+            source: MarkerSourceError(marker),
+        }))
+        .context(ExternalSnafu)
+        .unwrap_err()
+    }
+
+    #[test]
+    fn test_should_retry_flush_error_retries_request_outdated_and_wrapped_stale_markers() {
+        let stale_cursor = flow_error_with_status(StatusCode::RequestOutdated);
+        assert!(should_retry_flush_error(&stale_cursor));
+
+        let unexpected = flow_error_with_status(StatusCode::Unexpected);
+        assert!(!should_retry_flush_error(&unexpected));
+
+        let wrapped_stale_cursor = external_error_with_source_marker(
+            "storage returned STALE_CURSOR: given_seq=8527000 min_readable_seq=8550000",
+        );
+        assert!(should_retry_flush_error(&wrapped_stale_cursor));
+
+        let wrapped_stale_fence =
+            external_error_with_source_marker("storage hint REBIND_SNAPSHOT_FENCE for repair");
+        assert!(should_retry_flush_error(&wrapped_stale_fence));
+
+        let generic_wrapped = external_error_with_source_marker("generic network error");
+        assert!(!should_retry_flush_error(&generic_wrapped));
     }
 
     #[test]

--- a/src/flow/src/batching_mode/error_chain.rs
+++ b/src/flow/src/batching_mode/error_chain.rs
@@ -1,0 +1,37 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+
+pub(crate) fn error_chain_contains_any(err: &(dyn Error + 'static), markers: &[&str]) -> bool {
+    fn contains_marker(text: String, markers: &[&str]) -> bool {
+        let text = text.to_ascii_lowercase();
+        markers.iter().any(|marker| text.contains(marker))
+    }
+
+    if contains_marker(err.to_string(), markers) || contains_marker(format!("{err:?}"), markers) {
+        return true;
+    }
+
+    let mut source = err.source();
+    while let Some(err) = source {
+        if contains_marker(err.to_string(), markers) || contains_marker(format!("{err:?}"), markers)
+        {
+            return true;
+        }
+        source = err.source();
+    }
+
+    false
+}

--- a/src/flow/src/batching_mode/state.rs
+++ b/src/flow/src/batching_mode/state.rs
@@ -59,6 +59,9 @@ pub struct TaskState {
     /// Set when the flow's query shape is deterministically incompatible
     /// with incremental execution (e.g. unsupported aggregate expressions).
     incremental_disabled: bool,
+    /// One-shot stale-cursor recovery guard. When set, the next execution must
+    /// run an unfiltered full recompute instead of dirty-scoped repair.
+    force_full_recompute: bool,
     exec_state: ExecState,
     /// Shutdown receiver
     pub(crate) shutdown_rx: oneshot::Receiver<()>,
@@ -85,6 +88,7 @@ impl TaskState {
             pending_fenced_repair: None,
             checkpoints: Default::default(),
             incremental_disabled: false,
+            force_full_recompute: false,
             exec_state: ExecState::Idle,
             shutdown_rx,
             task_handle: None,
@@ -124,6 +128,18 @@ impl TaskState {
         self.incremental_disabled
     }
 
+    pub fn force_full_recompute(&self) -> bool {
+        self.force_full_recompute
+    }
+
+    pub fn set_force_full_recompute(&mut self) {
+        self.force_full_recompute = true;
+    }
+
+    pub fn clear_force_full_recompute(&mut self) {
+        self.force_full_recompute = false;
+    }
+
     /// Permanently disable incremental mode for this task and
     /// immediately fall back to full snapshot for the current cycle.
     pub fn disable_incremental(&mut self) {
@@ -143,6 +159,7 @@ impl TaskState {
     pub fn advance_checkpoints(&mut self, watermark_map: HashMap<u64, u64>) {
         self.checkpoints = watermark_map.into_iter().collect();
         self.pending_fenced_repair = None;
+        self.clear_force_full_recompute();
         if !self.incremental_disabled {
             self.checkpoint_mode = CheckpointMode::Incremental;
         }
@@ -574,6 +591,38 @@ impl DirtyTimeWindows {
         } else {
             (total_window_time_range.num_seconds() / window_size.num_seconds()) as usize
         }
+    }
+
+    /// Returns a conservative cap for an explicit flush. Unlike
+    /// [`Self::effective_count`], this rounds represented coverage up and
+    /// preserves enough capacity to consume every separately stored range in a
+    /// single bounded flush round.
+    pub fn conservative_flush_window_count(&self, window_size: &Duration) -> usize {
+        if self.windows.is_empty() {
+            return 0;
+        }
+
+        let range_count = self.windows.len();
+        let window_nanos = window_size.as_nanos();
+        if window_nanos == 0 {
+            return range_count;
+        }
+
+        let total_nanos = self.windows.iter().fold(0_u128, |total, (start, end)| {
+            let represented = match end {
+                Some(end) => end
+                    .sub(start)
+                    .and_then(|duration| duration.to_std().ok())
+                    .unwrap_or_default(),
+                None => *window_size,
+            }
+            .as_nanos();
+            total.saturating_add(represented)
+        });
+        let rounded_up = total_nanos / window_nanos + u128::from(total_nanos % window_nanos != 0);
+        let rounded_up = rounded_up.min(usize::MAX as u128) as usize;
+
+        rounded_up.max(range_count)
     }
 
     /// Generate all filter expressions consuming all time windows

--- a/src/flow/src/batching_mode/task.rs
+++ b/src/flow/src/batching_mode/task.rs
@@ -235,6 +235,20 @@ struct ExecuteOnceOutcome {
     result: Result<Option<(usize, Duration)>, Error>,
 }
 
+fn merge_flush_execution_results(
+    first: Option<(usize, Duration)>,
+    second: Option<(usize, Duration)>,
+) -> Option<(usize, Duration)> {
+    match (first, second) {
+        (Some((first_rows, first_elapsed)), Some((second_rows, second_elapsed))) => Some((
+            first_rows.saturating_add(second_rows),
+            first_elapsed.saturating_add(second_elapsed),
+        )),
+        (Some(result), None) | (None, Some(result)) => Some(result),
+        (None, None) => None,
+    }
+}
+
 impl BatchingTask {
     #[allow(clippy::too_many_arguments)]
     pub fn try_new(
@@ -410,6 +424,37 @@ impl BatchingTask {
         outcome.result
     }
 
+    pub(crate) async fn execute_once_serialized_for_flush(
+        &self,
+        engine: &QueryEngineRef,
+        frontend_client: &Arc<FrontendClient>,
+    ) -> Result<Option<(usize, Duration)>, Error> {
+        let _execution_guard = self.execution_lock.lock().await;
+        let run_live_dirty_second = self.flush_has_pending_and_live_dirty_coverage();
+        let first = self
+            .execute_once_unlocked(
+                engine,
+                frontend_client,
+                self.current_flush_dirty_window_count(),
+            )
+            .await
+            .result?;
+
+        if !run_live_dirty_second {
+            return Ok(first);
+        }
+
+        let second = self
+            .execute_once_unlocked(
+                engine,
+                frontend_client,
+                self.current_flush_dirty_window_count(),
+            )
+            .await
+            .result?;
+        Ok(merge_flush_execution_results(first, second))
+    }
+
     /// Executes one flow evaluation under `execution_lock` and keeps the
     /// generated query context for the background loop's error logging/backoff.
     async fn execute_once_serialized_with_outcome(
@@ -464,6 +509,45 @@ impl BatchingTask {
                 result: Ok(None),
             }
         }
+    }
+
+    fn current_flush_dirty_window_count(&self) -> Option<usize> {
+        let time_window_size = self
+            .config
+            .time_window_expr
+            .as_ref()
+            .and_then(|expr| *expr.time_window_size())?;
+        let state = self.state.read().unwrap();
+        let dirty_count = state
+            .dirty_time_windows
+            .conservative_flush_window_count(&time_window_size);
+        let pending_count = state
+            .pending_fenced_repair()
+            .map(|repair| {
+                repair
+                    .pending_windows()
+                    .conservative_flush_window_count(&time_window_size)
+            })
+            .unwrap_or_default();
+        let total_count = dirty_count.saturating_add(pending_count);
+        let has_coverage = !state.dirty_time_windows.is_empty()
+            || state
+                .pending_fenced_repair()
+                .is_some_and(|repair| !repair.pending_windows().is_empty());
+
+        Some(if has_coverage && total_count == 0 {
+            1
+        } else {
+            total_count
+        })
+    }
+
+    fn flush_has_pending_and_live_dirty_coverage(&self) -> bool {
+        let state = self.state.read().unwrap();
+        state
+            .pending_fenced_repair()
+            .is_some_and(|repair| !repair.pending_windows().is_empty())
+            && !state.dirty_time_windows.is_empty()
     }
 
     /// Generates the insert plan. Caller must reach this through the serialized path.
@@ -1400,6 +1484,31 @@ impl BatchingTask {
                     self.config.flow_id
                 ),
             })?;
+
+        if self.state.read().unwrap().force_full_recompute() {
+            let retention_filter = self.config.expire_after.map(|_| {
+                (
+                    col_name.as_str(),
+                    expire_lower_bound,
+                    "force-full-recompute",
+                )
+            });
+            let (_, dirty_windows_to_restore) = self.drain_dirty_windows_signal();
+            let plan_info = self
+                .gen_unfiltered_plan_info(
+                    engine,
+                    query_ctx,
+                    sink_table_schema.clone(),
+                    primary_key_indices,
+                    allow_partial,
+                    dirty_windows_to_restore,
+                    retention_filter,
+                    QueryCoverage::UnfilteredFull,
+                )
+                .await?;
+
+            return Ok(Some(plan_info));
+        }
 
         if self.should_use_unfiltered_incremental_delta() {
             // In incremental mode, source correctness is defined by the

--- a/src/flow/src/batching_mode/task/ckpt.rs
+++ b/src/flow/src/batching_mode/task/ckpt.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::error::Error as StdError;
 use std::time::Duration;
 
 use client::OutputWithMetrics;
@@ -24,48 +23,13 @@ use common_telemetry::{debug, info};
 use crate::batching_mode::checkpoint::{
     FlowCheckpointDecision, FlowQueryFallbackReason, checkpoint_mode_label,
 };
+use crate::batching_mode::error_chain::error_chain_contains_any;
 use crate::batching_mode::state::{CheckpointMode, TaskState};
 use crate::batching_mode::task::{BatchingTask, QueryCoverage};
 use crate::metrics::{
     METRIC_FLOW_BATCHING_ENGINE_CHECKPOINT_DECISION_CNT, METRIC_FLOW_BATCHING_ENGINE_QUERY_MODE_CNT,
 };
 use crate::{Error, FlowId};
-
-/// Liveness guard: when a fenced repair query fails with a wrapped error whose
-/// text indicates a stale snapshot fence (even when `StatusCode::RequestOutdated`
-/// was lost through client layers), classify it as `SnapshotFenceExpired` to
-/// break the retry loop and force a rebind of the fence high `H`.
-///
-/// Long-term the structured `StatusCode` / retry hint path should be preserved
-/// end-to-end; this text fallback is a narrow safety measure.
-fn matches_stale_snapshot_fence_text(err: &Error) -> bool {
-    let markers = [
-        "STALE_SNAPSHOT_FENCE",
-        "REBIND_SNAPSHOT_FENCE",
-        "snapshot upper bound stale",
-    ];
-    // Check the top-level error Display and Debug.
-    let debug_str = format!("{:?}", err);
-    let display_str = err.to_string();
-    for marker in &markers {
-        if debug_str.contains(marker) || display_str.contains(marker) {
-            return true;
-        }
-    }
-    // Walk the error source chain.
-    let mut source = err.source();
-    while let Some(s) = source {
-        let debug_str = format!("{:?}", s);
-        let display_str = s.to_string();
-        for marker in &markers {
-            if debug_str.contains(marker) || display_str.contains(marker) {
-                return true;
-            }
-        }
-        source = s.source();
-    }
-    false
-}
 
 impl BatchingTask {
     /// Classify execution errors into checkpoint fallback reasons. A stale
@@ -81,13 +45,27 @@ impl BatchingTask {
                 FlowQueryFallbackReason::StaleCursor
             }
         } else if matches!(coverage, QueryCoverage::FencedRepairChunk { .. })
-            && matches_stale_snapshot_fence_text(err)
+            && error_chain_contains_any(
+                err,
+                &[
+                    "stale_snapshot_fence",
+                    "rebind_snapshot_fence",
+                    "snapshot upper bound stale",
+                ],
+            )
         {
-            // Narrow text-based fallback for wrapped errors where the
-            // structured StatusCode::RequestOutdated was lost through
-            // frontend/client layers. Without this fenced repair will
-            // retry the same stale `given_seq` every refresh tick.
             FlowQueryFallbackReason::SnapshotFenceExpired
+        } else if matches!(coverage, QueryCoverage::IncrementalDelta)
+            && error_chain_contains_any(
+                err,
+                &[
+                    "stale_cursor",
+                    "fallback_full_recompute",
+                    "incremental query stale",
+                ],
+            )
+        {
+            FlowQueryFallbackReason::StaleCursor
         } else if matches!(coverage, QueryCoverage::IncrementalDelta) {
             FlowQueryFallbackReason::IncrementalQueryFailure
         } else {
@@ -106,6 +84,11 @@ impl BatchingTask {
     ) -> Option<FlowCheckpointDecision> {
         state.after_query_exec(elapsed, false);
         let checkpoint_mode = state.checkpoint_mode();
+        if matches!(coverage, QueryCoverage::IncrementalDelta)
+            && matches!(reason, FlowQueryFallbackReason::StaleCursor)
+        {
+            state.set_force_full_recompute();
+        }
         if matches!(coverage, QueryCoverage::FencedRepairChunk { .. })
             && matches!(reason, FlowQueryFallbackReason::SnapshotFenceExpired)
         {

--- a/src/flow/src/batching_mode/task/test.rs
+++ b/src/flow/src/batching_mode/task/test.rs
@@ -13,12 +13,13 @@
 // limitations under the License.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fmt;
 
 use catalog::RegisterTableRequest;
 use catalog::memory::MemoryCatalogManager;
 use client::OutputWithMetrics;
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
-use common_error::ext::BoxedError;
+use common_error::ext::{BoxedError, ErrorExt, StackError};
 use common_error::mock::MockError;
 use common_error::status_code::StatusCode;
 use common_query::Output;
@@ -159,6 +160,149 @@ async fn test_dirty_time_windows_uses_batch_opts() {
     let state = task.state.read().unwrap();
     assert_eq!(7, state.dirty_time_windows.max_filter_num_per_query());
     assert_eq!(11, state.dirty_time_windows.time_window_merge_threshold());
+}
+
+#[tokio::test]
+async fn test_flush_dirty_window_count_forces_nonzero_for_tiny_dirty_coverage() {
+    let task = new_time_window_test_task_with_query(
+        "SELECT number, date_bin(INTERVAL '5 second', ts) AS time_window FROM numbers_with_ts GROUP BY time_window, number",
+    )
+    .await
+    .task;
+    {
+        let mut state = task.state.write().unwrap();
+        state
+            .dirty_time_windows
+            .add_window(Timestamp::new_second(1), Some(Timestamp::new_second(2)));
+    }
+
+    assert_eq!(Some(1), task.current_flush_dirty_window_count());
+}
+
+#[test]
+fn test_conservative_flush_window_count_rounds_up_and_preserves_ranges() {
+    let window_size = Duration::from_secs(5);
+    let mut slightly_over_one_window = DirtyTimeWindows::default();
+    slightly_over_one_window.add_window(Timestamp::new_second(0), Some(Timestamp::new_second(6)));
+    assert_eq!(
+        2,
+        slightly_over_one_window.conservative_flush_window_count(&window_size)
+    );
+
+    let mut separated_short_ranges = DirtyTimeWindows::default();
+    separated_short_ranges.add_window(Timestamp::new_second(0), Some(Timestamp::new_second(1)));
+    separated_short_ranges.add_window(Timestamp::new_second(30), Some(Timestamp::new_second(31)));
+    assert_eq!(
+        2,
+        separated_short_ranges.conservative_flush_window_count(&window_size)
+    );
+}
+
+#[tokio::test]
+async fn test_flush_dirty_window_count_includes_dirty_and_pending_fenced_repair() {
+    let task = new_time_window_test_task_with_query(
+        "SELECT number, date_bin(INTERVAL '5 second', ts) AS time_window FROM numbers_with_ts GROUP BY time_window, number",
+    )
+    .await
+    .task;
+    {
+        let mut state = task.state.write().unwrap();
+        state
+            .dirty_time_windows
+            .add_window(Timestamp::new_second(0), Some(Timestamp::new_second(10)));
+        state
+            .start_fenced_repair(BTreeMap::from([(1_u64, 10_u64)]))
+            .unwrap();
+        state
+            .dirty_time_windows
+            .add_window(Timestamp::new_second(20), Some(Timestamp::new_second(25)));
+    }
+
+    assert_eq!(Some(3), task.current_flush_dirty_window_count());
+}
+
+#[tokio::test]
+async fn test_flush_dual_queue_plans_pending_repair_then_live_dirty() {
+    let TestTaskParts {
+        task,
+        query_engine,
+        ..
+    } = new_time_window_test_task_with_query(
+        "SELECT number, date_bin(INTERVAL '5 second', ts) AS time_window FROM numbers_with_ts GROUP BY time_window, number",
+    )
+    .await;
+    let high = BTreeMap::from([(1_u64, 10_u64)]);
+    {
+        let mut state = task.state.write().unwrap();
+        state
+            .dirty_time_windows
+            .add_window(Timestamp::new_second(0), Some(Timestamp::new_second(1)));
+        state
+            .dirty_time_windows
+            .add_window(Timestamp::new_second(30), Some(Timestamp::new_second(31)));
+        state.start_fenced_repair(high.clone()).unwrap();
+        // This simulates a post-H dirty notification. It must remain outside
+        // the old fenced repair and be planned in the second flush round.
+        state
+            .dirty_time_windows
+            .add_window(Timestamp::new_second(60), Some(Timestamp::new_second(61)));
+    }
+
+    assert!(task.flush_has_pending_and_live_dirty_coverage());
+    let first_cap = task.current_flush_dirty_window_count();
+    assert_eq!(Some(3), first_cap);
+    let first_plan = task
+        .gen_query_with_time_window(
+            query_engine.clone(),
+            &aggregate_time_window_sink_schema(),
+            &[],
+            false,
+            first_cap,
+        )
+        .await
+        .unwrap()
+        .expect("first flush round should plan the pending fenced repair");
+    assert!(matches!(
+        first_plan.coverage,
+        QueryCoverage::FencedRepairChunk { .. }
+    ));
+    assert_eq!(task.state.read().unwrap().dirty_time_windows.len(), 1);
+    assert!(task.state.read().unwrap().fenced_repair_pending_is_empty());
+
+    {
+        let mut state = task.state.write().unwrap();
+        let decision = BatchingTask::apply_query_result_to_state(
+            &mut state,
+            &output_with_region_watermarks([(1_u64, Some(10_u64))]),
+            std::time::Duration::from_millis(1),
+            &first_plan.coverage,
+        );
+        assert!(matches!(
+            decision,
+            FlowCheckpointDecision::AdvancedFromFullSnapshot { .. }
+        ));
+        assert!(state.pending_fenced_repair().is_none());
+        assert_eq!(state.dirty_time_windows.len(), 1);
+    }
+
+    let second_cap = task.current_flush_dirty_window_count();
+    assert_eq!(Some(1), second_cap);
+    let second_plan = task
+        .gen_query_with_time_window(
+            query_engine,
+            &aggregate_time_window_sink_schema(),
+            &[],
+            false,
+            second_cap,
+        )
+        .await
+        .unwrap()
+        .expect("second flush round should plan the post-H live dirty window");
+    assert!(matches!(
+        second_plan.coverage,
+        QueryCoverage::IncrementalDelta
+    ));
+    assert!(task.state.read().unwrap().dirty_time_windows.is_empty());
 }
 
 #[tokio::test]
@@ -317,6 +461,67 @@ fn flow_error_with_status(status_code: StatusCode) -> Error {
     Err::<(), _>(BoxedError::new(MockError::new(status_code)))
         .context(crate::error::ExternalSnafu)
         .unwrap_err()
+}
+
+fn flow_error_with_message(message: &str) -> Error {
+    crate::error::InvalidQuerySnafu {
+        reason: message.to_string(),
+    }
+    .build()
+}
+
+#[derive(Debug)]
+struct MarkerSourceError(&'static str);
+
+impl fmt::Display for MarkerSourceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for MarkerSourceError {}
+
+#[derive(Debug)]
+struct WrappedMarkerError {
+    source: MarkerSourceError,
+}
+
+impl fmt::Display for WrappedMarkerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "External error")
+    }
+}
+
+impl std::error::Error for WrappedMarkerError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+impl ErrorExt for WrappedMarkerError {
+    fn status_code(&self) -> StatusCode {
+        StatusCode::Unexpected
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+impl StackError for WrappedMarkerError {
+    fn debug_fmt(&self, _: usize, _: &mut Vec<String>) {}
+
+    fn next(&self) -> Option<&dyn StackError> {
+        None
+    }
+}
+
+fn external_error_with_source_marker(marker: &'static str) -> Error {
+    Err::<(), _>(BoxedError::new(WrappedMarkerError {
+        source: MarkerSourceError(marker),
+    }))
+    .context(crate::error::ExternalSnafu)
+    .unwrap_err()
 }
 
 /// Test-only error that carries a non-RequestOutdated status code but
@@ -1277,6 +1482,115 @@ fn test_apply_query_failure_to_state_falls_back_from_incremental() {
     );
 }
 
+#[tokio::test]
+async fn test_stale_cursor_failure_next_plan_is_unfiltered_full_recompute() {
+    let TestTaskParts {
+        task,
+        query_engine,
+        ..
+    } = new_time_window_test_task_with_query(
+        "SELECT number, date_bin(INTERVAL '5 second', ts) AS time_window FROM numbers_with_ts GROUP BY time_window, number",
+    )
+    .await;
+
+    {
+        let mut state = task.state.write().unwrap();
+        state.advance_checkpoints(HashMap::from([(1_u64, 8527000_u64)]));
+        state
+            .dirty_time_windows
+            .add_window(Timestamp::new_second(10), Some(Timestamp::new_second(15)));
+    }
+
+    let incremental_plan = task
+        .gen_query_with_time_window(
+            query_engine.clone(),
+            &aggregate_time_window_sink_schema(),
+            &[],
+            false,
+            Some(1),
+        )
+        .await
+        .unwrap()
+        .expect("incremental mode with dirty signal should generate a delta plan");
+    assert!(matches!(
+        incremental_plan.coverage,
+        QueryCoverage::IncrementalDelta
+    ));
+
+    {
+        let mut state = task.state.write().unwrap();
+        let decision = BatchingTask::apply_query_failure_to_state(
+            &mut state,
+            std::time::Duration::from_millis(1),
+            &incremental_plan.coverage,
+            FlowQueryFallbackReason::StaleCursor,
+        );
+        assert_eq!(
+            decision,
+            Some(FlowCheckpointDecision::FallbackToFullSnapshot {
+                previous_mode: CheckpointMode::Incremental,
+                reason: FlowQueryFallbackReason::StaleCursor,
+            })
+        );
+        assert!(state.force_full_recompute());
+    }
+    task.handle_executed_query_failure(Some(&incremental_plan));
+
+    let repair_plan = task
+        .gen_query_with_time_window(
+            query_engine,
+            &aggregate_time_window_sink_schema(),
+            &[],
+            false,
+            Some(1),
+        )
+        .await
+        .unwrap()
+        .expect("stale cursor should force a full recompute retry");
+    assert!(matches!(
+        repair_plan.coverage,
+        QueryCoverage::UnfilteredFull
+    ));
+    assert!(task.state.read().unwrap().force_full_recompute());
+}
+
+#[test]
+fn test_stale_cursor_failure_flag_survives_failure_and_clears_after_full_success() {
+    let query_ctx = QueryContext::arc();
+    let (_tx, rx) = tokio::sync::oneshot::channel();
+    let mut state = TaskState::new(query_ctx, rx);
+    state.advance_checkpoints(HashMap::from([(1_u64, 10_u64)]));
+
+    BatchingTask::apply_query_failure_to_state(
+        &mut state,
+        std::time::Duration::from_millis(1),
+        &QueryCoverage::IncrementalDelta,
+        FlowQueryFallbackReason::StaleCursor,
+    );
+    assert!(state.force_full_recompute());
+
+    BatchingTask::apply_query_failure_to_state(
+        &mut state,
+        std::time::Duration::from_millis(1),
+        &QueryCoverage::UnfilteredFull,
+        FlowQueryFallbackReason::QueryFailure,
+    );
+    assert!(state.force_full_recompute());
+
+    let success_decision = BatchingTask::apply_query_result_to_state(
+        &mut state,
+        &output_with_region_watermarks([(1_u64, Some(20_u64))]),
+        std::time::Duration::from_millis(1),
+        &QueryCoverage::UnfilteredFull,
+    );
+    assert!(matches!(
+        success_decision,
+        FlowCheckpointDecision::AdvancedFromFullSnapshot { .. }
+    ));
+    assert!(!state.force_full_recompute());
+    assert_eq!(state.checkpoints(), &BTreeMap::from([(1_u64, 20_u64)]));
+}
+
 #[test]
 fn test_apply_query_failure_to_state_records_full_snapshot_failure() {
     let query_ctx = QueryContext::arc();
@@ -1318,6 +1632,48 @@ fn test_query_failure_reason_distinguishes_fenced_repair_stale_fence() {
         BatchingTask::query_failure_reason(&err, &QueryCoverage::IncrementalDelta),
         FlowQueryFallbackReason::StaleCursor
     );
+
+    for message in [
+        "wrapped storage error: STALE_CURSOR given_seq=8 min_readable_seq=9",
+        "storage hint FALLBACK_FULL_RECOMPUTE for flow incremental scan",
+        "incremental query stale, retry with full recompute",
+    ] {
+        let wrapped = flow_error_with_message(message);
+        assert_eq!(
+            BatchingTask::query_failure_reason(&wrapped, &QueryCoverage::IncrementalDelta),
+            FlowQueryFallbackReason::StaleCursor,
+            "{message}"
+        );
+    }
+
+    let source_chain_stale_cursor = external_error_with_source_marker(
+        "storage returned STALE_CURSOR: given_seq=8527000 min_readable_seq=8550000",
+    );
+    assert_eq!(
+        BatchingTask::query_failure_reason(
+            &source_chain_stale_cursor,
+            &QueryCoverage::IncrementalDelta
+        ),
+        FlowQueryFallbackReason::StaleCursor
+    );
+
+    for message in [
+        "wrapped storage error: STALE_SNAPSHOT_FENCE",
+        "storage hint REBIND_SNAPSHOT_FENCE for fenced repair",
+        "snapshot upper bound stale for region 1",
+    ] {
+        let wrapped = external_error_with_source_marker(message);
+        assert_eq!(
+            BatchingTask::query_failure_reason(
+                &wrapped,
+                &QueryCoverage::FencedRepairChunk {
+                    high: BTreeMap::new(),
+                },
+            ),
+            FlowQueryFallbackReason::SnapshotFenceExpired,
+            "{message}"
+        );
+    }
 
     let generic_err = flow_error_with_status(StatusCode::Unexpected);
     assert_eq!(


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up to #8409.

## What's changed and what's your intention?

Flow batching incremental reads can fall behind the source retention boundary under sustained write pressure. The storage layer then returns `STALE_CURSOR` / `FALLBACK_FULL_RECOMPUTE`, but those markers may be wrapped by frontend/client errors. The previous recovery path could treat the failure as generic, perform only dirty-window-scoped repair, advance checkpoints, and leave source-visible rows missing from the sink. `ADMIN FLUSH_FLOW` could also sample a stale zero window cap before waiting for an in-flight repair, or return the wrapped stale error instead of retrying the repaired state.

This PR makes stale recovery correctness-first:

- classify stale cursor and stale snapshot-fence markers through the full error source chain;
- force a one-shot unfiltered full recompute after a stale incremental cursor, clearing the guard only after a complete watermark proof;
- compute the explicit-flush dirty-window cap while holding the task execution lock;
- use a conservative flush cap that drains separated/sub-window ranges;
- when pending fenced repair and post-fence live dirty coverage coexist, process them in two bounded serialized rounds without merging post-`H` writes into the old fence;
- retry `ADMIN FLUSH_FLOW` up to three times for structured or wrapped stale errors.

The change does not alter public APIs or persisted metadata. A forced full recompute can be more expensive than scoped repair, but only occurs after storage explicitly reports that the incremental cursor is no longer readable.

Validation:

- `cargo fmt -p flow -- --check`
- `cargo test -p flow` (230 passed)
- `cargo clippy -p flow --all-targets -- -D warnings`
- live 100k rows/s, 5-minute sinkstress validation: 29,928,000 rows written with zero client errors; wrapped stale recovery retried inside `ADMIN FLUSH_FLOW`; source and sink converged to 154,432,508 rows with diff 0.

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.