### PR TITLE
feat: add procedure events for Flow DDL

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -229,7 +229,7 @@
 | `tracing.tokio_console_addr` | String | Unset | The tokio console address. |
 | `event_recorder` | -- | -- | Configuration options for the event recorder. |
 | `event_recorder.ttl` | String | `90d` | TTL for the events table that will be used to store the events. Default is `90d`. |
-| `event_recorder.event_types` | Array | -- | Event types to record. Current available event types: `region_migration`,<br/>`create_database`, `alter_database`, `drop_database`.<br/>When omitted, all current and future event types are recorded.<br/>Set to an empty array to disable event recording. |
+| `event_recorder.event_types` | Array | -- | Event types to record. Current available event types: `region_migration`,<br/>`create_database`, `alter_database`, `drop_database`, `create_flow`,<br/>`drop_flow`.<br/>When omitted, all current and future event types are recorded.<br/>Set to an empty array to disable event recording. |
 | `memory` | -- | -- | The memory options. |
 | `memory.enable_heap_profiling` | Bool | `true` | Whether to enable heap profiling activation during startup.<br/>When enabled, heap profiling will be activated if the `MALLOC_CONF` environment variable<br/>is set to "prof:true,prof_active:false". The official image adds this env variable.<br/>Default is true. |
 
@@ -436,7 +436,7 @@
 | `wal.create_topic_timeout` | String | `30s` | The timeout for creating a Kafka topic.<br/>**It's only used when the provider is `kafka`**. |
 | `event_recorder` | -- | -- | Configuration options for the event recorder. |
 | `event_recorder.ttl` | String | `90d` | TTL for the events table that will be used to store the events. Default is `90d`. |
-| `event_recorder.event_types` | Array | -- | Event types to record. Current available event types: `region_migration`,<br/>`create_database`, `alter_database`, `drop_database`.<br/>When omitted, all current and future event types are recorded.<br/>Set to an empty array to disable event recording. |
+| `event_recorder.event_types` | Array | -- | Event types to record. Current available event types: `region_migration`,<br/>`create_database`, `alter_database`, `drop_database`, `create_flow`,<br/>`drop_flow`.<br/>When omitted, all current and future event types are recorded.<br/>Set to an empty array to disable event recording. |
 | `stats_persistence` | -- | -- | Configuration options for the stats persistence. |
 | `stats_persistence.ttl` | String | `0s` | TTL for the stats table that will be used to store the stats.<br/>Set to `0s` to disable stats persistence.<br/>Default is `0s`.<br/>If you want to enable stats persistence, set the TTL to a value greater than 0.<br/>It is recommended to set a small value, e.g., `3h`. |
 | `stats_persistence.interval` | String | `10m` | The interval to persist the stats. Default is `10m`.<br/>The minimum value is `10m`, if the value is less than `10m`, it will be overridden to `10m`. |

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -307,7 +307,8 @@ create_topic_timeout = "30s"
 ## TTL for the events table that will be used to store the events. Default is `90d`.
 ttl = "90d"
 ## Event types to record. Current available event types: `region_migration`,
-## `create_database`, `alter_database`, `drop_database`.
+## `create_database`, `alter_database`, `drop_database`, `create_flow`,
+## `drop_flow`.
 ## When omitted, all current and future event types are recorded.
 ## Set to an empty array to disable event recording.
 #+ event_types = ["region_migration"]

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -896,7 +896,8 @@ default_ratio = 1.0
 ## TTL for the events table that will be used to store the events. Default is `90d`.
 ttl = "90d"
 ## Event types to record. Current available event types: `region_migration`,
-## `create_database`, `alter_database`, `drop_database`.
+## `create_database`, `alter_database`, `drop_database`, `create_flow`,
+## `drop_flow`.
 ## When omitted, all current and future event types are recorded.
 ## Set to an empty array to disable event recording.
 #+ event_types = ["region_migration"]

--- a/src/common/event-recorder/src/event_table.rs
+++ b/src/common/event-recorder/src/event_table.rs
@@ -112,6 +112,12 @@ pub const CATALOG_NAME_COLUMN: EventTableColumn =
 /// The canonical schema name dimension.
 pub const SCHEMA_NAME_COLUMN: EventTableColumn =
     EventTableColumn::new("schema_name", ColumnDataType::String, SemanticType::Field);
+/// The canonical Flow name dimension.
+pub const FLOW_NAME_COLUMN: EventTableColumn =
+    EventTableColumn::new("flow_name", ColumnDataType::String, SemanticType::Field);
+/// The canonical Flow identifier dimension.
+pub const FLOW_ID_COLUMN: EventTableColumn =
+    EventTableColumn::new("flow_id", ColumnDataType::Uint32, SemanticType::Field);
 
 /// Builds API schemas from canonical event-table columns while preserving their order.
 pub fn column_schemas<'a>(
@@ -211,6 +217,23 @@ mod tests {
             ["catalog_name", "schema_name"].map(|column_name| ColumnSchema {
                 column_name: column_name.to_string(),
                 datatype: ColumnDataType::String.into(),
+                semantic_type: SemanticType::Field.into(),
+                ..Default::default()
+            })
+        );
+    }
+
+    #[test]
+    fn flow_dimension_schema_preserves_names_types_semantics_and_order() {
+        assert_eq!(
+            column_schemas([&FLOW_NAME_COLUMN, &FLOW_ID_COLUMN]),
+            [
+                ("flow_name", ColumnDataType::String),
+                ("flow_id", ColumnDataType::Uint32),
+            ]
+            .map(|(column_name, datatype)| ColumnSchema {
+                column_name: column_name.to_string(),
+                datatype: datatype.into(),
                 semantic_type: SemanticType::Field.into(),
                 ..Default::default()
             })

--- a/src/common/meta/src/ddl/create_flow.rs
+++ b/src/common/meta/src/ddl/create_flow.rs
@@ -24,7 +24,8 @@ use async_trait::async_trait;
 use common_catalog::format_full_flow_name;
 use common_procedure::error::{FromJsonSnafu, ToJsonSnafu};
 use common_procedure::{
-    Context as ProcedureContext, LockKey, Procedure, Result as ProcedureResult, Status,
+    Context as ProcedureContext, EventContext, EventTrigger, LockKey, Procedure, ProcedureState,
+    Result as ProcedureResult, Status,
 };
 use common_telemetry::info;
 use common_telemetry::tracing_context::TracingContext;
@@ -38,6 +39,7 @@ use table::table_name::TableName;
 
 use crate::cache_invalidator::Context;
 use crate::ddl::DdlContext;
+use crate::ddl::event::flow::{CREATE_FLOW_EVENT_TYPE, CreateFlowEventIntent, FlowDdlEvent};
 use crate::ddl::utils::{add_peer_context_if_needed, map_to_procedure_error};
 use crate::error::{self, Result, UnexpectedSnafu};
 use crate::instruction::{CacheIdent, CreateFlow, DropFlow};
@@ -400,6 +402,41 @@ impl Procedure for CreateFlowProcedure {
             CatalogLock::Read(catalog_name).into(),
             FlowNameLock::new(catalog_name, flow_name).into(),
         ])
+    }
+
+    fn event(&self, ctx: &EventContext<'_>) -> Option<Box<dyn common_event_recorder::Event>> {
+        if !ctx.event_type_filter.allows(CREATE_FLOW_EVENT_TYPE) {
+            return None;
+        }
+
+        let event = match &ctx.trigger {
+            EventTrigger::Submitted => FlowDdlEvent::create_submitted(
+                &self.data.task.catalog_name,
+                &self.data.flow_context.schema,
+                &self.data.task.flow_name,
+                CreateFlowEventIntent {
+                    or_replace: self.data.task.or_replace,
+                    create_if_not_exists: self.data.task.create_if_not_exists,
+                    expire_after: self.data.task.expire_after,
+                    eval_interval_secs: self.data.task.eval_interval_secs,
+                },
+            ),
+            EventTrigger::Succeeded => {
+                let flow_id = match ctx.lifecycle_state {
+                    ProcedureState::Done {
+                        output: Some(output),
+                    } => output
+                        .downcast_ref::<FlowId>()
+                        .copied()
+                        .or(self.data.flow_id),
+                    _ => self.data.flow_id,
+                };
+                FlowDdlEvent::create_succeeded(flow_id)
+            }
+            _ => FlowDdlEvent::create_lifecycle(),
+        };
+
+        Some(Box::new(event))
     }
 }
 

