### PR TITLE
fix(ci): harden query regression runner

### DIFF
--- a/.github/runner-scale-sets/query-regression/Dockerfile
+++ b/.github/runner-scale-sets/query-regression/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update \
         git \
         gzip \
         jq \
+        libprotobuf-dev \
         libssl-dev \
         mold \
         openssh-client \
@@ -71,7 +72,9 @@ USER runner
 RUN set -eu \
     && test "$(id -u)" = "1001" \
     && temporary_cargo_home="$(mktemp --directory)" \
-    && trap 'rm -rf "${temporary_cargo_home}"' 0 \
+    && temporary_proto_dir="" \
+    && cleanup() { rm -rf "${temporary_cargo_home}" "${temporary_proto_dir}"; } \
+    && trap cleanup 0 \
     && export CARGO_HOME="${temporary_cargo_home}" \
     && test "${RUSTUP_AUTO_INSTALL}" = "0" \
     && rustup --version \
@@ -81,4 +84,18 @@ RUN set -eu \
     && printf 'Active toolchain: %s\n' "${active_toolchain}" \
     && case "${active_toolchain}" in "${RUST_TOOLCHAIN}-x86_64-unknown-linux-gnu"|"${RUST_TOOLCHAIN}-x86_64-unknown-linux-gnu "*) ;; *) exit 1;; esac \
     && test ! -w /opt/rustup \
-    && test ! -w /opt/cargo/bin
+    && test ! -w /opt/cargo/bin \
+    && test -r /usr/include/google/protobuf/any.proto \
+    && test -r /usr/include/google/protobuf/empty.proto \
+    && temporary_proto_dir="$(mktemp --directory)" \
+    && printf '%s\n' \
+        'syntax = "proto3";' \
+        'package smoke;' \
+        'import "google/protobuf/any.proto";' \
+        'import "google/protobuf/empty.proto";' \
+        'message Smoke { google.protobuf.Any any = 1; google.protobuf.Empty empty = 2; }' \
+        > "${temporary_proto_dir}/smoke.proto" \
+    && protoc --proto_path="${temporary_proto_dir}" --proto_path=/usr/include \
+        --descriptor_set_out="${temporary_proto_dir}/smoke.pb" \
+        "${temporary_proto_dir}/smoke.proto" \
+    && test -s "${temporary_proto_dir}/smoke.pb"

--- a/.github/runner-scale-sets/query-regression/README.md
+++ b/.github/runner-scale-sets/query-regression/README.md
@@ -56,13 +56,14 @@ egress to required GitHub Actions, artifact/cache, Rust/crate/toolchain, DNS,
 and image-registry endpoints; block unrelated cluster services, private ranges,
 and metadata endpoints unless a case requires them.
 
-### Office routing prerequisite
+### Network routing prerequisite
 
-Direct split routing through `.2` is an **external office-network prerequisite**.
-The gateway at `192.168.50.2` must route GitHub Actions, GitHub content,
-artifact/cache, crates.io, Rust toolchain, and image-registry traffic directly
-rather than through the VPN. Neither this repository nor Kubernetes configures
-that route. Verify it with the responsible network operator before any canary.
+Required split routing is an **external environment-specific prerequisite**. The
+responsible network operator must route GitHub Actions, GitHub content,
+artifact/cache, crates.io, Rust toolchain, and image-registry traffic through
+the approved path rather than the VPN where applicable. Neither this repository
+nor Kubernetes configures that route. Verify it with the responsible network
+operator before any canary.
 
 ## Runner image and workflow tools
 
@@ -85,11 +86,20 @@ Both digest-pinned init and runner containers use `IfNotPresent`: the immutable
 digest makes a cached image safe and avoids adding a registry dependency to every
 runner startup.
 
