### PR TITLE
fix: bind Prom remote read schema per query

### DIFF
--- a/src/frontend/src/instance/prom_store.rs
+++ b/src/frontend/src/instance/prom_store.rs
@@ -28,7 +28,7 @@ use auth::{
     PermissionTableTargets,
 };
 use client::OutputData;
-use common_catalog::format_full_table_name;
+use common_catalog::{format_full_table_name, parse_optional_catalog_and_schema_from_db_string};
 use common_error::ext::BoxedError;
 use common_query::Output;
 use common_query::prelude::GREPTIME_PHYSICAL_TABLE;
@@ -39,6 +39,7 @@ use operator::insert::{
 };
 use operator::statement::StatementExecutor;
 use prost::Message;
+use query::query_engine::options::{QueryOptions, validate_catalog_and_schema};
 use servers::error::{self, AuthSnafu, Result as ServerResult};
 use servers::http::header::{CONTENT_ENCODING_SNAPPY, CONTENT_TYPE_PROTOBUF, collect_plan_metrics};
 use servers::http::prom_store::PHYSICAL_TABLE_PARAM;
@@ -120,6 +121,24 @@ fn negotiate_response_type(accepted_response_types: &[i32]) -> ServerResult<Resp
     Ok(ResponseType::try_from(*response_type).unwrap())
 }
 
