### PR TITLE
fix(servers): reject affected rows overflow

### DIFF
--- a/src/servers/src/grpc/database.rs
+++ b/src/servers/src/grpc/database.rs
@@ -28,6 +28,16 @@ use crate::grpc::{TonicResult, cancellation};
 use crate::hint_headers;
 use crate::request_memory_limiter::ServerMemoryLimiter;
 
+static AFFECTED_ROWS_OUT_OF_RANGE_MESSAGE: &str =
+    "affected rows exceed the maximum value supported by the gRPC response";
+
+fn affected_rows_response(affected_rows: usize) -> Result<RawResponse, Status> {
+    let value = u32::try_from(affected_rows)
+        .map_err(|_| Status::out_of_range(AFFECTED_ROWS_OUT_OF_RANGE_MESSAGE))?;
+
+    Ok(RawResponse::AffectedRows(AffectedRows { value }))
+}
+
 pub(crate) struct DatabaseService {
     handler: GreptimeRequestHandler,
 }
@@ -70,7 +80,7 @@ impl GreptimeDatabase for DatabaseService {
                             ..Default::default()
                         }),
                     }),
-                    response: Some(RawResponse::AffectedRows(AffectedRows { value: rows as _ })),
+                    response: Some(affected_rows_response(rows)?),
                 },
                 OutputData::Stream(_) | OutputData::RecordBatches(_) => {
                     return Err(Status::unimplemented("GreptimeDatabase::Handle for query"));
@@ -109,7 +119,7 @@ impl GreptimeDatabase for DatabaseService {
 
         let handler = self.handler.clone();
         let request_future = async move {
-            let mut affected_rows = 0;
+            let mut affected_rows: usize = 0;
 
             let mut stream = request.into_inner();
             while let Some(request) = stream.next().await {
@@ -123,7 +133,11 @@ impl GreptimeDatabase for DatabaseService {
                 };
                 let output = handler.handle_request(request, hints.clone()).await?;
                 match output.data {
-                    OutputData::AffectedRows(rows) => affected_rows += rows,
+                    OutputData::AffectedRows(rows) => {
+                        affected_rows = affected_rows.checked_add(rows).ok_or_else(|| {
+                            Status::out_of_range(AFFECTED_ROWS_OUT_OF_RANGE_MESSAGE)
+                        })?
+                    }
                     OutputData::Stream(_) | OutputData::RecordBatches(_) => {
                         return Err(Status::unimplemented(
                             "GreptimeDatabase::HandleRequests for query",
@@ -138,9 +152,7 @@ impl GreptimeDatabase for DatabaseService {
                         ..Default::default()
                     }),
                 }),
-                response: Some(RawResponse::AffectedRows(AffectedRows {
-                    value: affected_rows as u32,
-                })),
+                response: Some(affected_rows_response(affected_rows)?),
             };
 
             Ok(Response::new(message))
@@ -158,5 +170,191 @@ impl GreptimeDatabase for DatabaseService {
             ))
         };
         cancellation::with_cancellation_handler(request_future, cancellation_future).await
+    }
+}
+
+#[cfg(all(test, target_pointer_width = "64"))]
+mod qx_079_tests {
+    use std::collections::VecDeque;
+    use std::pin::Pin;
+    use std::sync::{Arc, Mutex};
+
+    use api::v1::greptime_database_client::GreptimeDatabaseClient;
+    use api::v1::greptime_database_server::GreptimeDatabaseServer;
+    use api::v1::greptime_request::Request as DatabaseRequest;
+    use api::v1::greptime_response::Response as RawResponse;
+    use api::v1::{DdlRequest, GreptimeRequest, GreptimeResponse};
+    use async_trait::async_trait;
+    use common_grpc::flight::do_put::DoPutResponse;
+    use common_query::Output;
+    use futures::Stream;
+    use session::context::QueryContextRef;
+    use tokio::net::TcpListener;
+    use tokio::task::JoinHandle;
+    use tokio_stream::wrappers::TcpListenerStream;
+    use tonic::Code;
+    use tonic::transport::Channel;
+
+    use super::{AFFECTED_ROWS_OUT_OF_RANGE_MESSAGE, DatabaseService};
+    use crate::grpc::FlightCompression;
+    use crate::grpc::flight::PutRecordBatchRequestStream;
+    use crate::grpc::greptime_handler::GreptimeRequestHandler;
+    use crate::query_handler::grpc::GrpcQueryHandler;
+
+    struct AffectedRowsHandler {
+        outputs: Mutex<VecDeque<usize>>,
+    }
+
+    impl AffectedRowsHandler {
+        fn new(outputs: impl IntoIterator<Item = usize>) -> Self {
+            Self {
+                outputs: Mutex::new(outputs.into_iter().collect()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl GrpcQueryHandler for AffectedRowsHandler {
+        async fn do_query(
+            &self,
+            _query: DatabaseRequest,
+            _ctx: QueryContextRef,
+        ) -> crate::error::Result<Output> {
+            let rows = self
+                .outputs
+                .lock()
+                .expect("lock QX-079 affected rows handler")
+                .pop_front()
+                .expect("QX-079 handler received more requests than configured");
+            Ok(Output::new_with_affected_rows(rows))
+        }
+
+        fn handle_put_record_batch_stream(
+            &self,
+            _stream: PutRecordBatchRequestStream,
+            _ctx: QueryContextRef,
+        ) -> Pin<Box<dyn Stream<Item = crate::error::Result<DoPutResponse>> + Send>> {
+            Box::pin(futures::stream::empty())
+        }
+    }
+
+    fn database_request() -> GreptimeRequest {
+        GreptimeRequest {
+            header: None,
+            request: Some(DatabaseRequest::Ddl(DdlRequest::default())),
+        }
+    }
+
+    fn affected_rows(response: GreptimeResponse) -> u32 {
+        match response.response {
+            Some(RawResponse::AffectedRows(rows)) => rows.value,
+            None => panic!("QX-079 database response is missing affected rows"),
+        }
+    }
+
+    async fn start_database_server(
+        outputs: impl IntoIterator<Item = usize>,
+    ) -> (GreptimeDatabaseClient<Channel>, JoinHandle<()>) {
+        let query_handler = Arc::new(AffectedRowsHandler::new(outputs));
+        let request_handler =
+            GreptimeRequestHandler::new(query_handler, None, None, FlightCompression::None);
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind QX-079 database server");
+        let addr = listener
+            .local_addr()
+            .expect("get QX-079 database server address");
+        let server = tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(GreptimeDatabaseServer::new(DatabaseService::new(
+                    request_handler,
+                )))
+                .serve_with_incoming(TcpListenerStream::new(listener))
+                .await
+                .expect("serve QX-079 database server");
+        });
+        let client = GreptimeDatabaseClient::connect(format!("http://{addr}"))
+            .await
+            .expect("connect QX-079 database client");
+
+        (client, server)
+    }
+
+    #[tokio::test]
+    async fn qx_079_unary_u32_max_round_trips_exactly() {
+        let (mut client, server) = start_database_server([u32::MAX as usize]).await;
+
+        let result = client.handle(database_request()).await;
+        server.abort();
+
+        let response = result.expect("QX-079 unary u32::MAX request succeeds");
+        assert_eq!(affected_rows(response.into_inner()), u32::MAX);
+    }
+
+    #[tokio::test]
+    async fn qx_079_unary_above_u32_max_is_out_of_range() {
+        let (mut client, server) = start_database_server([(u32::MAX as usize) + 1]).await;
+
+        let result = client.handle(database_request()).await;
+        server.abort();
+
+        let status = result.expect_err("QX-079 unary affected rows above u32::MAX must fail");
+        assert_eq!(status.code(), Code::OutOfRange);
+        assert_eq!(status.message(), AFFECTED_ROWS_OUT_OF_RANGE_MESSAGE);
+    }
+
+    #[tokio::test]
+    async fn qx_079_client_stream_u32_control_sums_exactly() {
+        let (mut client, server) = start_database_server([7, 9]).await;
+
+        let result = client
+            .handle_requests(tokio_stream::iter([database_request(), database_request()]))
+            .await;
+        server.abort();
+
+        let response = result.expect("QX-079 client-stream u32 control succeeds");
+        assert_eq!(affected_rows(response.into_inner()), 16);
+    }
+
+    #[tokio::test]
+    async fn qx_079_client_stream_u32_max_round_trips_exactly() {
+        let (mut client, server) = start_database_server([(u32::MAX as usize) - 1, 1]).await;
+
+        let result = client
+            .handle_requests(tokio_stream::iter([database_request(), database_request()]))
+            .await;
+        server.abort();
+
+        let response = result.expect("QX-079 client-stream u32::MAX request succeeds");
+        assert_eq!(affected_rows(response.into_inner()), u32::MAX);
+    }
+
+    #[tokio::test]
+    async fn qx_079_client_stream_above_u32_max_is_out_of_range() {
+        let (mut client, server) = start_database_server([3_000_000_000, 2_000_000_000]).await;
+
+        let result = client
+            .handle_requests(tokio_stream::iter([database_request(), database_request()]))
+            .await;
+        server.abort();
+
+        let status =
+            result.expect_err("QX-079 client-stream affected rows above u32::MAX must fail");
+        assert_eq!(status.code(), Code::OutOfRange);
+        assert_eq!(status.message(), AFFECTED_ROWS_OUT_OF_RANGE_MESSAGE);
+    }
+
+    #[tokio::test]
+    async fn qx_079_client_stream_usize_overflow_is_out_of_range() {
+        let (mut client, server) = start_database_server([usize::MAX, 1]).await;
+
+        let result = client
+            .handle_requests(tokio_stream::iter([database_request(), database_request()]))
+            .await;
+        server.abort();
+
+        let status = result.expect_err("QX-079 client-stream usize overflow must fail");
+        assert_eq!(status.code(), Code::OutOfRange);
+        assert_eq!(status.message(), AFFECTED_ROWS_OUT_OF_RANGE_MESSAGE);
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

N/A

## What's changed and what's your intention?

GreptimeDatabase responses encode affected-row counts in a protobuf `u32`, while internal counts use `usize`. Unary and client-streaming paths previously used narrowing casts, so counts above `u32::MAX` returned successful but wrapped values. Client-stream aggregation could also overflow `usize`.

This change:

- converts affected-row responses with one checked `u32::try_from` helper;
- returns gRPC `OutOfRange` with a stable message when the protobuf range is exceeded;
- uses `checked_add` for client-stream aggregation and maps native overflow to the same status;
- adds six public loopback Tonic tests for unary and streaming controls, exact `u32::MAX` boundaries, protobuf overflow, and native `usize` overflow.

This does not change the protobuf wire format. The related affected-row narrowing in the server-streaming Flight encoder is separate scope because fixing it requires making that encoder fallible and propagating errors through the Flight stream path.

Validation:

```text
CARGO_TARGET_DIR=/mnt/nvme_rust/rust-targets/qx-079-affected-rows-overflow \
CARGO_BUILD_JOBS=1 \
RUSTC_WRAPPER=/home/discord9/.local/bin/sccache-pr2678 \
CARGO_INCREMENTAL=0 \
cargo nextest run -p servers --lib qx_079_

6 passed, 335 skipped
```

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.