### PR TITLE
fix(query): preserve remote dynamic filter target

### DIFF
--- a/src/frontend/src/instance/region_query.rs
+++ b/src/frontend/src/instance/region_query.rs
@@ -22,13 +22,11 @@ use client::region::{
 use common_error::ext::BoxedError;
 use common_meta::node_manager::NodeManagerRef;
 use common_query::request::QueryRequest;
-use common_recordbatch::SendableRecordBatchStream;
 use partition::manager::PartitionRuleManagerRef;
 use query::error::{RegionQuerySnafu, Result as QueryResult};
-use query::region_query::RegionQueryHandler;
+use query::region_query::{RegionQueryHandler, RegionQueryTarget, RoutedRegionQueryStream};
 use session::ReadPreference;
 use snafu::ResultExt;
-use store_api::storage::RegionId;
 
 use crate::error::{FindRegionPeerSnafu, RequestQuerySnafu, Result};
 
@@ -55,7 +53,7 @@ impl RegionQueryHandler for FrontendRegionQueryHandler {
         &self,
         read_preference: ReadPreference,
         request: QueryRequest,
-    ) -> QueryResult<SendableRecordBatchStream> {
+    ) -> QueryResult<RoutedRegionQueryStream> {
         self.do_get_inner(read_preference, request)
             .await
             .map_err(BoxedError::new)
@@ -64,11 +62,11 @@ impl RegionQueryHandler for FrontendRegionQueryHandler {
 
     async fn handle_remote_dyn_filter_update(
         &self,
-        region_id: RegionId,
+        target: &RegionQueryTarget,
         query_id: String,
         update: RemoteDynFilterUpdate,
     ) -> QueryResult<()> {
-        self.handle_remote_dyn_filter_update_inner(region_id, query_id, update)
+        self.handle_remote_dyn_filter_update_inner(target, query_id, update)
             .await
             .map_err(BoxedError::new)
             .context(RegionQuerySnafu)
@@ -76,11 +74,11 @@ impl RegionQueryHandler for FrontendRegionQueryHandler {
 
     async fn handle_remote_dyn_filter_unregister(
         &self,
-        region_id: RegionId,
+        target: &RegionQueryTarget,
         query_id: String,
         unregister: RemoteDynFilterUnregister,
     ) -> QueryResult<()> {
-        self.handle_remote_dyn_filter_unregister_inner(region_id, query_id, unregister)
+        self.handle_remote_dyn_filter_unregister_inner(target, query_id, unregister)
             .await
             .map_err(BoxedError::new)
             .context(RegionQuerySnafu)
@@ -92,10 +90,10 @@ impl FrontendRegionQueryHandler {
         &self,
         read_preference: ReadPreference,
         request: QueryRequest,
-    ) -> Result<SendableRecordBatchStream> {
+    ) -> Result<RoutedRegionQueryStream> {
         let region_id = request.region_id;
 
-        let peer = &self
+        let peer = self
             .partition_manager
             .find_region_leader(region_id)
             .await
@@ -104,29 +102,25 @@ impl FrontendRegionQueryHandler {
                 read_preference,
             })?;
 
-        let client = self.node_manager.datanode(peer).await;
+        let client = self.node_manager.datanode(&peer).await;
 
-        client
+        let stream = client
             .handle_query(request)
             .await
-            .context(RequestQuerySnafu)
+            .context(RequestQuerySnafu)?;
+        Ok(RoutedRegionQueryStream {
+            stream,
+            target: RegionQueryTarget::new(peer),
+        })
     }
 
     async fn handle_remote_dyn_filter_update_inner(
         &self,
-        region_id: RegionId,
+        target: &RegionQueryTarget,
         query_id: String,
         update: RemoteDynFilterUpdate,
     ) -> Result<()> {
-        let peer = &self
-            .partition_manager
-            .find_region_leader(region_id)
-            .await
-            .context(FindRegionPeerSnafu {
-                region_id,
-                read_preference: ReadPreference::Leader,
-            })?;
-        let client = self.node_manager.datanode(peer).await;
+        let client = self.node_manager.datanode(target.peer()).await;
         client
             .handle(build_remote_dyn_filter_update_request(query_id, update))
             .await
@@ -136,19 +130,11 @@ impl FrontendRegionQueryHandler {
 
     async fn handle_remote_dyn_filter_unregister_inner(
         &self,
-        region_id: RegionId,
+        target: &RegionQueryTarget,
         query_id: String,
         unregister: RemoteDynFilterUnregister,
     ) -> Result<()> {
-        let peer = &self
-            .partition_manager
-            .find_region_leader(region_id)
-            .await
-            .context(FindRegionPeerSnafu {
-                region_id,
-                read_preference: ReadPreference::Leader,
-            })?;
-        let client = self.node_manager.datanode(peer).await;
+        let client = self.node_manager.datanode(target.peer()).await;
         client
             .handle(build_remote_dyn_filter_unregister_request(
                 query_id, unregister,

--- a/src/frontend/src/instance/region_query.rs
+++ b/src/frontend/src/instance/region_query.rs
@@ -24,7 +24,7 @@ use common_meta::node_manager::NodeManagerRef;
 use common_query::request::QueryRequest;
 use partition::manager::PartitionRuleManagerRef;
 use query::error::{RegionQuerySnafu, Result as QueryResult};
-use query::region_query::{RegionQueryHandler, RegionQueryTarget, RoutedRegionQueryStream};
+use query::region_query::{RegionQueryHandler, RegionQueryTarget};
 use session::ReadPreference;
 use snafu::ResultExt;
 
@@ -49,12 +49,23 @@ impl FrontendRegionQueryHandler {
 
 #[async_trait]
 impl RegionQueryHandler for FrontendRegionQueryHandler {
-    async fn do_get(
+    async fn select_target(
         &self,
         read_preference: ReadPreference,
+        region_id: store_api::storage::RegionId,
+    ) -> QueryResult<RegionQueryTarget> {
+        self.select_target_inner(read_preference, region_id)
+            .await
+            .map_err(BoxedError::new)
+            .context(RegionQuerySnafu)
+    }
+
+    async fn do_get(
+        &self,
+        target: &RegionQueryTarget,
         request: QueryRequest,
-    ) -> QueryResult<RoutedRegionQueryStream> {
-        self.do_get_inner(read_preference, request)
+    ) -> QueryResult<common_recordbatch::SendableRecordBatchStream> {
+        self.do_get_inner(target, request)
             .await
             .map_err(BoxedError::new)
             .context(RegionQuerySnafu)
@@ -86,13 +97,11 @@ impl RegionQueryHandler for FrontendRegionQueryHandler {
 }
 
 impl FrontendRegionQueryHandler {
-    async fn do_get_inner(
+    async fn select_target_inner(
         &self,
         read_preference: ReadPreference,
-        request: QueryRequest,
-    ) -> Result<RoutedRegionQueryStream> {
-        let region_id = request.region_id;
-
+        region_id: store_api::storage::RegionId,
+    ) -> Result<RegionQueryTarget> {
         let peer = self
             .partition_manager
             .find_region_leader(region_id)
@@ -102,16 +111,20 @@ impl FrontendRegionQueryHandler {
                 read_preference,
             })?;
 
-        let client = self.node_manager.datanode(&peer).await;
+        Ok(RegionQueryTarget::new(peer))
+    }
 
-        let stream = client
+    async fn do_get_inner(
+        &self,
+        target: &RegionQueryTarget,
+        request: QueryRequest,
+    ) -> Result<common_recordbatch::SendableRecordBatchStream> {
+        self.node_manager
+            .datanode(target.peer())
+            .await
             .handle_query(request)
             .await
-            .context(RequestQuerySnafu)?;
-        Ok(RoutedRegionQueryStream {
-            stream,
-            target: RegionQueryTarget::new(peer),
-        })
+            .context(RequestQuerySnafu)
     }
 
     async fn handle_remote_dyn_filter_update_inner(

--- a/src/query/src/dist_plan/dyn_filter_bridge.rs
+++ b/src/query/src/dist_plan/dyn_filter_bridge.rs
@@ -27,6 +27,7 @@ use store_api::storage::RegionId;
 
 use crate::dist_plan::filter_id::build_remote_dyn_filter_id;
 use crate::dist_plan::{FilterId, QueryDynFilterRegistry, RemoteDynFilterProducerId, Subscriber};
+use crate::region_query::RegionQueryTarget;
 
 #[derive(Debug, Clone)]
 pub(crate) struct CapturedDynFilter {
@@ -93,9 +94,8 @@ fn downcast_dynamic_filter(
         .ok()
 }
 
-pub(crate) fn register_dyn_filters_for_region(
+pub(crate) fn register_remote_dyn_filters(
     registry: &QueryDynFilterRegistry,
-    region_id: RegionId,
     captured_dyn_filters: &[CapturedDynFilter],
 ) {
     for captured_dyn_filter in captured_dyn_filters {
@@ -103,8 +103,20 @@ pub(crate) fn register_dyn_filters_for_region(
             captured_dyn_filter.filter_id.clone(),
             captured_dyn_filter.alive_dyn_filter.clone(),
         );
-        let _ = registry
-            .register_subscriber(&captured_dyn_filter.filter_id, Subscriber::new(region_id));
+    }
+}
+
+pub(crate) fn register_dyn_filter_subscribers_for_region(
+    registry: &QueryDynFilterRegistry,
+    region_id: RegionId,
+    target: RegionQueryTarget,
+    captured_dyn_filters: &[CapturedDynFilter],
+) {
+    for captured_dyn_filter in captured_dyn_filters {
+        let _ = registry.register_subscriber(
+            &captured_dyn_filter.filter_id,
+            Subscriber::new(region_id, target.clone()),
+        );
     }
 }
 
@@ -231,6 +243,7 @@ mod tests {
     use std::fmt;
     use std::hash::{Hash, Hasher};
 
+    use common_meta::peer::Peer;
     use datafusion::execution::TaskContext;
     use datafusion_common::ScalarValue;
     use datafusion_expr::ColumnarValue;
@@ -239,6 +252,7 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
+    use crate::region_query::RegionQueryTarget;
 
     #[derive(Debug)]
     struct UnserializableExpr;
@@ -311,6 +325,13 @@ mod tests {
 
     fn test_remote_dyn_filter_producer_id(value: u64) -> RemoteDynFilterProducerId {
         RemoteDynFilterProducerId::new(value)
+    }
+
+    fn test_target(id: u64) -> RegionQueryTarget {
+        RegionQueryTarget::new(Peer {
+            id,
+            addr: format!("127.0.0.1:{id}"),
+        })
     }
 
     fn test_captured_dyn_filter(
@@ -544,7 +565,7 @@ mod tests {
     }
 
     #[test]
-    fn register_dyn_filters_for_region_reuses_existing_entry() {
+    fn register_dyn_filter_subscribers_for_region_reuses_existing_entry() {
         let registry = QueryDynFilterRegistry::new(test_query_id(1));
         let captured_dyn_filters = vec![test_captured_dyn_filter(
             test_remote_dyn_filter_producer_id(42),
@@ -555,8 +576,19 @@ mod tests {
         let first_region_id = RegionId::new(1024, 7);
         let second_region_id = RegionId::new(1024, 8);
 
-        register_dyn_filters_for_region(&registry, first_region_id, &captured_dyn_filters);
-        register_dyn_filters_for_region(&registry, second_region_id, &captured_dyn_filters);
+        register_remote_dyn_filters(&registry, &captured_dyn_filters);
+        register_dyn_filter_subscribers_for_region(
+            &registry,
+            first_region_id,
+            test_target(1),
+            &captured_dyn_filters,
+        );
+        register_dyn_filter_subscribers_for_region(
+            &registry,
+            second_region_id,
+            test_target(2),
+            &captured_dyn_filters,
+        );
 
         assert_eq!(registry.entry_count(), 1);
         let entry = registry.entries().pop().unwrap();
@@ -580,21 +612,18 @@ mod tests {
     }
 
     #[test]
-    fn register_dyn_filters_for_region_keeps_independent_producer_ids_distinct() {
+    fn register_remote_dyn_filters_keeps_independent_producer_ids_distinct() {
         let registry = QueryDynFilterRegistry::new(test_query_id(1));
-        let region_id = RegionId::new(1024, 7);
         let make_filter = |remote_dyn_filter_producer_id| {
             test_captured_dyn_filter(remote_dyn_filter_producer_id, 2, "host", 0)
         };
 
-        register_dyn_filters_for_region(
+        register_remote_dyn_filters(
             &registry,
-            region_id,
             &[make_filter(test_remote_dyn_filter_producer_id(42))],
         );
-        register_dyn_filters_for_region(
+        register_remote_dyn_filters(
             &registry,
-            region_id,
             &[make_filter(test_remote_dyn_filter_producer_id(43))],
         );
 

--- a/src/query/src/dist_plan/dyn_filter_bridge.rs
+++ b/src/query/src/dist_plan/dyn_filter_bridge.rs
@@ -113,21 +113,28 @@ pub(crate) fn register_dyn_filter_subscribers_for_region(
     region_id: RegionId,
     target: RegionQueryTarget,
     captured_dyn_filters: &[CapturedDynFilter],
-) {
+) -> Vec<(FilterId, Subscriber)> {
+    let mut added = Vec::new();
     for captured_dyn_filter in captured_dyn_filters {
-        let registration = registry.register_subscriber(
-            &captured_dyn_filter.filter_id,
-            Subscriber::new(region_id, target.clone()),
-        );
-        if registration == SubscriberRegistration::MissingFilter {
-            common_telemetry::warn!(
-                "Remote dynamic filter {} missing when registering subscriber for region {} at target {:?}",
-                captured_dyn_filter.filter_id,
-                region_id,
-                target
-            );
+        let subscriber = Subscriber::new(region_id, target.clone());
+        let registration =
+            registry.register_subscriber(&captured_dyn_filter.filter_id, subscriber.clone());
+        match registration {
+            SubscriberRegistration::Added => {
+                added.push((captured_dyn_filter.filter_id.clone(), subscriber))
+            }
+            SubscriberRegistration::Duplicate => {}
+            SubscriberRegistration::MissingFilter => {
+                common_telemetry::warn!(
+                    "Remote dynamic filter {} missing when registering subscriber for region {} at target {:?}",
+                    captured_dyn_filter.filter_id,
+                    region_id,
+                    target
+                );
+            }
         }
     }
+    added
 }
 
 fn build_captured_dyn_filter(
@@ -224,28 +231,79 @@ pub(crate) fn query_context_with_initial_dyn_filter_regs(
     region_id: RegionId,
     captured_dyn_filters: &[CapturedDynFilter],
 ) -> QueryContext {
-    let mut region_query_ctx = query_ctx.as_ref().clone();
     let regs = build_initial_dyn_filter_regs_for_region(captured_dyn_filters);
+    query_context_with_initial_dyn_filter_regs_value(query_ctx, region_id, &regs)
+}
+
+pub(crate) fn query_context_with_refreshed_initial_dyn_filter_regs(
+    query_ctx: &QueryContextRef,
+    _region_id: RegionId,
+    captured_dyn_filters: &[CapturedDynFilter],
+) -> QueryContext {
+    let refreshed = InitialDynFilterRegs::new(
+        captured_dyn_filters
+            .iter()
+            .map(|captured| {
+                attach_initial_snapshot(
+                    captured.initial_registration.clone(),
+                    &captured.alive_dyn_filter,
+                )
+            })
+            .collect(),
+    );
+    let serialized = match serialize_initial_dyn_filter_regs(&refreshed) {
+        Ok(serialized) => serialized,
+        Err(error) => {
+            common_telemetry::warn!(error; "Failed to refresh remote dynamic filter initial registrations; using optimization-time snapshots");
+            return query_context_with_initial_dyn_filter_regs(
+                query_ctx,
+                _region_id,
+                captured_dyn_filters,
+            );
+        }
+    };
+    query_context_with_serialized_initial_dyn_filter_regs(query_ctx, serialized)
+}
+
+fn query_context_with_initial_dyn_filter_regs_value(
+    query_ctx: &QueryContextRef,
+    region_id: RegionId,
+    regs: &InitialDynFilterRegs,
+) -> QueryContext {
+    let region_query_ctx = query_ctx.as_ref().clone();
     if regs.is_empty() {
         return region_query_ctx;
     }
 
-    if let Err(error) = regs.validate_default_bounds() {
-        common_telemetry::warn!(error; "Dropping initial remote dyn filter registrations for region {} that exceed configured bounds", region_id);
-        return region_query_ctx;
-    }
-
-    match regs.to_extension_value() {
-        Ok(serialized) => region_query_ctx.set_extension(
-            INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY,
-            serialized,
-        ),
+    match serialize_initial_dyn_filter_regs(regs) {
+        Ok(serialized) => {
+            return query_context_with_serialized_initial_dyn_filter_regs(query_ctx, serialized);
+        }
         Err(error) => {
-            common_telemetry::warn!(error; "Failed to serialize initial remote dyn filter registrations");
+            common_telemetry::warn!(error; "Failed to serialize initial remote dyn filter registrations for region {}", region_id)
         }
     }
 
     region_query_ctx
+}
+
+fn query_context_with_serialized_initial_dyn_filter_regs(
+    query_ctx: &QueryContextRef,
+    serialized: String,
+) -> QueryContext {
+    let mut region_query_ctx = query_ctx.as_ref().clone();
+    region_query_ctx.set_extension(
+        INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY,
+        serialized,
+    );
+    region_query_ctx
+}
+
+fn serialize_initial_dyn_filter_regs(
+    regs: &InitialDynFilterRegs,
+) -> std::result::Result<String, String> {
+    regs.validate_default_bounds()?;
+    regs.to_extension_value().map_err(|error| error.to_string())
 }
 
 #[cfg(test)]
@@ -374,6 +432,37 @@ mod tests {
             .update(lit(ScalarValue::Utf8(Some("x".repeat(payload_bytes)))) as _)
             .unwrap();
         dyn_filter
+    }
+
+    fn refreshed_regs(captured: &[CapturedDynFilter]) -> InitialDynFilterRegs {
+        let query_ctx = QueryContext::arc();
+        let region_query_ctx = query_context_with_refreshed_initial_dyn_filter_regs(
+            &query_ctx,
+            RegionId::new(1024, 7),
+            captured,
+        );
+        InitialDynFilterRegs::from_extension_value(
+            region_query_ctx
+                .extension(INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY)
+                .unwrap(),
+        )
+        .unwrap()
+    }
+
+    fn decode_snapshot(snapshot: &InitialDynFilterSnapshot, column_name: &str) -> String {
+        snapshot
+            .payload
+            .decode_datafusion_expr(
+                &TaskContext::default(),
+                &arrow_schema::Schema::new(vec![arrow_schema::Field::new(
+                    column_name,
+                    arrow_schema::DataType::Utf8,
+                    false,
+                )]),
+                REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES,
+            )
+            .unwrap()
+            .to_string()
     }
 
     #[test]
@@ -678,6 +767,118 @@ mod tests {
         );
         assert_eq!(decoded_children.len(), 1);
         assert!(decoded_children[0].as_any().is::<Column>());
+    }
+
+    #[test]
+    fn refreshed_initial_regs_use_live_filter_snapshot_without_mutating_capture() {
+        let dyn_filter = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![Arc::new(Column::new("host", 0)) as Arc<_>],
+            lit(true) as _,
+        ));
+        let captured = vec![
+            build_captured_dyn_filter(
+                test_remote_dyn_filter_producer_id(42),
+                0,
+                dyn_filter.clone(),
+            )
+            .unwrap(),
+        ];
+        let original_generation = captured[0]
+            .initial_registration
+            .initial_snapshot
+            .as_ref()
+            .unwrap()
+            .generation;
+        dyn_filter.update(lit(false) as _).unwrap();
+        dyn_filter.mark_complete();
+
+        let regs = refreshed_regs(&captured);
+
+        let snapshot = regs.regs[0].initial_snapshot.as_ref().unwrap();
+        assert_eq!(snapshot.generation, 2);
+        assert!(!snapshot.is_complete);
+        assert_ne!(decode_snapshot(snapshot, "host"), "true");
+        assert_eq!(
+            captured[0]
+                .initial_registration
+                .initial_snapshot
+                .as_ref()
+                .unwrap()
+                .generation,
+            original_generation
+        );
+    }
+
+    #[test]
+    fn refresh_keeps_old_snapshot_when_one_live_filter_cannot_encode() {
+        let good = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![Arc::new(Column::new("good", 0)) as Arc<_>],
+            lit(true) as _,
+        ));
+        let bad = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![Arc::new(Column::new("bad", 0)) as Arc<_>],
+            lit(true) as _,
+        ));
+        let captured = vec![
+            build_captured_dyn_filter(test_remote_dyn_filter_producer_id(42), 0, good.clone())
+                .unwrap(),
+            build_captured_dyn_filter(test_remote_dyn_filter_producer_id(42), 1, bad.clone())
+                .unwrap(),
+        ];
+        let old_bad_generation = captured[1]
+            .initial_registration
+            .initial_snapshot
+            .as_ref()
+            .unwrap()
+            .generation;
+        good.update(lit(false) as _).unwrap();
+        bad.update(Arc::new(UnserializableExpr) as _).unwrap();
+
+        let regs = refreshed_regs(&captured);
+        assert_eq!(
+            regs.regs[0].initial_snapshot.as_ref().unwrap().generation,
+            2
+        );
+        assert_eq!(
+            regs.regs[1].initial_snapshot.as_ref().unwrap().generation,
+            old_bad_generation
+        );
+    }
+
+    #[test]
+    fn refresh_aggregate_overflow_falls_back_to_original_snapshots() {
+        let payload_bytes = REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES * 3 / 5;
+        let first = test_dyn_filter_with_snapshot_payload("first", 0, 1);
+        let second = test_dyn_filter_with_snapshot_payload("second", 0, 1);
+        let captured = vec![
+            build_captured_dyn_filter(test_remote_dyn_filter_producer_id(42), 0, first.clone())
+                .unwrap(),
+            build_captured_dyn_filter(test_remote_dyn_filter_producer_id(42), 1, second.clone())
+                .unwrap(),
+        ];
+        let original = captured
+            .iter()
+            .map(|captured| {
+                captured
+                    .initial_registration
+                    .initial_snapshot
+                    .clone()
+                    .unwrap()
+            })
+            .collect::<Vec<_>>();
+        first
+            .update(lit(ScalarValue::Utf8(Some("x".repeat(payload_bytes)))) as _)
+            .unwrap();
+        second
+            .update(lit(ScalarValue::Utf8(Some("y".repeat(payload_bytes)))) as _)
+            .unwrap();
+
+        let regs = refreshed_regs(&captured);
+        for (refreshed, original) in regs.regs.iter().zip(original) {
+            let refreshed = refreshed.initial_snapshot.as_ref().unwrap();
+            assert_eq!(refreshed.generation, original.generation);
+            assert_eq!(refreshed.payload, original.payload);
+        }
     }
 
     #[test]

--- a/src/query/src/dist_plan/dyn_filter_bridge.rs
+++ b/src/query/src/dist_plan/dyn_filter_bridge.rs
@@ -26,7 +26,9 @@ use session::context::{QueryContext, QueryContextRef};
 use store_api::storage::RegionId;
 
 use crate::dist_plan::filter_id::build_remote_dyn_filter_id;
-use crate::dist_plan::{FilterId, QueryDynFilterRegistry, RemoteDynFilterProducerId, Subscriber};
+use crate::dist_plan::{
+    FilterId, QueryDynFilterRegistry, RemoteDynFilterProducerId, Subscriber, SubscriberRegistration,
+};
 use crate::region_query::RegionQueryTarget;
 
 #[derive(Debug, Clone)]
@@ -113,10 +115,18 @@ pub(crate) fn register_dyn_filter_subscribers_for_region(
     captured_dyn_filters: &[CapturedDynFilter],
 ) {
     for captured_dyn_filter in captured_dyn_filters {
-        let _ = registry.register_subscriber(
+        let registration = registry.register_subscriber(
             &captured_dyn_filter.filter_id,
             Subscriber::new(region_id, target.clone()),
         );
+        if registration == SubscriberRegistration::MissingFilter {
+            common_telemetry::warn!(
+                "Remote dynamic filter {} missing when registering subscriber for region {} at target {:?}",
+                captured_dyn_filter.filter_id,
+                region_id,
+                target
+            );
+        }
     }
 }
 

--- a/src/query/src/dist_plan/merge_scan.rs
+++ b/src/query/src/dist_plan/merge_scan.rs
@@ -61,10 +61,12 @@ use crate::dist_plan::analyzer::AliasMapping;
 use crate::dist_plan::analyzer::utils::patch_batch_timezone;
 use crate::dist_plan::dyn_filter_bridge::{
     CapturedDynFilter, capture_remote_dyn_filters_for_pushdown,
-    query_context_with_initial_dyn_filter_regs, register_dyn_filter_subscribers_for_region,
-    register_remote_dyn_filters,
+    query_context_with_refreshed_initial_dyn_filter_regs,
+    register_dyn_filter_subscribers_for_region, register_remote_dyn_filters,
 };
-use crate::dist_plan::{RemoteDynFilterProducerId, RemoteDynFilterRegistryLease};
+use crate::dist_plan::{
+    FilterId, RemoteDynFilterProducerId, RemoteDynFilterRegistryLease, Subscriber,
+};
 use crate::metrics::{MERGE_SCAN_ERRORS_TOTAL, MERGE_SCAN_POLL_ELAPSED, MERGE_SCAN_REGIONS};
 use crate::options::{FlowQueryExtensions, remote_dyn_filter_pushdown_enabled_from_extensions};
 use crate::query_engine::QueryEngineState;
@@ -97,20 +99,42 @@ fn acquire_remote_dyn_filter_registry_lease(
     )
 }
 
-fn query_context_for_remote_dyn_filter_region(
-    query_ctx: &QueryContextRef,
-    region_id: RegionId,
+fn register_remote_dyn_filters_for_region(
     remote_dyn_filter_registry_lease: Option<&RemoteDynFilterRegistryLease>,
     captured_dyn_filters: &[CapturedDynFilter],
-) -> session::context::QueryContext {
+) {
     if let Some(remote_dyn_filter_registry_lease) = remote_dyn_filter_registry_lease {
         register_remote_dyn_filters(
             remote_dyn_filter_registry_lease.registry(),
             captured_dyn_filters,
         );
     }
+}
 
-    query_context_with_initial_dyn_filter_regs(query_ctx, region_id, captured_dyn_filters)
+struct SubscriberRollbackGuard<'a> {
+    registry: &'a crate::dist_plan::QueryDynFilterRegistry,
+    added: Vec<(FilterId, Subscriber)>,
+}
+
+impl<'a> SubscriberRollbackGuard<'a> {
+    fn new(
+        registry: &'a crate::dist_plan::QueryDynFilterRegistry,
+        added: Vec<(FilterId, Subscriber)>,
+    ) -> Self {
+        Self { registry, added }
+    }
+
+    fn disarm(&mut self) {
+        self.added.clear();
+    }
+}
+
+impl Drop for SubscriberRollbackGuard<'_> {
+    fn drop(&mut self) {
+        for (filter_id, subscriber) in &self.added {
+            self.registry.remove_subscriber(filter_id, subscriber);
+        }
+    }
 }
 
 #[derive(Debug, Hash, PartialOrd, PartialEq, Eq, Clone)]
@@ -391,10 +415,36 @@ impl MergeScanExec {
                     region_id = %region_id,
                     partition = partition
                 ));
-                let mut region_query_ctx = query_context_for_remote_dyn_filter_region(
+                let region_start = Instant::now();
+                register_remote_dyn_filters_for_region(
+                    remote_dyn_filter_registry_lease.as_ref(),
+                    &captured_remote_dyn_filters,
+                );
+                let select_target_start = Instant::now();
+                let target = region_query_handler
+                    .select_target(read_preference, region_id)
+                    .instrument(region_span.clone())
+                    .await
+                    .map_err(|e| {
+                        MERGE_SCAN_ERRORS_TOTAL.inc();
+                        DataFusionError::External(Box::new(e))
+                    })?;
+                let select_target_cost = select_target_start.elapsed();
+                let mut subscriber_rollback =
+                    remote_dyn_filter_registry_lease.as_ref().map(|lease| {
+                        SubscriberRollbackGuard::new(
+                            lease.registry(),
+                            register_dyn_filter_subscribers_for_region(
+                                lease.registry(),
+                                region_id,
+                                target.clone(),
+                                &captured_remote_dyn_filters,
+                            ),
+                        )
+                    });
+                let mut region_query_ctx = query_context_with_refreshed_initial_dyn_filter_regs(
                     &query_ctx,
                     region_id,
-                    remote_dyn_filter_registry_lease.as_ref(),
                     &captured_remote_dyn_filters,
                 );
                 if live_analyze_metrics {
@@ -415,9 +465,6 @@ impl MergeScanExec {
                     region_id,
                     plan: plan.clone(),
                 };
-                let region_start = Instant::now();
-                let do_get_start = Instant::now();
-
                 if explain_verbose {
                     common_telemetry::info!(
                         "Merge scan one region, partition: {}, region_id: {}",
@@ -426,26 +473,27 @@ impl MergeScanExec {
                     );
                 }
 
-                let crate::region_query::RoutedRegionQueryStream { mut stream, target } =
-                    region_query_handler
-                        .do_get(read_preference, request)
-                        .instrument(region_span.clone())
-                        .await
-                        .map_err(|e| {
-                            MERGE_SCAN_ERRORS_TOTAL.inc();
-                            DataFusionError::External(Box::new(e))
-                        })?;
-                let do_get_cost = do_get_start.elapsed();
+                let do_get_start = Instant::now();
+                let do_get_result = region_query_handler
+                    .do_get(&target, request)
+                    .instrument(region_span.clone())
+                    .await;
+                if do_get_result.is_err() {
+                    drop(subscriber_rollback.take());
+                }
+                let mut stream = do_get_result.map_err(|e| {
+                    MERGE_SCAN_ERRORS_TOTAL.inc();
+                    DataFusionError::External(Box::new(e))
+                })?;
+                let do_get_cost = select_target_cost + do_get_start.elapsed();
+
+                if let Some(subscriber_rollback) = subscriber_rollback.as_mut() {
+                    subscriber_rollback.disarm();
+                }
 
                 if let Some(remote_dyn_filter_registry_lease) =
                     remote_dyn_filter_registry_lease.as_ref()
                 {
-                    register_dyn_filter_subscribers_for_region(
-                        remote_dyn_filter_registry_lease.registry(),
-                        region_id,
-                        target,
-                        &captured_remote_dyn_filters,
-                    );
                     remote_dyn_filter_registry_lease
                         .ensure_fanout_task(region_query_handler.clone());
                 }
@@ -1101,7 +1149,11 @@ mod tests {
 
     use async_trait::async_trait;
     use common_base::Plugins;
-    use common_query::request::INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY;
+    use common_meta::peer::Peer;
+    use common_query::request::{
+        INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY, InitialDynFilterRegs,
+    };
+    use common_recordbatch::EmptyRecordBatchStream;
     use common_recordbatch::adapter::{PlanMetrics, RecordBatchMetrics};
     use datafusion::config::ConfigOptions;
     use datafusion::execution::SessionStateBuilder;
@@ -1117,6 +1169,7 @@ mod tests {
     use session::query_id::QueryId;
     use table::table::scan::REGION_SCAN_EXEC_NAME;
     use table::table_name::TableName;
+    use tokio::sync::{Notify, oneshot};
     use uuid::Uuid;
 
     use super::*;
@@ -1124,6 +1177,13 @@ mod tests {
     use crate::options::QueryOptions;
     use crate::query_engine::{QueryEngineContext, QueryEngineState};
     use crate::region_query::RegionQueryHandler;
+
+    fn test_target(id: u64) -> crate::region_query::RegionQueryTarget {
+        crate::region_query::RegionQueryTarget::new(Peer {
+            id,
+            addr: format!("127.0.0.1:{id}"),
+        })
+    }
 
     fn test_query_id(value: u128) -> QueryId {
         QueryId::from(Uuid::from_u128(value))
@@ -1171,6 +1231,87 @@ mod tests {
         let mut session_state = state.session_state();
         session_state.config_mut().set_extension(state);
         QueryEngineContext::new(session_state, query_ctx).build_task_ctx()
+    }
+
+    fn remote_dyn_filter_test_exec(
+        handler: crate::region_query::RegionQueryHandlerRef,
+        query_ctx: QueryContextRef,
+    ) -> MergeScanExec {
+        let session_state = SessionStateBuilder::new().build();
+        let plan = LogicalPlanBuilder::empty(true)
+            .project(vec![lit(1i32).alias("col1")])
+            .unwrap()
+            .build()
+            .unwrap();
+        let schema = plan.schema().as_arrow().clone();
+
+        MergeScanExec::new(
+            &session_state,
+            TableName::new("catalog", "schema", "table"),
+            vec![RegionId::new(1024, 1)],
+            plan,
+            &schema,
+            handler,
+            query_ctx,
+            1,
+            AliasMapping::new(),
+            Some(RemoteDynFilterProducerId::new(42)),
+            false,
+        )
+        .unwrap()
+    }
+
+    fn install_remote_dyn_filter(exec: &MergeScanExec) -> Arc<DynamicFilterPhysicalExpr> {
+        let dyn_filter = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![Arc::new(Column::new("host", 0)) as Arc<_>],
+            physical_lit(true) as _,
+        ));
+        exec.handle_child_pushdown_result(
+            FilterPushdownPhase::Post,
+            ChildPushdownResult {
+                parent_filters: vec![ChildFilterPushdownResult {
+                    filter: dyn_filter.clone() as Arc<dyn datafusion_physical_expr::PhysicalExpr>,
+                    child_results: vec![PushedDown::Yes],
+                }],
+                self_filters: Vec::new(),
+            },
+            &ConfigOptions::new(),
+        )
+        .unwrap();
+        dyn_filter
+    }
+
+    fn query_engine_state(
+        handler: crate::region_query::RegionQueryHandlerRef,
+    ) -> Arc<QueryEngineState> {
+        Arc::new(QueryEngineState::new(
+            catalog::memory::new_memory_catalog_manager().unwrap(),
+            None,
+            Some(handler),
+            None,
+            None,
+            None,
+            false,
+            Plugins::default(),
+            QueryOptions::default(),
+        ))
+    }
+
+    fn empty_record_batch_stream() -> common_recordbatch::SendableRecordBatchStream {
+        Box::pin(EmptyRecordBatchStream::new(Arc::new(
+            datatypes::schema::Schema::new(Vec::new()),
+        )))
+    }
+
+    fn pending_record_batch_stream() -> common_recordbatch::SendableRecordBatchStream {
+        let stream = futures_util::stream::pending::<
+            datafusion_common::Result<datafusion::arrow::record_batch::RecordBatch>,
+        >();
+        let stream = RecordBatchStreamAdapter::new(Arc::new(ArrowSchema::empty()), stream);
+        Box::pin(
+            common_recordbatch::adapter::RecordBatchStreamAdapter::try_new(Box::pin(stream))
+                .unwrap(),
+        )
     }
 
     #[test]
@@ -1236,7 +1377,7 @@ mod tests {
     }
 
     #[test]
-    fn remote_dyn_filter_region_query_context_defers_subscriber_registration() {
+    fn remote_dyn_filter_producer_registration_defers_subscriber_registration() {
         let registry_manager = Arc::new(DynFilterRegistryManager::default());
         let query_ctx = QueryContext::arc();
         let query_id = query_ctx
@@ -1254,10 +1395,10 @@ mod tests {
         );
         assert_eq!(captured.captured_dyn_filters.len(), 1);
 
-        let region_query_ctx = query_context_for_remote_dyn_filter_region(
+        register_remote_dyn_filters_for_region(Some(&lease), &captured.captured_dyn_filters);
+        let region_query_ctx = query_context_with_refreshed_initial_dyn_filter_regs(
             &query_ctx,
             region_id,
-            Some(&lease),
             &captured.captured_dyn_filters,
         );
 
@@ -1277,7 +1418,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn failed_do_get_does_not_register_subscriber_or_start_fanout() {
+    async fn failed_do_get_rolls_back_new_subscriber_without_starting_fanout() {
         let handler = Arc::new(FailingRegionQueryHandler::default());
         let query_ctx = QueryContext::arc();
         let state = Arc::new(QueryEngineState::new(
@@ -1294,6 +1435,7 @@ mod tests {
         let lease = state
             .acquire_remote_dyn_filter_registry_lease(&query_ctx)
             .unwrap();
+        handler.set_registry(lease.registry_arc_for_test());
         let task_ctx = task_context_with_engine_state(state, query_ctx.clone());
         let plan = LogicalPlanBuilder::empty(true)
             .project(vec![lit(1i32).alias("col1")])
@@ -1335,11 +1477,182 @@ mod tests {
         let mut stream = exec.to_stream(task_ctx, 0).unwrap();
         assert!(stream.next().await.unwrap().is_err());
         assert_eq!(handler.do_get_calls.load(Ordering::SeqCst), 1);
+        assert!(handler.saw_subscriber.load(Ordering::SeqCst));
 
         let entries = lease.registry().entries();
         assert_eq!(entries.len(), 1);
         assert!(entries[0].subscribers().is_empty());
         assert!(!entries[0].fanout_started_for_test());
+    }
+
+    #[tokio::test]
+    async fn aborting_pending_do_get_poll_rolls_back_subscriber_without_starting_fanout() {
+        let handler = Arc::new(PendingDoGetHandler::default());
+        let query_ctx = QueryContext::arc();
+        let state = query_engine_state(handler.clone());
+        let lease = state
+            .acquire_remote_dyn_filter_registry_lease(&query_ctx)
+            .unwrap();
+        let exec = remote_dyn_filter_test_exec(handler.clone(), query_ctx.clone());
+        install_remote_dyn_filter(&exec);
+        let stream = exec
+            .to_stream(task_context_with_engine_state(state, query_ctx), 0)
+            .unwrap();
+
+        let poll = tokio::spawn(async move {
+            let mut stream = stream;
+            stream.next().await
+        });
+        handler.do_get_entered.notified().await;
+        let entries = lease.registry().entries();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].subscribers().len(), 1);
+        assert!(!entries[0].fanout_started_for_test());
+
+        poll.abort();
+        assert!(poll.await.unwrap_err().is_cancelled());
+
+        assert!(entries[0].subscribers().is_empty());
+        assert!(!entries[0].fanout_started_for_test());
+    }
+
+    #[tokio::test]
+    async fn failed_do_get_preserves_preexisting_duplicate_subscriber() {
+        let handler = Arc::new(FailingRegionQueryHandler::default());
+        let query_ctx = QueryContext::arc();
+        let state = query_engine_state(handler.clone());
+        let lease = state
+            .acquire_remote_dyn_filter_registry_lease(&query_ctx)
+            .unwrap();
+        let exec = remote_dyn_filter_test_exec(handler.clone(), query_ctx.clone());
+        install_remote_dyn_filter(&exec);
+
+        register_remote_dyn_filters_for_region(Some(&lease), &exec.captured_remote_dyn_filters());
+        let entry = lease.registry().entries().pop().unwrap();
+        let subscriber = Subscriber::new(RegionId::new(1024, 1), test_target(1));
+        assert!(matches!(
+            lease
+                .registry()
+                .register_subscriber(entry.filter_id(), subscriber.clone()),
+            crate::dist_plan::SubscriberRegistration::Added
+        ));
+
+        let mut stream = exec
+            .to_stream(task_context_with_engine_state(state, query_ctx), 0)
+            .unwrap();
+        assert!(stream.next().await.unwrap().is_err());
+
+        assert_eq!(entry.subscribers(), vec![subscriber]);
+        assert!(!entry.fanout_started_for_test());
+    }
+
+    #[tokio::test]
+    async fn failed_target_selection_registers_no_subscriber_or_fanout() {
+        let handler = Arc::new(SelectTargetErrorHandler::default());
+        let query_ctx = QueryContext::arc();
+        let state = query_engine_state(handler.clone());
+        let lease = state
+            .acquire_remote_dyn_filter_registry_lease(&query_ctx)
+            .unwrap();
+        let exec = remote_dyn_filter_test_exec(handler.clone(), query_ctx.clone());
+        install_remote_dyn_filter(&exec);
+
+        let mut stream = exec
+            .to_stream(task_context_with_engine_state(state, query_ctx), 0)
+            .unwrap();
+        assert!(stream.next().await.unwrap().is_err());
+
+        assert_eq!(handler.select_target_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(handler.do_get_calls.load(Ordering::SeqCst), 0);
+        let entries = lease.registry().entries();
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].subscribers().is_empty());
+        assert!(!entries[0].fanout_started_for_test());
+    }
+
+    #[tokio::test]
+    async fn frozen_target_is_reused_for_do_get_update_and_unregister() {
+        let (first_update_entered_tx, first_update_entered_rx) = oneshot::channel();
+        let (release_first_update_tx, release_first_update_rx) = oneshot::channel();
+        let (second_update_entered_tx, second_update_entered_rx) = oneshot::channel();
+        let (release_second_update_tx, release_second_update_rx) = oneshot::channel();
+        let (unregister_tx, unregister_rx) = oneshot::channel();
+        let handler = Arc::new(RoutingRegionQueryHandler::new(
+            first_update_entered_tx,
+            release_first_update_rx,
+            second_update_entered_tx,
+            release_second_update_rx,
+            unregister_tx,
+        ));
+        let query_ctx = QueryContext::arc();
+        let state = query_engine_state(handler.clone());
+        let lease = state
+            .acquire_remote_dyn_filter_registry_lease(&query_ctx)
+            .unwrap();
+        let exec = remote_dyn_filter_test_exec(handler.clone(), query_ctx.clone());
+        let dyn_filter = install_remote_dyn_filter(&exec);
+
+        let stream = exec
+            .to_stream(task_context_with_engine_state(state, query_ctx), 0)
+            .unwrap();
+        let poll = tokio::spawn(async move {
+            let mut stream = stream;
+            stream.next().await
+        });
+        handler.do_get_entered.notified().await;
+        assert_eq!(handler.do_get_targets(), vec![1]);
+
+        first_update_entered_rx.await.unwrap();
+        dyn_filter.update(physical_lit(false) as _).unwrap();
+        release_first_update_tx.send(()).unwrap();
+        second_update_entered_rx.await.unwrap();
+        assert_eq!(handler.update_targets(), vec![1, 1]);
+
+        poll.abort();
+        assert!(poll.await.unwrap_err().is_cancelled());
+        drop(exec);
+        drop(dyn_filter);
+        release_second_update_tx.send(()).unwrap();
+        unregister_rx.await.unwrap();
+        assert_eq!(handler.unregister_targets(), vec![1]);
+        drop(lease);
+    }
+
+    #[tokio::test]
+    async fn immediate_eof_do_get_receives_refreshed_remote_dyn_filter_snapshot() {
+        let handler = Arc::new(ImmediateEofRegionQueryHandler::default());
+        let query_ctx = QueryContext::arc();
+        let state = query_engine_state(handler.clone());
+        let exec = remote_dyn_filter_test_exec(handler.clone(), query_ctx.clone());
+        let dyn_filter = install_remote_dyn_filter(&exec);
+        dyn_filter.update(physical_lit(false) as _).unwrap();
+
+        let mut stream = exec
+            .to_stream(task_context_with_engine_state(state, query_ctx), 0)
+            .unwrap();
+        assert!(stream.next().await.is_none());
+
+        let registrations = handler.registrations();
+        assert_eq!(registrations.regs.len(), 1);
+        let snapshot = registrations.regs[0].initial_snapshot.as_ref().unwrap();
+        assert!(snapshot.generation > 0);
+        assert!(!snapshot.is_complete);
+        assert_eq!(
+            snapshot
+                .payload
+                .decode_datafusion_expr(
+                    &TaskContext::default(),
+                    &ArrowSchema::new(vec![arrow_schema::Field::new(
+                        "host",
+                        arrow_schema::DataType::Boolean,
+                        false,
+                    )]),
+                    common_query::request::REMOTE_DYN_FILTER_PAYLOAD_MAX_BYTES,
+                )
+                .unwrap()
+                .to_string(),
+            "false"
+        );
     }
 
     #[test]
@@ -1377,16 +1690,45 @@ mod tests {
     #[derive(Default)]
     struct FailingRegionQueryHandler {
         do_get_calls: AtomicUsize,
+        saw_subscriber: std::sync::atomic::AtomicBool,
+        registry: std::sync::Mutex<Option<Arc<crate::dist_plan::QueryDynFilterRegistry>>>,
+    }
+
+    impl FailingRegionQueryHandler {
+        fn set_registry(&self, registry: Arc<crate::dist_plan::QueryDynFilterRegistry>) {
+            *self.registry.lock().unwrap() = Some(registry);
+        }
     }
 
     #[async_trait]
     impl RegionQueryHandler for FailingRegionQueryHandler {
-        async fn do_get(
+        async fn select_target(
             &self,
             _read_preference: ReadPreference,
+            _region_id: RegionId,
+        ) -> crate::error::Result<crate::region_query::RegionQueryTarget> {
+            Ok(test_target(1))
+        }
+
+        async fn do_get(
+            &self,
+            _target: &crate::region_query::RegionQueryTarget,
             _request: common_query::request::QueryRequest,
-        ) -> crate::error::Result<crate::region_query::RoutedRegionQueryStream> {
+        ) -> crate::error::Result<common_recordbatch::SendableRecordBatchStream> {
             self.do_get_calls.fetch_add(1, Ordering::SeqCst);
+            self.saw_subscriber.store(
+                self.registry
+                    .lock()
+                    .unwrap()
+                    .as_ref()
+                    .is_some_and(|registry| {
+                        registry
+                            .entries()
+                            .iter()
+                            .any(|entry| !entry.subscribers().is_empty())
+                    }),
+                Ordering::SeqCst,
+            );
             crate::error::UnimplementedSnafu {
                 operation: "test do_get failure",
             }
@@ -1412,13 +1754,295 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct PendingDoGetHandler {
+        do_get_entered: Notify,
+        never_complete: Notify,
+    }
+
     #[async_trait]
-    impl RegionQueryHandler for TestRegionQueryHandler {
-        async fn do_get(
+    impl RegionQueryHandler for PendingDoGetHandler {
+        async fn select_target(
             &self,
             _read_preference: ReadPreference,
+            _region_id: RegionId,
+        ) -> crate::error::Result<crate::region_query::RegionQueryTarget> {
+            Ok(test_target(1))
+        }
+
+        async fn do_get(
+            &self,
+            _target: &crate::region_query::RegionQueryTarget,
             _request: common_query::request::QueryRequest,
-        ) -> crate::error::Result<crate::region_query::RoutedRegionQueryStream> {
+        ) -> crate::error::Result<common_recordbatch::SendableRecordBatchStream> {
+            self.do_get_entered.notify_one();
+            self.never_complete.notified().await;
+            unreachable!("the test aborts the pending do_get future")
+        }
+
+        async fn handle_remote_dyn_filter_update(
+            &self,
+            _target: &crate::region_query::RegionQueryTarget,
+            _query_id: String,
+            _update: api::v1::region::RemoteDynFilterUpdate,
+        ) -> crate::error::Result<()> {
+            unreachable!("fanout must not start while do_get is pending")
+        }
+
+        async fn handle_remote_dyn_filter_unregister(
+            &self,
+            _target: &crate::region_query::RegionQueryTarget,
+            _query_id: String,
+            _unregister: api::v1::region::RemoteDynFilterUnregister,
+        ) -> crate::error::Result<()> {
+            unreachable!("fanout must not start while do_get is pending")
+        }
+    }
+
+    #[derive(Default)]
+    struct SelectTargetErrorHandler {
+        select_target_calls: AtomicUsize,
+        do_get_calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl RegionQueryHandler for SelectTargetErrorHandler {
+        async fn select_target(
+            &self,
+            _read_preference: ReadPreference,
+            _region_id: RegionId,
+        ) -> crate::error::Result<crate::region_query::RegionQueryTarget> {
+            self.select_target_calls.fetch_add(1, Ordering::SeqCst);
+            crate::error::UnimplementedSnafu {
+                operation: "test target selection failure",
+            }
+            .fail()
+        }
+
+        async fn do_get(
+            &self,
+            _target: &crate::region_query::RegionQueryTarget,
+            _request: common_query::request::QueryRequest,
+        ) -> crate::error::Result<common_recordbatch::SendableRecordBatchStream> {
+            self.do_get_calls.fetch_add(1, Ordering::SeqCst);
+            unreachable!("do_get must not run after select_target fails")
+        }
+
+        async fn handle_remote_dyn_filter_update(
+            &self,
+            _target: &crate::region_query::RegionQueryTarget,
+            _query_id: String,
+            _update: api::v1::region::RemoteDynFilterUpdate,
+        ) -> crate::error::Result<()> {
+            unreachable!("fanout must not start after select_target fails")
+        }
+
+        async fn handle_remote_dyn_filter_unregister(
+            &self,
+            _target: &crate::region_query::RegionQueryTarget,
+            _query_id: String,
+            _unregister: api::v1::region::RemoteDynFilterUnregister,
+        ) -> crate::error::Result<()> {
+            unreachable!("fanout must not start after select_target fails")
+        }
+    }
+
+    struct RoutingRegionQueryHandler {
+        route: Mutex<crate::region_query::RegionQueryTarget>,
+        do_get_entered: Notify,
+        do_get_targets: Mutex<Vec<u64>>,
+        update_targets: Mutex<Vec<u64>>,
+        unregister_targets: Mutex<Vec<u64>>,
+        update_calls: AtomicUsize,
+        first_update_entered_tx: Mutex<Option<oneshot::Sender<()>>>,
+        release_first_update_rx: Mutex<Option<oneshot::Receiver<()>>>,
+        second_update_entered_tx: Mutex<Option<oneshot::Sender<()>>>,
+        release_second_update_rx: Mutex<Option<oneshot::Receiver<()>>>,
+        unregister_tx: Mutex<Option<oneshot::Sender<()>>>,
+    }
+
+    impl RoutingRegionQueryHandler {
+        fn new(
+            first_update_entered_tx: oneshot::Sender<()>,
+            release_first_update_rx: oneshot::Receiver<()>,
+            second_update_entered_tx: oneshot::Sender<()>,
+            release_second_update_rx: oneshot::Receiver<()>,
+            unregister_tx: oneshot::Sender<()>,
+        ) -> Self {
+            Self {
+                route: Mutex::new(test_target(1)),
+                do_get_entered: Notify::new(),
+                do_get_targets: Mutex::new(Vec::new()),
+                update_targets: Mutex::new(Vec::new()),
+                unregister_targets: Mutex::new(Vec::new()),
+                update_calls: AtomicUsize::new(0),
+                first_update_entered_tx: Mutex::new(Some(first_update_entered_tx)),
+                release_first_update_rx: Mutex::new(Some(release_first_update_rx)),
+                second_update_entered_tx: Mutex::new(Some(second_update_entered_tx)),
+                release_second_update_rx: Mutex::new(Some(release_second_update_rx)),
+                unregister_tx: Mutex::new(Some(unregister_tx)),
+            }
+        }
+
+        fn do_get_targets(&self) -> Vec<u64> {
+            self.do_get_targets.lock().unwrap().clone()
+        }
+
+        fn update_targets(&self) -> Vec<u64> {
+            self.update_targets.lock().unwrap().clone()
+        }
+
+        fn unregister_targets(&self) -> Vec<u64> {
+            self.unregister_targets.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl RegionQueryHandler for RoutingRegionQueryHandler {
+        async fn select_target(
+            &self,
+            _read_preference: ReadPreference,
+            _region_id: RegionId,
+        ) -> crate::error::Result<crate::region_query::RegionQueryTarget> {
+            let mut route = self.route.lock().unwrap();
+            let target = route.clone();
+            *route = test_target(2);
+            Ok(target)
+        }
+
+        async fn do_get(
+            &self,
+            target: &crate::region_query::RegionQueryTarget,
+            _request: common_query::request::QueryRequest,
+        ) -> crate::error::Result<common_recordbatch::SendableRecordBatchStream> {
+            self.do_get_targets.lock().unwrap().push(target.peer().id);
+            self.do_get_entered.notify_one();
+            Ok(pending_record_batch_stream())
+        }
+
+        async fn handle_remote_dyn_filter_update(
+            &self,
+            target: &crate::region_query::RegionQueryTarget,
+            _query_id: String,
+            _update: api::v1::region::RemoteDynFilterUpdate,
+        ) -> crate::error::Result<()> {
+            self.update_targets.lock().unwrap().push(target.peer().id);
+            match self.update_calls.fetch_add(1, Ordering::SeqCst) {
+                0 => {
+                    if let Some(tx) = self.first_update_entered_tx.lock().unwrap().take() {
+                        let _ = tx.send(());
+                    }
+                    let release = { self.release_first_update_rx.lock().unwrap().take() };
+                    if let Some(release) = release {
+                        let _ = release.await;
+                    }
+                }
+                1 => {
+                    if let Some(tx) = self.second_update_entered_tx.lock().unwrap().take() {
+                        let _ = tx.send(());
+                    }
+                    let release = { self.release_second_update_rx.lock().unwrap().take() };
+                    if let Some(release) = release {
+                        let _ = release.await;
+                    }
+                }
+                _ => {}
+            }
+            Ok(())
+        }
+
+        async fn handle_remote_dyn_filter_unregister(
+            &self,
+            target: &crate::region_query::RegionQueryTarget,
+            _query_id: String,
+            _unregister: api::v1::region::RemoteDynFilterUnregister,
+        ) -> crate::error::Result<()> {
+            self.unregister_targets
+                .lock()
+                .unwrap()
+                .push(target.peer().id);
+            if let Some(tx) = self.unregister_tx.lock().unwrap().take() {
+                let _ = tx.send(());
+            }
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct ImmediateEofRegionQueryHandler {
+        registrations: Mutex<Option<InitialDynFilterRegs>>,
+    }
+
+    impl ImmediateEofRegionQueryHandler {
+        fn registrations(&self) -> InitialDynFilterRegs {
+            self.registrations.lock().unwrap().clone().unwrap()
+        }
+    }
+
+    #[async_trait]
+    impl RegionQueryHandler for ImmediateEofRegionQueryHandler {
+        async fn select_target(
+            &self,
+            _read_preference: ReadPreference,
+            _region_id: RegionId,
+        ) -> crate::error::Result<crate::region_query::RegionQueryTarget> {
+            Ok(test_target(1))
+        }
+
+        async fn do_get(
+            &self,
+            _target: &crate::region_query::RegionQueryTarget,
+            request: common_query::request::QueryRequest,
+        ) -> crate::error::Result<common_recordbatch::SendableRecordBatchStream> {
+            let registrations = request
+                .header
+                .and_then(|header| header.query_context)
+                .and_then(|query_context| {
+                    query_context
+                        .extensions
+                        .get(INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY)
+                        .cloned()
+                })
+                .map(|serialized| InitialDynFilterRegs::from_extension_value(&serialized).unwrap())
+                .unwrap();
+            *self.registrations.lock().unwrap() = Some(registrations);
+            Ok(empty_record_batch_stream())
+        }
+
+        async fn handle_remote_dyn_filter_update(
+            &self,
+            _target: &crate::region_query::RegionQueryTarget,
+            _query_id: String,
+            _update: api::v1::region::RemoteDynFilterUpdate,
+        ) -> crate::error::Result<()> {
+            Ok(())
+        }
+
+        async fn handle_remote_dyn_filter_unregister(
+            &self,
+            _target: &crate::region_query::RegionQueryTarget,
+            _query_id: String,
+            _unregister: api::v1::region::RemoteDynFilterUnregister,
+        ) -> crate::error::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl RegionQueryHandler for TestRegionQueryHandler {
+        async fn select_target(
+            &self,
+            _read_preference: ReadPreference,
+            _region_id: RegionId,
+        ) -> crate::error::Result<crate::region_query::RegionQueryTarget> {
+            unimplemented!("test only")
+        }
+
+        async fn do_get(
+            &self,
+            _target: &crate::region_query::RegionQueryTarget,
+            _request: common_query::request::QueryRequest,
+        ) -> crate::error::Result<common_recordbatch::SendableRecordBatchStream> {
             unimplemented!("test only")
         }
 

--- a/src/query/src/dist_plan/merge_scan.rs
+++ b/src/query/src/dist_plan/merge_scan.rs
@@ -61,7 +61,8 @@ use crate::dist_plan::analyzer::AliasMapping;
 use crate::dist_plan::analyzer::utils::patch_batch_timezone;
 use crate::dist_plan::dyn_filter_bridge::{
     CapturedDynFilter, capture_remote_dyn_filters_for_pushdown,
-    query_context_with_initial_dyn_filter_regs, register_dyn_filters_for_region,
+    query_context_with_initial_dyn_filter_regs, register_dyn_filter_subscribers_for_region,
+    register_remote_dyn_filters,
 };
 use crate::dist_plan::{RemoteDynFilterProducerId, RemoteDynFilterRegistryLease};
 use crate::metrics::{MERGE_SCAN_ERRORS_TOTAL, MERGE_SCAN_POLL_ELAPSED, MERGE_SCAN_REGIONS};
@@ -103,9 +104,8 @@ fn query_context_for_remote_dyn_filter_region(
     captured_dyn_filters: &[CapturedDynFilter],
 ) -> session::context::QueryContext {
     if let Some(remote_dyn_filter_registry_lease) = remote_dyn_filter_registry_lease {
-        register_dyn_filters_for_region(
+        register_remote_dyn_filters(
             remote_dyn_filter_registry_lease.registry(),
-            region_id,
             captured_dyn_filters,
         );
     }
@@ -426,19 +426,26 @@ impl MergeScanExec {
                     );
                 }
 
-                let mut stream = region_query_handler
-                    .do_get(read_preference, request)
-                    .instrument(region_span.clone())
-                    .await
-                    .map_err(|e| {
-                        MERGE_SCAN_ERRORS_TOTAL.inc();
-                        DataFusionError::External(Box::new(e))
-                    })?;
+                let crate::region_query::RoutedRegionQueryStream { mut stream, target } =
+                    region_query_handler
+                        .do_get(read_preference, request)
+                        .instrument(region_span.clone())
+                        .await
+                        .map_err(|e| {
+                            MERGE_SCAN_ERRORS_TOTAL.inc();
+                            DataFusionError::External(Box::new(e))
+                        })?;
                 let do_get_cost = do_get_start.elapsed();
 
                 if let Some(remote_dyn_filter_registry_lease) =
                     remote_dyn_filter_registry_lease.as_ref()
                 {
+                    register_dyn_filter_subscribers_for_region(
+                        remote_dyn_filter_registry_lease.registry(),
+                        region_id,
+                        target,
+                        &captured_remote_dyn_filters,
+                    );
                     remote_dyn_filter_registry_lease
                         .ensure_fanout_task(region_query_handler.clone());
                 }
@@ -1090,8 +1097,10 @@ impl MergeScanMetric {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use async_trait::async_trait;
+    use common_base::Plugins;
     use common_query::request::INITIAL_REMOTE_DYN_FILTER_REGISTRATIONS_EXTENSION_KEY;
     use common_recordbatch::adapter::{PlanMetrics, RecordBatchMetrics};
     use datafusion::config::ConfigOptions;
@@ -1111,7 +1120,9 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
-    use crate::dist_plan::{DynFilterRegistryManager, Subscriber};
+    use crate::dist_plan::DynFilterRegistryManager;
+    use crate::options::QueryOptions;
+    use crate::query_engine::{QueryEngineContext, QueryEngineState};
     use crate::region_query::RegionQueryHandler;
 
     fn test_query_id(value: u128) -> QueryId {
@@ -1151,6 +1162,15 @@ mod tests {
             false,
         )
         .unwrap()
+    }
+
+    fn task_context_with_engine_state(
+        state: Arc<QueryEngineState>,
+        query_ctx: QueryContextRef,
+    ) -> Arc<TaskContext> {
+        let mut session_state = state.session_state();
+        session_state.config_mut().set_extension(state);
+        QueryEngineContext::new(session_state, query_ctx).build_task_ctx()
     }
 
     #[test]
@@ -1216,7 +1236,7 @@ mod tests {
     }
 
     #[test]
-    fn remote_dyn_filter_region_query_context_registers_before_do_get() {
+    fn remote_dyn_filter_region_query_context_defers_subscriber_registration() {
         let registry_manager = Arc::new(DynFilterRegistryManager::default());
         let query_ctx = QueryContext::arc();
         let query_id = query_ctx
@@ -1243,7 +1263,7 @@ mod tests {
 
         let entries = lease.registry().entries();
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].subscribers(), vec![Subscriber::new(region_id)]);
+        assert!(entries[0].subscribers().is_empty());
         assert!(
             !entries[0].fanout_started_for_test(),
             "fanout must start only after do_get succeeds"
@@ -1254,6 +1274,72 @@ mod tests {
                 .is_some(),
             "initial RDF registrations must be present in the do_get query context"
         );
+    }
+
+    #[tokio::test]
+    async fn failed_do_get_does_not_register_subscriber_or_start_fanout() {
+        let handler = Arc::new(FailingRegionQueryHandler::default());
+        let query_ctx = QueryContext::arc();
+        let state = Arc::new(QueryEngineState::new(
+            catalog::memory::new_memory_catalog_manager().unwrap(),
+            None,
+            Some(handler.clone()),
+            None,
+            None,
+            None,
+            false,
+            Plugins::default(),
+            QueryOptions::default(),
+        ));
+        let lease = state
+            .acquire_remote_dyn_filter_registry_lease(&query_ctx)
+            .unwrap();
+        let task_ctx = task_context_with_engine_state(state, query_ctx.clone());
+        let plan = LogicalPlanBuilder::empty(true)
+            .project(vec![lit(1i32).alias("col1")])
+            .unwrap()
+            .build()
+            .unwrap();
+        let schema = plan.schema().as_arrow().clone();
+        let exec = MergeScanExec::new(
+            &SessionStateBuilder::new().build(),
+            TableName::new("catalog", "schema", "table"),
+            vec![RegionId::new(1024, 1)],
+            plan,
+            &schema,
+            handler.clone(),
+            query_ctx,
+            1,
+            AliasMapping::new(),
+            Some(RemoteDynFilterProducerId::new(42)),
+            false,
+        )
+        .unwrap();
+        let dyn_filter = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![Arc::new(Column::new("host", 0)) as Arc<_>],
+            physical_lit(true) as _,
+        )) as Arc<dyn datafusion_physical_expr::PhysicalExpr>;
+        exec.handle_child_pushdown_result(
+            FilterPushdownPhase::Post,
+            ChildPushdownResult {
+                parent_filters: vec![ChildFilterPushdownResult {
+                    filter: dyn_filter,
+                    child_results: vec![PushedDown::Yes],
+                }],
+                self_filters: Vec::new(),
+            },
+            &ConfigOptions::new(),
+        )
+        .unwrap();
+
+        let mut stream = exec.to_stream(task_ctx, 0).unwrap();
+        assert!(stream.next().await.unwrap().is_err());
+        assert_eq!(handler.do_get_calls.load(Ordering::SeqCst), 1);
+
+        let entries = lease.registry().entries();
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].subscribers().is_empty());
+        assert!(!entries[0].fanout_started_for_test());
     }
 
     #[test]
@@ -1288,19 +1374,28 @@ mod tests {
 
     struct TestRegionQueryHandler;
 
+    #[derive(Default)]
+    struct FailingRegionQueryHandler {
+        do_get_calls: AtomicUsize,
+    }
+
     #[async_trait]
-    impl RegionQueryHandler for TestRegionQueryHandler {
+    impl RegionQueryHandler for FailingRegionQueryHandler {
         async fn do_get(
             &self,
             _read_preference: ReadPreference,
             _request: common_query::request::QueryRequest,
-        ) -> crate::error::Result<common_recordbatch::SendableRecordBatchStream> {
-            unimplemented!("test only")
+        ) -> crate::error::Result<crate::region_query::RoutedRegionQueryStream> {
+            self.do_get_calls.fetch_add(1, Ordering::SeqCst);
+            crate::error::UnimplementedSnafu {
+                operation: "test do_get failure",
+            }
+            .fail()
         }
 
         async fn handle_remote_dyn_filter_update(
             &self,
-            _region_id: RegionId,
+            _target: &crate::region_query::RegionQueryTarget,
             _query_id: String,
             _update: api::v1::region::RemoteDynFilterUpdate,
         ) -> crate::error::Result<()> {
@@ -1309,7 +1404,36 @@ mod tests {
 
         async fn handle_remote_dyn_filter_unregister(
             &self,
-            _region_id: RegionId,
+            _target: &crate::region_query::RegionQueryTarget,
+            _query_id: String,
+            _unregister: api::v1::region::RemoteDynFilterUnregister,
+        ) -> crate::error::Result<()> {
+            unimplemented!("test only")
+        }
+    }
+
+    #[async_trait]
+    impl RegionQueryHandler for TestRegionQueryHandler {
+        async fn do_get(
+            &self,
+            _read_preference: ReadPreference,
+            _request: common_query::request::QueryRequest,
+        ) -> crate::error::Result<crate::region_query::RoutedRegionQueryStream> {
+            unimplemented!("test only")
+        }
+
+        async fn handle_remote_dyn_filter_update(
+            &self,
+            _target: &crate::region_query::RegionQueryTarget,
+            _query_id: String,
+            _update: api::v1::region::RemoteDynFilterUpdate,
+        ) -> crate::error::Result<()> {
+            unimplemented!("test only")
+        }
+
+        async fn handle_remote_dyn_filter_unregister(
+            &self,
+            _target: &crate::region_query::RegionQueryTarget,
             _query_id: String,
             _unregister: api::v1::region::RemoteDynFilterUnregister,
         ) -> crate::error::Result<()> {

--- a/src/query/src/dist_plan/planner.rs
+++ b/src/query/src/dist_plan/planner.rs
@@ -535,7 +535,7 @@ mod tests {
     use table::test_util::EmptyTable;
 
     use super::DistExtensionPlanner;
-    use crate::region_query::RegionQueryHandler;
+    use crate::region_query::{RegionQueryHandler, RegionQueryTarget};
 
     const LOGICAL_TABLE_ID: u32 = 1024;
     const PHYSICAL_TABLE_ID: u32 = 2048;
@@ -544,9 +544,17 @@ mod tests {
 
     #[async_trait]
     impl RegionQueryHandler for UnusedRegionQueryHandler {
-        async fn do_get(
+        async fn select_target(
             &self,
             _read_preference: ReadPreference,
+            _region_id: RegionId,
+        ) -> crate::error::Result<RegionQueryTarget> {
+            unreachable!("get_regions does not select region query targets")
+        }
+
+        async fn do_get(
+            &self,
+            _target: &RegionQueryTarget,
             _request: QueryRequest,
         ) -> crate::error::Result<SendableRecordBatchStream> {
             unreachable!("get_regions does not query regions")
@@ -554,7 +562,7 @@ mod tests {
 
         async fn handle_remote_dyn_filter_update(
             &self,
-            _region_id: RegionId,
+            _target: &RegionQueryTarget,
             _query_id: String,
             _update: RemoteDynFilterUpdate,
         ) -> crate::error::Result<()> {
@@ -563,7 +571,7 @@ mod tests {
 
         async fn handle_remote_dyn_filter_unregister(
             &self,
-            _region_id: RegionId,
+            _target: &RegionQueryTarget,
             _query_id: String,
             _unregister: RemoteDynFilterUnregister,
         ) -> crate::error::Result<()> {

--- a/src/query/src/dist_plan/remote_dyn_filter_registry.rs
+++ b/src/query/src/dist_plan/remote_dyn_filter_registry.rs
@@ -32,25 +32,30 @@ use crate::metrics::{
     REMOTE_DYN_FILTER_ENCODE_TOTAL, REMOTE_DYN_FILTER_PAYLOAD_BYTES,
     REMOTE_DYN_FILTER_UPDATE_RPC_TOTAL,
 };
-use crate::region_query::RegionQueryHandlerRef;
+use crate::region_query::{RegionQueryHandlerRef, RegionQueryTarget};
 
 const REMOTE_DYN_FILTER_RECONCILE_INTERVAL: Duration = Duration::from_secs(1);
 /// Bound best-effort RDF control RPCs so one bad subscriber cannot stall fanout.
 const REMOTE_DYN_FILTER_CONTROL_RPC_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Region subscribed to a remote dynamic filter.
+/// Region and target subscribed to a remote dynamic filter.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Subscriber {
     region_id: RegionId,
+    target: RegionQueryTarget,
 }
 
 impl Subscriber {
-    pub fn new(region_id: RegionId) -> Self {
-        Self { region_id }
+    pub fn new(region_id: RegionId, target: RegionQueryTarget) -> Self {
+        Self { region_id, target }
     }
 
     pub fn region_id(&self) -> RegionId {
         self.region_id
+    }
+
+    pub fn target(&self) -> &RegionQueryTarget {
+        &self.target
     }
 }
 
@@ -460,7 +465,7 @@ async fn fanout_update_for_query(
                 subscriber.region_id()
             ),
             region_query_handler.handle_remote_dyn_filter_update(
-                subscriber.region_id(),
+                subscriber.target(),
                 query_id.clone(),
                 update,
             ),
@@ -528,7 +533,7 @@ async fn unregister_entry_once_for_query(
                 subscriber.region_id()
             ),
             region_query_handler.handle_remote_dyn_filter_unregister(
-                subscriber.region_id(),
+                subscriber.target(),
                 query_id.clone(),
                 unregister,
             ),
@@ -798,6 +803,7 @@ impl DynFilterRegistryManager {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Barrier, Mutex};
     use std::thread;
@@ -805,6 +811,7 @@ mod tests {
 
     use api::v1::region::{RemoteDynFilterUnregister, RemoteDynFilterUpdate};
     use async_trait::async_trait;
+    use common_meta::peer::Peer;
     use common_query::request::QueryRequest;
     use datafusion_physical_expr::expressions::{Column, lit};
     use session::ReadPreference;
@@ -813,11 +820,11 @@ mod tests {
     use super::*;
     use crate::dist_plan::{FilterFingerprint, RemoteDynFilterProducerId};
     use crate::error::Result as QueryResult;
-    use crate::region_query::RegionQueryHandler;
+    use crate::region_query::{RegionQueryHandler, RegionQueryTarget};
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     struct RecordedUpdate {
-        region_id: RegionId,
+        target: RegionQueryTarget,
         query_id: String,
         filter_id: String,
         generation: u64,
@@ -827,7 +834,7 @@ mod tests {
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     struct RecordedUnregister {
-        region_id: RegionId,
+        target: RegionQueryTarget,
         query_id: String,
         filter_id: String,
     }
@@ -872,6 +879,16 @@ mod tests {
             panic!("timed out waiting for {expected} remote dyn filter updates");
         }
 
+        async fn wait_for_complete_update(&self) {
+            for _ in 0..300 {
+                if self.updates().iter().any(|update| update.is_complete) {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            panic!("timed out waiting for completed remote dyn filter update");
+        }
+
         async fn wait_for_unregister_count(&self, expected: usize) {
             for _ in 0..300 {
                 if self.unregisters().len() >= expected {
@@ -899,19 +916,19 @@ mod tests {
             &self,
             _read_preference: ReadPreference,
             _request: QueryRequest,
-        ) -> QueryResult<common_recordbatch::SendableRecordBatchStream> {
+        ) -> QueryResult<crate::region_query::RoutedRegionQueryStream> {
             unreachable!("remote dyn filter registry tests should not execute remote queries")
         }
 
         async fn handle_remote_dyn_filter_update(
             &self,
-            region_id: RegionId,
+            target: &RegionQueryTarget,
             query_id: String,
             update: RemoteDynFilterUpdate,
         ) -> QueryResult<()> {
             let should_block = self.block_next_update.swap(false, Ordering::SeqCst);
             self.updates.lock().unwrap().push(RecordedUpdate {
-                region_id,
+                target: target.clone(),
                 query_id,
                 filter_id: update.filter_id,
                 generation: update.generation,
@@ -927,12 +944,12 @@ mod tests {
 
         async fn handle_remote_dyn_filter_unregister(
             &self,
-            region_id: RegionId,
+            target: &RegionQueryTarget,
             query_id: String,
             unregister: RemoteDynFilterUnregister,
         ) -> QueryResult<()> {
             self.unregisters.lock().unwrap().push(RecordedUnregister {
-                region_id,
+                target: target.clone(),
                 query_id,
                 filter_id: unregister.filter_id,
             });
@@ -942,6 +959,13 @@ mod tests {
 
     fn test_query_id(value: u128) -> QueryId {
         QueryId::from(Uuid::from_u128(value))
+    }
+
+    fn test_target(id: u64) -> RegionQueryTarget {
+        RegionQueryTarget::new(Peer {
+            id,
+            addr: format!("127.0.0.1:{id}"),
+        })
     }
 
     fn test_filter_id(producer_ordinal: u32) -> FilterId {
@@ -1169,7 +1193,7 @@ mod tests {
         assert_eq!(entry.filter_id(), &filter_id);
         assert_eq!(registry.entry_count(), 1);
 
-        let subscriber = Subscriber::new(RegionId::new(1024, 1));
+        let subscriber = Subscriber::new(RegionId::new(1024, 1), test_target(1));
         assert_eq!(
             registry.register_subscriber(&filter_id, subscriber.clone()),
             SubscriberRegistration::Added
@@ -1179,6 +1203,22 @@ mod tests {
             SubscriberRegistration::Duplicate
         );
         assert_eq!(entry.subscribers().len(), 1);
+    }
+
+    #[test]
+    fn subscriber_identity_includes_region_and_target() {
+        let first_region = RegionId::new(1024, 1);
+        let second_region = RegionId::new(1024, 2);
+        let first_target = test_target(1);
+        let second_target = test_target(2);
+        let first = Subscriber::new(first_region, first_target.clone());
+
+        let mut subscribers = HashSet::new();
+        assert!(subscribers.insert(first.clone()));
+        assert!(!subscribers.insert(first));
+        assert!(subscribers.insert(Subscriber::new(first_region, second_target)));
+        assert!(subscribers.insert(Subscriber::new(second_region, first_target)));
+        assert_eq!(subscribers.len(), 3);
     }
 
     #[tokio::test]
@@ -1191,7 +1231,7 @@ mod tests {
             EntryRegistration::Inserted(entry) => entry,
             other => panic!("unexpected registration result: {other:?}"),
         };
-        let subscriber = Subscriber::new(RegionId::new(1024, 7));
+        let subscriber = Subscriber::new(RegionId::new(1024, 7), test_target(1));
         assert_eq!(
             registry.register_subscriber(&filter_id, subscriber.clone()),
             SubscriberRegistration::Added
@@ -1205,7 +1245,7 @@ mod tests {
             .await;
         let updates = handler.updates();
         assert_eq!(updates.len(), 1);
-        assert_eq!(updates[0].region_id, subscriber.region_id());
+        assert_eq!(&updates[0].target, subscriber.target());
         assert_eq!(updates[0].query_id, query_id.to_string());
         assert_eq!(updates[0].filter_id, filter_id.to_string());
         assert_eq!(updates[0].generation, filter.snapshot_generation());
@@ -1225,7 +1265,7 @@ mod tests {
         assert_eq!(updates.len(), 2);
         assert_eq!(updates[1].generation, filter.snapshot_generation());
 
-        let second_subscriber = Subscriber::new(RegionId::new(1024, 8));
+        let second_subscriber = Subscriber::new(RegionId::new(1024, 8), test_target(2));
         assert_eq!(
             registry.register_subscriber(&filter_id, second_subscriber.clone()),
             SubscriberRegistration::Added
@@ -1238,12 +1278,12 @@ mod tests {
         assert!(
             updates[2..]
                 .iter()
-                .any(|update| update.region_id == subscriber.region_id())
+                .any(|update| update.target == subscriber.target().clone())
         );
         assert!(
             updates[2..]
                 .iter()
-                .any(|update| update.region_id == second_subscriber.region_id())
+                .any(|update| update.target == second_subscriber.target().clone())
         );
         assert_eq!(entry.subscribers().len(), 2);
     }
@@ -1259,7 +1299,7 @@ mod tests {
         let _ = lease
             .registry()
             .register_remote_dyn_filter(filter_id.clone(), filter.clone());
-        let subscriber = Subscriber::new(RegionId::new(1024, 7));
+        let subscriber = Subscriber::new(RegionId::new(1024, 7), test_target(1));
         assert_eq!(
             lease
                 .registry()
@@ -1277,7 +1317,7 @@ mod tests {
         handler.wait_for_update_count(2).await;
         let updates = handler.updates();
         assert!(updates[1].generation > initial_generation);
-        assert_eq!(updates[1].region_id, subscriber.region_id());
+        assert_eq!(&updates[1].target, subscriber.target());
         assert_eq!(updates[1].filter_id, filter_id.to_string());
 
         filter.mark_complete();
@@ -1288,10 +1328,46 @@ mod tests {
         drop(lease);
         handler.wait_for_unregister_count(1).await;
         let unregisters = handler.unregisters();
-        assert_eq!(unregisters[0].region_id, subscriber.region_id());
+        assert_eq!(&unregisters[0].target, subscriber.target());
+        assert_eq!(unregisters[0].target, updates[0].target);
         assert_eq!(unregisters[0].filter_id, filter_id.to_string());
 
         wait_for_registry_drop(registry_weak).await;
+    }
+
+    #[tokio::test]
+    async fn late_subscriber_receives_completed_snapshot_at_its_target() {
+        let query_id = test_query_id(10);
+        let manager = Arc::new(DynFilterRegistryManager::default());
+        let lease = manager.acquire_lease(query_id);
+        let filter = test_dyn_filter(&["host"]);
+        let filter_id = test_filter_id(1);
+        let _ = lease
+            .registry()
+            .register_remote_dyn_filter(filter_id.clone(), filter.clone());
+
+        // Model the period while do_get is awaiting the selected target: the producer may
+        // advance and complete before a subscriber is registered.
+        filter.update(lit(false) as _).unwrap();
+        filter.mark_complete();
+
+        let subscriber = Subscriber::new(RegionId::new(1024, 7), test_target(7));
+        assert_eq!(
+            lease
+                .registry()
+                .register_subscriber(&filter_id, subscriber.clone()),
+            SubscriberRegistration::Added
+        );
+
+        let handler = Arc::new(RecordingRegionQueryHandler::default());
+        lease.ensure_fanout_task(handler.clone() as RegionQueryHandlerRef);
+        handler.wait_for_complete_update().await;
+
+        let updates = handler.updates();
+        let latest = updates.last().unwrap();
+        assert_eq!(&latest.target, subscriber.target());
+        assert_eq!(latest.generation, filter.snapshot_generation());
+        assert!(latest.is_complete);
     }
 
     #[tokio::test]
@@ -1309,7 +1385,7 @@ mod tests {
             EntryRegistration::Inserted(entry) => entry,
             other => panic!("unexpected registration result: {other:?}"),
         };
-        let subscriber = Subscriber::new(RegionId::new(1024, 7));
+        let subscriber = Subscriber::new(RegionId::new(1024, 7), test_target(1));
         assert_eq!(
             lease
                 .registry()
@@ -1347,7 +1423,7 @@ mod tests {
         let _ = lease
             .registry()
             .register_remote_dyn_filter(filter_id.clone(), filter.clone());
-        let first_subscriber = Subscriber::new(RegionId::new(1024, 7));
+        let first_subscriber = Subscriber::new(RegionId::new(1024, 7), test_target(1));
         assert_eq!(
             lease
                 .registry()
@@ -1363,7 +1439,7 @@ mod tests {
         handler.wait_for_update_count(2).await;
         assert!(handler.updates()[1].is_complete);
 
-        let late_subscriber = Subscriber::new(RegionId::new(1024, 8));
+        let late_subscriber = Subscriber::new(RegionId::new(1024, 8), test_target(1));
         assert_eq!(
             lease
                 .registry()
@@ -1374,14 +1450,15 @@ mod tests {
         handler.wait_for_update_count(4).await;
         let updates = handler.updates();
         assert!(
-            updates[2..].iter().any(
-                |update| update.region_id == first_subscriber.region_id() && update.is_complete
-            )
+            updates[2..]
+                .iter()
+                .any(|update| update.target == first_subscriber.target().clone()
+                    && update.is_complete)
         );
         assert!(
             updates[2..]
                 .iter()
-                .any(|update| update.region_id == late_subscriber.region_id()
+                .any(|update| update.target == late_subscriber.target().clone()
                     && update.is_complete)
         );
 
@@ -1401,7 +1478,7 @@ mod tests {
         let _ = lease
             .registry()
             .register_remote_dyn_filter(filter_id.clone(), filter.clone());
-        let subscriber = Subscriber::new(RegionId::new(1024, 7));
+        let subscriber = Subscriber::new(RegionId::new(1024, 7), test_target(1));
         assert_eq!(
             lease
                 .registry()
@@ -1416,7 +1493,7 @@ mod tests {
         drop(filter);
         handler.wait_for_unregister_count(1).await;
         let unregisters = handler.unregisters();
-        assert_eq!(unregisters[0].region_id, subscriber.region_id());
+        assert_eq!(&unregisters[0].target, subscriber.target());
         assert_eq!(unregisters[0].filter_id, filter_id.to_string());
 
         drop(lease);
@@ -1434,7 +1511,7 @@ mod tests {
         let _ = lease
             .registry()
             .register_remote_dyn_filter(filter_id.clone(), filter.clone());
-        let subscriber = Subscriber::new(RegionId::new(1024, 7));
+        let subscriber = Subscriber::new(RegionId::new(1024, 7), test_target(1));
         assert_eq!(
             lease
                 .registry()
@@ -1456,7 +1533,7 @@ mod tests {
         handler.wait_for_update_count(2).await;
         let updates = handler.updates();
         assert!(updates[1].generation > initial_generation);
-        assert_eq!(updates[1].region_id, subscriber.region_id());
+        assert_eq!(&updates[1].target, subscriber.target());
         assert_eq!(updates[1].filter_id, filter_id.to_string());
 
         drop(lease);
@@ -1475,7 +1552,7 @@ mod tests {
         let _ = lease
             .registry()
             .register_remote_dyn_filter(filter_id.clone(), filter.clone());
-        let subscriber = Subscriber::new(RegionId::new(1024, 7));
+        let subscriber = Subscriber::new(RegionId::new(1024, 7), test_target(1));
         assert_eq!(
             lease
                 .registry()
@@ -1492,7 +1569,7 @@ mod tests {
 
         handler.wait_for_unregister_count(1).await;
         let unregisters = handler.unregisters();
-        assert_eq!(unregisters[0].region_id, subscriber.region_id());
+        assert_eq!(&unregisters[0].target, subscriber.target());
         assert_eq!(unregisters[0].filter_id, filter_id.to_string());
         wait_for_registry_drop(registry_weak).await;
     }
@@ -1507,8 +1584,8 @@ mod tests {
             EntryRegistration::Inserted(entry) => entry,
             other => panic!("unexpected registration result: {other:?}"),
         };
-        let first_subscriber = Subscriber::new(RegionId::new(1024, 7));
-        let second_subscriber = Subscriber::new(RegionId::new(1024, 8));
+        let first_subscriber = Subscriber::new(RegionId::new(1024, 7), test_target(1));
+        let second_subscriber = Subscriber::new(RegionId::new(1024, 8), test_target(2));
         assert_eq!(
             registry.register_subscriber(&filter_id, first_subscriber.clone()),
             SubscriberRegistration::Added
@@ -1549,12 +1626,12 @@ mod tests {
         assert!(
             initial_updates
                 .iter()
-                .any(|update| update.region_id == first_subscriber.region_id())
+                .any(|update| update.target == first_subscriber.target().clone())
         );
         assert!(
             initial_updates
                 .iter()
-                .any(|update| update.region_id == second_subscriber.region_id())
+                .any(|update| update.target == second_subscriber.target().clone())
         );
 
         filter.update(lit(false) as _).unwrap();
@@ -1575,12 +1652,12 @@ mod tests {
         assert!(
             updates[2..]
                 .iter()
-                .any(|update| update.region_id == first_subscriber.region_id())
+                .any(|update| update.target == first_subscriber.target().clone())
         );
         assert!(
             updates[2..]
                 .iter()
-                .any(|update| update.region_id == second_subscriber.region_id())
+                .any(|update| update.target == second_subscriber.target().clone())
         );
 
         registry.unregister_all_once(&handler_ref).await;
@@ -1594,7 +1671,7 @@ mod tests {
         let filter = test_dyn_filter(&["host"]);
         let filter_id = test_filter_id(1);
         let _ = registry.register_remote_dyn_filter(filter_id.clone(), filter);
-        let subscriber = Subscriber::new(RegionId::new(1024, 7));
+        let subscriber = Subscriber::new(RegionId::new(1024, 7), test_target(1));
         assert_eq!(
             registry.register_subscriber(&filter_id, subscriber.clone()),
             SubscriberRegistration::Added
@@ -1608,7 +1685,7 @@ mod tests {
 
         let unregisters = handler.unregisters();
         assert_eq!(unregisters.len(), 1);
-        assert_eq!(unregisters[0].region_id, subscriber.region_id());
+        assert_eq!(&unregisters[0].target, subscriber.target());
         assert_eq!(unregisters[0].query_id, query_id.to_string());
         assert_eq!(unregisters[0].filter_id, filter_id.to_string());
     }

--- a/src/query/src/dist_plan/remote_dyn_filter_registry.rs
+++ b/src/query/src/dist_plan/remote_dyn_filter_registry.rs
@@ -247,6 +247,16 @@ impl QueryDynFilterRegistry {
         }
     }
 
+    /// Removes one exact subscriber without changing producer or fanout state.
+    pub(crate) fn remove_subscriber(&self, filter_id: &FilterId, subscriber: &Subscriber) -> bool {
+        self.inner
+            .read()
+            .unwrap()
+            .entries
+            .get(filter_id)
+            .is_some_and(|entry| entry.subscribers.write().unwrap().remove(subscriber))
+    }
+
     /// Starts missing producer fanout watchers for the registry's entries.
     ///
     /// Watchers do not hold the registry alive; dropping the registry closes their lifecycle channel.
@@ -680,6 +690,11 @@ impl RemoteDynFilterRegistryLease {
             other.registry.as_ref().unwrap(),
         )
     }
+
+    #[cfg(test)]
+    pub(crate) fn registry_arc_for_test(&self) -> Arc<QueryDynFilterRegistry> {
+        self.registry.as_ref().unwrap().clone()
+    }
 }
 
 impl Drop for RemoteDynFilterRegistryLease {
@@ -912,11 +927,19 @@ mod tests {
 
     #[async_trait]
     impl RegionQueryHandler for RecordingRegionQueryHandler {
-        async fn do_get(
+        async fn select_target(
             &self,
             _read_preference: ReadPreference,
+            _region_id: RegionId,
+        ) -> QueryResult<RegionQueryTarget> {
+            unreachable!("remote dyn filter registry tests should not execute remote queries")
+        }
+
+        async fn do_get(
+            &self,
+            _target: &RegionQueryTarget,
             _request: QueryRequest,
-        ) -> QueryResult<crate::region_query::RoutedRegionQueryStream> {
+        ) -> QueryResult<common_recordbatch::SendableRecordBatchStream> {
             unreachable!("remote dyn filter registry tests should not execute remote queries")
         }
 
@@ -1203,6 +1226,32 @@ mod tests {
             SubscriberRegistration::Duplicate
         );
         assert_eq!(entry.subscribers().len(), 1);
+    }
+
+    #[test]
+    fn remove_subscriber_removes_only_exact_key() {
+        let registry = QueryDynFilterRegistry::new(test_query_id(1));
+        let filter = test_dyn_filter(&["host"]);
+        let filter_id = test_filter_id(1);
+        let entry = match registry.register_remote_dyn_filter(filter_id.clone(), filter) {
+            EntryRegistration::Inserted(entry) => entry,
+            other => panic!("unexpected registration result: {other:?}"),
+        };
+        let first = Subscriber::new(RegionId::new(1024, 1), test_target(1));
+        let second = Subscriber::new(RegionId::new(1024, 1), test_target(2));
+        assert_eq!(
+            registry.register_subscriber(&filter_id, first.clone()),
+            SubscriberRegistration::Added
+        );
+        assert_eq!(
+            registry.register_subscriber(&filter_id, second.clone()),
+            SubscriberRegistration::Added
+        );
+
+        assert!(registry.remove_subscriber(&filter_id, &first));
+        assert!(!registry.remove_subscriber(&filter_id, &first));
+        assert_eq!(entry.subscribers(), vec![second]);
+        assert!(!entry.fanout_started_for_test());
     }
 
     #[test]

--- a/src/query/src/metrics.rs
+++ b/src/query/src/metrics.rs
@@ -434,13 +434,13 @@ mod tests {
             &self,
             _read_preference: ReadPreference,
             _request: common_query::request::QueryRequest,
-        ) -> Result<SendableRecordBatchStream> {
+        ) -> Result<crate::region_query::RoutedRegionQueryStream> {
             unreachable!("metrics tests should not execute remote queries")
         }
 
         async fn handle_remote_dyn_filter_update(
             &self,
-            _region_id: RegionId,
+            _target: &crate::region_query::RegionQueryTarget,
             _query_id: String,
             _update: RemoteDynFilterUpdate,
         ) -> Result<()> {
@@ -449,7 +449,7 @@ mod tests {
 
         async fn handle_remote_dyn_filter_unregister(
             &self,
-            _region_id: RegionId,
+            _target: &crate::region_query::RegionQueryTarget,
             _query_id: String,
             _unregister: RemoteDynFilterUnregister,
         ) -> Result<()> {

--- a/src/query/src/metrics.rs
+++ b/src/query/src/metrics.rs
@@ -430,11 +430,19 @@ mod tests {
 
     #[async_trait]
     impl RegionQueryHandler for NoopRegionQueryHandler {
-        async fn do_get(
+        async fn select_target(
             &self,
             _read_preference: ReadPreference,
+            _region_id: RegionId,
+        ) -> Result<crate::region_query::RegionQueryTarget> {
+            unreachable!("metrics tests should not execute remote queries")
+        }
+
+        async fn do_get(
+            &self,
+            _target: &crate::region_query::RegionQueryTarget,
             _request: common_query::request::QueryRequest,
-        ) -> Result<crate::region_query::RoutedRegionQueryStream> {
+        ) -> Result<SendableRecordBatchStream> {
             unreachable!("metrics tests should not execute remote queries")
         }
 

--- a/src/query/src/optimizer/pass_distribution.rs
+++ b/src/query/src/optimizer/pass_distribution.rs
@@ -153,7 +153,6 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema, SchemaRef, TimeUnit};
     use async_trait::async_trait;
     use common_query::request::QueryRequest;
-    use common_recordbatch::SendableRecordBatchStream;
     use datafusion::common::NullEquality;
     use datafusion::execution::SessionStateBuilder;
     use datafusion::physical_optimizer::PhysicalOptimizerRule;
@@ -182,13 +181,13 @@ mod tests {
             &self,
             _read_preference: ReadPreference,
             _request: QueryRequest,
-        ) -> QueryResult<SendableRecordBatchStream> {
+        ) -> QueryResult<crate::region_query::RoutedRegionQueryStream> {
             unreachable!("pass distribution tests should not execute remote queries")
         }
 
         async fn handle_remote_dyn_filter_update(
             &self,
-            _region_id: RegionId,
+            _target: &crate::region_query::RegionQueryTarget,
             _query_id: String,
             _update: RemoteDynFilterUpdate,
         ) -> QueryResult<()> {
@@ -197,7 +196,7 @@ mod tests {
 
         async fn handle_remote_dyn_filter_unregister(
             &self,
-            _region_id: RegionId,
+            _target: &crate::region_query::RegionQueryTarget,
             _query_id: String,
             _unregister: RemoteDynFilterUnregister,
         ) -> QueryResult<()> {

--- a/src/query/src/optimizer/pass_distribution.rs
+++ b/src/query/src/optimizer/pass_distribution.rs
@@ -177,11 +177,19 @@ mod tests {
 
     #[async_trait]
     impl RegionQueryHandler for NoopRegionQueryHandler {
-        async fn do_get(
+        async fn select_target(
             &self,
             _read_preference: ReadPreference,
+            _region_id: RegionId,
+        ) -> QueryResult<crate::region_query::RegionQueryTarget> {
+            unreachable!("pass distribution tests should not execute remote queries")
+        }
+
+        async fn do_get(
+            &self,
+            _target: &crate::region_query::RegionQueryTarget,
             _request: QueryRequest,
-        ) -> QueryResult<crate::region_query::RoutedRegionQueryStream> {
+        ) -> QueryResult<common_recordbatch::SendableRecordBatchStream> {
             unreachable!("pass distribution tests should not execute remote queries")
         }
 

--- a/src/query/src/region_query.rs
+++ b/src/query/src/region_query.rs
@@ -17,13 +17,36 @@ use std::sync::Arc;
 use api::v1::region::{RemoteDynFilterUnregister, RemoteDynFilterUpdate};
 use async_trait::async_trait;
 use common_meta::node_manager::NodeManagerRef;
+use common_meta::peer::Peer;
 use common_query::request::QueryRequest;
 use common_recordbatch::SendableRecordBatchStream;
 use partition::manager::PartitionRuleManagerRef;
 use session::ReadPreference;
-use store_api::storage::RegionId;
 
 use crate::error::Result;
+
+/// The peer selected to serve a region query.
+///
+/// The target is frozen when the query is dispatched. Follow-up controls must
+/// reuse it instead of resolving the region route again.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct RegionQueryTarget(Peer);
+
+impl RegionQueryTarget {
+    pub fn new(peer: Peer) -> Self {
+        Self(peer)
+    }
+
+    pub fn peer(&self) -> &Peer {
+        &self.0
+    }
+}
+
+/// The result of a region query together with its frozen target.
+pub struct RoutedRegionQueryStream {
+    pub stream: SendableRecordBatchStream,
+    pub target: RegionQueryTarget,
+}
 
 /// A factory to create a [`RegionQueryHandler`].
 pub trait RegionQueryHandlerFactory: Send + Sync {
@@ -43,21 +66,39 @@ pub trait RegionQueryHandler: Send + Sync {
         &self,
         read_preference: ReadPreference,
         request: QueryRequest,
-    ) -> Result<SendableRecordBatchStream>;
+    ) -> Result<RoutedRegionQueryStream>;
 
     async fn handle_remote_dyn_filter_update(
         &self,
-        region_id: RegionId,
+        target: &RegionQueryTarget,
         query_id: String,
         update: RemoteDynFilterUpdate,
     ) -> Result<()>;
 
     async fn handle_remote_dyn_filter_unregister(
         &self,
-        region_id: RegionId,
+        target: &RegionQueryTarget,
         query_id: String,
         unregister: RemoteDynFilterUnregister,
     ) -> Result<()>;
 }
 
 pub type RegionQueryHandlerRef = Arc<dyn RegionQueryHandler>;
+
+#[cfg(test)]
+mod tests {
+    use common_meta::peer::Peer;
+
+    use super::RegionQueryTarget;
+
+    #[test]
+    fn region_query_target_exposes_immutable_peer() {
+        let peer = Peer {
+            id: 42,
+            addr: "127.0.0.1:3001".to_string(),
+        };
+        let target = RegionQueryTarget::new(peer.clone());
+
+        assert_eq!(target.peer(), &peer);
+    }
+}

--- a/src/query/src/region_query.rs
+++ b/src/query/src/region_query.rs
@@ -42,12 +42,6 @@ impl RegionQueryTarget {
     }
 }
 
-/// The result of a region query together with its frozen target.
-pub struct RoutedRegionQueryStream {
-    pub stream: SendableRecordBatchStream,
-    pub target: RegionQueryTarget,
-}
-
 /// A factory to create a [`RegionQueryHandler`].
 pub trait RegionQueryHandlerFactory: Send + Sync {
     /// Build a [`RegionQueryHandler`] with the given partition manager and node manager.
@@ -62,11 +56,17 @@ pub type RegionQueryHandlerFactoryRef = Arc<dyn RegionQueryHandlerFactory>;
 
 #[async_trait]
 pub trait RegionQueryHandler: Send + Sync {
-    async fn do_get(
+    async fn select_target(
         &self,
         read_preference: ReadPreference,
+        region_id: store_api::storage::RegionId,
+    ) -> Result<RegionQueryTarget>;
+
+    async fn do_get(
+        &self,
+        target: &RegionQueryTarget,
         request: QueryRequest,
-    ) -> Result<RoutedRegionQueryStream>;
+    ) -> Result<SendableRecordBatchStream>;
 
     async fn handle_remote_dyn_filter_update(
         &self,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Remote dynamic filter registrations are attached to the datanode selected for a region query, but subsequent update and unregister controls previously resolved the region route again. This loses affinity when a route changes or when a `RegionQueryHandler` adapter selects a non-leader peer.

This PR preserves the dispatch target across the RDF lifecycle:

- `RegionQueryHandler::do_get` returns the record-batch stream together with an immutable `RegionQueryTarget`;
- MergeScan registers RDF subscribers only after the region query succeeds and associates each subscriber with the returned target;
- RDF update and unregister fanout reuse the stored target instead of resolving the route again;
- the OSS frontend still selects the region leader, so existing OSS routing behavior is unchanged.

The dispatch order is initial registration encoding → successful `do_get` → target-aware subscriber registration → fanout start → stream polling. Updates produced while `do_get` is pending are reconciled from the latest stable filter snapshot after the subscriber is registered. Failed dispatches leave no subscriber and never start fanout.

There are no protobuf, wire-format, schema, datanode registry, or user-facing API changes. The internal `RegionQueryHandler` adapter interface changes mechanically to return and consume the routed target. Same-region/same-target duplicate attempts retain the existing deduplication semantics; per-attempt refcounting is outside this change.

Validation:

- `cargo nextest run -p query` — 547 passed, 2 skipped
- `cargo nextest run -p frontend` — 90 passed
- `cargo nextest run -p query remote_dyn_filter` — 47 passed
- `cargo clippy -p query -p frontend --all-targets --all-features -- -D warnings`
- repository pre-push formatting, license, typo, and clippy hooks

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.