### PR TITLE
perf(query): prune RangeSelect input projections

### DIFF
--- a/src/query/src/range_select/plan.rs
+++ b/src/query/src/range_select/plan.rs
@@ -24,6 +24,7 @@ use std::time::Duration;
 use ahash::RandomState;
 use arrow::compute::{self, CastOptions, cast_with_options, take_arrays};
 use arrow_schema::{DataType, Field, Schema, SchemaRef, SortOptions, TimeUnit};
+use common_function::aggrs::aggr_wrapper::get_aggr_func;
 use common_recordbatch::DfSendableRecordBatchStream;
 use datafusion::common::Result as DataFusionResult;
 use datafusion::error::Result as DfResult;
@@ -585,8 +586,8 @@ impl RangeSelect {
                     others => others,
                 };
 
-                let expr = match &range_expr {
-                    Expr::AggregateFunction(aggr)
+                let expr = match get_aggr_func(range_expr) {
+                    Some(aggr)
                         if (aggr.func.name() == "last_value"
                             || aggr.func.name() == "first_value") =>
                     {
@@ -632,7 +633,7 @@ impl RangeSelect {
                             .alias(name)
                             .build()
                     }
-                    Expr::AggregateFunction(aggr) => {
+                    Some(aggr) => {
                         let order_by = if !aggr.params.order_by.is_empty() {
                             aggr.params
                                 .order_by
@@ -664,7 +665,7 @@ impl RangeSelect {
                             .alias(name)
                             .build()
                     }
-                    _ => Err(DataFusionError::Plan(format!(
+                    None => Err(DataFusionError::Plan(format!(
                         "Unexpected Expr: {} in RangeSelect",
                         range_fn.expr
                     ))),

--- a/src/query/src/range_select/plan_rewrite.rs
+++ b/src/query/src/range_select/plan_rewrite.rs
@@ -20,6 +20,7 @@ use arrow_schema::DataType;
 use async_recursion::async_recursion;
 use catalog::table_source::DfTableSourceProvider;
 use chrono::{DateTime, Utc};
+use common_function::aggrs::aggr_wrapper::get_aggr_func;
 use common_time::interval::{MS_PER_DAY, NANOS_PER_MILLI};
 use common_time::timestamp::TimeUnit;
 use common_time::{IntervalDayTime, IntervalMonthDayNano, IntervalYearMonth, Timestamp, Timezone};
@@ -651,7 +652,7 @@ fn build_range_input_projection(
             Expr::Alias(alias) => alias.expr.as_ref(),
             expr => expr,
         };
-        let Expr::AggregateFunction(aggr) = range_expr else {
+        let Some(aggr) = get_aggr_func(range_expr) else {
             return Err(DataFusionError::Plan(format!(
                 "Unexpected Expr: {} in RangeSelect",
                 range_expr
@@ -751,7 +752,7 @@ mod test {
     use catalog::memory::MemoryCatalogManager;
     use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
     use common_time::IntervalYearMonth;
-    use datafusion_expr::{BinaryExpr, Literal, Operator};
+    use datafusion_expr::{BinaryExpr, Literal, Operator, UserDefinedLogicalNodeCore};
     use datatypes::prelude::ConcreteDataType;
     use datatypes::schema::{ColumnSchema, Schema};
     use session::context::{QueryContext, QueryContextBuilder};
@@ -1018,6 +1019,84 @@ mod test {
             &["tag_0", "timestamp"],
         )
         .await;
+    }
+
+    #[tokio::test]
+    async fn range_select_input_projection_collects_nested_alias_dependencies() {
+        let plan = do_query(
+            r#"SELECT timestamp, tag_0, avg(field_0 + field_1) RANGE '5m' FROM test ALIGN '1h' BY (tag_0);"#,
+        )
+        .await
+        .unwrap();
+        let LogicalPlan::Extension(extension) = plan else {
+            panic!("expected RangeSelect rewrite output, got: {plan}");
+        };
+        let range_select = extension
+            .node
+            .as_any()
+            .downcast_ref::<RangeSelect>()
+            .expect("expected RangeSelect extension");
+        let mut range_exprs = range_select.range_expr.clone();
+        range_exprs[0].expr = range_exprs[0]
+            .expr
+            .clone()
+            .alias("inner_alias")
+            .alias("outer_alias");
+
+        let input = build_range_input_projection(
+            range_select.input.as_ref(),
+            &range_exprs,
+            &range_select.time_expr,
+            &range_select.by,
+        )
+        .unwrap();
+        let LogicalPlan::Projection(projection) = input else {
+            panic!("expected narrow Projection, got: {input}");
+        };
+        assert_eq!(
+            projection
+                .schema
+                .fields()
+                .iter()
+                .map(|field| field.name().as_str())
+                .collect::<Vec<_>>(),
+            ["tag_0", "timestamp", "field_0", "field_1"],
+        );
+    }
+
+    #[tokio::test]
+    async fn range_select_physical_plan_accepts_nested_aggregate_aliases() {
+        let query_ctx = QueryContext::arc();
+        let stmt = QueryLanguageParser::parse_sql(
+            r#"SELECT timestamp, tag_0, avg(field_0) RANGE '5m' FROM test ALIGN '1h' BY (tag_0);"#,
+            &query_ctx,
+        )
+        .unwrap();
+        let engine = create_test_engine().await;
+        let plan = engine
+            .planner()
+            .plan(&stmt, query_ctx.clone())
+            .await
+            .unwrap();
+        let LogicalPlan::Extension(extension) = plan else {
+            panic!("expected RangeSelect rewrite output, got: {plan}");
+        };
+        let range_select = extension
+            .node
+            .as_any()
+            .downcast_ref::<RangeSelect>()
+            .expect("expected RangeSelect extension");
+        let mut exprs = range_select.expressions();
+        exprs[0] = exprs[0].clone().alias("inner_alias").alias("outer_alias");
+        let plan = LogicalPlan::Extension(Extension {
+            node: Arc::new(
+                range_select
+                    .with_exprs_and_inputs(exprs, vec![range_select.input.as_ref().clone()])
+                    .unwrap(),
+            ),
+        });
+
+        engine.execute(plan, query_ctx).await.unwrap();
     }
 
     #[tokio::test]

--- a/src/query/src/range_select/plan_rewrite.rs
+++ b/src/query/src/range_select/plan_rewrite.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -30,6 +30,7 @@ use datafusion_common::tree_node::{Transformed, TreeNode, TreeNodeRecursion, Tre
 use datafusion_common::{DFSchema, DataFusionError, Result as DFResult};
 use datafusion_expr::expr::WildcardOptions;
 use datafusion_expr::simplify::SimplifyContext;
+use datafusion_expr::utils::expr_to_columns;
 use datafusion_expr::{
     Aggregate, Analyze, Cast, Distinct, DistinctOn, Explain, Expr, ExprSchemable, Extension,
     Literal, LogicalPlan, LogicalPlanBuilder, Projection,
@@ -423,9 +424,16 @@ impl RangePlanRewriter {
                 if need_default_by {
                     range_rewriter.by = default_by;
                 }
+                let range_exprs = range_rewriter.range_fn.into_iter().collect::<Vec<_>>();
+                let input = Arc::new(build_range_input_projection(
+                    input.as_ref(),
+                    &range_exprs,
+                    &time_index,
+                    &range_rewriter.by,
+                )?);
                 let range_select = RangeSelect::try_new(
-                    input.clone(),
-                    range_rewriter.range_fn.into_iter().collect(),
+                    input,
+                    range_exprs,
                     range_rewriter.align,
                     range_rewriter.align_to,
                     time_index,
@@ -627,6 +635,61 @@ impl RangePlanRewriter {
     }
 }
 
+/// Builds the narrow child projection required by [`RangeSelect`].
+///
+/// The physical Range implementation consumes aggregate arguments and aggregate
+/// ordering expressions, but does not support aggregate `FILTER` expressions.
+fn build_range_input_projection(
+    input: &LogicalPlan,
+    range_exprs: &[RangeFn],
+    time_expr: &Expr,
+    by_exprs: &[Expr],
+) -> DFResult<LogicalPlan> {
+    let mut required_columns = HashSet::new();
+    for range_expr in range_exprs {
+        let range_expr = match &range_expr.expr {
+            Expr::Alias(alias) => alias.expr.as_ref(),
+            expr => expr,
+        };
+        let Expr::AggregateFunction(aggr) = range_expr else {
+            return Err(DataFusionError::Plan(format!(
+                "Unexpected Expr: {} in RangeSelect",
+                range_expr
+            )));
+        };
+        if aggr.params.filter.is_some() {
+            return Err(DataFusionError::NotImplemented(
+                "Range aggregate FILTER is unsupported".to_string(),
+            ));
+        }
+        for expr in &aggr.params.args {
+            expr_to_columns(expr, &mut required_columns)?;
+        }
+        for sort_expr in &aggr.params.order_by {
+            expr_to_columns(&sort_expr.expr, &mut required_columns)?;
+        }
+    }
+    expr_to_columns(time_expr, &mut required_columns)?;
+    for by_expr in by_exprs {
+        expr_to_columns(by_expr, &mut required_columns)?;
+    }
+
+    let required_indices = required_columns
+        .iter()
+        .map(|column| input.schema().index_of_column(column))
+        .collect::<DFResult<BTreeSet<_>>>()?;
+    let projection = required_indices
+        .into_iter()
+        .map(|index| {
+            let (qualifier, field) = input.schema().qualified_field(index);
+            Expr::Column(Column::new(qualifier.cloned(), field.name()))
+        })
+        .collect::<Vec<_>>();
+    LogicalPlanBuilder::from(input.clone())
+        .project(projection)?
+        .build()
+}
+
 fn have_range_in_exprs(exprs: &[Expr]) -> bool {
     exprs.iter().any(|expr| {
         let mut find_range = false;
@@ -683,7 +746,7 @@ fn interval_only_in_expr(expr: &Expr) -> bool {
 #[cfg(test)]
 mod test {
 
-    use arrow::datatypes::IntervalUnit;
+    use arrow::datatypes::{IntervalUnit, TimeUnit};
     use catalog::RegisterTableRequest;
     use catalog::memory::MemoryCatalogManager;
     use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
@@ -839,9 +902,179 @@ mod test {
         let query = r#"SELECT timestamp, tag_0, tag_1, avg(field_0 + field_1) RANGE '5m' FROM test ALIGN '1h' by (tag_0,tag_1);"#;
         let expected = String::from(
             "RangeSelect: range_exprs=[avg(test.field_0 + test.field_1) RANGE 5m], align=3600000ms, align_to=0ms, align_by=[test.tag_0, test.tag_1], time_index=timestamp [timestamp:Timestamp(ms), tag_0:Utf8, tag_1:Utf8, avg(test.field_0 + test.field_1) RANGE 5m:Float64;N]\
-            \n  TableScan: test [tag_0:Utf8, tag_1:Utf8, tag_2:Utf8, tag_3:Utf8, tag_4:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N, field_2:Float64;N, field_3:Float64;N, field_4:Float64;N]",
+            \n  Projection: test.tag_0, test.tag_1, test.timestamp, test.field_0, test.field_1 [tag_0:Utf8, tag_1:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N]\
+            \n    TableScan: test [tag_0:Utf8, tag_1:Utf8, tag_2:Utf8, tag_3:Utf8, tag_4:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N, field_2:Float64;N, field_3:Float64;N, field_4:Float64;N]",
         );
         query_plan_compare(query, expected).await;
+    }
+
+    #[tokio::test]
+    async fn range_select_rewrite_projects_required_input_columns() {
+        let query = r#"SELECT timestamp, tag_0, tag_1, avg(field_0 + field_1) RANGE '5m' FROM test ALIGN '1h' by (tag_0,tag_1);"#;
+        let plan = do_query(query).await.unwrap();
+        let LogicalPlan::Extension(extension) = plan else {
+            panic!("expected RangeSelect rewrite output, got: {plan}");
+        };
+        let range_select = extension
+            .node
+            .as_any()
+            .downcast_ref::<RangeSelect>()
+            .expect("expected RangeSelect extension");
+
+        let LogicalPlan::Projection(projection) = range_select.input.as_ref() else {
+            panic!(
+                "expected a narrow Projection below RangeSelect, got: {}",
+                range_select.input
+            );
+        };
+        assert_eq!(
+            projection
+                .schema
+                .fields()
+                .iter()
+                .map(|field| field.name().as_str())
+                .collect::<Vec<_>>(),
+            vec!["tag_0", "tag_1", "timestamp", "field_0", "field_1",]
+        );
+        assert_eq!(
+            range_select
+                .schema
+                .fields()
+                .iter()
+                .map(|field| (
+                    field.name().as_str(),
+                    field.data_type().clone(),
+                    field.is_nullable()
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                (
+                    "timestamp",
+                    DataType::Timestamp(TimeUnit::Millisecond, None),
+                    false
+                ),
+                ("tag_0", DataType::Utf8, false),
+                ("tag_1", DataType::Utf8, false),
+                (
+                    "avg(test.field_0 + test.field_1) RANGE 5m",
+                    DataType::Float64,
+                    true,
+                ),
+            ]
+        );
+        assert_eq!(
+            range_select.schema.qualified_field(0).0,
+            projection.schema.qualified_field(2).0
+        );
+        assert_eq!(
+            range_select.schema.qualified_field(1).0,
+            projection.schema.qualified_field(0).0
+        );
+    }
+
+    async fn assert_range_select_input_columns(sql: &str, expected: &[&str]) {
+        let plan = do_query(sql).await.unwrap();
+        let LogicalPlan::Extension(extension) = plan else {
+            panic!("expected RangeSelect rewrite output, got: {plan}");
+        };
+        let range_select = extension
+            .node
+            .as_any()
+            .downcast_ref::<RangeSelect>()
+            .expect("expected RangeSelect extension");
+        let LogicalPlan::Projection(projection) = range_select.input.as_ref() else {
+            panic!("expected narrow Projection, got: {}", range_select.input);
+        };
+        assert_eq!(
+            projection
+                .schema
+                .fields()
+                .iter()
+                .map(|field| field.name().as_str())
+                .collect::<Vec<_>>(),
+            expected
+        );
+    }
+
+    #[tokio::test]
+    async fn range_select_input_projection_collects_range_dependencies() {
+        assert_range_select_input_columns(
+            r#"SELECT timestamp, tag_0, avg(field_0 + field_1) RANGE '5m', sum(field_2) RANGE '5m' FROM test ALIGN '1h' BY (tag_0);"#,
+            &["tag_0", "timestamp", "field_0", "field_1", "field_2"],
+        )
+        .await;
+        assert_range_select_input_columns(
+            r#"SELECT timestamp, tag_0, last_value(field_0 ORDER BY field_2) RANGE '5m' FROM test ALIGN '1h' BY (tag_0);"#,
+            &["tag_0", "timestamp", "field_0", "field_2"],
+        )
+        .await;
+        assert_range_select_input_columns(
+            r#"SELECT timestamp, count(*) RANGE '5m' FILL NULL FROM test ALIGN '1h';"#,
+            &["tag_0", "tag_1", "tag_2", "tag_3", "tag_4", "timestamp"],
+        )
+        .await;
+        assert_range_select_input_columns(
+            r#"SELECT timestamp, count(1) RANGE '5m' FILL PREV FROM test ALIGN '1h' BY (tag_0);"#,
+            &["tag_0", "timestamp"],
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn range_select_input_projection_resolves_derived_aliases() {
+        let plan = do_query(
+            r#"SELECT d.ts, d.group_tag, avg(d.value) RANGE '5m' FROM (SELECT timestamp AS ts, tag_0 AS group_tag, field_0 AS value, field_4 AS ignored FROM test) AS d ALIGN '1h' BY (d.group_tag);"#,
+        )
+        .await
+        .unwrap();
+        let LogicalPlan::Extension(extension) = plan else {
+            panic!("expected RangeSelect rewrite output, got: {plan}");
+        };
+        let range_select = extension
+            .node
+            .as_any()
+            .downcast_ref::<RangeSelect>()
+            .expect("expected RangeSelect extension");
+        let LogicalPlan::Projection(projection) = range_select.input.as_ref() else {
+            panic!("expected narrow Projection, got: {}", range_select.input);
+        };
+        assert_eq!(
+            projection
+                .schema
+                .fields()
+                .iter()
+                .map(|field| field.name().as_str())
+                .collect::<Vec<_>>(),
+            ["ts", "group_tag", "value"],
+        );
+        assert!(
+            projection
+                .schema
+                .fields()
+                .iter()
+                .enumerate()
+                .all(|(index, _)| projection
+                    .schema
+                    .qualified_field(index)
+                    .0
+                    .unwrap()
+                    .to_string()
+                    == "d")
+        );
+    }
+
+    #[tokio::test]
+    async fn range_select_rejects_aggregate_filter() {
+        let error = do_query(
+            r#"SELECT timestamp, tag_0, avg(field_0) FILTER (WHERE field_1 > 0) RANGE '5m' FROM test ALIGN '1h' BY (tag_0);"#,
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+        assert_eq!(
+            error,
+            "This feature is not implemented: Range aggregate FILTER is unsupported"
+        );
     }
 
     #[tokio::test]
@@ -850,7 +1083,8 @@ mod test {
         let expected = String::from(
             "Projection: avg(test.field_0 + test.field_1) RANGE 5m / Int64(4) [avg(test.field_0 + test.field_1) RANGE 5m / Int64(4):Float64;N]\
             \n  RangeSelect: range_exprs=[avg(test.field_0 + test.field_1) RANGE 5m], align=3600000ms, align_to=0ms, align_by=[test.tag_0, test.tag_1], time_index=timestamp [avg(test.field_0 + test.field_1) RANGE 5m:Float64;N, timestamp:Timestamp(ms), tag_0:Utf8, tag_1:Utf8]\
-            \n    TableScan: test [tag_0:Utf8, tag_1:Utf8, tag_2:Utf8, tag_3:Utf8, tag_4:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N, field_2:Float64;N, field_3:Float64;N, field_4:Float64;N]",
+            \n    Projection: test.tag_0, test.tag_1, test.timestamp, test.field_0, test.field_1 [tag_0:Utf8, tag_1:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N]\
+            \n      TableScan: test [tag_0:Utf8, tag_1:Utf8, tag_2:Utf8, tag_3:Utf8, tag_4:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N, field_2:Float64;N, field_3:Float64;N, field_4:Float64;N]",
         );
         query_plan_compare(query, expected).await;
     }
@@ -862,7 +1096,8 @@ mod test {
         let expected = String::from(
             "Projection: covar_samp(test.field_0 + test.field_1,test.field_1) RANGE 5m / Int64(4) [covar_samp(test.field_0 + test.field_1,test.field_1) RANGE 5m / Int64(4):Float64;N]\
             \n  RangeSelect: range_exprs=[covar_samp(test.field_0 + test.field_1,test.field_1) RANGE 5m], align=3600000ms, align_to=0ms, align_by=[test.tag_0, test.tag_1, test.tag_2, test.tag_3, test.tag_4], time_index=timestamp [covar_samp(test.field_0 + test.field_1,test.field_1) RANGE 5m:Float64;N, timestamp:Timestamp(ms), tag_0:Utf8, tag_1:Utf8, tag_2:Utf8, tag_3:Utf8, tag_4:Utf8]\
-            \n    TableScan: test [tag_0:Utf8, tag_1:Utf8, tag_2:Utf8, tag_3:Utf8, tag_4:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N, field_2:Float64;N, field_3:Float64;N, field_4:Float64;N]",
+            \n    Projection: test.tag_0, test.tag_1, test.tag_2, test.tag_3, test.tag_4, test.timestamp, test.field_0, test.field_1 [tag_0:Utf8, tag_1:Utf8, tag_2:Utf8, tag_3:Utf8, tag_4:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N]\
+            \n      TableScan: test [tag_0:Utf8, tag_1:Utf8, tag_2:Utf8, tag_3:Utf8, tag_4:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N, field_2:Float64;N, field_3:Float64;N, field_4:Float64;N]",
         );
         query_plan_compare(query, expected).await;
     }
@@ -873,7 +1108,8 @@ mod test {
         let expected = String::from(
             "Projection: (avg(test.field_0) RANGE 5m FILL NULL + sum(test.field_1) RANGE 5m FILL NULL) / Int64(4) [avg(test.field_0) RANGE 5m FILL NULL + sum(test.field_1) RANGE 5m FILL NULL / Int64(4):Float64;N]\
             \n  RangeSelect: range_exprs=[avg(test.field_0) RANGE 5m FILL NULL, sum(test.field_1) RANGE 5m FILL NULL], align=3600000ms, align_to=0ms, align_by=[test.tag_0, test.tag_1], time_index=timestamp [avg(test.field_0) RANGE 5m FILL NULL:Float64;N, sum(test.field_1) RANGE 5m FILL NULL:Float64;N, timestamp:Timestamp(ms), tag_0:Utf8, tag_1:Utf8]\
-            \n    TableScan: test [tag_0:Utf8, tag_1:Utf8, tag_2:Utf8, tag_3:Utf8, tag_4:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N, field_2:Float64;N, field_3:Float64;N, field_4:Float64;N]",
+            \n    Projection: test.tag_0, test.tag_1, test.timestamp, test.field_0, test.field_1 [tag_0:Utf8, tag_1:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N]\
+            \n      TableScan: test [tag_0:Utf8, tag_1:Utf8, tag_2:Utf8, tag_3:Utf8, tag_4:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N, field_2:Float64;N, field_3:Float64;N, field_4:Float64;N]",
         );
         query_plan_compare(query, expected).await;
     }
@@ -886,7 +1122,8 @@ mod test {
             \n  Filter: foo > Int64(1) [foo:Float64;N]\
             \n    Projection: (avg(test.field_0) RANGE 5m FILL NULL + sum(test.field_1) RANGE 5m FILL NULL) / Int64(4) AS foo [foo:Float64;N]\
             \n      RangeSelect: range_exprs=[avg(test.field_0) RANGE 5m FILL NULL, sum(test.field_1) RANGE 5m FILL NULL], align=3600000ms, align_to=0ms, align_by=[test.tag_0, test.tag_1], time_index=timestamp [avg(test.field_0) RANGE 5m FILL NULL:Float64;N, sum(test.field_1) RANGE 5m FILL NULL:Float64;N, timestamp:Timestamp(ms), tag_0:Utf8, tag_1:Utf8]\
-            \n        TableScan: test [tag_0:Utf8, tag_1:Utf8, tag_2:Utf8, tag_3:Utf8, tag_4:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N, field_2:Float64;N, field_3:Float64;N, field_4:Float64;N]",
+            \n        Projection: test.tag_0, test.tag_1, test.timestamp, test.field_0, test.field_1 [tag_0:Utf8, tag_1:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N]\
+            \n          TableScan: test [tag_0:Utf8, tag_1:Utf8, tag_2:Utf8, tag_3:Utf8, tag_4:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N, field_2:Float64;N, field_3:Float64;N, field_4:Float64;N]",
         );
         query_plan_compare(query, expected).await;
     }
@@ -897,9 +1134,10 @@ mod test {
         let expected = String::from(
             "Projection: (avg(a) RANGE 5m FILL NULL + sum(b) RANGE 5m FILL NULL) / Int64(4) [avg(a) RANGE 5m FILL NULL + sum(b) RANGE 5m FILL NULL / Int64(4):Float64;N]\
             \n  RangeSelect: range_exprs=[avg(a) RANGE 5m FILL NULL, sum(b) RANGE 5m FILL NULL], align=3600000ms, align_to=0ms, align_by=[c, d], time_index=timestamp [avg(a) RANGE 5m FILL NULL:Float64;N, sum(b) RANGE 5m FILL NULL:Float64;N, timestamp:Timestamp(ms), c:Utf8, d:Utf8]\
-            \n    Projection: test.field_0 AS a, test.field_1 AS b, test.tag_0 AS c, test.tag_1 AS d, test.timestamp [a:Float64;N, b:Float64;N, c:Utf8, d:Utf8, timestamp:Timestamp(ms)]\
-            \n      Filter: test.field_0 > Float64(1) [tag_0:Utf8, tag_1:Utf8, tag_2:Utf8, tag_3:Utf8, tag_4:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N, field_2:Float64;N, field_3:Float64;N, field_4:Float64;N]\
-            \n        TableScan: test [tag_0:Utf8, tag_1:Utf8, tag_2:Utf8, tag_3:Utf8, tag_4:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N, field_2:Float64;N, field_3:Float64;N, field_4:Float64;N]",
+            \n    Projection: a, b, c, d, test.timestamp [a:Float64;N, b:Float64;N, c:Utf8, d:Utf8, timestamp:Timestamp(ms)]\
+            \n      Projection: test.field_0 AS a, test.field_1 AS b, test.tag_0 AS c, test.tag_1 AS d, test.timestamp [a:Float64;N, b:Float64;N, c:Utf8, d:Utf8, timestamp:Timestamp(ms)]\
+            \n        Filter: test.field_0 > Float64(1) [tag_0:Utf8, tag_1:Utf8, tag_2:Utf8, tag_3:Utf8, tag_4:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N, field_2:Float64;N, field_3:Float64;N, field_4:Float64;N]\
+            \n          TableScan: test [tag_0:Utf8, tag_1:Utf8, tag_2:Utf8, tag_3:Utf8, tag_4:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N, field_2:Float64;N, field_3:Float64;N, field_4:Float64;N]",
         );
         query_plan_compare(query, expected).await;
     }
@@ -973,7 +1211,8 @@ mod test {
         let expected = String::from(
             "Projection: sin(avg(test.field_0 + test.field_1) RANGE 5m + Int64(1)) [sin(avg(test.field_0 + test.field_1) RANGE 5m + Int64(1)):Float64;N]\
             \n  RangeSelect: range_exprs=[avg(test.field_0 + test.field_1) RANGE 5m], align=3600000ms, align_to=0ms, align_by=[test.tag_0, test.tag_1], time_index=timestamp [avg(test.field_0 + test.field_1) RANGE 5m:Float64;N, timestamp:Timestamp(ms), tag_0:Utf8, tag_1:Utf8]\
-            \n    TableScan: test [tag_0:Utf8, tag_1:Utf8, tag_2:Utf8, tag_3:Utf8, tag_4:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N, field_2:Float64;N, field_3:Float64;N, field_4:Float64;N]",
+            \n    Projection: test.tag_0, test.tag_1, test.timestamp, test.field_0, test.field_1 [tag_0:Utf8, tag_1:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N]\
+            \n      TableScan: test [tag_0:Utf8, tag_1:Utf8, tag_2:Utf8, tag_3:Utf8, tag_4:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N, field_2:Float64;N, field_3:Float64;N, field_4:Float64;N]",
         );
         query_plan_compare(query, expected).await;
     }
@@ -984,7 +1223,8 @@ mod test {
         let expected = String::from(
             "Projection: avg(test.field_0) RANGE 5m FILL 6 + avg(test.field_0) RANGE 5m FILL 6 [avg(test.field_0) RANGE 5m FILL 6 + avg(test.field_0) RANGE 5m FILL 6:Float64]\
             \n  RangeSelect: range_exprs=[avg(test.field_0) RANGE 5m FILL 6], align=3600000ms, align_to=0ms, align_by=[test.tag_0, test.tag_1], time_index=timestamp [avg(test.field_0) RANGE 5m FILL 6:Float64, timestamp:Timestamp(ms), tag_0:Utf8, tag_1:Utf8]\
-            \n    TableScan: test [tag_0:Utf8, tag_1:Utf8, tag_2:Utf8, tag_3:Utf8, tag_4:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N, field_2:Float64;N, field_3:Float64;N, field_4:Float64;N]",
+            \n    Projection: test.tag_0, test.tag_1, test.timestamp, test.field_0 [tag_0:Utf8, tag_1:Utf8, timestamp:Timestamp(ms), field_0:Float64;N]\
+            \n      TableScan: test [tag_0:Utf8, tag_1:Utf8, tag_2:Utf8, tag_3:Utf8, tag_4:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N, field_2:Float64;N, field_3:Float64;N, field_4:Float64;N]",
         );
         query_plan_compare(query, expected).await;
     }
@@ -995,7 +1235,8 @@ mod test {
         let expected = String::from(
             "Projection: round(sin(avg(test.field_0 + test.field_1) RANGE 5m + Int64(1))) [round(sin(avg(test.field_0 + test.field_1) RANGE 5m + Int64(1))):Float64;N]\
             \n  RangeSelect: range_exprs=[avg(test.field_0 + test.field_1) RANGE 5m], align=3600000ms, align_to=0ms, align_by=[test.tag_0, test.tag_1], time_index=timestamp [avg(test.field_0 + test.field_1) RANGE 5m:Float64;N, timestamp:Timestamp(ms), tag_0:Utf8, tag_1:Utf8]\
-            \n    TableScan: test [tag_0:Utf8, tag_1:Utf8, tag_2:Utf8, tag_3:Utf8, tag_4:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N, field_2:Float64;N, field_3:Float64;N, field_4:Float64;N]",
+            \n    Projection: test.tag_0, test.tag_1, test.timestamp, test.field_0, test.field_1 [tag_0:Utf8, tag_1:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N]\
+            \n      TableScan: test [tag_0:Utf8, tag_1:Utf8, tag_2:Utf8, tag_3:Utf8, tag_4:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N, field_2:Float64;N, field_3:Float64;N, field_4:Float64;N]",
         );
         query_plan_compare(query, expected).await;
     }
@@ -1006,7 +1247,8 @@ mod test {
         let expected = String::from(
             "Projection: gcd(arrow_cast(max(test.field_0 + Int64(1)) RANGE 5m FILL NULL, Utf8(\"Int64\")), arrow_cast(test.tag_0, Utf8(\"Int64\"))) + round(max(test.field_2 + Int64(1)) RANGE 6m FILL NULL + Int64(1)) + max(test.field_2 + Int64(3)) RANGE 10m FILL NULL * arrow_cast(test.tag_1, Utf8(\"Float64\")) + Int64(1) [gcd(arrow_cast(max(test.field_0 + Int64(1)) RANGE 5m FILL NULL,Utf8(\"Int64\")),arrow_cast(test.tag_0,Utf8(\"Int64\"))) + round(max(test.field_2 + Int64(1)) RANGE 6m FILL NULL + Int64(1)) + max(test.field_2 + Int64(3)) RANGE 10m FILL NULL * arrow_cast(test.tag_1,Utf8(\"Float64\")) + Int64(1):Float64;N]\
             \n  RangeSelect: range_exprs=[max(test.field_0 + Int64(1)) RANGE 5m FILL NULL, max(test.field_2 + Int64(1)) RANGE 6m FILL NULL, max(test.field_2 + Int64(3)) RANGE 10m FILL NULL], align=3600000ms, align_to=0ms, align_by=[test.tag_0, test.tag_1], time_index=timestamp [max(test.field_0 + Int64(1)) RANGE 5m FILL NULL:Float64;N, max(test.field_2 + Int64(1)) RANGE 6m FILL NULL:Float64;N, max(test.field_2 + Int64(3)) RANGE 10m FILL NULL:Float64;N, timestamp:Timestamp(ms), tag_0:Utf8, tag_1:Utf8]\
-            \n    TableScan: test [tag_0:Utf8, tag_1:Utf8, tag_2:Utf8, tag_3:Utf8, tag_4:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N, field_2:Float64;N, field_3:Float64;N, field_4:Float64;N]",
+            \n    Projection: test.tag_0, test.tag_1, test.timestamp, test.field_0, test.field_2 [tag_0:Utf8, tag_1:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_2:Float64;N]\
+            \n      TableScan: test [tag_0:Utf8, tag_1:Utf8, tag_2:Utf8, tag_3:Utf8, tag_4:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N, field_2:Float64;N, field_3:Float64;N, field_4:Float64;N]",
         );
         query_plan_compare(query, expected).await;
     }
@@ -1016,7 +1258,8 @@ mod test {
         let query = r#"SELECT min(CAST(field_0 AS Int64) + CAST(field_1 AS Int64)) RANGE '5m' FILL LINEAR FROM test ALIGN '1h' by (tag_0,tag_1);"#;
         let expected = String::from(
             "RangeSelect: range_exprs=[min(arrow_cast(test.field_0,Utf8(\"Int64\")) + arrow_cast(test.field_1,Utf8(\"Int64\"))) RANGE 5m FILL LINEAR], align=3600000ms, align_to=0ms, align_by=[test.tag_0, test.tag_1], time_index=timestamp [min(arrow_cast(test.field_0,Utf8(\"Int64\")) + arrow_cast(test.field_1,Utf8(\"Int64\"))) RANGE 5m FILL LINEAR:Float64;N]\
-            \n  TableScan: test [tag_0:Utf8, tag_1:Utf8, tag_2:Utf8, tag_3:Utf8, tag_4:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N, field_2:Float64;N, field_3:Float64;N, field_4:Float64;N]",
+            \n  Projection: test.tag_0, test.tag_1, test.timestamp, test.field_0, test.field_1 [tag_0:Utf8, tag_1:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N]\
+            \n    TableScan: test [tag_0:Utf8, tag_1:Utf8, tag_2:Utf8, tag_3:Utf8, tag_4:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, field_1:Float64;N, field_2:Float64;N, field_3:Float64;N, field_4:Float64;N]",
         );
         query_plan_compare(query, expected).await;
     }

--- a/tests/cases/distributed/optimizer/range_select_projection.result
+++ b/tests/cases/distributed/optimizer/range_select_projection.result
@@ -27,6 +27,8 @@ Affected Rows: 5
 -- SQLNESS REPLACE (metrics.*) REDACTED
 -- SQLNESS REPLACE (partitioning.*) REDACTED
 -- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
+-- SQLNESS REPLACE Total\s+rows:\s+\d+ Total rows: REDACTED
+-- SQLNESS REPLACE Dictionary\(UInt32,\s*Utf8\(([^)]*)\)\) Utf8($1)
 EXPLAIN ANALYZE VERBOSE SELECT
     ts,
     station,
@@ -52,7 +54,7 @@ ORDER BY station, "channel", ts;
 | 1_| 0_|_CooperativeExec REDACTED
 |_|_|_SeqScan: region=REDACTED, {"partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "projection": ["ts", "station", "channel", "value_a", "value_b"], "filters": ["station = Utf8(\"station-a\")", "unused_tag = Utf8(\"unused-a\")", "ts >= TimestampMillisecond(0, None)", "ts < TimestampMillisecond(15000, None)"], "flat_format": true, "REDACTED
 |_|_|_|
-|_|_| Total rows: 4_|
+|_|_| Total rows: REDACTED_|
 +-+-+-+
 
 SELECT

--- a/tests/cases/distributed/optimizer/range_select_projection.result
+++ b/tests/cases/distributed/optimizer/range_select_projection.result
@@ -1,0 +1,83 @@
+CREATE TABLE range_select_projection (
+    ts TIMESTAMP TIME INDEX,
+    station STRING,
+    "channel" STRING,
+    unused_tag STRING,
+    value_a DOUBLE,
+    value_b DOUBLE,
+    unused_value DOUBLE,
+    PRIMARY KEY (station, "channel", unused_tag),
+);
+
+Affected Rows: 0
+
+INSERT INTO range_select_projection VALUES
+    (0, 'station-a', 'channel-a', 'unused-a', 1.0, 10.0, 100.0),
+    (5000, 'station-a', 'channel-a', 'unused-a', 2.0, 20.0, 200.0),
+    (10000, 'station-a', 'channel-a', 'unused-a', 3.0, 30.0, 300.0),
+    (0, 'station-a', 'channel-b', 'unused-b', 4.0, 40.0, 400.0),
+    (5000, 'station-a', 'channel-b', 'unused-b', 5.0, 50.0, 500.0);
+
+Affected Rows: 5
+
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE (elapsed_compute.*) REDACTED
+-- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE (partitioning.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
+EXPLAIN ANALYZE VERBOSE SELECT
+    ts,
+    station,
+    "channel",
+    avg(value_a + value_b) RANGE '10s' AS avg_value
+FROM range_select_projection
+WHERE station = 'station-a'
+    AND unused_tag = 'unused-a'
+    AND ts >= '1970-01-01 00:00:00'
+    AND ts < '1970-01-01 00:00:15'
+ALIGN '5s' BY (station, "channel")
+ORDER BY station, "channel", ts;
+
++-+-+-+
+| stage | node | plan_|
++-+-+-+
+| 0_| 0_|_SortExec: expr=[station@1 ASC NULLS LAST, channel@2 ASC NULLS LAST, ts@0 ASC NULLS LAST], preserve_REDACTED
+|_|_|_ProjectionExec: expr=[ts@1 as ts, station@2 as station, channel@3 as channel, avg(range_select_projection.value_a + range_select_projection.value_b) RANGE 10s@0 as avg_value] REDACTED
+|_|_|_RangeSelectExec: range_expr=[avg(range_select_projection.value_a + range_select_projection.value_b) RANGE 10s], align=5000ms, align_to=0ms, align_by=[station@1, channel@2], time_index=ts REDACTED
+|_|_|_CoalescePartitionsExec REDACTED
+|_|_|_MergeScanExec: REDACTED
+|_|_|_|
+| 1_| 0_|_CooperativeExec REDACTED
+|_|_|_SeqScan: region=REDACTED, {"partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "projection": ["ts", "station", "channel", "value_a", "value_b"], "filters": ["station = Utf8(\"station-a\")", "unused_tag = Utf8(\"unused-a\")", "ts >= TimestampMillisecond(0, None)", "ts < TimestampMillisecond(15000, None)"], "flat_format": true, "REDACTED
+|_|_|_|
+|_|_| Total rows: 4_|
++-+-+-+
+
+SELECT
+    ts,
+    station,
+    "channel",
+    avg(value_a + value_b) RANGE '10s' AS avg_value
+FROM range_select_projection
+WHERE station = 'station-a'
+    AND unused_tag = 'unused-a'
+    AND ts >= '1970-01-01 00:00:00'
+    AND ts < '1970-01-01 00:00:15'
+ALIGN '5s' BY (station, "channel")
+ORDER BY station, "channel", ts;
+
++---------------------+-----------+-----------+-----------+
+| ts                  | station   | channel   | avg_value |
++---------------------+-----------+-----------+-----------+
+| 1969-12-31T23:59:55 | station-a | channel-a | 11.0      |
+| 1970-01-01T00:00:00 | station-a | channel-a | 16.5      |
+| 1970-01-01T00:00:05 | station-a | channel-a | 27.5      |
+| 1970-01-01T00:00:10 | station-a | channel-a | 33.0      |
++---------------------+-----------+-----------+-----------+
+
+DROP TABLE range_select_projection;
+
+Affected Rows: 0
+

--- a/tests/cases/distributed/optimizer/range_select_projection.sql
+++ b/tests/cases/distributed/optimizer/range_select_projection.sql
@@ -23,6 +23,8 @@ INSERT INTO range_select_projection VALUES
 -- SQLNESS REPLACE (metrics.*) REDACTED
 -- SQLNESS REPLACE (partitioning.*) REDACTED
 -- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
+-- SQLNESS REPLACE Total\s+rows:\s+\d+ Total rows: REDACTED
+-- SQLNESS REPLACE Dictionary\(UInt32,\s*Utf8\(([^)]*)\)\) Utf8($1)
 EXPLAIN ANALYZE VERBOSE SELECT
     ts,
     station,

--- a/tests/cases/distributed/optimizer/range_select_projection.sql
+++ b/tests/cases/distributed/optimizer/range_select_projection.sql
@@ -1,0 +1,52 @@
+CREATE TABLE range_select_projection (
+    ts TIMESTAMP TIME INDEX,
+    station STRING,
+    "channel" STRING,
+    unused_tag STRING,
+    value_a DOUBLE,
+    value_b DOUBLE,
+    unused_value DOUBLE,
+    PRIMARY KEY (station, "channel", unused_tag),
+);
+
+INSERT INTO range_select_projection VALUES
+    (0, 'station-a', 'channel-a', 'unused-a', 1.0, 10.0, 100.0),
+    (5000, 'station-a', 'channel-a', 'unused-a', 2.0, 20.0, 200.0),
+    (10000, 'station-a', 'channel-a', 'unused-a', 3.0, 30.0, 300.0),
+    (0, 'station-a', 'channel-b', 'unused-b', 4.0, 40.0, 400.0),
+    (5000, 'station-a', 'channel-b', 'unused-b', 5.0, 50.0, 500.0);
+
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE (elapsed_compute.*) REDACTED
+-- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE (partitioning.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
+EXPLAIN ANALYZE VERBOSE SELECT
+    ts,
+    station,
+    "channel",
+    avg(value_a + value_b) RANGE '10s' AS avg_value
+FROM range_select_projection
+WHERE station = 'station-a'
+    AND unused_tag = 'unused-a'
+    AND ts >= '1970-01-01 00:00:00'
+    AND ts < '1970-01-01 00:00:15'
+ALIGN '5s' BY (station, "channel")
+ORDER BY station, "channel", ts;
+
+SELECT
+    ts,
+    station,
+    "channel",
+    avg(value_a + value_b) RANGE '10s' AS avg_value
+FROM range_select_projection
+WHERE station = 'station-a'
+    AND unused_tag = 'unused-a'
+    AND ts >= '1970-01-01 00:00:00'
+    AND ts < '1970-01-01 00:00:15'
+ALIGN '5s' BY (station, "channel")
+ORDER BY station, "channel", ts;
+
+DROP TABLE range_select_projection;

--- a/tests/cases/standalone/common/range/nest.result
+++ b/tests/cases/standalone/common/range/nest.result
@@ -134,7 +134,8 @@ EXPLAIN SELECT ts, host, min(val) RANGE '5s' FROM host ALIGN '5s';
 | logical_plan_| RangeSelect: range_exprs=[min(host.val) RANGE 5s], align=5000ms, align_to=0ms, align_by=[host.host], time_index=ts |
 |_|_Projection: host.ts, host.host, host.val_|
 |_|_MergeScan [is_placeholder=false, remote_input=[_|
-|_| TableScan: host_|
+|_| Projection: host.ts, host.host, host.val_|
+|_|_TableScan: host_|
 |_| ]]_|
 | physical_plan | RangeSelectExec: range_expr=[min(host.val) RANGE 5s], align=5000ms, align_to=0ms, align_by=[host@1], time_index=ts |
 |_|_CoalescePartitionsExec_|


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

- Discussion: https://github.com/GreptimeTeam/greptimedb/discussions/8525
- Supersedes the projection-pruning portion of the closed draft #8557

## What's changed and what's your intention?

This PR narrows the input projection below the existing Complete RangeSelect executor.

The rewrite retains exactly the columns required by aggregate arguments and ordering, the range time expression, and `BY` expressions. Filter-only columns remain below the projection in the existing Filter plan. Qualified fields and derived-table aliases are preserved. Nested aggregate aliases are handled consistently in projection dependency extraction and physical planning. Aggregate-level `FILTER` is rejected explicitly because the current executor does not implement it.

This is an independently useful scan optimization. It does not add Partial/Final execution, wire serialization, configuration, or distributed placement.

Validation:
- full `range_select::plan_rewrite` module: 26 passed, including nested-alias projection and physical-planning regressions;
- `cargo check -p query`;
- Rust formatting and `git diff --check`;
- distributed `range_select_projection` SQLness passed;
- standalone and distributed `range/nest` SQLness passed with runner-generated plan snapshots.

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.