### PR TITLE
perf(promql): avoid repeated scans in sliding range evaluation

### DIFF
--- a/.github/runner-scale-sets/query-regression/README.md
+++ b/.github/runner-scale-sets/query-regression/README.md
@@ -31,7 +31,7 @@ kubectl -n arc-runners create secret generic greptimedb-arc-github-app \
 The values files here reference that secret by name.
 
 A maintainer applying the `query-regression` or `heavy-regression` label is
-**trust admission for that exact PR revision**. `query-regression` runs the five
+**trust admission for that exact PR revision**. `query-regression` runs the six
 routine default cases; `heavy-regression` runs only the high-cardinality
 `prom_remote_write_7913` remote-write case. The admitted job may use this scale
 set's dedicated, writable persistent cache. `pull_request: labeled` is the only

--- a/.github/scripts/query-regression-run.py
+++ b/.github/scripts/query-regression-run.py
@@ -30,6 +30,7 @@ DEFAULT_CASES = [
     "tests/perf/query_cases/prom_remote_write_run_heavy/case.toml",
     "tests/perf/query_cases/prom_remote_write_mixed_every/case.toml",
     "tests/perf/query_cases/prom_remote_write_integer_counter/case.toml",
+    "tests/perf/query_cases/promql_range_boundary/case.toml",
 ]
 
 HEAVY_CASES = [

--- a/src/promql/benches/bench_range_fn.rs
+++ b/src/promql/benches/bench_range_fn.rs
@@ -17,13 +17,28 @@
 use std::sync::Arc;
 
 use criterion::{BenchmarkId, Criterion, criterion_group};
-use datafusion::arrow::array::{Float64Array, TimestampMillisecondArray};
-use datafusion::physical_plan::ColumnarValue;
+use datafusion::arrow::array::{
+    Array, ArrayRef, DictionaryArray, Float64Array, TimestampMillisecondArray,
+};
+use datafusion::arrow::datatypes::{
+    DataType as ArrowDataType, Field as ArrowField, Int64Type, Schema,
+};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::ToDFSchema;
+use datafusion::datasource::memory::MemorySourceConfig;
+use datafusion::datasource::source::DataSourceExec;
+use datafusion::execution::context::TaskContext;
+use datafusion::logical_expr::{EmptyRelation, LogicalPlan};
+use datafusion::physical_plan::{ColumnarValue, ExecutionPlan};
 use datafusion_common::ScalarValue;
 use datafusion_common::config::ConfigOptions;
 use datafusion_expr::ScalarFunctionArgs;
 use datatypes::arrow::datatypes::{DataType, Field};
-use promql::functions::{Delta, IDelta, Increase, PredictLinear, QuantileOverTime, Rate};
+use futures::StreamExt;
+use promql::extension_plan::RangeManipulate;
+use promql::functions::{
+    Changes, Delta, IDelta, Increase, PredictLinear, QuantileOverTime, Rate, Resets,
+};
 use promql::range_array::RangeArray;
 
 fn build_sliding_ranges(
@@ -91,6 +106,18 @@ fn build_default_values(num_points: usize) -> Vec<f64> {
     (0..num_points).map(|i| i as f64 * 1.5 + 0.1).collect()
 }
 
+fn build_changing_values(num_points: usize) -> Vec<f64> {
+    (0..num_points)
+        .map(|i| match i % 48 {
+            0..=7 => 42.0,
+            8..=15 => 43.5,
+            16..=17 => f64::NAN,
+            18..=35 => 41.0,
+            _ => 44.0,
+        })
+        .collect()
+}
+
 fn make_extrapolated_rate_input(
     num_points: usize,
     window_size: u32,
@@ -114,6 +141,34 @@ fn make_idelta_input(num_points: usize, window_size: u32) -> Vec<ColumnarValue> 
     vec![
         ColumnarValue::Array(Arc::new(ts_range.into_dict())),
         ColumnarValue::Array(Arc::new(val_range.into_dict())),
+    ]
+}
+
+fn make_edge_count_input(
+    num_points: usize,
+    window_size: u32,
+    values: Vec<f64>,
+) -> Vec<ColumnarValue> {
+    let (ts_range, val_range, _) = build_sliding_ranges(num_points, window_size, values, 0);
+    vec![
+        ColumnarValue::Array(Arc::new(ts_range.into_dict())),
+        ColumnarValue::Array(Arc::new(val_range.into_dict())),
+    ]
+}
+
+fn make_edge_count_input_with_ranges(
+    values: Vec<f64>,
+    ranges: Vec<(u32, u32)>,
+) -> Vec<ColumnarValue> {
+    let timestamps = Arc::new(TimestampMillisecondArray::from_iter_values(
+        (0..values.len()).map(|index| index as i64 * 1_000),
+    ));
+    let values = Arc::new(Float64Array::from(values));
+    let timestamp_ranges = RangeArray::from_ranges(timestamps, ranges.clone()).unwrap();
+    let value_ranges = RangeArray::from_ranges(values, ranges).unwrap();
+    vec![
+        ColumnarValue::Array(Arc::new(timestamp_ranges.into_dict())),
+        ColumnarValue::Array(Arc::new(value_ranges.into_dict())),
     ]
 }
 
@@ -170,7 +225,10 @@ impl PreparedUdfCall {
     }
 }
 
-fn invoke_prepared(udf: &datafusion::logical_expr::ScalarUDF, prepared: &PreparedUdfCall) {
+fn invoke_prepared_output(
+    udf: &datafusion::logical_expr::ScalarUDF,
+    prepared: &PreparedUdfCall,
+) -> ColumnarValue {
     udf.invoke_with_args(ScalarFunctionArgs {
         args: prepared.args.clone(),
         arg_fields: prepared.arg_fields.clone(),
@@ -178,7 +236,50 @@ fn invoke_prepared(udf: &datafusion::logical_expr::ScalarUDF, prepared: &Prepare
         return_field: prepared.return_field.clone(),
         config_options: prepared.config_options.clone(),
     })
-    .unwrap();
+    .unwrap()
+}
+
+fn invoke_prepared(udf: &datafusion::logical_expr::ScalarUDF, prepared: &PreparedUdfCall) {
+    let _ = invoke_prepared_output(udf, prepared);
+}
+
+fn edge_count_oracle(
+    values: &[f64],
+    ranges: &[(u32, u32)],
+    predicate: impl Fn(f64, f64) -> bool,
+) -> Vec<Option<f64>> {
+    ranges
+        .iter()
+        .map(|(offset, length)| {
+            let window = &values[*offset as usize..(*offset + *length) as usize];
+            if window.is_empty() {
+                None
+            } else if window.len() == 1 {
+                Some(0.0)
+            } else {
+                Some(
+                    window
+                        .windows(2)
+                        .filter(|pair| predicate(pair[0], pair[1]))
+                        .count() as f64,
+                )
+            }
+        })
+        .collect()
+}
+
+fn assert_edge_count_output(
+    udf: &datafusion::logical_expr::ScalarUDF,
+    prepared: &PreparedUdfCall,
+    expected: &[Option<f64>],
+) {
+    let output = invoke_prepared_output(udf, prepared);
+    let ColumnarValue::Array(output) = output else {
+        panic!("edge-count range UDF must return an array");
+    };
+    let output = output.as_any().downcast_ref::<Float64Array>().unwrap();
+    let actual = output.iter().collect::<Vec<_>>();
+    assert_eq!(actual, expected);
 }
 
 fn bench_range_functions(c: &mut Criterion) {
@@ -352,4 +453,334 @@ fn bench_range_functions(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_range_functions);
+fn bench_edge_count_functions(c: &mut Criterion) {
+    let mut group = c.benchmark_group("edge_count_fn");
+    let num_points = 4_096;
+    let window_sizes = [4u32, 20, 240];
+    let changing_values = build_changing_values(num_points);
+    let resetting_values = build_resetting_counter_values(num_points);
+    let changes_udf = Changes::scalar_udf();
+    let resets_udf = Resets::scalar_udf();
+
+    for window_size in window_sizes {
+        let ranges = (0..=num_points - window_size as usize)
+            .map(|offset| (offset as u32, window_size))
+            .collect::<Vec<_>>();
+
+        let changes_prepared = PreparedUdfCall::new(make_edge_count_input(
+            num_points,
+            window_size,
+            changing_values.clone(),
+        ));
+        let changes_expected = edge_count_oracle(&changing_values, &ranges, |a, b| {
+            a != b && !(a.is_nan() && b.is_nan())
+        });
+        assert_edge_count_output(&changes_udf, &changes_prepared, &changes_expected);
+        group.bench_with_input(
+            BenchmarkId::new(
+                "changes_prebuilt_range_array",
+                format!("N{num_points}_w{window_size}"),
+            ),
+            &(),
+            |b, _| b.iter(|| invoke_prepared(&changes_udf, &changes_prepared)),
+        );
+
+        let resets_prepared = PreparedUdfCall::new(make_edge_count_input(
+            num_points,
+            window_size,
+            resetting_values.clone(),
+        ));
+        let resets_expected = edge_count_oracle(&resetting_values, &ranges, |a, b| b < a);
+        assert_edge_count_output(&resets_udf, &resets_prepared, &resets_expected);
+        group.bench_with_input(
+            BenchmarkId::new(
+                "resets_prebuilt_range_array",
+                format!("N{num_points}_w{window_size}"),
+            ),
+            &(),
+            |b, _| b.iter(|| invoke_prepared(&resets_udf, &resets_prepared)),
+        );
+    }
+
+    // Keep the backing arrays at N=4096 while evaluating only eight four-sample windows.
+    // This isolates implementations that scan a global backing prefix instead of each range.
+    let low_coverage_ranges = vec![
+        (0, 4),
+        (512, 4),
+        (1_024, 4),
+        (1_536, 4),
+        (2_048, 4),
+        (2_560, 4),
+        (3_584, 4),
+        (4_092, 4),
+    ];
+    assert_eq!(low_coverage_ranges.len(), 8);
+
+    let low_coverage_changes = PreparedUdfCall::new(make_edge_count_input_with_ranges(
+        changing_values.clone(),
+        low_coverage_ranges.clone(),
+    ));
+    let low_coverage_changes_expected =
+        edge_count_oracle(&changing_values, &low_coverage_ranges, |a, b| {
+            a != b && !(a.is_nan() && b.is_nan())
+        });
+    assert_edge_count_output(
+        &changes_udf,
+        &low_coverage_changes,
+        &low_coverage_changes_expected,
+    );
+    group.bench_with_input(
+        BenchmarkId::new("changes_low_coverage_full_backing", "N4096_windows8_w4"),
+        &(),
+        |b, _| b.iter(|| invoke_prepared(&changes_udf, &low_coverage_changes)),
+    );
+
+    let low_coverage_resets = PreparedUdfCall::new(make_edge_count_input_with_ranges(
+        resetting_values.clone(),
+        low_coverage_ranges.clone(),
+    ));
+    let low_coverage_resets_expected =
+        edge_count_oracle(&resetting_values, &low_coverage_ranges, |a, b| b < a);
+    assert_edge_count_output(
+        &resets_udf,
+        &low_coverage_resets,
+        &low_coverage_resets_expected,
+    );
+    group.bench_with_input(
+        BenchmarkId::new("resets_low_coverage_full_backing", "N4096_windows8_w4"),
+        &(),
+        |b, _| b.iter(|| invoke_prepared(&resets_udf, &low_coverage_resets)),
+    );
+
+    group.finish();
+}
+
+const RANGE_MANIPULATE_CADENCE_MS: i64 = 15_000;
+
+fn make_range_manipulate_batch(timestamps: Vec<i64>, field_count: usize) -> RecordBatch {
+    let mut fields = Vec::with_capacity(field_count + 1);
+    let mut columns: Vec<ArrayRef> = Vec::with_capacity(field_count + 1);
+    fields.push(ArrowField::new(
+        "timestamp",
+        ArrowDataType::Timestamp(datafusion::arrow::datatypes::TimeUnit::Millisecond, None),
+        false,
+    ));
+    columns.push(Arc::new(TimestampMillisecondArray::from(timestamps)) as _);
+
+    for field_index in 0..field_count {
+        fields.push(ArrowField::new(
+            format!("value_{field_index}"),
+            ArrowDataType::Float64,
+            false,
+        ));
+        let values = (0..columns[0].len())
+            .map(|row| row as f64 + field_index as f64 * 0.01)
+            .collect::<Vec<_>>();
+        columns.push(Arc::new(Float64Array::from(values)) as _);
+    }
+
+    RecordBatch::try_new(Arc::new(Schema::new(fields)), columns).unwrap()
+}
+
+async fn execute_and_drain(
+    plan: Arc<dyn ExecutionPlan>,
+    task_ctx: Arc<TaskContext>,
+) -> Vec<RecordBatch> {
+    let mut stream = plan.execute(0, task_ctx).unwrap();
+    let mut output = Vec::new();
+    while let Some(batch) = stream.next().await {
+        output.push(batch.unwrap());
+    }
+    output
+}
+
+fn range_keys(batch: &RecordBatch, index: usize) -> Vec<(u32, u32)> {
+    let ranges = batch
+        .column(index)
+        .as_any()
+        .downcast_ref::<DictionaryArray<Int64Type>>()
+        .unwrap()
+        .clone();
+    RangeArray::try_new(ranges)
+        .unwrap()
+        .ranges()
+        .map(Option::unwrap)
+        .collect()
+}
+
+fn brute_force_range_keys(
+    timestamps: &[i64],
+    evaluations: usize,
+    window_points: usize,
+) -> Vec<(u32, u32)> {
+    let range = window_points as i64 * RANGE_MANIPULATE_CADENCE_MS;
+    (0..evaluations)
+        .map(|evaluation| {
+            let current = evaluation as i64 * RANGE_MANIPULATE_CADENCE_MS;
+            let mut offset = None;
+            let mut length = 0;
+            for (index, timestamp) in timestamps.iter().enumerate() {
+                if *timestamp > current - range && *timestamp <= current {
+                    offset.get_or_insert(index as u32);
+                    length += 1;
+                }
+            }
+            (offset.unwrap_or(0), length)
+        })
+        .collect()
+}
+
+fn validate_range_manipulate_output(
+    output: &[RecordBatch],
+    field_count: usize,
+    expected_range_keys: Option<&[(u32, u32)]>,
+) {
+    let Some(expected_range_keys) = expected_range_keys else {
+        assert!(output.is_empty());
+        return;
+    };
+
+    assert_eq!(output.len(), 1);
+    let batch = &output[0];
+    assert_eq!(batch.num_rows(), expected_range_keys.len());
+
+    let timestamp_range_keys = range_keys(batch, field_count + 1);
+    assert_eq!(timestamp_range_keys, expected_range_keys);
+
+    for field_index in 0..field_count {
+        assert_eq!(range_keys(batch, field_index + 1), expected_range_keys);
+    }
+}
+
+fn bench_range_manipulate_wall_time(c: &mut Criterion) {
+    let mut group = c.benchmark_group("range_manipulate_wall_time");
+    let primary_points = 4_096;
+    let sparse_evaluations = primary_points - 1;
+    let mut cases = vec![
+        (
+            "one_field",
+            (0..primary_points)
+                .map(|point| point as i64 * RANGE_MANIPULATE_CADENCE_MS)
+                .collect::<Vec<_>>(),
+            primary_points,
+            4,
+            1,
+            false,
+        ),
+        (
+            "one_field",
+            (0..primary_points)
+                .map(|point| point as i64 * RANGE_MANIPULATE_CADENCE_MS)
+                .collect::<Vec<_>>(),
+            primary_points,
+            20,
+            1,
+            false,
+        ),
+        (
+            "one_field",
+            (0..primary_points)
+                .map(|point| point as i64 * RANGE_MANIPULATE_CADENCE_MS)
+                .collect::<Vec<_>>(),
+            primary_points,
+            240,
+            1,
+            false,
+        ),
+        (
+            "regular_sparse",
+            (0..sparse_evaluations)
+                .step_by(2)
+                .map(|point| point as i64 * RANGE_MANIPULATE_CADENCE_MS)
+                .collect::<Vec<_>>(),
+            sparse_evaluations,
+            20,
+            1,
+            false,
+        ),
+        (
+            "all_empty_pathological",
+            (0..primary_points)
+                .map(|point| {
+                    (primary_points as i64 + 21 + point as i64) * RANGE_MANIPULATE_CADENCE_MS
+                })
+                .collect::<Vec<_>>(),
+            primary_points,
+            20,
+            1,
+            true,
+        ),
+        (
+            "multi_field_control",
+            (0..primary_points)
+                .map(|point| point as i64 * RANGE_MANIPULATE_CADENCE_MS)
+                .collect::<Vec<_>>(),
+            primary_points,
+            20,
+            4,
+            false,
+        ),
+    ];
+
+    for (case_name, timestamps, evaluations, window_points, field_count, expect_empty) in
+        cases.drain(..)
+    {
+        let expected_range_keys = (!expect_empty)
+            .then(|| brute_force_range_keys(&timestamps, evaluations, window_points));
+        let input_batch = make_range_manipulate_batch(timestamps, field_count);
+        let input_rows = input_batch.num_rows();
+        let input_schema = input_batch.schema();
+        let logical_input = LogicalPlan::EmptyRelation(EmptyRelation {
+            produce_one_row: false,
+            schema: input_schema.clone().to_dfschema_ref().unwrap(),
+        });
+        let field_columns = (0..field_count)
+            .map(|field_index| format!("value_{field_index}"))
+            .collect::<Vec<_>>();
+        let logical_plan = RangeManipulate::new(
+            0,
+            (evaluations as i64 - 1) * RANGE_MANIPULATE_CADENCE_MS,
+            RANGE_MANIPULATE_CADENCE_MS,
+            window_points as i64 * RANGE_MANIPULATE_CADENCE_MS,
+            "timestamp".to_string(),
+            field_columns,
+            logical_input,
+        )
+        .unwrap();
+        let physical_input: Arc<dyn ExecutionPlan> = Arc::new(DataSourceExec::new(Arc::new(
+            MemorySourceConfig::try_new(&[vec![input_batch]], input_schema, None).unwrap(),
+        )));
+        let execution_plan = logical_plan.to_execution_plan(physical_input);
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let task_ctx = datafusion::prelude::SessionContext::new().task_ctx();
+
+        // Validate the public operator output and RangeArray keys before timing.
+        let output = runtime.block_on(execute_and_drain(execution_plan.clone(), task_ctx.clone()));
+        validate_range_manipulate_output(&output, field_count, expected_range_keys.as_deref());
+
+        // This measures public RangeManipulate execution wall time, including stream draining.
+        group.bench_with_input(
+            BenchmarkId::new(
+                case_name,
+                format!("N{input_rows}_eval{evaluations}_window{window_points}x15s"),
+            ),
+            &(),
+            |b, _| {
+                b.iter(|| {
+                    let output = runtime
+                        .block_on(execute_and_drain(execution_plan.clone(), task_ctx.clone()));
+                    std::hint::black_box(output);
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_range_functions,
+    bench_edge_count_functions,
+    bench_range_manipulate_wall_time
+);

--- a/src/promql/src/extension_plan/range_manipulate.rs
+++ b/src/promql/src/extension_plan/range_manipulate.rs
@@ -730,43 +730,23 @@ impl RangeManipulateStream {
         let mut ranges = Vec::with_capacity(((self.end - self.start) / self.interval + 1) as usize);
 
         // calculate for every aligned timestamp (`curr_ts`), assume the ts column is ordered.
-        let mut range_start_index = 0usize;
-        let mut last_range_start = 0;
-        let mut start_delta = 0;
+        let mut left = 0usize;
+        let mut right = 0usize;
         for curr_ts in (start..=end).step_by(self.interval as _) {
-            // determine range start
             let start_ts = curr_ts - self.range;
 
-            // advance cursor based on last range
-            let mut range_start = ts_column.len();
-            let mut range_end = 0;
-            let mut cursor = range_start_index + start_delta;
-            // search back to keep the result correct
-            while cursor < ts_column.len() && ts_column.value(cursor) > start_ts && cursor > 0 {
-                cursor -= 1;
+            while left < len && ts_column.value(left) <= start_ts {
+                left += 1;
+            }
+            right = right.max(left);
+            while right < len && ts_column.value(right) <= curr_ts {
+                right += 1;
             }
 
-            while cursor < ts_column.len() {
-                let ts = ts_column.value(cursor);
-                if range_start > cursor && ts > start_ts {
-                    range_start = cursor;
-                    range_start_index = range_start;
-                }
-                if ts <= curr_ts {
-                    range_end = range_end.max(cursor);
-                } else {
-                    range_start_index = range_start_index.saturating_sub(1usize);
-                    break;
-                }
-                cursor += 1;
-            }
-            if range_start > range_end {
+            if left == right {
                 ranges.push((0, 0));
-                start_delta = 0;
             } else {
-                ranges.push((range_start as _, (range_end + 1 - range_start) as _));
-                start_delta = range_start - last_range_start;
-                last_range_start = range_start;
+                ranges.push((left as _, (right - left) as _));
             }
         }
 
@@ -1112,8 +1092,13 @@ mod test {
         }
     }
 
-    #[test]
-    fn test_calculate_range_keeps_query_aligned_tail() {
+    fn calculate_range_for_test(
+        query_start: i64,
+        query_end: i64,
+        interval: i64,
+        range: i64,
+        timestamps: &[i64],
+    ) -> (Vec<(u32, u32)>, (i64, i64)) {
         let schema = Arc::new(Schema::new(vec![Field::new(
             TIME_INDEX_COLUMN,
             TimestampMillisecondType::DATA_TYPE,
@@ -1121,10 +1106,10 @@ mod test {
         )]));
         let empty_stream = MemoryStream::try_new(vec![], schema.clone(), None).unwrap();
         let stream = RangeManipulateStream {
-            start: 4,
-            end: 94,
-            interval: 30,
-            range: 15,
+            start: query_start,
+            end: query_end,
+            interval,
+            range,
             time_index: 0,
             field_columns: vec![],
             aligned_ts_array: Arc::new(TimestampMillisecondArray::from(vec![0i64; 0])),
@@ -1135,13 +1120,236 @@ mod test {
         };
         let batch = RecordBatch::try_new(
             schema,
-            vec![Arc::new(TimestampMillisecondArray::from(vec![20, 50, 80]))],
+            vec![Arc::new(TimestampMillisecondArray::from(
+                timestamps.to_vec(),
+            ))],
         )
         .unwrap();
 
-        let (ranges, bounds) = stream.calculate_range(&batch).unwrap();
+        stream.calculate_range(&batch).unwrap()
+    }
+
+    #[test]
+    fn calculate_range_keeps_query_aligned_tail() {
+        let (ranges, bounds) = calculate_range_for_test(4, 94, 30, 15, &[20, 50, 80]);
 
         assert_eq!(bounds, (34, 94));
         assert_eq!(ranges, vec![(0, 1), (1, 1), (2, 1)]);
+    }
+
+    /// Calculates exact offsets directly from the range predicate used by PromQL.
+    ///
+    /// Input timestamps are sorted and non-null. Interval is positive, range is
+    /// nonnegative, and test values are chosen to avoid `i64` overflow.
+    fn calculate_range_oracle(
+        timestamps: &[i64],
+        start: i64,
+        end: i64,
+        interval: i64,
+        range: i64,
+    ) -> Vec<(u32, u32)> {
+        // Match `calculate_range`'s explicit empty-input early return.
+        if timestamps.is_empty() || start > end {
+            return vec![];
+        }
+
+        (start..=end)
+            .step_by(interval as usize)
+            .map(|curr| {
+                let mut offset = None;
+                let mut length = 0;
+                for (index, &ts) in timestamps.iter().enumerate() {
+                    if ts > curr - range && ts <= curr {
+                        offset.get_or_insert(index);
+                        length += 1;
+                    }
+                }
+                (offset.unwrap_or(0) as u32, length)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn calculate_range_characterizes_returned_bounds() {
+        let cases = [
+            (
+                "positive non-aligned last timestamp plus range",
+                0,
+                100,
+                10,
+                9,
+                vec![13, 26],
+                (20, 30),
+            ),
+            (
+                "negative non-aligned last timestamp plus range",
+                -50,
+                50,
+                10,
+                9,
+                vec![-37, -26],
+                (-30, -20),
+            ),
+            (
+                "query alignment not based on epoch",
+                4,
+                94,
+                30,
+                15,
+                vec![20, 50, 80],
+                (34, 94),
+            ),
+            ("leading data", 0, 100, 10, 10, vec![-10, 15], (0, 20)),
+            (
+                "trailing data past query end",
+                0,
+                100,
+                10,
+                10,
+                vec![35, 45, 110],
+                (40, 100),
+            ),
+            (
+                "optimized start after query end",
+                0,
+                50,
+                10,
+                0,
+                vec![100],
+                (100, 50),
+            ),
+        ];
+
+        for (name, query_start, query_end, interval, range, timestamps, expected_bounds) in cases {
+            let (_, bounds) =
+                calculate_range_for_test(query_start, query_end, interval, range, &timestamps);
+            assert_eq!(bounds, expected_bounds, "{name}");
+        }
+    }
+
+    #[test]
+    fn calculate_range_matches_bruteforce_oracle_for_deterministic_cases() {
+        let cases = vec![
+            (
+                "duplicate lower and upper bounds",
+                vec![0, 10, 10, 20, 20, 30],
+                10,
+                20,
+                10,
+                10,
+            ),
+            (
+                "zero range excludes duplicates at current timestamp",
+                vec![10, 10, 10],
+                10,
+                10,
+                1,
+                0,
+            ),
+            (
+                "consecutive nonempty empty nonempty ranges",
+                vec![10, 30],
+                10,
+                30,
+                10,
+                5,
+            ),
+            ("step smaller than range", vec![0, 4, 8, 12], 0, 12, 3, 5),
+            ("step equal to range", vec![0, 5, 10, 15], 0, 15, 5, 5),
+            ("step greater than range", vec![0, 7, 14, 21], 0, 21, 7, 3),
+            (
+                "negative sparse/tail timestamps",
+                vec![-30, -20, -10, 0],
+                -25,
+                5,
+                5,
+                7,
+            ),
+            ("one sample", vec![42], 0, 100, 10, 15),
+            ("empty input", vec![], -20, 20, 5, 10),
+        ];
+
+        for (name, timestamps, query_start, query_end, interval, range) in cases {
+            let (actual, (start, end)) =
+                calculate_range_for_test(query_start, query_end, interval, range, &timestamps);
+            let expected = calculate_range_oracle(&timestamps, start, end, interval, range);
+            assert_eq!(actual, expected, "{name}");
+        }
+    }
+
+    #[test]
+    fn calculate_range_positive_time_translated_regression() {
+        let timestamps = [0, 10, 20, 30];
+        let expected = vec![(0, 1), (1, 1), (1, 1), (2, 1), (2, 1), (3, 1), (3, 1)];
+        let (actual, bounds) = calculate_range_for_test(5, 35, 5, 7, &timestamps);
+
+        assert_eq!(bounds, (5, 35));
+        assert_eq!(
+            calculate_range_oracle(&timestamps, bounds.0, bounds.1, 5, 7),
+            expected
+        );
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn calculate_range_matches_oracle_for_dense_positive_time_windows() {
+        let timestamps = (0..=3_600).step_by(15).collect::<Vec<i64>>();
+
+        for (name, range) in [
+            ("one minute", 60),
+            ("five minutes", 300),
+            ("one hour", 3_600),
+        ] {
+            let (actual, (start, end)) = calculate_range_for_test(0, 3_600, 15, range, &timestamps);
+            assert_eq!((start, end), (0, 3_600), "{name} bounds");
+            assert_eq!(
+                actual,
+                calculate_range_oracle(&timestamps, start, end, 15, range),
+                "{name} window"
+            );
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    struct TinyPrng(u64);
+
+    impl TinyPrng {
+        fn next_u64(&mut self) -> u64 {
+            self.0 ^= self.0 << 13;
+            self.0 ^= self.0 >> 7;
+            self.0 ^= self.0 << 17;
+            self.0
+        }
+
+        fn next_i64(&mut self, min: i64, max: i64) -> i64 {
+            min + (self.next_u64() % (max - min + 1) as u64) as i64
+        }
+    }
+
+    #[test]
+    fn calculate_range_matches_bruteforce_oracle_for_seeded_matrix() {
+        let mut prng = TinyPrng(0x5eed_cafe_f00d_baad);
+
+        for case in 0..512 {
+            let interval = prng.next_i64(1, 11);
+            let range = prng.next_i64(0, 25);
+            let query_start = prng.next_i64(-200, 200);
+            let query_end = query_start + interval * prng.next_i64(0, 20);
+            let mut timestamps = Vec::new();
+            let mut timestamp = prng.next_i64(-250, 250);
+            for _ in 0..prng.next_i64(0, 20) {
+                timestamp += prng.next_i64(0, 7);
+                timestamps.push(timestamp);
+            }
+
+            let (actual, (start, end)) =
+                calculate_range_for_test(query_start, query_end, interval, range, &timestamps);
+            let expected = calculate_range_oracle(&timestamps, start, end, interval, range);
+            assert_eq!(
+                actual, expected,
+                "case={case}, timestamps={timestamps:?}, query=({query_start}, {query_end}), \
+                 interval={interval}, range={range}, bounds=({start}, {end})"
+            );
+        }
     }
 }

--- a/src/promql/src/functions.rs
+++ b/src/promql/src/functions.rs
@@ -16,6 +16,7 @@ mod aggr_over_time;
 mod changes;
 mod deriv;
 mod double_exponential_smoothing;
+mod edge_count;
 mod extrapolate_rate;
 mod idelta;
 mod native_histogram;

--- a/src/promql/src/functions/changes.rs
+++ b/src/promql/src/functions/changes.rs
@@ -15,23 +15,9 @@
 //! Implementation of [`changes`](https://prometheus.io/docs/prometheus/latest/querying/functions/#changes) in PromQL. Refer to the [original
 //! implementation](https://github.com/prometheus/prometheus/blob/main/promql/functions.go#L1023-L1040).
 
-#[cfg(test)]
-use std::sync::Arc;
-
-use datafusion::arrow::array::{Float64Array, TimestampMillisecondArray};
-#[cfg(test)]
-use datafusion::common::DataFusionError;
 use datafusion::logical_expr::ScalarUDF;
-#[cfg(test)]
-use datafusion::physical_plan::ColumnarValue;
-#[cfg(test)]
-use datatypes::arrow::array::Array;
-#[cfg(test)]
-use datatypes::arrow::datatypes::DataType;
 
 use crate::functions::edge_count::{self, EdgeKind};
-#[cfg(test)]
-use crate::range_array::RangeArray;
 
 /// used to count the number of value changes that occur within a specific time range
 #[derive(Debug)]
@@ -47,33 +33,21 @@ impl Changes {
     }
 }
 
-#[allow(dead_code)]
-fn changes(_: &TimestampMillisecondArray, values: &Float64Array) -> Option<f64> {
-    if values.is_empty() {
-        None
-    } else {
-        let (first, rest) = values.values().split_first().unwrap();
-        let mut num_changes = 0;
-        let mut prev_element = first;
-        for cur_element in rest {
-            if cur_element != prev_element && !(cur_element.is_nan() && prev_element.is_nan()) {
-                num_changes += 1;
-            }
-            prev_element = cur_element;
-        }
-        Some(num_changes as f64)
-    }
-}
-
 #[cfg(test)]
 mod test {
+    use std::sync::Arc;
+
+    use datafusion::arrow::array::{Array, Float64Array, TimestampMillisecondArray};
     use datafusion::arrow::buffer::NullBuffer;
+    use datafusion::common::DataFusionError;
+    use datafusion::physical_plan::ColumnarValue;
     use datafusion_common::config::ConfigOptions;
     use datafusion_expr::ScalarFunctionArgs;
-    use datatypes::arrow::datatypes::Field;
+    use datatypes::arrow::datatypes::{DataType, Field};
 
     use super::*;
     use crate::functions::test_util::simple_range_udf_runner;
+    use crate::range_array::RangeArray;
 
     // build timestamp range and value range arrays for test
     fn build_test_range_arrays(
@@ -208,12 +182,10 @@ mod test {
         value_ranges: Vec<(u32, u32)>,
     ) -> Vec<Option<f64>> {
         assert_eq!(timestamp_ranges.len(), value_ranges.len());
-        assert!(
-            timestamp_ranges
-                .iter()
-                .zip(&value_ranges)
-                .all(|((_, timestamp_length), (_, value_length))| timestamp_length == value_length)
-        );
+        assert!(timestamp_ranges
+            .iter()
+            .zip(&value_ranges)
+            .all(|((_, timestamp_length), (_, value_length))| timestamp_length == value_length));
         assert_eq!(values.len(), raw_values.len());
         let nulls = values.iter().map(Option::is_none).collect::<Vec<_>>();
 

--- a/src/promql/src/functions/changes.rs
+++ b/src/promql/src/functions/changes.rs
@@ -182,10 +182,12 @@ mod test {
         value_ranges: Vec<(u32, u32)>,
     ) -> Vec<Option<f64>> {
         assert_eq!(timestamp_ranges.len(), value_ranges.len());
-        assert!(timestamp_ranges
-            .iter()
-            .zip(&value_ranges)
-            .all(|((_, timestamp_length), (_, value_length))| timestamp_length == value_length));
+        assert!(
+            timestamp_ranges
+                .iter()
+                .zip(&value_ranges)
+                .all(|((_, timestamp_length), (_, value_length))| timestamp_length == value_length)
+        );
         assert_eq!(values.len(), raw_values.len());
         let nulls = values.iter().map(Option::is_none).collect::<Vec<_>>();
 

--- a/src/promql/src/functions/changes.rs
+++ b/src/promql/src/functions/changes.rs
@@ -37,63 +37,28 @@ impl Changes {
 mod test {
     use std::sync::Arc;
 
-    use datafusion::arrow::array::{Array, Float64Array, TimestampMillisecondArray};
+    use datafusion::arrow::array::{Float64Array, TimestampMillisecondArray};
     use datafusion::arrow::buffer::NullBuffer;
-    use datafusion::common::DataFusionError;
-    use datafusion::physical_plan::ColumnarValue;
-    use datafusion_common::config::ConfigOptions;
-    use datafusion_expr::ScalarFunctionArgs;
-    use datatypes::arrow::datatypes::{DataType, Field};
+    use datatypes::arrow::array::Array;
 
     use super::*;
-    use crate::functions::test_util::simple_range_udf_runner;
+    use crate::functions::test_util::{
+        self, STALE_NAN, TinyPrng, assert_execution_error, build_test_range_arrays,
+        invoke_range_udf, simple_range_udf_runner,
+    };
     use crate::range_array::RangeArray;
 
-    // build timestamp range and value range arrays for test
-    fn build_test_range_arrays(
-        timestamps: Vec<i64>,
-        values: Vec<f64>,
-        ranges: Vec<(u32, u32)>,
-    ) -> (RangeArray, RangeArray) {
-        let ts_array = Arc::new(TimestampMillisecondArray::from_iter(
-            timestamps.into_iter().map(Some),
-        ));
-        let values_array = Arc::new(Float64Array::from_iter(values));
-
-        let ts_range_array = RangeArray::from_ranges(ts_array, ranges.clone()).unwrap();
-        let value_range_array = RangeArray::from_ranges(values_array, ranges).unwrap();
-
-        (ts_range_array, value_range_array)
-    }
-
-    fn invoke_range_udf(
-        udf: ScalarUDF,
-        timestamps: RangeArray,
-        values: RangeArray,
-    ) -> Result<ColumnarValue, DataFusionError> {
-        let number_rows = timestamps.len();
-        let args = vec![
-            ColumnarValue::Array(Arc::new(timestamps.into_dict())),
-            ColumnarValue::Array(Arc::new(values.into_dict())),
-        ];
-        let arg_fields = vec![
-            Arc::new(Field::new("timestamps", args[0].data_type(), false)),
-            Arc::new(Field::new("values", args[1].data_type(), false)),
-        ];
-        udf.invoke_with_args(ScalarFunctionArgs {
-            args,
-            arg_fields,
-            number_rows,
-            return_field: Arc::new(Field::new("result", DataType::Float64, false)),
-            config_options: Arc::new(ConfigOptions::default()),
-        })
-    }
-
-    fn assert_execution_error(error: DataFusionError, expected: &str) {
-        match error {
-            DataFusionError::Execution(message) => assert_eq!(message, expected),
-            other => panic!("expected execution error, got {other:?}"),
+    fn changes_oracle(values: &[f64]) -> Option<f64> {
+        let (first, rest) = values.split_first()?;
+        let mut changes = 0;
+        let mut previous = first;
+        for current in rest {
+            if current != previous && !(current.is_nan() && previous.is_nan()) {
+                changes += 1;
+            }
+            previous = current;
         }
+        Some(changes as f64)
     }
 
     #[test]
@@ -145,87 +110,6 @@ mod test {
         );
     }
 
-    const STALE_NAN: f64 = f64::from_bits(0x7ff0_0000_0000_0002);
-
-    struct TinyPrng(u64);
-
-    impl TinyPrng {
-        fn next_u32(&mut self) -> u32 {
-            self.0 ^= self.0 << 13;
-            self.0 ^= self.0 >> 7;
-            self.0 ^= self.0 << 17;
-            self.0 as u32
-        }
-
-        fn next_index(&mut self, bound: usize) -> usize {
-            (self.next_u32() as usize) % bound
-        }
-    }
-
-    fn changes_oracle(values: &[f64]) -> Option<f64> {
-        let (first, rest) = values.split_first()?;
-        let mut changes = 0;
-        let mut previous = first;
-        for current in rest {
-            if current != previous && !(current.is_nan() && previous.is_nan()) {
-                changes += 1;
-            }
-            previous = current;
-        }
-        Some(changes as f64)
-    }
-
-    fn run_oracle_ranges(
-        values: Vec<Option<f64>>,
-        raw_values: Vec<f64>,
-        timestamp_ranges: Vec<(u32, u32)>,
-        value_ranges: Vec<(u32, u32)>,
-    ) -> Vec<Option<f64>> {
-        assert_eq!(timestamp_ranges.len(), value_ranges.len());
-        assert!(
-            timestamp_ranges
-                .iter()
-                .zip(&value_ranges)
-                .all(|((_, timestamp_length), (_, value_length))| timestamp_length == value_length)
-        );
-        assert_eq!(values.len(), raw_values.len());
-        let nulls = values.iter().map(Option::is_none).collect::<Vec<_>>();
-
-        let expected = value_ranges
-            .iter()
-            .map(|(offset, length)| {
-                changes_oracle(&raw_values[*offset as usize..(*offset + *length) as usize])
-            })
-            .collect::<Vec<_>>();
-
-        let timestamp_values = (0..64)
-            .map(|value| Some(i64::from(value) * 1_000))
-            .collect::<Vec<_>>();
-        let timestamp_array = Arc::new(TimestampMillisecondArray::from_iter(timestamp_values));
-        let value_array = Arc::new(Float64Array::from_iter(values));
-        for (index, ((actual, expected), is_null)) in value_array
-            .values()
-            .iter()
-            .zip(&raw_values)
-            .zip(nulls)
-            .enumerate()
-        {
-            assert_eq!(actual.to_bits(), expected.to_bits());
-            assert_eq!(value_array.is_null(index), is_null);
-        }
-
-        let timestamp_ranges = RangeArray::from_ranges(timestamp_array, timestamp_ranges).unwrap();
-        let value_ranges = RangeArray::from_ranges(value_array, value_ranges).unwrap();
-        simple_range_udf_runner(
-            Changes::scalar_udf(),
-            timestamp_ranges,
-            value_ranges,
-            vec![],
-            expected.clone(),
-        );
-        expected
-    }
-
     #[test]
     fn changes_range_array_oracle_edge_cases() {
         let values = vec![
@@ -246,22 +130,26 @@ mod test {
             Some(0.0),
         ];
         let raw_values = values.iter().map(|value| value.unwrap()).collect();
-        let expected = run_oracle_ranges(
+        let expected = test_util::run_oracle_ranges(
             values,
             raw_values,
             vec![(5, 0), (2, 1), (7, 5), (0, 5), (11, 5), (16, 4)],
             vec![(0, 0), (0, 1), (4, 5), (0, 5), (8, 5), (1, 4)],
+            changes_oracle,
+            Changes::scalar_udf(),
         );
         assert_eq!(
             expected,
             vec![None, Some(0.0), Some(2.0), Some(2.0), Some(4.0), Some(2.0)]
         );
 
-        let expected = run_oracle_ranges(
+        let expected = test_util::run_oracle_ranges(
             vec![Some(2.0), None, Some(2.0)],
             vec![2.0, 0.0, 2.0],
             vec![(9, 3), (1, 1)],
             vec![(0, 3), (1, 1)],
+            changes_oracle,
+            Changes::scalar_udf(),
         );
         assert_eq!(expected, vec![Some(2.0), Some(0.0)]);
     }
@@ -292,7 +180,14 @@ mod test {
             value_ranges.push((prng.next_index(49 - length as usize) as u32, length));
         }
 
-        run_oracle_ranges(values, raw_values, timestamp_ranges, value_ranges);
+        test_util::run_oracle_ranges(
+            values,
+            raw_values,
+            timestamp_ranges,
+            value_ranges,
+            changes_oracle,
+            Changes::scalar_udf(),
+        );
     }
 
     #[test]

--- a/src/promql/src/functions/changes.rs
+++ b/src/promql/src/functions/changes.rs
@@ -15,22 +15,40 @@
 //! Implementation of [`changes`](https://prometheus.io/docs/prometheus/latest/querying/functions/#changes) in PromQL. Refer to the [original
 //! implementation](https://github.com/prometheus/prometheus/blob/main/promql/functions.go#L1023-L1040).
 
+#[cfg(test)]
 use std::sync::Arc;
 
-use common_macro::range_fn;
 use datafusion::arrow::array::{Float64Array, TimestampMillisecondArray};
+#[cfg(test)]
 use datafusion::common::DataFusionError;
-use datafusion::logical_expr::{ScalarUDF, Volatility};
+use datafusion::logical_expr::ScalarUDF;
+#[cfg(test)]
 use datafusion::physical_plan::ColumnarValue;
+#[cfg(test)]
 use datatypes::arrow::array::Array;
+#[cfg(test)]
 use datatypes::arrow::datatypes::DataType;
 
-use crate::functions::extract_array;
+use crate::functions::edge_count::{self, EdgeKind};
+#[cfg(test)]
 use crate::range_array::RangeArray;
 
 /// used to count the number of value changes that occur within a specific time range
-#[range_fn(name = Changes, ret = Float64Array, display_name = prom_changes)]
-pub fn changes(_: &TimestampMillisecondArray, values: &Float64Array) -> Option<f64> {
+#[derive(Debug)]
+pub struct Changes {}
+
+impl Changes {
+    pub const fn name() -> &'static str {
+        "prom_changes"
+    }
+
+    pub fn scalar_udf() -> ScalarUDF {
+        edge_count::scalar_udf(Self::name(), EdgeKind::Changes)
+    }
+}
+
+#[allow(dead_code)]
+fn changes(_: &TimestampMillisecondArray, values: &Float64Array) -> Option<f64> {
     if values.is_empty() {
         None
     } else {
@@ -49,6 +67,11 @@ pub fn changes(_: &TimestampMillisecondArray, values: &Float64Array) -> Option<f
 
 #[cfg(test)]
 mod test {
+    use datafusion::arrow::buffer::NullBuffer;
+    use datafusion_common::config::ConfigOptions;
+    use datafusion_expr::ScalarFunctionArgs;
+    use datatypes::arrow::datatypes::Field;
+
     use super::*;
     use crate::functions::test_util::simple_range_udf_runner;
 
@@ -67,6 +90,36 @@ mod test {
         let value_range_array = RangeArray::from_ranges(values_array, ranges).unwrap();
 
         (ts_range_array, value_range_array)
+    }
+
+    fn invoke_range_udf(
+        udf: ScalarUDF,
+        timestamps: RangeArray,
+        values: RangeArray,
+    ) -> Result<ColumnarValue, DataFusionError> {
+        let number_rows = timestamps.len();
+        let args = vec![
+            ColumnarValue::Array(Arc::new(timestamps.into_dict())),
+            ColumnarValue::Array(Arc::new(values.into_dict())),
+        ];
+        let arg_fields = vec![
+            Arc::new(Field::new("timestamps", args[0].data_type(), false)),
+            Arc::new(Field::new("values", args[1].data_type(), false)),
+        ];
+        udf.invoke_with_args(ScalarFunctionArgs {
+            args,
+            arg_fields,
+            number_rows,
+            return_field: Arc::new(Field::new("result", DataType::Float64, false)),
+            config_options: Arc::new(ConfigOptions::default()),
+        })
+    }
+
+    fn assert_execution_error(error: DataFusionError, expected: &str) {
+        match error {
+            DataFusionError::Execution(message) => assert_eq!(message, expected),
+            other => panic!("expected execution error, got {other:?}"),
+        }
     }
 
     #[test]
@@ -115,6 +168,249 @@ mod test {
             value_array_3,
             vec![],
             vec![Some(0.0), Some(0.0), Some(1.0), Some(1.0), None],
+        );
+    }
+
+    const STALE_NAN: f64 = f64::from_bits(0x7ff0_0000_0000_0002);
+
+    struct TinyPrng(u64);
+
+    impl TinyPrng {
+        fn next_u32(&mut self) -> u32 {
+            self.0 ^= self.0 << 13;
+            self.0 ^= self.0 >> 7;
+            self.0 ^= self.0 << 17;
+            self.0 as u32
+        }
+
+        fn next_index(&mut self, bound: usize) -> usize {
+            (self.next_u32() as usize) % bound
+        }
+    }
+
+    fn changes_oracle(values: &[f64]) -> Option<f64> {
+        let (first, rest) = values.split_first()?;
+        let mut changes = 0;
+        let mut previous = first;
+        for current in rest {
+            if current != previous && !(current.is_nan() && previous.is_nan()) {
+                changes += 1;
+            }
+            previous = current;
+        }
+        Some(changes as f64)
+    }
+
+    fn run_oracle_ranges(
+        values: Vec<Option<f64>>,
+        raw_values: Vec<f64>,
+        timestamp_ranges: Vec<(u32, u32)>,
+        value_ranges: Vec<(u32, u32)>,
+    ) -> Vec<Option<f64>> {
+        assert_eq!(timestamp_ranges.len(), value_ranges.len());
+        assert!(
+            timestamp_ranges
+                .iter()
+                .zip(&value_ranges)
+                .all(|((_, timestamp_length), (_, value_length))| timestamp_length == value_length)
+        );
+        assert_eq!(values.len(), raw_values.len());
+        let nulls = values.iter().map(Option::is_none).collect::<Vec<_>>();
+
+        let expected = value_ranges
+            .iter()
+            .map(|(offset, length)| {
+                changes_oracle(&raw_values[*offset as usize..(*offset + *length) as usize])
+            })
+            .collect::<Vec<_>>();
+
+        let timestamp_values = (0..64)
+            .map(|value| Some(i64::from(value) * 1_000))
+            .collect::<Vec<_>>();
+        let timestamp_array = Arc::new(TimestampMillisecondArray::from_iter(timestamp_values));
+        let value_array = Arc::new(Float64Array::from_iter(values));
+        for (index, ((actual, expected), is_null)) in value_array
+            .values()
+            .iter()
+            .zip(&raw_values)
+            .zip(nulls)
+            .enumerate()
+        {
+            assert_eq!(actual.to_bits(), expected.to_bits());
+            assert_eq!(value_array.is_null(index), is_null);
+        }
+
+        let timestamp_ranges = RangeArray::from_ranges(timestamp_array, timestamp_ranges).unwrap();
+        let value_ranges = RangeArray::from_ranges(value_array, value_ranges).unwrap();
+        simple_range_udf_runner(
+            Changes::scalar_udf(),
+            timestamp_ranges,
+            value_ranges,
+            vec![],
+            expected.clone(),
+        );
+        expected
+    }
+
+    #[test]
+    fn changes_range_array_oracle_edge_cases() {
+        let values = vec![
+            Some(-0.0),
+            Some(0.0),
+            Some(f64::INFINITY),
+            Some(f64::INFINITY),
+            Some(f64::NEG_INFINITY),
+            Some(f64::NAN),
+            Some(STALE_NAN),
+            Some(f64::NAN),
+            Some(3.0),
+            Some(1.0),
+            Some(2.0),
+            Some(3.0),
+            Some(1.0),
+            Some(3.0),
+            Some(0.0),
+        ];
+        let raw_values = values.iter().map(|value| value.unwrap()).collect();
+        let expected = run_oracle_ranges(
+            values,
+            raw_values,
+            vec![(5, 0), (2, 1), (7, 5), (0, 5), (11, 5), (16, 4)],
+            vec![(0, 0), (0, 1), (4, 5), (0, 5), (8, 5), (1, 4)],
+        );
+        assert_eq!(
+            expected,
+            vec![None, Some(0.0), Some(2.0), Some(2.0), Some(4.0), Some(2.0)]
+        );
+
+        let expected = run_oracle_ranges(
+            vec![Some(2.0), None, Some(2.0)],
+            vec![2.0, 0.0, 2.0],
+            vec![(9, 3), (1, 1)],
+            vec![(0, 3), (1, 1)],
+        );
+        assert_eq!(expected, vec![Some(2.0), Some(0.0)]);
+    }
+
+    #[test]
+    fn changes_range_array_seeded_differential() {
+        let mut prng = TinyPrng(0x2f6e_2b1d_834a_90c5);
+        let raw_values = (0..48)
+            .map(|_| match prng.next_index(12) {
+                0 => -0.0,
+                1 => 0.0,
+                2 => -2.0,
+                3 => -1.0,
+                4 => 1.0,
+                5 => 2.0,
+                6 => f64::INFINITY,
+                7 => f64::NEG_INFINITY,
+                8 | 9 => f64::NAN,
+                _ => STALE_NAN,
+            })
+            .collect::<Vec<_>>();
+        let values = raw_values.iter().copied().map(Some).collect();
+        let mut timestamp_ranges = Vec::new();
+        let mut value_ranges = Vec::new();
+        for _ in 0..32 {
+            let length = prng.next_index(13) as u32;
+            timestamp_ranges.push((prng.next_index(65 - length as usize) as u32, length));
+            value_ranges.push((prng.next_index(49 - length as usize) as u32, length));
+        }
+
+        run_oracle_ranges(values, raw_values, timestamp_ranges, value_ranges);
+    }
+
+    #[test]
+    fn changes_range_array_mismatch_errors() {
+        let timestamps = Arc::new(TimestampMillisecondArray::from_iter([
+            Some(0),
+            Some(1),
+            Some(2),
+        ]));
+        let values = Arc::new(Float64Array::from_iter([1.0, 2.0, 3.0]));
+        let error = invoke_range_udf(
+            Changes::scalar_udf(),
+            RangeArray::from_ranges(timestamps.clone(), [(0, 1), (1, 1)]).unwrap(),
+            RangeArray::from_ranges(values.clone(), [(0, 1)]).unwrap(),
+        )
+        .unwrap_err();
+        assert_execution_error(
+            error,
+            "RangeArray have different lengths in PromQL function prom_changes: array1=2, array2=1",
+        );
+
+        let error = invoke_range_udf(
+            Changes::scalar_udf(),
+            RangeArray::from_ranges(timestamps, [(0, 1), (1, 2)]).unwrap(),
+            RangeArray::from_ranges(values, [(0, 1), (1, 1)]).unwrap(),
+        )
+        .unwrap_err();
+        assert_execution_error(
+            error,
+            "RangeArray's element 1 have different lengths in PromQL function prom_changes: array1=2, array2=1",
+        );
+    }
+
+    #[test]
+    fn changes_range_array_boundaries_and_raw_nulls() {
+        // The 0.0 -> 1.0 edge enters the range; both identical windows contain no changes.
+        let (timestamps, values) = build_test_range_arrays(
+            vec![0, 1, 2, 3],
+            vec![0.0, 1.0, 1.0, 1.0],
+            vec![(1, 3), (1, 3)],
+        );
+        simple_range_udf_runner(
+            Changes::scalar_udf(),
+            timestamps,
+            values,
+            vec![],
+            vec![Some(0.0), Some(0.0)],
+        );
+
+        let (timestamps, values) = build_test_range_arrays(
+            vec![0, 1, 2, 3],
+            vec![1.0, 2.0, 3.0, 4.0],
+            vec![(0, 0), (2, 0), (4, 0)],
+        );
+        simple_range_udf_runner(
+            Changes::scalar_udf(),
+            timestamps,
+            values,
+            vec![],
+            vec![None, None, None],
+        );
+
+        let (timestamps, values) = build_test_range_arrays(
+            vec![0, 1, 2, 3],
+            vec![1.0, 2.0, 3.0, 4.0],
+            vec![(0, 1), (2, 1), (3, 1)],
+        );
+        simple_range_udf_runner(
+            Changes::scalar_udf(),
+            timestamps,
+            values,
+            vec![],
+            vec![Some(0.0), Some(0.0), Some(0.0)],
+        );
+
+        let values = Arc::new(Float64Array::new(
+            vec![10.0, 7.0, 10.0].into(),
+            Some(NullBuffer::from(vec![true, false, true])),
+        ));
+        assert!(!values.is_valid(1));
+        assert_eq!(values.value(1), 7.0);
+        let timestamps = Arc::new(TimestampMillisecondArray::from_iter([
+            Some(0),
+            Some(1),
+            Some(2),
+        ]));
+        simple_range_udf_runner(
+            Changes::scalar_udf(),
+            RangeArray::from_ranges(timestamps, [(0, 3)]).unwrap(),
+            RangeArray::from_ranges(values, [(0, 3)]).unwrap(),
+            vec![],
+            vec![Some(2.0)],
         );
     }
 }

--- a/src/promql/src/functions/edge_count.rs
+++ b/src/promql/src/functions/edge_count.rs
@@ -1,0 +1,192 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Float64Array, TimestampMillisecondArray};
+use datafusion::common::DataFusionError;
+use datafusion::logical_expr::{ScalarUDF, Volatility};
+use datafusion::physical_plan::ColumnarValue;
+use datafusion_expr::create_udf;
+use datatypes::arrow::array::Array;
+use datatypes::arrow::datatypes::DataType;
+
+use crate::functions::extract_range_array;
+use crate::range_array::RangeArray;
+
+#[derive(Clone, Copy)]
+pub(super) enum EdgeKind {
+    Changes,
+    Resets,
+}
+
+pub(super) fn scalar_udf(name: &'static str, kind: EdgeKind) -> ScalarUDF {
+    create_udf(
+        name,
+        input_type(),
+        DataType::Float64,
+        Volatility::Volatile,
+        Arc::new(
+            move |input: &[ColumnarValue]| -> Result<ColumnarValue, DataFusionError> {
+                calc(input, name, kind)
+            },
+        ) as _,
+    )
+}
+
+fn input_type() -> Vec<DataType> {
+    vec![
+        RangeArray::convert_data_type(TimestampMillisecondArray::new_null(0).data_type().clone()),
+        RangeArray::convert_data_type(Float64Array::new_null(0).data_type().clone()),
+    ]
+}
+
+fn calc(
+    input: &[ColumnarValue],
+    name: &str,
+    kind: EdgeKind,
+) -> Result<ColumnarValue, DataFusionError> {
+    assert_eq!(input.len(), 2);
+
+    let timestamp_ranges = extract_range_array(&input[0])?;
+    let value_ranges = extract_range_array(&input[1])?;
+    if timestamp_ranges.len() != value_ranges.len() {
+        return Err(DataFusionError::Execution(format!(
+            "RangeArray have different lengths in PromQL function {name}: array1={}, array2={}",
+            timestamp_ranges.len(),
+            value_ranges.len()
+        )));
+    }
+
+    timestamp_ranges
+        .values()
+        .as_any()
+        .downcast_ref::<TimestampMillisecondArray>()
+        .unwrap();
+    let values = value_ranges
+        .values()
+        .as_any()
+        .downcast_ref::<Float64Array>()
+        .unwrap();
+    let requested_edges = validate_windows(&timestamp_ranges, &value_ranges, name)?;
+    let raw_values = values.values();
+    let direct = should_scan_direct(requested_edges, raw_values.len());
+    let prefix = (!direct).then(|| build_prefix(raw_values.as_ref(), kind));
+
+    let mut result = Vec::with_capacity(value_ranges.len());
+    for index in 0..value_ranges.len() {
+        let (offset, len) = range_at(&value_ranges, index, name)?;
+        let end = checked_end(offset, len, index, name)?;
+        let count = match len {
+            0 => None,
+            1 => Some(0),
+            _ if direct => Some(count_edges(raw_values.as_ref(), offset, end, kind)),
+            _ => {
+                let prefix = prefix.as_ref().unwrap();
+                Some(prefix[end - 1] - prefix[offset])
+            }
+        };
+        result.push(count.map(|count| count as f64));
+    }
+
+    Ok(ColumnarValue::Array(Arc::new(Float64Array::from_iter(
+        result,
+    ))))
+}
+
+fn validate_windows(
+    timestamps: &RangeArray,
+    values: &RangeArray,
+    name: &str,
+) -> Result<usize, DataFusionError> {
+    let mut requested_edges = 0usize;
+    for index in 0..values.len() {
+        let (timestamp_offset, timestamp_len) = range_at(timestamps, index, name)?;
+        let (value_offset, value_len) = range_at(values, index, name)?;
+        if timestamp_len != value_len {
+            return Err(DataFusionError::Execution(format!(
+                "RangeArray's element {index} have different lengths in PromQL function {name}: array1={timestamp_len}, array2={value_len}"
+            )));
+        }
+        checked_end(timestamp_offset, timestamp_len, index, name)?;
+        checked_end(value_offset, value_len, index, name)?;
+        requested_edges = requested_edges.saturating_add(value_len.saturating_sub(1));
+    }
+    Ok(requested_edges)
+}
+
+fn range_at(
+    ranges: &RangeArray,
+    index: usize,
+    name: &str,
+) -> Result<(usize, usize), DataFusionError> {
+    ranges.get_offset_length(index).ok_or_else(|| {
+        DataFusionError::Execution(format!(
+            "RangeArray's element {index} is unavailable in PromQL function {name}"
+        ))
+    })
+}
+
+fn checked_end(
+    offset: usize,
+    len: usize,
+    index: usize,
+    name: &str,
+) -> Result<usize, DataFusionError> {
+    offset.checked_add(len).ok_or_else(|| {
+        DataFusionError::Execution(format!(
+            "RangeArray's element {index} has an invalid range in PromQL function {name}"
+        ))
+    })
+}
+
+fn should_scan_direct(requested_edges: usize, backing_len: usize) -> bool {
+    requested_edges <= backing_len.saturating_sub(1)
+}
+
+fn build_prefix(values: &[f64], kind: EdgeKind) -> Vec<u64> {
+    let mut prefix = Vec::with_capacity(values.len());
+    prefix.push(0);
+    for index in 1..values.len() {
+        prefix.push(prefix[index - 1] + u64::from(is_edge(values[index - 1], values[index], kind)));
+    }
+    prefix
+}
+
+fn count_edges(values: &[f64], offset: usize, end: usize, kind: EdgeKind) -> u64 {
+    let mut count = 0;
+    for index in offset + 1..end {
+        count += u64::from(is_edge(values[index - 1], values[index], kind));
+    }
+    count
+}
+
+fn is_edge(previous: f64, current: f64, kind: EdgeKind) -> bool {
+    match kind {
+        EdgeKind::Changes => previous != current && !(previous.is_nan() && current.is_nan()),
+        EdgeKind::Resets => current < previous,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn adaptive_gate_uses_direct_scan_at_threshold() {
+        assert!(should_scan_direct(4, 5));
+        assert!(!should_scan_direct(5, 5));
+        assert!(should_scan_direct(0, 0));
+    }
+}

--- a/src/promql/src/functions/resets.rs
+++ b/src/promql/src/functions/resets.rs
@@ -182,10 +182,12 @@ mod test {
         value_ranges: Vec<(u32, u32)>,
     ) -> Vec<Option<f64>> {
         assert_eq!(timestamp_ranges.len(), value_ranges.len());
-        assert!(timestamp_ranges
-            .iter()
-            .zip(&value_ranges)
-            .all(|((_, timestamp_length), (_, value_length))| timestamp_length == value_length));
+        assert!(
+            timestamp_ranges
+                .iter()
+                .zip(&value_ranges)
+                .all(|((_, timestamp_length), (_, value_length))| timestamp_length == value_length)
+        );
         assert_eq!(values.len(), raw_values.len());
         let nulls = values.iter().map(Option::is_none).collect::<Vec<_>>();
 

--- a/src/promql/src/functions/resets.rs
+++ b/src/promql/src/functions/resets.rs
@@ -37,63 +37,28 @@ impl Resets {
 mod test {
     use std::sync::Arc;
 
-    use datafusion::arrow::array::{Array, Float64Array, TimestampMillisecondArray};
+    use datafusion::arrow::array::{Float64Array, TimestampMillisecondArray};
     use datafusion::arrow::buffer::NullBuffer;
-    use datafusion::common::DataFusionError;
-    use datafusion::physical_plan::ColumnarValue;
-    use datafusion_common::config::ConfigOptions;
-    use datafusion_expr::ScalarFunctionArgs;
-    use datatypes::arrow::datatypes::{DataType, Field};
+    use datatypes::arrow::array::Array;
 
     use super::*;
-    use crate::functions::test_util::simple_range_udf_runner;
+    use crate::functions::test_util::{
+        self, STALE_NAN, TinyPrng, assert_execution_error, build_test_range_arrays,
+        invoke_range_udf, simple_range_udf_runner,
+    };
     use crate::range_array::RangeArray;
 
-    // build timestamp range and value range arrays for test
-    fn build_test_range_arrays(
-        timestamps: Vec<i64>,
-        values: Vec<f64>,
-        ranges: Vec<(u32, u32)>,
-    ) -> (RangeArray, RangeArray) {
-        let ts_array = Arc::new(TimestampMillisecondArray::from_iter(
-            timestamps.into_iter().map(Some),
-        ));
-        let values_array = Arc::new(Float64Array::from_iter(values));
-
-        let ts_range_array = RangeArray::from_ranges(ts_array, ranges.clone()).unwrap();
-        let value_range_array = RangeArray::from_ranges(values_array, ranges).unwrap();
-
-        (ts_range_array, value_range_array)
-    }
-
-    fn invoke_range_udf(
-        udf: ScalarUDF,
-        timestamps: RangeArray,
-        values: RangeArray,
-    ) -> Result<ColumnarValue, DataFusionError> {
-        let number_rows = timestamps.len();
-        let args = vec![
-            ColumnarValue::Array(Arc::new(timestamps.into_dict())),
-            ColumnarValue::Array(Arc::new(values.into_dict())),
-        ];
-        let arg_fields = vec![
-            Arc::new(Field::new("timestamps", args[0].data_type(), false)),
-            Arc::new(Field::new("values", args[1].data_type(), false)),
-        ];
-        udf.invoke_with_args(ScalarFunctionArgs {
-            args,
-            arg_fields,
-            number_rows,
-            return_field: Arc::new(Field::new("result", DataType::Float64, false)),
-            config_options: Arc::new(ConfigOptions::default()),
-        })
-    }
-
-    fn assert_execution_error(error: DataFusionError, expected: &str) {
-        match error {
-            DataFusionError::Execution(message) => assert_eq!(message, expected),
-            other => panic!("expected execution error, got {other:?}"),
+    fn resets_oracle(values: &[f64]) -> Option<f64> {
+        let (first, rest) = values.split_first()?;
+        let mut resets = 0;
+        let mut previous = first;
+        for current in rest {
+            if current < previous {
+                resets += 1;
+            }
+            previous = current;
         }
+        Some(resets as f64)
     }
 
     #[test]
@@ -145,87 +110,6 @@ mod test {
         );
     }
 
-    const STALE_NAN: f64 = f64::from_bits(0x7ff0_0000_0000_0002);
-
-    struct TinyPrng(u64);
-
-    impl TinyPrng {
-        fn next_u32(&mut self) -> u32 {
-            self.0 ^= self.0 << 13;
-            self.0 ^= self.0 >> 7;
-            self.0 ^= self.0 << 17;
-            self.0 as u32
-        }
-
-        fn next_index(&mut self, bound: usize) -> usize {
-            (self.next_u32() as usize) % bound
-        }
-    }
-
-    fn resets_oracle(values: &[f64]) -> Option<f64> {
-        let (first, rest) = values.split_first()?;
-        let mut resets = 0;
-        let mut previous = first;
-        for current in rest {
-            if current < previous {
-                resets += 1;
-            }
-            previous = current;
-        }
-        Some(resets as f64)
-    }
-
-    fn run_oracle_ranges(
-        values: Vec<Option<f64>>,
-        raw_values: Vec<f64>,
-        timestamp_ranges: Vec<(u32, u32)>,
-        value_ranges: Vec<(u32, u32)>,
-    ) -> Vec<Option<f64>> {
-        assert_eq!(timestamp_ranges.len(), value_ranges.len());
-        assert!(
-            timestamp_ranges
-                .iter()
-                .zip(&value_ranges)
-                .all(|((_, timestamp_length), (_, value_length))| timestamp_length == value_length)
-        );
-        assert_eq!(values.len(), raw_values.len());
-        let nulls = values.iter().map(Option::is_none).collect::<Vec<_>>();
-
-        let expected = value_ranges
-            .iter()
-            .map(|(offset, length)| {
-                resets_oracle(&raw_values[*offset as usize..(*offset + *length) as usize])
-            })
-            .collect::<Vec<_>>();
-
-        let timestamp_values = (0..64)
-            .map(|value| Some(i64::from(value) * 1_000))
-            .collect::<Vec<_>>();
-        let timestamp_array = Arc::new(TimestampMillisecondArray::from_iter(timestamp_values));
-        let value_array = Arc::new(Float64Array::from_iter(values));
-        for (index, ((actual, expected), is_null)) in value_array
-            .values()
-            .iter()
-            .zip(&raw_values)
-            .zip(nulls)
-            .enumerate()
-        {
-            assert_eq!(actual.to_bits(), expected.to_bits());
-            assert_eq!(value_array.is_null(index), is_null);
-        }
-
-        let timestamp_ranges = RangeArray::from_ranges(timestamp_array, timestamp_ranges).unwrap();
-        let value_ranges = RangeArray::from_ranges(value_array, value_ranges).unwrap();
-        simple_range_udf_runner(
-            Resets::scalar_udf(),
-            timestamp_ranges,
-            value_ranges,
-            vec![],
-            expected.clone(),
-        );
-        expected
-    }
-
     #[test]
     fn resets_range_array_oracle_edge_cases() {
         let values = vec![
@@ -246,22 +130,26 @@ mod test {
             Some(0.0),
         ];
         let raw_values = values.iter().map(|value| value.unwrap()).collect();
-        let expected = run_oracle_ranges(
+        let expected = test_util::run_oracle_ranges(
             values,
             raw_values,
             vec![(5, 0), (2, 1), (7, 5), (0, 5), (11, 5), (16, 4)],
             vec![(0, 0), (0, 1), (4, 5), (0, 5), (8, 5), (1, 4)],
+            resets_oracle,
+            Resets::scalar_udf(),
         );
         assert_eq!(
             expected,
             vec![None, Some(0.0), Some(0.0), Some(1.0), Some(2.0), Some(1.0)]
         );
 
-        let expected = run_oracle_ranges(
+        let expected = test_util::run_oracle_ranges(
             vec![Some(2.0), None, Some(2.0)],
             vec![2.0, 0.0, 2.0],
             vec![(9, 3), (1, 1)],
             vec![(0, 3), (1, 1)],
+            resets_oracle,
+            Resets::scalar_udf(),
         );
         assert_eq!(expected, vec![Some(1.0), Some(0.0)]);
     }
@@ -292,7 +180,14 @@ mod test {
             value_ranges.push((prng.next_index(49 - length as usize) as u32, length));
         }
 
-        run_oracle_ranges(values, raw_values, timestamp_ranges, value_ranges);
+        test_util::run_oracle_ranges(
+            values,
+            raw_values,
+            timestamp_ranges,
+            value_ranges,
+            resets_oracle,
+            Resets::scalar_udf(),
+        );
     }
 
     #[test]

--- a/src/promql/src/functions/resets.rs
+++ b/src/promql/src/functions/resets.rs
@@ -15,23 +15,9 @@
 //! Implementation of [`reset`](https://prometheus.io/docs/prometheus/latest/querying/functions/#resets) in PromQL. Refer to the [original
 //! implementation](https://github.com/prometheus/prometheus/blob/90b2f7a540b8a70d8d81372e6692dcbb67ccbaaa/promql/functions.go#L1004-L1021).
 
-#[cfg(test)]
-use std::sync::Arc;
-
-use datafusion::arrow::array::{Float64Array, TimestampMillisecondArray};
-#[cfg(test)]
-use datafusion::common::DataFusionError;
 use datafusion::logical_expr::ScalarUDF;
-#[cfg(test)]
-use datafusion::physical_plan::ColumnarValue;
-#[cfg(test)]
-use datatypes::arrow::array::Array;
-#[cfg(test)]
-use datatypes::arrow::datatypes::DataType;
 
 use crate::functions::edge_count::{self, EdgeKind};
-#[cfg(test)]
-use crate::range_array::RangeArray;
 
 /// used to count the number of times the time series starts over.
 #[derive(Debug)]
@@ -47,33 +33,21 @@ impl Resets {
     }
 }
 
-#[allow(dead_code)]
-fn resets(_: &TimestampMillisecondArray, values: &Float64Array) -> Option<f64> {
-    if values.is_empty() {
-        None
-    } else {
-        let (first, rest) = values.values().split_first().unwrap();
-        let mut num_resets = 0;
-        let mut prev_element = first;
-        for cur_element in rest {
-            if cur_element < prev_element {
-                num_resets += 1;
-            }
-            prev_element = cur_element;
-        }
-        Some(num_resets as f64)
-    }
-}
-
 #[cfg(test)]
 mod test {
+    use std::sync::Arc;
+
+    use datafusion::arrow::array::{Array, Float64Array, TimestampMillisecondArray};
     use datafusion::arrow::buffer::NullBuffer;
+    use datafusion::common::DataFusionError;
+    use datafusion::physical_plan::ColumnarValue;
     use datafusion_common::config::ConfigOptions;
     use datafusion_expr::ScalarFunctionArgs;
-    use datatypes::arrow::datatypes::Field;
+    use datatypes::arrow::datatypes::{DataType, Field};
 
     use super::*;
     use crate::functions::test_util::simple_range_udf_runner;
+    use crate::range_array::RangeArray;
 
     // build timestamp range and value range arrays for test
     fn build_test_range_arrays(
@@ -208,12 +182,10 @@ mod test {
         value_ranges: Vec<(u32, u32)>,
     ) -> Vec<Option<f64>> {
         assert_eq!(timestamp_ranges.len(), value_ranges.len());
-        assert!(
-            timestamp_ranges
-                .iter()
-                .zip(&value_ranges)
-                .all(|((_, timestamp_length), (_, value_length))| timestamp_length == value_length)
-        );
+        assert!(timestamp_ranges
+            .iter()
+            .zip(&value_ranges)
+            .all(|((_, timestamp_length), (_, value_length))| timestamp_length == value_length));
         assert_eq!(values.len(), raw_values.len());
         let nulls = values.iter().map(Option::is_none).collect::<Vec<_>>();
 

--- a/src/promql/src/functions/resets.rs
+++ b/src/promql/src/functions/resets.rs
@@ -15,22 +15,40 @@
 //! Implementation of [`reset`](https://prometheus.io/docs/prometheus/latest/querying/functions/#resets) in PromQL. Refer to the [original
 //! implementation](https://github.com/prometheus/prometheus/blob/90b2f7a540b8a70d8d81372e6692dcbb67ccbaaa/promql/functions.go#L1004-L1021).
 
+#[cfg(test)]
 use std::sync::Arc;
 
-use common_macro::range_fn;
 use datafusion::arrow::array::{Float64Array, TimestampMillisecondArray};
+#[cfg(test)]
 use datafusion::common::DataFusionError;
-use datafusion::logical_expr::{ScalarUDF, Volatility};
+use datafusion::logical_expr::ScalarUDF;
+#[cfg(test)]
 use datafusion::physical_plan::ColumnarValue;
+#[cfg(test)]
 use datatypes::arrow::array::Array;
+#[cfg(test)]
 use datatypes::arrow::datatypes::DataType;
 
-use crate::functions::extract_array;
+use crate::functions::edge_count::{self, EdgeKind};
+#[cfg(test)]
 use crate::range_array::RangeArray;
 
 /// used to count the number of times the time series starts over.
-#[range_fn(name = Resets, ret = Float64Array, display_name = prom_resets)]
-pub fn resets(_: &TimestampMillisecondArray, values: &Float64Array) -> Option<f64> {
+#[derive(Debug)]
+pub struct Resets {}
+
+impl Resets {
+    pub const fn name() -> &'static str {
+        "prom_resets"
+    }
+
+    pub fn scalar_udf() -> ScalarUDF {
+        edge_count::scalar_udf(Self::name(), EdgeKind::Resets)
+    }
+}
+
+#[allow(dead_code)]
+fn resets(_: &TimestampMillisecondArray, values: &Float64Array) -> Option<f64> {
     if values.is_empty() {
         None
     } else {
@@ -49,6 +67,11 @@ pub fn resets(_: &TimestampMillisecondArray, values: &Float64Array) -> Option<f6
 
 #[cfg(test)]
 mod test {
+    use datafusion::arrow::buffer::NullBuffer;
+    use datafusion_common::config::ConfigOptions;
+    use datafusion_expr::ScalarFunctionArgs;
+    use datatypes::arrow::datatypes::Field;
+
     use super::*;
     use crate::functions::test_util::simple_range_udf_runner;
 
@@ -67,6 +90,36 @@ mod test {
         let value_range_array = RangeArray::from_ranges(values_array, ranges).unwrap();
 
         (ts_range_array, value_range_array)
+    }
+
+    fn invoke_range_udf(
+        udf: ScalarUDF,
+        timestamps: RangeArray,
+        values: RangeArray,
+    ) -> Result<ColumnarValue, DataFusionError> {
+        let number_rows = timestamps.len();
+        let args = vec![
+            ColumnarValue::Array(Arc::new(timestamps.into_dict())),
+            ColumnarValue::Array(Arc::new(values.into_dict())),
+        ];
+        let arg_fields = vec![
+            Arc::new(Field::new("timestamps", args[0].data_type(), false)),
+            Arc::new(Field::new("values", args[1].data_type(), false)),
+        ];
+        udf.invoke_with_args(ScalarFunctionArgs {
+            args,
+            arg_fields,
+            number_rows,
+            return_field: Arc::new(Field::new("result", DataType::Float64, false)),
+            config_options: Arc::new(ConfigOptions::default()),
+        })
+    }
+
+    fn assert_execution_error(error: DataFusionError, expected: &str) {
+        match error {
+            DataFusionError::Execution(message) => assert_eq!(message, expected),
+            other => panic!("expected execution error, got {other:?}"),
+        }
     }
 
     #[test]
@@ -115,6 +168,249 @@ mod test {
             value_array_3,
             vec![],
             vec![Some(0.0), Some(0.0), Some(0.0), Some(0.0), None],
+        );
+    }
+
+    const STALE_NAN: f64 = f64::from_bits(0x7ff0_0000_0000_0002);
+
+    struct TinyPrng(u64);
+
+    impl TinyPrng {
+        fn next_u32(&mut self) -> u32 {
+            self.0 ^= self.0 << 13;
+            self.0 ^= self.0 >> 7;
+            self.0 ^= self.0 << 17;
+            self.0 as u32
+        }
+
+        fn next_index(&mut self, bound: usize) -> usize {
+            (self.next_u32() as usize) % bound
+        }
+    }
+
+    fn resets_oracle(values: &[f64]) -> Option<f64> {
+        let (first, rest) = values.split_first()?;
+        let mut resets = 0;
+        let mut previous = first;
+        for current in rest {
+            if current < previous {
+                resets += 1;
+            }
+            previous = current;
+        }
+        Some(resets as f64)
+    }
+
+    fn run_oracle_ranges(
+        values: Vec<Option<f64>>,
+        raw_values: Vec<f64>,
+        timestamp_ranges: Vec<(u32, u32)>,
+        value_ranges: Vec<(u32, u32)>,
+    ) -> Vec<Option<f64>> {
+        assert_eq!(timestamp_ranges.len(), value_ranges.len());
+        assert!(
+            timestamp_ranges
+                .iter()
+                .zip(&value_ranges)
+                .all(|((_, timestamp_length), (_, value_length))| timestamp_length == value_length)
+        );
+        assert_eq!(values.len(), raw_values.len());
+        let nulls = values.iter().map(Option::is_none).collect::<Vec<_>>();
+
+        let expected = value_ranges
+            .iter()
+            .map(|(offset, length)| {
+                resets_oracle(&raw_values[*offset as usize..(*offset + *length) as usize])
+            })
+            .collect::<Vec<_>>();
+
+        let timestamp_values = (0..64)
+            .map(|value| Some(i64::from(value) * 1_000))
+            .collect::<Vec<_>>();
+        let timestamp_array = Arc::new(TimestampMillisecondArray::from_iter(timestamp_values));
+        let value_array = Arc::new(Float64Array::from_iter(values));
+        for (index, ((actual, expected), is_null)) in value_array
+            .values()
+            .iter()
+            .zip(&raw_values)
+            .zip(nulls)
+            .enumerate()
+        {
+            assert_eq!(actual.to_bits(), expected.to_bits());
+            assert_eq!(value_array.is_null(index), is_null);
+        }
+
+        let timestamp_ranges = RangeArray::from_ranges(timestamp_array, timestamp_ranges).unwrap();
+        let value_ranges = RangeArray::from_ranges(value_array, value_ranges).unwrap();
+        simple_range_udf_runner(
+            Resets::scalar_udf(),
+            timestamp_ranges,
+            value_ranges,
+            vec![],
+            expected.clone(),
+        );
+        expected
+    }
+
+    #[test]
+    fn resets_range_array_oracle_edge_cases() {
+        let values = vec![
+            Some(-0.0),
+            Some(0.0),
+            Some(f64::INFINITY),
+            Some(f64::INFINITY),
+            Some(f64::NEG_INFINITY),
+            Some(f64::NAN),
+            Some(STALE_NAN),
+            Some(f64::NAN),
+            Some(3.0),
+            Some(1.0),
+            Some(2.0),
+            Some(3.0),
+            Some(1.0),
+            Some(3.0),
+            Some(0.0),
+        ];
+        let raw_values = values.iter().map(|value| value.unwrap()).collect();
+        let expected = run_oracle_ranges(
+            values,
+            raw_values,
+            vec![(5, 0), (2, 1), (7, 5), (0, 5), (11, 5), (16, 4)],
+            vec![(0, 0), (0, 1), (4, 5), (0, 5), (8, 5), (1, 4)],
+        );
+        assert_eq!(
+            expected,
+            vec![None, Some(0.0), Some(0.0), Some(1.0), Some(2.0), Some(1.0)]
+        );
+
+        let expected = run_oracle_ranges(
+            vec![Some(2.0), None, Some(2.0)],
+            vec![2.0, 0.0, 2.0],
+            vec![(9, 3), (1, 1)],
+            vec![(0, 3), (1, 1)],
+        );
+        assert_eq!(expected, vec![Some(1.0), Some(0.0)]);
+    }
+
+    #[test]
+    fn resets_range_array_seeded_differential() {
+        let mut prng = TinyPrng(0x2f6e_2b1d_834a_90c5);
+        let raw_values = (0..48)
+            .map(|_| match prng.next_index(12) {
+                0 => -0.0,
+                1 => 0.0,
+                2 => -2.0,
+                3 => -1.0,
+                4 => 1.0,
+                5 => 2.0,
+                6 => f64::INFINITY,
+                7 => f64::NEG_INFINITY,
+                8 | 9 => f64::NAN,
+                _ => STALE_NAN,
+            })
+            .collect::<Vec<_>>();
+        let values = raw_values.iter().copied().map(Some).collect();
+        let mut timestamp_ranges = Vec::new();
+        let mut value_ranges = Vec::new();
+        for _ in 0..32 {
+            let length = prng.next_index(13) as u32;
+            timestamp_ranges.push((prng.next_index(65 - length as usize) as u32, length));
+            value_ranges.push((prng.next_index(49 - length as usize) as u32, length));
+        }
+
+        run_oracle_ranges(values, raw_values, timestamp_ranges, value_ranges);
+    }
+
+    #[test]
+    fn resets_range_array_mismatch_errors() {
+        let timestamps = Arc::new(TimestampMillisecondArray::from_iter([
+            Some(0),
+            Some(1),
+            Some(2),
+        ]));
+        let values = Arc::new(Float64Array::from_iter([1.0, 2.0, 3.0]));
+        let error = invoke_range_udf(
+            Resets::scalar_udf(),
+            RangeArray::from_ranges(timestamps.clone(), [(0, 1), (1, 1)]).unwrap(),
+            RangeArray::from_ranges(values.clone(), [(0, 1)]).unwrap(),
+        )
+        .unwrap_err();
+        assert_execution_error(
+            error,
+            "RangeArray have different lengths in PromQL function prom_resets: array1=2, array2=1",
+        );
+
+        let error = invoke_range_udf(
+            Resets::scalar_udf(),
+            RangeArray::from_ranges(timestamps, [(0, 1), (1, 2)]).unwrap(),
+            RangeArray::from_ranges(values, [(0, 1), (1, 1)]).unwrap(),
+        )
+        .unwrap_err();
+        assert_execution_error(
+            error,
+            "RangeArray's element 1 have different lengths in PromQL function prom_resets: array1=2, array2=1",
+        );
+    }
+
+    #[test]
+    fn resets_range_array_boundaries_and_raw_nulls() {
+        // The 3.0 -> 1.0 edge enters the range; both identical windows contain no resets.
+        let (timestamps, values) = build_test_range_arrays(
+            vec![0, 1, 2, 3],
+            vec![3.0, 1.0, 1.0, 1.0],
+            vec![(1, 3), (1, 3)],
+        );
+        simple_range_udf_runner(
+            Resets::scalar_udf(),
+            timestamps,
+            values,
+            vec![],
+            vec![Some(0.0), Some(0.0)],
+        );
+
+        let (timestamps, values) = build_test_range_arrays(
+            vec![0, 1, 2, 3],
+            vec![1.0, 2.0, 3.0, 4.0],
+            vec![(0, 0), (2, 0), (4, 0)],
+        );
+        simple_range_udf_runner(
+            Resets::scalar_udf(),
+            timestamps,
+            values,
+            vec![],
+            vec![None, None, None],
+        );
+
+        let (timestamps, values) = build_test_range_arrays(
+            vec![0, 1, 2, 3],
+            vec![1.0, 2.0, 3.0, 4.0],
+            vec![(0, 1), (2, 1), (3, 1)],
+        );
+        simple_range_udf_runner(
+            Resets::scalar_udf(),
+            timestamps,
+            values,
+            vec![],
+            vec![Some(0.0), Some(0.0), Some(0.0)],
+        );
+
+        let values = Arc::new(Float64Array::new(
+            vec![10.0, 7.0, 10.0].into(),
+            Some(NullBuffer::from(vec![true, false, true])),
+        ));
+        assert!(!values.is_valid(1));
+        assert_eq!(values.value(1), 7.0);
+        let timestamps = Arc::new(TimestampMillisecondArray::from_iter([
+            Some(0),
+            Some(1),
+            Some(2),
+        ]));
+        simple_range_udf_runner(
+            Resets::scalar_udf(),
+            RangeArray::from_ranges(timestamps, [(0, 3)]).unwrap(),
+            RangeArray::from_ranges(values, [(0, 3)]).unwrap(),
+            vec![],
+            vec![Some(1.0)],
         );
     }
 }

--- a/src/promql/src/functions/test_util.rs
+++ b/src/promql/src/functions/test_util.rs
@@ -14,12 +14,14 @@
 
 use std::sync::Arc;
 
-use datafusion::arrow::array::Float64Array;
+use datafusion::arrow::array::{Float64Array, TimestampMillisecondArray};
+use datafusion::common::DataFusionError;
 use datafusion::logical_expr::ScalarUDF;
 use datafusion::physical_plan::ColumnarValue;
 use datafusion_common::ScalarValue;
 use datafusion_common::config::ConfigOptions;
 use datafusion_expr::ScalarFunctionArgs;
+use datatypes::arrow::array::Array;
 use datatypes::arrow::datatypes::{DataType, Field};
 
 use crate::functions::extract_array;
@@ -72,4 +74,129 @@ pub fn simple_range_udf_runner(
                 _ => false,
             })
     );
+}
+
+/// Build timestamp range and value range arrays for test.
+pub fn build_test_range_arrays(
+    timestamps: Vec<i64>,
+    values: Vec<f64>,
+    ranges: Vec<(u32, u32)>,
+) -> (RangeArray, RangeArray) {
+    let ts_array = Arc::new(TimestampMillisecondArray::from_iter(
+        timestamps.into_iter().map(Some),
+    ));
+    let values_array = Arc::new(Float64Array::from_iter(values));
+
+    let ts_range_array = RangeArray::from_ranges(ts_array, ranges.clone()).unwrap();
+    let value_range_array = RangeArray::from_ranges(values_array, ranges).unwrap();
+
+    (ts_range_array, value_range_array)
+}
+
+/// Invoke a range UDF and return the raw `ColumnarValue`.
+pub fn invoke_range_udf(
+    udf: ScalarUDF,
+    timestamps: RangeArray,
+    values: RangeArray,
+) -> Result<ColumnarValue, DataFusionError> {
+    let number_rows = timestamps.len();
+    let args = vec![
+        ColumnarValue::Array(Arc::new(timestamps.into_dict())),
+        ColumnarValue::Array(Arc::new(values.into_dict())),
+    ];
+    let arg_fields = vec![
+        Arc::new(Field::new("timestamps", args[0].data_type(), false)),
+        Arc::new(Field::new("values", args[1].data_type(), false)),
+    ];
+    udf.invoke_with_args(ScalarFunctionArgs {
+        args,
+        arg_fields,
+        number_rows,
+        return_field: Arc::new(Field::new("result", DataType::Float64, false)),
+        config_options: Arc::new(ConfigOptions::default()),
+    })
+}
+
+/// Assert that a `DataFusionError` is an `Execution` variant with the expected message.
+pub fn assert_execution_error(error: DataFusionError, expected: &str) {
+    match error {
+        DataFusionError::Execution(message) => assert_eq!(message, expected),
+        other => panic!("expected execution error, got {other:?}"),
+    }
+}
+
+/// Stale NaN as used by Prometheus.
+pub const STALE_NAN: f64 = f64::from_bits(0x7ff0_0000_0000_0002);
+
+/// A tiny PRNG for generating deterministic test data.
+pub struct TinyPrng(pub u64);
+
+impl TinyPrng {
+    pub fn next_u32(&mut self) -> u32 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        self.0 as u32
+    }
+
+    pub fn next_index(&mut self, bound: usize) -> usize {
+        (self.next_u32() as usize) % bound
+    }
+}
+
+/// Run the oracle-based differential test: build range arrays, verify raw bits and
+/// null validity, invoke the UDF via [`simple_range_udf_runner`], and return the
+/// expected values for further assertions.
+///
+/// `oracle` is the behavior-specific function (e.g. `changes_oracle` or `resets_oracle`)
+/// that computes the expected count for a slice of raw f64 values.
+pub fn run_oracle_ranges(
+    values: Vec<Option<f64>>,
+    raw_values: Vec<f64>,
+    timestamp_ranges: Vec<(u32, u32)>,
+    value_ranges: Vec<(u32, u32)>,
+    oracle: fn(&[f64]) -> Option<f64>,
+    udf: ScalarUDF,
+) -> Vec<Option<f64>> {
+    assert_eq!(timestamp_ranges.len(), value_ranges.len());
+    assert!(
+        timestamp_ranges
+            .iter()
+            .zip(&value_ranges)
+            .all(|((_, timestamp_length), (_, value_length))| timestamp_length == value_length)
+    );
+    assert_eq!(values.len(), raw_values.len());
+    let nulls = values.iter().map(Option::is_none).collect::<Vec<_>>();
+
+    let expected = value_ranges
+        .iter()
+        .map(|(offset, length)| oracle(&raw_values[*offset as usize..(*offset + *length) as usize]))
+        .collect::<Vec<_>>();
+
+    let timestamp_values = (0..64)
+        .map(|value| Some(i64::from(value) * 1_000))
+        .collect::<Vec<_>>();
+    let timestamp_array = Arc::new(TimestampMillisecondArray::from_iter(timestamp_values));
+    let value_array = Arc::new(Float64Array::from_iter(values));
+    for (index, ((actual, expected), is_null)) in value_array
+        .values()
+        .iter()
+        .zip(&raw_values)
+        .zip(nulls)
+        .enumerate()
+    {
+        assert_eq!(actual.to_bits(), expected.to_bits());
+        assert_eq!(value_array.is_null(index), is_null);
+    }
+
+    let timestamp_ranges = RangeArray::from_ranges(timestamp_array, timestamp_ranges).unwrap();
+    let value_ranges = RangeArray::from_ranges(value_array, value_ranges).unwrap();
+    simple_range_udf_runner(
+        udf,
+        timestamp_ranges,
+        value_ranges,
+        vec![],
+        expected.clone(),
+    );
+    expected
 }

--- a/tests/cases/standalone/common/promql/range_sparse_empty_trailing.result
+++ b/tests/cases/standalone/common/promql/range_sparse_empty_trailing.result
@@ -1,0 +1,32 @@
+-- Test: Sparse samples with intermediate empty windows and a valid trailing sample.
+--
+-- Two samples at t=0ms and t=100000ms (100s). A range vector with 25s window
+-- should produce results at t=0s (the first sample) and t=120s (the trailing
+-- sample), with the three intermediate steps returning no data (empty).
+CREATE TABLE range_sparse_empty_trailing (
+    ts TIMESTAMP TIME INDEX,
+    val DOUBLE,
+);
+
+Affected Rows: 0
+
+INSERT INTO range_sparse_empty_trailing (ts, val) VALUES
+    (0, 1.0),
+    (100000, 1.0);
+
+Affected Rows: 2
+
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (0, 120, '30s') count_over_time(range_sparse_empty_trailing[25s]);
+
++---------------------+------------------------------------+
+| ts                  | prom_count_over_time(ts_range,val) |
++---------------------+------------------------------------+
+| 1970-01-01T00:00:00 | 1.0                                |
+| 1970-01-01T00:02:00 | 1.0                                |
++---------------------+------------------------------------+
+
+DROP TABLE range_sparse_empty_trailing;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/promql/range_sparse_empty_trailing.sql
+++ b/tests/cases/standalone/common/promql/range_sparse_empty_trailing.sql
@@ -1,0 +1,19 @@
+-- Test: Sparse samples with intermediate empty windows and a valid trailing sample.
+--
+-- Two samples at t=0ms and t=100000ms (100s). A range vector with 25s window
+-- should produce results at t=0s (the first sample) and t=120s (the trailing
+-- sample), with the three intermediate steps returning no data (empty).
+
+CREATE TABLE range_sparse_empty_trailing (
+    ts TIMESTAMP TIME INDEX,
+    val DOUBLE,
+);
+
+INSERT INTO range_sparse_empty_trailing (ts, val) VALUES
+    (0, 1.0),
+    (100000, 1.0);
+
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (0, 120, '30s') count_over_time(range_sparse_empty_trailing[25s]);
+
+DROP TABLE range_sparse_empty_trailing;

--- a/tests/perf/README.md
+++ b/tests/perf/README.md
@@ -207,7 +207,7 @@ case for issue #7913. It writes 8192 series × 20160 samples through remote-writ
 in 1440-sample daily time chunks, flushing after each chunk before running 1d/7d/14d
 TQL selectors. It is not included in the default `all` case set because ingestion
 cost dominates routine CI validation. Adding the `heavy-regression` PR label runs
-only this case; `query-regression` runs the five routine default cases. Manual
+only this case; `query-regression` runs the six routine default cases. Manual
 workflow dispatch accepts the `heavy` token to select this case.
 
 ## OTLP trace load scenario
@@ -473,7 +473,7 @@ read-bench tool against each target's data directory.
 
 The workflow runs automatically only when `query-regression` or `heavy-regression`
 is added to a non-draft PR; it does not rerun on pushes, ready-for-review, or
-reopen events. `query-regression` runs the five routine default cases, while
+reopen events. `query-regression` runs the six routine default cases, while
 `heavy-regression` runs only the high-cardinality remote-write #7913 case. PR runs
 build base/candidate once and use `--allow-large-fixture`. Manual
 `workflow_dispatch` runs can pass `all`, `heavy`, one case path, or a

--- a/tests/perf/query_cases/promql_range_boundary/case.toml
+++ b/tests/perf/query_cases/promql_range_boundary/case.toml
@@ -1,0 +1,166 @@
+# PromQL overlapping range-boundary benchmark.
+#
+# 128 series × 780 timestamps at 15s cadence = 99,840 rows. Data starts one
+# hour before evaluation; 481 evaluations span two hours. `count_over_time` is
+# boundary-sensitive, while `sum_over_time` intentionally includes kernel scan
+# work and the plain selector controls unrelated path variance.
+
+[case]
+name = "promql_range_boundary"
+description = "PromQL overlapping range-boundary generation at 15-second scrape and evaluation cadence"
+
+[scenario]
+kind = "direct_readable_sst"
+seed = 8623
+
+[[scenario.tables]]
+database = "public"
+name = "promql_range_boundary"
+engine = "mito"
+append_mode = true
+sst_format = "flat"
+primary_key = ["host", "instance"]
+time_index = "ts"
+
+[[scenario.tables.columns]]
+name = "host"
+type = "STRING"
+semantic = "tag"
+distribution = { kind = "cardinality", values = 16, prefix = "host" }
+
+[[scenario.tables.columns]]
+name = "instance"
+type = "STRING"
+semantic = "tag"
+distribution = { kind = "cardinality", values = 128, prefix = "instance" }
+
+[[scenario.tables.columns]]
+name = "value"
+type = "DOUBLE"
+semantic = "field"
+distribution = { kind = "deterministic_wave", min = 0.0, max = 1000.0 }
+
+[[scenario.tables.columns]]
+name = "ts"
+type = "TIMESTAMP(9)"
+semantic = "timestamp"
+
+[scenario.layout]
+regions = 1
+sst_count = 13
+rows_per_sst = 7680
+row_group_size = 1920
+series_count = 128
+start_unix_nanos = 1704067200000000000
+step_nanos = 15000000000
+time_range_layout = "non_overlapping_per_sst"
+series_layout = "timestamp_major"
+
+[[scenario.queries]]
+name = "plain_selector_control_2h"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') promql_range_boundary{host=~'host.*'}"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 20
+
+# Four samples per full window: fixed-overhead/small-window control.
+[[scenario.queries]]
+name = "count_over_time_1m"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') count_over_time(promql_range_boundary{host=~'host.*'}[1m])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 20
+
+# Twenty samples per full window: representative dense overlap.
+[[scenario.queries]]
+name = "count_over_time_5m"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') count_over_time(promql_range_boundary{host=~'host.*'}[5m])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 20
+
+# 240 samples per full window: primary boundary-sensitive stress case.
+[[scenario.queries]]
+name = "count_over_time_1h"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') count_over_time(promql_range_boundary{host=~'host.*'}[1h])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 20
+
+# Edge-scan kernel candidates: the Phase 3 implementation replaces repeated
+# per-window scans with exact edge-prefix counts.
+[[scenario.queries]]
+name = "changes_5m"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') changes(promql_range_boundary{host=~'host.*'}[5m])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 20
+
+[[scenario.queries]]
+name = "changes_1h"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') changes(promql_range_boundary{host=~'host.*'}[1h])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 20
+
+[[scenario.queries]]
+name = "resets_5m"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') resets(promql_range_boundary{host=~'host.*'}[5m])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 20
+
+[[scenario.queries]]
+name = "resets_1h"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') resets(promql_range_boundary{host=~'host.*'}[1h])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 20
+
+# The deterministic wave is not a true monotonic counter. This query exercises
+# the regular rate path but is not a numeric counter-rate oracle.
+[[scenario.queries]]
+name = "rate_wave_5m"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') rate(promql_range_boundary{host=~'host.*'}[5m])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 20
+
+# Same wide boundaries as count, but the sum kernel scans all window values and
+# intentionally dilutes the boundary-only gain.
+[[scenario.queries]]
+name = "sum_over_time_1h_dilution"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') sum_over_time(promql_range_boundary{host=~'host.*'}[1h])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 20

--- a/tests/perf/test_query_regression_case_selection.py
+++ b/tests/perf/test_query_regression_case_selection.py
@@ -30,7 +30,7 @@ SPEC.loader.exec_module(runner)
 
 
 class QueryRegressionCaseSelectionTest(unittest.TestCase):
-    def test_all_selects_the_five_routine_cases(self) -> None:
+    def test_all_selects_the_routine_default_cases(self) -> None:
         self.assertEqual(
             runner.split_cases(["all"]),
             [
@@ -39,6 +39,7 @@ class QueryRegressionCaseSelectionTest(unittest.TestCase):
                 "tests/perf/query_cases/prom_remote_write_run_heavy/case.toml",
                 "tests/perf/query_cases/prom_remote_write_mixed_every/case.toml",
                 "tests/perf/query_cases/prom_remote_write_integer_counter/case.toml",
+                "tests/perf/query_cases/promql_range_boundary/case.toml",
             ],
         )
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR removes repeated scanning work from PromQL sliding range evaluation in two independent layers.

### 1. Two-pointer range boundary generation (`range_manipulate.rs`)

`RangeManipulateStream::calculate_range` used a stale cursor heuristic that rescanned each evaluation window — `O(E × samples-per-window)` — and could drop valid samples after sparse gaps or trailing empty windows. It is replaced with monotonic `left`/`right` pointers, reducing boundary generation to `O(N + E)` while preserving exact `(curr-range, curr]` semantics, start/end shortening, and canonical empty-window output. Regression tests cover the gap/tail sample-loss cases (including positive time shifts), duplicates, range-zero, and shortening.

### 2. Adaptive edge counting for `changes()`/`resets()` (`functions/`)

The generic `#[range_fn]` macro slices, downcasts, and independently rescans every overlapping window. For `changes` and `resets`, this PR replaces the macro path with hand-written UDF wrappers backed by one shared private kernel: a direct raw-offset scan when the requested number of internal edges is small, otherwise a single global `u64` edge prefix over the backing array so each window is answered by a prefix difference (or a short direct scan).

Behavior is preserved bit-for-bit, verified by differential and deterministic unit tests: raw null-buffer values (null slots participate via their physical buffer, matching the existing macro behavior), NaN equivalence in `changes`, NaN false-comparisons in `resets`, signed zero, infinities, empty/singleton windows, independent timestamp/value offsets, arbitrary/reordered/repeated window layouts, and the exact DataFusion error messages for shape mismatches. The shared proc macro, planner, serializer, and all other range functions are untouched.

### Benchmarks (release binaries, same pinned source, fixed CPU affinity, ABBA ordering)

Boundary (commit 1):

- Public `RangeManipulate` wall time: **~28%** faster at 1m/15s, **~66%** at 5m/15s, **~96%** at 1h/15s (micro benchmark).
- Warmed distributed TQL ANALYZE 1h queries: **~17–21%** faster end to end; shorter windows stayed within run-order noise.

Edge counting (commit 2):

- Dense sliding windows (k=4/20/240): **91.7–95.6%** less public UDF wall time (12–23×).
- Low-coverage fallback (N=4096 backing, only 8 windows): **73.9–74.4%** faster — the cost gate avoids global-prefix overhead.
- Warmed distributed TQL ANALYZE 5m/1h `changes`/`resets`: **12.1–19.7%** client and **12.0–20.9%** server latency improvement; unrelated controls moved within ABBA drift (−1% to +3.7%).

The large micro numbers reflect removing per-window `O(k)` rescans; end-to-end gains are smaller because storage scan and sort dominate query time. These are controlled single-host measurements, not fleet-wide guarantees.

### Limitations and compatibility

- No API, schema, wire, or persisted-format changes.
- Only `changes`/`resets` get a specialized kernel; `count`, `sum`, `min`/`max`, etc. still use the generic macro path (follow-up candidates).
- The existing raw null-buffer semantics are intentionally preserved rather than "fixed"; changing null behavior would be a separate, behavior-visible decision.

### CI coverage

This PR also wires the new `promql_range_boundary` case into the query-regression workflow's `DEFAULT_CASES` (`.github/scripts/query-regression-run.py`). A historical audit found range queries had zero coverage in query-regression runs (208/208 PromQL `ANALYZE` samples were bare selectors), which is how the range-path issues this PR fixes went unnoticed. The case costs about a minute of execution on top of the workflow's existing release builds, so label-triggered runs now permanently cover this path.

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
