### PR TITLE
feat: add mysql object store backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9252,6 +9252,7 @@ dependencies = [
  "snafu 0.8.6",
  "tempfile",
  "tokio",
+ "toml 0.8.23",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9388,6 +9388,7 @@ dependencies = [
  "opendal-service-fs",
  "opendal-service-gcs",
  "opendal-service-http",
+ "opendal-service-mysql",
  "opendal-service-oss",
  "opendal-service-s3",
 ]
@@ -9573,6 +9574,18 @@ dependencies = [
  "log",
  "opendal-core",
  "serde",
+]
+
+[[package]]
+name = "opendal-service-mysql"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cb3364a16d32aeb9c9c3232a81648926a5a8efa680f3316e0743ca2d5a37744"
+dependencies = [
+ "mea",
+ "opendal-core",
+ "serde",
+ "sqlx",
 ]
 
 [[package]]

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -25,6 +25,7 @@ enterprise = ["common-meta/enterprise", "frontend/enterprise", "meta-srv/enterpr
 # Developer-only helper binary gate for `query_perf_fixture`.
 # Kept out of `default` so normal/release builds don't compile them.
 dev-tools = []
+mysql-object-store = ["object-store/mysql-object-store"]
 tokio-console = ["common-telemetry/tokio-console"]
 vector_index = ["mito2/vector_index", "query/vector_index"]
 

--- a/src/object-store/Cargo.toml
+++ b/src/object-store/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 workspace = true
 
 [features]
+mysql-object-store = ["opendal/services-mysql"]
 services-memory = ["opendal/services-memory"]
 testing = ["derive_builder"]
 
@@ -31,7 +32,6 @@ opendal = { version = "0.57", features = [
     "services-fs",
     "services-gcs",
     "services-http",
-    "services-mysql",
     "services-oss",
     "services-s3",
 ] }

--- a/src/object-store/Cargo.toml
+++ b/src/object-store/Cargo.toml
@@ -50,3 +50,4 @@ object_store_opendal.workspace = true
 rand.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
+toml.workspace = true

--- a/src/object-store/Cargo.toml
+++ b/src/object-store/Cargo.toml
@@ -31,6 +31,7 @@ opendal = { version = "0.57", features = [
     "services-fs",
     "services-gcs",
     "services-http",
+    "services-mysql",
     "services-oss",
     "services-s3",
 ] }

--- a/src/object-store/src/config.rs
+++ b/src/object-store/src/config.rs
@@ -287,7 +287,8 @@ impl From<&GcsConnection> for Gcs {
 pub struct MysqlConfig {
     pub name: String,
     pub root: String,
-    pub addr: String,
+    #[serde(skip_serializing)]
+    pub connection_string: SecretString,
     pub table: Option<String>,
     #[serde(flatten)]
     pub cache: ObjectStorageCacheConfig,
@@ -297,7 +298,7 @@ impl From<&MysqlConfig> for Mysql {
     fn from(config: &MysqlConfig) -> Self {
         let root = util::normalize_dir(&config.root);
         let mut builder = Mysql::default()
-            .connection_string(&config.addr)
+            .connection_string(config.connection_string.expose_secret())
             .root(&root)
             .key_field("key")
             .value_field("value");
@@ -427,5 +428,35 @@ mod tests {
         assert!(azblob_config.is_object_storage());
         let mysql_config = ObjectStoreConfig::Mysql(MysqlConfig::default());
         assert!(mysql_config.is_object_storage());
+    }
+
+    #[test]
+    fn test_mysql_config_connection_string_serde() {
+        let config: ObjectStoreConfig = toml::from_str(
+            r#"
+type = "Mysql"
+name = "mysql-store"
+root = "/greptimedb"
+connection_string = "mysql://user:password@127.0.0.1:3306/greptime"
+table = "object_store"
+"#,
+        )
+        .unwrap();
+
+        let ObjectStoreConfig::Mysql(mysql_config) = config else {
+            unreachable!()
+        };
+
+        assert_eq!("mysql-store", mysql_config.name);
+        assert_eq!("/greptimedb", mysql_config.root);
+        assert_eq!(
+            "mysql://user:password@127.0.0.1:3306/greptime",
+            mysql_config.connection_string.expose_secret()
+        );
+        assert_eq!(Some("object_store"), mysql_config.table.as_deref());
+
+        let serialized = toml::to_string(&mysql_config).unwrap();
+        assert!(!serialized.contains("connection_string"));
+        assert!(!serialized.contains("password"));
     }
 }

--- a/src/object-store/src/config.rs
+++ b/src/object-store/src/config.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 
 use common_base::readable_size::ReadableSize;
 use common_base::secrets::{ExposeSecret, SecretString};
-use opendal::services::{Azblob, Gcs, Oss, S3};
+use opendal::services::{Azblob, Gcs, Mysql, Oss, S3};
 use serde::{Deserialize, Serialize};
 
 use crate::util;
@@ -32,6 +32,7 @@ pub enum ObjectStoreConfig {
     Oss(OssConfig),
     Azblob(AzblobConfig),
     Gcs(GcsConfig),
+    Mysql(MysqlConfig),
 }
 
 impl Default for ObjectStoreConfig {
@@ -49,6 +50,7 @@ impl ObjectStoreConfig {
             Self::Oss(_) => "Oss",
             Self::Azblob(_) => "Azblob",
             Self::Gcs(_) => "Gcs",
+            Self::Mysql(_) => "Mysql",
         }
     }
 
@@ -66,6 +68,7 @@ impl ObjectStoreConfig {
             Self::Oss(oss) => &oss.name,
             Self::Azblob(az) => &az.name,
             Self::Gcs(gcs) => &gcs.name,
+            Self::Mysql(mysql) => &mysql.name,
         };
 
         if name.trim().is_empty() {
@@ -83,6 +86,7 @@ impl ObjectStoreConfig {
             Self::Oss(oss) => Some(&oss.cache),
             Self::Azblob(az) => Some(&az.cache),
             Self::Gcs(gcs) => Some(&gcs.cache),
+            Self::Mysql(mysql) => Some(&mysql.cache),
         }
     }
 
@@ -94,6 +98,7 @@ impl ObjectStoreConfig {
             Self::Oss(oss) => Some(&mut oss.cache),
             Self::Azblob(az) => Some(&mut az.cache),
             Self::Gcs(gcs) => Some(&mut gcs.cache),
+            Self::Mysql(mysql) => Some(&mut mysql.cache),
         }
     }
 }
@@ -276,6 +281,37 @@ impl From<&GcsConnection> for Gcs {
             .endpoint(&connection.endpoint)
     }
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(default)]
+pub struct MysqlConfig {
+    pub name: String,
+    pub root: String,
+    pub addr: String,
+    pub table: Option<String>,
+    #[serde(flatten)]
+    pub cache: ObjectStorageCacheConfig,
+}
+
+impl From<&MysqlConfig> for Mysql {
+    fn from(config: &MysqlConfig) -> Self {
+        let root = util::normalize_dir(&config.root);
+        let mut builder = Mysql::default()
+            .connection_string(&config.addr)
+            .root(&root)
+            .key_field("key")
+            .value_field("value");
+
+        if let Some(table) = &config.table {
+            builder = builder.table(table);
+        } else {
+            builder = builder.table("greptime");
+        }
+
+        builder
+    }
+}
+
 /// The http client options to the storage.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
@@ -364,6 +400,17 @@ mod tests {
         });
         assert_eq!("test", s3_config.config_name());
         assert_eq!("S3", s3_config.provider_name());
+
+        let mysql_config = ObjectStoreConfig::Mysql(MysqlConfig::default());
+        assert_eq!("Mysql", mysql_config.config_name());
+        assert_eq!("Mysql", mysql_config.provider_name());
+
+        let mysql_config = ObjectStoreConfig::Mysql(MysqlConfig {
+            name: "test".to_string(),
+            ..Default::default()
+        });
+        assert_eq!("test", mysql_config.config_name());
+        assert_eq!("Mysql", mysql_config.provider_name());
     }
 
     #[test]
