### PR TITLE
fix(mito2): preserve referenced parquet in fast GC

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -654,7 +654,7 @@
 | `region_engine.mito.gc` | -- | -- | -- |
 | `region_engine.mito.gc.enable` | Bool | `false` | Whether GC is enabled. Need to be the same with metasrv's `gc.enable` or unexpected behavior will occur |
 | `region_engine.mito.gc.lingering_time` | String | `1h` | Lingering time before deleting files.<br/>Should be long enough to allow long running queries to finish.<br/>If set to None, then unused files will be deleted immediately. |
-| `region_engine.mito.gc.unknown_file_lingering_time` | String | `1d` | Lingering time before deleting unknown files (files with undetermined expel time).<br/>Only applies during full file listing GC.<br/>This uses the object's last-modified timestamp as a heuristic (strict less-than comparison);<br/>do not configure this value too small in production to avoid deleting pre-manifest files<br/>from in-progress compaction or flush.<br/>For active/open regions, an unknown file is deleted only if its object last-modified time exceeds this TTL.<br/>If the object store does not provide a last-modified timestamp, the file is conservatively kept.<br/>For dropped regions, unknown files are deleted immediately. |
+| `region_engine.mito.gc.unknown_file_lingering_time` | String | `1d` | Retained for compatibility.<br/>Active/open unknown files are retained to avoid pre-manifest publication races.<br/>Dropped unknown files are deleted immediately.<br/>This value currently does not affect those decisions. |
 | `region_engine.file` | -- | -- | Enable the file engine. |
 | `region_engine.metric` | -- | -- | Metric engine options. |
 | `logging` | -- | -- | The logging options. |

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -714,14 +714,10 @@ enable = false
 ## If set to None, then unused files will be deleted immediately.
 lingering_time = "1h"
 
-## Lingering time before deleting unknown files (files with undetermined expel time).
-## Only applies during full file listing GC.
-## This uses the object's last-modified timestamp as a heuristic (strict less-than comparison);
-## do not configure this value too small in production to avoid deleting pre-manifest files
-## from in-progress compaction or flush.
-## For active/open regions, an unknown file is deleted only if its object last-modified time exceeds this TTL.
-## If the object store does not provide a last-modified timestamp, the file is conservatively kept.
-## For dropped regions, unknown files are deleted immediately.
+## Retained for compatibility.
+## Active/open unknown files are retained to avoid pre-manifest publication races.
+## Dropped unknown files are deleted immediately.
+## This value currently does not affect those decisions.
 unknown_file_lingering_time = "1d"
 
 [[region_engine]]

--- a/src/meta-srv/src/gc/procedure.rs
+++ b/src/meta-srv/src/gc/procedure.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use api::v1::meta::MailboxMessage;
+use common_error::ext::BoxedError;
 use common_meta::instruction::{self, GcRegions, GetFileRefs, GetFileRefsReply, InstructionReply};
 use common_meta::key::TableMetadataManagerRef;
 use common_meta::key::table_repart::TableRepartValue;
@@ -352,19 +353,19 @@ impl BatchGcProcedure {
             .table_route_manager()
             .batch_get_physical_table_routes(&table_ids)
             .await
-            .context(TableMetadataManagerSnafu)?;
+            .map_err(BoxedError::new)
+            .with_context(|_| error::RetryLaterWithSourceSnafu {
+                reason: format!("Failed to get table routes for tables {:?}", table_ids),
+            })?;
 
         if table_routes.len() != table_ids.len() {
             // batch_get_physical_table_routes returns a subset on misses; treat that as error
             for table_id in &table_ids {
                 if !table_routes.contains_key(table_id) {
                     // indicate is a logical table id
-                    return error::InvalidArgumentsSnafu {
-                    err_msg: format!(
-                        "Unexpected logical table route: table {} resolved to physical table regions",
-                        table_id
-                    ),
-                }
+                    return error::RetryLaterSnafu {
+                        reason: format!("Missing table route for involved table {}", table_id),
+                    }
                     .fail();
                 }
             }
@@ -536,13 +537,9 @@ impl BatchGcProcedure {
                     );
                 }
                 Err(e) => {
-                    // Continue with other tables instead of failing completely
-                    // TODO(discord9): consider failing here instead
-                    warn!(
-                        "Failed to get table route for table {}: {}, skipping its regions",
-                        table_id, e
-                    );
-                    continue;
+                    return Err(BoxedError::new(e)).context(error::RetryLaterWithSourceSnafu {
+                        reason: format!("Failed to get table route for table {}", table_id),
+                    });
                 }
             }
         }
@@ -640,6 +637,14 @@ impl BatchGcProcedure {
                         .entry(*src_region)
                         .or_default()
                         .insert(*dst_region);
+                } else {
+                    return error::RetryLaterSnafu {
+                        reason: format!(
+                            "Missing leader route for related destination region {}",
+                            dst_region
+                        ),
+                    }
+                    .fail();
                 } // since read from manifest, no need to send to followers
             }
         }
