### PR TITLE
fix: restore pg_get_keywords views

### DIFF
--- a/src/catalog/src/table_source.rs
+++ b/src/catalog/src/table_source.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use common_catalog::format_full_table_name;
 use common_query::logical_plan::{SubstraitPlanDecoderRef, rename_logical_plan_columns};
+use datafusion::catalog::TableFunction;
 use datafusion::common::{ResolvedTableReference, TableReference};
 use datafusion::datasource::view::ViewTable;
 use datafusion::datasource::{TableProvider, provider_as_source};
@@ -47,6 +48,7 @@ pub struct DfTableSourceProvider {
     query_ctx: QueryContextRef,
     plan_decoder: SubstraitPlanDecoderRef,
     enable_ident_normalization: bool,
+    persisted_view_table_function: Option<Arc<TableFunction>>,
 }
 
 impl DfTableSourceProvider {
@@ -66,7 +68,17 @@ impl DfTableSourceProvider {
             query_ctx,
             plan_decoder,
             enable_ident_normalization,
+            persisted_view_table_function: None,
         }
+    }
+
+    /// Adds the exact table function used to reconstruct legacy persisted-view markers.
+    pub fn with_persisted_view_table_function(
+        mut self,
+        table_function: Option<Arc<TableFunction>>,
+    ) -> Self {
+        self.persisted_view_table_function = table_function;
+        self
     }
 
     /// Returns the query context.
@@ -147,7 +159,10 @@ impl DfTableSourceProvider {
             })?;
 
         // Build the catalog list provider for deserialization.
-        let catalog_list = Arc::new(DummyCatalogList::new(self.catalog_manager.clone()));
+        let catalog_list = Arc::new(
+            DummyCatalogList::new(self.catalog_manager.clone())
+                .with_persisted_view_table_function(self.persisted_view_table_function.clone()),
+        );
         let logical_plan = self
             .plan_decoder
             .decode(view_info.view_info.clone().into(), catalog_list, false)

--- a/src/catalog/src/table_source/dummy_catalog.rs
+++ b/src/catalog/src/table_source/dummy_catalog.rs
@@ -20,8 +20,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use common_catalog::format_full_table_name;
-use datafusion::catalog::{CatalogProvider, CatalogProviderList, SchemaProvider};
+use datafusion::catalog::{CatalogProvider, CatalogProviderList, SchemaProvider, TableFunction};
 use datafusion::datasource::TableProvider;
+use datafusion::error::DataFusionError;
 use session::context::QueryContextRef;
 use snafu::OptionExt;
 use table::table::adapter::DfTableProviderAdapter;
@@ -34,6 +35,8 @@ use crate::error::TableNotExistSnafu;
 pub struct DummyCatalogList {
     catalog_manager: CatalogManagerRef,
     query_ctx: Option<QueryContextRef>,
+    persisted_view_table_function: Option<Arc<TableFunction>>,
+    persisted_view_resolver: bool,
 }
 
 impl DummyCatalogList {
@@ -42,6 +45,8 @@ impl DummyCatalogList {
         Self {
             catalog_manager,
             query_ctx: None,
+            persisted_view_table_function: None,
+            persisted_view_resolver: false,
         }
     }
 
@@ -53,7 +58,19 @@ impl DummyCatalogList {
         Self {
             catalog_manager,
             query_ctx: Some(query_ctx),
+            persisted_view_table_function: None,
+            persisted_view_resolver: false,
         }
+    }
+
+    /// Enables the compatibility resolver used only for persisted view plans.
+    pub(super) fn with_persisted_view_table_function(
+        mut self,
+        table_function: Option<Arc<TableFunction>>,
+    ) -> Self {
+        self.persisted_view_table_function = table_function;
+        self.persisted_view_resolver = true;
+        self
     }
 }
 
@@ -85,6 +102,8 @@ impl CatalogProviderList for DummyCatalogList {
             catalog_name: catalog_name.to_string(),
             catalog_manager: self.catalog_manager.clone(),
             query_ctx: self.query_ctx.clone(),
+            persisted_view_table_function: self.persisted_view_table_function.clone(),
+            persisted_view_resolver: self.persisted_view_resolver,
         }))
     }
 }
