### PR TITLE
fix: enforce table-aware permissions across query and ingest protocols

### DIFF
--- a/src/auth/src/lib.rs
+++ b/src/auth/src/lib.rs
@@ -29,7 +29,10 @@ pub use common::{
     format_pg_scram_sha256_password_verifier, mysql_native_password_hash,
     static_user_provider_from_option, user_provider_from_option, userinfo_by_name,
 };
-pub use permission::{DefaultPermissionChecker, PermissionChecker, PermissionReq, PermissionResp};
+pub use permission::{
+    DefaultPermissionChecker, PermissionChecker, PermissionReq, PermissionResp,
+    PermissionTableTarget, PermissionTableTargets,
+};
 pub use user_info::UserInfo;
 pub use user_provider::static_user_provider::StaticUserProvider;
 pub use user_provider::{PgAuthInfo, UserProvider};

--- a/src/auth/src/permission.rs
+++ b/src/auth/src/permission.rs
@@ -15,6 +15,7 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
+use api::v1::RowInsertRequests;
 use api::v1::greptime_request::Request;
 use api::v1::query_request::Query;
 use common_telemetry::debug;
@@ -23,6 +24,73 @@ use sql::statements::statement::Statement;
 use crate::error::{PermissionDeniedSnafu, Result};
 use crate::user_info::DefaultUserInfo;
 use crate::{PermissionCheckerRef, UserInfo, UserInfoRef};
+
+/// A user-visible table target for permission checks.
+///
+/// Use [`PermissionTableTargets::resolved`] to validate that all components are
+/// non-empty before passing targets to a permission checker.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PermissionTableTarget {
+    pub catalog: String,
+    pub schema: String,
+    pub table: String,
+}
+
+impl PermissionTableTarget {
+    /// Creates a table target candidate.
+    pub fn new(
+        catalog: impl Into<String>,
+        schema: impl Into<String>,
+        table: impl Into<String>,
+    ) -> Self {
+        Self {
+            catalog: catalog.into(),
+            schema: schema.into(),
+            table: table.into(),
+        }
+    }
+}
+
+/// The result of resolving every table target in a permission request.
+///
+/// `Resolved(vec![])` means the request contains no table targets, while
+/// [`PermissionTableTargets::Unresolved`] means its targets could not be
+/// determined safely.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PermissionTableTargets {
+    /// Every target was resolved, including the valid empty-target case.
+    Resolved(Vec<PermissionTableTarget>),
+    /// One or more targets could not be determined safely.
+    Unresolved,
+}
+
+impl PermissionTableTargets {
+    /// Marks targets as resolved only when every component is non-empty.
+    pub fn resolved(targets: Vec<PermissionTableTarget>) -> Self {
+        if targets.iter().any(|target| {
+            target.catalog.is_empty() || target.schema.is_empty() || target.table.is_empty()
+        }) {
+            Self::Unresolved
+        } else {
+            Self::Resolved(targets)
+        }
+    }
+
+    /// Resolves logical table targets from normalized row insert requests.
+    pub fn from_row_insert_requests(
+        catalog: &str,
+        schema: &str,
+        requests: &RowInsertRequests,
+    ) -> Self {
+        Self::resolved(
+            requests
+                .inserts
+                .iter()
+                .map(|request| PermissionTableTarget::new(catalog, schema, &request.table_name))
+                .collect(),
+        )
+    }
+}
 
 #[derive(Debug, Clone)]
 pub enum PermissionReq<'a> {
@@ -92,6 +160,25 @@ pub trait PermissionChecker: Send + Sync {
     ) -> Result<PermissionResp> {
         self.check_permission(user_info, req)
     }
+
+    /// Checks the operation privilege and its resolved user-visible table targets.
+    ///
+    /// ACL-aware implementations must apply any admin bypass first, then reject
+    /// [`PermissionTableTargets::Unresolved`] for non-admin users.
+    fn check_permission_with_table_targets(
+        &self,
+        user_info: UserInfoRef,
+        req: PermissionReq,
+        targets: PermissionTableTargets,
+    ) -> Result<PermissionResp>;
+}
+
+fn check_permission_result(result: Result<PermissionResp>) -> Result<PermissionResp> {
+    match result {
+        Ok(PermissionResp::Reject) => PermissionDeniedSnafu.fail(),
+        Ok(PermissionResp::Allow) => Ok(PermissionResp::Allow),
+        Err(e) => Err(e),
+    }
 }
 
 impl PermissionChecker for Option<&PermissionCheckerRef> {
@@ -110,13 +197,25 @@ impl PermissionChecker for Option<&PermissionCheckerRef> {
         current_schema: Option<&str>,
     ) -> Result<PermissionResp> {
         match self {
-            Some(checker) => {
-                match checker.check_permission_with_context(user_info, req, current_schema) {
-                    Ok(PermissionResp::Reject) => PermissionDeniedSnafu.fail(),
-                    Ok(PermissionResp::Allow) => Ok(PermissionResp::Allow),
-                    Err(e) => Err(e),
-                }
-            }
+            Some(checker) => check_permission_result(checker.check_permission_with_context(
+                user_info,
+                req,
+                current_schema,
+            )),
+            None => Ok(PermissionResp::Allow),
+        }
+    }
+
+    fn check_permission_with_table_targets(
+        &self,
+        user_info: UserInfoRef,
+        req: PermissionReq,
+        targets: PermissionTableTargets,
+    ) -> Result<PermissionResp> {
+        match self {
+            Some(checker) => check_permission_result(
+                checker.check_permission_with_table_targets(user_info, req, targets),
+            ),
             None => Ok(PermissionResp::Allow),
         }
     }
@@ -164,11 +263,131 @@ impl PermissionChecker for DefaultPermissionChecker {
         // default allow all
         Ok(PermissionResp::Allow)
     }
+
+    fn check_permission_with_table_targets(
+        &self,
+        user_info: UserInfoRef,
+        req: PermissionReq,
+        _targets: PermissionTableTargets,
+    ) -> Result<PermissionResp> {
+        self.check_permission(user_info, req)
+    }
 }
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::{Error, InternalStateSnafu};
     use crate::user_info::PermissionMode;
+
+    struct TargetAwarePermissionChecker;
+
+    impl PermissionChecker for TargetAwarePermissionChecker {
+        fn check_permission(
+            &self,
+            _user_info: UserInfoRef,
+            _req: PermissionReq,
+        ) -> Result<PermissionResp> {
+            Ok(PermissionResp::Reject)
+        }
+
+        fn check_permission_with_table_targets(
+            &self,
+            _user_info: UserInfoRef,
+            _req: PermissionReq,
+            targets: PermissionTableTargets,
+        ) -> Result<PermissionResp> {
+            let PermissionTableTargets::Resolved(targets) = targets else {
+                return Ok(PermissionResp::Reject);
+            };
+            if targets.iter().any(|target| target.table == "error") {
+                return InternalStateSnafu {
+                    msg: "testing".to_string(),
+                }
+                .fail();
+            }
+            Ok(
+                if !targets.is_empty() && targets.iter().all(|target| target.table == "allowed") {
+                    PermissionResp::Allow
+                } else {
+                    PermissionResp::Reject
+                },
+            )
+        }
+    }
+
+    fn resolved_targets(table: &str) -> PermissionTableTargets {
+        PermissionTableTargets::resolved(vec![PermissionTableTarget::new(
+            "greptime", "public", table,
+        )])
+    }
+
+    #[test]
+    fn test_resolve_permission_table_targets() {
+        assert_eq!(
+            PermissionTableTargets::Resolved(Vec::new()),
+            PermissionTableTargets::resolved(Vec::new())
+        );
+        assert_eq!(
+            resolved_targets("metrics"),
+            PermissionTableTargets::Resolved(vec![PermissionTableTarget::new(
+                "greptime", "public", "metrics"
+            )])
+        );
+
+        for target in [
+            PermissionTableTarget::new("", "public", "metrics"),
+            PermissionTableTarget::new("greptime", "", "metrics"),
+            PermissionTableTarget::new("greptime", "public", ""),
+        ] {
+            assert_eq!(
+                PermissionTableTargets::Unresolved,
+                PermissionTableTargets::resolved(vec![target])
+            );
+        }
+    }
+
+    #[test]
+    fn test_resolve_row_insert_request_targets() {
+        let requests = RowInsertRequests {
+            inserts: ["cpu", "mem"]
+                .into_iter()
+                .map(|table_name| api::v1::RowInsertRequest {
+                    table_name: table_name.to_string(),
+                    ..Default::default()
+                })
+                .collect(),
+        };
+
+        assert_eq!(
+            PermissionTableTargets::Resolved(vec![
+                PermissionTableTarget::new("greptime", "public", "cpu"),
+                PermissionTableTarget::new("greptime", "public", "mem"),
+            ]),
+            PermissionTableTargets::from_row_insert_requests("greptime", "public", &requests)
+        );
+        assert_eq!(
+            PermissionTableTargets::Unresolved,
+            PermissionTableTargets::from_row_insert_requests("", "public", &requests)
+        );
+        assert_eq!(
+            PermissionTableTargets::Unresolved,
+            PermissionTableTargets::from_row_insert_requests("greptime", "", &requests)
+        );
+
+        let unresolved = RowInsertRequests {
+            inserts: vec![api::v1::RowInsertRequest::default()],
+        };
+        assert_eq!(
+            PermissionTableTargets::Unresolved,
+            PermissionTableTargets::from_row_insert_requests("greptime", "public", &unresolved)
+        );
+
+        let empty = RowInsertRequests::default();
+        assert_eq!(
+            PermissionTableTargets::Resolved(Vec::new()),
+            PermissionTableTargets::from_row_insert_requests("greptime", "public", &empty)
+        );
+    }
 
     #[test]
     fn test_default_permission_checker_allow_all_operations() {
@@ -243,5 +462,77 @@ mod tests {
         };
 
         assert!(req.is_write());
+    }
+
+    #[test]
+    fn test_table_target_permission_forwarding() {
+        let checker: PermissionCheckerRef = Arc::new(TargetAwarePermissionChecker);
+        let checker = Some(&checker);
+
+        let allowed = checker
+            .check_permission_with_table_targets(
+                crate::userinfo_by_name(None),
+                PermissionReq::PromStoreRead,
+                resolved_targets("allowed"),
+            )
+            .unwrap();
+        assert!(matches!(allowed, PermissionResp::Allow));
+
+        let rejected = checker.check_permission_with_table_targets(
+            crate::userinfo_by_name(None),
+            PermissionReq::PromStoreRead,
+            resolved_targets("denied"),
+        );
+        assert!(matches!(rejected, Err(Error::PermissionDenied { .. })));
+
+        let mixed = checker.check_permission_with_table_targets(
+            crate::userinfo_by_name(None),
+            PermissionReq::PromStoreRead,
+            PermissionTableTargets::resolved(vec![
+                PermissionTableTarget::new("greptime", "public", "allowed"),
+                PermissionTableTarget::new("greptime", "public", "denied"),
+            ]),
+        );
+        assert!(matches!(mixed, Err(Error::PermissionDenied { .. })));
+
+        let error = checker.check_permission_with_table_targets(
+            crate::userinfo_by_name(None),
+            PermissionReq::PromStoreRead,
+            resolved_targets("error"),
+        );
+        assert!(matches!(error, Err(Error::InternalState { msg }) if msg == "testing"));
+
+        let no_checker: Option<&PermissionCheckerRef> = None;
+        let allowed = no_checker
+            .check_permission_with_table_targets(
+                crate::userinfo_by_name(None),
+                PermissionReq::PromStoreRead,
+                PermissionTableTargets::Unresolved,
+            )
+            .unwrap();
+        assert!(matches!(allowed, PermissionResp::Allow));
+    }
+
+    #[test]
+    fn test_default_permission_checker_table_target_parity() {
+        let checker = DefaultPermissionChecker;
+
+        for (permission, req) in [
+            (PermissionMode::ReadOnly, PermissionReq::PromQuery),
+            (PermissionMode::ReadOnly, PermissionReq::PromStoreWrite),
+            (PermissionMode::WriteOnly, PermissionReq::PromQuery),
+            (PermissionMode::WriteOnly, PermissionReq::PromStoreWrite),
+        ] {
+            let user = DefaultUserInfo::with_name_and_permission("test_user", permission);
+            let direct = checker.check_permission(user.clone(), req.clone()).unwrap();
+            let targeted = checker
+                .check_permission_with_table_targets(user, req, resolved_targets("metrics"))
+                .unwrap();
+
+            assert_eq!(
+                matches!(direct, PermissionResp::Allow),
+                matches!(targeted, PermissionResp::Allow)
+            );
+        }
     }
 }

--- a/src/auth/src/permission.rs
+++ b/src/auth/src/permission.rs
@@ -53,8 +53,9 @@ impl PermissionTableTarget {
 
 /// The result of resolving every table target in a permission request.
 ///
-/// `Resolved(vec![])` means the request contains no table targets, while
-/// [`PermissionTableTargets::Unresolved`] means its targets could not be
+/// `Resolved(vec![])` means the request contains no table targets. The operation
+/// privilege must still be checked, but there are no table ACLs to evaluate.
+/// [`PermissionTableTargets::Unresolved`] means the targets could not be
 /// determined safely.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PermissionTableTargets {
@@ -171,6 +172,9 @@ pub trait PermissionChecker: Send + Sync {
     }
 
     /// Checks the operation privilege and its resolved user-visible table targets.
+    ///
+    /// [`PermissionTableTargets::Resolved`] with an empty vector still requires
+    /// checking the operation privilege in `req`, but has no table ACLs to check.
     ///
     /// ACL-aware implementations must apply any admin bypass first, then reject
     /// [`PermissionTableTargets::Unresolved`] for non-admin users.
@@ -313,9 +317,12 @@ mod tests {
         fn check_permission_with_table_targets(
             &self,
             _user_info: UserInfoRef,
-            _req: PermissionReq,
+            req: PermissionReq,
             targets: PermissionTableTargets,
         ) -> Result<PermissionResp> {
+            if !matches!(req, PermissionReq::PromStoreRead) {
+                return Ok(PermissionResp::Reject);
+            }
             let PermissionTableTargets::Resolved(targets) = targets else {
                 return Ok(PermissionResp::Reject);
             };
@@ -325,13 +332,11 @@ mod tests {
                 }
                 .fail();
             }
-            Ok(
-                if !targets.is_empty() && targets.iter().all(|target| target.table == "allowed") {
-                    PermissionResp::Allow
-                } else {
-                    PermissionResp::Reject
-                },
-            )
+            Ok(if targets.iter().all(|target| target.table == "allowed") {
+                PermissionResp::Allow
+            } else {
+                PermissionResp::Reject
+            })
         }
     }
 
@@ -498,6 +503,25 @@ mod tests {
             )
             .unwrap();
         assert!(matches!(allowed, PermissionResp::Allow));
+
+        let empty = checker
+            .check_permission_with_table_targets(
+                crate::userinfo_by_name(None),
+                PermissionReq::PromStoreRead,
+                PermissionTableTargets::resolved(Vec::new()),
+            )
+            .unwrap();
+        assert!(matches!(empty, PermissionResp::Allow));
+
+        let rejected_operation = checker.check_permission_with_table_targets(
+            crate::userinfo_by_name(None),
+            PermissionReq::PromStoreWrite,
+            PermissionTableTargets::resolved(Vec::new()),
+        );
+        assert!(matches!(
+            rejected_operation,
+            Err(Error::PermissionDenied { .. })
+        ));
 
         let rejected = checker.check_permission_with_table_targets(
             crate::userinfo_by_name(None),

--- a/src/auth/src/permission.rs
+++ b/src/auth/src/permission.rs
@@ -29,7 +29,7 @@ use crate::{PermissionCheckerRef, UserInfo, UserInfoRef};
 ///
 /// Use [`PermissionTableTargets::resolved`] to validate that all components are
 /// non-empty before passing targets to a permission checker.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PermissionTableTarget {
     pub catalog: String,
     pub schema: String,
@@ -161,6 +161,15 @@ pub trait PermissionChecker: Send + Sync {
         self.check_permission(user_info, req)
     }
 
+    /// Returns whether authorization depends on resolved table targets.
+    ///
+    /// The conservative default keeps target resolution enabled. Implementations
+    /// may return `false` only when their authorization result is independent of
+    /// the `targets` passed to [`Self::check_permission_with_table_targets`].
+    fn uses_table_targets(&self) -> bool {
+        true
+    }
+
     /// Checks the operation privilege and its resolved user-visible table targets.
     ///
     /// ACL-aware implementations must apply any admin bypass first, then reject
@@ -203,6 +212,13 @@ impl PermissionChecker for Option<&PermissionCheckerRef> {
                 current_schema,
             )),
             None => Ok(PermissionResp::Allow),
+        }
+    }
+
+    fn uses_table_targets(&self) -> bool {
+        match self {
+            Some(checker) => checker.uses_table_targets(),
+            None => false,
         }
     }
 
