### PR TITLE
test: cover legacy dense metric encoding

### DIFF
--- a/tests/compatibility/AGENTS.md
+++ b/tests/compatibility/AGENTS.md
@@ -35,6 +35,27 @@ This file is intended for AI agents editing compat cases or the compat runner. F
 - `verify.sql` runs on the **new (to)** binary. Output is compared against
   `verify.result`.
 
+## Old-Stage Datanode Configuration
+
+- A case may opt into a typed old-stage-only overlay:
+  ```toml
+  [old_config.datanode]
+  "region_engine.metric.sparse_primary_key_encoding" = false
+  ```
+- The first version accepts only boolean values under the logical positive
+  allowlist `region_engine.<engine>.<leaf/path>`. Paths must be lowercase,
+  non-empty, and must not contain `__`; arbitrary TOML, roles, and environment
+  variables are not supported.
+- The runner renders the old datanode TOML and updates the named
+  `[[region_engine]]` entry. It does not perform a generic TOML merge. The
+  current stage always uses a separately rendered clean config, including after
+  restart directives in `verify.sql`.
+- Selected cases are grouped by the full normalized old configuration profile.
+  Baseline cases share one lifecycle, equal non-empty profiles share another,
+  and distinct profiles run sequentially with independent SQLNESS_HOME/data/WAL
+  state and a fresh etcd start/stop/remove lifecycle. `--preserve-state` lists
+  every retained profile directory.
+
 ## PostgreSQL Protocol Cases
 
 - When using `-- SQLNESS PROTOCOL POSTGRES`, avoid unqualified table names
@@ -50,7 +71,8 @@ cargo run -p sqlness-runner -- compat --dry-run [--from-version vX.Y.Z] [--test-
 The dry-run performs full discovery and filtering (name, topology, metadata
 validation, namespace dedup, version-range matching) but starts no services,
 creates no temp dirs, and mutates no files. Use it to check which cases
-would be selected before a real run.
+would be selected before a real run. It also prints profile-to-case mappings
+and logical configuration keys, never configuration values.
 
 ## CI Version Window
 

--- a/tests/compatibility/AGENTS.md
+++ b/tests/compatibility/AGENTS.md
@@ -55,6 +55,16 @@ This file is intended for AI agents editing compat cases or the compat runner. F
   and distinct profiles run sequentially with independent SQLNESS_HOME/data/WAL
   state and a fresh etcd start/stop/remove lifecycle. `--preserve-state` lists
   every retained profile directory.
+- A case that depends on an old-stage metric encoding may couple that fixture to
+  a typed log assertion:
+  ```toml
+  [old_assert]
+  metric_primary_key_encoding = "dense"
+  ```
+  Only lowercase `dense` and `sparse` are accepted. The runner snapshots old
+  datanode logs immediately before that case's setup, then requires stable,
+  matching region-creation events before the current-stage restart. Assertions
+  do not affect profile grouping.
 
 ## PostgreSQL Protocol Cases
 

--- a/tests/compatibility/cases/legacy_dense_metric_primary_key/case.toml
+++ b/tests/compatibility/cases/legacy_dense_metric_primary_key/case.toml
@@ -1,0 +1,14 @@
+name = "legacy_dense_metric_primary_key"
+reason = "Verify dense-encoded metric regions written by released old binaries recover, accept new writes, and remain readable after restart."
+introduced_by = "PR #8470"
+topologies = ["distributed"]
+from_range = ["=v1.0.0", "=v1.1.0"]
+to_range = [">=v1.2.0"]
+features = ["metric", "dense_primary_key", "read", "write", "restart"]
+owner = "storage"
+
+[old_config.datanode]
+"region_engine.metric.sparse_primary_key_encoding" = false
+
+[old_assert]
+metric_primary_key_encoding = "dense"

--- a/tests/compatibility/cases/legacy_dense_metric_primary_key/setup.sql
+++ b/tests/compatibility/cases/legacy_dense_metric_primary_key/setup.sql
@@ -1,0 +1,19 @@
+CREATE TABLE legacy_dense_phy (
+  ts TIMESTAMP TIME INDEX,
+  val DOUBLE,
+  host STRING,
+  PRIMARY KEY (host)
+) ENGINE = metric WITH ('physical_metric_table' = '');
+
+CREATE TABLE legacy_dense_logical (
+  ts TIMESTAMP TIME INDEX,
+  val DOUBLE,
+  host STRING,
+  PRIMARY KEY (host)
+) ENGINE = metric WITH ('on_physical_table' = 'legacy_dense_phy');
+
+INSERT INTO legacy_dense_logical (ts, val, host) VALUES
+  ('2026-01-01 00:00:00', 1.0, 'old-a'),
+  ('2026-01-01 00:01:00', 2.0, 'old-b');
+
+ADMIN FLUSH_TABLE('legacy_dense_phy');

--- a/tests/compatibility/cases/legacy_dense_metric_primary_key/verify.result
+++ b/tests/compatibility/cases/legacy_dense_metric_primary_key/verify.result
@@ -24,9 +24,9 @@ DESC TABLE legacy_dense_phy;
 +------------+----------------------+-----+------+---------+---------------+
 | ts         | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
 | val        | Float64              |     | YES  |         | FIELD         |
+| host       | String               | PRI | YES  |         | TAG           |
 | __table_id | UInt32               | PRI | NO   |         | TAG           |
 | __tsid     | UInt64               | PRI | NO   |         | TAG           |
-| host       | String               | PRI | YES  |         | TAG           |
 +------------+----------------------+-----+------+---------+---------------+
 
 SELECT host, ts, val FROM legacy_dense_logical ORDER BY ts;
@@ -80,7 +80,7 @@ DESC TABLE legacy_dense_phy;
 +------------+----------------------+-----+------+---------+---------------+
 | ts         | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
 | val        | Float64              |     | YES  |         | FIELD         |
+| host       | String               | PRI | YES  |         | TAG           |
 | __table_id | UInt32               | PRI | NO   |         | TAG           |
 | __tsid     | UInt64               | PRI | NO   |         | TAG           |
-| host       | String               | PRI | YES  |         | TAG           |
 +------------+----------------------+-----+------+---------+---------------+

--- a/tests/compatibility/cases/legacy_dense_metric_primary_key/verify.result
+++ b/tests/compatibility/cases/legacy_dense_metric_primary_key/verify.result
@@ -1,0 +1,86 @@
+SHOW CREATE TABLE legacy_dense_phy;
+
++------------------+-------------------------------------------------+
+| Table            | Create Table                                    |
++------------------+-------------------------------------------------+
+| legacy_dense_phy | CREATE TABLE IF NOT EXISTS "legacy_dense_phy" ( |
+|                  |   "ts" TIMESTAMP(3) NOT NULL,                   |
+|                  |   "val" DOUBLE NULL,                            |
+|                  |   "host" STRING NULL,                           |
+|                  |   TIME INDEX ("ts"),                            |
+|                  |   PRIMARY KEY ("host")                          |
+|                  | )                                               |
+|                  |                                                 |
+|                  | ENGINE=metric                                   |
+|                  | WITH(                                           |
+|                  |   physical_metric_table = ''                    |
+|                  | )                                               |
++------------------+-------------------------------------------------+
+
+DESC TABLE legacy_dense_phy;
+
++------------+----------------------+-----+------+---------+---------------+
+| Column     | Type                 | Key | Null | Default | Semantic Type |
++------------+----------------------+-----+------+---------+---------------+
+| ts         | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
+| val        | Float64              |     | YES  |         | FIELD         |
+| __table_id | UInt32               | PRI | NO   |         | TAG           |
+| __tsid     | UInt64               | PRI | NO   |         | TAG           |
+| host       | String               | PRI | YES  |         | TAG           |
++------------+----------------------+-----+------+---------+---------------+
+
+SELECT host, ts, val FROM legacy_dense_logical ORDER BY ts;
+
++-------+---------------------+-----+
+| host  | ts                  | val |
++-------+---------------------+-----+
+| old-a | 2026-01-01T00:00:00 | 1.0 |
+| old-b | 2026-01-01T00:01:00 | 2.0 |
++-------+---------------------+-----+
+
+INSERT INTO legacy_dense_logical (ts, val, host) VALUES ('2026-01-01 00:02:00', 3.0, 'new-c'), ('2026-01-01 00:03:00', 4.0, 'new-d');
+
+Affected Rows: 2
+
+ADMIN FLUSH_TABLE('legacy_dense_phy');
+
++---------------------------------------+
+| ADMIN FLUSH_TABLE('legacy_dense_phy') |
++---------------------------------------+
+| 0                                     |
++---------------------------------------+
+
+SELECT host, ts, val FROM legacy_dense_logical ORDER BY ts;
+
++-------+---------------------+-----+
+| host  | ts                  | val |
++-------+---------------------+-----+
+| old-a | 2026-01-01T00:00:00 | 1.0 |
+| old-b | 2026-01-01T00:01:00 | 2.0 |
+| new-c | 2026-01-01T00:02:00 | 3.0 |
+| new-d | 2026-01-01T00:03:00 | 4.0 |
++-------+---------------------+-----+
+
+-- SQLNESS ARG restart=true
+SELECT host, ts, val FROM legacy_dense_logical ORDER BY ts;
+
++-------+---------------------+-----+
+| host  | ts                  | val |
++-------+---------------------+-----+
+| old-a | 2026-01-01T00:00:00 | 1.0 |
+| old-b | 2026-01-01T00:01:00 | 2.0 |
+| new-c | 2026-01-01T00:02:00 | 3.0 |
+| new-d | 2026-01-01T00:03:00 | 4.0 |
++-------+---------------------+-----+
+
+DESC TABLE legacy_dense_phy;
+
++------------+----------------------+-----+------+---------+---------------+
+| Column     | Type                 | Key | Null | Default | Semantic Type |
++------------+----------------------+-----+------+---------+---------------+
+| ts         | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
+| val        | Float64              |     | YES  |         | FIELD         |
+| __table_id | UInt32               | PRI | NO   |         | TAG           |
+| __tsid     | UInt64               | PRI | NO   |         | TAG           |
+| host       | String               | PRI | YES  |         | TAG           |
++------------+----------------------+-----+------+---------+---------------+

--- a/tests/compatibility/cases/legacy_dense_metric_primary_key/verify.sql
+++ b/tests/compatibility/cases/legacy_dense_metric_primary_key/verify.sql
@@ -1,0 +1,16 @@
+SHOW CREATE TABLE legacy_dense_phy;
+
+DESC TABLE legacy_dense_phy;
+
+SELECT host, ts, val FROM legacy_dense_logical ORDER BY ts;
+
+INSERT INTO legacy_dense_logical (ts, val, host) VALUES ('2026-01-01 00:02:00', 3.0, 'new-c'), ('2026-01-01 00:03:00', 4.0, 'new-d');
+
+ADMIN FLUSH_TABLE('legacy_dense_phy');
+
+SELECT host, ts, val FROM legacy_dense_logical ORDER BY ts;
+
+-- SQLNESS ARG restart=true
+SELECT host, ts, val FROM legacy_dense_logical ORDER BY ts;
+
+DESC TABLE legacy_dense_phy;

--- a/tests/runner/src/cmd/compat.rs
+++ b/tests/runner/src/cmd/compat.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use clap::Parser;
@@ -92,6 +92,16 @@ impl SetupProgress {
             self.failed.push(index);
             !fail_fast
         }
+    }
+
+    /// Records a setup or old-stage assertion result as one setup outcome.
+    fn record_result(
+        &mut self,
+        index: usize,
+        result: &Result<(), String>,
+        fail_fast: bool,
+    ) -> bool {
+        self.record(index, result.is_ok(), fail_fast)
     }
 
     /// Returns whether successful setup cases may advance to the current stage.
