### PR TITLE
fix: harden repartition gc cleanup

### DIFF
--- a/src/meta-srv/src/gc/procedure.rs
+++ b/src/meta-srv/src/gc/procedure.rs
@@ -47,6 +47,52 @@ use crate::metrics::{METRIC_META_GC_DATANODE_CALLS_TOTAL, METRIC_META_GC_FAILED_
 use crate::procedure::utils::{instruction_error_result, instruction_to_error};
 use crate::service::mailbox::{Channel, MailboxReceiver, MailboxRef};
 
+fn reconcile_region_repartition_mapping(
+    repartition_value: &mut TableRepartValue,
+    src_region: RegionId,
+    observed_manifest_dst_regions: &HashSet<RegionId>,
+    observed_dst_regions: Option<&HashSet<RegionId>>,
+    has_tmp_ref: bool,
+    source_gc_succeeded: bool,
+) {
+    let had_existing_entry = repartition_value.src_to_dst.contains_key(&src_region);
+    let mut next_dst_regions = repartition_value
+        .src_to_dst
+        .get(&src_region)
+        .cloned()
+        .unwrap_or_default();
+
+    if source_gc_succeeded && !has_tmp_ref {
+        // Only remove destinations whose manifest was actually observed by this GC cycle.
+        // Destinations without a manifest-version snapshot may be temporarily absent from current
+        // routes or otherwise unobserved; deleting them here would turn a partial ref snapshot
+        // into an irreversible dropped-region tombstone loss.
+        for dst_region in observed_manifest_dst_regions {
+            next_dst_regions.remove(dst_region);
+        }
+    }
+
+    if let Some(observed_dst_regions) = observed_dst_regions {
+        next_dst_regions.extend(observed_dst_regions.iter().copied());
+    }
+
+    if next_dst_regions.is_empty() {
+        if has_tmp_ref || (had_existing_entry && !source_gc_succeeded) {
+            // Keep an empty tombstone so dropped regions with only tmp refs stay discoverable by
+            // later dropped-region GC cycles.
+            repartition_value
+                .src_to_dst
+                .insert(src_region, BTreeSet::new());
+        } else {
+            repartition_value.src_to_dst.remove(&src_region);
+        }
+    } else {
+        repartition_value
+            .src_to_dst
+            .insert(src_region, next_dst_regions);
+    }
+}
+
 async fn send_get_file_refs_inner(
     mailbox: &MailboxRef,
     server_addr: &str,
@@ -427,18 +473,44 @@ impl BatchGcProcedure {
             for src_region in all_src_regions {
                 let cross_dst = cross_refs.get(&src_region);
                 let has_tmp_ref = tmp_refs.contains(&src_region);
-
-                if let Some(dst_regions) = cross_dst {
-                    let mut set = BTreeSet::new();
-                    set.extend(dst_regions.iter().copied());
-                    new_value.src_to_dst.insert(src_region, set);
-                } else if has_tmp_ref {
-                    // Keep a tombstone entry with an empty set so dropped regions that still
-                    // have tmp refs are preserved; removing it would lose the repartition trace.
-                    new_value.src_to_dst.insert(src_region, BTreeSet::new());
-                } else {
-                    new_value.src_to_dst.remove(&src_region);
+                let mut observed_manifest_dst = self
+                    .data
+                    .related_regions
+                    .get(&src_region)
+                    .into_iter()
+                    .flatten()
+                    .filter(|dst_region| {
+                        self.data
+                            .file_refs
+                            .manifest_version
+                            .contains_key(dst_region)
+                    })
+                    .copied()
+                    .collect::<HashSet<_>>();
+                if self
+                    .data
+                    .file_refs
+                    .manifest_version
+                    .contains_key(&src_region)
+                {
+                    // Reused source regions can also be repartition destinations. Query-region
+                    // manifest versions prove the source region's normal manifest was observed,
+                    // so self-mappings can be reconciled instead of being preserved forever.
+                    observed_manifest_dst.insert(src_region);
                 }
+                let source_gc_succeeded = self.data.gc_report.as_ref().is_some_and(|report| {
+                    report.processed_regions.contains(&src_region)
+                        && !report.need_retry_regions.contains(&src_region)
+                });
+
+                reconcile_region_repartition_mapping(
+                    &mut new_value,
+                    src_region,
+                    &observed_manifest_dst,
+                    cross_dst,
+                    has_tmp_ref,
+                    source_gc_succeeded,
+                );
             }
 
             // If there is no repartition info to persist, skip creating/updating the key
@@ -859,6 +931,151 @@ impl BatchGcProcedure {
         }
 
         Ok(all_report)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, BTreeSet, HashSet};
+
+    use super::*;
+
+    fn btree_set(regions: impl IntoIterator<Item = RegionId>) -> BTreeSet<RegionId> {
+        regions.into_iter().collect()
+    }
+
+    fn hash_set(regions: impl IntoIterator<Item = RegionId>) -> HashSet<RegionId> {
+        regions.into_iter().collect()
+    }
+
+    #[test]
+    fn test_reconcile_repartition_mapping_preserves_unobserved_destinations() {
+        let src = RegionId::new(1024, 1);
+        let observed = RegionId::new(1024, 2);
+        let unqueried = RegionId::new(1024, 3);
+        let mut value = TableRepartValue {
+            src_to_dst: BTreeMap::from([(src, btree_set([observed, unqueried]))]),
+        };
+
+        reconcile_region_repartition_mapping(
+            &mut value,
+            src,
+            &hash_set([observed]),
+            Some(&hash_set([observed])),
+            false,
+            true,
+        );
+
+        assert_eq!(
+            value.src_to_dst.get(&src).cloned(),
+            Some(btree_set([observed, unqueried]))
+        );
+    }
+
+    #[test]
+    fn test_reconcile_repartition_mapping_prunes_only_observed_manifest_destinations() {
+        let src = RegionId::new(1024, 1);
+        let stale_dst = RegionId::new(1024, 2);
+        let live_dst = RegionId::new(1024, 3);
+        let mut value = TableRepartValue {
+            src_to_dst: BTreeMap::from([(src, btree_set([stale_dst, live_dst]))]),
+        };
+
+        reconcile_region_repartition_mapping(
+            &mut value,
+            src,
+            &hash_set([stale_dst, live_dst]),
+            Some(&hash_set([live_dst])),
+            false,
+            true,
+        );
+
+        assert_eq!(
+            value.src_to_dst.get(&src).cloned(),
+            Some(btree_set([live_dst]))
+        );
+    }
+
+    #[test]
+    fn test_reconcile_repartition_mapping_tmp_refs_do_not_erase_existing_destinations() {
+        let src = RegionId::new(1024, 1);
+        let existing = RegionId::new(1024, 2);
+        let mut value = TableRepartValue {
+            src_to_dst: BTreeMap::from([(src, btree_set([existing]))]),
+        };
+
+        reconcile_region_repartition_mapping(
+            &mut value,
+            src,
+            &hash_set([existing]),
+            None,
+            true,
+            true,
+        );
+
+        assert_eq!(
+            value.src_to_dst.get(&src).cloned(),
+            Some(btree_set([existing]))
+        );
+    }
+
+    #[test]
+    fn test_reconcile_repartition_mapping_keeps_tmp_ref_tombstone() {
+        let src = RegionId::new(1024, 1);
+        let mut value = TableRepartValue::new();
+
+        reconcile_region_repartition_mapping(&mut value, src, &HashSet::new(), None, true, true);
+
+        assert_eq!(value.src_to_dst.get(&src), Some(&BTreeSet::new()));
+    }
+
+    #[test]
+    fn test_reconcile_repartition_mapping_keeps_mapping_without_query_proof() {
+        let src = RegionId::new(1024, 1);
+        let unqueried = RegionId::new(1024, 2);
+        let mut value = TableRepartValue {
+            src_to_dst: BTreeMap::from([(src, btree_set([unqueried]))]),
+        };
+
+        reconcile_region_repartition_mapping(&mut value, src, &HashSet::new(), None, false, false);
+
+        assert_eq!(
+            value.src_to_dst.get(&src).cloned(),
+            Some(btree_set([unqueried]))
+        );
+    }
+
+    #[test]
+    fn test_reconcile_repartition_mapping_preserves_positive_refs_on_retry() {
+        let src = RegionId::new(1024, 1);
+        let observed = RegionId::new(1024, 2);
+        let mut value = TableRepartValue::new();
+
+        reconcile_region_repartition_mapping(
+            &mut value,
+            src,
+            &hash_set([observed]),
+            Some(&hash_set([observed])),
+            false,
+            false,
+        );
+
+        assert_eq!(
+            value.src_to_dst.get(&src).cloned(),
+            Some(btree_set([observed]))
+        );
+    }
+
+    #[test]
+    fn test_reconcile_repartition_mapping_prunes_observed_self_destination() {
+        let src = RegionId::new(1024, 1);
+        let mut value = TableRepartValue {
+            src_to_dst: BTreeMap::from([(src, btree_set([src]))]),
+        };
+
+        reconcile_region_repartition_mapping(&mut value, src, &hash_set([src]), None, false, true);
+
+        assert!(!value.src_to_dst.contains_key(&src));
     }
 }
 

--- a/tests-integration/tests/repartition.rs
+++ b/tests-integration/tests/repartition.rs
@@ -124,6 +124,213 @@ async fn test_repartition_multi_hop_fulltext_index_gc_file() {
     }
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_repartition_multi_hop_plain_gc_full_file_listing_file() {
+    if StorageType::File.test_on() {
+        common_telemetry::init_default_ut_logging();
+        test_repartition_multi_hop_plain_gc_full_file_listing().await;
+    }
+}
+
+async fn test_repartition_multi_hop_plain_gc_full_file_listing() {
+    let store_type = StorageType::File;
+    let cluster_name = "test_repartition_multi_hop_plain_gc_full_file_listing";
+    let table_name = "repartition_multi_hop_plain_table";
+    let (store_config, _guard) = get_test_store_config(&store_type);
+    let datanodes = 3u64;
+    let home_dir = create_temp_dir("test_repartition_multi_hop_plain_gc_data_home");
+
+    let cluster = GreptimeDbClusterBuilder::new(cluster_name)
+        .await
+        .with_shared_home_dir(Arc::new(home_dir))
+        .with_datanodes(datanodes as u32)
+        .with_store_config(store_config)
+        .with_datanode_wal_config(DatanodeWalConfig::Noop)
+        .with_metasrv_gc_config(GcSchedulerOptions {
+            enable: true,
+            gc_cooldown_period: Duration::from_nanos(1),
+            ..Default::default()
+        })
+        .with_datanode_gc_config(GcConfig {
+            enable: true,
+            lingering_time: Some(Duration::from_secs(0)),
+            unknown_file_lingering_time: Duration::from_secs(0),
+            ..Default::default()
+        })
+        .build(true)
+        .await;
+    let metasrv = &cluster.metasrv;
+    let ticker = metasrv.gc_ticker().unwrap();
+
+    let query_ctx = QueryContext::arc();
+    let instance = cluster.fe_instance();
+
+    run_sql(
+        instance,
+        r#"
+        CREATE TABLE `repartition_multi_hop_plain_table`(
+          `id` INT,
+          `msg` STRING,
+          `ts` TIMESTAMP TIME INDEX,
+          PRIMARY KEY(`id`)
+        ) PARTITION ON COLUMNS (`id`) (
+          `id` < 100,
+          `id` >= 100
+        ) ENGINE = mito
+          WITH ('sst_format' = 'flat');
+    "#,
+        query_ctx.clone(),
+    )
+    .await
+    .unwrap();
+
+    run_sql(
+        instance,
+        r#"
+        INSERT INTO `repartition_multi_hop_plain_table` VALUES
+          (10, 'low partition', '2022-01-01 00:00:00'),
+          (60, 'middle partition', '2022-01-01 00:00:01'),
+          (90, 'high partition', '2022-01-01 00:00:02'),
+          (120, 'outer partition', '2022-01-01 00:00:03');
+    "#,
+        query_ctx.clone(),
+    )
+    .await
+    .unwrap();
+    run_sql(
+        instance,
+        "ADMIN FLUSH_TABLE('repartition_multi_hop_plain_table')",
+        query_ctx.clone(),
+    )
+    .await
+    .unwrap();
+
+    run_sql(
+        instance,
+        r#"
+        ALTER TABLE `repartition_multi_hop_plain_table` SPLIT PARTITION (
+          `id` < 100
+        ) INTO (
+          `id` < 50,
+          `id` >= 50 AND `id` < 100
+        );
+    "#,
+        query_ctx.clone(),
+    )
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    run_sql(
+        instance,
+        r#"
+        ALTER TABLE `repartition_multi_hop_plain_table` SPLIT PARTITION (
+          `id` >= 50 AND `id` < 100
+        ) INTO (
+          `id` >= 50 AND `id` < 75,
+          `id` >= 75 AND `id` < 100
+        );
+    "#,
+        query_ctx.clone(),
+    )
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    run_sql(
+        instance,
+        r#"
+        INSERT INTO `repartition_multi_hop_plain_table` VALUES
+          (80, 'fresh in soon dropped source', '2022-01-01 00:00:04');
+    "#,
+        query_ctx.clone(),
+    )
+    .await
+    .unwrap();
+    run_sql(
+        instance,
+        "ADMIN FLUSH_TABLE('repartition_multi_hop_plain_table')",
+        query_ctx.clone(),
+    )
+    .await
+    .unwrap();
+
+    let query = "SELECT id, msg FROM `repartition_multi_hop_plain_table` ORDER BY id";
+    let expected = "\
++-----+------------------------------+
+| id  | msg                          |
++-----+------------------------------+
+| 10  | low partition                |
+| 60  | middle partition             |
+| 80  | fresh in soon dropped source |
+| 90  | high partition               |
+| 120 | outer partition              |
++-----+------------------------------+";
+    let result = run_sql(instance, query, query_ctx.clone()).await.unwrap();
+    check_output_stream(result.data, expected).await;
+
+    let manifest_entries = cluster_manifest_data_entries(&cluster).await;
+    assert!(
+        manifest_entries
+            .iter()
+            .any(|(_, origin_region_id, region_id)| origin_region_id != region_id),
+        "expected at least one cross-origin data SST before GC, got {manifest_entries:?}"
+    );
+
+    run_sql(
+        instance,
+        r#"
+        ALTER TABLE `repartition_multi_hop_plain_table` MERGE PARTITION (
+          `id` >= 50 AND `id` < 75,
+          `id` >= 75 AND `id` < 100
+        );
+    "#,
+        query_ctx.clone(),
+    )
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    trigger_table_gc_with_full_file_listing(metasrv, table_name, true).await;
+    trigger_full_gc(&ticker).await;
+
+    let result = run_sql(instance, query, query_ctx.clone()).await.unwrap();
+    check_output_stream(result.data, expected).await;
+
+    let manifest_data_paths = cluster_manifest_data_paths(&cluster).await;
+    assert!(
+        !manifest_data_paths.is_empty(),
+        "expected manifest data paths after GC"
+    );
+    let storage_paths = cluster.list_sst_files_from_all_datanodes().await;
+    assert!(
+        manifest_data_paths.is_subset(&storage_paths),
+        "manifest data paths should exist in storage after GC, missing: {:?}",
+        manifest_data_paths
+            .difference(&storage_paths)
+            .collect::<Vec<_>>()
+    );
+
+    let cross_origin_data_paths = cluster_manifest_data_entries(&cluster)
+        .await
+        .into_iter()
+        .filter_map(|(file_path, origin_region_id, region_id)| {
+            (origin_region_id != region_id).then_some(file_path)
+        })
+        .collect::<BTreeSet<_>>();
+    assert!(
+        !cross_origin_data_paths.is_empty(),
+        "expected cross-origin data SSTs after GC"
+    );
+    assert!(
+        cross_origin_data_paths.is_subset(&storage_paths),
+        "cross-origin manifest data paths should exist in storage after GC, missing: {:?}",
+        cross_origin_data_paths
+            .difference(&storage_paths)
+            .collect::<Vec<_>>()
+    );
+}
+
 async fn test_repartition_multi_hop_fulltext_index_gc() {
     let store_type = StorageType::File;
     let cluster_name = "test_repartition_multi_hop_fulltext_index_gc";
@@ -780,6 +987,14 @@ ORDER BY partition_ordinal_position;",
 }
 
 async fn trigger_table_gc(metasrv: &Arc<Metasrv>, table_name: &str) {
+    trigger_table_gc_with_full_file_listing(metasrv, table_name, false).await;
+}
+
+async fn trigger_table_gc_with_full_file_listing(
+    metasrv: &Arc<Metasrv>,
+    table_name: &str,
+    full_file_listing: bool,
+) {
     info!("triggering table gc for table: {}", table_name);
     let table_metadata_manager = metasrv.table_metadata_manager();
     let table_id = table_metadata_manager
@@ -808,7 +1023,7 @@ async fn trigger_table_gc(metasrv: &Arc<Metasrv>, table_name: &str) {
         metasrv.table_metadata_manager().clone(),
         metasrv.options().grpc.server_addr.clone(),
         region_ids.clone(),
-        false,                   // full_file_listing
+        full_file_listing,
         Duration::from_secs(10), // timeout
         Default::default(),
     );
@@ -858,6 +1073,31 @@ async fn cluster_manifest_index_entries(
         );
     }
     entries
+}
+
+async fn cluster_manifest_data_entries(
+    cluster: &GreptimeDbCluster,
+) -> Vec<(String, RegionId, RegionId)> {
+    let mut entries = Vec::new();
+    for datanode in cluster.datanode_instances.values() {
+        let region_server = datanode.region_server();
+        let mito = region_server.mito_engine().unwrap();
+        entries.extend(
+            mito.all_ssts_from_manifest()
+                .await
+                .into_iter()
+                .map(|entry| (entry.file_path, entry.origin_region_id, entry.region_id)),
+        );
+    }
+    entries
+}
+
+async fn cluster_manifest_data_paths(cluster: &GreptimeDbCluster) -> BTreeSet<String> {
+    cluster_manifest_data_entries(cluster)
+        .await
+        .into_iter()
+        .map(|(file_path, _, _)| file_path)
+        .collect()
 }
 
 async fn cluster_manifest_index_paths(cluster: &GreptimeDbCluster) -> BTreeSet<String> {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up hardening after #8445.

#8441 is related to repartitioned index rebuild serialization, but intentionally out of scope here.

## What's changed and what's your intention?

This PR hardens `table_repart` cleanup to be fail-closed under partial GC file-reference observations.

Before this change, `cleanup_region_repartition()` rewrote a source region's destination set from exactly the destinations observed in the current GC file-ref snapshot. If a GC cycle had partial or retrying observations, that could shrink or remove the only persisted `table_repart` mapping used by later dropped-region GC cycles.

The new cleanup logic:

- starts from the existing source→destination mapping as the baseline;
- unions positive observed `cross_region_refs` instead of replacing existing mappings;
- prunes destinations only when the destination manifest was observed in this GC cycle, the source GC completed without retry, and there are no tmp refs;
- preserves empty tombstones when tmp refs or retry/no-success conditions mean the source should remain discoverable;
- handles source self-destinations when the source manifest was observed.

This PR also adds regression coverage:

- unit tests for preserving unobserved destinations, pruning only observed stale destinations, keeping tmp-ref tombstones, preserving positive refs on retry, and pruning observed self-destinations;
- a File-only integration test for plain non-index Mito data SSTs across multi-hop repartition, explicit `full_file_listing=true` table GC, full GC, query correctness, and manifest data path survival in storage.

Limitations / scope:

- This does not add broader GC/repartition locking.
- This does not enforce related manifest versions during deletion.
- `FileRefsManifest.manifest_version` is used only as proof that a normal manifest was observed for safe cleanup pruning.
- #8445's missing-related-target fail-closed behavior is a prerequisite, not reimplemented here.
- Rebuild-index serialization remains out of scope for this PR.

Compatibility:

- No API, wire-format, or persisted-format changes.

Validation:

- `cargo fmt -p meta-srv -p tests-integration -- --check`
- `git diff --check`
- `cargo nextest run -p meta-srv --features mock test_reconcile_repartition_mapping`
- `cargo test -p tests-integration --test main test_repartition_multi_hop_plain_gc_full_file_listing_file -- --nocapture`

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