+The runner optionally imports only the non-sensitive `HTTP_PROXY`,
+`HTTPS_PROXY`, and `NO_PROXY` variables from the
+`query-regression-runner-local-env` ConfigMap. Manage that ConfigMap locally in
+the target namespace; private endpoint configuration must not be committed, and
+credentials or secrets must never be placed in a ConfigMap.
+
 Before builds, the workflow asserts UID/GID 1001 and exact image tool versions:
 `libprotoc 3.21.12`, `uv 0.11.26`, `mold 2.30.0`, `Python 3.12.3`, `sccache
 0.16.0`, root-owned `rustup 1.29.0`, and the image-baked
 `nightly-2026-03-21` Rust toolchain. Rustup, Cargo, and Rustc must resolve from
 `/opt/cargo/bin`; the runner cannot write `/opt/rustup` or `/opt/cargo/bin`.
+Protobuf well-known includes, including `google/protobuf/any.proto` and
+`google/protobuf/empty.proto`, are an image contract and must compile with
+`protoc`.
 `actions-rust-lang/setup-rust-toolchain@v1` is intentionally removed. The
 workflow sets its warning-denying mold `RUSTFLAGS` directly, disables automatic
 Rustup installation, and performs no runtime toolchain downloads.
@@ -107,6 +117,9 @@ corresponding cache or image contract changes.
 `queue: max`, and `cancel-in-progress: false`; admitted jobs queue rather than
 replacing older pending jobs. During maintenance, cancel admitted queued runs as
 well as pausing ARC. Runner Pods have `activeDeadlineSeconds=12600`.
+The runner requests 6 CPU and limits at 8 CPU to preserve `minipc-3`
+allocatable-capacity scheduling headroom; do not reset the request to 8 CPU
+without revalidating scheduling capacity.
 
 The cache claim `query-regression-build-cache` is a nominal 600Gi `local-path`
 PVC in `arc-runners`. It is `ReadWriteOnce`; `local-path` uses
@@ -184,7 +197,7 @@ exists; they are not mounted by the current configuration.
 
 ## Deploy and pause safely
 
-First verify external `.2` routing and the disk preflight. Apply the PVC; while
+First verify the configured external network route and the disk preflight. Apply the PVC; while
 the scale set is paused, it is expected to remain `Pending` because
 WaitForFirstConsumer has no scheduled runner:
 
@@ -263,8 +276,8 @@ ABI-marker output, initial/base/candidate sccache statistics, and cache report.
 Confirm the image tool contract (root-owned Rustup/Cargo paths, baked nightly,
 and non-writable `/opt` roots) and that the ephemeral Cargo home contains only
 the mounted registry/Git data before Cargo creates per-Pod state.
-Obtain dependency and tool network byte counters from the
-identified `.2` counter source, filtered to `minipc-3` and the dependency/tool
+Obtain dependency and tool network byte counters from the configured
+environment counter source, filtered to `minipc-3` and the dependency/tool
 destinations.
 
 Accept the canary only when all of the following hold:
@@ -278,7 +291,8 @@ Accept the canary only when all of the following hold:
 - warm dependency/tool network bytes are at most 10% of cold fill bytes;
 - cache sizes remain below soft watermarks, node free space remains at least
   300GiB, and the benchmark is correct without TLS EOFs or timeouts;
-- `.2` confirms this traffic is outside VPN accounting.
+- the configured environment counter source confirms this traffic is outside VPN
+  accounting.
 
 Immediately return to 0/0 after either canary unless ongoing normal operation
 has been explicitly approved; return immediately on any traffic, cache, disk,

--- a/.github/runner-scale-sets/query-regression/values-8-cores.yaml
+++ b/.github/runner-scale-sets/query-regression/values-8-cores.yaml
@@ -27,7 +27,7 @@ template:
           claimName: query-regression-build-cache
     initContainers:
       - name: initialize-build-cache
