### PR TITLE
feat: grant creators access to newly created databases

### DIFF
--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -556,13 +556,11 @@ impl StartCommand {
             create_database_metadata_committer: None,
         };
 
-        let ddl_manager = DdlManager::try_new(
+        let ddl_manager = DdlManager::new(
             ddl_context,
             procedure_manager.clone(),
             Arc::new(StandaloneRepartitionProcedureFactory),
-            false,
-        )
-        .context(error::InitDdlManagerSnafu)?;
+        );
 
         let ddl_manager = if let Some(configurator) =
             plugins.get::<DdlManagerConfiguratorRef<DdlManagerConfigureContext>>()

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -553,13 +553,14 @@ impl StartCommand {
             region_failure_detector_controller: Arc::new(NoopRegionFailureDetectorControl),
             soft_drop_enabled: false,
             soft_drop_retention: None,
+            create_database_metadata_committer: None,
         };
 
         let ddl_manager = DdlManager::try_new(
             ddl_context,
             procedure_manager.clone(),
             Arc::new(StandaloneRepartitionProcedureFactory),
-            true,
+            false,
         )
         .context(error::InitDdlManagerSnafu)?;
 
@@ -578,6 +579,9 @@ impl StartCommand {
         } else {
             ddl_manager
         };
+        ddl_manager
+            .register_loaders()
+            .context(error::InitDdlManagerSnafu)?;
 
         let procedure_executor = creator
             .procedure_executor_creator