@@ -378,5 +425,7 @@ mod tests {
         assert!(gcs_config.is_object_storage());
         let azblob_config = ObjectStoreConfig::Azblob(AzblobConfig::default());
         assert!(azblob_config.is_object_storage());
+        let mysql_config = ObjectStoreConfig::Mysql(MysqlConfig::default());
+        assert!(mysql_config.is_object_storage());
     }
 }

--- a/src/object-store/src/config.rs
+++ b/src/object-store/src/config.rs
@@ -16,7 +16,9 @@ use std::time::Duration;
 
 use common_base::readable_size::ReadableSize;
 use common_base::secrets::{ExposeSecret, SecretString};
-use opendal::services::{Azblob, Gcs, Mysql, Oss, S3};
+#[cfg(feature = "mysql-object-store")]
+use opendal::services::Mysql;
+use opendal::services::{Azblob, Gcs, Oss, S3};
 use serde::{Deserialize, Serialize};
 
 use crate::util;
@@ -32,6 +34,7 @@ pub enum ObjectStoreConfig {
     Oss(OssConfig),
     Azblob(AzblobConfig),
     Gcs(GcsConfig),
+    #[cfg(feature = "mysql-object-store")]
     Mysql(MysqlConfig),
 }
 
@@ -50,6 +53,7 @@ impl ObjectStoreConfig {
             Self::Oss(_) => "Oss",
             Self::Azblob(_) => "Azblob",
             Self::Gcs(_) => "Gcs",
+            #[cfg(feature = "mysql-object-store")]
             Self::Mysql(_) => "Mysql",
         }
     }
