### PR TITLE
perf: optimize OTLP trace ingestion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13213,6 +13213,7 @@ dependencies = [
  "futures",
  "futures-util",
  "headers",
+ "hex",
  "hostname 0.3.1",
  "http 1.3.1",
  "humantime",

--- a/config/config.md
+++ b/config/config.md
@@ -73,7 +73,7 @@
 | `jaeger.enable` | Bool | `true` | Whether to enable Jaeger protocol in HTTP API. |
 | `otlp` | -- | -- | OpenTelemetry protocol options. |
 | `otlp.enable` | Bool | `true` | Whether to enable OpenTelemetry protocol in HTTP API. |
-| `otlp.trace_ingest_chunk_size` | Integer | `128` | Maximum spans per trace ingest chunk. Set to 0 to disable splitting. |
+| `otlp.trace_ingest_chunk_size` | Integer | `512` | Maximum spans per trace ingest chunk. Set to 0 to disable splitting. |
 | `prom_store` | -- | -- | Prometheus remote storage options |
 | `prom_store.enable` | Bool | `true` | Whether to enable Prometheus remote write and read in HTTP API. |
 | `prom_store.with_metric_engine` | Bool | `true` | Whether to store the data from Prometheus remote write in metric engine. |
@@ -305,7 +305,7 @@
 | `jaeger.enable` | Bool | `true` | Whether to enable Jaeger protocol in HTTP API. |
 | `otlp` | -- | -- | OpenTelemetry protocol options. |
 | `otlp.enable` | Bool | `true` | Whether to enable OpenTelemetry protocol in HTTP API. |
-| `otlp.trace_ingest_chunk_size` | Integer | `128` | Maximum spans per trace ingest chunk. Set to 0 to disable splitting. |
+| `otlp.trace_ingest_chunk_size` | Integer | `512` | Maximum spans per trace ingest chunk. Set to 0 to disable splitting. |
 | `prom_store` | -- | -- | Prometheus remote storage options |
 | `prom_store.enable` | Bool | `true` | Whether to enable Prometheus remote write and read in HTTP API. |
 | `prom_store.with_metric_engine` | Bool | `true` | Whether to store the data from Prometheus remote write in metric engine. |

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -232,7 +232,7 @@ enable = true
 ## Whether to enable OpenTelemetry protocol in HTTP API.
 enable = true
 ## Maximum spans per trace ingest chunk. Set to 0 to disable splitting.
-trace_ingest_chunk_size = 128
+trace_ingest_chunk_size = 512
 
 ## Prometheus remote storage options
 [prom_store]

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -199,7 +199,7 @@ enable = true
 ## Whether to enable OpenTelemetry protocol in HTTP API.
 enable = true
 ## Maximum spans per trace ingest chunk. Set to 0 to disable splitting.
-trace_ingest_chunk_size = 128
+trace_ingest_chunk_size = 512
 
 ## Prometheus remote storage options
 [prom_store]

--- a/src/frontend/src/instance/otlp/README.md
+++ b/src/frontend/src/instance/otlp/README.md
@@ -67,7 +67,7 @@ The parser in
 produces one `TraceSpanGroup` per resource/scope pair.
 
 `ingest_trace_spans` in [`trace_ingest.rs`](trace_ingest.rs) splits the spans in
-each group into owned chunks. `trace_ingest_chunk_size` defaults to 128; setting
+each group into owned chunks. `trace_ingest_chunk_size` defaults to 512; setting
 it to 0 disables splitting. The option is defined in
 [`service_config/otlp.rs`](../../service_config/otlp.rs).
 

--- a/src/frontend/src/service_config/otlp.rs
+++ b/src/frontend/src/service_config/otlp.rs
@@ -14,7 +14,7 @@
 
 use serde::{Deserialize, Serialize};
 
-const DEFAULT_TRACE_INGEST_CHUNK_SIZE: usize = 128;
+const DEFAULT_TRACE_INGEST_CHUNK_SIZE: usize = 512;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default)]
@@ -41,10 +41,7 @@ mod tests {
     fn test_otlp_options() {
         let default = OtlpOptions::default();
         assert!(default.enable);
-        assert_eq!(
-            default.trace_ingest_chunk_size,
-            DEFAULT_TRACE_INGEST_CHUNK_SIZE
-        );
+        assert_eq!(default.trace_ingest_chunk_size, 512);
 
         let options: OtlpOptions = toml::from_str("enable = false").unwrap();
         assert!(!options.enable);

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -68,6 +68,7 @@ either.workspace = true
 futures.workspace = true
 futures-util.workspace = true
 headers = "0.4"
+hex.workspace = true
 hostname = "0.3"
 http.workspace = true
 humantime.workspace = true

--- a/src/servers/src/otlp/trace/v1.rs
+++ b/src/servers/src/otlp/trace/v1.rs
@@ -15,10 +15,11 @@
 use std::collections::{HashMap, HashSet};
 
 use api::v1::column_data_type_extension::TypeExt;
+use api::v1::helper::time_index_column_schema;
 use api::v1::value::ValueData;
 use api::v1::{
     ColumnDataType, ColumnDataTypeExtension, ColumnSchema, JsonTypeExtension, RowInsertRequests,
-    Value,
+    SemanticType, Value,
 };
 use common_catalog::consts::{trace_operations_table_name, trace_services_table_name};
 use common_grpc::precision::Precision;
@@ -35,7 +36,7 @@ use crate::otlp::trace::{
     SPAN_KIND_COLUMN, SPAN_NAME_COLUMN, SPAN_STATUS_CODE, SPAN_STATUS_MESSAGE_COLUMN,
     TIMESTAMP_COLUMN, TRACE_ID_COLUMN, TRACE_STATE_COLUMN, TraceAuxData,
 };
-use crate::otlp::utils::{any_value_to_jsonb, make_column_data, make_string_column_data};
+use crate::otlp::utils::any_value_to_jsonb;
 use crate::query_handler::PipelineHandlerRef;
 use crate::row_writer::{self, MultiTableData, TableData};
 
@@ -43,6 +44,55 @@ const APPROXIMATE_COLUMN_COUNT: usize = 30;
 
 // Use a timestamp(2100-01-01 00:00:00) as large as possible.
 const MAX_TIMESTAMP: i64 = 4102444800000000000;
+
+struct FixedTraceColumnIndexes {
+    timestamp: usize,
+    timestamp_end: usize,
+    duration_nano: usize,
+    parent_span_id: usize,
+    trace_id: usize,
+    span_id: usize,
+    span_kind: usize,
+    span_name: usize,
+    span_status_code: usize,
+    span_status_message: usize,
+    trace_state: usize,
+    scope_name: usize,
+    scope_version: usize,
+}
+
+impl FixedTraceColumnIndexes {
+    fn resolve(writer: &mut TableData) -> Result<Self> {
+        let timestamp = writer.ensure_column(time_index_column_schema(
+            TIMESTAMP_COLUMN,
+            ColumnDataType::TimestampNanosecond,
+        ))?;
+        let mut field = |name: &str, datatype: ColumnDataType| {
+            writer.ensure_column(ColumnSchema {
+                column_name: name.to_string(),
+                datatype: datatype as i32,
+                semantic_type: SemanticType::Field as i32,
+                ..Default::default()
+            })
+        };
+
+        Ok(Self {
+            timestamp,
+            timestamp_end: field("timestamp_end", ColumnDataType::TimestampNanosecond)?,
+            duration_nano: field(DURATION_NANO_COLUMN, ColumnDataType::Uint64)?,
+            parent_span_id: field(PARENT_SPAN_ID_COLUMN, ColumnDataType::String)?,
+            trace_id: field(TRACE_ID_COLUMN, ColumnDataType::String)?,
+            span_id: field(SPAN_ID_COLUMN, ColumnDataType::String)?,
+            span_kind: field(SPAN_KIND_COLUMN, ColumnDataType::String)?,
+            span_name: field(SPAN_NAME_COLUMN, ColumnDataType::String)?,
+            span_status_code: field(SPAN_STATUS_CODE, ColumnDataType::String)?,
+            span_status_message: field(SPAN_STATUS_MESSAGE_COLUMN, ColumnDataType::String)?,
+            trace_state: field(TRACE_STATE_COLUMN, ColumnDataType::String)?,
+            scope_name: field(SCOPE_NAME_COLUMN, ColumnDataType::String)?,
+            scope_version: field(SCOPE_VERSION_COLUMN, ColumnDataType::String)?,
+        })
+    }
+}
 
 /// Distinguishes raw bytes from JSONB values that both use a binary protobuf value.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -248,12 +298,17 @@ fn build_trace_table_data_from_iter(
     mut batch_schema: Option<&mut TraceBatchSchema>,
 ) -> Result<TableData> {
     let mut trace_writer = TableData::new(APPROXIMATE_COLUMN_COUNT, spans.len());
+    if spans.len() == 0 {
+        return Ok(trace_writer);
+    }
+    let fixed_columns = FixedTraceColumnIndexes::resolve(&mut trace_writer)?;
     for span in spans {
         let row_index = trace_writer.num_rows();
         write_span_to_row_inner(
             &mut trace_writer,
             span,
             row_index,
+            &fixed_columns,
             batch_schema.as_deref_mut(),
         )?;
     }
@@ -283,7 +338,8 @@ pub fn build_aux_table_requests(
 
 pub fn write_span_to_row(writer: &mut TableData, span: TraceSpan) -> Result<()> {
     let row_index = writer.num_rows();
-    write_span_to_row_inner(writer, span, row_index, None)
+    let fixed_columns = FixedTraceColumnIndexes::resolve(writer)?;
+    write_span_to_row_inner(writer, span, row_index, &fixed_columns, None)
 }
 
 /// Writes one span and optionally records its dynamic columns for reconciliation.
@@ -291,47 +347,73 @@ fn write_span_to_row_inner(
     writer: &mut TableData,
     span: TraceSpan,
     row_index: usize,
+    fixed_columns: &FixedTraceColumnIndexes,
     mut batch_schema: Option<&mut TraceBatchSchema>,
 ) -> Result<()> {
     let mut row = writer.alloc_one_row();
 
-    // write ts
-    row_writer::write_ts_to_nanos(
-        writer,
-        TIMESTAMP_COLUMN,
-        Some(span.start_in_nanosecond as i64),
-        Precision::Nanosecond,
-        &mut row,
-    )?;
-
-    // write fields
-    let fields = vec![
-        make_column_data(
-            "timestamp_end",
-            ColumnDataType::TimestampNanosecond,
+    for (index, value) in [
+        (
+            fixed_columns.timestamp,
+            Some(ValueData::TimestampNanosecondValue(
+                span.start_in_nanosecond as i64,
+            )),
+        ),
+        (
+            fixed_columns.timestamp_end,
             Some(ValueData::TimestampNanosecondValue(
                 span.end_in_nanosecond as i64,
             )),
         ),
-        make_column_data(
-            DURATION_NANO_COLUMN,
-            ColumnDataType::Uint64,
+        (
+            fixed_columns.duration_nano,
             Some(ValueData::U64Value(
                 span.end_in_nanosecond - span.start_in_nanosecond,
             )),
         ),
-        make_string_column_data(PARENT_SPAN_ID_COLUMN, span.parent_span_id),
-        make_string_column_data(TRACE_ID_COLUMN, Some(span.trace_id)),
-        make_string_column_data(SPAN_ID_COLUMN, Some(span.span_id)),
-        make_string_column_data(SPAN_KIND_COLUMN, Some(span.span_kind)),
-        make_string_column_data(SPAN_NAME_COLUMN, Some(span.span_name)),
-        make_string_column_data(SPAN_STATUS_CODE, Some(span.span_status_code)),
-        make_string_column_data(SPAN_STATUS_MESSAGE_COLUMN, Some(span.span_status_message)),
-        make_string_column_data(TRACE_STATE_COLUMN, Some(span.trace_state)),
-        make_string_column_data(SCOPE_NAME_COLUMN, Some(span.scope_name)),
-        make_string_column_data(SCOPE_VERSION_COLUMN, Some(span.scope_version)),
-    ];
-    row_writer::write_fields(writer, fields.into_iter(), &mut row)?;
+        (
+            fixed_columns.parent_span_id,
+            span.parent_span_id.map(ValueData::StringValue),
+        ),
+        (
+            fixed_columns.trace_id,
+            Some(ValueData::StringValue(span.trace_id)),
+        ),
+        (
+            fixed_columns.span_id,
+            Some(ValueData::StringValue(span.span_id)),
+        ),
+        (
+            fixed_columns.span_kind,
+            Some(ValueData::StringValue(span.span_kind)),
+        ),
+        (
+            fixed_columns.span_name,
+            Some(ValueData::StringValue(span.span_name)),
+        ),
+        (
+            fixed_columns.span_status_code,
+            Some(ValueData::StringValue(span.span_status_code)),
+        ),
+        (
+            fixed_columns.span_status_message,
+            Some(ValueData::StringValue(span.span_status_message)),
+        ),
+        (
+            fixed_columns.trace_state,
+            Some(ValueData::StringValue(span.trace_state)),
+        ),
+        (
+            fixed_columns.scope_name,
+            Some(ValueData::StringValue(span.scope_name)),
+        ),
+        (
+            fixed_columns.scope_version,
+            Some(ValueData::StringValue(span.scope_version)),
+        ),
+    ] {
+        row[index].value_data = value;
+    }
 
     if let Some(service_name) = span.service_name {
         if let Some(batch_schema) = batch_schema.as_deref_mut() {
@@ -597,6 +679,65 @@ mod tests {
             span_links: SpanLinks::from(vec![]),
             start_in_nanosecond: 1,
             end_in_nanosecond: 2,
+        }
+    }
+
+    #[test]
+    fn test_fixed_trace_columns_keep_schema_and_values_aligned() {
+        let table_data = build_trace_table_data(&[make_span("svc", "trace", "span")]).unwrap();
+        let (schema, rows) = table_data.into_schema_and_rows();
+        let expected = [
+            (
+                TIMESTAMP_COLUMN,
+                Some(ValueData::TimestampNanosecondValue(1)),
+            ),
+            (
+                "timestamp_end",
+                Some(ValueData::TimestampNanosecondValue(2)),
+            ),
+            (DURATION_NANO_COLUMN, Some(ValueData::U64Value(1))),
+            (PARENT_SPAN_ID_COLUMN, None),
+            (
+                TRACE_ID_COLUMN,
+                Some(ValueData::StringValue("trace".to_string())),
+            ),
+            (
+                SPAN_ID_COLUMN,
+                Some(ValueData::StringValue("span".to_string())),
+            ),
+            (
+                SPAN_KIND_COLUMN,
+                Some(ValueData::StringValue("SPAN_KIND_SERVER".to_string())),
+            ),
+            (
+                SPAN_NAME_COLUMN,
+                Some(ValueData::StringValue("op".to_string())),
+            ),
+            (
+                SPAN_STATUS_CODE,
+                Some(ValueData::StringValue("STATUS_CODE_UNSET".to_string())),
+            ),
+            (
+                SPAN_STATUS_MESSAGE_COLUMN,
+                Some(ValueData::StringValue(String::new())),
+            ),
+            (
+                TRACE_STATE_COLUMN,
+                Some(ValueData::StringValue(String::new())),
+            ),
+            (
+                SCOPE_NAME_COLUMN,
+                Some(ValueData::StringValue("scope".to_string())),
+            ),
+            (
+                SCOPE_VERSION_COLUMN,
+                Some(ValueData::StringValue("v1".to_string())),
+            ),
+        ];
+
+        for (index, (name, value)) in expected.into_iter().enumerate() {
+            assert_eq!(schema[index].column_name, name);
+            assert_eq!(rows[0].values[index].value_data, value);
         }
     }
 

--- a/src/servers/src/otlp/utils.rs
+++ b/src/servers/src/otlp/utils.rs
@@ -14,12 +14,11 @@
 
 use api::v1::ColumnDataType;
 use api::v1::value::ValueData;
-use itertools::Itertools;
 use jsonb::{Number as JsonbNumber, Value as JsonbValue};
 use opentelemetry_proto::tonic::common::v1::{KeyValue, any_value};
 
 pub fn bytes_to_hex_string(bs: &[u8]) -> String {
-    bs.iter().map(|b| format!("{:02x}", b)).join("")
+    hex::encode(bs)
 }
 
 pub fn any_value_to_jsonb(value: any_value::Value) -> JsonbValue<'static> {

--- a/src/servers/src/row_writer.rs
+++ b/src/servers/src/row_writer.rs
@@ -74,6 +74,23 @@ impl TableData {
         self.rows.reserve(additional);
     }
 
+    pub(crate) fn ensure_column(&mut self, column_schema: ColumnSchema) -> Result<usize> {
+        if let Some(index) = self.column_indexes.get(&column_schema.column_name).copied() {
+            check_schema_number(
+                column_schema.datatype,
+                column_schema.semantic_type,
+                &self.schema[index],
+            )?;
+            return Ok(index);
+        }
+
+        let index = self.schema.len();
+        let name = column_schema.column_name.clone();
+        self.schema.push(column_schema);
+        self.column_indexes.insert(name, index);
+        Ok(index)
+    }
+
     #[allow(dead_code)]
     pub fn columns(&self) -> &Vec<ColumnSchema> {
         &self.schema


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This pull request improves the OTLP trace-ingestion hot path by resolving fixed column indexes once per chunk, writing fixed values directly by index, and replacing per-byte formatting with `hex::encode`. It raises the default `otlp.trace_ingest_chunk_size` from 128 to 512 and updates the example configurations, generated configuration reference, and ingestion README. Explicit chunk-size settings remain unchanged, but deployments relying on the released default will batch more spans per chunk.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