@@ -95,6 +114,8 @@ struct DummyCatalogProvider {
     catalog_name: String,
     catalog_manager: CatalogManagerRef,
     query_ctx: Option<QueryContextRef>,
+    persisted_view_table_function: Option<Arc<TableFunction>>,
+    persisted_view_resolver: bool,
 }
 
 impl CatalogProvider for DummyCatalogProvider {
@@ -112,6 +133,8 @@ impl CatalogProvider for DummyCatalogProvider {
             schema_name: schema_name.to_string(),
             catalog_manager: self.catalog_manager.clone(),
             query_ctx: self.query_ctx.clone(),
+            persisted_view_table_function: self.persisted_view_table_function.clone(),
+            persisted_view_resolver: self.persisted_view_resolver,
         }))
     }
 }
@@ -131,6 +154,8 @@ struct DummySchemaProvider {
     schema_name: String,
     catalog_manager: CatalogManagerRef,
     query_ctx: Option<QueryContextRef>,
+    persisted_view_table_function: Option<Arc<TableFunction>>,
+    persisted_view_resolver: bool,
 }
 
 #[async_trait]
@@ -144,6 +169,21 @@ impl SchemaProvider for DummySchemaProvider {
     }
 
     async fn table(&self, name: &str) -> datafusion::error::Result<Option<Arc<dyn TableProvider>>> {
+        if self.persisted_view_resolver && name == "pg_get_keywords()" {
+            let table_function = self.persisted_view_table_function.as_ref().ok_or_else(|| {
+                DataFusionError::Plan(
+                    "persisted view table function 'pg_get_keywords' is not available".to_string(),
+                )
+            })?;
+            if table_function.name() != "pg_get_keywords" {
+                return Err(DataFusionError::Plan(format!(
+                    "persisted view table function 'pg_get_keywords' was injected as '{}'",
+                    table_function.name()
+                )));
+            }
+            return Ok(Some(table_function.create_table_provider(&[])?));
+        }
+
         let table = self
             .catalog_manager
             .table(
@@ -173,5 +213,155 @@ impl fmt::Debug for DummySchemaProvider {
             .field("catalog_name", &self.catalog_name)
             .field("schema_name", &self.schema_name)
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow::datatypes::Schema;
+    use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
+    use datafusion::catalog::TableFunctionImpl;
+    use datafusion::datasource::empty::EmptyTable;
+    use datafusion::logical_expr::Expr;
+    use datatypes::schema::Schema as GreptimeSchema;
+    use table::metadata::{TableInfoBuilder, TableMetaBuilder};
+    use table::test_util::EmptyTable as GreptimeEmptyTable;
+
+    use super::*;
+    use crate::RegisterTableRequest;
+    use crate::memory::MemoryCatalogManager;
+
+    #[derive(Debug)]
+    struct TestTableFunction {
+        fail: bool,
+    }
+
+    impl TableFunctionImpl for TestTableFunction {
+        fn call(&self, args: &[Expr]) -> datafusion::error::Result<Arc<dyn TableProvider>> {
+            assert!(args.is_empty());
+            if self.fail {
+                return Err(DataFusionError::Plan(
+                    "test table function failure".to_string(),
+                ));
+            }
+            Ok(Arc::new(EmptyTable::new(Arc::new(Schema::empty()))))
+        }
+    }
+
+    fn catalog_manager_with_sentinel() -> CatalogManagerRef {
+        let catalog_manager = MemoryCatalogManager::with_default_setup();
+        let table_info = TableInfoBuilder::new(
+            "pg_get_keywords()",
+            TableMetaBuilder::empty()
+                .schema(Arc::new(GreptimeSchema::new(vec![])))
+                .primary_key_indices(vec![])
+                .value_indices(vec![])
+                .next_column_id(1024)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+        catalog_manager
+            .register_table_sync(RegisterTableRequest {
+                catalog: DEFAULT_CATALOG_NAME.to_string(),
+                schema: DEFAULT_SCHEMA_NAME.to_string(),
+                table_name: "pg_get_keywords()".to_string(),
+                table_id: 1024,
+                table: GreptimeEmptyTable::from_table_info(&table_info),
+            })
+            .unwrap();
+        catalog_manager
+    }
+
+    fn persisted_schema_provider(
+        table_function: Option<Arc<TableFunction>>,
+    ) -> DummySchemaProvider {
+        DummySchemaProvider {
+            catalog_name: "greptime".to_string(),
+            schema_name: "public".to_string(),
+            catalog_manager: MemoryCatalogManager::with_default_setup(),
+            query_ctx: None,
+            persisted_view_table_function: table_function,
+            persisted_view_resolver: true,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_resolve_persisted_view_table_function() {
+        let table_function = Arc::new(TableFunction::new(
+            "pg_get_keywords".to_string(),
+            Arc::new(TestTableFunction { fail: false }),
+        ));
+        assert!(
+            persisted_schema_provider(Some(table_function))
+                .table("pg_get_keywords()")
+                .await
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_persisted_view_resolver_does_not_fallback() {
+        let catalog_manager = catalog_manager_with_sentinel();
+        let generic_catalog = DummyCatalogList::new(catalog_manager.clone());
+        assert!(
+            generic_catalog
+                .catalog("greptime")
+                .unwrap()
+                .schema("public")
+                .unwrap()
+                .table("pg_get_keywords()")
+                .await
+                .unwrap()
+                .is_some()
+        );
+
+        let missing = DummyCatalogList::new(catalog_manager.clone())
+            .with_persisted_view_table_function(None)
+            .catalog("greptime")
+            .unwrap()
+            .schema("public")
+            .unwrap()
+            .table("pg_get_keywords()")
+            .await
+            .unwrap_err();
+        assert!(missing.to_string().contains("not available"));
+
+        let other = DummyCatalogList::new(catalog_manager)
+            .with_persisted_view_table_function(None)
+            .catalog("greptime")
+            .unwrap()
+            .schema("public")
+            .unwrap()
+            .table("other()")
+            .await
+            .unwrap_err();
+        assert!(other.to_string().contains("greptime.public.other()"));
+        assert!(!other.to_string().contains("not available"));
+
+        let mismatched = Arc::new(TableFunction::new(
+            "another_function".to_string(),
+            Arc::new(TestTableFunction { fail: false }),
+        ));
+        let mismatched = persisted_schema_provider(Some(mismatched))
+            .table("pg_get_keywords()")
+            .await
+            .unwrap_err();
+        assert!(mismatched.to_string().contains("was injected as"));
+
+        let failing = Arc::new(TableFunction::new(
+            "pg_get_keywords".to_string(),
+            Arc::new(TestTableFunction { fail: true }),
+        ));
+        let failing = persisted_schema_provider(Some(failing))
+            .table("pg_get_keywords()")
+            .await
+            .unwrap_err();
+        assert_eq!(
+            failing.to_string(),
+            "Error during planning: test table function failure"
+        );
     }
 }

--- a/src/operator/src/statement/ddl.rs
+++ b/src/operator/src/statement/ddl.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::{HashMap, HashSet};
+use std::ops::ControlFlow;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -83,7 +84,10 @@ use sql::statements::create::{
     CreateExternalTable, CreateFlow, CreateTable, CreateTableLike, CreateView, Partitions,
 };
 use sql::statements::statement::Statement;
-use sqlparser::ast::{Expr, Ident, UnaryOperator, Value as ParserValue};
+use sqlparser::ast::{
+    Expr, Ident, ObjectNamePart, TableFactor, UnaryOperator, Value as ParserValue, Visit, VisitMut,
+    Visitor, VisitorMut,
+};
 use store_api::metric_engine_consts::{LOGICAL_TABLE_METADATA_KEY, METRIC_ENGINE_NAME};
 use store_api::mito_engine_options::APPEND_MODE_KEY;
 use substrait::{DFLogicalSubstraitConvertor, SubstraitPlan};
@@ -123,6 +127,115 @@ const ALLOWED_FLOW_OPTIONS: [&str; 2] = [
     DEFER_ON_MISSING_SOURCE_KEY,
     FLOW_EXPERIMENTAL_ENABLE_INCREMENTAL_READ_KEY,
 ];
+
+const PERSISTED_VIEW_TABLE_FUNCTION: &str = "pg_get_keywords";
+
+/// Reject table functions that cannot be reconstructed from persisted view plans.
+fn validate_view_table_functions(
+    query: &sql::statements::query::Query,
+    view_name: &str,
+) -> Result<()> {
+    struct TableFunctionValidator {
+        valid: bool,
+    }
+
+    impl Visitor for TableFunctionValidator {
+        type Break = ();
+
+        fn pre_visit_table_factor(
+            &mut self,
+            table_factor: &TableFactor,
+        ) -> ControlFlow<Self::Break> {
+            match table_factor {
+                TableFactor::Table {
+                    name,
+                    args: Some(args),
+                    with_hints,
+                    version,
+                    with_ordinality,
+                    partitions,
+                    json_path,
+                    sample,
+                    index_hints,
+                    ..
+                } => {
+                    let exact_marker = matches!(
+                        name.0.as_slice(),
+                        [ObjectNamePart::Identifier(Ident {
+                            value,
+                            quote_style,
+                            ..
+                        })] if match quote_style {
+                            None => value.eq_ignore_ascii_case(PERSISTED_VIEW_TABLE_FUNCTION),
+                            Some(_) => value == PERSISTED_VIEW_TABLE_FUNCTION,
+                        }
+                    );
+                    self.valid = exact_marker
+                        && args.args.is_empty()
+                        && args.settings.is_none()
+                        && with_hints.is_empty()
+                        && version.is_none()
+                        && !with_ordinality
+                        && partitions.is_empty()
+                        && json_path.is_none()
+                        && sample.is_none()
+                        && index_hints.is_empty();
+                }
+                TableFactor::Function { .. } | TableFactor::TableFunction { .. } => {
+                    self.valid = false;
+                }
+                _ => return ControlFlow::Continue(()),
+            }
+
+            if self.valid {
+                ControlFlow::Continue(())
+            } else {
+                ControlFlow::Break(())
+            }
+        }
+    }
+
+    let mut validator = TableFunctionValidator { valid: true };
+    let _ = query.inner.visit(&mut validator);
+    ensure!(
+        validator.valid,
+        error::InvalidViewSnafu {
+            msg: format!(
+                "only {PERSISTED_VIEW_TABLE_FUNCTION}() is supported as a table function source"
+            ),
+            view_name: view_name.to_string(),
+        }
+    );
+    Ok(())
+}
+
+/// Canonicalizes the validated compatibility marker for DataFusion's table-function registry.
+fn canonicalize_view_table_functions(query: &mut sql::statements::query::Query) {
+    struct TableFunctionCanonicalizer;
+
+    impl VisitorMut for TableFunctionCanonicalizer {
+        type Break = ();
+
+        fn pre_visit_table_factor(
+            &mut self,
+            table_factor: &mut TableFactor,
+        ) -> ControlFlow<Self::Break> {
+            if let TableFactor::Table { name, args, .. } = table_factor
+                && args.is_some()
+                && let [ObjectNamePart::Identifier(ident)] = name.0.as_mut_slice()
+                && ident
+                    .value
+                    .eq_ignore_ascii_case(PERSISTED_VIEW_TABLE_FUNCTION)
+            {
+                ident.value = PERSISTED_VIEW_TABLE_FUNCTION.to_string();
+                ident.quote_style = None;
+            }
+            ControlFlow::Continue(())
+        }
+    }
+
+    let _ = VisitMut::visit(&mut query.inner, &mut TableFunctionCanonicalizer);
+}
 
 fn build_procedure_id_output(procedure_id: Vec<u8>) -> Result<Output> {
     let procedure_id = String::from_utf8_lossy(&procedure_id).to_string();
@@ -904,8 +1017,11 @@ impl StatementExecutor {
         // convert input into logical plan
         let logical_plan = match &*create_view.query {
             Statement::Query(query) => {
+                let mut query_for_planning = query.clone();
+                validate_view_table_functions(query, &create_view.name.to_string())?;
+                canonicalize_view_table_functions(&mut query_for_planning);
                 self.plan(
-                    &QueryStatement::Sql(Statement::Query(query.clone())),
+                    &QueryStatement::Sql(Statement::Query(query_for_planning)),
                     ctx.clone(),
                 )
                 .await?
@@ -2764,6 +2880,80 @@ mod test {
 
     use super::*;
     use crate::expr_helper;
+
+    fn validate_create_view_query(query: &str) -> Result<()> {
+        let stmt = ParserContext::create_with_dialect(
+            &format!("CREATE VIEW test_view AS {query}"),
+            &GreptimeDbDialect {},
+            ParseOptions::default(),
+        )
+        .unwrap()
+        .pop()
+        .unwrap();
+        let Statement::CreateView(create_view) = stmt else {
+            unreachable!()
+        };
+        let Statement::Query(query) = &*create_view.query else {
+            unreachable!()
+        };
+        validate_view_table_functions(query, "test_view")
+    }
+
+    #[test]
+    fn test_validate_view_table_functions() {
+        for query in [
+            "SELECT * FROM numbers",
+            "SELECT lower('keyword') FROM numbers",
+            "SELECT generate_series(1, 2) FROM numbers",
+            "SELECT * FROM pg_get_keywords() AS keywords",
+            "SELECT * FROM PG_GET_KEYWORDS()",
+            "SELECT * FROM \"pg_get_keywords\"()",
+            "WITH keywords AS (SELECT * FROM pg_get_keywords()) SELECT * FROM keywords",
+            "SELECT * FROM (SELECT * FROM pg_get_keywords() AS keywords) AS nested",
+            "SELECT * FROM numbers JOIN pg_get_keywords() AS keywords ON true",
+        ] {
+            assert!(validate_create_view_query(query).is_ok(), "{query}");
+        }
+
+        for query in [
+            "SELECT * FROM pg_get_keywords(1)",
+            "SELECT * FROM generate_series(1, 2)",
+            "SELECT * FROM \"PG_GET_KEYWORDS\"()",
+            "SELECT * FROM public.pg_get_keywords()",
+            "SELECT * FROM pg_get_keywords() WITH ORDINALITY",
+            "SELECT * FROM pg_get_keywords() WITH (NOLOCK)",
+        ] {
+            assert!(validate_create_view_query(query).is_err(), "{query}");
+        }
+    }
+
+    #[test]
+    fn test_canonicalize_view_table_functions_preserves_original_query() {
+        let stmt = ParserContext::create_with_dialect(
+            "CREATE VIEW test_view AS SELECT * FROM \"pg_get_keywords\"()",
+            &GreptimeDbDialect {},
+            ParseOptions::default(),
+        )
+        .unwrap()
+        .pop()
+        .unwrap();
+        let Statement::CreateView(create_view) = stmt else {
+            unreachable!()
+        };
+        let Statement::Query(query) = &*create_view.query else {
+            unreachable!()
+        };
+        let mut query_for_planning = query.clone();
+        canonicalize_view_table_functions(&mut query_for_planning);
+
+        assert!(query.to_string().contains("\"pg_get_keywords\""));
+        assert!(query_for_planning.to_string().contains("pg_get_keywords()"));
+        assert!(
+            !query_for_planning
+                .to_string()
+                .contains("\"pg_get_keywords\"")
+        );
+    }
 
     #[derive(Default)]
     struct RecordingProcedureExecutor {

--- a/src/query/src/datafusion/planner.rs
+++ b/src/query/src/datafusion/planner.rs
@@ -80,7 +80,8 @@ impl DfContextProviderAdapter {
                 .config_options()
                 .sql_parser
                 .enable_ident_normalization,
-        );
+        )
+        .with_persisted_view_table_function(engine_state.table_function("pg_get_keywords"));
 
         let tables = resolve_tables(table_names, &mut table_provider).await?;
         let file_formats = SessionStateDefaults::default_file_formats()

--- a/src/query/src/planner.rs
+++ b/src/query/src/planner.rs
@@ -217,7 +217,8 @@ impl DfLogicalPlanner {
                 .config_options()
                 .sql_parser
                 .enable_ident_normalization,
-        );
+        )
+        .with_persisted_view_table_function(self.engine_state.table_function("pg_get_keywords"));
 
         let context_provider = DfContextProviderAdapter::try_new(
             self.engine_state.clone(),

--- a/src/query/src/query_engine/default_serializer.rs
+++ b/src/query/src/query_engine/default_serializer.rs
@@ -186,16 +186,26 @@ impl SubstraitPlanDecoder for DefaultPlanDecoder {
 
 #[cfg(test)]
 mod tests {
+    use catalog::{CatalogManagerRef, RegisterTableRequest};
+    use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, NUMBERS_TABLE_ID};
     use datafusion::catalog::TableProvider;
+    use datafusion_common::TableReference;
     use datafusion_expr::{LogicalPlanBuilder, LogicalTableSource, col, lit};
     use datatypes::arrow::datatypes::SchemaRef;
     use session::context::QueryContext;
+    use substrait::substrait_proto_df::proto::Plan;
+    use substrait::substrait_proto_df::proto::plan_rel::RelType as PlanRelType;
+    use substrait::substrait_proto_df::proto::read_rel::ReadType;
+    use substrait::substrait_proto_df::proto::rel::RelType;
+    use table::table::numbers::{NUMBERS_TABLE_NAME, NumbersTable};
 
     use super::*;
     use crate::QueryEngineFactory;
     use crate::dummy_catalog::DummyCatalogList;
     use crate::optimizer::test_util::mock_table_provider;
     use crate::options::QueryOptions;
+    use crate::parser::QueryLanguageParser;
+    use crate::plan::extract_and_rewrite_full_table_names;
 
     fn mock_plan(schema: SchemaRef) -> LogicalPlan {
         let table_source = LogicalTableSource::new(schema);
@@ -208,6 +218,71 @@ mod tests {
             .unwrap()
             .build()
             .unwrap()
+    }
+
+    fn test_engine_with_numbers_table() -> (crate::query_engine::QueryEngineRef, CatalogManagerRef)
+    {
+        let catalog_manager = catalog::memory::new_memory_catalog_manager().unwrap();
+        catalog_manager
+            .register_table_sync(RegisterTableRequest {
+                catalog: DEFAULT_CATALOG_NAME.to_string(),
+                schema: DEFAULT_SCHEMA_NAME.to_string(),
+                table_name: NUMBERS_TABLE_NAME.to_string(),
+                table_id: NUMBERS_TABLE_ID,
+                table: NumbersTable::table(NUMBERS_TABLE_ID),
+            })
+            .unwrap();
+
+        let engine = QueryEngineFactory::new(
+            catalog_manager.clone(),
+            None,
+            None,
+            None,
+            None,
+            false,
+            QueryOptions::default(),
+        )
+        .query_engine();
+        (engine, catalog_manager)
+    }
+
+    async fn plan_sql(
+        engine: &crate::query_engine::QueryEngineRef,
+        query_ctx: &QueryContextRef,
+        sql: &str,
+    ) -> LogicalPlan {
+        let statement = QueryLanguageParser::parse_sql(sql, query_ctx).unwrap();
+        engine
+            .planner()
+            .plan(&statement, query_ctx.clone())
+            .await
+            .unwrap()
+    }
+
+    fn named_table_names(plan: &Plan) -> &[String] {
+        let Some(PlanRelType::Root(root)) =
+            plan.relations.first().and_then(|rel| rel.rel_type.as_ref())
+        else {
+            panic!("expected a root relation");
+        };
+        let Some(RelType::Project(project)) = root
+            .input
+            .as_ref()
+            .and_then(|input| input.rel_type.as_ref())
+        else {
+            panic!("expected the root input to be a project relation");
+        };
+        let Some(RelType::Read(read)) = project
+            .input
+            .as_ref()
+            .and_then(|input| input.rel_type.as_ref())
+        else {
+            panic!("expected the project input to be a read relation");
+        };
+        let Some(ReadType::NamedTable(table)) = read.read_type.as_ref() else {
+            panic!("expected the read relation to be a named table");
+        };
+        &table.names
     }
 
     #[tokio::test]
@@ -247,6 +322,60 @@ mod tests {
             "Filter: devices.k0 = Utf8(\"hello\")
   TableScan: devices",
             decode_plan.to_string(),
+        );
+    }
+
+    #[tokio::test]
+    async fn test_pg_get_keywords_legacy_named_table_shape() {
+        let (engine, _) = test_engine_with_numbers_table();
+        let query_ctx = QueryContext::arc();
+        let plan = plan_sql(&engine, &query_ctx, "SELECT * FROM pg_get_keywords()").await;
+
+        let LogicalPlan::Projection(projection) = &plan else {
+            panic!("expected pg_get_keywords() to have a projection root, got {plan}");
+        };
+        let LogicalPlan::TableScan(scan) = projection.input.as_ref() else {
+            panic!("expected the projection to wrap a TableScan, got {plan}");
+        };
+        let TableReference::Bare { table } = &scan.table_name else {
+            panic!("expected the table function scan to have a bare table reference");
+        };
+        assert_eq!(table.as_ref(), "pg_get_keywords()");
+
+        let (_, rewritten_plan) = extract_and_rewrite_full_table_names(plan, query_ctx).unwrap();
+        let encoded = DFLogicalSubstraitConvertor
+            .encode(&rewritten_plan, DefaultSerializer)
+            .unwrap();
+        let substrait_plan = Plan::decode(encoded).unwrap();
+        assert_eq!(
+            named_table_names(&substrait_plan),
+            &["greptime", "public", "pg_get_keywords()"]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_generic_plan_decoder_does_not_resolve_persisted_view_table_function() {
+        let (engine, catalog_manager) = test_engine_with_numbers_table();
+        let query_ctx = QueryContext::arc();
+        let plan = plan_sql(&engine, &query_ctx, "SELECT * FROM pg_get_keywords()").await;
+        let (_, rewritten_plan) =
+            extract_and_rewrite_full_table_names(plan, query_ctx.clone()).unwrap();
+        let encoded = DFLogicalSubstraitConvertor
+            .encode(&rewritten_plan, DefaultSerializer)
+            .unwrap();
+
+        let decoder = engine.engine_context(query_ctx).new_plan_decoder().unwrap();
+        assert!(
+            decoder
+                .decode(
+                    encoded,
+                    Arc::new(catalog::table_source::dummy_catalog::DummyCatalogList::new(
+                        catalog_manager,
+                    )),
+                    false,
+                )
+                .await
+                .is_err()
         );
     }
 }

--- a/tests/cases/standalone/common/view/view.result
+++ b/tests/cases/standalone/common/view/view.result
@@ -78,6 +78,95 @@ DROP VIEW IF EXISTS v2;
 
 Affected Rows: 0
 
+CREATE VIEW pg_keywords_view AS SELECT * FROM pg_get_keywords();
+
+Affected Rows: 0
+
+SELECT count(*) FROM pg_keywords_view;
+
++----------+
+| count(*) |
++----------+
+| 494      |
++----------+
+
+SELECT count(*) FROM pg_keywords_view;
+
++----------+
+| count(*) |
++----------+
+| 494      |
++----------+
+
+DROP VIEW pg_keywords_view;
+
+Affected Rows: 0
+
+CREATE VIEW pg_keywords_upper_view AS SELECT * FROM PG_GET_KEYWORDS();
+
+Affected Rows: 0
+
+SELECT count(*) FROM pg_keywords_upper_view;
+
++----------+
+| count(*) |
++----------+
+| 494      |
++----------+
+
+SELECT count(*) FROM pg_keywords_upper_view;
+
++----------+
+| count(*) |
++----------+
+| 494      |
++----------+
+
+DROP VIEW pg_keywords_upper_view;
+
+Affected Rows: 0
+
+CREATE VIEW pg_keywords_quoted_view AS SELECT * FROM "pg_get_keywords"();
+
+Affected Rows: 0
+
+SELECT count(*) FROM pg_keywords_quoted_view;
+
++----------+
+| count(*) |
++----------+
+| 494      |
++----------+
+
+SELECT count(*) FROM pg_keywords_quoted_view;
+
++----------+
+| count(*) |
++----------+
+| 494      |
++----------+
+
+DROP VIEW pg_keywords_quoted_view;
+
+Affected Rows: 0
+
+CREATE VIEW rejected_quoted_pg_keywords_view AS SELECT * FROM "PG_GET_KEYWORDS"();
+
+Error: 1004(InvalidArguments), Invalid view "rejected_quoted_pg_keywords_view": only pg_get_keywords() is supported as a table function source
+
+CREATE VIEW rejected_pg_keywords_view AS SELECT * FROM pg_get_keywords(1);
+
+Error: 1004(InvalidArguments), Invalid view "rejected_pg_keywords_view": only pg_get_keywords() is supported as a table function source
+
+CREATE VIEW rejected_udtf_view AS SELECT * FROM generate_series(1, 2);
+
+Error: 1004(InvalidArguments), Invalid view "rejected_udtf_view": only pg_get_keywords() is supported as a table function source
+
+SHOW VIEWS;
+
+++
+++
+
 DROP TABLE t1;
 
 Affected Rows: 0

--- a/tests/cases/standalone/common/view/view.sql
+++ b/tests/cases/standalone/common/view/view.sql
@@ -39,6 +39,38 @@ DROP VIEW v2;
 
 DROP VIEW IF EXISTS v2;
 
+CREATE VIEW pg_keywords_view AS SELECT * FROM pg_get_keywords();
+
+SELECT count(*) FROM pg_keywords_view;
+
+SELECT count(*) FROM pg_keywords_view;
+
+DROP VIEW pg_keywords_view;
+
+CREATE VIEW pg_keywords_upper_view AS SELECT * FROM PG_GET_KEYWORDS();
+
+SELECT count(*) FROM pg_keywords_upper_view;
+
+SELECT count(*) FROM pg_keywords_upper_view;
+
+DROP VIEW pg_keywords_upper_view;
+
+CREATE VIEW pg_keywords_quoted_view AS SELECT * FROM "pg_get_keywords"();
+
+SELECT count(*) FROM pg_keywords_quoted_view;
+
+SELECT count(*) FROM pg_keywords_quoted_view;
+
+DROP VIEW pg_keywords_quoted_view;
+
+CREATE VIEW rejected_quoted_pg_keywords_view AS SELECT * FROM "PG_GET_KEYWORDS"();
+
+CREATE VIEW rejected_pg_keywords_view AS SELECT * FROM pg_get_keywords(1);
+
+CREATE VIEW rejected_udtf_view AS SELECT * FROM generate_series(1, 2);
+
+SHOW VIEWS;
+
 DROP TABLE t1;
 
 SHOW TABLES;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Supersedes the closed draft #8523 with a current-upstream replay.

## What's changed and what's your intention?

Persisted views serialize a `pg_get_keywords()` table-function scan as the legacy named-table marker `greptime.public.pg_get_keywords()`. During view reconstruction, that marker was previously sent through ordinary catalog lookup, which erased the provider identity and made the persisted view unqueryable.

This change:

- injects the registered `pg_get_keywords` table function only into persisted-view SQL resolution;
- reconstructs only the exact legacy `pg_get_keywords()` marker before catalog lookup, without changing generic plan decoding or unknown-marker behavior;
- validates CREATE VIEW table-function sources before metadata submission;
- accepts unquoted identifiers case-insensitively and quoted exact-lowercase identifiers, canonicalizing only the cloned query used for planning while retaining the original view definition;
- rejects unsupported/parameterized/modified table-function sources so no unrecoverable view metadata is created; and
- adds focused resolver, serialization, validation, and standalone/distributed sqlness coverage.

No Substrait, protobuf, metadata schema, or persisted marker format changes are introduced. Existing affected `pg_get_keywords()` views remain readable through the compatibility resolver. The exact `pg_get_keywords()` component is intentionally reserved during persisted-view decoding.

Validation:

- `cargo nextest run -p catalog table_source::dummy_catalog::tests`
- focused operator validation/canonicalization nextest controls
- focused query legacy-marker/generic-decoder nextest controls
- `cargo check -p operator -p catalog -p query`
- `cargo sqlness bare -t view --bins-dir /mnt/nvme_rust/rust-targets/qx-043-current-upstream/debug`
- `cargo fmt --check`
- `git diff --check`

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
