### PR TITLE
fix: stabilize remote analyze stage ordering

### DIFF
--- a/src/query/src/dist_plan/merge_scan.rs
+++ b/src/query/src/dist_plan/merge_scan.rs
@@ -658,7 +658,7 @@ impl MergeScanExec {
     pub fn sub_stage_metrics(&self) -> Vec<RecordBatchMetrics> {
         let sub_stage_metrics = self.sub_stage_metrics.lock().unwrap();
         let mut metrics: Vec<_> = sub_stage_metrics.iter().collect();
-        metrics.sort_by_key(|(region_id, _)| **region_id);
+        metrics.sort_unstable_by_key(|(region_id, _)| **region_id);
         metrics
             .into_iter()
             .map(|(_, metrics)| metrics.clone())

--- a/src/query/src/dist_plan/merge_scan.rs
+++ b/src/query/src/dist_plan/merge_scan.rs
@@ -656,11 +656,12 @@ impl MergeScanExec {
     }
 
     pub fn sub_stage_metrics(&self) -> Vec<RecordBatchMetrics> {
-        self.sub_stage_metrics
-            .lock()
-            .unwrap()
-            .values()
-            .cloned()
+        let sub_stage_metrics = self.sub_stage_metrics.lock().unwrap();
+        let mut metrics: Vec<_> = sub_stage_metrics.iter().collect();
+        metrics.sort_by_key(|(region_id, _)| **region_id);
+        metrics
+            .into_iter()
+            .map(|(_, metrics)| metrics.clone())
             .collect()
     }
 
@@ -1144,6 +1145,44 @@ mod tests {
         let exec = merge_scan_exec_with_sorted_input(3, 4);
 
         assert!(exec.properties().output_ordering().is_some());
+    }
+
+    #[test]
+    fn sub_stage_metrics_are_sorted_by_region_id() {
+        let exec = merge_scan_exec_with_sorted_input(0, 1);
+        let higher_region = RegionId::new(1024, 2);
+        let lower_region = RegionId::new(1024, 1);
+        let higher_metrics = RecordBatchMetrics {
+            plan_metrics: vec![PlanMetrics {
+                plan: "higher region".to_string(),
+                plan_name: "higher region".to_string(),
+                level: 0,
+                metrics: Vec::new(),
+            }],
+            ..Default::default()
+        };
+        let lower_metrics = RecordBatchMetrics {
+            plan_metrics: vec![PlanMetrics {
+                plan: "lower region".to_string(),
+                plan_name: "lower region".to_string(),
+                level: 0,
+                metrics: Vec::new(),
+            }],
+            ..Default::default()
+        };
+
+        let mut sub_stage_metrics = exec.sub_stage_metrics.lock().unwrap();
+        sub_stage_metrics.insert(higher_region, higher_metrics);
+        sub_stage_metrics.insert(lower_region, lower_metrics);
+        drop(sub_stage_metrics);
+
+        let metrics = exec.sub_stage_metrics();
+        let plans: Vec<_> = metrics
+            .iter()
+            .map(|metrics| metrics.plan_metrics[0].plan.as_str())
+            .collect();
+
+        assert_eq!(plans, ["lower region", "higher region"]);
     }
 
     #[test]

--- a/tests/compatibility/cases/analyze_verbose_remote_metrics_extension/verify.result
+++ b/tests/compatibility/cases/analyze_verbose_remote_metrics_extension/verify.result
@@ -22,12 +22,12 @@ EXPLAIN ANALYZE VERBOSE SELECT count(*) FROM t_analyze_verbose_remote_metrics_ex
 | 1_| 0_|_AggregateExec: mode=Final, gby=[], aggr=[__count_state(t_analyze_verbose_remote_REDACTED
 |_|_|_CoalescePartitionsExec REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[], aggr=[__count_state(t_analyze_verbose_remote_REDACTED
-|_|_|_SeqScan: region=REDACTED, {"partition_count":REDACTED, "projection": ["ts"], "filters": ["host >= Utf8(\"m\") AND host IS NOT NULL"], "flat_format": REDACTED, "REDACTED
+|_|_|_SeqScan: region=REDACTED, {"partition_count":REDACTED, "projection": ["ts"], "filters": ["host < Utf8(\"m\") OR host IS NULL"], "files": REDACTED, "flat_format": REDACTED, "REDACTED
 |_|_|_|
 | 1_| 1_|_AggregateExec: mode=Final, gby=[], aggr=[__count_state(t_analyze_verbose_remote_REDACTED
 |_|_|_CoalescePartitionsExec REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[], aggr=[__count_state(t_analyze_verbose_remote_REDACTED
-|_|_|_SeqScan: region=REDACTED, {"partition_count":REDACTED, "projection": ["ts"], "filters": ["host < Utf8(\"m\") OR host IS NULL"], "files": REDACTED, "flat_format": REDACTED, "REDACTED
+|_|_|_SeqScan: region=REDACTED, {"partition_count":REDACTED, "projection": ["ts"], "filters": ["host >= Utf8(\"m\") AND host IS NOT NULL"], "flat_format": REDACTED, "REDACTED
 |_|_|_|
 |_|_| Total rows: 1_|
 +-+-+-+


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up to #8405.

## What's changed and what's your intention?

`MergeScanExec` stored remote sub-stage metrics in a hash map and returned its values without ordering them. `EXPLAIN ANALYZE` then assigned stage node numbers by enumerating that unstable order, so semantically identical remote scan branches could swap node IDs across runs and make the compatibility snapshot flaky.

This PR:

- sorts sub-stage metrics by `RegionId` before dropping the map keys;
- adds a unit test that inserts regions in reverse order and verifies deterministic output;
- regenerates the affected compatibility snapshot with the stable ascending-region order.

The change only stabilizes diagnostic output ordering. It does not change query execution, APIs, schemas, or persisted data.

Validation:

- `cargo nextest run -p query sub_stage_metrics_are_sorted_by_region_id`
- `analyze_verbose_remote_metrics_extension` compatibility case, generated once through the runner and then rerun successfully
- `git diff --check`

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
