### PR TITLE
fix(mito): notify bulk writes on WAL error

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,10 @@ change-coupling points, and gotchas:
    `.agents/architecture-invariants.md`).
 7. Use a conventional-commit title, sign off commits (`git commit -s`), and sign
    the CLA.
+8. When creating or updating a pull request, follow
+   [`.github/pull_request_template.md`](.github/pull_request_template.md): include
+   the CLA statement, fill the change-intention section with enough detail, and
+   update checklist items accurately.
 
 ## More
 

--- a/src/mito2/src/region_write_ctx.rs
+++ b/src/mito2/src/region_write_ctx.rs
@@ -41,6 +41,63 @@ struct WriteNotify {
     num_rows: usize,
 }
 
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use common_recordbatch::DfRecordBatch;
+    use datatypes::arrow::array::{ArrayRef, TimestampMillisecondArray};
+    use datatypes::arrow::datatypes::{DataType, Field, Schema};
+    use store_api::logstore::provider::Provider;
+    use tokio::sync::oneshot;
+
+    use super::*;
+    use crate::error::UnexpectedSnafu;
+    use crate::memtable::bulk::part::BulkPart;
+    use crate::test_util::version_util::VersionControlBuilder;
+
+    #[test]
+    fn test_set_error_marks_bulk_notifiers_failed() {
+        let builder = VersionControlBuilder::new();
+        let region_id = builder.region_id();
+        let version_control = Arc::new(builder.build());
+        let mut ctx =
+            RegionWriteCtx::new(region_id, &version_control, Provider::noop_provider(), None);
+        let (tx, rx) = oneshot::channel();
+
+        assert!(ctx.push_bulk(OptionOutputTx::from(tx), new_bulk_part(), None));
+        ctx.set_error(Arc::new(
+            UnexpectedSnafu {
+                reason: "wal failed".to_string(),
+            }
+            .build(),
+        ));
+        drop(ctx);
+
+        let result = rx.blocking_recv().unwrap();
+        assert!(result.is_err(), "bulk notifier should report WAL error");
+    }
+
+    fn new_bulk_part() -> BulkPart {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "ts",
+            DataType::Timestamp(datatypes::arrow::datatypes::TimeUnit::Millisecond, None),
+            false,
+        )]));
+        let arrays = vec![Arc::new(TimestampMillisecondArray::from(vec![1, 2])) as ArrayRef];
+        let batch = DfRecordBatch::try_new(schema, arrays).unwrap();
+
+        BulkPart {
+            batch,
+            max_timestamp: 2,
+            min_timestamp: 1,
+            sequence: 0,
+            timestamp_index: 0,
+            raw_data: None,
+        }
+    }
+}
+
 impl WriteNotify {
     /// Creates a new notify from the `sender`.
     fn new(sender: OptionOutputTx, num_rows: usize) -> WriteNotify {
@@ -201,8 +258,11 @@ impl RegionWriteCtx {
 
     /// Sets error and marks all write operations are failed.
     pub(crate) fn set_error(&mut self, err: Arc<Error>) {
-        // Set error for all notifiers
+        // Set error for all notifiers.
         for notify in &mut self.notifiers {
+            notify.err = Some(err.clone());
+        }
+        for notify in &mut self.bulk_notifiers {
             notify.err = Some(err.clone());
         }
 

--- a/src/mito2/src/region_write_ctx.rs
+++ b/src/mito2/src/region_write_ctx.rs
@@ -41,63 +41,6 @@ struct WriteNotify {
     num_rows: usize,
 }
 
-#[cfg(test)]
-mod tests {
-    use std::sync::Arc;
-
-    use common_recordbatch::DfRecordBatch;
-    use datatypes::arrow::array::{ArrayRef, TimestampMillisecondArray};
-    use datatypes::arrow::datatypes::{DataType, Field, Schema};
-    use store_api::logstore::provider::Provider;
-    use tokio::sync::oneshot;
-
-    use super::*;
-    use crate::error::UnexpectedSnafu;
-    use crate::memtable::bulk::part::BulkPart;
-    use crate::test_util::version_util::VersionControlBuilder;
-
-    #[test]
-    fn test_set_error_marks_bulk_notifiers_failed() {
-        let builder = VersionControlBuilder::new();
-        let region_id = builder.region_id();
-        let version_control = Arc::new(builder.build());
-        let mut ctx =
-            RegionWriteCtx::new(region_id, &version_control, Provider::noop_provider(), None);
-        let (tx, rx) = oneshot::channel();
-
-        assert!(ctx.push_bulk(OptionOutputTx::from(tx), new_bulk_part(), None));
-        ctx.set_error(Arc::new(
-            UnexpectedSnafu {
-                reason: "wal failed".to_string(),
-            }
-            .build(),
-        ));
-        drop(ctx);
-
-        let result = rx.blocking_recv().unwrap();
-        assert!(result.is_err(), "bulk notifier should report WAL error");
-    }
-
-    fn new_bulk_part() -> BulkPart {
-        let schema = Arc::new(Schema::new(vec![Field::new(
-            "ts",
-            DataType::Timestamp(datatypes::arrow::datatypes::TimeUnit::Millisecond, None),
-            false,
-        )]));
-        let arrays = vec![Arc::new(TimestampMillisecondArray::from(vec![1, 2])) as ArrayRef];
-        let batch = DfRecordBatch::try_new(schema, arrays).unwrap();
-
-        BulkPart {
-            batch,
-            max_timestamp: 2,
-            min_timestamp: 1,
-            sequence: 0,
-            timestamp_index: 0,
-            raw_data: None,
-        }
-    }
-}
-
 impl WriteNotify {
     /// Creates a new notify from the `sender`.
     fn new(sender: OptionOutputTx, num_rows: usize) -> WriteNotify {
@@ -412,5 +355,62 @@ impl RegionWriteCtx {
         }
         self.version_control
             .set_sequence_and_entry_id(self.next_sequence - 1, self.next_entry_id - 1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use common_recordbatch::DfRecordBatch;
+    use datatypes::arrow::array::{ArrayRef, TimestampMillisecondArray};
+    use datatypes::arrow::datatypes::{DataType, Field, Schema};
+    use store_api::logstore::provider::Provider;
+    use tokio::sync::oneshot;
+
+    use super::*;
+    use crate::error::UnexpectedSnafu;
+    use crate::memtable::bulk::part::BulkPart;
+    use crate::test_util::version_util::VersionControlBuilder;
+
+    #[test]
+    fn test_set_error_marks_bulk_notifiers_failed() {
+        let builder = VersionControlBuilder::new();
+        let region_id = builder.region_id();
+        let version_control = Arc::new(builder.build());
+        let mut ctx =
+            RegionWriteCtx::new(region_id, &version_control, Provider::noop_provider(), None);
+        let (tx, rx) = oneshot::channel();
+
+        assert!(ctx.push_bulk(OptionOutputTx::from(tx), new_bulk_part(), None));
+        ctx.set_error(Arc::new(
+            UnexpectedSnafu {
+                reason: "wal failed".to_string(),
+            }
+            .build(),
+        ));
+        drop(ctx);
+
+        let result = rx.blocking_recv().unwrap();
+        assert!(result.is_err(), "bulk notifier should report WAL error");
+    }
+
+    fn new_bulk_part() -> BulkPart {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "ts",
+            DataType::Timestamp(datatypes::arrow::datatypes::TimeUnit::Millisecond, None),
+            false,
+        )]));
+        let arrays = vec![Arc::new(TimestampMillisecondArray::from(vec![1, 2])) as ArrayRef];
+        let batch = DfRecordBatch::try_new(schema, arrays).unwrap();
+
+        BulkPart {
+            batch,
+            max_timestamp: 2,
+            min_timestamp: 1,
+            sequence: 0,
+            timestamp_index: 0,
+            raw_data: None,
+        }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

N/A

## What's changed and what's your intention?

This PR fixes the WAL-error path for mito2 bulk writes.

Previously, `RegionWriteCtx::set_error()` only attached the error to normal write notifiers. Bulk write notifiers were left unmarked, and `WriteNotify` reports `Ok(num_rows)` on drop when no error is set. As a result, a bulk insert could report successful affected rows even if `add_wal_entry()` or `write_to_wal()` failed before writing to the memtable.

The change makes `set_error()` propagate the same error to `bulk_notifiers` as well as normal `notifiers`, so all buffered write requests in the context observe the WAL failure consistently.

A regression test covers this behavior by registering a bulk notifier, calling `set_error()`, dropping the context, and asserting the receiver gets an error instead of success.

This PR does not change public APIs, wire formats, persisted data formats, or schemas.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.

## Test Plan

- `rtk cargo test -p mito2 region_write_ctx::tests::test_set_error_marks_bulk_notifiers_failed`
- `rtk cargo clippy -p mito2 --all-targets --all-features -- -D warnings`
