### PR TITLE
feat!: add authentication to /config

### DIFF
--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -135,6 +135,12 @@ pub static PUBLIC_API_PREFIX: [&str; 4] = [
     "/v1/splunk/services/collector/health",
 ];
 
+/// Paths that live outside the `/v1/` API prefix but still require
+/// authentication (e.g. `/config`, which exposes the full runtime options,
+/// potentially including credentials). Has no effect when no user provider is
+/// configured.
+pub static AUTH_REQUIRED_PATHS: [&str; 1] = ["/config"];
+
 #[derive(Default)]
 pub struct HttpServer {
     router: StdMutex<Router>,

--- a/src/servers/src/http/authorize.rs
+++ b/src/servers/src/http/authorize.rs
@@ -39,7 +39,7 @@ use crate::error::{
 use crate::http::header::{GREPTIME_TIMEZONE_HEADER_NAME, GreptimeDbName};
 use crate::http::result::error_result::ErrorResponse;
 use crate::http::splunk::is_splunk_request;
-use crate::http::{AUTHORIZATION_HEADER, HTTP_API_PREFIX, PUBLIC_API_PREFIX};
+use crate::http::{AUTH_REQUIRED_PATHS, AUTHORIZATION_HEADER, HTTP_API_PREFIX, PUBLIC_API_PREFIX};
 use crate::influxdb::{is_influxdb_request, is_influxdb_v2_request};
 
 /// AuthState is a holder state for [`UserProviderRef`]
@@ -342,6 +342,11 @@ fn need_auth<B>(req: &Request<B>) -> bool {
         }
     }
 
+    // Paths outside the `/v1/` prefix that expose sensitive data.
+    if AUTH_REQUIRED_PATHS.contains(&path) {
+        return true;
+    }
+
     path.starts_with(HTTP_API_PREFIX)
 }
 
@@ -409,6 +414,28 @@ mod tests {
             .unwrap();
 
         assert!(need_auth(&req));
+
+        // `/config` lives outside `/v1/` but exposes sensitive runtime options,
+        // so it must require authentication.
+        let req = Request::builder()
+            .uri("http://127.0.0.1/config")
+            .body(())
+            .unwrap();
+        assert!(need_auth(&req));
+
+        // query strings must not affect the decision
+        let req = Request::builder()
+            .uri("http://127.0.0.1/config?format=json")
+            .body(())
+            .unwrap();
+        assert!(need_auth(&req));
+
+        // unrelated root-level paths are still public
+        let req = Request::builder()
+            .uri("http://127.0.0.1/status")
+            .body(())
+            .unwrap();
+        assert!(!need_auth(&req));
     }
 
     #[test]

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -273,6 +273,23 @@ pub async fn test_http_auth(store_type: StorageType) {
         .await;
     assert_eq!(res.status(), StatusCode::FORBIDDEN);
 
+    // 6. `/config` exposes the full runtime options (potentially including
+    //    credentials), so it must require authentication too.
+    let res = client.get("/config").send().await;
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    let res = client
+        .get("/config")
+        .header("Authorization", basic_auth("greptime_user", "wrong_pwd"))
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    let res = client
+        .get("/config")
+        .header("Authorization", basic_auth("greptime_user", "greptime_pwd"))
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+
     guard.remove_all().await;
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

`/config` may contain sensitive information about server setup. this patch adds authentication to it.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
