### PR TITLE
test: stabilize ttl instant sqlness case

### DIFF
--- a/tests/cases/standalone/common/ttl/ttl_instant.result
+++ b/tests/cases/standalone/common/ttl/ttl_instant.result
@@ -107,7 +107,7 @@ CREATE TABLE test_ttl(
        ts TIMESTAMP TIME INDEX,
        val INT,
        PRIMARY KEY (`val`)
-) WITH (ttl = '1s');
+) WITH (ttl = '5s');
 
 Affected Rows: 0
 
@@ -125,7 +125,7 @@ SHOW CREATE TABLE test_ttl;
 |          |                                         |
 |          | ENGINE=mito                             |
 |          | WITH(                                   |
-|          |   ttl = '1s'                            |
+|          |   ttl = '5s'                            |
 |          | )                                       |
 +----------+-----------------------------------------+
 
@@ -183,6 +183,13 @@ ORDER BY
 | 2   |
 | 3   |
 +-----+
+
+ALTER TABLE
+       test_ttl
+SET
+       ttl = '1s';
+
+Affected Rows: 0
 
 -- SQLNESS SLEEP 2s
 ADMIN flush_table('test_ttl');
@@ -279,7 +286,7 @@ ORDER BY
 ALTER TABLE
        test_ttl
 SET
-       ttl = '1s';
+       ttl = '5s';
 
 Affected Rows: 0
 
@@ -306,6 +313,13 @@ ORDER BY
 | 2   |
 | 3   |
 +-----+
+
+ALTER TABLE
+       test_ttl
+SET
+       ttl = '1s';
+
+Affected Rows: 0
 
 -- SQLNESS SLEEP 2s
 ADMIN flush_table('test_ttl');

--- a/tests/cases/standalone/common/ttl/ttl_instant.sql
+++ b/tests/cases/standalone/common/ttl/ttl_instant.sql
@@ -55,7 +55,7 @@ CREATE TABLE test_ttl(
        ts TIMESTAMP TIME INDEX,
        val INT,
        PRIMARY KEY (`val`)
-) WITH (ttl = '1s');
+) WITH (ttl = '5s');
 
 SHOW CREATE TABLE test_ttl;
 
@@ -83,6 +83,11 @@ from
        test_ttl
 ORDER BY
        val;
+
+ALTER TABLE
+       test_ttl
+SET
+       ttl = '1s';
 
 -- SQLNESS SLEEP 2s
 ADMIN flush_table('test_ttl');
@@ -135,7 +140,7 @@ ORDER BY
 ALTER TABLE
        test_ttl
 SET
-       ttl = '1s';
+       ttl = '5s';
 
 INSERT INTO
        test_ttl
@@ -150,6 +155,11 @@ from
        test_ttl
 ORDER BY
        val;
+
+ALTER TABLE
+       test_ttl
+SET
+       ttl = '1s';
 
 -- SQLNESS SLEEP 2s
 ADMIN flush_table('test_ttl');


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Failed CI job: https://github.com/GreptimeTeam/greptimedb/actions/runs/29821226649/job/88607522494

## What's changed and what's your intention?

The `ttl_instant` SQLness case used a 1-second TTL both when asserting that rows survived flush/compaction and when asserting that rows expired after a 2-second sleep. In the failed distributed run, flushing took about 970 ms and compaction started roughly 1.025 seconds after insertion, so the engine correctly expired the SST before the live-row assertion.

This change uses a 5-second TTL for live-row assertions and explicitly switches the table to a 1-second TTL immediately before each existing 2-second expiration wait. This preserves expiration coverage without requiring distributed flush and compaction to finish within one second. The SQLness result is regenerated accordingly.

This test-only change does not affect APIs, persisted data, or schema compatibility.

## PR Checklist

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.

## Test Plan

- [x] `cargo sqlness bare -t ttl_instant`
- [x] `git diff --check`