### PR TITLE
fix: reject datanode startup on GC config mismatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5938,7 +5938,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=a2b39f9841760b6290e89be4206cae6b332afdf0#a2b39f9841760b6290e89be4206cae6b332afdf0"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=b135eb1d44e01ede4a0ac77913fb8b64c35f0fdf#b135eb1d44e01ede4a0ac77913fb8b64c35f0fdf"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5938,7 +5938,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=b135eb1d44e01ede4a0ac77913fb8b64c35f0fdf#b135eb1d44e01ede4a0ac77913fb8b64c35f0fdf"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=f5e8e703c2037dadc566f96f312d4b7a928a0157#f5e8e703c2037dadc566f96f312d4b7a928a0157"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5938,7 +5938,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=f5e8e703c2037dadc566f96f312d4b7a928a0157#f5e8e703c2037dadc566f96f312d4b7a928a0157"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=c6f92ee9e12ee7bd5ee3c0956b1c9caa39be3f76#c6f92ee9e12ee7bd5ee3c0956b1c9caa39be3f76"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5938,7 +5938,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=6fc4d88851c5ad16846698e4dff6e74c1f7a48ba#6fc4d88851c5ad16846698e4dff6e74c1f7a48ba"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=a2b39f9841760b6290e89be4206cae6b332afdf0#a2b39f9841760b6290e89be4206cae6b332afdf0"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ fs2 = "0.4"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "a2b39f9841760b6290e89be4206cae6b332afdf0" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "b135eb1d44e01ede4a0ac77913fb8b64c35f0fdf" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ fs2 = "0.4"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "6fc4d88851c5ad16846698e4dff6e74c1f7a48ba" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "a2b39f9841760b6290e89be4206cae6b332afdf0" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ fs2 = "0.4"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "f5e8e703c2037dadc566f96f312d4b7a928a0157" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "c6f92ee9e12ee7bd5ee3c0956b1c9caa39be3f76" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ fs2 = "0.4"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "b135eb1d44e01ede4a0ac77913fb8b64c35f0fdf" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "f5e8e703c2037dadc566f96f312d4b7a928a0157" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -110,10 +110,11 @@ impl Datanode {
 
     pub async fn start_heartbeat(&mut self) -> Result<()> {
         if let Some(task) = &self.heartbeat_task {
-            // Safety: The event_receiver must exist.
-            let receiver = self.region_event_receiver.take().unwrap();
-
-            task.start(receiver, self.leases_notifier.clone()).await?;
+            task.start(
+                &mut self.region_event_receiver,
+                self.leases_notifier.clone(),
+            )
+            .await?;
         }
         Ok(())
     }
@@ -273,13 +274,7 @@ impl DatanodeBuilder {
             schema_cache,
         ));
 
