### PR TITLE
feat(flow): handle time_ranges in DirtyWindowRequest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5984,7 +5984,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=a618b74452db2f3b2f4d1586b6c244d6999abea0#a618b74452db2f3b2f4d1586b6c244d6999abea0"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=8127f179c7d928bf57396a5e050560b3e7cd3cf9#8127f179c7d928bf57396a5e050560b3e7cd3cf9"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",
@@ -6530,7 +6530,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -7748,7 +7748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.5",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -9010,7 +9010,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11183,7 +11183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -11231,7 +11231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11244,7 +11244,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -12678,7 +12678,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13588,7 +13588,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14580,7 +14580,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5984,7 +5984,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=8127f179c7d928bf57396a5e050560b3e7cd3cf9#8127f179c7d928bf57396a5e050560b3e7cd3cf9"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=a937a645546b377a8ba88b43dd82a294e63d99ac#a937a645546b377a8ba88b43dd82a294e63d99ac"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2222,7 +2222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5984,7 +5984,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=c6f92ee9e12ee7bd5ee3c0956b1c9caa39be3f76#c6f92ee9e12ee7bd5ee3c0956b1c9caa39be3f76"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=a618b74452db2f3b2f4d1586b6c244d6999abea0#a618b74452db2f3b2f4d1586b6c244d6999abea0"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",
@@ -6530,7 +6530,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -9010,7 +9010,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11162,7 +11162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -11182,8 +11182,8 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.14.0",
+ "heck 0.5.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -11231,7 +11231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11244,7 +11244,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -12678,7 +12678,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13559,7 +13559,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1961e2ef424c1424204d3a5d6975f934f56b6d50ff5732382d84ebf460e147f7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -13588,7 +13588,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -14580,7 +14580,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -16331,7 +16331,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ fs2 = "0.4"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "8127f179c7d928bf57396a5e050560b3e7cd3cf9" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "a937a645546b377a8ba88b43dd82a294e63d99ac" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ fs2 = "0.4"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "c6f92ee9e12ee7bd5ee3c0956b1c9caa39be3f76" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "a618b74452db2f3b2f4d1586b6c244d6999abea0" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ fs2 = "0.4"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "a618b74452db2f3b2f4d1586b6c244d6999abea0" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "8127f179c7d928bf57396a5e050560b3e7cd3cf9" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/src/flow/Cargo.toml
+++ b/src/flow/Cargo.toml
@@ -81,6 +81,7 @@ tonic.workspace = true
 arrow-flight.workspace = true
 catalog = { workspace = true, features = ["testing"] }
 common-catalog.workspace = true
+common-meta = { workspace = true, features = ["testing"] }
 pretty_assertions.workspace = true
 prost.workspace = true
 query.workspace = true

--- a/src/flow/src/batching_mode/engine.rs
+++ b/src/flow/src/batching_mode/engine.rs
@@ -236,13 +236,26 @@ impl BatchingEngine {
                             continue;
                         };
                         for timestamp in timestamps {
-                            let align_start = expr
-                                .eval(common_time::Timestamp::new(*timestamp, *unit))?
-                                .0
-                                .context(UnexpectedSnafu {
-                                    reason: "Failed to eval start value",
-                                })?;
-                            all_dirty_windows.insert(align_start);
+                            // On alignment failure, fall back to marking the
+                            // whole task dirty so the dirty signal is never
+                            // lost (the caller treats this RPC as accepted and
+                            // will not retry).
+                            match expr.eval(common_time::Timestamp::new(*timestamp, *unit)) {
+                                Ok((Some(align_start), _)) => {
+                                    all_dirty_windows.insert(align_start);
+                                }
+                                res => {
+                                    warn!(
+                                        "Failed to align dirty timestamp {} for flow id = {:?}: {:?}, marking the task fully dirty",
+                                        timestamp,
+                                        task.config.flow_id,
+                                        res.err().map(|e| e.to_string()).unwrap_or_else(|| {
+                                            "missing window lower bound".to_string()
+                                        })
+                                    );
+                                    is_dirty = true;
+                                }
+                            }
                         }
                         for time_range in time_ranges {
                             if time_range.end_exclusive <= time_range.start_inclusive {
@@ -252,12 +265,25 @@ impl BatchingEngine {
                                 );
                                 continue;
                             }
-                            let (align_start, align_end) = DirtyTimeWindows::align_time_window(
+                            match DirtyTimeWindows::align_time_window(
                                 common_time::Timestamp::new(time_range.start_inclusive, *unit),
                                 Some(common_time::Timestamp::new(time_range.end_exclusive, *unit)),
                                 expr,
-                            )?;
-                            all_dirty_ranges.push((align_start, align_end));
+                            ) {
+                                Ok((align_start, align_end)) => {
+                                    all_dirty_ranges.push((align_start, align_end));
+                                }
+                                Err(err) => {
+                                    warn!(
+                                        "Failed to align dirty time range [{}, {}) for flow id = {:?}: {}, marking the task fully dirty",
+                                        time_range.start_inclusive,
+                                        time_range.end_exclusive,
+                                        task.config.flow_id,
+                                        err
+                                    );
+                                    is_dirty = true;
+                                }
+                            }
                         }
                     }
                 }

--- a/src/flow/src/batching_mode/engine.rs
+++ b/src/flow/src/batching_mode/engine.rs
@@ -152,6 +152,11 @@ impl BatchingEngine {
             .collect()
     }
 
