### PR TITLE
fix(mito2): serialize local file publication with GC

### DIFF
--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -17,6 +17,7 @@ use std::time::{Duration, Instant};
 
 use async_stream::try_stream;
 use common_time::Timestamp;
+use futures::future::try_join_all;
 use futures::{Stream, TryStreamExt};
 use object_store::services::Fs;
 use object_store::util::{join_dir, with_instrument_layers};
@@ -200,28 +201,28 @@ impl AccessLayer {
         logical_region_id: RegionId,
         files: &[FileMeta],
     ) -> Result<()> {
+        let mut validations = Vec::with_capacity(files.len() * 2);
         for file in files {
             let path = location::sst_file_path(&self.table_dir, file.file_id(), self.path_type);
-            self.validate_publication_object(
+            validations.push(self.validate_publication_object(
                 logical_region_id,
                 file.file_id().file_id(),
                 path,
                 file.file_size,
-            )
-            .await?;
+            ));
 
             if file.exists_index() {
                 let index_id = file.index_id();
                 let path = location::index_file_path(&self.table_dir, index_id, self.path_type);
-                self.validate_publication_object(
+                validations.push(self.validate_publication_object(
                     logical_region_id,
                     index_id.file_id(),
                     path,
                     file.index_file_size(),
-                )
-                .await?;
+                ));
             }
         }
+        try_join_all(validations).await?;
         Ok(())
     }
 

--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -22,7 +22,7 @@ use object_store::services::Fs;
 use object_store::util::{join_dir, with_instrument_layers};
 use object_store::{ATOMIC_WRITE_DIR, ErrorKind, OLD_ATOMIC_WRITE_DIR, ObjectStore};
 use smallvec::SmallVec;
-use snafu::ResultExt;
+use snafu::{IntoError, ResultExt};
 use store_api::metadata::RegionMetadataRef;
 use store_api::region_request::PathType;
 use store_api::sst_entry::StorageSstEntry;
@@ -33,12 +33,13 @@ use crate::cache::file_cache::{FileCacheRef, FileType, IndexKey};
 use crate::cache::write_cache::SstUploadRequest;
 use crate::config::{BloomFilterConfig, FulltextIndexConfig, IndexConfig, InvertedIndexConfig};
 use crate::error::{
-    CleanDirSnafu, DeleteIndexSnafu, DeleteIndexesSnafu, DeleteSstsSnafu, OpenDalSnafu, Result,
+    CleanDirSnafu, DeleteIndexSnafu, DeleteIndexesSnafu, DeleteSstsSnafu, OpenDalSnafu,
+    PublicationObjectStatSnafu, PublicationSizeMismatchSnafu, Result,
 };
 use crate::metrics::{COMPACTION_STAGE_ELAPSED, FLUSH_ELAPSED};
 use crate::read::FlatSource;
 use crate::region::options::IndexOptions;
-use crate::sst::file::{FileHandle, RegionFileId, RegionIndexId};
+use crate::sst::file::{FileHandle, FileMeta, RegionFileId, RegionIndexId};
 use crate::sst::index::IndexerBuilderImpl;
 use crate::sst::index::intermediate::IntermediateManager;
 use crate::sst::index::puffin_manager::{PuffinManagerFactory, SstPuffinManager};
