### PR TITLE
feat: add database DDL procedure events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2593,6 +2593,7 @@ dependencies = [
  "common-base",
  "common-catalog",
  "common-error",
+ "common-event-recorder",
  "common-grpc-expr",
  "common-macro",
  "common-procedure",

--- a/config/config.md
+++ b/config/config.md
@@ -229,7 +229,7 @@
 | `tracing.tokio_console_addr` | String | Unset | The tokio console address. |
 | `event_recorder` | -- | -- | Configuration options for the event recorder. |
 | `event_recorder.ttl` | String | `90d` | TTL for the events table that will be used to store the events. Default is `90d`. |
-| `event_recorder.event_types` | Array | -- | Event types to record. Current available event type: `region_migration`.<br/>When omitted, all current and future event types are recorded.<br/>Set to an empty array to disable event recording. |
+| `event_recorder.event_types` | Array | -- | Event types to record. Current available event types: `region_migration`,<br/>`create_database`, `alter_database`, `drop_database`.<br/>When omitted, all current and future event types are recorded.<br/>Set to an empty array to disable event recording. |
 | `memory` | -- | -- | The memory options. |
 | `memory.enable_heap_profiling` | Bool | `true` | Whether to enable heap profiling activation during startup.<br/>When enabled, heap profiling will be activated if the `MALLOC_CONF` environment variable<br/>is set to "prof:true,prof_active:false". The official image adds this env variable.<br/>Default is true. |
 
@@ -436,7 +436,7 @@
 | `wal.create_topic_timeout` | String | `30s` | The timeout for creating a Kafka topic.<br/>**It's only used when the provider is `kafka`**. |
 | `event_recorder` | -- | -- | Configuration options for the event recorder. |
 | `event_recorder.ttl` | String | `90d` | TTL for the events table that will be used to store the events. Default is `90d`. |
-| `event_recorder.event_types` | Array | -- | Event types to record. Current available event type: `region_migration`.<br/>When omitted, all current and future event types are recorded.<br/>Set to an empty array to disable event recording. |
+| `event_recorder.event_types` | Array | -- | Event types to record. Current available event types: `region_migration`,<br/>`create_database`, `alter_database`, `drop_database`.<br/>When omitted, all current and future event types are recorded.<br/>Set to an empty array to disable event recording. |
 | `stats_persistence` | -- | -- | Configuration options for the stats persistence. |
 | `stats_persistence.ttl` | String | `0s` | TTL for the stats table that will be used to store the stats.<br/>Set to `0s` to disable stats persistence.<br/>Default is `0s`.<br/>If you want to enable stats persistence, set the TTL to a value greater than 0.<br/>It is recommended to set a small value, e.g., `3h`. |
 | `stats_persistence.interval` | String | `10m` | The interval to persist the stats. Default is `10m`.<br/>The minimum value is `10m`, if the value is less than `10m`, it will be overridden to `10m`. |

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -306,7 +306,8 @@ create_topic_timeout = "30s"
 [event_recorder]
 ## TTL for the events table that will be used to store the events. Default is `90d`.
 ttl = "90d"
-## Event types to record. Current available event type: `region_migration`.
+## Event types to record. Current available event types: `region_migration`,
+## `create_database`, `alter_database`, `drop_database`.
 ## When omitted, all current and future event types are recorded.
 ## Set to an empty array to disable event recording.
 #+ event_types = ["region_migration"]

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -895,7 +895,8 @@ default_ratio = 1.0
 [event_recorder]
 ## TTL for the events table that will be used to store the events. Default is `90d`.
 ttl = "90d"
-## Event types to record. Current available event type: `region_migration`.
+## Event types to record. Current available event types: `region_migration`,
+## `create_database`, `alter_database`, `drop_database`.
 ## When omitted, all current and future event types are recorded.
 ## Set to an empty array to disable event recording.
 #+ event_types = ["region_migration"]

--- a/src/common/meta/Cargo.toml
+++ b/src/common/meta/Cargo.toml
@@ -34,6 +34,7 @@ chrono.workspace = true
 common-base.workspace = true
 common-catalog.workspace = true
 common-error.workspace = true
+common-event-recorder.workspace = true
 common-grpc-expr.workspace = true
 common-macro.workspace = true
 common-procedure.workspace = true
@@ -97,6 +98,7 @@ uuid.workspace = true
 
 [dev-dependencies]
 chrono.workspace = true
+common-event-recorder = { workspace = true, features = ["testing"] }
 common-procedure = { workspace = true, features = ["testing"] }
 common-procedure-test.workspace = true
 common-test-util.workspace = true

--- a/src/common/meta/src/ddl.rs
+++ b/src/common/meta/src/ddl.rs
@@ -44,6 +44,7 @@ pub mod drop_database;
 pub mod drop_flow;
 pub mod drop_table;
 pub mod drop_view;
+pub(crate) mod event;
 pub mod flow_meta;
 pub mod purge_dropped_table;
 pub mod table_meta;

--- a/src/common/meta/src/ddl/alter_database.rs
+++ b/src/common/meta/src/ddl/alter_database.rs
@@ -14,7 +14,9 @@
 
 use async_trait::async_trait;
 use common_procedure::error::{FromJsonSnafu, Result as ProcedureResult, ToJsonSnafu};
-use common_procedure::{Context as ProcedureContext, LockKey, Procedure, Status};
+use common_procedure::{
+    Context as ProcedureContext, EventContext, EventTrigger, LockKey, Procedure, Status,
+};
 use common_telemetry::tracing::info;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, ensure};