+fn resolve_remote_query_target(
+    ctx: &QueryContextRef,
+    query: &Query,
+    table_name: &str,
+) -> PermissionTableTarget {
+    match prom_store::extract_schema_from_query(query) {
+        Some(database) => {
+            let (catalog, schema) = parse_optional_catalog_and_schema_from_db_string(&database);
+            PermissionTableTarget::new(
+                catalog.unwrap_or_else(|| ctx.current_catalog().to_string()),
+                schema,
+                table_name,
+            )
+        }
+        None => PermissionTableTarget::new(ctx.current_catalog(), ctx.current_schema(), table_name),
+    }
+}
+
 #[instrument(skip_all, fields(table_name))]
 async fn to_query_result(table_name: &str, output: Output) -> ServerResult<QueryResult> {
     let OutputData::Stream(stream) = output.data else {
@@ -179,21 +198,18 @@ impl Instance {
         &self,
         ctx: QueryContextRef,
         queries: &[Query],
-        table_names: &[String],
+        query_targets: &[PermissionTableTarget],
     ) -> ServerResult<Vec<(String, Output)>> {
         let mut results = Vec::with_capacity(queries.len());
 
-        let catalog_name = ctx.current_catalog();
-        let schema_name = ctx.current_schema();
-
-        for (query, table_name) in queries.iter().zip(table_names) {
+        for (query, target) in queries.iter().zip(query_targets) {
             let output = self
-                .handle_remote_query(&ctx, catalog_name, &schema_name, table_name, query)
+                .handle_remote_query(&ctx, &target.catalog, &target.schema, &target.table, query)
                 .await
                 .map_err(BoxedError::new)
                 .context(error::ExecuteQuerySnafu)?;
 
-            results.push((table_name.clone(), output));
+            results.push((target.table.clone(), output));
         }
         Ok(results)
     }
@@ -472,16 +488,27 @@ impl PromStoreProtocolHandler for Instance {
             .iter()
             .map(prom_store::table_name)
             .collect::<ServerResult<Vec<_>>>()?;
-        let catalog = ctx.current_catalog();
-        let schema = ctx.current_schema();
+        let query_targets = request
+            .queries
+            .iter()
+            .zip(&table_names)
+            .map(|(query, table_name)| resolve_remote_query_target(&ctx, query, table_name))
+            .collect::<Vec<_>>();
+        let disallow_cross_catalog_query = self
+            .plugins
+            .get::<QueryOptions>()
+            .map(|opts| opts.disallow_cross_catalog_query)
+            .unwrap_or_default();
+        if disallow_cross_catalog_query {
+            for target in &query_targets {
+                validate_catalog_and_schema(&target.catalog, &target.schema, &ctx)
+                    .map_err(BoxedError::new)
+                    .context(error::ExecuteQuerySnafu)?;
+            }
+        }
         let targets = self
             .resolve_query_permission_targets(
-                PermissionTableTargets::resolved(
-                    table_names
-                        .iter()
-                        .map(|table| PermissionTableTarget::new(catalog, &schema, table))
-                        .collect(),
-                ),
+                PermissionTableTargets::resolved(query_targets.clone()),
                 &ctx,
             )
             .await?;
@@ -492,7 +519,7 @@ impl PromStoreProtocolHandler for Instance {
 
         // TODO(dennis): use read_hints to speedup query if possible
         let results = self
-            .handle_remote_queries(ctx, &request.queries, &table_names)
+            .handle_remote_queries(ctx, &request.queries, &query_targets)
             .await?;
 
         match response_type {
@@ -683,6 +710,7 @@ impl PromStoreProtocolHandler for ExportMetricHandler {
 mod tests {
     use std::sync::Arc;
 
+    use api::prom_store::remote::LabelMatcher;
     use session::context::QueryContext;
 
     use super::*;
@@ -745,5 +773,56 @@ mod tests {
                 .get(PHYSICAL_TABLE_METADATA_KEY)
                 .map(String::as_str)
         );
+    }
+
+    fn query_with_database(database: &str) -> Query {
+        Query {
+            matchers: vec![LabelMatcher {
+                name: servers::prom_store::DATABASE_LABEL.to_string(),
+                value: database.to_string(),
+                r#type: api::prom_store::remote::label_matcher::Type::Eq as i32,
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_resolve_remote_query_target() {
+        let ctx = Arc::new(QueryContext::with("request_catalog", "request_schema"));
+
+        assert_eq!(
+            PermissionTableTarget::new("request_catalog", "request_schema", "fallback_metric"),
+            resolve_remote_query_target(&ctx, &Query::default(), "fallback_metric")
+        );
+        assert_eq!(
+            PermissionTableTarget::new("request_catalog", "selected_schema", "schema_metric"),
+            resolve_remote_query_target(
+                &ctx,
+                &query_with_database("selected_schema"),
+                "schema_metric"
+            )
+        );
+        assert_eq!(
+            PermissionTableTarget::new("selected_catalog", "selected_schema", "catalog_metric"),
+            resolve_remote_query_target(
+                &ctx,
+                &query_with_database("selected_catalog-selected_schema"),
+                "catalog_metric"
+            )
+        );
+    }
+
+    #[test]
+    fn test_resolve_remote_query_target_preserves_context() {
+        let ctx = Arc::new(QueryContext::with("request_catalog", "request_schema"));
+
+        resolve_remote_query_target(
+            &ctx,
+            &query_with_database("selected_catalog-selected_schema"),
+            "metric",
+        );
+
+        assert_eq!("request_catalog", ctx.current_catalog());
+        assert_eq!("request_schema", ctx.current_schema());
     }
 }

--- a/src/servers/src/http/prom_store.rs
+++ b/src/servers/src/http/prom_store.rs
@@ -49,7 +49,7 @@ use crate::prom_remote_write::decode::PromSeriesProcessor;
 use crate::prom_remote_write::decode_remote_write_request;
 use crate::prom_remote_write::v2::{decode_remote_write_v2_request, into_write_requests};
 use crate::prom_remote_write::validation::PromValidationMode;
-use crate::prom_store::{extract_schema_from_read_request, snappy_decompress};
+use crate::prom_store::snappy_decompress;
 use crate::query_handler::{PipelineHandlerRef, PromStoreProtocolHandlerRef, PromStoreResponse};
 
 pub const PHYSICAL_TABLE_PARAM: &str = "physical_table";
@@ -752,11 +752,6 @@ pub async fn remote_read(
     query_ctx.set_channel(Channel::Prometheus);
 
     let request = decode_remote_read_request(body).await?;
-
-    // Extract schema from special labels and set it in query context
-    if let Some(schema) = extract_schema_from_read_request(&request) {
-        query_ctx.set_current_schema(&schema);
-    }
 
     let query_ctx = Arc::new(query_ctx);
     let _timer = crate::metrics::METRIC_HTTP_PROM_STORE_READ_ELAPSED

--- a/src/servers/src/prom_store.rs
+++ b/src/servers/src/prom_store.rs
@@ -19,7 +19,7 @@ use std::collections::BTreeMap;
 use std::hash::{Hash, Hasher};
 
 use api::prom_store::remote::label_matcher::Type as MatcherType;
-use api::prom_store::remote::{Label, Query, ReadRequest, Sample, TimeSeries, WriteRequest};
+use api::prom_store::remote::{Label, Query, Sample, TimeSeries, WriteRequest};
 use api::v1::RowInsertRequests;
 use arrow::array::{Array, AsArray};
 use arrow::datatypes::{Float64Type, TimestampMillisecondType};
@@ -121,19 +121,15 @@ pub fn table_name(q: &Query) -> Result<String> {
     Ok(matcher.value.clone())
 }
 
-/// Extract schema from remote read request. Returns the first schema found from any query's matchers.
-pub fn extract_schema_from_read_request(request: &ReadRequest) -> Option<String> {
-    for query in &request.queries {
-        for matcher in &query.matchers {
-            if is_database_selection_label(&matcher.name)
-                && matcher.r#type == MatcherType::Eq as i32
-            {
-                return Some(matcher.value.clone());
-            }
-        }
-    }
-
-    None
+/// Extract database selector from a remote read query.
+pub fn extract_schema_from_query(query: &Query) -> Option<String> {
+    query
+        .matchers
+        .iter()
+        .find(|matcher| {
+            is_database_selection_label(&matcher.name) && matcher.r#type == MatcherType::Eq as i32
+        })
+        .map(|matcher| matcher.value.clone())
 }
 
 /// Create a DataFrame from a remote Query
@@ -691,6 +687,38 @@ mod tests {
                 Err(error::Error::InvalidPromRemoteRequest { .. })
             ));
         }
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn test_extract_schema_from_query() {
+        let query = Query::default();
+        assert_eq!(None, extract_schema_from_query(&query));
+
+        for label in [DATABASE_LABEL, DATABASE_LABEL_ALT, SCHEMA_LABEL] {
+            let query = Query {
+                matchers: vec![LabelMatcher {
+                    name: label.to_string(),
+                    value: "selected_schema".to_string(),
+                    r#type: EQ_TYPE,
+                }],
+                ..Default::default()
+            };
+            assert_eq!(
+                Some("selected_schema".to_string()),
+                extract_schema_from_query(&query)
+            );
+        }
+
+        let query = Query {
+            matchers: vec![LabelMatcher {
+                name: DATABASE_LABEL.to_string(),
+                value: "selected_schema".to_string(),
+                r#type: NEQ_TYPE,
+            }],
+            ..Default::default()
+        };
+        assert_eq!(None, extract_schema_from_query(&query));
     }
 
     #[test]

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -2977,37 +2977,16 @@ pub async fn test_prometheus_remote_write_with_pipeline(store_type: StorageType)
     guard.remove_all().await;
 }
 
-pub async fn test_prometheus_remote_schema_labels(store_type: StorageType) {
-    common_telemetry::init_default_ut_logging();
-    let (app, mut guard) =
-        setup_test_prom_app_with_frontend(store_type, "test_prometheus_remote_schema_labels").await;
-    let client = TestClient::new(app).await;
-
-    // Create test schemas
-    let res = client
-        .post("/v1/sql?sql=create database test_schema_1")
-        .header("Content-Type", "application/x-www-form-urlencoded")
-        .send()
-        .await;
-    assert_eq!(res.status(), StatusCode::OK);
-
-    let res = client
-        .post("/v1/sql?sql=create database test_schema_2")
-        .header("Content-Type", "application/x-www-form-urlencoded")
-        .send()
-        .await;
-    assert_eq!(res.status(), StatusCode::OK);
-
-    // Write data with __schema__ label
-    let schema_series = TimeSeries {
+fn qx_077_schema_series(schema: &str, value: f64) -> TimeSeries {
+    TimeSeries {
         labels: vec![
             Label {
                 name: "__name__".to_string(),
-                value: "metric_with_schema".to_string(),
+                value: "qx_077_schema_metric".to_string(),
             },
             Label {
                 name: "__schema__".to_string(),
-                value: "test_schema_1".to_string(),
+                value: schema.to_string(),
             },
             Label {
                 name: "instance".to_string(),
@@ -3015,19 +2994,121 @@ pub async fn test_prometheus_remote_schema_labels(store_type: StorageType) {
             },
         ],
         samples: vec![Sample {
-            value: 100.0,
+            value,
             timestamp: 1000,
         }],
         ..Default::default()
-    };
+    }
+}
 
-    let write_request = WriteRequest {
-        timeseries: vec![schema_series],
+fn qx_077_schema_query(schema: Option<&str>) -> Query {
+    let mut matchers = vec![LabelMatcher {
+        name: "__name__".to_string(),
+        value: "qx_077_schema_metric".to_string(),
+        r#type: MatcherType::Eq as i32,
+    }];
+    if let Some(schema) = schema {
+        matchers.push(LabelMatcher {
+            name: "__schema__".to_string(),
+            value: schema.to_string(),
+            r#type: MatcherType::Eq as i32,
+        });
+    }
+
+    Query {
+        start_timestamp_ms: 500,
+        end_timestamp_ms: 1500,
+        matchers,
+        ..Default::default()
+    }
+}
+
+async fn post_qx_077_remote_read(client: &TestClient, queries: Vec<Query>) -> ReadResponse {
+    let read_request = ReadRequest {
+        queries,
         ..Default::default()
     };
-    let serialized_request = write_request.encode_to_vec();
-    let compressed_request =
-        prom_store::snappy_compress(&serialized_request).expect("failed to encode snappy");
+    let compressed_request = prom_store::snappy_compress(&read_request.encode_to_vec())
+        .expect("failed to encode snappy");
+
+    let response = client
+        .post("/v1/prometheus/read")
+        .body(compressed_request)
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response_body = response.bytes().await;
+    let decompressed_response = prom_store::snappy_decompress(&response_body).unwrap();
+    ReadResponse::decode(decompressed_response.as_slice()).unwrap()
+}
+
+async fn post_qx_077_remote_read_from_schema_a(
+    client: &TestClient,
+    queries: Vec<Query>,
+) -> ReadResponse {
+    let read_request = ReadRequest {
+        queries,
+        ..Default::default()
+    };
+    let compressed_request = prom_store::snappy_compress(&read_request.encode_to_vec())
+        .expect("failed to encode snappy");
+
+    let response = client
+        .post("/v1/prometheus/read")
+        .header(GREPTIME_DB_HEADER_NAME.clone(), "qx_077_schema_a")
+        .body(compressed_request)
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response_body = response.bytes().await;
+    let decompressed_response = prom_store::snappy_decompress(&response_body).unwrap();
+    ReadResponse::decode(decompressed_response.as_slice()).unwrap()
+}
+
+fn qx_077_read_sample_values(read_response: ReadResponse) -> Vec<f64> {
+    read_response
+        .results
+        .into_iter()
+        .map(|result| {
+            assert_eq!(result.timeseries.len(), 1);
+            let timeseries = &result.timeseries[0];
+            assert_eq!(timeseries.samples.len(), 1);
+            assert_eq!(timeseries.samples[0].timestamp, 1000);
+            timeseries.samples[0].value
+        })
+        .collect()
+}
+
+pub async fn test_prometheus_remote_schema_labels(store_type: StorageType) {
+    common_telemetry::init_default_ut_logging();
+    let (app, mut guard) =
+        setup_test_prom_app_with_frontend(store_type, "test_prometheus_remote_schema_labels").await;
+    let client = TestClient::new(app).await;
+
+    const SCHEMA_A: &str = "qx_077_schema_a";
+    const SCHEMA_B: &str = "qx_077_schema_b";
+
+    for schema in [SCHEMA_A, SCHEMA_B] {
+        let res = client
+            .post(&format!("/v1/sql?sql=create database {schema}"))
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .send()
+            .await;
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    // Both series have the same metric, non-schema labels, and timestamp.
+    let write_request = WriteRequest {
+        timeseries: vec![
+            qx_077_schema_series(SCHEMA_A, 101.0),
+            qx_077_schema_series(SCHEMA_B, 202.0),
+        ],
+        ..Default::default()
+    };
+    let compressed_request = prom_store::snappy_compress(&write_request.encode_to_vec())
+        .expect("failed to encode snappy");
 
     let res = client
         .post("/v1/prometheus/write")
@@ -3037,50 +3118,71 @@ pub async fn test_prometheus_remote_schema_labels(store_type: StorageType) {
         .await;
     assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
-    // Read data from test_schema_1 using __schema__ matcher
-    let read_request = ReadRequest {
-        queries: vec![Query {
-            start_timestamp_ms: 500,
-            end_timestamp_ms: 1500,
-            matchers: vec![
-                LabelMatcher {
-                    name: "__name__".to_string(),
-                    value: "metric_with_schema".to_string(),
-                    r#type: MatcherType::Eq as i32,
-                },
-                LabelMatcher {
-                    name: "__schema__".to_string(),
-                    value: "test_schema_1".to_string(),
-                    r#type: MatcherType::Eq as i32,
-                },
+    // Independent controls establish that each selector resolves its own schema.
+    assert_eq!(
+        qx_077_read_sample_values(
+            post_qx_077_remote_read(&client, vec![qx_077_schema_query(Some(SCHEMA_A))]).await,
+        ),
+        vec![101.0]
+    );
+    assert_eq!(
+        qx_077_read_sample_values(
+            post_qx_077_remote_read(&client, vec![qx_077_schema_query(Some(SCHEMA_B))]).await,
+        ),
+        vec![202.0]
+    );
+
+    // Results must stay aligned with the request query order.
+    let forward_values = qx_077_read_sample_values(
+        post_qx_077_remote_read(
+            &client,
+            vec![
+                qx_077_schema_query(Some(SCHEMA_A)),
+                qx_077_schema_query(Some(SCHEMA_B)),
             ],
-            ..Default::default()
-        }],
-        ..Default::default()
-    };
+        )
+        .await,
+    );
+    let reverse_values = qx_077_read_sample_values(
+        post_qx_077_remote_read(
+            &client,
+            vec![
+                qx_077_schema_query(Some(SCHEMA_B)),
+                qx_077_schema_query(Some(SCHEMA_A)),
+            ],
+        )
+        .await,
+    );
+    assert_eq!(
+        (forward_values, reverse_values),
+        (vec![101.0, 202.0], vec![202.0, 101.0])
+    );
 
-    let serialized_read_request = read_request.encode_to_vec();
-    let compressed_read_request =
-        prom_store::snappy_compress(&serialized_read_request).expect("failed to encode snappy");
-
-    let mut result = client
-        .post("/v1/prometheus/read")
-        .body(compressed_read_request)
-        .send()
-        .await;
-    assert_eq!(result.status(), StatusCode::OK);
-
-    let response_body = result.chunk().await.unwrap();
-    let decompressed_response = prom_store::snappy_decompress(&response_body).unwrap();
-    let read_response = ReadResponse::decode(&decompressed_response[..]).unwrap();
-
-    assert_eq!(read_response.results.len(), 1);
-    assert_eq!(read_response.results[0].timeseries.len(), 1);
-
-    let timeseries = &read_response.results[0].timeseries[0];
-    assert_eq!(timeseries.samples.len(), 1);
-    assert_eq!(timeseries.samples[0].value, 100.0);
-    assert_eq!(timeseries.samples[0].timestamp, 1000);
+    // With request database A, unqualified queries must resolve to A independently.
+    let explicit_then_default_values = qx_077_read_sample_values(
+        post_qx_077_remote_read_from_schema_a(
+            &client,
+            vec![
+                qx_077_schema_query(Some(SCHEMA_B)),
+                qx_077_schema_query(None),
+            ],
+        )
+        .await,
+    );
+    let default_then_explicit_values = qx_077_read_sample_values(
+        post_qx_077_remote_read_from_schema_a(
+            &client,
+            vec![
+                qx_077_schema_query(None),
+                qx_077_schema_query(Some(SCHEMA_B)),
+            ],
+        )
+        .await,
+    );
+    assert_eq!(
+        (explicit_then_default_values, default_then_explicit_values),
+        (vec![202.0, 101.0], vec![101.0, 202.0])
+    );
 
     // write data to unknown schema
     let unknown_schema_series = TimeSeries {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

N/A

## What's changed and what's your intention?

Prometheus remote-read requests may contain multiple queries with independent database/schema selectors. Previously, the HTTP handler extracted the first selector across the entire request and mutated one shared query context, causing every later query to read from the first query's schema.

This PR:

- extracts database selectors per remote-read query instead of per request;
- resolves one canonical catalog/schema/table target for each query;
- uses the same ordered targets for cross-catalog validation, table-aware permission checks, and query execution;
- preserves request-schema fallback for queries without an equality selector; and
- adds focused unit and HTTP integration coverage for explicit and mixed-schema query ordering.

There are no persisted-format, wire-format, or user-facing API changes.

Focused validation:

- `CARGO_PROFILE_TEST_DEBUG=0 cargo nextest run -p servers --lib test_extract_schema_from_query`
- `CARGO_PROFILE_TEST_DEBUG=0 cargo nextest run -p frontend --lib test_resolve_remote_query_target`
- focused frontend permission-target unit tests
- `cargo nextest run -p tests-integration --test main integration_http_file_test::test_prometheus_remote_schema_labels`

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