@@ -1124,8 +1129,11 @@ mod tests {
     use api::v1::meta::mailbox_message::Payload;
     use common_meta::instruction::{GcRegionsReply, InstructionReply};
     use common_meta::key::TableMetadataManager;
+    use common_meta::key::table_route::TableRouteValue;
+    use common_meta::kv_backend::TxnService;
     use common_meta::kv_backend::memory::MemoryKvBackend;
     use common_meta::peer::Peer;
+    use common_meta::rpc::router::{Region, RegionRoute};
     use common_meta::sequence::SequenceBuilder;
     use common_time::util::current_time_millis;
     use store_api::storage::FileId;
@@ -1199,6 +1207,107 @@ mod tests {
         assert_eq!(report.deleted_files[&region_id], Vec::<FileId>::new());
         assert!(!report.processed_regions.contains(&region_id));
         assert!(report.need_retry_regions.contains(&region_id));
+    }
+
+    #[tokio::test]
+    async fn test_get_file_references_fails_when_related_destination_route_is_missing() {
+        let source_region = RegionId::new(1024, 1);
+        let destination_region = RegionId::new(1024, 2);
+        let kv_backend = Arc::new(MemoryKvBackend::new());
+        let table_metadata_manager = Arc::new(TableMetadataManager::new(kv_backend.clone()));
+        let route = PhysicalTableRouteValue::new(vec![
+            RegionRoute {
+                region: Region::new_test(source_region),
+                leader_peer: Some(Peer::new(1, "leader")),
+                follower_peers: vec![],
+                leader_state: None,
+                leader_down_since: None,
+                write_route_policy: None,
+            },
+            RegionRoute {
+                region: Region::new_test(destination_region),
+                leader_peer: None,
+                follower_peers: vec![],
+                leader_state: None,
+                leader_down_since: None,
+                write_route_policy: None,
+            },
+        ]);
+        let (txn, _) = table_metadata_manager
+            .table_route_manager()
+            .table_route_storage()
+            .build_create_txn(1024, &TableRouteValue::Physical(route))
+            .unwrap();
+        kv_backend.txn(txn).await.unwrap();
+        let mut procedure = BatchGcProcedure::new(
+            MailboxContext::new(
+                SequenceBuilder::new("test_missing_related_route", kv_backend.clone()).build(),
+            )
+            .mailbox()
+            .clone(),
+            table_metadata_manager,
+            "localhost".to_string(),
+            vec![source_region],
+            true,
+            Duration::from_secs(10),
+            HashMap::new(),
+        );
+        procedure.data.related_regions =
+            HashMap::from([(source_region, HashSet::from([destination_region]))]);
+
+        let err = procedure.get_file_references().await.unwrap_err();
+        assert!(err.is_retryable());
+        assert!(err.to_string().contains(&destination_region.to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_discover_route_for_regions_fails_retryably_when_table_route_is_missing() {
+        let procedure = batch_gc_procedure();
+        let regions = [RegionId::new(1024, 1)];
+
+        let result = procedure.discover_route_for_regions(&regions).await;
+        let Err(err) = result else {
+            panic!("missing table route unexpectedly returned partial routes");
+        };
+        assert!(err.is_retryable());
+        assert!(err.to_string().contains("table route"));
+    }
+
+    #[tokio::test]
+    async fn test_find_related_regions_fails_retryably_when_logical_physical_route_is_missing() {
+        let logical_table_id = 1024;
+        let physical_table_id = 2048;
+        let region = RegionId::new(logical_table_id, 1);
+        let kv_backend = Arc::new(MemoryKvBackend::new());
+        let table_metadata_manager = Arc::new(TableMetadataManager::new(kv_backend.clone()));
+        let (txn, _) = table_metadata_manager
+            .table_route_manager()
+            .table_route_storage()
+            .build_create_txn(
+                logical_table_id,
+                &TableRouteValue::logical(physical_table_id),
+            )
+            .unwrap();
+        kv_backend.txn(txn).await.unwrap();
+        let procedure = BatchGcProcedure::new(
+            MailboxContext::new(
+                SequenceBuilder::new("test_missing_physical_route", kv_backend).build(),
+            )
+            .mailbox()
+            .clone(),
+            table_metadata_manager,
+            "localhost".to_string(),
+            vec![region],
+            true,
+            Duration::from_secs(10),
+            HashMap::new(),
+        );
+
+        let err = procedure.find_related_regions(&[region]).await.unwrap_err();
+        assert!(err.is_retryable());
+        assert!(err.to_string().contains("table route"));
+        let source = std::error::Error::source(&err).expect("batch lookup source is preserved");
+        assert!(source.to_string().contains(&physical_table_id.to_string()));
     }
 
     #[tokio::test]

--- a/src/mito2/src/gc.rs
+++ b/src/mito2/src/gc.rs
@@ -1086,6 +1086,13 @@ impl LocalGcWorker {
         // When full_file_listing is false, skip expensive list operations and only delete
         // files that are tracked in recently_removed_files
         if !self.full_file_listing {
+            // Parquet files are identified only by file ID. A full file reference also
+            // carries the index version, but that version must not affect Parquet GC.
+            let parquet_tmp_ref_file_ids = in_tmp_ref
+                .iter()
+                .map(|(file_id, _)| *file_id)
+                .collect::<HashSet<_>>();
+
             // Only delete files that:
             // 1. Are in recently_removed_files (tracked in manifest)
             // 2. Are not in use(in manifest or tmp ref)
@@ -1094,9 +1101,9 @@ impl LocalGcWorker {
                 .iter()
                 .filter(|file_id| {
                     let in_use = match file_id {
-                        RemovedFile::File(file_id, index_version) => {
-                            in_manifest.get(file_id) == Some(index_version)
-                                || in_tmp_ref.contains(&(*file_id, *index_version))
+                        RemovedFile::File(file_id, _) => {
+                            in_manifest.contains_key(file_id)
+                                || parquet_tmp_ref_file_ids.contains(file_id)
                         }
                         RemovedFile::Index(file_id, index_version) => {
                             in_manifest.get(file_id) == Some(&Some(*index_version))

--- a/src/mito2/src/gc.rs
+++ b/src/mito2/src/gc.rs
@@ -67,8 +67,6 @@ fn should_delete_file(
     is_linger: bool,
     is_eligible_for_delete: bool,
     is_region_dropped: bool,
-    entry: &Entry,
-    unknown_file_may_linger_until: chrono::DateTime<chrono::Utc>,
 ) -> bool {
     if is_in_manifest || is_in_tmp_ref {
         return false;
@@ -79,24 +77,12 @@ fn should_delete_file(
         return is_eligible_for_delete;
     }
 
-    // Unknown file: not in manifest, tmp_ref, or known removed records.
-    // For dropped regions, unknown files not protected by manifest/tmp refs/cross-region refs
-    // are deleted immediately. This relies on meta collecting FileRefsManifest from related
-    // active regions before issuing dropped-region GC; preserving young unknown files would
-    // also require keeping the table_repart tombstone for retry.
-    // For active/open regions, only delete if the object's last-modified time exceeds the
-    // unknown_file_lingering_time TTL.
-    if is_region_dropped {
-        return true;
-    }
-
-    entry
-        .metadata()
-        .last_modified()
-        .map(|ts| {
-            ts.into_inner().as_millisecond() < unknown_file_may_linger_until.timestamp_millis()
-        })
-        .unwrap_or(false)
+    // Unknown file: not in manifest, tmp_ref, or known removed records. Active
+    // regions retain these files indefinitely to avoid deleting a file that was
+    // flushed or compacted before its manifest publication. Dropped regions can
+    // delete unknown files immediately because they are no longer being
+    // published or queried.
+    is_region_dropped
 }
 
 /// Limit the amount of concurrent GC jobs on the datanode
@@ -155,10 +141,9 @@ pub struct GcConfig {
     ///
     #[serde(with = "humantime_serde")]
     pub lingering_time: Option<Duration>,
-    /// Lingering time before deleting unknown files(files with undetermine expel time).
-    /// expel time is the time when the file is considered as removed, as in removed from the manifest.
-    /// This should only occur rarely, as manifest keep tracks in `removed_files` field
-    /// unless something goes wrong.
+    /// Compatibility setting retained for TOML/config compatibility.
+    /// Unknown files in active/open regions are retained; unknown files in dropped
+    /// regions are deleted immediately.
     #[serde(with = "humantime_serde")]
     pub unknown_file_lingering_time: Duration,
     /// Maximum concurrent list operations per GC job.
@@ -176,9 +161,8 @@ impl Default for GcConfig {
             enable: false,
             // expect long running queries to be finished(or at least be able to notify it's using a deleted file) within a reasonable time
             lingering_time: Some(Duration::from_secs(60 * 60)),
-            // 1 day, for unknown expel time, which is when this file get removed from manifest.
-            // Only applies to full-listing GC for active/open regions. A long default avoids
-            // accidentally deleting pre-manifest files (e.g. compaction/flush still in progress).
+            // Retained for TOML compatibility; active unknown files are kept and dropped
+            // unknown files are deleted immediately, regardless of this value.
             unknown_file_lingering_time: Duration::from_secs(24 * 60 * 60),
             max_concurrent_lister_per_gc_job: 32,
             max_concurrent_gc_job: 4,
@@ -917,7 +901,6 @@ impl LocalGcWorker {
         in_tmp_ref: &HashSet<(FileId, Option<IndexVersion>)>,
         may_linger_files: &HashSet<&RemovedFile>,
         eligible_for_delete: &HashSet<&RemovedFile>,
-        unknown_file_may_linger_until: chrono::DateTime<chrono::Utc>,
     ) -> Vec<RemovedFile> {
         let mut ready_for_delete = vec![];
         // all group by file id for easier checking
@@ -977,8 +960,6 @@ impl LocalGcWorker {
                         is_linger,
                         is_eligible_for_delete,
                         is_region_dropped,
-                        &entry,
-                        unknown_file_may_linger_until,
                     )
                 }
                 FileType::Puffin(version) => {
@@ -1006,8 +987,6 @@ impl LocalGcWorker {
                         is_linger,
                         is_eligible_for_delete,
                         is_region_dropped,
-                        &entry,
-                        unknown_file_may_linger_until,
                     )
                 }
             };
@@ -1059,13 +1038,6 @@ impl LocalGcWorker {
                     .map(|t| now - t)
             })
             .transpose()?;
-
-        let unknown_file_may_linger_until = now
-            - chrono::Duration::from_std(self.opt.unknown_file_lingering_time).with_context(
-                |_| DurationOutOfRangeSnafu {
-                    input: self.opt.unknown_file_lingering_time,
-                },
-            )?;
 
         // files that may linger, which means they are not in use but may still be kept for a while
         let threshold =
@@ -1139,7 +1111,6 @@ impl LocalGcWorker {
             in_tmp_ref,
             &all_may_linger_files,
             &eligible_for_removal,
-            unknown_file_may_linger_until,
         );
 
         Ok(all_unused_files_ready_for_delete)

--- a/src/mito2/src/gc.rs
+++ b/src/mito2/src/gc.rs
@@ -1091,6 +1091,13 @@ impl LocalGcWorker {
         // When full_file_listing is false, skip expensive list operations and only delete
         // files that are tracked in recently_removed_files
         if !self.full_file_listing {
+            // Parquet files are identified only by file ID. A full file reference also
+            // carries the index version, but that version must not affect Parquet GC.
+            let parquet_tmp_ref_file_ids = in_tmp_ref
+                .iter()
+                .map(|(file_id, _)| *file_id)
+                .collect::<HashSet<_>>();
+
             // Only delete files that:
             // 1. Are in recently_removed_files (tracked in manifest)
             // 2. Are not in use(in manifest or tmp ref)
@@ -1099,9 +1106,9 @@ impl LocalGcWorker {
                 .iter()
                 .filter(|file_id| {
                     let in_use = match file_id {
-                        RemovedFile::File(file_id, index_version) => {
-                            in_manifest.get(file_id) == Some(index_version)
-                                || in_tmp_ref.contains(&(*file_id, *index_version))
+                        RemovedFile::File(file_id, _) => {
+                            in_manifest.contains_key(file_id)
+                                || parquet_tmp_ref_file_ids.contains(file_id)
                         }
                         RemovedFile::Index(file_id, index_version) => {
                             in_manifest.get(file_id) == Some(&Some(*index_version))

--- a/src/mito2/src/gc/worker_test.rs
+++ b/src/mito2/src/gc/worker_test.rs
@@ -25,7 +25,7 @@ use object_store::{Entry, ObjectStore, services};
 use store_api::metadata::RegionMetadataRef;
 use store_api::region_engine::RegionEngine as _;
 use store_api::region_request::{RegionCompactRequest, RegionRequest};
-use store_api::storage::{FileRef, FileRefsManifest, RegionId};
+use store_api::storage::{FileId, FileRef, FileRefsManifest, RegionId};
 
 use crate::access_layer::AccessLayerRef;
 use crate::config::MitoConfig;
@@ -69,6 +69,65 @@ async fn create_gc_worker(
     )
     .await
     .unwrap()
+}
+
+#[tokio::test]
+async fn test_fast_gc_respects_parquet_tmp_ref_regardless_of_index_version() {
+    let mut env = TestEnv::new().await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+    let region_id = RegionId::new(1, 1);
+    env.get_schema_metadata_manager()
+        .register_region_table_info(
+            region_id.table_id(),
+            "test_table",
+            "test_catalog",
+            "test_schema",
+            None,
+            env.get_kv_backend(),
+        )
+        .await;
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Create(CreateRequestBuilder::new().build()),
+        )
+        .await
+        .unwrap();
+
+    let region = engine.get_region(region_id).unwrap();
+    let gc_worker = create_gc_worker(
+        &engine,
+        BTreeMap::from([(region_id, Some(region))]),
+        &FileRefsManifest::default(),
+        false,
+    )
+    .await;
+    let file_id = FileId::random();
+    let tmp_refs = HashSet::from([FileRef::new(region_id, file_id, Some(1))]);
+    let in_tmp_ref = tmp_refs
+        .iter()
+        .map(|file_ref| (file_ref.file_id, file_ref.index_version))
+        .collect();
+    let deletable = gc_worker
+        .list_to_be_deleted_files(
+            region_id,
+            false,
+            &HashMap::new(),
+            &in_tmp_ref,
+            BTreeMap::from([(
+                common_time::Timestamp::new_millisecond(0),
+                HashSet::from([
+                    RemovedFile::File(file_id, Some(2)),
+                    RemovedFile::Index(file_id, 1),
+                    RemovedFile::Index(file_id, 3),
+                ]),
+            )]),
+            vec![],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(deletable, vec![RemovedFile::Index(file_id, 3)]);
 }
 
 /// Test insert/flush then truncate can allow gc worker to delete files

--- a/src/mito2/src/gc/worker_test.rs
+++ b/src/mito2/src/gc/worker_test.rs
@@ -26,7 +26,7 @@ use object_store::{Entry, ObjectStore, services};
 use store_api::metadata::RegionMetadataRef;
 use store_api::region_engine::RegionEngine as _;
 use store_api::region_request::{RegionCompactRequest, RegionRequest};
-use store_api::storage::{FileRef, FileRefsManifest, RegionId};
+use store_api::storage::{FileId, FileRef, FileRefsManifest, RegionId};
 
 use crate::access_layer::AccessLayerRef;
 use crate::config::MitoConfig;
@@ -143,6 +143,65 @@ async fn test_gc_worker_ignores_dropping_marker_file() {
     );
     assert!(report.need_retry_regions.is_empty());
     assert_eq!(GC_SKIPPED_UNPARSABLE_FILES.get(), before);
+}
+
+#[tokio::test]
+async fn test_fast_gc_respects_parquet_tmp_ref_regardless_of_index_version() {
+    let mut env = TestEnv::new().await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+    let region_id = RegionId::new(1, 1);
+    env.get_schema_metadata_manager()
+        .register_region_table_info(
+            region_id.table_id(),
+            "test_table",
+            "test_catalog",
+            "test_schema",
+            None,
+            env.get_kv_backend(),
+        )
+        .await;
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Create(CreateRequestBuilder::new().build()),
+        )
+        .await
+        .unwrap();
+
+    let region = engine.get_region(region_id).unwrap();
+    let gc_worker = create_gc_worker(
+        &engine,
+        BTreeMap::from([(region_id, Some(region))]),
+        &FileRefsManifest::default(),
+        false,
+    )
+    .await;
+    let file_id = FileId::random();
+    let tmp_refs = HashSet::from([FileRef::new(region_id, file_id, Some(1))]);
+    let in_tmp_ref = tmp_refs
+        .iter()
+        .map(|file_ref| (file_ref.file_id, file_ref.index_version))
+        .collect();
+    let deletable = gc_worker
+        .list_to_be_deleted_files(
+            region_id,
+            false,
+            &HashMap::new(),
+            &in_tmp_ref,
+            BTreeMap::from([(
+                common_time::Timestamp::new_millisecond(0),
+                HashSet::from([
+                    RemovedFile::File(file_id, Some(2)),
+                    RemovedFile::Index(file_id, 1),
+                    RemovedFile::Index(file_id, 3),
+                ]),
+            )]),
+            vec![],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(deletable, vec![RemovedFile::Index(file_id, 3)]);
 }
 
 /// Test insert/flush then truncate can allow gc worker to delete files

--- a/src/mito2/src/gc/worker_test.rs
+++ b/src/mito2/src/gc/worker_test.rs
@@ -22,7 +22,7 @@ use bytes::Bytes;
 use common_base::Plugins;
 use common_telemetry::init_default_ut_logging;
 use futures::TryStreamExt;
-use object_store::{Entry, ObjectStore, services};
+use object_store::{Entry, ObjectStore};
 use store_api::metadata::RegionMetadataRef;
 use store_api::region_engine::RegionEngine as _;
 use store_api::region_request::{RegionCompactRequest, RegionRequest};
@@ -34,7 +34,7 @@ use crate::engine::MitoEngine;
 use crate::engine::compaction_test::{delete_and_flush, put_and_flush};
 use crate::engine::region_hook::{RegionGcInfo, RegionHook, RegionHookRef};
 use crate::error::UnexpectedSnafu;
-use crate::gc::{GcConfig, LocalGcWorker, should_delete_file};
+use crate::gc::{GcConfig, LocalGcWorker};
 use crate::manifest::action::RemovedFile;
 use crate::metrics::GC_SKIPPED_UNPARSABLE_FILES;
 use crate::region::MitoRegionRef;
@@ -567,16 +567,14 @@ async fn test_gc_worker_compact_with_ref() {
     assert!(report.need_retry_regions.is_empty());
 }
 
-// --- Tests for unknown_file_lingering_time TTL logic ---
+// --- Tests for unknown-file retention policy ---
 
-/// Helper to write a dummy parquet file to an in-memory object store and
-/// retrieve its Entry via listing.
+/// Helper to write a file to an object store and retrieve its Entry via listing.
 async fn write_and_list_entry(store: &ObjectStore, path: &str) -> Entry {
     store
-        .write(path, b"dummy_parquet_content".as_slice())
+        .write(path, b"dummy_file_content".as_slice())
         .await
         .unwrap();
-    // List the parent directory to get the entry.
     let parent = std::path::Path::new(path).parent().and_then(|p| {
         if p.as_os_str().is_empty() {
             None
@@ -586,302 +584,148 @@ async fn write_and_list_entry(store: &ObjectStore, path: &str) -> Entry {
     });
     let prefix = match parent {
         Some(p) => format!("{}/", p.to_str().unwrap()),
-        None => String::new(), // root
+        None => String::new(),
     };
-    let lister = store.lister_with(&prefix).await.unwrap();
-    let entries: Vec<Entry> = lister.try_collect().await.unwrap();
+    let entries: Vec<Entry> = store
+        .lister_with(&prefix)
+        .await
+        .unwrap()
+        .try_collect()
+        .await
+        .unwrap();
     let expected_name = std::path::Path::new(path)
         .file_name()
         .unwrap()
         .to_str()
         .unwrap();
-    match entries.iter().find(|e| e.name() == expected_name) {
-        Some(e) => e.clone(),
-        None => {
-            panic!(
-                "entry '{}' not found when listing prefix '{}'; entries: {:?}",
-                expected_name,
-                prefix,
-                entries.iter().map(|e| e.name()).collect::<Vec<_>>()
-            )
-        }
-    }
+    entries
+        .into_iter()
+        .find(|entry| entry.name() == expected_name)
+        .unwrap_or_else(|| {
+            panic!("entry '{expected_name}' not found when listing prefix '{prefix}'")
+        })
 }
 
-/// Test: active/open region unknown file within TTL (last_modified newer than
-/// threshold) should NOT be deleted.
-/// NOTE: Memory backend leaves `last_modified` as `None`, so this test also
-/// covers the "missing last_modified → keep" conservative behavior.
+async fn create_full_listing_gc_worker() -> (LocalGcWorker, ObjectStore) {
+    let mut env = TestEnv::new().await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+    let region_id = RegionId::new(1, 1);
+    env.get_schema_metadata_manager()
+        .register_region_table_info(
+            region_id.table_id(),
+            "test_table",
+            "test_catalog",
+            "test_schema",
+            None,
+            env.get_kv_backend(),
+        )
+        .await;
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Create(CreateRequestBuilder::new().build()),
+        )
+        .await
+        .unwrap();
+
+    let region = engine.get_region(region_id).unwrap();
+    let store = region.access_layer.object_store().clone();
+    let manifest_version = region.manifest_ctx.manifest().await.manifest_version;
+    let file_ref_manifest = FileRefsManifest {
+        manifest_version: [(region_id, manifest_version)].into(),
+        ..Default::default()
+    };
+    let worker = create_gc_worker(
+        &engine,
+        BTreeMap::from([(region_id, Some(region))]),
+        &file_ref_manifest,
+        true,
+    )
+    .await;
+    (worker, store)
+}
+
 #[tokio::test]
-async fn test_unknown_file_within_ttl_not_deleted() {
-    let builder = services::Memory::default();
-    let store = ObjectStore::new(builder).unwrap().finish();
+async fn test_active_unknown_parquet_and_puffin_are_retained() {
+    let (worker, store) = create_full_listing_gc_worker().await;
+    let region_id = RegionId::new(1, 1);
+    let parquet_id = FileId::random();
+    let puffin_id = FileId::random();
+    let parquet_path = object_store::util::join_path(
+        &worker.access_layer.build_region_dir(region_id),
+        &format!("{parquet_id}.parquet"),
+    );
+    let puffin_path = object_store::util::join_path(
+        &object_store::util::join_dir(&worker.access_layer.build_region_dir(region_id), "index"),
+        &format!("{puffin_id}.1.puffin"),
+    );
+    write_and_list_entry(&store, &parquet_path).await;
+    write_and_list_entry(&store, &puffin_path).await;
 
-    let entry = write_and_list_entry(&store, "test/1.parquet").await;
+    let report = worker.run().await.unwrap();
 
-    // unknown_file_may_linger_until set to epoch (very old) → file is "too young"
-    // since last_modified is ~now.
-    let threshold = chrono::DateTime::from_timestamp(0, 0).unwrap();
-
-    let should_delete = should_delete_file(
-        false, // not in manifest
-        false, // not in tmp_ref
-        false, // not in may_linger
-        false, // not eligible for delete
-        false, // active region (not dropped)
-        &entry, threshold,
+    assert!(
+        report
+            .deleted_files
+            .get(&region_id)
+            .is_none_or(|files| !files.contains(&parquet_id))
     );
     assert!(
-        !should_delete,
-        "Active-region unknown file within TTL should NOT be deleted"
+        report
+            .deleted_indexes
+            .get(&region_id)
+            .is_none_or(|files| !files.contains(&(puffin_id, 1)))
     );
+    assert!(report.need_retry_regions.is_empty());
+    assert!(store.exists(&parquet_path).await.unwrap());
+    assert!(store.exists(&puffin_path).await.unwrap());
 }
 
-/// Test: active/open region unknown file exceeding TTL (last_modified older
-/// than threshold) should be deleted.
 #[tokio::test]
-async fn test_unknown_file_exceeded_ttl_deleted() {
-    // Use Fs backend so that last_modified is properly set on file metadata.
-    let tmp_dir = common_test_util::temp_dir::create_temp_dir("gc_unknown_ttl");
-    let root = tmp_dir.path().to_string_lossy().to_string();
-    let builder = services::Fs::default().root(&root);
-    let store = ObjectStore::new(builder).unwrap().finish();
-
-    let entry = write_and_list_entry(&store, "2.parquet").await;
-
-    // threshold set far into the future → any file with last_modified before now
-    // is guaranteed to be older than the threshold.
-    let threshold = chrono::Utc::now() + chrono::Duration::days(1);
-
-    let should_delete = should_delete_file(
-        false, // not in manifest
-        false, // not in tmp_ref
-        false, // not in may_linger
-        false, // not eligible for delete
-        false, // active region (not dropped)
-        &entry, threshold,
+async fn test_dropped_unknown_parquet_and_puffin_are_deleted() {
+    let (worker, store) = create_full_listing_gc_worker().await;
+    let region_id = RegionId::new(1, 1);
+    let parquet_id = FileId::random();
+    let puffin_id = FileId::random();
+    let parquet_path = object_store::util::join_path(
+        &worker.access_layer.build_region_dir(region_id),
+        &format!("{parquet_id}.parquet"),
     );
-    assert!(
-        should_delete,
-        "Active-region unknown file exceeding TTL should be deleted"
+    let puffin_path = object_store::util::join_path(
+        &object_store::util::join_dir(&worker.access_layer.build_region_dir(region_id), "index"),
+        &format!("{puffin_id}.1.puffin"),
     );
-}
+    let entries = vec![
+        write_and_list_entry(&store, &parquet_path).await,
+        write_and_list_entry(&store, &puffin_path).await,
+    ];
 
-/// Test: dropped region unknown file should always be deleted regardless of TTL.
-#[tokio::test]
-async fn test_unknown_file_dropped_region_deleted() {
-    let builder = services::Memory::default();
-    let store = ObjectStore::new(builder).unwrap().finish();
+    let deletable = worker
+        .list_to_be_deleted_files(
+            region_id,
+            true,
+            &HashMap::new(),
+            &HashSet::new(),
+            BTreeMap::new(),
+            entries,
+        )
+        .await
+        .unwrap();
 
-    let entry = write_and_list_entry(&store, "test/3.parquet").await;
-
-    // Even with threshold far in the past (epoch), dropped region deletes immediately.
-    let threshold = chrono::DateTime::from_timestamp(0, 0).unwrap();
-
-    let should_delete = should_delete_file(
-        false, // not in manifest
-        false, // not in tmp_ref
-        false, // not in may_linger
-        false, // not eligible for delete
-        true,  // region dropped
-        &entry, threshold,
+    assert_eq!(
+        deletable,
+        vec![
+            RemovedFile::File(parquet_id, None),
+            RemovedFile::Index(puffin_id, 1),
+        ]
     );
-    assert!(
-        should_delete,
-        "Dropped region unknown file should be deleted immediately"
-    );
-}
+    assert!(store.exists(&parquet_path).await.unwrap());
+    assert!(store.exists(&puffin_path).await.unwrap());
 
-/// Test: file in manifest should NOT be deleted even if unknown.
-#[tokio::test]
-async fn test_file_in_manifest_not_deleted() {
-    let builder = services::Memory::default();
-    let store = ObjectStore::new(builder).unwrap().finish();
+    worker.delete_files(region_id, &deletable).await.unwrap();
 
-    let entry = write_and_list_entry(&store, "test/4.parquet").await;
-    let threshold = chrono::Utc::now() + chrono::Duration::days(1);
-
-    let should_delete = should_delete_file(
-        true,  // in manifest
-        false, // not in tmp_ref
-        false, false, false, // active region
-        &entry, threshold,
-    );
-    assert!(!should_delete, "File in manifest should NOT be deleted");
-}
-
-/// Test: file in tmp_ref should NOT be deleted even if unknown.
-#[tokio::test]
-async fn test_file_in_tmp_ref_not_deleted() {
-    let builder = services::Memory::default();
-    let store = ObjectStore::new(builder).unwrap().finish();
-
-    let entry = write_and_list_entry(&store, "test/5.parquet").await;
-    let threshold = chrono::Utc::now() + chrono::Duration::days(1);
-
-    let should_delete = should_delete_file(
-        false, true, // in tmp_ref
-        false, false, false, // active region
-        &entry, threshold,
-    );
-    assert!(!should_delete, "File in tmp_ref should NOT be deleted");
-}
-
-/// Test: known removed file that is still lingering should NOT be deleted.
-/// (is_linger=true but is_eligible_for_delete=false)
-#[tokio::test]
-async fn test_known_file_still_lingering_not_deleted() {
-    let builder = services::Memory::default();
-    let store = ObjectStore::new(builder).unwrap().finish();
-
-    let entry = write_and_list_entry(&store, "test/6.parquet").await;
-    let threshold = chrono::Utc::now() + chrono::Duration::days(1);
-
-    let should_delete = should_delete_file(
-        false, false, true,  // is_linger
-        false, // not yet eligible for delete
-        false, &entry, threshold,
-    );
-    assert!(
-        !should_delete,
-        "Known file still in lingering period should NOT be deleted"
-    );
-}
-
-/// Test: known removed file eligible for delete should be deleted.
-/// (is_linger=true and is_eligible_for_delete=true)
-#[tokio::test]
-async fn test_known_file_eligible_for_delete_deleted() {
-    let builder = services::Memory::default();
-    let store = ObjectStore::new(builder).unwrap().finish();
-
-    let entry = write_and_list_entry(&store, "test/7.parquet").await;
-    let threshold = chrono::DateTime::from_timestamp(0, 0).unwrap();
-
-    let should_delete = should_delete_file(
-        false, false, true, // is_linger
-        true, // eligible for delete
-        false, &entry, threshold,
-    );
-    assert!(
-        should_delete,
-        "Known file eligible for delete should be deleted"
-    );
-}
-
-// --- Tests for boundary conditions and explicit "keep" semantics ---
-
-/// Test: when `last_modified` equals the cutoff exactly, the file should be
-/// kept (strict `<` comparison, not `<=`).
-#[tokio::test]
-async fn test_unknown_file_at_cutoff_not_deleted() {
-    // Use Fs backend for real last_modified
-    let tmp_dir = common_test_util::temp_dir::create_temp_dir("gc_at_cutoff");
-    let root = tmp_dir.path().to_string_lossy().to_string();
-    let builder = services::Fs::default().root(&root);
-    let store = ObjectStore::new(builder).unwrap().finish();
-
-    let entry = write_and_list_entry(&store, "cutoff.parquet").await;
-
-    // Set threshold to the actual last_modified → should NOT be deleted (strict <)
-    let actual_mtime_millis = entry
-        .metadata()
-        .last_modified()
-        .map(|ts| ts.into_inner().as_millisecond())
-        .expect("Fs backend must provide last_modified");
-    // Construct a chrono::DateTime at exactly the same millisecond
-    let threshold = chrono::DateTime::from_timestamp_millis(actual_mtime_millis).unwrap();
-
-    let should_delete = should_delete_file(
-        false, // not in manifest
-        false, // not in tmp_ref
-        false, // not in may_linger
-        false, // not eligible for delete
-        false, // active region
-        &entry, threshold,
-    );
-    assert!(
-        !should_delete,
-        "File at exact cutoff (last_modified == threshold) should NOT be deleted (strict < comparison)"
-    );
-}
-
-/// Test: active unknown file with missing `last_modified` (e.g. object store
-/// that does not provide the timestamp) should be conservatively kept.
-#[tokio::test]
-async fn test_missing_last_modified_unknown_kept() {
-    // Memory backend does NOT set last_modified
-    let builder = services::Memory::default();
-    let store = ObjectStore::new(builder).unwrap().finish();
-
-    let entry = write_and_list_entry(&store, "test/missing_mtime.parquet").await;
-    // Verify that last_modified is indeed None
-    assert!(
-        entry.metadata().last_modified().is_none(),
-        "Memory backend must not provide last_modified for this test"
-    );
-
-    // threshold in the far past → should still NOT delete
-    let threshold = chrono::DateTime::from_timestamp(0, 0).unwrap();
-
-    let should_delete = should_delete_file(
-        false, false, false, false, // active unknown
-        false, // active region
-        &entry, threshold,
-    );
-    assert!(
-        !should_delete,
-        "Missing last_modified should keep the file (conservative behavior)"
-    );
-}
-
-/// Test: file in manifest should NOT be deleted even when its object
-/// `last_modified` is very old (far below the TTL cutoff).
-#[tokio::test]
-async fn test_file_in_manifest_old_mtime_kept() {
-    let tmp_dir = common_test_util::temp_dir::create_temp_dir("gc_manifest_old");
-    let root = tmp_dir.path().to_string_lossy().to_string();
-    let builder = services::Fs::default().root(&root);
-    let store = ObjectStore::new(builder).unwrap().finish();
-
-    let entry = write_and_list_entry(&store, "in_manifest.parquet").await;
-    // threshold far in the future → mtime is definitely old, but manifest protects
-    let threshold = chrono::Utc::now() + chrono::Duration::days(1);
-
-    let should_delete = should_delete_file(
-        true,  // in manifest
-        false, // not in tmp_ref
-        false, false, false, // not linger/eligible, active
-        &entry, threshold,
-    );
-    assert!(
-        !should_delete,
-        "File in manifest should NOT be deleted even with old last-modified time"
-    );
-}
-
-/// Test: file in tmp_ref should NOT be deleted even when its object
-/// `last_modified` is very old (far below the TTL cutoff).
-#[tokio::test]
-async fn test_file_in_tmp_ref_old_mtime_kept() {
-    let tmp_dir = common_test_util::temp_dir::create_temp_dir("gc_tmpref_old");
-    let root = tmp_dir.path().to_string_lossy().to_string();
-    let builder = services::Fs::default().root(&root);
-    let store = ObjectStore::new(builder).unwrap().finish();
-
-    let entry = write_and_list_entry(&store, "in_tmp_ref.parquet").await;
-    // threshold far in the future → mtime is definitely old, but tmp_ref protects
-    let threshold = chrono::Utc::now() + chrono::Duration::days(1);
-
-    let should_delete = should_delete_file(
-        false, true, // in tmp_ref
-        false, false, false, // not linger/eligible, active
-        &entry, threshold,
-    );
-    assert!(
-        !should_delete,
-        "File in tmp_ref should NOT be deleted even with old last-modified time"
-    );
+    assert!(!store.exists(&parquet_path).await.unwrap());
+    assert!(!store.exists(&puffin_path).await.unwrap());
 }
 
 /// A region hook that records `on_region_gc` calls, for testing the GC hook.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Found while reviewing the broader publication protocol in #8537. This PR replaces that approach with a smaller GC policy fix.

## What's changed and what's your intention?

This PR fixes three GC safety issues without adding publication gates, persisted state, route epochs, or wire-format changes.

1. **Fast GC protects referenced Parquet files by `FileId`.**
   A Parquet file's identity does not include the Puffin index version. A temporary reference to `(file_id, v1)` must therefore protect the same Parquet object even when its removed-file record carries `v2`. Puffin files remain protected by the exact `(FileId, IndexVersion)` pair.

2. **Dropped-region GC fails closed when route/reference discovery is incomplete.**
   Table-route lookup failures and missing related destination leaders now return retryable errors instead of silently omitting regions. This prevents dropped-region full-list GC from continuing without all cross-region references needed after repartition. Existing dropped-primary route overrides remain unchanged.

3. **Active/open regions no longer delete unknown files.**
   A newly written flush or compaction output is visible in object storage before it is published to the manifest. Treating an old unknown object as deletable can therefore race with publication and leave the manifest referencing a deleted object. Full-list GC now:
   - retains unknown Parquet and Puffin objects for active/open regions;
   - continues deleting manifest-known removed files using the existing lingering/reference checks;
   - continues deleting unknown objects for dropped regions.

The tradeoff is intentional: a genuine unknown orphan in an active region can remain until the region is dropped. This removes the publication race with a small policy change instead of #8537's publication gate, object validation, additional context state, and lock protocol.

`unknown_file_lingering_time` remains accepted with the same default for configuration compatibility, but no longer affects active/dropped unknown-file decisions. The example and generated configuration documentation are updated accordingly.

No persisted manifest/WAL format, wire format, schema, or public request representation changes.

Verification:

- focused `mito2` tests covering fast Parquet references, active unknown retention through `LocalGcWorker::run()`, and physical dropped unknown deletion;
- focused `meta-srv` tests covering missing related leaders, missing route discovery, and logical routes with missing physical routes;
- `cargo check -p mito2 --features test`;
- `cargo check -p meta-srv --features mock`;
- `cargo fmt --all --check`;
- `taplo check --no-auto-config config/datanode.example.toml`;
- `git diff --check`.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
