### PR TITLE
fix: preserve leader cache configuration and record cache hits

### DIFF
--- a/src/meta-srv/src/service/store/cached_kv.rs
+++ b/src/meta-srv/src/service/store/cached_kv.rs
@@ -247,11 +247,6 @@ impl KvBackend for LeaderCachedKvBackend {
         }
 
         let cached_res = self.cache.batch_get(req.clone()).await?;
-        // The cache hit all keys
-        if cached_res.kvs.len() == req.keys.len() {
-            return Ok(cached_res);
-        }
-
         let hit_keys = cached_res
             .kvs
             .iter()
@@ -261,6 +256,11 @@ impl KvBackend for LeaderCachedKvBackend {
         metrics::METRIC_META_KV_CACHE_HIT
             .with_label_values(&["batch_get"])
             .inc_by(hit_keys.len() as u64);
+
+        // The cache hit all keys
+        if cached_res.kvs.len() == req.keys.len() {
+            return Ok(cached_res);
+        }
 
         let missed_keys = req
             .keys

--- a/src/meta-srv/src/state.rs
+++ b/src/meta-srv/src/state.rs
@@ -98,7 +98,11 @@ impl State {
 
 pub fn become_leader(enable_leader_cache: bool) -> impl FnOnce(&State) -> State {
     move |prev| match prev {
-        State::Leader(leader) => State::Leader(LeaderState { ..leader.clone() }),
+        State::Leader(leader) => {
+            let mut new_leader = leader.clone();
+            new_leader.enable_leader_cache = enable_leader_cache;
+            State::Leader(new_leader)
+        }
         State::Follower(follower) => State::Leader(LeaderState {
             server_addr: follower.server_addr.clone(),
             enable_leader_cache,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR fixes two leader-cache issues in MetaSrv:

- Preserve the `enable_leader_cache` argument when `become_leader` is called while the previous state is already `Leader`. Previously, the cloned leader state retained its old cache setting.
- Record `batch_get` cache hits before returning on a full cache hit. Previously, fully cached requests bypassed the cache-hit metric increment.

This change does not alter public APIs, persisted data, wire formats, or schemas.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