@@ -22,6 +24,7 @@ use strum::AsRefStr;
 
 use crate::cache_invalidator::Context;
 use crate::ddl::DdlContext;
+use crate::ddl::event::database::{ALTER_DATABASE_EVENT_TYPE, DatabaseDdlEvent};
 use crate::ddl::utils::map_to_procedure_error;
 use crate::error::{Result, SchemaNotFoundSnafu};
 use crate::instruction::CacheIdent;
@@ -171,6 +174,23 @@ impl Procedure for AlterDatabaseProcedure {
         ];
 
         LockKey::new(lock_key)
+    }
+
+    fn event(&self, ctx: &EventContext<'_>) -> Option<Box<dyn common_event_recorder::Event>> {
+        if !ctx.event_type_filter.allows(ALTER_DATABASE_EVENT_TYPE) {
+            return None;
+        }
+
+        let event = if matches!(&ctx.trigger, EventTrigger::Submitted) {
+            DatabaseDdlEvent::alter_submitted(
+                self.data.catalog(),
+                self.data.schema(),
+                &self.data.kind,
+            )
+        } else {
+            DatabaseDdlEvent::alter_lifecycle()
+        };
+        Some(Box::new(event))
     }
 }
 

--- a/src/common/meta/src/ddl/create_database.rs
+++ b/src/common/meta/src/ddl/create_database.rs
@@ -18,13 +18,17 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use common_error::ext::{BoxedError, ErrorExt};
 use common_procedure::error::{FromJsonSnafu, Result as ProcedureResult, ToJsonSnafu};
-use common_procedure::{Context as ProcedureContext, LockKey, Procedure, ProcedureId, Status};
+use common_procedure::{
+    Context as ProcedureContext, EventContext, EventTrigger, LockKey, Procedure, ProcedureId,
+    Status,
+};
 use serde::{Deserialize, Serialize};
 use serde_with::{DefaultOnNull, serde_as};
 use snafu::{ResultExt, ensure};
 use strum::AsRefStr;
 
 use crate::ddl::DdlContext;
+use crate::ddl::event::database::{CREATE_DATABASE_EVENT_TYPE, DatabaseDdlEvent};
 use crate::ddl::utils::map_to_procedure_error;
 use crate::error::{self, Result};
 use crate::instruction::{CacheIdent, UserCacheIdent};
@@ -272,6 +276,24 @@ impl Procedure for CreateDatabaseProcedure {
         ];
 
         LockKey::new(lock_key)
+    }
+
+    fn event(&self, ctx: &EventContext<'_>) -> Option<Box<dyn common_event_recorder::Event>> {
+        if !ctx.event_type_filter.allows(CREATE_DATABASE_EVENT_TYPE) {
+            return None;
+        }
+
+        let event = if matches!(&ctx.trigger, EventTrigger::Submitted) {
+            DatabaseDdlEvent::create_submitted(
+                &self.data.catalog,
+                &self.data.schema,
+                self.data.create_if_not_exists,
+                &self.data.options,
+            )
+        } else {
+            DatabaseDdlEvent::create_lifecycle()
+        };
+        Some(Box::new(event))
     }
 }
 

--- a/src/common/meta/src/ddl/drop_database.rs
+++ b/src/common/meta/src/ddl/drop_database.rs
@@ -23,7 +23,8 @@ use std::fmt::Debug;
 use common_error::ext::BoxedError;
 use common_procedure::error::{ExternalSnafu, FromJsonSnafu, ToJsonSnafu};
 use common_procedure::{
-    Context as ProcedureContext, LockKey, Procedure, Result as ProcedureResult, Status,
+    Context as ProcedureContext, EventContext, EventTrigger, LockKey, Procedure,
+    Result as ProcedureResult, Status,
 };
 use futures::stream::BoxStream;
 use serde::{Deserialize, Serialize};
@@ -32,6 +33,7 @@ use tonic::async_trait;
 
 use self::start::DropDatabaseStart;
 use crate::ddl::DdlContext;
+use crate::ddl::event::database::{DROP_DATABASE_EVENT_TYPE, DatabaseDdlEvent};
 use crate::ddl::utils::map_to_procedure_error;
 use crate::error::Result;
 use crate::key::table_name::TableNameValue;
@@ -170,6 +172,23 @@ impl Procedure for DropDatabaseProcedure {
         ];
 
         LockKey::new(lock_key)
+    }
+
+    fn event(&self, ctx: &EventContext<'_>) -> Option<Box<dyn common_event_recorder::Event>> {
+        if !ctx.event_type_filter.allows(DROP_DATABASE_EVENT_TYPE) {
+            return None;
+        }
+
+        let event = if matches!(&ctx.trigger, EventTrigger::Submitted) {
+            DatabaseDdlEvent::drop_submitted(
+                &self.context.catalog,
+                &self.context.schema,
+                self.context.drop_if_exists,
+            )
+        } else {
+            DatabaseDdlEvent::drop_lifecycle()
+        };
+        Some(Box::new(event))
     }
 }
 