+    /// Mark dirty time windows for batching flows.
+    ///
+    /// Both `timestamps` and `time_ranges` (`[start_inclusive, end_exclusive)`)
+    /// in each `DirtyWindowRequest` are bare `i64`s interpreted in the source
+    /// table's time index column native unit, resolved via table metadata.
     pub async fn handle_mark_dirty_time_window(
         &self,
         reqs: DirtyWindowRequests,
@@ -1063,6 +1068,7 @@ mod tests {
     use common_meta::key::table_route::TableRouteValue;
     use common_meta::key::test_utils::new_test_table_info_with_name;
     use common_meta::kv_backend::memory::MemoryKvBackend;
+    use common_time::timestamp::TimeUnit;
     use query::options::QueryOptions;
     use session::context::QueryContext;
 
@@ -1226,11 +1232,87 @@ GROUP BY l.number, time_window
     }
 
     async fn new_test_task(flow_id: FlowId) -> (BatchingTask, oneshot::Sender<()>) {
-        new_test_task_with_time_window_expr(flow_id, None).await
+        new_test_task_for_source(flow_id, "numbers_with_ts", None).await
     }
 
     async fn new_test_task_with_time_window_expr(
         flow_id: FlowId,
+        time_window_expr: Option<TimeWindowExpr>,
+    ) -> (BatchingTask, oneshot::Sender<()>) {
+        new_test_task_for_source(flow_id, "numbers_with_ts", time_window_expr).await
+    }
+
+    fn test_table_info_with_ts_unit(
+        table_id: TableId,
+        table_name: &str,
+        unit: TimeUnit,
+    ) -> table::metadata::TableInfo {
+        use datatypes::schema::{ColumnSchema, SchemaBuilder};
+        use table::metadata::{TableInfoBuilder, TableMetaBuilder};
+
+        let ts_type = match unit {
+            TimeUnit::Second => ConcreteDataType::timestamp_second_datatype(),
+            TimeUnit::Millisecond => ConcreteDataType::timestamp_millisecond_datatype(),
+            TimeUnit::Microsecond => ConcreteDataType::timestamp_microsecond_datatype(),
+            TimeUnit::Nanosecond => ConcreteDataType::timestamp_nanosecond_datatype(),
+        };
+        let column_schemas = vec![
+            ColumnSchema::new("col1", ConcreteDataType::int32_datatype(), true),
+            ColumnSchema::new("ts", ts_type, false).with_time_index(true),
+        ];
+        let schema = SchemaBuilder::try_from(column_schemas)
+            .unwrap()
+            .build()
+            .unwrap();
+        let meta = TableMetaBuilder::empty()
+            .schema(Arc::new(schema))
+            .primary_key_indices(vec![0])
+            .engine("engine")
+            .next_column_id(3)
+            .build()
+            .unwrap();
+        TableInfoBuilder::default()
+            .table_id(table_id)
+            .table_version(0)
+            .name(table_name)
+            .catalog_name("greptime")
+            .schema_name("public")
+            .meta(meta)
+            .build()
+            .unwrap()
+    }
+
+    /// A 5-second `date_bin` time window expr over the test table's `ts` column.
+    async fn test_time_window_expr() -> TimeWindowExpr {
+        let query_engine = create_test_query_engine();
+        let ctx = QueryContext::arc();
+        let plan = sql_to_df_plan(
+            ctx.clone(),
+            query_engine.clone(),
+            "SELECT date_bin(INTERVAL '5 second', ts) AS time_window FROM numbers_with_ts GROUP BY time_window",
+            true,
+        )
+        .await
+        .unwrap();
+        let (column_name, time_window_expr, _, df_schema) = find_time_window_expr(
+            &plan,
+            query_engine.engine_state().catalog_manager().clone(),
+            ctx,
+        )
+        .await
+        .unwrap();
+        TimeWindowExpr::from_expr(
+            &time_window_expr.unwrap(),
+            &column_name,
+            &df_schema,
+            &query_engine.engine_state().session_state(),
+        )
+        .unwrap()
+    }
+
+    async fn new_test_task_for_source(
+        flow_id: FlowId,
+        source_table_name: &str,
         time_window_expr: Option<TimeWindowExpr>,
     ) -> (BatchingTask, oneshot::Sender<()>) {
         let query_engine = create_test_query_engine();
@@ -1259,7 +1341,7 @@ GROUP BY l.number, time_window
             source_table_names: vec![[
                 "greptime".to_string(),
                 "public".to_string(),
-                "numbers_with_ts".to_string(),
+                source_table_name.to_string(),
             ]],
             query_ctx: ctx,
             catalog_manager: query_engine.engine_state().catalog_manager().clone(),
@@ -1293,33 +1375,8 @@ GROUP BY l.number, time_window
             .unwrap();
 
         // Build a task with a 5-second time window expr.
-        let query_engine = create_test_query_engine();
-        let ctx = QueryContext::arc();
-        let plan = sql_to_df_plan(
-            ctx.clone(),
-            query_engine.clone(),
-            "SELECT date_bin(INTERVAL '5 second', ts) AS time_window FROM numbers_with_ts GROUP BY time_window",
-            true,
-        )
-        .await
-        .unwrap();
-        let (column_name, time_window_expr, _, df_schema) = find_time_window_expr(
-            &plan,
-            query_engine.engine_state().catalog_manager().clone(),
-            ctx,
-        )
-        .await
-        .unwrap();
-        let time_window_expr = TimeWindowExpr::from_expr(
-            &time_window_expr.unwrap(),
-            &column_name,
-            &df_schema,
-            &query_engine.engine_state().session_state(),
-        )
-        .unwrap();
-
         let (task, shutdown_tx) =
-            new_test_task_with_time_window_expr(1, Some(time_window_expr)).await;
+            new_test_task_with_time_window_expr(1, Some(test_time_window_expr().await)).await;
         let task_identity = task.clone();
         engine.runtime.write().await.insert(1, task, shutdown_tx);
 
@@ -1355,6 +1412,79 @@ GROUP BY l.number, time_window
             Duration::from_secs(15),
             state.dirty_time_windows.window_size()
         );
+    }
+
+    /// Dirty timestamps and time ranges are interpreted in the source table's
+    /// time index native unit. The same physical range [3s, 11s) expressed in
+    /// second/millisecond/microsecond/nanosecond units must align to the same
+    /// dirty window [0s, 15s).
+    #[tokio::test]
+    async fn test_handle_mark_dirty_time_window_time_index_units() {
+        let engine = new_test_engine().await;
+
+        let cases = [
+            (TimeUnit::Second, 1u32, "t_sec", 3i64, 11i64),
+            (TimeUnit::Millisecond, 2, "t_ms", 3_000, 11_000),
+            (TimeUnit::Microsecond, 3, "t_us", 3_000_000, 11_000_000),
+            (
+                TimeUnit::Nanosecond,
+                4,
+                "t_ns",
+                3_000_000_000,
+                11_000_000_000,
+            ),
+        ];
+
+        let mut task_identities = vec![];
+        let mut requests = vec![];
+        for (unit, table_id, table_name, start_inclusive, end_exclusive) in cases {
+            engine
+                .table_meta
+                .create_table_metadata(
+                    test_table_info_with_ts_unit(table_id, table_name, unit),
+                    TableRouteValue::physical(vec![]),
+                    HashMap::new(),
+                )
+                .await
+                .unwrap();
+
+            let (task, shutdown_tx) = new_test_task_for_source(
+                table_id as FlowId,
+                table_name,
+                Some(test_time_window_expr().await),
+            )
+            .await;
+            task_identities.push((table_id, task.clone()));
+            engine
+                .runtime
+                .write()
+                .await
+                .insert(table_id as FlowId, task, shutdown_tx);
+
+            requests.push(DirtyWindowRequest {
+                table_id,
+                timestamps: vec![],
+                time_ranges: vec![TimeRange {
+                    start_inclusive,
+                    end_exclusive,
+                }],
+            });
+        }
+
+        engine
+            .handle_mark_dirty_time_window(DirtyWindowRequests { requests })
+            .await
+            .unwrap();
+
+        for (table_id, task) in task_identities {
+            let state = task.state.read().unwrap();
+            assert_eq!(1, state.dirty_time_windows.len(), "table id = {table_id}");
+            assert_eq!(
+                Duration::from_secs(15),
+                state.dirty_time_windows.window_size(),
+                "table id = {table_id}"
+            );
+        }
     }
 
     async fn install_abort_observed_handle(task: &BatchingTask) -> oneshot::Receiver<()> {

--- a/src/flow/src/batching_mode/engine.rs
+++ b/src/flow/src/batching_mode/engine.rs
@@ -53,7 +53,7 @@ use crate::batching_mode::utils::sql_to_df_plan;
 use crate::engine::{FlowEngine, FlowStatProvider};
 use crate::error::{
     CreateFlowSnafu, DatafusionSnafu, ExternalSnafu, FlowAlreadyExistSnafu, FlowNotFoundSnafu,
-    InvalidQuerySnafu, TableNotFoundMetaSnafu, UnexpectedSnafu, UnsupportedSnafu,
+    InvalidQuerySnafu, JoinTaskSnafu, TableNotFoundMetaSnafu, UnexpectedSnafu, UnsupportedSnafu,
 };
 use crate::metrics::METRIC_FLOW_BATCHING_ENGINE_BULK_MARK_TIME_WINDOW;
 use crate::{CreateFlowArgs, Error, FlowId, TableName};
@@ -241,26 +241,15 @@ impl BatchingEngine {
                             continue;
                         };
                         for timestamp in timestamps {
-                            // On alignment failure, fall back to marking the
-                            // whole task dirty so the dirty signal is never
-                            // lost (the caller treats this RPC as accepted and
-                            // will not retry).
-                            match expr.eval(common_time::Timestamp::new(*timestamp, *unit)) {
-                                Ok((Some(align_start), _)) => {
-                                    all_dirty_windows.insert(align_start);
-                                }
-                                res => {
-                                    warn!(
-                                        "Failed to align dirty timestamp {} for flow id = {:?}: {:?}, marking the task fully dirty",
-                                        timestamp,
-                                        task.config.flow_id,
-                                        res.err().map(|e| e.to_string()).unwrap_or_else(|| {
-                                            "missing window lower bound".to_string()
-                                        })
-                                    );
-                                    is_dirty = true;
-                                }
-                            }
+                            let align_start = expr
+                                .eval(common_time::Timestamp::new(*timestamp, *unit))?
+                                .0
+                                .context(UnexpectedSnafu {
+                                    reason: format!(
+                                        "Failed to align dirty timestamp {timestamp}: missing window lower bound"
+                                    ),
+                                })?;
+                            all_dirty_windows.insert(align_start);
                         }
                         for time_range in time_ranges {
                             if time_range.end_exclusive <= time_range.start_inclusive {
@@ -270,25 +259,12 @@ impl BatchingEngine {
                                 );
                                 continue;
                             }
-                            match DirtyTimeWindows::align_time_window(
+                            let (align_start, align_end) = DirtyTimeWindows::align_time_window(
                                 common_time::Timestamp::new(time_range.start_inclusive, *unit),
                                 Some(common_time::Timestamp::new(time_range.end_exclusive, *unit)),
                                 expr,
-                            ) {
-                                Ok((align_start, align_end)) => {
-                                    all_dirty_ranges.push((align_start, align_end));
-                                }
-                                Err(err) => {
-                                    warn!(
-                                        "Failed to align dirty time range [{}, {}) for flow id = {:?}: {}, marking the task fully dirty",
-                                        time_range.start_inclusive,
-                                        time_range.end_exclusive,
-                                        task.config.flow_id,
-                                        err
-                                    );
-                                    is_dirty = true;
-                                }
-                            }
+                            )?;
+                            all_dirty_ranges.push((align_start, align_end));
                         }
                     }
                 }
