### PR TITLE
fix(query): validate merge scan remote schema

### DIFF
--- a/src/query/src/dist_plan/merge_scan.rs
+++ b/src/query/src/dist_plan/merge_scan.rs
@@ -17,7 +17,10 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use ahash::{HashMap, HashSet};
-use arrow_schema::{Schema as ArrowSchema, SchemaRef as ArrowSchemaRef, SortOptions};
+use arrow_schema::{
+    ArrowError, DataType as ArrowDataType, Schema as ArrowSchema, SchemaRef as ArrowSchemaRef,
+    SortOptions,
+};
 use async_stream::stream;
 use common_catalog::parse_catalog_and_schema_from_db_string;
 use common_plugins::GREPTIME_EXEC_READ_COST;
@@ -71,6 +74,70 @@ fn query_engine_state_from_task_context(context: &TaskContext) -> Option<Arc<Que
 fn remote_dyn_filter_enabled(query_ctx: &QueryContextRef) -> Result<bool> {
     remote_dyn_filter_pushdown_enabled_from_extensions(&query_ctx.extensions())
         .map_err(|err| DataFusionError::External(Box::new(err)))
+}
+
+fn remote_schema_mismatch(message: impl Into<String>) -> DataFusionError {
+    DataFusionError::ArrowError(Box::new(ArrowError::SchemaError(message.into())), None)
+}
+
+/// Validates the remote schema before positional column handling.
+///
+/// A timestamp timezone difference is the only intentional exception: its unit
+/// must match, and replacing the actual timestamp datatype with the expected
+/// datatype must make the complete field equal.
+fn validate_remote_schema(
+    expected: &ArrowSchema,
+    actual: &ArrowSchema,
+    source: &str,
+) -> Result<()> {
+    if expected.metadata() != actual.metadata() {
+        return Err(remote_schema_mismatch(format!(
+            "MergeScan {source} schema metadata mismatch: expected {:?}, actual {:?}",
+            expected.metadata(),
+            actual.metadata()
+        )));
+    }
+
+    if expected.fields().len() != actual.fields().len() {
+        return Err(remote_schema_mismatch(format!(
+            "MergeScan {source} schema field count mismatch: expected {}, actual {}",
+            expected.fields().len(),
+            actual.fields().len()
+        )));
+    }
+
+    for (index, (expected_field, actual_field)) in expected
+        .fields()
+        .iter()
+        .zip(actual.fields().iter())
+        .enumerate()
+    {
+        if expected_field == actual_field {
+            continue;
+        }
+
+        let timezone_only_difference = matches!(
+            (expected_field.data_type(), actual_field.data_type()),
+            (
+                ArrowDataType::Timestamp(expected_unit, expected_timezone),
+                ArrowDataType::Timestamp(actual_unit, actual_timezone),
+            ) if expected_unit == actual_unit
+                && expected_timezone != actual_timezone
+                && actual_field
+                    .as_ref()
+                    .clone()
+                    .with_data_type(expected_field.data_type().clone())
+                    == expected_field.as_ref().clone()
+        );
+        if !timezone_only_difference {
+            return Err(remote_schema_mismatch(format!(
+                "MergeScan {source} schema field mismatch at position {index}: expected {:?}, actual {:?}",
+                expected_field, actual_field
+            )));
+        }
+    }
+
+    Ok(())
 }
 
 fn acquire_remote_dyn_filter_registry_lease(
@@ -422,6 +489,15 @@ impl MergeScanExec {
                         MERGE_SCAN_ERRORS_TOTAL.inc();
                         DataFusionError::External(Box::new(e))
                     })?;
+                validate_remote_schema(
+                    arrow_schema.as_ref(),
+                    stream.schema().arrow_schema().as_ref(),
+                    "advertised remote stream",
+                )
+                .map_err(|error| {
+                    MERGE_SCAN_ERRORS_TOTAL.inc();
+                    error
+                })?;
                 let do_get_cost = do_get_start.elapsed();
 
                 if let Some(remote_dyn_filter_registry_lease) =
