### PR TITLE
fix: enforce COPY FROM row limit

### DIFF
--- a/src/operator/src/statement/copy_table_from.rs
+++ b/src/operator/src/statement/copy_table_from.rs
@@ -417,7 +417,23 @@ impl StatementExecutor {
 
         let mut rows_inserted = 0;
         let mut insert_cost = 0;
-        let max_insert_rows = req.limit.map(|n| n as usize);
+        let max_insert_rows = req
+            .limit
+            .map(|n| {
+                usize::try_from(n).map_err(|_| {
+                    error::InvalidCopyParameterSnafu {
+                        key: "limit".to_string(),
+                        value: n.to_string(),
+                    }
+                    .build()
+                })
+            })
+            .transpose()?;
+        if max_insert_rows == Some(0) {
+            return Ok(gen_insert_output(rows_inserted, insert_cost));
+        }
+
+        let mut accepted_rows = 0;
         for (compat_schema, file_schema_projection, projected_table_schema, file_metadata) in files
         {
             let mut stream = self
@@ -443,6 +459,17 @@ impl StatementExecutor {
 
             while let Some(r) = stream.next().await {
                 let record_batch = r.context(error::ReadDfRecordBatchSnafu)?;
+                let record_batch = if let Some(max_insert_rows) = max_insert_rows {
+                    let remaining_rows = max_insert_rows - accepted_rows;
+                    if record_batch.num_rows() > remaining_rows {
+                        record_batch.slice(0, remaining_rows)
+                    } else {
+                        record_batch
+                    }
+                } else {
+                    record_batch
+                };
+                let record_batch_rows = record_batch.num_rows();
                 let vectors =
                     Helper::try_into_vectors(record_batch.columns()).context(IntoVectorsSnafu)?;
 
@@ -463,6 +490,7 @@ impl StatementExecutor {
                     },
                     query_ctx.clone(),
                 ));
+                accepted_rows += record_batch_rows;
 
                 if pending_mem_size as u64 >= pending_mem_threshold {
                     let (rows, cost) = batch_insert(&mut pending, &mut pending_mem_size).await?;
@@ -471,8 +499,14 @@ impl StatementExecutor {
                 }
 
                 if let Some(max_insert_rows) = max_insert_rows
-                    && rows_inserted >= max_insert_rows
+                    && accepted_rows == max_insert_rows
                 {
+                    if !pending.is_empty() {
+                        let (rows, cost) =
+                            batch_insert(&mut pending, &mut pending_mem_size).await?;
+                        rows_inserted += rows;
+                        insert_cost += cost;
+                    }
                     return Ok(gen_insert_output(rows_inserted, insert_cost));
                 }
             }

--- a/tests/cases/standalone/common/copy/copy_from_fs_parquet.result
+++ b/tests/cases/standalone/common/copy/copy_from_fs_parquet.result
@@ -243,3 +243,86 @@ drop table demo_with_less_columns;
 
 Affected Rows: 0
 
+-- QX-083: COPY FROM Parquet honors LIMIT for a single file.
+CREATE TABLE qx_083_copy_limit_source(pk_col INTEGER PRIMARY KEY, ts TIMESTAMP TIME INDEX);
+
+Affected Rows: 0
+
+INSERT INTO qx_083_copy_limit_source VALUES
+    (1, 1704067200000),
+    (2, 1704067201000),
+    (3, 1704067202000);
+
+Affected Rows: 3
+
+COPY qx_083_copy_limit_source TO '${SQLNESS_HOME}/qx_083_copy_limit.parquet' WITH (format='parquet');
+
+Affected Rows: 3
+
+-- LIMIT 0 control: affected rows 0; count 0.
+CREATE TABLE qx_083_copy_limit_limit_0(pk_col INTEGER PRIMARY KEY, ts TIMESTAMP TIME INDEX);
+
+Affected Rows: 0
+
+COPY qx_083_copy_limit_limit_0 FROM '${SQLNESS_HOME}/qx_083_copy_limit.parquet' WITH (format='parquet') LIMIT 0;
+
+Affected Rows: 0
+
+SELECT count(*) FROM qx_083_copy_limit_limit_0;
+
++----------+
+| count(*) |
++----------+
+| 0        |
++----------+
+
+-- LIMIT 1 target: affected rows 1; count 1.
+CREATE TABLE qx_083_copy_limit_limit_1(pk_col INTEGER PRIMARY KEY, ts TIMESTAMP TIME INDEX);
+
+Affected Rows: 0
+
+COPY qx_083_copy_limit_limit_1 FROM '${SQLNESS_HOME}/qx_083_copy_limit.parquet' WITH (format='parquet') LIMIT 1;
+
+Affected Rows: 1
+
+SELECT count(*) FROM qx_083_copy_limit_limit_1;
+
++----------+
+| count(*) |
++----------+
+| 1        |
++----------+
+
+-- Cross-file LIMIT 4 target: affected rows 4; count 4.
+CREATE TABLE qx_083_copy_limit_cross_file(host string, cpu double, memory double, ts TIMESTAMP TIME INDEX);
+
+Affected Rows: 0
+
+COPY qx_083_copy_limit_cross_file FROM '${SQLNESS_HOME}/demo/export/parquet_files/' WITH (start_time='2022-06-15 07:02:36') LIMIT 4;
+
+Affected Rows: 4
+
+SELECT count(*) FROM qx_083_copy_limit_cross_file;
+
++----------+
+| count(*) |
++----------+
+| 4        |
++----------+
+
+DROP TABLE qx_083_copy_limit_source;
+
+Affected Rows: 0
+
+DROP TABLE qx_083_copy_limit_limit_0;
+
+Affected Rows: 0
+
+DROP TABLE qx_083_copy_limit_limit_1;
+
+Affected Rows: 0
+
+DROP TABLE qx_083_copy_limit_cross_file;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/copy/copy_from_fs_parquet.sql
+++ b/tests/cases/standalone/common/copy/copy_from_fs_parquet.sql
@@ -99,3 +99,42 @@ drop table with_limit_rows_segment;
 drop table demo_with_external_column;
 
 drop table demo_with_less_columns;
+
+-- QX-083: COPY FROM Parquet honors LIMIT for a single file.
+CREATE TABLE qx_083_copy_limit_source(pk_col INTEGER PRIMARY KEY, ts TIMESTAMP TIME INDEX);
+
+INSERT INTO qx_083_copy_limit_source VALUES
+    (1, 1704067200000),
+    (2, 1704067201000),
+    (3, 1704067202000);
+
+COPY qx_083_copy_limit_source TO '${SQLNESS_HOME}/qx_083_copy_limit.parquet' WITH (format='parquet');
+
+-- LIMIT 0 control: affected rows 0; count 0.
+CREATE TABLE qx_083_copy_limit_limit_0(pk_col INTEGER PRIMARY KEY, ts TIMESTAMP TIME INDEX);
+
+COPY qx_083_copy_limit_limit_0 FROM '${SQLNESS_HOME}/qx_083_copy_limit.parquet' WITH (format='parquet') LIMIT 0;
+
+SELECT count(*) FROM qx_083_copy_limit_limit_0;
+
+-- LIMIT 1 target: affected rows 1; count 1.
+CREATE TABLE qx_083_copy_limit_limit_1(pk_col INTEGER PRIMARY KEY, ts TIMESTAMP TIME INDEX);
+
+COPY qx_083_copy_limit_limit_1 FROM '${SQLNESS_HOME}/qx_083_copy_limit.parquet' WITH (format='parquet') LIMIT 1;
+
+SELECT count(*) FROM qx_083_copy_limit_limit_1;
+
+-- Cross-file LIMIT 4 target: affected rows 4; count 4.
+CREATE TABLE qx_083_copy_limit_cross_file(host string, cpu double, memory double, ts TIMESTAMP TIME INDEX);
+
+COPY qx_083_copy_limit_cross_file FROM '${SQLNESS_HOME}/demo/export/parquet_files/' WITH (start_time='2022-06-15 07:02:36') LIMIT 4;
+
+SELECT count(*) FROM qx_083_copy_limit_cross_file;
+
+DROP TABLE qx_083_copy_limit_source;
+
+DROP TABLE qx_083_copy_limit_limit_0;
+
+DROP TABLE qx_083_copy_limit_limit_1;
+
+DROP TABLE qx_083_copy_limit_cross_file;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

QX-083

## What's changed and what's your intention?

`COPY TABLE FROM ... LIMIT N` could silently import and report more than `N` rows when the remaining capacity ended inside a pending record batch. For example, `LIMIT 1` imported and reported all three rows from a small Parquet batch.

This change:

- enforces the row limit globally across all matched files and reader batches;
- tracks rows accepted into pending insert requests separately from completed affected rows;
- slices the final oversized record batch before vector conversion and insertion;
- flushes accepted pending inserts before returning after reaching the limit;
- returns `0` affected rows for `LIMIT 0` after metadata/schema validation, without polling a data stream;
- keeps affected-row and cost accounting based only on completed insert outputs; and
- replaces the lossy `u64` to `usize` limit cast with checked conversion.

The change does not alter persisted formats, wire formats, public APIs, schemas, or existing non-transactional insertion-error behavior. It is backward compatible.

Validation:

- focused SQLness case passed three consecutive post-regeneration runs, covering existing no-limit and `LIMIT 3` controls, `LIMIT 0`, single-batch `LIMIT 1`, and cross-file `LIMIT 4`;
- `cargo nextest run -p operator`: 76 passed, 1 skipped;
- `make fmt` and `git diff --check` passed.

Non-blocking coverage gaps disclosed during independent review:

- no direct same-file later-batch or 32 MiB threshold-flush execution case;
- no injected insertion-error/partial-completion test;
- no explicit stream-drop/resource-cleanup probe;
- the non-representable `u64` to `usize` branch cannot be exercised on the current 64-bit target.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.