### PR TITLE
fix(metric-engine): validate logical projection indices

### DIFF
--- a/src/metric-engine/src/engine/read.rs
+++ b/src/metric-engine/src/engine/read.rs
@@ -25,7 +25,8 @@ use store_api::storage::{RegionId, ScanRequest, SequenceNumber};
 
 use crate::engine::MetricEngineInner;
 use crate::error::{
-    InvalidMetadataSnafu, LogicalRegionNotFoundSnafu, MitoReadOperationSnafu, Result,
+    InvalidMetadataSnafu, InvalidRequestSnafu, LogicalRegionNotFoundSnafu, MitoReadOperationSnafu,
+    Result,
 };
 use crate::metrics::MITO_OPERATION_ELAPSED;
 use crate::utils;
@@ -192,8 +193,16 @@ impl MetricEngineInner {
             .await?;
         let projected_logical_names = origin_projection
             .iter()
-            .map(|i| all_logical_columns[*i].clone())
-            .collect::<Vec<_>>();
+            .map(|&index| {
+                all_logical_columns
+                    .get(index)
+                    .cloned()
+                    .with_context(|| InvalidRequestSnafu {
+                        region_id: logical_region_id,
+                        reason: format!("projection index {index} is out of bounds"),
+                    })
+            })
+            .collect::<Result<Vec<_>>>()?;
 
         // generate physical projection
         let mut physical_projection = Vec::with_capacity(origin_projection.len());
@@ -302,12 +311,41 @@ impl MetricEngineInner {
 
 #[cfg(test)]
 mod test {
+    use common_error::ext::ErrorExt;
+    use common_error::status_code::StatusCode;
     use store_api::region_request::RegionRequest;
 
     use super::*;
     use crate::test_util::{
         TestEnv, alter_logical_region_add_tag_columns, create_logical_region_request,
     };
+
+    #[tokio::test]
+    async fn test_invalid_logical_projection() {
+        let env = TestEnv::new().await;
+        env.init_metric_region().await;
+
+        let logical_region_id = env.default_logical_region_id();
+        let invalid_index = usize::MAX;
+        let request = ScanRequest {
+            projection_input: Some(vec![invalid_index].into()),
+            ..Default::default()
+        };
+
+        let error =
+            match RegionEngine::handle_query(&env.metric(), logical_region_id, request).await {
+                Ok(_) => panic!("invalid logical projection unexpectedly succeeded"),
+                Err(error) => error,
+            };
+
+        assert_eq!(error.status_code(), StatusCode::InvalidArguments);
+        assert!(
+            error.to_string().contains(&format!(
+                "projection index {invalid_index} is out of bounds"
+            )),
+            "unexpected error: {error}"
+        );
+    }
 
     #[tokio::test]
     async fn test_transform_scan_req() {

--- a/src/metric-engine/src/engine/read.rs
+++ b/src/metric-engine/src/engine/read.rs
@@ -196,7 +196,7 @@ impl MetricEngineInner {
             .map(|&index| {
                 all_logical_columns
                     .get(index)
-                    .cloned()
+                    .map(String::as_str)
                     .with_context(|| InvalidRequestSnafu {
                         region_id: logical_region_id,
                         reason: format!("projection index {index} is out of bounds"),
@@ -215,7 +215,7 @@ impl MetricEngineInner {
 
         for name in projected_logical_names {
             // Safety: logical columns is a strict subset of physical columns
-            physical_projection.push(physical_metadata.column_index_by_name(&name).unwrap());
+            physical_projection.push(physical_metadata.column_index_by_name(name).unwrap());
         }
 
         Ok(physical_projection)


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

N/A

## What's changed and what's your intention?

Metric Engine rewrites public logical-region projection indices into physical-region indices. It previously indexed the logical column list directly, so an invalid projection such as `usize::MAX` panicked before Mito could validate the request.

This PR:

- validates each logical projection index with a checked lookup;
- returns the existing `InvalidRequest` error, exposed as `InvalidArguments`, with the logical region ID and offending index;
- adds a regression test through the public `RegionEngine::handle_query` path.

The change does not alter wire, persisted, schema, or data formats.

Validation:

- Regression test before the fix: panic reproduced 4/4.
- `CARGO_BUILD_JOBS=1 cargo nextest run -p metric-engine --lib -E 'test(engine::read::test::test_invalid_logical_projection)' --no-fail-fast`
- `CARGO_BUILD_JOBS=1 cargo nextest run -p metric-engine --lib -E 'test(engine::read::test)' --no-fail-fast`
- `cargo fmt --all`
- `git diff --check`

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