@@ -312,15 +288,7 @@ impl BatchingEngine {
             handles.push(handle);
         }
         for handle in handles {
-            match handle.await {
-                Err(e) => {
-                    warn!("Failed to handle inserts: {e}");
-                }
-                Ok(Ok(())) => (),
-                Ok(Err(e)) => {
-                    warn!("Failed to handle inserts: {e}");
-                }
-            }
+            handle.await.context(JoinTaskSnafu)??;
         }
 
         Ok(())
@@ -1485,6 +1453,50 @@ GROUP BY l.number, time_window
                 "table id = {table_id}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn test_handle_mark_dirty_time_window_returns_error_on_alignment_failure() {
+        let engine = new_test_engine().await;
+        let table_id = 10;
+        let table_name = "t_bad_timestamp";
+
+        engine
+            .table_meta
+            .create_table_metadata(
+                test_table_info_with_ts_unit(table_id, table_name, TimeUnit::Second),
+                TableRouteValue::physical(vec![]),
+                HashMap::new(),
+            )
+            .await
+            .unwrap();
+
+        let (task, shutdown_tx) = new_test_task_for_source(
+            table_id as FlowId,
+            table_name,
+            Some(test_time_window_expr().await),
+        )
+        .await;
+        engine
+            .runtime
+            .write()
+            .await
+            .insert(table_id as FlowId, task, shutdown_tx);
+
+        let result = engine
+            .handle_mark_dirty_time_window(DirtyWindowRequests {
+                requests: vec![DirtyWindowRequest {
+                    table_id,
+                    timestamps: vec![i64::MAX],
+                    time_ranges: vec![],
+                }],
+            })
+            .await;
+
+        assert!(
+            result.is_err(),
+            "invalid timestamp alignment should be returned to the caller"
+        );
     }
 
     async fn install_abort_observed_handle(task: &BatchingTask) -> oneshot::Receiver<()> {

--- a/src/flow/src/batching_mode/engine.rs
+++ b/src/flow/src/batching_mode/engine.rs
@@ -46,6 +46,7 @@ use tokio::sync::{RwLock, oneshot};
 use crate::batching_mode::BatchingModeOptions;
 use crate::batching_mode::eval_schedule::EvalSchedule;
 use crate::batching_mode::frontend_client::FrontendClient;
+use crate::batching_mode::state::DirtyTimeWindows;
 use crate::batching_mode::task::{BatchingTask, TaskArgs};
 use crate::batching_mode::time_window::{TimeWindowExpr, find_time_window_expr};
 use crate::batching_mode::utils::sql_to_df_plan;
@@ -157,11 +158,13 @@ impl BatchingEngine {
     ) -> Result<(), Error> {
         let table_info_mgr = self.table_meta.table_info_manager();
 
-        let mut group_by_table_id: HashMap<u32, Vec<_>> = HashMap::new();
+        let mut group_by_table_id: HashMap<u32, (Vec<i64>, Vec<api::v1::flow::TimeRange>)> =
+            HashMap::new();
         for r in reqs.requests {
             let tid = TableId::from(r.table_id);
             let entry = group_by_table_id.entry(tid).or_default();
-            entry.extend(r.timestamps);
+            entry.0.extend(r.timestamps);
+            entry.1.extend(r.time_ranges);
         }
         let tids = group_by_table_id.keys().cloned().collect::<Vec<TableId>>();
         let table_infos =
@@ -174,7 +177,7 @@ impl BatchingEngine {
 
         let group_by_table_name = group_by_table_id
             .into_iter()
-            .filter_map(|(id, timestamps)| {
+            .filter_map(|(id, (timestamps, time_ranges))| {
                 let table_name = table_infos.get(&id).map(|info| info.table_name());
                 let Some(table_name) = table_name else {
                     warn!("Failed to get table infos for table id: {:?}", id);
@@ -191,7 +194,7 @@ impl BatchingEngine {
                     .as_timestamp()
                     .unwrap()
                     .unit();
-                Some((table_name, (timestamps, time_index_unit)))
+                Some((table_name, (timestamps, time_ranges, time_index_unit)))
             })
             .collect::<HashMap<_, _>>();
 
@@ -219,13 +222,15 @@ impl BatchingEngine {
 
             let group_by_table_name = group_by_table_name.clone();
             let task = task.clone();
-
             let handle: JoinHandle<Result<(), Error>> = tokio::spawn(async move {
                 let src_table_names = &task.config.source_table_names;
                 let mut all_dirty_windows = HashSet::new();
+                let mut all_dirty_ranges = Vec::new();
                 let mut is_dirty = false;
                 for src_table_name in src_table_names {
-                    if let Some((timestamps, unit)) = group_by_table_name.get(src_table_name) {
+                    if let Some((timestamps, time_ranges, unit)) =
+                        group_by_table_name.get(src_table_name)
+                    {
                         let Some(expr) = &task.config.time_window_expr else {
                             is_dirty = true;
                             continue;
@@ -239,6 +244,21 @@ impl BatchingEngine {
                                 })?;
                             all_dirty_windows.insert(align_start);
                         }
+                        for time_range in time_ranges {
+                            if time_range.end_exclusive <= time_range.start_inclusive {
+                                warn!(
+                                    "Ignoring invalid dirty time range with start_inclusive={} >= end_exclusive={}",
+                                    time_range.start_inclusive, time_range.end_exclusive
+                                );
+                                continue;
+                            }
+                            let (align_start, align_end) = DirtyTimeWindows::align_time_window(
+                                common_time::Timestamp::new(time_range.start_inclusive, *unit),
+                                Some(common_time::Timestamp::new(time_range.end_exclusive, *unit)),
+                                expr,
+                            )?;
+                            all_dirty_ranges.push((align_start, align_end));
+                        }
                     }
                 }
                 let mut state = task.state.write().unwrap();
@@ -248,6 +268,9 @@ impl BatchingEngine {
                 let flow_id_label = task.config.flow_id.to_string();
                 for timestamp in all_dirty_windows {
                     state.dirty_time_windows.add_window(timestamp, None);
+                }
+                for (start, end) in all_dirty_ranges {
+                    state.dirty_time_windows.add_window(start, end);
                 }
 
                 METRIC_FLOW_BATCHING_ENGINE_BULK_MARK_TIME_WINDOW

--- a/src/flow/src/batching_mode/engine.rs
+++ b/src/flow/src/batching_mode/engine.rs
@@ -1030,9 +1030,12 @@ impl FlowEngine for BatchingEngine {
 
 #[cfg(test)]
 mod tests {
+    use api::v1::flow::{DirtyWindowRequest, TimeRange};
     use catalog::memory::new_memory_catalog_manager;
     use common_meta::key::TableMetadataManager;
     use common_meta::key::flow::FlowMetadataManager;
+    use common_meta::key::table_route::TableRouteValue;
+    use common_meta::key::test_utils::new_test_table_info_with_name;
     use common_meta::kv_backend::memory::MemoryKvBackend;
     use query::options::QueryOptions;
     use session::context::QueryContext;
@@ -1197,6 +1200,13 @@ GROUP BY l.number, time_window
     }
 
     async fn new_test_task(flow_id: FlowId) -> (BatchingTask, oneshot::Sender<()>) {
+        new_test_task_with_time_window_expr(flow_id, None).await
+    }
+
+    async fn new_test_task_with_time_window_expr(
+        flow_id: FlowId,
+        time_window_expr: Option<TimeWindowExpr>,
+    ) -> (BatchingTask, oneshot::Sender<()>) {
         let query_engine = create_test_query_engine();
         let ctx = QueryContext::arc();
         let plan = sql_to_df_plan(
@@ -1213,7 +1223,7 @@ GROUP BY l.number, time_window
             flow_id,
             query: "SELECT number, ts FROM numbers_with_ts",
             plan,
-            time_window_expr: None,
+            time_window_expr,
             expire_after: None,
             sink_table_name: [
                 "greptime".to_string(),
@@ -1235,6 +1245,90 @@ GROUP BY l.number, time_window
         .unwrap();
 
         (task, tx)
+    }
+
+    #[tokio::test]
+    async fn test_handle_mark_dirty_time_window_with_time_ranges() {
+        let engine = new_test_engine().await;
+
+        // Register the source table info so the engine can resolve the table
+        // name and the time index unit (millisecond).
+        let mut table_info = new_test_table_info_with_name(1, "numbers_with_ts");
+        table_info.catalog_name = "greptime".to_string();
+        table_info.schema_name = "public".to_string();
+        engine
+            .table_meta
+            .create_table_metadata(
+                table_info,
+                TableRouteValue::physical(vec![]),
+                HashMap::new(),
+            )
+            .await
+            .unwrap();
+
+        // Build a task with a 5-second time window expr.
+        let query_engine = create_test_query_engine();
+        let ctx = QueryContext::arc();
+        let plan = sql_to_df_plan(
+            ctx.clone(),
+            query_engine.clone(),
+            "SELECT date_bin(INTERVAL '5 second', ts) AS time_window FROM numbers_with_ts GROUP BY time_window",
+            true,
+        )
+        .await
+        .unwrap();
+        let (column_name, time_window_expr, _, df_schema) = find_time_window_expr(
+            &plan,
+            query_engine.engine_state().catalog_manager().clone(),
+            ctx,
+        )
+        .await
+        .unwrap();
+        let time_window_expr = TimeWindowExpr::from_expr(
+            &time_window_expr.unwrap(),
+            &column_name,
+            &df_schema,
+            &query_engine.engine_state().session_state(),
+        )
+        .unwrap();
+
+        let (task, shutdown_tx) =
+            new_test_task_with_time_window_expr(1, Some(time_window_expr)).await;
+        let task_identity = task.clone();
+        engine.runtime.write().await.insert(1, task, shutdown_tx);
+
+        engine
+            .handle_mark_dirty_time_window(DirtyWindowRequests {
+                requests: vec![DirtyWindowRequest {
+                    table_id: 1,
+                    timestamps: vec![],
+                    time_ranges: vec![
+                        // [3s, 11s) aligns to window start 0s and window end 15s.
+                        TimeRange {
+                            start_inclusive: 3_000,
+                            end_exclusive: 11_000,
+                        },
+                        // Empty and reversed ranges are invalid and skipped.
+                        TimeRange {
+                            start_inclusive: 5_000,
+                            end_exclusive: 5_000,
+                        },
+                        TimeRange {
+                            start_inclusive: 9_000,
+                            end_exclusive: 4_000,
+                        },
+                    ],
+                }],
+            })
+            .await
+            .unwrap();
+
+        let state = task_identity.state.read().unwrap();
+        assert_eq!(1, state.dirty_time_windows.len());
+        assert_eq!(
+            Duration::from_secs(15),
+            state.dirty_time_windows.window_size()
+        );
     }
 
     async fn install_abort_observed_handle(task: &BatchingTask) -> oneshot::Receiver<()> {

--- a/src/flow/src/batching_mode/state.rs
+++ b/src/flow/src/batching_mode/state.rs
@@ -738,7 +738,7 @@ impl DirtyTimeWindows {
                     }
                     .fail()?
                 };
-                self.align_time_window(start, end, time_window_expr)?
+                Self::align_time_window(start, end, time_window_expr)?
             } else {
                 (start, end)
             };
@@ -769,8 +769,9 @@ impl DirtyTimeWindows {
         Ok(ret)
     }
 
-    fn align_time_window(
-        &self,
+    /// Align a time range `[start, end)`(end is optional and exclusive) to
+    /// time window boundaries defined by the time window expr.
+    pub(crate) fn align_time_window(
         start: Timestamp,
         end: Option<Timestamp>,
         time_window_expr: &TimeWindowExpr,
@@ -1180,11 +1181,13 @@ mod test {
                 .unwrap()
                 .unwrap();
 
-            let dirty = DirtyTimeWindows::default();
             for (before_align, expected_after_align) in aligns {
-                let after_align = dirty
-                    .align_time_window(before_align.0, before_align.1, &time_window_expr)
-                    .unwrap();
+                let after_align = DirtyTimeWindows::align_time_window(
+                    before_align.0,
+                    before_align.1,
+                    &time_window_expr,
+                )
+                .unwrap();
                 assert_eq!(expected_after_align, after_align);
             }
         }

--- a/src/flow/src/batching_mode/state.rs
+++ b/src/flow/src/batching_mode/state.rs
@@ -817,12 +817,24 @@ impl DirtyTimeWindows {
 
         // previous time window
         let mut prev_tw = None;
-        for (lower_bound, upper_bound) in std::mem::take(&mut self.windows) {
+        for (mut lower_bound, upper_bound) in std::mem::take(&mut self.windows) {
             // filter out expired time window
-            if let Some(expire_lower_bound) = expire_lower_bound
-                && lower_bound < expire_lower_bound
-            {
-                continue;
+            if let Some(expire_lower_bound) = expire_lower_bound {
+                match upper_bound {
+                    // A bounded range ending at or before the expire bound is
+                    // fully expired, drop it.
+                    Some(upper_bound) if upper_bound <= expire_lower_bound => continue,
+                    // A bounded range crossing the expire bound keeps its
+                    // still-live suffix. The expire bound is aligned to the
+                    // time window boundary by the caller, so the clipped start
+                    // stays aligned.
+                    Some(_) if lower_bound < expire_lower_bound => {
+                        lower_bound = expire_lower_bound;
+                    }
+                    // Unbounded windows keep the start-based behavior.
+                    None if lower_bound < expire_lower_bound => continue,
+                    _ => {}
+                }
             }
 
             let Some(prev_tw) = &mut prev_tw else {
@@ -1204,6 +1216,59 @@ mod test {
                 dirty.add_window(start, end);
             }
             dirty.merge_dirty_time_windows(window_size, None).unwrap();
+            assert_eq!(expected, dirty.windows);
+        }
+
+        // Expire bound handling for bounded ranges vs unbounded windows.
+        let expire_testcases = vec![
+            // A bounded range ending at the expire bound is fully expired.
+            (
+                vec![(Timestamp::new_second(0), Some(Timestamp::new_second(10)))],
+                BTreeMap::from([]),
+            ),
+            // A bounded range ending before the expire bound is fully expired.
+            (
+                vec![(Timestamp::new_second(0), Some(Timestamp::new_second(5)))],
+                BTreeMap::from([]),
+            ),
+            // A bounded range crossing the expire bound keeps its live
+            // suffix: [0s, 15s) with expire 10s becomes [10s, 15s).
+            (
+                vec![(Timestamp::new_second(0), Some(Timestamp::new_second(15)))],
+                BTreeMap::from([(
+                    Timestamp::new_second(10),
+                    Some(Timestamp::new_second(15)),
+                )]),
+            ),
+            // A bounded range starting at the expire bound is kept intact.
+            (
+                vec![(Timestamp::new_second(10), Some(Timestamp::new_second(15)))],
+                BTreeMap::from([(
+                    Timestamp::new_second(10),
+                    Some(Timestamp::new_second(15)),
+                )]),
+            ),
+            // An unbounded window starting before the expire bound is
+            // dropped, preserving the existing start-based behavior.
+            (
+                vec![(Timestamp::new_second(5), None)],
+                BTreeMap::from([]),
+            ),
+            // An unbounded window starting at the expire bound is kept.
+            (
+                vec![(Timestamp::new_second(10), None)],
+                BTreeMap::from([(Timestamp::new_second(10), None)]),
+            ),
+        ];
+
+        for (windows, expected) in expire_testcases {
+            let mut dirty = DirtyTimeWindows::default();
+            for (start, end) in windows {
+                dirty.add_window(start, end);
+            }
+            dirty
+                .merge_dirty_time_windows(window_size, Some(Timestamp::new_second(10)))
+                .unwrap();
             assert_eq!(expected, dirty.windows);
         }
     }

--- a/src/flow/src/batching_mode/state.rs
+++ b/src/flow/src/batching_mode/state.rs
@@ -1161,10 +1161,7 @@ mod test {
                     (Timestamp::new_second(0), Some(Timestamp::new_second(15))),
                     (Timestamp::new_second(5), Some(Timestamp::new_second(10))),
                 ],
-                BTreeMap::from([(
-                    Timestamp::new_second(0),
-                    Some(Timestamp::new_second(15)),
-                )]),
+                BTreeMap::from([(Timestamp::new_second(0), Some(Timestamp::new_second(15)))]),
             ),
             // An unbounded dirty window nested in a bounded range must not
             // shrink the range either: [0s, 15s) merged with 3s (window end
@@ -1174,26 +1171,17 @@ mod test {
                     (Timestamp::new_second(0), Some(Timestamp::new_second(15))),
                     (Timestamp::new_second(3), None),
                 ],
-                BTreeMap::from([(
-                    Timestamp::new_second(0),
-                    Some(Timestamp::new_second(15)),
-                )]),
+                BTreeMap::from([(Timestamp::new_second(0), Some(Timestamp::new_second(15)))]),
             ),
             // Disjoint bounded ranges far apart are kept separate.
             (
                 vec![
                     (Timestamp::new_second(0), Some(Timestamp::new_second(5))),
-                    (
-                        Timestamp::new_second(100),
-                        Some(Timestamp::new_second(110)),
-                    ),
+                    (Timestamp::new_second(100), Some(Timestamp::new_second(110))),
                 ],
                 BTreeMap::from([
                     (Timestamp::new_second(0), Some(Timestamp::new_second(5))),
-                    (
-                        Timestamp::new_second(100),
-                        Some(Timestamp::new_second(110)),
-                    ),
+                    (Timestamp::new_second(100), Some(Timestamp::new_second(110))),
                 ]),
             ),
             // Overlapping bounded ranges are unioned: [0s, 10s) and [5s, 20s)
@@ -1203,10 +1191,7 @@ mod test {
                     (Timestamp::new_second(0), Some(Timestamp::new_second(10))),
                     (Timestamp::new_second(5), Some(Timestamp::new_second(20))),
                 ],
-                BTreeMap::from([(
-                    Timestamp::new_second(0),
-                    Some(Timestamp::new_second(20)),
-                )]),
+                BTreeMap::from([(Timestamp::new_second(0), Some(Timestamp::new_second(20)))]),
             ),
         ];
 
@@ -1235,25 +1220,16 @@ mod test {
             // suffix: [0s, 15s) with expire 10s becomes [10s, 15s).
             (
                 vec![(Timestamp::new_second(0), Some(Timestamp::new_second(15)))],
-                BTreeMap::from([(
-                    Timestamp::new_second(10),
-                    Some(Timestamp::new_second(15)),
-                )]),
+                BTreeMap::from([(Timestamp::new_second(10), Some(Timestamp::new_second(15)))]),
             ),
             // A bounded range starting at the expire bound is kept intact.
             (
                 vec![(Timestamp::new_second(10), Some(Timestamp::new_second(15)))],
-                BTreeMap::from([(
-                    Timestamp::new_second(10),
-                    Some(Timestamp::new_second(15)),
-                )]),
+                BTreeMap::from([(Timestamp::new_second(10), Some(Timestamp::new_second(15)))]),
             ),
             // An unbounded window starting before the expire bound is
             // dropped, preserving the existing start-based behavior.
-            (
-                vec![(Timestamp::new_second(5), None)],
-                BTreeMap::from([]),
-            ),
+            (vec![(Timestamp::new_second(5), None)], BTreeMap::from([])),
             // An unbounded window starting at the expire bound is kept.
             (
                 vec![(Timestamp::new_second(10), None)],

--- a/src/flow/src/batching_mode/state.rs
+++ b/src/flow/src/batching_mode/state.rs
@@ -848,7 +848,9 @@ impl DirtyTimeWindows {
                 .map(|dist| dist <= window_size * self.time_window_merge_threshold as i32)
                 .unwrap_or(false)
             {
-                prev_tw.1 = Some(cur_upper);
+                // Union the two windows: the current window may be contained
+                // in the previous one, so keep the larger upper bound.
+                prev_tw.1 = Some(prev_upper.max(cur_upper));
             } else {
                 new_windows.insert(prev_tw.0, prev_tw.1);
                 *prev_tw = (lower_bound, Some(cur_upper));
@@ -1133,6 +1135,76 @@ mod test {
                 .as_ref()
                 .map(|e| unparser.expr_to_sql(e).unwrap().to_string());
             assert_eq!(expected_filter_expr, to_sql.as_deref());
+        }
+    }
+
+    #[test]
+    fn test_merge_dirty_time_windows_with_bounded_ranges() {
+        let window_size = chrono::Duration::seconds(5);
+        let testcases = vec![
+            // A contained bounded range must not shrink the containing window:
+            // [0s, 15s) merged with nested [5s, 10s) stays [0s, 15s).
+            (
+                vec![
+                    (Timestamp::new_second(0), Some(Timestamp::new_second(15))),
+                    (Timestamp::new_second(5), Some(Timestamp::new_second(10))),
+                ],
+                BTreeMap::from([(
+                    Timestamp::new_second(0),
+                    Some(Timestamp::new_second(15)),
+                )]),
+            ),
+            // An unbounded dirty window nested in a bounded range must not
+            // shrink the range either: [0s, 15s) merged with 3s (window end
+            // 8s) stays [0s, 15s).
+            (
+                vec![
+                    (Timestamp::new_second(0), Some(Timestamp::new_second(15))),
+                    (Timestamp::new_second(3), None),
+                ],
+                BTreeMap::from([(
+                    Timestamp::new_second(0),
+                    Some(Timestamp::new_second(15)),
+                )]),
+            ),
+            // Disjoint bounded ranges far apart are kept separate.
+            (
+                vec![
+                    (Timestamp::new_second(0), Some(Timestamp::new_second(5))),
+                    (
+                        Timestamp::new_second(100),
+                        Some(Timestamp::new_second(110)),
+                    ),
+                ],
+                BTreeMap::from([
+                    (Timestamp::new_second(0), Some(Timestamp::new_second(5))),
+                    (
+                        Timestamp::new_second(100),
+                        Some(Timestamp::new_second(110)),
+                    ),
+                ]),
+            ),
+            // Overlapping bounded ranges are unioned: [0s, 10s) and [5s, 20s)
+            // become [0s, 20s).
+            (
+                vec![
+                    (Timestamp::new_second(0), Some(Timestamp::new_second(10))),
+                    (Timestamp::new_second(5), Some(Timestamp::new_second(20))),
+                ],
+                BTreeMap::from([(
+                    Timestamp::new_second(0),
+                    Some(Timestamp::new_second(20)),
+                )]),
+            ),
+        ];
+
+        for (windows, expected) in testcases {
+            let mut dirty = DirtyTimeWindows::default();
+            for (start, end) in windows {
+                dirty.add_window(start, end);
+            }
+            dirty.merge_dirty_time_windows(window_size, None).unwrap();
+            assert_eq!(expected, dirty.windows);
         }
     }
 

--- a/src/flow/src/batching_mode/state.rs
+++ b/src/flow/src/batching_mode/state.rs
@@ -769,7 +769,7 @@ impl DirtyTimeWindows {
         Ok(ret)
     }
 
-    /// Align a time range `[start, end)`(end is optional and exclusive) to
+    /// Align a time range `[start, end)` (end is optional and exclusive) to
     /// time window boundaries defined by the time window expr.
     pub(crate) fn align_time_window(
         start: Timestamp,

--- a/src/operator/src/bulk_insert.rs
+++ b/src/operator/src/bulk_insert.rs
@@ -303,6 +303,7 @@ impl Inserter {
                             requests: vec![DirtyWindowRequest {
                                 table_id,
                                 timestamps,
+                                time_ranges: vec![],
                             }],
                         })
                         .await


### PR DESCRIPTION
## Summary

- Bump greptime-proto to include the new `time_ranges` field on `DirtyWindowRequest` (GreptimeTeam/greptime-proto#330). Note: the proto PR is still open; the rev currently pins its head commit `a618b744` and should be updated once it merges.
- Handle `DirtyWindowRequest::time_ranges` in `BatchingEngine::handle_mark_dirty_time_window`: each `[start_inclusive, end_exclusive)` range is aligned to time window boundaries (via the now-`pub(crate)` `DirtyTimeWindows::align_time_window`) and inserted as a dirty window with an explicit end, alongside the existing per-timestamp dirty marking.
- Flows without a `time_window_expr` fall back to `set_dirty()`, same as the timestamp path; invalid ranges (`end <= start`) are warned and skipped.
- Fix the `DirtyWindowRequest` construction site in `operator/bulk_insert.rs` for the new field.

## Checklist

- [x] `cargo check --workspace`
- [x] `cargo clippy -p flow -p operator --all-targets` (no warnings)
- [x] `cargo nextest run -p flow` (226 passed)