@@ -262,6 +278,10 @@ impl PermissionChecker for DefaultPermissionChecker {
 
         // default allow all
         Ok(PermissionResp::Allow)
+    }
+
+    fn uses_table_targets(&self) -> bool {
+        false
     }
 
     fn check_permission_with_table_targets(
@@ -468,6 +488,7 @@ mod tests {
     fn test_table_target_permission_forwarding() {
         let checker: PermissionCheckerRef = Arc::new(TargetAwarePermissionChecker);
         let checker = Some(&checker);
+        assert!(checker.uses_table_targets());
 
         let allowed = checker
             .check_permission_with_table_targets(
@@ -503,6 +524,7 @@ mod tests {
         assert!(matches!(error, Err(Error::InternalState { msg }) if msg == "testing"));
 
         let no_checker: Option<&PermissionCheckerRef> = None;
+        assert!(!no_checker.uses_table_targets());
         let allowed = no_checker
             .check_permission_with_table_targets(
                 crate::userinfo_by_name(None),
@@ -516,6 +538,7 @@ mod tests {
     #[test]
     fn test_default_permission_checker_table_target_parity() {
         let checker = DefaultPermissionChecker;
+        assert!(!checker.uses_table_targets());
 
         for (permission, req) in [
             (PermissionMode::ReadOnly, PermissionReq::PromQuery),

--- a/src/auth/tests/mod.rs
+++ b/src/auth/tests/mod.rs
@@ -18,7 +18,10 @@ use std::sync::Arc;
 use api::v1::greptime_request::Request;
 use auth::error::Error::InternalState;
 use auth::error::InternalStateSnafu;
-use auth::{PermissionChecker, PermissionCheckerRef, PermissionReq, PermissionResp, UserInfoRef};
+use auth::{
+    PermissionChecker, PermissionCheckerRef, PermissionReq, PermissionResp, PermissionTableTargets,
+    UserInfoRef,
+};
 use sql::statements::show::{ShowDatabases, ShowKind};
 use sql::statements::statement::Statement;
 
@@ -38,6 +41,15 @@ impl PermissionChecker for DummyPermissionChecker {
             }
             .fail(),
         }
+    }
+
+    fn check_permission_with_table_targets(
+        &self,
+        user_info: UserInfoRef,
+        req: PermissionReq,
+        _targets: PermissionTableTargets,
+    ) -> auth::error::Result<PermissionResp> {
+        self.check_permission(user_info, req)
     }
 }
 

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -70,18 +70,20 @@ use prometheus::HistogramTimer;
 use promql_parser::label::Matcher;
 use query::QueryEngineRef;
 use query::metrics::OnDone;
-use query::parser::{PromQuery, QueryLanguageParser, QueryStatement};
+use query::parser::{PromQuery, QueryStatement};
 use query::query_engine::DescribeResult;
 use query::query_engine::options::{QueryOptions, validate_catalog_and_schema};
 use servers::error::{
     self as server_error, AuthSnafu, CommonMetaSnafu, ExecuteQuerySnafu,
-    OtlpMetricModeIncompatibleSnafu, ParsePromQLSnafu, UnexpectedResultSnafu,
+    OtlpMetricModeIncompatibleSnafu, UnexpectedResultSnafu,
 };
 use servers::interceptor::{
     PromQueryInterceptor, PromQueryInterceptorRef, SqlQueryInterceptor, SqlQueryInterceptorRef,
 };
 use servers::otlp::metrics::legacy_normalize_otlp_name;
-use servers::prometheus_handler::{PrometheusHandler, resolve_schema_from_matchers};
+use servers::prometheus_handler::{
+    ParsedPromQuery, PrometheusHandler, resolve_schema_from_matchers,
+};
 use servers::query_handler::sql::SqlQueryHandler;
 use session::context::{Channel, QueryContextRef};
 use session::table_name::table_idents_to_full_name;
@@ -1082,19 +1084,14 @@ impl Instance {
 
     fn prom_queries_permission_targets(
         &self,
-        queries: &[PromQuery],
+        queries: &[ParsedPromQuery],
         query_ctx: &QueryContextRef,
     ) -> server_error::Result<PermissionTableTargets> {
         let mut targets = Vec::new();
         let mut resolved = true;
 
         for query in queries {
-            let stmt = QueryLanguageParser::parse_promql(query, query_ctx).with_context(|_| {
-                ParsePromQLSnafu {
-                    query: query.clone(),
-                }
-            })?;
-            let QueryStatement::Promql(eval_stmt, _) = stmt else {
+            let QueryStatement::Promql(eval_stmt, _) = query.statement() else {
                 unreachable!("query is parsed from promql");
             };
 
@@ -1123,27 +1120,32 @@ impl PrometheusHandler for Instance {
         query: &PromQuery,
         query_ctx: QueryContextRef,
     ) -> server_error::Result<Output> {
+        let query = ParsedPromQuery::parse(query.clone(), &query_ctx)?;
+        self.do_query_parsed(query, query_ctx).await
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn do_query_parsed(
+        &self,
+        query: ParsedPromQuery,
+        query_ctx: QueryContextRef,
+    ) -> server_error::Result<Output> {
         let interceptor = self
             .plugins
             .get::<PromQueryInterceptorRef<server_error::Error>>();
 
         self.check_prom_query_privilege(&query_ctx)?;
 
-        let stmt = QueryLanguageParser::parse_promql(query, &query_ctx).with_context(|_| {
-            ParsePromQLSnafu {
-                query: query.clone(),
-            }
-        })?;
+        let targets =
+            self.prom_queries_permission_targets(std::slice::from_ref(&query), &query_ctx)?;
+        self.check_query_target_permission(targets, &query_ctx)
+            .await?;
+
+        let (query, stmt) = query.into_parts();
 
         let QueryStatement::Promql(eval_stmt, _) = &stmt else {
             unreachable!("query is parsed from promql");
         };
-        let targets = match self.prom_expr_permission_targets(&eval_stmt.expr, &query_ctx)? {
-            Some(targets) => PermissionTableTargets::resolved(targets),
-            None => PermissionTableTargets::Unresolved,
-        };
-        self.check_query_target_permission(targets, &query_ctx)
-            .await?;
 
         let plan = self
             .statement_executor
@@ -1152,7 +1154,7 @@ impl PrometheusHandler for Instance {
             .map_err(BoxedError::new)
             .context(ExecuteQuerySnafu)?;
 
-        interceptor.pre_execute(query, &eval_stmt.expr, Some(&plan), query_ctx.clone())?;
+        interceptor.pre_execute(&query, &eval_stmt.expr, Some(&plan), query_ctx.clone())?;
 
         // Take the EvalStmt from the original QueryStatement and use it to create the CatalogQueryStatement.
         let query_statement = if let QueryStatement::Promql(eval_stmt, alias) = stmt {
@@ -1215,6 +1217,20 @@ impl PrometheusHandler for Instance {
     async fn check_query_permission(
         &self,
         queries: &[PromQuery],
+        query_ctx: &QueryContextRef,
+    ) -> server_error::Result<()> {
+        let queries = queries
+            .iter()
+            .cloned()
+            .map(|query| ParsedPromQuery::parse(query, query_ctx))
+            .collect::<server_error::Result<Vec<_>>>()?;
+        self.check_query_permission_parsed(&queries, query_ctx)
+            .await
+    }
+
+    async fn check_query_permission_parsed(
+        &self,
+        queries: &[ParsedPromQuery],
         query_ctx: &QueryContextRef,
     ) -> server_error::Result<()> {
         self.check_prom_query_privilege(query_ctx)?;

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -26,6 +26,7 @@ mod promql;
 mod region_query;
 pub mod standalone;
 
+use std::collections::HashSet;
 use std::pin::Pin;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, atomic};
@@ -58,7 +59,7 @@ use common_telemetry::logging::SlowQueryOptions;
 use common_telemetry::{debug, error, tracing};
 use dashmap::DashMap;
 use datafusion_expr::LogicalPlan;
-use futures::{Stream, StreamExt};
+use futures::{Stream, StreamExt, future};
 use lazy_static::lazy_static;
 use operator::delete::DeleterRef;
 use operator::insert::InserterRef;
@@ -1013,28 +1014,66 @@ impl Instance {
             .transpose()
     }
 
+    async fn is_physical_query_permission_target(
+        &self,
+        target: &PermissionTableTarget,
+        query_ctx: &QueryContextRef,
+    ) -> server_error::Result<bool> {
+        self.catalog_manager
+            .table(
+                &target.catalog,
+                &target.schema,
+                &target.table,
+                Some(query_ctx),
+            )
+            .await
+            .map(|table| table.is_some_and(|table| table.table_info().is_physical_table()))
+            .map_err(BoxedError::new)
+            .context(ExecuteQuerySnafu)
+    }
+
     async fn resolve_query_permission_targets(
         &self,
         targets: PermissionTableTargets,
         query_ctx: &QueryContextRef,
     ) -> server_error::Result<PermissionTableTargets> {
-        let PermissionTableTargets::Resolved(targets) = targets else {
+        const CONCURRENCY: usize = 8;
+
+        let checker = self.plugins.get::<PermissionCheckerRef>();
+        if !checker.as_ref().uses_table_targets() {
+            return Ok(targets);
+        }
+
+        let PermissionTableTargets::Resolved(mut targets) = targets else {
             return Ok(PermissionTableTargets::Unresolved);
         };
-        for target in &targets {
-            let table = self
-                .catalog_manager
-                .table(
-                    &target.catalog,
-                    &target.schema,
-                    &target.table,
-                    Some(query_ctx),
-                )
-                .await
-                .map_err(BoxedError::new)
-                .context(ExecuteQuerySnafu)?;
-            if table.is_some_and(|table| table.table_info().is_physical_table()) {
-                return Ok(PermissionTableTargets::Unresolved);
+        if targets.len() > 1 {
+            let mut seen = HashSet::with_capacity(targets.len());
+            targets.retain(|target| seen.insert(target.clone()));
+        }
+        if let [target] = targets.as_slice() {
+            return if self
+                .is_physical_query_permission_target(target, query_ctx)
+                .await?
+            {
+                Ok(PermissionTableTargets::Unresolved)
+            } else {
+                Ok(PermissionTableTargets::resolved(targets))
+            };
+        }
+
+        // Bound catalog load and inspect results in target order to preserve serial semantics.
+        for chunk in targets.chunks(CONCURRENCY) {
+            let results = future::join_all(
+                chunk
+                    .iter()
+                    .map(|target| self.is_physical_query_permission_target(target, query_ctx)),
+            )
+            .await;
+            for result in results {
+                if result? {
+                    return Ok(PermissionTableTargets::Unresolved);
+                }
             }
         }
 
@@ -1202,18 +1241,47 @@ impl PrometheusHandler for Instance {
         schema: &str,
         query_ctx: &QueryContextRef,
     ) -> server_error::Result<Vec<String>> {
+        let checker = self.plugins.get::<PermissionCheckerRef>();
+        if !checker.as_ref().uses_table_targets() {
+            let Some(metric) = metric_names.first() else {
+                return Ok(metric_names);
+            };
+            let target =
+                PermissionTableTarget::new(query_ctx.current_catalog(), schema, metric.as_str());
+            let result = checker
+                .as_ref()
+                .check_permission_with_table_targets(
+                    query_ctx.current_user(),
+                    PermissionReq::PromQuery,
+                    PermissionTableTargets::resolved(vec![target]),
+                )
+                .context(AuthSnafu);
+            return match result {
+                Ok(_) => Ok(metric_names),
+                Err(error)
+                    if error.status_code()
+                        == common_error::status_code::StatusCode::PermissionDenied =>
+                {
+                    Ok(Vec::new())
+                }
+                Err(error) => Err(error),
+            };
+        }
+
         let mut allowed = Vec::with_capacity(metric_names.len());
         for metric in metric_names {
             let target =
                 PermissionTableTarget::new(query_ctx.current_catalog(), schema, metric.as_str());
-            match self
-                .check_query_target_permission(
+            match checker
+                .as_ref()
+                .check_permission_with_table_targets(
+                    query_ctx.current_user(),
+                    PermissionReq::PromQuery,
                     PermissionTableTargets::resolved(vec![target]),
-                    query_ctx,
                 )
-                .await
+                .context(AuthSnafu)
             {
-                Ok(()) => allowed.push(metric),
+                Ok(_) => allowed.push(metric),
                 Err(error)
                     if error.status_code()
                         == common_error::status_code::StatusCode::PermissionDenied => {}
@@ -1751,6 +1819,35 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct TargetIndependentPermissionChecker {
+        checks: atomic::AtomicUsize,
+    }
+
+    impl PermissionChecker for TargetIndependentPermissionChecker {
+        fn check_permission(
+            &self,
+            _user_info: UserInfoRef,
+            _req: PermissionReq,
+        ) -> auth::error::Result<PermissionResp> {
+            self.checks.fetch_add(1, atomic::Ordering::Relaxed);
+            Ok(PermissionResp::Allow)
+        }
+
+        fn uses_table_targets(&self) -> bool {
+            false
+        }
+
+        fn check_permission_with_table_targets(
+            &self,
+            user_info: UserInfoRef,
+            req: PermissionReq,
+            _targets: PermissionTableTargets,
+        ) -> auth::error::Result<PermissionResp> {
+            self.check_permission(user_info, req)
+        }
+    }
+
     struct BlockingInsertSelectInterceptor {
         started_tx: mpsc::UnboundedSender<()>,
         finish_rx: std::sync::Mutex<Option<oneshot::Receiver<()>>>,
@@ -2130,6 +2227,74 @@ mod tests {
         results.remove(0).with_context(|_| ExecuteSqlSnafu {
             sql: sql.to_string(),
         })
+    }
+
+    #[tokio::test]
+    async fn test_target_independent_checker_skips_target_resolution() -> TestResult<()> {
+        let physical_table = "physical_metric";
+        let checker = Arc::new(TargetIndependentPermissionChecker::default());
+        let plugins = Plugins::new();
+        plugins.insert::<PermissionCheckerRef>(checker.clone());
+        let instance = test_instance_with_plugins(
+            test_physical_table(1024, physical_table)?,
+            test_table(1025, "target")?,
+            plugins,
+        )
+        .await?;
+
+        let ctx = test_query_ctx(1);
+        let physical_target = PermissionTableTarget::new("greptime", "public", physical_table);
+        assert_eq!(
+            PermissionTableTargets::Resolved(vec![physical_target.clone()]),
+            instance
+                .resolve_query_permission_targets(
+                    PermissionTableTargets::resolved(vec![physical_target]),
+                    &ctx,
+                )
+                .await
+                .unwrap()
+        );
+        assert_eq!(
+            vec![physical_table.to_string(), "target".to_string()],
+            PrometheusHandler::filter_metadata_metric_names(
+                &instance,
+                vec![physical_table.to_string(), "target".to_string()],
+                "public",
+                &ctx,
+            )
+            .await
+            .unwrap()
+        );
+        assert_eq!(1, checker.checks.load(atomic::Ordering::Relaxed));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_query_permission_targets_are_deduplicated() -> TestResult<()> {
+        let plugins = Plugins::new();
+        plugins.insert::<PermissionCheckerRef>(Arc::new(RejectUnresolvedPermissionChecker));
+        let instance = test_instance_with_plugins(
+            test_table(1024, "source")?,
+            test_table(1025, "target")?,
+            plugins,
+        )
+        .await?;
+        let ctx = test_query_ctx(1);
+        let target = PermissionTableTarget::new("greptime", "public", "target");
+
+        assert_eq!(
+            PermissionTableTargets::Resolved(vec![target.clone()]),
+            instance
+                .resolve_query_permission_targets(
+                    PermissionTableTargets::resolved(vec![target.clone(), target]),
+                    &ctx,
+                )
+                .await
+                .unwrap()
+        );
+
+        Ok(())
     }
 
     #[tokio::test]

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -396,8 +396,8 @@ impl Instance {
 
     async fn check_otlp_legacy(
         &self,
-        names: &[&String],
-        ctx: QueryContextRef,
+        names: &[String],
+        ctx: &QueryContextRef,
     ) -> server_error::Result<bool> {
         let db_string = ctx.get_db_string();
         // fast cache check
@@ -436,13 +436,6 @@ impl Instance {
 
         // means no existing table is found, use new mode
         if table_ids.is_empty() {
-            let cache = self
-                .otlp_metrics_table_legacy_cache
-                .entry(db_string)
-                .or_default();
-            names.iter().for_each(|name| {
-                cache.insert((*name).clone(), false);
-            });
             return Ok(false);
         }
 
@@ -464,10 +457,6 @@ impl Instance {
                     .unwrap_or(&OTLP_LEGACY_DEFAULT_VALUE)
             })
             .collect::<Vec<_>>();
-        let cache = self
-            .otlp_metrics_table_legacy_cache
-            .entry(db_string)
-            .or_default();
         if !options.is_empty() {
             // check value consistency
             let has_prom = options.iter().any(|opt| *opt == OTLP_METRIC_COMPAT_PROM);
@@ -475,28 +464,34 @@ impl Instance {
                 .iter()
                 .any(|opt| *opt == OTLP_LEGACY_DEFAULT_VALUE.as_str());
             ensure!(!(has_prom && has_legacy), OtlpMetricModeIncompatibleSnafu);
-            let flag = has_legacy;
-            names.iter().for_each(|name| {
-                cache.insert((*name).clone(), flag);
-            });
-            Ok(flag)
+            Ok(has_legacy)
         } else {
             // no table info, use new mode
-            names.iter().for_each(|name| {
-                cache.insert((*name).clone(), false);
-            });
             Ok(false)
         }
+    }
+
+    fn cache_otlp_legacy(
+        &self,
+        names: &[String],
+        ctx: &QueryContextRef,
+        is_legacy: bool,
+    ) -> server_error::Result<()> {
+        let cache = self
+            .otlp_metrics_table_legacy_cache
+            .entry(ctx.get_db_string())
+            .or_default();
+        cache_legacy_mode(&cache, names, is_legacy)
     }
 }
 
 fn fast_legacy_check(
     cache: &DashMap<String, bool>,
-    names: &[&String],
+    names: &[String],
 ) -> server_error::Result<Option<bool>> {
     let hit_cache = names
         .iter()
-        .filter_map(|name| cache.get(*name))
+        .filter_map(|name| cache.get(name))
         .collect::<Vec<_>>();
     if !hit_cache.is_empty() {
         let hit_legacy = hit_cache.iter().any(|en| *en.value());
@@ -507,20 +502,22 @@ fn fast_legacy_check(
         // add doc links in err msg later
         ensure!(!(hit_legacy && hit_prom), OtlpMetricModeIncompatibleSnafu);
 
-        let flag = hit_legacy;
-        // drop hit_cache to release references before inserting to avoid deadlock
-        drop(hit_cache);
-
-        // set cache for all names
-        names.iter().for_each(|name| {
-            if !cache.contains_key(*name) {
-                cache.insert((*name).clone(), flag);
-            }
-        });
-        Ok(Some(flag))
+        Ok(Some(hit_legacy))
     } else {
         Ok(None)
     }
+}
+
+fn cache_legacy_mode(
+    cache: &DashMap<String, bool>,
+    names: &[String],
+    is_legacy: bool,
+) -> server_error::Result<()> {
+    for name in names {
+        let cached = cache.entry(name.clone()).or_insert(is_legacy);
+        ensure!(*cached == is_legacy, OtlpMetricModeIncompatibleSnafu);
+    }
+    Ok(())
 }
 
 /// If the relevant variables are set, the timeout is enforced for all PostgreSQL statements.
@@ -1199,16 +1196,46 @@ impl PrometheusHandler for Instance {
         Ok(())
     }
 
+    async fn filter_query_metric_names(
+        &self,
+        metric_names: Vec<String>,
+        schema: &str,
+        query_ctx: &QueryContextRef,
+    ) -> server_error::Result<Vec<String>> {
+        let mut allowed = Vec::with_capacity(metric_names.len());
+        for metric in metric_names {
+            let target =
+                PermissionTableTarget::new(query_ctx.current_catalog(), schema, metric.as_str());
+            match self
+                .check_query_target_permission(
+                    PermissionTableTargets::resolved(vec![target]),
+                    query_ctx,
+                )
+                .await
+            {
+                Ok(()) => allowed.push(metric),
+                Err(error)
+                    if error.status_code()
+                        == common_error::status_code::StatusCode::PermissionDenied => {}
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(allowed)
+    }
+
     async fn query_metric_names(
         &self,
         matchers: Vec<Matcher>,
         schema: &str,
         ctx: &QueryContextRef,
     ) -> server_error::Result<Vec<String>> {
-        self.handle_query_metric_names(matchers, schema, ctx)
+        let metric_names = self
+            .handle_query_metric_names(matchers, schema, ctx)
             .await
             .map_err(BoxedError::new)
-            .context(ExecuteQuerySnafu)
+            .context(ExecuteQuerySnafu)?;
+        self.filter_query_metric_names(metric_names, schema, ctx)
+            .await
     }
 
     async fn query_label_values(
@@ -1479,11 +1506,9 @@ mod tests {
     use std::collections::HashMap;
     use std::future::Future;
     use std::pin::Pin;
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::{Arc, Barrier};
+    use std::sync::Arc;
     use std::task::{Context, Poll};
-    use std::thread;
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
 
     use api::prom_store::remote::label_matcher::Type as PromMatcherType;
     use api::prom_store::remote::{LabelMatcher, Query as RemoteQuery, ReadRequest};
@@ -1509,8 +1534,9 @@ mod tests {
     use datafusion_expr::{LogicalPlanBuilder, LogicalTableSource};
     use datatypes::prelude::ConcreteDataType;
     use datatypes::schema::{ColumnSchema, Schema as GtSchema, SchemaRef as GtSchemaRef};
+    use log_query::LogQuery;
     use query::query_engine::options::QueryOptions;
-    use servers::query_handler::PromStoreProtocolHandler;
+    use servers::query_handler::{LogQueryHandler, PromStoreProtocolHandler};
     use session::context::{Channel, ConnInfo, QueryContext, QueryContextBuilder};
     use snafu::{Location, Snafu};
     use sql::dialect::GreptimeDbDialect;
@@ -1519,6 +1545,7 @@ mod tests {
     use store_api::storage::ScanRequest;
     use strfmt::Format;
     use table::metadata::{FilterPushDownType, TableInfo, TableInfoBuilder, TableMetaBuilder};
+    use table::table_name::TableName;
     use table::test_util::EmptyTable;
     use table::{Table, TableRef};
     use tokio::sync::{mpsc, oneshot};
@@ -1710,7 +1737,13 @@ mod tests {
             _req: PermissionReq,
             targets: PermissionTableTargets,
         ) -> auth::error::Result<PermissionResp> {
-            Ok(if matches!(targets, PermissionTableTargets::Unresolved) {
+            let reject = match targets {
+                PermissionTableTargets::Unresolved => true,
+                PermissionTableTargets::Resolved(targets) => {
+                    targets.iter().any(|target| target.table == "denied")
+                }
+            };
+            Ok(if reject {
                 PermissionResp::Reject
             } else {
                 PermissionResp::Allow
@@ -2071,6 +2104,17 @@ mod tests {
                 .await
                 .unwrap()
         );
+        assert_eq!(
+            vec!["target".to_string()],
+            PrometheusHandler::filter_query_metric_names(
+                &instance,
+                vec!["target".to_string(), "denied".to_string()],
+                "public",
+                &ctx,
+            )
+            .await
+            .unwrap()
+        );
 
         let query = PromQuery {
             query: physical_table.to_string(),
@@ -2107,6 +2151,17 @@ mod tests {
             let err = results.remove(0).unwrap_err();
             assert_eq!(StatusCode::PermissionDenied, err.status_code(), "{sql}");
         }
+        let err = LogQueryHandler::query(
+            &instance,
+            LogQuery {
+                table: TableName::new("greptime", "public", physical_table),
+                ..Default::default()
+            },
+            ctx.clone(),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(StatusCode::PermissionDenied, err.status_code());
         let err = instance
             .do_describe_inner(parse_one_sql("SELECT * FROM physical_metric"), ctx.clone())
             .await
@@ -2146,119 +2201,23 @@ mod tests {
     }
 
     #[test]
-    fn test_fast_legacy_check_deadlock_prevention() {
-        // Create a DashMap to simulate the cache
+    fn test_fast_legacy_check_is_read_only() {
         let cache = DashMap::new();
+        cache.insert("metric1".to_string(), true);
 
-        // Pre-populate cache with some entries
-        cache.insert("metric1".to_string(), true); // legacy mode
-        cache.insert("metric2".to_string(), false); // prom mode
-        cache.insert("metric3".to_string(), true); // legacy mode
+        let names = vec!["metric1".to_string(), "metric2".to_string()];
+        assert_eq!(Some(true), fast_legacy_check(&cache, &names).unwrap());
+        assert!(!cache.contains_key("metric2"));
 
-        // Test case 1: Normal operation with cache hits
-        let metric1 = "metric1".to_string();
-        let metric4 = "metric4".to_string();
-        let names1 = vec![&metric1, &metric4];
-        let result = fast_legacy_check(&cache, &names1);
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), Some(true)); // should return legacy mode
+        cache_legacy_mode(&cache, &names, true).unwrap();
+        assert!(*cache.get("metric2").unwrap().value());
+        assert!(cache_legacy_mode(&cache, &names, false).is_err());
+        assert!(*cache.get("metric2").unwrap().value());
 
-        // Verify that metric4 was added to cache
-        assert!(cache.contains_key("metric4"));
-        assert!(*cache.get("metric4").unwrap().value());
-
-        // Test case 2: No cache hits
-        let metric5 = "metric5".to_string();
-        let metric6 = "metric6".to_string();
-        let names2 = vec![&metric5, &metric6];
-        let result = fast_legacy_check(&cache, &names2);
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), None); // should return None as no cache hits
-
-        // Test case 3: Incompatible modes should return error
         let cache_incompatible = DashMap::new();
-        cache_incompatible.insert("metric1".to_string(), true); // legacy
-        cache_incompatible.insert("metric2".to_string(), false); // prom
-        let metric1_test = "metric1".to_string();
-        let metric2_test = "metric2".to_string();
-        let names3 = vec![&metric1_test, &metric2_test];
-        let result = fast_legacy_check(&cache_incompatible, &names3);
-        assert!(result.is_err()); // should error due to incompatible modes
-
-        // Test case 4: Intensive concurrent access to test deadlock prevention
-        // This test specifically targets the scenario where multiple threads
-        // access the same cache entries simultaneously
-        let cache_concurrent = Arc::new(DashMap::new());
-        cache_concurrent.insert("shared_metric".to_string(), true);
-
-        let num_threads = 8;
-        let operations_per_thread = 100;
-        let barrier = Arc::new(Barrier::new(num_threads));
-        let success_flag = Arc::new(AtomicBool::new(true));
-
-        let handles: Vec<_> = (0..num_threads)
-            .map(|thread_id| {
-                let cache_clone = Arc::clone(&cache_concurrent);
-                let barrier_clone = Arc::clone(&barrier);
-                let success_flag_clone = Arc::clone(&success_flag);
-
-                thread::spawn(move || {
-                    // Wait for all threads to be ready
-                    barrier_clone.wait();
-
-                    let start_time = Instant::now();
-                    for i in 0..operations_per_thread {
-                        // Each operation references existing cache entry and adds new ones
-                        let shared_metric = "shared_metric".to_string();
-                        let new_metric = format!("thread_{}_metric_{}", thread_id, i);
-                        let names = vec![&shared_metric, &new_metric];
-
-                        match fast_legacy_check(&cache_clone, &names) {
-                            Ok(_) => {}
-                            Err(_) => {
-                                success_flag_clone.store(false, Ordering::Relaxed);
-                                return;
-                            }
-                        }
-
-                        // If the test takes too long, it likely means deadlock
-                        if start_time.elapsed() > Duration::from_secs(10) {
-                            success_flag_clone.store(false, Ordering::Relaxed);
-                            return;
-                        }
-                    }
-                })
-            })
-            .collect();
-
-        // Join all threads with timeout
-        let start_time = Instant::now();
-        for (i, handle) in handles.into_iter().enumerate() {
-            let join_result = handle.join();
-
-            // Check if we're taking too long (potential deadlock)
-            if start_time.elapsed() > Duration::from_secs(30) {
-                panic!("Test timed out - possible deadlock detected!");
-            }
-
-            if join_result.is_err() {
-                panic!("Thread {} panicked during execution", i);
-            }
-        }
-
-        // Verify all operations completed successfully
-        assert!(
-            success_flag.load(Ordering::Relaxed),
-            "Some operations failed"
-        );
-
-        // Verify that many new entries were added (proving operations completed)
-        let final_count = cache_concurrent.len();
-        assert!(
-            final_count > 1 + num_threads * operations_per_thread / 2,
-            "Expected more cache entries, got {}",
-            final_count
-        );
+        cache_incompatible.insert("metric1".to_string(), true);
+        cache_incompatible.insert("metric2".to_string(), false);
+        assert!(fast_legacy_check(&cache_incompatible, &names).is_err());
     }
 
     #[test]

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -1196,7 +1196,7 @@ impl PrometheusHandler for Instance {
         Ok(())
     }
 
-    async fn filter_query_metric_names(
+    async fn filter_metadata_metric_names(
         &self,
         metric_names: Vec<String>,
         schema: &str,
@@ -1229,13 +1229,10 @@ impl PrometheusHandler for Instance {
         schema: &str,
         ctx: &QueryContextRef,
     ) -> server_error::Result<Vec<String>> {
-        let metric_names = self
-            .handle_query_metric_names(matchers, schema, ctx)
+        self.handle_query_metric_names(matchers, schema, ctx)
             .await
             .map_err(BoxedError::new)
-            .context(ExecuteQuerySnafu)?;
-        self.filter_query_metric_names(metric_names, schema, ctx)
-            .await
+            .context(ExecuteQuerySnafu)
     }
 
     async fn query_label_values(
@@ -1534,6 +1531,7 @@ mod tests {
     use datafusion_expr::{LogicalPlanBuilder, LogicalTableSource};
     use datatypes::prelude::ConcreteDataType;
     use datatypes::schema::{ColumnSchema, Schema as GtSchema, SchemaRef as GtSchemaRef};
+    use datatypes::vectors::{StringVector, VectorRef};
     use log_query::LogQuery;
     use query::query_engine::options::QueryOptions;
     use servers::query_handler::{LogQueryHandler, PromStoreProtocolHandler};
@@ -1541,12 +1539,14 @@ mod tests {
     use snafu::{Location, Snafu};
     use sql::dialect::GreptimeDbDialect;
     use store_api::data_source::DataSource;
-    use store_api::metric_engine_consts::PHYSICAL_TABLE_METADATA_KEY;
+    use store_api::metric_engine_consts::{
+        LOGICAL_TABLE_METADATA_KEY, METRIC_ENGINE_NAME, PHYSICAL_TABLE_METADATA_KEY,
+    };
     use store_api::storage::ScanRequest;
     use strfmt::Format;
     use table::metadata::{FilterPushDownType, TableInfo, TableInfoBuilder, TableMetaBuilder};
     use table::table_name::TableName;
-    use table::test_util::EmptyTable;
+    use table::test_util::{EmptyTable, MemTable};
     use table::{Table, TableRef};
     use tokio::sync::{mpsc, oneshot};
 
@@ -1971,6 +1971,44 @@ mod tests {
         Ok(EmptyTable::from_table_info(&table_info))
     }
 
+    fn test_logical_table(table_id: u32, table_name: &str) -> TestResult<table::TableRef> {
+        let mut table_info = test_table_info(table_id, table_name)?;
+        table_info.meta.engine = METRIC_ENGINE_NAME.to_string();
+        table_info.meta.options.extra_options.insert(
+            LOGICAL_TABLE_METADATA_KEY.to_string(),
+            "physical_metric".to_string(),
+        );
+        Ok(EmptyTable::from_table_info(&table_info))
+    }
+
+    fn test_metric_names_table() -> TableRef {
+        let schema = Arc::new(GtSchema::new(vec![
+            ColumnSchema::new("table_catalog", ConcreteDataType::string_datatype(), false),
+            ColumnSchema::new("table_schema", ConcreteDataType::string_datatype(), false),
+            ColumnSchema::new("table_name", ConcreteDataType::string_datatype(), false),
+            ColumnSchema::new("engine", ConcreteDataType::string_datatype(), false),
+            ColumnSchema::new("create_options", ConcreteDataType::string_datatype(), false),
+        ]));
+        let columns: Vec<VectorRef> = vec![
+            Arc::new(StringVector::from(vec!["greptime", "greptime"])),
+            Arc::new(StringVector::from(vec!["public", "public"])),
+            Arc::new(StringVector::from(vec!["denied", "target"])),
+            Arc::new(StringVector::from(vec!["metric", "metric"])),
+            Arc::new(StringVector::from(vec![
+                "on_physical_table=physical_metric",
+                "on_physical_table=physical_metric",
+            ])),
+        ];
+        let record_batch = RecordBatch::new(schema, columns).unwrap();
+        MemTable::new_with_catalog(
+            "tables",
+            record_batch,
+            2048,
+            "greptime".to_string(),
+            "information_schema".to_string(),
+        )
+    }
+
     fn pending_table(
         table_id: u32,
         table_name: &str,
@@ -2015,6 +2053,15 @@ mod tests {
         target_table: TableRef,
         plugins: Plugins,
     ) -> TestResult<Instance> {
+        test_instance_with_plugins_and_metric_names(source_table, target_table, plugins, None).await
+    }
+
+    async fn test_instance_with_plugins_and_metric_names(
+        source_table: TableRef,
+        target_table: TableRef,
+        plugins: Plugins,
+        metric_names_table: Option<TableRef>,
+    ) -> TestResult<Instance> {
         let kv_backend = Arc::new(MemoryKvBackend::new());
         let process_manager = Arc::new(ProcessManager::new("test-frontend".to_string(), None));
         let catalog_manager = catalog::memory::MemoryCatalogManager::new_with_table(source_table);
@@ -2030,6 +2077,24 @@ mod tests {
             .with_context(|_| RegisterTableSnafu {
                 table_name: target_table_name.to_string(),
             })?;
+        if let Some(table) = metric_names_table {
+            catalog_manager
+                .deregister_table_sync(catalog::DeregisterTableRequest {
+                    catalog: "greptime".to_string(),
+                    schema: "information_schema".to_string(),
+                    table_name: "tables".to_string(),
+                })
+                .unwrap();
+            catalog_manager
+                .register_table_sync(catalog::RegisterTableRequest {
+                    catalog: "greptime".to_string(),
+                    schema: "information_schema".to_string(),
+                    table_name: "tables".to_string(),
+                    table_id: 2048,
+                    table,
+                })
+                .unwrap();
+        }
         catalog_manager.register_process_list_table(process_manager.clone());
 
         let cache_registry = test_cache_registry(kv_backend.clone())?;
@@ -2106,7 +2171,7 @@ mod tests {
         );
         assert_eq!(
             vec!["target".to_string()],
-            PrometheusHandler::filter_query_metric_names(
+            PrometheusHandler::filter_metadata_metric_names(
                 &instance,
                 vec!["target".to_string(), "denied".to_string()],
                 "public",
@@ -2195,6 +2260,53 @@ mod tests {
         )
         .await
         .unwrap_err();
+        assert_eq!(StatusCode::PermissionDenied, err.status_code());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_non_exact_query_discovery_keeps_denied_targets_for_batch_check() -> TestResult<()>
+    {
+        let plugins = Plugins::new();
+        plugins.insert::<PermissionCheckerRef>(Arc::new(RejectUnresolvedPermissionChecker));
+        let instance = test_instance_with_plugins_and_metric_names(
+            test_logical_table(1024, "denied")?,
+            test_logical_table(1025, "target")?,
+            plugins,
+            Some(test_metric_names_table()),
+        )
+        .await?;
+        let ctx = test_query_ctx(1);
+
+        let mut metric_names = PrometheusHandler::query_metric_names(
+            &instance,
+            vec![Matcher::new(
+                promql_parser::label::MatchOp::NotEqual,
+                "__name__",
+                "",
+            )],
+            "public",
+            &ctx,
+        )
+        .await
+        .unwrap();
+        metric_names.sort_unstable();
+        assert_eq!(
+            vec!["denied".to_string(), "target".to_string()],
+            metric_names
+        );
+
+        let queries = metric_names
+            .into_iter()
+            .map(|query| PromQuery {
+                query,
+                ..Default::default()
+            })
+            .collect::<Vec<_>>();
+        let err = PrometheusHandler::check_query_permission(&instance, &queries, &ctx)
+            .await
+            .unwrap_err();
         assert_eq!(StatusCode::PermissionDenied, err.status_code());
 
         Ok(())

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -33,7 +33,10 @@ use std::time::{Duration, SystemTime};
 
 use async_stream::stream;
 use async_trait::async_trait;
-use auth::{PermissionChecker, PermissionCheckerRef, PermissionReq};
+use auth::{
+    PermissionChecker, PermissionCheckerRef, PermissionReq, PermissionTableTarget,
+    PermissionTableTargets,
+};
 use catalog::CatalogManagerRef;
 use catalog::process_manager::{
     ProcessManagerRef, QueryStatement as CatalogQueryStatement, SlowQueryTimer,
@@ -77,7 +80,7 @@ use servers::interceptor::{
     PromQueryInterceptor, PromQueryInterceptorRef, SqlQueryInterceptor, SqlQueryInterceptorRef,
 };
 use servers::otlp::metrics::legacy_normalize_otlp_name;
-use servers::prometheus_handler::PrometheusHandler;
+use servers::prometheus_handler::{PrometheusHandler, resolve_schema_from_matchers};
 use servers::query_handler::sql::SqlQueryHandler;
 use session::context::{Channel, QueryContextRef};
 use session::table_name::table_idents_to_full_name;
@@ -89,6 +92,7 @@ use sql::statements::comment::CommentObject;
 use sql::statements::copy::{CopyDatabase, CopyTable};
 use sql::statements::statement::Statement;
 use sql::statements::tql::Tql;
+use sql::util::{extract_tables_from_prom_expr_checked, extract_tables_from_statement_checked};
 use sqlparser::ast::{AnalyzeFormat, ObjectName};
 pub use standalone::StandaloneDatanodeManager;
 use table::requests::{OTLP_METRIC_COMPAT_KEY, OTLP_METRIC_COMPAT_PROM};
@@ -584,6 +588,47 @@ fn attach_timeout(output: Output, mut timeout: Duration) -> Result<Output> {
 }
 
 impl Instance {
+    async fn check_sql_permission(
+        &self,
+        stmt: &Statement,
+        query_ctx: &QueryContextRef,
+    ) -> Result<()> {
+        self.plugins
+            .get::<PermissionCheckerRef>()
+            .as_ref()
+            .check_permission_with_context(
+                query_ctx.current_user(),
+                PermissionReq::SqlStatement(stmt),
+                Some(&query_ctx.current_schema()),
+            )
+            .context(PermissionSnafu)?;
+
+        let targets = match extract_tables_from_statement_checked(stmt) {
+            Some(tables) => PermissionTableTargets::resolved(
+                tables
+                    .map(|name| {
+                        table_idents_to_full_name(&name, query_ctx).map(
+                            |(catalog, schema, table)| {
+                                PermissionTableTarget::new(catalog, schema, table)
+                            },
+                        )
+                    })
+                    .collect::<std::result::Result<Vec<_>, _>>()
+                    .map_err(BoxedError::new)
+                    .context(ExternalSnafu)?,
+            ),
+            None => PermissionTableTargets::Unresolved,
+        };
+        let targets = self
+            .resolve_query_permission_targets(targets, query_ctx)
+            .await
+            .map_err(BoxedError::new)
+            .context(ExternalSnafu)?;
+        self.check_table_permission(query_ctx, PermissionReq::SqlStatement(stmt), targets)
+            .context(PermissionSnafu)?;
+        Ok(())
+    }
+
     #[tracing::instrument(skip_all, name = "SqlQueryHandler::do_analyze_stream_query")]
     async fn do_analyze_stream_query_inner(
         &self,
@@ -608,15 +653,7 @@ impl Instance {
         validate_analyze_stream_statement(&mut stmt)?;
         query_ctx.set_explain_format(AnalyzeFormat::JSON.to_string());
 
-        let checker_ref = self.plugins.get::<PermissionCheckerRef>();
-        checker_ref
-            .as_ref()
-            .check_permission_with_context(
-                query_ctx.current_user(),
-                PermissionReq::SqlStatement(&stmt),
-                Some(&query_ctx.current_schema()),
-            )
-            .context(PermissionSnafu)?;
+        self.check_sql_permission(&stmt, &query_ctx).await?;
         check_permission(self.plugins.clone(), &stmt, &query_ctx)?;
         let catalog_name = query_ctx.current_catalog().to_string();
         let schema_name = query_ctx.current_schema();
@@ -657,9 +694,6 @@ impl Instance {
             Err(e) => return vec![Err(e)],
         };
 
-        let checker_ref = self.plugins.get::<PermissionCheckerRef>();
-        let checker = checker_ref.as_ref();
-
         match parse_stmt(query.as_ref(), query_ctx.sql_dialect())
             .and_then(|stmts| query_interceptor.post_parsing(stmts, query_ctx.clone()))
         {
@@ -675,14 +709,7 @@ impl Instance {
 
                 let mut results = Vec::with_capacity(stmts.len());
                 for stmt in stmts {
-                    if let Err(e) = checker
-                        .check_permission_with_context(
-                            query_ctx.current_user(),
-                            PermissionReq::SqlStatement(&stmt),
-                            Some(&query_ctx.current_schema()),
-                        )
-                        .context(PermissionSnafu)
-                    {
+                    if let Err(e) = self.check_sql_permission(&stmt, &query_ctx).await {
                         results.push(Err(e));
                         break;
                     }
@@ -850,15 +877,7 @@ impl Instance {
             || matches!(&stmt, Statement::Explain(explain) if is_inner_plannable(explain.statement.as_ref()));
 
         if plannable {
-            self.plugins
-                .get::<PermissionCheckerRef>()
-                .as_ref()
-                .check_permission_with_context(
-                    query_ctx.current_user(),
-                    PermissionReq::SqlStatement(&stmt),
-                    Some(&query_ctx.current_schema()),
-                )
-                .context(PermissionSnafu)?;
+            self.check_sql_permission(&stmt, &query_ctx).await?;
 
             let plan = self
                 .query_engine
@@ -965,6 +984,101 @@ pub fn attach_timer(output: Output, timer: HistogramTimer) -> Output {
     }
 }
 
+impl Instance {
+    fn check_prom_query_privilege(&self, query_ctx: &QueryContextRef) -> server_error::Result<()> {
+        self.plugins
+            .get::<PermissionCheckerRef>()
+            .as_ref()
+            .check_permission(query_ctx.current_user(), PermissionReq::PromQuery)
+            .context(AuthSnafu)?;
+        Ok(())
+    }
+
+    fn prom_expr_permission_targets(
+        &self,
+        expr: &promql_parser::parser::Expr,
+        query_ctx: &QueryContextRef,
+    ) -> server_error::Result<Option<Vec<PermissionTableTarget>>> {
+        extract_tables_from_prom_expr_checked(expr)
+            .map(|tables| {
+                tables
+                    .map(|name| {
+                        table_idents_to_full_name(&name, query_ctx).map(
+                            |(catalog, schema, table)| {
+                                PermissionTableTarget::new(catalog, schema, table)
+                            },
+                        )
+                    })
+                    .collect::<std::result::Result<Vec<_>, _>>()
+                    .map_err(BoxedError::new)
+                    .context(ExecuteQuerySnafu)
+            })
+            .transpose()
+    }
+
+    async fn resolve_query_permission_targets(
+        &self,
+        targets: PermissionTableTargets,
+        query_ctx: &QueryContextRef,
+    ) -> server_error::Result<PermissionTableTargets> {
+        let PermissionTableTargets::Resolved(targets) = targets else {
+            return Ok(PermissionTableTargets::Unresolved);
+        };
+        for target in &targets {
+            let table = self
+                .catalog_manager
+                .table(
+                    &target.catalog,
+                    &target.schema,
+                    &target.table,
+                    Some(query_ctx),
+                )
+                .await
+                .map_err(BoxedError::new)
+                .context(ExecuteQuerySnafu)?;
+            if table.is_some_and(|table| table.table_info().is_physical_table()) {
+                return Ok(PermissionTableTargets::Unresolved);
+            }
+        }
+
+        Ok(PermissionTableTargets::resolved(targets))
+    }
+
+    fn prom_queries_permission_targets(
+        &self,
+        queries: &[PromQuery],
+        query_ctx: &QueryContextRef,
+    ) -> server_error::Result<PermissionTableTargets> {
+        let mut targets = Vec::new();
+        let mut resolved = true;
+
+        for query in queries {
+            let stmt = QueryLanguageParser::parse_promql(query, query_ctx).with_context(|_| {
+                ParsePromQLSnafu {
+                    query: query.clone(),
+                }
+            })?;
+            let QueryStatement::Promql(eval_stmt, _) = stmt else {
+                unreachable!("query is parsed from promql");
+            };
+
+            if let Some(query_targets) =
+                self.prom_expr_permission_targets(&eval_stmt.expr, query_ctx)?
+            {
+                targets.extend(query_targets);
+            } else {
+                resolved = false;
+            }
+        }
+
+        Ok(if resolved {
+            PermissionTableTargets::resolved(targets)
+        } else {
+            PermissionTableTargets::Unresolved
+        })
+    }
+}
+
 #[async_trait]
 impl PrometheusHandler for Instance {
     #[tracing::instrument(skip_all)]
@@ -977,11 +1091,7 @@ impl PrometheusHandler for Instance {
             .plugins
             .get::<PromQueryInterceptorRef<server_error::Error>>();
 
-        self.plugins
-            .get::<PermissionCheckerRef>()
-            .as_ref()
-            .check_permission(query_ctx.current_user(), PermissionReq::PromQuery)
-            .context(AuthSnafu)?;
+        self.check_prom_query_privilege(&query_ctx)?;
 
         let stmt = QueryLanguageParser::parse_promql(query, &query_ctx).with_context(|_| {
             ParsePromQLSnafu {
@@ -989,16 +1099,22 @@ impl PrometheusHandler for Instance {
             }
         })?;
 
+        let QueryStatement::Promql(eval_stmt, _) = &stmt else {
+            unreachable!("query is parsed from promql");
+        };
+        let targets = match self.prom_expr_permission_targets(&eval_stmt.expr, &query_ctx)? {
+            Some(targets) => PermissionTableTargets::resolved(targets),
+            None => PermissionTableTargets::Unresolved,
+        };
+        self.check_query_target_permission(targets, &query_ctx)
+            .await?;
+
         let plan = self
             .statement_executor
             .plan(&stmt, query_ctx.clone())
             .await
             .map_err(BoxedError::new)
             .context(ExecuteQuerySnafu)?;
-
-        let QueryStatement::Promql(eval_stmt, _) = &stmt else {
-            unreachable!("query is parsed from promql");
-        };
 
         interceptor.pre_execute(query, &eval_stmt.expr, Some(&plan), query_ctx.clone())?;
 
@@ -1060,12 +1176,36 @@ impl PrometheusHandler for Instance {
         Ok(interceptor.post_execute(output, query_ctx)?)
     }
 
+    async fn check_query_permission(
+        &self,
+        queries: &[PromQuery],
+        query_ctx: &QueryContextRef,
+    ) -> server_error::Result<()> {
+        self.check_prom_query_privilege(query_ctx)?;
+        let targets = self.prom_queries_permission_targets(queries, query_ctx)?;
+        self.check_query_target_permission(targets, query_ctx).await
+    }
+
+    async fn check_query_target_permission(
+        &self,
+        targets: PermissionTableTargets,
+        query_ctx: &QueryContextRef,
+    ) -> server_error::Result<()> {
+        let targets = self
+            .resolve_query_permission_targets(targets, query_ctx)
+            .await?;
+        self.check_table_permission(query_ctx, PermissionReq::PromQuery, targets)
+            .context(AuthSnafu)?;
+        Ok(())
+    }
+
     async fn query_metric_names(
         &self,
         matchers: Vec<Matcher>,
+        schema: &str,
         ctx: &QueryContextRef,
     ) -> server_error::Result<Vec<String>> {
-        self.handle_query_metric_names(matchers, ctx)
+        self.handle_query_metric_names(matchers, schema, ctx)
             .await
             .map_err(BoxedError::new)
             .context(ExecuteQuerySnafu)
@@ -1080,7 +1220,16 @@ impl PrometheusHandler for Instance {
         end: SystemTime,
         ctx: &QueryContextRef,
     ) -> server_error::Result<Vec<String>> {
-        self.handle_query_label_values(metric, label_name, matchers, start, end, ctx)
+        let schema =
+            resolve_schema_from_matchers(&matchers)?.unwrap_or_else(|| ctx.current_schema());
+        let target = PermissionTableTarget::new(ctx.current_catalog(), schema.as_str(), &metric);
+        self.check_query_target_permission(
+            PermissionTableTargets::resolved(vec![target.clone()]),
+            ctx,
+        )
+        .await?;
+
+        self.handle_query_label_values(target, label_name, matchers, start, end, ctx)
             .await
             .map_err(BoxedError::new)
             .context(ExecuteQuerySnafu)
@@ -1336,7 +1485,10 @@ mod tests {
     use std::thread;
     use std::time::{Duration, Instant};
 
+    use api::prom_store::remote::label_matcher::Type as PromMatcherType;
+    use api::prom_store::remote::{LabelMatcher, Query as RemoteQuery, ReadRequest};
     use api::v1::meta::{ProcedureDetailResponse, ReconcileRequest, ReconcileResponse};
+    use auth::{PermissionResp, UserInfoRef};
     use catalog::process_manager::ProcessManager;
     use common_base::Plugins;
     use common_error::ext::{BoxedError, PlainError};
@@ -1358,10 +1510,12 @@ mod tests {
     use datatypes::prelude::ConcreteDataType;
     use datatypes::schema::{ColumnSchema, Schema as GtSchema, SchemaRef as GtSchemaRef};
     use query::query_engine::options::QueryOptions;
+    use servers::query_handler::PromStoreProtocolHandler;
     use session::context::{Channel, ConnInfo, QueryContext, QueryContextBuilder};
     use snafu::{Location, Snafu};
     use sql::dialect::GreptimeDbDialect;
     use store_api::data_source::DataSource;
+    use store_api::metric_engine_consts::PHYSICAL_TABLE_METADATA_KEY;
     use store_api::storage::ScanRequest;
     use strfmt::Format;
     use table::metadata::{FilterPushDownType, TableInfo, TableInfoBuilder, TableMetaBuilder};
@@ -1537,6 +1691,31 @@ mod tests {
                 .process_id(process_id)
                 .build(),
         )
+    }
+
+    struct RejectUnresolvedPermissionChecker;
+
+    impl PermissionChecker for RejectUnresolvedPermissionChecker {
+        fn check_permission(
+            &self,
+            _user_info: UserInfoRef,
+            _req: PermissionReq,
+        ) -> auth::error::Result<PermissionResp> {
+            Ok(PermissionResp::Allow)
+        }
+
+        fn check_permission_with_table_targets(
+            &self,
+            _user_info: UserInfoRef,
+            _req: PermissionReq,
+            targets: PermissionTableTargets,
+        ) -> auth::error::Result<PermissionResp> {
+            Ok(if matches!(targets, PermissionTableTargets::Unresolved) {
+                PermissionResp::Reject
+            } else {
+                PermissionResp::Allow
+            })
+        }
     }
 
     struct BlockingInsertSelectInterceptor {
@@ -1749,6 +1928,16 @@ mod tests {
         Ok(EmptyTable::from_table_info(&table_info))
     }
 
+    fn test_physical_table(table_id: u32, table_name: &str) -> TestResult<table::TableRef> {
+        let mut table_info = test_table_info(table_id, table_name)?;
+        table_info
+            .meta
+            .options
+            .extra_options
+            .insert(PHYSICAL_TABLE_METADATA_KEY.to_string(), String::new());
+        Ok(EmptyTable::from_table_info(&table_info))
+    }
+
     fn pending_table(
         table_id: u32,
         table_name: &str,
@@ -1843,6 +2032,117 @@ mod tests {
         results.remove(0).with_context(|_| ExecuteSqlSnafu {
             sql: sql.to_string(),
         })
+    }
+
+    #[tokio::test]
+    async fn test_physical_query_targets_fail_closed() -> TestResult<()> {
+        let physical_table = "physical_metric";
+        let plugins = Plugins::new();
+        plugins.insert::<PermissionCheckerRef>(Arc::new(RejectUnresolvedPermissionChecker));
+        let instance = test_instance_with_plugins(
+            test_physical_table(1024, physical_table)?,
+            test_table(1025, "target")?,
+            plugins,
+        )
+        .await?;
+
+        let ctx = test_query_ctx(1);
+        let logical_target = PermissionTableTarget::new("greptime", "public", "target");
+        assert_eq!(
+            PermissionTableTargets::Resolved(vec![logical_target.clone()]),
+            instance
+                .resolve_query_permission_targets(
+                    PermissionTableTargets::resolved(vec![logical_target.clone()]),
+                    &ctx,
+                )
+                .await
+                .unwrap()
+        );
+        let physical_target = PermissionTableTarget::new("greptime", "public", physical_table);
+        assert_eq!(
+            PermissionTableTargets::Unresolved,
+            instance
+                .resolve_query_permission_targets(
+                    PermissionTableTargets::resolved(
+                        vec![logical_target, physical_target.clone(),]
+                    ),
+                    &ctx,
+                )
+                .await
+                .unwrap()
+        );
+
+        let query = PromQuery {
+            query: physical_table.to_string(),
+            ..Default::default()
+        };
+        let err = PrometheusHandler::check_query_target_permission(
+            &instance,
+            PermissionTableTargets::resolved(vec![physical_target]),
+            &ctx,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(StatusCode::PermissionDenied, err.status_code());
+        let err = PrometheusHandler::check_query_permission(
+            &instance,
+            std::slice::from_ref(&query),
+            &ctx,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(StatusCode::PermissionDenied, err.status_code());
+        let err = PrometheusHandler::do_query(&instance, &query, ctx.clone())
+            .await
+            .unwrap_err();
+        assert_eq!(StatusCode::PermissionDenied, err.status_code());
+
+        for sql in [
+            "SELECT * FROM physical_metric",
+            "TQL EVAL (0, 10, '5s') physical_metric",
+            "INSERT INTO target SELECT * FROM physical_metric",
+        ] {
+            let mut results = instance.do_query_inner(sql, ctx.clone()).await;
+            assert_eq!(1, results.len(), "{sql}");
+            let err = results.remove(0).unwrap_err();
+            assert_eq!(StatusCode::PermissionDenied, err.status_code(), "{sql}");
+        }
+        let err = instance
+            .do_describe_inner(parse_one_sql("SELECT * FROM physical_metric"), ctx.clone())
+            .await
+            .unwrap_err();
+        assert_eq!(StatusCode::PermissionDenied, err.status_code());
+
+        let request = ReadRequest {
+            queries: vec![RemoteQuery {
+                matchers: vec![LabelMatcher {
+                    r#type: PromMatcherType::Eq as i32,
+                    name: servers::prom_store::METRIC_NAME_LABEL.to_string(),
+                    value: physical_table.to_string(),
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let Err(err) = PromStoreProtocolHandler::read(&instance, request, ctx.clone()).await else {
+            panic!("physical remote-read target must be rejected");
+        };
+        assert_eq!(StatusCode::PermissionDenied, err.status_code());
+
+        let err = PrometheusHandler::query_label_values(
+            &instance,
+            physical_table.to_string(),
+            "host".to_string(),
+            vec![],
+            SystemTime::UNIX_EPOCH,
+            SystemTime::UNIX_EPOCH,
+            &ctx,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(StatusCode::PermissionDenied, err.status_code());
+
+        Ok(())
     }
 
     #[test]

--- a/src/frontend/src/instance/grpc.rs
+++ b/src/frontend/src/instance/grpc.rs
@@ -26,7 +26,9 @@ use api::v1::{
 };
 use async_stream::try_stream;
 use async_trait::async_trait;
-use auth::{PermissionChecker, PermissionCheckerRef, PermissionReq};
+use auth::{
+    PermissionChecker, PermissionCheckerRef, PermissionReq, PermissionResp, PermissionTableTargets,
+};
 use common_error::ext::BoxedError;
 use common_grpc::flight::do_put::DoPutResponse;
 use common_query::Output;
@@ -332,6 +334,32 @@ fn fill_catalog_and_schema_from_context(ddl_expr: &mut DdlExpr, ctx: &QueryConte
 }
 
 impl Instance {
+    pub(crate) fn check_table_permission(
+        &self,
+        ctx: &QueryContextRef,
+        req: PermissionReq<'_>,
+        targets: PermissionTableTargets,
+    ) -> auth::error::Result<PermissionResp> {
+        self.plugins
+            .get::<PermissionCheckerRef>()
+            .as_ref()
+            .check_permission_with_table_targets(ctx.current_user(), req, targets)
+    }
+
+    /// Checks every logical table targeted by normalized row inserts.
+    pub(crate) fn check_row_insert_permission(
+        &self,
+        requests: &RowInsertRequests,
+        ctx: &QueryContextRef,
+        req: PermissionReq<'_>,
+    ) -> auth::error::Result<PermissionResp> {
+        let catalog = ctx.current_catalog();
+        let schema = ctx.current_schema();
+        let targets = PermissionTableTargets::from_row_insert_requests(catalog, &schema, requests);
+
+        self.check_table_permission(ctx, req, targets)
+    }
+
     fn handle_put_record_batch_stream_inner(
         &self,
         mut stream: servers::grpc::flight::PutRecordBatchRequestStream,

--- a/src/frontend/src/instance/influxdb.rs
+++ b/src/frontend/src/instance/influxdb.rs
@@ -67,6 +67,8 @@ impl InfluxdbLineProtocolHandler for Instance {
         interceptor_ref.pre_execute(&request.lines, ctx.clone())?;
 
         let requests = request.try_into()?;
+        self.check_row_insert_permission(&requests, &ctx, PermissionReq::LineProtocol)
+            .context(AuthSnafu)?;
 
         let aligner = InfluxdbLineTimestampAligner {
             catalog_manager: self.catalog_manager(),
@@ -76,6 +78,10 @@ impl InfluxdbLineProtocolHandler for Instance {
         let requests = interceptor_ref
             .post_lines_conversion(requests, ctx.clone())
             .await?;
+
+        let ctx = Arc::new(ctx.fork());
+        self.check_row_insert_permission(&requests, &ctx, PermissionReq::LineProtocol)
+            .context(AuthSnafu)?;
 
         let ctx = ctx_with_default_merge_mode(ctx, self.influxdb_default_merge_mode);
         let ctx = {

--- a/src/frontend/src/instance/log_handler.rs
+++ b/src/frontend/src/instance/log_handler.rs
@@ -33,9 +33,12 @@ use table::Table;
 
 use crate::instance::Instance;
 
-#[async_trait]
-impl PipelineHandler for Instance {
-    async fn insert(&self, log: RowInsertRequests, ctx: QueryContextRef) -> ServerResult<Output> {
+impl Instance {
+    async fn prepare_log_insert(
+        &self,
+        log: RowInsertRequests,
+        ctx: QueryContextRef,
+    ) -> ServerResult<RowInsertRequests> {
         self.plugins
             .get::<PermissionCheckerRef>()
             .as_ref()
@@ -48,7 +51,37 @@ impl PipelineHandler for Instance {
             .as_ref()
             .pre_ingest(log, ctx.clone())?;
 
-        self.handle_log_inserts(log, ctx).await
+        self.check_row_insert_permission(&log, &ctx, PermissionReq::LogWrite)
+            .context(AuthSnafu)?;
+
+        Ok(log)
+    }
+}
+
+#[async_trait]
+impl PipelineHandler for Instance {
+    async fn insert(&self, log: RowInsertRequests, ctx: QueryContextRef) -> ServerResult<Output> {
+        let log = self.prepare_log_insert(log, ctx.clone()).await?;
+        self.handle_log_inserts(log, Arc::new(ctx.fork())).await
+    }
+
+    async fn insert_all(
+        &self,
+        inputs: Vec<(QueryContextRef, RowInsertRequests)>,
+    ) -> ServerResult<Vec<ServerResult<Output>>> {
+        let mut prepared = Vec::with_capacity(inputs.len());
+        for (ctx, log) in inputs {
+            let log = self.prepare_log_insert(log, ctx.clone()).await?;
+            // Detach from context clones retained by pre-ingest hooks so the
+            // checked schema cannot change before this batch is written.
+            prepared.push((Arc::new(ctx.fork()), log));
+        }
+
+        let mut outputs = Vec::with_capacity(prepared.len());
+        for (ctx, log) in prepared {
+            outputs.push(self.handle_log_inserts(log, ctx).await);
+        }
+        Ok(outputs)
     }
 
     async fn get_pipeline(

--- a/src/frontend/src/instance/logs.rs
+++ b/src/frontend/src/instance/logs.rs
@@ -14,10 +14,7 @@
 
 use std::ops::Deref;
 
-use auth::{
-    PermissionChecker, PermissionCheckerRef, PermissionReq, PermissionTableTarget,
-    PermissionTableTargets,
-};
+use auth::{PermissionReq, PermissionTableTarget, PermissionTableTargets};
 use client::Output;
 use common_error::ext::BoxedError;
 use log_query::LogQuery;
@@ -42,15 +39,9 @@ impl LogQueryHandler for Instance {
             &request.table.schema_name,
             &request.table.table_name,
         )]);
+        let targets = self.resolve_query_permission_targets(targets, &ctx).await?;
 
-        self.plugins
-            .get::<PermissionCheckerRef>()
-            .as_ref()
-            .check_permission_with_table_targets(
-                ctx.current_user(),
-                PermissionReq::LogQuery,
-                targets,
-            )
+        self.check_table_permission(&ctx, PermissionReq::LogQuery, targets)
             .context(AuthSnafu)?;
 
         interceptor.as_ref().pre_query(&request, ctx.clone())?;

--- a/src/frontend/src/instance/logs.rs
+++ b/src/frontend/src/instance/logs.rs
@@ -14,7 +14,10 @@
 
 use std::ops::Deref;
 
-use auth::{PermissionChecker, PermissionCheckerRef, PermissionReq};
+use auth::{
+    PermissionChecker, PermissionCheckerRef, PermissionReq, PermissionTableTarget,
+    PermissionTableTargets,
+};
 use client::Output;
 use common_error::ext::BoxedError;
 use log_query::LogQuery;
@@ -34,11 +37,20 @@ impl LogQueryHandler for Instance {
         let interceptor = self
             .plugins
             .get::<LogQueryInterceptorRef<server_error::Error>>();
+        let targets = PermissionTableTargets::resolved(vec![PermissionTableTarget::new(
+            &request.table.catalog_name,
+            &request.table.schema_name,
+            &request.table.table_name,
+        )]);
 
         self.plugins
             .get::<PermissionCheckerRef>()
             .as_ref()
-            .check_permission(ctx.current_user(), PermissionReq::LogQuery)
+            .check_permission_with_table_targets(
+                ctx.current_user(),
+                PermissionReq::LogQuery,
+                targets,
+            )
             .context(AuthSnafu)?;
 
         interceptor.as_ref().pre_query(&request, ctx.clone())?;

--- a/src/frontend/src/instance/opentsdb.rs
+++ b/src/frontend/src/instance/opentsdb.rs
@@ -15,7 +15,10 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use auth::{PermissionChecker, PermissionCheckerRef, PermissionReq};
+use auth::{
+    PermissionChecker, PermissionCheckerRef, PermissionReq, PermissionTableTarget,
+    PermissionTableTargets,
+};
 use common_error::ext::BoxedError;
 use common_telemetry::tracing;
 use servers::error::{self as server_error, AuthSnafu, ExecuteGrpcQuerySnafu};
@@ -28,8 +31,33 @@ use table::requests::{SEMANTIC_SIGNAL_TYPE, SEMANTIC_SOURCE, SIGNAL_TYPE_METRIC,
 
 use crate::instance::Instance;
 
+fn permission_targets(data_points: &[DataPoint], ctx: &QueryContextRef) -> PermissionTableTargets {
+    let catalog = ctx.current_catalog();
+    let schema = ctx.current_schema();
+    PermissionTableTargets::resolved(
+        data_points
+            .iter()
+            .map(|data_point| PermissionTableTarget::new(catalog, &schema, data_point.metric()))
+            .collect(),
+    )
+}
+
 #[async_trait]
 impl OpentsdbProtocolHandler for Instance {
+    async fn preflight(
+        &self,
+        data_points: &[DataPoint],
+        ctx: QueryContextRef,
+    ) -> server_error::Result<()> {
+        self.check_table_permission(
+            &ctx,
+            PermissionReq::Opentsdb,
+            permission_targets(data_points, &ctx),
+        )
+        .context(AuthSnafu)?;
+        Ok(())
+    }
+
     #[tracing::instrument(skip_all, fields(protocol = "opentsdb"))]
     async fn exec(
         &self,
@@ -43,6 +71,8 @@ impl OpentsdbProtocolHandler for Instance {
             .context(AuthSnafu)?;
 
         let (requests, _) = data_point_to_grpc_row_insert_requests(data_points)?;
+        self.check_row_insert_permission(&requests, &ctx, PermissionReq::Opentsdb)
+            .context(AuthSnafu)?;
 
         let ctx = {
             let mut c = (*ctx).clone();
@@ -62,5 +92,34 @@ impl OpentsdbProtocolHandler for Instance {
             common_query::OutputData::AffectedRows(rows) => rows,
             _ => unreachable!(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use session::context::QueryContext;
+
+    use super::*;
+
+    #[test]
+    fn test_permission_targets_do_not_require_row_conversion() {
+        let data_points = [
+            DataPoint::new("cpu".to_string(), 0, 1.0, vec![]),
+            DataPoint::new(
+                "mem".to_string(),
+                0,
+                1.0,
+                vec![("greptime_value".to_string(), "tag".to_string())],
+            ),
+        ];
+        assert!(data_point_to_grpc_row_insert_requests(data_points.to_vec()).is_err());
+
+        assert_eq!(
+            PermissionTableTargets::Resolved(vec![
+                PermissionTableTarget::new("greptime", "public", "cpu"),
+                PermissionTableTarget::new("greptime", "public", "mem"),
+            ]),
+            permission_targets(&data_points, &QueryContext::arc())
+        );
     }
 }

--- a/src/frontend/src/instance/otlp.rs
+++ b/src/frontend/src/instance/otlp.rs
@@ -19,8 +19,12 @@ pub mod trace_types;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use auth::{PermissionChecker, PermissionCheckerRef, PermissionReq};
+use auth::{
+    PermissionChecker, PermissionCheckerRef, PermissionReq, PermissionTableTarget,
+    PermissionTableTargets,
+};
 use client::Output;
+use common_catalog::consts::{trace_operations_table_name, trace_services_table_name};
 use common_error::ext::BoxedError;
 use common_query::prelude::GREPTIME_PHYSICAL_TABLE;
 use common_telemetry::tracing;
@@ -32,6 +36,7 @@ use servers::error::{self, AuthSnafu, Result as ServerResult};
 use servers::http::prom_store::PHYSICAL_TABLE_PARAM;
 use servers::interceptor::{OpenTelemetryProtocolInterceptor, OpenTelemetryProtocolInterceptorRef};
 use servers::otlp;
+use servers::otlp::trace::span::TraceSpanGroup;
 use servers::query_handler::{
     OpenTelemetryProtocolHandler, PipelineHandlerRef, TraceIngestOutcome,
 };
@@ -46,6 +51,37 @@ use table::requests::{
 use self::trace_ingest::trace_conventions;
 use crate::instance::Instance;
 use crate::metrics::{OTLP_LOGS_ROWS, OTLP_METRICS_ROWS};
+
+fn trace_permission_targets(
+    table_name: &str,
+    groups: &[TraceSpanGroup],
+    ctx: &QueryContextRef,
+) -> PermissionTableTargets {
+    let catalog = ctx.current_catalog();
+    let schema = ctx.current_schema();
+    if catalog.is_empty() || schema.is_empty() || table_name.is_empty() {
+        return PermissionTableTargets::Unresolved;
+    }
+
+    let has_spans = groups.iter().any(|group| !group.spans.is_empty());
+    if !has_spans {
+        return PermissionTableTargets::resolved(Vec::new());
+    }
+
+    let mut targets = vec![PermissionTableTarget::new(catalog, &schema, table_name)];
+    if groups
+        .iter()
+        .flat_map(|group| &group.spans)
+        .any(|span| span.service_name.is_some())
+    {
+        targets.extend([
+            PermissionTableTarget::new(catalog, &schema, trace_services_table_name(table_name)),
+            PermissionTableTarget::new(catalog, &schema, trace_operations_table_name(table_name)),
+        ]);
+    }
+
+    PermissionTableTargets::resolved(targets)
+}
 
 #[async_trait]
 impl OpenTelemetryProtocolHandler for Instance {
@@ -65,6 +101,7 @@ impl OpenTelemetryProtocolHandler for Instance {
             .plugins
             .get::<OpenTelemetryProtocolInterceptorRef<servers::error::Error>>();
         interceptor_ref.pre_execute(ctx.clone())?;
+        let ctx = Arc::new(ctx.fork());
 
         let input_names = request
             .resource_metrics
@@ -85,6 +122,8 @@ impl OpenTelemetryProtocolHandler for Instance {
 
         let (requests, rows, semantic_index) =
             otlp::metrics::to_grpc_insert_requests(request, &mut metric_ctx)?;
+        self.check_row_insert_permission(&requests, &ctx, PermissionReq::Otlp)
+            .context(AuthSnafu)?;
         OTLP_METRICS_ROWS.inc_by(rows as u64);
 
         let ctx = {
@@ -140,10 +179,14 @@ impl OpenTelemetryProtocolHandler for Instance {
             .plugins
             .get::<OpenTelemetryProtocolInterceptorRef<servers::error::Error>>();
         interceptor_ref.pre_execute(ctx.clone())?;
+        let ctx = Arc::new(ctx.fork());
 
         // `schema_url` is consumed by `parse`, so derive conventions first.
         let conventions = trace_conventions(&request);
         let spans = otlp::trace::span::parse(request);
+        let targets = trace_permission_targets(&table_name, &spans, &ctx);
+        self.check_table_permission(&ctx, PermissionReq::Otlp, targets)
+            .context(AuthSnafu)?;
         self.ingest_trace_spans(
             pipeline_handler,
             &pipeline,
@@ -176,6 +219,7 @@ impl OpenTelemetryProtocolHandler for Instance {
             .plugins
             .get::<OpenTelemetryProtocolInterceptorRef<servers::error::Error>>();
         interceptor_ref.pre_execute(ctx.clone())?;
+        let ctx = Arc::new(ctx.fork());
 
         // `as_req_iter` clones this ctx into each `temp_ctx`, so identity set here
         // reaches the context that drives table auto-create.
@@ -196,9 +240,14 @@ impl OpenTelemetryProtocolHandler for Instance {
         )
         .await?;
 
-        let mut outputs = vec![];
+        let batches = opt_req.as_req_iter(ctx).collect::<Vec<_>>();
+        for (temp_ctx, requests) in &batches {
+            self.check_row_insert_permission(requests, temp_ctx, PermissionReq::Otlp)
+                .context(AuthSnafu)?;
+        }
 
-        for (temp_ctx, requests) in opt_req.as_req_iter(ctx) {
+        let mut outputs = Vec::with_capacity(batches.len());
+        for (temp_ctx, requests) in batches {
             let cnt = requests
                 .inserts
                 .iter()
@@ -215,5 +264,56 @@ impl OpenTelemetryProtocolHandler for Instance {
         }
 
         Ok(outputs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use auth::{PermissionTableTarget, PermissionTableTargets};
+    use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
+    use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue, any_value};
+    use opentelemetry_proto::tonic::resource::v1::Resource;
+    use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans, Span};
+    use session::context::QueryContext;
+
+    use super::trace_permission_targets;
+
+    #[test]
+    fn test_trace_permission_targets() {
+        let request = ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                resource: Some(Resource {
+                    attributes: vec![KeyValue {
+                        key: "service.name".to_string(),
+                        value: Some(AnyValue {
+                            value: Some(any_value::Value::StringValue("frontend".to_string())),
+                        }),
+                    }],
+                    ..Default::default()
+                }),
+                scope_spans: vec![ScopeSpans {
+                    spans: vec![Span::default()],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        };
+        let groups = servers::otlp::trace::span::parse(request);
+        let ctx = Arc::new(QueryContext::with("greptime", "public"));
+
+        assert_eq!(
+            PermissionTableTargets::Resolved(vec![
+                PermissionTableTarget::new("greptime", "public", "traces"),
+                PermissionTableTarget::new("greptime", "public", "traces_services"),
+                PermissionTableTarget::new("greptime", "public", "traces_operations"),
+            ]),
+            trace_permission_targets("traces", &groups, &ctx)
+        );
+        assert_eq!(
+            PermissionTableTargets::Unresolved,
+            trace_permission_targets("", &groups, &ctx)
+        );
     }
 }

--- a/src/frontend/src/instance/otlp.rs
+++ b/src/frontend/src/instance/otlp.rs
@@ -107,11 +107,11 @@ impl OpenTelemetryProtocolHandler for Instance {
             .resource_metrics
             .iter()
             .flat_map(|r| r.scope_metrics.iter())
-            .flat_map(|s| s.metrics.iter().map(|m| &m.name))
+            .flat_map(|s| s.metrics.iter().map(|m| m.name.clone()))
             .collect::<Vec<_>>();
 
         // See [`OtlpMetricCtx`] for details
-        let is_legacy = self.check_otlp_legacy(&input_names, ctx.clone()).await?;
+        let is_legacy = self.check_otlp_legacy(&input_names, &ctx).await?;
 
         let mut metric_ctx = ctx
             .protocol_ctx()
@@ -124,6 +124,7 @@ impl OpenTelemetryProtocolHandler for Instance {
             otlp::metrics::to_grpc_insert_requests(request, &mut metric_ctx)?;
         self.check_row_insert_permission(&requests, &ctx, PermissionReq::Otlp)
             .context(AuthSnafu)?;
+        self.cache_otlp_legacy(&input_names, &ctx, is_legacy)?;
         OTLP_METRICS_ROWS.inc_by(rows as u64);
 
         let ctx = {

--- a/src/frontend/src/instance/prom_store.rs
+++ b/src/frontend/src/instance/prom_store.rs
@@ -407,6 +407,16 @@ impl PromStoreProtocolHandler for Instance {
         Ok(())
     }
 
+    async fn write_prepared(
+        &self,
+        request: RowInsertRequests,
+        ctx: QueryContextRef,
+        with_metric_engine: bool,
+    ) -> ServerResult<Output> {
+        self.execute_prom_store_write(request, ctx, with_metric_engine)
+            .await
+    }
+
     async fn write(
         &self,
         request: RowInsertRequests,
@@ -414,8 +424,7 @@ impl PromStoreProtocolHandler for Instance {
         with_metric_engine: bool,
     ) -> ServerResult<Output> {
         let (request, ctx) = self.prepare_prom_store_write(request, ctx).await?;
-        self.execute_prom_store_write(request, ctx, with_metric_engine)
-            .await
+        self.write_prepared(request, ctx, with_metric_engine).await
     }
 
     async fn write_all(
@@ -430,9 +439,7 @@ impl PromStoreProtocolHandler for Instance {
 
         let mut outputs = Vec::with_capacity(prepared.len());
         for (request, ctx) in prepared {
-            let output = self
-                .execute_prom_store_write(request, ctx, with_metric_engine)
-                .await;
+            let output = self.write_prepared(request, ctx, with_metric_engine).await;
             let failed = output.is_err();
             outputs.push(output);
             if failed {
@@ -615,7 +622,7 @@ impl PromStoreProtocolHandler for ExportMetricHandler {
         Ok(())
     }
 
-    async fn write(
+    async fn write_prepared(
         &self,
         request: RowInsertRequests,
         ctx: QueryContextRef,
@@ -633,6 +640,15 @@ impl PromStoreProtocolHandler for ExportMetricHandler {
             .context(error::ExecuteGrpcQuerySnafu)
     }
 
+    async fn write(
+        &self,
+        request: RowInsertRequests,
+        ctx: QueryContextRef,
+        with_metric_engine: bool,
+    ) -> ServerResult<Output> {
+        self.write_prepared(request, ctx, with_metric_engine).await
+    }
+
     async fn write_all(
         &self,
         requests: Vec<(QueryContextRef, RowInsertRequests)>,
@@ -640,7 +656,7 @@ impl PromStoreProtocolHandler for ExportMetricHandler {
     ) -> ServerResult<Vec<ServerResult<Output>>> {
         let mut outputs = Vec::with_capacity(requests.len());
         for (ctx, request) in requests {
-            let output = self.write(request, ctx, with_metric_engine).await;
+            let output = self.write_prepared(request, ctx, with_metric_engine).await;
             let failed = output.is_err();
             outputs.push(output);
             if failed {

--- a/src/frontend/src/instance/prom_store.rs
+++ b/src/frontend/src/instance/prom_store.rs
@@ -23,7 +23,10 @@ use api::v1::{
     RowInsertRequests, SemanticType,
 };
 use async_trait::async_trait;
-use auth::{PermissionChecker, PermissionCheckerRef, PermissionReq};
+use auth::{
+    PermissionChecker, PermissionCheckerRef, PermissionReq, PermissionTableTarget,
+    PermissionTableTargets,
+};
 use client::OutputData;
 use common_catalog::format_full_table_name;
 use common_error::ext::BoxedError;
@@ -176,22 +179,21 @@ impl Instance {
         &self,
         ctx: QueryContextRef,
         queries: &[Query],
+        table_names: &[String],
     ) -> ServerResult<Vec<(String, Output)>> {
         let mut results = Vec::with_capacity(queries.len());
 
         let catalog_name = ctx.current_catalog();
         let schema_name = ctx.current_schema();
 
-        for query in queries {
-            let table_name = prom_store::table_name(query)?;
-
+        for (query, table_name) in queries.iter().zip(table_names) {
             let output = self
-                .handle_remote_query(&ctx, catalog_name, &schema_name, &table_name, query)
+                .handle_remote_query(&ctx, catalog_name, &schema_name, table_name, query)
                 .await
                 .map_err(BoxedError::new)
                 .context(error::ExecuteQuerySnafu)?;
 
-            results.push((table_name, output));
+            results.push((table_name.clone(), output));
         }
         Ok(results)
     }
@@ -348,33 +350,22 @@ impl PendingRowsSchemaAlterer for Instance {
     }
 }
 
-#[async_trait]
-impl PromStoreProtocolHandler for Instance {
-    async fn pre_write(
+impl Instance {
+    async fn prepare_prom_store_write(
         &self,
-        request: &RowInsertRequests,
+        request: RowInsertRequests,
         ctx: QueryContextRef,
-    ) -> ServerResult<()> {
-        self.plugins
-            .get::<PermissionCheckerRef>()
-            .as_ref()
-            .check_permission(ctx.current_user(), PermissionReq::PromStoreWrite)
-            .context(AuthSnafu)?;
-        let interceptor_ref = self
-            .plugins
-            .get::<PromStoreProtocolInterceptorRef<servers::error::Error>>();
-        interceptor_ref.pre_write(request, ctx)?;
-        Ok(())
+    ) -> ServerResult<(RowInsertRequests, QueryContextRef)> {
+        PromStoreProtocolHandler::pre_write(self, &request, ctx.clone()).await?;
+        Ok((request, Arc::new(ctx.fork())))
     }
 
-    async fn write(
+    async fn execute_prom_store_write(
         &self,
         request: RowInsertRequests,
         ctx: QueryContextRef,
         with_metric_engine: bool,
     ) -> ServerResult<Output> {
-        self.pre_write(&request, ctx.clone()).await?;
-
         let output = if with_metric_engine {
             let physical_table = ctx
                 .extension(PHYSICAL_TABLE_PARAM)
@@ -393,6 +384,63 @@ impl PromStoreProtocolHandler for Instance {
 
         Ok(output)
     }
+}
+
+#[async_trait]
+impl PromStoreProtocolHandler for Instance {
+    async fn pre_write(
+        &self,
+        request: &RowInsertRequests,
+        ctx: QueryContextRef,
+    ) -> ServerResult<()> {
+        self.plugins
+            .get::<PermissionCheckerRef>()
+            .as_ref()
+            .check_permission(ctx.current_user(), PermissionReq::PromStoreWrite)
+            .context(AuthSnafu)?;
+        let interceptor_ref = self
+            .plugins
+            .get::<PromStoreProtocolInterceptorRef<servers::error::Error>>();
+        interceptor_ref.pre_write(request, ctx.clone())?;
+        self.check_row_insert_permission(request, &ctx, PermissionReq::PromStoreWrite)
+            .context(AuthSnafu)?;
+        Ok(())
+    }
+
+    async fn write(
+        &self,
+        request: RowInsertRequests,
+        ctx: QueryContextRef,
+        with_metric_engine: bool,
+    ) -> ServerResult<Output> {
+        let (request, ctx) = self.prepare_prom_store_write(request, ctx).await?;
+        self.execute_prom_store_write(request, ctx, with_metric_engine)
+            .await
+    }
+
+    async fn write_all(
+        &self,
+        requests: Vec<(QueryContextRef, RowInsertRequests)>,
+        with_metric_engine: bool,
+    ) -> ServerResult<Vec<ServerResult<Output>>> {
+        let mut prepared = Vec::with_capacity(requests.len());
+        for (ctx, request) in requests {
+            prepared.push(self.prepare_prom_store_write(request, ctx).await?);
+        }
+
+        let mut outputs = Vec::with_capacity(prepared.len());
+        for (request, ctx) in prepared {
+            let output = self
+                .execute_prom_store_write(request, ctx, with_metric_engine)
+                .await;
+            let failed = output.is_err();
+            outputs.push(output);
+            if failed {
+                break;
+            }
+        }
+        Ok(outputs)
+    }
 
     #[instrument(skip_all, fields(table_name))]
     async fn read(
@@ -405,15 +453,40 @@ impl PromStoreProtocolHandler for Instance {
             .as_ref()
             .check_permission(ctx.current_user(), PermissionReq::PromStoreRead)
             .context(AuthSnafu)?;
+
         let interceptor_ref = self
             .plugins
             .get::<PromStoreProtocolInterceptorRef<servers::error::Error>>();
         interceptor_ref.pre_read(&request, ctx.clone())?;
+        let ctx = Arc::new(ctx.fork());
+
+        let table_names = request
+            .queries
+            .iter()
+            .map(prom_store::table_name)
+            .collect::<ServerResult<Vec<_>>>()?;
+        let catalog = ctx.current_catalog();
+        let schema = ctx.current_schema();
+        let targets = self
+            .resolve_query_permission_targets(
+                PermissionTableTargets::resolved(
+                    table_names
+                        .iter()
+                        .map(|table| PermissionTableTarget::new(catalog, &schema, table))
+                        .collect(),
+                ),
+                &ctx,
+            )
+            .await?;
+        self.check_table_permission(&ctx, PermissionReq::PromStoreRead, targets)
+            .context(AuthSnafu)?;
 
         let response_type = negotiate_response_type(&request.accepted_response_types)?;
 
         // TODO(dennis): use read_hints to speedup query if possible
-        let results = self.handle_remote_queries(ctx, &request.queries).await?;
+        let results = self
+            .handle_remote_queries(ctx, &request.queries, &table_names)
+            .await?;
 
         match response_type {
             ResponseType::Samples => {
@@ -534,6 +607,14 @@ impl ExportMetricHandler {
 
 #[async_trait]
 impl PromStoreProtocolHandler for ExportMetricHandler {
+    async fn pre_write(
+        &self,
+        _request: &RowInsertRequests,
+        _ctx: QueryContextRef,
+    ) -> ServerResult<()> {
+        Ok(())
+    }
+
     async fn write(
         &self,
         request: RowInsertRequests,
@@ -550,6 +631,23 @@ impl PromStoreProtocolHandler for ExportMetricHandler {
             .await
             .map_err(BoxedError::new)
             .context(error::ExecuteGrpcQuerySnafu)
+    }
+
+    async fn write_all(
+        &self,
+        requests: Vec<(QueryContextRef, RowInsertRequests)>,
+        with_metric_engine: bool,
+    ) -> ServerResult<Vec<ServerResult<Output>>> {
+        let mut outputs = Vec::with_capacity(requests.len());
+        for (ctx, request) in requests {
+            let output = self.write(request, ctx, with_metric_engine).await;
+            let failed = output.is_err();
+            outputs.push(output);
+            if failed {
+                break;
+            }
+        }
+        Ok(outputs)
     }
 
     async fn read(

--- a/src/frontend/src/instance/promql.rs
+++ b/src/frontend/src/instance/promql.rs
@@ -14,16 +14,16 @@
 
 use std::time::SystemTime;
 
+use auth::PermissionTableTarget;
 use catalog::information_schema::TABLES;
 use client::OutputData;
 use common_catalog::consts::INFORMATION_SCHEMA_NAME;
 use common_catalog::format_full_table_name;
 use common_recordbatch::util;
 use common_telemetry::tracing;
-use promql_parser::label::{MatchOp, Matcher, Matchers};
+use promql_parser::label::{Matcher, Matchers};
 use query::promql;
 use query::promql::planner::PromPlanner;
-use servers::prom_store::is_database_selection_label;
 use servers::prometheus;
 use session::context::QueryContextRef;
 use snafu::{OptionExt, ResultExt};
@@ -41,6 +41,7 @@ impl Instance {
     pub(crate) async fn handle_query_metric_names(
         &self,
         matchers: Vec<Matcher>,
+        schema: &str,
         ctx: &QueryContextRef,
     ) -> Result<Vec<String>> {
         let _timer = crate::metrics::PROMQL_QUERY_METRICS_ELAPSED
@@ -68,8 +69,9 @@ impl Instance {
                 table_name: "greptime.information_schema.tables",
             })?;
 
-        let logical_plan = prometheus::metric_name_matchers_to_plan(dataframe, matchers, ctx)
-            .context(PrometheusMetricNamesQueryPlanSnafu)?;
+        let logical_plan =
+            prometheus::metric_name_matchers_to_plan(dataframe, matchers, schema, ctx)
+                .context(PrometheusMetricNamesQueryPlanSnafu)?;
 
         let results = self
             .query_engine
@@ -102,28 +104,18 @@ impl Instance {
     #[tracing::instrument(skip_all)]
     pub(crate) async fn handle_query_label_values(
         &self,
-        metric: String,
+        target: PermissionTableTarget,
         label_name: String,
         matchers: Vec<Matcher>,
         start: SystemTime,
         end: SystemTime,
         ctx: &QueryContextRef,
     ) -> Result<Vec<String>> {
-        let table_schema = matchers
-            .iter()
-            .find_map(|m| {
-                if is_database_selection_label(&m.name) && m.op == MatchOp::Equal {
-                    Some(m.value.clone())
-                } else {
-                    None
-                }
-            })
-            .unwrap_or_else(|| ctx.current_schema());
-
-        let full_table_name = format_full_table_name(ctx.current_catalog(), &table_schema, &metric);
+        let full_table_name =
+            format_full_table_name(&target.catalog, &target.schema, &target.table);
         let table = self
             .catalog_manager
-            .table(ctx.current_catalog(), &table_schema, &metric, Some(ctx))
+            .table(&target.catalog, &target.schema, &target.table, Some(ctx))
             .await
             .context(CatalogSnafu)?
             .with_context(|| TableNotFoundSnafu {

--- a/src/pipeline/src/etl/ctx_req.rs
+++ b/src/pipeline/src/etl/ctx_req.rs
@@ -214,11 +214,9 @@ impl ContextReq {
     }
 
     pub fn as_req_iter(self, ctx: QueryContextRef) -> ContextReqIter {
-        let ctx = (*ctx).clone();
-
         ContextReqIter {
             opt_req: self.req.into_iter(),
-            ctx_template: ctx,
+            ctx_template: ctx.fork(),
         }
     }
 
@@ -249,12 +247,49 @@ impl Iterator for ContextReqIter {
 
     fn next(&mut self) -> Option<Self::Item> {
         let (mut opt, req_vec) = self.opt_req.next()?;
-        let mut ctx = self.ctx_template.clone();
+        let mut ctx = self.ctx_template.fork();
         if let Some(schema) = opt.schema.take() {
             ctx.set_current_schema(&schema);
         }
         opt.set_query_context(&mut ctx);
 
         Some((Arc::new(ctx), RowInsertRequests { inserts: req_vec }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_collected_contexts_keep_independent_schemas() {
+        let mut req = ContextReq::default();
+        for schema in ["schema_a", "schema_b"] {
+            let mut opt = ContextOpt::default();
+            opt.set_schema(schema.to_string());
+            req.add_row(
+                &opt,
+                RowInsertRequest {
+                    table_name: "metrics".to_string(),
+                    rows: None,
+                },
+            );
+        }
+
+        let original = Arc::new(QueryContext::with("greptime", "public"));
+        let batches = req.as_req_iter(original.clone()).collect::<Vec<_>>();
+        let mut schemas = batches
+            .iter()
+            .map(|(ctx, _)| ctx.current_schema())
+            .collect::<Vec<_>>();
+        schemas.sort_unstable();
+
+        assert_eq!(vec!["schema_a", "schema_b"], schemas);
+        assert_eq!("public", original.current_schema());
+
+        let other_schema = batches[1].0.current_schema();
+        batches[0].0.set_current_schema("changed");
+        assert_eq!(other_schema, batches[1].0.current_schema());
+        assert_eq!("public", original.current_schema());
     }
 }

--- a/src/servers/src/grpc/prom_query_gateway.rs
+++ b/src/servers/src/grpc/prom_query_gateway.rs
@@ -36,7 +36,7 @@ use crate::grpc::TonicResult;
 use crate::grpc::context_auth::auth;
 use crate::grpc::greptime_handler::create_query_context;
 use crate::http::prometheus::{PrometheusJsonResponse, retrieve_metric_name_and_result_type};
-use crate::prometheus_handler::PrometheusHandlerRef;
+use crate::prometheus_handler::{ParsedPromQuery, PrometheusHandlerRef};
 
 pub struct PrometheusGatewayService {
     handler: PrometheusHandlerRef,
@@ -127,14 +127,14 @@ impl PrometheusGatewayService {
             .with_label_values(&[db.as_str()])
             .start_timer();
 
-        let result = self.handler.do_query(&query, ctx).await;
-        let (metric_name, mut result_type) =
-            match retrieve_metric_name_and_result_type(&query.query) {
-                Ok((metric_name, result_type)) => (metric_name, result_type),
-                Err(err) => {
-                    return PrometheusJsonResponse::error(err.status_code(), err.output_msg());
-                }
-            };
+        let query = match ParsedPromQuery::parse(query, &ctx) {
+            Ok(query) => query,
+            Err(err) => {
+                return PrometheusJsonResponse::error(err.status_code(), err.output_msg());
+            }
+        };
+        let (metric_name, mut result_type) = retrieve_metric_name_and_result_type(query.expr());
+        let result = self.handler.do_query_parsed(query, ctx).await;
         // range query only returns matrix
         if is_range_query {
             result_type = ValueType::Matrix;

--- a/src/servers/src/http/event.rs
+++ b/src/servers/src/http/event.rs
@@ -986,12 +986,11 @@ pub(crate) async fn execute_log_context_req(
 ) -> Result<HttpResponse> {
     let db = query_ctx.get_db_string();
 
-    let mut outputs = Vec::with_capacity(ctx_req.map_len());
     let mut total_rows: u64 = 0;
     let mut fail = false;
-    for (temp_ctx, act_req) in ctx_req.as_req_iter(query_ctx) {
-        let output = handler.insert(act_req, temp_ctx).await;
-
+    let batches = ctx_req.as_req_iter(query_ctx).collect::<Vec<_>>();
+    let outputs = handler.insert_all(batches).await?;
+    for output in &outputs {
         if let Ok(Output {
             data: OutputData::AffectedRows(rows),
             meta: _,
@@ -1001,7 +1000,6 @@ pub(crate) async fn execute_log_context_req(
         } else {
             fail = true;
         }
-        outputs.push(output);
     }
 
     // Record one aggregate metric sample for the whole ingestion request.

--- a/src/servers/src/http/opentsdb.rs
+++ b/src/servers/src/http/opentsdb.rs
@@ -90,6 +90,12 @@ pub async fn put(
     ctx.set_channel(Channel::Opentsdb);
     let ctx = Arc::new(ctx);
 
+    if summary || details {
+        opentsdb_handler
+            .preflight(&data_points, ctx.clone())
+            .await?;
+    }
+
     let response = if !summary && !details {
         if let Err(e) = opentsdb_handler.exec(data_points, ctx.clone()).await {
             // Not debugging purpose, failed fast.

--- a/src/servers/src/http/prom_store.rs
+++ b/src/servers/src/http/prom_store.rs
@@ -280,11 +280,16 @@ async fn remote_write_v2(
     };
     debug_assert_eq!(outcome.samples_written, sample_count);
     debug_assert_eq!(outcome.histograms_written, histogram_count);
-    record_remote_write_samples(&db, sample_count);
-    record_remote_write_histograms(&db, histogram_count);
+    record_remote_write_samples(&db, outcome.samples_written);
+    record_remote_write_histograms(&db, outcome.histograms_written);
 
     let mut headers = write_cost_header_map(outcome.write_cost);
-    append_remote_write_v2_written_headers(&mut headers, sample_count, histogram_count, 0);
+    append_remote_write_v2_written_headers(
+        &mut headers,
+        outcome.samples_written,
+        outcome.histograms_written,
+        0,
+    );
 
     Ok((StatusCode::NO_CONTENT, headers).into_response())
 }

--- a/src/servers/src/http/prom_store.rs
+++ b/src/servers/src/http/prom_store.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use api::prom_store::remote::ReadRequest;
 use api::v1::RowInsertRequests;
+use async_trait::async_trait;
 use axum::Extension;
 use axum::body::Bytes;
 use axum::extract::{Query, State};
@@ -356,6 +357,18 @@ struct PromWriteV2Error {
 
 type PromWriteBatch = (QueryContextRef, RowInsertRequests);
 
+#[async_trait]
+trait PromWriteBatcher: Send + Sync {
+    async fn submit(&self, requests: RowInsertRequests, ctx: QueryContextRef) -> Result<u64>;
+}
+
+#[async_trait]
+impl PromWriteBatcher for PendingRowsBatcher {
+    async fn submit(&self, requests: RowInsertRequests, ctx: QueryContextRef) -> Result<u64> {
+        PendingRowsBatcher::submit(self, requests, ctx).await
+    }
+}
+
 fn into_prom_write_batches(req: ContextReq, query_ctx: QueryContextRef) -> Vec<PromWriteBatch> {
     req.as_req_iter(query_ctx).collect()
 }
@@ -470,6 +483,17 @@ async fn write_prometheus_v2_rows_with_progress(
         });
     }
 
+    if prom_store_with_metric_engine && let Some(batcher) = pending_rows_batcher {
+        return write_batched_prometheus_v2_rows_with_progress(
+            prom_store_handler,
+            batcher.as_ref(),
+            prom_store_with_metric_engine,
+            sample_batches,
+            histogram_batches,
+        )
+        .await;
+    }
+
     let sample_batch_count = sample_batches.len();
     let mut batches = sample_batches;
     batches.extend(histogram_batches);
@@ -511,6 +535,60 @@ async fn write_prometheus_v2_rows_with_progress(
             samples_written,
             histograms_written,
         });
+    }
+
+    Ok(PromWriteV2Outcome {
+        write_cost,
+        samples_written,
+        histograms_written,
+    })
+}
+
+async fn write_batched_prometheus_v2_rows_with_progress<B: PromWriteBatcher + ?Sized>(
+    prom_store_handler: PromStoreProtocolHandlerRef,
+    batcher: &B,
+    prom_store_with_metric_engine: bool,
+    sample_batches: Vec<PromWriteBatch>,
+    histogram_batches: Vec<PromWriteBatch>,
+) -> std::result::Result<PromWriteV2Outcome, PromWriteV2Error> {
+    let sample_batch_count = sample_batches.len();
+    let mut batches = sample_batches;
+    batches.extend(histogram_batches);
+    preflight_prometheus_rows(&prom_store_handler, &mut batches)
+        .await
+        .map_err(|error| PromWriteV2Error {
+            error,
+            samples_written: 0,
+            histograms_written: 0,
+        })?;
+
+    let mut samples_written = 0;
+    let mut histograms_written = 0;
+    let mut write_cost = 0;
+    let mut batches = batches.into_iter();
+    for (ctx, requests) in batches.by_ref().take(sample_batch_count) {
+        let rows = batcher
+            .submit(requests, ctx)
+            .await
+            .map_err(|error| PromWriteV2Error {
+                error,
+                samples_written,
+                histograms_written,
+            })?;
+        samples_written += rows;
+    }
+    for (ctx, requests) in batches {
+        let rows = prom_write_row_count(&requests);
+        let output = prom_store_handler
+            .write_prepared(requests, ctx, prom_store_with_metric_engine)
+            .await
+            .map_err(|error| PromWriteV2Error {
+                error,
+                samples_written,
+                histograms_written,
+            })?;
+        write_cost += output.meta.cost;
+        histograms_written += rows;
     }
 
     Ok(PromWriteV2Outcome {
@@ -691,7 +769,10 @@ async fn decode_remote_read_request(body: Bytes) -> Result<ReadRequest> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use api::prom_store::remote::ReadRequest;
+    use api::v1::{Row, RowInsertRequest, Rows};
     use async_trait::async_trait;
     use common_query::Output;
     use pipeline::GreptimePipelineParams;
@@ -778,6 +859,130 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_mixed_v2_preflights_all_then_batches_only_samples() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let handler: PromStoreProtocolHandlerRef = Arc::new(RecordingPromStoreHandler {
+            events: events.clone(),
+        });
+        let batcher = RecordingPromWriteBatcher {
+            events: events.clone(),
+        };
+
+        let Ok(outcome) = write_batched_prometheus_v2_rows_with_progress(
+            handler,
+            &batcher,
+            true,
+            vec![test_prom_write_batch("sample")],
+            vec![test_prom_write_batch("histogram")],
+        )
+        .await
+        else {
+            panic!("mixed remote write should succeed")
+        };
+
+        assert_eq!(1, outcome.samples_written);
+        assert_eq!(1, outcome.histograms_written);
+        assert_eq!(
+            vec![
+                "pre:sample".to_string(),
+                "pre:histogram".to_string(),
+                "batch:sample".to_string(),
+                "direct:histogram".to_string(),
+            ],
+            *events.lock().unwrap()
+        );
+    }
+
+    fn test_prom_write_batch(table_name: &str) -> PromWriteBatch {
+        (
+            Arc::new(QueryContext::with("greptime", "public")),
+            RowInsertRequests {
+                inserts: vec![RowInsertRequest {
+                    table_name: table_name.to_string(),
+                    rows: Some(Rows {
+                        schema: Vec::new(),
+                        rows: vec![Row { values: Vec::new() }],
+                    }),
+                }],
+            },
+        )
+    }
+
+    fn record_write_event(events: &Mutex<Vec<String>>, phase: &str, request: &RowInsertRequests) {
+        events.lock().unwrap().push(format!(
+            "{phase}:{}",
+            request.inserts.first().unwrap().table_name
+        ));
+    }
+
+    struct RecordingPromWriteBatcher {
+        events: Arc<Mutex<Vec<String>>>,
+    }
+
+    #[async_trait]
+    impl PromWriteBatcher for RecordingPromWriteBatcher {
+        async fn submit(&self, requests: RowInsertRequests, _ctx: QueryContextRef) -> Result<u64> {
+            record_write_event(&self.events, "batch", &requests);
+            Ok(prom_write_row_count(&requests))
+        }
+    }
+
+    struct RecordingPromStoreHandler {
+        events: Arc<Mutex<Vec<String>>>,
+    }
+
+    #[async_trait]
+    impl PromStoreProtocolHandler for RecordingPromStoreHandler {
+        async fn pre_write(
+            &self,
+            request: &RowInsertRequests,
+            _ctx: QueryContextRef,
+        ) -> Result<()> {
+            record_write_event(&self.events, "pre", request);
+            Ok(())
+        }
+
+        async fn write_prepared(
+            &self,
+            request: RowInsertRequests,
+            _ctx: QueryContextRef,
+            _with_metric_engine: bool,
+        ) -> Result<Output> {
+            record_write_event(&self.events, "direct", &request);
+            Ok(Output::new_with_affected_rows(0))
+        }
+
+        async fn write(
+            &self,
+            _request: RowInsertRequests,
+            _ctx: QueryContextRef,
+            _with_metric_engine: bool,
+        ) -> Result<Output> {
+            unreachable!("mixed v2 writes use preflighted execution")
+        }
+
+        async fn write_all(
+            &self,
+            _requests: Vec<(QueryContextRef, RowInsertRequests)>,
+            _with_metric_engine: bool,
+        ) -> Result<Vec<Result<Output>>> {
+            unreachable!("mixed v2 writes preserve sample and histogram routing")
+        }
+
+        async fn read(
+            &self,
+            _request: ReadRequest,
+            _ctx: QueryContextRef,
+        ) -> Result<PromStoreResponse> {
+            unimplemented!()
+        }
+
+        async fn ingest_metrics(&self, _metrics: Metrics) -> Result<()> {
+            unimplemented!()
+        }
+    }
+
+    #[tokio::test]
     async fn test_remote_write_v2_ignores_pipeline() {
         let request = api::greptime_proto::io::prometheus::write::v2::Request {
             symbols: vec![String::new()],
@@ -836,6 +1041,15 @@ mod tests {
             _ctx: QueryContextRef,
         ) -> Result<()> {
             Ok(())
+        }
+
+        async fn write_prepared(
+            &self,
+            _request: RowInsertRequests,
+            _ctx: QueryContextRef,
+            _with_metric_engine: bool,
+        ) -> Result<Output> {
+            unreachable!("empty remote write v2 request should not write")
         }
 
         async fn write(

--- a/src/servers/src/http/prom_store.rs
+++ b/src/servers/src/http/prom_store.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use api::prom_store::remote::ReadRequest;
+use api::v1::RowInsertRequests;
 use axum::Extension;
 use axum::body::Bytes;
 use axum::extract::{Query, State};
@@ -30,7 +31,7 @@ use pipeline::{ContextReq, PipelineDefinition};
 use prometheus::HistogramTimer;
 use prost::Message;
 use serde::{Deserialize, Serialize};
-use session::context::{Channel, QueryContext};
+use session::context::{Channel, QueryContext, QueryContextRef};
 use snafu::prelude::*;
 use table::requests::{
     METADATA_QUALITY_INFERRED, SEMANTIC_METRIC_METADATA_QUALITY, SEMANTIC_SIGNAL_TYPE,
@@ -178,13 +179,13 @@ async fn remote_write_v1(
     } else {
         req.as_insert_requests()
     };
+    let batches = into_prom_write_batches(req, query_ctx);
 
     let outcome = match write_prometheus_rows_with_progress(
         prom_store_handler,
         pending_rows_batcher,
         prom_store_with_metric_engine,
-        query_ctx,
-        req,
+        batches,
     )
     .await
     {
@@ -251,67 +252,38 @@ async fn remote_write_v2(
         Ok(req) => req,
         Err(error) => return Ok(remote_write_v2_error_response(error, 0, 0, 0)),
     };
-
-    let outcome = if req.sample_count > 0 {
-        match write_prometheus_rows_with_progress(
-            prom_store_handler.clone(),
-            pending_rows_batcher.clone(),
-            prom_store_with_metric_engine,
-            query_ctx.clone(),
-            req.samples,
-        )
-        .await
-        {
-            Ok(outcome) => outcome,
-            Err(error) => {
-                record_remote_write_samples(&db, error.rows_written);
-                return Ok(remote_write_v2_error_response(
-                    error.error,
-                    error.rows_written,
-                    0,
-                    0,
-                ));
-            }
-        }
-    } else {
-        PromWriteOutcome {
-            write_cost: 0,
-            rows_written: 0,
+    let sample_count = req.sample_count;
+    let histogram_count = req.histogram_count;
+    let sample_batches = into_prom_write_batches(req.samples, query_ctx.clone());
+    let histogram_batches = into_prom_write_batches(req.histograms, query_ctx);
+    let outcome = match write_prometheus_v2_rows_with_progress(
+        prom_store_handler,
+        pending_rows_batcher,
+        prom_store_with_metric_engine,
+        sample_batches,
+        histogram_batches,
+    )
+    .await
+    {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            record_remote_write_samples(&db, error.samples_written);
+            record_remote_write_histograms(&db, error.histograms_written);
+            return Ok(remote_write_v2_error_response(
+                error.error,
+                error.samples_written,
+                error.histograms_written,
+                0,
+            ));
         }
     };
-    let samples_written = outcome.rows_written;
-    record_remote_write_samples(&db, samples_written);
-    let mut histograms_written = 0;
-    let mut write_cost = outcome.write_cost;
+    debug_assert_eq!(outcome.samples_written, sample_count);
+    debug_assert_eq!(outcome.histograms_written, histogram_count);
+    record_remote_write_samples(&db, sample_count);
+    record_remote_write_histograms(&db, histogram_count);
 
-    if req.histogram_count > 0 {
-        let outcome = match write_prometheus_rows_with_progress(
-            prom_store_handler,
-            None,
-            prom_store_with_metric_engine,
-            query_ctx,
-            req.histograms,
-        )
-        .await
-        {
-            Ok(outcome) => outcome,
-            Err(error) => {
-                record_remote_write_histograms(&db, error.rows_written);
-                return Ok(remote_write_v2_error_response(
-                    error.error,
-                    samples_written,
-                    error.rows_written,
-                    0,
-                ));
-            }
-        };
-        histograms_written = outcome.rows_written;
-        record_remote_write_histograms(&db, histograms_written);
-        write_cost += outcome.write_cost;
-    }
-
-    let mut headers = write_cost_header_map(write_cost);
-    append_remote_write_v2_written_headers(&mut headers, samples_written, histograms_written, 0);
+    let mut headers = write_cost_header_map(outcome.write_cost);
+    append_remote_write_v2_written_headers(&mut headers, sample_count, histogram_count, 0);
 
     Ok((StatusCode::NO_CONTENT, headers).into_response())
 }
@@ -370,7 +342,38 @@ struct PromWriteError {
     rows_written: u64,
 }
 
-/// Writes one decoded PRW batch and keeps the number of persisted rows on error.
+struct PromWriteV2Outcome {
+    write_cost: usize,
+    samples_written: u64,
+    histograms_written: u64,
+}
+
+struct PromWriteV2Error {
+    error: error::Error,
+    samples_written: u64,
+    histograms_written: u64,
+}
+
+type PromWriteBatch = (QueryContextRef, RowInsertRequests);
+
+fn into_prom_write_batches(req: ContextReq, query_ctx: QueryContextRef) -> Vec<PromWriteBatch> {
+    req.as_req_iter(query_ctx).collect()
+}
+
+async fn preflight_prometheus_rows(
+    prom_store_handler: &PromStoreProtocolHandlerRef,
+    batches: &mut [PromWriteBatch],
+) -> Result<()> {
+    for (ctx, reqs) in batches {
+        prom_store_handler.pre_write(reqs, ctx.clone()).await?;
+        // Detach from context clones retained by pre-write hooks so the checked
+        // schema cannot change before this prepared batch is written.
+        *ctx = Arc::new(ctx.fork());
+    }
+    Ok(())
+}
+
+/// Writes preflighted PRW batches and keeps the number of persisted rows on error.
 ///
 /// The v2 handler uses that partial progress to return Prometheus' written
 /// sample/histogram headers even when a later table write fails.
@@ -378,19 +381,17 @@ async fn write_prometheus_rows_with_progress(
     prom_store_handler: PromStoreProtocolHandlerRef,
     pending_rows_batcher: Option<Arc<PendingRowsBatcher>>,
     prom_store_with_metric_engine: bool,
-    query_ctx: Arc<QueryContext>,
-    req: ContextReq,
+    mut batches: Vec<PromWriteBatch>,
 ) -> std::result::Result<PromWriteOutcome, PromWriteError> {
     if prom_store_with_metric_engine && let Some(batcher) = pending_rows_batcher {
+        preflight_prometheus_rows(&prom_store_handler, &mut batches)
+            .await
+            .map_err(|error| PromWriteError {
+                error,
+                rows_written: 0,
+            })?;
         let mut rows_written = 0;
-        for (temp_ctx, reqs) in req.as_req_iter(query_ctx) {
-            prom_store_handler
-                .pre_write(&reqs, temp_ctx.clone())
-                .await
-                .map_err(|error| PromWriteError {
-                    error,
-                    rows_written,
-                })?;
+        for (temp_ctx, reqs) in batches {
             let rows = batcher
                 .submit(reqs, temp_ctx)
                 .await
@@ -406,29 +407,132 @@ async fn write_prometheus_rows_with_progress(
         });
     }
 
+    let row_counts = batches
+        .iter()
+        .map(|(_, request)| prom_write_row_count(request))
+        .collect::<Vec<_>>();
+    let batch_count = batches.len();
+    let outputs = prom_store_handler
+        .write_all(batches, prom_store_with_metric_engine)
+        .await
+        .map_err(|error| PromWriteError {
+            error,
+            rows_written: 0,
+        })?;
+    let output_count = outputs.len();
     let mut write_cost = 0;
     let mut rows_written = 0;
-    for (temp_ctx, reqs) in req.as_req_iter(query_ctx) {
-        let cnt: u64 = reqs
-            .inserts
-            .iter()
-            .filter_map(|s| s.rows.as_ref().map(|r| r.rows.len() as u64))
-            .sum();
-        let output = prom_store_handler
-            .write(reqs, temp_ctx, prom_store_with_metric_engine)
-            .await
-            .map_err(|error| PromWriteError {
-                error,
-                rows_written,
-            })?;
+    for (output, rows) in outputs.into_iter().zip(row_counts) {
+        let output = output.map_err(|error| PromWriteError {
+            error,
+            rows_written,
+        })?;
         write_cost += output.meta.cost;
-        rows_written += cnt;
+        rows_written += rows;
+    }
+    if output_count != batch_count {
+        return Err(PromWriteError {
+            error: incomplete_prom_write_error(),
+            rows_written,
+        });
     }
 
     Ok(PromWriteOutcome {
         write_cost,
         rows_written,
     })
+}
+
+async fn write_prometheus_v2_rows_with_progress(
+    prom_store_handler: PromStoreProtocolHandlerRef,
+    pending_rows_batcher: Option<Arc<PendingRowsBatcher>>,
+    prom_store_with_metric_engine: bool,
+    sample_batches: Vec<PromWriteBatch>,
+    histogram_batches: Vec<PromWriteBatch>,
+) -> std::result::Result<PromWriteV2Outcome, PromWriteV2Error> {
+    if histogram_batches.is_empty() {
+        return write_prometheus_rows_with_progress(
+            prom_store_handler,
+            pending_rows_batcher,
+            prom_store_with_metric_engine,
+            sample_batches,
+        )
+        .await
+        .map(|outcome| PromWriteV2Outcome {
+            write_cost: outcome.write_cost,
+            samples_written: outcome.rows_written,
+            histograms_written: 0,
+        })
+        .map_err(|error| PromWriteV2Error {
+            error: error.error,
+            samples_written: error.rows_written,
+            histograms_written: 0,
+        });
+    }
+
+    let sample_batch_count = sample_batches.len();
+    let mut batches = sample_batches;
+    batches.extend(histogram_batches);
+    let row_counts = batches
+        .iter()
+        .map(|(_, request)| prom_write_row_count(request))
+        .collect::<Vec<_>>();
+    let batch_count = batches.len();
+    let outputs = prom_store_handler
+        .write_all(batches, prom_store_with_metric_engine)
+        .await
+        .map_err(|error| PromWriteV2Error {
+            error,
+            samples_written: 0,
+            histograms_written: 0,
+        })?;
+
+    let mut write_cost = 0;
+    let mut samples_written = 0;
+    let mut histograms_written = 0;
+    let mut output_count = 0;
+    for (index, (output, rows)) in outputs.into_iter().zip(row_counts).enumerate() {
+        let output = output.map_err(|error| PromWriteV2Error {
+            error,
+            samples_written,
+            histograms_written,
+        })?;
+        write_cost += output.meta.cost;
+        if index < sample_batch_count {
+            samples_written += rows;
+        } else {
+            histograms_written += rows;
+        }
+        output_count += 1;
+    }
+    if output_count != batch_count {
+        return Err(PromWriteV2Error {
+            error: incomplete_prom_write_error(),
+            samples_written,
+            histograms_written,
+        });
+    }
+
+    Ok(PromWriteV2Outcome {
+        write_cost,
+        samples_written,
+        histograms_written,
+    })
+}
+
+fn prom_write_row_count(request: &RowInsertRequests) -> u64 {
+    request
+        .inserts
+        .iter()
+        .filter_map(|insert| insert.rows.as_ref().map(|rows| rows.rows.len() as u64))
+        .sum()
+}
+
+fn incomplete_prom_write_error() -> error::Error {
+    InternalSnafu {
+        err_msg: "prometheus write handler returned before processing every batch".to_string(),
+    }
+    .build()
 }
 
 fn record_remote_write_samples(db: &str, rows: u64) {
@@ -588,7 +692,6 @@ async fn decode_remote_read_request(body: Bytes) -> Result<ReadRequest> {
 #[cfg(test)]
 mod tests {
     use api::prom_store::remote::ReadRequest;
-    use api::v1::RowInsertRequests;
     use async_trait::async_trait;
     use common_query::Output;
     use pipeline::GreptimePipelineParams;
@@ -727,6 +830,14 @@ mod tests {
 
     #[async_trait]
     impl PromStoreProtocolHandler for NoopPromStoreHandler {
+        async fn pre_write(
+            &self,
+            _request: &RowInsertRequests,
+            _ctx: QueryContextRef,
+        ) -> Result<()> {
+            Ok(())
+        }
+
         async fn write(
             &self,
             _request: RowInsertRequests,
@@ -734,6 +845,15 @@ mod tests {
             _with_metric_engine: bool,
         ) -> Result<Output> {
             unreachable!("empty remote write v2 request should not write")
+        }
+
+        async fn write_all(
+            &self,
+            requests: Vec<(QueryContextRef, RowInsertRequests)>,
+            _with_metric_engine: bool,
+        ) -> Result<Vec<Result<Output>>> {
+            assert!(requests.is_empty());
+            Ok(Vec::new())
         }
 
         async fn read(

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -26,6 +26,7 @@ use arrow::datatypes::{
     UInt8Type, UInt16Type, UInt32Type, UInt64Type,
 };
 use arrow_schema::{DataType, IntervalUnit};
+use auth::{PermissionTableTarget, PermissionTableTargets};
 use axum::extract::{Path, Query, State};
 use axum::{Extension, Form};
 use catalog::CatalogManagerRef;
@@ -62,6 +63,7 @@ use snafu::{Location, OptionExt, ResultExt};
 use store_api::metric_engine_consts::{
     DATA_SCHEMA_TABLE_ID_COLUMN_NAME, DATA_SCHEMA_TSID_COLUMN_NAME, LOGICAL_TABLE_METADATA_KEY,
 };
+use table::TableRef;
 
 pub use super::result::prometheus_resp::PrometheusJsonResponse;
 use crate::error::{
@@ -70,7 +72,7 @@ use crate::error::{
 };
 use crate::http::header::collect_plan_metrics;
 use crate::prom_store::{FIELD_NAME_LABEL, METRIC_NAME_LABEL, is_database_selection_label};
-use crate::prometheus_handler::PrometheusHandlerRef;
+use crate::prometheus_handler::{PrometheusHandlerRef, resolve_schema_from_matchers};
 
 /// For [ValueType::Vector] result type
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq)]
@@ -232,12 +234,22 @@ pub struct InstantQuery {
 /// Helper macro which try to evaluate the expression and return its results.
 /// If the evaluation fails, return a `PrometheusJsonResponse` early.
 macro_rules! try_call_return_response {
-    ($handle: expr) => {
+    ($handle: expr, $status_code: expr) => {
         match $handle {
             Ok(res) => res,
             Err(err) => {
                 let msg = err.to_string();
-                return PrometheusJsonResponse::error(StatusCode::InvalidArguments, msg);
+                return PrometheusJsonResponse::error($status_code, msg);
+            }
+        }
+    };
+    ($handle: expr) => {
+        match $handle {
+            Ok(res) => res,
+            Err(err) => {
+                let status_code = err.status_code();
+                let msg = err.to_string();
+                return PrometheusJsonResponse::error(status_code, msg);
             }
         }
     };
@@ -271,7 +283,10 @@ pub async fn instant_query(
         alias: None,
     };
 
-    let promql_expr = try_call_return_response!(promql_parser::parser::parse(&prom_query.query));
+    let promql_expr = try_call_return_response!(
+        promql_parser::parser::parse(&prom_query.query),
+        StatusCode::InvalidArguments
+    );
 
     // update catalog and schema in query context if necessary
     if let Some(db) = &params.db {
@@ -284,17 +299,47 @@ pub async fn instant_query(
         .with_label_values(&[query_ctx.get_db_string().as_str(), "instant_query"])
         .start_timer();
 
-    if let Some(name_matchers) = find_metric_name_not_equal_matchers(&promql_expr)
-        && !name_matchers.is_empty()
-    {
-        debug!("Find metric name matchers: {:?}", name_matchers);
+    let metric_name_discovery =
+        try_call_return_response!(find_metric_name_not_equal_matchers(&promql_expr));
+    if let Some(discovery) = metric_name_discovery {
+        debug!("Find metric name matchers: {:?}", discovery.name_matchers);
 
-        let metric_names =
-            try_call_return_response!(handler.query_metric_names(name_matchers, &query_ctx).await);
+        try_call_return_response!(handler.check_query_permission(&[], &query_ctx).await);
+        let (static_targets, unresolved_selectors) =
+            try_call_return_response!(static_promql_targets(&promql_expr, &query_ctx));
+        try_call_return_response!(
+            handler
+                .check_query_target_permission(static_targets, &query_ctx,)
+                .await
+        );
+        if unresolved_selectors != 1 {
+            try_call_return_response!(
+                handler
+                    .check_query_target_permission(PermissionTableTargets::Unresolved, &query_ctx,)
+                    .await
+            );
+            return do_instant_query(&handler, &prom_query, query_ctx).await;
+        }
+
+        let schema = discovery
+            .schema
+            .unwrap_or_else(|| query_ctx.current_schema());
+        let metric_names = try_call_return_response!(
+            handler
+                .query_metric_names(discovery.name_matchers, &schema, &query_ctx)
+                .await
+        );
 
         debug!("Find metric names: {:?}", metric_names);
 
-        if metric_names.is_empty() {
+        let prom_queries = expand_metric_name_queries(&prom_query, &promql_expr, metric_names);
+        try_call_return_response!(
+            handler
+                .check_query_permission(&prom_queries, &query_ctx)
+                .await
+        );
+
+        if prom_queries.is_empty() {
             let result_type = promql_expr.value_type();
 
             return PrometheusJsonResponse::success(PrometheusResponse::PromData(PromData {
@@ -303,23 +348,11 @@ pub async fn instant_query(
             }));
         }
 
-        let responses = join_all(metric_names.into_iter().map(|metric| {
-            let mut prom_query = prom_query.clone();
-            let mut promql_expr = promql_expr.clone();
+        let responses = join_all(prom_queries.into_iter().map(|prom_query| {
             let query_ctx = query_ctx.clone();
             let handler = handler.clone();
 
-            async move {
-                update_metric_name_matcher(&mut promql_expr, &metric);
-                let new_query = promql_expr.to_string();
-                debug!(
-                    "Updated promql, before: {}, after: {}",
-                    &prom_query.query, new_query
-                );
-                prom_query.query = new_query;
-
-                do_instant_query(&handler, &prom_query, query_ctx).await
-            }
+            async move { do_instant_query(&handler, &prom_query, query_ctx).await }
         }))
         .await;
 
@@ -383,7 +416,10 @@ pub async fn range_query(
         alias: None,
     };
 
-    let promql_expr = try_call_return_response!(promql_parser::parser::parse(&prom_query.query));
+    let promql_expr = try_call_return_response!(
+        promql_parser::parser::parse(&prom_query.query),
+        StatusCode::InvalidArguments
+    );
 
     // update catalog and schema in query context if necessary
     if let Some(db) = &params.db {
@@ -395,40 +431,58 @@ pub async fn range_query(
         .with_label_values(&[query_ctx.get_db_string().as_str(), "range_query"])
         .start_timer();
 
-    if let Some(name_matchers) = find_metric_name_not_equal_matchers(&promql_expr)
-        && !name_matchers.is_empty()
-    {
-        debug!("Find metric name matchers: {:?}", name_matchers);
+    let metric_name_discovery =
+        try_call_return_response!(find_metric_name_not_equal_matchers(&promql_expr));
+    if let Some(discovery) = metric_name_discovery {
+        debug!("Find metric name matchers: {:?}", discovery.name_matchers);
 
-        let metric_names =
-            try_call_return_response!(handler.query_metric_names(name_matchers, &query_ctx).await);
+        try_call_return_response!(handler.check_query_permission(&[], &query_ctx).await);
+        let (static_targets, unresolved_selectors) =
+            try_call_return_response!(static_promql_targets(&promql_expr, &query_ctx));
+        try_call_return_response!(
+            handler
+                .check_query_target_permission(static_targets, &query_ctx,)
+                .await
+        );
+        if unresolved_selectors != 1 {
+            try_call_return_response!(
+                handler
+                    .check_query_target_permission(PermissionTableTargets::Unresolved, &query_ctx,)
+                    .await
+            );
+            return do_range_query(&handler, &prom_query, query_ctx).await;
+        }
+
+        let schema = discovery
+            .schema
+            .unwrap_or_else(|| query_ctx.current_schema());
+        let metric_names = try_call_return_response!(
+            handler
+                .query_metric_names(discovery.name_matchers, &schema, &query_ctx)
+                .await
+        );
 
         debug!("Find metric names: {:?}", metric_names);
 
-        if metric_names.is_empty() {
+        let prom_queries = expand_metric_name_queries(&prom_query, &promql_expr, metric_names);
+        try_call_return_response!(
+            handler
+                .check_query_permission(&prom_queries, &query_ctx)
+                .await
+        );
+
+        if prom_queries.is_empty() {
             return PrometheusJsonResponse::success(PrometheusResponse::PromData(PromData {
                 result_type: ValueType::Matrix.to_string(),
                 ..Default::default()
             }));
         }
 
-        let responses = join_all(metric_names.into_iter().map(|metric| {
-            let mut prom_query = prom_query.clone();
-            let mut promql_expr = promql_expr.clone();
+        let responses = join_all(prom_queries.into_iter().map(|prom_query| {
             let query_ctx = query_ctx.clone();
             let handler = handler.clone();
 
-            async move {
-                update_metric_name_matcher(&mut promql_expr, &metric);
-                let new_query = promql_expr.to_string();
-                debug!(
-                    "Updated promql, before: {}, after: {}",
-                    &prom_query.query, new_query
-                );
-                prom_query.query = new_query;
-
-                do_range_query(&handler, &prom_query, query_ctx).await
-            }
+            async move { do_range_query(&handler, &prom_query, query_ctx).await }
         }))
         .await;
 
@@ -552,50 +606,82 @@ pub async fn labels_query(
         .with_label_values(&[query_ctx.get_db_string().as_str(), "labels_query"])
         .start_timer();
 
-    // Fetch all tag columns. It will be used as white-list for tag names.
-    let mut labels = match get_all_column_names(&catalog, &schema, &handler.catalog_manager()).await
-    {
-        Ok(labels) => labels,
-        Err(e) => return PrometheusJsonResponse::error(e.status_code(), e.output_msg()),
+    let prom_queries = if queries.is_empty() {
+        try_call_return_response!(handler.check_query_permission(&[], &query_ctx).await);
+        Vec::new()
+    } else {
+        let start = params
+            .start
+            .or(form_params.start)
+            .unwrap_or_else(yesterday_rfc3339);
+        let end = params
+            .end
+            .or(form_params.end)
+            .unwrap_or_else(current_time_rfc3339);
+        let lookback = params
+            .lookback
+            .or(form_params.lookback)
+            .unwrap_or_else(|| DEFAULT_LOOKBACK_STRING.to_string());
+        let prom_queries = queries
+            .into_iter()
+            .map(|query| PromQuery {
+                query,
+                start: start.clone(),
+                end: end.clone(),
+                step: DEFAULT_LOOKBACK_STRING.to_string(),
+                lookback: lookback.clone(),
+                alias: None,
+            })
+            .collect::<Vec<_>>();
+        try_call_return_response!(
+            handler
+                .check_query_permission(&prom_queries, &query_ctx)
+                .await
+        );
+        prom_queries
     };
-    // insert the special metric name label
-    let _ = labels.insert(METRIC_NAME.to_string());
 
     // Fetch all columns if no query matcher is provided
-    if queries.is_empty() {
+    if prom_queries.is_empty() {
+        let (mut labels, table_names) =
+            match get_all_column_names(&catalog, &schema, &handler.catalog_manager()).await {
+                Ok(result) => result,
+                Err(e) => return PrometheusJsonResponse::error(e.status_code(), e.output_msg()),
+            };
+        try_call_return_response!(
+            handler
+                .check_query_target_permission(
+                    current_schema_metric_targets(&query_ctx, &table_names),
+                    &query_ctx,
+                )
+                .await
+        );
+        let _ = labels.insert(METRIC_NAME.to_string());
         let mut labels_vec = labels.into_iter().collect::<Vec<_>>();
         labels_vec.sort_unstable();
         return PrometheusJsonResponse::success(PrometheusResponse::Labels(labels_vec));
     }
 
-    // Otherwise, run queries and extract column name from result set.
-    let start = params
-        .start
-        .or(form_params.start)
-        .unwrap_or_else(yesterday_rfc3339);
-    let end = params
-        .end
-        .or(form_params.end)
-        .unwrap_or_else(current_time_rfc3339);
-    let lookback = params
-        .lookback
-        .or(form_params.lookback)
-        .unwrap_or_else(|| DEFAULT_LOOKBACK_STRING.to_string());
+    // Fetch tag columns only from the tables checked above.
+    let mut labels = match resolved_promql_targets(&prom_queries, &query_ctx) {
+        Some(targets) => {
+            match get_target_column_names(&targets, &handler.catalog_manager(), &query_ctx).await {
+                Ok(labels) => labels,
+                Err(e) => return PrometheusJsonResponse::error(e.status_code(), e.output_msg()),
+            }
+        }
+        None => match get_all_column_names(&catalog, &schema, &handler.catalog_manager()).await {
+            Ok((labels, _)) => labels,
+            Err(e) => return PrometheusJsonResponse::error(e.status_code(), e.output_msg()),
+        },
+    };
+    let _ = labels.insert(METRIC_NAME.to_string());
 
     let mut fetched_labels = HashSet::new();
     let _ = fetched_labels.insert(METRIC_NAME.to_string());
 
     let mut merge_map = HashMap::new();
-    for query in queries {
-        let prom_query = PromQuery {
-            query,
-            start: start.clone(),
-            end: end.clone(),
-            step: DEFAULT_LOOKBACK_STRING.to_string(),
-            lookback: lookback.clone(),
-            alias: None,
-        };
-
+    for prom_query in prom_queries {
         let result = handler.do_query(&prom_query, query_ctx.clone()).await;
         handle_schema_err!(
             retrieve_labels_name_from_query_result(result, &mut fetched_labels, &mut merge_map)
@@ -605,8 +691,6 @@ pub async fn labels_query(
 
     // intersect `fetched_labels` with `labels` to filter out non-tag columns
     fetched_labels.retain(|l| labels.contains(l));
-    let _ = labels.insert(METRIC_NAME.to_string());
-
     let mut sorted_labels: Vec<String> = fetched_labels.into_iter().collect();
     sorted_labels.sort();
     let merge_map = merge_map
@@ -623,27 +707,57 @@ async fn get_all_column_names(
     catalog: &str,
     schema: &str,
     manager: &CatalogManagerRef,
-) -> std::result::Result<HashSet<String>, catalog::error::Error> {
+) -> std::result::Result<(HashSet<String>, Vec<String>), catalog::error::Error> {
     let mut labels = HashSet::new();
+    let mut table_names = Vec::new();
     let mut tables = manager.tables(catalog, schema, None);
     while let Some(table) = tables.try_next().await? {
-        for column in table.primary_key_columns() {
-            if column.name != DATA_SCHEMA_TABLE_ID_COLUMN_NAME
-                && column.name != DATA_SCHEMA_TSID_COLUMN_NAME
-            {
-                labels.insert(column.name);
-            }
+        if is_internal_physical_metric_table(&table) {
+            continue;
         }
+        table_names.push(table.table_info().name.clone());
+        extend_tag_column_names(&mut labels, &table);
     }
 
+    Ok((labels, table_names))
+}
+
+async fn get_target_column_names(
+    targets: &[PermissionTableTarget],
+    manager: &CatalogManagerRef,
+    query_ctx: &QueryContext,
+) -> std::result::Result<HashSet<String>, catalog::error::Error> {
+    let mut labels = HashSet::new();
+    for target in targets {
+        if let Some(table) = manager
+            .table(
+                &target.catalog,
+                &target.schema,
+                &target.table,
+                Some(query_ctx),
+            )
+            .await?
+            && !is_internal_physical_metric_table(&table)
+        {
+            extend_tag_column_names(&mut labels, &table);
+        }
+    }
     Ok(labels)
+}
+
+fn extend_tag_column_names(labels: &mut HashSet<String>, table: &TableRef) {
+    labels.extend(table.primary_key_columns().filter_map(|column| {
+        (column.name != DATA_SCHEMA_TABLE_ID_COLUMN_NAME
+            && column.name != DATA_SCHEMA_TSID_COLUMN_NAME)
+            .then_some(column.name)
+    }));
 }
 
 async fn retrieve_series_from_query_result(
     result: Result<Output>,
     series: &mut Vec<HashMap<Column, String>>,
     query_ctx: &QueryContext,
-    table_name: &str,
+    target: &PermissionTableTarget,
     manager: &CatalogManagerRef,
     metrics: &mut HashMap<String, u64>,
 ) -> Result<()> {
@@ -652,16 +766,16 @@ async fn retrieve_series_from_query_result(
     // fetch tag list
     let table = manager
         .table(
-            query_ctx.current_catalog(),
-            &query_ctx.current_schema(),
-            table_name,
+            &target.catalog,
+            &target.schema,
+            &target.table,
             Some(query_ctx),
         )
         .await?
         .with_context(|| TableNotFoundSnafu {
-            catalog: query_ctx.current_catalog(),
-            schema: query_ctx.current_schema(),
-            table: table_name,
+            catalog: &target.catalog,
+            schema: &target.schema,
+            table: &target.table,
         })?;
     let tag_columns = table
         .primary_key_columns()
@@ -670,13 +784,13 @@ async fn retrieve_series_from_query_result(
 
     match result.data {
         OutputData::RecordBatches(batches) => {
-            record_batches_to_series(batches, series, table_name, &tag_columns)
+            record_batches_to_series(batches, series, &target.table, &tag_columns)
         }
         OutputData::Stream(stream) => {
             let batches = RecordBatches::try_collect(stream)
                 .await
                 .context(CollectRecordbatchSnafu)?;
-            record_batches_to_series(batches, series, table_name, &tag_columns)
+            record_batches_to_series(batches, series, &target.table, &tag_columns)
         }
         OutputData::AffectedRows(_) => Err(Error::UnexpectedResult {
             reason: "expected data result, but got affected rows".to_string(),
@@ -1095,6 +1209,28 @@ pub(crate) fn try_update_catalog_schema(ctx: &mut QueryContext, catalog: &str, s
     }
 }
 
+fn current_schema_metric_targets(
+    query_ctx: &QueryContext,
+    metric_names: &[String],
+) -> PermissionTableTargets {
+    PermissionTableTargets::resolved(
+        metric_names
+            .iter()
+            .map(|metric| {
+                PermissionTableTarget::new(
+                    query_ctx.current_catalog(),
+                    query_ctx.current_schema(),
+                    metric,
+                )
+            })
+            .collect(),
+    )
+}
+
+fn is_internal_physical_metric_table(table: &TableRef) -> bool {
+    table.table_info().is_physical_table()
+}
+
 fn promql_expr_to_metric_name(expr: &PromqlExpr) -> Option<String> {
     let mut metric_names = HashSet::new();
     collect_metric_names(expr, &mut metric_names);
@@ -1195,23 +1331,161 @@ where
     }
 }
 
-/// Try to find the `__name__` matchers which op is not `MatchOp::Equal`.
-fn find_metric_name_not_equal_matchers(expr: &PromqlExpr) -> Option<Vec<Matcher>> {
+struct MetricNameDiscovery {
+    name_matchers: Vec<Matcher>,
+    schema: Option<String>,
+}
+
+/// Finds non-equality `__name__` matchers and their unambiguous schema.
+fn find_metric_name_not_equal_matchers(expr: &PromqlExpr) -> Result<Option<MetricNameDiscovery>> {
+    if find_metric_name_and_matchers(expr, |name, matchers| {
+        (name.is_none() && !matchers.or_matchers.is_empty()).then_some(())
+    })
+    .is_some()
+    {
+        return Ok(None);
+    }
+
     find_metric_name_and_matchers(expr, |name, matchers| {
         // Has name, ignore the matchers
         if name.is_some() {
             return None;
         }
 
-        // FIXME(dennis): we don't consider the nested and `or` matchers yet.
-        Some(matchers.find_matchers(METRIC_NAME))
+        let name_matchers = matchers.find_matchers(METRIC_NAME);
+        if name_matchers.len() != 1 || name_matchers[0].op == MatchOp::Equal {
+            return None;
+        }
+
+        Some(
+            resolve_schema_from_matchers(&matchers.matchers).map(|schema| MetricNameDiscovery {
+                name_matchers,
+                schema,
+            }),
+        )
     })
-    .map(|matchers| {
-        matchers
-            .into_iter()
-            .filter(|m| !matches!(m.op, MatchOp::Equal))
-            .collect::<Vec<_>>()
-    })
+    .transpose()
+}
+
+fn expand_metric_name_queries(
+    query: &PromQuery,
+    expr: &PromqlExpr,
+    metric_names: Vec<String>,
+) -> Vec<PromQuery> {
+    metric_names
+        .into_iter()
+        .map(|metric| {
+            let mut query = query.clone();
+            let mut expr = expr.clone();
+            update_metric_name_matcher(&mut expr, &metric);
+            query.query = expr.to_string();
+            query
+        })
+        .collect()
+}
+
+fn static_promql_targets(
+    expr: &PromqlExpr,
+    query_ctx: &QueryContextRef,
+) -> Result<(PermissionTableTargets, usize)> {
+    let mut targets = Vec::new();
+    let mut unresolved_selectors = 0;
+    collect_static_promql_targets(expr, query_ctx, &mut targets, &mut unresolved_selectors)?;
+    Ok((
+        PermissionTableTargets::resolved(targets),
+        unresolved_selectors,
+    ))
+}
+
+fn resolved_promql_targets(
+    queries: &[PromQuery],
+    query_ctx: &QueryContextRef,
+) -> Option<Vec<PermissionTableTarget>> {
+    let mut targets = Vec::new();
+    for query in queries {
+        let expr = promql_parser::parser::parse(&query.query).ok()?;
+        let (PermissionTableTargets::Resolved(query_targets), unresolved_selectors) =
+            static_promql_targets(&expr, query_ctx).ok()?
+        else {
+            return None;
+        };
+        if unresolved_selectors != 0 {
+            return None;
+        }
+        for target in query_targets {
+            if !targets.contains(&target) {
+                targets.push(target);
+            }
+        }
+    }
+    Some(targets)
+}
+
+fn collect_static_promql_targets(
+    expr: &PromqlExpr,
+    query_ctx: &QueryContextRef,
+    targets: &mut Vec<PermissionTableTarget>,
+    unresolved_selectors: &mut usize,
+) -> Result<()> {
+    match expr {
+        PromqlExpr::Aggregate(AggregateExpr { expr, .. })
+        | PromqlExpr::Unary(UnaryExpr { expr })
+        | PromqlExpr::Paren(ParenExpr { expr })
+        | PromqlExpr::Subquery(SubqueryExpr { expr, .. }) => {
+            collect_static_promql_targets(expr, query_ctx, targets, unresolved_selectors)?
+        }
+        PromqlExpr::Binary(BinaryExpr { lhs, rhs, .. }) => {
+            collect_static_promql_targets(lhs, query_ctx, targets, unresolved_selectors)?;
+            collect_static_promql_targets(rhs, query_ctx, targets, unresolved_selectors)?;
+        }
+        PromqlExpr::VectorSelector(selector) => {
+            collect_static_vector_target(selector, query_ctx, targets, unresolved_selectors)?
+        }
+        PromqlExpr::MatrixSelector(MatrixSelector { vs, .. }) => {
+            collect_static_vector_target(vs, query_ctx, targets, unresolved_selectors)?
+        }
+        PromqlExpr::Call(Call { args, .. }) => {
+            for expr in &args.args {
+                collect_static_promql_targets(expr, query_ctx, targets, unresolved_selectors)?;
+            }
+        }
+        PromqlExpr::NumberLiteral(_) | PromqlExpr::StringLiteral(_) | PromqlExpr::Extension(_) => {}
+    }
+    Ok(())
+}
+
+fn collect_static_vector_target(
+    selector: &VectorSelector,
+    query_ctx: &QueryContextRef,
+    targets: &mut Vec<PermissionTableTarget>,
+    unresolved_selectors: &mut usize,
+) -> Result<()> {
+    if selector.name.is_none() && !selector.matchers.or_matchers.is_empty() {
+        *unresolved_selectors += 1;
+        return Ok(());
+    }
+
+    let metric = selector.name.clone().or_else(|| {
+        let mut matchers = selector.matchers.find_matchers(METRIC_NAME);
+        if matchers.len() == 1 && matchers[0].op == MatchOp::Equal {
+            matchers.pop().map(|matcher| matcher.value)
+        } else {
+            None
+        }
+    });
+    let Some(metric) = metric else {
+        *unresolved_selectors += 1;
+        return Ok(());
+    };
+
+    let schema = resolve_schema_from_matchers(&selector.matchers.matchers)?
+        .unwrap_or_else(|| query_ctx.current_schema());
+    targets.push(PermissionTableTarget::new(
+        query_ctx.current_catalog(),
+        schema,
+        metric,
+    ));
+    Ok(())
 }
 
 /// Update the `__name__` matchers in expression into special value
@@ -1236,7 +1510,7 @@ fn update_metric_name_matcher(expr: &mut PromqlExpr, metric_name: &str) {
             }
 
             for m in &mut matchers.matchers {
-                if m.name == METRIC_NAME {
+                if m.name == METRIC_NAME && m.op != MatchOp::Equal {
                     m.op = MatchOp::Equal;
                     m.value = metric_name.to_string();
                 }
@@ -1249,7 +1523,7 @@ fn update_metric_name_matcher(expr: &mut PromqlExpr, metric_name: &str) {
             }
 
             for m in &mut matchers.matchers {
-                if m.name == METRIC_NAME {
+                if m.name == METRIC_NAME && m.op != MatchOp::Equal {
                     m.op = MatchOp::Equal;
                     m.value = metric_name.to_string();
                 }
@@ -1294,35 +1568,99 @@ pub async fn label_values_query(
         .with_label_values(&[query_ctx.get_db_string().as_str(), "label_values_query"])
         .start_timer();
 
+    let matches = params.matches.0;
     if label_name == METRIC_NAME_LABEL {
+        try_call_return_response!(handler.check_query_permission(&[], &query_ctx).await);
+        let exact_metric_names = matches
+            .iter()
+            .filter_map(|selector| retrieve_exact_metric_name_from_promql(selector))
+            .collect::<Vec<_>>();
+        try_call_return_response!(
+            handler
+                .check_query_target_permission(
+                    current_schema_metric_targets(&query_ctx, &exact_metric_names),
+                    &query_ctx,
+                )
+                .await
+        );
         let catalog_manager = handler.catalog_manager();
 
         let mut table_names = try_call_return_response!(
-            retrieve_table_names(&query_ctx, catalog_manager, params.matches.0).await
+            retrieve_table_names(&query_ctx, catalog_manager, matches).await
+        );
+        try_call_return_response!(
+            handler
+                .check_query_target_permission(
+                    current_schema_metric_targets(&query_ctx, &table_names),
+                    &query_ctx,
+                )
+                .await
         );
 
         truncate_results(&mut table_names, params.limit);
         return PrometheusJsonResponse::success(PrometheusResponse::LabelValues(table_names));
     } else if label_name == FIELD_NAME_LABEL {
-        let field_columns = handle_schema_err!(
-            retrieve_field_names(&query_ctx, handler.catalog_manager(), params.matches.0).await
-        )
-        .unwrap_or_default();
+        try_call_return_response!(handler.check_query_permission(&[], &query_ctx).await);
+        let enumerate_all = matches.is_empty();
+        let metric_names = matches
+            .iter()
+            .map(|selector| retrieve_exact_metric_name_from_promql(selector))
+            .collect::<Vec<_>>();
+        if metric_names.iter().any(Option::is_none) {
+            try_call_return_response!(
+                handler
+                    .check_query_target_permission(PermissionTableTargets::Unresolved, &query_ctx,)
+                    .await
+            );
+        }
+        let metric_names = metric_names.into_iter().flatten().collect::<Vec<_>>();
+
+        try_call_return_response!(
+            handler
+                .check_query_target_permission(
+                    current_schema_metric_targets(&query_ctx, &metric_names),
+                    &query_ctx,
+                )
+                .await
+        );
+
+        let (field_columns, table_names) = if !enumerate_all && metric_names.is_empty() {
+            (HashSet::new(), Vec::new())
+        } else {
+            handle_schema_err!(
+                retrieve_field_names(&query_ctx, handler.catalog_manager(), metric_names).await
+            )
+            .unwrap_or_default()
+        };
+        try_call_return_response!(
+            handler
+                .check_query_target_permission(
+                    current_schema_metric_targets(&query_ctx, &table_names),
+                    &query_ctx,
+                )
+                .await
+        );
         let mut field_columns = field_columns.into_iter().collect::<Vec<_>>();
         field_columns.sort_unstable();
         truncate_results(&mut field_columns, params.limit);
         return PrometheusJsonResponse::success(PrometheusResponse::LabelValues(field_columns));
     } else if is_database_selection_label(&label_name) {
+        try_call_return_response!(handler.check_query_permission(&[], &query_ctx).await);
         let catalog_manager = handler.catalog_manager();
 
-        let mut schema_names = try_call_return_response!(
-            retrieve_schema_names(&query_ctx, catalog_manager, params.matches.0).await
+        let (mut schema_names, targets) = try_call_return_response!(
+            retrieve_schema_names(&query_ctx, catalog_manager, matches).await
+        );
+        try_call_return_response!(
+            handler
+                .check_query_target_permission(targets, &query_ctx)
+                .await
         );
         truncate_results(&mut schema_names, params.limit);
         return PrometheusJsonResponse::success(PrometheusResponse::LabelValues(schema_names));
     }
 
-    let queries = params.matches.0;
+    let queries = matches;
     if queries.is_empty() {
         return PrometheusJsonResponse::error(
             StatusCode::InvalidArguments,
@@ -1332,6 +1670,26 @@ pub async fn label_values_query(
 
     let start = params.start.unwrap_or_else(yesterday_rfc3339);
     let end = params.end.unwrap_or_else(current_time_rfc3339);
+    let lookback = params
+        .lookback
+        .unwrap_or_else(|| DEFAULT_LOOKBACK_STRING.to_string());
+    let prom_queries = queries
+        .into_iter()
+        .map(|query| PromQuery {
+            query,
+            start: start.clone(),
+            end: end.clone(),
+            step: DEFAULT_LOOKBACK_STRING.to_string(),
+            lookback: lookback.clone(),
+            alias: None,
+        })
+        .collect::<Vec<_>>();
+    try_call_return_response!(
+        handler
+            .check_query_permission(&prom_queries, &query_ctx)
+            .await
+    );
+
     let mut label_values = HashSet::new();
 
     let start = try_call_return_response!(
@@ -1343,8 +1701,11 @@ pub async fn label_values_query(
             .context(ParseTimestampSnafu { timestamp: &end })
     );
 
-    for query in queries {
-        let promql_expr = try_call_return_response!(promql_parser::parser::parse(&query));
+    for prom_query in prom_queries {
+        let promql_expr = try_call_return_response!(
+            promql_parser::parser::parse(&prom_query.query),
+            StatusCode::InvalidArguments
+        );
         let PromqlExpr::VectorSelector(mut vector_selector) = promql_expr else {
             return PrometheusJsonResponse::error(
                 StatusCode::InvalidArguments,
@@ -1414,24 +1775,30 @@ async fn retrieve_table_names(
     let mut tables_stream = catalog_manager.tables(catalog, &schema, Some(query_ctx));
     let mut table_names = Vec::new();
 
-    // we only provide very limited support for matcher against __name__
-    let name_matcher = matches
-        .first()
-        .and_then(|matcher| promql_parser::parser::parse(matcher).ok())
-        .and_then(|expr| {
-            if let PromqlExpr::VectorSelector(vector_selector) = expr {
-                let matchers = vector_selector.matchers.matchers;
-                for matcher in matchers {
-                    if matcher.name == METRIC_NAME_LABEL {
-                        return Some(matcher);
-                    }
+    let name_matchers = matches
+        .iter()
+        .map(|selector| {
+            let expr = promql_parser::parser::parse(selector)
+                .map_err(|reason| InvalidQuerySnafu { reason }.build())?;
+            let PromqlExpr::VectorSelector(selector) = expr else {
+                return InvalidQuerySnafu {
+                    reason: "expected vector selector".to_string(),
                 }
-
-                None
-            } else {
-                None
+                .fail();
+            };
+            if !selector.matchers.or_matchers.is_empty() {
+                return Ok(None);
             }
-        });
+            if let Some(name) = selector.name {
+                return Ok(Some(Matcher::new(MatchOp::Equal, METRIC_NAME_LABEL, &name)));
+            }
+            Ok(selector
+                .matchers
+                .matchers
+                .into_iter()
+                .find(|matcher| matcher.name == METRIC_NAME_LABEL))
+        })
+        .collect::<Result<Vec<_>>>()?;
 
     while let Some(table) = tables_stream.next().await {
         let table = table?;
@@ -1441,6 +1808,7 @@ async fn retrieve_table_names(
             .options
             .extra_options
             .contains_key(LOGICAL_TABLE_METADATA_KEY)
+            || is_internal_physical_metric_table(&table)
         {
             // skip non-prometheus (non-metricengine) tables for __name__ query
             continue;
@@ -1448,25 +1816,18 @@ async fn retrieve_table_names(
 
         let table_name = &table.table_info().name;
 
-        if let Some(matcher) = &name_matcher {
-            match &matcher.op {
-                MatchOp::Equal => {
-                    if table_name == &matcher.value {
-                        table_names.push(table_name.clone());
-                    }
-                }
-                MatchOp::Re(reg) => {
-                    if reg.is_match(table_name) {
-                        table_names.push(table_name.clone());
-                    }
-                }
-                _ => {
-                    // != and !~ are not supported:
-                    // vector must contains at least one non-empty matcher
-                    table_names.push(table_name.clone());
-                }
-            }
-        } else {
+        if name_matchers.is_empty()
+            || name_matchers.iter().any(|matcher| match matcher {
+                None => true,
+                Some(matcher) => match &matcher.op {
+                    MatchOp::Equal => table_name == &matcher.value,
+                    MatchOp::Re(reg) => reg.is_match(table_name),
+                    // != and !~ are not supported, so include every table and
+                    // let the caller authorize the complete candidate set.
+                    _ => true,
+                },
+            })
+        {
             table_names.push(table_name.clone());
         }
     }
@@ -1479,24 +1840,26 @@ async fn retrieve_field_names(
     query_ctx: &QueryContext,
     manager: CatalogManagerRef,
     matches: Vec<String>,
-) -> Result<HashSet<String>> {
+) -> Result<(HashSet<String>, Vec<String>)> {
     let mut field_columns = HashSet::new();
+    let mut table_names = Vec::new();
     let catalog = query_ctx.current_catalog();
     let schema = query_ctx.current_schema();
 
     if matches.is_empty() {
         // query all tables if no matcher is provided
-        while let Some(table) = manager
-            .tables(catalog, &schema, Some(query_ctx))
-            .next()
-            .await
-        {
+        let mut tables = manager.tables(catalog, &schema, Some(query_ctx));
+        while let Some(table) = tables.next().await {
             let table = table?;
+            if is_internal_physical_metric_table(&table) {
+                continue;
+            }
+            table_names.push(table.table_info().name.clone());
             for column in table.field_columns() {
                 field_columns.insert(column.name);
             }
         }
-        return Ok(field_columns);
+        return Ok((field_columns, table_names));
     }
 
     for table_name in matches {
@@ -1509,20 +1872,30 @@ async fn retrieve_field_names(
                 table: table_name.clone(),
             })?;
 
+        if is_internal_physical_metric_table(&table) {
+            continue;
+        }
+        table_names.push(table.table_info().name.clone());
         for column in table.field_columns() {
             field_columns.insert(column.name);
         }
     }
-    Ok(field_columns)
+    Ok((field_columns, table_names))
 }
 
 async fn retrieve_schema_names(
     query_ctx: &QueryContext,
     catalog_manager: CatalogManagerRef,
     matches: Vec<String>,
-) -> Result<Vec<String>> {
+) -> Result<(Vec<String>, PermissionTableTargets)> {
     let mut schemas = Vec::new();
+    let mut targets = Vec::new();
     let catalog = query_ctx.current_catalog();
+    let metric_names = matches
+        .iter()
+        .map(|match_item| retrieve_exact_metric_name_from_promql(match_item))
+        .collect::<Vec<_>>();
+    let unresolved = metric_names.is_empty() || metric_names.iter().any(Option::is_none);
 
     let candidate_schemas = catalog_manager
         .schema_names(catalog, Some(query_ctx))
@@ -1530,15 +1903,17 @@ async fn retrieve_schema_names(
 
     for schema in candidate_schemas {
         let mut found = true;
-        for match_item in &matches {
-            if let Some(table_name) = retrieve_metric_name_from_promql(match_item) {
-                let exists = catalog_manager
-                    .table_exists(catalog, &schema, &table_name, Some(query_ctx))
-                    .await?;
-                if !exists {
-                    found = false;
-                    break;
-                }
+        for table_name in metric_names.iter().flatten() {
+            let table = catalog_manager
+                .table(catalog, &schema, table_name, Some(query_ctx))
+                .await?;
+            let Some(table) = table else {
+                found = false;
+                continue;
+            };
+            targets.push(PermissionTableTarget::new(catalog, &schema, table_name));
+            if is_internal_physical_metric_table(&table) {
+                found = false;
             }
         }
 
@@ -1549,16 +1924,28 @@ async fn retrieve_schema_names(
 
     schemas.sort_unstable();
 
-    Ok(schemas)
+    let targets = if unresolved {
+        PermissionTableTargets::Unresolved
+    } else {
+        PermissionTableTargets::resolved(targets)
+    };
+    Ok((schemas, targets))
 }
 
-/// Try to parse and extract the name of referenced metric from the promql query.
-///
-/// Returns the metric name if exactly one unique metric is referenced, otherwise None.
-/// Multiple references to the same metric are allowed.
-fn retrieve_metric_name_from_promql(query: &str) -> Option<String> {
-    let promql_expr = promql_parser::parser::parse(query).ok()?;
-    promql_expr_to_metric_name(&promql_expr)
+fn retrieve_exact_metric_name_from_promql(query: &str) -> Option<String> {
+    let PromqlExpr::VectorSelector(selector) = promql_parser::parser::parse(query).ok()? else {
+        return None;
+    };
+    if let Some(name) = selector.name {
+        return (!name.is_empty()).then_some(name);
+    }
+
+    let mut name_matchers = selector.matchers.find_matchers(METRIC_NAME);
+    if name_matchers.len() != 1 {
+        return None;
+    }
+    let matcher = name_matchers.pop()?;
+    (matcher.op == MatchOp::Equal && !matcher.value.is_empty()).then_some(matcher.value)
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -1616,11 +2003,9 @@ pub async fn series_query(
         .with_label_values(&[query_ctx.get_db_string().as_str(), "series_query"])
         .start_timer();
 
-    let mut series = Vec::new();
-    let mut merge_map = HashMap::new();
-    for query in queries {
-        let table_name = retrieve_metric_name_from_promql(&query).unwrap_or_default();
-        let prom_query = PromQuery {
+    let prom_queries = queries
+        .into_iter()
+        .map(|query| PromQuery {
             query,
             start: start.clone(),
             end: end.clone(),
@@ -1628,6 +2013,27 @@ pub async fn series_query(
             step: DEFAULT_LOOKBACK_STRING.to_string(),
             lookback: lookback.clone(),
             alias: None,
+        })
+        .collect::<Vec<_>>();
+    try_call_return_response!(
+        handler
+            .check_query_permission(&prom_queries, &query_ctx)
+            .await
+    );
+
+    let mut series = Vec::new();
+    let mut merge_map = HashMap::new();
+    for prom_query in prom_queries {
+        let Some(target) = resolved_promql_targets(std::slice::from_ref(&prom_query), &query_ctx)
+            .and_then(|targets| match targets.as_slice() {
+                [target] => Some(target.clone()),
+                _ => None,
+            })
+        else {
+            return PrometheusJsonResponse::error(
+                StatusCode::InvalidArguments,
+                "series selector must resolve exactly one metric table",
+            );
         };
         let result = handler.do_query(&prom_query, query_ctx.clone()).await;
 
@@ -1636,7 +2042,7 @@ pub async fn series_query(
                 result,
                 &mut series,
                 &query_ctx,
-                &table_name,
+                &target,
                 &handler.catalog_manager(),
                 &mut merge_map,
             )
@@ -1670,7 +2076,10 @@ pub async fn parse_query(
     Form(form_params): Form<ParseQuery>,
 ) -> PrometheusJsonResponse {
     if let Some(query) = params.query.or(form_params.query) {
-        let ast = try_call_return_response!(promql_parser::parser::parse(&query));
+        let ast = try_call_return_response!(
+            promql_parser::parser::parse(&query),
+            StatusCode::InvalidArguments
+        );
         PrometheusJsonResponse::success(PrometheusResponse::ParseResult(ast))
     } else {
         PrometheusJsonResponse::error(StatusCode::InvalidArguments, "query is required")
@@ -1683,11 +2092,13 @@ mod tests {
     use std::sync::Arc;
 
     use catalog::memory::MemoryCatalogManager;
+    use catalog::{RegisterSchemaRequest, RegisterTableRequest};
     use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
     use datatypes::prelude::ConcreteDataType;
     use datatypes::schema::{ColumnSchema, Schema};
     use promql_parser::parser::value::ValueType;
     use table::metadata::{TableInfoBuilder, TableMetaBuilder, TableType, TableVersion};
+    use table::requests::TableOptions;
     use table::test_util::EmptyTable;
 
     use super::*;
@@ -1698,6 +2109,24 @@ mod tests {
         expected_metric: Option<&'static str>,
         expected_type: ValueType,
         should_error: bool,
+    }
+
+    fn permission_denied_response() -> PrometheusJsonResponse {
+        let result: auth::error::Result<()> = auth::error::PermissionDeniedSnafu.fail();
+        try_call_return_response!(result);
+        unreachable!()
+    }
+
+    #[test]
+    fn test_try_call_return_response_preserves_status() {
+        use axum::response::IntoResponse;
+
+        let response = permission_denied_response();
+        assert_eq!(Some(StatusCode::PermissionDenied), response.status_code);
+        assert_eq!(
+            axum::http::StatusCode::FORBIDDEN,
+            response.into_response().status()
+        );
     }
 
     #[test]
@@ -1919,11 +2348,17 @@ mod tests {
                 true,
             ),
         ]));
+        let mut options = TableOptions::default();
+        options.extra_options.insert(
+            LOGICAL_TABLE_METADATA_KEY.to_string(),
+            "physical_metrics".to_string(),
+        );
         let meta = TableMetaBuilder::empty()
             .schema(schema)
             .primary_key_indices(vec![1, 2, 4])
             .engine("metric".to_string())
             .next_column_id(5)
+            .options(options)
             .build()
             .unwrap();
         let table_info = TableInfoBuilder::default()
@@ -1936,16 +2371,411 @@ mod tests {
             .meta(meta)
             .build()
             .unwrap();
-        let manager: CatalogManagerRef =
+        let manager =
             MemoryCatalogManager::new_with_table(EmptyTable::from_table_info(&table_info));
 
-        let labels = get_all_column_names(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, &manager)
-            .await
+        let physical_schema = Arc::new(Schema::new(vec![
+            ColumnSchema::new(
+                "greptime_timestamp",
+                ConcreteDataType::timestamp_millisecond_datatype(),
+                false,
+            )
+            .with_time_index(true),
+            ColumnSchema::new(
+                "physical_only_tag",
+                ConcreteDataType::string_datatype(),
+                false,
+            ),
+            ColumnSchema::new(
+                "physical_only_value",
+                ConcreteDataType::float64_datatype(),
+                true,
+            ),
+        ]));
+        let mut physical_options = TableOptions::default();
+        physical_options.extra_options.insert(
+            store_api::metric_engine_consts::PHYSICAL_TABLE_METADATA_KEY.to_string(),
+            String::new(),
+        );
+        let physical_meta = TableMetaBuilder::empty()
+            .schema(physical_schema)
+            .primary_key_indices(vec![1])
+            .engine("metric".to_string())
+            .next_column_id(3)
+            .options(physical_options)
+            .build()
             .unwrap();
+        let physical_table_info = TableInfoBuilder::default()
+            .table_id(1025)
+            .table_version(0 as TableVersion)
+            .name("physical_metrics")
+            .catalog_name(DEFAULT_CATALOG_NAME)
+            .schema_name(DEFAULT_SCHEMA_NAME)
+            .table_type(TableType::Base)
+            .meta(physical_meta)
+            .build()
+            .unwrap();
+        let physical_table = EmptyTable::from_table_info(&physical_table_info);
+        manager
+            .register_table_sync(RegisterTableRequest {
+                catalog: DEFAULT_CATALOG_NAME.to_string(),
+                schema: DEFAULT_SCHEMA_NAME.to_string(),
+                table_name: "physical_metrics".to_string(),
+                table_id: 1025,
+                table: physical_table,
+            })
+            .unwrap();
+        let manager: CatalogManagerRef = manager;
+
+        let (labels, table_names) =
+            get_all_column_names(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, &manager)
+                .await
+                .unwrap();
 
         assert_eq!(
             labels,
             HashSet::from(["host".to_string(), "region".to_string()])
+        );
+        assert_eq!(table_names, vec!["cpu_usage"]);
+
+        let query_ctx = QueryContext::with(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME);
+        let (schemas, targets) =
+            retrieve_schema_names(&query_ctx, manager.clone(), vec!["cpu_usage".to_string()])
+                .await
+                .unwrap();
+        assert_eq!(schemas, vec![DEFAULT_SCHEMA_NAME]);
+        assert_eq!(
+            targets,
+            PermissionTableTargets::Resolved(vec![PermissionTableTarget::new(
+                DEFAULT_CATALOG_NAME,
+                DEFAULT_SCHEMA_NAME,
+                "cpu_usage",
+            )])
+        );
+
+        let (_, targets) = retrieve_schema_names(
+            &query_ctx,
+            manager.clone(),
+            vec![r#"{__name__=~"cpu.*"}"#.to_string()],
+        )
+        .await
+        .unwrap();
+        assert_eq!(targets, PermissionTableTargets::Unresolved);
+
+        let (schemas, targets) = retrieve_schema_names(&query_ctx, manager.clone(), vec![])
+            .await
+            .unwrap();
+        assert!(schemas.contains(&DEFAULT_SCHEMA_NAME.to_string()));
+        assert_eq!(targets, PermissionTableTargets::Unresolved);
+
+        let (schemas, targets) = retrieve_schema_names(
+            &query_ctx,
+            manager.clone(),
+            vec!["physical_metrics".to_string()],
+        )
+        .await
+        .unwrap();
+        assert!(schemas.is_empty());
+        assert_eq!(
+            targets,
+            PermissionTableTargets::Resolved(vec![PermissionTableTarget::new(
+                DEFAULT_CATALOG_NAME,
+                DEFAULT_SCHEMA_NAME,
+                "physical_metrics",
+            )])
+        );
+
+        let (schemas, targets) = retrieve_schema_names(
+            &query_ctx,
+            manager.clone(),
+            vec!["missing".to_string(), "physical_metrics".to_string()],
+        )
+        .await
+        .unwrap();
+        assert!(schemas.is_empty());
+        assert_eq!(
+            targets,
+            PermissionTableTargets::Resolved(vec![PermissionTableTarget::new(
+                DEFAULT_CATALOG_NAME,
+                DEFAULT_SCHEMA_NAME,
+                "physical_metrics",
+            )])
+        );
+
+        assert_eq!(
+            vec!["cpu_usage".to_string()],
+            retrieve_table_names(
+                &query_ctx,
+                manager.clone(),
+                vec!["missing".to_string(), r#"{__name__=~"cpu.*"}"#.to_string(),],
+            )
+            .await
+            .unwrap()
+        );
+        assert!(
+            retrieve_table_names(
+                &query_ctx,
+                manager.clone(),
+                vec!["cpu_usage".to_string(), "{".to_string()],
+            )
+            .await
+            .is_err()
+        );
+
+        let (fields, table_names) = retrieve_field_names(
+            &query_ctx,
+            manager.clone(),
+            vec!["physical_metrics".to_string()],
+        )
+        .await
+        .unwrap();
+        assert!(fields.is_empty());
+        assert!(table_names.is_empty());
+
+        let (fields, table_names) = retrieve_field_names(&query_ctx, manager, vec![])
+            .await
+            .unwrap();
+        assert_eq!(fields, HashSet::from(["value".to_string()]));
+        assert_eq!(table_names, vec!["cpu_usage"]);
+    }
+
+    #[tokio::test]
+    async fn test_get_target_column_names_uses_selected_schema() {
+        let manager = MemoryCatalogManager::with_default_setup();
+        manager
+            .register_schema_sync(RegisterSchemaRequest {
+                catalog: DEFAULT_CATALOG_NAME.to_string(),
+                schema: "private".to_string(),
+            })
+            .unwrap();
+
+        for (schema_name, tag_name, table_id) in [
+            (DEFAULT_SCHEMA_NAME, "public_tag", 2048),
+            ("private", "private_tag", 2049),
+        ] {
+            let schema = Arc::new(Schema::new(vec![
+                ColumnSchema::new(
+                    "greptime_timestamp",
+                    ConcreteDataType::timestamp_millisecond_datatype(),
+                    false,
+                )
+                .with_time_index(true),
+                ColumnSchema::new(tag_name, ConcreteDataType::string_datatype(), false),
+                ColumnSchema::new("value", ConcreteDataType::float64_datatype(), true),
+            ]));
+            let meta = TableMetaBuilder::empty()
+                .schema(schema)
+                .primary_key_indices(vec![1])
+                .engine("metric".to_string())
+                .next_column_id(3)
+                .build()
+                .unwrap();
+            let table_info = TableInfoBuilder::default()
+                .table_id(table_id)
+                .table_version(0 as TableVersion)
+                .name("cpu")
+                .catalog_name(DEFAULT_CATALOG_NAME)
+                .schema_name(schema_name)
+                .table_type(TableType::Base)
+                .meta(meta)
+                .build()
+                .unwrap();
+            manager
+                .register_table_sync(RegisterTableRequest {
+                    catalog: DEFAULT_CATALOG_NAME.to_string(),
+                    schema: schema_name.to_string(),
+                    table_name: "cpu".to_string(),
+                    table_id,
+                    table: EmptyTable::from_table_info(&table_info),
+                })
+                .unwrap();
+        }
+
+        let query_ctx = Arc::new(QueryContext::with(
+            DEFAULT_CATALOG_NAME,
+            DEFAULT_SCHEMA_NAME,
+        ));
+        let queries = [PromQuery {
+            query: r#"{__name__="cpu",__schema__="private"}"#.to_string(),
+            ..Default::default()
+        }];
+        let targets = resolved_promql_targets(&queries, &query_ctx).unwrap();
+        let manager: CatalogManagerRef = manager;
+
+        assert_eq!(
+            get_target_column_names(&targets, &manager, &query_ctx)
+                .await
+                .unwrap(),
+            HashSet::from(["private_tag".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_metric_name_discovery_uses_selected_schema() {
+        let expr =
+            promql_parser::parser::parse(r#"{__name__=~"cpu.*",__database__="private"}"#).unwrap();
+        let discovery = find_metric_name_not_equal_matchers(&expr).unwrap().unwrap();
+
+        assert_eq!(discovery.schema.as_deref(), Some("private"));
+        assert_eq!(discovery.name_matchers.len(), 1);
+        assert_eq!(discovery.name_matchers[0].value, "cpu.*");
+        assert!(matches!(discovery.name_matchers[0].op, MatchOp::Re(_)));
+
+        let expr = promql_parser::parser::parse(
+            r#"{__name__=~"cpu.*",__database__="private",__schema__="public"}"#,
+        )
+        .unwrap();
+        let discovery = find_metric_name_not_equal_matchers(&expr).unwrap().unwrap();
+        assert_eq!(discovery.schema.as_deref(), Some("public"));
+    }
+
+    #[test]
+    fn test_metric_name_discovery_rejects_unsafe_selector_shapes() {
+        for promql in [
+            r#"{__name__="denied",__name__=~"no_such_.*"}"#,
+            r#"{__name__=~"cpu.*" or job="api"}"#,
+        ] {
+            let expr = promql_parser::parser::parse(promql).unwrap();
+            assert!(
+                find_metric_name_not_equal_matchers(&expr)
+                    .unwrap()
+                    .is_none(),
+                "{promql}"
+            );
+        }
+
+        let expr = promql_parser::parser::parse(r#"{__name__=~"cpu.*" or job="api"}"#).unwrap();
+        assert_eq!(
+            (PermissionTableTargets::Resolved(vec![]), 1),
+            static_promql_targets(&expr, &QueryContext::arc()).unwrap()
+        );
+
+        let expr =
+            promql_parser::parser::parse(r#"allowed{job="api" or instance="host"}"#).unwrap();
+        assert_eq!(
+            (
+                PermissionTableTargets::Resolved(vec![PermissionTableTarget::new(
+                    "greptime", "public", "allowed",
+                )]),
+                0,
+            ),
+            static_promql_targets(&expr, &QueryContext::arc()).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_metric_name_discovery_ignores_or_matchers_on_named_selector() {
+        let expr = promql_parser::parser::parse(
+            r#"{__name__=~"cpu.*"} + allowed{job="api" or instance="host"}"#,
+        )
+        .unwrap();
+
+        let discovery = find_metric_name_not_equal_matchers(&expr).unwrap().unwrap();
+        assert_eq!(discovery.name_matchers[0].value, "cpu.*");
+    }
+
+    #[test]
+    fn test_retrieve_exact_metric_name_from_selector() {
+        assert_eq!(
+            retrieve_exact_metric_name_from_promql(r#"cpu{host="a"}"#).as_deref(),
+            Some("cpu")
+        );
+        assert_eq!(
+            retrieve_exact_metric_name_from_promql(r#"{__name__="cpu",host="a"}"#).as_deref(),
+            Some("cpu")
+        );
+        assert!(retrieve_exact_metric_name_from_promql(r#"{__name__=~"cpu.*"}"#).is_none());
+    }
+
+    #[test]
+    fn test_expand_metric_name_queries_preserves_schema_matcher() {
+        let query = PromQuery {
+            query: r#"{__name__=~"cpu.*",__database__="private"}"#.to_string(),
+            ..Default::default()
+        };
+        let expr = promql_parser::parser::parse(&query.query).unwrap();
+        let queries = expand_metric_name_queries(
+            &query,
+            &expr,
+            vec!["cpu_user".to_string(), "cpu_system".to_string()],
+        );
+
+        assert_eq!(queries.len(), 2);
+        for (query, metric_name) in queries.iter().zip(["cpu_user", "cpu_system"]) {
+            let PromqlExpr::VectorSelector(selector) =
+                promql_parser::parser::parse(&query.query).unwrap()
+            else {
+                panic!("expected vector selector");
+            };
+            assert!(selector.matchers.matchers.iter().any(|matcher| {
+                matcher.name == METRIC_NAME
+                    && matcher.op == MatchOp::Equal
+                    && matcher.value == metric_name
+            }));
+            assert!(selector.matchers.matchers.iter().any(|matcher| {
+                matcher.name == "__database__"
+                    && matcher.op == MatchOp::Equal
+                    && matcher.value == "private"
+            }));
+        }
+    }
+
+    #[test]
+    fn test_expand_metric_name_queries_preserves_exact_selector() {
+        let query = PromQuery {
+            query: r#"denied + {__name__=~"cpu.*"}"#.to_string(),
+            ..Default::default()
+        };
+        let expr = promql_parser::parser::parse(&query.query).unwrap();
+        let queries = expand_metric_name_queries(&query, &expr, vec!["cpu_user".to_string()]);
+
+        assert_eq!(queries.len(), 1);
+        let expanded = promql_parser::parser::parse(&queries[0].query).unwrap();
+        let ctx = Arc::new(QueryContext::with("greptime", "public"));
+        let (PermissionTableTargets::Resolved(mut targets), unresolved_selectors) =
+            static_promql_targets(&expanded, &ctx).unwrap()
+        else {
+            panic!("expected resolved targets");
+        };
+        assert_eq!(unresolved_selectors, 0);
+        targets.sort_unstable_by(|left, right| left.table.cmp(&right.table));
+        assert_eq!(
+            targets,
+            vec![
+                PermissionTableTarget::new("greptime", "public", "cpu_user"),
+                PermissionTableTarget::new("greptime", "public", "denied"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_static_promql_targets_keep_exact_selector_during_discovery() {
+        let expr = promql_parser::parser::parse(
+            r#"denied + {__name__=~"no_match_.*",__schema__="private"}"#,
+        )
+        .unwrap();
+        let ctx = Arc::new(QueryContext::with("greptime", "public"));
+
+        assert_eq!(
+            static_promql_targets(&expr, &ctx).unwrap(),
+            (
+                PermissionTableTargets::resolved(vec![PermissionTableTarget::new(
+                    "greptime", "public", "denied",
+                )]),
+                1,
+            )
+        );
+    }
+
+    #[test]
+    fn test_static_promql_targets_count_unresolved_selectors() {
+        let expr =
+            promql_parser::parser::parse(r#"{__name__=~"no_such_metric"} or {job="api"}"#).unwrap();
+        let ctx = Arc::new(QueryContext::with("greptime", "public"));
+
+        assert_eq!(
+            static_promql_targets(&expr, &ctx).unwrap(),
+            (PermissionTableTargets::resolved(Vec::new()), 2)
         );
     }
 }

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -54,7 +54,7 @@ use promql_parser::parser::{
     AggregateExpr, BinaryExpr, Call, Expr as PromqlExpr, LabelModifier, MatrixSelector, ParenExpr,
     SubqueryExpr, UnaryExpr, VectorSelector,
 };
-use query::parser::{DEFAULT_LOOKBACK_STRING, PromQuery, QueryLanguageParser};
+use query::parser::{DEFAULT_LOOKBACK_STRING, PromQuery, QueryStatement};
 use serde::de::{self, MapAccess, Visitor};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -68,11 +68,13 @@ use table::TableRef;
 pub use super::result::prometheus_resp::PrometheusJsonResponse;
 use crate::error::{
     CollectRecordbatchSnafu, ConvertScalarValueSnafu, DataFusionSnafu, Error, InvalidQuerySnafu,
-    NotSupportedSnafu, ParseTimestampSnafu, Result, TableNotFoundSnafu, UnexpectedResultSnafu,
+    NotSupportedSnafu, Result, TableNotFoundSnafu, UnexpectedResultSnafu,
 };
 use crate::http::header::collect_plan_metrics;
 use crate::prom_store::{FIELD_NAME_LABEL, METRIC_NAME_LABEL, is_database_selection_label};
-use crate::prometheus_handler::{PrometheusHandlerRef, resolve_schema_from_matchers};
+use crate::prometheus_handler::{
+    ParsedPromQuery, PrometheusHandlerRef, resolve_schema_from_matchers,
+};
 
 /// For [ValueType::Vector] result type
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq)]
@@ -234,6 +236,15 @@ pub struct InstantQuery {
 /// Helper macro which try to evaluate the expression and return its results.
 /// If the evaluation fails, return a `PrometheusJsonResponse` early.
 macro_rules! try_call_return_response {
+    (@output_msg $handle: expr, $status_code: expr) => {
+        match $handle {
+            Ok(res) => res,
+            Err(err) => {
+                let msg = err.output_msg();
+                return PrometheusJsonResponse::error($status_code, msg);
+            }
+        }
+    };
     ($handle: expr, $status_code: expr) => {
         match $handle {
             Ok(res) => res,
@@ -283,30 +294,29 @@ pub async fn instant_query(
         alias: None,
     };
 
-    let promql_expr = try_call_return_response!(
-        promql_parser::parser::parse(&prom_query.query),
-        StatusCode::InvalidArguments
-    );
-
     // update catalog and schema in query context if necessary
     if let Some(db) = &params.db {
         let (catalog, schema) = parse_catalog_and_schema_from_db_string(db);
         try_update_catalog_schema(&mut query_ctx, &catalog, &schema);
     }
     let query_ctx = Arc::new(query_ctx);
-
     let _timer = crate::metrics::METRIC_HTTP_PROMETHEUS_PROMQL_ELAPSED
         .with_label_values(&[query_ctx.get_db_string().as_str(), "instant_query"])
         .start_timer();
+    let prom_query = try_call_return_response!(
+        @output_msg ParsedPromQuery::parse(prom_query, &query_ctx),
+        StatusCode::InvalidArguments
+    );
+    let promql_expr = prom_query.expr();
 
     let metric_name_discovery =
-        try_call_return_response!(find_metric_name_not_equal_matchers(&promql_expr));
+        try_call_return_response!(find_metric_name_not_equal_matchers(promql_expr));
     if let Some(discovery) = metric_name_discovery {
         debug!("Find metric name matchers: {:?}", discovery.name_matchers);
 
         try_call_return_response!(handler.check_query_permission(&[], &query_ctx).await);
         let (static_targets, unresolved_selectors) =
-            try_call_return_response!(static_promql_targets(&promql_expr, &query_ctx));
+            try_call_return_response!(static_promql_targets(promql_expr, &query_ctx));
         try_call_return_response!(
             handler
                 .check_query_target_permission(static_targets, &query_ctx,)
@@ -318,7 +328,7 @@ pub async fn instant_query(
                     .check_query_target_permission(PermissionTableTargets::Unresolved, &query_ctx,)
                     .await
             );
-            return do_instant_query(&handler, &prom_query, query_ctx).await;
+            return do_instant_query(&handler, prom_query, query_ctx).await;
         }
 
         let schema = discovery
@@ -332,10 +342,10 @@ pub async fn instant_query(
 
         debug!("Find metric names: {:?}", metric_names);
 
-        let prom_queries = expand_metric_name_queries(&prom_query, &promql_expr, metric_names);
+        let prom_queries = expand_metric_name_queries(&prom_query, metric_names);
         try_call_return_response!(
             handler
-                .check_query_permission(&prom_queries, &query_ctx)
+                .check_query_permission_parsed(&prom_queries, &query_ctx)
                 .await
         );
 
@@ -352,7 +362,7 @@ pub async fn instant_query(
             let query_ctx = query_ctx.clone();
             let handler = handler.clone();
 
-            async move { do_instant_query(&handler, &prom_query, query_ctx).await }
+            async move { do_instant_query(&handler, prom_query, query_ctx).await }
         }))
         .await;
 
@@ -364,21 +374,18 @@ pub async fn instant_query(
             })
             .unwrap()
     } else {
-        do_instant_query(&handler, &prom_query, query_ctx).await
+        do_instant_query(&handler, prom_query, query_ctx).await
     }
 }
 
 /// Executes a single instant query and returns response
 async fn do_instant_query(
     handler: &PrometheusHandlerRef,
-    prom_query: &PromQuery,
+    prom_query: ParsedPromQuery,
     query_ctx: QueryContextRef,
 ) -> PrometheusJsonResponse {
-    let result = handler.do_query(prom_query, query_ctx).await;
-    let (metric_name, result_type) = match retrieve_metric_name_and_result_type(&prom_query.query) {
-        Ok((metric_name, result_type)) => (metric_name, result_type),
-        Err(err) => return PrometheusJsonResponse::error(err.status_code(), err.output_msg()),
-    };
+    let (metric_name, result_type) = retrieve_metric_name_and_result_type(prom_query.expr());
+    let result = handler.do_query_parsed(prom_query, query_ctx).await;
     PrometheusJsonResponse::from_query_result(result, metric_name, result_type).await
 }
 
@@ -416,11 +423,6 @@ pub async fn range_query(
         alias: None,
     };
 
-    let promql_expr = try_call_return_response!(
-        promql_parser::parser::parse(&prom_query.query),
-        StatusCode::InvalidArguments
-    );
-
     // update catalog and schema in query context if necessary
     if let Some(db) = &params.db {
         let (catalog, schema) = parse_catalog_and_schema_from_db_string(db);
@@ -430,15 +432,20 @@ pub async fn range_query(
     let _timer = crate::metrics::METRIC_HTTP_PROMETHEUS_PROMQL_ELAPSED
         .with_label_values(&[query_ctx.get_db_string().as_str(), "range_query"])
         .start_timer();
+    let prom_query = try_call_return_response!(
+        @output_msg ParsedPromQuery::parse(prom_query, &query_ctx),
+        StatusCode::InvalidArguments
+    );
+    let promql_expr = prom_query.expr();
 
     let metric_name_discovery =
-        try_call_return_response!(find_metric_name_not_equal_matchers(&promql_expr));
+        try_call_return_response!(find_metric_name_not_equal_matchers(promql_expr));
     if let Some(discovery) = metric_name_discovery {
         debug!("Find metric name matchers: {:?}", discovery.name_matchers);
 
         try_call_return_response!(handler.check_query_permission(&[], &query_ctx).await);
         let (static_targets, unresolved_selectors) =
-            try_call_return_response!(static_promql_targets(&promql_expr, &query_ctx));
+            try_call_return_response!(static_promql_targets(promql_expr, &query_ctx));
         try_call_return_response!(
             handler
                 .check_query_target_permission(static_targets, &query_ctx,)
@@ -450,7 +457,7 @@ pub async fn range_query(
                     .check_query_target_permission(PermissionTableTargets::Unresolved, &query_ctx,)
                     .await
             );
-            return do_range_query(&handler, &prom_query, query_ctx).await;
+            return do_range_query(&handler, prom_query, query_ctx).await;
         }
 
         let schema = discovery
@@ -464,10 +471,10 @@ pub async fn range_query(
 
         debug!("Find metric names: {:?}", metric_names);
 
-        let prom_queries = expand_metric_name_queries(&prom_query, &promql_expr, metric_names);
+        let prom_queries = expand_metric_name_queries(&prom_query, metric_names);
         try_call_return_response!(
             handler
-                .check_query_permission(&prom_queries, &query_ctx)
+                .check_query_permission_parsed(&prom_queries, &query_ctx)
                 .await
         );
 
@@ -482,7 +489,7 @@ pub async fn range_query(
             let query_ctx = query_ctx.clone();
             let handler = handler.clone();
 
-            async move { do_range_query(&handler, &prom_query, query_ctx).await }
+            async move { do_range_query(&handler, prom_query, query_ctx).await }
         }))
         .await;
 
@@ -495,21 +502,18 @@ pub async fn range_query(
             })
             .unwrap()
     } else {
-        do_range_query(&handler, &prom_query, query_ctx).await
+        do_range_query(&handler, prom_query, query_ctx).await
     }
 }
 
 /// Executes a single range query and returns response
 async fn do_range_query(
     handler: &PrometheusHandlerRef,
-    prom_query: &PromQuery,
+    prom_query: ParsedPromQuery,
     query_ctx: QueryContextRef,
 ) -> PrometheusJsonResponse {
-    let result = handler.do_query(prom_query, query_ctx).await;
-    let metric_name = match retrieve_metric_name_and_result_type(&prom_query.query) {
-        Err(err) => return PrometheusJsonResponse::error(err.status_code(), err.output_msg()),
-        Ok((metric_name, _)) => metric_name,
-    };
+    let (metric_name, _) = retrieve_metric_name_and_result_type(prom_query.expr());
+    let result = handler.do_query_parsed(prom_query, query_ctx).await;
     PrometheusJsonResponse::from_query_result(result, metric_name, ValueType::Matrix).await
 }
 
@@ -633,9 +637,15 @@ pub async fn labels_query(
                 alias: None,
             })
             .collect::<Vec<_>>();
+        let prom_queries = try_call_return_response!(
+            prom_queries
+                .into_iter()
+                .map(|query| ParsedPromQuery::parse(query, &query_ctx))
+                .collect::<Result<Vec<_>>>()
+        );
         try_call_return_response!(
             handler
-                .check_query_permission(&prom_queries, &query_ctx)
+                .check_query_permission_parsed(&prom_queries, &query_ctx)
                 .await
         );
         prom_queries
@@ -682,7 +692,7 @@ pub async fn labels_query(
 
     let mut merge_map = HashMap::new();
     for prom_query in prom_queries {
-        let result = handler.do_query(&prom_query, query_ctx.clone()).await;
+        let result = handler.do_query_parsed(prom_query, query_ctx.clone()).await;
         handle_schema_err!(
             retrieve_labels_name_from_query_result(result, &mut fetched_labels, &mut merge_map)
                 .await
@@ -1178,14 +1188,12 @@ fn record_batches_to_labels_name(
 }
 
 pub(crate) fn retrieve_metric_name_and_result_type(
-    promql: &str,
-) -> Result<(Option<String>, ValueType)> {
-    let promql_expr = promql_parser::parser::parse(promql)
-        .map_err(|reason| InvalidQuerySnafu { reason }.build())?;
-    let metric_name = promql_expr_to_metric_name(&promql_expr);
-    let result_type = promql_expr.value_type();
-
-    Ok((metric_name, result_type))
+    promql_expr: &PromqlExpr,
+) -> (Option<String>, ValueType) {
+    (
+        promql_expr_to_metric_name(promql_expr),
+        promql_expr.value_type(),
+    )
 }
 
 /// Tries to get catalog and schema from an optional db param. And retrieves
@@ -1368,17 +1376,14 @@ fn find_metric_name_not_equal_matchers(expr: &PromqlExpr) -> Result<Option<Metri
 }
 
 fn expand_metric_name_queries(
-    query: &PromQuery,
-    expr: &PromqlExpr,
+    query: &ParsedPromQuery,
     metric_names: Vec<String>,
-) -> Vec<PromQuery> {
+) -> Vec<ParsedPromQuery> {
     metric_names
         .into_iter()
         .map(|metric| {
             let mut query = query.clone();
-            let mut expr = expr.clone();
-            update_metric_name_matcher(&mut expr, &metric);
-            query.query = expr.to_string();
+            query.update_expr(|expr| update_metric_name_matcher(expr, &metric));
             query
         })
         .collect()
@@ -1398,14 +1403,13 @@ fn static_promql_targets(
 }
 
 fn resolved_promql_targets(
-    queries: &[PromQuery],
+    queries: &[ParsedPromQuery],
     query_ctx: &QueryContextRef,
 ) -> Option<Vec<PermissionTableTarget>> {
     let mut targets = Vec::new();
     for query in queries {
-        let expr = promql_parser::parser::parse(&query.query).ok()?;
         let (PermissionTableTargets::Resolved(query_targets), unresolved_selectors) =
-            static_promql_targets(&expr, query_ctx).ok()?
+            static_promql_targets(query.expr(), query_ctx).ok()?
         else {
             return None;
         };
@@ -1685,29 +1689,35 @@ pub async fn label_values_query(
             alias: None,
         })
         .collect::<Vec<_>>();
+    let prom_queries = try_call_return_response!(
+        prom_queries
+            .into_iter()
+            .map(|query| ParsedPromQuery::parse(query, &query_ctx))
+            .collect::<Result<Vec<_>>>()
+    );
     try_call_return_response!(
         handler
-            .check_query_permission(&prom_queries, &query_ctx)
+            .check_query_permission_parsed(&prom_queries, &query_ctx)
             .await
     );
 
     let mut label_values = HashSet::new();
 
-    let start = try_call_return_response!(
-        QueryLanguageParser::parse_promql_timestamp(&start)
-            .context(ParseTimestampSnafu { timestamp: &start })
-    );
-    let end = try_call_return_response!(
-        QueryLanguageParser::parse_promql_timestamp(&end)
-            .context(ParseTimestampSnafu { timestamp: &end })
-    );
+    let Some(first_query) = prom_queries.first() else {
+        unreachable!("empty match[] is rejected above")
+    };
+    let QueryStatement::Promql(eval_stmt, _) = first_query.statement() else {
+        unreachable!("query is parsed from PromQL")
+    };
+    let start = eval_stmt.start;
+    let end = eval_stmt.end;
 
     for prom_query in prom_queries {
-        let promql_expr = try_call_return_response!(
-            promql_parser::parser::parse(&prom_query.query),
-            StatusCode::InvalidArguments
-        );
-        let PromqlExpr::VectorSelector(mut vector_selector) = promql_expr else {
+        let (_, statement) = prom_query.into_parts();
+        let QueryStatement::Promql(eval_stmt, _) = statement else {
+            unreachable!("query is parsed from PromQL")
+        };
+        let PromqlExpr::VectorSelector(mut vector_selector) = eval_stmt.expr else {
             return PrometheusJsonResponse::error(
                 StatusCode::InvalidArguments,
                 "expected vector selector",
@@ -2018,12 +2028,13 @@ pub async fn series_query(
         .collect::<Vec<_>>();
     let mut expanded_queries = Vec::new();
     for prom_query in prom_queries {
-        let promql_expr = try_call_return_response!(
-            promql_parser::parser::parse(&prom_query.query),
+        let prom_query = try_call_return_response!(
+            @output_msg ParsedPromQuery::parse(prom_query, &query_ctx),
             StatusCode::InvalidArguments
         );
+        let promql_expr = prom_query.expr();
         let Some(discovery) =
-            try_call_return_response!(find_metric_name_not_equal_matchers(&promql_expr))
+            try_call_return_response!(find_metric_name_not_equal_matchers(promql_expr))
         else {
             expanded_queries.push(prom_query);
             continue;
@@ -2031,7 +2042,7 @@ pub async fn series_query(
 
         try_call_return_response!(handler.check_query_permission(&[], &query_ctx).await);
         let (static_targets, unresolved_selectors) =
-            try_call_return_response!(static_promql_targets(&promql_expr, &query_ctx));
+            try_call_return_response!(static_promql_targets(promql_expr, &query_ctx));
         try_call_return_response!(
             handler
                 .check_query_target_permission(static_targets, &query_ctx)
@@ -2055,16 +2066,12 @@ pub async fn series_query(
                 .query_metric_names(discovery.name_matchers, &schema, &query_ctx)
                 .await
         );
-        expanded_queries.extend(expand_metric_name_queries(
-            &prom_query,
-            &promql_expr,
-            metric_names,
-        ));
+        expanded_queries.extend(expand_metric_name_queries(&prom_query, metric_names));
     }
     let prom_queries = expanded_queries;
     try_call_return_response!(
         handler
-            .check_query_permission(&prom_queries, &query_ctx)
+            .check_query_permission_parsed(&prom_queries, &query_ctx)
             .await
     );
 
@@ -2082,7 +2089,7 @@ pub async fn series_query(
                 "series selector must resolve exactly one metric table",
             );
         };
-        let result = handler.do_query(&prom_query, query_ctx.clone()).await;
+        let result = handler.do_query_parsed(prom_query, query_ctx.clone()).await;
 
         handle_schema_err!(
             retrieve_series_from_query_result(
@@ -2169,8 +2176,19 @@ mod tests {
 
     #[async_trait::async_trait]
     impl PrometheusHandler for TestPrometheusHandler {
-        async fn do_query(&self, query: &PromQuery, _: QueryContextRef) -> Result<Output> {
-            self.queries.lock().unwrap().push(query.query.clone());
+        async fn do_query(&self, _: &PromQuery, _: QueryContextRef) -> Result<Output> {
+            unreachable!("HTTP handlers should execute the parsed query")
+        }
+
+        async fn do_query_parsed(
+            &self,
+            query: ParsedPromQuery,
+            _: QueryContextRef,
+        ) -> Result<Output> {
+            self.queries
+                .lock()
+                .unwrap()
+                .push(query.query().query.clone());
             Ok(Output::new_with_record_batches(RecordBatches::empty()))
         }
 
@@ -2241,6 +2259,18 @@ mod tests {
         unreachable!()
     }
 
+    fn invalid_promql_response() -> PrometheusJsonResponse {
+        let result = ParsedPromQuery::parse(
+            PromQuery {
+                query: "up{".to_string(),
+                ..Default::default()
+            },
+            &QueryContext::arc(),
+        );
+        try_call_return_response!(@output_msg result, StatusCode::InvalidArguments);
+        unreachable!()
+    }
+
     #[test]
     fn test_try_call_return_response_preserves_status() {
         use axum::response::IntoResponse;
@@ -2251,6 +2281,64 @@ mod tests {
             axum::http::StatusCode::FORBIDDEN,
             response.into_response().status()
         );
+    }
+
+    #[test]
+    fn test_try_call_return_response_preserves_error_source() {
+        let response = invalid_promql_response();
+        assert_eq!(Some(StatusCode::InvalidArguments), response.status_code);
+        let error = response.error.unwrap();
+        assert!(
+            error.contains("unexpected end of input inside braces"),
+            "{error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_promql_timer_records_parse_errors() {
+        let handler: PrometheusHandlerRef = Arc::new(TestPrometheusHandler {
+            catalog_manager: MemoryCatalogManager::new(),
+            denied_table: None,
+            metric_names: Vec::new(),
+            queries: Mutex::new(Vec::new()),
+        });
+        let query_ctx = QueryContext::with("promql_timer_test", "parse_error");
+        let db = query_ctx.get_db_string();
+
+        let instant_histogram = crate::metrics::METRIC_HTTP_PROMETHEUS_PROMQL_ELAPSED
+            .with_label_values(&[db.as_str(), "instant_query"]);
+        let instant_count = instant_histogram.get_sample_count();
+        let response = instant_query(
+            State(handler.clone()),
+            Query(InstantQuery {
+                query: Some("up{".to_string()),
+                ..Default::default()
+            }),
+            Extension(query_ctx),
+            Form(InstantQuery::default()),
+        )
+        .await;
+        assert_eq!(Some(StatusCode::InvalidArguments), response.status_code);
+        assert_eq!(instant_count + 1, instant_histogram.get_sample_count());
+
+        let range_histogram = crate::metrics::METRIC_HTTP_PROMETHEUS_PROMQL_ELAPSED
+            .with_label_values(&[db.as_str(), "range_query"]);
+        let range_count = range_histogram.get_sample_count();
+        let response = range_query(
+            State(handler),
+            Query(RangeQuery {
+                query: Some("up{".to_string()),
+                start: Some("0".to_string()),
+                end: Some("1".to_string()),
+                step: Some("1s".to_string()),
+                ..Default::default()
+            }),
+            Extension(QueryContext::with("promql_timer_test", "parse_error")),
+            Form(RangeQuery::default()),
+        )
+        .await;
+        assert_eq!(Some(StatusCode::InvalidArguments), response.status_code);
+        assert_eq!(range_count + 1, range_histogram.get_sample_count());
     }
 
     #[tokio::test]
@@ -2364,17 +2452,19 @@ mod tests {
             .unwrap()
             .iter()
             .map(|query| {
-                resolved_promql_targets(
-                    &[PromQuery {
+                let query = ParsedPromQuery::parse(
+                    PromQuery {
                         query: query.clone(),
                         ..Default::default()
-                    }],
+                    },
                     &target_ctx,
                 )
-                .unwrap()
-                .pop()
-                .unwrap()
-                .table
+                .unwrap();
+                resolved_promql_targets(std::slice::from_ref(&query), &target_ctx)
+                    .unwrap()
+                    .pop()
+                    .unwrap()
+                    .table
             })
             .collect_vec();
         targets.sort_unstable();
@@ -2549,7 +2639,8 @@ mod tests {
         ];
 
         for test_case in test_cases {
-            let result = retrieve_metric_name_and_result_type(test_case.promql);
+            let result = promql_parser::parser::parse(test_case.promql)
+                .map(|expr| retrieve_metric_name_and_result_type(&expr));
 
             if test_case.should_error {
                 assert!(
@@ -2847,10 +2938,14 @@ mod tests {
             DEFAULT_CATALOG_NAME,
             DEFAULT_SCHEMA_NAME,
         ));
-        let queries = [PromQuery {
-            query: r#"{__name__="cpu",__schema__="private"}"#.to_string(),
-            ..Default::default()
-        }];
+        let queries = [ParsedPromQuery::parse(
+            PromQuery {
+                query: r#"{__name__="cpu",__schema__="private"}"#.to_string(),
+                ..Default::default()
+            },
+            &query_ctx,
+        )
+        .unwrap()];
         let targets = resolved_promql_targets(&queries, &query_ctx).unwrap();
         let manager: CatalogManagerRef = manager;
 
@@ -2945,18 +3040,16 @@ mod tests {
             query: r#"{__name__=~"cpu.*",__database__="private"}"#.to_string(),
             ..Default::default()
         };
-        let expr = promql_parser::parser::parse(&query.query).unwrap();
+        let ctx = QueryContext::arc();
+        let query = ParsedPromQuery::parse(query, &ctx).unwrap();
         let queries = expand_metric_name_queries(
             &query,
-            &expr,
             vec!["cpu_user".to_string(), "cpu_system".to_string()],
         );
 
         assert_eq!(queries.len(), 2);
         for (query, metric_name) in queries.iter().zip(["cpu_user", "cpu_system"]) {
-            let PromqlExpr::VectorSelector(selector) =
-                promql_parser::parser::parse(&query.query).unwrap()
-            else {
+            let PromqlExpr::VectorSelector(selector) = query.expr() else {
                 panic!("expected vector selector");
             };
             assert!(selector.matchers.matchers.iter().any(|matcher| {
@@ -2978,14 +3071,15 @@ mod tests {
             query: r#"denied + {__name__=~"cpu.*"}"#.to_string(),
             ..Default::default()
         };
-        let expr = promql_parser::parser::parse(&query.query).unwrap();
-        let queries = expand_metric_name_queries(&query, &expr, vec!["cpu_user".to_string()]);
+        let ctx = QueryContext::arc();
+        let query = ParsedPromQuery::parse(query, &ctx).unwrap();
+        let queries = expand_metric_name_queries(&query, vec!["cpu_user".to_string()]);
 
         assert_eq!(queries.len(), 1);
-        let expanded = promql_parser::parser::parse(&queries[0].query).unwrap();
+        let expanded = queries[0].expr();
         let ctx = Arc::new(QueryContext::with("greptime", "public"));
         let (PermissionTableTargets::Resolved(mut targets), unresolved_selectors) =
-            static_promql_targets(&expanded, &ctx).unwrap()
+            static_promql_targets(expanded, &ctx).unwrap()
         else {
             panic!("expected resolved targets");
         };

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -1588,10 +1588,11 @@ pub async fn label_values_query(
         let mut table_names = try_call_return_response!(
             retrieve_table_names(&query_ctx, catalog_manager, matches).await
         );
-        try_call_return_response!(
+        table_names = try_call_return_response!(
             handler
-                .check_query_target_permission(
-                    current_schema_metric_targets(&query_ctx, &table_names),
+                .filter_query_metric_names(
+                    table_names,
+                    query_ctx.current_schema().as_str(),
                     &query_ctx,
                 )
                 .await

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -1590,7 +1590,7 @@ pub async fn label_values_query(
         );
         table_names = try_call_return_response!(
             handler
-                .filter_query_metric_names(
+                .filter_metadata_metric_names(
                     table_names,
                     query_ctx.current_schema().as_str(),
                     &query_ctx,

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -2101,8 +2101,10 @@ mod tests {
     use table::metadata::{TableInfoBuilder, TableMetaBuilder, TableType, TableVersion};
     use table::requests::TableOptions;
     use table::test_util::EmptyTable;
+    use table::test_util::table_info::test_table_info;
 
     use super::*;
+    use crate::prometheus_handler::PrometheusHandler;
 
     struct TestCase {
         name: &'static str,
@@ -2110,6 +2112,75 @@ mod tests {
         expected_metric: Option<&'static str>,
         expected_type: ValueType,
         should_error: bool,
+    }
+
+    struct DenyTablePrometheusHandler {
+        catalog_manager: CatalogManagerRef,
+    }
+
+    #[async_trait::async_trait]
+    impl PrometheusHandler for DenyTablePrometheusHandler {
+        async fn do_query(&self, _: &PromQuery, _: QueryContextRef) -> Result<Output> {
+            unreachable!()
+        }
+
+        async fn check_query_permission(&self, _: &[PromQuery], _: &QueryContextRef) -> Result<()> {
+            Ok(())
+        }
+
+        async fn check_query_target_permission(
+            &self,
+            targets: PermissionTableTargets,
+            _: &QueryContextRef,
+        ) -> Result<()> {
+            if matches!(
+                targets,
+                PermissionTableTargets::Resolved(targets)
+                    if targets.iter().any(|target| target.table == "denied")
+            ) {
+                return auth::error::PermissionDeniedSnafu
+                    .fail()
+                    .context(crate::error::AuthSnafu);
+            }
+            Ok(())
+        }
+
+        async fn filter_metadata_metric_names(
+            &self,
+            metric_names: Vec<String>,
+            _: &str,
+            _: &QueryContextRef,
+        ) -> Result<Vec<String>> {
+            Ok(metric_names
+                .into_iter()
+                .filter(|metric| metric != "denied")
+                .collect())
+        }
+
+        async fn query_metric_names(
+            &self,
+            _: Vec<Matcher>,
+            _: &str,
+            _: &QueryContextRef,
+        ) -> Result<Vec<String>> {
+            unreachable!()
+        }
+
+        async fn query_label_values(
+            &self,
+            _: String,
+            _: String,
+            _: Vec<Matcher>,
+            _: std::time::SystemTime,
+            _: std::time::SystemTime,
+            _: &QueryContextRef,
+        ) -> Result<Vec<String>> {
+            unreachable!()
+        }
+
+        fn catalog_manager(&self) -> CatalogManagerRef {
+            self.catalog_manager.clone()
+        }
     }
 
     fn permission_denied_response() -> PrometheusJsonResponse {
@@ -2123,6 +2194,59 @@ mod tests {
         use axum::response::IntoResponse;
 
         let response = permission_denied_response();
+        assert_eq!(Some(StatusCode::PermissionDenied), response.status_code);
+        assert_eq!(
+            axum::http::StatusCode::FORBIDDEN,
+            response.into_response().status()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_field_name_enumeration_fails_closed() {
+        use axum::response::IntoResponse;
+
+        let mut allowed = test_table_info(
+            1024,
+            "allowed",
+            DEFAULT_SCHEMA_NAME,
+            DEFAULT_CATALOG_NAME,
+            Arc::new(Schema::new(vec![])),
+        );
+        allowed.meta.options.extra_options.insert(
+            LOGICAL_TABLE_METADATA_KEY.to_string(),
+            "physical_metrics".to_string(),
+        );
+        let manager = MemoryCatalogManager::new_with_table(EmptyTable::from_table_info(&allowed));
+        let mut denied = allowed.clone();
+        denied.ident.table_id = 1025;
+        denied.name = "denied".to_string();
+        manager
+            .register_table_sync(RegisterTableRequest {
+                catalog: DEFAULT_CATALOG_NAME.to_string(),
+                schema: DEFAULT_SCHEMA_NAME.to_string(),
+                table_name: denied.name.clone(),
+                table_id: denied.table_id(),
+                table: EmptyTable::from_table_info(&denied),
+            })
+            .unwrap();
+        let query_ctx = QueryContext::with(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME);
+        assert_eq!(
+            vec!["allowed".to_string(), "denied".to_string()],
+            retrieve_table_names(&query_ctx, manager.clone(), Vec::new())
+                .await
+                .unwrap()
+        );
+
+        let response = label_values_query(
+            State(Arc::new(DenyTablePrometheusHandler {
+                catalog_manager: manager,
+            })),
+            Path(FIELD_NAME_LABEL.to_string()),
+            Extension(query_ctx),
+            Query(LabelValueQuery::default()),
+        )
+        .await;
+
         assert_eq!(Some(StatusCode::PermissionDenied), response.status_code);
         assert_eq!(
             axum::http::StatusCode::FORBIDDEN,

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -2016,6 +2016,52 @@ pub async fn series_query(
             alias: None,
         })
         .collect::<Vec<_>>();
+    let mut expanded_queries = Vec::new();
+    for prom_query in prom_queries {
+        let promql_expr = try_call_return_response!(
+            promql_parser::parser::parse(&prom_query.query),
+            StatusCode::InvalidArguments
+        );
+        let Some(discovery) =
+            try_call_return_response!(find_metric_name_not_equal_matchers(&promql_expr))
+        else {
+            expanded_queries.push(prom_query);
+            continue;
+        };
+
+        try_call_return_response!(handler.check_query_permission(&[], &query_ctx).await);
+        let (static_targets, unresolved_selectors) =
+            try_call_return_response!(static_promql_targets(&promql_expr, &query_ctx));
+        try_call_return_response!(
+            handler
+                .check_query_target_permission(static_targets, &query_ctx)
+                .await
+        );
+        if unresolved_selectors != 1 {
+            try_call_return_response!(
+                handler
+                    .check_query_target_permission(PermissionTableTargets::Unresolved, &query_ctx)
+                    .await
+            );
+            expanded_queries.push(prom_query);
+            continue;
+        }
+
+        let schema = discovery
+            .schema
+            .unwrap_or_else(|| query_ctx.current_schema());
+        let metric_names = try_call_return_response!(
+            handler
+                .query_metric_names(discovery.name_matchers, &schema, &query_ctx)
+                .await
+        );
+        expanded_queries.extend(expand_metric_name_queries(
+            &prom_query,
+            &promql_expr,
+            metric_names,
+        ));
+    }
+    let prom_queries = expanded_queries;
     try_call_return_response!(
         handler
             .check_query_permission(&prom_queries, &query_ctx)
@@ -2090,7 +2136,7 @@ pub async fn parse_query(
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
 
     use catalog::memory::MemoryCatalogManager;
     use catalog::{RegisterSchemaRequest, RegisterTableRequest};
@@ -2114,14 +2160,18 @@ mod tests {
         should_error: bool,
     }
 
-    struct DenyTablePrometheusHandler {
+    struct TestPrometheusHandler {
         catalog_manager: CatalogManagerRef,
+        denied_table: Option<&'static str>,
+        metric_names: Vec<String>,
+        queries: Mutex<Vec<String>>,
     }
 
     #[async_trait::async_trait]
-    impl PrometheusHandler for DenyTablePrometheusHandler {
-        async fn do_query(&self, _: &PromQuery, _: QueryContextRef) -> Result<Output> {
-            unreachable!()
+    impl PrometheusHandler for TestPrometheusHandler {
+        async fn do_query(&self, query: &PromQuery, _: QueryContextRef) -> Result<Output> {
+            self.queries.lock().unwrap().push(query.query.clone());
+            Ok(Output::new_with_record_batches(RecordBatches::empty()))
         }
 
         async fn check_query_permission(&self, _: &[PromQuery], _: &QueryContextRef) -> Result<()> {
@@ -2136,7 +2186,9 @@ mod tests {
             if matches!(
                 targets,
                 PermissionTableTargets::Resolved(targets)
-                    if targets.iter().any(|target| target.table == "denied")
+                    if self.denied_table.is_some_and(|denied| {
+                        targets.iter().any(|target| target.table == denied)
+                    })
             ) {
                 return auth::error::PermissionDeniedSnafu
                     .fail()
@@ -2163,7 +2215,7 @@ mod tests {
             _: &str,
             _: &QueryContextRef,
         ) -> Result<Vec<String>> {
-            unreachable!()
+            Ok(self.metric_names.clone())
         }
 
         async fn query_label_values(
@@ -2238,8 +2290,11 @@ mod tests {
         );
 
         let response = label_values_query(
-            State(Arc::new(DenyTablePrometheusHandler {
+            State(Arc::new(TestPrometheusHandler {
                 catalog_manager: manager,
+                denied_table: Some("denied"),
+                metric_names: Vec::new(),
+                queries: Mutex::new(Vec::new()),
             })),
             Path(FIELD_NAME_LABEL.to_string()),
             Extension(query_ctx),
@@ -2252,6 +2307,78 @@ mod tests {
             axum::http::StatusCode::FORBIDDEN,
             response.into_response().status()
         );
+    }
+
+    #[tokio::test]
+    async fn test_series_query_expands_metric_name_regex() {
+        let cpu_user = test_table_info(
+            1024,
+            "cpu_user",
+            DEFAULT_SCHEMA_NAME,
+            DEFAULT_CATALOG_NAME,
+            Arc::new(Schema::new(vec![])),
+        );
+        let manager = MemoryCatalogManager::new_with_table(EmptyTable::from_table_info(&cpu_user));
+        let mut cpu_system = cpu_user.clone();
+        cpu_system.ident.table_id = 1025;
+        cpu_system.name = "cpu_system".to_string();
+        manager
+            .register_table_sync(RegisterTableRequest {
+                catalog: DEFAULT_CATALOG_NAME.to_string(),
+                schema: DEFAULT_SCHEMA_NAME.to_string(),
+                table_name: cpu_system.name.clone(),
+                table_id: cpu_system.table_id(),
+                table: EmptyTable::from_table_info(&cpu_system),
+            })
+            .unwrap();
+
+        let handler = Arc::new(TestPrometheusHandler {
+            catalog_manager: manager,
+            denied_table: None,
+            metric_names: vec!["cpu_user".to_string(), "cpu_system".to_string()],
+            queries: Mutex::new(Vec::new()),
+        });
+        let state: PrometheusHandlerRef = handler.clone();
+        let query_ctx = QueryContext::with(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME);
+        let target_ctx = Arc::new(query_ctx.clone());
+        let response = series_query(
+            State(state),
+            Query(SeriesQuery {
+                matches: Matches(vec![r#"{__name__=~"cpu_.*"}"#.to_string()]),
+                ..Default::default()
+            }),
+            Extension(query_ctx),
+            Form(SeriesQuery::default()),
+        )
+        .await;
+
+        assert!(
+            response.status_code.is_none(),
+            "status={:?}, error={:?}",
+            response.status_code,
+            response.error
+        );
+        let mut targets = handler
+            .queries
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|query| {
+                resolved_promql_targets(
+                    &[PromQuery {
+                        query: query.clone(),
+                        ..Default::default()
+                    }],
+                    &target_ctx,
+                )
+                .unwrap()
+                .pop()
+                .unwrap()
+                .table
+            })
+            .collect_vec();
+        targets.sort_unstable();
+        assert_eq!(vec!["cpu_system", "cpu_user"], targets);
     }
 
     #[test]

--- a/src/servers/src/prom_store.rs
+++ b/src/servers/src/prom_store.rs
@@ -98,20 +98,27 @@ pub struct Metrics {
 
 /// Get table name from remote query
 pub fn table_name(q: &Query) -> Result<String> {
-    let label_matches = &q.matchers;
-
-    label_matches
+    let mut matchers = q
+        .matchers
         .iter()
-        .find_map(|m| {
-            if m.name == METRIC_NAME_LABEL {
-                Some(m.value.clone())
-            } else {
-                None
-            }
-        })
+        .filter(|matcher| matcher.name == METRIC_NAME_LABEL);
+    let matcher = matchers
+        .next()
         .context(error::InvalidPromRemoteRequestSnafu {
             msg: "missing '__name__' label in timeseries",
-        })
+        })?;
+
+    if matcher.r#type != MatcherType::Eq as i32
+        || matcher.value.is_empty()
+        || matchers.next().is_some()
+    {
+        return Err(error::InvalidPromRemoteRequestSnafu {
+            msg: "expected exactly one non-empty equality matcher for '__name__'".to_string(),
+        }
+        .build());
+    }
+
+    Ok(matcher.value.clone())
 }
 
 /// Extract schema from remote read request. Returns the first schema found from any query's matchers.
@@ -645,6 +652,40 @@ mod tests {
             ..Default::default()
         };
         assert_eq!("test", table_name(&q).unwrap());
+
+        for matchers in [
+            vec![LabelMatcher {
+                name: METRIC_NAME_LABEL.to_string(),
+                value: "test.*".to_string(),
+                r#type: RE_TYPE,
+            }],
+            vec![LabelMatcher {
+                name: METRIC_NAME_LABEL.to_string(),
+                value: String::new(),
+                r#type: EQ_TYPE,
+            }],
+            vec![
+                LabelMatcher {
+                    name: METRIC_NAME_LABEL.to_string(),
+                    value: "test".to_string(),
+                    r#type: EQ_TYPE,
+                },
+                LabelMatcher {
+                    name: METRIC_NAME_LABEL.to_string(),
+                    value: "other".to_string(),
+                    r#type: EQ_TYPE,
+                },
+            ],
+        ] {
+            let q = Query {
+                matchers,
+                ..Default::default()
+            };
+            assert!(matches!(
+                table_name(&q),
+                Err(error::Error::InvalidPromRemoteRequest { .. })
+            ));
+        }
     }
 
     #[test]

--- a/src/servers/src/prometheus.rs
+++ b/src/servers/src/prometheus.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use catalog::system_schema::information_schema::tables::{
-    ENGINE as TABLE_ENGINE, TABLE_CATALOG, TABLE_NAME, TABLE_SCHEMA,
+    CREATE_OPTIONS, ENGINE as TABLE_ENGINE, TABLE_CATALOG, TABLE_NAME, TABLE_SCHEMA,
 };
 use common_telemetry::tracing;
 use datafusion::dataframe::DataFrame;
@@ -22,6 +22,7 @@ use datafusion_expr::LogicalPlan;
 use promql_parser::label::{MatchOp, Matcher};
 use session::context::QueryContextRef;
 use snafu::ResultExt;
+use store_api::metric_engine_consts::{LOGICAL_TABLE_METADATA_KEY, PHYSICAL_TABLE_METADATA_KEY};
 
 use crate::error::{self, Result};
 
@@ -35,16 +36,34 @@ const MAX_METRICS_NUM: usize = 1024;
 pub fn metric_name_matchers_to_plan(
     dataframe: DataFrame,
     matchers: Vec<Matcher>,
+    schema: &str,
     ctx: &QueryContextRef,
 ) -> Result<LogicalPlan> {
     assert!(!matchers.is_empty());
 
-    let mut conditions = Vec::with_capacity(matchers.len() + 3);
+    let mut conditions = Vec::with_capacity(matchers.len() + 5);
 
     conditions.push(col(TABLE_CATALOG).eq(lit(ctx.current_catalog())));
-    conditions.push(col(TABLE_SCHEMA).eq(lit(ctx.current_schema())));
+    conditions.push(col(TABLE_SCHEMA).eq(lit(schema)));
     // Must be metric engine
     conditions.push(col(TABLE_ENGINE).eq(lit("metric")));
+    // Physical metric tables are internal. PromQL queries user-visible logical tables.
+    conditions.push(
+        regexp_match(
+            col(CREATE_OPTIONS),
+            lit(format!("(^| ){LOGICAL_TABLE_METADATA_KEY}=")),
+            None,
+        )
+        .is_not_null(),
+    );
+    conditions.push(
+        regexp_match(
+            col(CREATE_OPTIONS),
+            lit(format!("(^| ){PHYSICAL_TABLE_METADATA_KEY}=")),
+            None,
+        )
+        .is_null(),
+    );
 
     for m in matchers {
         let value = &m.value;
@@ -80,4 +99,85 @@ pub fn metric_name_matchers_to_plan(
         .context(error::DataFrameSnafu)?;
 
     Ok(dataframe.into_parts().1)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::array::StringArray;
+    use arrow::record_batch::RecordBatch;
+    use arrow_schema::{DataType, Field, Schema};
+    use datafusion::prelude::SessionContext;
+    use promql_parser::label::{MatchOp, Matcher};
+    use session::context::QueryContext;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_metric_name_plan_only_returns_logical_metric_tables() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(TABLE_CATALOG, DataType::Utf8, false),
+            Field::new(TABLE_SCHEMA, DataType::Utf8, false),
+            Field::new(TABLE_NAME, DataType::Utf8, false),
+            Field::new(TABLE_ENGINE, DataType::Utf8, false),
+            Field::new(CREATE_OPTIONS, DataType::Utf8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec!["greptime"; 5])),
+                Arc::new(StringArray::from(vec![
+                    "public", "private", "private", "private", "private",
+                ])),
+                Arc::new(StringArray::from(vec![
+                    "logical_public",
+                    "logical_private",
+                    "physical",
+                    "misleading",
+                    "mito",
+                ])),
+                Arc::new(StringArray::from(vec![
+                    "metric", "metric", "metric", "metric", "mito",
+                ])),
+                Arc::new(StringArray::from(vec![
+                    "on_physical_table=physical",
+                    "ttl=1d on_physical_table=physical",
+                    "physical_metric_table=",
+                    "foo=x on_physical_table=physical physical_metric_table=",
+                    "on_physical_table=physical",
+                ])),
+            ],
+        )
+        .unwrap();
+
+        let session = SessionContext::new();
+        let dataframe = session.read_batch(batch).unwrap();
+        let query_ctx = Arc::new(QueryContext::with("greptime", "public"));
+        let plan = metric_name_matchers_to_plan(
+            dataframe,
+            vec![Matcher::new(MatchOp::NotEqual, "__name__", "")],
+            "private",
+            &query_ctx,
+        )
+        .unwrap();
+        let batches = session
+            .execute_logical_plan(plan)
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+
+        let mut names = Vec::new();
+        for batch in batches {
+            let column = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
+            names.extend(column.iter().flatten().map(str::to_owned));
+        }
+        assert_eq!(vec!["logical_private"], names);
+    }
 }

--- a/src/servers/src/prometheus_handler.rs
+++ b/src/servers/src/prometheus_handler.rs
@@ -76,8 +76,8 @@ pub trait PrometheusHandler {
         query_ctx: &QueryContextRef,
     ) -> Result<()>;
 
-    /// Removes metric names that the current user cannot query.
-    async fn filter_query_metric_names(
+    /// Removes inaccessible metric names from metadata enumeration results.
+    async fn filter_metadata_metric_names(
         &self,
         metric_names: Vec<String>,
         schema: &str,

--- a/src/servers/src/prometheus_handler.rs
+++ b/src/servers/src/prometheus_handler.rs
@@ -18,26 +18,69 @@ use std::sync::Arc;
 use std::time::SystemTime;
 
 use async_trait::async_trait;
+use auth::PermissionTableTargets;
 use catalog::CatalogManagerRef;
 use common_query::Output;
-use promql_parser::label::Matcher;
+use promql_parser::label::{MatchOp, Matcher};
 use query::parser::PromQuery;
 use session::context::QueryContextRef;
 
-use crate::error::Result;
+use crate::error::{InvalidQuerySnafu, Result};
 
 pub const PROMETHEUS_API_VERSION: &str = "v1";
 
+const PROMQL_SCHEMA_MATCHERS: [&str; 2] = ["__database__", "__schema__"];
+
 pub type PrometheusHandlerRef = Arc<dyn PrometheusHandler + Send + Sync>;
+
+/// Resolves the optional schema selector shared by Prometheus query paths.
+///
+/// Like the PromQL planner, the last equality matcher selects the schema.
+pub fn resolve_schema_from_matchers(matchers: &[Matcher]) -> Result<Option<String>> {
+    let mut schema = None;
+    for matcher in matchers
+        .iter()
+        .filter(|matcher| PROMQL_SCHEMA_MATCHERS.contains(&matcher.name.as_str()))
+    {
+        if matcher.op != MatchOp::Equal || matcher.value.is_empty() {
+            return Err(InvalidQuerySnafu {
+                reason: format!(
+                    "expected a non-empty equality matcher for '{}'",
+                    matcher.name
+                ),
+            }
+            .build());
+        }
+        schema = Some(matcher.value.clone());
+    }
+    Ok(schema)
+}
 
 #[async_trait]
 pub trait PrometheusHandler {
     async fn do_query(&self, query: &PromQuery, query_ctx: QueryContextRef) -> Result<Output>;
 
+    /// Checks access to every table referenced by a batch of PromQL queries.
+    ///
+    /// An empty batch still checks the operation privilege.
+    async fn check_query_permission(
+        &self,
+        queries: &[PromQuery],
+        query_ctx: &QueryContextRef,
+    ) -> Result<()>;
+
+    /// Checks access to targets resolved by Prometheus metadata APIs.
+    async fn check_query_target_permission(
+        &self,
+        targets: PermissionTableTargets,
+        query_ctx: &QueryContextRef,
+    ) -> Result<()>;
+
     /// Query metric table names by the `__name__` matchers.
     async fn query_metric_names(
         &self,
         matchers: Vec<Matcher>,
+        schema: &str,
         ctx: &QueryContextRef,
     ) -> Result<Vec<String>>;
 
@@ -52,4 +95,54 @@ pub trait PrometheusHandler {
     ) -> Result<Vec<String>>;
 
     fn catalog_manager(&self) -> CatalogManagerRef;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_schema_from_matchers() {
+        assert_eq!(resolve_schema_from_matchers(&[]).unwrap(), None);
+
+        for label in ["__database__", "__schema__"] {
+            let matchers = [Matcher::new(MatchOp::Equal, label, "private")];
+            assert_eq!(
+                resolve_schema_from_matchers(&matchers).unwrap(),
+                Some("private".to_string())
+            );
+        }
+
+        let matchers = [Matcher::new(
+            MatchOp::Equal,
+            "x_greptime_database",
+            "private",
+        )];
+        assert_eq!(resolve_schema_from_matchers(&matchers).unwrap(), None);
+
+        let matchers = [
+            Matcher::new(MatchOp::Equal, "__database__", "private"),
+            Matcher::new(MatchOp::Equal, "__schema__", "public"),
+        ];
+        assert_eq!(
+            resolve_schema_from_matchers(&matchers).unwrap(),
+            Some("public".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_schema_from_matchers_rejects_unsafe_matchers() {
+        assert!(
+            resolve_schema_from_matchers(&[Matcher::new(
+                MatchOp::NotEqual,
+                "__database__",
+                "private",
+            )])
+            .is_err()
+        );
+        assert!(
+            resolve_schema_from_matchers(&[Matcher::new(MatchOp::Equal, "__database__", "",)])
+                .is_err()
+        );
+    }
 }

--- a/src/servers/src/prometheus_handler.rs
+++ b/src/servers/src/prometheus_handler.rs
@@ -22,16 +22,69 @@ use auth::PermissionTableTargets;
 use catalog::CatalogManagerRef;
 use common_query::Output;
 use promql_parser::label::{MatchOp, Matcher};
-use query::parser::PromQuery;
+use promql_parser::parser::Expr as PromqlExpr;
+use query::parser::{PromQuery, QueryLanguageParser, QueryStatement};
 use session::context::QueryContextRef;
+use snafu::ResultExt;
 
-use crate::error::{InvalidQuerySnafu, Result};
+use crate::error::{InvalidQuerySnafu, ParsePromQLSnafu, Result};
 
 pub const PROMETHEUS_API_VERSION: &str = "v1";
 
 const PROMQL_SCHEMA_MATCHERS: [&str; 2] = ["__database__", "__schema__"];
 
 pub type PrometheusHandlerRef = Arc<dyn PrometheusHandler + Send + Sync>;
+
+/// A Prometheus query paired with its parsed statement.
+#[derive(Debug, Clone)]
+pub struct ParsedPromQuery {
+    query: PromQuery,
+    statement: QueryStatement,
+}
+
+impl ParsedPromQuery {
+    /// Parses a Prometheus query once for permission checking and execution.
+    pub fn parse(query: PromQuery, query_ctx: &QueryContextRef) -> Result<Self> {
+        let statement =
+            QueryLanguageParser::parse_promql(&query, query_ctx).with_context(|_| {
+                ParsePromQLSnafu {
+                    query: query.clone(),
+                }
+            })?;
+        Ok(Self { query, statement })
+    }
+
+    /// Returns the original query parameters.
+    pub fn query(&self) -> &PromQuery {
+        &self.query
+    }
+
+    /// Returns the parsed query statement.
+    pub fn statement(&self) -> &QueryStatement {
+        &self.statement
+    }
+
+    /// Returns the parsed PromQL expression.
+    pub fn expr(&self) -> &PromqlExpr {
+        let QueryStatement::Promql(eval_stmt, _) = &self.statement else {
+            unreachable!("query is parsed from PromQL")
+        };
+        &eval_stmt.expr
+    }
+
+    pub(crate) fn update_expr(&mut self, update: impl FnOnce(&mut PromqlExpr)) {
+        let QueryStatement::Promql(eval_stmt, _) = &mut self.statement else {
+            unreachable!("query is parsed from PromQL")
+        };
+        update(&mut eval_stmt.expr);
+        self.query.query = eval_stmt.expr.to_string();
+    }
+
+    /// Splits the parsed query into its original parameters and statement.
+    pub fn into_parts(self) -> (PromQuery, QueryStatement) {
+        (self.query, self.statement)
+    }
+}
 
 /// Resolves the optional schema selector shared by Prometheus query paths.
 ///
@@ -60,6 +113,15 @@ pub fn resolve_schema_from_matchers(matchers: &[Matcher]) -> Result<Option<Strin
 pub trait PrometheusHandler {
     async fn do_query(&self, query: &PromQuery, query_ctx: QueryContextRef) -> Result<Output>;
 
+    /// Executes a query whose statement has already been parsed.
+    async fn do_query_parsed(
+        &self,
+        query: ParsedPromQuery,
+        query_ctx: QueryContextRef,
+    ) -> Result<Output> {
+        self.do_query(query.query(), query_ctx).await
+    }
+
     /// Checks access to every table referenced by a batch of PromQL queries.
     ///
     /// An empty batch still checks the operation privilege.
@@ -68,6 +130,19 @@ pub trait PrometheusHandler {
         queries: &[PromQuery],
         query_ctx: &QueryContextRef,
     ) -> Result<()>;
+
+    /// Checks access without parsing the queries again.
+    async fn check_query_permission_parsed(
+        &self,
+        queries: &[ParsedPromQuery],
+        query_ctx: &QueryContextRef,
+    ) -> Result<()> {
+        let queries = queries
+            .iter()
+            .map(|query| query.query().clone())
+            .collect::<Vec<_>>();
+        self.check_query_permission(&queries, query_ctx).await
+    }
 
     /// Checks access to targets resolved by Prometheus metadata APIs.
     async fn check_query_target_permission(

--- a/src/servers/src/prometheus_handler.rs
+++ b/src/servers/src/prometheus_handler.rs
@@ -76,7 +76,7 @@ pub trait PrometheusHandler {
         query_ctx: &QueryContextRef,
     ) -> Result<()>;
 
-    /// Removes inaccessible metric names from metadata enumeration results.
+    /// Removes inaccessible metric names from logical-table metadata enumeration results.
     async fn filter_metadata_metric_names(
         &self,
         metric_names: Vec<String>,

--- a/src/servers/src/prometheus_handler.rs
+++ b/src/servers/src/prometheus_handler.rs
@@ -76,6 +76,14 @@ pub trait PrometheusHandler {
         query_ctx: &QueryContextRef,
     ) -> Result<()>;
 
+    /// Removes metric names that the current user cannot query.
+    async fn filter_query_metric_names(
+        &self,
+        metric_names: Vec<String>,
+        schema: &str,
+        query_ctx: &QueryContextRef,
+    ) -> Result<Vec<String>>;
+
     /// Query metric table names by the `__name__` matchers.
     async fn query_metric_names(
         &self,

--- a/src/servers/src/query_handler.rs
+++ b/src/servers/src/query_handler.rs
@@ -80,6 +80,9 @@ pub trait InfluxdbLineProtocolHandler {
 
 #[async_trait]
 pub trait OpentsdbProtocolHandler {
+    /// Checks all points in one external request before per-point debug execution.
+    async fn preflight(&self, data_points: &[DataPoint], ctx: QueryContextRef) -> Result<()>;
+
     /// A successful request will not return a response.
     /// Only on error will the socket return a line of data.
     async fn exec(&self, data_points: Vec<DataPoint>, ctx: QueryContextRef) -> Result<usize>;
@@ -95,9 +98,7 @@ pub struct PromStoreResponse {
 #[async_trait]
 pub trait PromStoreProtocolHandler {
     /// Runs pre-write checks/hooks for prometheus remote write requests.
-    async fn pre_write(&self, _request: &RowInsertRequests, _ctx: QueryContextRef) -> Result<()> {
-        Ok(())
-    }
+    async fn pre_write(&self, request: &RowInsertRequests, ctx: QueryContextRef) -> Result<()>;
 
     /// Handling prometheus remote write requests
     async fn write(
@@ -106,6 +107,13 @@ pub trait PromStoreProtocolHandler {
         ctx: QueryContextRef,
         with_metric_engine: bool,
     ) -> Result<Output>;
+
+    /// Checks every batch before writing any of them.
+    async fn write_all(
+        &self,
+        requests: Vec<(QueryContextRef, RowInsertRequests)>,
+        with_metric_engine: bool,
+    ) -> Result<Vec<Result<Output>>>;
 
     /// Handling prometheus remote read requests
     async fn read(&self, request: ReadRequest, ctx: QueryContextRef) -> Result<PromStoreResponse>;
@@ -154,6 +162,12 @@ pub trait OpenTelemetryProtocolHandler: PipelineHandler {
 #[async_trait]
 pub trait PipelineHandler {
     async fn insert(&self, input: RowInsertRequests, ctx: QueryContextRef) -> Result<Output>;
+
+    /// Checks every batch before inserting any of them.
+    async fn insert_all(
+        &self,
+        inputs: Vec<(QueryContextRef, RowInsertRequests)>,
+    ) -> Result<Vec<Result<Output>>>;
 
     async fn get_pipeline(
         &self,

--- a/src/servers/src/query_handler.rs
+++ b/src/servers/src/query_handler.rs
@@ -100,6 +100,14 @@ pub trait PromStoreProtocolHandler {
     /// Runs pre-write checks/hooks for prometheus remote write requests.
     async fn pre_write(&self, request: &RowInsertRequests, ctx: QueryContextRef) -> Result<()>;
 
+    /// Writes one batch after [`Self::pre_write`] has succeeded for the entire request.
+    async fn write_prepared(
+        &self,
+        request: RowInsertRequests,
+        ctx: QueryContextRef,
+        with_metric_engine: bool,
+    ) -> Result<Output>;
+
     /// Handling prometheus remote write requests
     async fn write(
         &self,

--- a/src/servers/tests/http/opentsdb_test.rs
+++ b/src/servers/tests/http/opentsdb_test.rs
@@ -37,6 +37,10 @@ struct DummyInstance {
 
 #[async_trait]
 impl OpentsdbProtocolHandler for DummyInstance {
+    async fn preflight(&self, _data_points: &[DataPoint], _ctx: QueryContextRef) -> Result<()> {
+        Ok(())
+    }
+
     async fn exec(&self, data_points: Vec<DataPoint>, _ctx: QueryContextRef) -> Result<usize> {
         let data_point = data_points.first().unwrap();
         if data_point.metric() == "should_failed" {

--- a/src/servers/tests/http/prom_store_test.rs
+++ b/src/servers/tests/http/prom_store_test.rs
@@ -73,7 +73,7 @@ impl PromStoreProtocolHandler for DummyInstance {
         Ok(())
     }
 
-    async fn write(
+    async fn write_prepared(
         &self,
         request: RowInsertRequests,
         ctx: QueryContextRef,
@@ -100,6 +100,15 @@ impl PromStoreProtocolHandler for DummyInstance {
         Ok(Output::new_with_affected_rows(0))
     }
 
+    async fn write(
+        &self,
+        request: RowInsertRequests,
+        ctx: QueryContextRef,
+        with_metric_engine: bool,
+    ) -> Result<Output> {
+        self.write_prepared(request, ctx, with_metric_engine).await
+    }
+
     async fn write_all(
         &self,
         requests: Vec<(QueryContextRef, RowInsertRequests)>,
@@ -107,7 +116,7 @@ impl PromStoreProtocolHandler for DummyInstance {
     ) -> Result<Vec<Result<Output>>> {
         let mut outputs = Vec::with_capacity(requests.len());
         for (ctx, request) in requests {
-            let output = self.write(request, ctx, with_metric_engine).await;
+            let output = self.write_prepared(request, ctx, with_metric_engine).await;
             let failed = output.is_err();
             outputs.push(output);
             if failed {

--- a/src/servers/tests/http/prom_store_test.rs
+++ b/src/servers/tests/http/prom_store_test.rs
@@ -69,6 +69,10 @@ struct RemoteWriteCapture {
 
 #[async_trait]
 impl PromStoreProtocolHandler for DummyInstance {
+    async fn pre_write(&self, _request: &RowInsertRequests, _ctx: QueryContextRef) -> Result<()> {
+        Ok(())
+    }
+
     async fn write(
         &self,
         request: RowInsertRequests,
@@ -94,6 +98,23 @@ impl PromStoreProtocolHandler for DummyInstance {
             .await;
 
         Ok(Output::new_with_affected_rows(0))
+    }
+
+    async fn write_all(
+        &self,
+        requests: Vec<(QueryContextRef, RowInsertRequests)>,
+        with_metric_engine: bool,
+    ) -> Result<Vec<Result<Output>>> {
+        let mut outputs = Vec::with_capacity(requests.len());
+        for (ctx, request) in requests {
+            let output = self.write(request, ctx, with_metric_engine).await;
+            let failed = output.is_err();
+            outputs.push(output);
+            if failed {
+                break;
+            }
+        }
+        Ok(outputs)
     }
 
     async fn read(&self, request: ReadRequest, ctx: QueryContextRef) -> Result<PromStoreResponse> {

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -233,6 +233,18 @@ impl From<&QueryContext> for api::v1::QueryContext {
 }
 
 impl QueryContext {
+    /// Forks this context with an independent snapshot of mutable session data.
+    ///
+    /// Unlike [`Clone`], changes to the schema, user, timezone, and other fields
+    /// held in mutable session data do not affect this context.
+    pub fn fork(&self) -> Self {
+        let mut fork = self.clone();
+        fork.mutable_session_data = Arc::new(RwLock::new(
+            self.mutable_session_data.read().unwrap().clone(),
+        ));
+        fork
+    }
+
     pub fn arc() -> QueryContextRef {
         Arc::new(
             QueryContextBuilder::default()
@@ -769,6 +781,17 @@ mod test {
 
         let context = QueryContext::with(DEFAULT_CATALOG_NAME, "test");
         assert_eq!("test", context.get_db_string());
+    }
+
+    #[test]
+    fn test_fork_has_independent_mutable_session_data() {
+        let context = QueryContext::with(DEFAULT_CATALOG_NAME, "public");
+        let fork = context.fork();
+
+        fork.set_current_schema("private");
+
+        assert_eq!(context.current_schema(), "public");
+        assert_eq!(fork.current_schema(), "private");
     }
 
     #[test]

--- a/src/session/src/lib.rs
+++ b/src/session/src/lib.rs
@@ -53,7 +53,7 @@ pub struct Session {
 pub type SessionRef = Arc<Session>;
 
 /// A container for mutable items in query context
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct MutableInner {
     schema: String,
     user_info: UserInfoRef,

--- a/src/sql/src/util.rs
+++ b/src/sql/src/util.rs
@@ -244,6 +244,10 @@ fn extract_tables_from_statement(stmt: &Statement, names: &mut HashSet<ObjectNam
             names.extend(drop.table_names().iter().cloned());
             true
         }
+        Statement::UndropTable(undrop) => {
+            names.insert(undrop.table_name().clone());
+            true
+        }
         Statement::TruncateTable(truncate) => {
             names.insert(truncate.table_name().clone());
             true
@@ -827,6 +831,7 @@ TQL EVAL (now() - '15s'::interval, now(), '5s') count_values("status_code", {__n
                 vec!["physical_metric", "target"],
             ),
             ("ALTER TABLE old RENAME new", vec!["new", "old"]),
+            ("UNDROP TABLE restored", vec!["restored"]),
             ("SHOW TABLES", vec![]),
         ] {
             let stmt = ParserContext::create_with_dialect(

--- a/src/sql/src/util.rs
+++ b/src/sql/src/util.rs
@@ -317,7 +317,34 @@ fn extract_tables_from_statement(stmt: &Statement, names: &mut HashSet<ObjectNam
         Statement::Copy(Copy::CopyQueryTo(copy)) => {
             extract_tables_from_statement(&copy.query, names)
         }
-        _ => true,
+        Statement::Copy(Copy::CopyDatabase(_)) => true,
+        Statement::DropDatabase(_)
+        | Statement::DropFlow(_)
+        | Statement::CreateDatabase(_)
+        | Statement::AlterDatabase(_)
+        | Statement::ShowDatabases(_)
+        | Statement::ShowTables(_)
+        | Statement::ShowTableStatus(_)
+        | Statement::ShowCharset(_)
+        | Statement::ShowCollation(_)
+        | Statement::ShowCreateDatabase(_)
+        | Statement::ShowCreateFlow(_)
+        | Statement::ShowFlows(_)
+        | Statement::ShowStatus(_)
+        | Statement::ShowSearchPath(_)
+        | Statement::ShowViews(_)
+        | Statement::SetVariables(_)
+        | Statement::ShowVariables(_)
+        | Statement::Use(_)
+        | Statement::Admin(_)
+        | Statement::FetchCursor(_)
+        | Statement::CloseCursor(_)
+        | Statement::Kill(_)
+        | Statement::ShowProcesslist(_) => true,
+        #[cfg(feature = "enterprise")]
+        Statement::DropTrigger(_)
+        | Statement::ShowCreateTrigger(_)
+        | Statement::ShowTriggers(_) => true,
     }
 }
 
@@ -800,6 +827,7 @@ TQL EVAL (now() - '15s'::interval, now(), '5s') count_values("status_code", {__n
                 vec!["physical_metric", "target"],
             ),
             ("ALTER TABLE old RENAME new", vec!["new", "old"]),
+            ("SHOW TABLES", vec![]),
         ] {
             let stmt = ParserContext::create_with_dialect(
                 sql,

--- a/src/sql/src/util.rs
+++ b/src/sql/src/util.rs
@@ -26,7 +26,7 @@ use serde::Serialize;
 use snafu::ensure;
 use sqlparser::ast::{
     Array, Expr, Ident, ObjectName, ObjectNamePart, SqlOption, Value, ValueWithSpan,
-    Visit as AstVisit, Visitor,
+    Visit as AstVisit, Visitor, visit_relations,
 };
 use sqlparser_derive::{Visit, VisitMut};
 
@@ -34,8 +34,12 @@ use crate::ast::ObjectNamePartExt;
 use crate::error::{InvalidExprAsOptionValueSnafu, InvalidSqlSnafu, Result};
 use crate::parser::ParserContext;
 use crate::parsers::with_tql_parser::CteContent;
+use crate::statements::alter::AlterTableOperation;
+use crate::statements::comment::CommentObject;
+use crate::statements::copy::{Copy, CopyTable};
 use crate::statements::create::SqlOrTql;
 use crate::statements::query::Query;
+use crate::statements::statement::Statement;
 use crate::statements::tql::Tql;
 
 const SCHEMA_MATCHER: &str = "__schema__";
@@ -195,6 +199,153 @@ pub fn extract_tables_from_query_checked(
     complete.then_some(names.into_iter())
 }
 
+/// Walks through a [`Statement`] and extracts all referenced tables, returning
+/// `None` if any table reference cannot be resolved statically.
+pub fn extract_tables_from_statement_checked(
+    stmt: &Statement,
+) -> Option<impl Iterator<Item = ObjectName>> {
+    let mut names = HashSet::new();
+    extract_tables_from_statement(stmt, &mut names).then_some(names.into_iter())
+}
+
+fn extract_tables_from_statement(stmt: &Statement, names: &mut HashSet<ObjectName>) -> bool {
+    match stmt {
+        Statement::Tql(tql) => extract_tables_from_tql(tql, names),
+        Statement::Insert(insert) => {
+            collect_relations(&insert.inner, names);
+            true
+        }
+        Statement::Delete(delete) => {
+            collect_relations(&delete.inner, names);
+            true
+        }
+        Statement::Query(query) => extract_tables_from_query_ast(query, names),
+        Statement::CreateTable(create) => {
+            names.insert(create.name.clone());
+            true
+        }
+        Statement::CreateExternalTable(create) => {
+            names.insert(create.name.clone());
+            true
+        }
+        Statement::AlterTable(alter) => {
+            let current = alter.table_name().clone();
+            names.insert(current.clone());
+            if let AlterTableOperation::RenameTable { new_table_name } = alter.alter_operation() {
+                let mut renamed = current;
+                if let Some(last) = renamed.0.last_mut() {
+                    *last = ObjectNamePart::Identifier(Ident::new(new_table_name));
+                }
+                names.insert(renamed);
+            }
+            true
+        }
+        Statement::DropTable(drop) => {
+            names.extend(drop.table_names().iter().cloned());
+            true
+        }
+        Statement::TruncateTable(truncate) => {
+            names.insert(truncate.table_name().clone());
+            true
+        }
+        Statement::CreateTableLike(create) => {
+            names.extend([create.table_name.clone(), create.source_name.clone()]);
+            true
+        }
+        Statement::CreateView(create) => {
+            names.insert(create.name.clone());
+            extract_tables_from_statement(&create.query, names)
+        }
+        Statement::CreateFlow(create) => {
+            names.insert(create.sink_table_name.clone());
+            extract_tables_from_sql_or_tql(&create.query, names)
+        }
+        #[cfg(feature = "enterprise")]
+        Statement::CreateTrigger(create) => {
+            extract_tables_from_sql_or_tql(&create.trigger_on.query, names)
+        }
+        #[cfg(feature = "enterprise")]
+        Statement::AlterTrigger(alter) => match &alter.operation.trigger_on {
+            Some(trigger_on) => extract_tables_from_sql_or_tql(&trigger_on.query, names),
+            None => true,
+        },
+        Statement::DropView(drop) => {
+            names.insert(drop.view_name.clone());
+            true
+        }
+        Statement::Explain(explain) => extract_tables_from_statement(&explain.statement, names),
+        Statement::DeclareCursor(cursor) => extract_tables_from_query_ast(&cursor.query, names),
+        Statement::DescribeTable(describe) => {
+            names.insert(describe.name().clone());
+            true
+        }
+        Statement::ShowCreateTable(show) => {
+            names.insert(show.table_name.clone());
+            true
+        }
+        Statement::ShowCreateView(show) => {
+            names.insert(show.view_name.clone());
+            true
+        }
+        Statement::ShowColumns(show) => {
+            names.insert(metadata_table_name(&show.table, show.database.as_deref()));
+            true
+        }
+        Statement::ShowIndex(show) => {
+            names.insert(metadata_table_name(&show.table, show.database.as_deref()));
+            true
+        }
+        Statement::ShowRegion(show) => {
+            names.insert(metadata_table_name(&show.table, show.database.as_deref()));
+            true
+        }
+        Statement::Comment(comment) => {
+            if let CommentObject::Table(table) | CommentObject::Column { table, .. } =
+                &comment.object
+            {
+                names.insert(table.clone());
+            }
+            true
+        }
+        Statement::Copy(Copy::CopyTable(copy)) => {
+            let table = match copy {
+                CopyTable::To(args) | CopyTable::From(args) => &args.table_name,
+            };
+            names.insert(table.clone());
+            true
+        }
+        Statement::Copy(Copy::CopyQueryTo(copy)) => {
+            extract_tables_from_statement(&copy.query, names)
+        }
+        _ => true,
+    }
+}
+
+fn extract_tables_from_query_ast(query: &Query, names: &mut HashSet<ObjectName>) -> bool {
+    extract_tables_from_sql_query(&query.inner, names);
+    extract_tables_from_hybrid_cte_query(query, names)
+}
+
+fn extract_tables_from_sql_or_tql(query: &SqlOrTql, names: &mut HashSet<ObjectName>) -> bool {
+    let (query_names, complete) = extract_tables_from_query_inner(query);
+    names.extend(query_names);
+    complete
+}
+
+fn collect_relations(ast: &impl AstVisit, names: &mut HashSet<ObjectName>) {
+    let _ = visit_relations(ast, |relation| {
+        names.insert(relation.clone());
+        ControlFlow::<()>::Continue(())
+    });
+}
+
+fn metadata_table_name(table: &str, database: Option<&str>) -> ObjectName {
+    let mut parts = Vec::with_capacity(usize::from(database.is_some()) + 1);
+    parts.extend(database.map(Ident::new));
+    parts.push(Ident::new(table));
+    ObjectName::from(parts)
+}
+
 fn extract_tables_from_query_inner(query: &SqlOrTql) -> (HashSet<ObjectName>, bool) {
     let mut names = HashSet::new();
 
@@ -270,6 +421,15 @@ fn extract_tables_from_tql(tql: &Tql, names: &mut HashSet<ObjectName>) -> bool {
     extract_tables_from_prom_expr(&expr, names)
 }
 
+/// Extracts all tables referenced by a [`PromExpr`], returning `None`
+/// if any table reference cannot be resolved statically.
+pub fn extract_tables_from_prom_expr_checked(
+    expr: &PromExpr,
+) -> Option<impl Iterator<Item = ObjectName>> {
+    let mut names = HashSet::new();
+    extract_tables_from_prom_expr(expr, &mut names).then_some(names.into_iter())
+}
+
 fn extract_tables_from_prom_expr(expr: &PromExpr, names: &mut HashSet<ObjectName>) -> bool {
     struct TableCollector<'a> {
         names: &'a mut HashSet<ObjectName>,
@@ -306,6 +466,10 @@ fn extract_metric_name_from_vector_selector(
     selector: &PromVectorSelector,
     names: &mut HashSet<ObjectName>,
 ) -> bool {
+    if selector.name.is_none() && !selector.matchers.or_matchers.is_empty() {
+        return false;
+    }
+
     let metric_name = selector.name.clone().or_else(|| {
         let mut metric_name_matchers = selector.matchers.find_matchers(METRIC_NAME);
         if metric_name_matchers.len() == 1 && metric_name_matchers[0].op == MatchOp::Equal {
@@ -561,13 +725,22 @@ TQL EVAL (now() - '15s'::interval, now(), '5s') count_values("status_code", {__n
     fn test_extract_tables_from_tql_query_completeness() {
         let testcases = [
             ("cpu", true, vec!["cpu"]),
+            ("cpu + mem", true, vec!["cpu", "mem"]),
+            (r#"cpu{__database__="private"}"#, true, vec!["private.cpu"]),
+            ("1 + 2", true, vec![]),
             (r#"{__name__="cpu"}"#, true, vec!["cpu"]),
+            (r#"cpu{job="api" or instance="host"}"#, true, vec!["cpu"]),
             (r#"cpu + {job="api"}"#, false, vec!["cpu"]),
             (r#"{__name__=~"cpu.*"}"#, false, vec![]),
+            (r#"{__name__=~"cpu.*" or job="api"}"#, false, vec![]),
             (r#"cpu{__schema__=~"private.*"}"#, false, vec![]),
         ];
 
         for (promql, expected_complete, expected_tables) in testcases {
+            let expected_tables = expected_tables
+                .into_iter()
+                .map(str::to_string)
+                .collect_vec();
             let sql = format!("TQL EVAL (0, 10, '5s') {promql}");
             let mut stmts = ParserContext::create_with_dialect(
                 &sql,
@@ -593,6 +766,53 @@ TQL EVAL (now() - '15s'::interval, now(), '5s') count_values("status_code", {__n
                 extract_tables_from_query_checked(&query).is_some(),
                 "{promql}"
             );
+
+            let expr = promql_parser::parser::parse(promql).unwrap();
+            let direct_tables = extract_tables_from_prom_expr_checked(&expr).map(|tables| {
+                let mut tables = tables
+                    .map(|table| format_raw_object_name(&table))
+                    .collect_vec();
+                tables.sort();
+                tables
+            });
+            assert_eq!(
+                expected_complete.then(|| expected_tables.clone()),
+                direct_tables
+            );
+        }
+    }
+
+    #[test]
+    fn test_extract_tables_from_statement() {
+        for (sql, expected) in [
+            ("SELECT * FROM physical_metric", vec!["physical_metric"]),
+            (
+                "INSERT INTO target SELECT * FROM physical_metric",
+                vec!["physical_metric", "target"],
+            ),
+            (
+                "TQL EVAL (0, 10, '5s') physical_metric",
+                vec!["physical_metric"],
+            ),
+            (
+                "CREATE VIEW target AS SELECT * FROM physical_metric",
+                vec!["physical_metric", "target"],
+            ),
+            ("ALTER TABLE old RENAME new", vec!["new", "old"]),
+        ] {
+            let stmt = ParserContext::create_with_dialect(
+                sql,
+                &GreptimeDbDialect {},
+                ParseOptions::default(),
+            )
+            .unwrap()
+            .remove(0);
+            let mut tables = extract_tables_from_statement_checked(&stmt)
+                .unwrap()
+                .map(|table| format_raw_object_name(&table))
+                .collect_vec();
+            tables.sort();
+            assert_eq!(expected, tables, "{sql}");
         }
     }
 

--- a/src/sql/src/util.rs
+++ b/src/sql/src/util.rs
@@ -26,7 +26,7 @@ use serde::Serialize;
 use snafu::ensure;
 use sqlparser::ast::{
     Array, Expr, Ident, ObjectName, ObjectNamePart, SqlOption, Value, ValueWithSpan,
-    Visit as AstVisit, Visitor, visit_relations,
+    Visit as AstVisit, Visitor,
 };
 use sqlparser_derive::{Visit, VisitMut};
 
@@ -333,10 +333,7 @@ fn extract_tables_from_sql_or_tql(query: &SqlOrTql, names: &mut HashSet<ObjectNa
 }
 
 fn collect_relations(ast: &impl AstVisit, names: &mut HashSet<ObjectName>) {
-    let _ = visit_relations(ast, |relation| {
-        names.insert(relation.clone());
-        ControlFlow::<()>::Continue(())
-    });
+    let _ = ast.visit(&mut RelationCollector::new(names));
 }
 
 fn metadata_table_name(table: &str, database: Option<&str>) -> ObjectName {
@@ -788,6 +785,10 @@ TQL EVAL (now() - '15s'::interval, now(), '5s') count_values("status_code", {__n
             ("SELECT * FROM physical_metric", vec!["physical_metric"]),
             (
                 "INSERT INTO target SELECT * FROM physical_metric",
+                vec!["physical_metric", "target"],
+            ),
+            (
+                "INSERT INTO target WITH cte AS (SELECT * FROM physical_metric) SELECT * FROM cte",
                 vec!["physical_metric", "target"],
             ),
             (


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This pull request fixes table-level authorization gaps where several query and ingestion paths checked the operation type without reliably passing every concrete catalog, schema, and table target to ACL-aware permission checkers.

### What changes

- Adds resolved and unresolved table-target states. Ambiguous targets fail closed, while target-independent permission checkers retain their existing behavior.
- Extracts every statically referenced SQL, TQL, and PromQL table, including sources, destinations, CTEs, rename targets, and cross-schema selectors.
- Applies table authorization to Prometheus queries and metadata, remote read/write, OTLP, OpenTSDB, InfluxDB, and log ingestion.
- Rejects internal physical metric tables as user query targets and filters inaccessible logical metrics from metadata enumeration.
- Preflights every normalized batch before writing anything, preventing an unauthorized later batch from leaving partial data behind.
- Deduplicates targets, bounds concurrent catalog resolution, and avoids redundant metadata lookups.

### Behavior examples

- `INSERT INTO dst SELECT * FROM src` now requires access to both `src` and `dst`.
- PromQL metric discovery resolves logical metric candidates before execution; physical or unsafe unresolved targets are rejected.
- A remote-write, OTLP, or log request spanning multiple tables or schemas authorizes every final target before the first batch is persisted.

### Compatibility

Custom implementations of `PermissionChecker`, `PromStoreProtocolHandler`, `PipelineHandler`, or `OpentsdbProtocolHandler` must implement the new target-aware or preflight methods. This PR does not change configuration, persisted-data, or wire formats.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
