### PR TITLE
fix(query): preserve bare plan names in analyze json

### DIFF
--- a/src/query/src/analyze.rs
+++ b/src/query/src/analyze.rs
@@ -355,7 +355,7 @@ impl JsonMetrics {
         let mut elapsed_compute = 0;
         let mut output_rows = 0;
         let mut other_metrics = HashMap::default();
-        let (name, param) = raw_name.split_once(": ").unwrap_or_default();
+        let (name, param) = raw_name.split_once(": ").unwrap_or((raw_name, ""));
 
         for (name, value) in plan_metrics.metrics.into_iter() {
             if name == "elapsed_compute" {
@@ -452,5 +452,43 @@ mod tests {
         let rebuilt = rebuilt.as_any().downcast_ref::<DistAnalyzeExec>().unwrap();
 
         assert_eq!(rebuilt.input().schema().field(0).name(), "replacement");
+    }
+
+    #[test]
+    fn qbs_analyze_json_preserves_plan_name_without_parameters() {
+        let input = empty_plan("input");
+        let mut collector = MetricCollector::new(false);
+        accept(input.as_ref(), &mut collector).unwrap();
+
+        let plan_metrics = &collector.record_batch_metrics.plan_metrics;
+        assert_eq!(plan_metrics.len(), 1);
+        assert_eq!(plan_metrics[0].level, 0);
+        assert_eq!(plan_metrics[0].plan, input.name());
+
+        let analyze: Arc<dyn ExecutionPlan> = Arc::new(DistAnalyzeExec::new(
+            input.clone(),
+            false,
+            AnalyzeFormat::JSON,
+        ));
+        let metrics = analyze_plan_metrics_to_json_value(&analyze, false).unwrap();
+        let plan_name = metrics[0]["plan"]["name"].as_str().unwrap();
+        let plan_param = metrics[0]["plan"]["param"].as_str().unwrap();
+
+        assert!(!plan_name.is_empty());
+        assert_eq!(plan_name, input.name());
+        assert!(plan_param.is_empty());
+    }
+
+    #[test]
+    fn qbs_analyze_json_splits_plan_name_and_parameters() {
+        let (_, metrics) = JsonMetrics::from_plan_metrics(PlanMetrics {
+            plan: "FilterExec: predicate".to_string(),
+            plan_name: "FilterExec".to_string(),
+            level: 0,
+            metrics: vec![],
+        });
+
+        assert_eq!(metrics.name, "FilterExec");
+        assert_eq!(metrics.param, "predicate");
     }
 }

--- a/tests/cases/standalone/tql-explain-analyze/analyze.result
+++ b/tests/cases/standalone/tql-explain-analyze/analyze.result
@@ -192,7 +192,7 @@ TQL ANALYZE FORMAT JSON (0, 10, '5s') test;
 +-+-+-+
 | stage | node | plan_|
 +-+-+-+
-| 0_| 0_| {"name":"","param":"","output_rows":0,"REDACTED
+| 0_| 0_| {"name":"CooperativeExec","param":"","output_rows":0,"REDACTED
 | 1_| 0_| {"name":"PromInstantManipulateExec","param":"range=[0..10000], lookback=[300000], interval=[5000], time index=[j]","output_rows":0,"REDACTED
 | 1_| 1_| {"name":"PromInstantManipulateExec","param":"range=[0..10000], lookback=[300000], interval=[5000], time index=[j]","output_rows":0,"REDACTED
 |_|_| Total rows: 0_|
@@ -213,7 +213,7 @@ TQL ANALYZE VERBOSE FORMAT JSON (0, 10, '5s') test;
 +-+-+-+
 | stage | node | plan_|
 +-+-+-+
-| 0_| 0_| {"name":"","param":"","output_rows":0,"REDACTED
+| 0_| 0_| {"name":"CooperativeExec","param":"","output_rows":0,"REDACTED
 | 1_| 0_| {"name":"PromInstantManipulateExec","param":"range=[0..10000], lookback=[300000], interval=[5000], time index=[j]","output_rows":0,"REDACTED
 | 1_| 1_| {"name":"PromInstantManipulateExec","param":"range=[0..10000], lookback=[300000], interval=[5000], time index=[j]","output_rows":0,"REDACTED
 |_|_| Total rows: 0_|


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

N/A

## What's changed and what's your intention?

Analyze JSON currently erases execution-plan names that do not contain a `: ` parameter separator. `JsonMetrics::from_plan_metrics()` falls back to an empty tuple when `split_once()` finds no separator, so valid operators such as `CooperativeExec` are rendered with an empty name.

This PR preserves the complete plan string as `name` and uses an empty `param` when no separator exists. Existing first-separator name/parameter splitting remains unchanged.

It also adds focused unit coverage for bare and parameterized plan names and regenerates the existing TQL Analyze JSON expectation.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments. (No public API changes.)
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