--- a/src/common/meta/src/ddl/event.rs
+++ b/src/common/meta/src/ddl/event.rs
@@ -12,14 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod alter_logical_tables;
-mod alter_table;
-mod create_flow;
-mod create_logical_tables;
-mod create_table;
-pub(crate) mod create_view;
-mod drop_database;
-mod drop_flow;
-mod drop_table;
-mod drop_view;
-mod event;
+pub(crate) mod database;

--- a/src/common/meta/src/ddl/event.rs
+++ b/src/common/meta/src/ddl/event.rs
@@ -12,4 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Events emitted by DDL procedures.
+
 pub(crate) mod database;

--- a/src/common/meta/src/ddl/event/database.rs
+++ b/src/common/meta/src/ddl/event/database.rs
@@ -1,0 +1,241 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+use std::collections::HashMap;
+
+use api::v1::{ColumnSchema, Row};
+use common_event_recorder::Event;
+use common_event_recorder::error::{Result, SerializeEventSnafu};
+use common_event_recorder::event_table::{
+    CATALOG_NAME_COLUMN as EVENT_TABLE_CATALOG_NAME_COLUMN,
+    SCHEMA_NAME_COLUMN as EVENT_TABLE_SCHEMA_NAME_COLUMN, column_schemas, nullable_string,
+};
+use serde::Serialize;
+use snafu::ResultExt;
+
+use crate::rpc::ddl::{AlterDatabaseKind, SetDatabaseOption, UnsetDatabaseOption};
+
+pub(crate) const CREATE_DATABASE_EVENT_TYPE: &str = "create_database";
+pub(crate) const ALTER_DATABASE_EVENT_TYPE: &str = "alter_database";
+pub(crate) const DROP_DATABASE_EVENT_TYPE: &str = "drop_database";
+const PAYLOAD_VERSION: u8 = 1;
+const TTL_OPTION_NAME: &str = "ttl";
+
+#[derive(Debug)]
+pub(crate) struct DatabaseDdlEvent {
+    event_type: &'static str,
+    catalog_name: Option<String>,
+    schema_name: Option<String>,
+    payload: Option<DatabaseDdlPayload>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+enum DatabaseDdlPayload {
+    Create(CreateDatabasePayload),
+    Alter(AlterDatabasePayload),
+    Drop(DropDatabasePayload),
+}
+
+#[derive(Debug, Serialize)]
+struct CreateDatabasePayload {
+    version: u8,
+    create_if_not_exists: bool,
+    options: Vec<DatabaseOptionIntent>,
+}
+
+#[derive(Debug, Serialize)]
+struct AlterDatabasePayload {
+    version: u8,
+    #[serde(flatten)]
+    intent: AlterDatabaseIntent,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+enum AlterDatabaseIntent {
+    Set { options: Vec<DatabaseOptionIntent> },
+    Unset { options: Vec<String> },
+}
+
+#[derive(Debug, Serialize)]
+struct DropDatabasePayload {
+    version: u8,
+    drop_if_exists: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct DatabaseOptionIntent {
+    key: String,
+    value: String,
+}
+
+impl DatabaseDdlEvent {
+    pub(crate) fn create_submitted(
+        catalog_name: &str,
+        schema_name: &str,
+        create_if_not_exists: bool,
+        options: &HashMap<String, String>,
+    ) -> Self {
+        let mut options = options.iter().collect::<Vec<_>>();
+        options.sort_unstable_by_key(|(left, _)| *left);
+        let options = options
+            .into_iter()
+            .map(|(key, value)| DatabaseOptionIntent {
+                key: key.clone(),
+                value: value.clone(),
+            })
+            .collect();
+        Self::submitted(
+            CREATE_DATABASE_EVENT_TYPE,
+            catalog_name,
+            schema_name,
+            DatabaseDdlPayload::Create(CreateDatabasePayload {
+                version: PAYLOAD_VERSION,
+                create_if_not_exists,
+                options,
+            }),
+        )
+    }
+
+    pub(crate) fn alter_submitted(
+        catalog_name: &str,
+        schema_name: &str,
+        kind: &AlterDatabaseKind,
+    ) -> Self {
+        let intent = match kind {
+            AlterDatabaseKind::SetDatabaseOptions(options) => AlterDatabaseIntent::Set {
+                options: options
+                    .0
+                    .iter()
+                    .map(|option| match option {
+                        SetDatabaseOption::Ttl(ttl) => DatabaseOptionIntent {
+                            key: TTL_OPTION_NAME.to_string(),
+                            value: ttl.to_string(),
+                        },
+                        SetDatabaseOption::Other(key, value) => DatabaseOptionIntent {
+                            key: key.clone(),
+                            value: value.clone(),
+                        },
+                    })
+                    .collect(),
+            },
+            AlterDatabaseKind::UnsetDatabaseOptions(options) => {
+                let options = options
+                    .0
+                    .iter()
+                    .map(|option| match option {
+                        UnsetDatabaseOption::Ttl => TTL_OPTION_NAME.to_string(),
+                        UnsetDatabaseOption::Other(key) => key.clone(),
+                    })
+                    .collect();
+                AlterDatabaseIntent::Unset { options }
+            }
+        };
+        Self::submitted(
+            ALTER_DATABASE_EVENT_TYPE,
+            catalog_name,
+            schema_name,
+            DatabaseDdlPayload::Alter(AlterDatabasePayload {
+                version: PAYLOAD_VERSION,
+                intent,
+            }),
+        )
+    }
+
+    pub(crate) fn drop_submitted(
+        catalog_name: &str,
+        schema_name: &str,
+        drop_if_exists: bool,
+    ) -> Self {
+        Self::submitted(
+            DROP_DATABASE_EVENT_TYPE,
+            catalog_name,
+            schema_name,
+            DatabaseDdlPayload::Drop(DropDatabasePayload {
+                version: PAYLOAD_VERSION,
+                drop_if_exists,
+            }),
+        )
+    }
+
+    pub(crate) fn create_lifecycle() -> Self {
+        Self::lifecycle(CREATE_DATABASE_EVENT_TYPE)
+    }
+
+    pub(crate) fn alter_lifecycle() -> Self {
+        Self::lifecycle(ALTER_DATABASE_EVENT_TYPE)
+    }
+
+    pub(crate) fn drop_lifecycle() -> Self {
+        Self::lifecycle(DROP_DATABASE_EVENT_TYPE)
+    }
+
+    fn submitted(
+        event_type: &'static str,
+        catalog_name: &str,
+        schema_name: &str,
+        payload: DatabaseDdlPayload,
+    ) -> Self {
+        Self {
+            event_type,
+            catalog_name: Some(catalog_name.to_string()),
+            schema_name: Some(schema_name.to_string()),
+            payload: Some(payload),
+        }
+    }
+
+    fn lifecycle(event_type: &'static str) -> Self {
+        Self {
+            event_type,
+            catalog_name: None,
+            schema_name: None,
+            payload: None,
+        }
+    }
+}
+
+impl Event for DatabaseDdlEvent {
+    fn event_type(&self) -> &str {
+        self.event_type
+    }
+
+    fn json_payload(&self) -> Result<serde_json::Value> {
+        match &self.payload {
+            Some(payload) => serde_json::to_value(payload).context(SerializeEventSnafu),
+            None => Ok(serde_json::Value::Null),
+        }
+    }
+
+    fn extra_schema(&self) -> Vec<ColumnSchema> {
+        column_schemas([
+            &EVENT_TABLE_CATALOG_NAME_COLUMN,
+            &EVENT_TABLE_SCHEMA_NAME_COLUMN,
+        ])
+    }
+
+    fn extra_rows(&self) -> Result<Vec<Row>> {
+        Ok(vec![Row {
+            values: vec![
+                nullable_string(self.catalog_name.as_deref()),
+                nullable_string(self.schema_name.as_deref()),
+            ],
+        }])
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/src/common/meta/src/ddl/tests/event.rs
+++ b/src/common/meta/src/ddl/tests/event.rs
@@ -12,14 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod alter_logical_tables;
-mod alter_table;
-mod create_flow;
-mod create_logical_tables;
-mod create_table;
-pub(crate) mod create_view;
-mod drop_database;
-mod drop_flow;
-mod drop_table;
-mod drop_view;
-mod event;
+mod database;

--- a/src/common/meta/src/ddl/tests/event/database.rs
+++ b/src/common/meta/src/ddl/tests/event/database.rs
@@ -1,0 +1,360 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use api::v1::alter_database_expr::Kind as PbAlterDatabaseKind;
+use api::v1::value::ValueData;
+use api::v1::{AlterDatabaseExpr, Row, SetDatabaseOptions as PbSetDatabaseOptions, Value};
+use common_event_recorder::event_table::{
+    CATALOG_NAME_COLUMN as EVENT_TABLE_CATALOG_NAME_COLUMN,
+    PROCEDURE_ERROR_COLUMN as EVENT_TABLE_PROCEDURE_ERROR_COLUMN,
+    PROCEDURE_ID_COLUMN as EVENT_TABLE_PROCEDURE_ID_COLUMN,
+    PROCEDURE_STATE_COLUMN as EVENT_TABLE_PROCEDURE_STATE_COLUMN,
+    PROCEDURE_TRIGGER_COLUMN as EVENT_TABLE_PROCEDURE_TRIGGER_COLUMN,
+    SCHEMA_NAME_COLUMN as EVENT_TABLE_SCHEMA_NAME_COLUMN,
+};
+use common_event_recorder::testing::assert_event_contract;
+use common_event_recorder::{Event, EventTypeFilter};
+use common_procedure::{
+    EventContext, EventTrigger, Procedure, ProcedureEvent, ProcedureId, ProcedureState,
+};
+
+use crate::ddl::alter_database::AlterDatabaseProcedure;
+use crate::ddl::create_database::CreateDatabaseProcedure;
+use crate::ddl::drop_database::DropDatabaseProcedure;
+use crate::ddl::event::database::{
+    ALTER_DATABASE_EVENT_TYPE, CREATE_DATABASE_EVENT_TYPE, DROP_DATABASE_EVENT_TYPE,
+    DatabaseDdlEvent,
+};
+use crate::rpc::ddl::{
+    AlterDatabaseKind, SetDatabaseOption, SetDatabaseOptions, UnsetDatabaseOption,
+    UnsetDatabaseOptions,
+};
+use crate::test_util::{MockDatanodeManager, new_ddl_context};
+
+#[test]
+fn test_create_database_submitted_event_contract() {
+    let options = HashMap::from([
+        ("password".to_string(), "do-not-record".to_string()),
+        ("compaction.type".to_string(), "twcs".to_string()),
+    ]);
+    let event = DatabaseDdlEvent::create_submitted("greptime", "metrics", true, &options);
+
+    assert_event_locator(
+        &event,
+        CREATE_DATABASE_EVENT_TYPE,
+        Some("greptime"),
+        Some("metrics"),
+    );
+    assert_eq!(
+        event.json_payload().unwrap(),
+        serde_json::json!({
+            "version": 1,
+            "create_if_not_exists": true,
+            "options": [
+                {"key": "compaction.type", "value": "twcs"},
+                {"key": "password", "value": "do-not-record"}
+            ]
+        })
+    );
+    assert!(
+        !event
+            .json_payload()
+            .unwrap()
+            .to_string()
+            .contains("CreateMetadata")
+    );
+}
+
+#[test]
+fn test_alter_database_set_and_unset_event_contracts() {
+    let set = DatabaseDdlEvent::alter_submitted(
+        "greptime",
+        "metrics",
+        &AlterDatabaseKind::SetDatabaseOptions(SetDatabaseOptions(vec![
+            SetDatabaseOption::Other("secret_token".to_string(), "hidden".to_string()),
+            SetDatabaseOption::Ttl(std::time::Duration::from_secs(3600).into()),
+        ])),
+    );
+    assert_event_locator(
+        &set,
+        ALTER_DATABASE_EVENT_TYPE,
+        Some("greptime"),
+        Some("metrics"),
+    );
+    assert_eq!(
+        set.json_payload().unwrap(),
+        serde_json::json!({
+            "version": 1,
+            "action": "set",
+            "options": [
+                {"key": "secret_token", "value": "hidden"},
+                {"key": "ttl", "value": "1h"}
+            ]
+        })
+    );
+
+    let unset = DatabaseDdlEvent::alter_submitted(
+        "greptime",
+        "metrics",
+        &AlterDatabaseKind::UnsetDatabaseOptions(UnsetDatabaseOptions(vec![
+            UnsetDatabaseOption::Ttl,
+            UnsetDatabaseOption::Other("compaction.type".to_string()),
+        ])),
+    );
+    assert_event_locator(
+        &unset,
+        ALTER_DATABASE_EVENT_TYPE,
+        Some("greptime"),
+        Some("metrics"),
+    );
+    assert_eq!(
+        unset.json_payload().unwrap(),
+        serde_json::json!({
+            "version": 1,
+            "action": "unset",
+            "options": ["ttl", "compaction.type"]
+        })
+    );
+}
+
+#[test]
+fn test_drop_database_submitted_event_contract() {
+    let event = DatabaseDdlEvent::drop_submitted("greptime", "metrics", true);
+
+    assert_event_locator(
+        &event,
+        DROP_DATABASE_EVENT_TYPE,
+        Some("greptime"),
+        Some("metrics"),
+    );
+    assert_eq!(
+        event.json_payload().unwrap(),
+        serde_json::json!({"version": 1, "drop_if_exists": true})
+    );
+}
+
+#[test]
+fn test_database_lifecycle_events_have_fixed_schema_and_null_intent() {
+    for (event, event_type) in [
+        (
+            DatabaseDdlEvent::create_lifecycle(),
+            CREATE_DATABASE_EVENT_TYPE,
+        ),
+        (
+            DatabaseDdlEvent::alter_lifecycle(),
+            ALTER_DATABASE_EVENT_TYPE,
+        ),
+        (DatabaseDdlEvent::drop_lifecycle(), DROP_DATABASE_EVENT_TYPE),
+    ] {
+        assert_event_locator(&event, event_type, None, None);
+        assert_eq!(event.json_payload().unwrap(), serde_json::Value::Null);
+    }
+
+    assert_eq!(
+        DatabaseDdlEvent::create_lifecycle().extra_schema(),
+        DatabaseDdlEvent::create_submitted("c", "s", false, &HashMap::new()).extra_schema()
+    );
+}
+
+#[test]
+fn test_database_events_preserve_procedure_envelope_contract() {
+    let procedure_id = ProcedureId::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
+    let submitted = ProcedureEvent::new(
+        procedure_id,
+        Box::new(DatabaseDdlEvent::create_submitted(
+            "greptime",
+            "metrics",
+            false,
+            &HashMap::new(),
+        )),
+        ProcedureState::Running,
+        EventTrigger::Submitted,
+    );
+    let lifecycle = ProcedureEvent::new(
+        procedure_id,
+        Box::new(DatabaseDdlEvent::create_lifecycle()),
+        ProcedureState::Done { output: None },
+        EventTrigger::Succeeded,
+    );
+
+    assert_procedure_event_contract(
+        &submitted,
+        CREATE_DATABASE_EVENT_TYPE,
+        "Running",
+        "Submitted",
+        Some("greptime"),
+        Some("metrics"),
+    );
+    assert_procedure_event_contract(
+        &lifecycle,
+        CREATE_DATABASE_EVENT_TYPE,
+        "Done",
+        "Succeeded",
+        None,
+        None,
+    );
+    assert_eq!(lifecycle.json_payload().unwrap(), serde_json::Value::Null);
+}
+
+#[test]
+fn test_create_database_event_filter() {
+    let procedure = CreateDatabaseProcedure::new(
+        "greptime".to_string(),
+        "metrics".to_string(),
+        false,
+        HashMap::new(),
+        None,
+        new_ddl_context(Arc::new(MockDatanodeManager::new(()))),
+    );
+
+    assert_database_event_filter(&procedure, CREATE_DATABASE_EVENT_TYPE);
+}
+
+#[test]
+fn test_alter_database_event_filter() {
+    let procedure = AlterDatabaseProcedure::new(
+        crate::rpc::ddl::AlterDatabaseTask {
+            alter_expr: AlterDatabaseExpr {
+                catalog_name: "greptime".to_string(),
+                schema_name: "metrics".to_string(),
+                kind: Some(PbAlterDatabaseKind::SetDatabaseOptions(
+                    PbSetDatabaseOptions {
+                        set_database_options: vec![],
+                    },
+                )),
+            },
+        },
+        new_ddl_context(Arc::new(MockDatanodeManager::new(()))),
+    )
+    .unwrap();
+
+    assert_database_event_filter(&procedure, ALTER_DATABASE_EVENT_TYPE);
+}
+
+#[test]
+fn test_drop_database_event_filter() {
+    let procedure = DropDatabaseProcedure::new(
+        "greptime".to_string(),
+        "metrics".to_string(),
+        false,
+        new_ddl_context(Arc::new(MockDatanodeManager::new(()))),
+    );
+
+    assert_database_event_filter(&procedure, DROP_DATABASE_EVENT_TYPE);
+}
+
+fn assert_database_event_filter(procedure: &dyn Procedure, event_type: &str) {
+    let state = ProcedureState::Running;
+    let event_context = |event_type_filter| EventContext {
+        procedure_id: ProcedureId::random(),
+        lifecycle_state: &state,
+        trigger: EventTrigger::Submitted,
+        event_type_filter: Arc::new(event_type_filter),
+    };
+
+    let allowed = procedure
+        .event(&event_context(EventTypeFilter::Only(HashSet::from([
+            event_type.to_string(),
+        ]))))
+        .unwrap();
+    assert_eq!(allowed.event_type(), event_type);
+
+    assert!(
+        procedure
+            .event(&event_context(EventTypeFilter::Only(HashSet::from([
+                String::from("other_event",)
+            ]))))
+            .is_none()
+    );
+    assert!(
+        procedure
+            .event(&event_context(EventTypeFilter::Only(HashSet::new())))
+            .is_none()
+    );
+}
+
+fn assert_event_locator(
+    event: &DatabaseDdlEvent,
+    event_type: &str,
+    catalog_name: Option<&str>,
+    schema_name: Option<&str>,
+) {
+    assert_event_contract(
+        event,
+        event_type,
+        &[
+            EVENT_TABLE_CATALOG_NAME_COLUMN.column_schema(),
+            EVENT_TABLE_SCHEMA_NAME_COLUMN.column_schema(),
+        ],
+        &[Row {
+            values: vec![
+                Value {
+                    value_data: catalog_name.map(|value| ValueData::StringValue(value.to_string())),
+                },
+                Value {
+                    value_data: schema_name.map(|value| ValueData::StringValue(value.to_string())),
+                },
+            ],
+        }],
+    );
+}
+
+fn assert_procedure_event_contract(
+    event: &ProcedureEvent,
+    event_type: &str,
+    procedure_state: &str,
+    procedure_trigger: &str,
+    catalog_name: Option<&str>,
+    schema_name: Option<&str>,
+) {
+    assert_event_contract(
+        event,
+        event_type,
+        &[
+            EVENT_TABLE_PROCEDURE_ID_COLUMN.column_schema(),
+            EVENT_TABLE_PROCEDURE_STATE_COLUMN.column_schema(),
+            EVENT_TABLE_PROCEDURE_ERROR_COLUMN.column_schema(),
+            EVENT_TABLE_PROCEDURE_TRIGGER_COLUMN.column_schema(),
+            EVENT_TABLE_CATALOG_NAME_COLUMN.column_schema(),
+            EVENT_TABLE_SCHEMA_NAME_COLUMN.column_schema(),
+        ],
+        &[Row {
+            values: vec![
+                Value {
+                    value_data: Some(ValueData::StringValue(
+                        "00000000-0000-0000-0000-000000000001".to_string(),
+                    )),
+                },
+                Value {
+                    value_data: Some(ValueData::StringValue(procedure_state.to_string())),
+                },
+                Value {
+                    value_data: Some(ValueData::StringValue(String::new())),
+                },
+                Value {
+                    value_data: Some(ValueData::StringValue(procedure_trigger.to_string())),
+                },
+                Value {
+                    value_data: catalog_name.map(|value| ValueData::StringValue(value.to_string())),
+                },
+                Value {
+                    value_data: schema_name.map(|value| ValueData::StringValue(value.to_string())),
+                },
+            ],
+        }],
+    );
+}

--- a/tests-integration/tests/database_ddl_events.rs
+++ b/tests-integration/tests/database_ddl_events.rs
@@ -1,0 +1,155 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use client::OutputData;
+use common_event_recorder::DEFAULT_FLUSH_INTERVAL_SECONDS;
+use common_test_util::recordbatch::check_output_stream;
+use common_test_util::temp_dir::create_temp_dir;
+use servers::query_handler::sql::SqlQueryHandler;
+use session::context::QueryContext;
+use tests_integration::cluster::GreptimeDbClusterBuilder;
+use tests_integration::standalone::GreptimeDbStandaloneBuilder;
+use tests_integration::test_util::{StorageType, get_test_store_config};
+
+const DATABASE_NAME: &str = "database_ddl_events";
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_database_ddl_events() {
+    let store_type = StorageType::File;
+    if !store_type.test_on() {
+        return;
+    }
+
+    common_telemetry::init_default_ut_logging();
+    let (store_config, _guard) = get_test_store_config(&store_type);
+    let home_dir = create_temp_dir("test_database_ddl_events_data_home");
+    let cluster = GreptimeDbClusterBuilder::new("test_database_ddl_events")
+        .await
+        .with_datanodes(1)
+        .with_store_config(store_config)
+        .with_shared_home_dir(Arc::new(home_dir))
+        .build(true)
+        .await;
+    let instance = cluster.fe_instance();
+
+    execute_database_ddl(instance).await;
+
+    tokio::time::sleep(DEFAULT_FLUSH_INTERVAL_SECONDS * 2).await;
+
+    assert_database_events(instance).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_standalone_database_ddl_events() {
+    common_telemetry::init_default_ut_logging();
+    let standalone = GreptimeDbStandaloneBuilder::new("test_standalone_database_ddl_events")
+        .build()
+        .await;
+    let instance = standalone.fe_instance();
+
+    execute_database_ddl(instance).await;
+
+    tokio::time::sleep(DEFAULT_FLUSH_INTERVAL_SECONDS * 2).await;
+
+    assert_database_events(instance).await;
+}
+
+async fn execute_database_ddl(instance: &Arc<frontend::instance::Instance>) {
+    for sql in [
+        format!("CREATE DATABASE IF NOT EXISTS {DATABASE_NAME} WITH (ttl = '1h')"),
+        format!("ALTER DATABASE {DATABASE_NAME} SET 'ttl' = '2h'"),
+        format!("DROP DATABASE IF EXISTS {DATABASE_NAME}"),
+    ] {
+        let output = instance
+            .do_query(&sql, QueryContext::arc())
+            .await
+            .remove(0)
+            .unwrap();
+        assert!(matches!(output.data, OutputData::AffectedRows(_)));
+    }
+}
+
+async fn assert_database_events(instance: &Arc<frontend::instance::Instance>) {
+    assert_database_event(
+        instance,
+        "create_database",
+        r#"json_path_match(payload, '$.version == 1')
+   AND json_path_match(payload, '$.create_if_not_exists == true')
+   AND json_path_match(payload, '$.options[0].key == "ttl"')
+   AND json_path_match(payload, '$.options[0].value == "1h"')"#,
+    )
+    .await;
+    assert_database_event(
+        instance,
+        "alter_database",
+        r#"json_path_match(payload, '$.version == 1')
+   AND json_path_match(payload, '$.action == "set"')
+   AND json_path_match(payload, '$.options[0].key == "ttl"')
+   AND json_path_match(payload, '$.options[0].value == "2h"')"#,
+    )
+    .await;
+    assert_database_event(
+        instance,
+        "drop_database",
+        r#"json_path_match(payload, '$.version == 1')
+   AND json_path_match(payload, '$.drop_if_exists == true')"#,
+    )
+    .await;
+}
+
+async fn assert_database_event(
+    instance: &Arc<frontend::instance::Instance>,
+    event_type: &str,
+    submitted_payload_predicate: &str,
+) {
+    let submitted = format!(
+        r#"SELECT count(*) AS event_count
+FROM greptime_private.events
+WHERE type = '{event_type}'
+  AND procedure_state = 'Running'
+  AND procedure_trigger = 'Submitted'
+  AND catalog_name = 'greptime'
+  AND schema_name = '{DATABASE_NAME}'
+  AND {submitted_payload_predicate}"#
+    );
+    assert_single_event(instance, &submitted).await;
+
+    let lifecycle = format!(
+        r#"SELECT count(*) AS event_count
+FROM greptime_private.events
+WHERE type = '{event_type}'
+  AND procedure_state = 'Done'
+  AND procedure_trigger = 'Succeeded'
+  AND catalog_name IS NULL
+  AND schema_name IS NULL
+  AND json_is_null(payload)"#
+    );
+    assert_single_event(instance, &lifecycle).await;
+}
+
+async fn assert_single_event(instance: &Arc<frontend::instance::Instance>, query: &str) {
+    let result = instance
+        .do_query(query, QueryContext::arc())
+        .await
+        .remove(0);
+    let expected = "\
++-------------+
+| event_count |
++-------------+
+| 1           |
++-------------+";
+    check_output_stream(result.unwrap().data, expected).await;
+}

--- a/tests-integration/tests/database_ddl_events.rs
+++ b/tests-integration/tests/database_ddl_events.rs
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use client::OutputData;
-use common_event_recorder::DEFAULT_FLUSH_INTERVAL_SECONDS;
-use common_test_util::recordbatch::check_output_stream;
+use common_recordbatch::RecordBatches;
 use common_test_util::temp_dir::create_temp_dir;
 use servers::query_handler::sql::SqlQueryHandler;
 use session::context::QueryContext;
@@ -47,8 +47,6 @@ async fn test_database_ddl_events() {
 
     execute_database_ddl(instance).await;
 
-    tokio::time::sleep(DEFAULT_FLUSH_INTERVAL_SECONDS * 2).await;
-
     assert_database_events(instance).await;
 }
 
@@ -61,8 +59,6 @@ async fn test_standalone_database_ddl_events() {
     let instance = standalone.fe_instance();
 
     execute_database_ddl(instance).await;
-
-    tokio::time::sleep(DEFAULT_FLUSH_INTERVAL_SECONDS * 2).await;
 
     assert_database_events(instance).await;
 }
@@ -141,15 +137,39 @@ WHERE type = '{event_type}'
 }
 
 async fn assert_single_event(instance: &Arc<frontend::instance::Instance>, query: &str) {
-    let result = instance
+    for _ in 0..60 {
+        if event_count_is_one(instance, query).await {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+
+    panic!("timed out waiting for database DDL event: {query}");
+}
+
+async fn event_count_is_one(instance: &Arc<frontend::instance::Instance>, query: &str) -> bool {
+    let Ok(output) = instance
         .do_query(query, QueryContext::arc())
         .await
-        .remove(0);
-    let expected = "\
+        .remove(0)
+    else {
+        return false;
+    };
+    let OutputData::Stream(stream) = output.data else {
+        unreachable!("event-count query must return a stream");
+    };
+    let Ok(batches) = RecordBatches::try_collect(stream).await else {
+        return false;
+    };
+    let Ok(actual) = batches.pretty_print() else {
+        return false;
+    };
+
+    actual.to_string()
+        == "\
 +-------------+
 | event_count |
 +-------------+
 | 1           |
-+-------------+";
-    check_output_stream(result.unwrap().data, expected).await;
++-------------+"
 }

--- a/tests-integration/tests/database_ddl_events.rs
+++ b/tests-integration/tests/database_ddl_events.rs
@@ -165,7 +165,7 @@ async fn event_count_is_one(instance: &Arc<frontend::instance::Instance>, query:
         return false;
     };
 
-    actual.to_string()
+    actual
         == "\
 +-------------+
 | event_count |

--- a/tests-integration/tests/main.rs
+++ b/tests-integration/tests/main.rs
@@ -14,6 +14,7 @@
 
 #![recursion_limit = "256"]
 
+mod database_ddl_events;
 #[macro_use]
 mod grpc;
 #[macro_use]

--- a/tests/conf/metasrv-test.toml.template
+++ b/tests/conf/metasrv-test.toml.template
@@ -25,3 +25,6 @@ trigger_flush_threshold = 100
 
 [stats_persistence]
 ttl = "0s"
+
+[event_recorder]
+event_types = []

--- a/tests/conf/standalone-test.toml.template
+++ b/tests/conf/standalone-test.toml.template
@@ -46,3 +46,6 @@ runtime_size = 2
 [procedure]
 max_retry_times = 3
 retry_delay = "500ms"
+
+[event_recorder]
+event_types = []


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

- #8648

## What's changed and what's your intention?

Add procedure lifecycle events for `CREATE DATABASE`, `ALTER DATABASE`, and `DROP DATABASE` on top of the shared event-recorder infrastructure from #8648.

- Emit `create_database`, `alter_database`, and `drop_database` events from the corresponding MetaSrv procedures, respecting the recorder's shared event-type filter.
- Submitted events include a versioned DDL-intent payload plus catalog and schema locator columns; lifecycle events preserve the schema and emit null locators with a JSON-null payload.
- Organize DDL event sources under the singular `ddl::event` module, with database events in `event/database.rs`; this leaves a per-domain extension point for table and flow events.
- Reuse #8648's event-table definitions and `assert_event_contract` test utility for unit contract coverage.
- Add MetaSrv-backed and standalone integration coverage that queries the recorded rows in `greptime_private.events`, uses polling instead of a fixed wait, and disables unrelated SQL event recording in sqlness tests.
- Document all selectable event types in the MetaSrv and standalone configuration examples, then regenerate `config/config.md`.
- No user-facing API, persisted metadata, or wire-format compatibility changes. Documentation is intentionally limited to generated configuration reference updates.

Validation completed:

- `cargo fmt --all`
- `make fmt-toml`
- `make clippy`
- `make config-docs`

The relevant `cargo nextest` run is pending because the shared build directory was locked.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.