### PR TITLE
ci: split export import v2 e2e test

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -803,6 +803,72 @@ jobs:
           path: /tmp/sqlness*
           retention-days: 3
 
+  export-import-v2-e2e:
+    if: ${{ github.repository == 'GreptimeTeam/greptimedb' }}
+    name: Export/Import V2 E2E Test
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "export-import-v2-e2e"
+          cache-all-crates: "true"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Setup MinIO
+        working-directory: tests-integration/fixtures
+        run: ../../.github/scripts/pull-test-deps-images.sh && docker compose up -d --wait minio
+      - name: Download pre-built binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: bins
+          path: .
+      - name: Unzip binaries
+        run: tar -xvf ./bins.tar.gz
+      - name: Start GreptimeDB standalone
+        run: |
+          ./bins/greptime standalone start > greptimedb.log 2>&1 &
+          greptime_pid=$!
+          echo "Waiting for GreptimeDB..."
+          for i in {1..60}; do
+            if curl -sf http://localhost:4000/health > /dev/null; then
+              echo "GreptimeDB is ready"
+              exit 0
+            fi
+            if ! kill -0 "${greptime_pid}" 2>/dev/null; then
+              cat greptimedb.log
+              exit 1
+            fi
+            sleep 1
+          done
+          cat greptimedb.log
+          exit 1
+      - name: Run export/import v2 E2E tests
+        run: cargo test -p cli data::export_v2::tests --lib -- --ignored --test-threads=1
+        env:
+          GREPTIME_ADDR: 127.0.0.1:4000
+          GT_S3_BUCKET: greptime
+          GT_S3_ACCESS_KEY_ID: superpower_ci_user
+          GT_S3_ACCESS_KEY: superpower_password
+          GT_S3_REGION: us-west-2
+          GT_S3_ENDPOINT_URL: http://127.0.0.1:9000
+      - name: Upload GreptimeDB logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: export-import-v2-e2e-logs
+          path: greptimedb.log
+          if-no-files-found: warn
+          retention-days: 3
+
   fmt:
     if: ${{ github.repository == 'GreptimeTeam/greptimedb' }}
     name: Rustfmt
@@ -912,38 +978,6 @@ jobs:
       - name: Setup external services
         working-directory: tests-integration/fixtures
         run: ../../.github/scripts/pull-test-deps-images.sh && docker compose up -d --wait
-
-      - name: Build GreptimeDB standalone
-        run: cargo build --bin greptime --features "dashboard,pg_kvbackend,mysql_kvbackend,vector_index"
-
-      - name: Start GreptimeDB standalone
-        run: |
-          ./target/debug/greptime standalone start > greptimedb.log 2>&1 &
-          greptime_pid=$!
-          echo "Waiting for GreptimeDB..."
-          for i in {1..60}; do
-            if curl -sf http://localhost:4000/health > /dev/null; then
-              echo "GreptimeDB is ready"
-              exit 0
-            fi
-            if ! kill -0 "${greptime_pid}" 2>/dev/null; then
-              cat greptimedb.log
-              exit 1
-            fi
-            sleep 1
-          done
-          cat greptimedb.log
-          exit 1
-
-      - name: Run export/import v2 E2E tests
-        run: cargo test -p cli data::export_v2::tests --lib -- --ignored --test-threads=1
-        env:
-          GREPTIME_ADDR: 127.0.0.1:4000
-          GT_S3_BUCKET: greptime
-          GT_S3_ACCESS_KEY_ID: superpower_ci_user
-          GT_S3_ACCESS_KEY: superpower_password
-          GT_S3_REGION: us-west-2
-          GT_S3_ENDPOINT_URL: http://127.0.0.1:9000
 
       - name: Run nextest cases
         run: cargo nextest run --workspace -F dashboard -F pg_kvbackend -F mysql_kvbackend -F vector_index


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

- Split the export/import v2 ignored E2E tests out of the ARM `test` job into a dedicated `Export/Import V2 E2E Test` job.
- Reuse the pre-built `bins/greptime` artifact produced by the existing `build` job, avoiding a redundant standalone binary build.
- Start only MinIO for this E2E job instead of the full external-service suite.
- Upload `greptimedb.log` when the E2E job fails to simplify diagnosis.
- This reduces the duration of the main `test` job while allowing the E2E test to run in parallel with sqlness.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
