### PR TITLE
chore: ignore mysql connection reset error

### DIFF
--- a/src/servers/src/mysql/server.rs
+++ b/src/servers/src/mysql/server.rs
@@ -45,6 +45,7 @@ const DEFAULT_RESULT_SET_WRITE_BUFFER_SIZE: usize = 100 * 1024;
 const CLIENT_DISCONNECT_ERROR_KINDS: &[std::io::ErrorKind] = &[
     std::io::ErrorKind::ConnectionAborted,
     std::io::ErrorKind::ConnectionReset,
+    std::io::ErrorKind::BrokenPipe,
 ];
 
 /// [`MysqlSpawnRef`] stores arc refs
@@ -238,17 +239,6 @@ impl MysqlServer {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::CLIENT_DISCONNECT_ERROR_KINDS;
-
-    #[test]
-    fn test_client_disconnect_error_kinds() {
-        assert!(CLIENT_DISCONNECT_ERROR_KINDS.contains(&std::io::ErrorKind::ConnectionAborted));
-        assert!(CLIENT_DISCONNECT_ERROR_KINDS.contains(&std::io::ErrorKind::ConnectionReset));
-    }
-}
-
 pub const MYSQL_SERVER: &str = "MYSQL_SERVER";
 
 #[async_trait]
@@ -285,5 +275,17 @@ impl Server for MysqlServer {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CLIENT_DISCONNECT_ERROR_KINDS;
+
+    #[test]
+    fn test_client_disconnect_error_kinds() {
+        assert!(CLIENT_DISCONNECT_ERROR_KINDS.contains(&std::io::ErrorKind::ConnectionAborted));
+        assert!(CLIENT_DISCONNECT_ERROR_KINDS.contains(&std::io::ErrorKind::ConnectionReset));
+        assert!(CLIENT_DISCONNECT_ERROR_KINDS.contains(&std::io::ErrorKind::BrokenPipe));
     }
 }

--- a/src/servers/src/mysql/server.rs
+++ b/src/servers/src/mysql/server.rs
@@ -42,6 +42,11 @@ use crate::tls::ReloadableTlsServerConfig;
 // Default size of ResultSet write buffer: 100KB
 const DEFAULT_RESULT_SET_WRITE_BUFFER_SIZE: usize = 100 * 1024;
 
+const CLIENT_DISCONNECT_ERROR_KINDS: &[std::io::ErrorKind] = &[
+    std::io::ErrorKind::ConnectionAborted,
+    std::io::ErrorKind::ConnectionReset,
+];
+
 /// [`MysqlSpawnRef`] stores arc refs
 /// that should be passed to new [`MysqlInstanceShim`]s.
 pub struct MysqlSpawnRef {
@@ -181,7 +186,7 @@ impl MysqlServer {
         crate::metrics::METRIC_MYSQL_CONNECTIONS.inc();
         if let Err(e) = Self::do_handle(stream, spawn_ref, spawn_config, process_id).await {
             if let Error::InternalIo { error } = &e
-                && error.kind() == std::io::ErrorKind::ConnectionAborted
+                && CLIENT_DISCONNECT_ERROR_KINDS.contains(&error.kind())
             {
                 // This is a client-side error, we don't need to log it.
             } else {
@@ -230,6 +235,17 @@ impl MysqlServer {
             }
             _ => plain_run_with_options(shim, w, ops, init_params).await,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CLIENT_DISCONNECT_ERROR_KINDS;
+
+    #[test]
+    fn test_client_disconnect_error_kinds() {
+        assert!(CLIENT_DISCONNECT_ERROR_KINDS.contains(&std::io::ErrorKind::ConnectionAborted));
+        assert!(CLIENT_DISCONNECT_ERROR_KINDS.contains(&std::io::ErrorKind::ConnectionReset));
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

As the title suggest.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
