### PR TITLE
fix: convert literals in joins and subqueries

### DIFF
--- a/src/query/src/optimizer/type_conversion.rs
+++ b/src/query/src/optimizer/type_conversion.rs
@@ -104,8 +104,11 @@ impl ExtensionAnalyzerRule for TypeConversionRule {
             }
 
             LogicalPlan::Join(join) => {
+                let Ok(schema) = join.left.schema().join(join.right.schema()) else {
+                    return Ok(Transformed::no(LogicalPlan::Join(join)));
+                };
                 let mut converter = TypeConverter {
-                    schema: std::sync::Arc::new(join.left.schema().join(join.right.schema())?),
+                    schema: std::sync::Arc::new(schema),
                     query_ctx: ctx.query_ctx(),
                 };
                 let plan = LogicalPlan::Join(join);
@@ -325,9 +328,9 @@ mod tests {
     use std::sync::Arc;
 
     use datafusion_common::arrow::datatypes::Field;
-    use datafusion_common::{Column, DFSchema};
+    use datafusion_common::{Column, DFSchema, NullEquality};
     use datafusion_expr::expr::Exists;
-    use datafusion_expr::{JoinType, Literal, LogicalPlanBuilder, Subquery};
+    use datafusion_expr::{Join, JoinConstraint, JoinType, Literal, LogicalPlanBuilder, Subquery};
     use datafusion_sql::TableReference;
     use session::context::QueryContext;
 
@@ -592,6 +595,47 @@ mod tests {
                 .lit())
             )
         );
+    }
+
+    #[test]
+    fn test_semi_anti_join_with_duplicate_unqualified_fields() {
+        let left = Arc::new(
+            LogicalPlanBuilder::values(vec![vec![1_i64.lit()]])
+                .unwrap()
+                .build()
+                .unwrap(),
+        );
+        let right = Arc::new(
+            LogicalPlanBuilder::values(vec![vec![2_i64.lit()]])
+                .unwrap()
+                .build()
+                .unwrap(),
+        );
+        let context = QueryEngineContext::mock();
+
+        for join_type in [JoinType::LeftSemi, JoinType::LeftAnti] {
+            let join = Join::try_new(
+                Arc::clone(&left),
+                Arc::clone(&right),
+                vec![(
+                    Expr::Column(Column::from_name("column1")),
+                    Expr::Column(Column::from_name("column1")),
+                )],
+                None,
+                join_type,
+                JoinConstraint::On,
+                NullEquality::NullEqualsNothing,
+                false,
+            )
+            .unwrap();
+
+            let result = TypeConversionRule.analyze(
+                LogicalPlan::Join(join),
+                &context,
+                &ConfigOptions::default(),
+            );
+            assert!(result.is_ok(), "{join_type:?}: {result:?}");
+        }
     }
 
     #[test]

