### PR TITLE
fix: terminate datanode on fatal heartbeat reconnect

### DIFF
--- a/src/datanode/src/heartbeat.rs
+++ b/src/datanode/src/heartbeat.rs
@@ -20,6 +20,7 @@ use std::time::Duration;
 use api::v1::meta::heartbeat_request::NodeWorkloads;
 use api::v1::meta::{DatanodeWorkloads, HeartbeatRequest, NodeInfo, Peer, RegionRole, RegionStat};
 use common_base::Plugins;
+use common_error::ext::ErrorExt;
 use common_meta::cache_invalidator::CacheInvalidatorRef;
 use common_meta::datanode::{EnvVars, REGION_STATISTIC_KEY};
 use common_meta::distributed_time_constants::BASE_HEARTBEAT_INTERVAL;
@@ -406,6 +407,9 @@ impl HeartbeatTask {
                                 sleep.as_mut().reset(Instant::now());
                             }
                             Err(e) => {
+                                exit_if_non_retryable_reconnect_error(&e, |code| {
+                                    std::process::exit(code)
+                                });
                                 // Before the META_LEASE_SECS expires,
                                 // any retries are meaningless, it always reads the old meta leader address.
                                 // Triggers to retry after retry_interval from Metasrv config.
@@ -458,5 +462,46 @@ impl HeartbeatTask {
         }
 
         Ok(())
+    }
+}
+
+fn exit_if_non_retryable_reconnect_error(error: &error::Error, exit: impl FnOnce(i32)) {
+    if !error.is_retryable() {
+        error!(error; "Non-retryable error while reconnecting to metasrv, exiting process");
+        exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use store_api::storage::RegionId;
+
+    use super::*;
+
+    #[test]
+    fn test_gc_config_mismatch_exits_process_on_reconnect() {
+        let error = error::GcConfigMismatchSnafu {
+            metasrv_gc_enabled: true,
+            datanode_gc_enabled: false,
+        }
+        .build();
+        let mut exit_code = None;
+
+        exit_if_non_retryable_reconnect_error(&error, |code| exit_code = Some(code));
+
+        assert_eq!(Some(1), exit_code);
+    }
+
+    #[test]
+    fn test_retryable_reconnect_error_does_not_exit_process() {
+        let error = error::RegionBusySnafu {
+            region_id: RegionId::new(1024, 1),
+        }
+        .build();
+        let mut exit_called = false;
+
+        exit_if_non_retryable_reconnect_error(&error, |_| exit_called = true);
+
+        assert!(!exit_called);
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

- Follow-up to #8509.

## What's changed and what's your intention?

- Consult `ErrorExt::is_retryable()` when recreating a broken datanode heartbeat stream.
- Keep the existing delayed reconnect behavior for retryable failures.
- Log non-retryable failures and terminate the datanode process with exit code 1.

PR #8509 rejects an initial metasrv/datanode GC configuration mismatch. After startup, however, a broken heartbeat stream calls the same handshake from a generic reconnect loop, which previously retried `GcConfigMismatch` forever despite its `NonRetryable` hint. Panicking in the detached heartbeat task would only terminate that Tokio task, so this follow-up exits the process explicitly and lets the supervisor restart the datanode after its configuration is corrected.

This change does not alter APIs, wire formats, schemas, or persisted data.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.

## Tests

- `cargo fmt --package datanode -- --check`
- `cargo nextest run -p datanode reconnect --retries 0`
- `git diff --check`