### PR TITLE
feat: update flow windows after metric batch flush

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13215,6 +13215,7 @@ dependencies = [
  "loki-proto",
  "metric-engine",
  "mime_guess",
+ "moka",
  "mysql_async",
  "mysql_common 0.34.1",
  "notify",

--- a/config/config.md
+++ b/config/config.md
@@ -82,6 +82,7 @@
 | `prom_store.max_concurrent_flushes` | Integer | `256` | Max number of concurrent batch flushes. |
 | `prom_store.worker_channel_capacity` | Integer | `65526` | Capacity of the pending batch worker channel. |
 | `prom_store.max_inflight_requests` | Integer | `3000` | Max inflight write requests before backpressure. |
+| `prom_store.flow_notification_queue_capacity` | Integer | `1024` | Maximum number of logical-table flow notifications waiting in the shared queue. |
 | `wal` | -- | -- | The WAL options. |
 | `wal.provider` | String | `raft_engine` | The provider of the WAL.<br/>- `raft_engine`: the wal is stored in the local file system by raft-engine.<br/>- `kafka`: it's remote wal that data is stored in Kafka. |
 | `wal.dir` | String | Unset | The directory to store the WAL files.<br/>**It's only used when the provider is `raft_engine`**. |
@@ -314,6 +315,7 @@
 | `prom_store.max_concurrent_flushes` | Integer | `256` | Max number of concurrent batch flushes. |
 | `prom_store.worker_channel_capacity` | Integer | `65526` | Capacity of the pending batch worker channel. |
 | `prom_store.max_inflight_requests` | Integer | `3000` | Max inflight write requests before backpressure. |
+| `prom_store.flow_notification_queue_capacity` | Integer | `1024` | Maximum number of logical-table flow notifications waiting in the shared queue. |
 | `meta_client` | -- | -- | The metasrv client options. |
 | `meta_client.metasrv_addrs` | Array | -- | The addresses of the metasrv. |
 | `meta_client.timeout` | String | `3s` | Operation timeout. |

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -251,6 +251,8 @@ with_metric_engine = true
 #+worker_channel_capacity = 65526
 ## Max inflight write requests before backpressure.
 #+max_inflight_requests = 3000
+## Maximum number of logical-table flow notifications waiting in the shared queue.
+#+flow_notification_queue_capacity = 1024
 
 ## The metasrv client options.
 [meta_client]

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -218,6 +218,8 @@ with_metric_engine = true
 #+worker_channel_capacity = 65526
 ## Max inflight write requests before backpressure.
 #+max_inflight_requests = 3000
+## Maximum number of logical-table flow notifications waiting in the shared queue.
+#+flow_notification_queue_capacity = 1024
 
 ## The WAL options.
 [wal]

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -47,6 +47,7 @@ use common_base::Plugins;
 use common_base::cancellation::CancellableFuture;
 use common_error::ext::{BoxedError, ErrorExt};
 use common_event_recorder::EventRecorderRef;
+use common_meta::cache::TableFlownodeSetCacheRef;
 use common_meta::cache_invalidator::CacheInvalidatorRef;
 use common_meta::key::TableMetadataManagerRef;
 use common_meta::key::table_name::TableNameKey;
@@ -180,6 +181,10 @@ impl Instance {
 
     pub fn partition_manager(&self) -> &PartitionRuleManagerRef {
         self.inserter.partition_manager()
+    }
+
+    pub fn table_flownode_set_cache(&self) -> &TableFlownodeSetCacheRef {
+        self.inserter.table_flownode_set_cache()
     }
 
     pub fn cache_invalidator(&self) -> &CacheInvalidatorRef {

--- a/src/frontend/src/server.rs
+++ b/src/frontend/src/server.rs
@@ -138,6 +138,7 @@ where
                     opts.prom_store.max_concurrent_flushes,
                     opts.prom_store.worker_channel_capacity,
                     opts.prom_store.max_inflight_requests,
+                    opts.prom_store.flow_notification_queue_capacity,
                 )
             } else {
                 None

--- a/src/frontend/src/server.rs
+++ b/src/frontend/src/server.rs
@@ -130,6 +130,7 @@ where
                     self.instance.partition_manager().clone(),
                     self.instance.node_manager().clone(),
                     self.instance.catalog_manager().clone(),
+                    self.instance.table_flownode_set_cache().clone(),
                     opts.prom_store.with_metric_engine,
                     self.instance.clone(),
                     opts.prom_store.pending_rows_flush_interval,

--- a/src/frontend/src/service_config/prom_store.rs
+++ b/src/frontend/src/service_config/prom_store.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::num::NonZeroUsize;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -30,6 +31,9 @@ pub struct PromStoreOptions {
     pub worker_channel_capacity: usize,
     #[serde(default = "default_max_inflight_requests")]
     pub max_inflight_requests: usize,
+    /// Maximum number of logical-table flow notifications waiting in the shared queue.
+    #[serde(default = "default_flow_notification_queue_capacity")]
+    pub flow_notification_queue_capacity: NonZeroUsize,
 }
 
 fn default_max_batch_rows() -> usize {
@@ -48,6 +52,10 @@ fn default_max_inflight_requests() -> usize {
     3000
 }
 
+fn default_flow_notification_queue_capacity() -> NonZeroUsize {
+    NonZeroUsize::new(1024).unwrap_or(NonZeroUsize::MIN)
+}
+
 impl Default for PromStoreOptions {
     fn default() -> Self {
         Self {
@@ -58,6 +66,7 @@ impl Default for PromStoreOptions {
             max_concurrent_flushes: default_max_concurrent_flushes(),
             worker_channel_capacity: default_worker_channel_capacity(),
             max_inflight_requests: default_max_inflight_requests(),
+            flow_notification_queue_capacity: default_flow_notification_queue_capacity(),
         }
     }
 }
@@ -68,7 +77,8 @@ mod tests {
 
     use super::PromStoreOptions;
     use crate::service_config::prom_store::{
-        default_max_batch_rows, default_max_concurrent_flushes, default_max_inflight_requests,
+        default_flow_notification_queue_capacity, default_max_batch_rows,
+        default_max_concurrent_flushes, default_max_inflight_requests,
         default_worker_channel_capacity,
     };
 
@@ -90,6 +100,10 @@ mod tests {
         assert_eq!(
             default.max_inflight_requests,
             default_max_inflight_requests()
+        );
+        assert_eq!(
+            default.flow_notification_queue_capacity,
+            default_flow_notification_queue_capacity()
         );
     }
 }

--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -1128,6 +1128,10 @@ impl Inserter {
     pub fn partition_manager(&self) -> &PartitionRuleManagerRef {
         &self.partition_manager
     }
+
+    pub fn table_flownode_set_cache(&self) -> &TableFlownodeSetCacheRef {
+        &self.table_flownode_set_cache
+    }
 }
 
 fn request_is_native_histogram(request_schema: &[ColumnSchema]) -> bool {

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -155,6 +155,7 @@ common-base.workspace = true
 common-test-util.workspace = true
 criterion = "0.5"
 json5 = "0.4"
+moka.workspace = true
 mysql_async = { version = "0.35", default-features = false, features = [
     "default-rustls",
 ] }

--- a/src/servers/benches/flush_batch_physical.rs
+++ b/src/servers/benches/flush_batch_physical.rs
@@ -31,7 +31,7 @@ use partition::partition::{PartitionRule, PartitionRuleRef, RegionMask};
 use servers::error::{self, Result};
 use servers::pending_rows_batcher::{
     PhysicalFlushCatalogProvider, PhysicalFlushNodeRequester, PhysicalFlushPartitionProvider,
-    PhysicalTableMetadata, TableBatch, flush_batch_physical,
+    PhysicalTableMetadata, RecordBatchWithTsIdx, TableBatch, flush_batch_physical,
 };
 use store_api::storage::RegionId;
 use table::test_util::table_info::test_table_info;
@@ -201,7 +201,7 @@ fn make_table_batches(
             TableBatch {
                 table_name: format!("logical_{}", i),
                 table_id: (100 + i) as u32,
-                batches: vec![batch],
+                batches: vec![RecordBatchWithTsIdx::try_new(batch, 0).unwrap()],
                 row_count,
             }
         })

--- a/src/servers/src/metrics.rs
+++ b/src/servers/src/metrics.rs
@@ -177,6 +177,12 @@ lazy_static! {
         "Total pending rows flush failures"
     )
     .unwrap();
+    pub static ref FLOW_NOTIFICATION_DROPPED: IntCounterVec = register_int_counter_vec!(
+        "greptime_prom_store_flow_notification_dropped_total",
+        "Total flow notifications dropped by the pending rows batcher",
+        &["reason"]
+    )
+    .unwrap();
     pub static ref PENDING_ROWS_BATCH_INGEST_STAGE_ELAPSED: HistogramVec = register_histogram_vec!(
         "greptime_prom_store_pending_rows_batch_ingest_stage_elapsed",
         "Elapsed time of pending rows batch ingestion stages in seconds",

--- a/src/servers/src/pending_rows_batcher.rs
+++ b/src/servers/src/pending_rows_batcher.rs
@@ -37,6 +37,7 @@ use common_telemetry::tracing_context::TracingContext;
 use common_telemetry::{debug, error, warn};
 use dashmap::DashMap;
 use dashmap::mapref::entry::Entry;
+use futures::StreamExt;
 use metric_engine::batch_modifier::{TagColumnInfo, modify_batch_sparse};
 use partition::manager::PartitionRuleManagerRef;
 use partition::partition::PartitionRuleRef;
@@ -64,6 +65,7 @@ const PHYSICAL_TABLE_KEY: &str = "physical_table";
 const PENDING_ROWS_BATCH_SYNC_ENV: &str = "PENDING_ROWS_BATCH_SYNC";
 const WORKER_IDLE_TIMEOUT_MULTIPLIER: u32 = 3;
 const PHYSICAL_REGION_ESSENTIAL_COLUMN_COUNT: usize = 3;
+const MAX_CONCURRENT_FLOW_NOTIFICATIONS: usize = 8;
 
 #[async_trait]
 pub trait PendingRowsSchemaAlterer: Send + Sync {
@@ -1394,49 +1396,76 @@ fn extract_timestamps(table_batch: &TableBatch) -> Vec<i64> {
     timestamps
 }
 
+async fn notify_flow_dirty_windows_for_table(
+    table_id: TableId,
+    timestamps: Vec<i64>,
+    peers: HashSet<Peer>,
+    node_manager: NodeManagerRef,
+) {
+    for peer in peers {
+        if let Err(e) = node_manager
+            .flownode(&peer)
+            .await
+            .handle_mark_window_dirty(DirtyWindowRequests {
+                requests: vec![DirtyWindowRequest {
+                    table_id,
+                    timestamps: timestamps.clone(),
+                }],
+            })
+            .await
+        {
+            error!(e; "Failed to mark timestamps as dirty, table: {}", table_id);
+        }
+    }
+}
+
 fn notify_flow_dirty_windows_after_flush(
     table_batches: Vec<TableBatch>,
     table_flownode_set_cache: TableFlownodeSetCacheRef,
     node_manager: NodeManagerRef,
 ) {
     common_runtime::spawn_global(async move {
-        for table_batch in table_batches {
-            let timestamps = extract_timestamps(&table_batch);
-            if timestamps.is_empty() {
-                continue;
-            }
+        let (notification_tx, notification_rx) = mpsc::channel(table_batches.len().max(1));
+        let resolve_flownodes = async move {
+            futures::stream::iter(table_batches)
+                .for_each_concurrent(MAX_CONCURRENT_FLOW_NOTIFICATIONS, |table_batch| {
+                    let table_flownode_set_cache = table_flownode_set_cache.clone();
+                    let notification_tx = notification_tx.clone();
+                    async move {
+                        let timestamps = extract_timestamps(&table_batch);
+                        if timestamps.is_empty() {
+                            return;
+                        }
 
-            let flownodes = match table_flownode_set_cache.get(table_batch.table_id).await {
-                Ok(Some(flownodes)) => flownodes,
-                Ok(None) => continue,
-                Err(e) => {
-                    error!(e; "Failed to get flownodes for table id: {}", table_batch.table_id);
-                    continue;
-                }
-            };
-            let peers: HashSet<_> = flownodes.values().cloned().collect();
-
-            for peer in peers {
-                let node_manager = node_manager.clone();
-                let timestamps = timestamps.clone();
-                let table_id = table_batch.table_id;
-                common_runtime::spawn_global(async move {
-                    if let Err(e) = node_manager
-                        .flownode(&peer)
-                        .await
-                        .handle_mark_window_dirty(DirtyWindowRequests {
-                            requests: vec![DirtyWindowRequest {
-                                table_id,
-                                timestamps,
-                            }],
-                        })
-                        .await
-                    {
-                        error!(e; "Failed to mark timestamps as dirty, table: {}", table_id);
+                        let table_id = table_batch.table_id;
+                        let flownodes = match table_flownode_set_cache.get(table_id).await {
+                            Ok(Some(flownodes)) => flownodes,
+                            Ok(None) => return,
+                            Err(e) => {
+                                error!(e; "Failed to get flownodes for table id: {}", table_id);
+                                return;
+                            }
+                        };
+                        let peers = flownodes.values().cloned().collect::<HashSet<_>>();
+                        let _ = notification_tx.send((table_id, timestamps, peers)).await;
                     }
-                });
-            }
-        }
+                })
+                .await;
+        };
+        let notify_flownodes = tokio_stream::wrappers::ReceiverStream::new(notification_rx)
+            .for_each_concurrent(
+                MAX_CONCURRENT_FLOW_NOTIFICATIONS,
+                |(table_id, timestamps, peers)| {
+                    notify_flow_dirty_windows_for_table(
+                        table_id,
+                        timestamps,
+                        peers,
+                        node_manager.clone(),
+                    )
+                },
+            );
+
+        futures::future::join(resolve_flownodes, notify_flownodes).await;
     });
 }
 
@@ -1772,9 +1801,10 @@ fn record_batch_to_ipc(record_batch: RecordBatch) -> Result<(Bytes, Bytes, Bytes
 
 #[cfg(test)]
 mod tests {
+    use std::any::Any;
     use std::collections::{HashMap, HashSet};
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
     use std::time::{Duration, Instant};
 
     use api::region::RegionResponse;
@@ -1795,9 +1825,15 @@ mod tests {
     use common_meta::error::Result as MetaResult;
     use common_meta::instruction::{CacheIdent, CreateFlow};
     use common_meta::kv_backend::memory::MemoryKvBackend;
+    use common_meta::kv_backend::{KvBackend, TxnService};
     use common_meta::node_manager::{
         Datanode, DatanodeManager, DatanodeRef, Flownode, FlownodeManager, FlownodeRef,
         NodeManagerRef,
+    };
+    use common_meta::rpc::store::{
+        BatchDeleteRequest, BatchDeleteResponse, BatchGetRequest, BatchGetResponse,
+        BatchPutRequest, BatchPutResponse, DeleteRangeRequest, DeleteRangeResponse, PutRequest,
+        PutResponse, RangeRequest, RangeResponse,
     };
     use common_query::request::QueryRequest;
     use common_recordbatch::SendableRecordBatchStream;
@@ -1811,7 +1847,7 @@ mod tests {
     use store_api::storage::RegionId;
     use table::metadata::TableId;
     use table::test_util::table_info::test_table_info;
-    use tokio::sync::{Semaphore, mpsc, oneshot};
+    use tokio::sync::{Notify, Semaphore, mpsc, oneshot};
     use tokio::time::sleep;
 
     use super::{
@@ -2435,6 +2471,118 @@ mod tests {
             .await
             .unwrap();
         cache
+    }
+
+    struct BlockingRangeKvBackend {
+        range_started: Mutex<Option<oneshot::Sender<()>>>,
+        range_release: Arc<Notify>,
+    }
+
+    impl TxnService for BlockingRangeKvBackend {
+        type Error = common_meta::error::Error;
+    }
+
+    #[async_trait]
+    impl KvBackend for BlockingRangeKvBackend {
+        fn name(&self) -> &str {
+            "blocking_range"
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        async fn range(&self, _req: RangeRequest) -> MetaResult<RangeResponse> {
+            let range_started = self.range_started.lock().unwrap().take();
+            if let Some(range_started) = range_started {
+                let _ = range_started.send(());
+                self.range_release.notified().await;
+            }
+            Ok(RangeResponse {
+                kvs: Vec::new(),
+                more: false,
+            })
+        }
+
+        async fn put(&self, _req: PutRequest) -> MetaResult<PutResponse> {
+            unimplemented!()
+        }
+
+        async fn batch_put(&self, _req: BatchPutRequest) -> MetaResult<BatchPutResponse> {
+            unimplemented!()
+        }
+
+        async fn batch_get(&self, _req: BatchGetRequest) -> MetaResult<BatchGetResponse> {
+            unimplemented!()
+        }
+
+        async fn delete_range(&self, _req: DeleteRangeRequest) -> MetaResult<DeleteRangeResponse> {
+            unimplemented!()
+        }
+
+        async fn batch_delete(&self, _req: BatchDeleteRequest) -> MetaResult<BatchDeleteResponse> {
+            unimplemented!()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_flow_notifications_do_not_block_on_previous_table_cache_lookup() {
+        let blocked_table_id = 41;
+        let cached_table_id = 42;
+        let peer = Peer {
+            id: 7,
+            addr: "flow-7".to_string(),
+        };
+        let (range_started_tx, range_started_rx) = oneshot::channel();
+        let range_release = Arc::new(Notify::new());
+        let cache = Arc::new(new_table_flownode_set_cache(
+            "test".to_string(),
+            CacheBuilder::new(2).build(),
+            Arc::new(BlockingRangeKvBackend {
+                range_started: Mutex::new(Some(range_started_tx)),
+                range_release: range_release.clone(),
+            }),
+        ));
+        cache
+            .invalidate(&[CacheIdent::CreateFlow(CreateFlow {
+                flow_id: 1,
+                source_table_ids: vec![cached_table_id],
+                partition_to_peer_mapping: vec![(0, peer)],
+            })])
+            .await
+            .unwrap();
+        let (requests_tx, mut requests_rx) = mpsc::unbounded_channel();
+        let _requests_tx = requests_tx.clone();
+        let node_manager: NodeManagerRef = Arc::new(FlowNotificationMockNodeManager {
+            flownode: Arc::new(RecordingFlownode { requests_tx }),
+        });
+        let table_batches = vec![
+            TableBatch {
+                table_name: "blocked".to_string(),
+                table_id: blocked_table_id,
+                batches: vec![mock_aligned_tag_batch("tag1", "host-1", 1000, 1.0)],
+                row_count: 1,
+            },
+            TableBatch {
+                table_name: "cached".to_string(),
+                table_id: cached_table_id,
+                batches: vec![mock_aligned_tag_batch("tag1", "host-2", 2000, 2.0)],
+                row_count: 1,
+            },
+        ];
+
+        notify_flow_dirty_windows_after_flush(table_batches, cache, node_manager);
+
+        tokio::time::timeout(Duration::from_secs(1), range_started_rx)
+            .await
+            .unwrap()
+            .unwrap();
+        let requests = tokio::time::timeout(Duration::from_secs(1), requests_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(cached_table_id, requests.requests[0].table_id);
+        range_release.notify_one();
     }
 
     #[tokio::test]

--- a/src/servers/src/pending_rows_batcher.rs
+++ b/src/servers/src/pending_rows_batcher.rs
@@ -16,11 +16,13 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use api::v1::flow::{DirtyWindowRequest, DirtyWindowRequests};
 use api::v1::meta::Peer;
 use api::v1::region::{
     BulkInsertRequest, RegionRequest, RegionRequestHeader, bulk_insert_request, region_request,
 };
 use api::v1::{ArrowIpc, ColumnSchema, RowInsertRequests, Rows};
+use arrow::array::Array;
 use arrow::compute::{concat_batches, filter_record_batch};
 use arrow::datatypes::{DataType as ArrowDataType, Schema as ArrowSchema, TimeUnit};
 use arrow::record_batch::RecordBatch;
@@ -28,10 +30,11 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use catalog::CatalogManagerRef;
 use common_grpc::flight::{FlightEncoder, FlightMessage};
+use common_meta::cache::TableFlownodeSetCacheRef;
 use common_meta::node_manager::NodeManagerRef;
 use common_query::prelude::{GREPTIME_PHYSICAL_TABLE, greptime_timestamp, greptime_value};
 use common_telemetry::tracing_context::TracingContext;
-use common_telemetry::{debug, warn};
+use common_telemetry::{debug, error, warn};
 use dashmap::DashMap;
 use dashmap::mapref::entry::Entry;
 use metric_engine::batch_modifier::{TagColumnInfo, modify_batch_sparse};
@@ -205,7 +208,7 @@ struct BatchKey {
     physical_table: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TableBatch {
     pub table_name: String,
     pub table_id: TableId,
@@ -225,7 +228,7 @@ struct TableResolutionPlan {
 }
 
 struct PendingBatch {
-    tables: HashMap<String, TableBatch>,
+    tables: HashMap<TableId, TableBatch>,
     created_at: Instant,
     total_row_count: usize,
     db_string: String,
@@ -283,6 +286,7 @@ pub struct PendingRowsBatcher {
     partition_manager: PartitionRuleManagerRef,
     node_manager: NodeManagerRef,
     catalog_manager: CatalogManagerRef,
+    table_flownode_set_cache: TableFlownodeSetCacheRef,
     flush_semaphore: Arc<Semaphore>,
     inflight_semaphore: Arc<Semaphore>,
     worker_channel_capacity: usize,
@@ -298,6 +302,7 @@ impl PendingRowsBatcher {
         partition_manager: PartitionRuleManagerRef,
         node_manager: NodeManagerRef,
         catalog_manager: CatalogManagerRef,
+        table_flownode_set_cache: TableFlownodeSetCacheRef,
         prom_store_with_metric_engine: bool,
         schema_alterer: PendingRowsSchemaAltererRef,
         flush_interval: Duration,
@@ -334,6 +339,7 @@ impl PendingRowsBatcher {
             partition_manager,
             node_manager,
             catalog_manager,
+            table_flownode_set_cache,
             prom_store_with_metric_engine,
             schema_alterer,
             flush_semaphore: Arc::new(Semaphore::new(max_concurrent_flushes)),
@@ -805,6 +811,7 @@ impl PendingRowsBatcher {
             self.partition_manager.clone(),
             self.node_manager.clone(),
             self.catalog_manager.clone(),
+            self.table_flownode_set_cache.clone(),
             self.flush_interval,
             worker_idle_timeout,
             self.max_batch_rows,
@@ -833,6 +840,22 @@ impl PendingBatch {
             waiters: Vec::new(),
         }
     }
+
+    fn add_table_batch(
+        &mut self,
+        table_name: String,
+        table_id: TableId,
+        record_batch: RecordBatch,
+    ) {
+        let entry = self.tables.entry(table_id).or_insert_with(|| TableBatch {
+            table_name,
+            table_id,
+            batches: Vec::new(),
+            row_count: 0,
+        });
+        entry.row_count += record_batch.num_rows();
+        entry.batches.push(record_batch);
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -845,6 +868,7 @@ fn start_worker(
     partition_manager: PartitionRuleManagerRef,
     node_manager: NodeManagerRef,
     catalog_manager: CatalogManagerRef,
+    table_flownode_set_cache: TableFlownodeSetCacheRef,
     flush_interval: Duration,
     worker_idle_timeout: Duration,
     max_batch_rows: usize,
@@ -873,14 +897,7 @@ fn start_worker(
                             pending_batch.waiters.push(FlushWaiter { response_tx, _permit });
 
                             for (table_name, table_id, record_batch) in table_batches {
-                                let entry = pending_batch.tables.entry(table_name.clone()).or_insert_with(|| TableBatch {
-                                    table_name,
-                                    table_id,
-                                    batches: Vec::new(),
-                                    row_count: 0,
-                                });
-                                entry.row_count += record_batch.num_rows();
-                                entry.batches.push(record_batch);
+                                pending_batch.add_table_batch(table_name, table_id, record_batch);
                             }
 
                             pending_batch.total_row_count += total_rows;
@@ -893,17 +910,19 @@ fn start_worker(
                                         partition_manager.clone(),
                                         node_manager.clone(),
                                         catalog_manager.clone(),
+                                        table_flownode_set_cache.clone(),
                                         flush_semaphore.clone(),
                                     ).await;
                             }
                         }
                         None => {
                             if let Some(flush) = drain_batch(&mut batch) {
-                                flush_batch(
+                                flush_batch_with_managers(
                                     flush,
                                     partition_manager.clone(),
                                     node_manager.clone(),
                                     catalog_manager.clone(),
+                                    table_flownode_set_cache.clone(),
                                 ).await;
                             }
                             break;
@@ -939,17 +958,19 @@ fn start_worker(
                                 partition_manager.clone(),
                                 node_manager.clone(),
                                 catalog_manager.clone(),
+                                table_flownode_set_cache.clone(),
                                 flush_semaphore.clone(),
                             ).await;
                     }
                 }
                 _ = shutdown_rx.recv() => {
                     if let Some(flush) = drain_batch(&mut batch) {
-                        flush_batch(
+                        flush_batch_with_managers(
                             flush,
                             partition_manager.clone(),
                             node_manager.clone(),
                             catalog_manager.clone(),
+                            table_flownode_set_cache.clone(),
                         ).await;
                     }
                     break;
@@ -1010,18 +1031,33 @@ async fn spawn_flush(
     partition_manager: PartitionRuleManagerRef,
     node_manager: NodeManagerRef,
     catalog_manager: CatalogManagerRef,
+    table_flownode_set_cache: TableFlownodeSetCacheRef,
     semaphore: Arc<Semaphore>,
 ) {
     match semaphore.acquire_owned().await {
         Ok(permit) => {
             tokio::spawn(async move {
                 let _permit = permit;
-                flush_batch(flush, partition_manager, node_manager, catalog_manager).await;
+                flush_batch_with_managers(
+                    flush,
+                    partition_manager,
+                    node_manager,
+                    catalog_manager,
+                    table_flownode_set_cache,
+                )
+                .await;
             });
         }
         Err(err) => {
             warn!(err; "Flush semaphore closed, flushing inline");
-            flush_batch(flush, partition_manager, node_manager, catalog_manager).await;
+            flush_batch_with_managers(
+                flush,
+                partition_manager,
+                node_manager,
+                catalog_manager,
+                table_flownode_set_cache,
+            )
+            .await;
         }
     }
 }
@@ -1206,11 +1242,36 @@ async fn flush_region_writes_concurrently(
     Ok(affected_rows)
 }
 
-async fn flush_batch(
+async fn flush_batch_with_managers(
     flush: FlushBatch,
     partition_manager: PartitionRuleManagerRef,
     node_manager: NodeManagerRef,
     catalog_manager: CatalogManagerRef,
+    table_flownode_set_cache: TableFlownodeSetCacheRef,
+) {
+    let partition_provider = PartitionManagerPhysicalFlushAdapter { partition_manager };
+    let node_requester = NodeManagerPhysicalFlushAdapter {
+        node_manager: node_manager.clone(),
+    };
+    let catalog_provider = CatalogManagerPhysicalFlushAdapter { catalog_manager };
+    flush_batch(
+        flush,
+        &partition_provider,
+        &node_requester,
+        &catalog_provider,
+        node_manager,
+        table_flownode_set_cache,
+    )
+    .await;
+}
+
+async fn flush_batch(
+    flush: FlushBatch,
+    partition_manager: &(impl PhysicalFlushPartitionProvider + ?Sized),
+    node_manager: &(impl PhysicalFlushNodeRequester + ?Sized),
+    catalog_manager: &(impl PhysicalFlushCatalogProvider + ?Sized),
+    flow_node_manager: NodeManagerRef,
+    table_flownode_set_cache: TableFlownodeSetCacheRef,
 ) {
     let FlushBatch {
         table_batches,
@@ -1227,16 +1288,13 @@ async fn flush_batch(
         .extension(PHYSICAL_TABLE_KEY)
         .unwrap_or(GREPTIME_PHYSICAL_TABLE)
         .to_string();
-    let partition_provider = PartitionManagerPhysicalFlushAdapter { partition_manager };
-    let node_requester = NodeManagerPhysicalFlushAdapter { node_manager };
-    let catalog_provider = CatalogManagerPhysicalFlushAdapter { catalog_manager };
     let result = flush_batch_physical(
         &table_batches,
         &physical_table_name,
         &ctx,
-        &partition_provider,
-        &node_requester,
-        &catalog_provider,
+        partition_manager,
+        node_manager,
+        catalog_manager,
     )
     .await;
 
@@ -1259,7 +1317,88 @@ async fn flush_batch(
         total_row_count, elapsed
     );
 
+    notify_flow_dirty_windows_after_flush(
+        &result,
+        &table_batches,
+        table_flownode_set_cache,
+        flow_node_manager,
+    );
     notify_waiters(waiters, result.map(|_| ()));
+}
+
+fn extract_timestamps(table_batch: &TableBatch) -> Vec<i64> {
+    let mut timestamps = Vec::with_capacity(table_batch.row_count);
+    for batch in &table_batch.batches {
+        let Some(timestamp_column) = batch.column_by_name(greptime_timestamp()) else {
+            error!("Failed to extract timestamps from record batch: missing timestamp column");
+            continue;
+        };
+        let Some((timestamp_values, _)) =
+            datatypes::timestamp::timestamp_array_to_primitive(timestamp_column)
+        else {
+            error!("Failed to extract timestamps from record batch");
+            continue;
+        };
+
+        if timestamp_values.null_count() == 0 {
+            timestamps.extend_from_slice(timestamp_values.values());
+        } else {
+            timestamps.extend(timestamp_values.iter().flatten());
+        }
+    }
+    timestamps
+}
+
+fn notify_flow_dirty_windows_after_flush(
+    result: &Result<usize>,
+    table_batches: &[TableBatch],
+    table_flownode_set_cache: TableFlownodeSetCacheRef,
+    node_manager: NodeManagerRef,
+) {
+    if result.is_err() {
+        return;
+    }
+
+    let table_batches = table_batches.to_vec();
+    common_runtime::spawn_global(async move {
+        for table_batch in table_batches {
+            let timestamps = extract_timestamps(&table_batch);
+            if timestamps.is_empty() {
+                continue;
+            }
+
+            let flownodes = match table_flownode_set_cache.get(table_batch.table_id).await {
+                Ok(Some(flownodes)) => flownodes,
+                Ok(None) => continue,
+                Err(e) => {
+                    error!(e; "Failed to get flownodes for table id: {}", table_batch.table_id);
+                    continue;
+                }
+            };
+            let peers: HashSet<_> = flownodes.values().cloned().collect();
+
+            for peer in peers {
+                let node_manager = node_manager.clone();
+                let timestamps = timestamps.clone();
+                let table_id = table_batch.table_id;
+                common_runtime::spawn_global(async move {
+                    if let Err(e) = node_manager
+                        .flownode(&peer)
+                        .await
+                        .handle_mark_window_dirty(DirtyWindowRequests {
+                            requests: vec![DirtyWindowRequest {
+                                table_id,
+                                timestamps,
+                            }],
+                        })
+                        .await
+                    {
+                        error!(e; "Failed to mark timestamps as dirty, table: {}", table_id);
+                    }
+                });
+            }
+        }
+    });
 }
 
 /// Flushes a batch of logical table rows by transforming them into the physical table format
@@ -1608,14 +1747,19 @@ mod tests {
     use arrow::record_batch::RecordBatch;
     use async_trait::async_trait;
     use catalog::error::Result as CatalogResult;
+    use common_meta::cache::{TableFlownodeSetCacheRef, new_table_flownode_set_cache};
     use common_meta::error::Result as MetaResult;
+    use common_meta::instruction::{CacheIdent, CreateFlow};
+    use common_meta::kv_backend::memory::MemoryKvBackend;
     use common_meta::node_manager::{
         Datanode, DatanodeManager, DatanodeRef, Flownode, FlownodeManager, FlownodeRef,
+        NodeManagerRef,
     };
     use common_query::request::QueryRequest;
     use common_recordbatch::SendableRecordBatchStream;
     use dashmap::DashMap;
     use datatypes::schema::{ColumnSchema as DtColumnSchema, Schema as DtSchema};
+    use moka::future::CacheBuilder;
     use partition::error::Result as PartitionResult;
     use partition::partition::{PartitionRule, PartitionRuleRef, RegionMask};
     use smallvec::SmallVec;
@@ -1627,14 +1771,15 @@ mod tests {
     use tokio::time::sleep;
 
     use super::{
-        BatchKey, Error, FlushRegionWrite, FlushWaiter, PendingBatch, PendingRowsBatcher,
-        PendingWorker, PhysicalFlushCatalogProvider, PhysicalFlushNodeRequester,
-        PhysicalFlushPartitionProvider, PhysicalTableMetadata, PlannedRegionBatch,
-        ResolvedRegionBatch, TableBatch, WorkerCommand, columns_taxonomy, drain_batch,
-        encode_region_write_requests, flush_batch_physical, flush_region_writes_concurrently,
-        plan_region_batches, remove_worker_if_same_channel, should_close_worker_on_idle_timeout,
-        should_dispatch_concurrently, strip_partition_columns_from_batch,
-        transform_logical_batches_to_physical,
+        BatchKey, Error, FlushBatch, FlushRegionWrite, FlushWaiter, PendingBatch,
+        PendingRowsBatcher, PendingWorker, PhysicalFlushCatalogProvider,
+        PhysicalFlushNodeRequester, PhysicalFlushPartitionProvider, PhysicalTableMetadata,
+        PlannedRegionBatch, ResolvedRegionBatch, TableBatch, WorkerCommand, columns_taxonomy,
+        drain_batch, encode_region_write_requests, extract_timestamps, flush_batch,
+        flush_batch_physical, flush_region_writes_concurrently, greptime_timestamp,
+        notify_flow_dirty_windows_after_flush, plan_region_batches, remove_worker_if_same_channel,
+        should_close_worker_on_idle_timeout, should_dispatch_concurrently,
+        strip_partition_columns_from_batch, transform_logical_batches_to_physical,
     };
     use crate::error;
 
@@ -1668,6 +1813,48 @@ mod tests {
             ],
         )
         .unwrap()
+    }
+
+    fn mock_timestamp_batch(timestamps: Vec<Option<i64>>) -> RecordBatch {
+        RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![Field::new(
+                greptime_timestamp(),
+                ArrowDataType::Timestamp(arrow::datatypes::TimeUnit::Millisecond, None),
+                true,
+            )])),
+            vec![Arc::new(TimestampMillisecondArray::from(timestamps))],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_extract_timestamps_appends_non_null_batches_in_order() {
+        let table_batch = TableBatch {
+            table_name: "cpu".to_string(),
+            table_id: 42,
+            batches: vec![
+                mock_tag_batch("tag1", "host-1", 1000, 1.0),
+                mock_tag_batch("tag1", "host-1", 2000, 2.0),
+            ],
+            row_count: 2,
+        };
+
+        assert_eq!(vec![1000, 2000], extract_timestamps(&table_batch));
+    }
+
+    #[test]
+    fn test_extract_timestamps_omits_nulls_and_retains_order() {
+        let table_batch = TableBatch {
+            table_name: "cpu".to_string(),
+            table_id: 42,
+            batches: vec![
+                mock_timestamp_batch(vec![Some(1000), None, Some(3000)]),
+                mock_timestamp_batch(vec![None, Some(5000)]),
+            ],
+            row_count: 5,
+        };
+
+        assert_eq!(vec![1000, 3000, 5000], extract_timestamps(&table_batch));
     }
 
     fn mock_physical_table_metadata(table_id: TableId) -> PhysicalTableMetadata {
@@ -1818,6 +2005,7 @@ mod tests {
     #[derive(Default)]
     struct MockFlushNodeRequester {
         writes: Arc<AtomicUsize>,
+        fail: bool,
     }
 
     #[async_trait]
@@ -1828,6 +2016,11 @@ mod tests {
             _request: RegionRequest,
         ) -> error::Result<RegionResponse> {
             self.writes.fetch_add(1, Ordering::SeqCst);
+            if self.fail {
+                return Err(Error::Internal {
+                    err_msg: "physical write failed".to_string(),
+                });
+            }
             Ok(RegionResponse::new(0))
         }
     }
@@ -1866,7 +2059,7 @@ mod tests {
         let permit = Arc::new(Semaphore::new(1)).try_acquire_owned().unwrap();
         let mut batch = Some(PendingBatch {
             tables: HashMap::from([(
-                "cpu".to_string(),
+                42,
                 TableBatch {
                     table_name: "cpu".to_string(),
                     table_id: 42,
@@ -1891,6 +2084,29 @@ mod tests {
         assert_eq!(1, flush.table_batches.len());
         assert_eq!(ctx.get_db_string(), flush.db_string);
         assert_eq!(ctx.current_catalog(), flush.ctx.current_catalog());
+    }
+
+    #[test]
+    fn test_pending_batch_keeps_same_name_batches_with_distinct_table_ids() {
+        let ctx = session::context::QueryContext::arc();
+        let mut pending_batch = PendingBatch::new(ctx);
+
+        pending_batch.add_table_batch(
+            "cpu".to_string(),
+            42,
+            mock_tag_batch("tag1", "host-1", 1000, 1.0),
+        );
+        pending_batch.add_table_batch(
+            "cpu".to_string(),
+            43,
+            mock_tag_batch("tag1", "host-1", 2000, 2.0),
+        );
+
+        assert_eq!(2, pending_batch.tables.len());
+        assert_eq!(42, pending_batch.tables[&42].table_id);
+        assert_eq!(43, pending_batch.tables[&43].table_id);
+        assert_eq!("cpu", pending_batch.tables[&42].table_name);
+        assert_eq!("cpu", pending_batch.tables[&43].table_name);
     }
 
     #[derive(Clone)]
@@ -1971,6 +2187,247 @@ mod tests {
         async fn flownode(&self, _node: &Peer) -> FlownodeRef {
             Arc::new(NoopFlownode)
         }
+    }
+
+    struct RecordingFlownode {
+        requests_tx: mpsc::UnboundedSender<DirtyWindowRequests>,
+    }
+
+    #[async_trait]
+    impl Flownode for RecordingFlownode {
+        async fn handle(&self, _request: FlowRequest) -> MetaResult<FlowResponse> {
+            unimplemented!()
+        }
+
+        async fn handle_inserts(&self, _request: InsertRequests) -> MetaResult<FlowResponse> {
+            unimplemented!()
+        }
+
+        async fn handle_mark_window_dirty(
+            &self,
+            req: DirtyWindowRequests,
+        ) -> MetaResult<FlowResponse> {
+            self.requests_tx.send(req).unwrap();
+            Ok(FlowResponse::default())
+        }
+    }
+
+    struct FlowNotificationMockNodeManager {
+        flownode: FlownodeRef,
+    }
+
+    #[async_trait]
+    impl DatanodeManager for FlowNotificationMockNodeManager {
+        async fn datanode(&self, _node: &Peer) -> DatanodeRef {
+            unimplemented!()
+        }
+    }
+
+    #[async_trait]
+    impl FlownodeManager for FlowNotificationMockNodeManager {
+        async fn flownode(&self, _node: &Peer) -> FlownodeRef {
+            self.flownode.clone()
+        }
+    }
+
+    async fn mock_table_flownode_cache(table_id: TableId, peer: Peer) -> TableFlownodeSetCacheRef {
+        let cache = Arc::new(new_table_flownode_set_cache(
+            "test".to_string(),
+            CacheBuilder::new(1).build(),
+            Arc::new(MemoryKvBackend::default()),
+        ));
+        cache
+            .invalidate(&[CacheIdent::CreateFlow(CreateFlow {
+                flow_id: 1,
+                source_table_ids: vec![table_id],
+                partition_to_peer_mapping: vec![(0, peer.clone()), (1, peer)],
+            })])
+            .await
+            .unwrap();
+        cache
+    }
+
+    #[tokio::test]
+    async fn test_successful_flush_notifies_flownode_with_logical_table_timestamps() {
+        let table_id = 42;
+        let peer = Peer {
+            id: 7,
+            addr: "flow-7".to_string(),
+        };
+        let cache = mock_table_flownode_cache(table_id, peer).await;
+        let (requests_tx, mut requests_rx) = mpsc::unbounded_channel();
+        let _requests_tx = requests_tx.clone();
+        let node_manager: NodeManagerRef = Arc::new(FlowNotificationMockNodeManager {
+            flownode: Arc::new(RecordingFlownode { requests_tx }),
+        });
+        let table_batches = vec![TableBatch {
+            table_name: "cpu".to_string(),
+            table_id,
+            batches: vec![mock_tag_batch("tag1", "host-1", 1000, 1.0)],
+            row_count: 1,
+        }];
+
+        notify_flow_dirty_windows_after_flush(
+            &Ok::<usize, Error>(1),
+            &table_batches,
+            cache,
+            node_manager,
+        );
+
+        let requests = tokio::time::timeout(Duration::from_secs(1), requests_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            vec![api::v1::flow::DirtyWindowRequest {
+                table_id,
+                timestamps: vec![1000],
+            }],
+            requests.requests
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), requests_rx.recv())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_successful_flush_coalesces_logical_batches_per_flownode() {
+        let table_id = 42;
+        let peer = Peer {
+            id: 7,
+            addr: "flow-7".to_string(),
+        };
+        let cache = mock_table_flownode_cache(table_id, peer).await;
+        let (requests_tx, mut requests_rx) = mpsc::unbounded_channel();
+        let _requests_tx = requests_tx.clone();
+        let node_manager: NodeManagerRef = Arc::new(FlowNotificationMockNodeManager {
+            flownode: Arc::new(RecordingFlownode { requests_tx }),
+        });
+        let table_batches = vec![TableBatch {
+            table_name: "cpu".to_string(),
+            table_id,
+            batches: vec![
+                mock_tag_batch("tag1", "host-1", 1000, 1.0),
+                mock_tag_batch("tag1", "host-1", 2000, 2.0),
+            ],
+            row_count: 2,
+        }];
+
+        notify_flow_dirty_windows_after_flush(
+            &Ok::<usize, Error>(2),
+            &table_batches,
+            cache,
+            node_manager,
+        );
+
+        let requests = tokio::time::timeout(Duration::from_secs(1), requests_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            vec![api::v1::flow::DirtyWindowRequest {
+                table_id,
+                timestamps: vec![1000, 2000],
+            }],
+            requests.requests
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), requests_rx.recv())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_failed_flush_does_not_notify_flownode() {
+        let table_id = 42;
+        let peer = Peer {
+            id: 7,
+            addr: "flow-7".to_string(),
+        };
+        let cache = mock_table_flownode_cache(table_id, peer).await;
+        let (requests_tx, mut requests_rx) = mpsc::unbounded_channel();
+        let _requests_tx = requests_tx.clone();
+        let node_manager: NodeManagerRef = Arc::new(FlowNotificationMockNodeManager {
+            flownode: Arc::new(RecordingFlownode { requests_tx }),
+        });
+        let table_batches = vec![TableBatch {
+            table_name: "cpu".to_string(),
+            table_id,
+            batches: vec![mock_tag_batch("tag1", "host-1", 1000, 1.0)],
+            row_count: 1,
+        }];
+
+        notify_flow_dirty_windows_after_flush(
+            &Err(Error::Internal {
+                err_msg: "flush failed".to_string(),
+            }),
+            &table_batches,
+            cache,
+            node_manager,
+        );
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), requests_rx.recv())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_flush_batch_does_not_notify_flownode_after_physical_write_error() {
+        let table_id = 42;
+        let peer = Peer {
+            id: 7,
+            addr: "flow-7".to_string(),
+        };
+        let cache = mock_table_flownode_cache(table_id, peer).await;
+        let (requests_tx, mut requests_rx) = mpsc::unbounded_channel();
+        let _requests_tx = requests_tx.clone();
+        let flow_node_manager: NodeManagerRef = Arc::new(FlowNotificationMockNodeManager {
+            flownode: Arc::new(RecordingFlownode { requests_tx }),
+        });
+        let ctx = session::context::QueryContext::arc();
+        let table_batches = vec![TableBatch {
+            table_name: "cpu".to_string(),
+            table_id,
+            batches: vec![mock_tag_batch("tag1", "host-1", 1000, 1.0)],
+            row_count: 1,
+        }];
+        let writes = Arc::new(AtomicUsize::new(0));
+
+        flush_batch(
+            FlushBatch {
+                table_batches,
+                total_row_count: 1,
+                db_string: ctx.get_db_string(),
+                ctx,
+                waiters: Vec::new(),
+            },
+            &MockFlushPartitionProvider {
+                partition_rule_calls: Arc::new(AtomicUsize::new(0)),
+                region_leader_calls: Arc::new(AtomicUsize::new(0)),
+            },
+            &MockFlushNodeRequester {
+                writes: writes.clone(),
+                fail: true,
+            },
+            &MockFlushCatalogProvider {
+                table: Some(mock_physical_table_metadata(1024)),
+            },
+            flow_node_manager,
+            cache,
+        )
+        .await;
+
+        assert_eq!(1, writes.load(Ordering::SeqCst));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), requests_rx.recv())
+                .await
+                .is_err()
+        );
     }
 
     #[async_trait]

--- a/src/servers/src/pending_rows_batcher.rs
+++ b/src/servers/src/pending_rows_batcher.rs
@@ -1301,29 +1301,32 @@ async fn flush_batch(
     let elapsed = start.elapsed().as_secs_f64();
     FLUSH_ELAPSED.observe(elapsed);
 
-    if result.is_err() {
-        FLUSH_FAILURES.inc();
-        FLUSH_DROPPED_ROWS.inc_by(total_row_count as u64);
-    } else if let Ok(affected_rows) = &result {
-        FLUSH_TOTAL.inc();
-        FLUSH_ROWS.observe(total_row_count as f64);
-        operator::metrics::DIST_INGEST_ROW_COUNT
-            .with_label_values(&[db_string.as_str()])
-            .inc_by(*affected_rows as u64);
-    }
-
     debug!(
         "Pending rows batch flushed, total rows: {}, elapsed time: {}s",
         total_row_count, elapsed
     );
 
-    notify_flow_dirty_windows_after_flush(
-        &result,
-        &table_batches,
-        table_flownode_set_cache,
-        flow_node_manager,
-    );
-    notify_waiters(waiters, result.map(|_| ()));
+    match result {
+        Ok(affected_rows) => {
+            FLUSH_TOTAL.inc();
+            FLUSH_ROWS.observe(total_row_count as f64);
+            operator::metrics::DIST_INGEST_ROW_COUNT
+                .with_label_values(&[db_string.as_str()])
+                .inc_by(affected_rows as u64);
+
+            notify_flow_dirty_windows_after_flush(
+                table_batches,
+                table_flownode_set_cache,
+                flow_node_manager,
+            );
+            notify_waiters(waiters, Ok(()));
+        }
+        Err(err) => {
+            FLUSH_FAILURES.inc();
+            FLUSH_DROPPED_ROWS.inc_by(total_row_count as u64);
+            notify_waiters(waiters, Err(err));
+        }
+    }
 }
 
 fn extract_timestamps(table_batch: &TableBatch) -> Vec<i64> {
@@ -1350,16 +1353,10 @@ fn extract_timestamps(table_batch: &TableBatch) -> Vec<i64> {
 }
 
 fn notify_flow_dirty_windows_after_flush(
-    result: &Result<usize>,
-    table_batches: &[TableBatch],
+    table_batches: Vec<TableBatch>,
     table_flownode_set_cache: TableFlownodeSetCacheRef,
     node_manager: NodeManagerRef,
 ) {
-    if result.is_err() {
-        return;
-    }
-
-    let table_batches = table_batches.to_vec();
     common_runtime::spawn_global(async move {
         for table_batch in table_batches {
             let timestamps = extract_timestamps(&table_batch);
@@ -2267,12 +2264,7 @@ mod tests {
             row_count: 1,
         }];
 
-        notify_flow_dirty_windows_after_flush(
-            &Ok::<usize, Error>(1),
-            &table_batches,
-            cache,
-            node_manager,
-        );
+        notify_flow_dirty_windows_after_flush(table_batches, cache, node_manager);
 
         let requests = tokio::time::timeout(Duration::from_secs(1), requests_rx.recv())
             .await
@@ -2315,12 +2307,7 @@ mod tests {
             row_count: 2,
         }];
 
-        notify_flow_dirty_windows_after_flush(
-            &Ok::<usize, Error>(2),
-            &table_batches,
-            cache,
-            node_manager,
-        );
+        notify_flow_dirty_windows_after_flush(table_batches, cache, node_manager);
 
         let requests = tokio::time::timeout(Duration::from_secs(1), requests_rx.recv())
             .await
@@ -2341,7 +2328,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_failed_flush_does_not_notify_flownode() {
+    async fn test_flush_batch_notifies_flownode_after_successful_physical_write() {
         let table_id = 42;
         let peer = Peer {
             id: 7,
@@ -2350,29 +2337,53 @@ mod tests {
         let cache = mock_table_flownode_cache(table_id, peer).await;
         let (requests_tx, mut requests_rx) = mpsc::unbounded_channel();
         let _requests_tx = requests_tx.clone();
-        let node_manager: NodeManagerRef = Arc::new(FlowNotificationMockNodeManager {
+        let flow_node_manager: NodeManagerRef = Arc::new(FlowNotificationMockNodeManager {
             flownode: Arc::new(RecordingFlownode { requests_tx }),
         });
+        let ctx = session::context::QueryContext::arc();
         let table_batches = vec![TableBatch {
             table_name: "cpu".to_string(),
             table_id,
             batches: vec![mock_tag_batch("tag1", "host-1", 1000, 1.0)],
             row_count: 1,
         }];
+        let writes = Arc::new(AtomicUsize::new(0));
 
-        notify_flow_dirty_windows_after_flush(
-            &Err(Error::Internal {
-                err_msg: "flush failed".to_string(),
-            }),
-            &table_batches,
+        flush_batch(
+            FlushBatch {
+                table_batches,
+                total_row_count: 1,
+                db_string: ctx.get_db_string(),
+                ctx,
+                waiters: Vec::new(),
+            },
+            &MockFlushPartitionProvider {
+                partition_rule_calls: Arc::new(AtomicUsize::new(0)),
+                region_leader_calls: Arc::new(AtomicUsize::new(0)),
+            },
+            &MockFlushNodeRequester {
+                writes: writes.clone(),
+                fail: false,
+            },
+            &MockFlushCatalogProvider {
+                table: Some(mock_physical_table_metadata(1024)),
+            },
+            flow_node_manager,
             cache,
-            node_manager,
-        );
+        )
+        .await;
 
-        assert!(
-            tokio::time::timeout(Duration::from_millis(50), requests_rx.recv())
-                .await
-                .is_err()
+        assert_eq!(1, writes.load(Ordering::SeqCst));
+        let requests = tokio::time::timeout(Duration::from_secs(1), requests_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            vec![api::v1::flow::DirtyWindowRequest {
+                table_id,
+                timestamps: vec![1000],
+            }],
+            requests.requests
         );
     }
 

--- a/src/servers/src/pending_rows_batcher.rs
+++ b/src/servers/src/pending_rows_batcher.rs
@@ -17,13 +17,12 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use api::v1::flow::{DirtyWindowRequest, DirtyWindowRequests, TimeRange};
+use api::v1::flow::{DirtyWindowRequest, DirtyWindowRequests};
 use api::v1::meta::Peer;
 use api::v1::region::{
     BulkInsertRequest, RegionRequest, RegionRequestHeader, bulk_insert_request, region_request,
 };
 use api::v1::{ArrowIpc, ColumnSchema, RowInsertRequests, Rows};
-#[cfg(test)]
 use arrow::array::Array;
 use arrow::compute::{concat_batches, filter_record_batch};
 use arrow::datatypes::{DataType as ArrowDataType, Schema as ArrowSchema, TimeUnit};
@@ -68,9 +67,6 @@ const PENDING_ROWS_BATCH_SYNC_ENV: &str = "PENDING_ROWS_BATCH_SYNC";
 const WORKER_IDLE_TIMEOUT_MULTIPLIER: u32 = 3;
 const PHYSICAL_REGION_ESSENTIAL_COLUMN_COUNT: usize = 3;
 const MAX_CONCURRENT_FLOW_NOTIFICATIONS: usize = 8;
-const DENSE_TIMESTAMP_RANGE_FACTOR_NUMERATOR: i128 = 11;
-const DENSE_TIMESTAMP_RANGE_FACTOR_DENOMINATOR: i128 = 10;
-
 #[async_trait]
 pub trait PendingRowsSchemaAlterer: Send + Sync {
     /// Batch-create multiple logical tables that are missing.
@@ -1382,7 +1378,6 @@ async fn flush_batch(
     }
 }
 
-#[cfg(test)]
 fn extract_timestamps(table_batch: &TableBatch) -> Vec<i64> {
     let mut timestamps = Vec::with_capacity(table_batch.row_count);
     for batch in &table_batch.batches {
@@ -1409,67 +1404,6 @@ fn extract_timestamps(table_batch: &TableBatch) -> Vec<i64> {
 struct FlowNotification {
     table_id: TableId,
     timestamps: Vec<i64>,
-    time_ranges: Vec<TimeRange>,
-    min_timestamp: i64,
-    max_timestamp: i64,
-}
-
-fn compact_flow_notification(table_batch: TableBatch) -> Option<FlowNotification> {
-    let mut timestamps = Vec::new();
-    let mut time_ranges = Vec::new();
-    let mut min_timestamp: Option<i64> = None;
-    let mut max_timestamp: Option<i64> = None;
-
-    for batch in table_batch.batches {
-        let timestamp_column = batch.batch.column(batch.timestamp_index);
-        let Some((timestamp_values, _)) =
-            datatypes::timestamp::timestamp_array_to_primitive(timestamp_column)
-        else {
-            error!(
-                "Failed to extract timestamps from record batch, table_id: {}, timestamp_index: {}",
-                table_batch.table_id, batch.timestamp_index
-            );
-            continue;
-        };
-
-        let mut batch_min: Option<i64> = None;
-        let mut batch_max: Option<i64> = None;
-        let mut timestamp_count = 0usize;
-        for timestamp in timestamp_values.iter().flatten() {
-            batch_min = Some(batch_min.map_or(timestamp, |min| min.min(timestamp)));
-            batch_max = Some(batch_max.map_or(timestamp, |max| max.max(timestamp)));
-            timestamp_count += 1;
-        }
-
-        let (Some(batch_min), Some(batch_max)) = (batch_min, batch_max) else {
-            continue;
-        };
-        min_timestamp = Some(min_timestamp.map_or(batch_min, |min| min.min(batch_min)));
-        max_timestamp = Some(max_timestamp.map_or(batch_max, |max| max.max(batch_max)));
-        let timestamp_span = i128::from(batch_max) - i128::from(batch_min);
-        let is_dense = timestamp_span * DENSE_TIMESTAMP_RANGE_FACTOR_DENOMINATOR
-            < timestamp_count as i128 * DENSE_TIMESTAMP_RANGE_FACTOR_NUMERATOR;
-        if is_dense && let Some(end_exclusive) = batch_max.checked_add(1) {
-            time_ranges.push(TimeRange {
-                start_inclusive: batch_min,
-                end_exclusive,
-            });
-        } else {
-            timestamps.extend(timestamp_values.iter().flatten());
-        }
-    }
-
-    if timestamps.is_empty() && time_ranges.is_empty() {
-        return None;
-    }
-
-    Some(FlowNotification {
-        table_id: table_batch.table_id,
-        timestamps,
-        time_ranges,
-        min_timestamp: min_timestamp?,
-        max_timestamp: max_timestamp?,
-    })
 }
 
 fn try_enqueue_flow_notification(
@@ -1481,11 +1415,9 @@ fn try_enqueue_flow_notification(
         Err(mpsc::error::TrySendError::Full(notification)) => {
             FLOW_NOTIFICATION_DROPPED.with_label_values(&["full"]).inc();
             warn!(
-                "Dropping flow notification because queue is full, table_id: {}, queue_capacity: {}, min_timestamp: {}, max_timestamp: {}",
+                "Dropping flow notification because queue is full, table_id: {}, queue_capacity: {}",
                 notification.table_id,
-                tx.max_capacity(),
-                notification.min_timestamp,
-                notification.max_timestamp
+                tx.max_capacity()
             );
             false
         }
@@ -1494,11 +1426,9 @@ fn try_enqueue_flow_notification(
                 .with_label_values(&["closed"])
                 .inc();
             error!(
-                "Dropping flow notification because queue is closed, table_id: {}, queue_capacity: {}, min_timestamp: {}, max_timestamp: {}",
+                "Dropping flow notification because queue is closed, table_id: {}, queue_capacity: {}",
                 notification.table_id,
-                tx.max_capacity(),
-                notification.min_timestamp,
-                notification.max_timestamp
+                tx.max_capacity()
             );
             false
         }
@@ -1507,9 +1437,17 @@ fn try_enqueue_flow_notification(
 
 fn enqueue_flow_notifications(table_batches: Vec<TableBatch>, tx: &mpsc::Sender<FlowNotification>) {
     for table_batch in table_batches {
-        if let Some(notification) = compact_flow_notification(table_batch) {
-            try_enqueue_flow_notification(tx, notification);
+        let timestamps = extract_timestamps(&table_batch);
+        if timestamps.is_empty() {
+            continue;
         }
+        try_enqueue_flow_notification(
+            tx,
+            FlowNotification {
+                table_id: table_batch.table_id,
+                timestamps,
+            },
+        );
     }
 }
 
@@ -1537,7 +1475,7 @@ async fn handle_flow_notification(
                 requests: vec![DirtyWindowRequest {
                     table_id,
                     timestamps: notification.timestamps.clone(),
-                    time_ranges: notification.time_ranges.clone(),
+                    time_ranges: Vec::new(),
                 }],
             })
             .await
@@ -1919,7 +1857,7 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use api::region::RegionResponse;
-    use api::v1::flow::{DirtyWindowRequests, FlowRequest, FlowResponse, TimeRange};
+    use api::v1::flow::{DirtyWindowRequests, FlowRequest, FlowResponse};
     use api::v1::meta::Peer;
     use api::v1::region::{InsertRequests, RegionRequest, region_request};
     use api::v1::value::ValueData;
@@ -1966,13 +1904,12 @@ mod tests {
         PendingRowsBatcher, PendingWorker, PhysicalFlushCatalogProvider,
         PhysicalFlushNodeRequester, PhysicalFlushPartitionProvider, PhysicalTableMetadata,
         PlannedRegionBatch, RecordBatchWithTsIdx, ResolvedRegionBatch, TableBatch, WorkerCommand,
-        columns_taxonomy, compact_flow_notification, drain_batch, encode_region_write_requests,
-        extract_timestamps, flush_batch, flush_batch_physical, flush_region_writes_concurrently,
-        greptime_timestamp, notify_flow_dirty_windows_after_flush, plan_region_batches,
-        remove_worker_if_same_channel, should_close_worker_on_idle_timeout,
-        should_dispatch_concurrently, start_flow_notification_worker,
-        strip_partition_columns_from_batch, transform_logical_batches_to_physical,
-        try_enqueue_flow_notification,
+        columns_taxonomy, drain_batch, encode_region_write_requests, extract_timestamps,
+        flush_batch, flush_batch_physical, flush_region_writes_concurrently, greptime_timestamp,
+        notify_flow_dirty_windows_after_flush, plan_region_batches, remove_worker_if_same_channel,
+        should_close_worker_on_idle_timeout, should_dispatch_concurrently,
+        start_flow_notification_worker, strip_partition_columns_from_batch,
+        transform_logical_batches_to_physical, try_enqueue_flow_notification,
     };
     use crate::error;
     use crate::metrics::FLOW_NOTIFICATION_DROPPED;
@@ -2198,49 +2135,11 @@ mod tests {
     }
 
     #[test]
-    fn test_compact_flow_notification() {
-        let testcases = [
-            (
-                vec![Some(1), Some(2), Some(3)],
-                Vec::new(),
-                vec![TimeRange {
-                    start_inclusive: 1,
-                    end_exclusive: 4,
-                }],
-            ),
-            (vec![Some(1), Some(1000)], vec![1, 1000], Vec::new()),
-            (
-                vec![Some(i64::MAX - 1), Some(i64::MAX)],
-                vec![i64::MAX - 1, i64::MAX],
-                Vec::new(),
-            ),
-        ];
-
-        for (timestamps, expected_timestamps, expected_ranges) in testcases {
-            let table_batch = TableBatch {
-                table_name: "cpu".to_string(),
-                table_id: 42,
-                row_count: timestamps.len(),
-                batches: vec![mock_timestamp_batch(timestamps)],
-            };
-
-            let notification = compact_flow_notification(table_batch).unwrap();
-            assert_eq!(expected_timestamps, notification.timestamps);
-            assert_eq!(expected_ranges, notification.time_ranges);
-        }
-    }
-
-    #[test]
     fn test_flow_notification_queue_drops_when_full() {
         let (tx, mut rx) = mpsc::channel(1);
-        let notification = |table_id| {
-            compact_flow_notification(TableBatch {
-                table_name: format!("table-{table_id}"),
-                table_id,
-                row_count: 1,
-                batches: vec![mock_timestamp_batch(vec![Some(table_id as i64)])],
-            })
-            .unwrap()
+        let notification = |table_id| super::FlowNotification {
+            table_id,
+            timestamps: vec![table_id as i64],
         };
         let dropped = FLOW_NOTIFICATION_DROPPED.with_label_values(&["full"]);
         let dropped_before = dropped.get();
@@ -2792,11 +2691,8 @@ mod tests {
         assert_eq!(
             vec![api::v1::flow::DirtyWindowRequest {
                 table_id,
-                timestamps: Vec::new(),
-                time_ranges: vec![TimeRange {
-                    start_inclusive: 1000,
-                    end_exclusive: 1001,
-                }],
+                timestamps: vec![1000],
+                time_ranges: Vec::new(),
             }],
             requests.requests
         );
@@ -2839,17 +2735,8 @@ mod tests {
         assert_eq!(
             vec![api::v1::flow::DirtyWindowRequest {
                 table_id,
-                timestamps: Vec::new(),
-                time_ranges: vec![
-                    TimeRange {
-                        start_inclusive: 1000,
-                        end_exclusive: 1001,
-                    },
-                    TimeRange {
-                        start_inclusive: 2000,
-                        end_exclusive: 2001,
-                    },
-                ],
+                timestamps: vec![1000, 2000],
+                time_ranges: Vec::new(),
             }],
             requests.requests
         );
@@ -2914,11 +2801,8 @@ mod tests {
         assert_eq!(
             vec![api::v1::flow::DirtyWindowRequest {
                 table_id,
-                timestamps: Vec::new(),
-                time_ranges: vec![TimeRange {
-                    start_inclusive: 1000,
-                    end_exclusive: 1001,
-                }],
+                timestamps: vec![1000],
+                time_ranges: Vec::new(),
             }],
             requests.requests
         );

--- a/src/servers/src/pending_rows_batcher.rs
+++ b/src/servers/src/pending_rows_batcher.rs
@@ -1417,7 +1417,13 @@ async fn notify_flow_dirty_windows_for_table(
             })
             .await
         {
-            error!(e; "Failed to mark timestamps as dirty, table: {}", table_id);
+            error!(
+                e;
+                "Failed to mark timestamps as dirty, table_id: {}, peer_id: {}, peer_addr: {}",
+                table_id,
+                peer.id,
+                peer.addr
+            );
         }
     }
 }

--- a/src/servers/src/pending_rows_batcher.rs
+++ b/src/servers/src/pending_rows_batcher.rs
@@ -208,11 +208,56 @@ struct BatchKey {
     physical_table: String,
 }
 
+/// An aligned logical record batch and its timestamp column index.
+#[derive(Debug, Clone)]
+pub struct RecordBatchWithTsIdx {
+    /// The aligned logical record batch.
+    batch: RecordBatch,
+    /// The timestamp column index in `batch`.
+    timestamp_index: usize,
+}
+
+impl RecordBatchWithTsIdx {
+    /// Creates a record batch with a validated timestamp column index.
+    pub fn try_new(batch: RecordBatch, timestamp_index: usize) -> Result<Self> {
+        let schema = batch.schema();
+        let timestamp_field = schema.fields().get(timestamp_index).with_context(|| {
+            error::InvalidPromRemoteRequestSnafu {
+                msg: format!(
+                    "Timestamp column index {} is out of bounds for record batch with {} columns",
+                    timestamp_index,
+                    batch.num_columns()
+                ),
+            }
+        })?;
+        ensure!(
+            matches!(timestamp_field.data_type(), ArrowDataType::Timestamp(_, _)),
+            error::InvalidPromRemoteRequestSnafu {
+                msg: format!(
+                    "Column at index {} is not a timestamp column: {:?}",
+                    timestamp_index,
+                    timestamp_field.data_type()
+                ),
+            }
+        );
+
+        Ok(Self {
+            batch,
+            timestamp_index,
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn into_parts(self) -> (RecordBatch, usize) {
+        (self.batch, self.timestamp_index)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct TableBatch {
     pub table_name: String,
     pub table_id: TableId,
-    pub batches: Vec<RecordBatch>,
+    pub batches: Vec<RecordBatchWithTsIdx>,
     pub row_count: usize,
 }
 
@@ -256,7 +301,7 @@ struct PendingWorker {
 
 enum WorkerCommand {
     Submit {
-        table_batches: Vec<(String, u32, RecordBatch)>,
+        table_batches: Vec<(String, u32, RecordBatchWithTsIdx)>,
         total_rows: usize,
         ctx: QueryContextRef,
         response_tx: oneshot::Sender<std::result::Result<(), Arc<Error>>>,
@@ -437,7 +482,7 @@ impl PendingRowsBatcher {
         &self,
         requests: RowInsertRequests,
         ctx: &QueryContextRef,
-    ) -> Result<(Vec<(String, u32, RecordBatch)>, usize)> {
+    ) -> Result<(Vec<(String, u32, RecordBatchWithTsIdx)>, usize)> {
         let catalog = ctx.current_catalog().to_string();
         let schema = ctx.current_schema();
 
@@ -743,7 +788,7 @@ impl PendingRowsBatcher {
     fn build_aligned_batches(
         table_rows: &[(String, Rows)],
         region_schemas: &HashMap<String, (Arc<ArrowSchema>, u32)>,
-    ) -> Result<Vec<(String, u32, RecordBatch)>> {
+    ) -> Result<Vec<(String, u32, RecordBatchWithTsIdx)>> {
         let mut aligned_batches = Vec::with_capacity(table_rows.len());
         for (table_name, rows) in table_rows {
             let (region_schema, table_id) =
@@ -845,7 +890,7 @@ impl PendingBatch {
         &mut self,
         table_name: String,
         table_id: TableId,
-        record_batch: RecordBatch,
+        record_batch: RecordBatchWithTsIdx,
     ) {
         let entry = self.tables.entry(table_id).or_insert_with(|| TableBatch {
             table_name,
@@ -853,7 +898,7 @@ impl PendingBatch {
             batches: Vec::new(),
             row_count: 0,
         });
-        entry.row_count += record_batch.num_rows();
+        entry.row_count += record_batch.batch.num_rows();
         entry.batches.push(record_batch);
     }
 }
@@ -1332,10 +1377,7 @@ async fn flush_batch(
 fn extract_timestamps(table_batch: &TableBatch) -> Vec<i64> {
     let mut timestamps = Vec::with_capacity(table_batch.row_count);
     for batch in &table_batch.batches {
-        let Some(timestamp_column) = batch.column_by_name(greptime_timestamp()) else {
-            error!("Failed to extract timestamps from record batch: missing timestamp column");
-            continue;
-        };
+        let timestamp_column = batch.batch.column(batch.timestamp_index);
         let Some((timestamp_values, _)) =
             datatypes::timestamp::timestamp_array_to_primitive(timestamp_column)
         else {
@@ -1500,6 +1542,7 @@ fn transform_logical_batches_to_physical(
         let table_id = table_batch.table_id;
 
         for batch in &table_batch.batches {
+            let batch = &batch.batch;
             let batch_schema = batch.schema();
             let start = Instant::now();
             let (tag_columns, essential_col_indices) = columns_taxonomy(
@@ -1738,7 +1781,11 @@ mod tests {
     use api::v1::flow::{DirtyWindowRequests, FlowRequest, FlowResponse};
     use api::v1::meta::Peer;
     use api::v1::region::{InsertRequests, RegionRequest, region_request};
-    use api::v1::{ColumnSchema, Row, RowInsertRequest, RowInsertRequests, Rows};
+    use api::v1::value::ValueData;
+    use api::v1::{
+        ColumnDataType, ColumnSchema, Row, RowInsertRequest, RowInsertRequests, Rows, SemanticType,
+        Value,
+    };
     use arrow::array::{BinaryArray, BooleanArray, StringArray, TimestampMillisecondArray};
     use arrow::datatypes::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
     use arrow::record_batch::RecordBatch;
@@ -1771,14 +1818,15 @@ mod tests {
         BatchKey, Error, FlushBatch, FlushRegionWrite, FlushWaiter, PendingBatch,
         PendingRowsBatcher, PendingWorker, PhysicalFlushCatalogProvider,
         PhysicalFlushNodeRequester, PhysicalFlushPartitionProvider, PhysicalTableMetadata,
-        PlannedRegionBatch, ResolvedRegionBatch, TableBatch, WorkerCommand, columns_taxonomy,
-        drain_batch, encode_region_write_requests, extract_timestamps, flush_batch,
-        flush_batch_physical, flush_region_writes_concurrently, greptime_timestamp,
+        PlannedRegionBatch, RecordBatchWithTsIdx, ResolvedRegionBatch, TableBatch, WorkerCommand,
+        columns_taxonomy, drain_batch, encode_region_write_requests, extract_timestamps,
+        flush_batch, flush_batch_physical, flush_region_writes_concurrently, greptime_timestamp,
         notify_flow_dirty_windows_after_flush, plan_region_batches, remove_worker_if_same_channel,
         should_close_worker_on_idle_timeout, should_dispatch_concurrently,
         strip_partition_columns_from_batch, transform_logical_batches_to_physical,
     };
     use crate::error;
+    use crate::prom_row_builder::rows_to_aligned_record_batch;
 
     fn mock_rows(row_count: usize, schema_name: &str) -> Rows {
         Rows {
@@ -1812,8 +1860,17 @@ mod tests {
         .unwrap()
     }
 
-    fn mock_timestamp_batch(timestamps: Vec<Option<i64>>) -> RecordBatch {
-        RecordBatch::try_new(
+    fn mock_aligned_tag_batch(
+        tag_name: &str,
+        tag_value: &str,
+        ts: i64,
+        val: f64,
+    ) -> RecordBatchWithTsIdx {
+        RecordBatchWithTsIdx::try_new(mock_tag_batch(tag_name, tag_value, ts, val), 0).unwrap()
+    }
+
+    fn mock_timestamp_batch(timestamps: Vec<Option<i64>>) -> RecordBatchWithTsIdx {
+        let batch = RecordBatch::try_new(
             Arc::new(ArrowSchema::new(vec![Field::new(
                 greptime_timestamp(),
                 ArrowDataType::Timestamp(arrow::datatypes::TimeUnit::Millisecond, None),
@@ -1821,7 +1878,8 @@ mod tests {
             )])),
             vec![Arc::new(TimestampMillisecondArray::from(timestamps))],
         )
-        .unwrap()
+        .unwrap();
+        RecordBatchWithTsIdx::try_new(batch, 0).unwrap()
     }
 
     #[test]
@@ -1830,8 +1888,8 @@ mod tests {
             table_name: "cpu".to_string(),
             table_id: 42,
             batches: vec![
-                mock_tag_batch("tag1", "host-1", 1000, 1.0),
-                mock_tag_batch("tag1", "host-1", 2000, 2.0),
+                mock_aligned_tag_batch("tag1", "host-1", 1000, 1.0),
+                mock_aligned_tag_batch("tag1", "host-1", 2000, 2.0),
             ],
             row_count: 2,
         };
@@ -1852,6 +1910,141 @@ mod tests {
         };
 
         assert_eq!(vec![1000, 3000, 5000], extract_timestamps(&table_batch));
+    }
+
+    #[test]
+    fn test_record_batch_with_ts_idx_rejects_out_of_bounds_index() {
+        let batch = mock_tag_batch("tag1", "host-1", 1000, 1.0);
+
+        assert!(RecordBatchWithTsIdx::try_new(batch, 3).is_err());
+    }
+
+    #[test]
+    fn test_record_batch_with_ts_idx_rejects_non_timestamp_column() {
+        let batch = mock_tag_batch("tag1", "host-1", 1000, 1.0);
+
+        assert!(RecordBatchWithTsIdx::try_new(batch, 1).is_err());
+    }
+
+    #[test]
+    fn test_extract_timestamps_supports_per_batch_timestamp_indices() {
+        let timestamp_first = RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![
+                Field::new(
+                    "ts",
+                    ArrowDataType::Timestamp(arrow::datatypes::TimeUnit::Millisecond, None),
+                    false,
+                ),
+                Field::new("host", ArrowDataType::Utf8, true),
+            ])),
+            vec![
+                Arc::new(TimestampMillisecondArray::from(vec![1000, 2000])),
+                Arc::new(StringArray::from(vec!["host-1", "host-2"])),
+            ],
+        )
+        .unwrap();
+        let timestamp_second = RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![
+                Field::new("host", ArrowDataType::Utf8, true),
+                Field::new(
+                    "timestamp",
+                    ArrowDataType::Timestamp(arrow::datatypes::TimeUnit::Millisecond, None),
+                    false,
+                ),
+            ])),
+            vec![
+                Arc::new(StringArray::from(vec!["host-3", "host-4"])),
+                Arc::new(TimestampMillisecondArray::from(vec![3000, 4000])),
+            ],
+        )
+        .unwrap();
+        let table_batch = TableBatch {
+            table_name: "cpu".to_string(),
+            table_id: 42,
+            batches: vec![
+                RecordBatchWithTsIdx::try_new(timestamp_first, 0).unwrap(),
+                RecordBatchWithTsIdx::try_new(timestamp_second, 1).unwrap(),
+            ],
+            row_count: 4,
+        };
+
+        assert_eq!(
+            vec![1000, 2000, 3000, 4000],
+            extract_timestamps(&table_batch)
+        );
+    }
+
+    #[test]
+    fn test_extract_timestamps_uses_aligned_custom_timestamp_index() {
+        let rows = Rows {
+            schema: vec![
+                ColumnSchema {
+                    column_name: greptime_timestamp().to_string(),
+                    datatype: ColumnDataType::TimestampMillisecond as i32,
+                    semantic_type: SemanticType::Timestamp as i32,
+                    ..Default::default()
+                },
+                ColumnSchema {
+                    column_name: "host".to_string(),
+                    datatype: ColumnDataType::String as i32,
+                    semantic_type: SemanticType::Tag as i32,
+                    ..Default::default()
+                },
+                ColumnSchema {
+                    column_name: "greptime_value".to_string(),
+                    datatype: ColumnDataType::Float64 as i32,
+                    semantic_type: SemanticType::Field as i32,
+                    ..Default::default()
+                },
+            ],
+            rows: vec![
+                Row {
+                    values: vec![
+                        Value {
+                            value_data: Some(ValueData::TimestampMillisecondValue(1000)),
+                        },
+                        Value {
+                            value_data: Some(ValueData::StringValue("host-1".to_string())),
+                        },
+                        Value {
+                            value_data: Some(ValueData::F64Value(1.0)),
+                        },
+                    ],
+                },
+                Row {
+                    values: vec![
+                        Value {
+                            value_data: Some(ValueData::TimestampMillisecondValue(2000)),
+                        },
+                        Value {
+                            value_data: Some(ValueData::StringValue("host-2".to_string())),
+                        },
+                        Value {
+                            value_data: Some(ValueData::F64Value(2.0)),
+                        },
+                    ],
+                },
+            ],
+        };
+        let target_schema = ArrowSchema::new(vec![
+            Field::new("host", ArrowDataType::Utf8, true),
+            Field::new(
+                "timestamp",
+                ArrowDataType::Timestamp(arrow::datatypes::TimeUnit::Millisecond, None),
+                false,
+            ),
+            Field::new("greptime_value", ArrowDataType::Float64, true),
+        ]);
+        let batch = rows_to_aligned_record_batch(&rows, &target_schema).unwrap();
+        assert_eq!(1, batch.timestamp_index);
+        let table_batch = TableBatch {
+            table_name: "cpu".to_string(),
+            table_id: 42,
+            row_count: batch.batch.num_rows(),
+            batches: vec![batch],
+        };
+
+        assert_eq!(vec![1000, 2000], extract_timestamps(&table_batch));
     }
 
     fn mock_physical_table_metadata(table_id: TableId) -> PhysicalTableMetadata {
@@ -2060,7 +2253,7 @@ mod tests {
                 TableBatch {
                     table_name: "cpu".to_string(),
                     table_id: 42,
-                    batches: vec![mock_tag_batch("tag1", "host-1", 1000, 1.0)],
+                    batches: vec![mock_aligned_tag_batch("tag1", "host-1", 1000, 1.0)],
                     row_count: 1,
                 },
             )]),
@@ -2091,12 +2284,12 @@ mod tests {
         pending_batch.add_table_batch(
             "cpu".to_string(),
             42,
-            mock_tag_batch("tag1", "host-1", 1000, 1.0),
+            mock_aligned_tag_batch("tag1", "host-1", 1000, 1.0),
         );
         pending_batch.add_table_batch(
             "cpu".to_string(),
             43,
-            mock_tag_batch("tag1", "host-1", 2000, 2.0),
+            mock_aligned_tag_batch("tag1", "host-1", 2000, 2.0),
         );
 
         assert_eq!(2, pending_batch.tables.len());
@@ -2260,7 +2453,7 @@ mod tests {
         let table_batches = vec![TableBatch {
             table_name: "cpu".to_string(),
             table_id,
-            batches: vec![mock_tag_batch("tag1", "host-1", 1000, 1.0)],
+            batches: vec![mock_aligned_tag_batch("tag1", "host-1", 1000, 1.0)],
             row_count: 1,
         }];
 
@@ -2301,8 +2494,8 @@ mod tests {
             table_name: "cpu".to_string(),
             table_id,
             batches: vec![
-                mock_tag_batch("tag1", "host-1", 1000, 1.0),
-                mock_tag_batch("tag1", "host-1", 2000, 2.0),
+                mock_aligned_tag_batch("tag1", "host-1", 1000, 1.0),
+                mock_aligned_tag_batch("tag1", "host-1", 2000, 2.0),
             ],
             row_count: 2,
         }];
@@ -2344,7 +2537,7 @@ mod tests {
         let table_batches = vec![TableBatch {
             table_name: "cpu".to_string(),
             table_id,
-            batches: vec![mock_tag_batch("tag1", "host-1", 1000, 1.0)],
+            batches: vec![mock_aligned_tag_batch("tag1", "host-1", 1000, 1.0)],
             row_count: 1,
         }];
         let writes = Arc::new(AtomicUsize::new(0));
@@ -2404,7 +2597,7 @@ mod tests {
         let table_batches = vec![TableBatch {
             table_name: "cpu".to_string(),
             table_id,
-            batches: vec![mock_tag_batch("tag1", "host-1", 1000, 1.0)],
+            batches: vec![mock_aligned_tag_batch("tag1", "host-1", 1000, 1.0)],
             row_count: 1,
         }];
         let writes = Arc::new(AtomicUsize::new(0));
@@ -2831,7 +3024,7 @@ mod tests {
 
     #[test]
     fn test_transform_logical_batches_to_physical_success() {
-        let batch = mock_tag_batch("tag1", "v1", 1000, 1.0);
+        let batch = mock_aligned_tag_batch("tag1", "v1", 1000, 1.0);
 
         let table_batches = vec![TableBatch {
             table_name: "t1".to_string(),
@@ -2855,7 +3048,7 @@ mod tests {
 
     #[test]
     fn test_transform_logical_batches_to_physical_taxonomy_failure() {
-        let batch = mock_tag_batch("tag1", "v1", 1000, 1.0);
+        let batch = mock_aligned_tag_batch("tag1", "v1", 1000, 1.0);
 
         let table_batches = vec![TableBatch {
             table_name: "t1".to_string(),
@@ -2879,8 +3072,8 @@ mod tests {
 
     #[test]
     fn test_transform_logical_batches_to_physical_multiple_batches() {
-        let batch1 = mock_tag_batch("tag1", "v1", 1000, 1.0);
-        let batch2 = mock_tag_batch("tag2", "v2", 2000, 2.0);
+        let batch1 = mock_aligned_tag_batch("tag1", "v1", 1000, 1.0);
+        let batch2 = mock_aligned_tag_batch("tag2", "v2", 2000, 2.0);
 
         let table_batches = vec![
             TableBatch {
@@ -2908,8 +3101,8 @@ mod tests {
 
     #[test]
     fn test_transform_logical_batches_to_physical_mixed_success_failure() {
-        let batch1 = mock_tag_batch("tag1", "v1", 1000, 1.0);
-        let batch2 = mock_tag_batch("tag2", "v2", 2000, 2.0);
+        let batch1 = mock_aligned_tag_batch("tag1", "v1", 1000, 1.0);
+        let batch2 = mock_aligned_tag_batch("tag2", "v2", 2000, 2.0);
 
         let table_batches = vec![
             TableBatch {
@@ -2941,7 +3134,7 @@ mod tests {
         let table_batches = vec![TableBatch {
             table_name: "t1".to_string(),
             table_id: 11,
-            batches: vec![mock_tag_batch("tag1", "host-1", 1000, 1.0)],
+            batches: vec![mock_aligned_tag_batch("tag1", "host-1", 1000, 1.0)],
             row_count: 1,
         }];
         let partition_calls = Arc::new(AtomicUsize::new(0));
@@ -2991,7 +3184,7 @@ mod tests {
         let table_batches = vec![TableBatch {
             table_name: "t1".to_string(),
             table_id: 11,
-            batches: vec![mock_tag_batch("tag1", "host-1", 1000, 1.0)],
+            batches: vec![mock_aligned_tag_batch("tag1", "host-1", 1000, 1.0)],
             row_count: 1,
         }];
         let ctx = session::context::QueryContext::arc();
@@ -3020,7 +3213,7 @@ mod tests {
         let table_batches = vec![TableBatch {
             table_name: "t1".to_string(),
             table_id: 11,
-            batches: vec![mock_tag_batch("tag1", "host-1", 1000, 1.0)],
+            batches: vec![mock_aligned_tag_batch("tag1", "host-1", 1000, 1.0)],
             row_count: 1,
         }];
         let partition_calls = Arc::new(AtomicUsize::new(0));
@@ -3057,13 +3250,13 @@ mod tests {
             TableBatch {
                 table_name: "broken".to_string(),
                 table_id: 11,
-                batches: vec![mock_tag_batch("unknown_tag", "host-1", 1000, 1.0)],
+                batches: vec![mock_aligned_tag_batch("unknown_tag", "host-1", 1000, 1.0)],
                 row_count: 1,
             },
             TableBatch {
                 table_name: "healthy".to_string(),
                 table_id: 12,
-                batches: vec![mock_tag_batch("tag1", "host-2", 2000, 2.0)],
+                batches: vec![mock_aligned_tag_batch("tag1", "host-2", 2000, 2.0)],
                 row_count: 1,
             },
         ];

--- a/src/servers/src/pending_rows_batcher.rs
+++ b/src/servers/src/pending_rows_batcher.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::{HashMap, HashSet};
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -22,6 +23,7 @@ use api::v1::region::{
     BulkInsertRequest, RegionRequest, RegionRequestHeader, bulk_insert_request, region_request,
 };
 use api::v1::{ArrowIpc, ColumnSchema, RowInsertRequests, Rows};
+#[cfg(test)]
 use arrow::array::Array;
 use arrow::compute::{concat_batches, filter_record_batch};
 use arrow::datatypes::{DataType as ArrowDataType, Schema as ArrowSchema, TimeUnit};
@@ -51,9 +53,9 @@ use tokio::sync::{OwnedSemaphorePermit, Semaphore, broadcast, mpsc, oneshot};
 use crate::error;
 use crate::error::{Error, Result};
 use crate::metrics::{
-    FLUSH_DROPPED_ROWS, FLUSH_ELAPSED, FLUSH_FAILURES, FLUSH_ROWS, FLUSH_TOTAL, PENDING_BATCHES,
-    PENDING_ROWS, PENDING_ROWS_BATCH_FLUSH_STAGE_ELAPSED, PENDING_ROWS_BATCH_INGEST_STAGE_ELAPSED,
-    PENDING_WORKERS,
+    FLOW_NOTIFICATION_DROPPED, FLUSH_DROPPED_ROWS, FLUSH_ELAPSED, FLUSH_FAILURES, FLUSH_ROWS,
+    FLUSH_TOTAL, PENDING_BATCHES, PENDING_ROWS, PENDING_ROWS_BATCH_FLUSH_STAGE_ELAPSED,
+    PENDING_ROWS_BATCH_INGEST_STAGE_ELAPSED, PENDING_WORKERS,
 };
 use crate::prom_row_builder::{
     build_prom_create_table_schema_from_proto, identify_missing_columns_from_proto,
@@ -335,7 +337,7 @@ pub struct PendingRowsBatcher {
     partition_manager: PartitionRuleManagerRef,
     node_manager: NodeManagerRef,
     catalog_manager: CatalogManagerRef,
-    table_flownode_set_cache: TableFlownodeSetCacheRef,
+    flow_notification_tx: mpsc::Sender<FlowNotification>,
     flush_semaphore: Arc<Semaphore>,
     inflight_semaphore: Arc<Semaphore>,
     worker_channel_capacity: usize,
@@ -359,6 +361,7 @@ impl PendingRowsBatcher {
         max_concurrent_flushes: usize,
         worker_channel_capacity: usize,
         max_inflight_requests: usize,
+        flow_notification_queue_capacity: NonZeroUsize,
     ) -> Option<Arc<Self>> {
         // Disable the batcher if flush is disabled or configuration is invalid.
         // Zero values for these knobs either cause panics (e.g., zero-capacity channels)
@@ -380,6 +383,13 @@ impl PendingRowsBatcher {
             .unwrap_or(true);
         let workers = Arc::new(DashMap::new());
         PENDING_WORKERS.set(workers.len() as i64);
+        let (flow_notification_tx, flow_notification_rx) =
+            mpsc::channel(flow_notification_queue_capacity.get());
+        start_flow_notification_worker(
+            flow_notification_rx,
+            table_flownode_set_cache,
+            node_manager.clone(),
+        );
 
         Some(Arc::new(Self {
             workers,
@@ -388,7 +398,7 @@ impl PendingRowsBatcher {
             partition_manager,
             node_manager,
             catalog_manager,
-            table_flownode_set_cache,
+            flow_notification_tx,
             prom_store_with_metric_engine,
             schema_alterer,
             flush_semaphore: Arc::new(Semaphore::new(max_concurrent_flushes)),
@@ -860,7 +870,7 @@ impl PendingRowsBatcher {
             self.partition_manager.clone(),
             self.node_manager.clone(),
             self.catalog_manager.clone(),
-            self.table_flownode_set_cache.clone(),
+            self.flow_notification_tx.clone(),
             self.flush_interval,
             worker_idle_timeout,
             self.max_batch_rows,
@@ -917,7 +927,7 @@ fn start_worker(
     partition_manager: PartitionRuleManagerRef,
     node_manager: NodeManagerRef,
     catalog_manager: CatalogManagerRef,
-    table_flownode_set_cache: TableFlownodeSetCacheRef,
+    flow_notification_tx: mpsc::Sender<FlowNotification>,
     flush_interval: Duration,
     worker_idle_timeout: Duration,
     max_batch_rows: usize,
@@ -959,7 +969,7 @@ fn start_worker(
                                         partition_manager.clone(),
                                         node_manager.clone(),
                                         catalog_manager.clone(),
-                                        table_flownode_set_cache.clone(),
+                                        flow_notification_tx.clone(),
                                         flush_semaphore.clone(),
                                     ).await;
                             }
@@ -971,7 +981,7 @@ fn start_worker(
                                     partition_manager.clone(),
                                     node_manager.clone(),
                                     catalog_manager.clone(),
-                                    table_flownode_set_cache.clone(),
+                                    flow_notification_tx.clone(),
                                 ).await;
                             }
                             break;
@@ -1007,7 +1017,7 @@ fn start_worker(
                                 partition_manager.clone(),
                                 node_manager.clone(),
                                 catalog_manager.clone(),
-                                table_flownode_set_cache.clone(),
+                                flow_notification_tx.clone(),
                                 flush_semaphore.clone(),
                             ).await;
                     }
@@ -1019,7 +1029,7 @@ fn start_worker(
                             partition_manager.clone(),
                             node_manager.clone(),
                             catalog_manager.clone(),
-                            table_flownode_set_cache.clone(),
+                            flow_notification_tx.clone(),
                         ).await;
                     }
                     break;
@@ -1080,7 +1090,7 @@ async fn spawn_flush(
     partition_manager: PartitionRuleManagerRef,
     node_manager: NodeManagerRef,
     catalog_manager: CatalogManagerRef,
-    table_flownode_set_cache: TableFlownodeSetCacheRef,
+    flow_notification_tx: mpsc::Sender<FlowNotification>,
     semaphore: Arc<Semaphore>,
 ) {
     match semaphore.acquire_owned().await {
@@ -1092,7 +1102,7 @@ async fn spawn_flush(
                     partition_manager,
                     node_manager,
                     catalog_manager,
-                    table_flownode_set_cache,
+                    flow_notification_tx,
                 )
                 .await;
             });
@@ -1104,7 +1114,7 @@ async fn spawn_flush(
                 partition_manager,
                 node_manager,
                 catalog_manager,
-                table_flownode_set_cache,
+                flow_notification_tx,
             )
             .await;
         }
@@ -1296,7 +1306,7 @@ async fn flush_batch_with_managers(
     partition_manager: PartitionRuleManagerRef,
     node_manager: NodeManagerRef,
     catalog_manager: CatalogManagerRef,
-    table_flownode_set_cache: TableFlownodeSetCacheRef,
+    flow_notification_tx: mpsc::Sender<FlowNotification>,
 ) {
     let partition_provider = PartitionManagerPhysicalFlushAdapter { partition_manager };
     let node_requester = NodeManagerPhysicalFlushAdapter {
@@ -1308,8 +1318,7 @@ async fn flush_batch_with_managers(
         &partition_provider,
         &node_requester,
         &catalog_provider,
-        node_manager,
-        table_flownode_set_cache,
+        flow_notification_tx,
     )
     .await;
 }
@@ -1319,8 +1328,7 @@ async fn flush_batch(
     partition_manager: &(impl PhysicalFlushPartitionProvider + ?Sized),
     node_manager: &(impl PhysicalFlushNodeRequester + ?Sized),
     catalog_manager: &(impl PhysicalFlushCatalogProvider + ?Sized),
-    flow_node_manager: NodeManagerRef,
-    table_flownode_set_cache: TableFlownodeSetCacheRef,
+    flow_notification_tx: mpsc::Sender<FlowNotification>,
 ) {
     let FlushBatch {
         table_batches,
@@ -1363,12 +1371,8 @@ async fn flush_batch(
                 .with_label_values(&[db_string.as_str()])
                 .inc_by(affected_rows as u64);
 
-            notify_flow_dirty_windows_after_flush(
-                table_batches,
-                table_flownode_set_cache,
-                flow_node_manager,
-            );
             notify_waiters(waiters, Ok(()));
+            enqueue_flow_notifications(table_batches, &flow_notification_tx);
         }
         Err(err) => {
             FLUSH_FAILURES.inc();
@@ -1406,11 +1410,15 @@ struct FlowNotification {
     table_id: TableId,
     timestamps: Vec<i64>,
     time_ranges: Vec<TimeRange>,
+    min_timestamp: i64,
+    max_timestamp: i64,
 }
 
 fn compact_flow_notification(table_batch: TableBatch) -> Option<FlowNotification> {
     let mut timestamps = Vec::new();
     let mut time_ranges = Vec::new();
+    let mut min_timestamp: Option<i64> = None;
+    let mut max_timestamp: Option<i64> = None;
 
     for batch in table_batch.batches {
         let timestamp_column = batch.batch.column(batch.timestamp_index);
@@ -1436,6 +1444,8 @@ fn compact_flow_notification(table_batch: TableBatch) -> Option<FlowNotification
         let (Some(batch_min), Some(batch_max)) = (batch_min, batch_max) else {
             continue;
         };
+        min_timestamp = Some(min_timestamp.map_or(batch_min, |min| min.min(batch_min)));
+        max_timestamp = Some(max_timestamp.map_or(batch_max, |max| max.max(batch_max)));
         let timestamp_span = i128::from(batch_max) - i128::from(batch_min);
         let is_dense = timestamp_span * DENSE_TIMESTAMP_RANGE_FACTOR_DENOMINATOR
             < timestamp_count as i128 * DENSE_TIMESTAMP_RANGE_FACTOR_NUMERATOR;
@@ -1457,16 +1467,68 @@ fn compact_flow_notification(table_batch: TableBatch) -> Option<FlowNotification
         table_id: table_batch.table_id,
         timestamps,
         time_ranges,
+        min_timestamp: min_timestamp?,
+        max_timestamp: max_timestamp?,
     })
 }
 
-async fn notify_flow_dirty_windows_for_table(
-    table_id: TableId,
-    timestamps: Vec<i64>,
-    time_ranges: Vec<TimeRange>,
-    peers: HashSet<Peer>,
+fn try_enqueue_flow_notification(
+    tx: &mpsc::Sender<FlowNotification>,
+    notification: FlowNotification,
+) -> bool {
+    match tx.try_send(notification) {
+        Ok(()) => true,
+        Err(mpsc::error::TrySendError::Full(notification)) => {
+            FLOW_NOTIFICATION_DROPPED.with_label_values(&["full"]).inc();
+            warn!(
+                "Dropping flow notification because queue is full, table_id: {}, queue_capacity: {}, min_timestamp: {}, max_timestamp: {}",
+                notification.table_id,
+                tx.max_capacity(),
+                notification.min_timestamp,
+                notification.max_timestamp
+            );
+            false
+        }
+        Err(mpsc::error::TrySendError::Closed(notification)) => {
+            FLOW_NOTIFICATION_DROPPED
+                .with_label_values(&["closed"])
+                .inc();
+            error!(
+                "Dropping flow notification because queue is closed, table_id: {}, queue_capacity: {}, min_timestamp: {}, max_timestamp: {}",
+                notification.table_id,
+                tx.max_capacity(),
+                notification.min_timestamp,
+                notification.max_timestamp
+            );
+            false
+        }
+    }
+}
+
+fn enqueue_flow_notifications(table_batches: Vec<TableBatch>, tx: &mpsc::Sender<FlowNotification>) {
+    for table_batch in table_batches {
+        if let Some(notification) = compact_flow_notification(table_batch) {
+            try_enqueue_flow_notification(tx, notification);
+        }
+    }
+}
+
+async fn handle_flow_notification(
+    notification: FlowNotification,
+    table_flownode_set_cache: TableFlownodeSetCacheRef,
     node_manager: NodeManagerRef,
 ) {
+    let table_id = notification.table_id;
+    let flownodes = match table_flownode_set_cache.get(table_id).await {
+        Ok(Some(flownodes)) => flownodes,
+        Ok(None) => return,
+        Err(e) => {
+            error!(e; "Failed to get flownodes for table id: {}", table_id);
+            return;
+        }
+    };
+    let peers = flownodes.values().cloned().collect::<HashSet<_>>();
+
     for peer in peers {
         if let Err(e) = node_manager
             .flownode(&peer)
@@ -1474,8 +1536,8 @@ async fn notify_flow_dirty_windows_for_table(
             .handle_mark_window_dirty(DirtyWindowRequests {
                 requests: vec![DirtyWindowRequest {
                     table_id,
-                    timestamps: timestamps.clone(),
-                    time_ranges: time_ranges.clone(),
+                    timestamps: notification.timestamps.clone(),
+                    time_ranges: notification.time_ranges.clone(),
                 }],
             })
             .await
@@ -1491,61 +1553,31 @@ async fn notify_flow_dirty_windows_for_table(
     }
 }
 
+fn start_flow_notification_worker(
+    notification_rx: mpsc::Receiver<FlowNotification>,
+    table_flownode_set_cache: TableFlownodeSetCacheRef,
+    node_manager: NodeManagerRef,
+) {
+    common_runtime::spawn_global(async move {
+        tokio_stream::wrappers::ReceiverStream::new(notification_rx)
+            .for_each_concurrent(MAX_CONCURRENT_FLOW_NOTIFICATIONS, |notification| {
+                let table_flownode_set_cache = table_flownode_set_cache.clone();
+                let node_manager = node_manager.clone();
+                handle_flow_notification(notification, table_flownode_set_cache, node_manager)
+            })
+            .await;
+    });
+}
+
+#[cfg(test)]
 fn notify_flow_dirty_windows_after_flush(
     table_batches: Vec<TableBatch>,
     table_flownode_set_cache: TableFlownodeSetCacheRef,
     node_manager: NodeManagerRef,
 ) {
-    common_runtime::spawn_global(async move {
-        let (notification_tx, notification_rx) = mpsc::channel(table_batches.len().max(1));
-        let resolve_flownodes = async move {
-            futures::stream::iter(table_batches)
-                .for_each_concurrent(MAX_CONCURRENT_FLOW_NOTIFICATIONS, |table_batch| {
-                    let table_flownode_set_cache = table_flownode_set_cache.clone();
-                    let notification_tx = notification_tx.clone();
-                    async move {
-                        let Some(notification) = compact_flow_notification(table_batch) else {
-                            return;
-                        };
-
-                        let table_id = notification.table_id;
-                        let flownodes = match table_flownode_set_cache.get(table_id).await {
-                            Ok(Some(flownodes)) => flownodes,
-                            Ok(None) => return,
-                            Err(e) => {
-                                error!(e; "Failed to get flownodes for table id: {}", table_id);
-                                return;
-                            }
-                        };
-                        let peers = flownodes.values().cloned().collect::<HashSet<_>>();
-                        let _ = notification_tx
-                            .send((
-                                table_id,
-                                notification.timestamps,
-                                notification.time_ranges,
-                                peers,
-                            ))
-                            .await;
-                    }
-                })
-                .await;
-        };
-        let notify_flownodes = tokio_stream::wrappers::ReceiverStream::new(notification_rx)
-            .for_each_concurrent(
-                MAX_CONCURRENT_FLOW_NOTIFICATIONS,
-                |(table_id, timestamps, time_ranges, peers)| {
-                    notify_flow_dirty_windows_for_table(
-                        table_id,
-                        timestamps,
-                        time_ranges,
-                        peers,
-                        node_manager.clone(),
-                    )
-                },
-            );
-
-        futures::future::join(resolve_flownodes, notify_flownodes).await;
-    });
+    let (tx, rx) = mpsc::channel(table_batches.len().max(1));
+    start_flow_notification_worker(rx, table_flownode_set_cache, node_manager);
+    enqueue_flow_notifications(table_batches, &tx);
 }
 
 /// Flushes a batch of logical table rows by transforming them into the physical table format
@@ -1938,10 +1970,12 @@ mod tests {
         extract_timestamps, flush_batch, flush_batch_physical, flush_region_writes_concurrently,
         greptime_timestamp, notify_flow_dirty_windows_after_flush, plan_region_batches,
         remove_worker_if_same_channel, should_close_worker_on_idle_timeout,
-        should_dispatch_concurrently, strip_partition_columns_from_batch,
-        transform_logical_batches_to_physical,
+        should_dispatch_concurrently, start_flow_notification_worker,
+        strip_partition_columns_from_batch, transform_logical_batches_to_physical,
+        try_enqueue_flow_notification,
     };
     use crate::error;
+    use crate::metrics::FLOW_NOTIFICATION_DROPPED;
     use crate::prom_row_builder::rows_to_aligned_record_batch;
 
     fn mock_rows(row_count: usize, schema_name: &str) -> Rows {
@@ -2194,6 +2228,28 @@ mod tests {
             assert_eq!(expected_timestamps, notification.timestamps);
             assert_eq!(expected_ranges, notification.time_ranges);
         }
+    }
+
+    #[test]
+    fn test_flow_notification_queue_drops_when_full() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let notification = |table_id| {
+            compact_flow_notification(TableBatch {
+                table_name: format!("table-{table_id}"),
+                table_id,
+                row_count: 1,
+                batches: vec![mock_timestamp_batch(vec![Some(table_id as i64)])],
+            })
+            .unwrap()
+        };
+        let dropped = FLOW_NOTIFICATION_DROPPED.with_label_values(&["full"]);
+        let dropped_before = dropped.get();
+
+        assert!(try_enqueue_flow_notification(&tx, notification(1)));
+        assert!(!try_enqueue_flow_notification(&tx, notification(2)));
+
+        assert_eq!(1, rx.try_recv().unwrap().table_id);
+        assert_eq!(dropped_before + 1, dropped.get());
     }
 
     fn mock_physical_table_metadata(table_id: TableId) -> PhysicalTableMetadata {
@@ -2586,6 +2642,15 @@ mod tests {
         cache
     }
 
+    fn mock_flow_notification_sender(
+        cache: TableFlownodeSetCacheRef,
+        node_manager: NodeManagerRef,
+    ) -> mpsc::Sender<super::FlowNotification> {
+        let (tx, rx) = mpsc::channel(16);
+        start_flow_notification_worker(rx, cache, node_manager);
+        tx
+    }
+
     struct BlockingRangeKvBackend {
         range_started: Mutex<Option<oneshot::Sender<()>>>,
         range_release: Arc<Notify>,
@@ -2808,6 +2873,7 @@ mod tests {
         let flow_node_manager: NodeManagerRef = Arc::new(FlowNotificationMockNodeManager {
             flownode: Arc::new(RecordingFlownode { requests_tx }),
         });
+        let flow_notification_tx = mock_flow_notification_sender(cache, flow_node_manager.clone());
         let ctx = session::context::QueryContext::arc();
         let table_batches = vec![TableBatch {
             table_name: "cpu".to_string(),
@@ -2836,8 +2902,7 @@ mod tests {
             &MockFlushCatalogProvider {
                 table: Some(mock_physical_table_metadata(1024)),
             },
-            flow_node_manager,
-            cache,
+            flow_notification_tx,
         )
         .await;
 
@@ -2872,6 +2937,7 @@ mod tests {
         let flow_node_manager: NodeManagerRef = Arc::new(FlowNotificationMockNodeManager {
             flownode: Arc::new(RecordingFlownode { requests_tx }),
         });
+        let flow_notification_tx = mock_flow_notification_sender(cache, flow_node_manager.clone());
         let ctx = session::context::QueryContext::arc();
         let table_batches = vec![TableBatch {
             table_name: "cpu".to_string(),
@@ -2900,8 +2966,7 @@ mod tests {
             &MockFlushCatalogProvider {
                 table: Some(mock_physical_table_metadata(1024)),
             },
-            flow_node_manager,
-            cache,
+            flow_notification_tx,
         )
         .await;
 

--- a/src/servers/src/pending_rows_batcher.rs
+++ b/src/servers/src/pending_rows_batcher.rs
@@ -16,7 +16,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use api::v1::flow::{DirtyWindowRequest, DirtyWindowRequests};
+use api::v1::flow::{DirtyWindowRequest, DirtyWindowRequests, TimeRange};
 use api::v1::meta::Peer;
 use api::v1::region::{
     BulkInsertRequest, RegionRequest, RegionRequestHeader, bulk_insert_request, region_request,
@@ -66,6 +66,8 @@ const PENDING_ROWS_BATCH_SYNC_ENV: &str = "PENDING_ROWS_BATCH_SYNC";
 const WORKER_IDLE_TIMEOUT_MULTIPLIER: u32 = 3;
 const PHYSICAL_REGION_ESSENTIAL_COLUMN_COUNT: usize = 3;
 const MAX_CONCURRENT_FLOW_NOTIFICATIONS: usize = 8;
+const DENSE_TIMESTAMP_RANGE_FACTOR_NUMERATOR: i128 = 11;
+const DENSE_TIMESTAMP_RANGE_FACTOR_DENOMINATOR: i128 = 10;
 
 #[async_trait]
 pub trait PendingRowsSchemaAlterer: Send + Sync {
@@ -1376,6 +1378,7 @@ async fn flush_batch(
     }
 }
 
+#[cfg(test)]
 fn extract_timestamps(table_batch: &TableBatch) -> Vec<i64> {
     let mut timestamps = Vec::with_capacity(table_batch.row_count);
     for batch in &table_batch.batches {
@@ -1399,9 +1402,68 @@ fn extract_timestamps(table_batch: &TableBatch) -> Vec<i64> {
     timestamps
 }
 
+struct FlowNotification {
+    table_id: TableId,
+    timestamps: Vec<i64>,
+    time_ranges: Vec<TimeRange>,
+}
+
+fn compact_flow_notification(table_batch: TableBatch) -> Option<FlowNotification> {
+    let mut timestamps = Vec::new();
+    let mut time_ranges = Vec::new();
+
+    for batch in table_batch.batches {
+        let timestamp_column = batch.batch.column(batch.timestamp_index);
+        let Some((timestamp_values, _)) =
+            datatypes::timestamp::timestamp_array_to_primitive(timestamp_column)
+        else {
+            error!(
+                "Failed to extract timestamps from record batch, table_id: {}, timestamp_index: {}",
+                table_batch.table_id, batch.timestamp_index
+            );
+            continue;
+        };
+
+        let mut batch_min: Option<i64> = None;
+        let mut batch_max: Option<i64> = None;
+        let mut timestamp_count = 0usize;
+        for timestamp in timestamp_values.iter().flatten() {
+            batch_min = Some(batch_min.map_or(timestamp, |min| min.min(timestamp)));
+            batch_max = Some(batch_max.map_or(timestamp, |max| max.max(timestamp)));
+            timestamp_count += 1;
+        }
+
+        let (Some(batch_min), Some(batch_max)) = (batch_min, batch_max) else {
+            continue;
+        };
+        let timestamp_span = i128::from(batch_max) - i128::from(batch_min);
+        let is_dense = timestamp_span * DENSE_TIMESTAMP_RANGE_FACTOR_DENOMINATOR
+            < timestamp_count as i128 * DENSE_TIMESTAMP_RANGE_FACTOR_NUMERATOR;
+        if is_dense && let Some(end_exclusive) = batch_max.checked_add(1) {
+            time_ranges.push(TimeRange {
+                start_inclusive: batch_min,
+                end_exclusive,
+            });
+        } else {
+            timestamps.extend(timestamp_values.iter().flatten());
+        }
+    }
+
+    if timestamps.is_empty() && time_ranges.is_empty() {
+        return None;
+    }
+
+    Some(FlowNotification {
+        table_id: table_batch.table_id,
+        timestamps,
+        time_ranges,
+    })
+}
+
 async fn notify_flow_dirty_windows_for_table(
     table_id: TableId,
     timestamps: Vec<i64>,
+    time_ranges: Vec<TimeRange>,
     peers: HashSet<Peer>,
     node_manager: NodeManagerRef,
 ) {
@@ -1413,6 +1475,7 @@ async fn notify_flow_dirty_windows_for_table(
                 requests: vec![DirtyWindowRequest {
                     table_id,
                     timestamps: timestamps.clone(),
+                    time_ranges: time_ranges.clone(),
                 }],
             })
             .await
@@ -1441,12 +1504,11 @@ fn notify_flow_dirty_windows_after_flush(
                     let table_flownode_set_cache = table_flownode_set_cache.clone();
                     let notification_tx = notification_tx.clone();
                     async move {
-                        let timestamps = extract_timestamps(&table_batch);
-                        if timestamps.is_empty() {
+                        let Some(notification) = compact_flow_notification(table_batch) else {
                             return;
-                        }
+                        };
 
-                        let table_id = table_batch.table_id;
+                        let table_id = notification.table_id;
                         let flownodes = match table_flownode_set_cache.get(table_id).await {
                             Ok(Some(flownodes)) => flownodes,
                             Ok(None) => return,
@@ -1456,7 +1518,14 @@ fn notify_flow_dirty_windows_after_flush(
                             }
                         };
                         let peers = flownodes.values().cloned().collect::<HashSet<_>>();
-                        let _ = notification_tx.send((table_id, timestamps, peers)).await;
+                        let _ = notification_tx
+                            .send((
+                                table_id,
+                                notification.timestamps,
+                                notification.time_ranges,
+                                peers,
+                            ))
+                            .await;
                     }
                 })
                 .await;
@@ -1464,10 +1533,11 @@ fn notify_flow_dirty_windows_after_flush(
         let notify_flownodes = tokio_stream::wrappers::ReceiverStream::new(notification_rx)
             .for_each_concurrent(
                 MAX_CONCURRENT_FLOW_NOTIFICATIONS,
-                |(table_id, timestamps, peers)| {
+                |(table_id, timestamps, time_ranges, peers)| {
                     notify_flow_dirty_windows_for_table(
                         table_id,
                         timestamps,
+                        time_ranges,
                         peers,
                         node_manager.clone(),
                     )
@@ -1817,7 +1887,7 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use api::region::RegionResponse;
-    use api::v1::flow::{DirtyWindowRequests, FlowRequest, FlowResponse};
+    use api::v1::flow::{DirtyWindowRequests, FlowRequest, FlowResponse, TimeRange};
     use api::v1::meta::Peer;
     use api::v1::region::{InsertRequests, RegionRequest, region_request};
     use api::v1::value::ValueData;
@@ -1864,11 +1934,12 @@ mod tests {
         PendingRowsBatcher, PendingWorker, PhysicalFlushCatalogProvider,
         PhysicalFlushNodeRequester, PhysicalFlushPartitionProvider, PhysicalTableMetadata,
         PlannedRegionBatch, RecordBatchWithTsIdx, ResolvedRegionBatch, TableBatch, WorkerCommand,
-        columns_taxonomy, drain_batch, encode_region_write_requests, extract_timestamps,
-        flush_batch, flush_batch_physical, flush_region_writes_concurrently, greptime_timestamp,
-        notify_flow_dirty_windows_after_flush, plan_region_batches, remove_worker_if_same_channel,
-        should_close_worker_on_idle_timeout, should_dispatch_concurrently,
-        strip_partition_columns_from_batch, transform_logical_batches_to_physical,
+        columns_taxonomy, compact_flow_notification, drain_batch, encode_region_write_requests,
+        extract_timestamps, flush_batch, flush_batch_physical, flush_region_writes_concurrently,
+        greptime_timestamp, notify_flow_dirty_windows_after_flush, plan_region_batches,
+        remove_worker_if_same_channel, should_close_worker_on_idle_timeout,
+        should_dispatch_concurrently, strip_partition_columns_from_batch,
+        transform_logical_batches_to_physical,
     };
     use crate::error;
     use crate::prom_row_builder::rows_to_aligned_record_batch;
@@ -2090,6 +2161,39 @@ mod tests {
         };
 
         assert_eq!(vec![1000, 2000], extract_timestamps(&table_batch));
+    }
+
+    #[test]
+    fn test_compact_flow_notification() {
+        let testcases = [
+            (
+                vec![Some(1), Some(2), Some(3)],
+                Vec::new(),
+                vec![TimeRange {
+                    start_inclusive: 1,
+                    end_exclusive: 4,
+                }],
+            ),
+            (vec![Some(1), Some(1000)], vec![1, 1000], Vec::new()),
+            (
+                vec![Some(i64::MAX - 1), Some(i64::MAX)],
+                vec![i64::MAX - 1, i64::MAX],
+                Vec::new(),
+            ),
+        ];
+
+        for (timestamps, expected_timestamps, expected_ranges) in testcases {
+            let table_batch = TableBatch {
+                table_name: "cpu".to_string(),
+                table_id: 42,
+                row_count: timestamps.len(),
+                batches: vec![mock_timestamp_batch(timestamps)],
+            };
+
+            let notification = compact_flow_notification(table_batch).unwrap();
+            assert_eq!(expected_timestamps, notification.timestamps);
+            assert_eq!(expected_ranges, notification.time_ranges);
+        }
     }
 
     fn mock_physical_table_metadata(table_id: TableId) -> PhysicalTableMetadata {
@@ -2623,7 +2727,11 @@ mod tests {
         assert_eq!(
             vec![api::v1::flow::DirtyWindowRequest {
                 table_id,
-                timestamps: vec![1000],
+                timestamps: Vec::new(),
+                time_ranges: vec![TimeRange {
+                    start_inclusive: 1000,
+                    end_exclusive: 1001,
+                }],
             }],
             requests.requests
         );
@@ -2666,7 +2774,17 @@ mod tests {
         assert_eq!(
             vec![api::v1::flow::DirtyWindowRequest {
                 table_id,
-                timestamps: vec![1000, 2000],
+                timestamps: Vec::new(),
+                time_ranges: vec![
+                    TimeRange {
+                        start_inclusive: 1000,
+                        end_exclusive: 1001,
+                    },
+                    TimeRange {
+                        start_inclusive: 2000,
+                        end_exclusive: 2001,
+                    },
+                ],
             }],
             requests.requests
         );
@@ -2731,7 +2849,11 @@ mod tests {
         assert_eq!(
             vec![api::v1::flow::DirtyWindowRequest {
                 table_id,
-                timestamps: vec![1000],
+                timestamps: Vec::new(),
+                time_ranges: vec![TimeRange {
+                    start_inclusive: 1000,
+                    end_exclusive: 1001,
+                }],
             }],
             requests.requests
         );

--- a/src/servers/src/pending_rows_batcher.rs
+++ b/src/servers/src/pending_rows_batcher.rs
@@ -1383,7 +1383,10 @@ fn extract_timestamps(table_batch: &TableBatch) -> Vec<i64> {
         let Some((timestamp_values, _)) =
             datatypes::timestamp::timestamp_array_to_primitive(timestamp_column)
         else {
-            error!("Failed to extract timestamps from record batch");
+            error!(
+                "Failed to extract timestamps from record batch, table_id: {}, timestamp_index: {}",
+                table_batch.table_id, batch.timestamp_index
+            );
             continue;
         };
 

--- a/src/servers/src/prom_row_builder.rs
+++ b/src/servers/src/prom_row_builder.rs
@@ -37,6 +37,7 @@ use snafu::{OptionExt, ResultExt, ensure};
 
 use crate::error;
 use crate::error::Result;
+use crate::pending_rows_batcher::RecordBatchWithTsIdx;
 
 /// Extract timestamp, field, and tag column names from a logical region schema.
 fn unzip_logical_region_schema(
@@ -85,7 +86,7 @@ fn unzip_logical_region_schema(
 pub(crate) fn rows_to_aligned_record_batch(
     rows: &Rows,
     target_schema: &ArrowSchema,
-) -> Result<RecordBatch> {
+) -> Result<RecordBatchWithTsIdx> {
     let row_count = rows.rows.len();
     let column_count = rows.schema.len();
 
@@ -105,6 +106,15 @@ pub(crate) fn rows_to_aligned_record_batch(
 
     let (target_ts_name, target_field_name, _target_tags) =
         unzip_logical_region_schema(target_schema)?;
+    let timestamp_index = target_schema
+        .column_with_name(&target_ts_name)
+        .map(|(index, _)| index)
+        .with_context(|| error::UnexpectedResultSnafu {
+            reason: format!(
+                "Failed to resolve timestamp column '{}' in target schema",
+                target_ts_name
+            ),
+        })?;
 
     // Map effective target column name → (source column index, source arrow type).
     // Handles prom renames: Timestamp → target ts name, Float64 → target field name.
@@ -165,7 +175,7 @@ pub(crate) fn rows_to_aligned_record_batch(
 
     let batch = RecordBatch::try_new(Arc::new(target_schema.clone()), columns)
         .context(error::ArrowSnafu)?;
-    Ok(batch)
+    RecordBatchWithTsIdx::try_new(batch, timestamp_index)
 }
 
 /// Identify tag columns in the proto `rows_schema` that are absent from the
@@ -367,7 +377,9 @@ mod tests {
             Field::new("my_value", DataType::Float64, true),
         ]);
 
-        let batch = rows_to_aligned_record_batch(&rows, &target).unwrap();
+        let aligned_batch = rows_to_aligned_record_batch(&rows, &target).unwrap();
+        let (batch, timestamp_index) = aligned_batch.into_parts();
+        assert_eq!(0, timestamp_index);
         assert_eq!(batch.schema().as_ref(), &target);
         assert_eq!(2, batch.num_rows());
         assert_eq!(3, batch.num_columns());
@@ -456,7 +468,9 @@ mod tests {
             Field::new("my_value", DataType::Float64, true),
         ]);
 
-        let batch = rows_to_aligned_record_batch(&rows, &target).unwrap();
+        let aligned_batch = rows_to_aligned_record_batch(&rows, &target).unwrap();
+        let (batch, timestamp_index) = aligned_batch.into_parts();
+        assert_eq!(0, timestamp_index);
         assert_eq!(batch.schema().as_ref(), &target);
         assert_eq!(1, batch.num_rows());
         assert_eq!(4, batch.num_columns());

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -661,6 +661,7 @@ async fn setup_test_prom_app_with_frontend_inner(
             4,
             64,
             64,
+            std::num::NonZeroUsize::new(1024).unwrap(),
         )
     } else {
         None

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -653,6 +653,7 @@ async fn setup_test_prom_app_with_frontend_inner(
             frontend_ref.partition_manager().clone(),
             frontend_ref.node_manager().clone(),
             frontend_ref.catalog_manager().clone(),
+            frontend_ref.table_flownode_set_cache().clone(),
             true,
             frontend_ref.clone(),
             Duration::from_millis(50),

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -2147,6 +2147,7 @@ max_batch_rows = 100000
 max_concurrent_flushes = 256
 worker_channel_capacity = 65526
 max_inflight_requests = 3000
+flow_notification_queue_capacity = 1024
 
 [wal]
 provider = "raft_engine"


### PR DESCRIPTION
## Summary

- Add post-flush dirty-window notifications for metric writes through `PendingRowsBatcher`, so batching-mode flows are updated when Prometheus remote write uses the pending-row batcher path.
- Notifications fire only after the entire physical flush succeeds; failed flushes (including partial region failures) send no notification. Notification errors are best-effort and never affect the persisted write result.
- Optimize timestamp extraction with a null-free fast path (`extend_from_slice(values())`) and a nullable fallback (`iter().flatten()`).
- Refactor notifier to take ownership of `Vec<TableBatch>`, eliminating the per-flush vector clone.
- Key `PendingBatch` by logical `TableId` to prevent same-name drop/recreate merging within one flush interval.

## Known follow-ups (from self-review)

- Per-peer `Vec<i64>` clone in notifier could use `Arc<Vec<i64>>`; intentionally deferred as the cost is negligible for typical peer counts.
- No integration/sqlness test for end-to-end flow notification through the batcher.
- Cache lookup `Err` path and multi-table flush path lack dedicated unit tests.

## Test Plan

- [x] `cargo nextest run -p servers --lib --retries 0` — 293 tests pass
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p servers -p frontend -p operator -p tests-integration`
- [x] `git diff --check`