### PR TITLE
fix(flow): avoid duplicate incremental planning warnings

### DIFF
--- a/src/flow/src/batching_mode/task.rs
+++ b/src/flow/src/batching_mode/task.rs
@@ -616,7 +616,7 @@ impl BatchingTask {
         };
         let incremental_safe = incremental_plan.is_some();
         if coverage.is_incremental_delta() && !incremental_safe {
-            warn!(
+            debug!(
                 "Flow {flow_id} skipped unsafe incremental delta fallback; \
                  restored dirty signal instead of executing an unfiltered full snapshot"
             );


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

N/A

## What's changed and what's your intention?

Incremental plan preparation already emits a cause-specific warning when it cannot safely build the incremental plan, including unsupported query shapes, sink-table lookup failures, and rewrite failures. The caller then emitted a second generic warning for the same skipped evaluation. Persistent catalog or rewrite failures therefore produced two warnings per retry.

This PR downgrades only the caller's generic safety-action message to debug. The cause-specific warnings remain at warning level, and the debug message still covers otherwise-silent `None` preparation paths. Dirty-signal restoration, checkpoint state, retries, and query execution behavior are unchanged.

Verification:
- `cargo fmt --check --package flow`
- `cargo nextest run -p flow test_prepare_plan_for_incremental_disables_on_non_aggregate test_unsafe_incremental_plan_skip_restores_dirty_without_query` (2 passed)

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.