### PR TITLE
fix: Use prepared file locations for CSV strict headers integration test

### DIFF
--- a/tests-integration/src/tests/instance_test.rs
+++ b/tests-integration/src/tests/instance_test.rs
@@ -1098,6 +1098,10 @@ async fn test_execute_copy_from_csv_strict_headers(instance: Arc<dyn MockInstanc
     let unknown_path = tmp_dir.path().join("unknown.csv");
     let missing_path = tmp_dir.path().join("missing.csv");
     let duplicate_path = tmp_dir.path().join("duplicate.csv");
+    let matching_location = prepare_path(matching_path.to_str().unwrap());
+    let unknown_location = prepare_path(unknown_path.to_str().unwrap());
+    let missing_location = prepare_path(missing_path.to_str().unwrap());
+    let duplicate_location = prepare_path(duplicate_path.to_str().unwrap());
     std::fs::write(
         &matching_path,
         "ts,host_id,reading_value\n2024-01-01T00:00:00,1,10.5\n",
@@ -1127,7 +1131,7 @@ async fn test_execute_copy_from_csv_strict_headers(instance: Arc<dyn MockInstanc
         &instance,
         &format!(
             "COPY csv_strict_headers FROM '{}' WITH (FORMAT='csv', STRICT_HEADERS='true');",
-            matching_path.display()
+            matching_location
         ),
     )
     .await
@@ -1149,7 +1153,7 @@ async fn test_execute_copy_from_csv_strict_headers(instance: Arc<dyn MockInstanc
         &instance,
         &format!(
             "COPY csv_strict_headers FROM '{}' WITH (FORMAT='csv', STRICT_HEADERS='true');",
-            unknown_path.display()
+            unknown_location
         ),
     )
     .await
@@ -1173,7 +1177,7 @@ async fn test_execute_copy_from_csv_strict_headers(instance: Arc<dyn MockInstanc
         &instance,
         &format!(
             "COPY csv_strict_headers FROM '{}' WITH (FORMAT='csv', STRICT_HEADERS='true');",
-            missing_path.display()
+            missing_location
         ),
     )
     .await
@@ -1197,7 +1201,7 @@ async fn test_execute_copy_from_csv_strict_headers(instance: Arc<dyn MockInstanc
         &instance,
         &format!(
             "COPY csv_strict_headers FROM '{}' WITH (FORMAT='csv', STRICT_HEADERS='true');",
-            duplicate_path.display()
+            duplicate_location
         ),
     )
     .await


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Related to https://github.com/GreptimeTeam/greptimedb/pull/8426

## What's changed and what's your intention?

This PR fixes the Windows CI failure in the CSV strict-header integration test.

The test writes temporary CSV files and then embeds their file paths into `COPY ... FROM '<path>'` SQL statements. On Windows, raw temporary paths can contain backslashes, which are not the expected object-store path delimiter for these test locations. Other integration tests in this file already use `prepare_path()` before embedding local paths into SQL. This PR applies the same helper to the CSV strict-header test.

Specifically, the test now prepares the four temporary CSV file locations with `prepare_path()`:

- `matching.csv`
- `unknown.csv`
- `missing.csv`
- `duplicate.csv`

Those prepared locations are then used in the `COPY csv_strict_headers FROM ...` statements.

This keeps the fix scoped to the test setup and does not change production object-store URL parsing behavior.

Compatibility impact:

- No API compatibility impact.
- No schema or data compatibility impact.
- Test-only change.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.