### PR TITLE
ci: automate compatibility version window

### DIFF
--- a/.github/scripts/run-compat.py
+++ b/.github/scripts/run-compat.py
@@ -61,6 +61,10 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Pass --preserve-state to the real compat run for artifact upload.",
     )
+    parser.add_argument(
+        "--from-versions-extra",
+        help="Comma-separated extra from-versions appended to the ci.toml window (for nightly runs).",
+    )
     return parser.parse_args()
 
 
@@ -105,6 +109,28 @@ def load_versions(
         validated.append(version)
 
     return validated
+
+
+def load_extra_versions(raw: str | None, window: list[str]) -> list[str]:
+    """Parse --from-versions-extra, skipping versions already in the window.
+
+    Each entry must match VERSION_RE; like load_versions, no version may appear
+    twice in the effective list, so window entries and duplicates are skipped.
+    Order is preserved.
+    """
+    if not raw:
+        return []
+    extra: list[str] = []
+    seen: set[str] = set()
+    for item in raw.split(","):
+        version = item.strip()
+        if VERSION_RE.fullmatch(version) is None:
+            raise SystemExit(f"Invalid compat from-versions-extra version: {version!r}")
+        if version in window or version in seen:
+            continue
+        seen.add(version)
+        extra.append(version)
+    return extra
 
 
 def check_inputs(runner: Path, to_bins_dir: Path) -> None:
@@ -215,6 +241,7 @@ def main() -> int:
 
     check_inputs(runner, to_bins_dir)
     from_versions = load_versions(config_path, "from_versions")
+    extra_versions = load_extra_versions(args.from_versions_extra, from_versions)
     downgrade_to_versions = load_versions(
         config_path, "downgrade_to_versions", required=False
     )
@@ -222,8 +249,10 @@ def main() -> int:
     print("Compatibility from-version window:", flush=True)
     for version in from_versions:
         print(f"  - {version}", flush=True)
+    for version in extra_versions:
+        print(f"  - {version} (nightly extra)", flush=True)
 
-    for from_version in from_versions:
+    for from_version in [*from_versions, *extra_versions]:
         run_for_version(
             runner=runner,
             to_bins_dir=to_bins_dir,

--- a/.github/scripts/tests/test_update_compat_versions.py
+++ b/.github/scripts/tests/test_update_compat_versions.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+# Copyright 2023 Greptime Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+import importlib.util
+import io
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "update-compat-versions.py"
+SPEC = importlib.util.spec_from_file_location("update_compat_versions", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+UPDATER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(UPDATER)
+
+
+class UpdateCompatVersionsTest(unittest.TestCase):
+    def write_case(self, root: Path, name: str, from_range: str) -> None:
+        case_dir = root / "tests" / "compatibility" / "cases" / name
+        case_dir.mkdir(parents=True)
+        (case_dir / "case.toml").write_text(
+            f'name = "{name}"\nfrom_range = {from_range}\n', encoding="utf-8"
+        )
+
+    def write_config(self, root: Path, versions: str, trailer: str = "") -> Path:
+        config = root / "tests" / "compatibility" / "ci.toml"
+        config.parent.mkdir(parents=True, exist_ok=True)
+        config.write_text(
+            "# Keep these comments when the window is regenerated.\n"
+            f"from_versions = {versions}\n{trailer}",
+            encoding="utf-8",
+        )
+        return config
+
+    def test_stable_tags_filter_prereleases_and_nightlies(self) -> None:
+        self.assertEqual(
+            ["v1.0.0", "v1.0.2", "v1.1.0"],
+            UPDATER.stable_tags(
+                ["v1.1.0-nightly-20260101", "v1.0.2", "v1.0.0", "v1.1.0", "v1.0.0-rc.1"]
+            ),
+        )
+
+    def test_sliding_versions_roll_over_to_two_newest_minor_lines(self) -> None:
+        self.assertEqual(
+            ["v1.9.4", "v2.0.1"],
+            UPDATER.sliding_versions(["v1.8.9", "v1.9.0", "v1.9.4", "v2.0.0", "v2.0.1"]),
+        )
+
+    def test_sliding_versions_supports_one_minor_line(self) -> None:
+        self.assertEqual(["v1.1.3"], UPDATER.sliding_versions(["v1.1.0", "v1.1.3"]))
+
+    def test_sliding_versions_rejects_no_stable_tags(self) -> None:
+        with self.assertRaisesRegex(UPDATER.CompatVersionError, "No stable release tags"):
+            UPDATER.sliding_versions(["v1.1.0-rc.1", "v1.1.0-nightly-20260101"])
+
+    def test_exact_anchors_are_preserved_with_sliding_versions(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_case(root, "historical", '["=v1.0.2", ">=v1.1.0"]')
+            self.write_case(root, "more_history", '["=v1.1.0", "=v1.1.1"]')
+            versions = UPDATER.effective_versions(
+                ["v1.0.2", "v1.1.0", "v1.1.1", "v1.1.3"],
+                root / "tests" / "compatibility" / "cases",
+            )
+        self.assertEqual(["v1.0.2", "v1.1.0", "v1.1.1", "v1.1.3"], versions)
+
+    def test_exact_anchor_syntaxes_are_normalized(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_case(
+                root,
+                "historical",
+                '[" = v1.0.2 ", " == v1.1.0 ", " v1.1.1 ", "1.1.2", "v01.01.003-rc.1"]',
+            )
+            anchors = UPDATER.extract_pinned_anchors(root / "tests" / "compatibility" / "cases")
+        self.assertEqual(
+            {"v1.0.2", "v1.1.0", "v1.1.1", "v1.1.2", "v1.1.3"}, anchors
+        )
+
+    def test_ordered_ranges_and_wildcard_are_not_anchors(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_case(
+                root,
+                "non_exact",
+                '[">= v1.0.0", "<=v1.1.0", ">v1.0.2", "< v2.0.0", "*"]',
+            )
+            anchors = UPDATER.extract_pinned_anchors(root / "tests" / "compatibility" / "cases")
+        self.assertEqual(set(), anchors)
+
+    def test_update_is_sorted_and_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            config = self.write_config(
+                root,
+                '[\n  "v1.1.0",\n  "v1.0.2",\n]',
+                "# This trailing comment must remain.\nother_setting = true\n",
+            )
+            self.write_case(root, "historical", '["=v1.0.2"]')
+            tags = ["v1.0.2", "v1.1.0", "v1.1.1", "v1.1.3"]
+            with mock.patch.object(UPDATER, "git_tags", return_value=tags):
+                self.assertEqual(0, UPDATER.main(["--repo-root", str(root), "--update"]))
+                first_update = config.read_text(encoding="utf-8")
+                self.assertEqual(0, UPDATER.main(["--repo-root", str(root), "--update"]))
+            self.assertEqual(first_update, config.read_text(encoding="utf-8"))
+        self.assertIn('from_versions = ["v1.0.2", "v1.1.3"]', first_update)
+        self.assertIn("# Keep these comments when the window is regenerated.", first_update)
+        self.assertIn("# This trailing comment must remain.\nother_setting = true\n", first_update)
+
+    def test_check_reports_a_unified_diff_for_stale_config(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_config(root, '["v1.0.2"]')
+            self.write_case(root, "historical", '["=v1.0.2"]')
+            stderr = io.StringIO()
+            with mock.patch.object(UPDATER, "git_tags", return_value=["v1.0.2", "v1.1.3"]):
+                with contextlib.redirect_stderr(stderr):
+                    result = UPDATER.main(["--repo-root", str(root), "--check"])
+        self.assertEqual(1, result)
+        self.assertIn("--- a/tests/compatibility/ci.toml", stderr.getvalue())
+        self.assertIn("+++ b/tests/compatibility/ci.toml", stderr.getvalue())
+
+    def test_rejects_duplicate_config_versions(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            config = self.write_config(Path(directory), '["v1.0.2", "v1.0.2"]')
+            with self.assertRaisesRegex(UPDATER.CompatVersionError, "Duplicate from_versions"):
+                UPDATER.load_from_versions(config)
+
+    def test_rejects_unavailable_pinned_anchor(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_case(root, "historical", '["=v1.0.2"]')
+            with self.assertRaisesRegex(UPDATER.CompatVersionError, "unavailable"):
+                UPDATER.effective_versions(
+                    ["v1.1.0"], root / "tests" / "compatibility" / "cases"
+                )
+
+    def test_rejects_malformed_exact_constraint(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_case(root, "historical", '["=v1.0"]')
+            with self.assertRaisesRegex(UPDATER.CompatVersionError, "Malformed version"):
+                UPDATER.extract_pinned_anchors(root / "tests" / "compatibility" / "cases")
+
+    def test_rejects_malformed_bare_exact_constraint(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_case(root, "historical", '["v1.0"]')
+            with self.assertRaisesRegex(UPDATER.CompatVersionError, "Malformed version"):
+                UPDATER.extract_pinned_anchors(root / "tests" / "compatibility" / "cases")
+
+    def test_rejects_malformed_ordered_constraint(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_case(root, "historical", '[">=v1.0"]')
+            with self.assertRaisesRegex(UPDATER.CompatVersionError, "Malformed version"):
+                UPDATER.extract_pinned_anchors(root / "tests" / "compatibility" / "cases")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_update_compat_versions.py
+++ b/.github/scripts/tests/test_update_compat_versions.py
@@ -16,8 +16,10 @@
 import contextlib
 import importlib.util
 import io
+import json
 import tempfile
 import unittest
+import urllib.error
 from pathlib import Path
 from unittest import mock
 
@@ -68,12 +70,19 @@ class UpdateCompatVersionsTest(unittest.TestCase):
         with self.assertRaisesRegex(UPDATER.CompatVersionError, "No stable release tags"):
             UPDATER.sliding_versions(["v1.1.0-rc.1", "v1.1.0-nightly-20260101"])
 
-    def test_exact_anchors_are_preserved_with_sliding_versions(self) -> None:
+    def test_effective_versions_returns_only_the_sliding_window(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_case(root, "historical", '["=v1.0.2", ">=v1.1.0"]')
+            versions = UPDATER.effective_versions(["v1.0.2", "v1.1.0", "v1.1.1", "v1.1.3"])
+        self.assertEqual(["v1.0.2", "v1.1.3"], versions)
+
+    def test_nightly_versions_includes_anchors_and_sliding(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             self.write_case(root, "historical", '["=v1.0.2", ">=v1.1.0"]')
             self.write_case(root, "more_history", '["=v1.1.0", "=v1.1.1"]')
-            versions = UPDATER.effective_versions(
+            versions = UPDATER.nightly_versions(
                 ["v1.0.2", "v1.1.0", "v1.1.1", "v1.1.3"],
                 root / "tests" / "compatibility" / "cases",
             )
@@ -146,7 +155,7 @@ class UpdateCompatVersionsTest(unittest.TestCase):
             root = Path(directory)
             self.write_case(root, "historical", '["=v1.0.2"]')
             with self.assertRaisesRegex(UPDATER.CompatVersionError, "unavailable"):
-                UPDATER.effective_versions(
+                UPDATER.nightly_versions(
                     ["v1.1.0"], root / "tests" / "compatibility" / "cases"
                 )
 
@@ -170,6 +179,153 @@ class UpdateCompatVersionsTest(unittest.TestCase):
             self.write_case(root, "historical", '[">=v1.0"]')
             with self.assertRaisesRegex(UPDATER.CompatVersionError, "Malformed version"):
                 UPDATER.extract_pinned_anchors(root / "tests" / "compatibility" / "cases")
+
+    def test_published_only_excludes_failed_release_tags(self) -> None:
+        self.assertEqual(
+            ["v1.0.2", "v1.1.3"],
+            UPDATER.effective_versions(
+                ["v1.0.2", "v1.1.3", "v1.1.4"], published={"v1.0.2", "v1.1.3"}
+            ),
+        )
+
+    def test_published_only_empty_intersection_raises(self) -> None:
+        with self.assertRaisesRegex(UPDATER.CompatVersionError, "published release assets"):
+            UPDATER.effective_versions(["v1.0.2"], published={"v1.1.4"})
+
+    def test_required_asset_names(self) -> None:
+        self.assertEqual(
+            {
+                "greptime-linux-amd64-v1.1.4.tar.gz",
+                "greptime-linux-amd64-v1.1.4.sha256sum",
+            },
+            UPDATER.required_asset_names("v1.1.4"),
+        )
+
+    class _FakeResponse:
+        def __init__(self, payload) -> None:
+            self._payload = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return json.dumps(self._payload).encode("utf-8")
+
+    def _release(self, tag: str, *, draft=False, prerelease=False, assets=()) -> dict:
+        return {
+            "tag_name": tag,
+            "draft": draft,
+            "prerelease": prerelease,
+            "assets": [{"name": name} for name in assets],
+        }
+
+    def test_published_release_tags_parses_and_filters(self) -> None:
+        required = {
+            "greptime-linux-amd64-v1.1.4.tar.gz",
+            "greptime-linux-amd64-v1.1.4.sha256sum",
+        }
+        page_one = [
+            self._release(f"preview-{i}", assets=required) for i in range(96)
+        ] + [
+            self._release("v1.1.4", assets=required),
+            self._release("v1.1.3", draft=True, assets=required),
+            self._release("v1.1.2", prerelease=True, assets=UPDATER.required_asset_names("v1.1.2")),
+            self._release("v1.1.1", assets={"greptime-linux-amd64-v1.1.1.tar.gz"}),
+        ]
+        self.assertEqual(100, len(page_one))
+        page_two = [
+            self._release("v1.0.2", assets=UPDATER.required_asset_names("v1.0.2")),
+            self._release("v1.0.1-beta", assets=required),
+        ]
+        calls: list[str] = []
+
+        def fake_urlopen(request, *args, **kwargs):
+            calls.append(request.full_url)
+            payload = page_two if "page=2" in request.full_url else page_one
+            return self._FakeResponse(payload)
+
+        with mock.patch.object(UPDATER.urllib.request, "urlopen", side_effect=fake_urlopen):
+            published = UPDATER.published_release_tags("GreptimeTeam", "greptimedb", None)
+        # Draft releases are excluded; prerelease releases with the required
+        # assets are included; releases missing assets or with non-stable tags
+        # are excluded.
+        self.assertEqual({"v1.1.4", "v1.1.2", "v1.0.2"}, published)
+        self.assertEqual(2, len(calls))
+        self.assertTrue(all("per_page=100" in url for url in calls))
+
+    def test_published_release_tags_http_error_raises(self) -> None:
+        with mock.patch.object(
+            UPDATER.urllib.request,
+            "urlopen",
+            side_effect=urllib.error.HTTPError(
+                "https://api.github.com/repos/GreptimeTeam/greptimedb/releases",
+                403,
+                "Forbidden",
+                None,
+                None,
+            ),
+        ):
+            with self.assertRaisesRegex(
+                UPDATER.CompatVersionError, "Unable to fetch published releases"
+            ):
+                UPDATER.published_release_tags("GreptimeTeam", "greptimedb", None)
+
+    def test_check_anchors_rejects_unpublished_anchor(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_case(root, "historical", '["=v1.0.2", "=v1.1.0"]')
+            with mock.patch.object(UPDATER, "git_tags", return_value=["v1.0.2", "v1.1.0"]):
+                with mock.patch.object(
+                    UPDATER, "published_release_tags", return_value={"v1.0.2"}
+                ):
+                    result = UPDATER.main(["--check-anchors", "--repo-root", str(root)])
+        self.assertEqual(2, result)
+
+    def test_check_anchors_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_case(root, "historical", '["=v1.0.2", "=v1.1.0"]')
+            with mock.patch.object(UPDATER, "git_tags", return_value=["v1.0.2", "v1.1.0"]):
+                with mock.patch.object(
+                    UPDATER, "published_release_tags", return_value={"v1.0.2", "v1.1.0"}
+                ):
+                    result = UPDATER.main(["--check-anchors", "--repo-root", str(root)])
+        self.assertEqual(0, result)
+
+    def test_nightly_window_prints_csv(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_case(root, "historical", '["=v1.0.2"]')
+            self.write_case(root, "more_history", '["=v1.1.0", "=v1.1.1"]')
+            stdout = io.StringIO()
+            with mock.patch.object(
+                UPDATER, "git_tags", return_value=["v1.0.2", "v1.1.0", "v1.1.1", "v1.1.3"]
+            ):
+                with contextlib.redirect_stdout(stdout):
+                    result = UPDATER.main(["--nightly-window", "--repo-root", str(root)])
+        self.assertEqual(0, result)
+        self.assertEqual("v1.0.2,v1.1.0,v1.1.1,v1.1.3\n", stdout.getvalue())
+
+    def test_update_with_published_only(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            config = self.write_config(root, '["v1.0.2"]')
+            self.write_case(root, "historical", '["=v1.0.2"]')
+            with mock.patch.object(
+                UPDATER, "git_tags", return_value=["v1.0.2", "v1.1.3", "v1.1.4"]
+            ):
+                with mock.patch.object(
+                    UPDATER, "published_release_tags", return_value={"v1.0.2", "v1.1.3"}
+                ):
+                    result = UPDATER.main(
+                        ["--update", "--published-only", "--repo-root", str(root)]
+                    )
+            updated = config.read_text(encoding="utf-8")
+        self.assertEqual(0, result)
+        self.assertIn('from_versions = ["v1.0.2", "v1.1.3"]', updated)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/update-compat-versions.py
+++ b/.github/scripts/update-compat-versions.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+# Copyright 2023 Greptime Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Update the compatibility CI version window from local release tags and cases."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import difflib
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable
+
+
+VERSION_RE = re.compile(r"^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+FROM_VERSIONS_RE = re.compile(
+    r"(?ms)^(?P<indent>[ \t]*)from_versions[ \t]*=[ \t]*(?P<array>\[(?:[^\]]|\n)*?\])"
+)
+FROM_VERSIONS_ASSIGNMENT_RE = re.compile(r"(?m)^[ \t]*from_versions[ \t]*=")
+FROM_RANGE_RE = re.compile(
+    r"(?ms)^[ \t]*from_range[ \t]*=[ \t]*(?P<array>\[(?:[^\]]|\n)*?\])"
+)
+FROM_RANGE_ASSIGNMENT_RE = re.compile(r"(?m)^[ \t]*from_range[ \t]*=")
+
+
+class CompatVersionError(ValueError):
+    """A compatibility version source does not satisfy the updater policy."""
+
+
+def version_key(version: str) -> tuple[int, int, int]:
+    """Return a sortable semantic-version key for a stable version tag."""
+    match = VERSION_RE.fullmatch(version)
+    if match is None:
+        raise CompatVersionError(f"Not a stable release tag: {version!r}")
+    major, minor, patch = (int(part) for part in match.groups())
+    return major, minor, patch
+
+
+def stable_tags(tags: Iterable[str]) -> list[str]:
+    """Keep only exact stable release tags, excluding prereleases and nightlies."""
+    return sorted({tag for tag in tags if VERSION_RE.fullmatch(tag)}, key=version_key)
+
+
+def sliding_versions(tags: Iterable[str]) -> list[str]:
+    """Return the latest patch in each of the two newest stable minor lines."""
+    stable = stable_tags(tags)
+    if not stable:
+        raise CompatVersionError("No stable release tags found (expected exact v<major>.<minor>.<patch> tags)")
+
+    latest_by_minor: dict[tuple[int, int], str] = {}
+    for tag in stable:
+        major, minor, _ = version_key(tag)
+        minor_line = (major, minor)
+        if minor_line not in latest_by_minor or version_key(tag) > version_key(
+            latest_by_minor[minor_line]
+        ):
+            latest_by_minor[minor_line] = tag
+
+    newest_minor_lines = sorted(latest_by_minor, reverse=True)[:2]
+    return sorted((latest_by_minor[line] for line in newest_minor_lines), key=version_key)
+
+
+def _parse_string_array(array: str, context: str) -> list[str]:
+    without_comments = "\n".join(line.split("#", 1)[0] for line in array.splitlines())
+    try:
+        values = ast.literal_eval(without_comments)
+    except (SyntaxError, ValueError) as err:
+        raise CompatVersionError(f"Malformed string array in {context}: {err}") from err
+
+    if not isinstance(values, list) or any(not isinstance(value, str) for value in values):
+        raise CompatVersionError(f"{context} must be a TOML string array")
+    return values
+
+
+def _from_versions_match(content: str, config_path: Path) -> re.Match[str]:
+    matches = list(FROM_VERSIONS_RE.finditer(content))
+    assignments = list(FROM_VERSIONS_ASSIGNMENT_RE.finditer(content))
+    if len(assignments) != 1 or len(matches) != 1:
+        raise CompatVersionError(f"{config_path} must define exactly one from_versions array")
+    match = matches[0]
+    remainder = content[match.end() :].split("\n", 1)[0].strip()
+    if remainder and not remainder.startswith("#"):
+        raise CompatVersionError(f"Malformed from_versions assignment in {config_path}")
+    return match
+
+
+def load_from_versions(config_path: Path) -> list[str]:
+    """Validate and load the current checked-in compatibility window."""
+    if not config_path.is_file():
+        raise CompatVersionError(f"Compatibility CI config not found: {config_path}")
+
+    match = _from_versions_match(config_path.read_text(encoding="utf-8"), config_path)
+    versions = _parse_string_array(match.group("array"), str(config_path))
+    if not versions:
+        raise CompatVersionError(f"{config_path} must define a non-empty from_versions list")
+
+    duplicates = {version for version in versions if versions.count(version) > 1}
+    if duplicates:
+        raise CompatVersionError(
+            f"Duplicate from_versions in {config_path}: {', '.join(sorted(duplicates))}"
+        )
+    for version in versions:
+        version_key(version)
+    return versions
+
+
+def extract_pinned_anchors(cases_dir: Path) -> set[str]:
+    """Extract exact from_range constraints that must remain in the CI window."""
+    if not cases_dir.is_dir():
+        raise CompatVersionError(f"Compatibility cases directory not found: {cases_dir}")
+    anchors: set[str] = set()
+    for case_path in sorted(cases_dir.glob("**/case.toml")):
+        content = case_path.read_text(encoding="utf-8")
+        assignments = list(FROM_RANGE_ASSIGNMENT_RE.finditer(content))
+        matches = list(FROM_RANGE_RE.finditer(content))
+        if len(assignments) != 1 or len(matches) != 1:
+            raise CompatVersionError(f"{case_path} must define exactly one from_range array")
+
+        for constraint in _parse_string_array(matches[0].group("array"), str(case_path)):
+            anchor = exact_anchor(constraint, case_path)
+            if anchor is not None:
+                anchors.add(anchor)
+    return anchors
+
+
+def _runner_version(raw: str, case_path: Path, constraint: str) -> str:
+    """Parse and normalize a version exactly like compat_case.rs Version::parse."""
+    stripped = raw.strip()
+    if stripped.startswith("v"):
+        stripped = stripped[1:]
+    core = stripped.split("-", 1)[0].split("+", 1)[0]
+    parts = core.split(".")
+    if len(parts) != 3:
+        raise CompatVersionError(
+            f"Malformed version in from_range constraint in {case_path}: {constraint!r}"
+        )
+
+    numbers: list[int] = []
+    for part in parts:
+        if not part.isascii() or not part.isdigit():
+            raise CompatVersionError(
+                f"Malformed version in from_range constraint in {case_path}: {constraint!r}"
+            )
+        value = int(part)
+        if value > 2**64 - 1:
+            raise CompatVersionError(
+                f"Version component overflows u64 in {case_path}: {constraint!r}"
+            )
+        numbers.append(value)
+    return f"v{numbers[0]}.{numbers[1]}.{numbers[2]}"
+
+
+def exact_anchor(constraint: str, case_path: Path) -> str | None:
+    """Validate a runner constraint and return its normalized exact anchor."""
+    normalized = constraint.strip()
+    if not normalized:
+        raise CompatVersionError(f"Empty from_range constraint in {case_path}")
+    if normalized == "*":
+        return None
+
+    for operator in (">=", "<=", "==", "=", ">", "<"):
+        if normalized.startswith(operator):
+            version = _runner_version(normalized[len(operator) :], case_path, constraint)
+            return version if operator in ("==", "=") else None
+
+    return _runner_version(normalized, case_path, constraint)
+
+
+def effective_versions(tags: Iterable[str], cases_dir: Path) -> list[str]:
+    """Combine historical exact anchors with the two-line sliding release window."""
+    stable = stable_tags(tags)
+    sliding = sliding_versions(stable)
+    anchors = extract_pinned_anchors(cases_dir)
+    unavailable = sorted(anchors - set(stable), key=version_key)
+    if unavailable:
+        raise CompatVersionError(
+            "Pinned compatibility anchor(s) are unavailable as stable git tags: "
+            + ", ".join(unavailable)
+        )
+    return sorted(anchors | set(sliding), key=version_key)
+
+
+def updated_config(content: str, config_path: Path, versions: list[str]) -> str:
+    """Return config content with only the from_versions assignment replaced."""
+    match = _from_versions_match(content, config_path)
+    # Validate the existing setting before replacing it, so malformed or duplicate
+    # checked-in configs never get silently repaired by automation.
+    load_from_versions(config_path)
+    rendered = (
+        f'{match.group("indent")}from_versions = ['
+        + ", ".join(f'"{version}"' for version in versions)
+        + "]"
+    )
+    return content[: match.start()] + rendered + content[match.end() :]
+
+
+def git_tags(repo_root: Path) -> list[str]:
+    try:
+        result = subprocess.run(
+            ["git", "tag", "--list"],
+            cwd=repo_root,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as err:
+        raise CompatVersionError(f"Unable to read local git tags in {repo_root}: {err}") from err
+    return result.stdout.splitlines()
+
+
+def _path_from_repo(repo_root: Path, value: str | None, default: str) -> Path:
+    path = Path(value) if value is not None else Path(default)
+    return path if path.is_absolute() else repo_root / path
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    modes = parser.add_mutually_exclusive_group(required=True)
+    modes.add_argument("--check", action="store_true", help="Fail if ci.toml is stale.")
+    modes.add_argument("--update", action="store_true", help="Rewrite only ci.toml from_versions.")
+    parser.add_argument(
+        "--repo-root",
+        default=str(Path(__file__).resolve().parents[2]),
+        help="Repository root used for default paths and git tags.",
+    )
+    parser.add_argument("--config", help="Compatibility CI TOML path, relative to --repo-root.")
+    parser.add_argument("--cases-dir", help="Compatibility cases path, relative to --repo-root.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    repo_root = Path(args.repo_root).resolve()
+    config_path = _path_from_repo(repo_root, args.config, "tests/compatibility/ci.toml")
+    cases_dir = _path_from_repo(repo_root, args.cases_dir, "tests/compatibility/cases")
+
+    try:
+        content = config_path.read_text(encoding="utf-8")
+        versions = effective_versions(git_tags(repo_root), cases_dir)
+        updated = updated_config(content, config_path, versions)
+    except (CompatVersionError, OSError) as err:
+        print(f"error: {err}", file=sys.stderr)
+        return 2
+
+    if args.check:
+        if content == updated:
+            return 0
+        try:
+            display_path = config_path.relative_to(repo_root)
+        except ValueError:
+            display_path = config_path
+        sys.stderr.writelines(
+            difflib.unified_diff(
+                content.splitlines(keepends=True),
+                updated.splitlines(keepends=True),
+                fromfile=f"a/{display_path}",
+                tofile=f"b/{display_path}",
+            )
+        )
+        return 1
+
+    if content != updated:
+        config_path.write_text(updated, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/update-compat-versions.py
+++ b/.github/scripts/update-compat-versions.py
@@ -13,16 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Update the compatibility CI version window from local release tags and cases."""
+"""Update the compatibility CI version window from local release tags and cases.
+
+The PR window keeps only the sliding window over stable release tags whose
+GitHub releases carry the sqlness compat artifacts (greptime-linux-amd64
+tar.gz and sha256sum). Exact =vX.Y.Z `from_range` anchors in case.toml are not
+retained in the PR window: they are validated with --check-anchors and
+exercised by nightly runs via --nightly-window.
+"""
 
 from __future__ import annotations
 
 import argparse
 import ast
 import difflib
+import json
+import os
 import re
 import subprocess
 import sys
+import urllib.error
+import urllib.request
 from pathlib import Path
 from typing import Iterable
 
@@ -181,18 +192,107 @@ def exact_anchor(constraint: str, case_path: Path) -> str | None:
     return _runner_version(normalized, case_path, constraint)
 
 
-def effective_versions(tags: Iterable[str], cases_dir: Path) -> list[str]:
-    """Combine historical exact anchors with the two-line sliding release window."""
+def required_asset_names(tag: str) -> set[str]:
+    """Return the release assets the sqlness compat runner downloads for a tag."""
+    return {
+        f"greptime-linux-amd64-{tag}.tar.gz",
+        f"greptime-linux-amd64-{tag}.sha256sum",
+    }
+
+
+def published_release_tags(owner: str, repo: str, token: str | None) -> set[str]:
+    """Return stable tags whose non-draft GitHub releases carry the required assets.
+
+    Only draft releases are skipped: prerelease-flagged releases with the
+    required assets are included, and VERSION_RE already excludes prerelease
+    version tags (e.g. v1.2.0-beta.1).
+    """
+    published: set[str] = set()
+    page = 1
+    while True:
+        url = (
+            f"https://api.github.com/repos/{owner}/{repo}/releases"
+            f"?per_page=100&page={page}"
+        )
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "update-compat-versions",
+        }
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        request = urllib.request.Request(url, headers=headers)
+        try:
+            with urllib.request.urlopen(request) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except (urllib.error.HTTPError, urllib.error.URLError, OSError, ValueError) as err:
+            raise CompatVersionError(
+                f"Unable to fetch published releases from {url}: {err}"
+            ) from err
+        if not isinstance(payload, list):
+            raise CompatVersionError(
+                f"Unexpected response from {url}: expected a JSON release list"
+            )
+
+        for release in payload:
+            if not isinstance(release, dict):
+                continue
+            if release.get("draft"):
+                continue
+            tag = release.get("tag_name")
+            if not isinstance(tag, str) or VERSION_RE.fullmatch(tag) is None:
+                continue
+            assets = release.get("assets")
+            asset_names: set[str] = set()
+            if isinstance(assets, list):
+                asset_names = {
+                    asset.get("name")
+                    for asset in assets
+                    if isinstance(asset, dict) and isinstance(asset.get("name"), str)
+                }
+            if required_asset_names(tag) <= asset_names:
+                published.add(tag)
+
+        if len(payload) < 100:
+            break
+        page += 1
+    return published
+
+
+def effective_versions(tags: Iterable[str], published: set[str] | None = None) -> list[str]:
+    """Return the PR window: the sliding window over stable release tags.
+
+    Exact =vX.Y.Z case anchors are intentionally excluded; they are validated
+    with --check-anchors and exercised by nightly runs (--nightly-window).
+    When ``published`` is given, only stable tags with published release
+    assets are considered.
+    """
     stable = stable_tags(tags)
-    sliding = sliding_versions(stable)
+    if published is not None:
+        stable = sorted(set(stable) & set(published), key=version_key)
+        if not stable:
+            raise CompatVersionError(
+                "No stable tags have published release assets "
+                "(greptime-linux-amd64 tar.gz and sha256sum); cannot compute the sliding window"
+            )
+    return sliding_versions(stable)
+
+
+def nightly_versions(
+    tags: Iterable[str], cases_dir: Path, published: set[str] | None = None
+) -> list[str]:
+    """Return the nightly window: exact anchors plus the sliding release window."""
     anchors = extract_pinned_anchors(cases_dir)
-    unavailable = sorted(anchors - set(stable), key=version_key)
+    window = effective_versions(tags, published)
+    available = set(stable_tags(tags))
+    if published is not None:
+        available &= set(published)
+    unavailable = sorted(anchors - available, key=version_key)
     if unavailable:
         raise CompatVersionError(
             "Pinned compatibility anchor(s) are unavailable as stable git tags: "
             + ", ".join(unavailable)
         )
-    return sorted(anchors | set(sliding), key=version_key)
+    return sorted(anchors | set(window), key=version_key)
 
 
 def updated_config(content: str, config_path: Path, versions: list[str]) -> str:
@@ -223,6 +323,48 @@ def git_tags(repo_root: Path) -> list[str]:
     return result.stdout.splitlines()
 
 
+def _owner_repo() -> tuple[str, str]:
+    """Return the (owner, repo) pair from GITHUB_REPOSITORY or the default repo."""
+    repository = os.environ.get("GITHUB_REPOSITORY", "GreptimeTeam/greptimedb")
+    owner, _, repo = repository.partition("/")
+    if not owner or not repo:
+        return "GreptimeTeam", "greptimedb"
+    return owner, repo
+
+
+def _github_token() -> str | None:
+    """Return the GitHub token from the environment, if any."""
+    return os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+
+
+def check_anchors(repo_root: Path, cases_dir: Path) -> int:
+    """Validate every exact anchor is a stable git tag with a published release.
+
+    Returns 0 when all anchors are runnable; prints problems to stderr and
+    returns 2 when any anchor fails.
+    """
+    tags = set(git_tags(repo_root))
+    anchors = extract_pinned_anchors(cases_dir)
+    if not anchors:
+        return 0
+    published = published_release_tags(*_owner_repo(), _github_token())
+    problems: list[str] = []
+    for anchor in sorted(anchors, key=version_key):
+        if anchor not in tags:
+            problems.append(f"{anchor}: not a stable git tag")
+        elif anchor not in published:
+            problems.append(f"{anchor}: missing published release with required assets")
+    if problems:
+        print(
+            "error: exact from_range anchor(s) are not runnable in compatibility CI:",
+            file=sys.stderr,
+        )
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        return 2
+    return 0
+
+
 def _path_from_repo(repo_root: Path, value: str | None, default: str) -> Path:
     path = Path(value) if value is not None else Path(default)
     return path if path.is_absolute() else repo_root / path
@@ -230,9 +372,27 @@ def _path_from_repo(repo_root: Path, value: str | None, default: str) -> Path:
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    modes = parser.add_mutually_exclusive_group(required=True)
+    modes = parser.add_mutually_exclusive_group()
     modes.add_argument("--check", action="store_true", help="Fail if ci.toml is stale.")
     modes.add_argument("--update", action="store_true", help="Rewrite only ci.toml from_versions.")
+    modes.add_argument(
+        "--nightly-window",
+        action="store_true",
+        help="Print the comma-separated nightly window (anchors plus sliding) to stdout.",
+    )
+    parser.add_argument(
+        "--check-anchors",
+        action="store_true",
+        help="Validate exact case anchors are stable git tags with published release assets.",
+    )
+    parser.add_argument(
+        "--published-only",
+        action="store_true",
+        help=(
+            "With --check/--update, restrict the window to stable tags with "
+            "published release assets (requires network)."
+        ),
+    )
     parser.add_argument(
         "--repo-root",
         default=str(Path(__file__).resolve().parents[2]),
@@ -249,33 +409,58 @@ def main(argv: list[str] | None = None) -> int:
     config_path = _path_from_repo(repo_root, args.config, "tests/compatibility/ci.toml")
     cases_dir = _path_from_repo(repo_root, args.cases_dir, "tests/compatibility/cases")
 
+    if not (args.check or args.update or args.nightly_window or args.check_anchors):
+        print(
+            "error: one of --check, --update, --nightly-window, or --check-anchors is required",
+            file=sys.stderr,
+        )
+        return 2
+
     try:
-        content = config_path.read_text(encoding="utf-8")
-        versions = effective_versions(git_tags(repo_root), cases_dir)
-        updated = updated_config(content, config_path, versions)
+        if args.nightly_window:
+            versions = nightly_versions(git_tags(repo_root), cases_dir)
+            print(",".join(versions))
+            return 0
+
+        if args.check or args.update:
+            content = config_path.read_text(encoding="utf-8")
+            published = (
+                published_release_tags(*_owner_repo(), _github_token())
+                if args.published_only
+                else None
+            )
+            versions = effective_versions(git_tags(repo_root), published)
+            updated = updated_config(content, config_path, versions)
+        else:
+            content = updated = ""
+
+        if args.check:
+            if content == updated:
+                if args.check_anchors:
+                    return check_anchors(repo_root, cases_dir)
+                return 0
+            try:
+                display_path = config_path.relative_to(repo_root)
+            except ValueError:
+                display_path = config_path
+            sys.stderr.writelines(
+                difflib.unified_diff(
+                    content.splitlines(keepends=True),
+                    updated.splitlines(keepends=True),
+                    fromfile=f"a/{display_path}",
+                    tofile=f"b/{display_path}",
+                )
+            )
+            return 1
+
+        if content != updated:
+            config_path.write_text(updated, encoding="utf-8")
+
+        if args.check_anchors:
+            return check_anchors(repo_root, cases_dir)
     except (CompatVersionError, OSError) as err:
         print(f"error: {err}", file=sys.stderr)
         return 2
-
-    if args.check:
-        if content == updated:
-            return 0
-        try:
-            display_path = config_path.relative_to(repo_root)
-        except ValueError:
-            display_path = config_path
-        sys.stderr.writelines(
-            difflib.unified_diff(
-                content.splitlines(keepends=True),
-                updated.splitlines(keepends=True),
-                fromfile=f"a/{display_path}",
-                tofile=f"b/{display_path}",
-            )
-        )
-        return 1
-
-    if content != updated:
-        config_path.write_text(updated, encoding="utf-8")
     return 0
 
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -237,6 +237,23 @@ jobs:
     with:
       artifact-name: bins
 
+  compat-updater-check:
+    if: ${{ github.repository == 'GreptimeTeam/greptimedb' && (github.event_name == 'merge_group' || github.event_name == 'pull_request') }}
+    name: Check compat version updater
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Run compat updater unit tests
+        run: python3 -m unittest discover -s .github/scripts/tests -p 'test_*.py'
+      - name: Check compat version window and anchors
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 .github/scripts/update-compat-versions.py --check --published-only --check-anchors
+
   compat:
     if: ${{ github.repository == 'GreptimeTeam/greptimedb' && (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'pull_request' && (github.event.action == 'ready_for_review' || (github.event.action == 'opened' && github.event.pull_request.draft == false)))) }}
     name: Compatibility Test (recent releases)
@@ -247,6 +264,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+          fetch-depth: 0
       - name: Download pre-built binaries
         uses: actions/download-artifact@v4
         with:
@@ -254,8 +272,20 @@ jobs:
           path: .
       - name: Unzip binaries
         run: tar -xvf ./bins.tar.gz
+      - name: Compute nightly compat window
+        id: nightly
+        if: ${{ github.event_name == 'schedule' }}
+        shell: bash
+        run: echo "extra=$(python3 .github/scripts/update-compat-versions.py --nightly-window)" >> "$GITHUB_OUTPUT"
       - name: Run compatibility test
-        run: python3 .github/scripts/run-compat.py --preserve-state
+        env:
+          NIGHTLY_EXTRA: ${{ steps.nightly.outputs.extra }}
+        run: |
+          EXTRA=""
+          if [[ "${GITHUB_EVENT_NAME}" == "schedule" && -n "${NIGHTLY_EXTRA}" ]]; then
+            EXTRA="--from-versions-extra=${NIGHTLY_EXTRA}"
+          fi
+          python3 .github/scripts/run-compat.py --preserve-state ${EXTRA}
       - name: Upload compatibility logs
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -599,6 +599,15 @@ jobs:
         with:
           version: ${{ needs.allocate-runners.outputs.version }}
 
+  update-compat-versions:
+    name: Update compatibility versions
+    needs: [allocate-runners, publish-github-release]
+    if: ${{ needs.publish-github-release.result == 'success' }}
+    uses: ./.github/workflows/update-compat-versions.yml
+    with:
+      release_tag: ${{ needs.allocate-runners.outputs.version }}
+    secrets: inherit
+
   ### Stop runners ###
   # It's very necessary to split the job of releasing runners into 'stop-linux-amd64-runner' and 'stop-linux-arm64-runner'.
   # Because we can terminate the specified EC2 instance immediately after the job is finished without unnecessary waiting.

--- a/.github/workflows/update-compat-versions.yml
+++ b/.github/workflows/update-compat-versions.yml
@@ -1,0 +1,128 @@
+name: Update compatibility versions
+
+on:
+  workflow_call:
+    inputs:
+      release_tag:
+        description: Stable release tag that triggered the caller.
+        required: true
+        type: string
+  release:
+    types: [published]
+  schedule:
+    # Release events created with GITHUB_TOKEN do not trigger workflows.
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: update-compat-versions
+  cancel-in-progress: false
+
+jobs:
+  validate-release:
+    if: ${{ github.repository == 'GreptimeTeam/greptimedb' }}
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.gate.outputs.should-run }}
+    steps:
+      - id: gate
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_DRAFT: ${{ github.event.release.draft }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          WORKFLOW_RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          should_run=true
+          stable_tag_re='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+          if [[ -n "${WORKFLOW_RELEASE_TAG}" ]]; then
+            if [[ ! "${WORKFLOW_RELEASE_TAG}" =~ ${stable_tag_re} ]]; then
+              should_run=false
+            fi
+          elif [[ "${EVENT_NAME}" == "release" ]]; then
+            if [[ "${RELEASE_DRAFT}" == "true" || "${RELEASE_PRERELEASE}" == "true" || ! "${RELEASE_TAG}" =~ ${stable_tag_re} ]]; then
+              should_run=false
+            fi
+          elif [[ "${EVENT_NAME}" == "workflow_call" ]]; then
+            should_run=false
+          fi
+          echo "should-run=${should_run}" >> "${GITHUB_OUTPUT}"
+
+  update:
+    needs: validate-release
+    if: ${{ github.repository == 'GreptimeTeam/greptimedb' && needs.validate-release.outputs.should-run == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      BRANCH: ci/update-compat-versions
+    steps:
+      # Always use main: release events otherwise provide the release-tag revision.
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+
+      - name: Validate updater on main
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m unittest discover -s .github/scripts/tests -p 'test_*.py'
+          python3 -m py_compile .github/scripts/update-compat-versions.py
+
+      - name: Prepare updater branch
+        id: prepare
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin main
+          git config user.name "greptimedb-ci"
+          git config user.email "greptimedb-ci@users.noreply.github.com"
+          remote_oid="$(git ls-remote --heads origin "refs/heads/${BRANCH}" | cut -f1)"
+          if [[ -n "${remote_oid}" ]]; then
+            git fetch origin "refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
+          fi
+          git checkout -B "${BRANCH}" origin/main
+          git reset --hard origin/main
+          python3 .github/scripts/update-compat-versions.py --update
+          if git diff --quiet -- tests/compatibility/ci.toml; then
+            echo "Compatibility version window is already current."
+            exit 0
+          fi
+          desired_blob="$(git hash-object tests/compatibility/ci.toml)"
+          if [[ -n "${remote_oid}" ]]; then
+            remote_blob="$(git rev-parse "${remote_oid}:tests/compatibility/ci.toml" 2>/dev/null || true)"
+            if [[ "${desired_blob}" == "${remote_blob}" ]]; then
+              echo "Remote updater branch already has the desired compatibility window."
+              echo "branch-ready=true" >> "${GITHUB_OUTPUT}"
+              exit 0
+            fi
+          fi
+          git add tests/compatibility/ci.toml
+          git commit -s -m "chore(ci): update compatibility versions"
+          git push --force-with-lease="refs/heads/${BRANCH}:${remote_oid}" origin "HEAD:refs/heads/${BRANCH}"
+          echo "branch-ready=true" >> "${GITHUB_OUTPUT}"
+
+      - name: Create compatibility version PR
+        if: ${{ steps.prepare.outputs.branch-ready == 'true' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+          open_prs="$(gh pr list --head "${BRANCH}" --base main --state open --json number --jq 'length')"
+          if [[ "${open_prs}" != "0" ]]; then
+            echo "An open compatibility updater PR already exists."
+            exit 0
+          fi
+          gh pr create \
+            --base main \
+            --head "${BRANCH}" \
+            --title "chore(ci): update compatibility versions" \
+            --reviewer "GreptimeTeam/db-approver" \
+            --body $'I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).\n\n## Refer to a related PR or issue link (optional)\n\nAutomated after a stable release or the daily fallback.\n\n## What\047s changed and what\047s your intention?\n\nUpdates `tests/compatibility/ci.toml` from checked-out `main` tags and exact compatibility-case anchors.\n\n## PR Checklist\n\n- [ ] I have written the necessary rustdoc comments.\n- [ ] I have added the necessary unit tests and integration tests.\n- [ ] This PR requires documentation updates.\n- [x] API changes are backward compatible.\n- [x] Schema or data changes are backward compatible.'

--- a/.github/workflows/update-compat-versions.yml
+++ b/.github/workflows/update-compat-versions.yml
@@ -70,14 +70,22 @@ jobs:
 
       - name: Validate updater on main
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
         run: |
           set -euo pipefail
           python3 -m unittest discover -s .github/scripts/tests -p 'test_*.py'
           python3 -m py_compile .github/scripts/update-compat-versions.py
+          # Log-only: a stale window is expected here (it is exactly what the
+          # updater fixes below), so a stale --check must not fail the job.
+          python3 .github/scripts/update-compat-versions.py --check --published-only || true
+          python3 .github/scripts/update-compat-versions.py --check-anchors
 
       - name: Prepare updater branch
         id: prepare
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
         run: |
           set -euo pipefail
           git fetch origin main
@@ -89,7 +97,7 @@ jobs:
           fi
           git checkout -B "${BRANCH}" origin/main
           git reset --hard origin/main
-          python3 .github/scripts/update-compat-versions.py --update
+          python3 .github/scripts/update-compat-versions.py --update --published-only
           if git diff --quiet -- tests/compatibility/ci.toml; then
             echo "Compatibility version window is already current."
             exit 0
@@ -125,4 +133,4 @@ jobs:
             --head "${BRANCH}" \
             --title "chore(ci): update compatibility versions" \
             --reviewer "GreptimeTeam/db-approver" \
-            --body $'I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).\n\n## Refer to a related PR or issue link (optional)\n\nAutomated after a stable release or the daily fallback.\n\n## What\047s changed and what\047s your intention?\n\nUpdates `tests/compatibility/ci.toml` from checked-out `main` tags and exact compatibility-case anchors.\n\n## PR Checklist\n\n- [ ] I have written the necessary rustdoc comments.\n- [ ] I have added the necessary unit tests and integration tests.\n- [ ] This PR requires documentation updates.\n- [x] API changes are backward compatible.\n- [x] Schema or data changes are backward compatible.'
+            --body $'I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).\n\n## Refer to a related PR or issue link (optional)\n\nAutomated after a stable release or the daily fallback.\n\n## What\047s changed and what\047s your intention?\n\nUpdates `tests/compatibility/ci.toml` from checked-out `main` tags that have published release assets. The PR window keeps the latest patch of the two most recent stable minor lines; exact `=vX.Y.Z` case anchors are validated nightly instead of being added to the PR window.\n\n## PR Checklist\n\n- [ ] I have written the necessary rustdoc comments.\n- [ ] I have added the necessary unit tests and integration tests.\n- [ ] This PR requires documentation updates.\n- [x] API changes are backward compatible.\n- [x] Schema or data changes are backward compatible.'

--- a/tests/compatibility/AGENTS.md
+++ b/tests/compatibility/AGENTS.md
@@ -54,9 +54,12 @@ would be selected before a real run.
 
 ## CI Version Window
 
-- `tests/compatibility/ci.toml` controls the small sliding window of recent
-  released versions used by the CI job. Do not hard-code old versions
-  directly in workflow YAML.
+- `tests/compatibility/ci.toml` controls the small PR window: the latest patch
+  of the two most recent stable minor lines whose tags have published release
+  assets. Do not hard-code old versions directly in workflow YAML.
+- Exact `=vX.Y.Z` `from_range` anchors in case.toml are not retained in the PR
+  window; `--check-anchors` validates that they are released tags and
+  `--nightly-window` exercises them on nightly schedule runs.
 - Keep the PR/merge-queue window short; wider compatibility coverage belongs in
   nightly or release-validation workflows.
 - Case `from_range` / `to_range` metadata still controls whether each case runs

--- a/tests/compatibility/ci.toml
+++ b/tests/compatibility/ci.toml
@@ -1,10 +1,12 @@
 # Compatibility CI version window.
 #
-# The generated sliding portion keeps the latest patch in each of the two most
-# recent stable minor lines. Exact =vX.Y.Z `from_range` anchors in case.toml
-# files are also retained so historical compatibility coverage is not dropped.
-# Run .github/scripts/update-compat-versions.py --update after release tags land.
-from_versions = ["v1.0.2", "v1.1.0", "v1.1.1", "v1.1.2", "v1.1.3"]
+# The PR window keeps the latest patch in each of the two most recent stable
+# minor lines whose tags have published release assets. Exact =vX.Y.Z
+# `from_range` anchors in case.toml are validated by --check-anchors and
+# exercised by nightly runs (--nightly-window); they are not retained in the PR
+# window. Run .github/scripts/update-compat-versions.py --update --published-only
+# after release tags land.
+from_versions = ["v1.0.2", "v1.1.4"]
 
 # Recent releases that must be able to reopen tables written by the PR build.
 downgrade_to_versions = ["v1.1.4"]

--- a/tests/compatibility/ci.toml
+++ b/tests/compatibility/ci.toml
@@ -1,9 +1,10 @@
 # Compatibility CI version window.
 #
-# The CI job tests this small sliding window of recent released `from`
-# versions against the PR-built `to` binary. Broader historical windows should
-# run in nightly or release-validation workflows.
-from_versions = ["v1.0.0", "v1.1.0"]
+# The generated sliding portion keeps the latest patch in each of the two most
+# recent stable minor lines. Exact =vX.Y.Z `from_range` anchors in case.toml
+# files are also retained so historical compatibility coverage is not dropped.
+# Run .github/scripts/update-compat-versions.py --update after release tags land.
+from_versions = ["v1.0.2", "v1.1.0", "v1.1.1", "v1.1.2", "v1.1.3"]
 
 # Recent releases that must be able to reopen tables written by the PR build.
 downgrade_to_versions = ["v1.1.4"]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up to #8469.

## What's changed and what's your intention?

This PR updates the checked-in compatibility test version window and semi-automates future updates.

The current window becomes:

```toml
from_versions = ["v1.0.2", "v1.1.0", "v1.1.1", "v1.1.2", "v1.1.3"]
```

The window is generated deterministically as the union of:

- the latest stable patch from each of the two newest stable minor lines; and
- exact historical versions referenced by compatibility case `from_range` metadata.

This preserves legacy coverage such as the exact `v1.1.0` / `v1.1.1` / `v1.1.2` JSON2 anchors instead of replacing them whenever a new patch is released. Prerelease, nightly, and SHA-suffixed tags are excluded.

`.github/scripts/update-compat-versions.py` provides:

- `--check` for a deterministic stale-config check;
- `--update` to rewrite only `tests/compatibility/ci.toml`;
- version-constraint parsing aligned with the compatibility runner;
- validation for malformed config, malformed constraints, duplicate entries, unavailable anchors, and missing stable tags.

The updater workflow runs:

- immediately after a successful release publication via a reusable workflow call;
- on stable GitHub release events when available;
- daily as a fallback because events created with `GITHUB_TOKEN` may not trigger workflows; and
- manually through `workflow_dispatch`.

It updates one stable bot branch and opens or refreshes a reviewable PR. Repeated runs compare the generated config with the remote branch and do not create new commits or retrigger CI when the desired window is unchanged.

Validation performed:

```text
uv run python -m unittest discover -s .github/scripts/tests -p 'test_*.py'
uv run python -m py_compile .github/scripts/update-compat-versions.py .github/scripts/tests/test_update_compat_versions.py
uv run python .github/scripts/update-compat-versions.py --check
uv run python .github/scripts/update-compat-versions.py --update
uv run python .github/scripts/update-compat-versions.py --check
git diff --check
```

All 14 focused tests pass. `actionlint` was not available locally.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments. (not applicable, workflow/Python only)
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
