### PR TITLE
fix: preserve nulls in timestamp arrays

### DIFF
--- a/src/servers/src/postgres/types.rs
+++ b/src/servers/src/postgres/types.rs
@@ -1055,17 +1055,22 @@ pub(super) fn parameters_to_scalar_values(
                                 TimestampType::Nanosecond(_) => {
                                     let values = data
                                         .into_iter()
-                                        .filter_map(|ts| {
-                                            ts.and_then(|ts| {
-                                                ts.and_utc().timestamp_nanos_opt().map(|nanos| {
+                                        .map(|ts| match ts {
+                                            None => {
+                                                Ok(ScalarValue::TimestampNanosecond(None, None))
+                                            }
+                                            Some(ts) => ts
+                                                .and_utc()
+                                                .timestamp_nanos_opt()
+                                                .map(|nanos| {
                                                     ScalarValue::TimestampNanosecond(
                                                         Some(nanos),
                                                         None,
                                                     )
                                                 })
-                                            })
+                                                .ok_or_else(|| numeric_out_of_range_error(ts)),
                                         })
-                                        .collect::<Vec<_>>();
+                                        .collect::<PgWireResult<Vec<_>>>()?;
                                     ScalarValue::List(ScalarValue::new_list(
                                         &values,
                                         &ArrowDataType::Timestamp(TimeUnit::Nanosecond, None),
@@ -2049,6 +2054,53 @@ mod test {
             }
             error => panic!("expected numeric out-of-range error, got {error:?}"),
         }
+    }
+
+    fn qbs_timestamp_nanosecond_array_plan() -> LogicalPlan {
+        build_plan_with_params(vec![(
+            "$1",
+            DataType::List(Arc::new(Field::new(
+                "item",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                true,
+            ))),
+        )])
+    }
+
+    #[test]
+    fn test_qbs_pg_timestamp_nanosecond_array_preserves_null_slot() {
+        let portal = make_portal(
+            vec![Some(Type::TIMESTAMP_ARRAY)],
+            vec![s(
+                r#"{"2024-01-01 00:00:00.000001",NULL,"2024-01-01 00:00:00.000003"}"#,
+            )],
+        );
+
+        let values =
+            parameters_to_scalar_values(&qbs_timestamp_nanosecond_array_plan(), &portal).unwrap();
+        let expected = ScalarValue::List(ScalarValue::new_list(
+            &[
+                ScalarValue::TimestampNanosecond(Some(1_704_067_200_000_001_000), None),
+                ScalarValue::TimestampNanosecond(None, None),
+                ScalarValue::TimestampNanosecond(Some(1_704_067_200_000_003_000), None),
+            ],
+            &ArrowDataType::Timestamp(TimeUnit::Nanosecond, None),
+            true,
+        ));
+        assert_eq!(expected, values[0]);
+    }
+
+    #[test]
+    fn test_qbs_pg_timestamp_nanosecond_array_out_of_range_rejected() {
+        let portal = make_portal(
+            vec![Some(Type::TIMESTAMP_ARRAY)],
+            vec![s(r#"{"3000-01-01 00:00:00"}"#)],
+        );
+
+        assert_numeric_out_of_range(parameters_to_scalar_values(
+            &qbs_timestamp_nanosecond_array_plan(),
+            &portal,
+        ));
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

N/A.

## What's changed and what's your intention?

PostgreSQL `TIMESTAMP_ARRAY` parameters targeting nanosecond timestamps used `filter_map`, which silently dropped SQL `NULL` elements and non-null timestamps outside the nanosecond range. Dropping elements changed the array length and shifted later values to the wrong positions.

This PR replaces the lossy conversion with a fallible, position-preserving map:

- SQL `NULL` elements become typed null nanosecond timestamp scalars at the same positions.
- In-range non-null timestamps retain the existing conversion behavior.
- Out-of-range non-null timestamps return the existing PostgreSQL `22023` / `numeric_value_out_of_range` error instead of being silently removed.

Focused regression tests cover an interior null between two valid values and the controlled out-of-range error.

This change does not alter the wire format, schema format, public API, or other timestamp units.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
