### PR TITLE
fix(mito2): adapt batch size for wide rows

### DIFF
--- a/src/mito2/benches/bench_cache_stream.rs
+++ b/src/mito2/benches/bench_cache_stream.rs
@@ -36,6 +36,8 @@ use mito2::sst::parquet::DEFAULT_ROW_GROUP_SIZE;
 use mito2::sst::{FlatSchemaOptions, to_flat_sst_arrow_schema};
 use mito2::test_util::bench_util::{CpuDataGenerator, cpu_metadata};
 
+const DEFAULT_BATCH_SIZE: usize = 8 * 1024;
+
 fn cache_flat_range_stream_bench(c: &mut Criterion) {
     let metadata = Arc::new(cpu_metadata());
     let region_id = metadata.region_id;
@@ -73,6 +75,7 @@ fn cache_flat_range_stream_bench(c: &mut Criterion) {
             None, // No projection
             None, // No predicate
             false,
+            DEFAULT_BATCH_SIZE,
         )
         .unwrap(),
     );

--- a/src/mito2/benches/memtable_bench.rs
+++ b/src/mito2/benches/memtable_bench.rs
@@ -37,6 +37,8 @@ use mito2::sst::{FlatSchemaOptions, to_flat_sst_arrow_schema};
 use mito2::test_util::bench_util::{CpuDataGenerator, cpu_metadata};
 use mito2::test_util::memtable_util;
 
+const DEFAULT_BATCH_SIZE: usize = 8 * 1024;
+
 /// Writes rows.
 fn write_rows(c: &mut Criterion) {
     let metadata = Arc::new(memtable_util::metadata_with_primary_key(vec![1, 0], true));
@@ -263,6 +265,7 @@ fn flat_merge_iterator_bench(c: &mut Criterion) {
                 None, // No projection
                 None, // No predicate
                 false,
+                DEFAULT_BATCH_SIZE,
             )
             .unwrap(),
         );
@@ -333,6 +336,7 @@ fn bulk_part_record_batch_iter_filter(c: &mut Criterion) {
                     None,                    // No projection
                     Some(predicate.clone()), // With hostname filter
                     false,
+                    DEFAULT_BATCH_SIZE,
                 )
                 .unwrap(),
             );
@@ -363,6 +367,7 @@ fn bulk_part_record_batch_iter_filter(c: &mut Criterion) {
                     None, // No projection
                     None, // No predicate
                     false,
+                    DEFAULT_BATCH_SIZE,
                 )
                 .unwrap(),
             );

--- a/src/mito2/src/batch_size.rs
+++ b/src/mito2/src/batch_size.rs
@@ -1,0 +1,82 @@
+// Copyright 2026 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Utilities for choosing an execution batch size from source statistics.
+
+use crate::sst::parquet::DEFAULT_READ_BATCH_SIZE;
+
+/// Approximate decoded bytes to produce in one batch.
+pub(crate) const TARGET_BATCH_BYTES: usize = 64 * 1024 * 1024;
+
+/// Estimates a batch size from `(num_rows, estimated_bytes)` pairs.
+pub(crate) fn estimate_batch_size(sources: impl IntoIterator<Item = (u64, u64)>) -> usize {
+    let max_row_width = sources
+        .into_iter()
+        .filter_map(|(rows, bytes)| estimate_row_width(rows, bytes))
+        .max();
+
+    let Some(row_width) = max_row_width else {
+        return DEFAULT_READ_BATCH_SIZE;
+    };
+
+    (TARGET_BATCH_BYTES as u64 / row_width).clamp(1, DEFAULT_READ_BATCH_SIZE as u64) as usize
+}
+
+/// Returns the ceiling of the estimated bytes per row.
+fn estimate_row_width(rows: u64, bytes: u64) -> Option<u64> {
+    if rows == 0 || bytes == 0 {
+        return None;
+    }
+
+    Some(bytes / rows + u64::from(bytes % rows != 0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_estimate_batch_size_without_stats() {
+        assert_eq!(DEFAULT_READ_BATCH_SIZE, estimate_batch_size([]));
+        assert_eq!(
+            DEFAULT_READ_BATCH_SIZE,
+            estimate_batch_size([(0, 100), (100, 0)])
+        );
+    }
+
+    #[test]
+    fn test_estimate_batch_size_for_narrow_and_wide_rows() {
+        assert_eq!(DEFAULT_READ_BATCH_SIZE, estimate_batch_size([(100, 100)]));
+        assert_eq!(256, estimate_batch_size([(1, 256 * 1024)]));
+        assert_eq!(1, estimate_batch_size([(1, TARGET_BATCH_BYTES as u64 + 1)]));
+    }
+
+    #[test]
+    fn test_estimate_batch_size_uses_widest_known_source() {
+        assert_eq!(
+            256,
+            estimate_batch_size([(100, 0), (100, 100), (4, 1024 * 1024)])
+        );
+    }
+
+    #[test]
+    fn test_estimate_batch_size_saturates() {
+        assert_eq!(
+            DEFAULT_READ_BATCH_SIZE,
+            estimate_batch_size([(u64::MAX, u64::MAX)])
+        );
+        assert_eq!(1, estimate_batch_size([(1, u64::MAX)]));
+        assert_eq!(1, estimate_batch_size([(2, u64::MAX)]));
+    }
+}

--- a/src/mito2/src/batch_size.rs
+++ b/src/mito2/src/batch_size.rs
@@ -39,7 +39,7 @@ fn estimate_row_width(rows: u64, bytes: u64) -> Option<u64> {
         return None;
     }
 
-    Some(bytes / rows + u64::from(bytes % rows != 0))
+    Some(bytes / rows + u64::from(!bytes.is_multiple_of(rows)))
 }
 
 #[cfg(test)]

--- a/src/mito2/src/batch_size.rs
+++ b/src/mito2/src/batch_size.rs
@@ -1,4 +1,4 @@
-// Copyright 2026 Greptime Team
+// Copyright 2023 Greptime Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mito2/src/compaction.rs
+++ b/src/mito2/src/compaction.rs
@@ -29,7 +29,6 @@ use std::time::Instant;
 
 use api::v1::region::compact_request;
 use api::v1::region::compact_request::Options;
-use arrow_schema::Schema;
 use common_base::Plugins;
 use common_base::cancellation::CancellationHandle;
 use common_memory_manager::OnExhaustedPolicy;
@@ -43,7 +42,7 @@ use datafusion_expr::Expr;
 use datatypes::extension::json::is_structured_json_field;
 use datatypes::types::json_type::JsonNativeType;
 use parquet::arrow::parquet_to_arrow_schema;
-use parquet::file::metadata::PageIndexPolicy;
+use parquet::file::metadata::{PageIndexPolicy, ParquetMetaData};
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt};
 use store_api::metadata::RegionMetadataRef;