@@ -188,6 +189,69 @@ impl AccessLayer {
     /// Returns the object store of the layer.
     pub fn object_store(&self) -> &ObjectStore {
         &self.object_store
+    }
+
+    /// Validates that files about to be published by a manifest edit are visible in object storage.
+    ///
+    /// A zero expected size is treated as unknown for compatibility, but the object must still
+    /// exist. Index validation always uses the file metadata's current index version.
+    pub(crate) async fn validate_publication_files(
+        &self,
+        logical_region_id: RegionId,
+        files: &[FileMeta],
+    ) -> Result<()> {
+        for file in files {
+            let path = location::sst_file_path(&self.table_dir, file.file_id(), self.path_type);
+            self.validate_publication_object(
+                logical_region_id,
+                file.file_id().file_id(),
+                path,
+                file.file_size,
+            )
+            .await?;
+
+            if file.exists_index() {
+                let index_id = file.index_id();
+                let path = location::index_file_path(&self.table_dir, index_id, self.path_type);
+                self.validate_publication_object(
+                    logical_region_id,
+                    index_id.file_id(),
+                    path,
+                    file.index_file_size(),
+                )
+                .await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn validate_publication_object(
+        &self,
+        logical_region_id: RegionId,
+        file_id: FileId,
+        path: String,
+        expected_size: u64,
+    ) -> Result<()> {
+        let metadata = self.object_store.stat(&path).await.map_err(|error| {
+            PublicationObjectStatSnafu {
+                region_id: logical_region_id,
+                file_id,
+                path: path.clone(),
+            }
+            .into_error(error)
+        })?;
+        let actual_size = metadata.content_length();
+        if expected_size != 0 && actual_size != expected_size {
+            return PublicationSizeMismatchSnafu {
+                region_id: logical_region_id,
+                file_id,
+                path,
+                expected_size,
+                actual_size,
+            }
+            .fail();
+        }
+        Ok(())
     }
 
     /// Returns the path type of the layer.
@@ -717,5 +781,267 @@ impl FilePathProvider for RegionFilePathFactory {
 
     fn build_sst_file_path(&self, file_id: RegionFileId) -> String {
         location::sst_file_path(&self.table_dir, file_id, self.path_type)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common_error::ext::{ErrorExt, RetryHint};
+    use common_error::status_code::StatusCode;
+    use common_test_util::temp_dir::{TempDir, create_temp_dir};
+    use object_store::services::Fs;
+
+    use super::*;
+    use crate::sst::file::IndexType;
+    use crate::sst::index::intermediate::IntermediateManager;
+    use crate::sst::index::puffin_manager::PuffinManagerFactory;
+    use crate::test_util::scheduler_util::SchedulerEnv;
+
+    fn file_meta(region_id: RegionId, file_size: u64) -> FileMeta {
+        FileMeta {
+            region_id,
+            file_id: FileId::random(),
+            file_size,
+            ..Default::default()
+        }
+    }
+
+    async fn write_parquet(access_layer: &AccessLayer, file: &FileMeta, bytes: Vec<u8>) {
+        let path = location::sst_file_path(
+            access_layer.table_dir(),
+            file.file_id(),
+            access_layer.path_type(),
+        );
+        access_layer
+            .object_store()
+            .write(&path, bytes)
+            .await
+            .unwrap();
+    }
+
+    async fn access_layer_with_path_type(
+        table_dir: &str,
+        path_type: PathType,
+    ) -> (TempDir, AccessLayer) {
+        let data_dir = create_temp_dir("publication-validator");
+        let root = data_dir.path().display().to_string();
+        let index_aux_path = data_dir.path().join("index_aux");
+        let puffin_manager = PuffinManagerFactory::new(&index_aux_path, 4096, None, None)
+            .await
+            .unwrap();
+        let intermediate_manager = IntermediateManager::init_fs(index_aux_path.to_str().unwrap())
+            .await
+            .unwrap();
+        let access_layer = AccessLayer::new(
+            table_dir,
+            path_type,
+            ObjectStore::new(Fs::default().root(&root))
+                .unwrap()
+                .finish(),
+            puffin_manager,
+            intermediate_manager,
+        );
+        (data_dir, access_layer)
+    }
+
+    #[tokio::test]
+    async fn test_validate_publication_files_valid_parquet() {
+        let env = SchedulerEnv::new().await;
+        let region_id = RegionId::new(1, 1);
+        let file = file_meta(region_id, 0);
+        write_parquet(&env.access_layer, &file, b"sst".to_vec()).await;
+
+        env.access_layer
+            .validate_publication_files(region_id, &[file])
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_validate_publication_files_rejects_missing_parquet() {
+        let env = SchedulerEnv::new().await;
+        let region_id = RegionId::new(1, 1);
+        let file = file_meta(region_id, 3);
+
+        let err = env
+            .access_layer
+            .validate_publication_files(region_id, &[file])
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::Error::PublicationObjectStat { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_validate_publication_files_rejects_parquet_size_mismatch() {
+        let env = SchedulerEnv::new().await;
+        let region_id = RegionId::new(1, 1);
+        let file = file_meta(region_id, 4);
+        write_parquet(&env.access_layer, &file, b"sst".to_vec()).await;
+
+        let err = env
+            .access_layer
+            .validate_publication_files(region_id, &[file.clone()])
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            &err,
+            crate::error::Error::PublicationSizeMismatch { .. }
+        ));
+        assert_eq!(err.status_code(), StatusCode::StorageUnavailable);
+        assert_eq!(err.retry_hint(), RetryHint::Retryable);
+    }
+
+    #[tokio::test]
+    async fn test_validate_publication_files_without_index_does_not_require_puffin() {
+        let env = SchedulerEnv::new().await;
+        let region_id = RegionId::new(1, 1);
+        let file = file_meta(region_id, 3);
+        write_parquet(&env.access_layer, &file, b"sst".to_vec()).await;
+
+        env.access_layer
+            .validate_publication_files(region_id, &[file])
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_validate_publication_files_rejects_missing_or_wrong_versioned_index() {
+        let env = SchedulerEnv::new().await;
+        let region_id = RegionId::new(1, 1);
+        let mut file = file_meta(region_id, 3);
+        file.available_indexes.push(IndexType::InvertedIndex);
+        file.index_version = 7;
+        file.index_file_size = 5;
+        write_parquet(&env.access_layer, &file, b"sst".to_vec()).await;
+
+        assert!(matches!(
+            env.access_layer
+                .validate_publication_files(region_id, &[file.clone()])
+                .await,
+            Err(crate::error::Error::PublicationObjectStat { .. })
+        ));
+
+        let legacy_path = location::index_file_path(
+            env.access_layer.table_dir(),
+            RegionIndexId::new(file.file_id(), 0),
+            env.access_layer.path_type(),
+        );
+        env.access_layer
+            .object_store()
+            .write(&legacy_path, b"index".to_vec())
+            .await
+            .unwrap();
+        assert!(matches!(
+            env.access_layer
+                .validate_publication_files(region_id, &[file.clone()])
+                .await,
+            Err(crate::error::Error::PublicationObjectStat { .. })
+        ));
+
+        let current_path = location::index_file_path(
+            env.access_layer.table_dir(),
+            file.index_id(),
+            env.access_layer.path_type(),
+        );
+        env.access_layer
+            .object_store()
+            .write(&current_path, b"bad".to_vec())
+            .await
+            .unwrap();
+        assert!(matches!(
+            env.access_layer
+                .validate_publication_files(region_id, &[file.clone()])
+                .await,
+            Err(crate::error::Error::PublicationSizeMismatch { .. })
+        ));
+
+        env.access_layer
+            .object_store()
+            .write(&current_path, b"index".to_vec())
+            .await
+            .unwrap();
+        env.access_layer
+            .validate_publication_files(region_id, &[file])
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_validate_publication_files_uses_file_origin_region_and_layer_path_type() {
+        let (_data_dir, access_layer) = access_layer_with_path_type("table", PathType::Data).await;
+        let logical_region_id = RegionId::new(1, 1);
+        let file_origin_region_id = RegionId::new(1, 2);
+        let file = file_meta(file_origin_region_id, 3);
+        write_parquet(&access_layer, &file, b"sst".to_vec()).await;
+
+        access_layer
+            .validate_publication_files(logical_region_id, &[file])
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_validate_publication_files_accepts_zero_expected_index_size_but_rejects_missing()
+    {
+        let env = SchedulerEnv::new().await;
+        let region_id = RegionId::new(1, 1);
+        let mut file = file_meta(region_id, 0);
+        file.available_indexes.push(IndexType::InvertedIndex);
+        file.index_version = 4;
+        write_parquet(&env.access_layer, &file, b"sst".to_vec()).await;
+
+        assert!(matches!(
+            env.access_layer
+                .validate_publication_files(region_id, &[file.clone()])
+                .await,
+            Err(crate::error::Error::PublicationObjectStat { .. })
+        ));
+
+        let path = location::index_file_path(
+            env.access_layer.table_dir(),
+            file.index_id(),
+            env.access_layer.path_type(),
+        );
+        env.access_layer
+            .object_store()
+            .write(&path, b"any-size".to_vec())
+            .await
+            .unwrap();
+        env.access_layer
+            .validate_publication_files(region_id, &[file])
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_publication_object_stat_preserves_not_found_source_and_is_retryable() {
+        let env = SchedulerEnv::new().await;
+        let logical_region_id = RegionId::new(1, 1);
+        let file = file_meta(RegionId::new(1, 2), 0);
+        let err = env
+            .access_layer
+            .validate_publication_files(logical_region_id, &[file.clone()])
+            .await
+            .unwrap_err();
+
+        match &err {
+            crate::error::Error::PublicationObjectStat {
+                region_id,
+                file_id,
+                error,
+                ..
+            } => {
+                assert_eq!(*region_id, logical_region_id);
+                assert_eq!(*file_id, file.file_id);
+                assert_eq!(error.kind(), ErrorKind::NotFound);
+            }
+            other => panic!("unexpected publication validator error: {other:?}"),
+        }
+        assert!(std::error::Error::source(&err).is_some());
+        assert_eq!(err.status_code(), StatusCode::StorageUnavailable);
+        assert_eq!(err.retry_hint(), RetryHint::Retryable);
     }
 }

--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -17,8 +17,7 @@ use std::time::{Duration, Instant};
 
 use async_stream::try_stream;
 use common_time::Timestamp;
-use futures::future::try_join_all;
-use futures::{Stream, TryStreamExt};
+use futures::{Stream, StreamExt, TryStreamExt};
 use object_store::services::Fs;
 use object_store::util::{join_dir, with_instrument_layers};
 use object_store::{ATOMIC_WRITE_DIR, ErrorKind, OLD_ATOMIC_WRITE_DIR, ObjectStore};
@@ -192,19 +191,20 @@ impl AccessLayer {
         &self.object_store
     }
 
-    /// Validates that files about to be published by a manifest edit are visible in object storage.
+    /// Validates local files about to be published by a normal manifest edit.
     ///
     /// A zero expected size is treated as unknown for compatibility, but the object must still
     /// exist. Index validation always uses the file metadata's current index version.
-    pub(crate) async fn validate_publication_files(
+    pub(crate) async fn validate_local_publication_files(
         &self,
         logical_region_id: RegionId,
         files: &[FileMeta],
     ) -> Result<()> {
+        debug_assert!(files.iter().all(|file| file.region_id == logical_region_id));
         let mut validations = Vec::with_capacity(files.len() * 2);
         for file in files {
             let path = location::sst_file_path(&self.table_dir, file.file_id(), self.path_type);
-            validations.push(self.validate_publication_object(
+            validations.push(self.validate_local_publication_object(
                 logical_region_id,
                 file.file_id().file_id(),
                 path,
@@ -214,7 +214,7 @@ impl AccessLayer {
             if file.exists_index() {
                 let index_id = file.index_id();
                 let path = location::index_file_path(&self.table_dir, index_id, self.path_type);
-                validations.push(self.validate_publication_object(
+                validations.push(self.validate_local_publication_object(
                     logical_region_id,
                     index_id.file_id(),
                     path,
@@ -222,11 +222,14 @@ impl AccessLayer {
                 ));
             }
         }
-        try_join_all(validations).await?;
+        futures::stream::iter(validations)
+            .buffer_unordered(8)
+            .try_collect::<Vec<_>>()
+            .await?;
         Ok(())
     }
 
-    async fn validate_publication_object(
+    async fn validate_local_publication_object(
         &self,
         logical_region_id: RegionId,
         file_id: FileId,
@@ -789,13 +792,9 @@ impl FilePathProvider for RegionFilePathFactory {
 mod tests {
     use common_error::ext::{ErrorExt, RetryHint};
     use common_error::status_code::StatusCode;
-    use common_test_util::temp_dir::{TempDir, create_temp_dir};
-    use object_store::services::Fs;
 
     use super::*;
     use crate::sst::file::IndexType;
-    use crate::sst::index::intermediate::IntermediateManager;
-    use crate::sst::index::puffin_manager::PuffinManagerFactory;
     use crate::test_util::scheduler_util::SchedulerEnv;
 
     fn file_meta(region_id: RegionId, file_size: u64) -> FileMeta {
@@ -820,53 +819,28 @@ mod tests {
             .unwrap();
     }
 
-    async fn access_layer_with_path_type(
-        table_dir: &str,
-        path_type: PathType,
-    ) -> (TempDir, AccessLayer) {
-        let data_dir = create_temp_dir("publication-validator");
-        let root = data_dir.path().display().to_string();
-        let index_aux_path = data_dir.path().join("index_aux");
-        let puffin_manager = PuffinManagerFactory::new(&index_aux_path, 4096, None, None)
-            .await
-            .unwrap();
-        let intermediate_manager = IntermediateManager::init_fs(index_aux_path.to_str().unwrap())
-            .await
-            .unwrap();
-        let access_layer = AccessLayer::new(
-            table_dir,
-            path_type,
-            ObjectStore::new(Fs::default().root(&root))
-                .unwrap()
-                .finish(),
-            puffin_manager,
-            intermediate_manager,
-        );
-        (data_dir, access_layer)
-    }
-
     #[tokio::test]
-    async fn test_validate_publication_files_valid_parquet() {
+    async fn test_validate_local_publication_files_valid_parquet() {
         let env = SchedulerEnv::new().await;
-        let region_id = RegionId::new(1, 1);
-        let file = file_meta(region_id, 0);
+        let expected_region_id = RegionId::new(1, 1);
+        let file = file_meta(expected_region_id, 0);
         write_parquet(&env.access_layer, &file, b"sst".to_vec()).await;
 
         env.access_layer
-            .validate_publication_files(region_id, &[file])
+            .validate_local_publication_files(expected_region_id, &[file])
             .await
             .unwrap();
     }
 
     #[tokio::test]
-    async fn test_validate_publication_files_rejects_missing_parquet() {
+    async fn test_validate_local_publication_files_rejects_missing_parquet() {
         let env = SchedulerEnv::new().await;
         let region_id = RegionId::new(1, 1);
         let file = file_meta(region_id, 3);
 
         let err = env
             .access_layer
-            .validate_publication_files(region_id, &[file])
+            .validate_local_publication_files(region_id, &[file])
             .await
             .unwrap_err();
         assert!(matches!(
@@ -876,7 +850,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_validate_publication_files_rejects_parquet_size_mismatch() {
+    async fn test_validate_local_publication_files_rejects_parquet_size_mismatch() {
         let env = SchedulerEnv::new().await;
         let region_id = RegionId::new(1, 1);
         let file = file_meta(region_id, 4);
@@ -884,7 +858,7 @@ mod tests {
 
         let err = env
             .access_layer
-            .validate_publication_files(region_id, &[file.clone()])
+            .validate_local_publication_files(region_id, &[file.clone()])
             .await
             .unwrap_err();
         assert!(matches!(
@@ -896,20 +870,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_validate_publication_files_without_index_does_not_require_puffin() {
+    async fn test_validate_local_publication_files_without_index_does_not_require_puffin() {
         let env = SchedulerEnv::new().await;
         let region_id = RegionId::new(1, 1);
         let file = file_meta(region_id, 3);
         write_parquet(&env.access_layer, &file, b"sst".to_vec()).await;
 
         env.access_layer
-            .validate_publication_files(region_id, &[file])
+            .validate_local_publication_files(region_id, &[file])
             .await
             .unwrap();
     }
 
     #[tokio::test]
-    async fn test_validate_publication_files_rejects_missing_or_wrong_versioned_index() {
+    async fn test_validate_local_publication_files_rejects_missing_or_wrong_versioned_index() {
         let env = SchedulerEnv::new().await;
         let region_id = RegionId::new(1, 1);
         let mut file = file_meta(region_id, 3);
@@ -920,7 +894,7 @@ mod tests {
 
         assert!(matches!(
             env.access_layer
-                .validate_publication_files(region_id, &[file.clone()])
+                .validate_local_publication_files(region_id, &[file.clone()])
                 .await,
             Err(crate::error::Error::PublicationObjectStat { .. })
         ));
@@ -937,7 +911,7 @@ mod tests {
             .unwrap();
         assert!(matches!(
             env.access_layer
-                .validate_publication_files(region_id, &[file.clone()])
+                .validate_local_publication_files(region_id, &[file.clone()])
                 .await,
             Err(crate::error::Error::PublicationObjectStat { .. })
         ));
@@ -954,7 +928,7 @@ mod tests {
             .unwrap();
         assert!(matches!(
             env.access_layer
-                .validate_publication_files(region_id, &[file.clone()])
+                .validate_local_publication_files(region_id, &[file.clone()])
                 .await,
             Err(crate::error::Error::PublicationSizeMismatch { .. })
         ));
@@ -965,28 +939,14 @@ mod tests {
             .await
             .unwrap();
         env.access_layer
-            .validate_publication_files(region_id, &[file])
+            .validate_local_publication_files(region_id, &[file])
             .await
             .unwrap();
     }
 
     #[tokio::test]
-    async fn test_validate_publication_files_uses_file_origin_region_and_layer_path_type() {
-        let (_data_dir, access_layer) = access_layer_with_path_type("table", PathType::Data).await;
-        let logical_region_id = RegionId::new(1, 1);
-        let file_origin_region_id = RegionId::new(1, 2);
-        let file = file_meta(file_origin_region_id, 3);
-        write_parquet(&access_layer, &file, b"sst".to_vec()).await;
-
-        access_layer
-            .validate_publication_files(logical_region_id, &[file])
-            .await
-            .unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_validate_publication_files_accepts_zero_expected_index_size_but_rejects_missing()
-    {
+    async fn test_validate_local_publication_files_accepts_zero_expected_index_size_but_rejects_missing()
+     {
         let env = SchedulerEnv::new().await;
         let region_id = RegionId::new(1, 1);
         let mut file = file_meta(region_id, 0);
@@ -996,7 +956,7 @@ mod tests {
 
         assert!(matches!(
             env.access_layer
-                .validate_publication_files(region_id, &[file.clone()])
+                .validate_local_publication_files(region_id, &[file.clone()])
                 .await,
             Err(crate::error::Error::PublicationObjectStat { .. })
         ));
@@ -1012,7 +972,7 @@ mod tests {
             .await
             .unwrap();
         env.access_layer
-            .validate_publication_files(region_id, &[file])
+            .validate_local_publication_files(region_id, &[file])
             .await
             .unwrap();
     }
@@ -1020,11 +980,11 @@ mod tests {
     #[tokio::test]
     async fn test_publication_object_stat_preserves_not_found_source_and_is_retryable() {
         let env = SchedulerEnv::new().await;
-        let logical_region_id = RegionId::new(1, 1);
-        let file = file_meta(RegionId::new(1, 2), 0);
+        let expected_region_id = RegionId::new(1, 1);
+        let file = file_meta(expected_region_id, 0);
         let err = env
             .access_layer
-            .validate_publication_files(logical_region_id, &[file.clone()])
+            .validate_local_publication_files(expected_region_id, &[file.clone()])
             .await
             .unwrap_err();
 
@@ -1035,7 +995,7 @@ mod tests {
                 error,
                 ..
             } => {
-                assert_eq!(*region_id, logical_region_id);
+                assert_eq!(*region_id, expected_region_id);
                 assert_eq!(*file_id, file.file_id);
                 assert_eq!(error.kind(), ErrorKind::NotFound);
             }

--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -820,36 +820,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_validate_local_publication_files_valid_parquet() {
-        let env = SchedulerEnv::new().await;
-        let expected_region_id = RegionId::new(1, 1);
-        let file = file_meta(expected_region_id, 0);
-        write_parquet(&env.access_layer, &file, b"sst".to_vec()).await;
-
-        env.access_layer
-            .validate_local_publication_files(expected_region_id, &[file])
-            .await
-            .unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_validate_local_publication_files_rejects_missing_parquet() {
-        let env = SchedulerEnv::new().await;
-        let region_id = RegionId::new(1, 1);
-        let file = file_meta(region_id, 3);
-
-        let err = env
-            .access_layer
-            .validate_local_publication_files(region_id, &[file])
-            .await
-            .unwrap_err();
-        assert!(matches!(
-            err,
-            crate::error::Error::PublicationObjectStat { .. }
-        ));
-    }
-
-    #[tokio::test]
     async fn test_validate_local_publication_files_rejects_parquet_size_mismatch() {
         let env = SchedulerEnv::new().await;
         let region_id = RegionId::new(1, 1);
@@ -870,7 +840,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_validate_local_publication_files_without_index_does_not_require_puffin() {
+    async fn test_validate_local_publication_files_valid_parquet_without_index() {
         let env = SchedulerEnv::new().await;
         let region_id = RegionId::new(1, 1);
         let file = file_meta(region_id, 3);

--- a/src/mito2/src/compaction.rs
+++ b/src/mito2/src/compaction.rs
@@ -1966,6 +1966,7 @@ mod tests {
             .unwrap();
             Arc::new(ManifestContext::new(
                 manager,
+                env.access_layer.clone(),
                 RegionRoleState::Leader(RegionLeaderState::Staging),
                 None,
             ))

--- a/src/mito2/src/compaction/compactor.rs
+++ b/src/mito2/src/compaction/compactor.rs
@@ -182,11 +182,12 @@ pub async fn open_compaction_region(
     let manifest = manifest_manager.manifest();
     let region_metadata = manifest.metadata.clone();
     let hook: Option<RegionHookRef> = req.plugins.get();
-    let manifest_ctx = Arc::new(ManifestContext::new(
+    let manifest_ctx = Arc::new(ManifestContext::new_with_local_publication_protocol(
         manifest_manager,
         access_layer.clone(),
         RegionRoleState::Leader(RegionLeaderState::Writable),
         hook,
+        false,
     ));
 
     let file_purger = {

--- a/src/mito2/src/compaction/compactor.rs
+++ b/src/mito2/src/compaction/compactor.rs
@@ -184,6 +184,7 @@ pub async fn open_compaction_region(
     let hook: Option<RegionHookRef> = req.plugins.get();
     let manifest_ctx = Arc::new(ManifestContext::new(
         manifest_manager,
+        access_layer.clone(),
         RegionRoleState::Leader(RegionLeaderState::Writable),
         hook,
     ));

--- a/src/mito2/src/engine/open_test.rs
+++ b/src/mito2/src/engine/open_test.rs
@@ -30,7 +30,7 @@ use store_api::region_request::{
     PathType, RegionCleanUpRequest, RegionCloseRequest, RegionOpenRequest, RegionPutRequest,
     RegionRequest,
 };
-use store_api::storage::{RegionId, ScanRequest};
+use store_api::storage::{FileId, RegionId, ScanRequest};
 use tokio::sync::oneshot;
 
 use crate::compaction::compactor::{OpenCompactionRegionRequest, open_compaction_region};
@@ -38,8 +38,10 @@ use crate::config::MitoConfig;
 use crate::engine::flush_test::MockRegionHook;
 use crate::engine::region_hook::RegionHookRef;
 use crate::error;
+use crate::manifest::action::{RegionEdit, RegionMetaAction, RegionMetaActionList};
 use crate::region::opener::{PartitionExprFetcher, PartitionExprFetcherRef};
 use crate::region::options::RegionOptions;
+use crate::sst::file::FileMeta;
 use crate::sst::location::region_dir_from_table_dir;
 use crate::test_util::{
     CreateRequestBuilder, LogStoreImpl, TestEnv, build_rows, flush_region, put_rows, reopen_region,
@@ -764,6 +766,29 @@ async fn test_open_compaction_region_with_format(flat_format: bool) {
     .unwrap();
 
     assert_eq!(region_id, compaction_region.region_id);
+
+    // Remote compaction has its own manifest context and must not validate against the local
+    // object paths before applying its manifest edit.
+    let missing_local_file = FileMeta {
+        region_id,
+        file_id: FileId::random(),
+        ..Default::default()
+    };
+    compaction_region
+        .manifest_ctx
+        .update_manifest_for_compaction(RegionMetaActionList::with_action(RegionMetaAction::Edit(
+            RegionEdit {
+                files_to_add: vec![missing_local_file],
+                files_to_remove: vec![],
+                timestamp_ms: None,
+                compaction_time_window: None,
+                flushed_entry_id: None,
+                flushed_sequence: None,
+                committed_sequence: None,
+            },
+        )))
+        .await
+        .unwrap();
 }
 
 /// Returns a dummy fetcher that returns the expr_json only once.

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -67,6 +67,40 @@ pub enum Error {
         error: object_store::Error,
     },
 
+    #[snafu(display(
+        "Failed to stat published object for region {} file {} at {}",
+        region_id,
+        file_id,
+        path
+    ))]
+    PublicationObjectStat {
+        region_id: RegionId,
+        file_id: FileId,
+        path: String,
+        #[snafu(source)]
+        error: object_store::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display(
+        "Published object for region {} file {} at {} has size {}, expected {}",
+        region_id,
+        file_id,
+        path,
+        actual_size,
+        expected_size
+    ))]
+    PublicationSizeMismatch {
+        region_id: RegionId,
+        file_id: FileId,
+        path: String,
+        expected_size: u64,
+        actual_size: u64,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Fail to compress object by {}, path: {}", compress_type, path))]
     CompressObject {
         compress_type: CompressionType,
@@ -1324,7 +1358,10 @@ impl ErrorExt for Error {
 
         match self {
             DataTypeMismatch { source, .. } => source.status_code(),
-            OpenDal { .. } | ReadParquet { .. } => StatusCode::StorageUnavailable,
+            OpenDal { .. }
+            | ReadParquet { .. }
+            | PublicationObjectStat { .. }
+            | PublicationSizeMismatch { .. } => StatusCode::StorageUnavailable,
             WriteWal { source, .. } | ReadWal { source, .. } | DeleteWal { source, .. } => {
                 source.status_code()
             }
@@ -1513,7 +1550,9 @@ impl ErrorExt for Error {
             | UpdateManifest { .. }
             | RegionStopped { .. }
             | RegionBusy { .. }
-            | FlushableRegionState { .. } => RetryHint::Retryable,
+            | FlushableRegionState { .. }
+            | PublicationObjectStat { .. }
+            | PublicationSizeMismatch { .. } => RetryHint::Retryable,
 
             OpenDal { error, .. }
             | DeleteSsts { error, .. }

--- a/src/mito2/src/gc.rs
+++ b/src/mito2/src/gc.rs
@@ -23,6 +23,8 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
+#[cfg(test)]
+use std::sync::Mutex;
 use std::time::Duration;
 
 use common_meta::datanode::GcStat;
@@ -205,6 +207,131 @@ pub struct LocalGcWorker {
     /// Set to false for regular GC operations to optimize performance.
     /// Set to true periodically or when you need to clean up orphan files.
     pub full_file_listing: bool,
+    #[cfg(test)]
+    test_finalization_barrier: Option<TestFinalizationBarrier>,
+}
+
+#[derive(Default)]
+struct ManifestLiveSet {
+    parquet: HashSet<FileId>,
+    indexes: HashSet<(FileId, IndexVersion)>,
+}
+
+impl ManifestLiveSet {
+    fn from_manifest(manifest: &RegionManifest) -> Self {
+        let mut live_set = Self::default();
+        for (file_id, meta) in &manifest.files {
+            live_set.parquet.insert(*file_id);
+            if let Some(index_version) = meta.index_version() {
+                live_set.indexes.insert((*file_id, index_version));
+            }
+        }
+        live_set
+    }
+
+    fn from_manifests(normal: &RegionManifest, staging: Option<&RegionManifest>) -> Self {
+        let mut live_set = Self::from_manifest(normal);
+        if let Some(staging) = staging {
+            live_set.union(&Self::from_manifest(staging));
+        }
+        live_set
+    }
+
+    fn union(&mut self, other: &Self) {
+        self.parquet.extend(other.parquet.iter().copied());
+        self.indexes.extend(other.indexes.iter().copied());
+    }
+
+    fn contains_file(&self, file_id: FileId, file_type: FileType) -> bool {
+        match file_type {
+            FileType::Parquet => self.parquet.contains(&file_id),
+            FileType::Puffin(index_version) => self.indexes.contains(&(file_id, index_version)),
+        }
+    }
+}
+
+#[derive(Default)]
+struct TmpRefLiveSet {
+    parquet: HashSet<FileId>,
+    indexes: HashSet<(FileId, IndexVersion)>,
+}
+
+impl From<&HashSet<(FileId, Option<IndexVersion>)>> for TmpRefLiveSet {
+    fn from(tmp_ref_files: &HashSet<(FileId, Option<IndexVersion>)>) -> Self {
+        let mut live_set = Self::default();
+        for (file_id, index_version) in tmp_ref_files {
+            live_set.parquet.insert(*file_id);
+            if let Some(index_version) = index_version {
+                live_set.indexes.insert((*file_id, *index_version));
+            }
+        }
+        live_set
+    }
+}
+
+impl TmpRefLiveSet {
+    fn contains_file(&self, file_id: FileId, file_type: FileType) -> bool {
+        match file_type {
+            FileType::Parquet => self.parquet.contains(&file_id),
+            FileType::Puffin(index_version) => self.indexes.contains(&(file_id, index_version)),
+        }
+    }
+}
+
+enum RegionGcOutcome {
+    Processed(Vec<RemovedFile>),
+    NeedRetry,
+}
+
+/// Test-only synchronization point after full-listing GC has classified candidates and before it
+/// starts finalization.
+#[cfg(test)]
+#[derive(Clone, Debug)]
+pub(crate) struct TestFinalizationBarrier {
+    reached: Arc<tokio::sync::Semaphore>,
+    release: Arc<tokio::sync::Semaphore>,
+    candidates: Arc<Mutex<Option<Vec<RemovedFile>>>>,
+}
+
+#[cfg(test)]
+impl TestFinalizationBarrier {
+    pub(crate) fn new() -> Self {
+        Self {
+            reached: Arc::new(tokio::sync::Semaphore::new(0)),
+            release: Arc::new(tokio::sync::Semaphore::new(0)),
+            candidates: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    pub(crate) async fn wait_until_reached(&self) -> Vec<RemovedFile> {
+        tokio::time::timeout(Duration::from_secs(10), self.reached.acquire())
+            .await
+            .expect("timed out waiting for GC finalization barrier")
+            .expect("test finalization barrier must remain open")
+            .forget();
+        self.candidates
+            .lock()
+            .expect("test finalization candidates lock must not be poisoned")
+            .clone()
+            .expect("GC finalization barrier must record candidates before signaling")
+    }
+
+    pub(crate) fn release(&self) {
+        self.release.add_permits(1);
+    }
+
+    async fn wait(&self, candidates: Vec<RemovedFile>) {
+        *self
+            .candidates
+            .lock()
+            .expect("test finalization candidates lock must not be poisoned") = Some(candidates);
+        self.reached.add_permits(1);
+        tokio::time::timeout(Duration::from_secs(10), self.release.acquire())
+            .await
+            .expect("timed out waiting to release GC finalization barrier")
+            .expect("test finalization barrier must remain open")
+            .forget();
+    }
 }
 
 pub struct ManifestOpenConfig {
@@ -267,7 +394,18 @@ impl LocalGcWorker {
             file_ref_manifest,
             _permit: permit,
             full_file_listing,
+            #[cfg(test)]
+            test_finalization_barrier: None,
         })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_test_finalization_barrier(
+        mut self,
+        barrier: TestFinalizationBarrier,
+    ) -> Self {
+        self.test_finalization_barrier = Some(barrier);
+        self
     }
 
     /// Get tmp ref files for all current regions
@@ -302,6 +440,7 @@ impl LocalGcWorker {
 
         let mut deleted_files = HashMap::new();
         let mut deleted_indexes = HashMap::new();
+        let mut need_retry_regions = HashSet::new();
         let mut processed_regions = HashSet::new();
         let tmp_ref_files = self.read_tmp_ref_files().await?;
         for (region_id, region) in &self.regions {
@@ -321,23 +460,30 @@ impl LocalGcWorker {
                 .get(region_id)
                 .cloned()
                 .unwrap_or_else(HashSet::new);
-            let files = self
+            let outcome = self
                 .do_region_gc(*region_id, region.clone(), &tmp_ref_files)
                 .await?;
-            let index_files = files
-                .iter()
-                .filter_map(|f| f.index_version().map(|v| (f.file_id(), v)))
-                .collect_vec();
-            let data_files = files
-                .into_iter()
-                .filter_map(|f| match f {
-                    RemovedFile::File(file_id, _) => Some(file_id),
-                    RemovedFile::Index(_, _) => None,
-                })
-                .collect();
-            deleted_files.insert(*region_id, data_files);
-            deleted_indexes.insert(*region_id, index_files);
-            processed_regions.insert(*region_id);
+            match outcome {
+                RegionGcOutcome::Processed(files) => {
+                    let index_files = files
+                        .iter()
+                        .filter_map(|f| f.index_version().map(|v| (f.file_id(), v)))
+                        .collect_vec();
+                    let data_files = files
+                        .into_iter()
+                        .filter_map(|f| match f {
+                            RemovedFile::File(file_id, _) => Some(file_id),
+                            RemovedFile::Index(_, _) => None,
+                        })
+                        .collect();
+                    deleted_files.insert(*region_id, data_files);
+                    deleted_indexes.insert(*region_id, index_files);
+                    processed_regions.insert(*region_id);
+                }
+                RegionGcOutcome::NeedRetry => {
+                    need_retry_regions.insert(*region_id);
+                }
+            }
             debug!(
                 "GC for region {} took {} secs.",
                 region_id,
@@ -351,7 +497,7 @@ impl LocalGcWorker {
         let report = GcReport {
             deleted_files,
             deleted_indexes,
-            need_retry_regions: HashSet::new(),
+            need_retry_regions,
             processed_regions,
         };
         Ok(report)
@@ -379,12 +525,12 @@ impl LocalGcWorker {
             region_present = region.is_some()
         )
     )]
-    pub async fn do_region_gc(
+    async fn do_region_gc(
         &self,
         region_id: RegionId,
         region: Option<MitoRegionRef>,
         tmp_ref_files: &HashSet<FileRef>,
-    ) -> Result<Vec<RemovedFile>> {
+    ) -> Result<RegionGcOutcome> {
         let mode = if self.full_file_listing {
             "full_listing"
         } else {
@@ -409,26 +555,26 @@ impl LocalGcWorker {
             }
         );
 
+        let expected_manifest_version = self
+            .file_ref_manifest
+            .manifest_version
+            .get(&region_id)
+            .cloned();
         let manifest = if let Some(region) = &region {
             let manifest = region.manifest_ctx.manifest().await;
             // If the manifest version does not match, skip GC for this region to avoid deleting files that are still in use.
-            let file_ref_manifest_version = self
-                .file_ref_manifest
-                .manifest_version
-                .get(&region.region_id())
-                .cloned();
-            if file_ref_manifest_version != Some(manifest.manifest_version) {
+            if expected_manifest_version != Some(manifest.manifest_version) {
                 // should be rare enough(few seconds after leader update manifest version), just skip gc for this region
                 warn!(
                     "Tmp ref files manifest version {:?} does not match region {} manifest version {}, skip gc for this region",
-                    file_ref_manifest_version,
+                    expected_manifest_version,
                     region.region_id(),
                     manifest.manifest_version
                 );
                 GC_ERRORS_TOTAL
                     .with_label_values(&["manifest_mismatch"])
                     .inc();
-                return Ok(vec![]);
+                return Ok(RegionGcOutcome::NeedRetry);
             }
             Some(manifest)
         } else {
@@ -470,21 +616,18 @@ impl LocalGcWorker {
 
         let current_files = manifest.as_ref().map(|m| &m.files);
 
-        let in_manifest = if let Some(current_files) = current_files {
-            current_files
-                .iter()
-                .map(|(file_id, meta)| (*file_id, meta.index_version()))
-                .collect::<HashMap<_, _>>()
-        } else {
-            Default::default()
-        };
+        let in_manifest = manifest
+            .as_deref()
+            .map(|manifest| ManifestLiveSet::from_manifests(manifest, None))
+            .unwrap_or_default();
 
         let is_region_dropped = region.is_none();
 
-        let in_tmp_ref = tmp_ref_files
+        let tmp_ref_files = tmp_ref_files
             .iter()
             .map(|file_ref| (file_ref.file_id, file_ref.index_version))
             .collect::<HashSet<_>>();
+        let in_tmp_ref = TmpRefLiveSet::from(&tmp_ref_files);
 
         let deletable_files = self
             .list_to_be_deleted_files(
@@ -493,11 +636,9 @@ impl LocalGcWorker {
                 &in_manifest,
                 &in_tmp_ref,
                 recently_removed_files,
-                all_entries,
+                all_entries.clone(),
             )
             .await?;
-
-        let unused_file_cnt = deletable_files.len();
 
         info!(
             "gc: for region{}{region_id}: In manifest file cnt: {}, Tmp ref file cnt: {}, recently removed files: {}, Unused files to delete count: {}",
@@ -522,24 +663,74 @@ impl LocalGcWorker {
             region_id
         );
 
+        #[cfg(test)]
+        if let Some(barrier) = &self.test_finalization_barrier {
+            barrier.wait(deletable_files.clone()).await;
+        }
+
+        let Some(region) = region else {
+            let _delete_timer = GC_DURATION_SECONDS
+                .with_label_values(&["delete_files"])
+                .start_timer();
+            self.delete_files(region_id, &deletable_files).await?;
+            return Ok(RegionGcOutcome::Processed(deletable_files));
+        };
+
+        let publication_guard = region.manifest_ctx.lock_publication_owned().await;
+        let manager = region.manifest_ctx.manifest_manager.write().await;
+        if !matches!(
+            region.manifest_ctx.current_state(),
+            RegionRoleState::Leader(_)
+        ) {
+            drop(manager);
+            drop(publication_guard);
+            return Ok(RegionGcOutcome::NeedRetry);
+        }
+
+        let current_manifest = manager.manifest();
+        if expected_manifest_version != Some(current_manifest.manifest_version) {
+            drop(manager);
+            drop(publication_guard);
+            return Ok(RegionGcOutcome::NeedRetry);
+        }
+
+        let final_in_manifest = ManifestLiveSet::from_manifests(
+            &current_manifest,
+            manager.staging_manifest().as_deref(),
+        );
+        let final_recently_removed_files = self
+            .get_removed_files_expel_times(&current_manifest)
+            .await?;
+        let final_deletable_files = self
+            .list_to_be_deleted_files(
+                region_id,
+                false,
+                &final_in_manifest,
+                &in_tmp_ref,
+                final_recently_removed_files,
+                all_entries,
+            )
+            .await?;
+        drop(manager);
+
         let _delete_timer = GC_DURATION_SECONDS
             .with_label_values(&["delete_files"])
             .start_timer();
-        self.delete_files(region_id, &deletable_files).await?;
-
+        self.delete_files(region_id, &final_deletable_files).await?;
         debug!(
             "Successfully deleted {} unused files for region {}",
-            unused_file_cnt, region_id
+            final_deletable_files.len(),
+            region_id
         );
-        if let Some(region) = &region {
-            let _update_timer = GC_DURATION_SECONDS
-                .with_label_values(&["update_manifest"])
-                .start_timer();
-            self.update_manifest_removed_files(region, deletable_files.clone())
-                .await?;
-        }
 
-        Ok(deletable_files)
+        let _update_timer = GC_DURATION_SECONDS
+            .with_label_values(&["update_manifest"])
+            .start_timer();
+        self.update_manifest_removed_files(&region, final_deletable_files.clone())
+            .await?;
+        drop(publication_guard);
+
+        Ok(RegionGcOutcome::Processed(final_deletable_files))
     }
 
     #[common_telemetry::tracing::instrument(
@@ -838,25 +1029,13 @@ impl LocalGcWorker {
         &self,
         is_region_dropped: bool,
         entries: Vec<Entry>,
-        in_manifest: &HashMap<FileId, Option<IndexVersion>>,
-        in_tmp_ref: &HashSet<(FileId, Option<IndexVersion>)>,
+        in_manifest: &ManifestLiveSet,
+        in_tmp_ref: &TmpRefLiveSet,
         may_linger_files: &HashSet<&RemovedFile>,
         eligible_for_delete: &HashSet<&RemovedFile>,
         unknown_file_may_linger_until: chrono::DateTime<chrono::Utc>,
     ) -> Vec<RemovedFile> {
         let mut ready_for_delete = vec![];
-        // all group by file id for easier checking
-        let in_tmp_ref: HashMap<FileId, HashSet<IndexVersion>> =
-            in_tmp_ref
-                .iter()
-                .fold(HashMap::new(), |mut acc, (file, version)| {
-                    let indices = acc.entry(*file).or_default();
-                    if let Some(version) = version {
-                        indices.insert(*version);
-                    }
-                    acc
-                });
-
         let may_linger_files: HashMap<FileId, HashSet<&RemovedFile>> = may_linger_files
             .iter()
             .fold(HashMap::new(), |mut acc, file| {
@@ -887,8 +1066,8 @@ impl LocalGcWorker {
 
             let should_delete = match file_type {
                 FileType::Parquet => {
-                    let is_in_manifest = in_manifest.contains_key(&file_id);
-                    let is_in_tmp_ref = in_tmp_ref.contains_key(&file_id);
+                    let is_in_manifest = in_manifest.contains_file(file_id, file_type);
+                    let is_in_tmp_ref = in_tmp_ref.contains_file(file_id, file_type);
                     let is_linger = may_linger_files.contains_key(&file_id);
                     let is_eligible_for_delete = eligible_for_delete.contains_key(&file_id);
 
@@ -904,14 +1083,8 @@ impl LocalGcWorker {
                 }
                 FileType::Puffin(version) => {
                     // notice need to check both file id and version
-                    let is_in_manifest = in_manifest
-                        .get(&file_id)
-                        .map(|opt_ver| *opt_ver == Some(version))
-                        .unwrap_or(false);
-                    let is_in_tmp_ref = in_tmp_ref
-                        .get(&file_id)
-                        .map(|versions| versions.contains(&version))
-                        .unwrap_or(false);
+                    let is_in_manifest = in_manifest.contains_file(file_id, file_type);
+                    let is_in_tmp_ref = in_tmp_ref.contains_file(file_id, file_type);
                     let is_linger = may_linger_files
                         .get(&file_id)
                         .map(|files| files.contains(&&RemovedFile::Index(file_id, version)))
@@ -959,12 +1132,12 @@ impl LocalGcWorker {
     /// improves performance. When `full_file_listing` is true, it read from `all_entries` to find
     /// and delete orphan files (files not tracked in the manifest).
     ///
-    pub async fn list_to_be_deleted_files(
+    async fn list_to_be_deleted_files(
         &self,
         region_id: RegionId,
         is_region_dropped: bool,
-        in_manifest: &HashMap<FileId, Option<IndexVersion>>,
-        in_tmp_ref: &HashSet<(FileId, Option<IndexVersion>)>,
+        in_manifest: &ManifestLiveSet,
+        in_tmp_ref: &TmpRefLiveSet,
         recently_removed_files: BTreeMap<Timestamp, HashSet<RemovedFile>>,
         all_entries: Vec<Entry>,
     ) -> Result<Vec<RemovedFile>> {
@@ -1020,13 +1193,14 @@ impl LocalGcWorker {
                 .iter()
                 .filter(|file_id| {
                     let in_use = match file_id {
-                        RemovedFile::File(file_id, index_version) => {
-                            in_manifest.get(file_id) == Some(index_version)
-                                || in_tmp_ref.contains(&(*file_id, *index_version))
+                        RemovedFile::File(file_id, _) => {
+                            in_manifest.contains_file(*file_id, FileType::Parquet)
+                                || in_tmp_ref.contains_file(*file_id, FileType::Parquet)
                         }
                         RemovedFile::Index(file_id, index_version) => {
-                            in_manifest.get(file_id) == Some(&Some(*index_version))
-                                || in_tmp_ref.contains(&(*file_id, Some(*index_version)))
+                            in_manifest.contains_file(*file_id, FileType::Puffin(*index_version))
+                                || in_tmp_ref
+                                    .contains_file(*file_id, FileType::Puffin(*index_version))
                         }
                     };
                     !in_use

--- a/src/mito2/src/gc.rs
+++ b/src/mito2/src/gc.rs
@@ -524,16 +524,14 @@ impl LocalGcWorker {
             .collect::<HashSet<_>>();
 
         let Some(region) = region else {
-            let deletable_files = self
-                .list_to_be_deleted_files(
-                    region_id,
-                    true,
-                    &HashMap::new(),
-                    &tmp_ref_files,
-                    Default::default(),
-                    all_entries,
-                )
-                .await?;
+            let deletable_files = self.list_to_be_deleted_files(
+                region_id,
+                true,
+                &HashMap::new(),
+                &tmp_ref_files,
+                Default::default(),
+                all_entries,
+            )?;
             let _delete_timer = GC_DURATION_SECONDS
                 .with_label_values(&["delete_files"])
                 .start_timer();
@@ -575,16 +573,14 @@ impl LocalGcWorker {
             .values()
             .map(|files| files.len())
             .sum::<usize>();
-        let final_deletable_files = self
-            .list_to_be_deleted_files(
-                region_id,
-                false,
-                &final_in_manifest,
-                &tmp_ref_files,
-                final_recently_removed_files,
-                all_entries,
-            )
-            .await?;
+        let final_deletable_files = self.list_to_be_deleted_files(
+            region_id,
+            false,
+            &final_in_manifest,
+            &tmp_ref_files,
+            final_recently_removed_files,
+            all_entries,
+        )?;
         info!(
             "gc: for region {region_id}: In manifest file cnt: {}, Tmp ref file cnt: {}, recently removed files: {}, Unused files to delete count: {}",
             current_manifest.files.len(),
@@ -910,7 +906,7 @@ impl LocalGcWorker {
     }
 
     #[allow(clippy::too_many_arguments)]
-    async fn filter_deletable_files(
+    fn filter_deletable_files(
         &self,
         is_region_dropped: bool,
         entries: Vec<Entry>,
@@ -1020,7 +1016,7 @@ impl LocalGcWorker {
     /// improves performance. When `full_file_listing` is true, it read from `all_entries` to find
     /// and delete orphan files (files not tracked in the manifest).
     ///
-    async fn list_to_be_deleted_files(
+    fn list_to_be_deleted_files(
         &self,
         region_id: RegionId,
         is_region_dropped: bool,
@@ -1108,32 +1104,27 @@ impl LocalGcWorker {
         let mut in_tmp_ref_indexes = HashMap::<FileId, HashSet<IndexVersion>>::new();
         for (file_id, index_version) in in_tmp_ref {
             in_tmp_ref_parquet.insert(*file_id);
-            match index_version {
-                Some(index_version) => {
-                    in_tmp_ref_indexes
-                        .entry(*file_id)
-                        .or_default()
-                        .insert(*index_version);
-                }
-                None => {}
+            if let Some(index_version) = index_version {
+                in_tmp_ref_indexes
+                    .entry(*file_id)
+                    .or_default()
+                    .insert(*index_version);
             }
         }
 
         // Full file listing mode: get the full list of files from object store
 
         // Step 3: Filter files to determine which ones can be deleted
-        let all_unused_files_ready_for_delete = self
-            .filter_deletable_files(
-                is_region_dropped,
-                all_entries,
-                in_manifest,
-                &in_tmp_ref_parquet,
-                &in_tmp_ref_indexes,
-                &all_may_linger_files,
-                &eligible_for_removal,
-                unknown_file_may_linger_until,
-            )
-            .await;
+        let all_unused_files_ready_for_delete = self.filter_deletable_files(
+            is_region_dropped,
+            all_entries,
+            in_manifest,
+            &in_tmp_ref_parquet,
+            &in_tmp_ref_indexes,
+            &all_may_linger_files,
+            &eligible_for_removal,
+            unknown_file_may_linger_until,
+        );
 
         Ok(all_unused_files_ready_for_delete)
     }

--- a/src/mito2/src/gc.rs
+++ b/src/mito2/src/gc.rs
@@ -23,8 +23,6 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
-#[cfg(test)]
-use std::sync::Mutex;
 use std::time::Duration;
 
 use common_meta::datanode::GcStat;
@@ -52,7 +50,7 @@ use crate::metrics::{
     GC_DELETE_FILE_CNT, GC_DURATION_SECONDS, GC_ERRORS_TOTAL, GC_FILES_DELETED_TOTAL,
     GC_ORPHANED_INDEX_FILES, GC_RUNS_TOTAL, GC_SKIPPED_UNPARSABLE_FILES,
 };
-use crate::region::{MitoRegionRef, RegionRoleState};
+use crate::region::{MitoRegionRef, RegionLeaderState, RegionRoleState};
 use crate::sst::file::{RegionFileId, RegionIndexId, delete_files, delete_indexes};
 use crate::sst::location::{self};
 
@@ -211,86 +209,18 @@ pub struct LocalGcWorker {
     test_finalization_barrier: Option<TestFinalizationBarrier>,
 }
 
-#[derive(Default)]
-struct ManifestLiveSet {
-    parquet: HashSet<FileId>,
-    indexes: HashSet<(FileId, IndexVersion)>,
-}
-
-impl ManifestLiveSet {
-    fn from_manifest(manifest: &RegionManifest) -> Self {
-        let mut live_set = Self::default();
-        for (file_id, meta) in &manifest.files {
-            live_set.parquet.insert(*file_id);
-            if let Some(index_version) = meta.index_version() {
-                live_set.indexes.insert((*file_id, index_version));
-            }
-        }
-        live_set
-    }
-
-    fn from_manifests(normal: &RegionManifest, staging: Option<&RegionManifest>) -> Self {
-        let mut live_set = Self::from_manifest(normal);
-        if let Some(staging) = staging {
-            live_set.union(&Self::from_manifest(staging));
-        }
-        live_set
-    }
-
-    fn union(&mut self, other: &Self) {
-        self.parquet.extend(other.parquet.iter().copied());
-        self.indexes.extend(other.indexes.iter().copied());
-    }
-
-    fn contains_file(&self, file_id: FileId, file_type: FileType) -> bool {
-        match file_type {
-            FileType::Parquet => self.parquet.contains(&file_id),
-            FileType::Puffin(index_version) => self.indexes.contains(&(file_id, index_version)),
-        }
-    }
-}
-
-#[derive(Default)]
-struct TmpRefLiveSet {
-    parquet: HashSet<FileId>,
-    indexes: HashSet<(FileId, IndexVersion)>,
-}
-
-impl From<&HashSet<(FileId, Option<IndexVersion>)>> for TmpRefLiveSet {
-    fn from(tmp_ref_files: &HashSet<(FileId, Option<IndexVersion>)>) -> Self {
-        let mut live_set = Self::default();
-        for (file_id, index_version) in tmp_ref_files {
-            live_set.parquet.insert(*file_id);
-            if let Some(index_version) = index_version {
-                live_set.indexes.insert((*file_id, *index_version));
-            }
-        }
-        live_set
-    }
-}
-
-impl TmpRefLiveSet {
-    fn contains_file(&self, file_id: FileId, file_type: FileType) -> bool {
-        match file_type {
-            FileType::Parquet => self.parquet.contains(&file_id),
-            FileType::Puffin(index_version) => self.indexes.contains(&(file_id, index_version)),
-        }
-    }
-}
-
 enum RegionGcOutcome {
     Processed(Vec<RemovedFile>),
     NeedRetry,
 }
 
-/// Test-only synchronization point after full-listing GC has classified candidates and before it
-/// starts finalization.
+/// Test-only synchronization point after active-region full listing and before it takes the
+/// publication gate for finalization.
 #[cfg(test)]
 #[derive(Clone, Debug)]
 pub(crate) struct TestFinalizationBarrier {
     reached: Arc<tokio::sync::Semaphore>,
     release: Arc<tokio::sync::Semaphore>,
-    candidates: Arc<Mutex<Option<Vec<RemovedFile>>>>,
 }
 
 #[cfg(test)]
@@ -299,32 +229,22 @@ impl TestFinalizationBarrier {
         Self {
             reached: Arc::new(tokio::sync::Semaphore::new(0)),
             release: Arc::new(tokio::sync::Semaphore::new(0)),
-            candidates: Arc::new(Mutex::new(None)),
         }
     }
 
-    pub(crate) async fn wait_until_reached(&self) -> Vec<RemovedFile> {
+    pub(crate) async fn wait_until_reached(&self) {
         tokio::time::timeout(Duration::from_secs(10), self.reached.acquire())
             .await
             .expect("timed out waiting for GC finalization barrier")
             .expect("test finalization barrier must remain open")
             .forget();
-        self.candidates
-            .lock()
-            .expect("test finalization candidates lock must not be poisoned")
-            .clone()
-            .expect("GC finalization barrier must record candidates before signaling")
     }
 
     pub(crate) fn release(&self) {
         self.release.add_permits(1);
     }
 
-    async fn wait(&self, candidates: Vec<RemovedFile>) {
-        *self
-            .candidates
-            .lock()
-            .expect("test finalization candidates lock must not be poisoned") = Some(candidates);
+    async fn wait(&self) {
         self.reached.add_permits(1);
         tokio::time::timeout(Duration::from_secs(10), self.release.acquire())
             .await
@@ -598,75 +518,22 @@ impl LocalGcWorker {
             vec![]
         };
 
-        let recently_removed_files = if let Some(manifest) = &manifest {
-            self.get_removed_files_expel_times(manifest).await?
-        } else {
-            Default::default()
-        };
-
-        if recently_removed_files.is_empty() {
-            // no files to remove, skip
-            debug!("No recently removed files to gc for region {}", region_id);
-        }
-
-        let removed_file_cnt = recently_removed_files
-            .values()
-            .map(|s| s.len())
-            .sum::<usize>();
-
-        let current_files = manifest.as_ref().map(|m| &m.files);
-
-        let in_manifest = manifest
-            .as_deref()
-            .map(|manifest| ManifestLiveSet::from_manifests(manifest, None))
-            .unwrap_or_default();
-
-        let is_region_dropped = region.is_none();
-
         let tmp_ref_files = tmp_ref_files
             .iter()
             .map(|file_ref| (file_ref.file_id, file_ref.index_version))
             .collect::<HashSet<_>>();
-        let in_tmp_ref = TmpRefLiveSet::from(&tmp_ref_files);
-
-        let deletable_files = self.list_to_be_deleted_files(
-            region_id,
-            is_region_dropped,
-            &in_manifest,
-            &in_tmp_ref,
-            recently_removed_files,
-            all_entries.clone(),
-        )?;
-
-        info!(
-            "gc: for region{}{region_id}: In manifest file cnt: {}, Tmp ref file cnt: {}, recently removed files: {}, Unused files to delete count: {}",
-            if region.is_none() {
-                "(region dropped)"
-            } else {
-                ""
-            },
-            current_files.map(|c| c.len()).unwrap_or(0),
-            tmp_ref_files.len(),
-            removed_file_cnt,
-            deletable_files.len(),
-        );
-        debug!(
-            "gc: deletable files for region {}: {:?}",
-            region_id, &deletable_files
-        );
-
-        debug!(
-            "Found {} unused index files to delete for region {}",
-            deletable_files.len(),
-            region_id
-        );
-
-        #[cfg(test)]
-        if let Some(barrier) = &self.test_finalization_barrier {
-            barrier.wait(deletable_files.clone()).await;
-        }
 
         let Some(region) = region else {
+            let deletable_files = self
+                .list_to_be_deleted_files(
+                    region_id,
+                    true,
+                    &HashMap::new(),
+                    &tmp_ref_files,
+                    Default::default(),
+                    all_entries,
+                )
+                .await?;
             let _delete_timer = GC_DURATION_SECONDS
                 .with_label_values(&["delete_files"])
                 .start_timer();
@@ -674,12 +541,16 @@ impl LocalGcWorker {
             return Ok(RegionGcOutcome::Processed(deletable_files));
         };
 
-        let publication_guard = region.manifest_ctx.lock_publication_owned().await;
+        #[cfg(test)]
+        if let Some(barrier) = &self.test_finalization_barrier {
+            barrier.wait().await;
+        }
+
+        let publication_guard = region.manifest_ctx.publication_gate.lock().await;
         let manager = region.manifest_ctx.manifest_manager.write().await;
-        if !matches!(
-            region.manifest_ctx.current_state(),
-            RegionRoleState::Leader(_)
-        ) {
+        if region.manifest_ctx.current_state()
+            != RegionRoleState::Leader(RegionLeaderState::Writable)
+        {
             drop(manager);
             drop(publication_guard);
             return Ok(RegionGcOutcome::NeedRetry);
@@ -692,21 +563,39 @@ impl LocalGcWorker {
             return Ok(RegionGcOutcome::NeedRetry);
         }
 
-        let final_in_manifest = ManifestLiveSet::from_manifests(
-            &current_manifest,
-            manager.staging_manifest().as_deref(),
-        );
+        let final_in_manifest = current_manifest
+            .files
+            .iter()
+            .map(|(file_id, meta)| (*file_id, meta.index_version()))
+            .collect::<HashMap<_, _>>();
         let final_recently_removed_files = self
             .get_removed_files_expel_times(&current_manifest)
             .await?;
-        let final_deletable_files = self.list_to_be_deleted_files(
-            region_id,
-            false,
-            &final_in_manifest,
-            &in_tmp_ref,
-            final_recently_removed_files,
-            all_entries,
-        )?;
+        let removed_file_cnt = final_recently_removed_files
+            .values()
+            .map(|files| files.len())
+            .sum::<usize>();
+        let final_deletable_files = self
+            .list_to_be_deleted_files(
+                region_id,
+                false,
+                &final_in_manifest,
+                &tmp_ref_files,
+                final_recently_removed_files,
+                all_entries,
+            )
+            .await?;
+        info!(
+            "gc: for region {region_id}: In manifest file cnt: {}, Tmp ref file cnt: {}, recently removed files: {}, Unused files to delete count: {}",
+            current_manifest.files.len(),
+            tmp_ref_files.len(),
+            removed_file_cnt,
+            final_deletable_files.len(),
+        );
+        debug!(
+            "gc: deletable files for region {}: {:?}",
+            region_id, &final_deletable_files
+        );
         drop(manager);
 
         let _delete_timer = GC_DURATION_SECONDS
@@ -1021,12 +910,13 @@ impl LocalGcWorker {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn filter_deletable_files(
+    async fn filter_deletable_files(
         &self,
         is_region_dropped: bool,
         entries: Vec<Entry>,
-        in_manifest: &ManifestLiveSet,
-        in_tmp_ref: &TmpRefLiveSet,
+        in_manifest: &HashMap<FileId, Option<IndexVersion>>,
+        in_tmp_ref_parquet: &HashSet<FileId>,
+        in_tmp_ref_indexes: &HashMap<FileId, HashSet<IndexVersion>>,
         may_linger_files: &HashSet<&RemovedFile>,
         eligible_for_delete: &HashSet<&RemovedFile>,
         unknown_file_may_linger_until: chrono::DateTime<chrono::Utc>,
@@ -1062,8 +952,8 @@ impl LocalGcWorker {
 
             let should_delete = match file_type {
                 FileType::Parquet => {
-                    let is_in_manifest = in_manifest.contains_file(file_id, file_type);
-                    let is_in_tmp_ref = in_tmp_ref.contains_file(file_id, file_type);
+                    let is_in_manifest = in_manifest.contains_key(&file_id);
+                    let is_in_tmp_ref = in_tmp_ref_parquet.contains(&file_id);
                     let is_linger = may_linger_files.contains_key(&file_id);
                     let is_eligible_for_delete = eligible_for_delete.contains_key(&file_id);
 
@@ -1079,8 +969,10 @@ impl LocalGcWorker {
                 }
                 FileType::Puffin(version) => {
                     // notice need to check both file id and version
-                    let is_in_manifest = in_manifest.contains_file(file_id, file_type);
-                    let is_in_tmp_ref = in_tmp_ref.contains_file(file_id, file_type);
+                    let is_in_manifest = in_manifest.get(&file_id) == Some(&Some(version));
+                    let is_in_tmp_ref = in_tmp_ref_indexes
+                        .get(&file_id)
+                        .is_some_and(|versions| versions.contains(&version));
                     let is_linger = may_linger_files
                         .get(&file_id)
                         .map(|files| files.contains(&&RemovedFile::Index(file_id, version)))
@@ -1128,12 +1020,12 @@ impl LocalGcWorker {
     /// improves performance. When `full_file_listing` is true, it read from `all_entries` to find
     /// and delete orphan files (files not tracked in the manifest).
     ///
-    fn list_to_be_deleted_files(
+    async fn list_to_be_deleted_files(
         &self,
         region_id: RegionId,
         is_region_dropped: bool,
-        in_manifest: &ManifestLiveSet,
-        in_tmp_ref: &TmpRefLiveSet,
+        in_manifest: &HashMap<FileId, Option<IndexVersion>>,
+        in_tmp_ref: &HashSet<(FileId, Option<IndexVersion>)>,
         recently_removed_files: BTreeMap<Timestamp, HashSet<RemovedFile>>,
         all_entries: Vec<Entry>,
     ) -> Result<Vec<RemovedFile>> {
@@ -1189,14 +1081,13 @@ impl LocalGcWorker {
                 .iter()
                 .filter(|file_id| {
                     let in_use = match file_id {
-                        RemovedFile::File(file_id, _) => {
-                            in_manifest.contains_file(*file_id, FileType::Parquet)
-                                || in_tmp_ref.contains_file(*file_id, FileType::Parquet)
+                        RemovedFile::File(file_id, index_version) => {
+                            in_manifest.contains_key(file_id)
+                                || in_tmp_ref.contains(&(*file_id, *index_version))
                         }
                         RemovedFile::Index(file_id, index_version) => {
-                            in_manifest.contains_file(*file_id, FileType::Puffin(*index_version))
-                                || in_tmp_ref
-                                    .contains_file(*file_id, FileType::Puffin(*index_version))
+                            in_manifest.get(file_id) == Some(&Some(*index_version))
+                                || in_tmp_ref.contains(&(*file_id, Some(*index_version)))
                         }
                     };
                     !in_use
@@ -1213,18 +1104,36 @@ impl LocalGcWorker {
             return Ok(files_to_delete);
         }
 
+        let mut in_tmp_ref_parquet = HashSet::new();
+        let mut in_tmp_ref_indexes = HashMap::<FileId, HashSet<IndexVersion>>::new();
+        for (file_id, index_version) in in_tmp_ref {
+            in_tmp_ref_parquet.insert(*file_id);
+            match index_version {
+                Some(index_version) => {
+                    in_tmp_ref_indexes
+                        .entry(*file_id)
+                        .or_default()
+                        .insert(*index_version);
+                }
+                None => {}
+            }
+        }
+
         // Full file listing mode: get the full list of files from object store
 
         // Step 3: Filter files to determine which ones can be deleted
-        let all_unused_files_ready_for_delete = self.filter_deletable_files(
-            is_region_dropped,
-            all_entries,
-            in_manifest,
-            in_tmp_ref,
-            &all_may_linger_files,
-            &eligible_for_removal,
-            unknown_file_may_linger_until,
-        );
+        let all_unused_files_ready_for_delete = self
+            .filter_deletable_files(
+                is_region_dropped,
+                all_entries,
+                in_manifest,
+                &in_tmp_ref_parquet,
+                &in_tmp_ref_indexes,
+                &all_may_linger_files,
+                &eligible_for_removal,
+                unknown_file_may_linger_until,
+            )
+            .await;
 
         Ok(all_unused_files_ready_for_delete)
     }

--- a/src/mito2/src/gc.rs
+++ b/src/mito2/src/gc.rs
@@ -629,16 +629,14 @@ impl LocalGcWorker {
             .collect::<HashSet<_>>();
         let in_tmp_ref = TmpRefLiveSet::from(&tmp_ref_files);
 
-        let deletable_files = self
-            .list_to_be_deleted_files(
-                region_id,
-                is_region_dropped,
-                &in_manifest,
-                &in_tmp_ref,
-                recently_removed_files,
-                all_entries.clone(),
-            )
-            .await?;
+        let deletable_files = self.list_to_be_deleted_files(
+            region_id,
+            is_region_dropped,
+            &in_manifest,
+            &in_tmp_ref,
+            recently_removed_files,
+            all_entries.clone(),
+        )?;
 
         info!(
             "gc: for region{}{region_id}: In manifest file cnt: {}, Tmp ref file cnt: {}, recently removed files: {}, Unused files to delete count: {}",
@@ -701,16 +699,14 @@ impl LocalGcWorker {
         let final_recently_removed_files = self
             .get_removed_files_expel_times(&current_manifest)
             .await?;
-        let final_deletable_files = self
-            .list_to_be_deleted_files(
-                region_id,
-                false,
-                &final_in_manifest,
-                &in_tmp_ref,
-                final_recently_removed_files,
-                all_entries,
-            )
-            .await?;
+        let final_deletable_files = self.list_to_be_deleted_files(
+            region_id,
+            false,
+            &final_in_manifest,
+            &in_tmp_ref,
+            final_recently_removed_files,
+            all_entries,
+        )?;
         drop(manager);
 
         let _delete_timer = GC_DURATION_SECONDS
@@ -1132,7 +1128,7 @@ impl LocalGcWorker {
     /// improves performance. When `full_file_listing` is true, it read from `all_entries` to find
     /// and delete orphan files (files not tracked in the manifest).
     ///
-    async fn list_to_be_deleted_files(
+    fn list_to_be_deleted_files(
         &self,
         region_id: RegionId,
         is_region_dropped: bool,

--- a/src/mito2/src/gc/worker_test.rs
+++ b/src/mito2/src/gc/worker_test.rs
@@ -32,7 +32,7 @@ use store_api::region_engine::RegionEngine as _;
 use store_api::region_request::{
     PathType, RegionCompactRequest, RegionFlushRequest, RegionRequest,
 };
-use store_api::storage::{FileId, FileRef, FileRefsManifest, RegionId, ScanRequest};
+use store_api::storage::{FileId, FileRef, FileRefsManifest, GcReport, RegionId, ScanRequest};
 use tokio::sync::Semaphore;
 
 use crate::config::MitoConfig;
@@ -287,6 +287,76 @@ async fn create_gc_worker(
     .unwrap()
 }
 
+struct PublicationRace {
+    region_id: RegionId,
+    region: MitoRegionRef,
+    file_id: FileId,
+    path: String,
+    barrier: TestFinalizationBarrier,
+    flush: tokio::task::JoinHandle<std::result::Result<(), String>>,
+    gc: tokio::task::JoinHandle<crate::error::Result<GcReport>>,
+}
+
+async fn arrange_publication_race(
+    engine: &MitoEngine,
+    hook: &PauseAfterSstWritten,
+) -> PublicationRace {
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new().build();
+    let table_dir = request.table_dir.clone();
+    engine
+        .handle_request(region_id, RegionRequest::Create(request.clone()))
+        .await
+        .unwrap();
+    put_rows(
+        engine,
+        region_id,
+        Rows {
+            schema: rows_schema(&request),
+            rows: build_rows(0, 3),
+        },
+    )
+    .await;
+
+    let region = engine.get_region(region_id).unwrap();
+    let manifest_before_flush = region.manifest_ctx.manifest().await;
+    let flush_engine = engine.clone();
+    let flush = tokio::spawn(async move {
+        flush_engine
+            .handle_request(
+                region_id,
+                RegionRequest::Flush(RegionFlushRequest::default()),
+            )
+            .await
+            .map(|_| ())
+            .map_err(|error| error.to_string())
+    });
+    let file_id = hook.wait_until_written().await;
+    let path = parquet_path(&table_dir, region_id, file_id);
+    wait_until_gc_cutoff_is_after_file_mtime(region.access_layer.object_store(), &path).await;
+
+    let barrier = TestFinalizationBarrier::new();
+    let gc_worker = create_gc_worker(
+        engine,
+        BTreeMap::from([(region_id, Some(region.clone()))]),
+        &file_refs_manifest(region_id, &manifest_before_flush),
+        true,
+    )
+    .await
+    .with_test_finalization_barrier(barrier.clone());
+    let gc = tokio::spawn(async move { gc_worker.run().await });
+
+    PublicationRace {
+        region_id,
+        region,
+        file_id,
+        path,
+        barrier,
+        flush,
+        gc,
+    }
+}
+
 #[tokio::test]
 async fn test_full_gc_tmp_refs_keep_all_live_index_versions() {
     let mut env = TestEnv::new().await;
@@ -352,7 +422,6 @@ async fn test_full_gc_tmp_refs_keep_all_live_index_versions() {
             Default::default(),
             entries,
         )
-        .await
         .unwrap();
 
     assert_eq!(deletable_files, vec![RemovedFile::Index(file_id, 3)]);
@@ -802,49 +871,15 @@ async fn test_full_gc_does_not_delete_sst_published_before_finalization() {
         .create_engine_with_plugins(gc_config_with_zero_unknown_ttl(), plugins)
         .await;
 
-    let region_id = RegionId::new(1, 1);
-    let request = CreateRequestBuilder::new().build();
-    let table_dir = request.table_dir.clone();
-    let column_schemas = rows_schema(&request);
-    engine
-        .handle_request(region_id, RegionRequest::Create(request))
-        .await
-        .unwrap();
-    put_rows(
-        &engine,
+    let PublicationRace {
         region_id,
-        Rows {
-            schema: column_schemas,
-            rows: build_rows(0, 3),
-        },
-    )
-    .await;
-
-    let region = engine.get_region(region_id).unwrap();
-    let manifest_before_flush = region.manifest_ctx.manifest().await;
-    let flush_engine = engine.clone();
-    let flush = tokio::spawn(async move {
-        flush_engine
-            .handle_request(
-                region_id,
-                RegionRequest::Flush(RegionFlushRequest::default()),
-            )
-            .await
-    });
-    let file_id = hook.wait_until_written().await;
-    let path = parquet_path(&table_dir, region_id, file_id);
-    wait_until_gc_cutoff_is_after_file_mtime(region.access_layer.object_store(), &path).await;
-
-    let barrier = TestFinalizationBarrier::new();
-    let gc_worker = create_gc_worker(
-        &engine,
-        BTreeMap::from([(region_id, Some(region.clone()))]),
-        &file_refs_manifest(region_id, &manifest_before_flush),
-        true,
-    )
-    .await
-    .with_test_finalization_barrier(barrier.clone());
-    let gc = tokio::spawn(async move { gc_worker.run().await });
+        region,
+        file_id,
+        path,
+        barrier,
+        flush,
+        gc,
+    } = arrange_publication_race(&engine, &hook).await;
     barrier.wait_until_reached().await;
 
     hook.release();
@@ -894,49 +929,15 @@ async fn test_full_gc_delete_before_publication_fails_closed_and_flush_can_retry
         .create_engine_with_plugins(gc_config_with_zero_unknown_ttl(), plugins)
         .await;
 
-    let region_id = RegionId::new(1, 1);
-    let request = CreateRequestBuilder::new().build();
-    let table_dir = request.table_dir.clone();
-    let column_schemas = rows_schema(&request);
-    engine
-        .handle_request(region_id, RegionRequest::Create(request))
-        .await
-        .unwrap();
-    put_rows(
-        &engine,
+    let PublicationRace {
         region_id,
-        Rows {
-            schema: column_schemas,
-            rows: build_rows(0, 3),
-        },
-    )
-    .await;
-
-    let region = engine.get_region(region_id).unwrap();
-    let manifest_before_flush = region.manifest_ctx.manifest().await;
-    let flush_engine = engine.clone();
-    let flush = tokio::spawn(async move {
-        flush_engine
-            .handle_request(
-                region_id,
-                RegionRequest::Flush(RegionFlushRequest::default()),
-            )
-            .await
-    });
-    let file_id = hook.wait_until_written().await;
-    let path = parquet_path(&table_dir, region_id, file_id);
-    wait_until_gc_cutoff_is_after_file_mtime(region.access_layer.object_store(), &path).await;
-
-    let barrier = TestFinalizationBarrier::new();
-    let gc_worker = create_gc_worker(
-        &engine,
-        BTreeMap::from([(region_id, Some(region.clone()))]),
-        &file_refs_manifest(region_id, &manifest_before_flush),
-        true,
-    )
-    .await
-    .with_test_finalization_barrier(barrier.clone());
-    let gc = tokio::spawn(async move { gc_worker.run().await });
+        region,
+        file_id,
+        path,
+        barrier,
+        flush,
+        gc,
+    } = arrange_publication_race(&engine, &hook).await;
     barrier.wait_until_reached().await;
     barrier.release();
     wait_for_permit(&delete_completed, "target Parquet delete completion").await;
@@ -1004,49 +1005,15 @@ async fn test_full_gc_delete_error_does_not_block_publisher_recovery() {
         .create_engine_with_plugins(gc_config_with_zero_unknown_ttl(), plugins)
         .await;
 
-    let region_id = RegionId::new(1, 1);
-    let request = CreateRequestBuilder::new().build();
-    let table_dir = request.table_dir.clone();
-    let column_schemas = rows_schema(&request);
-    engine
-        .handle_request(region_id, RegionRequest::Create(request))
-        .await
-        .unwrap();
-    put_rows(
-        &engine,
-        region_id,
-        Rows {
-            schema: column_schemas,
-            rows: build_rows(0, 3),
-        },
-    )
-    .await;
-
-    let region = engine.get_region(region_id).unwrap();
-    let manifest_before_flush = region.manifest_ctx.manifest().await;
-    let flush_engine = engine.clone();
-    let flush = tokio::spawn(async move {
-        flush_engine
-            .handle_request(
-                region_id,
-                RegionRequest::Flush(RegionFlushRequest::default()),
-            )
-            .await
-    });
-    let file_id = hook.wait_until_written().await;
-    let path = parquet_path(&table_dir, region_id, file_id);
-    wait_until_gc_cutoff_is_after_file_mtime(region.access_layer.object_store(), &path).await;
-
-    let barrier = TestFinalizationBarrier::new();
-    let gc_worker = create_gc_worker(
-        &engine,
-        BTreeMap::from([(region_id, Some(region.clone()))]),
-        &file_refs_manifest(region_id, &manifest_before_flush),
-        true,
-    )
-    .await
-    .with_test_finalization_barrier(barrier.clone());
-    let gc = tokio::spawn(async move { gc_worker.run().await });
+    let PublicationRace {
+        region_id: _,
+        region,
+        file_id,
+        path,
+        barrier,
+        flush,
+        gc,
+    } = arrange_publication_race(&engine, &hook).await;
     barrier.wait_until_reached().await;
     barrier.release();
     wait_for_permit(&close_attempted, "injected Parquet delete close failure").await;

--- a/src/mito2/src/gc/worker_test.rs
+++ b/src/mito2/src/gc/worker_test.rs
@@ -370,7 +370,6 @@ async fn test_fast_gc_tmp_ref_filtering_protects_parquet_and_matching_puffin() {
             BTreeMap::from([(Timestamp::new_millisecond(0), removed_files)]),
             vec![],
         )
-        .await
         .unwrap();
 
     assert_eq!(deletable_files, vec![RemovedFile::Index(file_id, 2)]);

--- a/src/mito2/src/gc/worker_test.rs
+++ b/src/mito2/src/gc/worker_test.rs
@@ -13,25 +13,368 @@
 // limitations under the License.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use api::v1::Rows;
+use async_trait::async_trait;
+use common_base::Plugins;
+use common_recordbatch::RecordBatches;
 use common_telemetry::init_default_ut_logging;
+use common_time::Timestamp;
 use futures::TryStreamExt;
+use object_store::layers::mock::{
+    Error as MockError, ErrorKind, MockLayerBuilder, OpDelete, Result as ObjectStoreResult, oio,
+};
 use object_store::{Entry, ObjectStore, services};
+use store_api::metadata::RegionMetadataRef;
 use store_api::region_engine::RegionEngine as _;
-use store_api::region_request::{RegionCompactRequest, RegionRequest};
-use store_api::storage::{FileRef, FileRefsManifest, RegionId};
+use store_api::region_request::{
+    PathType, RegionCompactRequest, RegionFlushRequest, RegionRequest,
+};
+use store_api::storage::{FileId, FileRef, FileRefsManifest, RegionId, ScanRequest};
+use tokio::sync::Semaphore;
 
+use crate::cache::file_cache::FileType;
 use crate::config::MitoConfig;
 use crate::engine::MitoEngine;
 use crate::engine::compaction_test::{delete_and_flush, put_and_flush};
-use crate::gc::{GcConfig, LocalGcWorker, should_delete_file};
-use crate::manifest::action::RemovedFile;
+use crate::engine::region_hook::{RegionHook, RegionHookRef, SstFileInfo};
+use crate::gc::{
+    GcConfig, LocalGcWorker, ManifestLiveSet, TestFinalizationBarrier, TmpRefLiveSet,
+    should_delete_file,
+};
+use crate::manifest::action::{RegionManifest, RemovedFile};
 use crate::region::MitoRegionRef;
+use crate::sst::file::{FileMeta, IndexType, RegionFileId};
+use crate::sst::location;
 use crate::test_util::{
     CreateRequestBuilder, TestEnv, build_rows, flush_region, put_rows, rows_schema,
 };
+
+const RACE_TIMEOUT: Duration = Duration::from_secs(10);
+
+async fn wait_for_permit(semaphore: &Semaphore, step: &str) {
+    tokio::time::timeout(RACE_TIMEOUT, semaphore.acquire())
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for {step}"))
+        .expect("test semaphore must remain open")
+        .forget();
+}
+
+#[derive(Debug)]
+struct PauseAfterSstWritten {
+    reached: Arc<Semaphore>,
+    release: Arc<Semaphore>,
+    file_id: Mutex<Option<FileId>>,
+    paused: AtomicBool,
+}
+
+impl PauseAfterSstWritten {
+    fn new() -> Self {
+        Self {
+            reached: Arc::new(Semaphore::new(0)),
+            release: Arc::new(Semaphore::new(0)),
+            file_id: Mutex::new(None),
+            paused: AtomicBool::new(false),
+        }
+    }
+
+    async fn wait_until_written(&self) -> FileId {
+        wait_for_permit(&self.reached, "SST-written hook").await;
+        self.file_id
+            .lock()
+            .unwrap()
+            .expect("SST-written hook must record a file id")
+    }
+
+    fn release(&self) {
+        self.release.add_permits(1);
+    }
+}
+
+#[async_trait]
+impl RegionHook for PauseAfterSstWritten {
+    async fn on_sst_files_written(
+        &self,
+        _region_id: RegionId,
+        _region_metadata: &RegionMetadataRef,
+        files: &[SstFileInfo<'_>],
+    ) {
+        if self.paused.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        assert_eq!(1, files.len(), "the race tests write one Parquet SST");
+        *self.file_id.lock().unwrap() = Some(files[0].file_meta.file_id);
+        self.reached.add_permits(1);
+        wait_for_permit(&self.release, "release of SST-written hook").await;
+    }
+}
+
+struct FailCloseAfterParquetDelete {
+    inner: oio::Deleter,
+    deleted_parquet: bool,
+    close_attempted: Arc<Semaphore>,
+}
+
+impl oio::Delete for FailCloseAfterParquetDelete {
+    async fn delete(&mut self, path: &str, args: OpDelete) -> ObjectStoreResult<()> {
+        if path.ends_with(".parquet") {
+            // Model a batch delete whose close fails before the target request is committed.
+            self.deleted_parquet = true;
+            Ok(())
+        } else {
+            self.inner.delete(path, args).await
+        }
+    }
+
+    async fn close(&mut self) -> ObjectStoreResult<()> {
+        if self.deleted_parquet {
+            self.close_attempted.add_permits(1);
+            return Err(MockError::new(
+                ErrorKind::Unexpected,
+                "injected target Parquet batch-delete close failure",
+            ));
+        }
+        self.inner.close().await
+    }
+}
+
+struct SignalAfterParquetDelete {
+    inner: oio::Deleter,
+    deleted_parquet: bool,
+    completed: Arc<Semaphore>,
+}
+
+impl oio::Delete for SignalAfterParquetDelete {
+    async fn delete(&mut self, path: &str, args: OpDelete) -> ObjectStoreResult<()> {
+        self.deleted_parquet |= path.ends_with(".parquet");
+        self.inner.delete(path, args).await
+    }
+
+    async fn close(&mut self) -> ObjectStoreResult<()> {
+        let result = self.inner.close().await;
+        if result.is_ok() && self.deleted_parquet {
+            self.completed.add_permits(1);
+        }
+        result
+    }
+}
+
+fn gc_config_with_zero_unknown_ttl() -> MitoConfig {
+    MitoConfig {
+        gc: GcConfig {
+            enable: true,
+            lingering_time: None,
+            unknown_file_lingering_time: Duration::ZERO,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+fn file_refs_manifest(region_id: RegionId, manifest: &RegionManifest) -> FileRefsManifest {
+    FileRefsManifest {
+        file_refs: Default::default(),
+        manifest_version: [(region_id, manifest.manifest_version)].into(),
+        cross_region_refs: HashMap::new(),
+    }
+}
+
+fn version_contains_file(region: &MitoRegionRef, file_id: FileId) -> bool {
+    region
+        .version_control
+        .current()
+        .version
+        .ssts
+        .levels()
+        .iter()
+        .flat_map(|level| level.files())
+        .any(|file| file.file_id().file_id() == file_id)
+}
+
+async fn assert_rows_readable(engine: &MitoEngine, region_id: RegionId) {
+    let stream = engine
+        .scan_to_stream(region_id, ScanRequest::default())
+        .await
+        .unwrap();
+    let batches = RecordBatches::try_collect(stream).await.unwrap();
+    assert_eq!(
+        3,
+        batches.iter().map(|batch| batch.num_rows()).sum::<usize>()
+    );
+}
+
+fn parquet_path(table_dir: &str, region_id: RegionId, file_id: FileId) -> String {
+    location::sst_file_path(
+        table_dir,
+        RegionFileId::new(region_id, file_id),
+        PathType::Bare,
+    )
+}
+
+async fn entry_at_path(store: &ObjectStore, path: &str) -> Entry {
+    let parent = std::path::Path::new(path)
+        .parent()
+        .and_then(|parent| (!parent.as_os_str().is_empty()).then_some(parent));
+    let prefix = parent
+        .map(|parent| format!("{}/", parent.to_str().unwrap()))
+        .unwrap_or_default();
+    let expected_name = std::path::Path::new(path)
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap();
+    let lister = store.lister_with(&prefix).await.unwrap();
+    lister
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|entry| entry.name() == expected_name)
+        .unwrap_or_else(|| panic!("entry '{path}' not found when listing '{prefix}'"))
+}
+
+async fn wait_until_gc_cutoff_is_after_file_mtime(store: &ObjectStore, path: &str) {
+    let entry = entry_at_path(store, path).await;
+    let mtime_ms = entry
+        .metadata()
+        .last_modified()
+        .expect("FS object store must provide the target SST last-modified time")
+        .into_inner()
+        .as_millisecond();
+
+    tokio::time::timeout(RACE_TIMEOUT, async {
+        loop {
+            // `should_delete_file` compares these exact millisecond values with strict `<`.
+            if mtime_ms < chrono::Utc::now().timestamp_millis() {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| {
+        panic!(
+            "GC cutoff did not become strictly later than target SST mtime {mtime_ms} within {RACE_TIMEOUT:?}"
+        )
+    });
+}
+
+fn assert_target_is_candidate(candidates: &[RemovedFile], file_id: FileId) {
+    assert!(
+        candidates
+            .iter()
+            .any(|candidate| candidate.file_id() == file_id),
+        "GC candidates do not contain target SST {file_id}: {candidates:?}"
+    );
+}
+
+fn indexed_file_meta(region_id: RegionId, file_id: FileId, index_version: u64) -> FileMeta {
+    let mut meta = FileMeta {
+        region_id,
+        file_id,
+        index_version,
+        ..Default::default()
+    };
+    meta.available_indexes.push(IndexType::InvertedIndex);
+    meta
+}
+
+#[tokio::test]
+async fn test_manifest_live_set_protects_normal_and_staging_index_versions() {
+    let mut env = TestEnv::new().await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+    let region_id = RegionId::new(1, 1);
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Create(CreateRequestBuilder::new().build()),
+        )
+        .await
+        .unwrap();
+    let region = engine.get_region(region_id).unwrap();
+    let file_id = FileId::random();
+    let mut normal = (*region.manifest_ctx.manifest().await).clone();
+    normal
+        .files
+        .insert(file_id, indexed_file_meta(region_id, file_id, 1));
+    let mut staging = normal.clone();
+    staging
+        .files
+        .insert(file_id, indexed_file_meta(region_id, file_id, 2));
+    let live_set = ManifestLiveSet::from_manifests(&normal, Some(&staging));
+
+    assert!(live_set.contains_file(file_id, FileType::Puffin(1)));
+    assert!(live_set.contains_file(file_id, FileType::Puffin(2)));
+    assert!(!live_set.contains_file(file_id, FileType::Puffin(3)));
+    assert!(live_set.contains_file(file_id, FileType::Parquet));
+}
+
+#[test]
+fn test_tmp_ref_live_set_protects_parquet_and_matching_puffin_version() {
+    let file_id = FileId::random();
+    let no_index_live_set = TmpRefLiveSet::from(&HashSet::from([(file_id, None)]));
+    assert!(no_index_live_set.contains_file(file_id, FileType::Parquet));
+    assert!(!no_index_live_set.contains_file(file_id, FileType::Puffin(1)));
+
+    let indexed_live_set = TmpRefLiveSet::from(&HashSet::from([(file_id, Some(1))]));
+
+    assert!(indexed_live_set.contains_file(file_id, FileType::Parquet));
+    assert!(indexed_live_set.contains_file(file_id, FileType::Puffin(1)));
+    assert!(!indexed_live_set.contains_file(file_id, FileType::Puffin(2)));
+}
+
+#[tokio::test]
+async fn test_fast_gc_tmp_ref_filtering_protects_parquet_and_matching_puffin() {
+    let mut env = TestEnv::new().await;
+    let engine = env
+        .create_engine(MitoConfig {
+            gc: GcConfig {
+                lingering_time: None,
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+        .await;
+    let region_id = RegionId::new(1, 1);
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Create(CreateRequestBuilder::new().build()),
+        )
+        .await
+        .unwrap();
+    let region = engine.get_region(region_id).unwrap();
+    let manifest = region.manifest_ctx.manifest().await;
+    let worker = create_gc_worker(
+        &engine,
+        BTreeMap::from([(region_id, Some(region))]),
+        &file_refs_manifest(region_id, &manifest),
+        false,
+    )
+    .await;
+    let file_id = FileId::random();
+    let removed_files = HashSet::from([
+        RemovedFile::File(file_id, None),
+        RemovedFile::Index(file_id, 1),
+        RemovedFile::Index(file_id, 2),
+    ]);
+    let deletable_files = worker
+        .list_to_be_deleted_files(
+            region_id,
+            false,
+            &ManifestLiveSet::default(),
+            &TmpRefLiveSet::from(&HashSet::from([(file_id, Some(1))])),
+            BTreeMap::from([(Timestamp::new_millisecond(0), removed_files)]),
+            vec![],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(deletable_files, vec![RemovedFile::Index(file_id, 2)]);
+}
 
 async fn create_gc_worker(
     mito_engine: &MitoEngine,
@@ -156,6 +499,44 @@ async fn test_gc_worker_basic_truncate() {
 
     let manifest = region.manifest_ctx.manifest().await;
     assert!(manifest.removed_files.removed_files.is_empty() && manifest.files.is_empty());
+}
+
+#[tokio::test]
+async fn test_gc_worker_manifest_version_mismatch_needs_retry() {
+    let mut env = TestEnv::new().await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Create(CreateRequestBuilder::new().build()),
+        )
+        .await
+        .unwrap();
+    let region = engine.get_region(region_id).unwrap();
+    let manifest = region.manifest_ctx.manifest().await;
+    let file_ref_manifest = FileRefsManifest {
+        file_refs: Default::default(),
+        manifest_version: [(region_id, manifest.manifest_version + 1)].into(),
+        cross_region_refs: HashMap::new(),
+    };
+
+    let report = create_gc_worker(
+        &engine,
+        BTreeMap::from([(region_id, Some(region))]),
+        &file_ref_manifest,
+        true,
+    )
+    .await
+    .run()
+    .await
+    .unwrap();
+
+    assert_eq!(report.need_retry_regions, HashSet::from([region_id]));
+    assert!(!report.processed_regions.contains(&region_id));
+    assert!(!report.deleted_files.contains_key(&region_id));
+    assert!(!report.deleted_indexes.contains_key(&region_id));
 }
 
 /// Truncate with file refs should not delete files
@@ -420,6 +801,303 @@ async fn test_gc_worker_compact_with_ref() {
 
     assert_eq!(report.deleted_files.get(&region_id).unwrap().len(), 0);
     assert!(report.need_retry_regions.is_empty());
+}
+
+#[tokio::test]
+async fn test_full_gc_does_not_delete_sst_published_before_finalization() {
+    init_default_ut_logging();
+
+    let mock_layer = MockLayerBuilder::default().build().unwrap();
+    let mut env = TestEnv::new().await.with_mock_layer(mock_layer);
+    let hook = Arc::new(PauseAfterSstWritten::new());
+    let plugins = Plugins::new();
+    plugins.insert(hook.clone() as RegionHookRef);
+    let engine = env
+        .create_engine_with_plugins(gc_config_with_zero_unknown_ttl(), plugins)
+        .await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new().build();
+    let table_dir = request.table_dir.clone();
+    let column_schemas = rows_schema(&request);
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+    put_rows(
+        &engine,
+        region_id,
+        Rows {
+            schema: column_schemas,
+            rows: build_rows(0, 3),
+        },
+    )
+    .await;
+
+    let region = engine.get_region(region_id).unwrap();
+    let manifest_before_flush = region.manifest_ctx.manifest().await;
+    let flush_engine = engine.clone();
+    let flush = tokio::spawn(async move {
+        flush_engine
+            .handle_request(
+                region_id,
+                RegionRequest::Flush(RegionFlushRequest::default()),
+            )
+            .await
+    });
+    let file_id = hook.wait_until_written().await;
+    let path = parquet_path(&table_dir, region_id, file_id);
+    wait_until_gc_cutoff_is_after_file_mtime(region.access_layer.object_store(), &path).await;
+
+    let barrier = TestFinalizationBarrier::new();
+    let gc_worker = create_gc_worker(
+        &engine,
+        BTreeMap::from([(region_id, Some(region.clone()))]),
+        &file_refs_manifest(region_id, &manifest_before_flush),
+        true,
+    )
+    .await
+    .with_test_finalization_barrier(barrier.clone());
+    let gc = tokio::spawn(async move { gc_worker.run().await });
+    let candidates = barrier.wait_until_reached().await;
+    assert_target_is_candidate(&candidates, file_id);
+
+    hook.release();
+    flush.await.unwrap().unwrap();
+
+    let manifest = region.manifest_ctx.manifest().await;
+    assert!(manifest.files.contains_key(&file_id));
+    assert!(version_contains_file(&region, file_id));
+
+    barrier.release();
+    let report = gc.await.unwrap().unwrap();
+    assert!(report.need_retry_regions.contains(&region_id));
+    assert!(
+        !report
+            .deleted_files
+            .get(&region_id)
+            .is_some_and(|files| files.contains(&file_id)),
+        "GC must not report a published SST as deleted"
+    );
+
+    let object = region.access_layer.object_store().read(&path).await;
+    assert!(object.is_ok(), "published SST must remain readable: {path}");
+    assert_rows_readable(&engine, region_id).await;
+}
+
+#[tokio::test]
+async fn test_full_gc_delete_before_publication_fails_closed_and_flush_can_retry() {
+    init_default_ut_logging();
+
+    let delete_completed = Arc::new(Semaphore::new(0));
+    let completed = delete_completed.clone();
+    let mock_layer = MockLayerBuilder::default()
+        .deleter_factory(Arc::new(move |inner| {
+            Box::new(SignalAfterParquetDelete {
+                inner,
+                deleted_parquet: false,
+                completed: completed.clone(),
+            })
+        }))
+        .build()
+        .unwrap();
+    let mut env = TestEnv::new().await.with_mock_layer(mock_layer);
+    let hook = Arc::new(PauseAfterSstWritten::new());
+    let plugins = Plugins::new();
+    plugins.insert(hook.clone() as RegionHookRef);
+    let engine = env
+        .create_engine_with_plugins(gc_config_with_zero_unknown_ttl(), plugins)
+        .await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new().build();
+    let table_dir = request.table_dir.clone();
+    let column_schemas = rows_schema(&request);
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+    put_rows(
+        &engine,
+        region_id,
+        Rows {
+            schema: column_schemas,
+            rows: build_rows(0, 3),
+        },
+    )
+    .await;
+
+    let region = engine.get_region(region_id).unwrap();
+    let manifest_before_flush = region.manifest_ctx.manifest().await;
+    let flush_engine = engine.clone();
+    let flush = tokio::spawn(async move {
+        flush_engine
+            .handle_request(
+                region_id,
+                RegionRequest::Flush(RegionFlushRequest::default()),
+            )
+            .await
+    });
+    let file_id = hook.wait_until_written().await;
+    let path = parquet_path(&table_dir, region_id, file_id);
+    wait_until_gc_cutoff_is_after_file_mtime(region.access_layer.object_store(), &path).await;
+
+    let barrier = TestFinalizationBarrier::new();
+    let gc_worker = create_gc_worker(
+        &engine,
+        BTreeMap::from([(region_id, Some(region.clone()))]),
+        &file_refs_manifest(region_id, &manifest_before_flush),
+        true,
+    )
+    .await
+    .with_test_finalization_barrier(barrier.clone());
+    let gc = tokio::spawn(async move { gc_worker.run().await });
+    let candidates = barrier.wait_until_reached().await;
+    assert_target_is_candidate(&candidates, file_id);
+    barrier.release();
+    wait_for_permit(&delete_completed, "target Parquet delete completion").await;
+    assert!(
+        region
+            .access_layer
+            .object_store()
+            .read(&path)
+            .await
+            .is_err(),
+        "target SST must be absent before releasing its publisher"
+    );
+
+    hook.release();
+    let flush_result = flush.await.unwrap();
+    let report = gc.await.unwrap().unwrap();
+    assert!(
+        report
+            .deleted_files
+            .get(&region_id)
+            .is_some_and(|files| files.contains(&file_id)),
+        "GC report must contain the physically deleted target SST"
+    );
+    assert!(
+        flush_result.is_err(),
+        "a flush must not publish an SST that GC already deleted"
+    );
+
+    let manifest = region.manifest_ctx.manifest().await;
+    assert!(!manifest.files.contains_key(&file_id));
+    assert!(!version_contains_file(&region, file_id));
+    assert_rows_readable(&engine, region_id).await;
+
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Flush(RegionFlushRequest::default()),
+        )
+        .await
+        .unwrap();
+    assert_rows_readable(&engine, region_id).await;
+}
+
+#[tokio::test]
+async fn test_full_gc_delete_error_does_not_block_publisher_recovery() {
+    init_default_ut_logging();
+
+    let close_attempted = Arc::new(Semaphore::new(0));
+    let attempted = close_attempted.clone();
+    let mock_layer = MockLayerBuilder::default()
+        .deleter_factory(Arc::new(move |inner| {
+            Box::new(FailCloseAfterParquetDelete {
+                inner,
+                deleted_parquet: false,
+                close_attempted: attempted.clone(),
+            })
+        }))
+        .build()
+        .unwrap();
+    let mut env = TestEnv::new().await.with_mock_layer(mock_layer);
+    let hook = Arc::new(PauseAfterSstWritten::new());
+    let plugins = Plugins::new();
+    plugins.insert(hook.clone() as RegionHookRef);
+    let engine = env
+        .create_engine_with_plugins(gc_config_with_zero_unknown_ttl(), plugins)
+        .await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new().build();
+    let table_dir = request.table_dir.clone();
+    let column_schemas = rows_schema(&request);
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+    put_rows(
+        &engine,
+        region_id,
+        Rows {
+            schema: column_schemas,
+            rows: build_rows(0, 3),
+        },
+    )
+    .await;
+
+    let region = engine.get_region(region_id).unwrap();
+    let manifest_before_flush = region.manifest_ctx.manifest().await;
+    let flush_engine = engine.clone();
+    let flush = tokio::spawn(async move {
+        flush_engine
+            .handle_request(
+                region_id,
+                RegionRequest::Flush(RegionFlushRequest::default()),
+            )
+            .await
+    });
+    let file_id = hook.wait_until_written().await;
+    let path = parquet_path(&table_dir, region_id, file_id);
+    wait_until_gc_cutoff_is_after_file_mtime(region.access_layer.object_store(), &path).await;
+
+    let barrier = TestFinalizationBarrier::new();
+    let gc_worker = create_gc_worker(
+        &engine,
+        BTreeMap::from([(region_id, Some(region.clone()))]),
+        &file_refs_manifest(region_id, &manifest_before_flush),
+        true,
+    )
+    .await
+    .with_test_finalization_barrier(barrier.clone());
+    let gc = tokio::spawn(async move { gc_worker.run().await });
+    let candidates = barrier.wait_until_reached().await;
+    assert_target_is_candidate(&candidates, file_id);
+    barrier.release();
+    wait_for_permit(&close_attempted, "injected Parquet delete close failure").await;
+    let gc_result = tokio::time::timeout(RACE_TIMEOUT, gc)
+        .await
+        .expect("timed out waiting for GC after injected delete failure")
+        .unwrap();
+    assert!(
+        gc_result.is_err(),
+        "GC must surface the injected delete failure"
+    );
+
+    hook.release();
+    let flush_result = tokio::time::timeout(RACE_TIMEOUT, flush)
+        .await
+        .expect("timed out waiting for publisher after GC delete failure")
+        .unwrap();
+    assert!(
+        flush_result.is_ok(),
+        "publisher must continue after the failed GC delete is resolved"
+    );
+    assert!(
+        region
+            .manifest_ctx
+            .manifest()
+            .await
+            .files
+            .contains_key(&file_id)
+    );
+    assert!(version_contains_file(&region, file_id));
+    assert!(
+        region.access_layer.object_store().read(&path).await.is_ok(),
+        "failed batch delete must leave the target SST readable"
+    );
 }
 
 // --- Tests for unknown_file_lingering_time TTL logic ---

--- a/src/mito2/src/gc/worker_test.rs
+++ b/src/mito2/src/gc/worker_test.rs
@@ -22,7 +22,6 @@ use async_trait::async_trait;
 use common_base::Plugins;
 use common_recordbatch::RecordBatches;
 use common_telemetry::init_default_ut_logging;
-use common_time::Timestamp;
 use futures::TryStreamExt;
 use object_store::layers::mock::{
     Error as MockError, ErrorKind, MockLayerBuilder, OpDelete, Result as ObjectStoreResult, oio,
@@ -36,18 +35,14 @@ use store_api::region_request::{
 use store_api::storage::{FileId, FileRef, FileRefsManifest, RegionId, ScanRequest};
 use tokio::sync::Semaphore;
 
-use crate::cache::file_cache::FileType;
 use crate::config::MitoConfig;
 use crate::engine::MitoEngine;
 use crate::engine::compaction_test::{delete_and_flush, put_and_flush};
 use crate::engine::region_hook::{RegionHook, RegionHookRef, SstFileInfo};
-use crate::gc::{
-    GcConfig, LocalGcWorker, ManifestLiveSet, TestFinalizationBarrier, TmpRefLiveSet,
-    should_delete_file,
-};
+use crate::gc::{GcConfig, LocalGcWorker, TestFinalizationBarrier, should_delete_file};
 use crate::manifest::action::{RegionManifest, RemovedFile};
 use crate::region::MitoRegionRef;
-use crate::sst::file::{FileMeta, IndexType, RegionFileId};
+use crate::sst::file::{RegionFileId, RegionIndexId};
 use crate::sst::location;
 use crate::test_util::{
     CreateRequestBuilder, TestEnv, build_rows, flush_region, put_rows, rows_schema,
@@ -262,119 +257,6 @@ async fn wait_until_gc_cutoff_is_after_file_mtime(store: &ObjectStore, path: &st
     });
 }
 
-fn assert_target_is_candidate(candidates: &[RemovedFile], file_id: FileId) {
-    assert!(
-        candidates
-            .iter()
-            .any(|candidate| candidate.file_id() == file_id),
-        "GC candidates do not contain target SST {file_id}: {candidates:?}"
-    );
-}
-
-fn indexed_file_meta(region_id: RegionId, file_id: FileId, index_version: u64) -> FileMeta {
-    let mut meta = FileMeta {
-        region_id,
-        file_id,
-        index_version,
-        ..Default::default()
-    };
-    meta.available_indexes.push(IndexType::InvertedIndex);
-    meta
-}
-
-#[tokio::test]
-async fn test_manifest_live_set_protects_normal_and_staging_index_versions() {
-    let mut env = TestEnv::new().await;
-    let engine = env.create_engine(MitoConfig::default()).await;
-    let region_id = RegionId::new(1, 1);
-    engine
-        .handle_request(
-            region_id,
-            RegionRequest::Create(CreateRequestBuilder::new().build()),
-        )
-        .await
-        .unwrap();
-    let region = engine.get_region(region_id).unwrap();
-    let file_id = FileId::random();
-    let mut normal = (*region.manifest_ctx.manifest().await).clone();
-    normal
-        .files
-        .insert(file_id, indexed_file_meta(region_id, file_id, 1));
-    let mut staging = normal.clone();
-    staging
-        .files
-        .insert(file_id, indexed_file_meta(region_id, file_id, 2));
-    let live_set = ManifestLiveSet::from_manifests(&normal, Some(&staging));
-
-    assert!(live_set.contains_file(file_id, FileType::Puffin(1)));
-    assert!(live_set.contains_file(file_id, FileType::Puffin(2)));
-    assert!(!live_set.contains_file(file_id, FileType::Puffin(3)));
-    assert!(live_set.contains_file(file_id, FileType::Parquet));
-}
-
-#[test]
-fn test_tmp_ref_live_set_protects_parquet_and_matching_puffin_version() {
-    let file_id = FileId::random();
-    let no_index_live_set = TmpRefLiveSet::from(&HashSet::from([(file_id, None)]));
-    assert!(no_index_live_set.contains_file(file_id, FileType::Parquet));
-    assert!(!no_index_live_set.contains_file(file_id, FileType::Puffin(1)));
-
-    let indexed_live_set = TmpRefLiveSet::from(&HashSet::from([(file_id, Some(1))]));
-
-    assert!(indexed_live_set.contains_file(file_id, FileType::Parquet));
-    assert!(indexed_live_set.contains_file(file_id, FileType::Puffin(1)));
-    assert!(!indexed_live_set.contains_file(file_id, FileType::Puffin(2)));
-}
-
-#[tokio::test]
-async fn test_fast_gc_tmp_ref_filtering_protects_parquet_and_matching_puffin() {
-    let mut env = TestEnv::new().await;
-    let engine = env
-        .create_engine(MitoConfig {
-            gc: GcConfig {
-                lingering_time: None,
-                ..Default::default()
-            },
-            ..Default::default()
-        })
-        .await;
-    let region_id = RegionId::new(1, 1);
-    engine
-        .handle_request(
-            region_id,
-            RegionRequest::Create(CreateRequestBuilder::new().build()),
-        )
-        .await
-        .unwrap();
-    let region = engine.get_region(region_id).unwrap();
-    let manifest = region.manifest_ctx.manifest().await;
-    let worker = create_gc_worker(
-        &engine,
-        BTreeMap::from([(region_id, Some(region))]),
-        &file_refs_manifest(region_id, &manifest),
-        false,
-    )
-    .await;
-    let file_id = FileId::random();
-    let removed_files = HashSet::from([
-        RemovedFile::File(file_id, None),
-        RemovedFile::Index(file_id, 1),
-        RemovedFile::Index(file_id, 2),
-    ]);
-    let deletable_files = worker
-        .list_to_be_deleted_files(
-            region_id,
-            false,
-            &ManifestLiveSet::default(),
-            &TmpRefLiveSet::from(&HashSet::from([(file_id, Some(1))])),
-            BTreeMap::from([(Timestamp::new_millisecond(0), removed_files)]),
-            vec![],
-        )
-        .unwrap();
-
-    assert_eq!(deletable_files, vec![RemovedFile::Index(file_id, 2)]);
-}
-
 async fn create_gc_worker(
     mito_engine: &MitoEngine,
     regions: BTreeMap<RegionId, Option<MitoRegionRef>>,
@@ -403,6 +285,78 @@ async fn create_gc_worker(
     )
     .await
     .unwrap()
+}
+
+#[tokio::test]
+async fn test_full_gc_tmp_refs_keep_all_live_index_versions() {
+    let mut env = TestEnv::new().await;
+    let engine = env.create_engine(gc_config_with_zero_unknown_ttl()).await;
+    let region_id = RegionId::new(1, 1);
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Create(CreateRequestBuilder::new().build()),
+        )
+        .await
+        .unwrap();
+    let region = engine.get_region(region_id).unwrap();
+    let manifest = region.manifest_ctx.manifest().await;
+    let worker = create_gc_worker(
+        &engine,
+        BTreeMap::from([(region_id, Some(region))]),
+        &file_refs_manifest(region_id, &manifest),
+        true,
+    )
+    .await;
+
+    let file_id = FileId::random();
+    let parquet_path = parquet_path(worker.access_layer.table_dir(), region_id, file_id);
+    let index_paths = [1, 2, 3].map(|index_version| {
+        location::index_file_path(
+            worker.access_layer.table_dir(),
+            RegionIndexId::new(RegionFileId::new(region_id, file_id), index_version),
+            worker.access_layer.path_type(),
+        )
+    });
+    for path in &index_paths {
+        worker
+            .access_layer
+            .object_store()
+            .write(path, b"index".as_slice())
+            .await
+            .unwrap();
+    }
+    worker
+        .access_layer
+        .object_store()
+        .write(&parquet_path, b"parquet".as_slice())
+        .await
+        .unwrap();
+    wait_until_gc_cutoff_is_after_file_mtime(worker.access_layer.object_store(), &index_paths[2])
+        .await;
+
+    let mut entries = futures::future::join_all(
+        index_paths
+            .iter()
+            .map(|path| entry_at_path(worker.access_layer.object_store(), path)),
+    )
+    .await;
+    entries.push(entry_at_path(worker.access_layer.object_store(), &parquet_path).await);
+    let tmp_refs = HashSet::from([(file_id, Some(1)), (file_id, Some(2))]);
+    let deletable_files = worker
+        .list_to_be_deleted_files(
+            region_id,
+            false,
+            &HashMap::new(),
+            &tmp_refs,
+            Default::default(),
+            entries,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(deletable_files, vec![RemovedFile::Index(file_id, 3)]);
+    assert!(!deletable_files.contains(&RemovedFile::File(file_id, None)));
 }
 
 /// Test insert/flush then truncate can allow gc worker to delete files
@@ -536,6 +490,39 @@ async fn test_gc_worker_manifest_version_mismatch_needs_retry() {
     assert!(!report.processed_regions.contains(&region_id));
     assert!(!report.deleted_files.contains_key(&region_id));
     assert!(!report.deleted_indexes.contains_key(&region_id));
+}
+
+#[tokio::test]
+async fn test_gc_worker_staging_region_needs_retry() {
+    let mut env = TestEnv::new().await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+    let region_id = RegionId::new(1, 1);
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Create(CreateRequestBuilder::new().build()),
+        )
+        .await
+        .unwrap();
+    let region = engine.get_region(region_id).unwrap();
+    let mut manager = region.manifest_ctx.manifest_manager.write().await;
+    region.set_staging(&mut manager).await.unwrap();
+    drop(manager);
+    let manifest = region.manifest_ctx.manifest().await;
+
+    let report = create_gc_worker(
+        &engine,
+        BTreeMap::from([(region_id, Some(region))]),
+        &file_refs_manifest(region_id, &manifest),
+        true,
+    )
+    .await
+    .run()
+    .await
+    .unwrap();
+
+    assert_eq!(report.need_retry_regions, HashSet::from([region_id]));
+    assert!(!report.processed_regions.contains(&region_id));
 }
 
 /// Truncate with file refs should not delete files
@@ -858,8 +845,7 @@ async fn test_full_gc_does_not_delete_sst_published_before_finalization() {
     .await
     .with_test_finalization_barrier(barrier.clone());
     let gc = tokio::spawn(async move { gc_worker.run().await });
-    let candidates = barrier.wait_until_reached().await;
-    assert_target_is_candidate(&candidates, file_id);
+    barrier.wait_until_reached().await;
 
     hook.release();
     flush.await.unwrap().unwrap();
@@ -951,8 +937,7 @@ async fn test_full_gc_delete_before_publication_fails_closed_and_flush_can_retry
     .await
     .with_test_finalization_barrier(barrier.clone());
     let gc = tokio::spawn(async move { gc_worker.run().await });
-    let candidates = barrier.wait_until_reached().await;
-    assert_target_is_candidate(&candidates, file_id);
+    barrier.wait_until_reached().await;
     barrier.release();
     wait_for_permit(&delete_completed, "target Parquet delete completion").await;
     assert!(
@@ -1062,8 +1047,7 @@ async fn test_full_gc_delete_error_does_not_block_publisher_recovery() {
     .await
     .with_test_finalization_barrier(barrier.clone());
     let gc = tokio::spawn(async move { gc_worker.run().await });
-    let candidates = barrier.wait_until_reached().await;
-    assert_target_is_candidate(&candidates, file_id);
+    barrier.wait_until_reached().await;
     barrier.release();
     wait_for_permit(&close_attempted, "injected Parquet delete close failure").await;
     let gc_result = tokio::time::timeout(RACE_TIMEOUT, gc)

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -1289,9 +1289,11 @@ impl ManifestContext {
         is_staging: bool,
         check_state: impl FnOnce(RegionRoleState, RegionId) -> Result<()>,
     ) -> Result<ManifestVersion> {
-        let files_to_publish = (!is_staging && self.local_publication_protocol_enabled)
-            .then(|| self.local_files_to_publish(&action_list))
-            .unwrap_or_default();
+        let files_to_publish = if !is_staging && self.local_publication_protocol_enabled {
+            self.local_files_to_publish(&action_list)
+        } else {
+            Vec::new()
+        };
         // Publication validation and the manifest update share this gate with future active GC
         // finalization. Keep it before the manifest lock to preserve the global lock order.
         let _publication_guard = if files_to_publish.is_empty() {
@@ -1970,36 +1972,6 @@ mod tests {
         }
     }
 
-    async fn build_test_manifest_context(
-        env: &SchedulerEnv,
-        hook: RegionHookRef,
-    ) -> Arc<ManifestContext> {
-        let version_control = VersionControlBuilder::new().build();
-        let metadata = version_control.current().version.metadata.clone();
-        let manager = RegionManifestManager::new(
-            metadata,
-            0,
-            RegionManifestOptions {
-                manifest_dir: "".to_string(),
-                object_store: env.access_layer.object_store().clone(),
-                compress_type: CompressionType::Uncompressed,
-                checkpoint_distance: 10,
-                remove_file_options: Default::default(),
-                manifest_cache: None,
-            },
-            FormatType::PrimaryKey,
-            &Default::default(),
-        )
-        .await
-        .unwrap();
-        Arc::new(ManifestContext::new(
-            manager,
-            env.access_layer.clone(),
-            RegionRoleState::Leader(RegionLeaderState::Writable),
-            Some(hook),
-        ))
-    }
-
     fn empty_edit() -> RegionEdit {
         RegionEdit {
             files_to_add: Vec::new(),
@@ -2019,7 +1991,8 @@ mod tests {
             entered: Arc::new(Semaphore::new(0)),
             release: Arc::new(Semaphore::new(0)),
         });
-        let context = build_test_manifest_context(&env, hook.clone() as RegionHookRef).await;
+        let region = build_test_region_with_hook(&env, Some(hook.clone() as RegionHookRef)).await;
+        let context = region.manifest_ctx.clone();
         let file = FileMeta {
             region_id: context.manifest().await.metadata.region_id,
             file_id: FileId::random(),
@@ -2063,6 +2036,14 @@ mod tests {
         }))
     }
 
+    fn publication_file(region_id: RegionId) -> FileMeta {
+        FileMeta {
+            region_id,
+            file_id: FileId::random(),
+            ..Default::default()
+        }
+    }
+
     async fn write_publication_file(region: &MitoRegion, file: &FileMeta) {
         let path = location::sst_file_path(
             region.access_layer.table_dir(),
@@ -2078,80 +2059,30 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_update_manifest_rejects_missing_publication_file_without_mutation() {
+    async fn test_update_manifest_cross_only_skips_and_mixed_validates_local_files() {
         let env = SchedulerEnv::new().await;
         let region = build_test_region(&env).await;
-        let file = FileMeta {
-            region_id: region.region_id,
-            file_id: FileId::random(),
-            ..Default::default()
-        };
-        let before = region.manifest_ctx.manifest().await;
-
-        let err = region
-            .manifest_ctx
-            .update_manifest(RegionLeaderState::Writable, add_file_edit(file), false)
-            .await
-            .unwrap_err();
-        assert!(matches!(err, Error::PublicationObjectStat { .. }));
-
-        let after = region.manifest_ctx.manifest().await;
-        assert_eq!(before.manifest_version, after.manifest_version);
-        assert!(after.files.is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_update_manifest_allows_cross_region_file_without_validation() {
-        let env = SchedulerEnv::new().await;
-        let region = build_test_region(&env).await;
-        let file = FileMeta {
-            region_id: RegionId::new(1, 2),
-            file_id: FileId::random(),
-            ..Default::default()
-        };
-
+        let cross_region_file = publication_file(RegionId::new(1, 2));
         region
             .manifest_ctx
             .update_manifest(
                 RegionLeaderState::Writable,
-                add_file_edit(file.clone()),
+                add_file_edit(cross_region_file.clone()),
                 false,
             )
             .await
             .unwrap();
 
-        assert!(
-            region
-                .manifest_ctx
-                .manifest()
-                .await
-                .files
-                .contains_key(&file.file_id)
-        );
-    }
-
-    #[tokio::test]
-    async fn test_update_manifest_mixed_files_only_validates_local_files() {
-        let env = SchedulerEnv::new().await;
-        let region = build_test_region(&env).await;
-        let local_file = FileMeta {
-            region_id: region.region_id,
-            file_id: FileId::random(),
-            ..Default::default()
-        };
+        let local_file = publication_file(region.region_id);
         write_publication_file(&region, &local_file).await;
-        let cross_region_file = FileMeta {
-            region_id: RegionId::new(1, 2),
-            file_id: FileId::random(),
-            ..Default::default()
-        };
+        let mixed_cross_region_file = publication_file(RegionId::new(1, 2));
 
         region
             .manifest_ctx
             .update_manifest(
                 RegionLeaderState::Writable,
                 RegionMetaActionList::with_action(RegionMetaAction::Edit(RegionEdit {
-                    files_to_add: vec![local_file.clone(), cross_region_file.clone()],
+                    files_to_add: vec![local_file.clone(), mixed_cross_region_file.clone()],
                     ..empty_edit()
                 })),
                 false,
@@ -2160,78 +2091,22 @@ mod tests {
             .unwrap();
 
         let manifest = region.manifest_ctx.manifest().await;
-        assert!(manifest.files.contains_key(&local_file.file_id));
         assert!(manifest.files.contains_key(&cross_region_file.file_id));
-    }
-
-    #[tokio::test]
-    async fn test_staging_manifest_update_skips_local_publication_validation() {
-        let env = SchedulerEnv::new().await;
-        let region = build_test_region(&env).await;
-        let file = FileMeta {
-            region_id: region.region_id,
-            file_id: FileId::random(),
-            ..Default::default()
-        };
-
-        region
-            .manifest_ctx
-            .update_manifest(
-                RegionLeaderState::Writable,
-                add_file_edit(file.clone()),
-                true,
-            )
-            .await
-            .unwrap();
-
+        assert!(manifest.files.contains_key(&local_file.file_id));
         assert!(
-            region
-                .manifest_ctx
-                .staging_manifest()
-                .await
-                .unwrap()
+            manifest
                 .files
-                .contains_key(&file.file_id)
+                .contains_key(&mixed_cross_region_file.file_id)
         );
     }
 
     #[tokio::test]
-    async fn test_update_manifest_metadata_only_skips_publication_validation() {
+    async fn test_update_manifest_rejects_missing_local_and_skips_staging_validation() {
         let env = SchedulerEnv::new().await;
         let region = build_test_region(&env).await;
-        let before = region.manifest_ctx.manifest().await;
-
-        region
-            .manifest_ctx
-            .update_manifest(
-                RegionLeaderState::Writable,
-                RegionMetaActionList::with_action(RegionMetaAction::Edit(empty_edit())),
-                false,
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(
-            before.manifest_version + 1,
-            region.manifest_ctx.manifest().await.manifest_version
-        );
-    }
-
-    #[tokio::test]
-    async fn test_update_manifest_rejects_any_missing_file_from_multiple_edits() {
-        let env = SchedulerEnv::new().await;
-        let region = build_test_region(&env).await;
-        let present = FileMeta {
-            region_id: region.region_id,
-            file_id: FileId::random(),
-            ..Default::default()
-        };
+        let present = publication_file(region.region_id);
         write_publication_file(&region, &present).await;
-        let missing = FileMeta {
-            region_id: region.region_id,
-            file_id: FileId::random(),
-            ..Default::default()
-        };
+        let missing = publication_file(region.region_id);
         let before = region.manifest_ctx.manifest().await;
         let actions = RegionMetaActionList::new(vec![
             RegionMetaAction::Edit(RegionEdit {
@@ -2254,6 +2129,26 @@ mod tests {
         let after = region.manifest_ctx.manifest().await;
         assert_eq!(before.manifest_version, after.manifest_version);
         assert!(after.files.is_empty());
+
+        let staging_file = publication_file(region.region_id);
+        region
+            .manifest_ctx
+            .update_manifest(
+                RegionLeaderState::Writable,
+                add_file_edit(staging_file.clone()),
+                true,
+            )
+            .await
+            .unwrap();
+        assert!(
+            region
+                .manifest_ctx
+                .staging_manifest()
+                .await
+                .unwrap()
+                .files
+                .contains_key(&staging_file.file_id)
+        );
     }
 
     #[tokio::test]

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -68,8 +68,8 @@ pub(crate) struct PublicationGuard<'a> {
     _guard: tokio::sync::MutexGuard<'a, ()>,
 }
 
-#[allow(dead_code)]
 pub(crate) struct OwnedPublicationGuard {
+    #[cfg(test)]
     gate: Arc<tokio::sync::Mutex<()>>,
     _guard: tokio::sync::OwnedMutexGuard<()>,
 }
@@ -1094,12 +1094,7 @@ impl ManifestContext {
         self.hook.clone()
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn access_layer(&self) -> &AccessLayerRef {
-        &self.access_layer
-    }
-
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn publication_gate(&self) -> Arc<tokio::sync::Mutex<()>> {
         self.publication_gate.clone()
     }
@@ -1112,11 +1107,11 @@ impl ManifestContext {
         }
     }
 
-    #[allow(dead_code)]
     pub(crate) async fn lock_publication_owned(&self) -> OwnedPublicationGuard {
         let gate = self.publication_gate.clone();
         let guard = gate.clone().lock_owned().await;
         OwnedPublicationGuard {
+            #[cfg(test)]
             gate,
             _guard: guard,
         }
@@ -1630,8 +1625,8 @@ impl ManifestContext {
     }
 }
 
+#[cfg(test)]
 impl OwnedPublicationGuard {
-    #[allow(dead_code)]
     pub(crate) fn belongs_to(&self, manifest_ctx: &ManifestContext) -> bool {
         Arc::ptr_eq(&self.gate, &manifest_ctx.publication_gate)
     }

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -63,17 +63,6 @@ use crate::sst::file_purger::FilePurgerRef;
 use crate::sst::location::{index_file_path, sst_file_path};
 use crate::time_provider::TimeProviderRef;
 
-pub(crate) struct PublicationGuard<'a> {
-    gate: Arc<tokio::sync::Mutex<()>>,
-    _guard: tokio::sync::MutexGuard<'a, ()>,
-}
-
-pub(crate) struct OwnedPublicationGuard {
-    #[cfg(test)]
-    gate: Arc<tokio::sync::Mutex<()>>,
-    _guard: tokio::sync::OwnedMutexGuard<()>,
-}
-
 /// This is the approximate factor to estimate the size of wal.
 const ESTIMATED_WAL_FACTOR: f32 = 0.42825;
 
@@ -486,13 +475,6 @@ impl MitoRegion {
         &self,
         state: SettableRegionRoleState,
     ) -> Result<()> {
-        // A leader transition may publish staged files. Acquire the publication gate before the
-        // manifest lock to preserve the global lock order.
-        let publication_guard = if matches!(state, SettableRegionRoleState::Leader) {
-            Some(self.manifest_ctx.lock_publication().await)
-        } else {
-            None
-        };
         let mut manager: RwLockWriteGuard<'_, RegionManifestManager> =
             self.manifest_ctx.manifest_manager.write().await;
         let current_state = self.state();
@@ -505,13 +487,7 @@ impl MitoRegion {
                     RegionRoleState::Leader(RegionLeaderState::Staging) => {
                         info!("Exiting staging mode for region {}", self.region_id);
                         // Use the success exit path that merges all staged manifests
-                        self.exit_staging_on_success(
-                            &mut manager,
-                            publication_guard.as_ref().expect(
-                                "leader transition must hold the publication guard before the manifest lock",
-                            ),
-                        )
-                        .await?
+                        self.exit_staging_on_success(&mut manager).await?
                     }
                     RegionRoleState::Leader(RegionLeaderState::Writable) => {
                         // Already in desired state - no-op
@@ -642,9 +618,6 @@ impl MitoRegion {
         }
 
         drop(manager);
-        // Hooks may publish additional files, so release the publication gate before firing.
-        drop(publication_guard);
-
         // Merge both payloads so consumers see the complete set of actions in
         // one notification. The lock is released, so it's safe to fire.
         let merged = match (hook_payload, backfill_hook_payload) {
@@ -887,7 +860,6 @@ impl MitoRegion {
     pub(crate) async fn exit_staging_on_success(
         &self,
         manager: &mut RwLockWriteGuard<'_, RegionManifestManager>,
-        permit: &PublicationGuard<'_>,
     ) -> Result<Option<PendingManifestHook>> {
         let current_state = self.manifest_ctx.current_state();
         ensure!(
@@ -956,7 +928,7 @@ impl MitoRegion {
         // Pass `false` so it saves to normal directory, not staging.
         let pending = self
             .manifest_ctx
-            .update_locked_with_publication_guard(manager, merged_actions, false, permit)
+            .update_locked(manager, merged_actions, false)
             .await?;
         let new_version = pending.version();
         info!(
@@ -1056,8 +1028,10 @@ pub(crate) struct ManifestContext {
     region_id: RegionId,
     /// Access layer used by the publication path to validate objects before manifest updates.
     access_layer: AccessLayerRef,
+    /// Whether normal-manifest updates use the local publication protocol.
+    local_publication_protocol_enabled: bool,
     /// Serializes local file publication with active-region GC finalization.
-    publication_gate: Arc<tokio::sync::Mutex<()>>,
+    pub(crate) publication_gate: tokio::sync::Mutex<()>,
     /// The state of the region. The region checks the state before updating
     /// manifest.
     state: AtomicCell<RegionRoleState>,
@@ -1077,12 +1051,23 @@ impl ManifestContext {
         state: RegionRoleState,
         hook: Option<RegionHookRef>,
     ) -> Self {
+        Self::new_with_local_publication_protocol(manager, access_layer, state, hook, true)
+    }
+
+    pub(crate) fn new_with_local_publication_protocol(
+        manager: RegionManifestManager,
+        access_layer: AccessLayerRef,
+        state: RegionRoleState,
+        hook: Option<RegionHookRef>,
+        local_publication_protocol_enabled: bool,
+    ) -> Self {
         let region_id = manager.manifest().metadata.region_id;
         ManifestContext {
             manifest_manager: tokio::sync::RwLock::new(manager),
             region_id,
             access_layer,
-            publication_gate: Arc::new(tokio::sync::Mutex::new(())),
+            local_publication_protocol_enabled,
+            publication_gate: tokio::sync::Mutex::new(()),
             state: AtomicCell::new(state),
             staging_partition_info: Mutex::new(None),
             hook,
@@ -1094,35 +1079,21 @@ impl ManifestContext {
         self.hook.clone()
     }
 
-    #[cfg(test)]
-    pub(crate) fn publication_gate(&self) -> Arc<tokio::sync::Mutex<()>> {
-        self.publication_gate.clone()
-    }
-
-    pub(crate) async fn lock_publication(&self) -> PublicationGuard<'_> {
-        let guard = self.publication_gate.lock().await;
-        PublicationGuard {
-            gate: self.publication_gate.clone(),
-            _guard: guard,
+    fn local_files_to_publish(&self, action_list: &RegionMetaActionList) -> Vec<FileMeta> {
+        if !self.local_publication_protocol_enabled {
+            return Vec::new();
         }
-    }
 
-    pub(crate) async fn lock_publication_owned(&self) -> OwnedPublicationGuard {
-        let gate = self.publication_gate.clone();
-        let guard = gate.clone().lock_owned().await;
-        OwnedPublicationGuard {
-            #[cfg(test)]
-            gate,
-            _guard: guard,
-        }
-    }
-
-    fn files_to_publish(action_list: &RegionMetaActionList) -> Vec<FileMeta> {
         action_list
             .actions
             .iter()
             .filter_map(|action| match action {
-                RegionMetaAction::Edit(edit) => Some(edit.files_to_add.iter().cloned()),
+                RegionMetaAction::Edit(edit) => Some(
+                    edit.files_to_add
+                        .iter()
+                        .filter(|file| file.region_id == self.region_id)
+                        .cloned(),
+                ),
                 _ => None,
             })
             .flatten()
@@ -1294,39 +1265,6 @@ impl ManifestContext {
         action_list: RegionMetaActionList,
         is_staging: bool,
     ) -> Result<PendingManifestHook> {
-        ensure!(
-            Self::files_to_publish(&action_list).is_empty(),
-            UnexpectedSnafu {
-                reason: "manifest updates that publish files require the publication guard"
-            }
-        );
-        self.update_locked_impl(manager, action_list, is_staging)
-            .await
-    }
-
-    pub(crate) async fn update_locked_with_publication_guard(
-        &self,
-        manager: &mut RegionManifestManager,
-        action_list: RegionMetaActionList,
-        is_staging: bool,
-        guard: &PublicationGuard<'_>,
-    ) -> Result<PendingManifestHook> {
-        ensure!(
-            Arc::ptr_eq(&guard.gate, &self.publication_gate),
-            UnexpectedSnafu {
-                reason: "publication guard belongs to a different manifest context"
-            }
-        );
-        self.update_locked_impl(manager, action_list, is_staging)
-            .await
-    }
-
-    async fn update_locked_impl(
-        &self,
-        manager: &mut RegionManifestManager,
-        action_list: RegionMetaActionList,
-        is_staging: bool,
-    ) -> Result<PendingManifestHook> {
         let region_id = manager.manifest().metadata.region_id;
         // Clone before `action_list` is moved into `update` so the hook still
         // sees what was written.
@@ -1351,17 +1289,19 @@ impl ManifestContext {
         is_staging: bool,
         check_state: impl FnOnce(RegionRoleState, RegionId) -> Result<()>,
     ) -> Result<ManifestVersion> {
-        let files_to_publish = Self::files_to_publish(&action_list);
+        let files_to_publish = (!is_staging && self.local_publication_protocol_enabled)
+            .then(|| self.local_files_to_publish(&action_list))
+            .unwrap_or_default();
         // Publication validation and the manifest update share this gate with future active GC
         // finalization. Keep it before the manifest lock to preserve the global lock order.
         let _publication_guard = if files_to_publish.is_empty() {
             None
         } else {
-            Some(self.lock_publication().await)
+            Some(self.publication_gate.lock().await)
         };
         if !files_to_publish.is_empty() {
             self.access_layer
-                .validate_publication_files(self.region_id, &files_to_publish)
+                .validate_local_publication_files(self.region_id, &files_to_publish)
                 .await?;
         }
 
@@ -1426,28 +1366,15 @@ impl ManifestContext {
 
         // `update_locked` returns a `PendingManifestHook` we fire after releasing the lock.
         let region_id = manifest.metadata.region_id;
-        let pending = if files_to_publish.is_empty() {
-            self.update_locked(&mut manager, action_list, is_staging)
-                .await?
-        } else {
-            self.update_locked_with_publication_guard(
-                &mut manager,
-                action_list,
-                is_staging,
-                _publication_guard
-                    .as_ref()
-                    .expect("publication guard must be held when publishing files"),
-            )
-            .await?
-        };
+        let pending = self
+            .update_locked(&mut manager, action_list, is_staging)
+            .await?;
         let version = pending.version();
 
         // Drop the write lock before invoking the hook. Hook implementations may
         // read the manifest or send region requests that acquire this lock;
         // holding it would deadlock. Slow hooks also must not block manifest updates.
         drop(manager);
-        // Hooks are user-provided async code. Do not retain the publication gate while they run,
-        // otherwise a hook that triggers another publication path can self-deadlock.
         drop(_publication_guard);
 
         if self.state.load() == RegionRoleState::Follower {
@@ -1622,13 +1549,6 @@ impl ManifestContext {
         &self,
     ) -> Option<Arc<crate::manifest::action::RegionManifest>> {
         self.manifest_manager.read().await.staging_manifest()
-    }
-}
-
-#[cfg(test)]
-impl OwnedPublicationGuard {
-    pub(crate) fn belongs_to(&self, manifest_ctx: &ManifestContext) -> bool {
-        Arc::ptr_eq(&self.gate, &manifest_ctx.publication_gate)
     }
 }
 
@@ -1934,7 +1854,7 @@ mod tests {
     use object_store::services::Fs;
     use store_api::ManifestVersion;
     use store_api::logstore::provider::Provider;
-    use store_api::region_engine::{RegionRole, SettableRegionRoleState};
+    use store_api::region_engine::RegionRole;
     use store_api::region_request::PathType;
     use store_api::storage::{FileId, RegionId};
     use tokio::sync::Semaphore;
@@ -2128,63 +2048,12 @@ mod tests {
             .unwrap()
             .forget();
 
-        let gate = tokio::time::timeout(
-            Duration::from_secs(1),
-            context.publication_gate().lock_owned(),
-        )
-        .await
-        .expect("manifest hook ran while publication gate was still held");
+        let gate = tokio::time::timeout(Duration::from_secs(1), context.publication_gate.lock())
+            .await
+            .expect("manifest hook ran while publication gate was still held");
         drop(gate);
         hook.release.add_permits(1);
         update.await.unwrap().unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_exit_staging_hook_runs_after_publication_gate_is_released() {
-        let env = SchedulerEnv::new().await;
-        let hook = Arc::new(BlockingManifestHook {
-            entered: Arc::new(Semaphore::new(0)),
-            release: Arc::new(Semaphore::new(0)),
-        });
-        let region =
-            Arc::new(build_test_region_with_hook(&env, Some(hook.clone() as RegionHookRef)).await);
-        let mut manager = region.manifest_ctx.manifest_manager.write().await;
-        region.set_staging(&mut manager).await.unwrap();
-        manager
-            .update(
-                RegionMetaActionList::new(vec![
-                    RegionMetaAction::PartitionExprChange(RegionPartitionExprChange {
-                        partition_expr: Some("expr_a".to_string()),
-                    }),
-                    RegionMetaAction::Edit(empty_edit()),
-                ]),
-                true,
-            )
-            .await
-            .unwrap();
-        drop(manager);
-
-        let promotion_region = region.clone();
-        let promotion = tokio::spawn(async move {
-            promotion_region
-                .set_role_state_gracefully(SettableRegionRoleState::Leader)
-                .await
-        });
-        tokio::time::timeout(Duration::from_secs(1), hook.entered.acquire())
-            .await
-            .expect("staging promotion hook did not start")
-            .unwrap()
-            .forget();
-
-        let gate = tokio::time::timeout(
-            Duration::from_secs(1),
-            region.manifest_ctx.publication_gate().lock_owned(),
-        )
-        .await
-        .expect("staging promotion hook ran while publication gate was still held");
-        drop(gate);
-        hook.release.add_permits(1);
-        promotion.await.unwrap().unwrap();
     }
 
     fn add_file_edit(file: FileMeta) -> RegionMetaActionList {
@@ -2192,74 +2061,6 @@ mod tests {
             files_to_add: vec![file],
             ..empty_edit()
         }))
-    }
-
-    #[tokio::test]
-    async fn test_update_locked_rejects_file_add_without_publication_guard() {
-        let env = SchedulerEnv::new().await;
-        let region = build_test_region(&env).await;
-        let file = FileMeta {
-            region_id: region.region_id,
-            file_id: FileId::random(),
-            ..Default::default()
-        };
-
-        let mut manager = region.manifest_ctx.manifest_manager.write().await;
-        let before = manager.manifest();
-        assert!(matches!(
-            region
-                .manifest_ctx
-                .update_locked(&mut manager, add_file_edit(file), false)
-                .await,
-            Err(Error::Unexpected { .. })
-        ));
-
-        let after = manager.manifest();
-        assert_eq!(before.manifest_version, after.manifest_version);
-        assert_eq!(before.files, after.files);
-    }
-
-    #[tokio::test]
-    async fn test_update_locked_rejects_publication_guard_from_another_context() {
-        let env = SchedulerEnv::new().await;
-        let first_region = build_test_region(&env).await;
-        let second_region = build_test_region(&env).await;
-        let file = FileMeta {
-            region_id: second_region.region_id,
-            file_id: FileId::random(),
-            ..Default::default()
-        };
-
-        let guard = first_region.manifest_ctx.lock_publication().await;
-        let mut manager = second_region.manifest_ctx.manifest_manager.write().await;
-        let before = manager.manifest();
-        assert!(matches!(
-            second_region
-                .manifest_ctx
-                .update_locked_with_publication_guard(
-                    &mut manager,
-                    add_file_edit(file),
-                    false,
-                    &guard
-                )
-                .await,
-            Err(Error::Unexpected { .. })
-        ));
-
-        let after = manager.manifest();
-        assert_eq!(before.manifest_version, after.manifest_version);
-        assert_eq!(before.files, after.files);
-    }
-
-    #[tokio::test]
-    async fn test_owned_publication_guard_rejects_another_context() {
-        let env = SchedulerEnv::new().await;
-        let first_region = build_test_region(&env).await;
-        let second_region = build_test_region(&env).await;
-
-        let guard = first_region.manifest_ctx.lock_publication_owned().await;
-        assert!(guard.belongs_to(&first_region.manifest_ctx));
-        assert!(!guard.belongs_to(&second_region.manifest_ctx));
     }
 
     async fn write_publication_file(region: &MitoRegion, file: &FileMeta) {
@@ -2297,6 +2098,101 @@ mod tests {
         let after = region.manifest_ctx.manifest().await;
         assert_eq!(before.manifest_version, after.manifest_version);
         assert!(after.files.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_update_manifest_allows_cross_region_file_without_validation() {
+        let env = SchedulerEnv::new().await;
+        let region = build_test_region(&env).await;
+        let file = FileMeta {
+            region_id: RegionId::new(1, 2),
+            file_id: FileId::random(),
+            ..Default::default()
+        };
+
+        region
+            .manifest_ctx
+            .update_manifest(
+                RegionLeaderState::Writable,
+                add_file_edit(file.clone()),
+                false,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            region
+                .manifest_ctx
+                .manifest()
+                .await
+                .files
+                .contains_key(&file.file_id)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_manifest_mixed_files_only_validates_local_files() {
+        let env = SchedulerEnv::new().await;
+        let region = build_test_region(&env).await;
+        let local_file = FileMeta {
+            region_id: region.region_id,
+            file_id: FileId::random(),
+            ..Default::default()
+        };
+        write_publication_file(&region, &local_file).await;
+        let cross_region_file = FileMeta {
+            region_id: RegionId::new(1, 2),
+            file_id: FileId::random(),
+            ..Default::default()
+        };
+
+        region
+            .manifest_ctx
+            .update_manifest(
+                RegionLeaderState::Writable,
+                RegionMetaActionList::with_action(RegionMetaAction::Edit(RegionEdit {
+                    files_to_add: vec![local_file.clone(), cross_region_file.clone()],
+                    ..empty_edit()
+                })),
+                false,
+            )
+            .await
+            .unwrap();
+
+        let manifest = region.manifest_ctx.manifest().await;
+        assert!(manifest.files.contains_key(&local_file.file_id));
+        assert!(manifest.files.contains_key(&cross_region_file.file_id));
+    }
+
+    #[tokio::test]
+    async fn test_staging_manifest_update_skips_local_publication_validation() {
+        let env = SchedulerEnv::new().await;
+        let region = build_test_region(&env).await;
+        let file = FileMeta {
+            region_id: region.region_id,
+            file_id: FileId::random(),
+            ..Default::default()
+        };
+
+        region
+            .manifest_ctx
+            .update_manifest(
+                RegionLeaderState::Writable,
+                add_file_edit(file.clone()),
+                true,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            region
+                .manifest_ctx
+                .staging_manifest()
+                .await
+                .unwrap()
+                .files
+                .contains_key(&file.file_id)
+        );
     }
 
     #[tokio::test]
@@ -2397,7 +2293,6 @@ mod tests {
         let env = SchedulerEnv::new().await;
         let region = build_test_region(&env).await;
 
-        let permit = region.manifest_ctx.lock_publication().await;
         let mut manager = region.manifest_ctx.manifest_manager.write().await;
         region.set_staging(&mut manager).await.unwrap();
         manager
@@ -2413,12 +2308,8 @@ mod tests {
             .await
             .unwrap();
 
-        let _hook_payload = region
-            .exit_staging_on_success(&mut manager, &permit)
-            .await
-            .unwrap();
+        let _hook_payload = region.exit_staging_on_success(&mut manager).await.unwrap();
         drop(manager);
-        drop(permit);
 
         assert_eq!(
             region.version().metadata.partition_expr.as_deref(),
@@ -2435,7 +2326,6 @@ mod tests {
         let env = SchedulerEnv::new().await;
         let region = build_test_region(&env).await;
 
-        let permit = region.manifest_ctx.lock_publication().await;
         let mut manager = region.manifest_ctx.manifest_manager.write().await;
         region.set_staging(&mut manager).await.unwrap();
 
@@ -2457,12 +2347,8 @@ mod tests {
             .await
             .unwrap();
 
-        let _hook_payload = region
-            .exit_staging_on_success(&mut manager, &permit)
-            .await
-            .unwrap();
+        let _hook_payload = region.exit_staging_on_success(&mut manager).await.unwrap();
         drop(manager);
-        drop(permit);
 
         assert_eq!(
             region.version().metadata.partition_expr.as_deref(),
@@ -2479,7 +2365,6 @@ mod tests {
         let env = SchedulerEnv::new().await;
         let region = build_test_region(&env).await;
 
-        let permit = region.manifest_ctx.lock_publication().await;
         let mut manager = region.manifest_ctx.manifest_manager.write().await;
         region.set_staging(&mut manager).await.unwrap();
 
@@ -2501,7 +2386,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = region.exit_staging_on_success(&mut manager, &permit).await;
+        let result = region.exit_staging_on_success(&mut manager).await;
         assert!(matches!(result, Err(Error::Unexpected { .. })));
     }
 
@@ -2510,7 +2395,6 @@ mod tests {
         let env = SchedulerEnv::new().await;
         let region = build_test_region(&env).await;
 
-        let permit = region.manifest_ctx.lock_publication().await;
         let mut manager = region.manifest_ctx.manifest_manager.write().await;
         region.set_staging(&mut manager).await.unwrap();
 
@@ -2535,7 +2419,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = region.exit_staging_on_success(&mut manager, &permit).await;
+        let result = region.exit_staging_on_success(&mut manager).await;
         assert!(matches!(result, Err(Error::Unexpected { .. })));
     }
 

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -63,6 +63,17 @@ use crate::sst::file_purger::FilePurgerRef;
 use crate::sst::location::{index_file_path, sst_file_path};
 use crate::time_provider::TimeProviderRef;
 
+pub(crate) struct PublicationGuard<'a> {
+    gate: Arc<tokio::sync::Mutex<()>>,
+    _guard: tokio::sync::MutexGuard<'a, ()>,
+}
+
+#[allow(dead_code)]
+pub(crate) struct OwnedPublicationGuard {
+    gate: Arc<tokio::sync::Mutex<()>>,
+    _guard: tokio::sync::OwnedMutexGuard<()>,
+}
+
 /// This is the approximate factor to estimate the size of wal.
 const ESTIMATED_WAL_FACTOR: f32 = 0.42825;
 
@@ -475,6 +486,13 @@ impl MitoRegion {
         &self,
         state: SettableRegionRoleState,
     ) -> Result<()> {
+        // A leader transition may publish staged files. Acquire the publication gate before the
+        // manifest lock to preserve the global lock order.
+        let publication_guard = if matches!(state, SettableRegionRoleState::Leader) {
+            Some(self.manifest_ctx.lock_publication().await)
+        } else {
+            None
+        };
         let mut manager: RwLockWriteGuard<'_, RegionManifestManager> =
             self.manifest_ctx.manifest_manager.write().await;
         let current_state = self.state();
@@ -487,7 +505,13 @@ impl MitoRegion {
                     RegionRoleState::Leader(RegionLeaderState::Staging) => {
                         info!("Exiting staging mode for region {}", self.region_id);
                         // Use the success exit path that merges all staged manifests
-                        self.exit_staging_on_success(&mut manager).await?
+                        self.exit_staging_on_success(
+                            &mut manager,
+                            publication_guard.as_ref().expect(
+                                "leader transition must hold the publication guard before the manifest lock",
+                            ),
+                        )
+                        .await?
                     }
                     RegionRoleState::Leader(RegionLeaderState::Writable) => {
                         // Already in desired state - no-op
@@ -618,6 +642,8 @@ impl MitoRegion {
         }
 
         drop(manager);
+        // Hooks may publish additional files, so release the publication gate before firing.
+        drop(publication_guard);
 
         // Merge both payloads so consumers see the complete set of actions in
         // one notification. The lock is released, so it's safe to fire.
@@ -861,6 +887,7 @@ impl MitoRegion {
     pub(crate) async fn exit_staging_on_success(
         &self,
         manager: &mut RwLockWriteGuard<'_, RegionManifestManager>,
+        permit: &PublicationGuard<'_>,
     ) -> Result<Option<PendingManifestHook>> {
         let current_state = self.manifest_ctx.current_state();
         ensure!(
@@ -929,7 +956,7 @@ impl MitoRegion {
         // Pass `false` so it saves to normal directory, not staging.
         let pending = self
             .manifest_ctx
-            .update_locked(manager, merged_actions, false)
+            .update_locked_with_publication_guard(manager, merged_actions, false, permit)
             .await?;
         let new_version = pending.version();
         info!(
@@ -1026,6 +1053,11 @@ pub(crate) struct ManifestContext {
     /// [`update_locked`](Self::update_locked) (or an [`update_manifest`](Self::update_manifest)
     /// variant) so they produce a [`PendingManifestHook`].
     pub(crate) manifest_manager: tokio::sync::RwLock<RegionManifestManager>,
+    region_id: RegionId,
+    /// Access layer used by the publication path to validate objects before manifest updates.
+    access_layer: AccessLayerRef,
+    /// Serializes local file publication with active-region GC finalization.
+    publication_gate: Arc<tokio::sync::Mutex<()>>,
     /// The state of the region. The region checks the state before updating
     /// manifest.
     state: AtomicCell<RegionRoleState>,
@@ -1041,11 +1073,16 @@ pub(crate) struct ManifestContext {
 impl ManifestContext {
     pub(crate) fn new(
         manager: RegionManifestManager,
+        access_layer: AccessLayerRef,
         state: RegionRoleState,
         hook: Option<RegionHookRef>,
     ) -> Self {
+        let region_id = manager.manifest().metadata.region_id;
         ManifestContext {
             manifest_manager: tokio::sync::RwLock::new(manager),
+            region_id,
+            access_layer,
+            publication_gate: Arc::new(tokio::sync::Mutex::new(())),
             state: AtomicCell::new(state),
             staging_partition_info: Mutex::new(None),
             hook,
@@ -1055,6 +1092,46 @@ impl ManifestContext {
     /// Returns the region hook if one is registered.
     pub(crate) fn hook(&self) -> Option<RegionHookRef> {
         self.hook.clone()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn access_layer(&self) -> &AccessLayerRef {
+        &self.access_layer
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn publication_gate(&self) -> Arc<tokio::sync::Mutex<()>> {
+        self.publication_gate.clone()
+    }
+
+    pub(crate) async fn lock_publication(&self) -> PublicationGuard<'_> {
+        let guard = self.publication_gate.lock().await;
+        PublicationGuard {
+            gate: self.publication_gate.clone(),
+            _guard: guard,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) async fn lock_publication_owned(&self) -> OwnedPublicationGuard {
+        let gate = self.publication_gate.clone();
+        let guard = gate.clone().lock_owned().await;
+        OwnedPublicationGuard {
+            gate,
+            _guard: guard,
+        }
+    }
+
+    fn files_to_publish(action_list: &RegionMetaActionList) -> Vec<FileMeta> {
+        action_list
+            .actions
+            .iter()
+            .filter_map(|action| match action {
+                RegionMetaAction::Edit(edit) => Some(edit.files_to_add.iter().cloned()),
+                _ => None,
+            })
+            .flatten()
+            .collect()
     }
 
     pub(crate) fn staging_partition_info(&self) -> Option<StagingPartitionInfo> {
@@ -1222,6 +1299,39 @@ impl ManifestContext {
         action_list: RegionMetaActionList,
         is_staging: bool,
     ) -> Result<PendingManifestHook> {
+        ensure!(
+            Self::files_to_publish(&action_list).is_empty(),
+            UnexpectedSnafu {
+                reason: "manifest updates that publish files require the publication guard"
+            }
+        );
+        self.update_locked_impl(manager, action_list, is_staging)
+            .await
+    }
+
+    pub(crate) async fn update_locked_with_publication_guard(
+        &self,
+        manager: &mut RegionManifestManager,
+        action_list: RegionMetaActionList,
+        is_staging: bool,
+        guard: &PublicationGuard<'_>,
+    ) -> Result<PendingManifestHook> {
+        ensure!(
+            Arc::ptr_eq(&guard.gate, &self.publication_gate),
+            UnexpectedSnafu {
+                reason: "publication guard belongs to a different manifest context"
+            }
+        );
+        self.update_locked_impl(manager, action_list, is_staging)
+            .await
+    }
+
+    async fn update_locked_impl(
+        &self,
+        manager: &mut RegionManifestManager,
+        action_list: RegionMetaActionList,
+        is_staging: bool,
+    ) -> Result<PendingManifestHook> {
         let region_id = manager.manifest().metadata.region_id;
         // Clone before `action_list` is moved into `update` so the hook still
         // sees what was written.
@@ -1246,6 +1356,20 @@ impl ManifestContext {
         is_staging: bool,
         check_state: impl FnOnce(RegionRoleState, RegionId) -> Result<()>,
     ) -> Result<ManifestVersion> {
+        let files_to_publish = Self::files_to_publish(&action_list);
+        // Publication validation and the manifest update share this gate with future active GC
+        // finalization. Keep it before the manifest lock to preserve the global lock order.
+        let _publication_guard = if files_to_publish.is_empty() {
+            None
+        } else {
+            Some(self.lock_publication().await)
+        };
+        if !files_to_publish.is_empty() {
+            self.access_layer
+                .validate_publication_files(self.region_id, &files_to_publish)
+                .await?;
+        }
+
         // Acquires the write lock of the manifest manager.
         let mut manager = self.manifest_manager.write().await;
         // Gets current manifest.
@@ -1307,15 +1431,29 @@ impl ManifestContext {
 
         // `update_locked` returns a `PendingManifestHook` we fire after releasing the lock.
         let region_id = manifest.metadata.region_id;
-        let pending = self
-            .update_locked(&mut manager, action_list, is_staging)
-            .await?;
+        let pending = if files_to_publish.is_empty() {
+            self.update_locked(&mut manager, action_list, is_staging)
+                .await?
+        } else {
+            self.update_locked_with_publication_guard(
+                &mut manager,
+                action_list,
+                is_staging,
+                _publication_guard
+                    .as_ref()
+                    .expect("publication guard must be held when publishing files"),
+            )
+            .await?
+        };
         let version = pending.version();
 
         // Drop the write lock before invoking the hook. Hook implementations may
         // read the manifest or send region requests that acquire this lock;
         // holding it would deadlock. Slow hooks also must not block manifest updates.
         drop(manager);
+        // Hooks are user-provided async code. Do not retain the publication gate while they run,
+        // otherwise a hook that triggers another publication path can self-deadlock.
+        drop(_publication_guard);
 
         if self.state.load() == RegionRoleState::Follower {
             warn!(
@@ -1489,6 +1627,13 @@ impl ManifestContext {
         &self,
     ) -> Option<Arc<crate::manifest::action::RegionManifest>> {
         self.manifest_manager.read().await.staging_manifest()
+    }
+}
+
+impl OwnedPublicationGuard {
+    #[allow(dead_code)]
+    pub(crate) fn belongs_to(&self, manifest_ctx: &ManifestContext) -> bool {
+        Arc::ptr_eq(&self.gate, &manifest_ctx.publication_gate)
     }
 }
 
@@ -1784,18 +1929,23 @@ pub fn parse_partition_expr(partition_expr_str: Option<&str>) -> Result<Option<P
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::time::Duration;
 
+    use async_trait::async_trait;
     use common_datasource::compression::CompressionType;
     use common_test_util::temp_dir::create_temp_dir;
     use crossbeam_utils::atomic::AtomicCell;
     use object_store::ObjectStore;
     use object_store::services::Fs;
+    use store_api::ManifestVersion;
     use store_api::logstore::provider::Provider;
-    use store_api::region_engine::RegionRole;
+    use store_api::region_engine::{RegionRole, SettableRegionRoleState};
     use store_api::region_request::PathType;
     use store_api::storage::{FileId, RegionId};
+    use tokio::sync::Semaphore;
 
     use crate::access_layer::AccessLayer;
+    use crate::engine::region_hook::{RegionHook, RegionHookRef};
     use crate::error::Error;
     use crate::manifest::action::{
         RegionChange, RegionEdit, RegionMetaAction, RegionMetaActionList, RegionPartitionExprChange,
@@ -1804,12 +1954,32 @@ mod tests {
     use crate::region::{
         ManifestContext, ManifestStats, MitoRegion, RegionLeaderState, RegionRoleState, RegionStats,
     };
-    use crate::sst::FormatType;
+    use crate::sst::file::FileMeta;
     use crate::sst::index::intermediate::IntermediateManager;
     use crate::sst::index::puffin_manager::PuffinManagerFactory;
+    use crate::sst::{FormatType, location};
     use crate::test_util::scheduler_util::SchedulerEnv;
     use crate::test_util::version_util::VersionControlBuilder;
     use crate::time_provider::StdTimeProvider;
+
+    #[derive(Debug)]
+    struct BlockingManifestHook {
+        entered: Arc<Semaphore>,
+        release: Arc<Semaphore>,
+    }
+
+    #[async_trait]
+    impl RegionHook for BlockingManifestHook {
+        async fn on_manifest_updated(
+            &self,
+            _region_id: RegionId,
+            _action_list: &RegionMetaActionList,
+            _manifest_version: ManifestVersion,
+        ) {
+            self.entered.add_permits(1);
+            self.release.acquire().await.unwrap().forget();
+        }
+    }
 
     #[test]
     fn test_region_state_lock_free() {
@@ -1834,6 +2004,13 @@ mod tests {
     }
 
     async fn build_test_region(env: &SchedulerEnv) -> MitoRegion {
+        build_test_region_with_hook(env, None).await
+    }
+
+    async fn build_test_region_with_hook(
+        env: &SchedulerEnv,
+        hook: Option<RegionHookRef>,
+    ) -> MitoRegion {
         let builder = VersionControlBuilder::new();
         let version_control = Arc::new(builder.build());
         let metadata = version_control.current().version.metadata.clone();
@@ -1857,8 +2034,9 @@ mod tests {
 
         let manifest_ctx = Arc::new(ManifestContext::new(
             manager,
+            env.access_layer.clone(),
             RegionRoleState::Leader(RegionLeaderState::Writable),
-            None,
+            hook,
         ));
 
         MitoRegion {
@@ -1877,6 +2055,36 @@ mod tests {
         }
     }
 
+    async fn build_test_manifest_context(
+        env: &SchedulerEnv,
+        hook: RegionHookRef,
+    ) -> Arc<ManifestContext> {
+        let version_control = VersionControlBuilder::new().build();
+        let metadata = version_control.current().version.metadata.clone();
+        let manager = RegionManifestManager::new(
+            metadata,
+            0,
+            RegionManifestOptions {
+                manifest_dir: "".to_string(),
+                object_store: env.access_layer.object_store().clone(),
+                compress_type: CompressionType::Uncompressed,
+                checkpoint_distance: 10,
+                remove_file_options: Default::default(),
+                manifest_cache: None,
+            },
+            FormatType::PrimaryKey,
+            &Default::default(),
+        )
+        .await
+        .unwrap();
+        Arc::new(ManifestContext::new(
+            manager,
+            env.access_layer.clone(),
+            RegionRoleState::Leader(RegionLeaderState::Writable),
+            Some(hook),
+        ))
+    }
+
     fn empty_edit() -> RegionEdit {
         RegionEdit {
             files_to_add: Vec::new(),
@@ -1890,26 +2098,288 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_manifest_hook_runs_after_publication_gate_is_released() {
+        let env = SchedulerEnv::new().await;
+        let hook = Arc::new(BlockingManifestHook {
+            entered: Arc::new(Semaphore::new(0)),
+            release: Arc::new(Semaphore::new(0)),
+        });
+        let context = build_test_manifest_context(&env, hook.clone() as RegionHookRef).await;
+        let file = FileMeta {
+            region_id: context.manifest().await.metadata.region_id,
+            file_id: FileId::random(),
+            ..Default::default()
+        };
+        let path = location::sst_file_path(
+            env.access_layer.table_dir(),
+            file.file_id(),
+            env.access_layer.path_type(),
+        );
+        env.access_layer
+            .object_store()
+            .write(&path, b"sst".to_vec())
+            .await
+            .unwrap();
+
+        let update_context = context.clone();
+        let update = tokio::spawn(async move {
+            update_context
+                .update_manifest(RegionLeaderState::Writable, add_file_edit(file), false)
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(1), hook.entered.acquire())
+            .await
+            .expect("manifest hook did not start")
+            .unwrap()
+            .forget();
+
+        let gate = tokio::time::timeout(
+            Duration::from_secs(1),
+            context.publication_gate().lock_owned(),
+        )
+        .await
+        .expect("manifest hook ran while publication gate was still held");
+        drop(gate);
+        hook.release.add_permits(1);
+        update.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_exit_staging_hook_runs_after_publication_gate_is_released() {
+        let env = SchedulerEnv::new().await;
+        let hook = Arc::new(BlockingManifestHook {
+            entered: Arc::new(Semaphore::new(0)),
+            release: Arc::new(Semaphore::new(0)),
+        });
+        let region =
+            Arc::new(build_test_region_with_hook(&env, Some(hook.clone() as RegionHookRef)).await);
+        let mut manager = region.manifest_ctx.manifest_manager.write().await;
+        region.set_staging(&mut manager).await.unwrap();
+        manager
+            .update(
+                RegionMetaActionList::new(vec![
+                    RegionMetaAction::PartitionExprChange(RegionPartitionExprChange {
+                        partition_expr: Some("expr_a".to_string()),
+                    }),
+                    RegionMetaAction::Edit(empty_edit()),
+                ]),
+                true,
+            )
+            .await
+            .unwrap();
+        drop(manager);
+
+        let promotion_region = region.clone();
+        let promotion = tokio::spawn(async move {
+            promotion_region
+                .set_role_state_gracefully(SettableRegionRoleState::Leader)
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(1), hook.entered.acquire())
+            .await
+            .expect("staging promotion hook did not start")
+            .unwrap()
+            .forget();
+
+        let gate = tokio::time::timeout(
+            Duration::from_secs(1),
+            region.manifest_ctx.publication_gate().lock_owned(),
+        )
+        .await
+        .expect("staging promotion hook ran while publication gate was still held");
+        drop(gate);
+        hook.release.add_permits(1);
+        promotion.await.unwrap().unwrap();
+    }
+
+    fn add_file_edit(file: FileMeta) -> RegionMetaActionList {
+        RegionMetaActionList::with_action(RegionMetaAction::Edit(RegionEdit {
+            files_to_add: vec![file],
+            ..empty_edit()
+        }))
+    }
+
+    #[tokio::test]
+    async fn test_update_locked_rejects_file_add_without_publication_guard() {
+        let env = SchedulerEnv::new().await;
+        let region = build_test_region(&env).await;
+        let file = FileMeta {
+            region_id: region.region_id,
+            file_id: FileId::random(),
+            ..Default::default()
+        };
+
+        let mut manager = region.manifest_ctx.manifest_manager.write().await;
+        let before = manager.manifest();
+        assert!(matches!(
+            region
+                .manifest_ctx
+                .update_locked(&mut manager, add_file_edit(file), false)
+                .await,
+            Err(Error::Unexpected { .. })
+        ));
+
+        let after = manager.manifest();
+        assert_eq!(before.manifest_version, after.manifest_version);
+        assert_eq!(before.files, after.files);
+    }
+
+    #[tokio::test]
+    async fn test_update_locked_rejects_publication_guard_from_another_context() {
+        let env = SchedulerEnv::new().await;
+        let first_region = build_test_region(&env).await;
+        let second_region = build_test_region(&env).await;
+        let file = FileMeta {
+            region_id: second_region.region_id,
+            file_id: FileId::random(),
+            ..Default::default()
+        };
+
+        let guard = first_region.manifest_ctx.lock_publication().await;
+        let mut manager = second_region.manifest_ctx.manifest_manager.write().await;
+        let before = manager.manifest();
+        assert!(matches!(
+            second_region
+                .manifest_ctx
+                .update_locked_with_publication_guard(
+                    &mut manager,
+                    add_file_edit(file),
+                    false,
+                    &guard
+                )
+                .await,
+            Err(Error::Unexpected { .. })
+        ));
+
+        let after = manager.manifest();
+        assert_eq!(before.manifest_version, after.manifest_version);
+        assert_eq!(before.files, after.files);
+    }
+
+    #[tokio::test]
+    async fn test_owned_publication_guard_rejects_another_context() {
+        let env = SchedulerEnv::new().await;
+        let first_region = build_test_region(&env).await;
+        let second_region = build_test_region(&env).await;
+
+        let guard = first_region.manifest_ctx.lock_publication_owned().await;
+        assert!(guard.belongs_to(&first_region.manifest_ctx));
+        assert!(!guard.belongs_to(&second_region.manifest_ctx));
+    }
+
+    async fn write_publication_file(region: &MitoRegion, file: &FileMeta) {
+        let path = location::sst_file_path(
+            region.access_layer.table_dir(),
+            file.file_id(),
+            region.access_layer.path_type(),
+        );
+        region
+            .access_layer
+            .object_store()
+            .write(&path, b"sst".to_vec())
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_update_manifest_rejects_missing_publication_file_without_mutation() {
+        let env = SchedulerEnv::new().await;
+        let region = build_test_region(&env).await;
+        let file = FileMeta {
+            region_id: region.region_id,
+            file_id: FileId::random(),
+            ..Default::default()
+        };
+        let before = region.manifest_ctx.manifest().await;
+
+        let err = region
+            .manifest_ctx
+            .update_manifest(RegionLeaderState::Writable, add_file_edit(file), false)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::PublicationObjectStat { .. }));
+
+        let after = region.manifest_ctx.manifest().await;
+        assert_eq!(before.manifest_version, after.manifest_version);
+        assert!(after.files.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_update_manifest_metadata_only_skips_publication_validation() {
+        let env = SchedulerEnv::new().await;
+        let region = build_test_region(&env).await;
+        let before = region.manifest_ctx.manifest().await;
+
+        region
+            .manifest_ctx
+            .update_manifest(
+                RegionLeaderState::Writable,
+                RegionMetaActionList::with_action(RegionMetaAction::Edit(empty_edit())),
+                false,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            before.manifest_version + 1,
+            region.manifest_ctx.manifest().await.manifest_version
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_manifest_rejects_any_missing_file_from_multiple_edits() {
+        let env = SchedulerEnv::new().await;
+        let region = build_test_region(&env).await;
+        let present = FileMeta {
+            region_id: region.region_id,
+            file_id: FileId::random(),
+            ..Default::default()
+        };
+        write_publication_file(&region, &present).await;
+        let missing = FileMeta {
+            region_id: region.region_id,
+            file_id: FileId::random(),
+            ..Default::default()
+        };
+        let before = region.manifest_ctx.manifest().await;
+        let actions = RegionMetaActionList::new(vec![
+            RegionMetaAction::Edit(RegionEdit {
+                files_to_add: vec![present],
+                ..empty_edit()
+            }),
+            RegionMetaAction::Edit(RegionEdit {
+                files_to_add: vec![missing],
+                ..empty_edit()
+            }),
+        ]);
+
+        assert!(matches!(
+            region
+                .manifest_ctx
+                .update_manifest(RegionLeaderState::Writable, actions, false)
+                .await,
+            Err(Error::PublicationObjectStat { .. })
+        ));
+        let after = region.manifest_ctx.manifest().await;
+        assert_eq!(before.manifest_version, after.manifest_version);
+        assert!(after.files.is_empty());
+    }
+
+    #[tokio::test]
     async fn test_compaction_update_manifest_allows_editing_state() {
         let env = SchedulerEnv::new().await;
         let region = build_test_region(&env).await;
         region.set_editing(RegionLeaderState::Writable).unwrap();
 
         let file_id = FileId::random();
-        let action_list = RegionMetaActionList::with_action(RegionMetaAction::Edit(RegionEdit {
-            files_to_add: vec![crate::sst::file::FileMeta {
-                region_id: region.region_id,
-                file_id,
-                level: 1,
-                ..Default::default()
-            }],
-            files_to_remove: Vec::new(),
-            timestamp_ms: None,
-            compaction_time_window: None,
-            flushed_entry_id: None,
-            flushed_sequence: None,
-            committed_sequence: None,
-        }));
+        let file = crate::sst::file::FileMeta {
+            region_id: region.region_id,
+            file_id,
+            level: 1,
+            ..Default::default()
+        };
+        write_publication_file(&region, &file).await;
+        let action_list = add_file_edit(file);
 
         region
             .manifest_ctx
@@ -1932,6 +2402,7 @@ mod tests {
         let env = SchedulerEnv::new().await;
         let region = build_test_region(&env).await;
 
+        let permit = region.manifest_ctx.lock_publication().await;
         let mut manager = region.manifest_ctx.manifest_manager.write().await;
         region.set_staging(&mut manager).await.unwrap();
         manager
@@ -1947,8 +2418,12 @@ mod tests {
             .await
             .unwrap();
 
-        let _hook_payload = region.exit_staging_on_success(&mut manager).await.unwrap();
+        let _hook_payload = region
+            .exit_staging_on_success(&mut manager, &permit)
+            .await
+            .unwrap();
         drop(manager);
+        drop(permit);
 
         assert_eq!(
             region.version().metadata.partition_expr.as_deref(),
@@ -1965,6 +2440,7 @@ mod tests {
         let env = SchedulerEnv::new().await;
         let region = build_test_region(&env).await;
 
+        let permit = region.manifest_ctx.lock_publication().await;
         let mut manager = region.manifest_ctx.manifest_manager.write().await;
         region.set_staging(&mut manager).await.unwrap();
 
@@ -1986,8 +2462,12 @@ mod tests {
             .await
             .unwrap();
 
-        let _hook_payload = region.exit_staging_on_success(&mut manager).await.unwrap();
+        let _hook_payload = region
+            .exit_staging_on_success(&mut manager, &permit)
+            .await
+            .unwrap();
         drop(manager);
+        drop(permit);
 
         assert_eq!(
             region.version().metadata.partition_expr.as_deref(),
@@ -2004,6 +2484,7 @@ mod tests {
         let env = SchedulerEnv::new().await;
         let region = build_test_region(&env).await;
 
+        let permit = region.manifest_ctx.lock_publication().await;
         let mut manager = region.manifest_ctx.manifest_manager.write().await;
         region.set_staging(&mut manager).await.unwrap();
 
@@ -2025,7 +2506,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = region.exit_staging_on_success(&mut manager).await;
+        let result = region.exit_staging_on_success(&mut manager, &permit).await;
         assert!(matches!(result, Err(Error::Unexpected { .. })));
     }
 
@@ -2034,6 +2515,7 @@ mod tests {
         let env = SchedulerEnv::new().await;
         let region = build_test_region(&env).await;
 
+        let permit = region.manifest_ctx.lock_publication().await;
         let mut manager = region.manifest_ctx.manifest_manager.write().await;
         region.set_staging(&mut manager).await.unwrap();
 
@@ -2058,7 +2540,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = region.exit_staging_on_success(&mut manager).await;
+        let result = region.exit_staging_on_success(&mut manager, &permit).await;
         assert!(matches!(result, Err(Error::Unexpected { .. })));
     }
 
@@ -2147,6 +2629,7 @@ mod tests {
             .unwrap();
             Arc::new(ManifestContext::new(
                 manager,
+                env.access_layer.clone(),
                 RegionRoleState::Leader(RegionLeaderState::Staging),
                 None,
             ))
@@ -2216,6 +2699,7 @@ mod tests {
 
         let manifest_ctx = Arc::new(ManifestContext::new(
             manager,
+            access_layer.clone(),
             RegionRoleState::Leader(RegionLeaderState::Writable),
             None,
         ));

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -382,6 +382,7 @@ impl RegionOpener {
             // Region is writable after it is created.
             manifest_ctx: Arc::new(ManifestContext::new(
                 manifest_manager,
+                access_layer.clone(),
                 RegionRoleState::Leader(RegionLeaderState::Writable),
                 self.hook.clone(),
             )),
@@ -610,6 +611,7 @@ impl RegionOpener {
             // Region is always opened in read only mode.
             manifest_ctx: Arc::new(ManifestContext::new(
                 manifest_manager,
+                access_layer.clone(),
                 RegionRoleState::Follower,
                 self.hook.clone(),
             )),

--- a/src/mito2/src/test_util/scheduler_util.rs
+++ b/src/mito2/src/test_util/scheduler_util.rs
@@ -143,6 +143,7 @@ impl SchedulerEnv {
             )
             .await
             .unwrap(),
+            self.access_layer.clone(),
             RegionRoleState::Leader(RegionLeaderState::Writable),
             None,
         ))

--- a/src/mito2/src/worker/handle_apply_staging.rs
+++ b/src/mito2/src/worker/handle_apply_staging.rs
@@ -151,8 +151,12 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                     sender.send(result.map(|_| 0));
                     return;
                 };
+                // Acquire the publication gate before the manifest lock so promotion and active
+                // region GC use the same lock order.
+                let permit = region.manifest_ctx.lock_publication().await;
                 let mut manager = region.manifest_ctx.manifest_manager.write().await;
-                let hook_payload = match region.exit_staging_on_success(&mut manager).await {
+                let hook_payload = match region.exit_staging_on_success(&mut manager, &permit).await
+                {
                     Ok(payload) => payload,
                     Err(e) => {
                         sender.send(Err(e));
@@ -160,6 +164,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                     }
                 };
                 drop(manager);
+                drop(permit);
                 if let Some(pending) = hook_payload {
                     pending.fire().await;
                 }

--- a/src/mito2/src/worker/handle_apply_staging.rs
+++ b/src/mito2/src/worker/handle_apply_staging.rs
@@ -151,12 +151,8 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                     sender.send(result.map(|_| 0));
                     return;
                 };
-                // Acquire the publication gate before the manifest lock so promotion and active
-                // region GC use the same lock order.
-                let permit = region.manifest_ctx.lock_publication().await;
                 let mut manager = region.manifest_ctx.manifest_manager.write().await;
-                let hook_payload = match region.exit_staging_on_success(&mut manager, &permit).await
-                {
+                let hook_payload = match region.exit_staging_on_success(&mut manager).await {
                     Ok(payload) => payload,
                     Err(e) => {
                         sender.send(Err(e));
@@ -164,7 +160,6 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                     }
                 };
                 drop(manager);
-                drop(permit);
                 if let Some(pending) = hook_payload {
                     pending.fire().await;
                 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

N/A

## What's changed and what's your intention?

Full-listing GC can observe a local SST or Puffin object after it is written but before its normal-manifest edit is committed. With an earlier manifest snapshot, GC could delete the object immediately before or after the edit commits.

This PR narrowly coordinates same-region publication with active-region GC:

- normal-manifest edits validate only files whose physical origin matches the manifest region;
- object validation checks Parquet and current-version Puffin existence and size with at most eight concurrent stat requests;
- local publication and GC finalization share a per-region gate on the writable leader;
- active GC rechecks the role, manifest version, latest normal manifest, and temporary file references before deleting;
- GC reports role or manifest-version changes through `need_retry_regions`;
- deterministic tests cover commit-first, delete-first, deletion-error, and multiple live index-version schedules.

The protocol applies to local flush and local compaction on an active writable region. Remote compaction explicitly bypasses it because its manifest context is not shared with the region leader.

The following remain out of scope and continue to rely on their existing coordination:

- staging manifests and staging promotion;
- cross-origin references and repartition publication;
- remote compaction;
- dropped-region GC;
- leader failover fencing across datanodes.

The existing unknown-file lingering time remains the operational buffer. If same-region active GC wins the guarded race, publication fails with a retryable storage error instead of committing a missing local object.

There are no persisted, wire-format, API, or schema changes.

Verification:

- `cargo check -p mito2 --features test`
- focused local-publication, remote-compaction, and GC race tests
- `cargo fmt --check -p mito2`
- `git diff --check`
- repository commit and pre-push hooks

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
