### PR TITLE
fix(pipeline)!: check integer narrowing

### DIFF
--- a/src/pipeline/src/etl/transform/transformer/greptime/coerce.rs
+++ b/src/pipeline/src/etl/transform/transformer/greptime/coerce.rs
@@ -23,7 +23,7 @@ use vrl::value::Value as VrlValue;
 
 use crate::error::{
     CoerceIncompatibleTypesSnafu, CoerceJsonTypeToSnafu, CoerceStringToTypeSnafu,
-    CoerceTypeToJsonSnafu, CoerceUnsupportedEpochTypeSnafu, ColumnOptionsSnafu,
+    CoerceTypeToJsonSnafu, CoerceUnsupportedEpochTypeSnafu, ColumnOptionsSnafu, Error,
     InvalidTimestampSnafu, Result, TransformIndexStateMismatchSnafu,
     UnsupportedTypeInPipelineSnafu, VrlRegexValueSnafu,
 };
@@ -223,17 +223,65 @@ fn coerce_bool_value(b: bool, transform: &Transform) -> Result<Option<ValueData>
     Ok(Some(val))
 }
 
+fn handle_coercion_failure(transform: &Transform, error: Error) -> Result<Option<ValueData>> {
+    match transform.on_failure {
+        Some(OnFailure::Ignore) => Ok(None),
+        Some(OnFailure::Default) => match transform.get_default() {
+            Some(default) => Ok(Some(default.clone())),
+            None => transform.get_type_matched_default_val().map(Some),
+        },
+        None => Err(error),
+    }
+}
+
+fn integer_out_of_range<T: std::fmt::Display>(
+    value: T,
+    transform: &Transform,
+) -> Result<Option<ValueData>> {
+    handle_coercion_failure(
+        transform,
+        CoerceIncompatibleTypesSnafu {
+            msg: format!(
+                "integer value `{value}` is out of range for {}",
+                transform.type_.as_str_name()
+            ),
+        }
+        .build(),
+    )
+}
+
 fn coerce_i64_value(n: i64, transform: &Transform) -> Result<Option<ValueData>> {
-    let val = match &transform.type_ {
-        ColumnDataType::Int8 => ValueData::I8Value(n as i32),
-        ColumnDataType::Int16 => ValueData::I16Value(n as i32),
-        ColumnDataType::Int32 => ValueData::I32Value(n as i32),
+    let val = match transform.type_ {
+        ColumnDataType::Int8 => match i8::try_from(n) {
+            Ok(value) => ValueData::I8Value(value.into()),
+            Err(_) => return integer_out_of_range(n, transform),
+        },
+        ColumnDataType::Int16 => match i16::try_from(n) {
+            Ok(value) => ValueData::I16Value(value.into()),
+            Err(_) => return integer_out_of_range(n, transform),
+        },
+        ColumnDataType::Int32 => match i32::try_from(n) {
+            Ok(value) => ValueData::I32Value(value),
+            Err(_) => return integer_out_of_range(n, transform),
+        },
         ColumnDataType::Int64 => ValueData::I64Value(n),
 
-        ColumnDataType::Uint8 => ValueData::U8Value(n as u32),
-        ColumnDataType::Uint16 => ValueData::U16Value(n as u32),
-        ColumnDataType::Uint32 => ValueData::U32Value(n as u32),
-        ColumnDataType::Uint64 => ValueData::U64Value(n as u64),
+        ColumnDataType::Uint8 => match u8::try_from(n) {
+            Ok(value) => ValueData::U8Value(value.into()),
+            Err(_) => return integer_out_of_range(n, transform),
+        },
+        ColumnDataType::Uint16 => match u16::try_from(n) {
+            Ok(value) => ValueData::U16Value(value.into()),
+            Err(_) => return integer_out_of_range(n, transform),
+        },
+        ColumnDataType::Uint32 => match u32::try_from(n) {
+            Ok(value) => ValueData::U32Value(value),
+            Err(_) => return integer_out_of_range(n, transform),
+        },
+        ColumnDataType::Uint64 => match u64::try_from(n) {
+            Ok(value) => ValueData::U64Value(value),
+            Err(_) => return integer_out_of_range(n, transform),
+        },
 
         ColumnDataType::Float32 => ValueData::F32Value(n as f32),
         ColumnDataType::Float64 => ValueData::F64Value(n as f64),
@@ -260,15 +308,36 @@ fn coerce_i64_value(n: i64, transform: &Transform) -> Result<Option<ValueData>> 
 }
 
 fn coerce_u64_value(n: u64, transform: &Transform) -> Result<Option<ValueData>> {
-    let val = match &transform.type_ {
-        ColumnDataType::Int8 => ValueData::I8Value(n as i32),
-        ColumnDataType::Int16 => ValueData::I16Value(n as i32),
-        ColumnDataType::Int32 => ValueData::I32Value(n as i32),
-        ColumnDataType::Int64 => ValueData::I64Value(n as i64),
+    let val = match transform.type_ {
+        ColumnDataType::Int8 => match i8::try_from(n) {
+            Ok(value) => ValueData::I8Value(value.into()),
+            Err(_) => return integer_out_of_range(n, transform),
+        },
+        ColumnDataType::Int16 => match i16::try_from(n) {
+            Ok(value) => ValueData::I16Value(value.into()),
+            Err(_) => return integer_out_of_range(n, transform),
+        },
+        ColumnDataType::Int32 => match i32::try_from(n) {
+            Ok(value) => ValueData::I32Value(value),
+            Err(_) => return integer_out_of_range(n, transform),
+        },
+        ColumnDataType::Int64 => match i64::try_from(n) {
+            Ok(value) => ValueData::I64Value(value),
+            Err(_) => return integer_out_of_range(n, transform),
+        },
 
-        ColumnDataType::Uint8 => ValueData::U8Value(n as u32),
-        ColumnDataType::Uint16 => ValueData::U16Value(n as u32),
-        ColumnDataType::Uint32 => ValueData::U32Value(n as u32),
+        ColumnDataType::Uint8 => match u8::try_from(n) {
+            Ok(value) => ValueData::U8Value(value.into()),
+            Err(_) => return integer_out_of_range(n, transform),
+        },
+        ColumnDataType::Uint16 => match u16::try_from(n) {
+            Ok(value) => ValueData::U16Value(value.into()),
+            Err(_) => return integer_out_of_range(n, transform),
+        },
+        ColumnDataType::Uint32 => match u32::try_from(n) {
+            Ok(value) => ValueData::U32Value(value),
+            Err(_) => return integer_out_of_range(n, transform),
+        },
         ColumnDataType::Uint64 => ValueData::U64Value(n),
 
         ColumnDataType::Float32 => ValueData::F32Value(n as f32),
@@ -277,10 +346,22 @@ fn coerce_u64_value(n: u64, transform: &Transform) -> Result<Option<ValueData>> 
         ColumnDataType::Boolean => ValueData::BoolValue(n != 0),
         ColumnDataType::String => ValueData::StringValue(n.to_string()),
 
-        ColumnDataType::TimestampNanosecond => ValueData::TimestampNanosecondValue(n as i64),
-        ColumnDataType::TimestampMicrosecond => ValueData::TimestampMicrosecondValue(n as i64),
-        ColumnDataType::TimestampMillisecond => ValueData::TimestampMillisecondValue(n as i64),
-        ColumnDataType::TimestampSecond => ValueData::TimestampSecondValue(n as i64),
+        ColumnDataType::TimestampNanosecond => match i64::try_from(n) {
+            Ok(value) => ValueData::TimestampNanosecondValue(value),
+            Err(_) => return integer_out_of_range(n, transform),
+        },
+        ColumnDataType::TimestampMicrosecond => match i64::try_from(n) {
+            Ok(value) => ValueData::TimestampMicrosecondValue(value),
+            Err(_) => return integer_out_of_range(n, transform),
+        },
+        ColumnDataType::TimestampMillisecond => match i64::try_from(n) {
+            Ok(value) => ValueData::TimestampMillisecondValue(value),
+            Err(_) => return integer_out_of_range(n, transform),
+        },
+        ColumnDataType::TimestampSecond => match i64::try_from(n) {
+            Ok(value) => ValueData::TimestampSecondValue(value),
+            Err(_) => return integer_out_of_range(n, transform),
+        },
 
         ColumnDataType::Binary => {
             return CoerceJsonTypeToSnafu {
@@ -342,19 +423,15 @@ fn coerce_f64_value(n: f64, transform: &Transform) -> Result<Option<ValueData>> 
 macro_rules! coerce_string_value {
     ($s:expr, $transform:expr, $type:ident, $parse:ident) => {
         match $s.parse::<$type>() {
-            Ok(v) => Ok(Some(ValueData::$parse(v))),
-            Err(_) => match $transform.on_failure {
-                Some(OnFailure::Ignore) => Ok(None),
-                Some(OnFailure::Default) => match $transform.get_default() {
-                    Some(default) => Ok(Some(default.clone())),
-                    None => $transform.get_type_matched_default_val().map(Some),
-                },
-                None => CoerceStringToTypeSnafu {
+            Ok(v) => Ok(Some(ValueData::$parse(v.into()))),
+            Err(_) => handle_coercion_failure(
+                $transform,
+                CoerceStringToTypeSnafu {
                     s: $s,
                     ty: $transform.type_.as_str_name(),
                 }
-                .fail(),
-            },
+                .build(),
+            ),
         }
     };
 }
@@ -362,10 +439,10 @@ macro_rules! coerce_string_value {
 fn coerce_string_value(s: &str, transform: &Transform) -> Result<Option<ValueData>> {
     match transform.type_ {
         ColumnDataType::Int8 => {
-            coerce_string_value!(s, transform, i32, I8Value)
+            coerce_string_value!(s, transform, i8, I8Value)
         }
         ColumnDataType::Int16 => {
-            coerce_string_value!(s, transform, i32, I16Value)
+            coerce_string_value!(s, transform, i16, I16Value)
         }
         ColumnDataType::Int32 => {
             coerce_string_value!(s, transform, i32, I32Value)
@@ -375,10 +452,10 @@ fn coerce_string_value(s: &str, transform: &Transform) -> Result<Option<ValueDat
         }
 
         ColumnDataType::Uint8 => {
-            coerce_string_value!(s, transform, u32, U8Value)
+            coerce_string_value!(s, transform, u8, U8Value)
         }
         ColumnDataType::Uint16 => {
-            coerce_string_value!(s, transform, u32, U16Value)
+            coerce_string_value!(s, transform, u16, U16Value)
         }
         ColumnDataType::Uint32 => {
             coerce_string_value!(s, transform, u32, U32Value)
@@ -441,6 +518,148 @@ mod tests {
 
     use super::*;
     use crate::etl::field::Fields;
+
+    fn transform(type_: ColumnDataType) -> Transform {
+        Transform {
+            fields: Fields::default(),
+            type_,
+            default: None,
+            index: None,
+            index_options: None,
+            on_failure: None,
+            tag: false,
+        }
+    }
+
+    fn narrow_i64_value(type_: ColumnDataType, value: i64) -> ValueData {
+        match type_ {
+            ColumnDataType::Int8 => ValueData::I8Value(value as i32),
+            ColumnDataType::Int16 => ValueData::I16Value(value as i32),
+            ColumnDataType::Int32 => ValueData::I32Value(value as i32),
+            ColumnDataType::Uint8 => ValueData::U8Value(value as u32),
+            ColumnDataType::Uint16 => ValueData::U16Value(value as u32),
+            ColumnDataType::Uint32 => ValueData::U32Value(value as u32),
+            _ => unreachable!("narrow integer type required"),
+        }
+    }
+
+    fn checked_u64_value(type_: ColumnDataType, value: u64) -> ValueData {
+        match type_ {
+            ColumnDataType::Int8 => ValueData::I8Value(value as i32),
+            ColumnDataType::Int16 => ValueData::I16Value(value as i32),
+            ColumnDataType::Int32 => ValueData::I32Value(value as i32),
+            ColumnDataType::Int64 => ValueData::I64Value(value as i64),
+            ColumnDataType::Uint8 => ValueData::U8Value(value as u32),
+            ColumnDataType::Uint16 => ValueData::U16Value(value as u32),
+            ColumnDataType::Uint32 => ValueData::U32Value(value as u32),
+            ColumnDataType::TimestampNanosecond => {
+                ValueData::TimestampNanosecondValue(value as i64)
+            }
+            ColumnDataType::TimestampMicrosecond => {
+                ValueData::TimestampMicrosecondValue(value as i64)
+            }
+            ColumnDataType::TimestampMillisecond => {
+                ValueData::TimestampMillisecondValue(value as i64)
+            }
+            ColumnDataType::TimestampSecond => ValueData::TimestampSecondValue(value as i64),
+            _ => unreachable!("checked u64 target type required"),
+        }
+    }
+
+    fn assert_out_of_range(
+        result: crate::error::Result<Option<ValueData>>,
+        value: impl std::fmt::Display,
+        type_: ColumnDataType,
+    ) {
+        let error = result.unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "Failed to coerce value: integer value `{value}` is out of range for {}",
+                type_.as_str_name()
+            )
+        );
+        assert!(matches!(
+            error,
+            crate::error::Error::CoerceIncompatibleTypes { .. }
+        ));
+    }
+
+    #[test]
+    fn test_coerce_i64_narrowing_boundaries_and_overflows() {
+        // target type, inclusive minimum, inclusive maximum
+        let cases = [
+            (ColumnDataType::Int8, i8::MIN as i64, i8::MAX as i64),
+            (ColumnDataType::Int16, i16::MIN as i64, i16::MAX as i64),
+            (ColumnDataType::Int32, i32::MIN as i64, i32::MAX as i64),
+            (ColumnDataType::Uint8, u8::MIN as i64, u8::MAX as i64),
+            (ColumnDataType::Uint16, u16::MIN as i64, u16::MAX as i64),
+            (ColumnDataType::Uint32, u32::MIN as i64, u32::MAX as i64),
+        ];
+
+        for (type_, min, max) in cases {
+            let transform = transform(type_);
+            assert_eq!(
+                coerce_i64_value(min, &transform).unwrap(),
+                Some(narrow_i64_value(type_, min)),
+                "{type_:?} minimum"
+            );
+            assert_eq!(
+                coerce_i64_value(max, &transform).unwrap(),
+                Some(narrow_i64_value(type_, max)),
+                "{type_:?} maximum"
+            );
+            assert_out_of_range(coerce_i64_value(min - 1, &transform), min - 1, type_);
+            assert_out_of_range(coerce_i64_value(max + 1, &transform), max + 1, type_);
+        }
+    }
+
+    #[test]
+    fn test_coerce_i64_to_u64_rejects_negative_value() {
+        assert_out_of_range(
+            coerce_i64_value(-1, &transform(ColumnDataType::Uint64)),
+            -1,
+            ColumnDataType::Uint64,
+        );
+    }
+
+    #[test]
+    fn test_coerce_u64_checked_conversions() {
+        // target type, inclusive maximum
+        let cases = [
+            (ColumnDataType::Int8, i8::MAX as u64),
+            (ColumnDataType::Int16, i16::MAX as u64),
+            (ColumnDataType::Int32, i32::MAX as u64),
+            (ColumnDataType::Int64, i64::MAX as u64),
+            (ColumnDataType::Uint8, u8::MAX as u64),
+            (ColumnDataType::Uint16, u16::MAX as u64),
+            (ColumnDataType::Uint32, u32::MAX as u64),
+            (ColumnDataType::TimestampNanosecond, i64::MAX as u64),
+            (ColumnDataType::TimestampMicrosecond, i64::MAX as u64),
+            (ColumnDataType::TimestampMillisecond, i64::MAX as u64),
+            (ColumnDataType::TimestampSecond, i64::MAX as u64),
+        ];
+
+        for (type_, max) in cases {
+            let transform = transform(type_);
+            assert_eq!(
+                coerce_u64_value(max, &transform).unwrap(),
+                Some(checked_u64_value(type_, max)),
+                "{type_:?} maximum"
+            );
+            assert_out_of_range(coerce_u64_value(max + 1, &transform), max + 1, type_);
+        }
+
+        assert_eq!(
+            coerce_u64_value(u64::MAX, &transform(ColumnDataType::Uint64)).unwrap(),
+            Some(ValueData::U64Value(u64::MAX))
+        );
+        assert_out_of_range(
+            coerce_u64_value(u64::MAX, &transform(ColumnDataType::TimestampNanosecond)),
+            u64::MAX,
+            ColumnDataType::TimestampNanosecond,
+        );
+    }
 
     #[test]
     fn test_coerce_string_without_on_failure() {

--- a/src/pipeline/tests/on_failure.rs
+++ b/src/pipeline/tests/on_failure.rs
@@ -13,10 +13,30 @@
 // limitations under the License.
 
 use common_query::prelude::greptime_timestamp;
-use greptime_proto::v1::value::ValueData::{U8Value, U16Value};
+use greptime_proto::v1::value::ValueData;
+use greptime_proto::v1::value::ValueData::{I8Value, U8Value, U16Value};
 use greptime_proto::v1::{ColumnDataType, SemanticType};
 
 mod common;
+
+fn assert_on_failure_value(
+    input: &str,
+    type_: &str,
+    on_failure: &str,
+    default: Option<&str>,
+    expected: Option<ValueData>,
+) {
+    let input = format!(r#"[{{"value": {input}}}]"#);
+    let default = default
+        .map(|value| format!("    default: {value}\n"))
+        .unwrap_or_default();
+    let pipeline = format!(
+        "---\ntransform:\n  - fields:\n      - value\n    type: {type_}\n{default}    on_failure: {on_failure}\n"
+    );
+
+    let output = common::parse_and_exec(&input, &pipeline);
+    assert_eq!(output.rows[0].values[0].value_data, expected);
+}
 
 #[test]
 fn test_on_failure_with_ignore() {
@@ -132,6 +152,55 @@ transform:
 
     assert_eq!(output.schema, expected_schema);
     assert_eq!(output.rows[0].values[0].value_data, Some(U8Value(0)));
+}
+
+#[test]
+fn test_narrowing_overflow_honors_on_failure() {
+    // input, target type, on_failure, explicit default, expected value
+    let cases = [
+        // Numeric narrowing overflows honor ignore and both default modes.
+        ("-1", "uint8", "ignore", None, None),
+        ("-1", "uint8", "default", None, Some(U8Value(0))),
+        ("-1", "uint8", "default", Some("42"), Some(U8Value(42))),
+        ("256", "int8", "ignore", None, None),
+        ("256", "int8", "default", None, Some(I8Value(0))),
+        ("256", "int8", "default", Some("-42"), Some(I8Value(-42))),
+        // Numeric in-range boundaries remain exact.
+        ("0", "uint8", "ignore", None, Some(U8Value(0))),
+        ("255", "uint8", "ignore", None, Some(U8Value(255))),
+        ("-128", "int8", "ignore", None, Some(I8Value(-128))),
+        ("127", "int8", "ignore", None, Some(I8Value(127))),
+        // Numeric-string overflows follow the same policy.
+        (r#""-1""#, "uint8", "ignore", None, None),
+        (r#""-1""#, "uint8", "default", None, Some(U8Value(0))),
+        (r#""-1""#, "uint8", "default", Some("24"), Some(U8Value(24))),
+        (r#""256""#, "int8", "ignore", None, None),
+        (r#""256""#, "int8", "default", None, Some(I8Value(0))),
+        (
+            r#""256""#,
+            "int8",
+            "default",
+            Some("-24"),
+            Some(I8Value(-24)),
+        ),
+        // Numeric-string boundaries remain exact.
+        (r#""0""#, "uint8", "ignore", None, Some(U8Value(0))),
+        (r#""255""#, "uint8", "ignore", None, Some(U8Value(255))),
+        (r#""-128""#, "int8", "ignore", None, Some(I8Value(-128))),
+        (r#""127""#, "int8", "ignore", None, Some(I8Value(127))),
+        // Keep malformed-string default behavior as a control.
+        (
+            r#""not-a-number""#,
+            "int8",
+            "default",
+            Some("-7"),
+            Some(I8Value(-7)),
+        ),
+    ];
+
+    for (input, type_, on_failure, default, expected) in cases {
+        assert_on_failure_value(input, type_, on_failure, default, expected);
+    }
 }
 
 #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

N/A

## What's changed and what's your intention?

Pipeline transforms previously used unchecked integer casts when converting integral inputs to narrower declared types. For example, `-1` converted to `uint8` was materialized as `255`, while `256` converted to `int8` became `0`. Because those casts returned a value, the transform's `on_failure` policy was bypassed.

This PR:

- validates integral inputs against the logical width of signed and unsigned target types before widening them into protobuf backing fields;
- routes out-of-range integral values through the configured `on_failure` policy (`ignore`, explicit/implicit `default`, or a strict coercion error);
- parses narrow numeric strings as `i8`/`i16`/`u8`/`u16` so string inputs follow the same range rules;
- hardens the latent `u64` conversion path, including signed and timestamp-backed targets;
- adds focused strict-boundary, policy, numeric-string, in-range, and malformed-string controls.

### Compatibility

This intentionally changes behavior for out-of-range integral values. Inputs that previously relied on modulo wrapping now produce a strict error, null, or default according to `on_failure`. Silent wrapping is data corruption for a declared narrow type, so this PR does not retain a legacy wrapping mode.

There is no API shape, schema, wire-format, or persisted-format change, and existing stored data is unaffected.

### Known limitation / follow-up

Float-to-integral coercion remains unchanged and still needs a separate semantics decision covering fractional values, infinities, negative-to-unsigned conversion, and range handling. This PR is intentionally scoped to integral and numeric-string sources.

### Validation

- Focused checked-conversion unit tests: 3 passed.
- Full `on_failure` integration test binary: 5 passed.
- Affected crate suite before the final rebase: 143 passed; all-target/all-feature clippy passed with warnings denied.
- After rebasing onto current `upstream/main`, rebuilt GreptimeDB and verified the real `POST /v1/pipelines/_dryrun` path with numeric overflow, numeric-string overflow, signed/unsigned boundaries, and malformed-string controls.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