@@ -1050,7 +1049,7 @@ impl CompactionSstReaderBuilder<'_> {
     /// Build a [FlatSource] that yields Arrow `RecordBatch`s from reading all the input SST files,
     /// for compaction. The schema of the [FlatSource] is unified.
     async fn build_flat_sst_reader(self) -> Result<FlatSource> {
-        let scan_input = self.build_scan_input().await?.with_compaction(true);
+        let scan_input = self.build_scan_input().await?;
 
         let schema = scan_input.mapper.output_schema();
         let schema = schema.arrow_schema();
@@ -1063,6 +1062,20 @@ impl CompactionSstReaderBuilder<'_> {
 
     async fn build_scan_input(self) -> Result<ScanInput> {
         let schema = self.metadata.schema.arrow_schema();
+        let parquet_metadata = self.collect_parquet_metadata().await?;
+        let batch_size = crate::batch_size::estimate_batch_size(
+            parquet_metadata
+                .iter()
+                .flat_map(|metadata| metadata.row_groups())
+                .map(|row_group| {
+                    let uncompressed_bytes = row_group
+                        .columns()
+                        .iter()
+                        .map(|column| column.uncompressed_size() as u64)
+                        .sum();
+                    (row_group.num_rows() as u64, uncompressed_bytes)
+                }),
+        );
         let json_type_hint = if schema.fields().iter().any(is_structured_json_field) {
             let mut json_type_hint = schema
                 .fields()
@@ -1071,8 +1084,15 @@ impl CompactionSstReaderBuilder<'_> {
                 .map(|field| (field.name().clone(), JsonNativeType::Null))
                 .collect::<HashMap<_, _>>();
 
-            let schemas = self.collect_arrow_schemas_from_parquet().await?;
-            for schema in schemas {
+            for metadata in &parquet_metadata {
+                let file_metadata = metadata.file_metadata();
+                let schema = parquet_to_arrow_schema(
+                    file_metadata.schema_descr(),
+                    file_metadata.key_value_metadata(),
+                )
+                .context(ParquetToArrowSchemaSnafu {
+                    file: "compaction input",
+                })?;
                 for field in schema.fields() {
                     let Some(merged) = json_type_hint.get_mut(field.name()) else {
                         continue;
@@ -1102,6 +1122,8 @@ impl CompactionSstReaderBuilder<'_> {
 
         let mut scan_input = ScanInput::new(self.sst_layer, mapper)
             .with_files(self.inputs.to_vec())
+            .with_compaction(true)
+            .with_batch_size(batch_size)
             .with_append_mode(self.append_mode)
             // We use special cache strategy for compaction.
             .with_cache(CacheStrategy::Compaction(self.cache))
@@ -1120,8 +1142,8 @@ impl CompactionSstReaderBuilder<'_> {
         Ok(scan_input)
     }
 
-    async fn collect_arrow_schemas_from_parquet(&self) -> Result<Vec<Schema>> {
-        let mut schemas = Vec::with_capacity(self.inputs.len());
+    async fn collect_parquet_metadata(&self) -> Result<Vec<Arc<ParquetMetaData>>> {
+        let mut metadata = Vec::with_capacity(self.inputs.len());
 
         for file_handle in self.inputs {
             let file_path =
@@ -1144,17 +1166,9 @@ impl CompactionSstReaderBuilder<'_> {
                 Err(e) if e.is_object_not_found() => continue,
                 Err(e) => return Err(e),
             };
-            let file_metadata = parquet_metadata.file_metadata();
-
-            let schema = parquet_to_arrow_schema(
-                file_metadata.schema_descr(),
-                file_metadata.key_value_metadata(),
-            )
-            .context(ParquetToArrowSchemaSnafu { file: file_path })?;
-
-            schemas.push(schema);
+            metadata.push(parquet_metadata);
         }
-        Ok(schemas)
+        Ok(metadata)
     }
 }
 

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -553,8 +553,14 @@ impl RegionFlushTask {
             let compact_cost = compact_start.elapsed();
             flush_metrics.compact_memtable += compact_cost;
 
-            // Sets `for_flush` flag to true.
-            let mem_ranges = mem.ranges(None, RangesOptions::for_flush())?;
+            let mem_stats = mem.stats();
+            let batch_size = crate::batch_size::estimate_batch_size([(
+                mem_stats.num_rows() as u64,
+                mem_stats.bytes_allocated() as u64,
+            )]);
+            // Sets `for_flush` flag and propagates the reader batch size.
+            let mem_ranges =
+                mem.ranges(None, RangesOptions::for_flush().with_batch_size(batch_size))?;
             let num_mem_ranges = mem_ranges.ranges.len();
 
             // Aggregate stats from all ranges
@@ -918,6 +924,11 @@ fn memtable_flat_sources(
                     .map(|r| r.stats().max_sequence())
                     .max()
                     .unwrap_or(0);
+                let batch_size =
+                    crate::batch_size::estimate_batch_size(current_ranges.iter().map(|range| {
+                        let stats = range.stats();
+                        (stats.num_rows() as u64, stats.bytes_allocated() as u64)
+                    }));
 
                 let input_iters =
                     std::mem::replace(&mut input_iters, Vec::with_capacity(num_ranges));
@@ -927,12 +938,13 @@ fn memtable_flat_sources(
                     input_iters,
                 )?;
 
-                let maybe_dedup = merge_and_dedup(
+                let maybe_dedup = merge_and_dedup_with_batch_size(
                     &schema,
                     options.append_mode,
                     options.merge_mode(),
                     field_column_start,
                     input_iters,
+                    batch_size,
                 )?;
 
                 flat_sources
@@ -967,13 +979,19 @@ fn memtable_flat_sources(
                 .map(|r| r.stats().max_sequence())
                 .max()
                 .unwrap_or(0);
+            let batch_size =
+                crate::batch_size::estimate_batch_size(current_ranges.iter().map(|range| {
+                    let stats = range.stats();
+                    (stats.num_rows() as u64, stats.bytes_allocated() as u64)
+                }));
 
-            let maybe_dedup = merge_and_dedup(
+            let maybe_dedup = merge_and_dedup_with_batch_size(
                 &schema,
                 options.append_mode,
                 options.merge_mode(),
                 field_column_start,
                 input_iters,
+                batch_size,
             )?;
 
             flat_sources
@@ -1054,7 +1072,25 @@ pub fn merge_and_dedup(
     field_column_start: usize,
     input_iters: Vec<BoxedRecordBatchIterator>,
 ) -> Result<BoxedRecordBatchIterator> {
-    let merge_iter = FlatMergeIterator::new(schema.clone(), input_iters, DEFAULT_READ_BATCH_SIZE)?;
+    merge_and_dedup_with_batch_size(
+        schema,
+        append_mode,
+        merge_mode,
+        field_column_start,
+        input_iters,
+        DEFAULT_READ_BATCH_SIZE,
+    )
+}
+
+fn merge_and_dedup_with_batch_size(
+    schema: &SchemaRef,
+    append_mode: bool,
+    merge_mode: MergeMode,
+    field_column_start: usize,
+    input_iters: Vec<BoxedRecordBatchIterator>,
+    batch_size: usize,
+) -> Result<BoxedRecordBatchIterator> {
+    let merge_iter = FlatMergeIterator::new(schema.clone(), input_iters, batch_size)?;
     let maybe_dedup = if append_mode {
         // No dedup in append mode
         Box::new(merge_iter) as _

--- a/src/mito2/src/lib.rs
+++ b/src/mito2/src/lib.rs
@@ -25,6 +25,7 @@
 pub mod test_util;
 
 pub mod access_layer;
+mod batch_size;
 pub mod cache;
 pub mod compaction;
 pub mod config;

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -80,6 +80,8 @@ pub struct RangesOptions {
     pub predicate: PredicateGroup,
     /// Sequence range to filter the data.
     pub sequence: Option<SequenceRange>,
+    /// Maximum number of rows readers should produce in one batch.
+    pub batch_size: usize,
 }
 
 impl Default for RangesOptions {
@@ -89,6 +91,7 @@ impl Default for RangesOptions {
             pre_filter_mode: PreFilterMode::All,
             predicate: PredicateGroup::default(),
             sequence: None,
+            batch_size: crate::sst::parquet::DEFAULT_READ_BATCH_SIZE,
         }
     }
 }
@@ -101,6 +104,7 @@ impl RangesOptions {
             pre_filter_mode: PreFilterMode::All,
             predicate: PredicateGroup::default(),
             sequence: None,
+            batch_size: crate::sst::parquet::DEFAULT_READ_BATCH_SIZE,
         }
     }
 
@@ -122,6 +126,13 @@ impl RangesOptions {
     #[must_use]
     pub fn with_sequence(mut self, sequence: Option<SequenceRange>) -> Self {
         self.sequence = sequence;
+        self
+    }
+
+    /// Sets the maximum number of rows readers should produce in one batch.
+    #[must_use]
+    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = batch_size.clamp(1, crate::sst::parquet::DEFAULT_READ_BATCH_SIZE);
         self
     }
 }
@@ -441,6 +452,8 @@ impl MemtableBuilderProvider {
             Some(MemtableOptions::Bulk(config)) => Arc::new(
                 BulkMemtableBuilder::new(self.write_buffer_manager.clone(), !dedup, merge_mode)
                     .with_config(config.clone())
+                    // TODO(yingwen): How to change this when we changing the compaction max output file size?
+                    .with_max_merge_group_size(options.compaction.max_output_file_size())
                     .with_compact_dispatcher(self.compact_dispatcher.clone()),
             ),
             Some(MemtableOptions::TimeSeries) => Arc::new(TimeSeriesMemtableBuilder::new(
@@ -463,6 +476,7 @@ impl MemtableBuilderProvider {
             !dedup, // append_mode: true if not dedup, false if dedup
             merge_mode,
         )
+        .with_max_merge_group_size(options.compaction.max_output_file_size())
         .with_compact_dispatcher(self.compact_dispatcher.clone());
 
         if let Some(MemtableOptions::Bulk(config)) = &options.memtable {

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -452,8 +452,7 @@ impl MemtableBuilderProvider {
             Some(MemtableOptions::Bulk(config)) => Arc::new(
                 BulkMemtableBuilder::new(self.write_buffer_manager.clone(), !dedup, merge_mode)
                     .with_config(config.clone())
-                    // TODO(yingwen): How to change this when we changing the compaction max output file size?
-                    .with_max_merge_group_size(options.compaction.max_output_file_size())
+                    .with_max_encoded_merge_group_size(options.compaction.max_output_file_size())
                     .with_compact_dispatcher(self.compact_dispatcher.clone()),
             ),
             Some(MemtableOptions::TimeSeries) => Arc::new(TimeSeriesMemtableBuilder::new(
@@ -476,7 +475,7 @@ impl MemtableBuilderProvider {
             !dedup, // append_mode: true if not dedup, false if dedup
             merge_mode,
         )
-        .with_max_merge_group_size(options.compaction.max_output_file_size())
+        .with_max_encoded_merge_group_size(options.compaction.max_output_file_size())
         .with_compact_dispatcher(self.compact_dispatcher.clone());
 
         if let Some(MemtableOptions::Bulk(config)) = &options.memtable {

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -452,7 +452,6 @@ impl MemtableBuilderProvider {
             Some(MemtableOptions::Bulk(config)) => Arc::new(
                 BulkMemtableBuilder::new(self.write_buffer_manager.clone(), !dedup, merge_mode)
                     .with_config(config.clone())
-                    .with_max_encoded_merge_group_size(options.compaction.max_output_file_size())
                     .with_compact_dispatcher(self.compact_dispatcher.clone()),
             ),
             Some(MemtableOptions::TimeSeries) => Arc::new(TimeSeriesMemtableBuilder::new(
@@ -475,7 +474,6 @@ impl MemtableBuilderProvider {
             !dedup, // append_mode: true if not dedup, false if dedup
             merge_mode,
         )
-        .with_max_encoded_merge_group_size(options.compaction.max_output_file_size())
         .with_compact_dispatcher(self.compact_dispatcher.clone());
 
         if let Some(MemtableOptions::Bulk(config)) = &options.memtable {

--- a/src/mito2/src/memtable/bulk.rs
+++ b/src/mito2/src/memtable/bulk.rs
@@ -62,8 +62,8 @@ use crate::memtable::{
 use crate::read::flat_dedup::{FlatDedupIterator, FlatLastNonNull, FlatLastRow};
 use crate::read::flat_merge::FlatMergeIterator;
 use crate::region::options::MergeMode;
+use crate::sst::parquet::DEFAULT_ROW_GROUP_SIZE;
 use crate::sst::parquet::flat_format::field_column_start;
-use crate::sst::parquet::{DEFAULT_READ_BATCH_SIZE, DEFAULT_ROW_GROUP_SIZE};
 
 /// Default merge threshold for triggering compaction.
 const DEFAULT_MERGE_THRESHOLD: usize = 16;
@@ -175,30 +175,37 @@ impl BulkParts {
         self.unordered_part.is_empty() && self.parts.is_empty()
     }
 
-    /// Returns true if bulk parts or encoded parts should be merged.
-    /// Uses short-circuit counting to stop early once threshold is reached.
-    fn should_merge_parts(&self, merge_threshold: usize) -> bool {
+    /// Returns true if enough small parts of the same type are available to merge.
+    fn should_merge_parts(
+        &self,
+        merge_threshold: usize,
+        max_merge_group_size: Option<usize>,
+    ) -> bool {
         let mut bulk_count = 0;
         let mut encoded_count = 0;
-
         for wrapper in &self.parts {
-            if wrapper.merging {
+            if !Self::is_merge_candidate(wrapper, max_merge_group_size) {
                 continue;
             }
-
             if wrapper.part.is_encoded() {
                 encoded_count += 1;
             } else {
                 bulk_count += 1;
             }
-
-            // Short-circuit: stop counting if either threshold is reached
             if bulk_count >= merge_threshold || encoded_count >= merge_threshold {
                 return true;
             }
         }
 
         false
+    }
+
+    /// Returns whether a part is small enough to benefit from merging.
+    fn is_merge_candidate(wrapper: &BulkPartWrapper, max_merge_group_size: Option<usize>) -> bool {
+        !wrapper.merging
+            && max_merge_group_size
+                .map(|max_size| wrapper.part.estimated_size() < max_size)
+                .unwrap_or(true)
     }
 
     /// Returns true if the unordered_part should be compacted into a BulkPart.
@@ -208,25 +215,26 @@ impl BulkParts {
 
     /// Collects unmerged parts and marks them as being merged.
     /// Only collects parts of types that meet the threshold.
-    /// Parts are pre-grouped into chunks for parallel processing.
+    /// Parts are grouped by estimated size for parallel processing.
     fn collect_parts_to_merge(
         &mut self,
         merge_threshold: usize,
         max_merge_groups: usize,
+        max_merge_group_size: Option<usize>,
     ) -> CollectedParts {
-        // First pass: collect indices and row counts for each type
+        // First pass: collect indices and estimated sizes for each type.
         let mut bulk_indices: Vec<(usize, usize)> = Vec::new();
         let mut encoded_indices: Vec<(usize, usize)> = Vec::new();
 
         for (idx, wrapper) in self.parts.iter().enumerate() {
-            if wrapper.merging {
+            if !Self::is_merge_candidate(wrapper, max_merge_group_size) {
                 continue;
             }
-            let num_rows = wrapper.part.num_rows();
+            let estimated_size = wrapper.part.estimated_size();
             if wrapper.part.is_encoded() {
-                encoded_indices.push((idx, num_rows));
+                encoded_indices.push((idx, estimated_size));
             } else {
-                bulk_indices.push((idx, num_rows));
+                bulk_indices.push((idx, estimated_size));
             }
         }
 
@@ -238,6 +246,7 @@ impl BulkParts {
                 bulk_indices,
                 merge_threshold,
                 max_merge_groups,
+                max_merge_group_size,
             ));
         }
 
@@ -247,41 +256,79 @@ impl BulkParts {
                 encoded_indices,
                 merge_threshold,
                 max_merge_groups,
+                max_merge_group_size,
             ));
         }
 
         CollectedParts { groups }
     }
 
-    /// Sorts indices by row count, groups into chunks, marks as merging, and returns groups.
+    /// Plans groups, marks their parts as merging, and returns cloned parts.
     fn collect_and_group_parts(
         &mut self,
-        mut indices: Vec<(usize, usize)>,
+        indices: Vec<(usize, usize)>,
         merge_threshold: usize,
         max_merge_groups: usize,
+        max_merge_group_size: Option<usize>,
     ) -> Vec<Vec<PartToMerge>> {
-        if indices.is_empty() {
+        Self::group_parts_by_size(
+            indices,
+            merge_threshold,
+            max_merge_groups,
+            max_merge_group_size,
+        )
+        .into_iter()
+        .map(|group| {
+            group
+                .into_iter()
+                .map(|idx| {
+                    let wrapper = &mut self.parts[idx];
+                    wrapper.merging = true;
+                    wrapper.part.clone()
+                })
+                .collect()
+        })
+        .collect()
+    }
+
+    /// Groups sorted parts by both part count and cumulative size.
+    fn group_parts_by_size(
+        mut candidates: Vec<(usize, usize)>,
+        merge_threshold: usize,
+        max_merge_groups: usize,
+        max_merge_group_size: Option<usize>,
+    ) -> Vec<Vec<usize>> {
+        if candidates.len() < merge_threshold || max_merge_groups == 0 {
             return Vec::new();
         }
 
-        // Sort by row count for better grouping
-        indices.sort_unstable_by_key(|(_, num_rows)| *num_rows);
-
-        // Group into chunks of merge_threshold size, limit to max_merge_groups
-        indices
-            .chunks(merge_threshold)
-            .take(max_merge_groups)
-            .map(|chunk| {
-                chunk
-                    .iter()
-                    .map(|(idx, _)| {
-                        let wrapper = &mut self.parts[*idx];
-                        wrapper.merging = true;
-                        wrapper.part.clone()
-                    })
-                    .collect()
-            })
-            .collect()
+        candidates.sort_unstable_by_key(|(_, size)| *size);
+        let max_size = max_merge_group_size.unwrap_or(usize::MAX);
+        let mut groups = Vec::new();
+        let mut current = Vec::with_capacity(merge_threshold);
+        let mut current_size = 0usize;
+        for (idx, size) in candidates {
+            if !current.is_empty()
+                && (current.len() >= merge_threshold
+                    || current_size.saturating_add(size) > max_size)
+            {
+                if current.len() >= 2 {
+                    groups.push(std::mem::take(&mut current));
+                    if groups.len() >= max_merge_groups {
+                        return groups;
+                    }
+                } else {
+                    current.clear();
+                }
+                current_size = 0;
+            }
+            current.push(idx);
+            current_size = current_size.saturating_add(size);
+        }
+        if current.len() >= 2 && groups.len() < max_merge_groups {
+            groups.push(current);
+        }
+        groups
     }
 
     /// Installs merged parts and removes the original parts by file ids.
@@ -393,6 +440,8 @@ pub struct BulkMemtable {
     append_mode: bool,
     /// Mode to handle duplicate rows while merging
     merge_mode: MergeMode,
+    /// Soft maximum estimated size for one part merge group.
+    max_merge_group_size: Option<usize>,
 }
 
 impl std::fmt::Debug for BulkMemtable {
@@ -497,6 +546,7 @@ impl Memtable for BulkMemtable {
             predicate.predicate().cloned(),
             options.for_flush,
             options.pre_filter_mode,
+            options.batch_size,
         )?);
 
         // Adds ranges for regular parts and encoded parts
@@ -631,10 +681,12 @@ impl Memtable for BulkMemtable {
                 metadata.region_id,
                 id,
                 self.config.clone(),
+                self.max_merge_group_size,
             ))),
             compact_dispatcher: self.compact_dispatcher.clone(),
             append_mode: self.append_mode,
             merge_mode: self.merge_mode,
+            max_merge_group_size: self.max_merge_group_size,
         })
     }
 
@@ -650,7 +702,7 @@ impl Memtable for BulkMemtable {
             .parts
             .read()
             .unwrap()
-            .should_merge_parts(self.config.merge_threshold);
+            .should_merge_parts(self.config.merge_threshold, self.max_merge_group_size);
         if should_merge {
             compactor.merge_parts(
                 &self.parts,
@@ -675,6 +727,28 @@ impl BulkMemtable {
         append_mode: bool,
         merge_mode: MergeMode,
     ) -> Self {
+        Self::new_with_max_merge_group_size(
+            id,
+            config,
+            metadata,
+            write_buffer_manager,
+            compact_dispatcher,
+            append_mode,
+            merge_mode,
+            None,
+        )
+    }
+
+    fn new_with_max_merge_group_size(
+        id: MemtableId,
+        config: BulkMemtableConfig,
+        metadata: RegionMetadataRef,
+        write_buffer_manager: Option<WriteBufferManagerRef>,
+        compact_dispatcher: Option<Arc<CompactDispatcher>>,
+        append_mode: bool,
+        merge_mode: MergeMode,
+        max_merge_group_size: Option<usize>,
+    ) -> Self {
         let config = config.sanitize();
         let region_id = metadata.region_id;
         Self {
@@ -687,10 +761,16 @@ impl BulkMemtable {
             min_timestamp: AtomicI64::new(i64::MAX),
             max_sequence: AtomicU64::new(0),
             num_rows: AtomicUsize::new(0),
-            compactor: Arc::new(Mutex::new(MemtableCompactor::new(region_id, id, config))),
+            compactor: Arc::new(Mutex::new(MemtableCompactor::new(
+                region_id,
+                id,
+                config,
+                max_merge_group_size,
+            ))),
             compact_dispatcher,
             append_mode,
             merge_mode,
+            max_merge_group_size,
         }
     }
 
@@ -743,7 +823,7 @@ impl BulkMemtable {
     /// Returns whether the memtable should be compacted.
     fn should_compact(&self) -> bool {
         let parts = self.parts.read().unwrap();
-        parts.should_merge_parts(self.config.merge_threshold)
+        parts.should_merge_parts(self.config.merge_threshold, self.max_merge_group_size)
     }
 
     /// Schedules a compaction task using the CompactDispatcher.
@@ -1060,15 +1140,22 @@ struct MemtableCompactor {
     memtable_id: MemtableId,
     /// Configuration for the bulk memtable.
     config: BulkMemtableConfig,
+    max_merge_group_size: Option<usize>,
 }
 
 impl MemtableCompactor {
     /// Creates a new MemtableCompactor.
-    fn new(region_id: RegionId, memtable_id: MemtableId, config: BulkMemtableConfig) -> Self {
+    fn new(
+        region_id: RegionId,
+        memtable_id: MemtableId,
+        config: BulkMemtableConfig,
+        max_merge_group_size: Option<usize>,
+    ) -> Self {
         Self {
             region_id,
             memtable_id,
             config,
+            max_merge_group_size,
         }
     }
 
@@ -1083,10 +1170,11 @@ impl MemtableCompactor {
         let start = Instant::now();
 
         // Collect pre-grouped parts
-        let collected = bulk_parts
-            .write()
-            .unwrap()
-            .collect_parts_to_merge(self.config.merge_threshold, self.config.max_merge_groups);
+        let collected = bulk_parts.write().unwrap().collect_parts_to_merge(
+            self.config.merge_threshold,
+            self.config.max_merge_groups,
+            self.max_merge_group_size,
+        );
 
         if collected.groups.is_empty() {
             return Ok(());
@@ -1183,11 +1271,16 @@ impl MemtableCompactor {
             .max()
             .unwrap_or(0);
 
-        let context = Arc::new(BulkIterContext::new(
+        let batch_size = crate::batch_size::estimate_batch_size([(
+            estimated_total_rows as u64,
+            estimated_total_bytes as u64,
+        )]);
+        let context = Arc::new(BulkIterContext::new_with_batch_size(
             metadata.clone(),
             None, // No column projection for merging
             None, // No predicate for merging
             true,
+            batch_size,
         )?);
 
         let aligner = Json2Aligner::try_new(parts_to_merge.iter().map(PartToMerge::arrow_schema))?;
@@ -1202,8 +1295,7 @@ impl MemtableCompactor {
             return Ok(None);
         }
 
-        let merged_iter =
-            FlatMergeIterator::new(aligner.schema().clone(), iterators, DEFAULT_READ_BATCH_SIZE)?;
+        let merged_iter = FlatMergeIterator::new(aligner.schema().clone(), iterators, batch_size)?;
 
         let boxed_iter: BoxedRecordBatchIterator = if dedup {
             match merge_mode {
@@ -1301,7 +1393,7 @@ impl MemCompactTask {
             .parts
             .read()
             .unwrap()
-            .should_merge_parts(self.config.merge_threshold);
+            .should_merge_parts(self.config.merge_threshold, compactor.max_merge_group_size);
         if should_merge {
             compactor.merge_parts(
                 &self.parts,
@@ -1355,6 +1447,7 @@ pub struct BulkMemtableBuilder {
     compact_dispatcher: Option<Arc<CompactDispatcher>>,
     append_mode: bool,
     merge_mode: MergeMode,
+    max_merge_group_size: Option<usize>,
 }
 
 impl BulkMemtableBuilder {
@@ -1370,6 +1463,7 @@ impl BulkMemtableBuilder {
             compact_dispatcher: None,
             append_mode,
             merge_mode,
+            max_merge_group_size: None,
         }
     }
 
@@ -1385,6 +1479,12 @@ impl BulkMemtableBuilder {
         self
     }
 
+    /// Sets the soft maximum estimated size for one part merge group.
+    pub(crate) fn with_max_merge_group_size(mut self, max_size: Option<u64>) -> Self {
+        self.max_merge_group_size = max_size.and_then(|size| usize::try_from(size).ok());
+        self
+    }
+
     #[cfg(test)]
     pub(crate) fn config(&self) -> &BulkMemtableConfig {
         &self.config
@@ -1393,7 +1493,7 @@ impl BulkMemtableBuilder {
 
 impl MemtableBuilder for BulkMemtableBuilder {
     fn build(&self, id: MemtableId, metadata: &RegionMetadataRef) -> MemtableRef {
-        Arc::new(BulkMemtable::new(
+        Arc::new(BulkMemtable::new_with_max_merge_group_size(
             id,
             self.config.clone(),
             metadata.clone(),
@@ -1401,6 +1501,7 @@ impl MemtableBuilder for BulkMemtableBuilder {
             self.compact_dispatcher.clone(),
             self.append_mode,
             self.merge_mode,
+            self.max_merge_group_size,
         ))
     }
 
@@ -2249,7 +2350,7 @@ mod tests {
         }
 
         // Should not trigger merge since we have only 7 parts
-        assert!(!bulk_parts.should_merge_parts(DEFAULT_MERGE_THRESHOLD));
+        assert!(!bulk_parts.should_merge_parts(DEFAULT_MERGE_THRESHOLD, None));
     }
 
     #[test]
@@ -2271,7 +2372,33 @@ mod tests {
         }
 
         // Should trigger merge since we have 8 parts
-        assert!(bulk_parts.should_merge_parts(merge_threshold));
+        assert!(bulk_parts.should_merge_parts(merge_threshold, None));
+    }
+
+    #[test]
+    fn test_large_parts_are_not_merge_candidates() {
+        let mut bulk_parts = BulkParts::default();
+        let merge_threshold = 4;
+        for i in 0..merge_threshold {
+            let part = create_bulk_part_with_converter(
+                &format!("key_{}", i),
+                i as u32,
+                vec![1000 + i as i64],
+                vec![Some(i as f64)],
+                100 + i as u64,
+            )
+            .unwrap();
+            bulk_parts.parts.push(create_bulk_part_wrapper(part));
+        }
+
+        let max_size = bulk_parts.parts[0].part.estimated_size();
+        assert!(!bulk_parts.should_merge_parts(merge_threshold, Some(max_size)));
+        assert!(
+            bulk_parts
+                .collect_parts_to_merge(merge_threshold, 1, Some(max_size))
+                .groups
+                .is_empty()
+        );
     }
 
     #[test]
@@ -2293,7 +2420,7 @@ mod tests {
         }
 
         // Should trigger merge since we have 10 parts
-        assert!(bulk_parts.should_merge_parts(merge_threshold));
+        assert!(bulk_parts.should_merge_parts(merge_threshold, None));
 
         // Mark first 3 parts as merging
         for wrapper in bulk_parts.parts.iter_mut().take(3) {
@@ -2301,7 +2428,7 @@ mod tests {
         }
 
         // Now only 7 parts are available for merging, should not trigger
-        assert!(!bulk_parts.should_merge_parts(merge_threshold));
+        assert!(!bulk_parts.should_merge_parts(merge_threshold, None));
     }
 
     #[test]
@@ -2328,11 +2455,14 @@ mod tests {
         }
 
         // Should trigger merge since we have 16 parts
-        assert!(bulk_parts.should_merge_parts(DEFAULT_MERGE_THRESHOLD));
+        assert!(bulk_parts.should_merge_parts(DEFAULT_MERGE_THRESHOLD, None));
 
         // Collect parts to merge
-        let collected =
-            bulk_parts.collect_parts_to_merge(DEFAULT_MERGE_THRESHOLD, DEFAULT_MAX_MERGE_GROUPS);
+        let collected = bulk_parts.collect_parts_to_merge(
+            DEFAULT_MERGE_THRESHOLD,
+            DEFAULT_MAX_MERGE_GROUPS,
+            None,
+        );
 
         // Should have groups
         assert!(!collected.groups.is_empty());
@@ -2345,6 +2475,19 @@ mod tests {
         // Total parts collected should be 16
         let total_parts: usize = collected.groups.iter().map(|g| g.len()).sum();
         assert_eq!(16, total_parts);
+    }
+
+    #[test]
+    fn test_group_parts_by_size() {
+        let groups =
+            BulkParts::group_parts_by_size(vec![(0, 4), (1, 4), (2, 4), (3, 4)], 4, 4, Some(8));
+        assert_eq!(vec![vec![0, 1], vec![2, 3]], groups);
+    }
+
+    #[test]
+    fn test_group_parts_by_size_ignores_unmergeable_leftovers() {
+        let candidates = vec![(0, 9), (1, 9), (2, 9), (3, 20)];
+        assert!(BulkParts::group_parts_by_size(candidates, 4, 4, Some(10)).is_empty());
     }
 
     #[test]

--- a/src/mito2/src/memtable/bulk.rs
+++ b/src/mito2/src/memtable/bulk.rs
@@ -68,9 +68,6 @@ use crate::sst::parquet::flat_format::field_column_start;
 /// Default merge threshold for triggering compaction.
 const DEFAULT_MERGE_THRESHOLD: usize = 16;
 
-/// Soft limit for uncompressed bulk part accumulators and merge groups.
-const MAX_UNCOMPRESSED_PART_SIZE: usize = crate::batch_size::TARGET_BATCH_BYTES;
-
 /// Threshold for triggering merge of parts. Configurable via `GREPTIME_BULK_MERGE_THRESHOLD`.
 static MERGE_THRESHOLD: LazyLock<usize> =
     LazyLock::new(|| env_usize("GREPTIME_BULK_MERGE_THRESHOLD", DEFAULT_MERGE_THRESHOLD));
@@ -157,11 +154,6 @@ struct CollectedParts {
     groups: Vec<Vec<PartToMerge>>,
 }
 
-/// A merge candidate represented by `(part_index, estimated_bytes)`.
-type MergeCandidate = (usize, usize);
-/// Uncompressed and encoded merge candidates, respectively.
-type MergeCandidates = (Vec<MergeCandidate>, Vec<MergeCandidate>);
-
 /// All parts in a bulk memtable.
 #[derive(Default)]
 struct BulkParts {
@@ -183,31 +175,24 @@ impl BulkParts {
         self.unordered_part.is_empty() && self.parts.is_empty()
     }
 
-    /// Returns true if enough small parts of the same type are available to merge.
-    fn should_merge_parts(
-        &self,
-        merge_threshold: usize,
-        max_encoded_merge_group_size: Option<usize>,
-    ) -> bool {
-        let merge_threshold = merge_threshold.max(2);
+    /// Returns true if enough parts of the same type are available to merge.
+    fn should_merge_parts(&self, merge_threshold: usize, encode_bytes_threshold: usize) -> bool {
         let mut bulk_count = 0;
         let mut encoded_count = 0;
 
         for wrapper in &self.parts {
-            if !Self::is_merge_candidate(wrapper, max_encoded_merge_group_size) {
+            if !Self::is_merge_candidate(wrapper, encode_bytes_threshold) {
                 continue;
             }
 
             if wrapper.part.is_encoded() {
                 encoded_count += 1;
-                if encoded_count >= merge_threshold {
-                    return true;
-                }
             } else {
                 bulk_count += 1;
-                if bulk_count >= merge_threshold {
-                    return true;
-                }
+            }
+
+            if bulk_count >= merge_threshold || encoded_count >= merge_threshold {
+                return true;
             }
         }
 
@@ -215,62 +200,52 @@ impl BulkParts {
     }
 
     /// Returns whether a part is small enough to benefit from merging.
-    fn is_merge_candidate(
-        wrapper: &BulkPartWrapper,
-        max_encoded_merge_group_size: Option<usize>,
-    ) -> bool {
+    fn is_merge_candidate(wrapper: &BulkPartWrapper, encode_bytes_threshold: usize) -> bool {
         !wrapper.merging
             && Self::is_merge_candidate_by_size(
                 wrapper.part.is_encoded(),
                 wrapper.part.estimated_size(),
-                max_encoded_merge_group_size,
+                encode_bytes_threshold,
             )
     }
 
     fn is_merge_candidate_by_size(
         is_encoded: bool,
         estimated_size: usize,
-        max_encoded_merge_group_size: Option<usize>,
+        encode_bytes_threshold: usize,
     ) -> bool {
-        !is_encoded
-            || max_encoded_merge_group_size
-                .map(|max_size| estimated_size <= max_size / 2)
-                .unwrap_or(true)
-    }
-
-    fn merge_candidates(&self, max_encoded_merge_group_size: Option<usize>) -> MergeCandidates {
-        let mut bulk = Vec::new();
-        let mut encoded = Vec::new();
-        for (idx, wrapper) in self.parts.iter().enumerate() {
-            if !Self::is_merge_candidate(wrapper, max_encoded_merge_group_size) {
-                continue;
-            }
-            let candidate = (idx, wrapper.part.estimated_size());
-            if wrapper.part.is_encoded() {
-                encoded.push(candidate);
-            } else {
-                bulk.push(candidate);
-            }
-        }
-        (bulk, encoded)
+        !is_encoded || estimated_size <= encode_bytes_threshold
     }
 
     /// Returns true if the unordered_part should be compacted into a BulkPart.
-    fn should_compact_unordered_part(&self, incoming_bytes: usize) -> bool {
-        self.unordered_part.should_compact(incoming_bytes)
+    fn should_compact_unordered_part(&self, encode_bytes_threshold: usize) -> bool {
+        self.unordered_part.should_compact()
+            || self.unordered_part.estimated_bytes() > encode_bytes_threshold
     }
 
     /// Collects unmerged parts and marks them as being merged.
     /// Only collects parts of types that meet the threshold.
-    /// Parts are grouped by estimated size for parallel processing.
+    /// Parts are grouped by row count for parallel processing.
     fn collect_parts_to_merge(
         &mut self,
         merge_threshold: usize,
         max_merge_groups: usize,
-        max_encoded_merge_group_size: Option<usize>,
+        encode_bytes_threshold: usize,
     ) -> CollectedParts {
-        let merge_threshold = merge_threshold.max(2);
-        let (bulk_indices, encoded_indices) = self.merge_candidates(max_encoded_merge_group_size);
+        let mut bulk_indices = Vec::new();
+        let mut encoded_indices = Vec::new();
+
+        for (idx, wrapper) in self.parts.iter().enumerate() {
+            if !Self::is_merge_candidate(wrapper, encode_bytes_threshold) {
+                continue;
+            }
+            let num_rows = wrapper.part.num_rows();
+            if wrapper.part.is_encoded() {
+                encoded_indices.push((idx, num_rows));
+            } else {
+                bulk_indices.push((idx, num_rows));
+            }
+        }
 
         let mut groups = Vec::new();
 
@@ -280,7 +255,6 @@ impl BulkParts {
                 bulk_indices,
                 merge_threshold,
                 max_merge_groups,
-                None,
             ));
         }
 
@@ -290,87 +264,38 @@ impl BulkParts {
                 encoded_indices,
                 merge_threshold,
                 max_merge_groups,
-                max_encoded_merge_group_size,
             ));
         }
 
         CollectedParts { groups }
     }
 
-    /// Plans groups, marks their parts as merging, and returns cloned parts.
+    /// Sorts indices by row count, groups into chunks, marks as merging, and returns groups.
     fn collect_and_group_parts(
         &mut self,
-        indices: Vec<(usize, usize)>,
+        mut indices: Vec<(usize, usize)>,
         merge_threshold: usize,
         max_merge_groups: usize,
-        max_merge_group_size: Option<usize>,
     ) -> Vec<Vec<PartToMerge>> {
-        Self::group_parts_by_size(
-            indices,
-            merge_threshold,
-            max_merge_groups,
-            max_merge_group_size,
-        )
-        .into_iter()
-        .map(|group| {
-            group
-                .into_iter()
-                .map(|idx| {
-                    let wrapper = &mut self.parts[idx];
-                    wrapper.merging = true;
-                    wrapper.part.clone()
-                })
-                .collect()
-        })
-        .collect()
-    }
-
-    /// Groups sorted parts by both part count and cumulative size.
-    fn group_parts_by_size(
-        mut candidates: Vec<(usize, usize)>,
-        merge_threshold: usize,
-        max_merge_groups: usize,
-        max_merge_group_size: Option<usize>,
-    ) -> Vec<Vec<usize>> {
-        if candidates.len() < merge_threshold || max_merge_groups == 0 {
+        if indices.is_empty() {
             return Vec::new();
         }
 
-        let Some(max_size) = max_merge_group_size else {
-            return candidates
-                .chunks(merge_threshold)
-                .take(max_merge_groups)
-                .filter(|group| group.len() >= 2)
-                .map(|group| group.iter().map(|(idx, _)| *idx).collect())
-                .collect();
-        };
-
-        candidates.sort_unstable_by_key(|(_, size)| *size);
-        let mut groups = Vec::new();
-        let mut current = Vec::with_capacity(merge_threshold);
-        let mut current_size = 0usize;
-        for (idx, size) in candidates {
-            if !current.is_empty()
-                && (current.len() >= merge_threshold
-                    || current_size.saturating_add(size) > max_size)
-            {
-                if current.len() >= 2 {
-                    groups.push(std::mem::take(&mut current));
-                    if groups.len() >= max_merge_groups {
-                        return groups;
-                    }
-                } else {
-                    current.clear();
-                }
-                current_size = 0;
-            }
-            current.push(idx);
-            current_size = current_size.saturating_add(size);
-        }
-        if current.len() >= 2 && groups.len() < max_merge_groups {
-            groups.push(current);
-        }
-        groups
+        indices.sort_unstable_by_key(|(_, num_rows)| *num_rows);
+        indices
+            .chunks(merge_threshold)
+            .take(max_merge_groups)
+            .map(|chunk| {
+                chunk
+                    .iter()
+                    .map(|(idx, _)| {
+                        let wrapper = &mut self.parts[*idx];
+                        wrapper.merging = true;
+                        wrapper.part.clone()
+                    })
+                    .collect()
+            })
+            .collect()
     }
 
     /// Installs merged parts and removes the original parts by file ids.
@@ -482,16 +407,6 @@ pub struct BulkMemtable {
     append_mode: bool,
     /// Mode to handle duplicate rows while merging
     merge_mode: MergeMode,
-    /// Soft maximum estimated size for one compressed encoded-part merge group.
-    max_encoded_merge_group_size: Option<usize>,
-}
-
-struct BulkMemtableBuildOptions {
-    write_buffer_manager: Option<WriteBufferManagerRef>,
-    compact_dispatcher: Option<Arc<CompactDispatcher>>,
-    append_mode: bool,
-    merge_mode: MergeMode,
-    max_encoded_merge_group_size: Option<usize>,
 }
 
 impl std::fmt::Debug for BulkMemtable {
@@ -540,28 +455,13 @@ impl Memtable for BulkMemtable {
 
             let fragment_size = fragment.estimated_size();
             // Routes small parts to unordered_part based on row and byte thresholds.
-            if bulk_parts
-                .unordered_part
-                .should_accept(fragment.num_rows(), fragment_size)
+            if bulk_parts.unordered_part.should_accept(fragment.num_rows())
+                && fragment_size <= self.config.encode_bytes_threshold
             {
-                // Freeze the current accumulator before this fragment would take it over
-                // the uncompressed size limit.
-                if bulk_parts.should_compact_unordered_part(fragment_size) {
-                    if let Some(bulk_part) = bulk_parts.unordered_part.to_bulk_part()? {
-                        bulk_parts.parts.push(BulkPartWrapper {
-                            part: PartToMerge::Bulk {
-                                part: bulk_part,
-                                file_id: FileId::random(),
-                            },
-                            merging: false,
-                        });
-                    }
-                    bulk_parts.unordered_part.clear();
-                }
                 bulk_parts.unordered_part.push(fragment);
 
-                // Compacts unordered_part if threshold is reached
-                if bulk_parts.should_compact_unordered_part(0)
+                // Compacts unordered_part if the row or byte threshold is exceeded.
+                if bulk_parts.should_compact_unordered_part(self.config.encode_bytes_threshold)
                     && let Some(bulk_part) = bulk_parts.unordered_part.to_bulk_part()?
                 {
                     bulk_parts.parts.push(BulkPartWrapper {
@@ -749,12 +649,10 @@ impl Memtable for BulkMemtable {
                 metadata.region_id,
                 id,
                 self.config.clone(),
-                self.max_encoded_merge_group_size,
             ))),
             compact_dispatcher: self.compact_dispatcher.clone(),
             append_mode: self.append_mode,
             merge_mode: self.merge_mode,
-            max_encoded_merge_group_size: self.max_encoded_merge_group_size,
         })
     }
 
@@ -768,7 +666,7 @@ impl Memtable for BulkMemtable {
         // Unified merge for all parts
         let should_merge = self.parts.read().unwrap().should_merge_parts(
             self.config.merge_threshold,
-            self.max_encoded_merge_group_size,
+            self.config.encode_bytes_threshold,
         );
         if should_merge {
             compactor.merge_parts(
@@ -794,33 +692,6 @@ impl BulkMemtable {
         append_mode: bool,
         merge_mode: MergeMode,
     ) -> Self {
-        Self::new_with_options(
-            id,
-            config,
-            metadata,
-            BulkMemtableBuildOptions {
-                write_buffer_manager,
-                compact_dispatcher,
-                append_mode,
-                merge_mode,
-                max_encoded_merge_group_size: None,
-            },
-        )
-    }
-
-    fn new_with_options(
-        id: MemtableId,
-        config: BulkMemtableConfig,
-        metadata: RegionMetadataRef,
-        options: BulkMemtableBuildOptions,
-    ) -> Self {
-        let BulkMemtableBuildOptions {
-            write_buffer_manager,
-            compact_dispatcher,
-            append_mode,
-            merge_mode,
-            max_encoded_merge_group_size,
-        } = options;
         let config = config.sanitize();
         let region_id = metadata.region_id;
         Self {
@@ -833,16 +704,10 @@ impl BulkMemtable {
             min_timestamp: AtomicI64::new(i64::MAX),
             max_sequence: AtomicU64::new(0),
             num_rows: AtomicUsize::new(0),
-            compactor: Arc::new(Mutex::new(MemtableCompactor::new(
-                region_id,
-                id,
-                config,
-                max_encoded_merge_group_size,
-            ))),
+            compactor: Arc::new(Mutex::new(MemtableCompactor::new(region_id, id, config))),
             compact_dispatcher,
             append_mode,
             merge_mode,
-            max_encoded_merge_group_size,
         }
     }
 
@@ -897,7 +762,7 @@ impl BulkMemtable {
         let parts = self.parts.read().unwrap();
         parts.should_merge_parts(
             self.config.merge_threshold,
-            self.max_encoded_merge_group_size,
+            self.config.encode_bytes_threshold,
         )
     }
 
@@ -1215,22 +1080,15 @@ struct MemtableCompactor {
     memtable_id: MemtableId,
     /// Configuration for the bulk memtable.
     config: BulkMemtableConfig,
-    max_encoded_merge_group_size: Option<usize>,
 }
 
 impl MemtableCompactor {
     /// Creates a new MemtableCompactor.
-    fn new(
-        region_id: RegionId,
-        memtable_id: MemtableId,
-        config: BulkMemtableConfig,
-        max_encoded_merge_group_size: Option<usize>,
-    ) -> Self {
+    fn new(region_id: RegionId, memtable_id: MemtableId, config: BulkMemtableConfig) -> Self {
         Self {
             region_id,
             memtable_id,
             config,
-            max_encoded_merge_group_size,
         }
     }
 
@@ -1248,7 +1106,7 @@ impl MemtableCompactor {
         let collected = bulk_parts.write().unwrap().collect_parts_to_merge(
             self.config.merge_threshold,
             self.config.max_merge_groups,
-            self.max_encoded_merge_group_size,
+            self.config.encode_bytes_threshold,
         );
 
         if collected.groups.is_empty() {
@@ -1466,7 +1324,7 @@ impl MemCompactTask {
 
         let should_merge = self.parts.read().unwrap().should_merge_parts(
             self.config.merge_threshold,
-            compactor.max_encoded_merge_group_size,
+            self.config.encode_bytes_threshold,
         );
         if should_merge {
             compactor.merge_parts(
@@ -1521,7 +1379,6 @@ pub struct BulkMemtableBuilder {
     compact_dispatcher: Option<Arc<CompactDispatcher>>,
     append_mode: bool,
     merge_mode: MergeMode,
-    max_encoded_merge_group_size: Option<usize>,
 }
 
 impl BulkMemtableBuilder {
@@ -1537,7 +1394,6 @@ impl BulkMemtableBuilder {
             compact_dispatcher: None,
             append_mode,
             merge_mode,
-            max_encoded_merge_group_size: None,
         }
     }
 
@@ -1553,12 +1409,6 @@ impl BulkMemtableBuilder {
         self
     }
 
-    /// Sets the soft maximum estimated size for one compressed encoded-part merge group.
-    pub(crate) fn with_max_encoded_merge_group_size(mut self, max_size: Option<u64>) -> Self {
-        self.max_encoded_merge_group_size = max_size.and_then(|size| usize::try_from(size).ok());
-        self
-    }
-
     #[cfg(test)]
     pub(crate) fn config(&self) -> &BulkMemtableConfig {
         &self.config
@@ -1567,17 +1417,14 @@ impl BulkMemtableBuilder {
 
 impl MemtableBuilder for BulkMemtableBuilder {
     fn build(&self, id: MemtableId, metadata: &RegionMetadataRef) -> MemtableRef {
-        Arc::new(BulkMemtable::new_with_options(
+        Arc::new(BulkMemtable::new(
             id,
             self.config.clone(),
             metadata.clone(),
-            BulkMemtableBuildOptions {
-                write_buffer_manager: self.write_buffer_manager.clone(),
-                compact_dispatcher: self.compact_dispatcher.clone(),
-                append_mode: self.append_mode,
-                merge_mode: self.merge_mode,
-                max_encoded_merge_group_size: self.max_encoded_merge_group_size,
-            },
+            self.write_buffer_manager.clone(),
+            self.compact_dispatcher.clone(),
+            self.append_mode,
+            self.merge_mode,
         ))
     }
 
@@ -2336,6 +2183,60 @@ mod tests {
     }
 
     #[test]
+    fn test_bulk_memtable_unordered_part_byte_threshold() {
+        let metadata = metadata_for_test();
+        let first =
+            create_bulk_part_with_converter("first", 1, vec![1000], vec![Some(1.0)], 1).unwrap();
+        let second =
+            create_bulk_part_with_converter("second", 2, vec![2000], vec![Some(2.0)], 2).unwrap();
+        let threshold = first.estimated_size().max(second.estimated_size());
+        let memtable = BulkMemtable::new(
+            1004,
+            BulkMemtableConfig {
+                encode_bytes_threshold: threshold,
+                ..Default::default()
+            },
+            metadata.clone(),
+            None,
+            None,
+            false,
+            MergeMode::LastRow,
+        );
+        memtable.set_unordered_part_compact_threshold(usize::MAX);
+
+        // A part exactly at or below the threshold is accepted.
+        memtable.write_bulk(first).unwrap();
+        assert_eq!(1, memtable.parts.read().unwrap().unordered_part.num_parts());
+
+        // Compact after the accumulated size becomes larger than the threshold.
+        memtable.write_bulk(second).unwrap();
+        let parts = memtable.parts.read().unwrap();
+        assert!(parts.unordered_part.is_empty());
+        assert_eq!(1, parts.parts.len());
+        drop(parts);
+
+        let oversized =
+            create_bulk_part_with_converter("oversized", 3, vec![3000], vec![Some(3.0)], 3)
+                .unwrap();
+        let oversized_memtable = BulkMemtable::new(
+            1005,
+            BulkMemtableConfig {
+                encode_bytes_threshold: oversized.estimated_size() - 1,
+                ..Default::default()
+            },
+            metadata,
+            None,
+            None,
+            false,
+            MergeMode::LastRow,
+        );
+        oversized_memtable.write_bulk(oversized).unwrap();
+        let parts = oversized_memtable.parts.read().unwrap();
+        assert!(parts.unordered_part.is_empty());
+        assert_eq!(1, parts.parts.len());
+    }
+
+    #[test]
     fn test_bulk_memtable_unordered_part_with_ranges() {
         let metadata = metadata_for_test();
         let memtable = BulkMemtable::new(
@@ -2426,7 +2327,7 @@ mod tests {
         }
 
         // Should not trigger merge since we have only 7 parts
-        assert!(!bulk_parts.should_merge_parts(DEFAULT_MERGE_THRESHOLD, None));
+        assert!(!bulk_parts.should_merge_parts(DEFAULT_MERGE_THRESHOLD, usize::MAX));
     }
 
     #[test]
@@ -2448,7 +2349,7 @@ mod tests {
         }
 
         // Should trigger merge since we have 8 parts
-        assert!(bulk_parts.should_merge_parts(merge_threshold, None));
+        assert!(bulk_parts.should_merge_parts(merge_threshold, usize::MAX));
     }
 
     #[test]
@@ -2468,11 +2369,11 @@ mod tests {
         }
 
         let max_size = bulk_parts.parts[0].part.estimated_size();
-        assert!(bulk_parts.should_merge_parts(merge_threshold, Some(max_size)));
+        assert!(bulk_parts.should_merge_parts(merge_threshold, max_size));
         assert_eq!(
             1,
             bulk_parts
-                .collect_parts_to_merge(merge_threshold, 1, Some(max_size))
+                .collect_parts_to_merge(merge_threshold, 1, max_size)
                 .groups
                 .len()
         );
@@ -2497,7 +2398,7 @@ mod tests {
         }
 
         // Should trigger merge since we have 10 parts
-        assert!(bulk_parts.should_merge_parts(merge_threshold, None));
+        assert!(bulk_parts.should_merge_parts(merge_threshold, usize::MAX));
 
         // Mark first 3 parts as merging
         for wrapper in bulk_parts.parts.iter_mut().take(3) {
@@ -2505,7 +2406,7 @@ mod tests {
         }
 
         // Now only 7 parts are available for merging, should not trigger
-        assert!(!bulk_parts.should_merge_parts(merge_threshold, None));
+        assert!(!bulk_parts.should_merge_parts(merge_threshold, usize::MAX));
     }
 
     #[test]
@@ -2532,13 +2433,13 @@ mod tests {
         }
 
         // Should trigger merge since we have 16 parts
-        assert!(bulk_parts.should_merge_parts(DEFAULT_MERGE_THRESHOLD, None));
+        assert!(bulk_parts.should_merge_parts(DEFAULT_MERGE_THRESHOLD, usize::MAX));
 
         // Collect parts to merge
         let collected = bulk_parts.collect_parts_to_merge(
             DEFAULT_MERGE_THRESHOLD,
             DEFAULT_MAX_MERGE_GROUPS,
-            None,
+            usize::MAX,
         );
 
         // Should have groups
@@ -2555,39 +2456,10 @@ mod tests {
     }
 
     #[test]
-    fn test_group_parts_by_size() {
-        let groups =
-            BulkParts::group_parts_by_size(vec![(0, 4), (1, 4), (2, 4), (3, 4)], 4, 4, Some(8));
-        assert_eq!(vec![vec![0, 1], vec![2, 3]], groups);
-    }
-
-    #[test]
-    fn test_group_parts_by_size_ignores_unmergeable_leftovers() {
-        let candidates = vec![(0, 9), (1, 9), (2, 9), (3, 20)];
-        assert!(BulkParts::group_parts_by_size(candidates, 4, 4, Some(10)).is_empty());
-    }
-
-    #[test]
     fn test_encoded_merge_candidate_size_limit() {
-        assert!(BulkParts::is_merge_candidate_by_size(
-            false,
-            usize::MAX,
-            Some(8)
-        ));
-        assert!(BulkParts::is_merge_candidate_by_size(true, 4, Some(8)));
-        assert!(!BulkParts::is_merge_candidate_by_size(true, 5, Some(8)));
-        assert!(BulkParts::is_merge_candidate_by_size(
-            true,
-            usize::MAX,
-            None
-        ));
-    }
-
-    #[test]
-    fn test_unencoded_group_has_no_size_limit() {
-        let groups =
-            BulkParts::group_parts_by_size(vec![(0, usize::MAX), (1, usize::MAX)], 2, 1, None);
-        assert_eq!(vec![vec![0, 1]], groups);
+        assert!(BulkParts::is_merge_candidate_by_size(false, usize::MAX, 8));
+        assert!(BulkParts::is_merge_candidate_by_size(true, 8, 8));
+        assert!(!BulkParts::is_merge_candidate_by_size(true, 9, 8));
     }
 
     #[test]

--- a/src/mito2/src/memtable/bulk.rs
+++ b/src/mito2/src/memtable/bulk.rs
@@ -68,6 +68,9 @@ use crate::sst::parquet::flat_format::field_column_start;
 /// Default merge threshold for triggering compaction.
 const DEFAULT_MERGE_THRESHOLD: usize = 16;
 
+/// Soft limit for uncompressed bulk part accumulators and merge groups.
+const MAX_UNCOMPRESSED_PART_SIZE: usize = crate::batch_size::TARGET_BATCH_BYTES;
+
 /// Threshold for triggering merge of parts. Configurable via `GREPTIME_BULK_MERGE_THRESHOLD`.
 static MERGE_THRESHOLD: LazyLock<usize> =
     LazyLock::new(|| env_usize("GREPTIME_BULK_MERGE_THRESHOLD", DEFAULT_MERGE_THRESHOLD));
@@ -154,6 +157,11 @@ struct CollectedParts {
     groups: Vec<Vec<PartToMerge>>,
 }
 
+/// A merge candidate represented by `(part_index, estimated_bytes)`.
+type MergeCandidate = (usize, usize);
+/// Uncompressed and encoded merge candidates, respectively.
+type MergeCandidates = (Vec<MergeCandidate>, Vec<MergeCandidate>);
+
 /// All parts in a bulk memtable.
 #[derive(Default)]
 struct BulkParts {
@@ -179,21 +187,27 @@ impl BulkParts {
     fn should_merge_parts(
         &self,
         merge_threshold: usize,
-        max_merge_group_size: Option<usize>,
+        max_encoded_merge_group_size: Option<usize>,
     ) -> bool {
+        let merge_threshold = merge_threshold.max(2);
         let mut bulk_count = 0;
         let mut encoded_count = 0;
+
         for wrapper in &self.parts {
-            if !Self::is_merge_candidate(wrapper, max_merge_group_size) {
+            if !Self::is_merge_candidate(wrapper, max_encoded_merge_group_size) {
                 continue;
             }
+
             if wrapper.part.is_encoded() {
                 encoded_count += 1;
+                if encoded_count >= merge_threshold {
+                    return true;
+                }
             } else {
                 bulk_count += 1;
-            }
-            if bulk_count >= merge_threshold || encoded_count >= merge_threshold {
-                return true;
+                if bulk_count >= merge_threshold {
+                    return true;
+                }
             }
         }
 
@@ -201,16 +215,49 @@ impl BulkParts {
     }
 
     /// Returns whether a part is small enough to benefit from merging.
-    fn is_merge_candidate(wrapper: &BulkPartWrapper, max_merge_group_size: Option<usize>) -> bool {
+    fn is_merge_candidate(
+        wrapper: &BulkPartWrapper,
+        max_encoded_merge_group_size: Option<usize>,
+    ) -> bool {
         !wrapper.merging
-            && max_merge_group_size
-                .map(|max_size| wrapper.part.estimated_size() < max_size)
+            && Self::is_merge_candidate_by_size(
+                wrapper.part.is_encoded(),
+                wrapper.part.estimated_size(),
+                max_encoded_merge_group_size,
+            )
+    }
+
+    fn is_merge_candidate_by_size(
+        is_encoded: bool,
+        estimated_size: usize,
+        max_encoded_merge_group_size: Option<usize>,
+    ) -> bool {
+        !is_encoded
+            || max_encoded_merge_group_size
+                .map(|max_size| estimated_size <= max_size / 2)
                 .unwrap_or(true)
     }
 
+    fn merge_candidates(&self, max_encoded_merge_group_size: Option<usize>) -> MergeCandidates {
+        let mut bulk = Vec::new();
+        let mut encoded = Vec::new();
+        for (idx, wrapper) in self.parts.iter().enumerate() {
+            if !Self::is_merge_candidate(wrapper, max_encoded_merge_group_size) {
+                continue;
+            }
+            let candidate = (idx, wrapper.part.estimated_size());
+            if wrapper.part.is_encoded() {
+                encoded.push(candidate);
+            } else {
+                bulk.push(candidate);
+            }
+        }
+        (bulk, encoded)
+    }
+
     /// Returns true if the unordered_part should be compacted into a BulkPart.
-    fn should_compact_unordered_part(&self) -> bool {
-        self.unordered_part.should_compact()
+    fn should_compact_unordered_part(&self, incoming_bytes: usize) -> bool {
+        self.unordered_part.should_compact(incoming_bytes)
     }
 
     /// Collects unmerged parts and marks them as being merged.
@@ -220,23 +267,10 @@ impl BulkParts {
         &mut self,
         merge_threshold: usize,
         max_merge_groups: usize,
-        max_merge_group_size: Option<usize>,
+        max_encoded_merge_group_size: Option<usize>,
     ) -> CollectedParts {
-        // First pass: collect indices and estimated sizes for each type.
-        let mut bulk_indices: Vec<(usize, usize)> = Vec::new();
-        let mut encoded_indices: Vec<(usize, usize)> = Vec::new();
-
-        for (idx, wrapper) in self.parts.iter().enumerate() {
-            if !Self::is_merge_candidate(wrapper, max_merge_group_size) {
-                continue;
-            }
-            let estimated_size = wrapper.part.estimated_size();
-            if wrapper.part.is_encoded() {
-                encoded_indices.push((idx, estimated_size));
-            } else {
-                bulk_indices.push((idx, estimated_size));
-            }
-        }
+        let merge_threshold = merge_threshold.max(2);
+        let (bulk_indices, encoded_indices) = self.merge_candidates(max_encoded_merge_group_size);
 
         let mut groups = Vec::new();
 
@@ -246,7 +280,7 @@ impl BulkParts {
                 bulk_indices,
                 merge_threshold,
                 max_merge_groups,
-                max_merge_group_size,
+                None,
             ));
         }
 
@@ -256,7 +290,7 @@ impl BulkParts {
                 encoded_indices,
                 merge_threshold,
                 max_merge_groups,
-                max_merge_group_size,
+                max_encoded_merge_group_size,
             ));
         }
 
@@ -302,8 +336,16 @@ impl BulkParts {
             return Vec::new();
         }
 
+        let Some(max_size) = max_merge_group_size else {
+            return candidates
+                .chunks(merge_threshold)
+                .take(max_merge_groups)
+                .filter(|group| group.len() >= 2)
+                .map(|group| group.iter().map(|(idx, _)| *idx).collect())
+                .collect();
+        };
+
         candidates.sort_unstable_by_key(|(_, size)| *size);
-        let max_size = max_merge_group_size.unwrap_or(usize::MAX);
         let mut groups = Vec::new();
         let mut current = Vec::with_capacity(merge_threshold);
         let mut current_size = 0usize;
@@ -440,8 +482,16 @@ pub struct BulkMemtable {
     append_mode: bool,
     /// Mode to handle duplicate rows while merging
     merge_mode: MergeMode,
-    /// Soft maximum estimated size for one part merge group.
-    max_merge_group_size: Option<usize>,
+    /// Soft maximum estimated size for one compressed encoded-part merge group.
+    max_encoded_merge_group_size: Option<usize>,
+}
+
+struct BulkMemtableBuildOptions {
+    write_buffer_manager: Option<WriteBufferManagerRef>,
+    compact_dispatcher: Option<Arc<CompactDispatcher>>,
+    append_mode: bool,
+    merge_mode: MergeMode,
+    max_encoded_merge_group_size: Option<usize>,
 }
 
 impl std::fmt::Debug for BulkMemtable {
@@ -488,12 +538,30 @@ impl Memtable for BulkMemtable {
         {
             let mut bulk_parts = self.parts.write().unwrap();
 
-            // Routes small parts to unordered_part based on threshold
-            if bulk_parts.unordered_part.should_accept(fragment.num_rows()) {
+            let fragment_size = fragment.estimated_size();
+            // Routes small parts to unordered_part based on row and byte thresholds.
+            if bulk_parts
+                .unordered_part
+                .should_accept(fragment.num_rows(), fragment_size)
+            {
+                // Freeze the current accumulator before this fragment would take it over
+                // the uncompressed size limit.
+                if bulk_parts.should_compact_unordered_part(fragment_size) {
+                    if let Some(bulk_part) = bulk_parts.unordered_part.to_bulk_part()? {
+                        bulk_parts.parts.push(BulkPartWrapper {
+                            part: PartToMerge::Bulk {
+                                part: bulk_part,
+                                file_id: FileId::random(),
+                            },
+                            merging: false,
+                        });
+                    }
+                    bulk_parts.unordered_part.clear();
+                }
                 bulk_parts.unordered_part.push(fragment);
 
                 // Compacts unordered_part if threshold is reached
-                if bulk_parts.should_compact_unordered_part()
+                if bulk_parts.should_compact_unordered_part(0)
                     && let Some(bulk_part) = bulk_parts.unordered_part.to_bulk_part()?
                 {
                     bulk_parts.parts.push(BulkPartWrapper {
@@ -681,12 +749,12 @@ impl Memtable for BulkMemtable {
                 metadata.region_id,
                 id,
                 self.config.clone(),
-                self.max_merge_group_size,
+                self.max_encoded_merge_group_size,
             ))),
             compact_dispatcher: self.compact_dispatcher.clone(),
             append_mode: self.append_mode,
             merge_mode: self.merge_mode,
-            max_merge_group_size: self.max_merge_group_size,
+            max_encoded_merge_group_size: self.max_encoded_merge_group_size,
         })
     }
 
@@ -698,11 +766,10 @@ impl Memtable for BulkMemtable {
         }
 
         // Unified merge for all parts
-        let should_merge = self
-            .parts
-            .read()
-            .unwrap()
-            .should_merge_parts(self.config.merge_threshold, self.max_merge_group_size);
+        let should_merge = self.parts.read().unwrap().should_merge_parts(
+            self.config.merge_threshold,
+            self.max_encoded_merge_group_size,
+        );
         if should_merge {
             compactor.merge_parts(
                 &self.parts,
@@ -727,28 +794,33 @@ impl BulkMemtable {
         append_mode: bool,
         merge_mode: MergeMode,
     ) -> Self {
-        Self::new_with_max_merge_group_size(
+        Self::new_with_options(
             id,
             config,
             metadata,
+            BulkMemtableBuildOptions {
+                write_buffer_manager,
+                compact_dispatcher,
+                append_mode,
+                merge_mode,
+                max_encoded_merge_group_size: None,
+            },
+        )
+    }
+
+    fn new_with_options(
+        id: MemtableId,
+        config: BulkMemtableConfig,
+        metadata: RegionMetadataRef,
+        options: BulkMemtableBuildOptions,
+    ) -> Self {
+        let BulkMemtableBuildOptions {
             write_buffer_manager,
             compact_dispatcher,
             append_mode,
             merge_mode,
-            None,
-        )
-    }
-
-    fn new_with_max_merge_group_size(
-        id: MemtableId,
-        config: BulkMemtableConfig,
-        metadata: RegionMetadataRef,
-        write_buffer_manager: Option<WriteBufferManagerRef>,
-        compact_dispatcher: Option<Arc<CompactDispatcher>>,
-        append_mode: bool,
-        merge_mode: MergeMode,
-        max_merge_group_size: Option<usize>,
-    ) -> Self {
+            max_encoded_merge_group_size,
+        } = options;
         let config = config.sanitize();
         let region_id = metadata.region_id;
         Self {
@@ -765,12 +837,12 @@ impl BulkMemtable {
                 region_id,
                 id,
                 config,
-                max_merge_group_size,
+                max_encoded_merge_group_size,
             ))),
             compact_dispatcher,
             append_mode,
             merge_mode,
-            max_merge_group_size,
+            max_encoded_merge_group_size,
         }
     }
 
@@ -823,7 +895,10 @@ impl BulkMemtable {
     /// Returns whether the memtable should be compacted.
     fn should_compact(&self) -> bool {
         let parts = self.parts.read().unwrap();
-        parts.should_merge_parts(self.config.merge_threshold, self.max_merge_group_size)
+        parts.should_merge_parts(
+            self.config.merge_threshold,
+            self.max_encoded_merge_group_size,
+        )
     }
 
     /// Schedules a compaction task using the CompactDispatcher.
@@ -1140,7 +1215,7 @@ struct MemtableCompactor {
     memtable_id: MemtableId,
     /// Configuration for the bulk memtable.
     config: BulkMemtableConfig,
-    max_merge_group_size: Option<usize>,
+    max_encoded_merge_group_size: Option<usize>,
 }
 
 impl MemtableCompactor {
@@ -1149,13 +1224,13 @@ impl MemtableCompactor {
         region_id: RegionId,
         memtable_id: MemtableId,
         config: BulkMemtableConfig,
-        max_merge_group_size: Option<usize>,
+        max_encoded_merge_group_size: Option<usize>,
     ) -> Self {
         Self {
             region_id,
             memtable_id,
             config,
-            max_merge_group_size,
+            max_encoded_merge_group_size,
         }
     }
 
@@ -1173,7 +1248,7 @@ impl MemtableCompactor {
         let collected = bulk_parts.write().unwrap().collect_parts_to_merge(
             self.config.merge_threshold,
             self.config.max_merge_groups,
-            self.max_merge_group_size,
+            self.max_encoded_merge_group_size,
         );
 
         if collected.groups.is_empty() {
@@ -1275,7 +1350,7 @@ impl MemtableCompactor {
             estimated_total_rows as u64,
             estimated_total_bytes as u64,
         )]);
-        let context = Arc::new(BulkIterContext::new_with_batch_size(
+        let context = Arc::new(BulkIterContext::new(
             metadata.clone(),
             None, // No column projection for merging
             None, // No predicate for merging
@@ -1389,11 +1464,10 @@ impl MemCompactTask {
     fn compact(&self) -> Result<()> {
         let mut compactor = self.compactor.lock().unwrap();
 
-        let should_merge = self
-            .parts
-            .read()
-            .unwrap()
-            .should_merge_parts(self.config.merge_threshold, compactor.max_merge_group_size);
+        let should_merge = self.parts.read().unwrap().should_merge_parts(
+            self.config.merge_threshold,
+            compactor.max_encoded_merge_group_size,
+        );
         if should_merge {
             compactor.merge_parts(
                 &self.parts,
@@ -1447,7 +1521,7 @@ pub struct BulkMemtableBuilder {
     compact_dispatcher: Option<Arc<CompactDispatcher>>,
     append_mode: bool,
     merge_mode: MergeMode,
-    max_merge_group_size: Option<usize>,
+    max_encoded_merge_group_size: Option<usize>,
 }
 
 impl BulkMemtableBuilder {
@@ -1463,7 +1537,7 @@ impl BulkMemtableBuilder {
             compact_dispatcher: None,
             append_mode,
             merge_mode,
-            max_merge_group_size: None,
+            max_encoded_merge_group_size: None,
         }
     }
 
@@ -1479,9 +1553,9 @@ impl BulkMemtableBuilder {
         self
     }
 
-    /// Sets the soft maximum estimated size for one part merge group.
-    pub(crate) fn with_max_merge_group_size(mut self, max_size: Option<u64>) -> Self {
-        self.max_merge_group_size = max_size.and_then(|size| usize::try_from(size).ok());
+    /// Sets the soft maximum estimated size for one compressed encoded-part merge group.
+    pub(crate) fn with_max_encoded_merge_group_size(mut self, max_size: Option<u64>) -> Self {
+        self.max_encoded_merge_group_size = max_size.and_then(|size| usize::try_from(size).ok());
         self
     }
 
@@ -1493,15 +1567,17 @@ impl BulkMemtableBuilder {
 
 impl MemtableBuilder for BulkMemtableBuilder {
     fn build(&self, id: MemtableId, metadata: &RegionMetadataRef) -> MemtableRef {
-        Arc::new(BulkMemtable::new_with_max_merge_group_size(
+        Arc::new(BulkMemtable::new_with_options(
             id,
             self.config.clone(),
             metadata.clone(),
-            self.write_buffer_manager.clone(),
-            self.compact_dispatcher.clone(),
-            self.append_mode,
-            self.merge_mode,
-            self.max_merge_group_size,
+            BulkMemtableBuildOptions {
+                write_buffer_manager: self.write_buffer_manager.clone(),
+                compact_dispatcher: self.compact_dispatcher.clone(),
+                append_mode: self.append_mode,
+                merge_mode: self.merge_mode,
+                max_encoded_merge_group_size: self.max_encoded_merge_group_size,
+            },
         ))
     }
 
@@ -2376,7 +2452,7 @@ mod tests {
     }
 
     #[test]
-    fn test_large_parts_are_not_merge_candidates() {
+    fn test_raw_parts_do_not_use_encoded_merge_limit() {
         let mut bulk_parts = BulkParts::default();
         let merge_threshold = 4;
         for i in 0..merge_threshold {
@@ -2392,12 +2468,13 @@ mod tests {
         }
 
         let max_size = bulk_parts.parts[0].part.estimated_size();
-        assert!(!bulk_parts.should_merge_parts(merge_threshold, Some(max_size)));
-        assert!(
+        assert!(bulk_parts.should_merge_parts(merge_threshold, Some(max_size)));
+        assert_eq!(
+            1,
             bulk_parts
                 .collect_parts_to_merge(merge_threshold, 1, Some(max_size))
                 .groups
-                .is_empty()
+                .len()
         );
     }
 
@@ -2488,6 +2565,29 @@ mod tests {
     fn test_group_parts_by_size_ignores_unmergeable_leftovers() {
         let candidates = vec![(0, 9), (1, 9), (2, 9), (3, 20)];
         assert!(BulkParts::group_parts_by_size(candidates, 4, 4, Some(10)).is_empty());
+    }
+
+    #[test]
+    fn test_encoded_merge_candidate_size_limit() {
+        assert!(BulkParts::is_merge_candidate_by_size(
+            false,
+            usize::MAX,
+            Some(8)
+        ));
+        assert!(BulkParts::is_merge_candidate_by_size(true, 4, Some(8)));
+        assert!(!BulkParts::is_merge_candidate_by_size(true, 5, Some(8)));
+        assert!(BulkParts::is_merge_candidate_by_size(
+            true,
+            usize::MAX,
+            None
+        ));
+    }
+
+    #[test]
+    fn test_unencoded_group_has_no_size_limit() {
+        let groups =
+            BulkParts::group_parts_by_size(vec![(0, usize::MAX), (1, usize::MAX)], 2, 1, None);
+        assert_eq!(vec![vec![0, 1]], groups);
     }
 
     #[test]

--- a/src/mito2/src/memtable/bulk.rs
+++ b/src/mito2/src/memtable/bulk.rs
@@ -1029,6 +1029,32 @@ impl PartToMerge {
         }
     }
 
+    /// Returns `(num_rows, estimated_decoded_bytes)` for batch sizing.
+    fn batch_size_statistic(&self) -> Option<(u64, u64)> {
+        match self {
+            PartToMerge::Bulk { part, .. } => {
+                Some((part.num_rows() as u64, part.estimated_size() as u64))
+            }
+            PartToMerge::Multi { part, .. } => {
+                Some((part.num_rows() as u64, part.estimated_size() as u64))
+            }
+            PartToMerge::Encoded { part, .. } => part
+                .metadata()
+                .parquet_metadata
+                .row_groups()
+                .iter()
+                .map(|row_group| {
+                    let uncompressed_bytes = row_group
+                        .columns()
+                        .iter()
+                        .map(|column| column.uncompressed_size() as u64)
+                        .sum();
+                    (row_group.num_rows() as u64, uncompressed_bytes)
+                })
+                .max_by_key(|(_, uncompressed_bytes)| *uncompressed_bytes),
+        }
+    }
+
     /// Converts this part to `MemtableStats`.
     fn to_memtable_stats(&self, region_metadata: &RegionMetadataRef) -> MemtableStats {
         match self {
@@ -1204,10 +1230,11 @@ impl MemtableCompactor {
             .max()
             .unwrap_or(0);
 
-        let batch_size = crate::batch_size::estimate_batch_size([(
-            estimated_total_rows as u64,
-            estimated_total_bytes as u64,
-        )]);
+        let batch_size = crate::batch_size::estimate_batch_size(
+            parts_to_merge
+                .iter()
+                .filter_map(PartToMerge::batch_size_statistic),
+        );
         let context = Arc::new(BulkIterContext::new(
             metadata.clone(),
             None, // No column projection for merging
@@ -2460,6 +2487,47 @@ mod tests {
         assert!(BulkParts::is_merge_candidate_by_size(false, usize::MAX, 8));
         assert!(BulkParts::is_merge_candidate_by_size(true, 8, 8));
         assert!(!BulkParts::is_merge_candidate_by_size(true, 9, 8));
+    }
+
+    #[test]
+    fn test_encoded_part_batch_size_uses_largest_uncompressed_row_group() {
+        const NUM_ROWS: usize = 14;
+        const ROW_GROUP_SIZE: usize = 4;
+
+        let metadata = metadata_for_test();
+        let timestamps = (0..NUM_ROWS as i64).collect::<Vec<_>>();
+        let field_values = (0..NUM_ROWS)
+            .map(|value| Some(value as f64))
+            .collect::<Vec<_>>();
+        let bulk_part =
+            create_bulk_part_with_converter("key", 0, timestamps, field_values, 0).unwrap();
+        let encoder = BulkPartEncoder::new(metadata, ROW_GROUP_SIZE).unwrap();
+        let encoded_part = encoder.encode_part(&bulk_part).unwrap().unwrap();
+        let max_row_group = encoded_part
+            .metadata()
+            .parquet_metadata
+            .row_groups()
+            .iter()
+            .max_by_key(|row_group| {
+                row_group
+                    .columns()
+                    .iter()
+                    .map(|column| column.uncompressed_size() as u64)
+                    .sum::<u64>()
+            })
+            .unwrap();
+        let max_uncompressed_size = max_row_group
+            .columns()
+            .iter()
+            .map(|column| column.uncompressed_size() as u64)
+            .sum();
+        let expected = (max_row_group.num_rows() as u64, max_uncompressed_size);
+        let part = PartToMerge::Encoded {
+            part: encoded_part,
+            file_id: FileId::random(),
+        };
+
+        assert_eq!(Some(expected), part.batch_size_statistic());
     }
 
     #[test]

--- a/src/mito2/src/memtable/bulk/context.rs
+++ b/src/mito2/src/memtable/bulk/context.rs
@@ -26,6 +26,7 @@ use table::predicate::Predicate;
 
 use crate::error::Result;
 use crate::read::read_columns::ReadColumns;
+use crate::sst::parquet::DEFAULT_READ_BATCH_SIZE;
 use crate::sst::parquet::file_range::{PreFilterMode, RangeBase};
 use crate::sst::parquet::flat_format::FlatReadFormat;
 use crate::sst::parquet::prefilter::{CachedPrimaryKeyFilter, build_bulk_filter_plan};
@@ -39,6 +40,7 @@ pub struct BulkIterContext {
     /// Pre-extracted primary key filters for PK prefiltering.
     /// `None` if PK prefiltering is not applicable.
     pk_filters: Option<Arc<Vec<SimpleFilterEvaluator>>>,
+    batch_size: usize,
 }
 
 impl BulkIterContext {
@@ -54,6 +56,24 @@ impl BulkIterContext {
             predicate,
             skip_auto_convert,
             PreFilterMode::All,
+            DEFAULT_READ_BATCH_SIZE,
+        )
+    }
+
+    pub fn new_with_batch_size(
+        region_metadata: RegionMetadataRef,
+        projection: Option<&[ColumnId]>,
+        predicate: Option<Predicate>,
+        skip_auto_convert: bool,
+        batch_size: usize,
+    ) -> Result<Self> {
+        Self::new_with_pre_filter_mode(
+            region_metadata,
+            projection,
+            predicate,
+            skip_auto_convert,
+            PreFilterMode::All,
+            batch_size,
         )
     }
 
@@ -63,6 +83,7 @@ impl BulkIterContext {
         predicate: Option<Predicate>,
         skip_auto_convert: bool,
         pre_filter_mode: PreFilterMode,
+        batch_size: usize,
     ) -> Result<Self> {
         let codec = build_primary_key_codec(&region_metadata);
 
@@ -107,7 +128,12 @@ impl BulkIterContext {
             },
             predicate,
             pk_filters: filter_plan.pk_filters,
+            batch_size: batch_size.clamp(1, DEFAULT_READ_BATCH_SIZE),
         })
+    }
+
+    pub(crate) fn batch_size(&self) -> usize {
+        self.batch_size
     }
 
     /// Prunes row groups by stats.

--- a/src/mito2/src/memtable/bulk/context.rs
+++ b/src/mito2/src/memtable/bulk/context.rs
@@ -49,22 +49,6 @@ impl BulkIterContext {
         projection: Option<&[ColumnId]>,
         predicate: Option<Predicate>,
         skip_auto_convert: bool,
-    ) -> Result<Self> {
-        Self::new_with_pre_filter_mode(
-            region_metadata,
-            projection,
-            predicate,
-            skip_auto_convert,
-            PreFilterMode::All,
-            DEFAULT_READ_BATCH_SIZE,
-        )
-    }
-
-    pub fn new_with_batch_size(
-        region_metadata: RegionMetadataRef,
-        projection: Option<&[ColumnId]>,
-        predicate: Option<Predicate>,
-        skip_auto_convert: bool,
         batch_size: usize,
     ) -> Result<Self> {
         Self::new_with_pre_filter_mode(

--- a/src/mito2/src/memtable/bulk/part.rs
+++ b/src/mito2/src/memtable/bulk/part.rs
@@ -59,6 +59,7 @@ use crate::error::{
     EncodeMemtableSnafu, EncodeSnafu, InvalidMetadataSnafu, InvalidRequestSnafu,
     NewRecordBatchSnafu, Result,
 };
+use crate::memtable::bulk::MAX_UNCOMPRESSED_PART_SIZE;
 use crate::memtable::bulk::context::{BulkIterContext, BulkIterContextRef};
 use crate::memtable::bulk::json_align::Json2Aligner;
 use crate::memtable::bulk::part_reader::EncodedBulkPartIter;
@@ -337,6 +338,8 @@ pub struct UnorderedPart {
     parts: Vec<BulkPart>,
     /// Total number of rows across all parts.
     total_rows: usize,
+    /// Total estimated uncompressed bytes across all parts.
+    total_bytes: usize,
     /// Minimum timestamp across all parts.
     min_timestamp: i64,
     /// Maximum timestamp across all parts.
@@ -361,6 +364,7 @@ impl UnorderedPart {
         Self {
             parts: Vec::new(),
             total_rows: 0,
+            total_bytes: 0,
             min_timestamp: i64::MAX,
             max_timestamp: i64::MIN,
             max_sequence: 0,
@@ -389,19 +393,27 @@ impl UnorderedPart {
         self.compact_threshold
     }
 
-    /// Returns true if this part should accept the given row count.
-    pub fn should_accept(&self, num_rows: usize) -> bool {
-        num_rows < self.threshold
+    /// Returns true if this part should accept the given row count and estimated size.
+    pub fn should_accept(&self, num_rows: usize, estimated_bytes: usize) -> bool {
+        num_rows < self.threshold && estimated_bytes < MAX_UNCOMPRESSED_PART_SIZE
     }
 
-    /// Returns true if this part should be compacted.
-    pub fn should_compact(&self) -> bool {
-        self.total_rows >= self.compact_threshold
+    /// Returns true if the current accumulator should be compacted before adding
+    /// `incoming_bytes`. Pass zero after a push to check the accumulated thresholds.
+    pub fn should_compact(&self, incoming_bytes: usize) -> bool {
+        if incoming_bytes == 0 {
+            self.total_rows >= self.compact_threshold
+                || self.total_bytes >= MAX_UNCOMPRESSED_PART_SIZE
+        } else {
+            !self.parts.is_empty()
+                && self.total_bytes.saturating_add(incoming_bytes) > MAX_UNCOMPRESSED_PART_SIZE
+        }
     }
 
     /// Adds a BulkPart to this unordered collection.
     pub fn push(&mut self, part: BulkPart) {
         self.total_rows += part.num_rows();
+        self.total_bytes = self.total_bytes.saturating_add(part.estimated_size());
         self.min_timestamp = self.min_timestamp.min(part.min_timestamp);
         self.max_timestamp = self.max_timestamp.max(part.max_timestamp);
         self.max_sequence = self.max_sequence.max(part.sequence);
@@ -476,6 +488,7 @@ impl UnorderedPart {
     pub fn clear(&mut self) {
         self.parts.clear();
         self.total_rows = 0;
+        self.total_bytes = 0;
         self.min_timestamp = i64::MAX;
         self.max_timestamp = i64::MIN;
         self.max_sequence = 0;
@@ -1676,6 +1689,40 @@ mod tests {
         sequence: u64,
     }
 
+    #[test]
+    fn test_unordered_part_size_limit() {
+        let mut part = UnorderedPart::new();
+        part.total_bytes = MAX_UNCOMPRESSED_PART_SIZE - 1;
+        assert!(!part.should_compact(0));
+        assert!(!part.should_compact(2));
+
+        // The pre-add overflow check only applies to a non-empty accumulator.
+        part.parts.push(BulkPart {
+            batch: RecordBatch::new_empty(Arc::new(arrow::datatypes::Schema::empty())),
+            max_timestamp: 0,
+            min_timestamp: 0,
+            sequence: 0,
+            timestamp_index: 0,
+            raw_data: None,
+        });
+        assert!(part.should_compact(2));
+
+        part.total_bytes = MAX_UNCOMPRESSED_PART_SIZE;
+        assert!(part.should_compact(0));
+        part.clear();
+        assert_eq!(0, part.total_bytes);
+        assert!(part.is_empty());
+    }
+
+    #[test]
+    fn test_unordered_part_should_accept() {
+        let mut part = UnorderedPart::new();
+        part.set_threshold(10);
+        assert!(part.should_accept(9, MAX_UNCOMPRESSED_PART_SIZE - 1));
+        assert!(!part.should_accept(10, 1));
+        assert!(!part.should_accept(1, MAX_UNCOMPRESSED_PART_SIZE));
+    }
+
     fn encode(input: &[MutationInput]) -> EncodedBulkPart {
         let metadata = metadata_for_test();
         let kvs = input
@@ -1737,6 +1784,7 @@ mod tests {
                         Some(projection.as_slice()),
                         None,
                         false,
+                        crate::sst::parquet::DEFAULT_READ_BATCH_SIZE,
                     )
                     .unwrap(),
                 ),
@@ -1797,6 +1845,7 @@ mod tests {
                 None,
                 predicate,
                 false,
+                crate::sst::parquet::DEFAULT_READ_BATCH_SIZE,
             )
             .unwrap(),
         );
@@ -1831,6 +1880,7 @@ mod tests {
                     datafusion_expr::lit(ScalarValue::TimestampMillisecond(Some(300), None)),
                 )])),
                 false,
+                crate::sst::parquet::DEFAULT_READ_BATCH_SIZE,
             )
             .unwrap(),
         );
@@ -2811,6 +2861,7 @@ mod tests {
                     datafusion_expr::col("k0").eq(datafusion_expr::lit("m")),
                 ])),
                 false,
+                crate::sst::parquet::DEFAULT_READ_BATCH_SIZE,
             )
             .unwrap(),
         );
@@ -2830,13 +2881,23 @@ mod tests {
                     datafusion_expr::col("k0").eq(datafusion_expr::lit("nonexistent")),
                 ])),
                 false,
+                crate::sst::parquet::DEFAULT_READ_BATCH_SIZE,
             )
             .unwrap(),
         );
         assert!(multi.read(context, None, None).unwrap().is_none());
 
         // No predicate => all 6 rows.
-        let context = Arc::new(BulkIterContext::new(metadata.clone(), None, None, false).unwrap());
+        let context = Arc::new(
+            BulkIterContext::new(
+                metadata.clone(),
+                None,
+                None,
+                false,
+                crate::sst::parquet::DEFAULT_READ_BATCH_SIZE,
+            )
+            .unwrap(),
+        );
         let reader = multi
             .read(context, None, None)
             .unwrap()

--- a/src/mito2/src/memtable/bulk/part.rs
+++ b/src/mito2/src/memtable/bulk/part.rs
@@ -59,7 +59,6 @@ use crate::error::{
     EncodeMemtableSnafu, EncodeSnafu, InvalidMetadataSnafu, InvalidRequestSnafu,
     NewRecordBatchSnafu, Result,
 };
-use crate::memtable::bulk::MAX_UNCOMPRESSED_PART_SIZE;
 use crate::memtable::bulk::context::{BulkIterContext, BulkIterContextRef};
 use crate::memtable::bulk::json_align::Json2Aligner;
 use crate::memtable::bulk::part_reader::EncodedBulkPartIter;
@@ -393,21 +392,19 @@ impl UnorderedPart {
         self.compact_threshold
     }
 
-    /// Returns true if this part should accept the given row count and estimated size.
-    pub fn should_accept(&self, num_rows: usize, estimated_bytes: usize) -> bool {
-        num_rows < self.threshold && estimated_bytes < MAX_UNCOMPRESSED_PART_SIZE
+    /// Returns true if this part should accept the given row count.
+    pub fn should_accept(&self, num_rows: usize) -> bool {
+        num_rows < self.threshold
     }
 
-    /// Returns true if the current accumulator should be compacted before adding
-    /// `incoming_bytes`. Pass zero after a push to check the accumulated thresholds.
-    pub fn should_compact(&self, incoming_bytes: usize) -> bool {
-        if incoming_bytes == 0 {
-            self.total_rows >= self.compact_threshold
-                || self.total_bytes >= MAX_UNCOMPRESSED_PART_SIZE
-        } else {
-            !self.parts.is_empty()
-                && self.total_bytes.saturating_add(incoming_bytes) > MAX_UNCOMPRESSED_PART_SIZE
-        }
+    /// Returns true if this part should be compacted by row count.
+    pub fn should_compact(&self) -> bool {
+        self.total_rows >= self.compact_threshold
+    }
+
+    /// Returns the total estimated uncompressed bytes across all parts.
+    pub(super) fn estimated_bytes(&self) -> usize {
+        self.total_bytes
     }
 
     /// Adds a BulkPart to this unordered collection.
@@ -1690,27 +1687,22 @@ mod tests {
     }
 
     #[test]
-    fn test_unordered_part_size_limit() {
+    fn test_unordered_part_tracks_estimated_bytes() {
         let mut part = UnorderedPart::new();
-        part.total_bytes = MAX_UNCOMPRESSED_PART_SIZE - 1;
-        assert!(!part.should_compact(0));
-        assert!(!part.should_compact(2));
-
-        // The pre-add overflow check only applies to a non-empty accumulator.
-        part.parts.push(BulkPart {
+        let bulk_part = BulkPart {
             batch: RecordBatch::new_empty(Arc::new(arrow::datatypes::Schema::empty())),
             max_timestamp: 0,
             min_timestamp: 0,
             sequence: 0,
             timestamp_index: 0,
             raw_data: None,
-        });
-        assert!(part.should_compact(2));
+        };
+        let estimated_size = bulk_part.estimated_size();
 
-        part.total_bytes = MAX_UNCOMPRESSED_PART_SIZE;
-        assert!(part.should_compact(0));
+        part.push(bulk_part);
+        assert_eq!(estimated_size, part.estimated_bytes());
         part.clear();
-        assert_eq!(0, part.total_bytes);
+        assert_eq!(0, part.estimated_bytes());
         assert!(part.is_empty());
     }
 
@@ -1718,9 +1710,8 @@ mod tests {
     fn test_unordered_part_should_accept() {
         let mut part = UnorderedPart::new();
         part.set_threshold(10);
-        assert!(part.should_accept(9, MAX_UNCOMPRESSED_PART_SIZE - 1));
-        assert!(!part.should_accept(10, 1));
-        assert!(!part.should_accept(1, MAX_UNCOMPRESSED_PART_SIZE));
+        assert!(part.should_accept(9));
+        assert!(!part.should_accept(10));
     }
 
     fn encode(input: &[MutationInput]) -> EncodedBulkPart {

--- a/src/mito2/src/memtable/bulk/part_reader.rs
+++ b/src/mito2/src/memtable/bulk/part_reader.rs
@@ -583,6 +583,7 @@ mod tests {
                 None, // No projection
                 None, // No predicate
                 false,
+                crate::sst::parquet::DEFAULT_READ_BATCH_SIZE,
             )
             .unwrap(),
         );
@@ -617,6 +618,7 @@ mod tests {
                 Some(&[0, 2]),
                 Some(Predicate::new(vec![col("key1").eq(lit("key2"))])),
                 false,
+                crate::sst::parquet::DEFAULT_READ_BATCH_SIZE,
             )
             .unwrap(),
         );
@@ -757,6 +759,7 @@ mod tests {
                 None, // No projection
                 None, // No predicate
                 false,
+                1,
             )
             .unwrap(),
         );
@@ -765,7 +768,7 @@ mod tests {
         let expect_batches = vec![batch1, batch2];
         let iter = BulkPartBatchIter::new(expect_batches.clone(), context.clone(), None, 0, None);
 
-        // Collect all results
+        // Existing valid Arrow batches retain their boundaries even when the merge hint is lower.
         let result: Vec<_> = iter.map(|rb| rb.unwrap()).collect();
         assert_eq!(expect_batches, result);
     }

--- a/src/mito2/src/memtable/bulk/row_group_reader.rs
+++ b/src/mito2/src/memtable/bulk/row_group_reader.rs
@@ -28,12 +28,12 @@ use crate::error;
 use crate::error::ReadDataPartSnafu;
 use crate::memtable::bulk::chunk_reader::MemtableChunkReader;
 use crate::memtable::bulk::context::BulkIterContextRef;
-use crate::sst::parquet::DEFAULT_READ_BATCH_SIZE;
 
 pub(crate) struct MemtableRowGroupReaderBuilder {
     projection: ProjectionMask,
     arrow_metadata: ArrowReaderMetadata,
     data: Bytes,
+    batch_size: usize,
 }
 
 impl MemtableRowGroupReaderBuilder {
@@ -70,6 +70,7 @@ impl MemtableRowGroupReaderBuilder {
             projection,
             arrow_metadata,
             data,
+            batch_size: context.batch_size(),
         })
     }
 
@@ -87,7 +88,7 @@ impl MemtableRowGroupReaderBuilder {
         )
         .with_row_groups(vec![row_group_idx])
         .with_projection(self.projection.clone())
-        .with_batch_size(DEFAULT_READ_BATCH_SIZE);
+        .with_batch_size(self.batch_size);
 
         if let Some(selection) = row_selection {
             builder = builder.with_row_selection(selection);

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -920,9 +920,6 @@ impl ScanInput {
     #[must_use]
     pub(crate) fn with_files(mut self, files: Vec<FileHandle>) -> Self {
         self.files = files;
-        if self.compaction {
-            self.recompute_compaction_batch_size();
-        }
         self
     }
 
@@ -931,18 +928,11 @@ impl ScanInput {
         self.batch_size
     }
 
-    fn recompute_compaction_batch_size(&mut self) {
-        let file_stats = self.files.iter().map(|file| {
-            let meta = file.meta_ref();
-            if meta.num_rows == 0 || meta.num_row_groups == 0 {
-                return (0, 0);
-            }
-
-            let rows_per_group = meta.num_rows / meta.num_row_groups
-                + u64::from(meta.num_rows % meta.num_row_groups != 0);
-            (rows_per_group, meta.max_row_group_uncompressed_size)
-        });
-        self.batch_size = crate::batch_size::estimate_batch_size(file_stats);
+    /// Sets the scan-wide hint for rows in an execution batch.
+    #[must_use]
+    pub(crate) fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = batch_size;
+        self
     }
 
     /// Sets cache for this query.
@@ -1093,11 +1083,6 @@ impl ScanInput {
     #[must_use]
     pub(crate) fn with_compaction(mut self, compaction: bool) -> Self {
         self.compaction = compaction;
-        if compaction {
-            self.recompute_compaction_batch_size();
-        } else {
-            self.batch_size = crate::sst::parquet::DEFAULT_READ_BATCH_SIZE;
-        }
         self
     }
 
@@ -2148,27 +2133,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_scan_input_estimates_batch_size_only_for_compaction() {
+    async fn test_scan_input_uses_explicit_batch_size() {
         let metadata = Arc::new(metadata_with_primary_key(vec![0, 1], false));
         let mapper = FlatProjectionMapper::new(&metadata, [0, 2, 3]).unwrap();
         let env = SchedulerEnv::new().await;
-        let known = FileHandle::new(
-            FileMeta {
-                num_rows: 64,
-                num_row_groups: 2,
-                max_row_group_uncompressed_size: 8 * 1024 * 1024,
-                ..Default::default()
-            },
-            Arc::new(crate::sst::file_purger::NoopFilePurger),
-        );
-        let unknown = FileHandle::new(
-            FileMeta::default(),
-            Arc::new(crate::sst::file_purger::NoopFilePurger),
-        );
-
-        let input = ScanInput::new(env.access_layer.clone(), mapper)
-            .with_files(vec![unknown.clone(), known.clone()])
-            .with_memtables(vec![]);
+        let input = ScanInput::new(env.access_layer.clone(), mapper);
         assert_eq!(
             crate::sst::parquet::DEFAULT_READ_BATCH_SIZE,
             input.batch_size()
@@ -2177,14 +2146,14 @@ mod tests {
         let mapper = FlatProjectionMapper::new(&metadata, [0, 2, 3]).unwrap();
         let input = ScanInput::new(env.access_layer.clone(), mapper)
             .with_compaction(true)
-            .with_memtables(vec![])
-            .with_files(vec![known.clone(), unknown.clone()]);
+            .with_batch_size(256);
         assert_eq!(256, input.batch_size());
 
         let mapper = FlatProjectionMapper::new(&metadata, [0, 2, 3]).unwrap();
         let input = ScanInput::new(env.access_layer.clone(), mapper)
-            .with_files(vec![known, unknown])
-            .with_compaction(true);
+            .with_batch_size(256)
+            .with_compaction(true)
+            .with_compaction(false);
         assert_eq!(256, input.batch_size());
     }
 

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -813,6 +813,8 @@ pub struct ScanInput {
     pub(crate) memtables: Vec<MemRangeBuilder>,
     /// Handles to SST files to scan.
     pub(crate) files: Vec<FileHandle>,
+    /// Scan-wide hint for rows in an execution batch.
+    batch_size: usize,
     /// Cache.
     pub(crate) cache_strategy: CacheStrategy,
     /// Ignores file not found error.
@@ -866,6 +868,7 @@ impl ScanInput {
             region_partition_expr: None,
             memtables: Vec::new(),
             files: Vec::new(),
+            batch_size: crate::sst::parquet::DEFAULT_READ_BATCH_SIZE,
             cache_strategy: CacheStrategy::Disabled,
             ignore_file_not_found: false,
             max_concurrent_scan_files: DEFAULT_MAX_CONCURRENT_SCAN_FILES,
@@ -917,7 +920,29 @@ impl ScanInput {
     #[must_use]
     pub(crate) fn with_files(mut self, files: Vec<FileHandle>) -> Self {
         self.files = files;
+        if self.compaction {
+            self.recompute_compaction_batch_size();
+        }
         self
+    }
+
+    /// Returns the scan-wide hint for rows in an execution batch.
+    pub(crate) fn batch_size(&self) -> usize {
+        self.batch_size
+    }
+
+    fn recompute_compaction_batch_size(&mut self) {
+        let file_stats = self.files.iter().map(|file| {
+            let meta = file.meta_ref();
+            if meta.num_rows == 0 || meta.num_row_groups == 0 {
+                return (0, 0);
+            }
+
+            let rows_per_group = meta.num_rows / meta.num_row_groups
+                + u64::from(meta.num_rows % meta.num_row_groups != 0);
+            (rows_per_group, meta.max_row_group_uncompressed_size)
+        });
+        self.batch_size = crate::batch_size::estimate_batch_size(file_stats);
     }
 
     /// Sets cache for this query.
@@ -1068,6 +1093,11 @@ impl ScanInput {
     #[must_use]
     pub(crate) fn with_compaction(mut self, compaction: bool) -> Self {
         self.compaction = compaction;
+        if compaction {
+            self.recompute_compaction_batch_size();
+        } else {
+            self.batch_size = crate::sst::parquet::DEFAULT_READ_BATCH_SIZE;
+        }
         self
     }
 
@@ -1202,6 +1232,7 @@ impl ScanInput {
             .inverted_index_appliers(self.inverted_index_appliers.clone())
             .bloom_filter_index_appliers(self.bloom_filter_index_appliers.clone())
             .fulltext_index_appliers(self.fulltext_index_appliers.clone());
+        let reader = reader.batch_size(self.batch_size);
         let reader = if !self.compaction && may_build_selective_row_selection {
             reader.deferred_optional_page_index()
         } else {
@@ -2114,6 +2145,47 @@ mod tests {
             },
             Arc::new(crate::sst::file_purger::NoopFilePurger),
         )
+    }
+
+    #[tokio::test]
+    async fn test_scan_input_estimates_batch_size_only_for_compaction() {
+        let metadata = Arc::new(metadata_with_primary_key(vec![0, 1], false));
+        let mapper = FlatProjectionMapper::new(&metadata, [0, 2, 3]).unwrap();
+        let env = SchedulerEnv::new().await;
+        let known = FileHandle::new(
+            FileMeta {
+                num_rows: 64,
+                num_row_groups: 2,
+                max_row_group_uncompressed_size: 8 * 1024 * 1024,
+                ..Default::default()
+            },
+            Arc::new(crate::sst::file_purger::NoopFilePurger),
+        );
+        let unknown = FileHandle::new(
+            FileMeta::default(),
+            Arc::new(crate::sst::file_purger::NoopFilePurger),
+        );
+
+        let input = ScanInput::new(env.access_layer.clone(), mapper)
+            .with_files(vec![unknown.clone(), known.clone()])
+            .with_memtables(vec![]);
+        assert_eq!(
+            crate::sst::parquet::DEFAULT_READ_BATCH_SIZE,
+            input.batch_size()
+        );
+
+        let mapper = FlatProjectionMapper::new(&metadata, [0, 2, 3]).unwrap();
+        let input = ScanInput::new(env.access_layer.clone(), mapper)
+            .with_compaction(true)
+            .with_memtables(vec![])
+            .with_files(vec![known.clone(), unknown.clone()]);
+        assert_eq!(256, input.batch_size());
+
+        let mapper = FlatProjectionMapper::new(&metadata, [0, 2, 3]).unwrap();
+        let input = ScanInput::new(env.access_layer.clone(), mapper)
+            .with_files(vec![known, unknown])
+            .with_compaction(true);
+        assert_eq!(256, input.batch_size());
     }
 
     #[test]

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -224,9 +224,13 @@ impl SeqScan {
         } else {
             let schema = mapper.input_arrow_schema(stream_ctx.input.compaction);
             let metrics_reporter = part_metrics.map(|m| m.merge_metrics_reporter());
-            let reader =
-                FlatMergeReader::new(schema, sources, DEFAULT_READ_BATCH_SIZE, metrics_reporter)
-                    .await?;
+            let reader = FlatMergeReader::new(
+                schema,
+                sources,
+                stream_ctx.input.batch_size(),
+                metrics_reporter,
+            )
+            .await?;
             Box::pin(reader.into_stream())
         };
 

--- a/src/mito2/src/region/options.rs
+++ b/src/mito2/src/region/options.rs
@@ -280,13 +280,6 @@ pub enum CompactionOptions {
 }
 
 impl CompactionOptions {
-    /// Returns the soft maximum size for a compaction output file.
-    pub(crate) fn max_output_file_size(&self) -> Option<u64> {
-        match self {
-            CompactionOptions::Twcs(opts) => opts.max_output_file_size.map(|size| size.as_bytes()),
-        }
-    }
-
     pub(crate) fn time_window(&self) -> Option<Duration> {
         match self {
             CompactionOptions::Twcs(opts) => opts.time_window,

--- a/src/mito2/src/region/options.rs
+++ b/src/mito2/src/region/options.rs
@@ -280,6 +280,13 @@ pub enum CompactionOptions {
 }
 
 impl CompactionOptions {
+    /// Returns the soft maximum size for a compaction output file.
+    pub(crate) fn max_output_file_size(&self) -> Option<u64> {
+        match self {
+            CompactionOptions::Twcs(opts) => opts.max_output_file_size.map(|size| size.as_bytes()),
+        }
+    }
+
     pub(crate) fn time_window(&self) -> Option<Duration> {
         match self {
             CompactionOptions::Twcs(opts) => opts.time_window,

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -187,6 +187,8 @@ pub struct ParquetReaderBuilder {
     decode_primary_key_values: bool,
     page_index_policy: PageIndexPolicy,
     defer_optional_page_index: bool,
+    /// Scan-wide hint for rows in a decoded batch.
+    batch_size: usize,
 }
 
 impl ParquetReaderBuilder {
@@ -218,7 +220,15 @@ impl ParquetReaderBuilder {
             decode_primary_key_values: false,
             page_index_policy: Default::default(),
             defer_optional_page_index: false,
+            batch_size: DEFAULT_READ_BATCH_SIZE,
         }
+    }
+
+    /// Sets the scan-wide hint for rows in a decoded batch.
+    #[must_use]
+    pub(crate) fn batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = batch_size.clamp(1, DEFAULT_READ_BATCH_SIZE);
+        self
     }
 
     /// Attaches the predicate to the builder.
@@ -558,6 +568,7 @@ impl ParquetReaderBuilder {
             has_nested_projection,
             cache_strategy: self.cache_strategy.clone(),
             prefilter_builder: filter_plan.prefilter_builder,
+            batch_size: self.batch_size,
         };
 
         let partition_filter = self.build_partition_filter(&read_format, &prune_schema)?;
@@ -1749,6 +1760,8 @@ pub(crate) struct RowGroupReaderBuilder {
     cache_strategy: CacheStrategy,
     /// Pre-built prefilter state. `None` if prefiltering is not applicable.
     prefilter_builder: Option<PrefilterContextBuilder>,
+    /// Hint for rows in a decoded batch.
+    batch_size: usize,
 }
 
 /// Context passed to [RowGroupReaderBuilder::build()] carrying all information
@@ -1883,7 +1896,7 @@ impl RowGroupReaderBuilder {
             projection,
             range_fetcher,
             self.file_path.clone(),
-            DEFAULT_READ_BATCH_SIZE,
+            self.batch_size,
         )
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Closes #8479.

## What's changed and what's your intention?

This PR adapts Mito's execution batch size to the estimated decoded row width so that batches target approximately 64 MiB instead of always using the default row count. This prevents wide string rows from overflowing Arrow string offsets during flush and compaction.

The estimated batch size is propagated through memtable flushes, bulk-part compaction, region compaction scans, and Parquet readers. Bulk memtable merge groups are also bounded by the configured compaction output size so that already-large parts are not merged into oversized intermediate batches.

Unit tests cover batch-size estimation, size-aware part grouping, and compaction scan batch-size selection. No additional validation was run while creating this PR.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
