### PR TITLE
fix: demote expected remote dynamic filter misses

### DIFF
--- a/src/datanode/src/region_server/registrations.rs
+++ b/src/datanode/src/region_server/registrations.rs
@@ -21,7 +21,7 @@ use common_query::request::{
     DynFilterPayload, INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY, InitialDynFilterReg,
     InitialDynFilterRegs, REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES,
 };
-use common_telemetry::warn;
+use common_telemetry::{debug, warn};
 use dashmap::DashMap;
 use datafusion::arrow::datatypes::{Schema, SchemaRef};
 use datafusion::execution::{SessionStateBuilder, TaskContext};
@@ -557,7 +557,7 @@ pub(super) fn apply_remote_dyn_filter_update(
     REMOTE_DYN_FILTER_PAYLOAD_BYTES.observe(payload.len() as f64);
 
     let Some(query_regs) = regs_by_query.get_query(query_id) else {
-        warn!(
+        debug!(
             "Ignored remote dynamic filter update without query registration, query_id: {}, filter_id: {}",
             query_id, filter_id
         );
@@ -568,7 +568,7 @@ pub(super) fn apply_remote_dyn_filter_update(
 
     let mut query_regs = query_regs.lock().unwrap();
     let Some(registered) = query_regs.get_mut(filter_id) else {
-        warn!(
+        debug!(
             "Ignored remote dynamic filter update without filter registration, query_id: {}, filter_id: {}",
             query_id, filter_id
         );
@@ -589,7 +589,7 @@ pub(super) fn unregister_remote_dyn_filter(
     filter_id: &RemoteDynFilterId,
 ) -> RemoteDynFilterUpdateOutcome {
     let Some(query_regs) = regs_by_query.get_query(query_id) else {
-        warn!(
+        debug!(
             "Ignored remote dynamic filter unregister without query registration, query_id: {}, filter_id: {}",
             query_id, filter_id
         );
@@ -601,7 +601,7 @@ pub(super) fn unregister_remote_dyn_filter(
     let (registered, should_remove_query) = {
         let mut locked = query_regs.lock().unwrap();
         let Some(registered) = locked.remove(filter_id) else {
-            warn!(
+            debug!(
                 "Ignored remote dynamic filter unregister without filter registration, query_id: {}, filter_id: {}",
                 query_id, filter_id
             );

--- a/src/datanode/src/region_server/remote_dyn_filter.rs
+++ b/src/datanode/src/region_server/remote_dyn_filter.rs
@@ -225,8 +225,7 @@ impl RegionServer {
     ) {
         if matches!(
             outcome,
-            RemoteDynFilterUpdateOutcome::MissingRegistration
-                | RemoteDynFilterUpdateOutcome::AlreadyComplete
+            RemoteDynFilterUpdateOutcome::AlreadyComplete
                 | RemoteDynFilterUpdateOutcome::PayloadTooLarge
                 | RemoteDynFilterUpdateOutcome::DecodeFailed
         ) {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Remote dynamic filter updates and unregisters can legitimately arrive after the
datanode registration has already been removed. This happens when stream-scoped
cleanup wins the race with asynchronous frontend fanout, and when multiple
subscriber regions on the same datanode fan out unregister requests for a
query/filter registration that the first unregister already removed.

These expected lifecycle races return `MissingRegistration` as an idempotent
no-op, but previously emitted both a registry-specific warning and a generic
outcome warning for every late request. On multi-region queries this could
produce large warning bursts.

This PR:

- logs missing query/filter registrations at debug level;
- logs the generic `MissingRegistration` outcome at debug level;
- preserves warnings for `AlreadyComplete`, oversized payloads, decode failures,
  and other genuine anomalies;
- leaves outcomes, metrics, and control flow unchanged.

Validation:

- `cargo nextest run -p datanode test_apply_remote_dyn_filter_update_missing_registration`
- `cargo nextest run -p datanode test_remote_dyn_filter_unregister_removes_all_region_subscribers_for_filter`
- `rustfmt +nightly --edition 2024 --check src/datanode/src/region_server/registrations.rs src/datanode/src/region_server/remote_dyn_filter.rs`
- `git diff --cached --check`

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments. (No public API was added.)
- [x] I have added the necessary unit tests and integration tests. (Existing lifecycle tests cover the unchanged outcomes.)
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