--- a/src/common/meta/src/ddl.rs
+++ b/src/common/meta/src/ddl.rs
@@ -124,6 +124,9 @@ pub struct DdlContext {
     pub soft_drop_enabled: bool,
     /// Fixed retention used to calculate new soft-drop deadlines.
     pub soft_drop_retention: Option<Duration>,
+    /// Commits create-database metadata and the creator grant atomically.
+    pub create_database_metadata_committer:
+        Option<create_database::CreateDatabaseMetadataCommitterRef>,
 }
 
 impl DdlContext {

--- a/src/common/meta/src/ddl/create_database.rs
+++ b/src/common/meta/src/ddl/create_database.rs
@@ -13,10 +13,12 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use async_trait::async_trait;
+use common_error::ext::{BoxedError, ErrorExt};
 use common_procedure::error::{FromJsonSnafu, Result as ProcedureResult, ToJsonSnafu};
-use common_procedure::{Context as ProcedureContext, LockKey, Procedure, Status};
+use common_procedure::{Context as ProcedureContext, LockKey, Procedure, ProcedureId, Status};
 use serde::{Deserialize, Serialize};
 use serde_with::{DefaultOnNull, serde_as};
 use snafu::{ResultExt, ensure};
@@ -25,8 +27,38 @@ use strum::AsRefStr;
 use crate::ddl::DdlContext;
 use crate::ddl::utils::map_to_procedure_error;
 use crate::error::{self, Result};
+use crate::instruction::{CacheIdent, UserCacheIdent};
 use crate::key::schema_name::{SchemaNameKey, SchemaNameValue};
 use crate::lock_key::{CatalogLock, SchemaLock};
+use crate::rpc::ddl::CreatorGrantIntent;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AtomicCreateAccess {
+    AddedExactAll,
+    AlreadyEffectiveAll,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AtomicCreateOutcome {
+    Created(AtomicCreateAccess),
+    AlreadyCommitted,
+    UserChanged,
+    UserMissing,
+    SchemaConflict,
+}
+
+#[async_trait]
+pub trait CreateDatabaseMetadataCommitter: Send + Sync {
+    async fn commit(
+        &self,
+        catalog: &str,
+        schema: &str,
+        value: &SchemaNameValue,
+        creator: &CreatorGrantIntent,
+    ) -> std::result::Result<AtomicCreateOutcome, BoxedError>;
+}
+
+pub type CreateDatabaseMetadataCommitterRef = Arc<dyn CreateDatabaseMetadataCommitter>;
 
 pub struct CreateDatabaseProcedure {
     pub context: DdlContext,
@@ -41,6 +73,7 @@ impl CreateDatabaseProcedure {
         schema: String,
         create_if_not_exists: bool,
         options: HashMap<String, String>,
+        creator: Option<CreatorGrantIntent>,
         context: DdlContext,
     ) -> Self {
         Self {
@@ -51,6 +84,7 @@ impl CreateDatabaseProcedure {
                 schema,
                 create_if_not_exists,
                 options,
+                creator,
             },
         }
     }
@@ -85,8 +119,72 @@ impl CreateDatabaseProcedure {
         Ok(Status::executing(true))
     }
 
-    pub async fn on_create_metadata(&mut self) -> Result<Status> {
-        let value: SchemaNameValue = (&self.data.options).try_into()?;
+    pub async fn on_create_metadata(&mut self, procedure_id: ProcedureId) -> Result<Status> {
+        let mut value: SchemaNameValue = (&self.data.options).try_into()?;
+
+        if let Some(creator) = self.data.creator.as_ref() {
+            value.create_procedure_id = Some(procedure_id.to_string());
+            let Some(committer) = self.context.create_database_metadata_committer.as_ref() else {
+                return error::UnexpectedSnafu {
+                    err_msg: "Create-database creator grant committer is not configured"
+                        .to_string(),
+                }
+                .fail();
+            };
+            let _timer = crate::metrics::METRIC_META_CREATE_SCHEMA.start_timer();
+            let outcome = match committer
+                .commit(&self.data.catalog, &self.data.schema, &value, creator)
+                .await
+            {
+                Ok(outcome) => outcome,
+                Err(err) if err.is_retryable() => {
+                    return Err(error::Error::RetryLater {
+                        source: err,
+                        clean_poisons: false,
+                    });
+                }
+                Err(err) => return Err(err).context(error::ExternalSnafu),
+            };
+
+            match outcome {
+                AtomicCreateOutcome::Created(_) => {
+                    crate::metrics::METRIC_META_CREATE_SCHEMA_COUNTER.inc();
+                }
+                AtomicCreateOutcome::AlreadyCommitted => {}
+                AtomicCreateOutcome::UserChanged => {
+                    let source = error::UnexpectedSnafu {
+                        err_msg: format!(
+                            "User '{}' changed while creating database '{}.{}'",
+                            creator.username, self.data.catalog, self.data.schema
+                        ),
+                    }
+                    .build();
+                    return Err(error::Error::retry_later(source));
+                }
+                AtomicCreateOutcome::UserMissing => {
+                    return error::UnexpectedSnafu {
+                        err_msg: format!(
+                            "Creator '{}' no longer exists in catalog '{}'",
+                            creator.username, self.data.catalog
+                        ),
+                    }
+                    .fail();
+                }
+                AtomicCreateOutcome::SchemaConflict if self.data.create_if_not_exists => {
+                    return Ok(Status::done());
+                }
+                AtomicCreateOutcome::SchemaConflict => {
+                    return error::SchemaAlreadyExistsSnafu {
+                        catalog: &self.data.catalog,
+                        schema: &self.data.schema,
+                    }
+                    .fail();
+                }
+            }
+
+            self.data.state = CreateDatabaseState::InvalidateCreatorCache;
+            return Ok(Status::executing(true));
+        }
 
         self.context
             .table_metadata_manager
@@ -100,6 +198,33 @@ impl CreateDatabaseProcedure {
 
         Ok(Status::done())
     }
+
+    pub async fn on_invalidate_creator_cache(&mut self) -> Result<Status> {
+        let Some(creator) = self.data.creator.as_ref() else {
+            return Ok(Status::done());
+        };
+
+        let ident = CacheIdent::User(UserCacheIdent {
+            catalog: self.data.catalog.clone(),
+            username: creator.username.clone(),
+        });
+        let ctx = crate::cache_invalidator::Context {
+            subject: Some(format!(
+                "Invalidate creator cache after creating database '{}.{}' for '{}'",
+                self.data.catalog, self.data.schema, creator.username
+            )),
+        };
+        if let Err(source) = self
+            .context
+            .cache_invalidator
+            .invalidate(&ctx, &[ident])
+            .await
+        {
+            return Err(error::Error::retry_later(source));
+        }
+
+        Ok(Status::done())
+    }
 }
 
 #[async_trait]
@@ -108,12 +233,13 @@ impl Procedure for CreateDatabaseProcedure {
         Self::TYPE_NAME
     }
 
-    async fn execute(&mut self, _ctx: &ProcedureContext) -> ProcedureResult<Status> {
+    async fn execute(&mut self, ctx: &ProcedureContext) -> ProcedureResult<Status> {
         let state = &self.data.state;
 
         match state {
             CreateDatabaseState::Prepare => self.on_prepare().await,
-            CreateDatabaseState::CreateMetadata => self.on_create_metadata().await,
+            CreateDatabaseState::CreateMetadata => self.on_create_metadata(ctx.procedure_id).await,
+            CreateDatabaseState::InvalidateCreatorCache => self.on_invalidate_creator_cache().await,
         }
         .map_err(map_to_procedure_error)
     }
@@ -136,6 +262,7 @@ impl Procedure for CreateDatabaseProcedure {
 pub enum CreateDatabaseState {
     Prepare,
     CreateMetadata,
+    InvalidateCreatorCache,
 }
 
 #[serde_as]
@@ -147,4 +274,327 @@ pub struct CreateDatabaseData {
     pub create_if_not_exists: bool,
     #[serde_as(deserialize_as = "DefaultOnNull")]
     pub options: HashMap<String, String>,
+    #[serde(default)]
+    pub creator: Option<CreatorGrantIntent>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use common_error::ext::ErrorExt;
+
+    use super::*;
+    use crate::cache_invalidator::{CacheInvalidator, Context};
+    use crate::test_util::{MockDatanodeManager, new_ddl_context};
+
+    const PROCEDURE_ID: &str = "4ee0ba94-11f0-4d4d-9468-5ebf732e3ab2";
+
+    fn procedure_id() -> ProcedureId {
+        ProcedureId::parse_str(PROCEDURE_ID).unwrap()
+    }
+
+    struct MockCommitter {
+        calls: AtomicUsize,
+        outcomes: Mutex<VecDeque<std::result::Result<AtomicCreateOutcome, BoxedError>>>,
+    }
+
+    impl MockCommitter {
+        fn new(
+            outcomes: impl IntoIterator<Item = std::result::Result<AtomicCreateOutcome, BoxedError>>,
+        ) -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                outcomes: Mutex::new(outcomes.into_iter().collect()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl CreateDatabaseMetadataCommitter for MockCommitter {
+        async fn commit(
+            &self,
+            _catalog: &str,
+            _schema: &str,
+            value: &SchemaNameValue,
+            _creator: &CreatorGrantIntent,
+        ) -> std::result::Result<AtomicCreateOutcome, BoxedError> {
+            assert_eq!(value.create_procedure_id.as_deref(), Some(PROCEDURE_ID));
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            self.outcomes
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("unexpected commit call")
+        }
+    }
+
+    #[derive(Default)]
+    struct FailOnceInvalidator {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl CacheInvalidator for FailOnceInvalidator {
+        async fn invalidate(&self, _ctx: &Context, _caches: &[CacheIdent]) -> Result<()> {
+            if self.calls.fetch_add(1, Ordering::Relaxed) == 0 {
+                return error::UnexpectedSnafu {
+                    err_msg: "injected cache invalidation failure",
+                }
+                .fail();
+            }
+            Ok(())
+        }
+
+        fn invalidate_all(&self) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    fn procedure(
+        outcomes: impl IntoIterator<Item = std::result::Result<AtomicCreateOutcome, BoxedError>>,
+        cache_invalidator: Arc<dyn CacheInvalidator>,
+    ) -> (CreateDatabaseProcedure, Arc<MockCommitter>) {
+        let mut context = new_ddl_context(Arc::new(MockDatanodeManager::new(())));
+        context.cache_invalidator = cache_invalidator;
+        let committer = Arc::new(MockCommitter::new(outcomes));
+        context.create_database_metadata_committer = Some(committer.clone());
+        let procedure = CreateDatabaseProcedure::new(
+            "greptime".to_string(),
+            "metrics".to_string(),
+            false,
+            HashMap::new(),
+            Some(CreatorGrantIntent {
+                username: "alice".to_string(),
+                created_at_ns: 1,
+            }),
+            context,
+        );
+        (procedure, committer)
+    }
+
+    #[tokio::test]
+    async fn created_and_recovered_commits_retry_only_cache_invalidation() {
+        let invalidator = Arc::new(FailOnceInvalidator::default());
+        let (mut procedure, committer) = procedure(
+            [Ok(AtomicCreateOutcome::Created(
+                AtomicCreateAccess::AddedExactAll,
+            ))],
+            invalidator.clone(),
+        );
+        procedure.data.state = CreateDatabaseState::CreateMetadata;
+
+        assert!(
+            !procedure
+                .on_create_metadata(procedure_id())
+                .await
+                .unwrap()
+                .is_done()
+        );
+        assert!(matches!(
+            procedure.data.state,
+            CreateDatabaseState::InvalidateCreatorCache
+        ));
+        assert_eq!(committer.calls.load(Ordering::Relaxed), 1);
+
+        assert!(
+            procedure
+                .on_invalidate_creator_cache()
+                .await
+                .unwrap_err()
+                .is_retryable()
+        );
+        assert!(
+            procedure
+                .on_invalidate_creator_cache()
+                .await
+                .unwrap()
+                .is_done()
+        );
+        assert_eq!(committer.calls.load(Ordering::Relaxed), 1);
+        assert_eq!(invalidator.calls.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    async fn user_change_is_explicitly_retryable() {
+        let (mut procedure, committer) = procedure(
+            [Ok(AtomicCreateOutcome::UserChanged)],
+            Arc::new(FailOnceInvalidator::default()),
+        );
+        procedure.data.state = CreateDatabaseState::CreateMetadata;
+
+        let err = procedure
+            .on_create_metadata(procedure_id())
+            .await
+            .unwrap_err();
+        assert!(err.is_retryable());
+        assert!(matches!(
+            procedure.data.state,
+            CreateDatabaseState::CreateMetadata
+        ));
+        assert_eq!(committer.calls.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn lost_commit_response_replays_as_already_committed() {
+        let (mut procedure, committer) = procedure(
+            [
+                Err(BoxedError::new(
+                    error::ElectionLeaderLeaseChangedSnafu.build(),
+                )),
+                Ok(AtomicCreateOutcome::AlreadyCommitted),
+            ],
+            Arc::new(FailOnceInvalidator::default()),
+        );
+        procedure.data.state = CreateDatabaseState::CreateMetadata;
+
+        let err = procedure
+            .on_create_metadata(procedure_id())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, error::Error::RetryLater { .. }));
+        assert!(matches!(
+            procedure.data.state,
+            CreateDatabaseState::CreateMetadata
+        ));
+        assert!(
+            !procedure
+                .on_create_metadata(procedure_id())
+                .await
+                .unwrap()
+                .is_done()
+        );
+        assert!(matches!(
+            procedure.data.state,
+            CreateDatabaseState::InvalidateCreatorCache
+        ));
+        assert_eq!(committer.calls.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    async fn lost_state_transition_recovers_committed_business_state() {
+        let (mut procedure, committer) = procedure(
+            [
+                Ok(AtomicCreateOutcome::Created(
+                    AtomicCreateAccess::AddedExactAll,
+                )),
+                Ok(AtomicCreateOutcome::AlreadyCommitted),
+            ],
+            Arc::new(FailOnceInvalidator::default()),
+        );
+        let context = procedure.context.clone();
+        procedure.data.state = CreateDatabaseState::CreateMetadata;
+        let stale_json = procedure.dump().unwrap();
+
+        assert!(
+            !procedure
+                .on_create_metadata(procedure_id())
+                .await
+                .unwrap()
+                .is_done()
+        );
+        assert!(matches!(
+            procedure.data.state,
+            CreateDatabaseState::InvalidateCreatorCache
+        ));
+
+        let mut recovered = CreateDatabaseProcedure::from_json(&stale_json, context).unwrap();
+        assert_eq!(recovered.data.creator.as_ref().unwrap().username, "alice");
+        assert!(
+            !recovered
+                .on_create_metadata(procedure_id())
+                .await
+                .unwrap()
+                .is_done()
+        );
+        assert!(matches!(
+            recovered.data.state,
+            CreateDatabaseState::InvalidateCreatorCache
+        ));
+        assert_eq!(committer.calls.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    async fn missing_creator_uses_legacy_schema_path() {
+        let mut context = new_ddl_context(Arc::new(MockDatanodeManager::new(())));
+        let committer = Arc::new(MockCommitter::new([Ok(AtomicCreateOutcome::Created(
+            AtomicCreateAccess::AddedExactAll,
+        ))]));
+        context.create_database_metadata_committer = Some(committer.clone());
+        let mut procedure = CreateDatabaseProcedure::new(
+            "greptime".to_string(),
+            "legacy".to_string(),
+            false,
+            HashMap::new(),
+            None,
+            context,
+        );
+        procedure.data.state = CreateDatabaseState::CreateMetadata;
+
+        assert!(
+            procedure
+                .on_create_metadata(procedure_id())
+                .await
+                .unwrap()
+                .is_done()
+        );
+        assert_eq!(committer.calls.load(Ordering::Relaxed), 0);
+        assert!(
+            procedure
+                .context
+                .table_metadata_manager
+                .schema_manager()
+                .exists(SchemaNameKey::new("greptime", "legacy"))
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn creator_without_committer_fails_closed() {
+        let context = new_ddl_context(Arc::new(MockDatanodeManager::new(())));
+        let mut procedure = CreateDatabaseProcedure::new(
+            "greptime".to_string(),
+            "missing_committer".to_string(),
+            false,
+            HashMap::new(),
+            Some(CreatorGrantIntent {
+                username: "alice".to_string(),
+                created_at_ns: 1,
+            }),
+            context,
+        );
+        procedure.data.state = CreateDatabaseState::CreateMetadata;
+
+        assert!(procedure.on_create_metadata(procedure_id()).await.is_err());
+        assert!(
+            !procedure
+                .context
+                .table_metadata_manager
+                .schema_manager()
+                .exists(SchemaNameKey::new("greptime", "missing_committer"))
+                .await
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn legacy_procedure_json_defaults_creator() {
+        let context = new_ddl_context(Arc::new(MockDatanodeManager::new(())));
+        let procedure = CreateDatabaseProcedure::from_json(
+            r#"{
+                "state":"CreateMetadata",
+                "catalog":"greptime",
+                "schema":"metrics",
+                "create_if_not_exists":false,
+                "options":{}
+            }"#,
+            context,
+        )
+        .unwrap();
+
+        assert!(procedure.data.creator.is_none());
+    }
 }

--- a/src/common/meta/src/ddl/create_database.rs
+++ b/src/common/meta/src/ddl/create_database.rs
@@ -32,21 +32,34 @@ use crate::key::schema_name::{SchemaNameKey, SchemaNameValue};
 use crate::lock_key::{CatalogLock, SchemaLock};
 use crate::rpc::ddl::CreatorGrantIntent;
 
+/// Describes the creator-access result of an atomic create.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AtomicCreateAccess {
+    /// Added an exact `ALL` ACL entry for the new database.
     AddedExactAll,
+    /// The creator already had effective `ALL` access, so their ACL was unchanged.
     AlreadyEffectiveAll,
 }
 
+/// Outcome of atomically creating database metadata and ensuring creator access.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AtomicCreateOutcome {
+    /// This attempt created the database with the given access result.
     Created(AtomicCreateAccess),
+    /// The same create procedure committed during an earlier attempt.
     AlreadyCommitted,
+    /// The creator row changed concurrently and the operation should be retried.
     UserChanged,
+    /// The creator is missing or no longer identifies the same account generation.
     UserMissing,
+    /// A different value already exists for the database metadata.
     SchemaConflict,
 }
 
+/// Commits database metadata and any required creator access atomically.
+///
+/// Implementations classify conditional-write failures with [`AtomicCreateOutcome`] so the
+/// procedure can retry without overwriting concurrent user changes.
 #[async_trait]
 pub trait CreateDatabaseMetadataCommitter: Send + Sync {
     async fn commit(
@@ -58,8 +71,10 @@ pub trait CreateDatabaseMetadataCommitter: Send + Sync {
     ) -> std::result::Result<AtomicCreateOutcome, BoxedError>;
 }
 
+/// Shared [`CreateDatabaseMetadataCommitter`].
 pub type CreateDatabaseMetadataCommitterRef = Arc<dyn CreateDatabaseMetadataCommitter>;
 
+/// Procedure that creates a database and optionally ensures its creator has access.
 pub struct CreateDatabaseProcedure {
     pub context: DdlContext,
     pub data: CreateDatabaseData,
@@ -123,6 +138,7 @@ impl CreateDatabaseProcedure {
         let mut value: SchemaNameValue = (&self.data.options).try_into()?;
 
         if let Some(creator) = self.data.creator.as_ref() {
+            // Distinguishes a replay of this procedure from a competing create.
             value.create_procedure_id = Some(procedure_id.to_string());
             let Some(committer) = self.context.create_database_metadata_committer.as_ref() else {
                 return error::UnexpectedSnafu {
@@ -182,6 +198,7 @@ impl CreateDatabaseProcedure {
                 }
             }
 
+            // The durable transaction is complete; retry cache invalidation separately.
             self.data.state = CreateDatabaseState::InvalidateCreatorCache;
             return Ok(Status::executing(true));
         }
@@ -258,13 +275,18 @@ impl Procedure for CreateDatabaseProcedure {
     }
 }
 
+/// Persistent states of [`CreateDatabaseProcedure`].
 #[derive(Debug, Clone, Serialize, Deserialize, AsRefStr)]
 pub enum CreateDatabaseState {
+    /// Checks whether the database already exists.
     Prepare,
+    /// Creates metadata and, when supplied, ensures the creator has access atomically.
     CreateMetadata,
+    /// Invalidates the creator's cached user data after the durable commit.
     InvalidateCreatorCache,
 }
 
+/// Persistent data of [`CreateDatabaseProcedure`].
 #[serde_as]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CreateDatabaseData {
@@ -274,6 +296,7 @@ pub struct CreateDatabaseData {
     pub create_if_not_exists: bool,
     #[serde_as(deserialize_as = "DefaultOnNull")]
     pub options: HashMap<String, String>,
+    /// Authenticated creator whose access is ensured, absent for legacy schema-only requests.
     #[serde(default)]
     pub creator: Option<CreatorGrantIntent>,
 }

--- a/src/common/meta/src/ddl_manager.rs
+++ b/src/common/meta/src/ddl_manager.rs
@@ -208,24 +208,19 @@ pub struct DdlOptions {
 }
 
 impl DdlManager {
-    /// Returns a new [DdlManager] with all Ddl [BoxedProcedureLoader](common_procedure::procedure::BoxedProcedureLoader)s registered.
-    pub fn try_new(
+    /// Returns a new [DdlManager].
+    pub fn new(
         ddl_context: DdlContext,
         procedure_manager: ProcedureManagerRef,
         repartition_procedure_factory: RepartitionProcedureFactoryRef,
-        register_loaders: bool,
-    ) -> Result<Self> {
-        let manager = Self {
+    ) -> Self {
+        Self {
             ddl_context,
             procedure_manager,
             repartition_procedure_factory,
             #[cfg(feature = "enterprise")]
             trigger_ddl_manager: None,
-        };
-        if register_loaders {
-            manager.register_loaders()?;
         }
-        Ok(manager)
     }
 
     #[cfg(feature = "enterprise")]
@@ -1377,7 +1372,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_new() {
+    fn test_register_loaders() {
         let kv_backend = Arc::new(MemoryKvBackend::new());
         let table_metadata_manager = Arc::new(TableMetadataManager::new(kv_backend.clone()));
         let table_metadata_allocator = Arc::new(TableMetadataAllocator::new(
@@ -1399,7 +1394,7 @@ mod tests {
             None,
         ));
 
-        let _ = DdlManager::try_new(
+        let ddl_manager = DdlManager::new(
             DdlContext {
                 node_manager: Arc::new(DummyDatanodeManager),
                 cache_invalidator: Arc::new(DummyCacheInvalidator),
@@ -1416,8 +1411,8 @@ mod tests {
             },
             procedure_manager.clone(),
             Arc::new(DummyRepartitionProcedureFactory),
-            true,
         );
+        ddl_manager.register_loaders().unwrap();
 
         let expected_loaders = vec![
             CreateTableProcedure::TYPE_NAME,
@@ -1454,7 +1449,7 @@ mod tests {
             None,
         ));
 
-        let ddl_manager = DdlManager::try_new(
+        let ddl_manager = DdlManager::new(
             DdlContext {
                 node_manager: Arc::new(DummyDatanodeManager),
                 cache_invalidator: Arc::new(DummyCacheInvalidator),
@@ -1471,9 +1466,7 @@ mod tests {
             },
             procedure_manager,
             Arc::new(DummyRepartitionProcedureFactory),
-            true,
-        )
-        .unwrap();
+        );
 
         let err = ddl_manager
             .submit_undrop_table_task(UndropTableTask { table_id: 1024 })

--- a/src/common/meta/src/ddl_manager.rs
+++ b/src/common/meta/src/ddl_manager.rs
@@ -34,7 +34,7 @@ use crate::ddl::alter_database::AlterDatabaseProcedure;
 use crate::ddl::alter_logical_tables::AlterLogicalTablesProcedure;
 use crate::ddl::alter_table::AlterTableProcedure;
 use crate::ddl::comment_on::CommentOnProcedure;
-use crate::ddl::create_database::CreateDatabaseProcedure;
+use crate::ddl::create_database::{CreateDatabaseMetadataCommitterRef, CreateDatabaseProcedure};
 use crate::ddl::create_flow::CreateFlowProcedure;
 use crate::ddl::create_logical_tables::CreateLogicalTablesProcedure;
 use crate::ddl::create_table::CreateTableProcedure;
@@ -135,7 +135,7 @@ macro_rules! procedure_loader_entry {
     ($procedure:ident) => {
         (
             $procedure::TYPE_NAME,
-            &|context: DdlContext| -> BoxedProcedureLoader {
+            &|context: DdlContext| -> common_procedure::BoxedProcedureLoader {
                 Box::new(move |json: &str| {
                     let context = context.clone();
                     $procedure::from_json(json, context).map(|p| Box::new(p) as _)
@@ -234,6 +234,14 @@ impl DdlManager {
         self
     }
 
+    pub fn with_create_database_metadata_committer(
+        mut self,
+        committer: CreateDatabaseMetadataCommitterRef,
+    ) -> Self {
+        self.ddl_context.create_database_metadata_committer = Some(committer);
+        self
+    }
+
     /// Returns the [TableMetadataManagerRef].
     pub fn table_metadata_manager(&self) -> &TableMetadataManagerRef {
         &self.ddl_context.table_metadata_manager
@@ -251,6 +259,7 @@ impl DdlManager {
             CreateLogicalTablesProcedure,
             CreateViewProcedure,
             CreateFlowProcedure,
+            CreateDatabaseProcedure,
             AlterTableProcedure,
             AlterLogicalTablesProcedure,
             AlterDatabaseProcedure,
@@ -259,7 +268,6 @@ impl DdlManager {
             PurgeDroppedTableProcedure,
             DropFlowProcedure,
             TruncateTableProcedure,
-            CreateDatabaseProcedure,
             DropDatabaseProcedure,
             DropViewProcedure,
             CommentOnProcedure
@@ -546,11 +554,18 @@ impl DdlManager {
             schema,
             create_if_not_exists,
             options,
+            creator,
         }: CreateDatabaseTask,
     ) -> Result<(ProcedureId, Option<Output>)> {
         let context = self.create_context();
-        let procedure =
-            CreateDatabaseProcedure::new(catalog, schema, create_if_not_exists, options, context);
+        let procedure = CreateDatabaseProcedure::new(
+            catalog,
+            schema,
+            create_if_not_exists,
+            options,
+            creator,
+            context,
+        );
         let procedure_with_id = ProcedureWithId::with_random_id(Box::new(procedure));
 
         self.execute_procedure_and_wait(procedure_with_id).await
@@ -972,14 +987,16 @@ async fn handle_create_database_task(
     ddl_manager: &DdlManager,
     create_database_task: CreateDatabaseTask,
 ) -> Result<SubmitDdlTaskResponse> {
+    let catalog = create_database_task.catalog.clone();
+    let schema = create_database_task.schema.clone();
     let (id, _) = ddl_manager
-        .submit_create_database(create_database_task.clone())
+        .submit_create_database(create_database_task)
         .await?;
 
     let procedure_id = id.to_string();
     info!(
         "Database {}.{} is created via procedure_id {id:?}",
-        create_database_task.catalog, create_database_task.schema
+        catalog, schema
     );
 
     Ok(SubmitDdlTaskResponse {
@@ -1253,6 +1270,9 @@ mod tests {
     use super::DdlManager;
     use crate::cache_invalidator::DummyCacheInvalidator;
     use crate::ddl::alter_table::AlterTableProcedure;
+    use crate::ddl::create_database::{
+        AtomicCreateOutcome, CreateDatabaseMetadataCommitter, CreateDatabaseProcedure,
+    };
     use crate::ddl::create_table::CreateTableProcedure;
     use crate::ddl::drop_table::DropTableProcedure;
     use crate::ddl::flow_meta::FlowMetadataAllocator;
@@ -1267,9 +1287,10 @@ mod tests {
     use crate::peer::Peer;
     use crate::region_keeper::MemoryRegionKeeper;
     use crate::region_registry::LeaderRegionRegistry;
-    use crate::rpc::ddl::UndropTableTask;
+    use crate::rpc::ddl::{CreatorGrantIntent, UndropTableTask};
     use crate::sequence::SequenceBuilder;
     use crate::state_store::KvStateStore;
+    use crate::test_util::{MockDatanodeManager, new_ddl_context};
     use crate::wal_provider::WalProvider;
 
     /// A dummy implemented [NodeManager].
@@ -1314,6 +1335,47 @@ mod tests {
         }
     }
 
+    struct LoaderCommitter;
+
+    #[async_trait::async_trait]
+    impl CreateDatabaseMetadataCommitter for LoaderCommitter {
+        async fn commit(
+            &self,
+            _catalog: &str,
+            _schema: &str,
+            _value: &crate::key::schema_name::SchemaNameValue,
+            _creator: &CreatorGrantIntent,
+        ) -> std::result::Result<AtomicCreateOutcome, BoxedError> {
+            unreachable!()
+        }
+    }
+
+    #[test]
+    fn test_generic_loader_captures_configured_committer() {
+        let mut context = new_ddl_context(Arc::new(MockDatanodeManager::new(())));
+        let committer = Arc::new(LoaderCommitter);
+        context.create_database_metadata_committer = Some(committer.clone());
+        let loader = procedure_loader!(CreateDatabaseProcedure)[0].1(context);
+        assert_eq!(Arc::strong_count(&committer), 2);
+
+        let loaded = loader(
+            r#"{
+                "state":"CreateMetadata",
+                "catalog":"greptime",
+                "schema":"metrics",
+                "create_if_not_exists":false,
+                "options":{},
+                "creator":{"username":"alice","created_at_ns":42}
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(loaded.type_name(), "metasrv-procedure::CreateDatabase");
+        assert_eq!(Arc::strong_count(&committer), 3);
+        drop(loaded);
+        assert_eq!(Arc::strong_count(&committer), 2);
+    }
+
     #[test]
     fn test_try_new() {
         let kv_backend = Arc::new(MemoryKvBackend::new());
@@ -1350,6 +1412,7 @@ mod tests {
                 region_failure_detector_controller: Arc::new(NoopRegionFailureDetectorControl),
                 soft_drop_enabled: false,
                 soft_drop_retention: None,
+                create_database_metadata_committer: None,
             },
             procedure_manager.clone(),
             Arc::new(DummyRepartitionProcedureFactory),
@@ -1404,6 +1467,7 @@ mod tests {
                 region_failure_detector_controller: Arc::new(NoopRegionFailureDetectorControl),
                 soft_drop_enabled: true,
                 soft_drop_retention: Some(std::time::Duration::from_secs(1)),
+                create_database_metadata_committer: None,
             },
             procedure_manager,
             Arc::new(DummyRepartitionProcedureFactory),

--- a/src/common/meta/src/error.rs
+++ b/src/common/meta/src/error.rs
@@ -1353,7 +1353,7 @@ impl ErrorExt for Error {
             | AcquireMySqlClient { error, .. }
             | MySqlTransaction { error, .. } => retry_hint_from_sqlx_error(error),
             #[cfg(any(feature = "pg_kvbackend", feature = "mysql_kvbackend"))]
-            SqlExecutionTimeout { .. } => RetryHint::Retryable,
+            RdsTransactionRetryFailed { .. } | SqlExecutionTimeout { .. } => RetryHint::Retryable,
             _ => RetryHint::NonRetryable,
         }
     }
@@ -1454,6 +1454,14 @@ mod retry_hint_tests {
             duration: std::time::Duration::from_secs(1),
         }
         .build();
+
+        assert_eq!(err.retry_hint(), RetryHint::Retryable);
+    }
+
+    #[cfg(any(feature = "pg_kvbackend", feature = "mysql_kvbackend"))]
+    #[test]
+    fn test_rds_transaction_retry_failed_hint_is_retryable() {
+        let err = RdsTransactionRetryFailedSnafu.build();
 
         assert_eq!(err.retry_hint(), RetryHint::Retryable);
     }

--- a/src/common/meta/src/key/schema_name.rs
+++ b/src/common/meta/src/key/schema_name.rs
@@ -60,6 +60,9 @@ pub struct SchemaNameValue {
     pub ttl: Option<DatabaseTimeToLive>,
     #[serde(default)]
     pub extra_options: BTreeMap<String, String>,
+    /// Identifies the create-database procedure that wrote this value.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub create_procedure_id: Option<String>,
 }
 
 impl Display for SchemaNameValue {
@@ -103,7 +106,11 @@ impl TryFrom<&HashMap<String, String>> for SchemaNameValue {
             })
             .collect();
 
-        Ok(Self { ttl, extra_options })
+        Ok(Self {
+            ttl,
+            extra_options,
+            ..Default::default()
+        })
     }
 }
 
@@ -452,6 +459,7 @@ mod tests {
             Some(SchemaNameValue {
                 ttl: Some(Duration::from_secs(10).into()),
                 extra_options: BTreeMap::new(),
+                create_procedure_id: None,
             })
         );
 
@@ -474,7 +482,28 @@ mod tests {
             Some(SchemaNameValue {
                 ttl: Some(Duration::from_secs(15).into()),
                 extra_options: expected_options,
+                create_procedure_id: None,
             })
+        );
+    }
+
+    #[test]
+    fn test_create_procedure_id_serialization() {
+        let value = SchemaNameValue {
+            create_procedure_id: Some("4ee0ba94-11f0-4d4d-9468-5ebf732e3ab2".to_string()),
+            ..Default::default()
+        };
+        let raw = value.try_as_raw_value().unwrap();
+        assert_eq!(
+            SchemaNameValue::try_from_raw_value(&raw).unwrap(),
+            Some(value)
+        );
+
+        let raw = SchemaNameValue::default().try_as_raw_value().unwrap();
+        assert!(
+            !String::from_utf8(raw)
+                .unwrap()
+                .contains("create_procedure_id")
         );
     }
 

--- a/src/common/meta/src/rpc/ddl.rs
+++ b/src/common/meta/src/rpc/ddl.rs
@@ -361,6 +361,14 @@ impl SubmitDdlTaskRequest {
     }
 }
 
+fn ddl_timeout_secs(timeout: Duration) -> u32 {
+    timeout
+        .as_nanos()
+        .div_ceil(Duration::from_secs(1).as_nanos())
+        .try_into()
+        .unwrap_or(u32::MAX)
+}
+
 impl TryFrom<SubmitDdlTaskRequest> for PbDdlTaskRequest {
     type Error = error::Error;
 
@@ -434,7 +442,7 @@ impl TryFrom<SubmitDdlTaskRequest> for PbDdlTaskRequest {
         Ok(Self {
             header: None,
             query_context: Some(query_context.into()),
-            timeout_secs: timeout.as_secs() as u32,
+            timeout_secs: ddl_timeout_secs(timeout),
             wait,
             task: Some(task),
         })
@@ -1855,6 +1863,18 @@ mod tests {
     use table::test_util::table_info::test_table_info;
 
     use super::{AlterTableTask, CreateTableTask, *};
+
+    #[test]
+    fn test_ddl_timeout_secs() {
+        assert_eq!(ddl_timeout_secs(Duration::ZERO), 0);
+        assert_eq!(ddl_timeout_secs(Duration::from_nanos(1)), 1);
+        assert_eq!(ddl_timeout_secs(Duration::from_secs(1)), 1);
+        assert_eq!(ddl_timeout_secs(Duration::from_millis(1500)), 2);
+        assert_eq!(
+            ddl_timeout_secs(Duration::from_secs(u32::MAX as u64 + 1)),
+            u32::MAX
+        );
+    }
 
     #[test]
     fn test_basic_ser_de_create_table_task() {

--- a/src/common/meta/src/rpc/ddl.rs
+++ b/src/common/meta/src/rpc/ddl.rs
@@ -67,6 +67,18 @@ use crate::key::table_name::{TableNameKey, TableNameManager};
 /// Reserved query-context extension key for the frontend peer address that submitted a DDL request.
 pub const ORIGIN_FRONTEND_ADDR_EXTENSION_KEY: &str = "__greptime_origin_frontend.addr";
 
+/// Reserved query-context extension key for the authenticated database creator.
+pub const CREATE_DATABASE_CREATOR_EXTENSION_KEY: &str = "__greptime_create_database.creator";
+/// Internal gRPC metadata key for the authenticated database creator.
+pub const CREATE_DATABASE_CREATOR_METADATA_KEY: &str =
+    "x-greptime-internal-create-database-creator-bin";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CreatorGrantIntent {
+    pub username: String,
+    pub created_at_ns: i64,
+}
+
 /// DDL tasks
 #[derive(Debug, Clone)]
 pub enum DdlTask {
@@ -171,12 +183,14 @@ impl DdlTask {
         schema: String,
         create_if_not_exists: bool,
         options: HashMap<String, String>,
+        creator: Option<CreatorGrantIntent>,
     ) -> Self {
         DdlTask::CreateDatabase(CreateDatabaseTask {
             catalog,
             schema,
             create_if_not_exists,
             options,
+            creator,
         })
     }
 
@@ -351,7 +365,28 @@ impl TryFrom<SubmitDdlTaskRequest> for PbDdlTaskRequest {
     type Error = error::Error;
 
     fn try_from(request: SubmitDdlTaskRequest) -> Result<Self> {
-        let task = match request.task {
+        let SubmitDdlTaskRequest {
+            mut query_context,
+            wait,
+            timeout,
+            task,
+        } = request;
+
+        query_context
+            .extensions
+            .remove(CREATE_DATABASE_CREATOR_EXTENSION_KEY);
+        if let DdlTask::CreateDatabase(CreateDatabaseTask {
+            creator: Some(creator),
+            ..
+        }) = &task
+        {
+            query_context.extensions.insert(
+                CREATE_DATABASE_CREATOR_EXTENSION_KEY.to_string(),
+                serde_json::to_string(creator).context(error::SerdeJsonSnafu)?,
+            );
+        }
+
+        let task = match task {
             DdlTask::CreateTable(task) => Task::CreateTableTask(task.try_into()?),
             DdlTask::DropTable(task) => Task::DropTableTask(task.into()),
             DdlTask::UndropTable(task) => Task::UndropTableTask(task.into()),
@@ -398,9 +433,9 @@ impl TryFrom<SubmitDdlTaskRequest> for PbDdlTaskRequest {
 
         Ok(Self {
             header: None,
-            query_context: Some(request.query_context.into()),
-            timeout_secs: request.timeout.as_secs() as u32,
-            wait: request.wait,
+            query_context: Some(query_context.into()),
+            timeout_secs: timeout.as_secs() as u32,
+            wait,
             task: Some(task),
         })
     }
@@ -1027,6 +1062,8 @@ pub struct CreateDatabaseTask {
     pub create_if_not_exists: bool,
     #[serde_as(deserialize_as = "DefaultOnNull")]
     pub options: HashMap<String, String>,
+    #[serde(default)]
+    pub creator: Option<CreatorGrantIntent>,
 }
 
 impl TryFrom<PbCreateDatabaseTask> for CreateDatabaseTask {
@@ -1047,6 +1084,7 @@ impl TryFrom<PbCreateDatabaseTask> for CreateDatabaseTask {
             schema: schema_name,
             create_if_not_exists,
             options,
+            creator: None,
         })
     }
 }
@@ -1060,6 +1098,7 @@ impl TryFrom<CreateDatabaseTask> for PbCreateDatabaseTask {
             schema,
             create_if_not_exists,
             options,
+            creator: _,
         }: CreateDatabaseTask,
     ) -> Result<Self> {
         Ok(PbCreateDatabaseTask {
@@ -1869,6 +1908,53 @@ mod tests {
         let de = DdlTask::try_from(pb_task).unwrap();
 
         assert!(matches!(de, DdlTask::PurgeDroppedTable(task) if task == expected));
+    }
+
+    #[test]
+    fn test_create_database_creator_transport_sanitizes_extension() {
+        let request = |creator| {
+            let mut query_context = QueryContext::default();
+            query_context.extensions.insert(
+                CREATE_DATABASE_CREATOR_EXTENSION_KEY.to_string(),
+                "spoofed".to_string(),
+            );
+            SubmitDdlTaskRequest::new(
+                query_context,
+                DdlTask::new_create_database(
+                    "greptime".to_string(),
+                    "test".to_string(),
+                    false,
+                    HashMap::new(),
+                    creator,
+                ),
+            )
+        };
+        let creator = CreatorGrantIntent {
+            username: "alice".to_string(),
+            created_at_ns: 42,
+        };
+
+        let mut pb = PbDdlTaskRequest::try_from(request(Some(creator.clone()))).unwrap();
+        let encoded = pb
+            .query_context
+            .as_ref()
+            .unwrap()
+            .extensions
+            .get(CREATE_DATABASE_CREATOR_EXTENSION_KEY)
+            .unwrap();
+        assert_eq!(creator, serde_json::from_str(encoded).unwrap());
+        assert!(matches!(
+            DdlTask::try_from(pb.task.take().unwrap()).unwrap(),
+            DdlTask::CreateDatabase(CreateDatabaseTask { creator: None, .. })
+        ));
+
+        let pb = PbDdlTaskRequest::try_from(request(None)).unwrap();
+        assert!(
+            !pb.query_context
+                .unwrap()
+                .extensions
+                .contains_key(CREATE_DATABASE_CREATOR_EXTENSION_KEY)
+        );
     }
 
     #[test]

--- a/src/common/meta/src/test_util.rs
+++ b/src/common/meta/src/test_util.rs
@@ -208,6 +208,7 @@ pub fn new_ddl_context_with_kv_backend(
         region_failure_detector_controller: Arc::new(NoopRegionFailureDetectorControl),
         soft_drop_enabled: false,
         soft_drop_retention: Some(std::time::Duration::from_secs(7 * 24 * 60 * 60)),
+        create_database_metadata_committer: None,
     }
 }
 

--- a/src/frontend/src/instance/builder.rs
+++ b/src/frontend/src/instance/builder.rs
@@ -33,6 +33,8 @@ use operator::flow::FlowServiceOperator;
 use operator::insert::Inserter;
 use operator::procedure::ProcedureServiceOperator;
 use operator::request::Requester;
+#[cfg(feature = "enterprise")]
+use operator::statement::CreateDatabaseHandlerRef;
 use operator::statement::{
     ExecutorConfigureContext, StatementExecutor, StatementExecutorConfiguratorRef,
     StatementExecutorRef,
@@ -283,6 +285,13 @@ impl FrontendBuilder {
             } else {
                 statement_executor
             };
+
+        #[cfg(feature = "enterprise")]
+        let statement_executor = if let Some(handler) = plugins.get::<CreateDatabaseHandlerRef>() {
+            statement_executor.with_create_database_handler(handler)
+        } else {
+            statement_executor
+        };
 
         let statement_executor = Arc::new(statement_executor);
 

--- a/src/meta-client/src/client/procedure.rs
+++ b/src/meta-client/src/client/procedure.rs
@@ -16,6 +16,7 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
+use api::v1::meta::ddl_task_request::Task;
 use api::v1::meta::procedure_service_client::ProcedureServiceClient;
 use api::v1::meta::{
     DdlTaskRequest, DdlTaskResponse, GcRegionsRequest, GcRegionsResponse, GcTableRequest,
@@ -24,6 +25,9 @@ use api::v1::meta::{
     ReconcileRequest, ReconcileResponse, RequestHeader, ResponseHeader, Role,
 };
 use common_grpc::channel_manager::ChannelManager;
+use common_meta::rpc::ddl::{
+    CREATE_DATABASE_CREATOR_EXTENSION_KEY, CREATE_DATABASE_CREATOR_METADATA_KEY,
+};
 use common_meta::rpc::procedure::{
     GcRegionsRequest as MetaGcRegionsRequest, GcResponse as MetaGcResponse,
     GcTableRequest as MetaGcTableRequest,
@@ -377,6 +381,7 @@ impl Inner {
     }
 
     async fn submit_ddl_task(&self, mut req: DdlTaskRequest) -> Result<DdlTaskResponse> {
+        let creator = create_database_creator_metadata_value(&req);
         req.set_header(
             self.id,
             self.role,
@@ -388,6 +393,12 @@ impl Inner {
             "submit ddl task",
             move |mut client| {
                 let mut req = Request::new(req.clone());
+                if let Some(value) = creator.as_deref() {
+                    req.metadata_mut().insert_bin(
+                        CREATE_DATABASE_CREATOR_METADATA_KEY,
+                        tonic::metadata::MetadataValue::from_bytes(value.as_bytes()),
+                    );
+                }
                 req.set_timeout(timeout);
                 async move { client.ddl(req).await.map(|res| res.into_inner()) }
             },
@@ -417,6 +428,19 @@ impl Inner {
     }
 }
 
+fn create_database_creator_metadata_value(req: &DdlTaskRequest) -> Option<String> {
+    // StatementExecutor removes client values before attaching the authenticated creator.
+    if !matches!(req.task, Some(Task::CreateDatabaseTask(_))) {
+        return None;
+    }
+
+    req.query_context
+        .as_ref()?
+        .extensions
+        .get(CREATE_DATABASE_CREATOR_EXTENSION_KEY)
+        .cloned()
+}
+
 fn gc_timeout_secs(timeout: Option<Duration>) -> u32 {
     timeout
         .map(|timeout| timeout.as_secs().max(1).try_into().unwrap_or(u32::MAX))
@@ -439,11 +463,14 @@ mod tests {
     use async_trait::async_trait;
     use common_error::status_code::StatusCode;
     use common_meta::rpc::ddl::{
-        CommentObjectType, CommentOnTask, DdlTask, QueryContext, SubmitDdlTaskRequest,
+        CREATE_DATABASE_CREATOR_EXTENSION_KEY, CREATE_DATABASE_CREATOR_METADATA_KEY,
+        CommentObjectType, CommentOnTask, CreatorGrantIntent, DdlTask, QueryContext,
+        SubmitDdlTaskRequest,
     };
     use common_telemetry::common_error::ext::ErrorExt;
     use common_telemetry::info;
     use tokio::net::TcpListener;
+    use tokio::sync::mpsc;
     use tokio_stream::wrappers::{ReceiverStream, TcpListenerStream};
     use tonic::codec::CompressionEncoding;
     use tonic::{Request, Response, Status};
@@ -498,6 +525,7 @@ mod tests {
     #[derive(Clone)]
     struct MockProcedure {
         delay: Duration,
+        request_tx: Option<mpsc::UnboundedSender<Request<DdlTaskRequest>>>,
     }
 
     #[async_trait]
@@ -511,8 +539,11 @@ mod tests {
 
         async fn ddl(
             &self,
-            _request: Request<DdlTaskRequest>,
+            request: Request<DdlTaskRequest>,
         ) -> Result<Response<DdlTaskResponse>, Status> {
+            if let Some(request_tx) = &self.request_tx {
+                request_tx.send(request).unwrap();
+            }
             tokio::time::sleep(self.delay).await;
             Ok(Response::new(DdlTaskResponse {
                 header: Some(ResponseHeader {
@@ -560,6 +591,70 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_meta_client_forwards_create_database_creator_metadata() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr_str = listener.local_addr().unwrap().to_string();
+        let (request_tx, mut request_rx) = mpsc::unbounded_channel();
+        let heartbeat = MockHeartbeat {
+            leader_addr: addr_str.clone(),
+        };
+        let procedure = MockProcedure {
+            delay: Duration::ZERO,
+            request_tx: Some(request_tx),
+        };
+        let server = tonic::transport::Server::builder()
+            .add_service(
+                HeartbeatServer::new(heartbeat).accept_compressed(CompressionEncoding::Zstd),
+            )
+            .add_service(
+                ProcedureServiceServer::new(procedure).accept_compressed(CompressionEncoding::Zstd),
+            )
+            .serve_with_incoming(TcpListenerStream::new(listener));
+        let server_handle = tokio::spawn(server);
+
+        let mut client = MetaClientBuilder::new(0, Role::Frontend)
+            .enable_heartbeat()
+            .enable_procedure()
+            .build();
+        client.start(&[addr_str.as_str()]).await.unwrap();
+
+        let creator = CreatorGrantIntent {
+            username: "alice".to_string(),
+            created_at_ns: 42,
+        };
+        client
+            .submit_ddl_task(SubmitDdlTaskRequest::new(
+                QueryContext::default(),
+                DdlTask::new_create_database(
+                    "greptime".to_string(),
+                    "metrics".to_string(),
+                    false,
+                    Default::default(),
+                    Some(creator.clone()),
+                ),
+            ))
+            .await
+            .unwrap();
+
+        let request = request_rx.recv().await.unwrap();
+        let encoded = serde_json::to_string(&creator).unwrap();
+        assert_eq!(
+            request
+                .metadata()
+                .get_bin(CREATE_DATABASE_CREATOR_METADATA_KEY)
+                .unwrap()
+                .to_bytes()
+                .unwrap()
+                .as_ref(),
+            encoded.as_bytes()
+        );
+        let extensions = &request.into_inner().query_context.unwrap().extensions;
+        assert_eq!(extensions[CREATE_DATABASE_CREATOR_EXTENSION_KEY], encoded);
+
+        server_handle.abort();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_meta_client_ddl_request_timeout() {
         common_telemetry::init_default_ut_logging();
 
@@ -572,6 +667,7 @@ mod tests {
         };
         let procedure = MockProcedure {
             delay: Duration::from_secs(4),
+            request_tx: None,
         };
 
         let server = tonic::transport::Server::builder()

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -446,13 +446,11 @@ impl MetasrvBuilder {
                 options.grpc.server_addr.clone(),
             ))
         };
-        let ddl_manager = DdlManager::try_new(
+        let ddl_manager = DdlManager::new(
             ddl_context,
             procedure_manager_c,
             repartition_procedure_factory,
-            false,
-        )
-        .context(error::InitDdlManagerSnafu)?;
+        );
 
         let ddl_manager = if let Some(configurator) = plugins
             .as_ref()

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -432,6 +432,7 @@ impl MetasrvBuilder {
             region_failure_detector_controller,
             soft_drop_enabled: ddl_soft_drop_enabled(&options),
             soft_drop_retention: ddl_soft_drop_retention(&options),
+            create_database_metadata_committer: None,
         };
         let procedure_manager_c = procedure_manager.clone();
         let repartition_procedure_factory: RepartitionProcedureFactoryRef = if options.gc.enable {
@@ -449,7 +450,7 @@ impl MetasrvBuilder {
             ddl_context,
             procedure_manager_c,
             repartition_procedure_factory,
-            true,
+            false,
         )
         .context(error::InitDdlManagerSnafu)?;
 
@@ -468,6 +469,9 @@ impl MetasrvBuilder {
         } else {
             ddl_manager
         };
+        ddl_manager
+            .register_loaders()
+            .context(error::InitDdlManagerSnafu)?;
 
         let ddl_manager = Arc::new(ddl_manager);
 

--- a/src/meta-srv/src/procedure/utils.rs
+++ b/src/meta-srv/src/procedure/utils.rs
@@ -548,6 +548,7 @@ pub mod test_data {
             region_failure_detector_controller: Arc::new(NoopRegionFailureDetectorControl),
             soft_drop_enabled: false,
             soft_drop_retention: None,
+            create_database_metadata_committer: None,
         }
     }
 }

--- a/src/meta-srv/src/service/procedure.rs
+++ b/src/meta-srv/src/service/procedure.rs
@@ -309,14 +309,19 @@ impl procedure_service_server::ProcedureService for Metasrv {
     }
 }
 
+/// Restores the authenticated creator omitted from the protobuf create-database task.
+///
+/// The frontend sends the serialized [`CreatorGrantIntent`] in both a reserved query-context
+/// extension and internal gRPC metadata. This function removes the extension, requires both
+/// copies to match on a frontend create-database request, and writes the decoded intent into the
+/// task. Missing both preserves legacy and admin behavior; missing or mismatched copies fail
+/// closed.
 fn restore_create_database_creator(
     metadata: &MetadataMap,
     role: i32,
     task: &mut DdlTask,
     query_context: &mut QueryContext,
 ) -> Result<(), Status> {
-    // The body copy makes metadata loss fail closed; old frontends provide no matching
-    // internal metadata and cannot turn public hints into trusted creator context.
     let forwarded = query_context
         .extensions
         .remove(CREATE_DATABASE_CREATOR_EXTENSION_KEY);

--- a/src/meta-srv/src/service/procedure.rs
+++ b/src/meta-srv/src/service/procedure.rs
@@ -20,12 +20,15 @@ use api::v1::meta::{
     GcRegionsResponse, GcStats, GcTableRequest, GcTableResponse, MigrateRegionRequest,
     MigrateRegionResponse, ProcedureDetailRequest, ProcedureDetailResponse, ProcedureStateResponse,
     QueryProcedureRequest, ReconcileCatalog, ReconcileDatabase, ReconcileRequest,
-    ReconcileResponse, ReconcileTable, ResolveStrategy, procedure_service_server,
+    ReconcileResponse, ReconcileTable, ResolveStrategy, Role, procedure_service_server,
 };
 use common_meta::key::TableMetadataManagerRef;
 use common_meta::key::table_name::TableNameKey;
 use common_meta::procedure_executor::ExecutorContext;
-use common_meta::rpc::ddl::{DdlTask, SubmitDdlTaskRequest};
+use common_meta::rpc::ddl::{
+    CREATE_DATABASE_CREATOR_EXTENSION_KEY, CREATE_DATABASE_CREATOR_METADATA_KEY,
+    CreatorGrantIntent, DdlTask, QueryContext, SubmitDdlTaskRequest,
+};
 use common_meta::rpc::procedure::{
     self, GcRegionsRequest as MetaGcRegionsRequest, GcResponse,
     GcTableRequest as MetaGcTableRequest,
@@ -33,7 +36,8 @@ use common_meta::rpc::procedure::{
 use snafu::{OptionExt, ResultExt};
 use store_api::storage::RegionId;
 use table::table_reference::TableReference;
-use tonic::Request;
+use tonic::metadata::MetadataMap;
+use tonic::{Request, Status};
 
 use crate::error::{TableMetadataManagerSnafu, TableNotFoundSnafu};
 use crate::metasrv::Metasrv;
@@ -78,24 +82,26 @@ impl procedure_service_server::ProcedureService for Metasrv {
     async fn ddl(&self, request: Request<PbDdlTaskRequest>) -> GrpcResult<PbDdlTaskResponse> {
         check_leader!(self, request, PbDdlTaskResponse, "`ddl`");
 
+        let (metadata, _, request) = request.into_parts();
         let PbDdlTaskRequest {
             header,
             query_context,
             task,
             wait,
             timeout_secs,
-        } = request.into_inner();
+        } = request;
 
         let header = header.context(error::MissingRequestHeaderSnafu)?;
-        let query_context = query_context
+        let mut query_context = query_context
             .context(error::MissingRequiredParameterSnafu {
                 param: "query_context",
             })?
             .into();
-        let task: DdlTask = task
+        let mut task: DdlTask = task
             .context(error::MissingRequiredParameterSnafu { param: "task" })?
             .try_into()
             .context(error::ConvertProtoDataSnafu)?;
+        restore_create_database_creator(&metadata, header.role, &mut task, &mut query_context)?;
 
         let resp = self
             .ddl_manager()
@@ -303,6 +309,54 @@ impl procedure_service_server::ProcedureService for Metasrv {
     }
 }
 
+fn restore_create_database_creator(
+    metadata: &MetadataMap,
+    role: i32,
+    task: &mut DdlTask,
+    query_context: &mut QueryContext,
+) -> Result<(), Status> {
+    // The body copy makes metadata loss fail closed; old frontends provide no matching
+    // internal metadata and cannot turn public hints into trusted creator context.
+    let forwarded = query_context
+        .extensions
+        .remove(CREATE_DATABASE_CREATOR_EXTENSION_KEY);
+    let internal = metadata
+        .get_bin(CREATE_DATABASE_CREATOR_METADATA_KEY)
+        .map(|value| {
+            value
+                .to_bytes()
+                .map_err(|_| Status::invalid_argument("Invalid internal creator metadata"))
+        })
+        .transpose()?;
+
+    let (forwarded, internal) = match (forwarded, internal) {
+        (None, None) => return Ok(()),
+        (Some(forwarded), Some(internal)) => (forwarded, internal),
+        _ => {
+            return Err(Status::invalid_argument(
+                "Untrusted create-database creator context",
+            ));
+        }
+    };
+
+    let DdlTask::CreateDatabase(task) = task else {
+        return Err(Status::invalid_argument(
+            "Untrusted create-database creator context",
+        ));
+    };
+    if Role::try_from(role) != Ok(Role::Frontend) || forwarded.as_bytes() != internal.as_ref() {
+        return Err(Status::invalid_argument(
+            "Untrusted create-database creator context",
+        ));
+    }
+
+    task.creator = Some(
+        serde_json::from_str::<CreatorGrantIntent>(&forwarded)
+            .map_err(|_| Status::invalid_argument("Invalid internal creator metadata"))?,
+    );
+    Ok(())
+}
+
 impl Metasrv {
     fn normalize_gc_timeout(timeout: Duration) -> Option<Duration> {
         if timeout.is_zero() {
@@ -443,7 +497,46 @@ fn gc_response_to_table_pb(resp: GcResponse) -> GcTableResponse {
 mod tests {
     use std::time::Duration;
 
-    use super::Metasrv;
+    use api::v1::meta::Role;
+    use common_meta::rpc::ddl::{
+        CREATE_DATABASE_CREATOR_EXTENSION_KEY, CREATE_DATABASE_CREATOR_METADATA_KEY,
+        CreatorGrantIntent, DdlTask, QueryContext,
+    };
+    use tonic::metadata::{MetadataMap, MetadataValue};
+
+    use super::{Metasrv, restore_create_database_creator};
+
+    fn create_database_task() -> DdlTask {
+        DdlTask::new_create_database(
+            "greptime".to_string(),
+            "metrics".to_string(),
+            false,
+            Default::default(),
+            None,
+        )
+    }
+
+    fn creator_context(creator: Option<&str>) -> QueryContext {
+        let mut context = QueryContext::default();
+        if let Some(creator) = creator {
+            context.extensions.insert(
+                CREATE_DATABASE_CREATOR_EXTENSION_KEY.to_string(),
+                creator.to_string(),
+            );
+        }
+        context
+    }
+
+    fn creator_metadata(creator: Option<&str>) -> MetadataMap {
+        let mut metadata = MetadataMap::new();
+        if let Some(creator) = creator {
+            metadata.insert_bin(
+                CREATE_DATABASE_CREATOR_METADATA_KEY,
+                MetadataValue::from_bytes(creator.as_bytes()),
+            );
+        }
+        metadata
+    }
 
     #[test]
     fn test_normalize_gc_timeout() {
@@ -452,5 +545,100 @@ mod tests {
             Metasrv::normalize_gc_timeout(Duration::from_secs(10)),
             Some(Duration::from_secs(10))
         );
+    }
+
+    #[test]
+    fn test_restore_create_database_creator_requires_matching_internal_metadata() {
+        let mut task = create_database_task();
+        let mut legacy = QueryContext::default();
+        restore_create_database_creator(
+            &MetadataMap::new(),
+            Role::Frontend as i32,
+            &mut task,
+            &mut legacy,
+        )
+        .unwrap();
+
+        let creator = CreatorGrantIntent {
+            username: "alice".to_string(),
+            created_at_ns: 42,
+        };
+        let encoded = serde_json::to_string(&creator).unwrap();
+        let other = serde_json::to_string(&CreatorGrantIntent {
+            username: "mallory".to_string(),
+            created_at_ns: 99,
+        })
+        .unwrap();
+
+        for (name, body, metadata, role, create_database) in [
+            (
+                "body only",
+                Some(encoded.as_str()),
+                None,
+                Role::Frontend,
+                true,
+            ),
+            (
+                "metadata only",
+                None,
+                Some(encoded.as_str()),
+                Role::Frontend,
+                true,
+            ),
+            (
+                "mismatch",
+                Some(other.as_str()),
+                Some(encoded.as_str()),
+                Role::Frontend,
+                true,
+            ),
+            ("malformed", Some("{"), Some("{"), Role::Frontend, true),
+            (
+                "wrong role",
+                Some(encoded.as_str()),
+                Some(encoded.as_str()),
+                Role::Datanode,
+                true,
+            ),
+            (
+                "wrong task",
+                Some(encoded.as_str()),
+                Some(encoded.as_str()),
+                Role::Frontend,
+                false,
+            ),
+        ] {
+            let mut task = if create_database {
+                create_database_task()
+            } else {
+                DdlTask::new_drop_database("greptime".to_string(), "metrics".to_string(), false)
+            };
+            let mut context = creator_context(body);
+            assert!(
+                restore_create_database_creator(
+                    &creator_metadata(metadata),
+                    role as i32,
+                    &mut task,
+                    &mut context,
+                )
+                .is_err(),
+                "{name} must fail closed"
+            );
+        }
+
+        let mut task = create_database_task();
+        let mut trusted = creator_context(Some(&encoded));
+        restore_create_database_creator(
+            &creator_metadata(Some(&encoded)),
+            Role::Frontend as i32,
+            &mut task,
+            &mut trusted,
+        )
+        .unwrap();
+        let DdlTask::CreateDatabase(task) = task else {
+            unreachable!();
+        };
+        assert_eq!(task.creator, Some(creator));
+        assert!(trusted.extensions.is_empty());
     }
 }

--- a/src/operator/src/statement.rs
+++ b/src/operator/src/statement.rs
@@ -45,6 +45,8 @@ use common_meta::key::view_info::{ViewInfoManager, ViewInfoManagerRef};
 use common_meta::key::{TableMetadataManager, TableMetadataManagerRef};
 use common_meta::kv_backend::KvBackendRef;
 use common_meta::procedure_executor::ProcedureExecutorRef;
+#[cfg(feature = "enterprise")]
+use common_meta::rpc::ddl::CreatorGrantIntent;
 use common_query::Output;
 use common_telemetry::{debug, tracing, warn};
 use common_time::Timestamp;
@@ -101,6 +103,23 @@ pub trait StatementExecutorConfigurator: Send + Sync {
 
 pub type StatementExecutorConfiguratorRef = Arc<dyn StatementExecutorConfigurator>;
 
+#[cfg(feature = "enterprise")]
+#[async_trait::async_trait]
+pub trait CreateDatabaseHandler: Send + Sync {
+    fn creator(
+        &self,
+        query_ctx: &QueryContextRef,
+    ) -> std::result::Result<Option<CreatorGrantIntent>, BoxedError>;
+
+    async fn refresh_current_user(
+        &self,
+        query_ctx: &QueryContextRef,
+    ) -> std::result::Result<(), BoxedError>;
+}
+
+#[cfg(feature = "enterprise")]
+pub type CreateDatabaseHandlerRef = Arc<dyn CreateDatabaseHandler>;
+
 pub struct ExecutorConfigureContext {
     pub kv_backend: KvBackendRef,
 }
@@ -118,6 +137,8 @@ pub struct StatementExecutor {
     inserter: InserterRef,
     process_manager: Option<ProcessManagerRef>,
     origin_frontend_addr: String,
+    #[cfg(feature = "enterprise")]
+    create_database_handler: Option<CreateDatabaseHandlerRef>,
     #[cfg(feature = "enterprise")]
     trigger_querier: Option<TriggerQuerierRef>,
 }
@@ -168,6 +189,8 @@ impl StatementExecutor {
             process_manager,
             origin_frontend_addr,
             #[cfg(feature = "enterprise")]
+            create_database_handler: None,
+            #[cfg(feature = "enterprise")]
             trigger_querier: None,
         }
     }
@@ -175,6 +198,12 @@ impl StatementExecutor {
     #[cfg(feature = "enterprise")]
     pub fn with_trigger_querier(mut self, querier: TriggerQuerierRef) -> Self {
         self.trigger_querier = Some(querier);
+        self
+    }
+
+    #[cfg(feature = "enterprise")]
+    pub fn with_create_database_handler(mut self, handler: CreateDatabaseHandlerRef) -> Self {
+        self.create_database_handler = Some(handler);
         self
     }
 

--- a/src/operator/src/statement/ddl.rs
+++ b/src/operator/src/statement/ddl.rs
@@ -47,7 +47,7 @@ use common_meta::rpc::ddl::trigger::CreateTriggerTask;
 #[cfg(feature = "enterprise")]
 use common_meta::rpc::ddl::trigger::DropTriggerTask;
 use common_meta::rpc::ddl::{
-    CreateFlowTask, DdlTask, DropFlowTask, DropViewTask, SubmitDdlTaskRequest,
+    CreateFlowTask, CreatorGrantIntent, DdlTask, DropFlowTask, DropViewTask, SubmitDdlTaskRequest,
     SubmitDdlTaskResponse,
 };
 use common_query::Output;
@@ -2138,7 +2138,15 @@ impl StatementExecutor {
             }
         );
 
-        if !self
+        #[cfg(feature = "enterprise")]
+        let creator = match &self.create_database_handler {
+            Some(handler) => handler.creator(&query_context).context(ExternalSnafu)?,
+            None => None,
+        };
+        #[cfg(not(feature = "enterprise"))]
+        let creator = None;
+
+        let output = if !self
             .catalog_manager
             .schema_exists(catalog, database, None)
             .await
@@ -2150,16 +2158,27 @@ impl StatementExecutor {
                 database.to_string(),
                 create_if_not_exists,
                 options,
-                query_context,
+                query_context.clone(),
+                creator,
             )
             .await?;
 
-            Ok(Output::new_with_affected_rows(1))
+            Output::new_with_affected_rows(1)
         } else if create_if_not_exists {
-            Ok(Output::new_with_affected_rows(1))
+            Output::new_with_affected_rows(1)
         } else {
-            error::SchemaExistsSnafu { name: database }.fail()
+            return error::SchemaExistsSnafu { name: database }.fail();
+        };
+
+        #[cfg(feature = "enterprise")]
+        if let Some(handler) = &self.create_database_handler {
+            handler
+                .refresh_current_user(&query_context)
+                .await
+                .context(ExternalSnafu)?;
         }
+
+        Ok(output)
     }
 
     async fn create_database_procedure(
@@ -2169,10 +2188,11 @@ impl StatementExecutor {
         create_if_not_exists: bool,
         options: HashMap<String, String>,
         query_context: QueryContextRef,
+        creator: Option<CreatorGrantIntent>,
     ) -> Result<SubmitDdlTaskResponse> {
         let request = SubmitDdlTaskRequest::new(
             to_meta_query_context(query_context),
-            DdlTask::new_create_database(catalog, database, create_if_not_exists, options),
+            DdlTask::new_create_database(catalog, database, create_if_not_exists, options, creator),
         );
 
         self.procedure_executor

--- a/tests-integration/src/standalone.rs
+++ b/tests-integration/src/standalone.rs
@@ -238,28 +238,27 @@ impl GreptimeDbStandaloneBuilder {
         ));
 
         let repartition_procedure_factory = Arc::new(StandaloneRepartitionProcedureFactory);
-        let ddl_manager = Arc::new(
-            DdlManager::try_new(
-                DdlContext {
-                    node_manager: node_manager.clone(),
-                    cache_invalidator: cache_registry.clone(),
-                    memory_region_keeper: Arc::new(MemoryRegionKeeper::default()),
-                    leader_region_registry: Arc::new(LeaderRegionRegistry::default()),
-                    table_metadata_manager,
-                    table_metadata_allocator,
-                    flow_metadata_manager,
-                    flow_metadata_allocator,
-                    region_failure_detector_controller: Arc::new(NoopRegionFailureDetectorControl),
-                    soft_drop_enabled: false,
-                    soft_drop_retention: None,
-                    create_database_metadata_committer: None,
-                },
-                procedure_manager.clone(),
-                repartition_procedure_factory,
-                register_procedure_loaders,
-            )
-            .unwrap(),
-        );
+        let ddl_manager = Arc::new(DdlManager::new(
+            DdlContext {
+                node_manager: node_manager.clone(),
+                cache_invalidator: cache_registry.clone(),
+                memory_region_keeper: Arc::new(MemoryRegionKeeper::default()),
+                leader_region_registry: Arc::new(LeaderRegionRegistry::default()),
+                table_metadata_manager,
+                table_metadata_allocator,
+                flow_metadata_manager,
+                flow_metadata_allocator,
+                region_failure_detector_controller: Arc::new(NoopRegionFailureDetectorControl),
+                soft_drop_enabled: false,
+                soft_drop_retention: None,
+                create_database_metadata_committer: None,
+            },
+            procedure_manager.clone(),
+            repartition_procedure_factory,
+        ));
+        if register_procedure_loaders {
+            ddl_manager.register_loaders().unwrap();
+        }
         let procedure_executor = Arc::new(LocalProcedureExecutor::new(
             ddl_manager,
             procedure_manager.clone(),

--- a/tests-integration/src/standalone.rs
+++ b/tests-integration/src/standalone.rs
@@ -252,6 +252,7 @@ impl GreptimeDbStandaloneBuilder {
                     region_failure_detector_controller: Arc::new(NoopRegionFailureDetectorControl),
                     soft_drop_enabled: false,
                     soft_drop_retention: None,
+                    create_database_metadata_committer: None,
                 },
                 procedure_manager.clone(),
                 repartition_procedure_factory,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This pull request adds support for automatically granting authenticated users access to databases they create.

It securely propagates and validates creator context, atomically commits schema metadata with the creator grant, and makes retries and procedure recovery idempotent. Legacy clients remain compatible, while `SchemaNameValue` gains an optional, serde-defaulted procedure identifier.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
