### PR TITLE
fix(json2): treat empty object as null when insert

### DIFF
--- a/src/datatypes/src/vectors/json/builder.rs
+++ b/src/datatypes/src/vectors/json/builder.rs
@@ -114,6 +114,7 @@ fn json_variant_into_struct_value(
 fn json_variant_into_value(value: JsonVariant, expected_type: &ConcreteDataType) -> Result<Value> {
     let value = match (value, expected_type) {
         (JsonVariant::Null, _) | (_, ConcreteDataType::Null(_)) => Value::Null,
+        (JsonVariant::Object(object), _) if object.is_empty() => Value::Null,
         (JsonVariant::Bool(x), ConcreteDataType::Boolean(_)) => Value::Boolean(x),
         (JsonVariant::Number(JsonNumber::PosInt(x)), ConcreteDataType::UInt64(_)) => {
             Value::UInt64(x)
@@ -182,7 +183,7 @@ impl MutableVector for JsonVectorBuilder {
     }
 
     fn to_vector(&mut self) -> VectorRef {
-        self.try_build().unwrap_or_else(|e| panic!("{}", e))
+        self.try_build().unwrap_or_else(|e| panic!("{:?}", e))
     }
 
     fn to_vector_cloned(&self) -> VectorRef {
@@ -355,6 +356,14 @@ mod tests {
 
     #[test]
     fn test_json_variant_into_struct_value() -> Result<()> {
+        assert_eq!(
+            json_variant_into_value(
+                JsonVariant::Object(Default::default()),
+                &ConcreteDataType::string_datatype(),
+            )?,
+            Value::Null
+        );
+
         let item_type =
             ConcreteDataType::struct_datatype(StructType::new(Arc::new(vec![StructField::new(
                 "id".to_string(),

--- a/tests/cases/standalone/common/types/json/json2.result
+++ b/tests/cases/standalone/common/types/json/json2.result
@@ -150,7 +150,7 @@ select j.a, j.a.x from json2_table order by ts;
 | {"b":-2}                          |                                     |
 | {"b":3}                           |                                     |
 | {"b":-4}                          |                                     |
-| {"b":null}                        |                                     |
+|                                   |                                     |
 |                                   |                                     |
 | {"b":"s7"}                        |                                     |
 | {"b":8}                           |                                     |


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

as title

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