-        image: greptime-registry.cn-hangzhou.cr.aliyuncs.com/greptime/greptimedb-query-regression-runner@sha256:7022b551771dc82ec4c493f0c3db6ee3050ececd336598690a2165240ebe953e
+        image: greptime-registry.cn-hangzhou.cr.aliyuncs.com/greptime/greptimedb-query-regression-runner@sha256:2436278bf0756700c718927907cdbedac64d55c593f80b515acb44dec8b02cc1
         imagePullPolicy: IfNotPresent
         command:
           - /bin/sh
@@ -65,12 +65,32 @@ template:
             mountPath: /cache
     containers:
       - name: runner
-        image: greptime-registry.cn-hangzhou.cr.aliyuncs.com/greptime/greptimedb-query-regression-runner@sha256:7022b551771dc82ec4c493f0c3db6ee3050ececd336598690a2165240ebe953e
+        image: greptime-registry.cn-hangzhou.cr.aliyuncs.com/greptime/greptimedb-query-regression-runner@sha256:2436278bf0756700c718927907cdbedac64d55c593f80b515acb44dec8b02cc1
         imagePullPolicy: IfNotPresent
         command: ["/home/runner/run.sh"]
         env:
           - name: CARGO_HOME
             value: /home/runner/.cargo
+          - name: HTTP_PROXY
+            valueFrom:
+              configMapKeyRef:
+                name: query-regression-runner-local-env
+                key: HTTP_PROXY
+                optional: true
+          - name: HTTPS_PROXY
+            valueFrom:
+              configMapKeyRef:
+                name: query-regression-runner-local-env
+                key: HTTPS_PROXY
+                optional: true
+          - name: NO_PROXY
+            valueFrom:
+              configMapKeyRef:
+                name: query-regression-runner-local-env
+                key: NO_PROXY
+                optional: true
+          - name: UV_CACHE_DIR
+            value: /home/runner/.cargo/uv-cache
           - name: RUSTUP_HOME
             value: /opt/rustup
           - name: RUSTUP_TOOLCHAIN
@@ -99,7 +119,7 @@ template:
               - ALL
         resources:
           requests:
-            cpu: "8"
+            cpu: "6"
             memory: 24Gi
             ephemeral-storage: 80Gi
           limits:

--- a/.github/workflows/query-regression.yml
+++ b/.github/workflows/query-regression.yml
@@ -62,6 +62,7 @@ jobs:
     env:
       CARGO_PROFILE: ${{ github.event_name == 'pull_request' && 'nightly' || inputs.cargo_profile }}
       CARGO_HOME: /home/runner/.cargo
+      UV_CACHE_DIR: /home/runner/.cargo/uv-cache
       RUSTUP_HOME: /opt/rustup
       RUSTUP_TOOLCHAIN: nightly-2026-03-21
       RUSTUP_AUTO_INSTALL: "0"
@@ -111,6 +112,29 @@ jobs:
             [[ "$1" =~ ^[[:xdigit:]]{40}$ ]]
           }
 
