### PR TITLE
fix(flow): downgrade disabled incremental checkpoint log

### DIFF
--- a/src/flow/src/batching_mode/task/ckpt.rs
+++ b/src/flow/src/batching_mode/task/ckpt.rs
@@ -325,6 +325,15 @@ impl BatchingTask {
                 );
             }
             FlowCheckpointDecision::FallbackToFullSnapshot {
+                previous_mode: CheckpointMode::FullSnapshot,
+                reason: FlowQueryFallbackReason::IncrementalDisabled,
+            } => {
+                debug!(
+                    "Flow {flow_id} remains in full snapshot mode, reason={}",
+                    FlowQueryFallbackReason::IncrementalDisabled.as_label()
+                );
+            }
+            FlowCheckpointDecision::FallbackToFullSnapshot {
                 previous_mode,
                 reason,
             } => {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

N/A

## What's changed and what's your intention?

When incremental reads are disabled, a successful full-snapshot query produces a checkpoint decision with `previous_mode=full_snapshot` and `reason=incremental_disabled`. This is a steady state rather than a mode transition, but the generic fallback logger emitted a repeated warning saying the Flow had switched modes.

This PR handles that exact decision separately: it logs at debug level with `remains in full snapshot mode`. Actual fallback transitions and other fallback reasons continue to log at warning level. Checkpoint state and metrics are unchanged.

Verification:
- `cargo fmt --check --package flow`
- `cargo nextest run -p flow test_apply_query_result_to_state_stays_full_snapshot_when_incremental_disabled`

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.