### PR TITLE
test: add legacy JSON2 non-append compat case

### DIFF
--- a/tests/compatibility/cases/legacy_json2_non_append_table/case.toml
+++ b/tests/compatibility/cases/legacy_json2_non_append_table/case.toml
@@ -1,0 +1,8 @@
+name = "legacy_json2_non_append_table"
+reason = "Verify current binaries can read a non-append JSON2 table created by old binaries and migrate it to append_mode=true."
+introduced_by = "PR #8434"
+topologies = ["distributed"]
+from_range = ["=v1.1.0", "=v1.1.1", "=v1.1.2"]
+to_range = [">v1.1.1"]
+features = ["json", "json2", "table", "append_mode", "read"]
+owner = "query"

--- a/tests/compatibility/cases/legacy_json2_non_append_table/case.toml
+++ b/tests/compatibility/cases/legacy_json2_non_append_table/case.toml
@@ -3,6 +3,6 @@ reason = "Verify current binaries can read a non-append JSON2 table created by o
 introduced_by = "PR #8434"
 topologies = ["distributed"]
 from_range = ["=v1.1.0", "=v1.1.1", "=v1.1.2"]
-to_range = [">v1.1.1"]
+to_range = [">v1.1.2"]
 features = ["json", "json2", "table", "append_mode", "read"]
 owner = "query"

--- a/tests/compatibility/cases/legacy_json2_non_append_table/setup.sql
+++ b/tests/compatibility/cases/legacy_json2_non_append_table/setup.sql
@@ -1,0 +1,10 @@
+CREATE TABLE t_legacy_json2_non_append_table (
+  ts TIMESTAMP TIME INDEX,
+  j JSON2
+);
+
+INSERT INTO t_legacy_json2_non_append_table (ts, j) VALUES
+  ('2026-07-08 00:00:00+0000', '{"a": 1, "nested": {"s": "old-1"}}'),
+  ('2026-07-08 00:01:00+0000', '{"a": 2, "nested": {"s": "old-2"}}');
+
+ADMIN FLUSH_TABLE('t_legacy_json2_non_append_table');

--- a/tests/compatibility/cases/legacy_json2_non_append_table/verify.result
+++ b/tests/compatibility/cases/legacy_json2_non_append_table/verify.result
@@ -1,0 +1,63 @@
+SELECT ts, j.a AS a, j.nested.s AS nested_s
+FROM t_legacy_json2_non_append_table
+ORDER BY ts;
+
++---------------------+---+----------+
+| ts                  | a | nested_s |
++---------------------+---+----------+
+| 2026-07-08T00:00:00 | 1 | old-1    |
+| 2026-07-08T00:01:00 | 2 | old-2    |
++---------------------+---+----------+
+
+SHOW CREATE TABLE t_legacy_json2_non_append_table;
+
++---------------------------------+----------------------------------------------------------------+
+| Table                           | Create Table                                                   |
++---------------------------------+----------------------------------------------------------------+
+| t_legacy_json2_non_append_table | CREATE TABLE IF NOT EXISTS "t_legacy_json2_non_append_table" ( |
+|                                 |   "ts" TIMESTAMP(3) NOT NULL,                                  |
+|                                 |   "j" JSON2 NULL,                                              |
+|                                 |   TIME INDEX ("ts")                                            |
+|                                 | )                                                              |
+|                                 |                                                                |
+|                                 | ENGINE=mito                                                    |
+|                                 |                                                                |
++---------------------------------+----------------------------------------------------------------+
+
+ALTER TABLE t_legacy_json2_non_append_table SET 'append_mode' = 'true';
+
+Affected Rows: 0
+
+SHOW CREATE TABLE t_legacy_json2_non_append_table;
+
++---------------------------------+----------------------------------------------------------------+
+| Table                           | Create Table                                                   |
++---------------------------------+----------------------------------------------------------------+
+| t_legacy_json2_non_append_table | CREATE TABLE IF NOT EXISTS "t_legacy_json2_non_append_table" ( |
+|                                 |   "ts" TIMESTAMP(3) NOT NULL,                                  |
+|                                 |   "j" JSON2 NULL,                                              |
+|                                 |   TIME INDEX ("ts")                                            |
+|                                 | )                                                              |
+|                                 |                                                                |
+|                                 | ENGINE=mito                                                    |
+|                                 | WITH(                                                          |
+|                                 |   append_mode = 'true'                                         |
+|                                 | )                                                              |
++---------------------------------+----------------------------------------------------------------+
+
+INSERT INTO t_legacy_json2_non_append_table (ts, j) VALUES
+  ('2026-07-08 00:02:00+0000', '{"a": 3, "nested": {"s": "current-3"}}');
+
+Affected Rows: 1
+
+SELECT ts, j.a AS a, j.nested.s AS nested_s
+FROM t_legacy_json2_non_append_table
+ORDER BY ts;
+
++---------------------+---+-----------+
+| ts                  | a | nested_s  |
++---------------------+---+-----------+
+| 2026-07-08T00:00:00 | 1 | old-1     |
+| 2026-07-08T00:01:00 | 2 | old-2     |
+| 2026-07-08T00:02:00 | 3 | current-3 |
++---------------------+---+-----------+

--- a/tests/compatibility/cases/legacy_json2_non_append_table/verify.sql
+++ b/tests/compatibility/cases/legacy_json2_non_append_table/verify.sql
@@ -1,0 +1,16 @@
+SELECT ts, j.a AS a, j.nested.s AS nested_s
+FROM t_legacy_json2_non_append_table
+ORDER BY ts;
+
+SHOW CREATE TABLE t_legacy_json2_non_append_table;
+
+ALTER TABLE t_legacy_json2_non_append_table SET 'append_mode' = 'true';
+
+SHOW CREATE TABLE t_legacy_json2_non_append_table;
+
+INSERT INTO t_legacy_json2_non_append_table (ts, j) VALUES
+  ('2026-07-08 00:02:00+0000', '{"a": 3, "nested": {"s": "current-3"}}');
+
+SELECT ts, j.a AS a, j.nested.s AS nested_s
+FROM t_legacy_json2_non_append_table
+ORDER BY ts;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up compatibility coverage for #8434.

## What's changed and what's your intention?

Add a distributed sqlness compatibility case for JSON2 tables created by older binaries without `append_mode=true`.

The old binary creates the legacy table, writes nested JSON2 values, and flushes them to SSTs. The current binary then verifies that it can:

- open and read the legacy table and old SSTs;
- inspect the pre-migration table metadata;
- migrate the table with `ALTER TABLE ... SET append_mode = true`;
- write and read new JSON2 values after migration.

The case is limited to v1.1.0, v1.1.1, and v1.1.2 as old writers because later binaries reject creation of non-append JSON2 tables.

Validation:

- `v1.1.0 -> current` distributed compat: passed
- `v1.1.1 -> current` distributed compat: passed
- `v1.1.2 -> current` distributed compat: passed
- pre-push typos, formatting, license-header, and clippy hooks: passed

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.