### PR TITLE
Support unquoted postgres intervalstyle

### DIFF
--- a/src/operator/src/statement/set.rs
+++ b/src/operator/src/statement/set.rs
@@ -267,7 +267,7 @@ pub fn set_intervalstyle(exprs: Vec<Expr>, ctx: QueryContextRef) -> Result<()> {
         }
         _ => {
             return NotSupportedSnafu {
-                feat: "Set variable value must be a value",
+                feat: "Set variable value must be a value or identifier",
             }
             .fail();
         }

--- a/src/operator/src/statement/set.rs
+++ b/src/operator/src/statement/set.rs
@@ -256,15 +256,24 @@ pub fn set_intervalstyle(exprs: Vec<Expr>, ctx: QueryContextRef) -> Result<()> {
         }
         .fail();
     };
-    let Expr::Value(value) = var_value else {
-        return NotSupportedSnafu {
-            feat: "Set variable value must be a value",
+    let intervalstyle = match var_value {
+        Expr::Identifier(Ident {
+            value,
+            quote_style: _,
+            span: _,
+        }) => PGIntervalStyle::try_from(value.as_str()).context(InvalidConfigValueSnafu)?,
+        Expr::Value(value) => {
+            PGIntervalStyle::try_from(&value.value).context(InvalidConfigValueSnafu)?
         }
-        .fail();
+        _ => {
+            return NotSupportedSnafu {
+                feat: "Set variable value must be a value",
+            }
+            .fail();
+        }
     };
-    ctx.configuration_parameter().set_pg_intervalstyle_format(
-        PGIntervalStyle::try_from(&value.value).context(InvalidConfigValueSnafu)?,
-    );
+    ctx.configuration_parameter()
+        .set_pg_intervalstyle_format(intervalstyle);
     Ok(())
 }
 

--- a/tests-integration/tests/sql.rs
+++ b/tests-integration/tests/sql.rs
@@ -1160,6 +1160,12 @@ pub async fn test_postgres_intervalstyle(store_type: StorageType) {
     let client = validate_intervalstyle(client, "postgres", true).await;
     let client = validate_intervalstyle(client, "postgres_verbose", true).await;
     let client = validate_intervalstyle(client, "invalid_style", false).await;
+    assert!(
+        client
+            .simple_query("SET INTERVALSTYLE = postgres")
+            .await
+            .is_ok()
+    );
 
     let expected_formats: HashMap<&str, &str> = HashMap::from([
         ("iso_8601", "P1DT2H3M"),

--- a/tests-integration/tests/sql.rs
+++ b/tests-integration/tests/sql.rs
@@ -1166,6 +1166,13 @@ pub async fn test_postgres_intervalstyle(store_type: StorageType) {
             .await
             .is_ok()
     );
+    let result = get_row(
+        client
+            .simple_query("SELECT INTERVAL '1 day 2 hours 3 minutes'")
+            .await
+            .unwrap(),
+    );
+    assert_eq!(result, "1 day 02:03:00");
 
     let expected_formats: HashMap<&str, &str> = HashMap::from([
         ("iso_8601", "P1DT2H3M"),


### PR DESCRIPTION
## What

Allow PostgreSQL `SET INTERVALSTYLE = postgres` statements to use an unquoted identifier value.

## Why

PostgreSQL clients and extensions may send configuration values as bare identifiers. In particular, `postgres_fdw` initializes remote sessions with:

```sql
SET intervalstyle = postgres
```

GreptimeDB already accepts the quoted form:

```sql
SET INTERVALSTYLE = 'postgres'
```

and already supports `postgres` as a valid `PGIntervalStyle`, but the statement handler only accepted `Expr::Value`. This caused `postgres_fdw` queries against GreptimeDB's PostgreSQL protocol endpoint to fail during connection setup with:

```text
Not supported: Set variable value must be a value
```

## How

- Accept `Expr::Identifier` in `set_intervalstyle`.
- Reuse the existing `PGIntervalStyle::try_from(&str)` validation path.
- Add an integration test for `SET INTERVALSTYLE = postgres`.

## Validation

- Ran `git diff --check`.
- Could not run Rust tests locally because the current environment does not have a Rust toolchain installed.
