### PR TITLE
fix(datatypes): decode dictionary values in structs

### DIFF
--- a/src/datatypes/src/value.rs
+++ b/src/datatypes/src/value.rs
@@ -1218,12 +1218,18 @@ impl TryFrom<ScalarValue> for Value {
                     .collect::<Result<Vec<Value>>>()?;
                 Value::Struct(StructValue::try_new(items, struct_type)?)
             }
+            ScalarValue::Dictionary(_, decoded) => {
+                if decoded.is_null() {
+                    Value::Null
+                } else {
+                    (*decoded).try_into()?
+                }
+            }
             ScalarValue::Decimal32(_, _, _)
             | ScalarValue::Decimal64(_, _, _)
             | ScalarValue::Decimal256(_, _, _)
             | ScalarValue::FixedSizeList(_)
             | ScalarValue::LargeList(_)
-            | ScalarValue::Dictionary(_, _)
             | ScalarValue::Union(_, _, _)
             | ScalarValue::Float16(_)
             | ScalarValue::Utf8View(_)
@@ -2085,6 +2091,59 @@ pub(crate) mod tests {
         assert_eq!(
             Value::Struct(struct_value),
             scalar_struct_value.try_into().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_try_from_dictionary_scalar_value() {
+        let key_type = Box::new(ArrowDataType::Int8);
+
+        assert_eq!(
+            Value::String("dictionary string".into()),
+            ScalarValue::Dictionary(
+                key_type.clone(),
+                Box::new(ScalarValue::Utf8(Some("dictionary string".into())))
+            )
+            .try_into()
+            .unwrap()
+        );
+        assert_eq!(
+            Value::Null,
+            ScalarValue::Dictionary(key_type.clone(), Box::new(ScalarValue::Utf8(None)))
+                .try_into()
+                .unwrap()
+        );
+        assert_eq!(
+            Value::Null,
+            ScalarValue::Dictionary(
+                key_type.clone(),
+                Box::new(ScalarValue::new_null_list(ArrowDataType::Utf8, true, 1))
+            )
+            .try_into()
+            .unwrap()
+        );
+
+        let dictionary_type =
+            ArrowDataType::Dictionary(Box::new(ArrowDataType::Int8), Box::new(ArrowDataType::Utf8));
+        let list = ScalarValue::List(ScalarValue::new_list(
+            &[ScalarValue::Dictionary(
+                key_type.clone(),
+                Box::new(ScalarValue::Utf8(Some("nested".into()))),
+            )],
+            &dictionary_type,
+            true,
+        ));
+        assert_eq!(
+            Value::List(ListValue::new(
+                vec![Value::String("nested".into())],
+                Arc::new(ConcreteDataType::dictionary_datatype(
+                    ConcreteDataType::int8_datatype(),
+                    ConcreteDataType::string_datatype(),
+                )),
+            )),
+            ScalarValue::Dictionary(key_type, Box::new(list))
+                .try_into()
+                .unwrap()
         );
     }
 

--- a/src/datatypes/src/vectors/struct_vector.rs
+++ b/src/datatypes/src/vectors/struct_vector.rs
@@ -460,10 +460,80 @@ impl ScalarVectorBuilder for StructVectorBuilder {
 
 #[cfg(test)]
 mod tests {
+    use arrow::array::{ArrayRef, Int8Array, StringArray};
+    use arrow::datatypes::Field;
+    use arrow_array::DictionaryArray;
+    use arrow_schema::Fields;
+
     use super::*;
     use crate::types::StructField;
     use crate::value::ListValue;
     use crate::value::tests::*;
+
+    #[test]
+    fn test_nested_dictionary_struct_child_materializes() {
+        let dictionary = DictionaryArray::try_new(
+            Int8Array::from(vec![Some(0), None, Some(1)]),
+            Arc::new(StringArray::from(vec![Some("nested"), None])),
+        )
+        .unwrap();
+        let fields: Fields = vec![Arc::new(Field::new(
+            "dictionary",
+            dictionary.data_type().clone(),
+            true,
+        ))]
+        .into();
+        let struct_array = StructArray::new(fields.clone(), vec![Arc::new(dictionary)], None);
+        let vector = Helper::try_into_vector(Arc::new(struct_array) as ArrayRef).unwrap();
+        let struct_type = StructType::from(&fields);
+
+        assert_eq!(
+            vector.get(0),
+            Value::Struct(StructValue::new(
+                vec![Value::String("nested".into())],
+                struct_type.clone(),
+            ))
+        );
+        assert_eq!(
+            vector.get(1),
+            Value::Struct(StructValue::new(vec![Value::Null], struct_type.clone()))
+        );
+        assert_eq!(
+            vector.get(2),
+            Value::Struct(StructValue::new(vec![Value::Null], struct_type))
+        );
+    }
+
+    #[test]
+    fn test_struct_utf8_child_materializes() {
+        let fields: Fields = vec![Arc::new(Field::new("name", ArrowDataType::Utf8, true))].into();
+        let struct_array = StructArray::new(
+            fields.clone(),
+            vec![Arc::new(StringArray::from(vec!["plain"]))],
+            None,
+        );
+        let vector = Helper::try_into_vector(Arc::new(struct_array) as ArrayRef).unwrap();
+
+        assert_eq!(
+            vector.get(0),
+            Value::Struct(StructValue::new(
+                vec![Value::String("plain".into())],
+                StructType::from(&fields),
+            ))
+        );
+    }
+
+    #[test]
+    fn test_top_level_dictionary_materializes() {
+        let dictionary = DictionaryArray::try_new(
+            Int8Array::from(vec![Some(0)]),
+            Arc::new(StringArray::from(vec!["top-level"])),
+        )
+        .unwrap();
+        let vector = Helper::try_into_vector(Arc::new(dictionary) as ArrayRef).unwrap();
+
+        assert_eq!(vector.get(0), Value::String("top-level".into()));
+    }
 
     #[test]
     fn test_struct_vector_builder() {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

N/A

## What's changed and what's your intention?

- Decode `ScalarValue::Dictionary` to its logical value when converting to GreptimeDB `Value`, preserving null semantics for primitive and collection values.
- Allow `StructVector::get` to materialize a legal Arrow Struct containing a Dictionary child instead of panicking after conversion accepted the array.
- Add regressions for nested Dictionary Struct values, null keys, keys targeting null values, ordinary Struct values, top-level Dictionary values, and recursive Dictionary/List conversion.

This provides decoded-read semantics consistent with `DictionaryVector::get`. It does not add Dictionary re-encoding or type-preserving round-trip support.

Validation:

- `cargo nextest run -p datatypes dictionary` — 10 passed.
- `cargo nextest run -p datatypes` — 272 passed.
- `make fmt`
- `git diff --check`

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