@@ -68,6 +72,7 @@ impl ObjectStoreConfig {
             Self::Oss(oss) => &oss.name,
             Self::Azblob(az) => &az.name,
             Self::Gcs(gcs) => &gcs.name,
+            #[cfg(feature = "mysql-object-store")]
             Self::Mysql(mysql) => &mysql.name,
         };
 
@@ -86,6 +91,7 @@ impl ObjectStoreConfig {
             Self::Oss(oss) => Some(&oss.cache),
             Self::Azblob(az) => Some(&az.cache),
             Self::Gcs(gcs) => Some(&gcs.cache),
+            #[cfg(feature = "mysql-object-store")]
             Self::Mysql(mysql) => Some(&mysql.cache),
         }
     }
@@ -98,6 +104,7 @@ impl ObjectStoreConfig {
             Self::Oss(oss) => Some(&mut oss.cache),
             Self::Azblob(az) => Some(&mut az.cache),
             Self::Gcs(gcs) => Some(&mut gcs.cache),
+            #[cfg(feature = "mysql-object-store")]
             Self::Mysql(mysql) => Some(&mut mysql.cache),
         }
     }
@@ -282,6 +289,7 @@ impl From<&GcsConnection> for Gcs {
     }
 }
 
+#[cfg(feature = "mysql-object-store")]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 #[serde(default)]
 pub struct MysqlConfig {
@@ -294,6 +302,7 @@ pub struct MysqlConfig {
     pub cache: ObjectStorageCacheConfig,
 }
 
+#[cfg(feature = "mysql-object-store")]
 impl From<&MysqlConfig> for Mysql {
     fn from(config: &MysqlConfig) -> Self {
         let root = util::normalize_dir(&config.root);
@@ -402,16 +411,19 @@ mod tests {
         assert_eq!("test", s3_config.config_name());
         assert_eq!("S3", s3_config.provider_name());
 
-        let mysql_config = ObjectStoreConfig::Mysql(MysqlConfig::default());
-        assert_eq!("Mysql", mysql_config.config_name());
-        assert_eq!("Mysql", mysql_config.provider_name());
+        #[cfg(feature = "mysql-object-store")]
+        {
+            let mysql_config = ObjectStoreConfig::Mysql(MysqlConfig::default());
+            assert_eq!("Mysql", mysql_config.config_name());
+            assert_eq!("Mysql", mysql_config.provider_name());
 
-        let mysql_config = ObjectStoreConfig::Mysql(MysqlConfig {
-            name: "test".to_string(),
-            ..Default::default()
-        });
-        assert_eq!("test", mysql_config.config_name());
-        assert_eq!("Mysql", mysql_config.provider_name());
+            let mysql_config = ObjectStoreConfig::Mysql(MysqlConfig {
+                name: "test".to_string(),
+                ..Default::default()
+            });
+            assert_eq!("test", mysql_config.config_name());
+            assert_eq!("Mysql", mysql_config.provider_name());
+        }
     }
 
     #[test]
@@ -426,10 +438,14 @@ mod tests {
         assert!(gcs_config.is_object_storage());
         let azblob_config = ObjectStoreConfig::Azblob(AzblobConfig::default());
         assert!(azblob_config.is_object_storage());
-        let mysql_config = ObjectStoreConfig::Mysql(MysqlConfig::default());
-        assert!(mysql_config.is_object_storage());
+        #[cfg(feature = "mysql-object-store")]
+        {
+            let mysql_config = ObjectStoreConfig::Mysql(MysqlConfig::default());
+            assert!(mysql_config.is_object_storage());
+        }
     }
 
+    #[cfg(feature = "mysql-object-store")]
     #[test]
     fn test_mysql_config_connection_string_serde() {
         let config: ObjectStoreConfig = toml::from_str(

--- a/src/object-store/src/factory.rs
+++ b/src/object-store/src/factory.rs
@@ -16,10 +16,12 @@ use std::{fs, path};
 
 use common_telemetry::info;
 use opendal::layers::HttpClientLayer;
-use opendal::services::{Fs, Gcs, Oss, S3};
+use opendal::services::{Fs, Gcs, Mysql, Oss, S3};
 use snafu::prelude::*;
 
-use crate::config::{AzblobConfig, FileConfig, GcsConfig, ObjectStoreConfig, OssConfig, S3Config};
+use crate::config::{
+    AzblobConfig, FileConfig, GcsConfig, MysqlConfig, ObjectStoreConfig, OssConfig, S3Config,
+};
 use crate::error::{self, Result};
 use crate::services::Azblob;
 use crate::util::{build_http_client, clean_temp_dir, join_dir, normalize_dir};
@@ -36,7 +38,24 @@ pub async fn new_raw_object_store(
         ObjectStoreConfig::Oss(oss_config) => new_oss_object_store(oss_config).await,
         ObjectStoreConfig::Azblob(azblob_config) => new_azblob_object_store(azblob_config).await,
         ObjectStoreConfig::Gcs(gcs_config) => new_gcs_object_store(gcs_config).await,
+        ObjectStoreConfig::Mysql(mysql_config) => new_mysql_object_store(mysql_config).await,
     }
+}
+
+pub async fn new_mysql_object_store(mysql_config: &MysqlConfig) -> Result<ObjectStore> {
+    let root = util::normalize_dir(&mysql_config.root);
+    info!(
+        "The mysql object storage table is: {}, root is: {}",
+        mysql_config.table.as_deref().unwrap_or("greptime"),
+        root
+    );
+
+    let builder = Mysql::from(mysql_config);
+    let operator = ObjectStore::new(builder)
+        .context(error::InitBackendSnafu)?
+        .finish();
+
+    Ok(operator)
 }
 
 /// A helper function to create a file system object store.

--- a/src/object-store/src/factory.rs
+++ b/src/object-store/src/factory.rs
@@ -16,12 +16,14 @@ use std::{fs, path};
 
 use common_telemetry::info;
 use opendal::layers::HttpClientLayer;
-use opendal::services::{Fs, Gcs, Mysql, Oss, S3};
+#[cfg(feature = "mysql-object-store")]
+use opendal::services::Mysql;
+use opendal::services::{Fs, Gcs, Oss, S3};
 use snafu::prelude::*;
 
-use crate::config::{
-    AzblobConfig, FileConfig, GcsConfig, MysqlConfig, ObjectStoreConfig, OssConfig, S3Config,
-};
+#[cfg(feature = "mysql-object-store")]
+use crate::config::MysqlConfig;
+use crate::config::{AzblobConfig, FileConfig, GcsConfig, ObjectStoreConfig, OssConfig, S3Config};
 use crate::error::{self, Result};
 use crate::services::Azblob;
 use crate::util::{build_http_client, clean_temp_dir, join_dir, normalize_dir};
@@ -38,10 +40,12 @@ pub async fn new_raw_object_store(
         ObjectStoreConfig::Oss(oss_config) => new_oss_object_store(oss_config).await,
         ObjectStoreConfig::Azblob(azblob_config) => new_azblob_object_store(azblob_config).await,
         ObjectStoreConfig::Gcs(gcs_config) => new_gcs_object_store(gcs_config).await,
+        #[cfg(feature = "mysql-object-store")]
         ObjectStoreConfig::Mysql(mysql_config) => new_mysql_object_store(mysql_config).await,
     }
 }
 
+#[cfg(feature = "mysql-object-store")]
 pub async fn new_mysql_object_store(mysql_config: &MysqlConfig) -> Result<ObjectStore> {
     let root = util::normalize_dir(&mysql_config.root);
     info!(


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

As title says, this pr mainly add mysql object store backend support.

### Limitations

Currently, the MySQL object store backend does not support repartition operations because OpenDAL's MySQL service does not provide native `copy` support yet. Repartition may trigger region file copy through `object_store.copy()`, which will return `Unsupported` on this backend.

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