@@ -458,8 +468,8 @@ impl CompatCommand {
         index: usize,
         profile: CompatProfile,
         interceptor_registry: &Registry,
-        from_bins_dir: &PathBuf,
-        to_bins_dir: &PathBuf,
+        from_bins_dir: &Path,
+        to_bins_dir: &Path,
     ) -> ProfileOutcome {
         let profile_name = profile.name(index);
         let temp_dir = tempfile::Builder::new()
@@ -488,7 +498,7 @@ impl CompatCommand {
             ServerAddr::default(),
             WalConfig::RaftEngine,
             self.pull_version_on_need,
-            Some(from_bins_dir.clone()),
+            Some(from_bins_dir.to_path_buf()),
             store_config,
             vec![],
         );
@@ -507,14 +517,36 @@ impl CompatCommand {
 
         println!("Running setup phase for profile '{profile_name}'...");
         for (case_index, case) in profile.cases.iter().enumerate() {
-            match run_compat_phase(&db, case, interceptor_registry, CompatPhase::Setup).await {
+            let setup_result = if let Some(assertion) = &case.metadata.old_assert {
+                match env.compat_snapshot_datanode_logs(0) {
+                    Ok(snapshots) => {
+                        match run_compat_phase(&db, case, interceptor_registry, CompatPhase::Setup)
+                            .await
+                        {
+                            Ok(()) => {
+                                env.compat_assert_metric_primary_key_encoding(
+                                    &snapshots,
+                                    assertion.metric_primary_key_encoding,
+                                )
+                                .await
+                            }
+                            Err(error) => Err(error),
+                        }
+                    }
+                    Err(error) => Err(error),
+                }
+            } else {
+                run_compat_phase(&db, case, interceptor_registry, CompatPhase::Setup).await
+            };
+
+            match &setup_result {
                 Ok(()) => {
-                    setup_progress.record(case_index, true, self.fail_fast);
+                    setup_progress.record_result(case_index, &setup_result, self.fail_fast);
                     println!("  Setup: {} - OK", case.metadata.name);
                 }
                 Err(e) => {
                     println!("  Setup: {} - FAILED: {e}", case.metadata.name);
-                    if !setup_progress.record(case_index, false, self.fail_fast) {
+                    if !setup_progress.record_result(case_index, &setup_result, self.fail_fast) {
                         break;
                     }
                 }
@@ -534,7 +566,7 @@ impl CompatCommand {
                 env.compat_activate_current_profile();
             }
             println!("Restarting profile '{profile_name}' with new-version binary...");
-            env.compat_restart_all(&db, to_bins_dir.clone()).await;
+            env.compat_restart_all(&db, to_bins_dir.to_path_buf()).await;
 
             println!("Running verify phase for profile '{profile_name}'...");
             for case_index in setup_progress.successful {
@@ -1019,7 +1051,9 @@ mod tests {
     use std::path::PathBuf;
 
     use super::*;
-    use crate::cmd::compat_case::CaseMetadata;
+    use crate::cmd::compat_case::{
+        CaseMetadata, ExpectedMetricPrimaryKeyEncoding, OldStageAssertions,
+    };
 
     #[test]
     fn test_trim_trailing_blank_lines_preserves_single_final_newline() {
@@ -1042,6 +1076,7 @@ mod tests {
                 owner: "test".to_string(),
                 namespace: None,
                 old_config,
+                old_assert: None,
             },
             dir: PathBuf::from(name),
             namespace: name.to_string(),
@@ -1092,6 +1127,22 @@ mod tests {
     }
 
     #[test]
+    fn test_old_stage_assertions_do_not_split_config_profiles() {
+        let mut dense = test_case("dense", Some(old_profile(false)));
+        dense.metadata.old_assert = Some(OldStageAssertions {
+            metric_primary_key_encoding: ExpectedMetricPrimaryKeyEncoding::Dense,
+        });
+        let mut sparse = test_case("sparse", Some(old_profile(false)));
+        sparse.metadata.old_assert = Some(OldStageAssertions {
+            metric_primary_key_encoding: ExpectedMetricPrimaryKeyEncoding::Sparse,
+        });
+
+        let profiles = group_cases_by_profile(vec![dense, sparse]);
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(profiles[0].cases.len(), 2);
+    }
+
+    #[test]
     fn test_setup_failure_in_middle_verifies_other_successful_cases() {
         let mut progress = SetupProgress::default();
         for (index, succeeded) in [true, false, true].into_iter().enumerate() {
@@ -1112,5 +1163,16 @@ mod tests {
         assert_eq!(progress.successful, vec![0]);
         assert_eq!(progress.failed, vec![1]);
         assert!(!progress.should_transition(true));
+    }
+
+    #[test]
+    fn test_old_stage_assertion_failure_is_a_setup_failure() {
+        let mut progress = SetupProgress::default();
+        let assertion_failure = Err("expected dense metric encoding".to_string());
+
+        assert!(progress.record_result(0, &assertion_failure, false));
+        assert!(progress.successful.is_empty());
+        assert_eq!(progress.failed, vec![0]);
+        assert!(!progress.should_transition(false));
     }
 }

--- a/tests/runner/src/cmd/compat.rs
+++ b/tests/runner/src/cmd/compat.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -21,15 +22,83 @@ use sqlness::interceptor::template::DELIMITER as TEMPLATE_DELIMITER;
 use sqlness::interceptor::{InterceptorRef, Registry};
 
 use crate::cmd::bare::ServerAddr;
-use crate::cmd::compat_case::{self, CompatCase, try_infer_version, version_matches_range};
+use crate::cmd::compat_case::{
+    self, CompatCase, OldConfig, try_infer_version, version_matches_range,
+};
 use crate::env::bare::{Env, StoreConfig, WalConfig};
 use crate::protocol_interceptor::{self, POSTGRES, PROTOCOL_KEY};
+use crate::server_mode::validate_old_config_against_datanode_template;
 use crate::util;
 
 const COMPAT_TOPOLOGY: &str = "distributed";
 const COMMENT_PREFIX: &str = "--";
 const INTERCEPTOR_PREFIX: &str = "-- SQLNESS";
 const QUERY_DELIMITER: char = ';';
+
+/// A deterministic collection of cases that can share one compatibility lifecycle.
+#[derive(Debug)]
+struct CompatProfile {
+    old_config: Option<OldConfig>,
+    cases: Vec<CompatCase>,
+}
+
+impl CompatProfile {
+    fn name(&self, index: usize) -> String {
+        if self.old_config.is_some() {
+            format!("old-config-{index}")
+        } else {
+            "baseline".to_string()
+        }
+    }
+
+    fn config_keys(&self) -> Vec<&str> {
+        self.old_config
+            .as_ref()
+            .map(|config| config.keys().collect())
+            .unwrap_or_default()
+    }
+}
+
+/// Groups cases by their complete normalized old-stage configuration profile.
+fn group_cases_by_profile(cases: Vec<CompatCase>) -> Vec<CompatProfile> {
+    let mut grouped: BTreeMap<Option<OldConfig>, Vec<CompatCase>> = BTreeMap::new();
+    for case in cases {
+        grouped
+            .entry(case.metadata.old_config.clone())
+            .or_default()
+            .push(case);
+    }
+
+    grouped
+        .into_iter()
+        .map(|(old_config, cases)| CompatProfile { old_config, cases })
+        .collect()
+}
+
+/// Records which setup cases may advance to verification.
+#[derive(Default, Debug, PartialEq, Eq)]
+struct SetupProgress {
+    successful: Vec<usize>,
+    failed: Vec<usize>,
+}
+
+impl SetupProgress {
+    /// Records one attempted setup result and returns whether setup should continue.
+    fn record(&mut self, index: usize, succeeded: bool, fail_fast: bool) -> bool {
+        if succeeded {
+            self.successful.push(index);
+            true
+        } else {
+            self.failed.push(index);
+            !fail_fast
+        }
+    }
+
+    /// Returns whether successful setup cases may advance to the current stage.
+    fn should_transition(&self, fail_fast: bool) -> bool {
+        !self.successful.is_empty() && (!fail_fast || self.failed.is_empty())
+    }
+}
 
 /// Run compatibility tests in bare distributed mode.
 ///
@@ -102,7 +171,10 @@ impl CompatCommand {
         }
 
         // ---- 2. Resolve case directory ----
-        let case_dir = self.case_dir.unwrap_or_else(default_compat_case_dir);
+        let case_dir = self
+            .case_dir
+            .clone()
+            .unwrap_or_else(default_compat_case_dir);
 
         if !case_dir.is_dir() {
             panic!("Case directory not found: {}", case_dir.display());
@@ -273,8 +345,17 @@ impl CompatCommand {
             return;
         }
 
+        let selected_case_count = cases.len();
+        let profiles = group_cases_by_profile(cases);
+        for profile in &profiles {
+            if let Some(old_config) = &profile.old_config {
+                validate_old_config_against_datanode_template(old_config)
+                    .unwrap_or_else(|e| panic!("Invalid old datanode configuration profile: {e}"));
+            }
+        }
+
         if dry_run {
-            println!("DRY-RUN: would run {} compat case(s)", cases.len());
+            println!("DRY-RUN: would run {} compat case(s)", selected_case_count);
             println!("  topology:     {}", COMPAT_TOPOLOGY);
             println!(
                 "  from version: {}",
@@ -288,21 +369,29 @@ impl CompatCommand {
                     .as_deref()
                     .unwrap_or("unknown (use --to-bins-dir or build debug binary)")
             );
-            if pre_filter_count != cases.len() {
+            if pre_filter_count != selected_case_count {
                 println!();
                 println!(
                     "Version-range filtering reduced {} → {} cases (see 'Skipping case' messages above)",
-                    pre_filter_count,
-                    cases.len()
+                    pre_filter_count, selected_case_count
                 );
             }
             println!();
-            for c in &cases {
-                println!("  case:        {}", c.metadata.name);
-                println!("    namespace:   {}", c.namespace);
-                println!("    from_range:  {:?}", c.metadata.from_range);
-                println!("    to_range:    {:?}", c.metadata.to_range);
-                println!("    features:    {:?}", c.metadata.features);
+            for (index, profile) in profiles.iter().enumerate() {
+                println!("  profile: {}", profile.name(index));
+                let keys = profile.config_keys();
+                if keys.is_empty() {
+                    println!("    config keys: baseline");
+                } else {
+                    println!("    config keys: {}", keys.join(", "));
+                }
+                for c in &profile.cases {
+                    println!("    case:      {}", c.metadata.name);
+                    println!("      namespace: {}", c.namespace);
+                    println!("      from_range: {:?}", c.metadata.from_range);
+                    println!("      to_range:   {:?}", c.metadata.to_range);
+                    println!("      features:   {:?}", c.metadata.features);
+                }
             }
             println!();
             println!("Dry run complete. Remove --dry-run to execute.");
@@ -310,20 +399,71 @@ impl CompatCommand {
         }
 
         println!(
-            "Running {} compat case(s) with topology {}:",
-            cases.len(),
+            "Running compatibility profiles with topology {}:",
             COMPAT_TOPOLOGY
         );
-        for c in &cases {
+        for (index, profile) in profiles.iter().enumerate() {
             println!(
-                "  - {} (namespace: {}, topologies: {:?})",
-                c.metadata.name, c.namespace, c.metadata.topologies
+                "  - {}: {} case(s)",
+                profile.name(index),
+                profile.cases.len()
             );
         }
 
-        // ---- 6. Create temp directory (after filtering so early exits don't leave empty dirs) ----
+        // ---- 6. Build interceptor registry ----
+        let interceptor_registry = create_interceptor_registry();
+        let from_bins_dir =
+            from_bins_dir.expect("from_bins_dir must be resolved in non-dry-run mode");
+        let to_bins_dir = to_bins_dir.expect("to_bins_dir must be resolved in non-dry-run mode");
+        let mut failed = Vec::new();
+        let mut preserved_homes = Vec::new();
+
+        for (index, profile) in profiles.into_iter().enumerate() {
+            let outcome = self
+                .run_profile(
+                    index,
+                    profile,
+                    &interceptor_registry,
+                    &from_bins_dir,
+                    &to_bins_dir,
+                )
+                .await;
+            if let Some(home) = outcome.preserved_home {
+                preserved_homes.push(home);
+            }
+            let profile_failed = !outcome.failed_cases.is_empty();
+            failed.extend(outcome.failed_cases);
+            if profile_failed && self.fail_fast {
+                break;
+            }
+        }
+
+        if self.preserve_state {
+            println!("Preserved compatibility state directories:");
+            for home in preserved_homes {
+                println!("  - {}", home.display());
+            }
+        }
+
+        if failed.is_empty() {
+            println!("\n\x1b[32mAll compat tests passed!\x1b[0m");
+        } else {
+            println!("\n\x1b[31mFailed cases: {}\x1b[0m", failed.join(", "));
+            panic!("Compatibility profiles failed");
+        }
+    }
+
+    async fn run_profile(
+        &self,
+        index: usize,
+        profile: CompatProfile,
+        interceptor_registry: &Registry,
+        from_bins_dir: &PathBuf,
+        to_bins_dir: &PathBuf,
+    ) -> ProfileOutcome {
+        let profile_name = profile.name(index);
         let temp_dir = tempfile::Builder::new()
-            .prefix("sqlness-compat")
+            .prefix(&format!("sqlness-compat-{profile_name}-"))
             .tempdir()
             .unwrap();
         let sqlness_home = temp_dir.keep();
@@ -331,10 +471,6 @@ impl CompatCommand {
             std::env::set_var("SQLNESS_HOME", sqlness_home.display().to_string());
         }
 
-        // ---- 7. Build interceptor registry ----
-        let interceptor_registry = create_interceptor_registry();
-
-        // ---- 7b. Create Env for bare distributed mode ----
         let store_config = StoreConfig {
             store_addrs: if self.setup_etcd {
                 vec!["127.0.0.1:2379".to_string()]
@@ -347,93 +483,105 @@ impl CompatCommand {
             enable_flat_format: false,
             enable_gc: false,
         };
-
         let env = Env::new(
             sqlness_home.clone(),
             ServerAddr::default(),
             WalConfig::RaftEngine,
             self.pull_version_on_need,
-            from_bins_dir,
+            Some(from_bins_dir.clone()),
             store_config,
             vec![],
         );
-
-        // ---- 7c. Etcd cleanup guard ----
-        // Arm this only immediately before starting the cluster. Earlier validation
-        // failures should not stop an unrelated local container named `etcd`.
-        let mut etcd_guard = if self.setup_etcd {
-            Some(EtcdGuard::new())
-        } else {
-            None
-        };
-
-        // ---- 8. Run setup phase on old cluster ----
-        println!("Starting old-version distributed cluster with flownode...");
-        let mut db = env.compat_start_distributed(0).await;
-
-        println!("Running setup phase...");
-        for case in &cases {
-            run_compat_phase(&db, case, &interceptor_registry, CompatPhase::Setup)
-                .await
-                .unwrap_or_else(|e| panic!("Setup failed for case '{}': {e}", case.metadata.name));
-            println!("  Setup: {} - OK", case.metadata.name);
+        let configured_old_profile = profile.old_config.is_some();
+        if let Some(old_config) = profile.old_config.clone() {
+            env.compat_activate_old_profile(old_config);
         }
 
-        // ---- 9. Switch to "to" binary and restart cluster ----
-        // to_bins_dir was already resolved during version-range filtering
-        println!("Restarting cluster with new-version binary on preserved state...");
-        env.compat_restart_all(
-            &db,
-            to_bins_dir.expect("to_bins_dir must be resolved in non-dry-run mode"),
-        )
-        .await;
+        // Arm only immediately before this profile starts etcd. Scope guarantees
+        // cleanup finishes before the next profile can acquire the same container.
+        let mut etcd_guard = self.setup_etcd.then(EtcdGuard::new);
+        println!("Starting profile '{profile_name}' with old-version distributed cluster...");
+        let mut db = env.compat_start_distributed(0).await;
+        let mut failed_cases = Vec::new();
+        let mut setup_progress = SetupProgress::default();
 
-        // ---- 10. Run verify phase on new cluster ----
-        println!("Running verify phase...");
-        let mut failed = Vec::new();
-        for case in &cases {
-            match run_compat_phase(&db, case, &interceptor_registry, CompatPhase::Verify).await {
-                Ok(()) => println!("  Verify: {} - PASSED", case.metadata.name),
+        println!("Running setup phase for profile '{profile_name}'...");
+        for (case_index, case) in profile.cases.iter().enumerate() {
+            match run_compat_phase(&db, case, interceptor_registry, CompatPhase::Setup).await {
+                Ok(()) => {
+                    setup_progress.record(case_index, true, self.fail_fast);
+                    println!("  Setup: {} - OK", case.metadata.name);
+                }
                 Err(e) => {
-                    println!("  Verify: {} - FAILED: {e}", case.metadata.name);
-                    failed.push(case.metadata.name.clone());
-                    if self.fail_fast {
+                    println!("  Setup: {} - FAILED: {e}", case.metadata.name);
+                    if !setup_progress.record(case_index, false, self.fail_fast) {
                         break;
                     }
                 }
             }
         }
+        failed_cases.extend(
+            setup_progress
+                .failed
+                .iter()
+                .map(|index| profile.cases[*index].metadata.name.clone()),
+        );
 
-        // ---- 11. Stop cluster ----
+        if setup_progress.should_transition(self.fail_fast) {
+            // This transition is deliberately before every current process spawn.
+            // Subsequent verify-stage restart directives observe the clean stage too.
+            if configured_old_profile {
+                env.compat_activate_current_profile();
+            }
+            println!("Restarting profile '{profile_name}' with new-version binary...");
+            env.compat_restart_all(&db, to_bins_dir.clone()).await;
+
+            println!("Running verify phase for profile '{profile_name}'...");
+            for case_index in setup_progress.successful {
+                let case = &profile.cases[case_index];
+                match run_compat_phase(&db, case, interceptor_registry, CompatPhase::Verify).await {
+                    Ok(()) => println!("  Verify: {} - PASSED", case.metadata.name),
+                    Err(e) => {
+                        println!("  Verify: {} - FAILED: {e}", case.metadata.name);
+                        failed_cases.push(case.metadata.name.clone());
+                        if self.fail_fast {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
         db.compat_stop();
-
-        // ---- 12. Cleanup ----
-        // Etcd is always cleaned up; --preserve-state only preserves sqlness_home.
         if self.setup_etcd {
-            println!("Stopping etcd");
+            println!("Stopping etcd for profile '{profile_name}'");
             util::stop_rm_etcd();
         }
-
-        if !self.preserve_state {
-            println!("Removing state in {:?}", sqlness_home);
-            tokio::fs::remove_dir_all(sqlness_home)
-                .await
-                .unwrap_or_else(|e| println!("Warning: failed to clean up temp dir: {e}"));
-        }
-
-        // Disarm the etcd guard now that we've done normal cleanup.
         if let Some(mut guard) = etcd_guard.take() {
             guard.disarm();
         }
 
-        if failed.is_empty() {
-            println!("\n\x1b[32mAll compat tests passed!\x1b[0m");
+        let preserved_home = if self.preserve_state {
+            Some(sqlness_home)
         } else {
-            println!("\n\x1b[31mFailed cases: {}\x1b[0m", failed.join(", "));
-            // Explicitly drop the guard before exit so it doesn't double-cleanup.
-            std::process::exit(1);
+            println!("Removing state in {:?}", sqlness_home);
+            tokio::fs::remove_dir_all(sqlness_home)
+                .await
+                .unwrap_or_else(|e| println!("Warning: failed to clean up temp dir: {e}"));
+            None
+        };
+
+        ProfileOutcome {
+            failed_cases,
+            preserved_home,
         }
     }
+}
+
+/// Result of one isolated profile lifecycle.
+struct ProfileOutcome {
+    failed_cases: Vec<String>,
+    preserved_home: Option<PathBuf>,
 }
 
 /// Guard that stops/removes Docker etcd on drop (panic or early exit).
@@ -867,7 +1015,11 @@ fn simple_diff(expected: &str, actual: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::trim_trailing_blank_lines;
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::cmd::compat_case::CaseMetadata;
 
     #[test]
     fn test_trim_trailing_blank_lines_preserves_single_final_newline() {
@@ -875,5 +1027,90 @@ mod tests {
         trim_trailing_blank_lines(&mut output);
 
         assert_eq!(output, "SELECT 1;\n\n+---+\n");
+    }
+
+    fn test_case(name: &str, old_config: Option<OldConfig>) -> CompatCase {
+        CompatCase {
+            metadata: CaseMetadata {
+                name: name.to_string(),
+                reason: "test".to_string(),
+                introduced_by: "test".to_string(),
+                topologies: vec![COMPAT_TOPOLOGY.to_string()],
+                from_range: vec!["*".to_string()],
+                to_range: vec!["*".to_string()],
+                features: vec!["table".to_string()],
+                owner: "test".to_string(),
+                namespace: None,
+                old_config,
+            },
+            dir: PathBuf::from(name),
+            namespace: name.to_string(),
+        }
+    }
+
+    fn old_profile(value: bool) -> OldConfig {
+        OldConfig {
+            datanode: BTreeMap::from([(
+                "region_engine.metric.sparse_primary_key_encoding".to_string(),
+                value,
+            )]),
+        }
+    }
+
+    #[test]
+    fn test_group_cases_by_full_normalized_config_profile() {
+        let profiles = group_cases_by_profile(vec![
+            test_case("baseline_a", None),
+            test_case("same_a", Some(old_profile(false))),
+            test_case("baseline_b", None),
+            test_case("same_b", Some(old_profile(false))),
+            test_case("distinct", Some(old_profile(true))),
+        ]);
+
+        assert_eq!(profiles.len(), 3);
+        assert!(profiles[0].old_config.is_none());
+        assert_eq!(profiles[0].cases.len(), 2);
+        assert_eq!(profiles[1].cases.len(), 2);
+        assert_eq!(profiles[2].cases.len(), 1);
+        assert_eq!(
+            profiles[0]
+                .cases
+                .iter()
+                .map(|case| case.metadata.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["baseline_a", "baseline_b"]
+        );
+        assert_eq!(
+            profiles[1]
+                .cases
+                .iter()
+                .map(|case| case.metadata.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["same_a", "same_b"]
+        );
+        assert_ne!(profiles[1].old_config, profiles[2].old_config);
+    }
+
+    #[test]
+    fn test_setup_failure_in_middle_verifies_other_successful_cases() {
+        let mut progress = SetupProgress::default();
+        for (index, succeeded) in [true, false, true].into_iter().enumerate() {
+            assert!(progress.record(index, succeeded, false));
+        }
+
+        assert_eq!(progress.successful, vec![0, 2]);
+        assert_eq!(progress.failed, vec![1]);
+        assert!(progress.should_transition(false));
+    }
+
+    #[test]
+    fn test_fail_fast_stops_setup_without_marking_unattempted_cases() {
+        let mut progress = SetupProgress::default();
+        assert!(progress.record(0, true, true));
+        assert!(!progress.record(1, false, true));
+
+        assert_eq!(progress.successful, vec![0]);
+        assert_eq!(progress.failed, vec![1]);
+        assert!(!progress.should_transition(true));
     }
 }

--- a/tests/runner/src/cmd/compat_case.rs
+++ b/tests/runner/src/cmd/compat_case.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -43,6 +43,61 @@ pub struct CaseMetadata {
     /// Must match `[a-z0-9_]+`.
     #[serde(default)]
     pub namespace: Option<String>,
+    /// Optional old-stage-only configuration overlay.
+    #[serde(default)]
+    pub old_config: Option<OldConfig>,
+}
+
+/// Typed, role-scoped configuration applied only while the old binary runs.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OldConfig {
+    /// Datanode logical configuration paths and their boolean values.
+    pub datanode: BTreeMap<String, bool>,
+}
+
+impl OldConfig {
+    /// Returns the normalized logical paths in this profile without exposing values.
+    pub(crate) fn keys(&self) -> impl Iterator<Item = &str> {
+        self.datanode.keys().map(String::as_str)
+    }
+
+    /// Validates the deliberately narrow first-version configuration surface.
+    pub(crate) fn validate(&self) -> Result<(), String> {
+        if self.datanode.is_empty() {
+            return Err("old_config.datanode must not be empty".to_string());
+        }
+
+        for path in self.datanode.keys() {
+            validate_old_datanode_path(path)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Validates a logical path under the positive region-engine allowlist.
+pub(crate) fn validate_old_datanode_path(path: &str) -> Result<(), String> {
+    let segments: Vec<_> = path.split('.').collect();
+    if segments.len() < 3 || segments.first() != Some(&"region_engine") {
+        return Err(format!(
+            "old_config.datanode key '{path}' must match region_engine.<engine>.<leaf/path>"
+        ));
+    }
+
+    for segment in segments {
+        let mut chars = segment.chars();
+        if segment.contains("__")
+            || !matches!(chars.next(), Some(c) if c.is_ascii_lowercase())
+            || !chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+        {
+            return Err(format!(
+                "old_config.datanode key '{path}' contains an invalid path segment"
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 impl CaseMetadata {
@@ -52,6 +107,15 @@ impl CaseMetadata {
         self.namespace
             .clone()
             .unwrap_or_else(|| sanitize_namespace(case_dir_name))
+    }
+
+    fn validate_old_config(&self) -> Result<(), String> {
+        if let Some(old_config) = &self.old_config {
+            old_config
+                .validate()
+                .map_err(|e| format!("Case '{}' has invalid old_config: {e}", self.name))?;
+        }
+        Ok(())
     }
 }
 
@@ -140,6 +204,7 @@ pub fn discover_cases(case_root: &Path) -> Result<Vec<CompatCase>, String> {
 
         let metadata: CaseMetadata = toml::from_str(&content)
             .map_err(|e| format!("Failed to parse {}: {e}", case_toml_path.display()))?;
+        metadata.validate_old_config()?;
 
         let case_dir_name = path
             .file_name()
@@ -223,6 +288,7 @@ pub fn validate_cases_metadata(cases: &[CompatCase]) -> Result<(), String> {
         if case.metadata.features.is_empty() {
             return Err(format!("Case '{}' has empty features", case.metadata.name));
         }
+        case.metadata.validate_old_config()?;
     }
 
     Ok(())
@@ -482,6 +548,7 @@ mod tests {
                 features: vec!["table".to_string()],
                 owner: "team".to_string(),
                 namespace: None,
+                old_config: None,
             },
             dir: PathBuf::from("case"),
             namespace: "case".to_string(),
@@ -503,6 +570,7 @@ mod tests {
                 features: vec!["table".to_string()],
                 owner: "test".to_string(),
                 namespace: None,
+                old_config: None,
             },
             dir: PathBuf::from("bad_constraint"),
             namespace: "bad_constraint".to_string(),
@@ -524,6 +592,7 @@ mod tests {
                 features: vec!["table".to_string()],
                 owner: "test".to_string(),
                 namespace: None,
+                old_config: None,
             },
             dir: PathBuf::from("case_a"),
             namespace: "shared_name".to_string(),
@@ -539,6 +608,7 @@ mod tests {
                 features: vec!["table".to_string()],
                 owner: "test".to_string(),
                 namespace: None,
+                old_config: None,
             },
             dir: PathBuf::from("case_b"),
             namespace: "shared_name".to_string(),
@@ -563,6 +633,7 @@ mod tests {
                 features: vec!["table".to_string()],
                 owner: "test".to_string(),
                 namespace: Some("shared_name".to_string()),
+                old_config: None,
             },
             dir: PathBuf::from("case_a"),
             namespace: "shared_name".to_string(),
@@ -578,6 +649,7 @@ mod tests {
                 features: vec!["table".to_string()],
                 owner: "test".to_string(),
                 namespace: Some("shared_name".to_string()),
+                old_config: None,
             },
             dir: PathBuf::from("case_b"),
             namespace: "shared_name".to_string(),
@@ -599,6 +671,7 @@ mod tests {
                 features: vec!["table".to_string()],
                 owner: "team".to_string(),
                 namespace: None,
+                old_config: None,
             },
             dir: PathBuf::from("case"),
             namespace: "case".to_string(),
@@ -644,6 +717,93 @@ owner = "test"
             discover_cases(tmp.path()).expect("discover should succeed without verify.result");
         assert_eq!(cases.len(), 1);
         assert_eq!(cases[0].metadata.name, "test_case");
+        assert!(cases[0].metadata.old_config.is_none());
+    }
+
+    #[test]
+    fn test_metadata_parses_typed_old_datanode_config() {
+        let metadata: CaseMetadata = toml::from_str(
+            r#"
+name = "test_case"
+reason = "test"
+introduced_by = "test"
+topologies = ["distributed"]
+from_range = ["*"]
+to_range = ["*"]
+features = ["table"]
+owner = "test"
+
+[old_config.datanode]
+"region_engine.metric.sparse_primary_key_encoding" = false
+"#,
+        )
+        .unwrap();
+
+        let old_config = metadata.old_config.unwrap();
+        assert_eq!(
+            old_config
+                .datanode
+                .get("region_engine.metric.sparse_primary_key_encoding"),
+            Some(&false)
+        );
+        assert!(old_config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_metadata_rejects_non_bool_old_config_values() {
+        let base = r#"
+name = "test_case"
+reason = "test"
+introduced_by = "test"
+topologies = ["distributed"]
+from_range = ["*"]
+to_range = ["*"]
+features = ["table"]
+owner = "test"
+
+[old_config.datanode]
+"region_engine.metric.sparse_primary_key_encoding" = VALUE
+"#;
+
+        for value in ["1", "\"false\""] {
+            assert!(toml::from_str::<CaseMetadata>(&base.replace("VALUE", value)).is_err());
+        }
+    }
+
+    #[test]
+    fn test_metadata_rejects_non_allowlisted_old_config_role() {
+        let metadata = r#"
+name = "test_case"
+reason = "test"
+introduced_by = "test"
+topologies = ["distributed"]
+from_range = ["*"]
+to_range = ["*"]
+features = ["table"]
+owner = "test"
+
+[old_config.frontend]
+"region_engine.metric.sparse_primary_key_encoding" = false
+"#;
+
+        assert!(toml::from_str::<CaseMetadata>(metadata).is_err());
+    }
+
+    #[test]
+    fn test_old_config_rejects_unsafe_or_non_allowlisted_paths() {
+        for path in [
+            "region_engine.metric",
+            "region_engine..enabled",
+            "region_engine.metric.__enabled",
+            "region_engine.METRIC.enabled",
+            "REGION_ENGINE.metric.enabled",
+            "datanode.metric.enabled",
+        ] {
+            let old_config = OldConfig {
+                datanode: BTreeMap::from([(path.to_string(), false)]),
+            };
+            assert!(old_config.validate().is_err(), "path should fail: {path}");
+        }
     }
 
     #[test]

--- a/tests/runner/src/cmd/compat_case.rs
+++ b/tests/runner/src/cmd/compat_case.rs
@@ -46,6 +46,27 @@ pub struct CaseMetadata {
     /// Optional old-stage-only configuration overlay.
     #[serde(default)]
     pub old_config: Option<OldConfig>,
+    /// Optional assertion evaluated against old-stage datanode logs after setup.
+    #[serde(default)]
+    pub old_assert: Option<OldStageAssertions>,
+}
+
+/// Typed assertions over behavior observed while the old binary runs.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OldStageAssertions {
+    /// Expected encoding reported when an old datanode creates a metric region.
+    pub metric_primary_key_encoding: ExpectedMetricPrimaryKeyEncoding,
+}
+
+/// Expected primary-key encoding reported by the metric region creation log.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ExpectedMetricPrimaryKeyEncoding {
+    /// Dense primary-key encoding.
+    Dense,
+    /// Sparse primary-key encoding.
+    Sparse,
 }
 
 /// Typed, role-scoped configuration applied only while the old binary runs.
@@ -549,6 +570,7 @@ mod tests {
                 owner: "team".to_string(),
                 namespace: None,
                 old_config: None,
+                old_assert: None,
             },
             dir: PathBuf::from("case"),
             namespace: "case".to_string(),
@@ -571,6 +593,7 @@ mod tests {
                 owner: "test".to_string(),
                 namespace: None,
                 old_config: None,
+                old_assert: None,
             },
             dir: PathBuf::from("bad_constraint"),
             namespace: "bad_constraint".to_string(),
@@ -593,6 +616,7 @@ mod tests {
                 owner: "test".to_string(),
                 namespace: None,
                 old_config: None,
+                old_assert: None,
             },
             dir: PathBuf::from("case_a"),
             namespace: "shared_name".to_string(),
@@ -609,6 +633,7 @@ mod tests {
                 owner: "test".to_string(),
                 namespace: None,
                 old_config: None,
+                old_assert: None,
             },
             dir: PathBuf::from("case_b"),
             namespace: "shared_name".to_string(),
@@ -634,6 +659,7 @@ mod tests {
                 owner: "test".to_string(),
                 namespace: Some("shared_name".to_string()),
                 old_config: None,
+                old_assert: None,
             },
             dir: PathBuf::from("case_a"),
             namespace: "shared_name".to_string(),
@@ -650,6 +676,7 @@ mod tests {
                 owner: "test".to_string(),
                 namespace: Some("shared_name".to_string()),
                 old_config: None,
+                old_assert: None,
             },
             dir: PathBuf::from("case_b"),
             namespace: "shared_name".to_string(),
@@ -672,6 +699,7 @@ mod tests {
                 owner: "team".to_string(),
                 namespace: None,
                 old_config: None,
+                old_assert: None,
             },
             dir: PathBuf::from("case"),
             namespace: "case".to_string(),
@@ -787,6 +815,63 @@ owner = "test"
 "#;
 
         assert!(toml::from_str::<CaseMetadata>(metadata).is_err());
+    }
+
+    #[test]
+    fn test_metadata_parses_typed_old_stage_assertions() {
+        let base = r#"
+name = "test_case"
+reason = "test"
+introduced_by = "test"
+topologies = ["distributed"]
+from_range = ["*"]
+to_range = ["*"]
+features = ["table"]
+owner = "test"
+
+[old_assert]
+metric_primary_key_encoding = VALUE
+"#;
+
+        for (value, expected) in [
+            ("\"dense\"", ExpectedMetricPrimaryKeyEncoding::Dense),
+            ("\"sparse\"", ExpectedMetricPrimaryKeyEncoding::Sparse),
+        ] {
+            let metadata: CaseMetadata = toml::from_str(&base.replace("VALUE", value)).unwrap();
+            assert_eq!(
+                metadata.old_assert.unwrap().metric_primary_key_encoding,
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn test_metadata_rejects_invalid_old_stage_assertions() {
+        let base = r#"
+name = "test_case"
+reason = "test"
+introduced_by = "test"
+topologies = ["distributed"]
+from_range = ["*"]
+to_range = ["*"]
+features = ["table"]
+owner = "test"
+
+[old_assert]
+ASSERTION
+"#;
+
+        for assertion in [
+            "",
+            "metric_primary_key_encoding = \"Dense\"",
+            "metric_primary_key_encoding = \"other\"",
+            "unknown = \"dense\"",
+        ] {
+            assert!(
+                toml::from_str::<CaseMetadata>(&base.replace("ASSERTION", assertion)).is_err(),
+                "assertion should fail: {assertion:?}"
+            );
+        }
     }
 
     #[test]

--- a/tests/runner/src/env/bare.rs
+++ b/tests/runner/src/env/bare.rs
@@ -30,10 +30,10 @@ use tokio::sync::Mutex as TokioMutex;
 
 use crate::client::MultiProtocolClient;
 use crate::cmd::bare::ServerAddr;
-use crate::cmd::compat_case::try_infer_version;
+use crate::cmd::compat_case::{OldConfig, try_infer_version};
 use crate::formatter::{ErrorFormatter, MysqlFormatter, OutputFormatter, PostgresqlFormatter};
 use crate::protocol_interceptor::{MYSQL, PROTOCOL_KEY};
-use crate::server_mode::{GrpcArgStyle, ServerMode};
+use crate::server_mode::{CompatConfigStage, GrpcArgStyle, ServerMode};
 use crate::util;
 use crate::util::{PROGRAM, get_workspace_root, maybe_pull_binary};
 
@@ -104,6 +104,8 @@ pub struct Env {
     extra_args: Vec<String>,
     /// Cache for the inferred gRPC argument style per `bins_dir`.
     grpc_arg_style_cache: Arc<Mutex<HashMap<PathBuf, GrpcArgStyle>>>,
+    /// Active compatibility configuration stage, shared by initial starts and restarts.
+    compat_config_stage: Arc<Mutex<CompatConfigStage>>,
 }
 
 #[async_trait]
@@ -154,6 +156,7 @@ impl Env {
             store_config,
             extra_args,
             grpc_arg_style_cache: Arc::new(Mutex::new(HashMap::new())),
+            compat_config_stage: Arc::new(Mutex::new(CompatConfigStage::Baseline)),
         }
     }
 
@@ -348,7 +351,15 @@ impl Env {
             .unwrap();
 
         let arg_style = self.infer_grpc_arg_style(&bins_dir);
-        let args = mode.get_args(&self.sqlness_home, self, db_ctx, id, arg_style);
+        let compat_stage = self.compat_stage_for_start();
+        let args = mode.get_args(
+            &self.sqlness_home,
+            self,
+            db_ctx,
+            id,
+            arg_style,
+            &compat_stage,
+        );
         let check_ip_addrs = mode.check_addrs();
 
         for check_ip_addr in &check_ip_addrs {
@@ -643,6 +654,21 @@ impl Env {
     /// Start a distributed GreptimeDB cluster. Exposed for compat runner.
     pub(crate) async fn compat_start_distributed(&self, id: usize) -> GreptimeDB {
         self.start_distributed(id).await
+    }
+
+    /// Activates a typed old-stage configuration profile for subsequent starts and restarts.
+    pub(crate) fn compat_activate_old_profile(&self, old_config: OldConfig) {
+        *self.compat_config_stage.lock().unwrap() = CompatConfigStage::Old(old_config);
+    }
+
+    /// Atomically clears the old-stage overlay before starting the current binary.
+    pub(crate) fn compat_activate_current_profile(&self) {
+        *self.compat_config_stage.lock().unwrap() = CompatConfigStage::Current;
+    }
+
+    /// Returns the stage that a subsequent server spawn or restart will render.
+    pub(crate) fn compat_stage_for_start(&self) -> CompatConfigStage {
+        self.compat_config_stage.lock().unwrap().clone()
     }
 
     /// Full restart of all distributed processes with a new binary directory,
@@ -960,5 +986,66 @@ impl GreptimeDBContext {
 
     fn get_server_mode(&self, idx: usize) -> Option<&ServerMode> {
         self.server_modes.get(idx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    fn test_env() -> Env {
+        Env::new(
+            PathBuf::from("."),
+            ServerAddr::default(),
+            WalConfig::RaftEngine,
+            false,
+            Some(PathBuf::from(".")),
+            StoreConfig {
+                store_addrs: vec![],
+                setup_etcd: false,
+                setup_pg: None,
+                setup_mysql: None,
+                enable_flat_format: false,
+                enable_gc: false,
+            },
+            vec![],
+        )
+    }
+
+    fn old_config() -> OldConfig {
+        OldConfig {
+            datanode: BTreeMap::from([(
+                "region_engine.metric.sparse_primary_key_encoding".to_string(),
+                false,
+            )]),
+        }
+    }
+
+    #[test]
+    fn test_compat_stage_keeps_old_for_setup_restarts_then_stays_current() {
+        let env = test_env();
+        env.compat_activate_old_profile(old_config());
+        assert!(matches!(
+            env.compat_stage_for_start(),
+            CompatConfigStage::Old(_)
+        ));
+        // A setup restart consumes the same stage and therefore retains the overlay.
+        assert!(matches!(
+            env.compat_stage_for_start(),
+            CompatConfigStage::Old(_)
+        ));
+
+        env.compat_activate_current_profile();
+        // The transition happens before a current spawn, and verify restarts stay clean.
+        assert!(matches!(
+            env.compat_stage_for_start(),
+            CompatConfigStage::Current
+        ));
+        assert!(matches!(
+            env.compat_stage_for_start(),
+            CompatConfigStage::Current
+        ));
     }
 }

--- a/tests/runner/src/env/bare.rs
+++ b/tests/runner/src/env/bare.rs
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::fmt::Display;
-use std::fs::OpenOptions;
+use std::fs::{self, OpenOptions};
 use std::io;
-use std::io::Write;
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use common_error::ext::ErrorExt;
@@ -30,7 +30,7 @@ use tokio::sync::Mutex as TokioMutex;
 
 use crate::client::MultiProtocolClient;
 use crate::cmd::bare::ServerAddr;
-use crate::cmd::compat_case::{OldConfig, try_infer_version};
+use crate::cmd::compat_case::{ExpectedMetricPrimaryKeyEncoding, OldConfig, try_infer_version};
 use crate::formatter::{ErrorFormatter, MysqlFormatter, OutputFormatter, PostgresqlFormatter};
 use crate::protocol_interceptor::{MYSQL, PROTOCOL_KEY};
 use crate::server_mode::{CompatConfigStage, GrpcArgStyle, ServerMode};
@@ -46,6 +46,193 @@ const SERVER_MODE_FRONTEND_IDX: usize = 4;
 const SERVER_MODE_FLOWNODE_IDX: usize = 5;
 // Number of datanodes in distributed mode
 const DISTRIBUTED_DATANODE_COUNT: usize = 3;
+const OLD_ASSERT_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const OLD_ASSERT_POLL_DEADLINE: Duration = Duration::from_secs(5);
+const OLD_ASSERT_QUIET_WINDOW: Duration = Duration::from_millis(225);
+
+/// Byte offset captured for one old datanode log before a case's setup phase.
+#[derive(Debug, Clone)]
+pub(crate) struct DatanodeLogSnapshot {
+    path: PathBuf,
+    offset: u64,
+    ends_with_newline: bool,
+}
+
+#[derive(Clone, Copy)]
+struct AssertionTiming {
+    poll_interval: Duration,
+    deadline: Duration,
+    quiet_window: Duration,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MetricEncodingEvent {
+    region: String,
+    encoding: ExpectedMetricPrimaryKeyEncoding,
+}
+
+fn datanode_log_file_name(id: usize, node_id: u32) -> String {
+    format!("greptime-{id}-sqlness-datanode-{node_id}.log")
+}
+
+/// Parses complete metric-region creation records from a datanode log fragment.
+fn parse_metric_encoding_events(records: &str) -> Result<Vec<MetricEncodingEvent>, String> {
+    const PREFIX: &str = "Created physical metric region ";
+    const MARKER: &str = ", primary key encoding=";
+
+    records
+        .lines()
+        .map(|line| {
+            let line = strip_ansi_csi(line);
+            if !line.contains(PREFIX) {
+                return Ok(None);
+            }
+            let (_, remainder) = line.split_once(PREFIX).expect("prefix checked");
+            let (region, encoding) = match remainder.split_once(MARKER) {
+                Some(parts) => parts,
+                None => {
+                    return Err(
+                        "metric region candidate lacks primary-key encoding marker".to_string()
+                    );
+                }
+            };
+            let (encoding, _) = match encoding.split_once(',') {
+                Some(parts) => parts,
+                None => {
+                    return Err("metric region candidate lacks trailing encoding comma".to_string());
+                }
+            };
+            let encoding = match encoding {
+                "Dense" => ExpectedMetricPrimaryKeyEncoding::Dense,
+                "Sparse" => ExpectedMetricPrimaryKeyEncoding::Sparse,
+                _ => {
+                    return Err(format!(
+                        "metric region candidate has unknown encoding '{encoding}'"
+                    ));
+                }
+            };
+            Ok(Some(MetricEncodingEvent {
+                region: region.to_string(),
+                encoding,
+            }))
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(|events| events.into_iter().flatten().collect())
+}
+
+fn matched_metric_regions(
+    events: &[MetricEncodingEvent],
+    expected: ExpectedMetricPrimaryKeyEncoding,
+) -> Result<BTreeSet<String>, String> {
+    let mut regions = BTreeSet::new();
+    for event in events {
+        if event.encoding != expected {
+            return Err(format!(
+                "region '{}' reported {:?} primary-key encoding, expected {:?}",
+                event.region, event.encoding, expected
+            ));
+        }
+        regions.insert(event.region.clone());
+    }
+    Ok(regions)
+}
+
+fn strip_ansi_csi(input: &str) -> String {
+    let mut stripped = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\u{1b}' && chars.next_if_eq(&'[').is_some() {
+            for csi in chars.by_ref() {
+                if ('@'..='~').contains(&csi) {
+                    break;
+                }
+            }
+        } else {
+            stripped.push(ch);
+        }
+    }
+    stripped
+}
+
+fn post_snapshot_records<'a>(snapshot: &DatanodeLogSnapshot, appended: &'a str) -> (&'a str, bool) {
+    let appended = if snapshot.ends_with_newline {
+        appended
+    } else {
+        match appended.find('\n') {
+            Some(index) => &appended[index + 1..],
+            None => "",
+        }
+    };
+    match appended.rfind('\n') {
+        Some(index) => (&appended[..=index], index + 1 != appended.len()),
+        None => ("", !appended.is_empty()),
+    }
+}
+
+fn read_appended_log(snapshot: &DatanodeLogSnapshot) -> Result<(String, u64), String> {
+    let metadata = fs::metadata(&snapshot.path).map_err(|error| {
+        format!(
+            "Failed to read old datanode log {} after setup: {error}",
+            snapshot.path.display()
+        )
+    })?;
+    if metadata.len() < snapshot.offset {
+        return Err(format!(
+            "Old datanode log {} was truncated after setup snapshot ({} < {})",
+            snapshot.path.display(),
+            metadata.len(),
+            snapshot.offset
+        ));
+    }
+    let mut file = OpenOptions::new()
+        .read(true)
+        .open(&snapshot.path)
+        .map_err(|error| {
+            format!(
+                "Failed to read old datanode log {} after setup: {error}",
+                snapshot.path.display()
+            )
+        })?;
+    file.seek(SeekFrom::Start(snapshot.offset))
+        .map_err(|error| {
+            format!(
+                "Failed to seek old datanode log {}: {error}",
+                snapshot.path.display()
+            )
+        })?;
+    let mut appended = Vec::new();
+    file.read_to_end(&mut appended).map_err(|error| {
+        format!(
+            "Failed to read old datanode log {} after setup: {error}",
+            snapshot.path.display()
+        )
+    })?;
+    let appended_len = u64::try_from(appended.len()).map_err(|_| {
+        format!(
+            "Old datanode log {} appended byte count does not fit in u64",
+            snapshot.path.display()
+        )
+    })?;
+    let observed_length = snapshot.offset.checked_add(appended_len).ok_or_else(|| {
+        format!(
+            "Old datanode log {} observed length overflowed",
+            snapshot.path.display()
+        )
+    })?;
+    Ok((
+        String::from_utf8_lossy(&appended).into_owned(),
+        observed_length,
+    ))
+}
+
+fn truncate_diagnostic(value: &str) -> &str {
+    const MAX_DIAGNOSTIC_BYTES: usize = 4096;
+    if value.len() <= MAX_DIAGNOSTIC_BYTES {
+        value
+    } else {
+        value.get(..MAX_DIAGNOSTIC_BYTES).unwrap_or(value)
+    }
+}
 
 #[derive(Clone)]
 pub enum WalConfig {
@@ -331,7 +518,7 @@ impl Env {
         let log_file_name = match mode {
             ServerMode::Datanode { node_id, .. } => {
                 db_ctx.incr_datanode_id();
-                format!("greptime-{}-sqlness-datanode-{}.log", id, node_id)
+                datanode_log_file_name(id, node_id)
             }
             ServerMode::Flownode { .. } => format!("greptime-{}-sqlness-flownode.log", id),
             ServerMode::Frontend { .. } => format!("greptime-{}-sqlness-frontend.log", id),
@@ -669,6 +856,130 @@ impl Env {
     /// Returns the stage that a subsequent server spawn or restart will render.
     pub(crate) fn compat_stage_for_start(&self) -> CompatConfigStage {
         self.compat_config_stage.lock().unwrap().clone()
+    }
+
+    /// Captures byte offsets for all distributed datanode logs before one setup case.
+    pub(crate) fn compat_snapshot_datanode_logs(
+        &self,
+        id: usize,
+    ) -> Result<Vec<DatanodeLogSnapshot>, String> {
+        (0..DISTRIBUTED_DATANODE_COUNT)
+            .map(|node_id| {
+                let path = self
+                    .sqlness_home
+                    .join(datanode_log_file_name(id, node_id as u32));
+                let mut file = OpenOptions::new().read(true).open(&path).map_err(|error| {
+                    format!(
+                        "Failed to snapshot old datanode log {}: {error}",
+                        path.display()
+                    )
+                })?;
+                let metadata = file.metadata().map_err(|error| {
+                    format!(
+                        "Failed to snapshot old datanode log {}: {error}",
+                        path.display()
+                    )
+                })?;
+                let offset = metadata.len();
+                let ends_with_newline = if offset == 0 {
+                    true
+                } else {
+                    file.seek(SeekFrom::Start(offset - 1)).map_err(|error| {
+                        format!(
+                            "Failed to inspect old datanode log {}: {error}",
+                            path.display()
+                        )
+                    })?;
+                    let mut byte = [0];
+                    file.read_exact(&mut byte).map_err(|error| {
+                        format!(
+                            "Failed to inspect old datanode log {}: {error}",
+                            path.display()
+                        )
+                    })?;
+                    byte[0] == b'\n'
+                };
+                Ok(DatanodeLogSnapshot {
+                    path,
+                    offset,
+                    ends_with_newline,
+                })
+            })
+            .collect()
+    }
+
+    /// Waits for stable metric primary-key encoding events appended after snapshots.
+    pub(crate) async fn compat_assert_metric_primary_key_encoding(
+        &self,
+        snapshots: &[DatanodeLogSnapshot],
+        expected: ExpectedMetricPrimaryKeyEncoding,
+    ) -> Result<(), String> {
+        self.compat_assert_metric_primary_key_encoding_with_timing(
+            snapshots,
+            expected,
+            AssertionTiming {
+                poll_interval: OLD_ASSERT_POLL_INTERVAL,
+                deadline: OLD_ASSERT_POLL_DEADLINE,
+                quiet_window: OLD_ASSERT_QUIET_WINDOW,
+            },
+        )
+        .await
+    }
+
+    async fn compat_assert_metric_primary_key_encoding_with_timing(
+        &self,
+        snapshots: &[DatanodeLogSnapshot],
+        expected: ExpectedMetricPrimaryKeyEncoding,
+        timing: AssertionTiming,
+    ) -> Result<(), String> {
+        let deadline = Instant::now() + timing.deadline;
+        let mut previous_lengths = None;
+        let mut quiet_since = Instant::now();
+        let mut diagnostics = Vec::new();
+
+        loop {
+            let mut regions = BTreeSet::new();
+            let mut lengths = Vec::with_capacity(snapshots.len());
+            let mut has_incomplete = false;
+            diagnostics.clear();
+            for snapshot in snapshots {
+                let (appended, length) = read_appended_log(snapshot)?;
+                lengths.push(length);
+                diagnostics.push(format!(
+                    "{}: {}",
+                    snapshot.path.display(),
+                    truncate_diagnostic(&appended)
+                ));
+                let (records, incomplete) = post_snapshot_records(snapshot, &appended);
+                has_incomplete |= incomplete;
+                let events = parse_metric_encoding_events(records)?;
+                let matched = matched_metric_regions(&events, expected).map_err(|error| {
+                    format!("Old datanode log {} {error}", snapshot.path.display())
+                })?;
+                regions.extend(matched);
+            }
+
+            if previous_lengths.as_ref() != Some(&lengths) {
+                previous_lengths = Some(lengths);
+                quiet_since = Instant::now();
+            }
+
+            if !regions.is_empty()
+                && !has_incomplete
+                && quiet_since.elapsed() >= timing.quiet_window
+            {
+                return Ok(());
+            }
+
+            if Instant::now() >= deadline {
+                return Err(format!(
+                    "No stable old metric primary-key encoding event for expected {:?}; appended log diagnostics: {}",
+                    expected,
+                    diagnostics.join(" | ")
+                ));
+            }
+            tokio::time::sleep(timing.poll_interval).await;
+        }
     }
 
     /// Full restart of all distributed processes with a new binary directory,
@@ -1047,5 +1358,442 @@ mod tests {
             env.compat_stage_for_start(),
             CompatConfigStage::Current
         ));
+    }
+
+    fn event(region: &str, encoding: &str) -> String {
+        format!(
+            "Created physical metric region {region}, primary key encoding={encoding}, created\n"
+        )
+    }
+
+    #[test]
+    fn test_metric_encoding_parser_accepts_dense_duplicates_and_multiple_regions() {
+        let records = format!(
+            "{}{}{}",
+            event("a,1", "Dense"),
+            event("a,1", "Dense"),
+            event("b", "Dense")
+        );
+        let events = parse_metric_encoding_events(&records).unwrap();
+        assert_eq!(events.len(), 3);
+        assert_eq!(
+            matched_metric_regions(&events, ExpectedMetricPrimaryKeyEncoding::Dense).unwrap(),
+            BTreeSet::from(["a,1".to_string(), "b".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_metric_encoding_parser_rejects_mixed_or_opposite_encodings() {
+        let sparse = parse_metric_encoding_events(&event("region", "Sparse")).unwrap();
+        assert!(matched_metric_regions(&sparse, ExpectedMetricPrimaryKeyEncoding::Dense).is_err());
+
+        let mixed = parse_metric_encoding_events(&format!(
+            "{}{}",
+            event("dense", "Dense"),
+            event("sparse", "Sparse")
+        ))
+        .unwrap();
+        assert!(matched_metric_regions(&mixed, ExpectedMetricPrimaryKeyEncoding::Dense).is_err());
+        assert!(
+            matched_metric_regions(&[], ExpectedMetricPrimaryKeyEncoding::Dense)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn test_metric_encoding_parser_handles_ansi_prefixes_and_partial_records() {
+        let prefixed = format!(
+            "{{\"msg\":\"\u{1b}[32m{}\u{1b}[0m\"}}\n",
+            event("ansi", "Dense").trim()
+        );
+        let events = parse_metric_encoding_events(&prefixed).unwrap();
+        assert_eq!(events.len(), 1);
+
+        let partial = "Created physical metric region split, primary key encoding=Dense,";
+        assert!(parse_metric_encoding_events("").unwrap().is_empty());
+        assert_eq!(
+            parse_metric_encoding_events(&format!("{partial}\n"))
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_metric_encoding_parser_rejects_malformed_candidates() {
+        for line in [
+            "Created physical metric region r",
+            "Created physical metric region r, primary key encoding=Dense",
+            "Created physical metric region r, primary key encoding=Unknown,",
+        ] {
+            assert!(parse_metric_encoding_events(line).is_err(), "{line}");
+        }
+    }
+
+    #[test]
+    fn test_pre_snapshot_partial_line_is_discarded_through_its_boundary() {
+        let snapshot = DatanodeLogSnapshot {
+            path: PathBuf::from("unused"),
+            offset: 1,
+            ends_with_newline: false,
+        };
+        let appended = format!(
+            "old suffix, primary key encoding=Dense,\n{}",
+            event("new", "Dense")
+        );
+        let (records, incomplete) = post_snapshot_records(&snapshot, &appended);
+        assert!(!incomplete);
+        let events = parse_metric_encoding_events(records).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].region, "new");
+    }
+
+    #[test]
+    fn test_real_snapshot_discards_a_pre_snapshot_partial_line() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let env = Env::new(
+            temp_dir.path().to_path_buf(),
+            ServerAddr::default(),
+            WalConfig::RaftEngine,
+            false,
+            Some(PathBuf::from(".")),
+            StoreConfig {
+                store_addrs: vec![],
+                setup_etcd: false,
+                setup_pg: None,
+                setup_mysql: None,
+                enable_flat_format: false,
+                enable_gc: false,
+            },
+            vec![],
+        );
+        for node_id in 0..DISTRIBUTED_DATANODE_COUNT {
+            let content = if node_id == 0 { "old partial" } else { "" };
+            std::fs::write(
+                temp_dir
+                    .path()
+                    .join(datanode_log_file_name(0, node_id as u32)),
+                content,
+            )
+            .unwrap();
+        }
+        let snapshots = env.compat_snapshot_datanode_logs(0).unwrap();
+        assert!(!snapshots[0].ends_with_newline);
+        OpenOptions::new()
+            .append(true)
+            .open(&snapshots[0].path)
+            .unwrap()
+            .write_all(
+                format!(", primary key encoding=Sparse,\n{}", event("new", "Dense")).as_bytes(),
+            )
+            .unwrap();
+
+        let (appended, _) = read_appended_log(&snapshots[0]).unwrap();
+        let (records, incomplete) = post_snapshot_records(&snapshots[0], &appended);
+        assert!(!incomplete);
+        let events = parse_metric_encoding_events(records).unwrap();
+        assert_eq!(
+            events,
+            vec![MetricEncodingEvent {
+                region: "new".to_string(),
+                encoding: ExpectedMetricPrimaryKeyEncoding::Dense
+            }]
+        );
+    }
+
+    #[test]
+    fn test_completed_dense_then_completed_sparse_fails_after_partial_sparse_waits() {
+        let snapshot = DatanodeLogSnapshot {
+            path: PathBuf::from("unused"),
+            offset: 0,
+            ends_with_newline: true,
+        };
+        let partial = format!(
+            "{}Created physical metric region sparse, primary",
+            event("dense", "Dense")
+        );
+        let (records, incomplete) = post_snapshot_records(&snapshot, &partial);
+        assert!(incomplete);
+        assert!(
+            matched_metric_regions(
+                &parse_metric_encoding_events(records).unwrap(),
+                ExpectedMetricPrimaryKeyEncoding::Dense
+            )
+            .is_ok()
+        );
+
+        let completed = format!("{} key encoding=Sparse,\n", partial);
+        let (records, incomplete) = post_snapshot_records(&snapshot, &completed);
+        assert!(!incomplete);
+        assert!(
+            matched_metric_regions(
+                &parse_metric_encoding_events(records).unwrap(),
+                ExpectedMetricPrimaryKeyEncoding::Dense
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn test_datanode_log_snapshots_use_independent_offsets_and_ignore_previous_content() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let env = Env::new(
+            temp_dir.path().to_path_buf(),
+            ServerAddr::default(),
+            WalConfig::RaftEngine,
+            false,
+            Some(PathBuf::from(".")),
+            StoreConfig {
+                store_addrs: vec![],
+                setup_etcd: false,
+                setup_pg: None,
+                setup_mysql: None,
+                enable_flat_format: false,
+                enable_gc: false,
+            },
+            vec![],
+        );
+        for node_id in 0..DISTRIBUTED_DATANODE_COUNT {
+            std::fs::write(
+                temp_dir
+                    .path()
+                    .join(datanode_log_file_name(0, node_id as u32)),
+                event(&format!("old-{node_id}"), "Sparse"),
+            )
+            .unwrap();
+        }
+        let snapshots = env.compat_snapshot_datanode_logs(0).unwrap();
+        for (node_id, snapshot) in snapshots.iter().enumerate() {
+            std::fs::write(
+                &snapshot.path,
+                format!(
+                    "{}{}",
+                    event(&format!("old-{node_id}"), "Sparse"),
+                    event(&format!("new-{node_id}"), "Dense")
+                ),
+            )
+            .unwrap();
+        }
+
+        for (node_id, snapshot) in snapshots.iter().enumerate() {
+            let (appended, _) = read_appended_log(snapshot).unwrap();
+            assert_eq!(appended, event(&format!("new-{node_id}"), "Dense"));
+        }
+    }
+
+    #[test]
+    fn test_snapshot_rejects_missing_datanode_log() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let env = Env::new(
+            temp_dir.path().to_path_buf(),
+            ServerAddr::default(),
+            WalConfig::RaftEngine,
+            false,
+            Some(PathBuf::from(".")),
+            StoreConfig {
+                store_addrs: vec![],
+                setup_etcd: false,
+                setup_pg: None,
+                setup_mysql: None,
+                enable_flat_format: false,
+                enable_gc: false,
+            },
+            vec![],
+        );
+        std::fs::write(temp_dir.path().join(datanode_log_file_name(0, 0)), "").unwrap();
+        std::fs::write(temp_dir.path().join(datanode_log_file_name(0, 1)), "").unwrap();
+        assert!(env.compat_snapshot_datanode_logs(0).is_err());
+    }
+
+    #[test]
+    fn test_datanode_log_reader_rejects_truncation_and_read_errors() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("datanode.log");
+        std::fs::write(&path, "before\n").unwrap();
+        let snapshot = DatanodeLogSnapshot {
+            path: path.clone(),
+            offset: 7,
+            ends_with_newline: true,
+        };
+        std::fs::write(&path, "x\n").unwrap();
+        assert!(
+            read_appended_log(&snapshot)
+                .unwrap_err()
+                .contains("truncated")
+        );
+
+        let missing = DatanodeLogSnapshot {
+            path: temp_dir.path().join("missing.log"),
+            offset: 0,
+            ends_with_newline: true,
+        };
+        assert!(read_appended_log(&missing).is_err());
+    }
+
+    #[tokio::test]
+    async fn test_metric_assertion_waits_for_completed_stable_records() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let env = Env::new(
+            temp_dir.path().to_path_buf(),
+            ServerAddr::default(),
+            WalConfig::RaftEngine,
+            false,
+            Some(PathBuf::from(".")),
+            StoreConfig {
+                store_addrs: vec![],
+                setup_etcd: false,
+                setup_pg: None,
+                setup_mysql: None,
+                enable_flat_format: false,
+                enable_gc: false,
+            },
+            vec![],
+        );
+        for node_id in 0..DISTRIBUTED_DATANODE_COUNT {
+            std::fs::write(
+                temp_dir
+                    .path()
+                    .join(datanode_log_file_name(0, node_id as u32)),
+                "",
+            )
+            .unwrap();
+        }
+        let snapshots = env.compat_snapshot_datanode_logs(0).unwrap();
+        let event = event("split", "Dense");
+        let split_at = event.len() / 2;
+        std::fs::write(&snapshots[0].path, &event[..split_at]).unwrap();
+        let path = snapshots[0].path.clone();
+        let remainder = event[split_at..].to_string();
+        let writer = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(75)).await;
+            OpenOptions::new()
+                .append(true)
+                .open(path)
+                .unwrap()
+                .write_all(remainder.as_bytes())
+                .unwrap();
+        });
+
+        env.compat_assert_metric_primary_key_encoding(
+            &snapshots,
+            ExpectedMetricPrimaryKeyEncoding::Dense,
+        )
+        .await
+        .unwrap();
+        writer.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_polling_waits_for_incomplete_sparse_then_rejects_it_when_completed() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let env = Env::new(
+            temp_dir.path().to_path_buf(),
+            ServerAddr::default(),
+            WalConfig::RaftEngine,
+            false,
+            Some(PathBuf::from(".")),
+            StoreConfig {
+                store_addrs: vec![],
+                setup_etcd: false,
+                setup_pg: None,
+                setup_mysql: None,
+                enable_flat_format: false,
+                enable_gc: false,
+            },
+            vec![],
+        );
+        for node_id in 0..DISTRIBUTED_DATANODE_COUNT {
+            std::fs::write(
+                temp_dir
+                    .path()
+                    .join(datanode_log_file_name(0, node_id as u32)),
+                "",
+            )
+            .unwrap();
+        }
+        let snapshots = env.compat_snapshot_datanode_logs(0).unwrap();
+        OpenOptions::new()
+            .append(true)
+            .open(&snapshots[0].path)
+            .unwrap()
+            .write_all(
+                format!(
+                    "{}Created physical metric region sparse, primary",
+                    event("dense", "Dense")
+                )
+                .as_bytes(),
+            )
+            .unwrap();
+        let assertion_env = env.clone();
+        let assertion_snapshots = snapshots.clone();
+        let assertion = tokio::spawn(async move {
+            assertion_env
+                .compat_assert_metric_primary_key_encoding_with_timing(
+                    &assertion_snapshots,
+                    ExpectedMetricPrimaryKeyEncoding::Dense,
+                    AssertionTiming {
+                        poll_interval: Duration::from_millis(5),
+                        deadline: Duration::from_millis(500),
+                        quiet_window: Duration::from_millis(20),
+                    },
+                )
+                .await
+        });
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        assert!(!assertion.is_finished());
+        OpenOptions::new()
+            .append(true)
+            .open(&snapshots[0].path)
+            .unwrap()
+            .write_all(b" key encoding=Sparse,\n")
+            .unwrap();
+        let error = assertion.await.unwrap().unwrap_err();
+        assert!(error.contains("Sparse"));
+    }
+
+    #[tokio::test]
+    async fn test_metric_assertion_rejects_zero_events() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let env = Env::new(
+            temp_dir.path().to_path_buf(),
+            ServerAddr::default(),
+            WalConfig::RaftEngine,
+            false,
+            Some(PathBuf::from(".")),
+            StoreConfig {
+                store_addrs: vec![],
+                setup_etcd: false,
+                setup_pg: None,
+                setup_mysql: None,
+                enable_flat_format: false,
+                enable_gc: false,
+            },
+            vec![],
+        );
+        for node_id in 0..DISTRIBUTED_DATANODE_COUNT {
+            std::fs::write(
+                temp_dir
+                    .path()
+                    .join(datanode_log_file_name(0, node_id as u32)),
+                "unrelated old datanode log\n",
+            )
+            .unwrap();
+        }
+        let snapshots = env.compat_snapshot_datanode_logs(0).unwrap();
+
+        let error = env
+            .compat_assert_metric_primary_key_encoding_with_timing(
+                &snapshots,
+                ExpectedMetricPrimaryKeyEncoding::Dense,
+                AssertionTiming {
+                    poll_interval: Duration::from_millis(1),
+                    deadline: Duration::from_millis(20),
+                    quiet_window: Duration::from_millis(5),
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(error.contains("No stable old metric primary-key encoding event"));
     }
 }

--- a/tests/runner/src/server_mode.rs
+++ b/tests/runner/src/server_mode.rs
@@ -18,13 +18,43 @@ use std::sync::{Mutex, OnceLock};
 
 use serde::Serialize;
 use tinytemplate::TinyTemplate;
+use toml::Value;
 
 use crate::cmd::bare::ServerAddr;
-use crate::cmd::compat_case::Version;
+use crate::cmd::compat_case::{OldConfig, Version, validate_old_datanode_path};
 use crate::env::bare::{Env, GreptimeDBContext, ServiceProvider};
 use crate::util;
 
 const DEFAULT_LOG_LEVEL: &str = "--log-level=debug,hyper=warn,tower=warn,datafusion=warn,reqwest=warn,sqlparser=warn,h2=info,opendal=info";
+
+/// The explicitly active compatibility configuration stage.
+#[derive(Debug, Clone, Default)]
+pub(crate) enum CompatConfigStage {
+    /// Ordinary rendering without compatibility-specific configuration.
+    #[default]
+    Baseline,
+    /// Old binary configuration with its typed datanode overlay.
+    Old(OldConfig),
+    /// Newly rendered current-binary configuration with no old overlay.
+    Current,
+}
+
+impl CompatConfigStage {
+    fn file_suffix(&self) -> &'static str {
+        match self {
+            Self::Baseline => "",
+            Self::Old(_) => "-old",
+            Self::Current => "-current",
+        }
+    }
+
+    fn old_config(&self) -> Option<&OldConfig> {
+        match self {
+            Self::Old(config) => Some(config),
+            Self::Baseline | Self::Current => None,
+        }
+    }
+}
 
 /// Which set of gRPC CLI argument names to use when spawning a GreptimeDB binary.
 ///
@@ -152,6 +182,127 @@ struct ConfigContext {
     enable_flat_format: bool,
     // enable garbage collection in metasrv and datanodes
     enable_gc: bool,
+}
+
+/// Applies the intentionally narrow compatibility overlay to rendered datanode TOML.
+///
+/// This is not a generic TOML merge: every logical path selects one named entry in
+/// `[[region_engine]]`, then descends only through table values to set a boolean leaf.
+pub(crate) fn apply_old_datanode_overlay(
+    rendered: &str,
+    old_config: &OldConfig,
+) -> Result<String, String> {
+    let mut document: Value = toml::from_str(rendered)
+        .map_err(|e| format!("Failed to parse rendered datanode TOML: {e}"))?;
+
+    for (path, value) in &old_config.datanode {
+        validate_old_datanode_path(path)?;
+        apply_region_engine_bool(&mut document, path, *value)?;
+    }
+
+    toml::to_string(&document).map_err(|e| format!("Failed to render datanode TOML: {e}"))
+}
+
+/// Validates an old-stage overlay against the rendered datanode template used by
+/// the runner without creating state or starting services.
+pub(crate) fn validate_old_config_against_datanode_template(
+    old_config: &OldConfig,
+) -> Result<(), String> {
+    let mut path = util::sqlness_conf_path();
+    path.push("datanode-test.toml.template");
+    let template = std::fs::read_to_string(&path)
+        .map_err(|e| format!("Failed to read datanode template '{}': {e}", path.display()))?;
+    let mut tt = TinyTemplate::new();
+    tt.add_template("datanode", &template)
+        .map_err(|e| format!("Failed to parse datanode template: {e}"))?;
+    let rendered = tt
+        .render(
+            "datanode",
+            &ConfigContext {
+                wal_dir: "/tmp/wal".to_string(),
+                data_home: "/tmp/data".to_string(),
+                procedure_dir: "/tmp/procedure".to_string(),
+                is_raft_engine: true,
+                kafka_wal_broker_endpoints: String::new(),
+                use_etcd: true,
+                store_addrs: "\"127.0.0.1:2379\"".to_string(),
+                instance_id: 0,
+                addrs: [("metasrv_addr".to_string(), "127.0.0.1:3002".to_string())].into(),
+                enable_flat_format: false,
+                enable_gc: false,
+            },
+        )
+        .map_err(|e| format!("Failed to render datanode template: {e}"))?;
+
+    apply_old_datanode_overlay(&rendered, old_config).map(|_| ())
+}
+
+fn apply_region_engine_bool(document: &mut Value, path: &str, value: bool) -> Result<(), String> {
+    let segments: Vec<_> = path.split('.').collect();
+    let engine = segments[1];
+    let leaf_path = &segments[2..];
+    let root = document
+        .as_table_mut()
+        .ok_or_else(|| "Rendered datanode TOML root must be a table".to_string())?;
+    let entries = root
+        .get_mut("region_engine")
+        .ok_or_else(|| "Rendered datanode TOML has no region_engine array".to_string())?
+        .as_array_mut()
+        .ok_or_else(|| "Rendered datanode TOML region_engine must be an array".to_string())?;
+
+    let matching_entries: Vec<_> = entries
+        .iter()
+        .enumerate()
+        .filter_map(|(index, entry)| {
+            entry
+                .as_table()
+                .and_then(|table| table.contains_key(engine).then_some(index))
+        })
+        .collect();
+    if matching_entries.len() > 1 {
+        return Err(format!(
+            "Rendered datanode TOML has duplicate region_engine entry '{engine}'"
+        ));
+    }
+
+    let entry_index = if let Some(index) = matching_entries.first() {
+        *index
+    } else {
+        let mut engine_table = toml::map::Map::new();
+        engine_table.insert(engine.to_string(), Value::Table(toml::map::Map::new()));
+        entries.push(Value::Table(engine_table));
+        entries.len() - 1
+    };
+
+    let entry = entries[entry_index]
+        .as_table_mut()
+        .ok_or_else(|| format!("region_engine entry '{engine}' must be a table"))?;
+    let engine_value = entry
+        .get_mut(engine)
+        .ok_or_else(|| format!("region_engine entry '{engine}' is missing"))?;
+    let mut current = engine_value
+        .as_table_mut()
+        .ok_or_else(|| format!("region_engine entry '{engine}' must be a table"))?;
+
+    for segment in &leaf_path[..leaf_path.len() - 1] {
+        let node = current
+            .entry((*segment).to_string())
+            .or_insert_with(|| Value::Table(toml::map::Map::new()));
+        current = node.as_table_mut().ok_or_else(|| {
+            format!("old_config.datanode key '{path}' has non-table intermediate '{segment}'")
+        })?;
+    }
+
+    let leaf = leaf_path.last().expect("validated path has a leaf");
+    if let Some(existing) = current.get(*leaf)
+        && !existing.is_bool()
+    {
+        return Err(format!(
+            "old_config.datanode key '{path}' conflicts with an existing non-bool value"
+        ));
+    }
+    current.insert((*leaf).to_string(), Value::Boolean(value));
+    Ok(())
 }
 
 impl ServerMode {
@@ -304,6 +455,7 @@ impl ServerMode {
         sqlness_home: &Path,
         db_ctx: &GreptimeDBContext,
         id: usize,
+        compat_stage: &CompatConfigStage,
     ) -> String {
         let mut tt = TinyTemplate::new();
 
@@ -363,9 +515,25 @@ impl ServerMode {
         };
 
         let rendered = tt.render(self.name(), &ctx).unwrap();
+        let rendered = if matches!(self, Self::Datanode { .. }) {
+            compat_stage
+                .old_config()
+                .map(|config| apply_old_datanode_overlay(&rendered, config))
+                .transpose()
+                .unwrap_or_else(|e| panic!("Failed to apply old datanode config: {e}"))
+                .unwrap_or(rendered)
+        } else {
+            rendered
+        };
 
         let conf_file = data_home
-            .join(format!("{}-{}-{}.toml", self.name(), id, db_ctx.time()))
+            .join(format!(
+                "{}-{}-{}{}.toml",
+                self.name(),
+                id,
+                db_ctx.time(),
+                compat_stage.file_suffix()
+            ))
             .display()
             .to_string();
         println!(
@@ -385,6 +553,7 @@ impl ServerMode {
         db_ctx: &GreptimeDBContext,
         id: usize,
         arg_style: GrpcArgStyle,
+        compat_stage: &CompatConfigStage,
     ) -> Vec<String> {
         let mut args = env
             .extra_args()
@@ -408,7 +577,7 @@ impl ServerMode {
                         id
                     ),
                     "-c".to_string(),
-                    self.generate_config_file(sqlness_home, db_ctx, id),
+                    self.generate_config_file(sqlness_home, db_ctx, id, compat_stage),
                     format!("--http-addr={http_addr}"),
                     format!("{}={rpc_bind_addr}", arg_style.bind_addr_arg()),
                     format!("--mysql-addr={mysql_addr}"),
@@ -437,7 +606,7 @@ impl ServerMode {
                         id
                     ),
                     "-c".to_string(),
-                    self.generate_config_file(sqlness_home, db_ctx, id),
+                    self.generate_config_file(sqlness_home, db_ctx, id, compat_stage),
                 ]);
             }
             ServerMode::Metasrv {
@@ -459,7 +628,7 @@ impl ServerMode {
                         id
                     ),
                     "-c".to_string(),
-                    self.generate_config_file(sqlness_home, db_ctx, id),
+                    self.generate_config_file(sqlness_home, db_ctx, id, compat_stage),
                 ]);
 
                 if matches!(
@@ -538,7 +707,7 @@ impl ServerMode {
                     format!("--log-dir={}/logs", data_home.display()),
                     format!("--node-id={node_id}"),
                     "-c".to_string(),
-                    self.generate_config_file(sqlness_home, db_ctx, id),
+                    self.generate_config_file(sqlness_home, db_ctx, id, compat_stage),
                     format!("--metasrv-addrs={metasrv_addr}"),
                 ]);
             }
@@ -570,6 +739,7 @@ impl ServerMode {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::path::PathBuf;
 
     use super::*;
@@ -639,7 +809,14 @@ mod tests {
             postgres_addr: "127.0.0.1:4003".to_string(),
         };
         assert_uses_style(
-            &standalone.get_args(temp_dir, env, db_ctx, 0, style),
+            &standalone.get_args(
+                temp_dir,
+                env,
+                db_ctx,
+                0,
+                style,
+                &CompatConfigStage::Baseline,
+            ),
             style,
             false,
         );
@@ -652,7 +829,14 @@ mod tests {
             metasrv_addr: "127.0.0.1:4001".to_string(),
         };
         assert_uses_style(
-            &frontend.get_args(temp_dir, env, db_ctx, 0, style),
+            &frontend.get_args(
+                temp_dir,
+                env,
+                db_ctx,
+                0,
+                style,
+                &CompatConfigStage::Baseline,
+            ),
             style,
             true,
         );
@@ -663,7 +847,14 @@ mod tests {
             http_addr: "127.0.0.1:4200".to_string(),
         };
         assert_uses_style(
-            &metasrv.get_args(temp_dir, env, db_ctx, 0, style),
+            &metasrv.get_args(
+                temp_dir,
+                env,
+                db_ctx,
+                0,
+                style,
+                &CompatConfigStage::Baseline,
+            ),
             style,
             true,
         );
@@ -676,7 +867,14 @@ mod tests {
             node_id: 0,
         };
         assert_uses_style(
-            &datanode.get_args(temp_dir, env, db_ctx, 0, style),
+            &datanode.get_args(
+                temp_dir,
+                env,
+                db_ctx,
+                0,
+                style,
+                &CompatConfigStage::Baseline,
+            ),
             style,
             true,
         );
@@ -689,7 +887,14 @@ mod tests {
             node_id: 0,
         };
         assert_uses_style(
-            &flownode.get_args(temp_dir, env, db_ctx, 0, style),
+            &flownode.get_args(
+                temp_dir,
+                env,
+                db_ctx,
+                0,
+                style,
+                &CompatConfigStage::Baseline,
+            ),
             style,
             true,
         );
@@ -757,15 +962,131 @@ mod tests {
             node_id: 0,
         };
 
-        let metasrv_config =
-            std::fs::read_to_string(metasrv.generate_config_file(temp_dir.path(), &db_ctx, 0))
-                .unwrap();
-        let datanode_config =
-            std::fs::read_to_string(datanode.generate_config_file(temp_dir.path(), &db_ctx, 0))
-                .unwrap();
+        let metasrv_config = std::fs::read_to_string(metasrv.generate_config_file(
+            temp_dir.path(),
+            &db_ctx,
+            0,
+            &CompatConfigStage::Baseline,
+        ))
+        .unwrap();
+        let datanode_config = std::fs::read_to_string(datanode.generate_config_file(
+            temp_dir.path(),
+            &db_ctx,
+            0,
+            &CompatConfigStage::Baseline,
+        ))
+        .unwrap();
 
         assert!(metasrv_config.contains("[gc]\nenable = true"));
         assert!(metasrv_config.contains("[gc.experimental_soft_drop]\nenable = true"));
         assert!(datanode_config.contains("[region_engine.mito.gc]\nenable = true"));
+    }
+
+    fn metric_overlay() -> OldConfig {
+        OldConfig {
+            datanode: BTreeMap::from([(
+                "region_engine.metric.sparse_primary_key_encoding".to_string(),
+                false,
+            )]),
+        }
+    }
+
+    #[test]
+    fn test_old_overlay_targets_named_region_engine_entry() {
+        let rendered = r#"
+[[region_engine]]
+[region_engine.mito]
+enable_write_cache = true
+"#;
+
+        let overlaid = apply_old_datanode_overlay(rendered, &metric_overlay()).unwrap();
+        let value: Value = toml::from_str(&overlaid).unwrap();
+        let entries = value["region_engine"].as_array().unwrap();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(
+            entries[1]["metric"]["sparse_primary_key_encoding"].as_bool(),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn test_old_overlay_rejects_duplicate_engine_non_table_and_type_conflicts() {
+        let overlay = metric_overlay();
+        for rendered in [
+            "[[region_engine]]\n[region_engine.metric]\n\n[[region_engine]]\n[region_engine.metric]\n",
+            "[[region_engine]]\nmetric = false\n",
+            "[[region_engine]]\n[region_engine.metric]\nsparse_primary_key_encoding = \"false\"\n",
+            "[[region_engine]]\n[region_engine.metric]\ncache = false\n",
+        ] {
+            let actual_overlay = if rendered.contains("cache = false") {
+                OldConfig {
+                    datanode: BTreeMap::from([(
+                        "region_engine.metric.cache.enabled".to_string(),
+                        false,
+                    )]),
+                }
+            } else {
+                overlay.clone()
+            };
+            assert!(apply_old_datanode_overlay(rendered, &actual_overlay).is_err());
+        }
+    }
+
+    #[test]
+    fn test_actual_datanode_template_validates_old_profile_without_state() {
+        assert!(validate_old_config_against_datanode_template(&metric_overlay()).is_ok());
+    }
+
+    #[test]
+    fn test_old_and_current_datanode_configs_are_independently_rendered() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let (_, db_ctx) = test_env(temp_dir.path());
+        let datanode = ServerMode::Datanode {
+            rpc_bind_addr: "127.0.0.1:4301".to_string(),
+            rpc_server_addr: "127.0.0.1:4301".to_string(),
+            http_addr: "127.0.0.1:4300".to_string(),
+            metasrv_addr: "127.0.0.1:4001".to_string(),
+            node_id: 0,
+        };
+        let old_path = datanode.generate_config_file(
+            temp_dir.path(),
+            &db_ctx,
+            0,
+            &CompatConfigStage::Old(metric_overlay()),
+        );
+        let baseline_path = datanode.generate_config_file(
+            temp_dir.path(),
+            &db_ctx,
+            0,
+            &CompatConfigStage::Baseline,
+        );
+        let current_path =
+            datanode.generate_config_file(temp_dir.path(), &db_ctx, 0, &CompatConfigStage::Current);
+
+        assert_ne!(old_path, current_path);
+        assert!(!baseline_path.ends_with("-.toml"));
+        assert!(old_path.ends_with("-old.toml"));
+        assert!(current_path.ends_with("-current.toml"));
+        assert!(!old_path.ends_with("--old.toml"));
+        assert!(!current_path.ends_with("--current.toml"));
+        assert!(
+            std::fs::read_to_string(old_path)
+                .unwrap()
+                .contains("sparse_primary_key_encoding")
+        );
+        assert!(
+            !std::fs::read_to_string(current_path)
+                .unwrap()
+                .contains("sparse_primary_key_encoding")
+        );
+    }
+
+    #[test]
+    fn test_all_old_datanode_renders_receive_the_overlay() {
+        let rendered = "[[region_engine]]\n[region_engine.mito]\n";
+        for _ in 0..3 {
+            let overlaid = apply_old_datanode_overlay(rendered, &metric_overlay()).unwrap();
+            assert!(overlaid.contains("sparse_primary_key_encoding = false"));
+        }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

- Depends on #8601.
- Covers the persisted compatibility risk introduced by #8470.

This is a stacked PR. Until #8601 merges, the diff against `main` also contains the runner capability commits; the case itself is commit `3909073e73`.

## What's changed and what's your intention?

Adds `legacy_dense_metric_primary_key`, a distributed compatibility case for metric regions created by v1.0.0/v1.1.0 with the legacy datanode setting:

```toml
[old_config.datanode]
"region_engine.metric.sparse_primary_key_encoding" = false

[old_assert]
metric_primary_key_encoding = "dense"
```

The old-stage DDL intentionally contains no top-level or legacy primary-key encoding option. The typed assertion checks the authoritative Mito region-creation event and requires Dense metadata before upgrade, preventing a sparse fixture from passing accidentally.

After switching to v1.2.0+, the case verifies that the current binary can:

- recover and read rows written by the old binary;
- write and flush new rows into the legacy dense region;
- read old and new rows together;
- restart with a clean current-stage config and read the mixed data again.

The checked-in golden also verifies that `SHOW CREATE TABLE` persists no encoding option.

Validation performed:

- `cargo test -p sqlness-runner compat_case`
- compatibility dry-run for v1.0.0 → v1.2.0 selected the expected `old-config-0` profile
- `git diff --check`

The full released-binary lifecycle is intentionally delegated to the compatibility CI job.

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.