@@ -443,10 +519,18 @@ impl MergeScanExec {
                     poll_duration += poll_elapsed;
 
                     let batch = batch.map_err(|e| DataFusionError::External(Box::new(e)))?;
-                    let batch = patch_batch_timezone(
-                        arrow_schema.clone(),
-                        batch.into_df_record_batch().columns().to_vec(),
-                    )?;
+                    let df_batch = batch.into_df_record_batch();
+                    validate_remote_schema(
+                        arrow_schema.as_ref(),
+                        df_batch.schema().as_ref(),
+                        "remote record batch",
+                    )
+                    .map_err(|error| {
+                        MERGE_SCAN_ERRORS_TOTAL.inc();
+                        error
+                    })?;
+                    let batch =
+                        patch_batch_timezone(arrow_schema.clone(), df_batch.columns().to_vec())?;
                     metric.record_output_batch_rows(batch.num_rows());
                     if let Some(mut first_consume_timer) = first_consume_timer.take() {
                         first_consume_timer.stop();
@@ -1022,11 +1106,16 @@ impl MergeScanMetric {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeSet;
+    use std::collections::{BTreeSet, HashMap as StdHashMap};
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
 
+    use arrow::array::{Int64Array, TimestampMillisecondArray};
+    use arrow_schema::{DataType as TestArrowDataType, Field, TimeUnit};
     use async_trait::async_trait;
     use common_query::request::INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY;
     use common_recordbatch::adapter::{PlanMetrics, RecordBatchMetrics};
+    use common_recordbatch::{DfRecordBatch, RecordBatch, RecordBatchStream};
     use datafusion::config::ConfigOptions;
     use datafusion::execution::SessionStateBuilder;
     use datafusion::physical_plan::filter_pushdown::ChildFilterPushdownResult;
@@ -1036,6 +1125,10 @@ mod tests {
     use datafusion_physical_expr::expressions::{
         Column, DynamicFilterPhysicalExpr, lit as physical_lit,
     };
+    use datatypes::prelude::{ConcreteDataType, VectorRef};
+    use datatypes::schema::{ColumnSchema, Schema};
+    use datatypes::vectors::{Int64Vector, StringVector, TimestampMillisecondVector};
+    use futures_util::{Stream, TryStreamExt};
     use session::ReadPreference;
     use session::context::QueryContext;
     use session::query_id::QueryId;
@@ -1122,16 +1215,102 @@ mod tests {
         assert_eq!(registry_manager.registry_count(), 0);
     }
 
-    struct TestRegionQueryHandler;
+    #[derive(Clone)]
+    struct TestRegionResponse {
+        advertised_schema: Arc<Schema>,
+        batches: Vec<RecordBatch>,
+    }
+
+    #[derive(Default)]
+    struct TestRegionQueryHandler {
+        responses: HashMap<RegionId, TestRegionResponse>,
+    }
+
+    impl TestRegionQueryHandler {
+        fn new(responses: impl IntoIterator<Item = (RegionId, RecordBatch)>) -> Self {
+            let responses = responses
+                .into_iter()
+                .map(|(region_id, batch)| {
+                    (
+                        region_id,
+                        TestRegionResponse {
+                            advertised_schema: batch.schema.clone(),
+                            batches: vec![batch],
+                        },
+                    )
+                })
+                .collect();
+            Self { responses }
+        }
+
+        fn with_responses(
+            responses: impl IntoIterator<Item = (RegionId, Arc<Schema>, Vec<RecordBatch>)>,
+        ) -> Self {
+            let responses = responses
+                .into_iter()
+                .map(|(region_id, advertised_schema, batches)| {
+                    (
+                        region_id,
+                        TestRegionResponse {
+                            advertised_schema,
+                            batches,
+                        },
+                    )
+                })
+                .collect();
+            Self { responses }
+        }
+    }
+
+    struct TestRecordBatchStream {
+        schema: Arc<Schema>,
+        batches: Vec<RecordBatch>,
+        index: usize,
+    }
+
+    impl Stream for TestRecordBatchStream {
+        type Item = common_recordbatch::error::Result<RecordBatch>;
+
+        fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            if let Some(batch) = self.batches.get(self.index).cloned() {
+                self.index += 1;
+                Poll::Ready(Some(Ok(batch)))
+            } else {
+                Poll::Ready(None)
+            }
+        }
+    }
+
+    impl RecordBatchStream for TestRecordBatchStream {
+        fn schema(&self) -> Arc<Schema> {
+            self.schema.clone()
+        }
+
+        fn output_ordering(&self) -> Option<&[common_recordbatch::OrderOption]> {
+            None
+        }
+
+        fn metrics(&self) -> Option<RecordBatchMetrics> {
+            None
+        }
+    }
 
     #[async_trait]
     impl RegionQueryHandler for TestRegionQueryHandler {
         async fn do_get(
             &self,
             _read_preference: ReadPreference,
-            _request: common_query::request::QueryRequest,
+            request: common_query::request::QueryRequest,
         ) -> crate::error::Result<common_recordbatch::SendableRecordBatchStream> {
-            unimplemented!("test only")
+            let response = self
+                .responses
+                .get(&request.region_id)
+                .expect("test handler needs a response for every requested region");
+            Ok(Box::pin(TestRecordBatchStream {
+                schema: response.advertised_schema.clone(),
+                batches: response.batches.clone(),
+                index: 0,
+            }))
         }
 
         async fn handle_remote_dyn_filter_update(
@@ -1151,6 +1330,380 @@ mod tests {
         ) -> crate::error::Result<()> {
             unimplemented!("test only")
         }
+    }
+
+    fn int64_schema(columns: &[&str]) -> Arc<Schema> {
+        Arc::new(Schema::new(
+            columns
+                .iter()
+                .map(|name| ColumnSchema::new(*name, ConcreteDataType::int64_datatype(), false))
+                .collect(),
+        ))
+    }
+
+    fn record_batch(schema: Arc<Schema>, columns: Vec<VectorRef>) -> RecordBatch {
+        RecordBatch::new(schema, columns).expect("test record batch must match its schema")
+    }
+
+    fn expected_int64_schema() -> ArrowSchema {
+        int64_schema(&["a", "b"]).arrow_schema().as_ref().clone()
+    }
+
+    fn merge_scan_exec(
+        responses: Vec<(RegionId, RecordBatch)>,
+        expected_schema: ArrowSchema,
+        target_partition: usize,
+    ) -> MergeScanExec {
+        let regions = responses.iter().map(|(region_id, _)| *region_id).collect();
+        merge_scan_exec_with_handler(
+            regions,
+            expected_schema,
+            Arc::new(TestRegionQueryHandler::new(responses)),
+            target_partition,
+        )
+    }
+
+    fn merge_scan_exec_with_handler(
+        regions: Vec<RegionId>,
+        expected_schema: ArrowSchema,
+        handler: Arc<TestRegionQueryHandler>,
+        target_partition: usize,
+    ) -> MergeScanExec {
+        let plan = LogicalPlanBuilder::empty(true).build().unwrap();
+        MergeScanExec::new(
+            &SessionStateBuilder::new().build(),
+            TableName::new("catalog", "schema", "table"),
+            regions,
+            plan,
+            &expected_schema,
+            handler,
+            QueryContext::arc(),
+            target_partition,
+            AliasMapping::new(),
+            None,
+            false,
+        )
+        .unwrap()
+    }
+
+    async fn collect_merge_scan(
+        exec: MergeScanExec,
+    ) -> datafusion_common::Result<Vec<DfRecordBatch>> {
+        exec.execute(0, Arc::new(TaskContext::default()))?
+            .try_collect()
+            .await
+    }
+
+    fn assert_int64_batch(batch: &DfRecordBatch, values: (i64, i64)) {
+        assert_eq!(batch.schema().as_ref(), &expected_int64_schema());
+        let a = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("column a must be Int64");
+        let b = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("column b must be Int64");
+        assert_eq!((a.value(0), b.value(0)), values);
+    }
+
+    #[tokio::test]
+    async fn qbs_merge_scan_remote_schema_identity_canonical_single_region() {
+        let region_id = RegionId::new(1024, 1);
+        let batch = record_batch(
+            int64_schema(&["a", "b"]),
+            vec![
+                Arc::new(Int64Vector::from_slice([11])) as _,
+                Arc::new(Int64Vector::from_slice([12])) as _,
+            ],
+        );
+        let batches = collect_merge_scan(merge_scan_exec(
+            vec![(region_id, batch)],
+            expected_int64_schema(),
+            1,
+        ))
+        .await
+        .unwrap();
+
+        assert_eq!(batches.len(), 1);
+        assert_int64_batch(&batches[0], (11, 12));
+    }
+
+    #[tokio::test]
+    async fn qbs_merge_scan_remote_schema_identity_canonical_two_regions() {
+        let canonical_batch = || {
+            record_batch(
+                int64_schema(&["a", "b"]),
+                vec![
+                    Arc::new(Int64Vector::from_slice([11])) as _,
+                    Arc::new(Int64Vector::from_slice([12])) as _,
+                ],
+            )
+        };
+        let batches = collect_merge_scan(merge_scan_exec(
+            vec![
+                (RegionId::new(1024, 1), canonical_batch()),
+                (RegionId::new(1024, 2), canonical_batch()),
+            ],
+            expected_int64_schema(),
+            1,
+        ))
+        .await
+        .unwrap();
+
+        assert_eq!(batches.len(), 2);
+        for batch in &batches {
+            assert_int64_batch(batch, (11, 12));
+        }
+    }
+
+    #[tokio::test]
+    async fn qbs_merge_scan_remote_schema_identity_swapped_columns_never_relabels_positionally() {
+        let batch = record_batch(
+            int64_schema(&["b", "a"]),
+            vec![
+                Arc::new(Int64Vector::from_slice([2002])) as _,
+                Arc::new(Int64Vector::from_slice([1002])) as _,
+            ],
+        );
+
+        assert!(
+            collect_merge_scan(merge_scan_exec(
+                vec![(RegionId::new(1024, 2), batch)],
+                expected_int64_schema(),
+                1,
+            ))
+            .await
+            .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn qbs_merge_scan_remote_schema_identity_allows_timestamp_timezone_only_patch() {
+        let remote_arrow_schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            "ts",
+            TestArrowDataType::Timestamp(TimeUnit::Millisecond, Some("UTC".into())),
+            false,
+        )]));
+        let remote_schema = Arc::new(Schema::try_from(remote_arrow_schema).unwrap());
+        let timestamp_array: Arc<dyn arrow::array::Array> =
+            Arc::new(TimestampMillisecondArray::from(vec![1002]).with_timezone("UTC"));
+        let timestamp = TimestampMillisecondVector::try_from_arrow_array(timestamp_array)
+            .expect("timezone timestamp array must build a vector");
+        let batch = record_batch(remote_schema, vec![Arc::new(timestamp) as _]);
+        let expected_schema = ArrowSchema::new(vec![Field::new(
+            "ts",
+            TestArrowDataType::Timestamp(TimeUnit::Millisecond, Some("Asia/Shanghai".into())),
+            false,
+        )]);
+        let batches = collect_merge_scan(merge_scan_exec(
+            vec![(RegionId::new(1024, 1), batch)],
+            expected_schema.clone(),
+            1,
+        ))
+        .await
+        .unwrap();
+
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].schema().as_ref(), &expected_schema);
+        let timestamp = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<TimestampMillisecondArray>()
+            .expect("column ts must be a millisecond timestamp");
+        assert_eq!(timestamp.value(0), 1002);
+    }
+
+    #[tokio::test]
+    async fn qbs_merge_scan_remote_schema_identity_rejects_incompatible_type() {
+        let schema = Arc::new(Schema::new(vec![
+            ColumnSchema::new("a", ConcreteDataType::string_datatype(), false),
+            ColumnSchema::new("b", ConcreteDataType::int64_datatype(), false),
+        ]));
+        let batch = record_batch(
+            schema,
+            vec![
+                Arc::new(StringVector::from_slice(&["not-an-int"])) as _,
+                Arc::new(Int64Vector::from_slice([12])) as _,
+            ],
+        );
+
+        assert!(
+            collect_merge_scan(merge_scan_exec(
+                vec![(RegionId::new(1024, 1), batch)],
+                expected_int64_schema(),
+                1,
+            ))
+            .await
+            .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn qbs_merge_scan_remote_schema_identity_rejects_too_few_columns() {
+        let batch = record_batch(
+            int64_schema(&["a"]),
+            vec![Arc::new(Int64Vector::from_slice([11])) as _],
+        );
+
+        assert!(
+            collect_merge_scan(merge_scan_exec(
+                vec![(RegionId::new(1024, 1), batch)],
+                expected_int64_schema(),
+                1,
+            ))
+            .await
+            .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn qbs_merge_scan_remote_schema_identity_rejects_too_many_columns() {
+        let batch = record_batch(
+            int64_schema(&["a", "b", "extra"]),
+            vec![
+                Arc::new(Int64Vector::from_slice([11])) as _,
+                Arc::new(Int64Vector::from_slice([12])) as _,
+                Arc::new(Int64Vector::from_slice([13])) as _,
+            ],
+        );
+
+        assert!(
+            collect_merge_scan(merge_scan_exec(
+                vec![(RegionId::new(1024, 1), batch)],
+                expected_int64_schema(),
+                1,
+            ))
+            .await
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn merge_scan_remote_schema_identity_rejects_top_level_metadata_mismatch() {
+        let expected = expected_int64_schema();
+        let actual = ArrowSchema::new_with_metadata(
+            expected.fields().clone(),
+            StdHashMap::from([("remote".to_string(), "different".to_string())]),
+        );
+
+        assert!(validate_remote_schema(&expected, &actual, "test").is_err());
+    }
+
+    #[test]
+    fn merge_scan_remote_schema_identity_rejects_field_metadata_and_nullability_mismatch() {
+        let expected = expected_int64_schema();
+        let field_metadata_mismatch = ArrowSchema::new_with_metadata(
+            vec![
+                expected
+                    .field(0)
+                    .as_ref()
+                    .clone()
+                    .with_metadata(StdHashMap::from([(
+                        "remote".to_string(),
+                        "different".to_string(),
+                    )])),
+                expected.field(1).as_ref().clone(),
+            ],
+            expected.metadata().clone(),
+        );
+        let nullability_mismatch = ArrowSchema::new_with_metadata(
+            vec![
+                expected.field(0).as_ref().clone().with_nullable(true),
+                expected.field(1).as_ref().clone(),
+            ],
+            expected.metadata().clone(),
+        );
+
+        assert!(validate_remote_schema(&expected, &field_metadata_mismatch, "test").is_err());
+        assert!(validate_remote_schema(&expected, &nullability_mismatch, "test").is_err());
+    }
+
+    #[test]
+    fn merge_scan_remote_schema_identity_rejects_timestamp_unit_and_timezone_plus_other_field_mismatch()
+     {
+        let expected = ArrowSchema::new(vec![Field::new(
+            "ts",
+            TestArrowDataType::Timestamp(TimeUnit::Millisecond, Some("Asia/Shanghai".into())),
+            false,
+        )]);
+        let different_unit = ArrowSchema::new(vec![Field::new(
+            "ts",
+            TestArrowDataType::Timestamp(TimeUnit::Second, Some("UTC".into())),
+            false,
+        )]);
+        let timezone_plus_nullability = ArrowSchema::new(vec![Field::new(
+            "ts",
+            TestArrowDataType::Timestamp(TimeUnit::Millisecond, Some("UTC".into())),
+            true,
+        )]);
+
+        assert!(validate_remote_schema(&expected, &different_unit, "test").is_err());
+        assert!(validate_remote_schema(&expected, &timezone_plus_nullability, "test").is_err());
+    }
+
+    #[test]
+    fn merge_scan_remote_schema_identity_returns_arrow_schema_error() {
+        let expected = expected_int64_schema();
+        let actual = ArrowSchema::new_with_metadata(
+            vec![Field::new("other", TestArrowDataType::Int64, false)],
+            expected.metadata().clone(),
+        );
+
+        match validate_remote_schema(&expected, &actual, "test").unwrap_err() {
+            DataFusionError::ArrowError(error, None) => match error.as_ref() {
+                ArrowError::SchemaError(message) => {
+                    assert!(message.contains("field count mismatch"));
+                }
+                error => panic!("expected ArrowError::SchemaError, got {error:?}"),
+            },
+            error => panic!("expected DataFusionError::ArrowError(_, None), got {error:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn merge_scan_remote_schema_identity_rejects_incompatible_empty_advertised_schema() {
+        let region_id = RegionId::new(1024, 1);
+        let exec = merge_scan_exec_with_handler(
+            vec![region_id],
+            expected_int64_schema(),
+            Arc::new(TestRegionQueryHandler::with_responses(vec![(
+                region_id,
+                int64_schema(&["a"]),
+                vec![],
+            )])),
+            1,
+        );
+
+        assert!(collect_merge_scan(exec).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn merge_scan_remote_schema_identity_rejects_advertised_schema_inner_batch_mismatch() {
+        let region_id = RegionId::new(1024, 1);
+        let inner_batch = record_batch(
+            int64_schema(&["b", "a"]),
+            vec![
+                Arc::new(Int64Vector::from_slice([12])) as _,
+                Arc::new(Int64Vector::from_slice([11])) as _,
+            ],
+        )
+        .into_df_record_batch();
+        let batch = RecordBatch::from_df_record_batch(int64_schema(&["a", "b"]), inner_batch);
+        let exec = merge_scan_exec_with_handler(
+            vec![region_id],
+            expected_int64_schema(),
+            Arc::new(TestRegionQueryHandler::with_responses(vec![(
+                region_id,
+                int64_schema(&["a", "b"]),
+                vec![batch],
+            )])),
+            1,
+        );
+
+        assert!(collect_merge_scan(exec).await.is_err());
     }
 
     #[test]
@@ -1178,7 +1731,7 @@ mod tests {
 
         let session_state = SessionStateBuilder::new().build();
 
-        let handler = Arc::new(TestRegionQueryHandler);
+        let handler = Arc::new(TestRegionQueryHandler::default());
         let target_partition = 2;
 
         let exec = MergeScanExec::new(
@@ -1234,7 +1787,7 @@ mod tests {
         let regions = vec![RegionId::new(1024, 1)];
         let query_ctx = QueryContext::arc();
         let session_state = SessionStateBuilder::new().build();
-        let handler = Arc::new(TestRegionQueryHandler);
+        let handler = Arc::new(TestRegionQueryHandler::default());
         let exec = MergeScanExec::new(
             &session_state,
             table,
@@ -1347,7 +1900,7 @@ mod tests {
             vec![region_id],
             plan,
             &schema,
-            Arc::new(TestRegionQueryHandler),
+            Arc::new(TestRegionQueryHandler::default()),
             QueryContext::arc(),
             1,
             AliasMapping::new(),
@@ -1416,7 +1969,7 @@ mod tests {
             vec![logical_region_id],
             plan,
             &schema,
-            Arc::new(TestRegionQueryHandler),
+            Arc::new(TestRegionQueryHandler::default()),
             QueryContext::arc(),
             1,
             AliasMapping::new(),

--- a/src/query/src/dist_plan/merge_scan.rs
+++ b/src/query/src/dist_plan/merge_scan.rs
@@ -90,14 +90,6 @@ fn validate_remote_schema(
     actual: &ArrowSchema,
     source: &str,
 ) -> Result<()> {
-    if expected.metadata() != actual.metadata() {
-        return Err(remote_schema_mismatch(format!(
-            "MergeScan {source} schema metadata mismatch: expected {:?}, actual {:?}",
-            expected.metadata(),
-            actual.metadata()
-        )));
-    }
-
     if expected.fields().len() != actual.fields().len() {
         return Err(remote_schema_mismatch(format!(
             "MergeScan {source} schema field count mismatch: expected {}, actual {}",
@@ -494,10 +486,7 @@ impl MergeScanExec {
                     stream.schema().arrow_schema().as_ref(),
                     "advertised remote stream",
                 )
-                .map_err(|error| {
-                    MERGE_SCAN_ERRORS_TOTAL.inc();
-                    error
-                })?;
+                .inspect_err(|_| MERGE_SCAN_ERRORS_TOTAL.inc())?;
                 let do_get_cost = do_get_start.elapsed();
 
                 if let Some(remote_dyn_filter_registry_lease) =
@@ -525,10 +514,7 @@ impl MergeScanExec {
                         df_batch.schema().as_ref(),
                         "remote record batch",
                     )
-                    .map_err(|error| {
-                        MERGE_SCAN_ERRORS_TOTAL.inc();
-                        error
-                    })?;
+                    .inspect_err(|_| MERGE_SCAN_ERRORS_TOTAL.inc())?;
                     let batch =
                         patch_batch_timezone(arrow_schema.clone(), df_batch.columns().to_vec())?;
                     metric.record_output_batch_rows(batch.num_rows());
@@ -1582,14 +1568,18 @@ mod tests {
     }
 
     #[test]
-    fn merge_scan_remote_schema_identity_rejects_top_level_metadata_mismatch() {
-        let expected = expected_int64_schema();
+    fn merge_scan_remote_schema_identity_allows_top_level_metadata_mismatch() {
+        let fields = expected_int64_schema().fields().clone();
+        let expected = ArrowSchema::new_with_metadata(
+            fields.clone(),
+            StdHashMap::from([("greptime:version".to_string(), "1".to_string())]),
+        );
         let actual = ArrowSchema::new_with_metadata(
-            expected.fields().clone(),
-            StdHashMap::from([("remote".to_string(), "different".to_string())]),
+            fields,
+            StdHashMap::from([("greptime:version".to_string(), "0".to_string())]),
         );
 
-        assert!(validate_remote_schema(&expected, &actual, "test").is_err());
+        assert!(validate_remote_schema(&expected, &actual, "test").is_ok());
     }
 
     #[test]
@@ -1678,6 +1668,55 @@ mod tests {
         );
 
         assert!(collect_merge_scan(exec).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn merge_scan_remote_schema_identity_allows_top_level_metadata_version_mismatch() {
+        let fields = expected_int64_schema().fields().clone();
+        let expected_schema = ArrowSchema::new_with_metadata(
+            fields.clone(),
+            StdHashMap::from([("greptime:version".to_string(), "1".to_string())]),
+        );
+        let remote_schema = Arc::new(
+            Schema::try_from(Arc::new(ArrowSchema::new_with_metadata(
+                fields,
+                StdHashMap::from([("greptime:version".to_string(), "0".to_string())]),
+            )))
+            .unwrap(),
+        );
+        let region_id = RegionId::new(1024, 1);
+        let batch = record_batch(
+            remote_schema.clone(),
+            vec![
+                Arc::new(Int64Vector::from_slice([11])) as _,
+                Arc::new(Int64Vector::from_slice([12])) as _,
+            ],
+        );
+        let exec = merge_scan_exec_with_handler(
+            vec![region_id],
+            expected_schema.clone(),
+            Arc::new(TestRegionQueryHandler::with_responses(vec![(
+                region_id,
+                remote_schema,
+                vec![batch],
+            )])),
+            1,
+        );
+
+        let batches = collect_merge_scan(exec).await.unwrap();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].schema().as_ref(), &expected_schema);
+        let a = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("column a must be Int64");
+        let b = batches[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("column b must be Int64");
+        assert_eq!((a.value(0), b.value(0)), (11, 12));
     }
 
     #[tokio::test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Internal query bug QX-014.

## What's changed and what's your intention?

`MergeScanExec` previously discarded each remote `RecordBatch` schema and passed only positional arrays to the timezone patcher under the expected schema. This could silently relabel swapped same-typed columns and truncate extra columns.

This change validates the complete remote schema contract before positional handling:

- preflight each remote stream's advertised schema, including empty streams;
- validate every inner Arrow record batch schema because its wrapper schema is not guaranteed to match;
- require exact field count, order, names, nullability, field metadata, and data types;
- ignore top-level schema provenance metadata such as `greptime:version`, which may validly differ between frontend planning and reconstructed remote schemas;
- preserve the existing timestamp timezone-only repair when units and every other field property match;
- return a structured Arrow schema error instead of relabeling or truncating incompatible batches.

The change is internal to distributed query execution and does not alter public APIs, persisted data, or wire formats.

Validation:

- `cargo nextest run -p query merge_scan_remote_schema_identity` — 14 passed
- `cargo clippy -p query --all-targets --all-features -- -D warnings`
- `cargo sqlness bare -t 'standalone:alter_table$' --preserve-state --bins-dir <target>/debug`
- `rustfmt +nightly --edition 2024 --check src/query/src/dist_plan/merge_scan.rs`
- `git diff --check`

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
