### PR TITLE
fix(query): delegate merge sort cardinality effect

### DIFF
--- a/src/query/src/dist_plan/merge_sort.rs
+++ b/src/query/src/dist_plan/merge_sort.rs
@@ -21,6 +21,7 @@ use std::fmt;
 use std::sync::Arc;
 
 use datafusion::execution::TaskContext;
+use datafusion::physical_plan::execution_plan::CardinalityEffect;
 use datafusion::physical_plan::metrics::MetricsSet;
 use datafusion::physical_plan::projection::{ProjectionExec, make_with_child, update_ordering};
 use datafusion::physical_plan::sorts::sort::SortExec;
@@ -251,6 +252,10 @@ impl ExecutionPlan for MergeSortExec {
 
     fn partition_statistics(&self, partition: Option<usize>) -> Result<Statistics> {
         self.inner.partition_statistics(partition)
+    }
+
+    fn cardinality_effect(&self) -> CardinalityEffect {
+        self.inner.cardinality_effect()
     }
 
     /// Intentionally keeps DataFusion's generic limit pushdown disabled.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

- https://github.com/GreptimeTeam/datafusion/pull/18
- https://github.com/apache/datafusion/pull/23359

## What's changed and what's your intention?

Delegate `MergeSortExec::cardinality_effect()` to its inner `SortPreservingMergeExec`.

`MergeSortExec` is an opaque GreptimeDB wrapper, so the inner operator's fetch-aware cardinality metadata does not propagate automatically. This keeps the wrapper consistent with its delegated statistics and reports `Equal` without fetch or `LowerEqual` with fetch once the related DataFusion change is available.

No API, schema, or data compatibility changes.

Local checks were intentionally not run for this small delegation-only change; CI will validate it.

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.