### PR TITLE
chore: pin DataFusion cardinality effect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3690,7 +3690,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 [[package]]
 name = "datafusion"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "arrow 58.3.0",
  "arrow-schema 58.3.0",
@@ -3744,7 +3744,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3768,7 +3768,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3790,7 +3790,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -3814,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "futures",
  "log",
@@ -3824,7 +3824,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "arrow 58.3.0",
  "async-compression",
@@ -3858,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "arrow 58.3.0",
  "arrow-ipc 58.3.0",
@@ -3881,7 +3881,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3903,7 +3903,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3926,7 +3926,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3955,12 +3955,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 
 [[package]]
 name = "datafusion-execution"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "arrow 58.3.0",
  "arrow-buffer 58.3.0",
@@ -3982,7 +3982,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4004,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4016,7 +4016,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "arrow 58.3.0",
  "arrow-buffer 58.3.0",
@@ -4047,7 +4047,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4068,7 +4068,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4080,7 +4080,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "arrow 58.3.0",
  "arrow-ord 58.3.0",
@@ -4104,7 +4104,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4119,7 +4119,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4136,7 +4136,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -4145,7 +4145,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -4155,7 +4155,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -4204,7 +4204,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4227,7 +4227,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4241,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4257,7 +4257,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4275,7 +4275,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4306,7 +4306,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -4333,7 +4333,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4343,7 +4343,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4359,7 +4359,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -4372,7 +4372,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "arrow 58.3.0",
  "bigdecimal 0.4.8",
@@ -4390,7 +4390,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=7a84c45104d35408f00bbf880268c47193b73b28#7a84c45104d35408f00bbf880268c47193b73b28"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -342,21 +342,21 @@ git = "https://github.com/GreptimeTeam/greptime-meter.git"
 rev = "5618e779cf2bb4755b499c630fba4c35e91898cb"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "7a84c45104d35408f00bbf880268c47193b73b28" }
-datafusion-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "7a84c45104d35408f00bbf880268c47193b73b28" }
-datafusion-datasource = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "7a84c45104d35408f00bbf880268c47193b73b28" }
-datafusion-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "7a84c45104d35408f00bbf880268c47193b73b28" }
-datafusion-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "7a84c45104d35408f00bbf880268c47193b73b28" }
-datafusion-functions = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "7a84c45104d35408f00bbf880268c47193b73b28" }
-datafusion-functions-aggregate-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "7a84c45104d35408f00bbf880268c47193b73b28" }
-datafusion-functions-window-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "7a84c45104d35408f00bbf880268c47193b73b28" }
-datafusion-optimizer = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "7a84c45104d35408f00bbf880268c47193b73b28" }
-datafusion-physical-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "7a84c45104d35408f00bbf880268c47193b73b28" }
-datafusion-physical-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "7a84c45104d35408f00bbf880268c47193b73b28" }
-datafusion-physical-plan = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "7a84c45104d35408f00bbf880268c47193b73b28" }
-datafusion-proto = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "7a84c45104d35408f00bbf880268c47193b73b28" }
-datafusion-sql = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "7a84c45104d35408f00bbf880268c47193b73b28" }
-datafusion-substrait = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "7a84c45104d35408f00bbf880268c47193b73b28" }
+datafusion = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
+datafusion-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
+datafusion-datasource = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
+datafusion-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
+datafusion-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
+datafusion-functions = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
+datafusion-functions-aggregate-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
+datafusion-functions-window-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
+datafusion-optimizer = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
+datafusion-physical-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
+datafusion-physical-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
+datafusion-physical-plan = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
+datafusion-proto = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
+datafusion-sql = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
+datafusion-substrait = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
 sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "2aefa08a8d69c96eec2d6d6703598a009bba6e4c" }                           # on branch v0.61.x
 
 [profile.release]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

- https://github.com/GreptimeTeam/greptimedb/pull/8532
- https://github.com/GreptimeTeam/datafusion/pull/18

## What's changed and what's your intention?

- Pin the GreptimeTeam/datafusion patch and lockfile sources to merged commit `af8d0979ff2e0ad373980055355eea35dfed0457`.
- GreptimeDB PR #8532 already delegates `MergeSortExec` cardinality. This pin advances DataFusion to merged `GreptimeTeam/datafusion#18`, where `SortPreservingMergeExec` reports fetch-aware cardinality.
- Tests were not run: dependency pin-only follow-up; rely on CI.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.