### PR TITLE
feat: enlarge file meta cache

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -157,7 +157,7 @@
 | `region_engine.mito.auto_flush_interval` | String | `1h` | Interval to auto flush a region if it has not flushed yet. |
 | `region_engine.mito.global_write_buffer_size` | String | Auto | Global write buffer size for all regions. If not set, it's default to 1/8 of OS memory with a max limitation of 1GB. |
 | `region_engine.mito.global_write_buffer_reject_size` | String | Auto | Global write buffer size threshold to reject write requests. If not set, it's default to 2 times of `global_write_buffer_size`. |
-| `region_engine.mito.sst_meta_cache_size` | String | Auto | Cache size for SST metadata. Setting it to 0 to disable the cache.<br/>If not set, it's default to 1/32 of OS memory with a max limitation of 128MB. |
+| `region_engine.mito.sst_meta_cache_size` | String | Auto | Cache size for SST metadata. Setting it to 0 to disable the cache.<br/>If not set, it's default to 1/8 of OS memory with a max limitation of 512MB. |
 | `region_engine.mito.vector_cache_size` | String | Auto | Cache size for vectors and arrow arrays. Setting it to 0 to disable the cache.<br/>If not set, it's default to 1/16 of OS memory with a max limitation of 512MB. |
 | `region_engine.mito.page_cache_size` | String | Auto | Cache size for pages of SST row groups. Setting it to 0 to disable the cache.<br/>If not set, it's default to 1/8 of OS memory. |
 | `region_engine.mito.selector_result_cache_size` | String | Auto | Cache size for time series selector (e.g. `last_value()`). Setting it to 0 to disable the cache.<br/>If not set, it's default to 1/16 of OS memory with a max limitation of 512MB. |
@@ -560,7 +560,7 @@
 | `region_engine.mito.auto_flush_interval` | String | `1h` | Interval to auto flush a region if it has not flushed yet. |
 | `region_engine.mito.global_write_buffer_size` | String | Auto | Global write buffer size for all regions. If not set, it's default to 1/8 of OS memory with a max limitation of 1GB. |
 | `region_engine.mito.global_write_buffer_reject_size` | String | Auto | Global write buffer size threshold to reject write requests. If not set, it's default to 2 times of `global_write_buffer_size` |
-| `region_engine.mito.sst_meta_cache_size` | String | Auto | Cache size for SST metadata. Setting it to 0 to disable the cache.<br/>If not set, it's default to 1/32 of OS memory with a max limitation of 128MB. |
+| `region_engine.mito.sst_meta_cache_size` | String | Auto | Cache size for SST metadata. Setting it to 0 to disable the cache.<br/>If not set, it's default to 1/8 of OS memory with a max limitation of 512MB. |
 | `region_engine.mito.vector_cache_size` | String | Auto | Cache size for vectors and arrow arrays. Setting it to 0 to disable the cache.<br/>If not set, it's default to 1/16 of OS memory with a max limitation of 512MB. |
 | `region_engine.mito.page_cache_size` | String | Auto | Cache size for pages of SST row groups. Setting it to 0 to disable the cache.<br/>If not set, it's default to 1/8 of OS memory. |
 | `region_engine.mito.selector_result_cache_size` | String | Auto | Cache size for time series selector (e.g. `last_value()`). Setting it to 0 to disable the cache.<br/>If not set, it's default to 1/16 of OS memory with a max limitation of 512MB. |

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -469,9 +469,9 @@ auto_flush_interval = "1h"
 #+ global_write_buffer_reject_size = "2GB"
 
 ## Cache size for SST metadata. Setting it to 0 to disable the cache.
-## If not set, it's default to 1/32 of OS memory with a max limitation of 128MB.
+## If not set, it's default to 1/8 of OS memory with a max limitation of 512MB.
 ## @toml2docs:none-default="Auto"
-#+ sst_meta_cache_size = "128MB"
+#+ sst_meta_cache_size = "512MB"
 
 ## Cache size for vectors and arrow arrays. Setting it to 0 to disable the cache.
 ## If not set, it's default to 1/16 of OS memory with a max limitation of 512MB.

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -598,9 +598,9 @@ auto_flush_interval = "1h"
 #+ global_write_buffer_reject_size = "2GB"
 
 ## Cache size for SST metadata. Setting it to 0 to disable the cache.
-## If not set, it's default to 1/32 of OS memory with a max limitation of 128MB.
+## If not set, it's default to 1/8 of OS memory with a max limitation of 512MB.
 ## @toml2docs:none-default="Auto"