--- a/src/query/src/optimizer/type_conversion.rs
+++ b/src/query/src/optimizer/type_conversion.rs
@@ -43,7 +43,7 @@ impl ExtensionAnalyzerRule for TypeConversionRule {
         ctx: &QueryEngineContext,
         _config: &ConfigOptions,
     ) -> Result<LogicalPlan> {
-        plan.transform(&|plan| match plan {
+        plan.transform_up_with_subqueries(|plan| match plan {
             LogicalPlan::Filter(filter) => {
                 let mut converter = TypeConverter {
                     schema: filter.input.schema().clone(),
@@ -103,6 +103,22 @@ impl ExtensionAnalyzerRule for TypeConversionRule {
                 plan.with_new_exprs(expr, inputs).map(Transformed::yes)
             }
 
+            LogicalPlan::Join(join) => {
+                let mut converter = TypeConverter {
+                    schema: std::sync::Arc::new(join.left.schema().join(join.right.schema())?),
+                    query_ctx: ctx.query_ctx(),
+                };
+                let plan = LogicalPlan::Join(join);
+                let inputs = plan.inputs().into_iter().cloned().collect::<Vec<_>>();
+                let expr = plan
+                    .expressions_consider_join()
+                    .into_iter()
+                    .map(|e| e.rewrite(&mut converter).map(|x| x.data))
+                    .collect::<Result<Vec<_>>>()?;
+
+                plan.with_new_exprs(expr, inputs).map(Transformed::yes)
+            }
+
             LogicalPlan::Distinct { .. }
             | LogicalPlan::Limit { .. }
             | LogicalPlan::Subquery { .. }
@@ -115,8 +131,7 @@ impl ExtensionAnalyzerRule for TypeConversionRule {
             | LogicalPlan::Statement(_)
             | LogicalPlan::Ddl(_)
             | LogicalPlan::Copy(_)
-            | LogicalPlan::RecursiveQuery(_)
-            | LogicalPlan::Join { .. } => Ok(Transformed::no(plan)),
+            | LogicalPlan::RecursiveQuery(_) => Ok(Transformed::no(plan)),
         })
         .map(|x| x.data)
     }
@@ -311,7 +326,8 @@ mod tests {
 
     use datafusion_common::arrow::datatypes::Field;
     use datafusion_common::{Column, DFSchema};
-    use datafusion_expr::{Literal, LogicalPlanBuilder};
+    use datafusion_expr::expr::Exists;
+    use datafusion_expr::{JoinType, Literal, LogicalPlanBuilder, Subquery};
     use datafusion_sql::TableReference;
     use session::context::QueryContext;
 
@@ -518,5 +534,114 @@ mod tests {
             \n    Values: (Float64(1))",
         );
         assert_eq!(format!("{}", transformed_plan.display_indent()), expected);
+    }
+
+    #[test]
+    fn test_convert_join_filter_uses_input_schemas() {
+        let left = LogicalPlanBuilder::values(vec![vec![
+            ScalarValue::Int64(Some(1)).lit(),
+            ScalarValue::TimestampMillisecond(Some(1), None).lit(),
+        ]])
+        .unwrap()
+        .alias("left")
+        .unwrap()
+        .build()
+        .unwrap();
+        let right = LogicalPlanBuilder::values(vec![vec![ScalarValue::Int64(Some(1)).lit()]])
+            .unwrap()
+            .alias("right")
+            .unwrap()
+            .build()
+            .unwrap();
+        let left_key = Column::new(Some("left"), "column1");
+        let right_key = Column::new(Some("right"), "column1");
+        let timestamp_column = Column::new(Some("left"), "column2");
+        let plan = LogicalPlanBuilder::from(left)
+            .join(
+                right,
+                JoinType::RightSemi,
+                (vec![left_key.clone()], vec![right_key.clone()]),
+                Some(Expr::Column(timestamp_column.clone()).gt("2009-02-13 23:31:30".lit())),
+            )
+            .unwrap()
+            .build()
+            .unwrap();
+        let context = QueryEngineContext::mock();
+        context
+            .query_ctx()
+            .set_timezone(Timezone::from_tz_string("Asia/Shanghai").unwrap());
+
+        let transformed = TypeConversionRule
+            .analyze(plan, &context, &ConfigOptions::default())
+            .unwrap();
+        let LogicalPlan::Join(join) = transformed else {
+            panic!("expected join plan");
+        };
+
+        assert_eq!(
+            join.on,
+            vec![(Expr::Column(left_key), Expr::Column(right_key))]
+        );
+        assert_eq!(
+            join.filter,
+            Some(
+                Expr::Column(timestamp_column).gt(ScalarValue::TimestampSecond(
+                    Some(1_234_539_090),
+                    None
+                )
+                .lit())
+            )
+        );
+    }
+
+    #[test]
+    fn test_convert_exists_subquery_filter() {
+        let inner = LogicalPlanBuilder::values(vec![vec![
+            ScalarValue::TimestampMillisecond(Some(1), None).lit(),
+            false.lit(),
+        ]])
+        .unwrap()
+        .filter(
+            Expr::Column(Column::from_name("column1"))
+                .gt("2009-02-13 23:31:30+08:00".lit())
+                .and(Expr::Column(Column::from_name("column2")).eq("true".lit())),
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+        let outer = LogicalPlanBuilder::values(vec![vec![1_i64.lit()]])
+            .unwrap()
+            .filter(Expr::Exists(Exists {
+                subquery: Subquery {
+                    subquery: Arc::new(inner),
+                    outer_ref_columns: Default::default(),
+                    spans: Default::default(),
+                },
+                negated: false,
+            }))
+            .unwrap()
+            .build()
+            .unwrap();
+        let context = QueryEngineContext::mock();
+
+        let transformed = TypeConversionRule
+            .analyze(outer, &context, &ConfigOptions::default())
+            .unwrap();
+        let LogicalPlan::Filter(outer_filter) = transformed else {
+            panic!("expected outer filter");
+        };
+        let Expr::Exists(exists) = outer_filter.predicate else {
+            panic!("expected exists predicate");
+        };
+        let LogicalPlan::Filter(inner_filter) = exists.subquery.subquery.as_ref() else {
+            panic!("expected inner filter");
+        };
+
+        assert_eq!(
+            inner_filter.predicate,
+            Expr::Column(Column::from_name("column1"))
+                .gt(ScalarValue::TimestampSecond(Some(1_234_539_090), None).lit())
+                .and(Expr::Column(Column::from_name("column2")).eq(true.lit()))
+        );
     }
 }

--- a/tests/cases/standalone/common/order/limit.result
+++ b/tests/cases/standalone/common/order/limit.result
@@ -114,11 +114,11 @@ Error: 3001(EngineExecuteQuery), Error during planning: Expected LIMIT to be an 
 
 SELECT * FROM integers as int LIMIT (SELECT max(integers.i) FROM integers where i > 5);
 
-Error: 3001(EngineExecuteQuery), Error during planning: Cannot infer common argument type for comparison operation Timestamp(ms) > Int64
+Error: 3001(EngineExecuteQuery), Error during planning: Expected LIMIT to be an integer or null, but got Timestamp(ms)
 
 SELECT * FROM integers as int LIMIT (SELECT max(integers.i) FROM integers where i > 5);
 
-Error: 3001(EngineExecuteQuery), Error during planning: Cannot infer common argument type for comparison operation Timestamp(ms) > Int64
+Error: 3001(EngineExecuteQuery), Error during planning: Expected LIMIT to be an integer or null, but got Timestamp(ms)
 
 SELECT * FROM integers as int LIMIT (SELECT NULL);
 

--- a/tests/cases/standalone/common/query/type_conversion_traversal.result
+++ b/tests/cases/standalone/common/query/type_conversion_traversal.result
@@ -1,0 +1,144 @@
+-- String-to-timestamp and string-to-boolean conversion must traverse JOIN
+-- filters and correlated subqueries.
+DROP TABLE IF EXISTS type_conversion_join_left;
+
+Affected Rows: 0
+
+DROP TABLE IF EXISTS type_conversion_join_right;
+
+Affected Rows: 0
+
+DROP TABLE IF EXISTS type_conversion_exists_outer;
+
+Affected Rows: 0
+
+DROP TABLE IF EXISTS type_conversion_exists_inner;
+
+Affected Rows: 0
+
+CREATE TABLE type_conversion_join_left (
+    ts TIMESTAMP(3) TIME INDEX,
+    key_col INT PRIMARY KEY
+) ENGINE = mito;
+
+Affected Rows: 0
+
+CREATE TABLE type_conversion_join_right (
+    ts TIMESTAMP(3) TIME INDEX,
+    key_col INT PRIMARY KEY
+) ENGINE = mito;
+
+Affected Rows: 0
+
+INSERT INTO type_conversion_join_left VALUES
+    ('2024-04-01 00:00:00', 1),
+    ('2024-04-01 00:01:00', 2);
+
+Affected Rows: 2
+
+INSERT INTO type_conversion_join_right VALUES
+    ('2024-04-01 00:00:00', 1),
+    ('2024-04-01 00:01:00', 2);
+
+Affected Rows: 2
+
+SET TIME_ZONE = '+8:00';
+
+Affected Rows: 0
+
+SELECT l.key_col AS left_key, r.key_col AS right_key
+FROM type_conversion_join_left l
+LEFT JOIN type_conversion_join_right r
+  ON l.key_col = r.key_col AND l.ts > '2024-04-01 08:00:00'
+ORDER BY l.key_col;
+
++----------+-----------+
+| left_key | right_key |
++----------+-----------+
+| 1        |           |
+| 2        | 2         |
++----------+-----------+
+
+CREATE TABLE type_conversion_exists_outer (
+    ts TIMESTAMP(3) TIME INDEX,
+    key_col INT PRIMARY KEY
+) ENGINE = mito;
+
+Affected Rows: 0
+
+CREATE TABLE type_conversion_exists_inner (
+    ts TIMESTAMP(3) TIME INDEX,
+    key_col INT PRIMARY KEY,
+    enabled BOOLEAN
+) ENGINE = mito;
+
+Affected Rows: 0
+
+INSERT INTO type_conversion_exists_outer VALUES
+    ('2024-05-01 08:00:00', 1),
+    ('2024-05-01 08:01:00', 2),
+    ('2024-05-01 08:02:00', 3);
+
+Affected Rows: 3
+
+INSERT INTO type_conversion_exists_inner VALUES
+    ('2024-05-01 08:00:00', 1, true),
+    ('2024-05-01 08:01:00', 2, false),
+    ('2024-05-01 08:02:00', 3, true);
+
+Affected Rows: 3
+
+SELECT o.key_col
+FROM type_conversion_exists_outer o
+WHERE EXISTS (
+    SELECT 1
+    FROM type_conversion_exists_inner i
+    WHERE i.key_col = o.key_col
+      AND i.ts > '2024-05-01 08:00:00'
+      AND i.enabled = TRUE
+)
+ORDER BY o.key_col;
+
++---------+
+| key_col |
++---------+
+| 3       |
++---------+
+
+SELECT o.key_col
+FROM type_conversion_exists_outer o
+WHERE EXISTS (
+    SELECT 1
+    FROM type_conversion_exists_inner i
+    WHERE i.key_col = o.key_col
+      AND i.ts > TIMESTAMP '2024-05-01 00:00:00'
+      AND i.enabled = 'true'
+)
+ORDER BY o.key_col;
+
++---------+
+| key_col |
++---------+
+| 3       |
++---------+
+
+SET TIME_ZONE = 'UTC';
+
+Affected Rows: 0
+
+DROP TABLE type_conversion_join_left;
+
+Affected Rows: 0
+
+DROP TABLE type_conversion_join_right;
+
+Affected Rows: 0
+
+DROP TABLE type_conversion_exists_outer;
+
+Affected Rows: 0
+
+DROP TABLE type_conversion_exists_inner;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/query/type_conversion_traversal.sql
+++ b/tests/cases/standalone/common/query/type_conversion_traversal.sql
@@ -1,0 +1,81 @@
+-- String-to-timestamp and string-to-boolean conversion must traverse JOIN
+-- filters and correlated subqueries.
+
+DROP TABLE IF EXISTS type_conversion_join_left;
+DROP TABLE IF EXISTS type_conversion_join_right;
+DROP TABLE IF EXISTS type_conversion_exists_outer;
+DROP TABLE IF EXISTS type_conversion_exists_inner;
+
+CREATE TABLE type_conversion_join_left (
+    ts TIMESTAMP(3) TIME INDEX,
+    key_col INT PRIMARY KEY
+) ENGINE = mito;
+
+CREATE TABLE type_conversion_join_right (
+    ts TIMESTAMP(3) TIME INDEX,
+    key_col INT PRIMARY KEY
+) ENGINE = mito;
+
+INSERT INTO type_conversion_join_left VALUES
+    ('2024-04-01 00:00:00', 1),
+    ('2024-04-01 00:01:00', 2);
+INSERT INTO type_conversion_join_right VALUES
+    ('2024-04-01 00:00:00', 1),
+    ('2024-04-01 00:01:00', 2);
+
+SET TIME_ZONE = '+8:00';
+
+SELECT l.key_col AS left_key, r.key_col AS right_key
+FROM type_conversion_join_left l
+LEFT JOIN type_conversion_join_right r
+  ON l.key_col = r.key_col AND l.ts > '2024-04-01 08:00:00'
+ORDER BY l.key_col;
+
+CREATE TABLE type_conversion_exists_outer (
+    ts TIMESTAMP(3) TIME INDEX,
+    key_col INT PRIMARY KEY
+) ENGINE = mito;
+
+CREATE TABLE type_conversion_exists_inner (
+    ts TIMESTAMP(3) TIME INDEX,
+    key_col INT PRIMARY KEY,
+    enabled BOOLEAN
+) ENGINE = mito;
+
+INSERT INTO type_conversion_exists_outer VALUES
+    ('2024-05-01 08:00:00', 1),
+    ('2024-05-01 08:01:00', 2),
+    ('2024-05-01 08:02:00', 3);
+INSERT INTO type_conversion_exists_inner VALUES
+    ('2024-05-01 08:00:00', 1, true),
+    ('2024-05-01 08:01:00', 2, false),
+    ('2024-05-01 08:02:00', 3, true);
+
+SELECT o.key_col
+FROM type_conversion_exists_outer o
+WHERE EXISTS (
+    SELECT 1
+    FROM type_conversion_exists_inner i
+    WHERE i.key_col = o.key_col
+      AND i.ts > '2024-05-01 08:00:00'
+      AND i.enabled = TRUE
+)
+ORDER BY o.key_col;
+
+SELECT o.key_col
+FROM type_conversion_exists_outer o
+WHERE EXISTS (
+    SELECT 1
+    FROM type_conversion_exists_inner i
+    WHERE i.key_col = o.key_col
+      AND i.ts > TIMESTAMP '2024-05-01 00:00:00'
+      AND i.enabled = 'true'
+)
+ORDER BY o.key_col;
+
+SET TIME_ZONE = 'UTC';
+
+DROP TABLE type_conversion_join_left;
+DROP TABLE type_conversion_join_right;
+DROP TABLE type_conversion_exists_outer;
+DROP TABLE type_conversion_exists_inner;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

N/A

## What's changed and what's your intention?

GreptimeDB's type-conversion analyzer skipped JOIN expressions and logical plans embedded in subquery expressions. As a result, timezone-aware timestamp string conversion was not applied in JOIN filters or correlated subqueries, and Boolean string comparisons in correlated subqueries failed type coercion.

This change:

- traverses embedded subquery plans when applying `TypeConversionRule`;
- rewrites JOIN expressions using a schema containing both qualified inputs, including semi/anti JOINs whose output omits one side;
- preserves DataFusion's existing JOIN expression reconstruction order;
- adds focused analyzer and sqlness coverage for JOIN timestamp conversion and correlated timestamp/Boolean conversion.

No conversion semantics, API, schema, persisted data, or dependency versions change.

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.