### PR TITLE
fix: display codes in metasrv client errors

### DIFF
--- a/src/meta-client/src/error.rs
+++ b/src/meta-client/src/error.rs
@@ -29,7 +29,7 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("{}", msg))]
+    #[snafu(display("{}, code: {}, tonic code: {}", msg, code, tonic_code))]
     MetaServer {
         code: StatusCode,
         msg: String,

--- a/tests/runner/src/formatter.rs
+++ b/tests/runner/src/formatter.rs
@@ -40,11 +40,23 @@ impl<E: ErrorExt> Display for ErrorFormatter<E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let status_code = self.0.status_code();
         let root_cause = self.0.output_msg();
+        let root_cause = normalize_meta_client_error(&root_cause, status_code);
         write!(
             f,
             "Error: {}({status_code}), {root_cause}",
             status_code as u32
         )
+    }
+}
+
+fn normalize_meta_client_error(
+    root_cause: &str,
+    status_code: common_error::status_code::StatusCode,
+) -> &str {
+    let details_prefix = format!(", code: {status_code}, tonic code: ");
+    match root_cause.rsplit_once(&details_prefix) {
+        Some((message, tonic_code)) if !tonic_code.is_empty() => message,
+        _ => root_cause,
     }
 }
 
@@ -213,4 +225,53 @@ pub fn build_recordbatches_from_mysql_rows(rows: &[MySqlRow]) -> RecordBatches {
     // construct recordbatch
     RecordBatches::try_from_columns(schema, columns)
         .expect("Failed to construct recordbatches from columns. Please check the schema.")
+}
+
+#[cfg(test)]
+mod tests {
+    use common_error::ext::PlainError;
+    use common_error::status_code::StatusCode;
+
+    use super::*;
+
+    #[test]
+    fn test_normalize_meta_client_error() {
+        let error = PlainError::new(
+            "Invalid options, code: InvalidArguments, tonic code: Client specified an invalid argument"
+                .to_string(),
+            StatusCode::InvalidArguments,
+        );
+
+        assert_eq!(
+            "Error: 1004(InvalidArguments), Invalid options",
+            ErrorFormatter::from(error).to_string()
+        );
+    }
+
+    #[test]
+    fn test_preserve_regular_error() {
+        let error = PlainError::new(
+            "Invalid options without transport details".to_string(),
+            StatusCode::InvalidArguments,
+        );
+
+        assert_eq!(
+            "Error: 1004(InvalidArguments), Invalid options without transport details",
+            ErrorFormatter::from(error).to_string()
+        );
+    }
+
+    #[test]
+    fn test_preserve_error_with_mismatched_code() {
+        let error = PlainError::new(
+            "Invalid options, code: Unsupported, tonic code: Operation is not supported"
+                .to_string(),
+            StatusCode::InvalidArguments,
+        );
+
+        assert_eq!(
+            "Error: 1004(InvalidArguments), Invalid options, code: Unsupported, tonic code: Operation is not supported",
+            ErrorFormatter::from(error).to_string()
+        );
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

The meta-client's `MetaServer` error previously displayed only the server-provided message, which hid both the GreptimeDB status code and the underlying tonic transport code and made failures harder to diagnose.

Include both codes in the error's display output while keeping the existing error fields, status propagation, retry behavior, and compatibility unchanged.

Validation:

- `cargo fmt --all`
- `make check`
- `cargo nextest run -p meta-client` (36 tests passed)

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