--- a/src/common/meta/src/ddl/create_flow.rs
+++ b/src/common/meta/src/ddl/create_flow.rs
@@ -412,7 +412,6 @@ impl Procedure for CreateFlowProcedure {
         let event = match &ctx.trigger {
             EventTrigger::Submitted => FlowDdlEvent::create_submitted(
                 &self.data.task.catalog_name,
-                &self.data.flow_context.schema,
                 &self.data.task.flow_name,
                 CreateFlowEventIntent {
                     or_replace: self.data.task.or_replace,

--- a/src/common/meta/src/ddl/drop_flow.rs
+++ b/src/common/meta/src/ddl/drop_flow.rs
@@ -21,7 +21,8 @@ use common_error::ext::ErrorExt;
 use common_error::status_code::StatusCode;
 use common_procedure::error::{FromJsonSnafu, ToJsonSnafu};
 use common_procedure::{
-    Context as ProcedureContext, LockKey, Procedure, Result as ProcedureResult, Status,
+    Context as ProcedureContext, EventContext, EventTrigger, LockKey, Procedure,
+    Result as ProcedureResult, Status,
 };
 use common_telemetry::info;
 use futures::future::join_all;
@@ -31,6 +32,7 @@ use strum::AsRefStr;
 
 use crate::cache_invalidator::Context;
 use crate::ddl::DdlContext;
+use crate::ddl::event::flow::{DROP_FLOW_EVENT_TYPE, FlowDdlEvent};
 use crate::ddl::utils::{add_peer_context_if_needed, map_to_procedure_error};
 use crate::error::{self, Result};
 use crate::flow_name::FlowName;
@@ -218,6 +220,24 @@ impl Procedure for DropFlowProcedure {
         ];
 
         LockKey::new(lock_key)
+    }
+
+    fn event(&self, ctx: &EventContext<'_>) -> Option<Box<dyn common_event_recorder::Event>> {
+        if !ctx.event_type_filter.allows(DROP_FLOW_EVENT_TYPE) {
+            return None;
+        }
+
+        let event = match &ctx.trigger {
+            EventTrigger::Submitted => FlowDdlEvent::drop_submitted(
+                &self.data.task.catalog_name,
+                &self.data.task.flow_name,
+                self.data.task.flow_id,
+                self.data.task.drop_if_exists,
+            ),
+            _ => FlowDdlEvent::drop_lifecycle(),
+        };
+
+        Some(Box::new(event))
     }
 }
 

--- a/src/common/meta/src/ddl/event.rs
+++ b/src/common/meta/src/ddl/event.rs
@@ -15,3 +15,4 @@
 //! Events emitted by DDL procedures.
 
 pub(crate) mod database;
+pub(crate) mod flow;

--- a/src/common/meta/src/ddl/event/flow.rs
+++ b/src/common/meta/src/ddl/event/flow.rs
@@ -19,8 +19,8 @@ use api::v1::{ColumnSchema, Row};
 use common_event_recorder::Event;
 use common_event_recorder::error::{Result, SerializeEventSnafu};
 use common_event_recorder::event_table::{
-    CATALOG_NAME_COLUMN, FLOW_ID_COLUMN, FLOW_NAME_COLUMN, SCHEMA_NAME_COLUMN, column_schemas,
-    nullable_string, nullable_value,
+    CATALOG_NAME_COLUMN, FLOW_ID_COLUMN, FLOW_NAME_COLUMN, column_schemas, nullable_string,
+    nullable_value,
 };
 use serde::Serialize;
 use snafu::ResultExt;
@@ -66,7 +66,6 @@ enum FlowDdlPayload {
 pub(crate) struct FlowDdlEvent {
     event_type: &'static str,
     catalog_name: Option<String>,
-    schema_name: Option<String>,
     flow_name: Option<String>,
     flow_id: Option<u32>,
     payload: Option<FlowDdlPayload>,
@@ -76,14 +75,12 @@ impl FlowDdlEvent {
     /// Builds the bounded event emitted when creating a Flow is submitted.
     pub(crate) fn create_submitted(
         catalog_name: &str,
-        schema_name: &str,
         flow_name: &str,
         intent: CreateFlowEventIntent,
     ) -> Self {
         Self {
             event_type: CREATE_FLOW_EVENT_TYPE,
             catalog_name: Some(catalog_name.to_string()),
-            schema_name: Some(schema_name.to_string()),
             flow_name: Some(flow_name.to_string()),
             flow_id: None,
             payload: Some(FlowDdlPayload::Create(CreateFlowPayload {
@@ -106,7 +103,6 @@ impl FlowDdlEvent {
         Self {
             event_type: DROP_FLOW_EVENT_TYPE,
             catalog_name: Some(catalog_name.to_string()),
-            schema_name: None,
             flow_name: Some(flow_name.to_string()),
             flow_id: Some(flow_id),
             payload: Some(FlowDdlPayload::Drop(DropFlowPayload {
@@ -138,7 +134,6 @@ impl FlowDdlEvent {
         Self {
             event_type,
             catalog_name: None,
-            schema_name: None,
             flow_name: None,
             flow_id: None,
             payload: None,
@@ -159,19 +154,13 @@ impl Event for FlowDdlEvent {
     }
 
     fn extra_schema(&self) -> Vec<ColumnSchema> {
-        column_schemas([
-            &CATALOG_NAME_COLUMN,
-            &SCHEMA_NAME_COLUMN,
-            &FLOW_NAME_COLUMN,
-            &FLOW_ID_COLUMN,
-        ])
+        column_schemas([&CATALOG_NAME_COLUMN, &FLOW_NAME_COLUMN, &FLOW_ID_COLUMN])
     }
 
     fn extra_rows(&self) -> Result<Vec<Row>> {
         Ok(vec![Row {
             values: vec![
                 nullable_string(self.catalog_name.as_deref()),
-                nullable_string(self.schema_name.as_deref()),
                 nullable_string(self.flow_name.as_deref()),
                 nullable_value(self.flow_id.map(ValueData::U32Value)),
             ],

--- a/src/common/meta/src/ddl/event/flow.rs
+++ b/src/common/meta/src/ddl/event/flow.rs
@@ -1,0 +1,184 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+
+use api::v1::value::ValueData;
+use api::v1::{ColumnSchema, Row};
+use common_event_recorder::Event;
+use common_event_recorder::error::{Result, SerializeEventSnafu};
+use common_event_recorder::event_table::{
+    CATALOG_NAME_COLUMN, FLOW_ID_COLUMN, FLOW_NAME_COLUMN, SCHEMA_NAME_COLUMN, column_schemas,
+    nullable_string, nullable_value,
+};
+use serde::Serialize;
+use snafu::ResultExt;
+
+pub(crate) const CREATE_FLOW_EVENT_TYPE: &str = "create_flow";
+pub(crate) const DROP_FLOW_EVENT_TYPE: &str = "drop_flow";
+
+const PAYLOAD_VERSION: u8 = 1;
+
+/// The bounded Create Flow intent allowed in a submitted event payload.
+#[derive(Debug)]
+pub(crate) struct CreateFlowEventIntent {
+    pub(crate) or_replace: bool,
+    pub(crate) create_if_not_exists: bool,
+    pub(crate) expire_after: Option<i64>,
+    pub(crate) eval_interval_secs: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+struct CreateFlowPayload {
+    version: u8,
+    or_replace: bool,
+    create_if_not_exists: bool,
+    expire_after: Option<i64>,
+    eval_interval_secs: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+struct DropFlowPayload {
+    version: u8,
+    drop_if_exists: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+enum FlowDdlPayload {
+    Create(CreateFlowPayload),
+    Drop(DropFlowPayload),
+}
+
+/// A Flow DDL event with a schema shared by every lifecycle trigger.
+#[derive(Debug)]
+pub(crate) struct FlowDdlEvent {
+    event_type: &'static str,
+    catalog_name: Option<String>,
+    schema_name: Option<String>,
+    flow_name: Option<String>,
+    flow_id: Option<u32>,
+    payload: Option<FlowDdlPayload>,
+}
+
+impl FlowDdlEvent {
+    /// Builds the bounded event emitted when creating a Flow is submitted.
+    pub(crate) fn create_submitted(
+        catalog_name: &str,
+        schema_name: &str,
+        flow_name: &str,
+        intent: CreateFlowEventIntent,
+    ) -> Self {
+        Self {
+            event_type: CREATE_FLOW_EVENT_TYPE,
+            catalog_name: Some(catalog_name.to_string()),
+            schema_name: Some(schema_name.to_string()),
+            flow_name: Some(flow_name.to_string()),
+            flow_id: None,
+            payload: Some(FlowDdlPayload::Create(CreateFlowPayload {
+                version: PAYLOAD_VERSION,
+                or_replace: intent.or_replace,
+                create_if_not_exists: intent.create_if_not_exists,
+                expire_after: intent.expire_after,
+                eval_interval_secs: intent.eval_interval_secs,
+            })),
+        }
+    }
+
+    /// Builds the bounded event emitted when dropping a Flow is submitted.
+    pub(crate) fn drop_submitted(
+        catalog_name: &str,
+        flow_name: &str,
+        flow_id: u32,
+        drop_if_exists: bool,
+    ) -> Self {
+        Self {
+            event_type: DROP_FLOW_EVENT_TYPE,
+            catalog_name: Some(catalog_name.to_string()),
+            schema_name: None,
+            flow_name: Some(flow_name.to_string()),
+            flow_id: Some(flow_id),
+            payload: Some(FlowDdlPayload::Drop(DropFlowPayload {
+                version: PAYLOAD_VERSION,
+                drop_if_exists,
+            })),
+        }
+    }
+
+    /// Builds a lightweight Create Flow lifecycle event.
+    pub(crate) fn create_lifecycle() -> Self {
+        Self::lifecycle(CREATE_FLOW_EVENT_TYPE)
+    }
+
+    /// Builds a successful Create Flow event containing only a resolved ID.
+    pub(crate) fn create_succeeded(flow_id: Option<u32>) -> Self {
+        Self {
+            flow_id,
+            ..Self::lifecycle(CREATE_FLOW_EVENT_TYPE)
+        }
+    }
+
+    /// Builds a lightweight Drop Flow lifecycle event.
+    pub(crate) fn drop_lifecycle() -> Self {
+        Self::lifecycle(DROP_FLOW_EVENT_TYPE)
+    }
+
+    fn lifecycle(event_type: &'static str) -> Self {
+        Self {
+            event_type,
+            catalog_name: None,
+            schema_name: None,
+            flow_name: None,
+            flow_id: None,
+            payload: None,
+        }
+    }
+}
+
+impl Event for FlowDdlEvent {
+    fn event_type(&self) -> &str {
+        self.event_type
+    }
+
+    fn json_payload(&self) -> Result<serde_json::Value> {
+        match &self.payload {
+            Some(payload) => serde_json::to_value(payload).context(SerializeEventSnafu),
+            None => Ok(serde_json::Value::Null),
+        }
+    }
+
+    fn extra_schema(&self) -> Vec<ColumnSchema> {
+        column_schemas([
+            &CATALOG_NAME_COLUMN,
+            &SCHEMA_NAME_COLUMN,
+            &FLOW_NAME_COLUMN,
+            &FLOW_ID_COLUMN,
+        ])
+    }
+
+    fn extra_rows(&self) -> Result<Vec<Row>> {
+        Ok(vec![Row {
+            values: vec![
+                nullable_string(self.catalog_name.as_deref()),
+                nullable_string(self.schema_name.as_deref()),
+                nullable_string(self.flow_name.as_deref()),
+                nullable_value(self.flow_id.map(ValueData::U32Value)),
+            ],
+        }])
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/src/common/meta/src/ddl/tests/create_flow.rs
+++ b/src/common/meta/src/ddl/tests/create_flow.rs
@@ -40,7 +40,7 @@ use crate::key::table_route::TableRouteValue;
 use crate::rpc::ddl::{CreateFlowTask, FlowQueryContext, QueryContext};
 use crate::test_util::{MockFlownodeManager, new_ddl_context};
 
-fn test_query_context() -> QueryContext {
+pub(crate) fn test_query_context() -> QueryContext {
     QueryContext {
         current_catalog: DEFAULT_CATALOG_NAME.to_string(),
         current_schema: DEFAULT_SCHEMA_NAME.to_string(),

--- a/src/common/meta/src/ddl/tests/drop_flow.rs
+++ b/src/common/meta/src/ddl/tests/drop_flow.rs
@@ -29,7 +29,11 @@ use crate::key::table_route::TableRouteValue;
 use crate::rpc::ddl::DropFlowTask;
 use crate::test_util::{MockFlownodeManager, new_ddl_context};
 
-fn test_drop_flow_task(flow_name: &str, flow_id: u32, drop_if_exists: bool) -> DropFlowTask {
+pub(crate) fn test_drop_flow_task(
+    flow_name: &str,
+    flow_id: u32,
+    drop_if_exists: bool,
+) -> DropFlowTask {
     DropFlowTask {
         catalog_name: DEFAULT_CATALOG_NAME.to_string(),
         flow_name: flow_name.to_string(),

--- a/src/common/meta/src/ddl/tests/event.rs
+++ b/src/common/meta/src/ddl/tests/event.rs
@@ -13,3 +13,4 @@
 // limitations under the License.
 
 mod database;
+mod flow;

--- a/src/common/meta/src/ddl/tests/event/flow.rs
+++ b/src/common/meta/src/ddl/tests/event/flow.rs
@@ -20,7 +20,7 @@ use api::v1::{ColumnSchema, Row, Value};
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_event_recorder::event_table::{
     CATALOG_NAME_COLUMN, FLOW_ID_COLUMN, FLOW_NAME_COLUMN, PROCEDURE_ERROR_COLUMN,
-    PROCEDURE_ID_COLUMN, PROCEDURE_STATE_COLUMN, PROCEDURE_TRIGGER_COLUMN, SCHEMA_NAME_COLUMN,
+    PROCEDURE_ID_COLUMN, PROCEDURE_STATE_COLUMN, PROCEDURE_TRIGGER_COLUMN,
 };
 use common_event_recorder::testing::assert_event_contract;
 use common_event_recorder::{Event, EventTypeFilter};
@@ -43,7 +43,6 @@ use crate::test_util::{MockFlownodeManager, new_ddl_context};
 fn test_flow_submitted_event_contracts() {
     let create = FlowDdlEvent::create_submitted(
         "greptime",
-        "public",
         "metrics",
         CreateFlowEventIntent {
             or_replace: true,
@@ -59,7 +58,6 @@ fn test_flow_submitted_event_contracts() {
         &[Row {
             values: vec![
                 ValueData::StringValue("greptime".to_string()).into(),
-                ValueData::StringValue("public".to_string()).into(),
                 ValueData::StringValue("metrics".to_string()).into(),
                 Value { value_data: None },
             ],
@@ -84,7 +82,6 @@ fn test_flow_submitted_event_contracts() {
         &[Row {
             values: vec![
                 ValueData::StringValue("greptime".to_string()).into(),
-                Value { value_data: None },
                 ValueData::StringValue("metrics".to_string()).into(),
                 ValueData::U32Value(42).into(),
             ],
@@ -112,7 +109,6 @@ fn test_flow_lifecycle_events_have_fixed_schema_and_null_intent() {
                     Value { value_data: None },
                     Value { value_data: None },
                     Value { value_data: None },
-                    Value { value_data: None },
                 ],
             }],
         );
@@ -128,7 +124,6 @@ fn test_flow_lifecycle_events_have_fixed_schema_and_null_intent() {
             values: vec![
                 Value { value_data: None },
                 Value { value_data: None },
-                Value { value_data: None },
                 ValueData::U32Value(42).into(),
             ],
         }],
@@ -142,7 +137,6 @@ fn test_flow_events_preserve_procedure_envelope_contract() {
         procedure_id,
         Box::new(FlowDdlEvent::create_submitted(
             "greptime",
-            "public",
             "metrics",
             CreateFlowEventIntent {
                 or_replace: false,
@@ -168,7 +162,6 @@ fn test_flow_events_preserve_procedure_envelope_contract() {
         "Submitted",
         FlowEventLocator {
             catalog_name: Some("greptime"),
-            schema_name: Some("public"),
             flow_name: Some("metrics"),
             flow_id: None,
         },
@@ -180,7 +173,6 @@ fn test_flow_events_preserve_procedure_envelope_contract() {
         "Succeeded",
         FlowEventLocator {
             catalog_name: None,
-            schema_name: None,
             flow_name: None,
             flow_id: Some(42),
         },
@@ -214,7 +206,6 @@ fn test_drop_flow_event_filter() {
 fn flow_schema() -> Vec<ColumnSchema> {
     vec![
         CATALOG_NAME_COLUMN.column_schema(),
-        SCHEMA_NAME_COLUMN.column_schema(),
         FLOW_NAME_COLUMN.column_schema(),
         FLOW_ID_COLUMN.column_schema(),
     ]
@@ -222,7 +213,6 @@ fn flow_schema() -> Vec<ColumnSchema> {
 
 struct FlowEventLocator<'a> {
     catalog_name: Option<&'a str>,
-    schema_name: Option<&'a str>,
     flow_name: Option<&'a str>,
     flow_id: Option<u32>,
 }
@@ -252,7 +242,6 @@ fn assert_procedure_event_contract(
                 ValueData::StringValue(String::new()).into(),
                 ValueData::StringValue(trigger.to_string()).into(),
                 optional_string(locator.catalog_name),
-                optional_string(locator.schema_name),
                 optional_string(locator.flow_name),
                 locator
                     .flow_id

--- a/src/common/meta/src/ddl/tests/event/flow.rs
+++ b/src/common/meta/src/ddl/tests/event/flow.rs
@@ -1,0 +1,301 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use api::v1::value::ValueData;
+use api::v1::{ColumnSchema, Row, Value};
+use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
+use common_event_recorder::event_table::{
+    CATALOG_NAME_COLUMN, FLOW_ID_COLUMN, FLOW_NAME_COLUMN, PROCEDURE_ERROR_COLUMN,
+    PROCEDURE_ID_COLUMN, PROCEDURE_STATE_COLUMN, PROCEDURE_TRIGGER_COLUMN, SCHEMA_NAME_COLUMN,
+};
+use common_event_recorder::testing::assert_event_contract;
+use common_event_recorder::{Event, EventTypeFilter};
+use common_procedure::{
+    EventContext, EventTrigger, Procedure, ProcedureEvent, ProcedureId, ProcedureState,
+};
+use table::table_name::TableName;
+
+use crate::ddl::create_flow::CreateFlowProcedure;
+use crate::ddl::drop_flow::DropFlowProcedure;
+use crate::ddl::event::flow::{
+    CREATE_FLOW_EVENT_TYPE, CreateFlowEventIntent, DROP_FLOW_EVENT_TYPE, FlowDdlEvent,
+};
+use crate::ddl::test_util::flownode_handler::NaiveFlownodeHandler;
+use crate::ddl::tests::create_flow::{test_create_flow_task, test_query_context};
+use crate::ddl::tests::drop_flow::test_drop_flow_task;
+use crate::test_util::{MockFlownodeManager, new_ddl_context};
+
+#[test]
+fn test_flow_submitted_event_contracts() {
+    let create = FlowDdlEvent::create_submitted(
+        "greptime",
+        "public",
+        "metrics",
+        CreateFlowEventIntent {
+            or_replace: true,
+            create_if_not_exists: false,
+            expire_after: Some(300),
+            eval_interval_secs: Some(60),
+        },
+    );
+    assert_event_contract(
+        &create,
+        CREATE_FLOW_EVENT_TYPE,
+        &flow_schema(),
+        &[Row {
+            values: vec![
+                ValueData::StringValue("greptime".to_string()).into(),
+                ValueData::StringValue("public".to_string()).into(),
+                ValueData::StringValue("metrics".to_string()).into(),
+                Value { value_data: None },
+            ],
+        }],
+    );
+    assert_eq!(
+        create.json_payload().unwrap(),
+        serde_json::json!({
+            "version": 1,
+            "or_replace": true,
+            "create_if_not_exists": false,
+            "expire_after": 300,
+            "eval_interval_secs": 60,
+        })
+    );
+
+    let drop = FlowDdlEvent::drop_submitted("greptime", "metrics", 42, true);
+    assert_event_contract(
+        &drop,
+        DROP_FLOW_EVENT_TYPE,
+        &flow_schema(),
+        &[Row {
+            values: vec![
+                ValueData::StringValue("greptime".to_string()).into(),
+                Value { value_data: None },
+                ValueData::StringValue("metrics".to_string()).into(),
+                ValueData::U32Value(42).into(),
+            ],
+        }],
+    );
+    assert_eq!(
+        drop.json_payload().unwrap(),
+        serde_json::json!({"version": 1, "drop_if_exists": true})
+    );
+}
+
+#[test]
+fn test_flow_lifecycle_events_have_fixed_schema_and_null_intent() {
+    for (event, event_type) in [
+        (FlowDdlEvent::create_lifecycle(), CREATE_FLOW_EVENT_TYPE),
+        (FlowDdlEvent::create_succeeded(None), CREATE_FLOW_EVENT_TYPE),
+        (FlowDdlEvent::drop_lifecycle(), DROP_FLOW_EVENT_TYPE),
+    ] {
+        assert_event_contract(
+            &event,
+            event_type,
+            &flow_schema(),
+            &[Row {
+                values: vec![
+                    Value { value_data: None },
+                    Value { value_data: None },
+                    Value { value_data: None },
+                    Value { value_data: None },
+                ],
+            }],
+        );
+        assert_eq!(event.json_payload().unwrap(), serde_json::Value::Null);
+    }
+
+    let event = FlowDdlEvent::create_succeeded(Some(42));
+    assert_event_contract(
+        &event,
+        CREATE_FLOW_EVENT_TYPE,
+        &flow_schema(),
+        &[Row {
+            values: vec![
+                Value { value_data: None },
+                Value { value_data: None },
+                Value { value_data: None },
+                ValueData::U32Value(42).into(),
+            ],
+        }],
+    );
+}
+
+#[test]
+fn test_flow_events_preserve_procedure_envelope_contract() {
+    let procedure_id = ProcedureId::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
+    let submitted = ProcedureEvent::new(
+        procedure_id,
+        Box::new(FlowDdlEvent::create_submitted(
+            "greptime",
+            "public",
+            "metrics",
+            CreateFlowEventIntent {
+                or_replace: false,
+                create_if_not_exists: false,
+                expire_after: None,
+                eval_interval_secs: None,
+            },
+        )),
+        ProcedureState::Running,
+        EventTrigger::Submitted,
+    );
+    let succeeded = ProcedureEvent::new(
+        procedure_id,
+        Box::new(FlowDdlEvent::create_succeeded(Some(42))),
+        ProcedureState::Done { output: None },
+        EventTrigger::Succeeded,
+    );
+
+    assert_procedure_event_contract(
+        &submitted,
+        CREATE_FLOW_EVENT_TYPE,
+        "Running",
+        "Submitted",
+        FlowEventLocator {
+            catalog_name: Some("greptime"),
+            schema_name: Some("public"),
+            flow_name: Some("metrics"),
+            flow_id: None,
+        },
+    );
+    assert_procedure_event_contract(
+        &succeeded,
+        CREATE_FLOW_EVENT_TYPE,
+        "Done",
+        "Succeeded",
+        FlowEventLocator {
+            catalog_name: None,
+            schema_name: None,
+            flow_name: None,
+            flow_id: Some(42),
+        },
+    );
+}
+
+#[test]
+fn test_create_flow_event_filter() {
+    let procedure = CreateFlowProcedure::new(
+        test_create_flow_task(
+            "flow",
+            vec![],
+            TableName::new(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, "sink"),
+            false,
+        ),
+        test_query_context(),
+        new_ddl_context(Arc::new(MockFlownodeManager::new(NaiveFlownodeHandler))),
+    );
+    assert_flow_event_filter(&procedure, CREATE_FLOW_EVENT_TYPE);
+}
+
+#[test]
+fn test_drop_flow_event_filter() {
+    let procedure = DropFlowProcedure::new(
+        test_drop_flow_task("flow", 42, false),
+        new_ddl_context(Arc::new(MockFlownodeManager::new(NaiveFlownodeHandler))),
+    );
+    assert_flow_event_filter(&procedure, DROP_FLOW_EVENT_TYPE);
+}
+
+fn flow_schema() -> Vec<ColumnSchema> {
+    vec![
+        CATALOG_NAME_COLUMN.column_schema(),
+        SCHEMA_NAME_COLUMN.column_schema(),
+        FLOW_NAME_COLUMN.column_schema(),
+        FLOW_ID_COLUMN.column_schema(),
+    ]
+}
+
+struct FlowEventLocator<'a> {
+    catalog_name: Option<&'a str>,
+    schema_name: Option<&'a str>,
+    flow_name: Option<&'a str>,
+    flow_id: Option<u32>,
+}
+
+fn assert_procedure_event_contract(
+    event: &ProcedureEvent,
+    event_type: &str,
+    state: &str,
+    trigger: &str,
+    locator: FlowEventLocator<'_>,
+) {
+    let mut schema = vec![
+        PROCEDURE_ID_COLUMN.column_schema(),
+        PROCEDURE_STATE_COLUMN.column_schema(),
+        PROCEDURE_ERROR_COLUMN.column_schema(),
+        PROCEDURE_TRIGGER_COLUMN.column_schema(),
+    ];
+    schema.extend(flow_schema());
+    assert_event_contract(
+        event,
+        event_type,
+        &schema,
+        &[Row {
+            values: vec![
+                ValueData::StringValue(event.procedure_id.to_string()).into(),
+                ValueData::StringValue(state.to_string()).into(),
+                ValueData::StringValue(String::new()).into(),
+                ValueData::StringValue(trigger.to_string()).into(),
+                optional_string(locator.catalog_name),
+                optional_string(locator.schema_name),
+                optional_string(locator.flow_name),
+                locator
+                    .flow_id
+                    .map(ValueData::U32Value)
+                    .map(Into::into)
+                    .unwrap_or(Value { value_data: None }),
+            ],
+        }],
+    );
+}
+
+fn assert_flow_event_filter(procedure: &dyn Procedure, event_type: &str) {
+    let state = ProcedureState::Running;
+    let event_context = |event_type_filter| EventContext {
+        procedure_id: ProcedureId::random(),
+        lifecycle_state: &state,
+        trigger: EventTrigger::Submitted,
+        event_type_filter: Arc::new(event_type_filter),
+    };
+
+    assert!(
+        procedure
+            .event(&event_context(EventTypeFilter::Only(HashSet::from([
+                event_type.to_string()
+            ]))))
+            .is_some()
+    );
+    assert!(
+        procedure
+            .event(&event_context(EventTypeFilter::Only(HashSet::new())))
+            .is_none()
+    );
+    assert!(
+        procedure
+            .event(&event_context(EventTypeFilter::Only(HashSet::from([
+                "other_event".to_string(),
+            ]))))
+            .is_none()
+    );
+}
+
+fn optional_string(value: Option<&str>) -> Value {
+    value
+        .map(|value| ValueData::StringValue(value.to_string()).into())
+        .unwrap_or(Value { value_data: None })
+}

--- a/tests-integration/tests/database_ddl_event.rs
+++ b/tests-integration/tests/database_ddl_event.rs
@@ -13,16 +13,16 @@
 // limitations under the License.
 
 use std::sync::Arc;
-use std::time::Duration;
 
 use client::OutputData;
-use common_recordbatch::RecordBatches;
 use common_test_util::temp_dir::create_temp_dir;
 use servers::query_handler::sql::SqlQueryHandler;
 use session::context::QueryContext;
 use tests_integration::cluster::GreptimeDbClusterBuilder;
 use tests_integration::standalone::GreptimeDbStandaloneBuilder;
 use tests_integration::test_util::{StorageType, get_test_store_config};
+
+use crate::event_recorder_test_util::assert_single_event;
 
 const DATABASE_NAME: &str = "database_ddl_events";
 
@@ -134,42 +134,4 @@ WHERE type = '{event_type}'
   AND json_is_null(payload)"#
     );
     assert_single_event(instance, &lifecycle).await;
-}
-
-async fn assert_single_event(instance: &Arc<frontend::instance::Instance>, query: &str) {
-    for _ in 0..60 {
-        if event_count_is_one(instance, query).await {
-            return;
-        }
-        tokio::time::sleep(Duration::from_millis(250)).await;
-    }
-
-    panic!("timed out waiting for database DDL event: {query}");
-}
-
-async fn event_count_is_one(instance: &Arc<frontend::instance::Instance>, query: &str) -> bool {
-    let Ok(output) = instance
-        .do_query(query, QueryContext::arc())
-        .await
-        .remove(0)
-    else {
-        return false;
-    };
-    let OutputData::Stream(stream) = output.data else {
-        unreachable!("event-count query must return a stream");
-    };
-    let Ok(batches) = RecordBatches::try_collect(stream).await else {
-        return false;
-    };
-    let Ok(actual) = batches.pretty_print() else {
-        return false;
-    };
-
-    actual
-        == "\
-+-------------+
-| event_count |
-+-------------+
-| 1           |
-+-------------+"
 }

--- a/tests-integration/tests/event_recorder_test_util.rs
+++ b/tests-integration/tests/event_recorder_test_util.rs
@@ -72,7 +72,7 @@ async fn event_count_is_one(instance: &Arc<Instance>, query: &str) -> bool {
     };
 
     actual
-        == "\\
+        == "\
 +-------------+
 | event_count |
 +-------------+

--- a/tests-integration/tests/event_recorder_test_util.rs
+++ b/tests-integration/tests/event_recorder_test_util.rs
@@ -1,0 +1,101 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use client::OutputData;
+use common_recordbatch::RecordBatches;
+use datatypes::arrow::array::AsArray;
+use frontend::instance::Instance;
+use servers::query_handler::sql::SqlQueryHandler;
+use session::context::QueryContext;
+
+const MAX_ATTEMPTS: usize = 60;
+const POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+/// Asserts that the query eventually returns exactly one event.
+pub(crate) async fn assert_single_event(instance: &Arc<Instance>, query: &str) {
+    for _ in 0..MAX_ATTEMPTS {
+        if event_count_is_one(instance, query).await {
+            return;
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+
+    panic!("timed out waiting for event: {query}");
+}
+
+/// Returns the first non-null string from `column` once the query produces one.
+pub(crate) async fn find_eventually_string(
+    instance: &Arc<Instance>,
+    query: &str,
+    column: &str,
+) -> String {
+    for _ in 0..MAX_ATTEMPTS {
+        if let Some(value) = query_first_string(instance, query, column).await {
+            return value;
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+
+    panic!("timed out waiting for event query: {query}");
+}
+
+async fn event_count_is_one(instance: &Arc<Instance>, query: &str) -> bool {
+    let Ok(output) = instance
+        .do_query(query, QueryContext::arc())
+        .await
+        .remove(0)
+    else {
+        return false;
+    };
+    let OutputData::Stream(stream) = output.data else {
+        unreachable!("event-count query must return a stream");
+    };
+    let Ok(batches) = RecordBatches::try_collect(stream).await else {
+        return false;
+    };
+    let Ok(actual) = batches.pretty_print() else {
+        return false;
+    };
+
+    actual
+        == "\\
++-------------+
+| event_count |
++-------------+
+| 1           |
++-------------+"
+}
+
+async fn query_first_string(instance: &Arc<Instance>, query: &str, column: &str) -> Option<String> {
+    let output = instance
+        .do_query(query, QueryContext::arc())
+        .await
+        .remove(0)
+        .ok()?;
+    let OutputData::Stream(stream) = output.data else {
+        unreachable!("event query must return a stream");
+    };
+    let batches = RecordBatches::try_collect(stream).await.ok()?;
+    let batch = batches.take().into_iter().next()?;
+    batch
+        .column_by_name(column)?
+        .as_string::<i32>()
+        .iter()
+        .next()
+        .flatten()
+        .map(ToString::to_string)
+}

--- a/tests-integration/tests/flow_ddl_event.rs
+++ b/tests-integration/tests/flow_ddl_event.rs
@@ -14,11 +14,9 @@
 
 use std::sync::Arc;
 
-use common_test_util::temp_dir::create_temp_dir;
 use servers::query_handler::sql::SqlQueryHandler;
 use session::context::QueryContext;
-use tests_integration::cluster::GreptimeDbClusterBuilder;
-use tests_integration::test_util::{StorageType, get_test_store_config};
+use tests_integration::standalone::GreptimeDbStandaloneBuilder;
 use uuid::Uuid;
 
 use crate::event_recorder_test_util::{assert_single_event, find_eventually_string};
@@ -27,23 +25,12 @@ const CREATE_FLOW_EVENT_TYPE: &str = "create_flow";
 const DROP_FLOW_EVENT_TYPE: &str = "drop_flow";
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_flow_ddl_events_file() {
-    let store_type = StorageType::File;
-    if !store_type.test_on() {
-        return;
-    }
-
+async fn test_standalone_flow_ddl_events() {
     common_telemetry::init_default_ut_logging();
-    let (store_config, _guard) = get_test_store_config(&store_type);
-    let home_dir = create_temp_dir("test_flow_ddl_events_data_home");
-    let cluster = GreptimeDbClusterBuilder::new("test_flow_ddl_events")
-        .await
-        .with_datanodes(1)
-        .with_store_config(store_config)
-        .with_shared_home_dir(Arc::new(home_dir))
-        .build(true)
+    let standalone = GreptimeDbStandaloneBuilder::new("test_standalone_flow_ddl_events")
+        .build()
         .await;
-    let instance = cluster.fe_instance();
+    let instance = standalone.fe_instance();
     let suffix = Uuid::new_v4().simple();
     let missing_source = format!("flow_ddl_event_missing_source_{suffix}");
     let sink = format!("flow_ddl_event_sink_{suffix}");
@@ -61,7 +48,7 @@ async fn test_flow_ddl_events_file() {
     instance
         .do_query(
             &format!(
-                "CREATE FLOW IF NOT EXISTS {flow} SINK TO {sink} EVAL INTERVAL '10s' \\
+                "CREATE FLOW IF NOT EXISTS {flow} SINK TO {sink} EVAL INTERVAL '10s' \
                  WITH (defer_on_missing_source = true) AS SELECT val, ts FROM {missing_source}"
             ),
             QueryContext::arc(),
@@ -164,9 +151,13 @@ async fn find_submitted_procedure_id(
     find_eventually_string(
         instance,
         &format!(
-            "SELECT procedure_id FROM greptime_private.events \\
-             WHERE type = '{event_type}' AND flow_name = '{flow_name}' \\
-             AND procedure_trigger = 'Submitted' ORDER BY timestamp DESC LIMIT 1"
+            r#"SELECT procedure_id
+FROM greptime_private.events
+WHERE type = '{event_type}'
+  AND flow_name = '{flow_name}'
+  AND procedure_trigger = 'Submitted'
+ORDER BY timestamp DESC
+LIMIT 1"#,
         ),
         "procedure_id",
     )

--- a/tests-integration/tests/flow_ddl_event.rs
+++ b/tests-integration/tests/flow_ddl_event.rs
@@ -91,7 +91,6 @@ WHERE type = '{CREATE_FLOW_EVENT_TYPE}'
   AND procedure_state = 'Running'
   AND procedure_trigger = 'Submitted'
   AND catalog_name = 'greptime'
-  AND schema_name = 'public'
   AND flow_name = '{flow}'
   AND flow_id IS NULL
   AND json_path_match(payload, '$.version == 1')
@@ -112,7 +111,6 @@ WHERE type = '{CREATE_FLOW_EVENT_TYPE}'
   AND procedure_state = 'Done'
   AND procedure_trigger = 'Succeeded'
   AND catalog_name IS NULL
-  AND schema_name IS NULL
   AND flow_name IS NULL
   AND flow_id IS NOT NULL
   AND json_is_null(payload)"#,
@@ -133,7 +131,6 @@ WHERE type = '{DROP_FLOW_EVENT_TYPE}'
   AND procedure_state = 'Running'
   AND procedure_trigger = 'Submitted'
   AND catalog_name = 'greptime'
-  AND schema_name IS NULL
   AND flow_name = '{flow}'
   AND flow_id IS NOT NULL
   AND json_path_match(payload, '$.version == 1')
@@ -151,7 +148,6 @@ WHERE type = '{DROP_FLOW_EVENT_TYPE}'
   AND procedure_state = 'Done'
   AND procedure_trigger = 'Succeeded'
   AND catalog_name IS NULL
-  AND schema_name IS NULL
   AND flow_name IS NULL
   AND flow_id IS NULL
   AND json_is_null(payload)"#,

--- a/tests-integration/tests/flow_ddl_event.rs
+++ b/tests-integration/tests/flow_ddl_event.rs
@@ -1,0 +1,178 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use common_test_util::temp_dir::create_temp_dir;
+use servers::query_handler::sql::SqlQueryHandler;
+use session::context::QueryContext;
+use tests_integration::cluster::GreptimeDbClusterBuilder;
+use tests_integration::test_util::{StorageType, get_test_store_config};
+use uuid::Uuid;
+
+use crate::event_recorder_test_util::{assert_single_event, find_eventually_string};
+
+const CREATE_FLOW_EVENT_TYPE: &str = "create_flow";
+const DROP_FLOW_EVENT_TYPE: &str = "drop_flow";
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_flow_ddl_events_file() {
+    let store_type = StorageType::File;
+    if !store_type.test_on() {
+        return;
+    }
+
+    common_telemetry::init_default_ut_logging();
+    let (store_config, _guard) = get_test_store_config(&store_type);
+    let home_dir = create_temp_dir("test_flow_ddl_events_data_home");
+    let cluster = GreptimeDbClusterBuilder::new("test_flow_ddl_events")
+        .await
+        .with_datanodes(1)
+        .with_store_config(store_config)
+        .with_shared_home_dir(Arc::new(home_dir))
+        .build(true)
+        .await;
+    let instance = cluster.fe_instance();
+    let suffix = Uuid::new_v4().simple();
+    let missing_source = format!("flow_ddl_event_missing_source_{suffix}");
+    let sink = format!("flow_ddl_event_sink_{suffix}");
+    let flow = format!("flow_ddl_event_{suffix}");
+
+    instance
+        .do_query(
+            &format!("CREATE TABLE {sink} (val STRING, ts TIMESTAMP TIME INDEX)"),
+            QueryContext::arc(),
+        )
+        .await
+        .remove(0)
+        .unwrap();
+
+    instance
+        .do_query(
+            &format!(
+                "CREATE FLOW IF NOT EXISTS {flow} SINK TO {sink} EVAL INTERVAL '10s' \\
+                 WITH (defer_on_missing_source = true) AS SELECT val, ts FROM {missing_source}"
+            ),
+            QueryContext::arc(),
+        )
+        .await
+        .remove(0)
+        .unwrap();
+    assert_create_events(instance, &flow).await;
+
+    instance
+        .do_query(&format!("DROP FLOW IF EXISTS {flow}"), QueryContext::arc())
+        .await
+        .remove(0)
+        .unwrap();
+    assert_drop_events(instance, &flow).await;
+}
+
+async fn assert_create_events(instance: &Arc<frontend::instance::Instance>, flow: &str) {
+    let procedure_id = find_submitted_procedure_id(instance, CREATE_FLOW_EVENT_TYPE, flow).await;
+    assert_single_event(
+        instance,
+        &format!(
+            r#"SELECT count(*) AS event_count
+FROM greptime_private.events
+WHERE type = '{CREATE_FLOW_EVENT_TYPE}'
+  AND procedure_id = '{procedure_id}'
+  AND procedure_state = 'Running'
+  AND procedure_trigger = 'Submitted'
+  AND catalog_name = 'greptime'
+  AND schema_name = 'public'
+  AND flow_name = '{flow}'
+  AND flow_id IS NULL
+  AND json_path_match(payload, '$.version == 1')
+  AND json_path_match(payload, '$.or_replace == false')
+  AND json_path_match(payload, '$.create_if_not_exists == true')
+  AND json_path_match(payload, '$.expire_after == null')
+  AND json_path_match(payload, '$.eval_interval_secs == 10')"#,
+        ),
+    )
+    .await;
+    assert_single_event(
+        instance,
+        &format!(
+            r#"SELECT count(*) AS event_count
+FROM greptime_private.events
+WHERE type = '{CREATE_FLOW_EVENT_TYPE}'
+  AND procedure_id = '{procedure_id}'
+  AND procedure_state = 'Done'
+  AND procedure_trigger = 'Succeeded'
+  AND catalog_name IS NULL
+  AND schema_name IS NULL
+  AND flow_name IS NULL
+  AND flow_id IS NOT NULL
+  AND json_is_null(payload)"#,
+        ),
+    )
+    .await;
+}
+
+async fn assert_drop_events(instance: &Arc<frontend::instance::Instance>, flow: &str) {
+    let procedure_id = find_submitted_procedure_id(instance, DROP_FLOW_EVENT_TYPE, flow).await;
+    assert_single_event(
+        instance,
+        &format!(
+            r#"SELECT count(*) AS event_count
+FROM greptime_private.events
+WHERE type = '{DROP_FLOW_EVENT_TYPE}'
+  AND procedure_id = '{procedure_id}'
+  AND procedure_state = 'Running'
+  AND procedure_trigger = 'Submitted'
+  AND catalog_name = 'greptime'
+  AND schema_name IS NULL
+  AND flow_name = '{flow}'
+  AND flow_id IS NOT NULL
+  AND json_path_match(payload, '$.version == 1')
+  AND json_path_match(payload, '$.drop_if_exists == true')"#,
+        ),
+    )
+    .await;
+    assert_single_event(
+        instance,
+        &format!(
+            r#"SELECT count(*) AS event_count
+FROM greptime_private.events
+WHERE type = '{DROP_FLOW_EVENT_TYPE}'
+  AND procedure_id = '{procedure_id}'
+  AND procedure_state = 'Done'
+  AND procedure_trigger = 'Succeeded'
+  AND catalog_name IS NULL
+  AND schema_name IS NULL
+  AND flow_name IS NULL
+  AND flow_id IS NULL
+  AND json_is_null(payload)"#,
+        ),
+    )
+    .await;
+}
+
+async fn find_submitted_procedure_id(
+    instance: &Arc<frontend::instance::Instance>,
+    event_type: &str,
+    flow_name: &str,
+) -> String {
+    find_eventually_string(
+        instance,
+        &format!(
+            "SELECT procedure_id FROM greptime_private.events \\
+             WHERE type = '{event_type}' AND flow_name = '{flow_name}' \\
+             AND procedure_trigger = 'Submitted' ORDER BY timestamp DESC LIMIT 1"
+        ),
+        "procedure_id",
+    )
+    .await
+}

--- a/tests-integration/tests/main.rs
+++ b/tests-integration/tests/main.rs
@@ -14,11 +14,13 @@
 
 #![recursion_limit = "256"]
 
-mod database_ddl_events;
+mod database_ddl_event;
+mod event_recorder_test_util;
 #[macro_use]
 mod grpc;
 #[macro_use]
 mod http;
+mod flow_ddl_event;
 mod json2;
 mod jsonbench;
 #[macro_use]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

- Builds on #8648 and aligns with #8623.

## What's changed and what's your intention?

Add procedure-event recording for `CREATE FLOW` and `DROP FLOW`.

- Adds `create_flow` and `drop_flow` events with canonical Flow dimensions (`catalog_name`, `flow_name`, and `flow_id`) registered in the shared event-table schema.
- Records bounded submitted payloads and lightweight lifecycle rows; a successful create event contains only the resolved `flow_id`.
- Keeps sensitive or unbounded Flow definition details out of event payloads, including SQL text, comments, source/sink names, options, and query-context extensions.
- Organizes Flow DDL event construction under `ddl/event/flow.rs`, alongside the existing Database DDL event producer.
- Reuses a shared integration-test helper and matches the Database DDL event assertion style: submitted and lifecycle rows are correlated through `procedure_id`.
- Removes query-context `schema_name` from Flow event records because it is not part of Flow identity.
- Documents the new event types in standalone and metasrv recorder configuration, including regenerated configuration documentation.

Validation completed:

- `cargo fmt --all -- --check`
- `git diff --check`
- `make config-docs`
- `cargo check -p tests-integration --tests`
- `cargo clippy -p common-event-recorder -p common-meta --tests -- -D warnings`
- `cargo clippy -p tests-integration --test main -- -D warnings`
- `cargo nextest run -p common-meta 'ddl::tests::event::flow'`
- `cargo nextest run -p common-event-recorder event_table`

The File-storage Flow integration test was attempted but could not start because the local test cluster exhausted its available port pool (`No unused port found`); this is not reported as passing validation.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