+          fetch_with_retry() {
+            local ref="$1"
+            local depth="$2"
+            local attempt=1
+            local max_attempts=5
+            local delay
+
+            while (( attempt <= max_attempts )); do
+              if git fetch --no-tags --prune --depth="${depth}" origin "${ref}"; then
+                return 0
+              fi
+              printf 'Git fetch failed for %s (attempt %d/%d).\n' \
+                "${ref}" "${attempt}" "${max_attempts}" >&2
+              if (( attempt < max_attempts )); then
+                delay=$(( 2 ** (attempt - 1) ))
+                printf 'Retrying git fetch for %s in %d seconds.\n' "${ref}" "${delay}" >&2
+                sleep "${delay}"
+              fi
+              ((attempt += 1))
+            done
+            return 1
+          }
+
           initially_checked_out_base_sha="$(git rev-parse --verify HEAD)"
           is_full_sha "${initially_checked_out_base_sha}" || {
             printf 'Could not resolve initially checked-out BASE_REF commit.\n' >&2
@@ -123,7 +147,7 @@ jobs:
               is_full_sha "${value}" || fail_closed "Missing or invalid ${identity}."
             done
 
-            if ! git fetch --no-tags --prune --depth=2 origin "${EVENT_MERGE_SHA}"; then
+            if ! fetch_with_retry "${EVENT_MERGE_SHA}" 2; then
               fail_closed "Could not fetch event merge SHA ${EVENT_MERGE_SHA}."
             fi
             fetched_sha="$(git rev-parse --verify FETCH_HEAD 2>/dev/null)" \
@@ -148,7 +172,10 @@ jobs:
               || fail_closed "Event merge SHA has no non-head parent for the base build."
             VERIFIED_CANDIDATE_SHA="${fetched_sha,,}"
           else
-            git fetch --no-tags --prune --depth=1 origin "${CANDIDATE_REF}"
+            if ! fetch_with_retry "${CANDIDATE_REF}" 1; then
+              printf 'Could not fetch candidate ref %s.\n' "${CANDIDATE_REF}" >&2
+              exit 1
+            fi
             VERIFIED_CANDIDATE_SHA="$(git rev-parse --verify FETCH_HEAD)"
             VERIFIED_BASE_SHA="${initially_checked_out_base_sha}"
           fi
@@ -176,7 +203,23 @@ jobs:
           set -euo pipefail
           [[ "$(id -u)" == "1001" ]]
           [[ "$(id -g)" == "1001" ]]
+          [[ "${UV_CACHE_DIR}" == "/home/runner/.cargo/uv-cache" ]]
           [[ "$(protoc --version)" == "libprotoc 3.21.12" ]]
+          temporary_proto_dir="$(mktemp --directory)"
+          trap 'rm -rf "${temporary_proto_dir}"' EXIT
+          test -r /usr/include/google/protobuf/any.proto
+          test -r /usr/include/google/protobuf/empty.proto
+          printf '%s\n' \
+            'syntax = "proto3";' \
+            'package smoke;' \
+            'import "google/protobuf/any.proto";' \
+            'import "google/protobuf/empty.proto";' \
+            'message Smoke { google.protobuf.Any any = 1; google.protobuf.Empty empty = 2; }' \
+            > "${temporary_proto_dir}/smoke.proto"
+          protoc --proto_path="${temporary_proto_dir}" --proto_path=/usr/include \
+            --descriptor_set_out="${temporary_proto_dir}/smoke.pb" \
+            "${temporary_proto_dir}/smoke.proto"
+          test -s "${temporary_proto_dir}/smoke.pb"
           [[ "$(uv --version)" =~ ^uv[[:space:]]0\.11\.26([[:space:]]|$) ]]
           mold_version="$(mold --version)"
           [[ "${mold_version}" =~ ^mold[[:space:]]2\.30\.0([[:space:]]|$) ]]
@@ -213,13 +256,14 @@ jobs:
           readonly EXPECTED_CARGO_HOME="/home/runner/.cargo"
           readonly EXPECTED_CARGO_REGISTRY="/home/runner/.cargo/registry"
           readonly EXPECTED_CARGO_GIT="/home/runner/.cargo/git"
+          readonly EXPECTED_UV_CACHE_DIR="/home/runner/.cargo/uv-cache"
           readonly EXPECTED_RUSTUP_HOME="/opt/rustup"
           readonly EXPECTED_TARGET_DIR="/home/runner/query-regression-target"
           readonly EXPECTED_CACHE_META="/home/runner/query-regression-cache-meta"
           readonly EXPECTED_SCCACHE_DIR="/home/runner/.cache/sccache"
           readonly EXPECTED_RUSTC_WRAPPER="/usr/local/bin/sccache"
-          readonly RUNNER_IMAGE_DIGEST="sha256:7022b551771dc82ec4c493f0c3db6ee3050ececd336598690a2165240ebe953e"
-          readonly RUNNER_IMAGE_EPOCH="3"
+          readonly RUNNER_IMAGE_DIGEST="sha256:2436278bf0756700c718927907cdbedac64d55c593f80b515acb44dec8b02cc1"
+          readonly RUNNER_IMAGE_EPOCH="4"
 
           require_expected_root() {
             local name="$1"
@@ -276,6 +320,7 @@ jobs:
           require_expected_root CARGO_HOME "${CARGO_HOME}" "${EXPECTED_CARGO_HOME}"
           require_expected_root CARGO_REGISTRY "${CARGO_HOME}/registry" "${EXPECTED_CARGO_REGISTRY}"
           require_expected_root CARGO_GIT "${CARGO_HOME}/git" "${EXPECTED_CARGO_GIT}"
+          require_expected_root UV_CACHE_DIR "${UV_CACHE_DIR}" "${EXPECTED_UV_CACHE_DIR}"
           require_expected_root RUSTUP_HOME "${RUSTUP_HOME}" "${EXPECTED_RUSTUP_HOME}"
           require_expected_root CARGO_TARGET_DIR "${CARGO_TARGET_DIR}" "${EXPECTED_TARGET_DIR}"
           require_expected_root QUERY_REGRESSION_CACHE_META "${QUERY_REGRESSION_CACHE_META}" "${EXPECTED_CACHE_META}"
@@ -295,10 +340,10 @@ jobs:
           test -r "${RUSTUP_HOME}"
           test -x "${RUSTUP_HOME}"
           test ! -w "${RUSTUP_HOME}"
-          mkdir -p "${CARGO_HOME}" "${CARGO_HOME}/registry" "${CARGO_HOME}/git" \
+          mkdir -p "${CARGO_HOME}" "${CARGO_HOME}/registry" "${CARGO_HOME}/git" "${UV_CACHE_DIR}" \
             "${CARGO_TARGET_DIR}" "${QUERY_REGRESSION_CACHE_META}" "${SCCACHE_DIR}"
           for root in "${CARGO_HOME}" "${CARGO_HOME}/registry" "${CARGO_HOME}/git" \
-            "${CARGO_TARGET_DIR}" "${QUERY_REGRESSION_CACHE_META}" "${SCCACHE_DIR}"; do
+            "${UV_CACHE_DIR}" "${CARGO_TARGET_DIR}" "${QUERY_REGRESSION_CACHE_META}" "${SCCACHE_DIR}"; do
             test -w "${root}"
             touch "${root}/.query-regression-write-test"
             rm -f "${root}/.query-regression-write-test"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up to #8474.

## What's changed and what's your intention?

- Install `libprotobuf-dev` in the query-regression runner image and fail fast by compiling Protobuf well-known imports during image construction and workflow startup.
- Pin the validated runner image digest and bump its cache ABI epoch.
- Put uv cache data in the per-Pod writable Cargo home.
- Retry immutable Git fetches without weakening SHA or merge-parent validation.
- Request 6 CPUs while retaining an 8 CPU limit so the runner remains schedulable on `minipc-3`.
- Allow only `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` from an optional environment-local ConfigMap; no private endpoint is committed.
- Document the image, network, CPU, and cache contracts.

The pushed image is pinned as `sha256:2436278bf0756700c718927907cdbedac64d55c593f80b515acb44dec8b02cc1`. A real labeled-PR smoke passed end to end in [run 29395007276, attempt 5](https://github.com/GreptimeTeam/greptimedb/actions/runs/29395007276/attempts/5): base and candidate builds, fixtures, query regression, artifacts, cache reporting, and ARC scale-down all succeeded.

## PR Checklist

- [x] I have written the necessary rustdoc comments. (Not applicable: CI configuration only.)
- [x] I have added the necessary unit tests and integration tests. (Image/runtime smoke plus a real end-to-end run.)
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible. (No API change.)
- [x] Schema or data changes are backward compatible. (No schema or data change.)