-#+ sst_meta_cache_size = "128MB"
+#+ sst_meta_cache_size = "512MB"
 
 ## Cache size for vectors and arrow arrays. Setting it to 0 to disable the cache.
 ## If not set, it's default to 1/16 of OS memory with a max limitation of 512MB.

--- a/src/mito2/src/config.rs
+++ b/src/mito2/src/config.rs
@@ -38,7 +38,11 @@ pub(crate) const DEFAULT_MAX_CONCURRENT_SCAN_FILES: usize = 384;
 // Use `1/GLOBAL_WRITE_BUFFER_SIZE_FACTOR` of OS memory as global write buffer size in default mode
 const GLOBAL_WRITE_BUFFER_SIZE_FACTOR: u64 = 8;
 /// Use `1/SST_META_CACHE_SIZE_FACTOR` of OS memory size as SST meta cache size in default mode
-const SST_META_CACHE_SIZE_FACTOR: u64 = 32;
+const SST_META_CACHE_SIZE_FACTOR: u64 = 8;
+/// Use `1/PREFILTER_RESULT_CACHE_SIZE_FACTOR` of OS memory size as prefilter result cache size in default mode
+const PREFILTER_RESULT_CACHE_SIZE_FACTOR: u64 = 32;
+/// Use `1/INDEX_METADATA_CACHE_SIZE_FACTOR` of OS memory size as index metadata cache size in default mode
+const INDEX_METADATA_CACHE_SIZE_FACTOR: u64 = 32;
 /// Use `1/MEM_CACHE_SIZE_FACTOR` of OS memory size as mem cache size in default mode
 const MEM_CACHE_SIZE_FACTOR: u64 = 16;
 /// Use `1/PAGE_CACHE_SIZE_FACTOR` of OS memory size as page cache size in default mode
@@ -321,9 +325,14 @@ impl MitoConfig {
         );
         // Use 2x of global write buffer size as global write buffer reject size.
         let global_write_buffer_reject_size = global_write_buffer_size * 2;
-        // shouldn't be greater than 128MB in default mode.
+        // Page-index-bearing SST metadata can be much larger than footers alone.
+        // Keep the auto-sized default bounded, but allow a larger warm working set.
         let sst_meta_cache_size = cmp::min(
             sys_memory / SST_META_CACHE_SIZE_FACTOR,
+            ReadableSize::mb(512),
+        );
+        let prefilter_result_cache_size = cmp::min(
+            sys_memory / PREFILTER_RESULT_CACHE_SIZE_FACTOR,
             ReadableSize::mb(128),
         );
         // shouldn't be greater than 512MB in default mode.
@@ -338,7 +347,7 @@ impl MitoConfig {
         self.selector_result_cache_size = mem_cache_size;
         self.range_result_cache_size = mem_cache_size;
         // Use a smaller cache size because prefilter result usually should be small.
-        self.prefilter_result_cache_size = sst_meta_cache_size;
+        self.prefilter_result_cache_size = prefilter_result_cache_size;
 
         self.index.adjust_buffer_and_cache_size(sys_memory);
     }
@@ -356,6 +365,24 @@ impl MitoConfig {
         self.write_cache_size = size;
         self.write_cache_ttl = ttl;
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_adjust_sst_metadata_and_prefilter_cache_caps_independently() {
+        let mut config = MitoConfig::default();
+
+        config.adjust_buffer_and_cache_size(ReadableSize::gb(1));
+        assert_eq!(ReadableSize::mb(128), config.sst_meta_cache_size);
+        assert_eq!(ReadableSize::mb(32), config.prefilter_result_cache_size);
+
+        config.adjust_buffer_and_cache_size(ReadableSize::gb(64));
+        assert_eq!(ReadableSize::mb(512), config.sst_meta_cache_size);
+        assert_eq!(ReadableSize::mb(128), config.prefilter_result_cache_size);
     }
 }
 
@@ -466,7 +493,7 @@ impl IndexConfig {
         self.content_cache_size = cmp::min(self.content_cache_size, cache_size);
 
         let metadata_cache_size = cmp::min(
-            sys_memory / SST_META_CACHE_SIZE_FACTOR,
+            sys_memory / INDEX_METADATA_CACHE_SIZE_FACTOR,
             ReadableSize::mb(64),
         );
         self.metadata_cache_size = cmp::min(self.metadata_cache_size, metadata_cache_size);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

enlarge metadata cache cap from 128MB to min(1/8 available, 512MB)

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