-        let gc_enabled = self.opts.region_engine.iter().any(|engine| {
-            if let RegionEngineConfig::Mito(config) = engine {
-                config.gc.enable
-            } else {
-                false
-            }
-        });
+        let gc_enabled = self.effective_mito_config().gc.enable;
 
         let file_ref_manager = Arc::new(FileReferenceManager::with_gc_enabled(
             Some(node_id),
@@ -483,6 +478,19 @@ impl DatanodeBuilder {
 
     // internal utils
 
+    fn effective_mito_config(&self) -> MitoConfig {
+        self.opts
+            .region_engine
+            .iter()
+            .filter_map(|engine| match engine {
+                RegionEngineConfig::Mito(config) => Some(config),
+                _ => None,
+            })
+            .next_back()
+            .cloned()
+            .unwrap_or_default()
+    }
+
     /// Builds [RegionEngineRef] from `store_engine` section in `opts`
     async fn build_store_engines(
         &mut self,
@@ -492,14 +500,11 @@ impl DatanodeBuilder {
         plugins: Plugins,
     ) -> Result<Vec<RegionEngineRef>> {
         let mut metric_engine_config = metric_engine::config::EngineConfig::default();
-        let mut mito_engine_config = MitoConfig::default();
         let mut file_engine_config = file_engine::config::EngineConfig::default();
 
         for engine in &self.opts.region_engine {
             match engine {
-                RegionEngineConfig::Mito(config) => {
-                    mito_engine_config = config.clone();
-                }
+                RegionEngineConfig::Mito(_) => {}
                 RegionEngineConfig::File(config) => {
                     file_engine_config = config.clone();
                 }
@@ -514,7 +519,7 @@ impl DatanodeBuilder {
         let mito_engine = self
             .build_mito_engine(
                 object_store_manager.clone(),
-                mito_engine_config,
+                self.effective_mito_config(),
                 schema_metadata_manager.clone(),
                 file_ref_manager.clone(),
                 fetcher.clone(),
@@ -825,11 +830,12 @@ mod tests {
     use common_meta::key::datanode_table::DatanodeTableManager;
     use common_meta::kv_backend::KvBackendRef;
     use common_meta::kv_backend::memory::MemoryKvBackend;
+    use mito2::config::MitoConfig;
     use mito2::engine::MITO_ENGINE_NAME;
     use store_api::region_request::RegionRequest;
     use store_api::storage::RegionId;
 
-    use crate::config::DatanodeOptions;
+    use crate::config::{DatanodeOptions, RegionEngineConfig};
     use crate::datanode::DatanodeBuilder;
     use crate::tests::{MockRegionEngine, mock_region_server};
 
@@ -848,6 +854,27 @@ mod tests {
 
         let r = kv.txn(txn).await.unwrap();
         assert!(r.succeeded);
+    }
+
+    #[test]
+    fn test_effective_mito_config_uses_last_entry() {
+        let mut first = MitoConfig::default();
+        first.gc.enable = true;
+        let mut last = MitoConfig::default();
+        last.gc.enable = false;
+        let builder = DatanodeBuilder::new(
+            DatanodeOptions {
+                region_engine: vec![
+                    RegionEngineConfig::Mito(first),
+                    RegionEngineConfig::Mito(last),
+                ],
+                ..Default::default()
+            },
+            Plugins::default(),
+            Arc::new(MemoryKvBackend::new()),
+        );
+
+        assert!(!builder.effective_mito_config().gc.enable);
     }
 
     #[tokio::test]

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -110,11 +110,10 @@ impl Datanode {
 
     pub async fn start_heartbeat(&mut self) -> Result<()> {
         if let Some(task) = &self.heartbeat_task {
-            task.start(
-                &mut self.region_event_receiver,
-                self.leases_notifier.clone(),
-            )
-            .await?;
+            // Safety: The event_receiver must exist.
+            let receiver = self.region_event_receiver.take().unwrap();
+
+            task.start(receiver, self.leases_notifier.clone()).await?;
         }
         Ok(())
     }
@@ -274,7 +273,13 @@ impl DatanodeBuilder {
             schema_cache,
         ));
 
-        let gc_enabled = self.effective_mito_config().gc.enable;
+        let gc_enabled = self.opts.region_engine.iter().any(|engine| {
+            if let RegionEngineConfig::Mito(config) = engine {
+                config.gc.enable
+            } else {
+                false
+            }
+        });
 
         let file_ref_manager = Arc::new(FileReferenceManager::with_gc_enabled(
             Some(node_id),
@@ -478,19 +483,6 @@ impl DatanodeBuilder {
 
     // internal utils
 
-    fn effective_mito_config(&self) -> MitoConfig {
-        self.opts
-            .region_engine
-            .iter()
-            .filter_map(|engine| match engine {
-                RegionEngineConfig::Mito(config) => Some(config),
-                _ => None,
-            })
-            .next_back()
-            .cloned()
-            .unwrap_or_default()
-    }
-
     /// Builds [RegionEngineRef] from `store_engine` section in `opts`
     async fn build_store_engines(
         &mut self,
@@ -500,11 +492,14 @@ impl DatanodeBuilder {
         plugins: Plugins,
     ) -> Result<Vec<RegionEngineRef>> {
         let mut metric_engine_config = metric_engine::config::EngineConfig::default();
+        let mut mito_engine_config = MitoConfig::default();
         let mut file_engine_config = file_engine::config::EngineConfig::default();
 
         for engine in &self.opts.region_engine {
             match engine {
-                RegionEngineConfig::Mito(_) => {}
+                RegionEngineConfig::Mito(config) => {
+                    mito_engine_config = config.clone();
+                }
                 RegionEngineConfig::File(config) => {
                     file_engine_config = config.clone();
                 }
@@ -519,7 +514,7 @@ impl DatanodeBuilder {
         let mito_engine = self
             .build_mito_engine(
                 object_store_manager.clone(),
-                self.effective_mito_config(),
+                mito_engine_config,
                 schema_metadata_manager.clone(),
                 file_ref_manager.clone(),
                 fetcher.clone(),
@@ -830,12 +825,11 @@ mod tests {
     use common_meta::key::datanode_table::DatanodeTableManager;
     use common_meta::kv_backend::KvBackendRef;
     use common_meta::kv_backend::memory::MemoryKvBackend;
-    use mito2::config::MitoConfig;
     use mito2::engine::MITO_ENGINE_NAME;
     use store_api::region_request::RegionRequest;
     use store_api::storage::RegionId;
 
-    use crate::config::{DatanodeOptions, RegionEngineConfig};
+    use crate::config::DatanodeOptions;
     use crate::datanode::DatanodeBuilder;
     use crate::tests::{MockRegionEngine, mock_region_server};
 
@@ -854,27 +848,6 @@ mod tests {
 
         let r = kv.txn(txn).await.unwrap();
         assert!(r.succeeded);
-    }
-
-    #[test]
-    fn test_effective_mito_config_uses_last_entry() {
-        let mut first = MitoConfig::default();
-        first.gc.enable = true;
-        let mut last = MitoConfig::default();
-        last.gc.enable = false;
-        let builder = DatanodeBuilder::new(
-            DatanodeOptions {
-                region_engine: vec![
-                    RegionEngineConfig::Mito(first),
-                    RegionEngineConfig::Mito(last),
-                ],
-                ..Default::default()
-            },
-            Plugins::default(),
-            Arc::new(MemoryKvBackend::new()),
-        );
-
-        assert!(!builder.effective_mito_config().gc.enable);
     }
 
     #[tokio::test]

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -287,6 +287,18 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display(
+        "GC configuration mismatch: metasrv.gc.enable={}, datanode.region_engine.mito.gc.enable={}",
+        metasrv_gc_enabled,
+        datanode_gc_enabled,
+    ))]
+    GcConfigMismatch {
+        metasrv_gc_enabled: bool,
+        datanode_gc_enabled: bool,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Unsupported output type, expected: {}", expected))]
     UnsupportedOutput {
         expected: String,
@@ -456,6 +468,7 @@ impl ErrorExt for Error {
             | ColumnNoneDefaultValue { .. }
             | MissingRequiredField { .. }
             | RegionEngineNotFound { .. }
+            | GcConfigMismatch { .. }
             | ParseAddr { .. }
             | TomlFormat { .. }
             | BuildDatanode { .. } => StatusCode::InvalidArguments,

--- a/src/datanode/src/heartbeat.rs
+++ b/src/datanode/src/heartbeat.rs
@@ -36,7 +36,7 @@ use common_stat::ResourceStatRef;
 use common_telemetry::{debug, error, info, trace, warn};
 use common_workload::DatanodeWorkloadType;
 use meta_client::MetaClientRef;
-use meta_client::client::heartbeat::HeartbeatConfig;
+use meta_client::client::heartbeat::{HeartbeatConfig, HeartbeatStream};
 use meta_client::client::{HeartbeatSender, MetaClient};
 use servers::addrs;
 use snafu::{OptionExt as _, ResultExt};
@@ -67,6 +67,32 @@ pub struct HeartbeatTask {
     region_alive_keeper: Arc<RegionAliveKeeper>,
     resource_stat: ResourceStatRef,
     env_vars: EnvVars,
+}
+
+struct RunningGuard {
+    running: Arc<AtomicBool>,
+    armed: bool,
+}
+
+impl RunningGuard {
+    fn new(running: Arc<AtomicBool>) -> Self {
+        Self {
+            running,
+            armed: true,
+        }
+    }
+
+    fn disarm(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for RunningGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            self.running.store(false, Ordering::Release);
+        }
+    }
 }
 
 impl Drop for HeartbeatTask {
@@ -121,15 +147,19 @@ impl HeartbeatTask {
 
     pub async fn create_streams(
         meta_client: &MetaClient,
+    ) -> Result<(HeartbeatSender, HeartbeatStream, HeartbeatConfig)> {
+        meta_client.heartbeat().await.context(MetaClientInitSnafu)
+    }
+
+    fn spawn_response_handler(
+        client_id: u64,
+        mut rx: HeartbeatStream,
         running: Arc<AtomicBool>,
         handler_executor: HeartbeatResponseHandlerExecutorRef,
         mailbox: MailboxRef,
         mut notify: Option<Arc<Notify>>,
         quit_signal: Arc<Notify>,
-    ) -> Result<(HeartbeatSender, HeartbeatConfig)> {
-        let client_id = meta_client.id();
-        let (tx, mut rx, config) = meta_client.heartbeat().await.context(MetaClientInitSnafu)?;
-
+    ) {
         let mut last_received_lease = Instant::now();
 
         let _handle = common_runtime::spawn_hb(async move {
@@ -178,7 +208,25 @@ impl HeartbeatTask {
             quit_signal.notify_one();
             info!("Heartbeat handling loop exit.");
         });
-        Ok((tx, config))
+    }
+
+    fn validate_gc_config(local_gc_enabled: bool, remote_gc_enabled: Option<bool>) -> Result<()> {
+        match remote_gc_enabled {
+            Some(remote_gc_enabled) if remote_gc_enabled != local_gc_enabled => {
+                error::GcConfigMismatchSnafu {
+                    metasrv_gc_enabled: remote_gc_enabled,
+                    datanode_gc_enabled: local_gc_enabled,
+                }
+                .fail()
+            }
+            Some(_) => Ok(()),
+            None => {
+                warn!(
+                    "Metasrv did not advertise metasrv.gc.enable during the heartbeat handshake; GC configuration compatibility was not verified. Upgrade Metasrv before relying on this check."
+                );
+                Ok(())
+            }
+        }
     }
 
     async fn handle_response(
@@ -196,7 +244,7 @@ impl HeartbeatTask {
     /// Start heartbeat task, spawn background task.
     pub async fn start(
         &self,
-        event_receiver: RegionServerEventReceiver,
+        event_receiver: &mut Option<RegionServerEventReceiver>,
         notify: Option<Arc<Notify>>,
     ) -> Result<()> {
         let running = self.running.clone();
@@ -207,6 +255,7 @@ impl HeartbeatTask {
             warn!("Heartbeat task started multiple times");
             return Ok(());
         }
+        let running_guard = RunningGuard::new(running.clone());
         let node_id = self.node_id;
         let node_epoch = self.node_epoch;
         let addr = &self.peer_addr;
@@ -221,15 +270,14 @@ impl HeartbeatTask {
 
         let quit_signal = Arc::new(Notify::new());
 
-        let (mut tx, config) = Self::create_streams(
-            &meta_client,
-            running.clone(),
-            handler_executor.clone(),
-            mailbox.clone(),
-            notify,
-            quit_signal.clone(),
-        )
-        .await?;
+        let client_id = meta_client.id();
+        let (mut tx, rx, config) = Self::create_streams(&meta_client).await?;
+
+        let mito_engine = self
+            .region_server
+            .mito_engine()
+            .context(RegionEngineNotFoundSnafu { name: "mito" })?;
+        Self::validate_gc_config(mito_engine.mito_config().gc.enable, config.gc_enabled)?;
 
         let interval = config.interval.as_millis() as u64;
         let mut retry_interval = config.retry_interval;
@@ -249,19 +297,27 @@ impl HeartbeatTask {
         let epoch = self.region_alive_keeper.epoch();
         let workload_types = self.workload_types.clone();
 
-        self.region_alive_keeper.start(Some(event_receiver)).await?;
+        self.region_alive_keeper
+            .start(event_receiver.take())
+            .await?;
         let mut last_sent = Instant::now();
         let total_cpu_millicores = self.resource_stat.get_total_cpu_millicores();
         let total_memory_bytes = self.resource_stat.get_total_memory_bytes();
         let resource_stat = self.resource_stat.clone();
         let region_alive_keeper = self.region_alive_keeper.clone();
-        let gc_limiter = self
-            .region_server
-            .mito_engine()
-            .context(RegionEngineNotFoundSnafu { name: "mito" })?
-            .gc_limiter();
+        let gc_limiter = mito_engine.gc_limiter();
         let mut env_var_extensions = HashMap::new();
         self.env_vars.into_extensions(&mut env_var_extensions);
+
+        Self::spawn_response_handler(
+            client_id,
+            rx,
+            running.clone(),
+            handler_executor.clone(),
+            mailbox.clone(),
+            notify,
+            quit_signal.clone(),
+        );
 
         common_runtime::spawn_hb(async move {
             let sleep = tokio::time::sleep(Duration::from_millis(0));
@@ -366,19 +422,19 @@ impl HeartbeatTask {
                     debug!("Sending heartbeat request: {:?}", req);
                     if let Err(e) = tx.send(req).await {
                         error!(e; "Failed to send heartbeat to metasrv");
-                        match Self::create_streams(
-                            &meta_client,
-                            running.clone(),
-                            handler_executor.clone(),
-                            mailbox.clone(),
-                            None,
-                            quit_signal.clone(),
-                        )
-                        .await
-                        {
-                            Ok((new_tx, new_config)) => {
+                        match Self::create_streams(&meta_client).await {
+                            Ok((new_tx, new_rx, new_config)) => {
                                 info!("Reconnected to metasrv, heartbeat config: {}", new_config);
                                 tx = new_tx;
+                                Self::spawn_response_handler(
+                                    client_id,
+                                    new_rx,
+                                    running.clone(),
+                                    handler_executor.clone(),
+                                    mailbox.clone(),
+                                    None,
+                                    quit_signal.clone(),
+                                );
                                 // Update retry_interval from new config
                                 retry_interval = new_config.retry_interval;
                                 // Update region_alive_keeper's heartbeat interval
@@ -403,6 +459,7 @@ impl HeartbeatTask {
             }
         });
 
+        running_guard.disarm();
         Ok(())
     }
 
@@ -441,5 +498,38 @@ impl HeartbeatTask {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common_error::ext::ErrorExt;
+
+    use super::*;
+
+    #[test]
+    fn test_initial_startup_gc_config_validation() {
+        assert!(HeartbeatTask::validate_gc_config(false, Some(false)).is_ok());
+        assert!(HeartbeatTask::validate_gc_config(true, Some(true)).is_ok());
+        assert!(HeartbeatTask::validate_gc_config(false, None).is_ok());
+
+        let err = HeartbeatTask::validate_gc_config(false, Some(true)).unwrap_err();
+        assert_eq!(
+            common_error::status_code::StatusCode::InvalidArguments,
+            err.status_code()
+        );
+        assert!(matches!(err, error::Error::GcConfigMismatch { .. }));
+    }
+
+    #[test]
+    fn test_running_guard_resets_state_after_initial_validation_failure() {
+        let running = Arc::new(AtomicBool::new(true));
+        let result: Result<()> = {
+            let _guard = RunningGuard::new(running.clone());
+            HeartbeatTask::validate_gc_config(false, Some(true))
+        };
+
+        assert!(result.is_err());
+        assert!(!running.load(Ordering::Acquire));
     }
 }

--- a/src/datanode/src/heartbeat.rs
+++ b/src/datanode/src/heartbeat.rs
@@ -36,7 +36,7 @@ use common_stat::ResourceStatRef;
 use common_telemetry::{debug, error, info, trace, warn};
 use common_workload::DatanodeWorkloadType;
 use meta_client::MetaClientRef;
-use meta_client::client::heartbeat::{HeartbeatConfig, HeartbeatStream};
+use meta_client::client::heartbeat::HeartbeatConfig;
 use meta_client::client::{HeartbeatSender, MetaClient};
 use servers::addrs;
 use snafu::{OptionExt as _, ResultExt};
@@ -67,32 +67,6 @@ pub struct HeartbeatTask {
     region_alive_keeper: Arc<RegionAliveKeeper>,
     resource_stat: ResourceStatRef,
     env_vars: EnvVars,
-}
-
-struct RunningGuard {
-    running: Arc<AtomicBool>,
-    armed: bool,
-}
-
-impl RunningGuard {
-    fn new(running: Arc<AtomicBool>) -> Self {
-        Self {
-            running,
-            armed: true,
-        }
-    }
-
-    fn disarm(mut self) {
-        self.armed = false;
-    }
-}
-
-impl Drop for RunningGuard {
-    fn drop(&mut self) {
-        if self.armed {
-            self.running.store(false, Ordering::Release);
-        }
-    }
 }
 
 impl Drop for HeartbeatTask {
@@ -147,19 +121,23 @@ impl HeartbeatTask {
 
     pub async fn create_streams(
         meta_client: &MetaClient,
-    ) -> Result<(HeartbeatSender, HeartbeatStream, HeartbeatConfig)> {
-        meta_client.heartbeat().await.context(MetaClientInitSnafu)
-    }
-
-    fn spawn_response_handler(
-        client_id: u64,
-        mut rx: HeartbeatStream,
+        local_gc_enabled: bool,
         running: Arc<AtomicBool>,
         handler_executor: HeartbeatResponseHandlerExecutorRef,
         mailbox: MailboxRef,
         mut notify: Option<Arc<Notify>>,
         quit_signal: Arc<Notify>,
-    ) {
+    ) -> Result<(HeartbeatSender, HeartbeatConfig)> {
+        let client_id = meta_client.id();
+        let (tx, mut rx, config) = meta_client.heartbeat().await.context(MetaClientInitSnafu)?;
+        if config.gc_enabled != local_gc_enabled {
+            return error::GcConfigMismatchSnafu {
+                metasrv_gc_enabled: config.gc_enabled,
+                datanode_gc_enabled: local_gc_enabled,
+            }
+            .fail();
+        }
+
         let mut last_received_lease = Instant::now();
 
         let _handle = common_runtime::spawn_hb(async move {
@@ -208,25 +186,7 @@ impl HeartbeatTask {
             quit_signal.notify_one();
             info!("Heartbeat handling loop exit.");
         });
-    }
-
-    fn validate_gc_config(local_gc_enabled: bool, remote_gc_enabled: Option<bool>) -> Result<()> {
-        match remote_gc_enabled {
-            Some(remote_gc_enabled) if remote_gc_enabled != local_gc_enabled => {
-                error::GcConfigMismatchSnafu {
-                    metasrv_gc_enabled: remote_gc_enabled,
-                    datanode_gc_enabled: local_gc_enabled,
-                }
-                .fail()
-            }
-            Some(_) => Ok(()),
-            None => {
-                warn!(
-                    "Metasrv did not advertise metasrv.gc.enable during the heartbeat handshake; GC configuration compatibility was not verified. Upgrade Metasrv before relying on this check."
-                );
-                Ok(())
-            }
-        }
+        Ok((tx, config))
     }
 
     async fn handle_response(
@@ -244,7 +204,7 @@ impl HeartbeatTask {
     /// Start heartbeat task, spawn background task.
     pub async fn start(
         &self,
-        event_receiver: &mut Option<RegionServerEventReceiver>,
+        event_receiver: RegionServerEventReceiver,
         notify: Option<Arc<Notify>>,
     ) -> Result<()> {
         let running = self.running.clone();
@@ -255,7 +215,6 @@ impl HeartbeatTask {
             warn!("Heartbeat task started multiple times");
             return Ok(());
         }
-        let running_guard = RunningGuard::new(running.clone());
         let node_id = self.node_id;
         let node_epoch = self.node_epoch;
         let addr = &self.peer_addr;
@@ -269,15 +228,24 @@ impl HeartbeatTask {
         let mailbox = Arc::new(HeartbeatMailbox::new(outgoing_tx));
 
         let quit_signal = Arc::new(Notify::new());
-
-        let client_id = meta_client.id();
-        let (mut tx, rx, config) = Self::create_streams(&meta_client).await?;
-
-        let mito_engine = self
+        let local_gc_enabled = self
             .region_server
             .mito_engine()
-            .context(RegionEngineNotFoundSnafu { name: "mito" })?;
-        Self::validate_gc_config(mito_engine.mito_config().gc.enable, config.gc_enabled)?;
+            .context(RegionEngineNotFoundSnafu { name: "mito" })?
+            .mito_config()
+            .gc
+            .enable;
+
+        let (mut tx, config) = Self::create_streams(
+            &meta_client,
+            local_gc_enabled,
+            running.clone(),
+            handler_executor.clone(),
+            mailbox.clone(),
+            notify,
+            quit_signal.clone(),
+        )
+        .await?;
 
         let interval = config.interval.as_millis() as u64;
         let mut retry_interval = config.retry_interval;
@@ -297,27 +265,19 @@ impl HeartbeatTask {
         let epoch = self.region_alive_keeper.epoch();
         let workload_types = self.workload_types.clone();
 
-        self.region_alive_keeper
-            .start(event_receiver.take())
-            .await?;
+        self.region_alive_keeper.start(Some(event_receiver)).await?;
         let mut last_sent = Instant::now();
         let total_cpu_millicores = self.resource_stat.get_total_cpu_millicores();
         let total_memory_bytes = self.resource_stat.get_total_memory_bytes();
         let resource_stat = self.resource_stat.clone();
         let region_alive_keeper = self.region_alive_keeper.clone();
-        let gc_limiter = mito_engine.gc_limiter();
+        let gc_limiter = self
+            .region_server
+            .mito_engine()
+            .context(RegionEngineNotFoundSnafu { name: "mito" })?
+            .gc_limiter();
         let mut env_var_extensions = HashMap::new();
         self.env_vars.into_extensions(&mut env_var_extensions);
-
-        Self::spawn_response_handler(
-            client_id,
-            rx,
-            running.clone(),
-            handler_executor.clone(),
-            mailbox.clone(),
-            notify,
-            quit_signal.clone(),
-        );
 
         common_runtime::spawn_hb(async move {
             let sleep = tokio::time::sleep(Duration::from_millis(0));
@@ -422,19 +382,20 @@ impl HeartbeatTask {
                     debug!("Sending heartbeat request: {:?}", req);
                     if let Err(e) = tx.send(req).await {
                         error!(e; "Failed to send heartbeat to metasrv");
-                        match Self::create_streams(&meta_client).await {
-                            Ok((new_tx, new_rx, new_config)) => {
+                        match Self::create_streams(
+                            &meta_client,
+                            local_gc_enabled,
+                            running.clone(),
+                            handler_executor.clone(),
+                            mailbox.clone(),
+                            None,
+                            quit_signal.clone(),
+                        )
+                        .await
+                        {
+                            Ok((new_tx, new_config)) => {
                                 info!("Reconnected to metasrv, heartbeat config: {}", new_config);
                                 tx = new_tx;
-                                Self::spawn_response_handler(
-                                    client_id,
-                                    new_rx,
-                                    running.clone(),
-                                    handler_executor.clone(),
-                                    mailbox.clone(),
-                                    None,
-                                    quit_signal.clone(),
-                                );
                                 // Update retry_interval from new config
                                 retry_interval = new_config.retry_interval;
                                 // Update region_alive_keeper's heartbeat interval
@@ -459,7 +420,6 @@ impl HeartbeatTask {
             }
         });
 
-        running_guard.disarm();
         Ok(())
     }
 
@@ -498,38 +458,5 @@ impl HeartbeatTask {
         }
 
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use common_error::ext::ErrorExt;
-
-    use super::*;
-
-    #[test]
-    fn test_initial_startup_gc_config_validation() {
-        assert!(HeartbeatTask::validate_gc_config(false, Some(false)).is_ok());
-        assert!(HeartbeatTask::validate_gc_config(true, Some(true)).is_ok());
-        assert!(HeartbeatTask::validate_gc_config(false, None).is_ok());
-
-        let err = HeartbeatTask::validate_gc_config(false, Some(true)).unwrap_err();
-        assert_eq!(
-            common_error::status_code::StatusCode::InvalidArguments,
-            err.status_code()
-        );
-        assert!(matches!(err, error::Error::GcConfigMismatch { .. }));
-    }
-
-    #[test]
-    fn test_running_guard_resets_state_after_initial_validation_failure() {
-        let running = Arc::new(AtomicBool::new(true));
-        let result: Result<()> = {
-            let _guard = RunningGuard::new(running.clone());
-            HeartbeatTask::validate_gc_config(false, Some(true))
-        };
-
-        assert!(result.is_err());
-        assert!(!running.load(Ordering::Acquire));
     }
 }

--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -237,7 +237,7 @@ mod tests {
                             is_handshake.then_some(api::v1::meta::HeartbeatConfig {
                                 heartbeat_interval_ms,
                                 retry_interval_ms: heartbeat_interval_ms,
-                                gc_enabled: None,
+                                gc_enabled: false,
                             });
                         is_handshake = false;
                         let response = HeartbeatResponse {

--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -237,6 +237,7 @@ mod tests {
                             is_handshake.then_some(api::v1::meta::HeartbeatConfig {
                                 heartbeat_interval_ms,
                                 retry_interval_ms: heartbeat_interval_ms,
+                                gc_enabled: None,
                             });
                         is_handshake = false;
                         let response = HeartbeatResponse {

--- a/src/meta-client/src/client/heartbeat.rs
+++ b/src/meta-client/src/client/heartbeat.rs
@@ -39,7 +39,7 @@ use crate::error::{InvalidResponseHeaderSnafu, Result};
 pub struct HeartbeatConfig {
     pub interval: Duration,
     pub retry_interval: Duration,
-    pub gc_enabled: Option<bool>,
+    pub gc_enabled: bool,
 }
 
 impl Default for HeartbeatConfig {
@@ -47,7 +47,7 @@ impl Default for HeartbeatConfig {
         Self {
             interval: BASE_HEARTBEAT_INTERVAL,
             retry_interval: BASE_HEARTBEAT_INTERVAL,
-            gc_enabled: None,
+            gc_enabled: false,
         }
     }
 }
@@ -56,7 +56,7 @@ impl fmt::Display for HeartbeatConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "interval={:?}, retry={:?}, gc_enabled={:?}",
+            "interval={:?}, retry={:?}, gc_enabled={}",
             self.interval, self.retry_interval, self.gc_enabled
         )
     }
@@ -80,11 +80,6 @@ impl HeartbeatConfig {
             );
             fallback
         }
-    }
-
-    fn from_handshake_response(res: &HeartbeatResponse) -> Result<Self> {
-        util::check_response_header(res.header.as_ref()).context(InvalidResponseHeaderSnafu)?;
-        Ok(Self::from_response(res))
     }
 }
 
@@ -267,8 +262,7 @@ impl Inner {
             .map_err(error::Error::from)?
             .context(error::CreateHeartbeatStreamSnafu)?;
 
-        // Validate the handshake response before trusting its configuration.
-        let config = HeartbeatConfig::from_handshake_response(&res)?;
+        let config = HeartbeatConfig::from_response(&res);
 
         info!(
             "Handshake successful with Metasrv at {}, received config: {}",
@@ -343,39 +337,5 @@ mod test {
             let header = req.header.unwrap();
             assert_eq!(8, header.member_id);
         }
-    }
-
-    #[test]
-    fn test_heartbeat_config_preserves_gc_enabled() {
-        for gc_enabled in [Some(false), Some(true), None] {
-            let config = HeartbeatConfig::from_response(&HeartbeatResponse {
-                heartbeat_config: Some(api::v1::meta::HeartbeatConfig {
-                    gc_enabled,
-                    ..Default::default()
-                }),
-                ..Default::default()
-            });
-            assert_eq!(gc_enabled, config.gc_enabled);
-        }
-    }
-
-    #[test]
-    fn test_handshake_response_requires_valid_header() {
-        let err = HeartbeatConfig::from_handshake_response(&HeartbeatResponse {
-            header: Some(api::v1::meta::ResponseHeader {
-                error: Some(api::v1::meta::Error {
-                    code: 500,
-                    err_msg: "handshake failed".to_string(),
-                }),
-                ..Default::default()
-            }),
-            heartbeat_config: Some(api::v1::meta::HeartbeatConfig {
-                gc_enabled: Some(true),
-                ..Default::default()
-            }),
-            ..Default::default()
-        })
-        .unwrap_err();
-        assert!(matches!(err, error::Error::InvalidResponseHeader { .. }));
     }
 }

--- a/src/meta-client/src/client/heartbeat.rs
+++ b/src/meta-client/src/client/heartbeat.rs
@@ -39,6 +39,7 @@ use crate::error::{InvalidResponseHeaderSnafu, Result};
 pub struct HeartbeatConfig {
     pub interval: Duration,
     pub retry_interval: Duration,
+    pub gc_enabled: Option<bool>,
 }
 
 impl Default for HeartbeatConfig {
@@ -46,6 +47,7 @@ impl Default for HeartbeatConfig {
         Self {
             interval: BASE_HEARTBEAT_INTERVAL,
             retry_interval: BASE_HEARTBEAT_INTERVAL,
+            gc_enabled: None,
         }
     }
 }
@@ -54,8 +56,8 @@ impl fmt::Display for HeartbeatConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "interval={:?}, retry={:?}",
-            self.interval, self.retry_interval
+            "interval={:?}, retry={:?}, gc_enabled={:?}",
+            self.interval, self.retry_interval, self.gc_enabled
         )
     }
 }
@@ -68,6 +70,7 @@ impl HeartbeatConfig {
             Self {
                 interval: Duration::from_millis(cfg.heartbeat_interval_ms),
                 retry_interval: Duration::from_millis(cfg.retry_interval_ms),
+                gc_enabled: cfg.gc_enabled,
             }
         } else {
             let fallback = Self::default();
@@ -77,6 +80,11 @@ impl HeartbeatConfig {
             );
             fallback
         }
+    }
+
+    fn from_handshake_response(res: &HeartbeatResponse) -> Result<Self> {
+        util::check_response_header(res.header.as_ref()).context(InvalidResponseHeaderSnafu)?;
+        Ok(Self::from_response(res))
     }
 }
 
@@ -259,8 +267,8 @@ impl Inner {
             .map_err(error::Error::from)?
             .context(error::CreateHeartbeatStreamSnafu)?;
 
-        // Extract heartbeat configuration from handshake response
-        let config = HeartbeatConfig::from_response(&res);
+        // Validate the handshake response before trusting its configuration.
+        let config = HeartbeatConfig::from_handshake_response(&res)?;
 
         info!(
             "Handshake successful with Metasrv at {}, received config: {}",
@@ -335,5 +343,39 @@ mod test {
             let header = req.header.unwrap();
             assert_eq!(8, header.member_id);
         }
+    }
+
+    #[test]
+    fn test_heartbeat_config_preserves_gc_enabled() {
+        for gc_enabled in [Some(false), Some(true), None] {
+            let config = HeartbeatConfig::from_response(&HeartbeatResponse {
+                heartbeat_config: Some(api::v1::meta::HeartbeatConfig {
+                    gc_enabled,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
+            assert_eq!(gc_enabled, config.gc_enabled);
+        }
+    }
+
+    #[test]
+    fn test_handshake_response_requires_valid_header() {
+        let err = HeartbeatConfig::from_handshake_response(&HeartbeatResponse {
+            header: Some(api::v1::meta::ResponseHeader {
+                error: Some(api::v1::meta::Error {
+                    code: 500,
+                    err_msg: "handshake failed".to_string(),
+                }),
+                ..Default::default()
+            }),
+            heartbeat_config: Some(api::v1::meta::HeartbeatConfig {
+                gc_enabled: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        })
+        .unwrap_err();
+        assert!(matches!(err, error::Error::InvalidResponseHeader { .. }));
     }
 }

--- a/src/meta-srv/src/handler.rs
+++ b/src/meta-srv/src/handler.rs
@@ -388,9 +388,7 @@ impl HeartbeatHandlerGroup {
         // Populate heartbeat_config during handshake
         let heartbeat_config = if is_handshake {
             let mut config: HeartbeatConfig = ctx.heartbeat_options_for(role).into();
-            if role == Role::Datanode {
-                config.gc_enabled = Some(ctx.gc_enabled);
-            }
+            config.gc_enabled = ctx.gc_enabled;
 
             info!(
                 "Handshake with {:?} node, sending config: {:?}",
@@ -889,7 +887,7 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use api::v1::meta::{HeartbeatRequest, MailboxMessage, RequestHeader, Role};
+    use api::v1::meta::{MailboxMessage, Role};
     use common_meta::kv_backend::memory::MemoryKvBackend;
     use common_meta::sequence::SequenceBuilder;
     use tokio::sync::mpsc;
@@ -898,70 +896,8 @@ mod tests {
     use crate::error;
     use crate::handler::collect_stats_handler::CollectStatsHandler;
     use crate::handler::response_header_handler::ResponseHeaderHandler;
-    use crate::handler::test_utils::TestEnv;
     use crate::handler::{HeartbeatHandlerGroup, HeartbeatMailbox, Pusher};
     use crate::service::mailbox::{Channel, MailboxReceiver, MailboxRef};
-
-    #[tokio::test]
-    async fn test_handshake_advertises_gc_config_to_datanode_only() {
-        let handler_group = HeartbeatHandlerGroup::default();
-
-        for gc_enabled in [false, true] {
-            let mut ctx = TestEnv::new().ctx().with_handshake(true);
-            ctx.gc_enabled = gc_enabled;
-            let response = handler_group
-                .handle(
-                    HeartbeatRequest {
-                        header: Some(RequestHeader {
-                            role: Role::Datanode.into(),
-                            ..Default::default()
-                        }),
-                        ..Default::default()
-                    },
-                    ctx,
-                )
-                .await
-                .unwrap();
-
-            assert_eq!(
-                Some(gc_enabled),
-                response.heartbeat_config.unwrap().gc_enabled
-            );
-        }
-
-        for role in [Role::Frontend, Role::Flownode] {
-            let response = handler_group
-                .handle(
-                    HeartbeatRequest {
-                        header: Some(RequestHeader {
-                            role: role.into(),
-                            ..Default::default()
-                        }),
-                        ..Default::default()
-                    },
-                    TestEnv::new().ctx().with_handshake(true),
-                )
-                .await
-                .unwrap();
-
-            assert_eq!(None, response.heartbeat_config.unwrap().gc_enabled);
-        }
-
-        let response = handler_group
-            .handle(
-                HeartbeatRequest {
-                    header: Some(RequestHeader {
-                        role: Role::Datanode.into(),
-                        ..Default::default()
-                    }),
-                    ..Default::default()
-                },
-                TestEnv::new().ctx(),
-            )
-            .await
-            .unwrap();
-        assert!(response.heartbeat_config.is_none());
-    }
 
     #[tokio::test]
     async fn test_mailbox() {

--- a/src/meta-srv/src/handler.rs
+++ b/src/meta-srv/src/handler.rs
@@ -21,8 +21,8 @@ use std::time::{Duration, Instant};
 
 use api::v1::meta::mailbox_message::Payload;
 use api::v1::meta::{
-    HeartbeatRequest, HeartbeatResponse, MailboxMessage, PROTOCOL_VERSION, RegionLease,
-    ResponseHeader, Role,
+    HeartbeatConfig, HeartbeatRequest, HeartbeatResponse, MailboxMessage, PROTOCOL_VERSION,
+    RegionLease, ResponseHeader, Role,
 };
 use check_leader_handler::CheckLeaderHandler;
 use collect_cluster_info_handler::{
@@ -387,7 +387,10 @@ impl HeartbeatHandlerGroup {
 
         // Populate heartbeat_config during handshake
         let heartbeat_config = if is_handshake {
-            let config = ctx.heartbeat_options_for(role).into();
+            let mut config: HeartbeatConfig = ctx.heartbeat_options_for(role).into();
+            if role == Role::Datanode {
+                config.gc_enabled = Some(ctx.gc_enabled);
+            }
 
             info!(
                 "Handshake with {:?} node, sending config: {:?}",
@@ -886,7 +889,7 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use api::v1::meta::{MailboxMessage, Role};
+    use api::v1::meta::{HeartbeatRequest, MailboxMessage, RequestHeader, Role};
     use common_meta::kv_backend::memory::MemoryKvBackend;
     use common_meta::sequence::SequenceBuilder;
     use tokio::sync::mpsc;
@@ -895,8 +898,70 @@ mod tests {
     use crate::error;
     use crate::handler::collect_stats_handler::CollectStatsHandler;
     use crate::handler::response_header_handler::ResponseHeaderHandler;
+    use crate::handler::test_utils::TestEnv;
     use crate::handler::{HeartbeatHandlerGroup, HeartbeatMailbox, Pusher};
     use crate::service::mailbox::{Channel, MailboxReceiver, MailboxRef};
+
+    #[tokio::test]
+    async fn test_handshake_advertises_gc_config_to_datanode_only() {
+        let handler_group = HeartbeatHandlerGroup::default();
+
+        for gc_enabled in [false, true] {
+            let mut ctx = TestEnv::new().ctx().with_handshake(true);
+            ctx.gc_enabled = gc_enabled;
+            let response = handler_group
+                .handle(
+                    HeartbeatRequest {
+                        header: Some(RequestHeader {
+                            role: Role::Datanode.into(),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    },
+                    ctx,
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(
+                Some(gc_enabled),
+                response.heartbeat_config.unwrap().gc_enabled
+            );
+        }
+
+        for role in [Role::Frontend, Role::Flownode] {
+            let response = handler_group
+                .handle(
+                    HeartbeatRequest {
+                        header: Some(RequestHeader {
+                            role: role.into(),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    },
+                    TestEnv::new().ctx().with_handshake(true),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(None, response.heartbeat_config.unwrap().gc_enabled);
+        }
+
+        let response = handler_group
+            .handle(
+                HeartbeatRequest {
+                    header: Some(RequestHeader {
+                        role: Role::Datanode.into(),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                TestEnv::new().ctx(),
+            )
+            .await
+            .unwrap();
+        assert!(response.heartbeat_config.is_none());
+    }
 
     #[tokio::test]
     async fn test_mailbox() {

--- a/src/meta-srv/src/handler/test_utils.rs
+++ b/src/meta-srv/src/handler/test_utils.rs
@@ -92,6 +92,7 @@ impl TestEnv {
             leader_region_registry: self.leader_region_registry.clone(),
             topic_stats_registry: self.topic_stats_registry.clone(),
             heartbeat_interval: BASE_HEARTBEAT_INTERVAL,
+            gc_enabled: false,
             is_handshake: false,
         }
     }

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -175,7 +175,7 @@ impl From<HeartbeatOptions> for HeartbeatConfig {
         Self {
             heartbeat_interval_ms: opts.interval.as_millis() as u64,
             retry_interval_ms: opts.retry_interval.as_millis() as u64,
-            gc_enabled: None,
+            gc_enabled: false,
         }
     }
 }

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -175,6 +175,7 @@ impl From<HeartbeatOptions> for HeartbeatConfig {
         Self {
             heartbeat_interval_ms: opts.interval.as_millis() as u64,
             retry_interval_ms: opts.retry_interval.as_millis() as u64,
+            gc_enabled: None,
         }
     }
 }
@@ -438,6 +439,7 @@ pub struct Context {
     pub leader_region_registry: LeaderRegionRegistryRef,
     pub topic_stats_registry: TopicStatsRegistryRef,
     pub heartbeat_interval: Duration,
+    pub gc_enabled: bool,
     pub is_handshake: bool,
 }
 
@@ -932,6 +934,7 @@ impl Metasrv {
             leader_region_registry,
             topic_stats_registry,
             heartbeat_interval: self.options().heartbeat_interval,
+            gc_enabled: self.options().gc.enable,
             is_handshake: false,
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

- Uses merged GreptimeTeam/greptime-proto#328 (`c6f92ee9e12ee7bd5ee3c0956b1c9caa39be3f76`)

## What's changed and what's your intention?

- Add metasrv `gc.enable` to the heartbeat configuration.
- Compare it with the constructed Mito engine GC setting during datanode heartbeat setup.
- Reject startup with `InvalidArguments` when the values differ.

The proto field is a plain boolean. An older metasrv that omits it is decoded as `false`. Runtime heartbeat lifecycle is unchanged.

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.

## Tests

- `cargo check -p datanode -p meta-client -p meta-srv --tests`
- `cargo fmt`
- `git diff --check`