### PR TITLE
fix: handle strict timestamp max bound

### DIFF
--- a/src/table/src/predicate.rs
+++ b/src/table/src/predicate.rs
@@ -259,10 +259,10 @@ fn extract_from_binary_expr(
             if reverse {
                 // [lit] < ts_col
                 let ts_val = ts.convert_to(ts_col_unit)?.value();
-                Some(TimestampRange::from_start(Timestamp::new(
-                    ts_val + 1,
-                    ts_col_unit,
-                )))
+                Some(match ts_val.checked_add(1) {
+                    Some(ts_val) => TimestampRange::from_start(Timestamp::new(ts_val, ts_col_unit)),
+                    None => TimestampRange::empty(),
+                })
             } else {
                 // ts_col < [lit]
                 ts.convert_to_ceil(ts_col_unit)
@@ -290,10 +290,10 @@ fn extract_from_binary_expr(
             } else {
                 // ts_col > [lit]
                 let ts_val = ts.convert_to(ts_col_unit)?.value();
-                Some(TimestampRange::from_start(Timestamp::new(
-                    ts_val + 1,
-                    ts_col_unit,
-                )))
+                Some(match ts_val.checked_add(1) {
+                    Some(ts_val) => TimestampRange::from_start(Timestamp::new(ts_val, ts_col_unit)),
+                    None => TimestampRange::empty(),
+                })
             }
         }
         Operator::GtEq => {
@@ -591,6 +591,86 @@ mod tests {
             col("ts").lt_eq(lit(ScalarValue::TimestampSecond(Some(1), None))),
             TimestampRange::until_end(Timestamp::new_millisecond(1000), true),
         );
+    }
+
+    #[test]
+    fn qbs_strict_timestamp_max_is_empty() {
+        let cases = [
+            (
+                TimeUnit::Second,
+                ScalarValue::TimestampSecond(Some(i64::MAX), None),
+            ),
+            (
+                TimeUnit::Millisecond,
+                ScalarValue::TimestampMillisecond(Some(i64::MAX), None),
+            ),
+            (
+                TimeUnit::Microsecond,
+                ScalarValue::TimestampMicrosecond(Some(i64::MAX), None),
+            ),
+            (
+                TimeUnit::Nanosecond,
+                ScalarValue::TimestampNanosecond(Some(i64::MAX), None),
+            ),
+        ];
+
+        for (unit, literal) in cases {
+            for (path, expr) in [
+                ("ts > MAX", col("ts").gt(lit(literal.clone()))),
+                ("MAX < ts", lit(literal).lt(col("ts"))),
+            ] {
+                let range = extract_time_range_from_expr("ts", unit, &expr).unwrap_or_else(|| {
+                    panic!("failed to extract range for {path}, unit: {unit:?}")
+                });
+                assert!(
+                    range.is_empty(),
+                    "strict MAX predicate must be unsatisfiable for {path}, unit: {unit:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn qbs_strict_timestamp_max_minus_one_is_singleton() {
+        let cases = [
+            (
+                TimeUnit::Second,
+                ScalarValue::TimestampSecond(Some(i64::MAX - 1), None),
+                ScalarValue::TimestampSecond(Some(i64::MAX), None),
+            ),
+            (
+                TimeUnit::Millisecond,
+                ScalarValue::TimestampMillisecond(Some(i64::MAX - 1), None),
+                ScalarValue::TimestampMillisecond(Some(i64::MAX), None),
+            ),
+            (
+                TimeUnit::Microsecond,
+                ScalarValue::TimestampMicrosecond(Some(i64::MAX - 1), None),
+                ScalarValue::TimestampMicrosecond(Some(i64::MAX), None),
+            ),
+            (
+                TimeUnit::Nanosecond,
+                ScalarValue::TimestampNanosecond(Some(i64::MAX - 1), None),
+                ScalarValue::TimestampNanosecond(Some(i64::MAX), None),
+            ),
+        ];
+
+        for (unit, max_minus_one, max) in cases {
+            let expected = TimestampRange::single(Timestamp::new(i64::MAX, unit));
+            for (path, expr) in [
+                ("ts > MAX-1", col("ts").gt(lit(max_minus_one.clone()))),
+                ("MAX-1 < ts", lit(max_minus_one).lt(col("ts"))),
+                ("ts >= MAX", col("ts").gt_eq(lit(max))),
+            ] {
+                let range = extract_time_range_from_expr("ts", unit, &expr).unwrap_or_else(|| {
+                    panic!("failed to extract range for {path}, unit: {unit:?}")
+                });
+                assert_eq!(
+                    expected, range,
+                    "unexpected range for {path}, unit: {unit:?}"
+                );
+            }
+        }
     }
 
     async fn gen_test_parquet_file(dir: &TempDir, cnt: usize) -> (String, Arc<Schema>) {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Strict timestamp lower-bound extraction previously computed `timestamp + 1` directly for `ts > literal` and the equivalent reversed form. At `i64::MAX`, debug builds panicked while release builds wrapped and produced a non-empty incorrect range.

This change uses checked addition after the existing timestamp-unit conversion. A successful increment keeps the existing inclusive lower-bound representation; overflow now yields an explicit empty range instead of being treated as an unconstrained predicate. Conversion-failure behavior remains unchanged.

Regression tests cover all timestamp units, both operand orders, the impossible strict `MAX` bound, and the neighboring `MAX - 1` singleton behavior.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.