### PR TITLE
feat(mito2): expose adaptive batch APIs

### DIFF
--- a/src/mito2/src/batch_size.rs
+++ b/src/mito2/src/batch_size.rs
@@ -20,7 +20,11 @@ use crate::sst::parquet::DEFAULT_READ_BATCH_SIZE;
 pub(crate) const TARGET_BATCH_BYTES: usize = 64 * 1024 * 1024;
 
 /// Estimates a batch size from `(num_rows, estimated_bytes)` pairs.
-pub(crate) fn estimate_batch_size(sources: impl IntoIterator<Item = (u64, u64)>) -> usize {
+///
+/// Uses the widest source with valid statistics and targets approximately 64 MiB of decoded data.
+/// The result is clamped to `1..=DEFAULT_READ_BATCH_SIZE`. Returns the default read batch size if
+/// no source contains usable statistics.
+pub fn estimate_batch_size(sources: impl IntoIterator<Item = (u64, u64)>) -> usize {
     let max_row_width = sources
         .into_iter()
         .filter_map(|(rows, bytes)| estimate_row_width(rows, bytes))

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -1082,7 +1082,11 @@ pub fn merge_and_dedup(
     )
 }
 
-fn merge_and_dedup_with_batch_size(
+/// Merges and optionally deduplicates record batch iterators with an explicit output batch size.
+///
+/// `batch_size` controls the target number of rows in batches assembled by the merge iterator.
+/// The other arguments have the same meaning as in [`merge_and_dedup`].
+pub fn merge_and_dedup_with_batch_size(
     schema: &SchemaRef,
     append_mode: bool,
     merge_mode: MergeMode,

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -1084,8 +1084,9 @@ pub fn merge_and_dedup(
 
 /// Merges and optionally deduplicates record batch iterators with an explicit output batch size.
 ///
-/// `batch_size` controls the target number of rows in batches assembled by the merge iterator.
-/// The other arguments have the same meaning as in [`merge_and_dedup`].
+/// `batch_size` controls the target number of rows in batches assembled by the merge iterator and
+/// is clamped to at least one. The other arguments have the same meaning as in
+/// [`merge_and_dedup`].
 pub fn merge_and_dedup_with_batch_size(
     schema: &SchemaRef,
     append_mode: bool,
@@ -1094,6 +1095,7 @@ pub fn merge_and_dedup_with_batch_size(
     input_iters: Vec<BoxedRecordBatchIterator>,
     batch_size: usize,
 ) -> Result<BoxedRecordBatchIterator> {
+    let batch_size = batch_size.max(1);
     let merge_iter = FlatMergeIterator::new(schema.clone(), input_iters, batch_size)?;
     let maybe_dedup = if append_mode {
         // No dedup in append mode

--- a/src/mito2/src/lib.rs
+++ b/src/mito2/src/lib.rs
@@ -25,7 +25,7 @@
 pub mod test_util;
 
 pub mod access_layer;
-mod batch_size;
+pub mod batch_size;
 pub mod cache;
 pub mod compaction;
 pub mod config;

--- a/src/mito2/src/read/flat_projection.rs
+++ b/src/mito2/src/read/flat_projection.rs
@@ -226,9 +226,7 @@ impl FlatProjectionMapper {
                     && self
                         .metadata
                         .column_by_name(&column.name)
-                        .is_some_and(|metadata| {
-                            self.metadata.primary_key.contains(&metadata.column_id)
-                        })
+                        .is_some_and(|metadata| metadata.semantic_type == SemanticType::Tag)
                 {
                     changed = true;
                     column.data_type = ConcreteDataType::dictionary_datatype(


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)


## What's changed and what's your intention?

This PR exposes the existing Mito2 adaptive batching helpers needed by the enterprise ingestion path:

- Makes `mito2::batch_size` public and exposes `estimate_batch_size`.
- Exposes `merge_and_dedup_with_batch_size` while keeping `merge_and_dedup` as the backward-compatible default-size wrapper.
- Adds rustdoc for the newly public APIs without exposing the internal target-byte constant or row-width helper.
- Identifies tag columns by their semantic type when mapping flat projections.

The enterprise implementation needs to derive a batch size from runtime source statistics and use the same value while reading and merging wide rows. Exposing these existing methods avoids duplicating Mito2 batching logic or introducing a static row-count configuration.

This is a source-compatible API addition and does not change persisted data or wire formats.

Validation:

- `make fmt`
- `git diff --check`

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
