### PR TITLE
feat: add a dedicated http api server port

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -34,7 +34,7 @@
 | `http.prom_validation_mode` | String | `strict` | Whether to enable validation for Prometheus remote write requests.<br/>Available options:<br/>- strict: deny invalid UTF-8 strings (default).<br/>- lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).<br/>- unchecked: do not valid strings. |
 | `http.experimental_enable_prometheus_native_histogram` | Bool | `false` | Experimental: enable Prometheus remote write v2 native histogram ingestion. |
 | `http.experimental_enable_explain_analyze_stream` | Bool | `true` | Experimental: enable POST /v1/sql/analyze/stream for streaming EXPLAIN ANALYZE VERBOSE metrics. |
-| `http.api_server_enable` | Bool | `false` | Whether to start the dedicated public HTTP **API** server. This server serves<br/>only the `v1` interfaces plus the dashboard, and shares every other `[http]`<br/>option with the main server. It is disabled by default; set to `true` to enable. |
+| `http.enable_api_server` | Bool | `false` | Whether to start the dedicated public HTTP **API** server. This server serves<br/>only the `v1` interfaces plus the dashboard, and shares every other `[http]`<br/>option with the main server. It is disabled by default; set to `true` to enable. |
 | `http.api_server_addr` | String | `127.0.0.1:4006` | The address to bind the dedicated HTTP API server, in the same form as `addr`.<br/>Defaults to `127.0.0.1:4006`. |
 | `grpc` | -- | -- | The gRPC server options. |
 | `grpc.bind_addr` | String | `127.0.0.1:4001` | The address to bind the gRPC server. |
@@ -257,7 +257,7 @@
 | `http.prom_validation_mode` | String | `strict` | Whether to enable validation for Prometheus remote write requests.<br/>Available options:<br/>- strict: deny invalid UTF-8 strings (default).<br/>- lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).<br/>- unchecked: do not valid strings. |
 | `http.experimental_enable_prometheus_native_histogram` | Bool | `false` | Experimental: enable Prometheus remote write v2 native histogram ingestion. |
 | `http.experimental_enable_explain_analyze_stream` | Bool | `true` | Experimental: enable POST /v1/sql/analyze/stream for streaming EXPLAIN ANALYZE VERBOSE metrics. |
-| `http.api_server_enable` | Bool | `false` | Whether to start the dedicated public HTTP **API** server. This server serves<br/>only the `v1` interfaces plus the dashboard, and shares every other `[http]`<br/>option with the main server. It is disabled by default; set to `true` to enable. |
+| `http.enable_api_server` | Bool | `false` | Whether to start the dedicated public HTTP **API** server. This server serves<br/>only the `v1` interfaces plus the dashboard, and shares every other `[http]`<br/>option with the main server. It is disabled by default; set to `true` to enable. |
 | `http.api_server_addr` | String | `127.0.0.1:4006` | The address to bind the dedicated HTTP API server, in the same form as `addr`.<br/>Defaults to `127.0.0.1:4006`. |
 | `grpc` | -- | -- | The gRPC server options. |
 | `grpc.bind_addr` | String | `127.0.0.1:4001` | The address to bind the gRPC server. |

--- a/config/config.md
+++ b/config/config.md
@@ -34,7 +34,7 @@
 | `http.prom_validation_mode` | String | `strict` | Whether to enable validation for Prometheus remote write requests.<br/>Available options:<br/>- strict: deny invalid UTF-8 strings (default).<br/>- lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).<br/>- unchecked: do not valid strings. |
 | `http.experimental_enable_prometheus_native_histogram` | Bool | `false` | Experimental: enable Prometheus remote write v2 native histogram ingestion. |
 | `http.experimental_enable_explain_analyze_stream` | Bool | `true` | Experimental: enable POST /v1/sql/analyze/stream for streaming EXPLAIN ANALYZE VERBOSE metrics. |
-| `http.api_server_enable` | Bool | `true` | Whether to start the dedicated public HTTP **API** server. This server serves<br/>only the `v1` interfaces plus the dashboard, and shares every other `[http]`<br/>option with the main server. It is enabled by default. |
+| `http.api_server_enable` | Bool | `false` | Whether to start the dedicated public HTTP **API** server. This server serves<br/>only the `v1` interfaces plus the dashboard, and shares every other `[http]`<br/>option with the main server. It is disabled by default; set to `true` to enable. |
 | `http.api_server_host` | String | `127.0.0.1` | Host of the dedicated HTTP API server. Defaults to `127.0.0.1`. |
 | `http.api_server_port` | Integer | `4006` | Port of the dedicated HTTP API server. Defaults to `4006`. |
 | `grpc` | -- | -- | The gRPC server options. |
@@ -258,7 +258,7 @@
 | `http.prom_validation_mode` | String | `strict` | Whether to enable validation for Prometheus remote write requests.<br/>Available options:<br/>- strict: deny invalid UTF-8 strings (default).<br/>- lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).<br/>- unchecked: do not valid strings. |
 | `http.experimental_enable_prometheus_native_histogram` | Bool | `false` | Experimental: enable Prometheus remote write v2 native histogram ingestion. |
 | `http.experimental_enable_explain_analyze_stream` | Bool | `true` | Experimental: enable POST /v1/sql/analyze/stream for streaming EXPLAIN ANALYZE VERBOSE metrics. |
-| `http.api_server_enable` | Bool | `true` | Whether to start the dedicated public HTTP **API** server. This server serves<br/>only the `v1` interfaces plus the dashboard, and shares every other `[http]`<br/>option with the main server. It is enabled by default. |
+| `http.api_server_enable` | Bool | `false` | Whether to start the dedicated public HTTP **API** server. This server serves<br/>only the `v1` interfaces plus the dashboard, and shares every other `[http]`<br/>option with the main server. It is disabled by default; set to `true` to enable. |
 | `http.api_server_host` | String | `127.0.0.1` | Host of the dedicated HTTP API server. Defaults to `127.0.0.1`. |
 | `http.api_server_port` | Integer | `4006` | Port of the dedicated HTTP API server. Defaults to `4006`. |
 | `grpc` | -- | -- | The gRPC server options. |

--- a/config/config.md
+++ b/config/config.md
@@ -34,6 +34,9 @@
 | `http.prom_validation_mode` | String | `strict` | Whether to enable validation for Prometheus remote write requests.<br/>Available options:<br/>- strict: deny invalid UTF-8 strings (default).<br/>- lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).<br/>- unchecked: do not valid strings. |
 | `http.experimental_enable_prometheus_native_histogram` | Bool | `false` | Experimental: enable Prometheus remote write v2 native histogram ingestion. |
 | `http.experimental_enable_explain_analyze_stream` | Bool | `true` | Experimental: enable POST /v1/sql/analyze/stream for streaming EXPLAIN ANALYZE VERBOSE metrics. |
+| `http.api_server_enable` | Bool | `true` | Whether to start the dedicated public HTTP **API** server. This server serves<br/>only the `v1` interfaces plus the dashboard, and shares every other `[http]`<br/>option with the main server. It is enabled by default. |
+| `http.api_server_host` | String | `127.0.0.1` | Host of the dedicated HTTP API server. Defaults to `127.0.0.1`. |
+| `http.api_server_port` | Integer | `4006` | Port of the dedicated HTTP API server. Defaults to `4006`. |
 | `grpc` | -- | -- | The gRPC server options. |
 | `grpc.bind_addr` | String | `127.0.0.1:4001` | The address to bind the gRPC server. |
 | `grpc.runtime_size` | Integer | `8` | The number of server worker threads. |
@@ -255,6 +258,9 @@
 | `http.prom_validation_mode` | String | `strict` | Whether to enable validation for Prometheus remote write requests.<br/>Available options:<br/>- strict: deny invalid UTF-8 strings (default).<br/>- lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).<br/>- unchecked: do not valid strings. |
 | `http.experimental_enable_prometheus_native_histogram` | Bool | `false` | Experimental: enable Prometheus remote write v2 native histogram ingestion. |
 | `http.experimental_enable_explain_analyze_stream` | Bool | `true` | Experimental: enable POST /v1/sql/analyze/stream for streaming EXPLAIN ANALYZE VERBOSE metrics. |
+| `http.api_server_enable` | Bool | `true` | Whether to start the dedicated public HTTP **API** server. This server serves<br/>only the `v1` interfaces plus the dashboard, and shares every other `[http]`<br/>option with the main server. It is enabled by default. |
+| `http.api_server_host` | String | `127.0.0.1` | Host of the dedicated HTTP API server. Defaults to `127.0.0.1`. |
+| `http.api_server_port` | Integer | `4006` | Port of the dedicated HTTP API server. Defaults to `4006`. |
 | `grpc` | -- | -- | The gRPC server options. |
 | `grpc.bind_addr` | String | `127.0.0.1:4001` | The address to bind the gRPC server. |
 | `grpc.server_addr` | String | `127.0.0.1:4001` | The address advertised to the metasrv, and used for connections from outside the host.<br/>If left empty or unset, the server will automatically use the IP address of the first network interface<br/>on the host, with the same port number as the one specified in `grpc.bind_addr`. |

--- a/config/config.md
+++ b/config/config.md
@@ -35,8 +35,7 @@
 | `http.experimental_enable_prometheus_native_histogram` | Bool | `false` | Experimental: enable Prometheus remote write v2 native histogram ingestion. |
 | `http.experimental_enable_explain_analyze_stream` | Bool | `true` | Experimental: enable POST /v1/sql/analyze/stream for streaming EXPLAIN ANALYZE VERBOSE metrics. |
 | `http.api_server_enable` | Bool | `false` | Whether to start the dedicated public HTTP **API** server. This server serves<br/>only the `v1` interfaces plus the dashboard, and shares every other `[http]`<br/>option with the main server. It is disabled by default; set to `true` to enable. |
-| `http.api_server_host` | String | `127.0.0.1` | Host of the dedicated HTTP API server. Defaults to `127.0.0.1`. |
-| `http.api_server_port` | Integer | `4006` | Port of the dedicated HTTP API server. Defaults to `4006`. |
+| `http.api_server_addr` | String | `127.0.0.1:4006` | The address to bind the dedicated HTTP API server, in the same form as `addr`.<br/>Defaults to `127.0.0.1:4006`. |
 | `grpc` | -- | -- | The gRPC server options. |
 | `grpc.bind_addr` | String | `127.0.0.1:4001` | The address to bind the gRPC server. |
 | `grpc.runtime_size` | Integer | `8` | The number of server worker threads. |
@@ -259,8 +258,7 @@
 | `http.experimental_enable_prometheus_native_histogram` | Bool | `false` | Experimental: enable Prometheus remote write v2 native histogram ingestion. |
 | `http.experimental_enable_explain_analyze_stream` | Bool | `true` | Experimental: enable POST /v1/sql/analyze/stream for streaming EXPLAIN ANALYZE VERBOSE metrics. |
 | `http.api_server_enable` | Bool | `false` | Whether to start the dedicated public HTTP **API** server. This server serves<br/>only the `v1` interfaces plus the dashboard, and shares every other `[http]`<br/>option with the main server. It is disabled by default; set to `true` to enable. |
-| `http.api_server_host` | String | `127.0.0.1` | Host of the dedicated HTTP API server. Defaults to `127.0.0.1`. |
-| `http.api_server_port` | Integer | `4006` | Port of the dedicated HTTP API server. Defaults to `4006`. |
+| `http.api_server_addr` | String | `127.0.0.1:4006` | The address to bind the dedicated HTTP API server, in the same form as `addr`.<br/>Defaults to `127.0.0.1:4006`. |
 | `grpc` | -- | -- | The gRPC server options. |
 | `grpc.bind_addr` | String | `127.0.0.1:4001` | The address to bind the gRPC server. |
 | `grpc.server_addr` | String | `127.0.0.1:4001` | The address advertised to the metasrv, and used for connections from outside the host.<br/>If left empty or unset, the server will automatically use the IP address of the first network interface<br/>on the host, with the same port number as the one specified in `grpc.bind_addr`. |

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -73,7 +73,7 @@ experimental_enable_explain_analyze_stream = true
 ## Whether to start the dedicated public HTTP **API** server. This server serves
 ## only the `v1` interfaces plus the dashboard, and shares every other `[http]`
 ## option with the main server. It is disabled by default; set to `true` to enable.
-api_server_enable = false
+enable_api_server = false
 ## The address to bind the dedicated HTTP API server, in the same form as `addr`.
 ## Defaults to `127.0.0.1:4006`.
 api_server_addr = "127.0.0.1:4006"

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -74,10 +74,9 @@ experimental_enable_explain_analyze_stream = true
 ## only the `v1` interfaces plus the dashboard, and shares every other `[http]`
 ## option with the main server. It is disabled by default; set to `true` to enable.
 api_server_enable = false
-## Host of the dedicated HTTP API server. Defaults to `127.0.0.1`.
-api_server_host = "127.0.0.1"
-## Port of the dedicated HTTP API server. Defaults to `4006`.
-api_server_port = 4006
+## The address to bind the dedicated HTTP API server, in the same form as `addr`.
+## Defaults to `127.0.0.1:4006`.
+api_server_addr = "127.0.0.1:4006"
 
 ## The gRPC server options.
 [grpc]

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -72,8 +72,8 @@ experimental_enable_explain_analyze_stream = true
 
 ## Whether to start the dedicated public HTTP **API** server. This server serves
 ## only the `v1` interfaces plus the dashboard, and shares every other `[http]`
-## option with the main server. It is enabled by default.
-api_server_enable = true
+## option with the main server. It is disabled by default; set to `true` to enable.
+api_server_enable = false
 ## Host of the dedicated HTTP API server. Defaults to `127.0.0.1`.
 api_server_host = "127.0.0.1"
 ## Port of the dedicated HTTP API server. Defaults to `4006`.

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -70,6 +70,15 @@ experimental_enable_prometheus_native_histogram = false
 ## Experimental: enable POST /v1/sql/analyze/stream for streaming EXPLAIN ANALYZE VERBOSE metrics.
 experimental_enable_explain_analyze_stream = true
 
+## Whether to start the dedicated public HTTP **API** server. This server serves
+## only the `v1` interfaces plus the dashboard, and shares every other `[http]`
+## option with the main server. It is enabled by default.
+api_server_enable = true
+## Host of the dedicated HTTP API server. Defaults to `127.0.0.1`.
+api_server_host = "127.0.0.1"
+## Port of the dedicated HTTP API server. Defaults to `4006`.
+api_server_port = 4006
+
 ## The gRPC server options.
 [grpc]
 ## The address to bind the gRPC server.

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -88,10 +88,9 @@ experimental_enable_explain_analyze_stream = true
 ## only the `v1` interfaces plus the dashboard, and shares every other `[http]`
 ## option with the main server. It is disabled by default; set to `true` to enable.
 api_server_enable = false
-## Host of the dedicated HTTP API server. Defaults to `127.0.0.1`.
-api_server_host = "127.0.0.1"
-## Port of the dedicated HTTP API server. Defaults to `4006`.
-api_server_port = 4006
+## The address to bind the dedicated HTTP API server, in the same form as `addr`.
+## Defaults to `127.0.0.1:4006`.
+api_server_addr = "127.0.0.1:4006"
 
 ## The gRPC server options.
 [grpc]

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -86,8 +86,8 @@ experimental_enable_explain_analyze_stream = true
 
 ## Whether to start the dedicated public HTTP **API** server. This server serves
 ## only the `v1` interfaces plus the dashboard, and shares every other `[http]`
-## option with the main server. It is enabled by default.
-api_server_enable = true
+## option with the main server. It is disabled by default; set to `true` to enable.
+api_server_enable = false
 ## Host of the dedicated HTTP API server. Defaults to `127.0.0.1`.
 api_server_host = "127.0.0.1"
 ## Port of the dedicated HTTP API server. Defaults to `4006`.

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -87,7 +87,7 @@ experimental_enable_explain_analyze_stream = true
 ## Whether to start the dedicated public HTTP **API** server. This server serves
 ## only the `v1` interfaces plus the dashboard, and shares every other `[http]`
 ## option with the main server. It is disabled by default; set to `true` to enable.
-api_server_enable = false
+enable_api_server = false
 ## The address to bind the dedicated HTTP API server, in the same form as `addr`.
 ## Defaults to `127.0.0.1:4006`.
 api_server_addr = "127.0.0.1:4006"

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -84,6 +84,15 @@ experimental_enable_prometheus_native_histogram = false
 ## Experimental: enable POST /v1/sql/analyze/stream for streaming EXPLAIN ANALYZE VERBOSE metrics.
 experimental_enable_explain_analyze_stream = true
 
+## Whether to start the dedicated public HTTP **API** server. This server serves
+## only the `v1` interfaces plus the dashboard, and shares every other `[http]`
+## option with the main server. It is enabled by default.
+api_server_enable = true
+## Host of the dedicated HTTP API server. Defaults to `127.0.0.1`.
+api_server_host = "127.0.0.1"
+## Port of the dedicated HTTP API server. Defaults to `4006`.
+api_server_port = 4006
+
 ## The gRPC server options.
 [grpc]
 ## The address to bind the gRPC server.

--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -203,7 +203,7 @@ mod tests {
         // When `[http]` is not present in the config, the dedicated API server is
         // disabled by default (its port/host defaults are still 4006 / 127.0.0.1).
         let parsed: FrontendOptions = toml::from_str("").unwrap();
-        assert!(!parsed.http.api_server_enable);
+        assert!(!parsed.http.enable_api_server);
         assert_eq!(parsed.http.api_server_addr, "127.0.0.1:4006");
     }
 

--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -204,8 +204,7 @@ mod tests {
         // disabled by default (its port/host defaults are still 4006 / 127.0.0.1).
         let parsed: FrontendOptions = toml::from_str("").unwrap();
         assert!(!parsed.http.api_server_enable);
-        assert_eq!(parsed.http.api_server_port, 4006);
-        assert_eq!(parsed.http.api_server_host, "127.0.0.1");
+        assert_eq!(parsed.http.api_server_addr, "127.0.0.1:4006");
     }
 
     struct SuspendableHeartbeatServer {

--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -198,6 +198,16 @@ mod tests {
         let _parsed: FrontendOptions = toml::from_str(&toml_string).unwrap();
     }
 
+    #[test]
+    fn test_http_api_server_defaults_on_when_absent() {
+        // When `[http]` is not present in the config, the dedicated API server must
+        // still be enabled by default on port 4006.
+        let parsed: FrontendOptions = toml::from_str("").unwrap();
+        assert!(parsed.http.api_server_enable);
+        assert_eq!(parsed.http.api_server_port, 4006);
+        assert_eq!(parsed.http.api_server_host, "127.0.0.1");
+    }
+
     struct SuspendableHeartbeatServer {
         suspend: Arc<AtomicBool>,
     }

--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -200,10 +200,10 @@ mod tests {
 
     #[test]
     fn test_http_api_server_defaults_on_when_absent() {
-        // When `[http]` is not present in the config, the dedicated API server must
-        // still be enabled by default on port 4006.
+        // When `[http]` is not present in the config, the dedicated API server is
+        // disabled by default (its port/host defaults are still 4006 / 127.0.0.1).
         let parsed: FrontendOptions = toml::from_str("").unwrap();
-        assert!(parsed.http.api_server_enable);
+        assert!(!parsed.http.api_server_enable);
         assert_eq!(parsed.http.api_server_port, 4006);
         assert_eq!(parsed.http.api_server_host, "127.0.0.1");
     }

--- a/src/frontend/src/server.rs
+++ b/src/frontend/src/server.rs
@@ -288,7 +288,7 @@ where
             self.http_server_builder(opts, request_memory_limiter)
         };
 
-        // The API server is configured entirely under `[http]` (`api_server_enable`,
+        // The API server is configured entirely under `[http]` (`enable_api_server`,
         // `api_server_host`, `api_server_port`) and shares every other `[http]`
         // option with the main server.
         let (internal, api) = builder

--- a/src/frontend/src/server.rs
+++ b/src/frontend/src/server.rs
@@ -281,18 +281,21 @@ where
         opts: &FrontendOptions,
         toml: String,
         request_memory_limiter: ServerMemoryLimiter,
-    ) -> Result<HttpServer> {
+    ) -> Result<(HttpServer, Option<HttpServer>)> {
         let builder = if let Some(builder) = self.http_server_builder.take() {
             builder
         } else {
             self.http_server_builder(opts, request_memory_limiter)
         };
 
-        let http_server = builder
+        // The API server is configured entirely under `[http]` (`api_server_enable`,
+        // `api_server_host`, `api_server_port`) and shares every other `[http]`
+        // option with the main server.
+        let (internal, api) = builder
             .with_metrics_handler(MetricsHandler)
             .with_greptime_config_options(toml)
-            .build();
-        Ok(http_server)
+            .build_servers();
+        Ok((internal, api))
     }
 
     pub fn build(mut self) -> Result<ServerHandlers> {
@@ -333,12 +336,22 @@ where
         }
 
         {
-            // Always init HTTP server
+            // Always init the internal/full HTTP server (v1 + internal interfaces)
+            // and, when enabled, the dedicated HTTP API server (v1 + dashboard only).
             let http_options = &opts.http;
             let http_addr = parse_addr(&http_options.addr)?;
-            let http_server =
+            let (http_server, http_api_server) =
                 self.build_http_server(&opts, toml, self.server_memory_limiter.clone())?;
             handlers.insert((Box::new(http_server), http_addr));
+
+            if let Some(http_api_server) = http_api_server {
+                let http_api_addr = parse_addr(&format!(
+                    "{}:{}",
+                    http_options.api_server_host, http_options.api_server_port
+                ))?;
+                info!("HTTP API server is enabled at {}", http_api_addr);
+                handlers.insert((Box::new(http_api_server), http_api_addr));
+            }
         }
 
         if opts.mysql.enable {

--- a/src/frontend/src/server.rs
+++ b/src/frontend/src/server.rs
@@ -345,10 +345,7 @@ where
             handlers.insert((Box::new(http_server), http_addr));
 
             if let Some(http_api_server) = http_api_server {
-                let http_api_addr = parse_addr(&format!(
-                    "{}:{}",
-                    http_options.api_server_host, http_options.api_server_port
-                ))?;
+                let http_api_addr = parse_addr(&http_options.api_server_addr)?;
                 info!("HTTP API server is enabled at {}", http_api_addr);
                 handlers.insert((Box::new(http_api_server), http_api_addr));
             }

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -232,7 +232,7 @@ pub struct HttpOptions {
     /// only the `v1` interfaces plus the dashboard. It shares every other
     /// `[http]` option with the main server and only differs by its bound
     /// address (see `api_server_addr`).
-    pub api_server_enable: bool,
+    pub enable_api_server: bool,
     /// The address to bind the dedicated HTTP API server, in the same form as
     /// `addr` (e.g. `127.0.0.1:4006`).
     pub api_server_addr: String,
@@ -250,7 +250,7 @@ impl Default for HttpOptions {
             prom_validation_mode: PromValidationMode::Strict,
             experimental_enable_prometheus_native_histogram: false,
             experimental_enable_explain_analyze_stream: true,
-            api_server_enable: false,
+            enable_api_server: false,
             api_server_addr: format!("127.0.0.1:{}", DEFAULT_HTTP_API_ADDR_PORT),
         }
     }
@@ -839,7 +839,7 @@ impl HttpServerBuilder {
 
     /// Builds the full HTTP server (serves the `v1` interfaces **and** the
     /// internal interfaces such as health, status, metrics, config and debug).
-    /// When [`HttpOptions::api_server_enable`] is `true`, it also builds a
+    /// When [`HttpOptions::enable_api_server`] is `true`, it also builds a
     /// dedicated HTTP **API** server that serves only the `v1` interfaces plus
     /// the dashboard.
     ///
@@ -856,7 +856,7 @@ impl HttpServerBuilder {
     /// second server is bound to `api_server_addr` (e.g. `127.0.0.1:4006`). The
     /// API server inherits **every** option from `[http]` except the bound address.
     pub fn build_servers(self) -> (HttpServer, Option<HttpServer>) {
-        let api_enabled = self.options.api_server_enable;
+        let api_enabled = self.options.enable_api_server;
         let api_addr = self.options.api_server_addr.clone();
 
         let internal = HttpServer {
@@ -1629,7 +1629,7 @@ mod test {
         let instance = Arc::new(DummyInstance { _tx: tx });
         // Enable the dedicated API server so the split behavior can be exercised.
         let options = HttpOptions {
-            api_server_enable: true,
+            enable_api_server: true,
             ..HttpOptions::default()
         };
         HttpServerBuilder::new(options)
@@ -1642,7 +1642,7 @@ mod test {
     pub async fn test_http_api_options_defaults() {
         let opts = HttpOptions::default();
         // The API server is disabled by default.
-        assert!(!opts.api_server_enable);
+        assert!(!opts.enable_api_server);
         assert_eq!(opts.api_server_addr, "127.0.0.1:4006");
     }
 
@@ -1715,7 +1715,7 @@ mod test {
             timeout: Duration::from_secs(42),
             body_limit: ReadableSize::mb(128),
             cors_allowed_origins: vec!["https://example.com".to_string()],
-            api_server_enable: true,
+            enable_api_server: true,
             ..HttpOptions::default()
         };
         let (internal, api) = HttpServerBuilder::new(http_opts.clone()).build_servers();
@@ -1761,7 +1761,7 @@ mod test {
         let (tx, _rx) = mpsc::channel(100);
         let instance = Arc::new(DummyInstance { _tx: tx });
         let options = HttpOptions {
-            api_server_enable: true,
+            enable_api_server: true,
             ..HttpOptions::default()
         };
         let builder = HttpServerBuilder::new(options)
@@ -1808,7 +1808,7 @@ mod test {
     #[test]
     fn test_build_servers_api_disabled_by_default() {
         // The API server is disabled by default, so `build_servers` returns no
-        // second server unless `api_server_enable` is set.
+        // second server unless `enable_api_server` is set.
         let (_internal, api) = HttpServerBuilder::new(HttpOptions::default()).build_servers();
         assert!(api.is_none());
     }

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -199,12 +199,11 @@ pub struct HttpOptions {
     /// Whether to start the dedicated public HTTP **API** server, which serves
     /// only the `v1` interfaces plus the dashboard. It shares every other
     /// `[http]` option with the main server and only differs by its bound
-    /// address (see `api_server_host` / `api_server_port`).
+    /// address (see `api_server_addr`).
     pub api_server_enable: bool,
-    /// Host of the dedicated HTTP API server. Defaults to `127.0.0.1`.
-    pub api_server_host: String,
-    /// Port of the dedicated HTTP API server. Defaults to `4006`.
-    pub api_server_port: u16,
+    /// The address to bind the dedicated HTTP API server, in the same form as
+    /// `addr` (e.g. `127.0.0.1:4006`).
+    pub api_server_addr: String,
 }
 
 impl Default for HttpOptions {
@@ -220,8 +219,7 @@ impl Default for HttpOptions {
             experimental_enable_prometheus_native_histogram: false,
             experimental_enable_explain_analyze_stream: true,
             api_server_enable: false,
-            api_server_host: "127.0.0.1".to_string(),
-            api_server_port: DEFAULT_HTTP_API_ADDR_PORT,
+            api_server_addr: format!("127.0.0.1:{}", DEFAULT_HTTP_API_ADDR_PORT),
         }
     }
 }
@@ -815,23 +813,20 @@ impl HttpServerBuilder {
 
     /// Builds the internal/full HTTP server (serves the `v1` interfaces **and**
     /// the internal interfaces such as health, status, metrics, config and debug).
-    /// When [`HttpOptions::api_server_enable`] is `true` (the default), it also
-    /// builds a dedicated HTTP **API** server that serves only the `v1`
-    /// interfaces plus the dashboard.
+    /// When [`HttpOptions::api_server_enable`] is `true`, it also builds a
+    /// dedicated HTTP **API** server that serves only the `v1` interfaces plus
+    /// the dashboard.
     ///
     /// The first returned server is bound to `self.options.addr` (e.g. port
     /// `4000`) and keeps the historical single-server behavior, so nothing that
     /// talks to it breaks. The optional second server is bound to
-    /// `api_server_host:api_server_port` (e.g. port `4006`) and is meant to be
-    /// the public-facing API surface. The API server inherits **every** option
-    /// from `[http]` except the bound address, so anything configured under
-    /// `[http]` is effective for both servers.
+    /// `api_server_addr` (e.g. `127.0.0.1:4006`) and is meant to be the
+    /// public-facing API surface. The API server inherits **every** option from
+    /// `[http]` except the bound address, so anything configured under `[http]`
+    /// is effective for both servers.
     pub fn build_servers(self) -> (HttpServer, Option<HttpServer>) {
         let api_enabled = self.options.api_server_enable;
-        let api_addr = format!(
-            "{}:{}",
-            self.options.api_server_host, self.options.api_server_port
-        );
+        let api_addr = self.options.api_server_addr.clone();
 
         let internal = HttpServer {
             options: self.options,
@@ -1612,8 +1607,7 @@ mod test {
         let opts = HttpOptions::default();
         // The API server is disabled by default.
         assert!(!opts.api_server_enable);
-        assert_eq!(opts.api_server_host, "127.0.0.1");
-        assert_eq!(opts.api_server_port, 4006);
+        assert_eq!(opts.api_server_addr, "127.0.0.1:4006");
     }
 
     #[tokio::test]

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -23,6 +23,7 @@ use async_trait::async_trait;
 use auth::UserProviderRef;
 use axum::extract::{DefaultBodyLimit, Request};
 use axum::http::StatusCode as HttpStatusCode;
+use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use axum::routing::Route;
 use axum::serve::ListenerExt;
@@ -130,6 +131,7 @@ const DEFAULT_HTTP_API_ADDR_PORT: u16 = 4006;
 pub const AUTHORIZATION_HEADER: &str = "x-greptime-auth";
 
 // TODO(fys): This is a temporary workaround, it will be improved later
+// these APIs will bypass authentication.
 pub static PUBLIC_API_PREFIX: [&str; 4] = [
     "/v1/influxdb/ping",
     "/v1/influxdb/health",
@@ -137,12 +139,24 @@ pub static PUBLIC_API_PREFIX: [&str; 4] = [
     "/v1/splunk/services/collector/health",
 ];
 
+/// Listener mode for an [`HttpServer`].
+///
+/// Both modes share the *same* complete route registry; the [`HttpServerKind::Api`]
+/// listener additionally installs an outer guard that only exposes the `/v1` APIs
+/// and the dashboard, returning `404` for every other path.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum HttpServerKind {
+    /// Serves the complete historical HTTP surface (both `v1` APIs and internal
+    /// interfaces such as health, status, metrics, config and debug).
+    #[default]
+    Full,
+    /// Serves only the `v1` interfaces plus the dashboard.
+    Api,
+}
+
 #[derive(Default)]
 pub struct HttpServer {
     router: StdMutex<Router>,
-    /// Accumulated internal-only (non-`v1`) routes such as `/metrics` and `/config`.
-    /// They are mounted on the internal/full HTTP server but not on the API-only server.
-    internal_router: StdMutex<Router>,
     shutdown_tx: Mutex<Option<Sender<()>>>,
     user_provider: Option<UserProviderRef>,
     memory_limiter: ServerMemoryLimiter,
@@ -150,24 +164,42 @@ pub struct HttpServer {
     // server configs
     options: HttpOptions,
     bind_addr: Option<SocketAddr>,
-    /// `true` when this server is the dedicated HTTP **API** server that serves
-    /// only the `v1` interfaces plus the dashboard. When `false` it is the
-    /// internal/full server that additionally serves health, status, metrics,
-    /// config and debug interfaces.
-    api_only: bool,
+    /// What this server instance exposes. See [`HttpServerKind`].
+    kind: HttpServerKind,
+}
+
+/// Returns `true` when `path` equals `root` or is nested directly under it
+/// (`root/...`). Uses an exact slash boundary so `/v1` does **not** match `/v10`
+/// or `/v1-internal`.
+pub(crate) fn is_namespace(path: &str, root: &str) -> bool {
+    path == root
+        || path
+            .strip_prefix(root)
+            .is_some_and(|suffix| suffix.starts_with('/'))
+}
+
+/// Paths visible on the dedicated API listener: the `/v1` APIs and the dashboard.
+pub fn is_api_listener_path(path: &str) -> bool {
+    is_namespace(path, HTTP_API_PREFIX_WITHOUT_TRAILING_SLASH) || is_namespace(path, "/dashboard")
+}
+
+/// Outer guard for the API listener. Rejects any path outside the API surface
+/// with `404 Not Found` before it can reach a handler (and before auth side
+/// effects). Reachability is kept separate from authentication.
+async fn enforce_api_surface(req: Request, next: Next) -> Response {
+    if !is_api_listener_path(req.uri().path()) {
+        return HttpStatusCode::NOT_FOUND.into_response();
+    }
+    next.run(req).await
 }
 
 impl HttpServer {
-    /// Returns `true` when this server also serves the internal-only interfaces
-    /// (health, ready, status, metrics, config, debug). Only the internal/full
-    /// server does; the API-only server does not.
-    fn serves_internal_routes(&self) -> bool {
-        !self.api_only
-    }
-
     /// A short human-readable label for this server instance, used in logs.
     fn kind(&self) -> &'static str {
-        if self.api_only { "HTTP API" } else { "HTTP" }
+        match self.kind {
+            HttpServerKind::Api => "HTTP API",
+            HttpServerKind::Full => "HTTP",
+        }
     }
 }
 
@@ -561,8 +593,6 @@ pub struct HttpServerBuilder {
     options: HttpOptions,
     user_provider: Option<UserProviderRef>,
     router: Router,
-    /// Accumulated internal (non-`v1`) routes such as `/metrics` and `/config`.
-    internal_router: Router,
     memory_limiter: ServerMemoryLimiter,
 }
 
@@ -572,7 +602,6 @@ impl HttpServerBuilder {
             options,
             user_provider: None,
             router: Router::new(),
-            internal_router: Router::new(),
             memory_limiter: ServerMemoryLimiter::default(),
         }
     }
@@ -691,9 +720,7 @@ impl HttpServerBuilder {
 
     pub fn with_metrics_handler(self, handler: MetricsHandler) -> Self {
         Self {
-            internal_router: self
-                .internal_router
-                .merge(HttpServer::route_metrics(handler)),
+            router: self.router.merge(HttpServer::route_metrics(handler)),
             ..self
         }
     }
@@ -752,7 +779,7 @@ impl HttpServerBuilder {
         });
 
         Self {
-            internal_router: self.internal_router.merge(config_router),
+            router: self.router.merge(config_router),
             ..self
         }
     }
@@ -804,26 +831,30 @@ impl HttpServerBuilder {
             user_provider: self.user_provider,
             shutdown_tx: Mutex::new(None),
             router: StdMutex::new(self.router),
-            internal_router: StdMutex::new(self.internal_router),
             bind_addr: None,
             memory_limiter: self.memory_limiter,
-            api_only: false,
+            kind: HttpServerKind::Full,
         }
     }
 
-    /// Builds the internal/full HTTP server (serves the `v1` interfaces **and**
-    /// the internal interfaces such as health, status, metrics, config and debug).
+    /// Builds the full HTTP server (serves the `v1` interfaces **and** the
+    /// internal interfaces such as health, status, metrics, config and debug).
     /// When [`HttpOptions::api_server_enable`] is `true`, it also builds a
     /// dedicated HTTP **API** server that serves only the `v1` interfaces plus
     /// the dashboard.
     ///
+    /// Both servers are built from the **same** complete route registry (so every
+    /// built-in, plugin and downstream route registered via `with_extra_router()`
+    /// is present on both). The API server additionally installs an outer guard
+    /// that exposes only the `/v1` and `/dashboard` namespaces, returning `404`
+    /// for everything else. This means downstream projects (e.g. enterprise) do
+    /// not need to classify their routes as public/internal: non-`/v1`
+    /// operational routes are hidden from the API listener automatically.
+    ///
     /// The first returned server is bound to `self.options.addr` (e.g. port
-    /// `4000`) and keeps the historical single-server behavior, so nothing that
-    /// talks to it breaks. The optional second server is bound to
-    /// `api_server_addr` (e.g. `127.0.0.1:4006`) and is meant to be the
-    /// public-facing API surface. The API server inherits **every** option from
-    /// `[http]` except the bound address, so anything configured under `[http]`
-    /// is effective for both servers.
+    /// `4000`) and keeps the historical single-server behavior. The optional
+    /// second server is bound to `api_server_addr` (e.g. `127.0.0.1:4006`). The
+    /// API server inherits **every** option from `[http]` except the bound address.
     pub fn build_servers(self) -> (HttpServer, Option<HttpServer>) {
         let api_enabled = self.options.api_server_enable;
         let api_addr = self.options.api_server_addr.clone();
@@ -833,15 +864,14 @@ impl HttpServerBuilder {
             user_provider: self.user_provider.clone(),
             shutdown_tx: Mutex::new(None),
             router: StdMutex::new(self.router.clone()),
-            internal_router: StdMutex::new(self.internal_router.clone()),
             bind_addr: None,
             memory_limiter: self.memory_limiter.clone(),
-            api_only: false,
+            kind: HttpServerKind::Full,
         };
 
         let api = if api_enabled {
-            // The API server shares every option with the internal/full server
-            // except the bound address.
+            // The API server shares every option with the full server except the
+            // bound address.
             let api_options = HttpOptions {
                 addr: api_addr,
                 ..internal.options.clone()
@@ -851,10 +881,9 @@ impl HttpServerBuilder {
                 user_provider: self.user_provider.clone(),
                 shutdown_tx: Mutex::new(None),
                 router: StdMutex::new(self.router),
-                internal_router: StdMutex::new(self.internal_router),
                 bind_addr: None,
                 memory_limiter: self.memory_limiter,
-                api_only: true,
+                kind: HttpServerKind::Api,
             })
         } else {
             None
@@ -865,35 +894,36 @@ impl HttpServerBuilder {
 }
 
 impl HttpServer {
-    /// Gets the router and adds necessary root routes (health, status, dashboard).
+    /// Builds the complete route registry shared by every HTTP server: all the
+    /// `v1` protocol routes, the root/health/status/metrics/config interfaces,
+    /// the dashboard and (via `build()`) the debug routes.
+    ///
+    /// Both [`HttpServerKind::Full`] and [`HttpServerKind::Api`] listeners are
+    /// built from this same router. The API listener hides the non-`v1` paths
+    /// later, in [`HttpServer::build`], via an outer guard. Keeping one router
+    /// means downstream routes added through `with_extra_router()` are present
+    /// on both listeners automatically, and the API guard decides exposure.
     pub fn make_app(&self) -> Router {
         let mut router = self.router.lock().unwrap().clone();
 
-        // The `v1` health check is available on every HTTP server (including the
-        // API-only server) so clients can probe it.
-        router = router.route(
-            &format!("/{HTTP_API_VERSION}/health"),
-            routing::get(handler::health).post(handler::health),
-        );
+        router = router
+            .route(
+                &format!("/{HTTP_API_VERSION}/health"),
+                routing::get(handler::health).post(handler::health),
+            )
+            .route("/", routing::get(handler::index))
+            .route(
+                "/health",
+                routing::get(handler::health).post(handler::health),
+            )
+            .route(
+                "/ready",
+                routing::get(handler::health).post(handler::health),
+            )
+            .route("/status", routing::get(handler::status));
 
-        if self.serves_internal_routes() {
-            // Internal-only interfaces live on the internal/full HTTP server.
-            router = router.merge(self.internal_router.lock().unwrap().clone());
-            router = router
-                .route("/", routing::get(handler::index))
-                .route(
-                    "/health",
-                    routing::get(handler::health).post(handler::health),
-                )
-                .route(
-                    "/ready",
-                    routing::get(handler::health).post(handler::health),
-                )
-                .route("/status", routing::get(handler::status));
-        }
-
-        // The dashboard runs on top of the `v1` APIs, so it is served on every
-        // HTTP server (including the API-only server).
+        // The dashboard runs on top of the `v1` APIs, so it is exposed on every
+        // HTTP server (the API listener's namespace guard allows `/dashboard`).
         #[cfg(feature = "dashboard")]
         {
             if !self.options.disable_dashboard {
@@ -1007,39 +1037,46 @@ impl HttpServer {
                     )),
             );
 
-        // Debug handlers only live on the server that serves the internal interfaces.
-        if self.serves_internal_routes() {
-            Ok(router.nest(
-                "/debug",
-                Router::new()
-                    // handler for changing log level dynamically
-                    .route("/log_level", routing::post(dyn_log::dyn_log_handler))
-                    .route("/enable_trace", routing::post(dyn_trace::dyn_trace_handler))
-                    .nest(
-                        "/prof",
-                        Router::new()
-                            .route("/cpu", routing::post(pprof::pprof_handler))
-                            .route("/mem", routing::post(mem_prof::mem_prof_handler))
-                            .route("/mem/symbol", routing::post(mem_prof::symbolicate_handler))
-                            .route(
-                                "/mem/activate",
-                                routing::post(mem_prof::activate_heap_prof_handler),
-                            )
-                            .route(
-                                "/mem/deactivate",
-                                routing::post(mem_prof::deactivate_heap_prof_handler),
-                            )
-                            .route(
-                                "/mem/status",
-                                routing::get(mem_prof::heap_prof_status_handler),
-                            ) // jemalloc gdump flag status and toggle
-                            .route(
-                                "/mem/gdump",
-                                routing::get(mem_prof::gdump_status_handler)
-                                    .post(mem_prof::gdump_toggle_handler),
-                            ),
-                    ),
-            ))
+        // Debug handlers are part of the complete router; the API listener hides
+        // them through the outer namespace guard applied below.
+        let router = router.nest(
+            "/debug",
+            Router::new()
+                // handler for changing log level dynamically
+                .route("/log_level", routing::post(dyn_log::dyn_log_handler))
+                .route("/enable_trace", routing::post(dyn_trace::dyn_trace_handler))
+                .nest(
+                    "/prof",
+                    Router::new()
+                        .route("/cpu", routing::post(pprof::pprof_handler))
+                        .route("/mem", routing::post(mem_prof::mem_prof_handler))
+                        .route("/mem/symbol", routing::post(mem_prof::symbolicate_handler))
+                        .route(
+                            "/mem/activate",
+                            routing::post(mem_prof::activate_heap_prof_handler),
+                        )
+                        .route(
+                            "/mem/deactivate",
+                            routing::post(mem_prof::deactivate_heap_prof_handler),
+                        )
+                        .route(
+                            "/mem/status",
+                            routing::get(mem_prof::heap_prof_status_handler),
+                        ) // jemalloc gdump flag status and toggle
+                        .route(
+                            "/mem/gdump",
+                            routing::get(mem_prof::gdump_status_handler)
+                                .post(mem_prof::gdump_toggle_handler),
+                        ),
+                ),
+        );
+
+        // Seal the API listener last: this is the outermost layer, applied after
+        // all middleware, debug routes and any caller/plugin routes, so that only
+        // `/v1` and `/dashboard` paths can reach a handler. Excluded paths return
+        // 404 before auth or any other side effect.
+        if self.kind == HttpServerKind::Api {
+            Ok(router.layer(middleware::from_fn(enforce_api_surface)))
         } else {
             Ok(router)
         }
@@ -1453,10 +1490,9 @@ impl Server for HttpServer {
     }
 
     fn name(&self) -> &str {
-        if self.api_only {
-            HTTP_API_SERVER
-        } else {
-            HTTP_SERVER
+        match self.kind {
+            HttpServerKind::Api => HTTP_API_SERVER,
+            HttpServerKind::Full => HTTP_SERVER,
         }
     }
 
@@ -1694,6 +1730,78 @@ mod test {
         assert_eq!(
             api.options.cors_allowed_origins,
             http_opts.cors_allowed_origins
+        );
+    }
+
+    #[test]
+    fn test_is_api_listener_path() {
+        // `/v1` namespace (exact slash boundary).
+        assert!(is_api_listener_path("/v1"));
+        assert!(is_api_listener_path("/v1/"));
+        assert!(is_api_listener_path("/v1/sql"));
+        assert!(!is_api_listener_path("/v10/sql"));
+        assert!(!is_api_listener_path("/v1-internal"));
+        // `/dashboard` namespace.
+        assert!(is_api_listener_path("/dashboard"));
+        assert!(is_api_listener_path("/dashboard/app.js"));
+        assert!(!is_api_listener_path("/dashboard-admin"));
+        // Operational paths are never API-visible.
+        assert!(!is_api_listener_path("/metrics"));
+        assert!(!is_api_listener_path("/status/plugin"));
+        assert!(!is_api_listener_path("/health"));
+    }
+
+    #[tokio::test]
+    pub async fn test_extra_router_respects_api_surface() {
+        // Downstream routes added through `with_extra_router()` (e.g. enterprise
+        // plugins or the `RouterConfigurator`) are present on the full listener
+        // and on the API listener's router, but the API listener's outer guard
+        // hides every non-`/v1` path automatically. This is what keeps the
+        // feature correct for greptimedb-enterprise with no downstream changes.
+        let (tx, _rx) = mpsc::channel(100);
+        let instance = Arc::new(DummyInstance { _tx: tx });
+        let options = HttpOptions {
+            api_server_enable: true,
+            ..HttpOptions::default()
+        };
+        let builder = HttpServerBuilder::new(options)
+            .with_sql_handler(instance)
+            .with_extra_router(
+                Router::new()
+                    .route("/status/plugin", routing::get(|| async { "ok" }))
+                    .route("/v1/plugin", routing::get(|| async { "ok" })),
+            );
+        let (full, api) = builder.build_servers();
+        let api = api.expect("API server is explicitly enabled");
+
+        let full_client = TestClient::new(full.build(full.make_app()).unwrap()).await;
+        let api_client = TestClient::new(api.build(api.make_app()).unwrap()).await;
+
+        // A non-`/v1` route is reachable on the full listener...
+        assert_eq!(
+            full_client.get("/status/plugin").send().await.status(),
+            StatusCode::OK
+        );
+        // ...and hidden (404) on the API listener, without the caller classifying it.
+        assert_eq!(
+            api_client.get("/status/plugin").send().await.status(),
+            StatusCode::NOT_FOUND
+        );
+
+        // A `/v1` route is reachable on both.
+        assert_eq!(
+            full_client.get("/v1/plugin").send().await.status(),
+            StatusCode::OK
+        );
+        assert_eq!(
+            api_client.get("/v1/plugin").send().await.status(),
+            StatusCode::OK
+        );
+
+        // Slash-boundary correctness on the API listener.
+        assert_eq!(
+            api_client.get("/v10/plugin").send().await.status(),
+            StatusCode::NOT_FOUND
         );
     }
 

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -123,6 +123,8 @@ pub const HTTP_API_PREFIX: &str = "/v1/";
 pub const HTTP_API_PREFIX_WITHOUT_TRAILING_SLASH: &str = "/v1";
 /// Default http body limit (64M).
 const DEFAULT_BODY_LIMIT: ReadableSize = ReadableSize::mb(64);
+/// Default address port for the public HTTP API server.
+const DEFAULT_HTTP_API_ADDR_PORT: u16 = 4006;
 
 /// Authorization header
 pub const AUTHORIZATION_HEADER: &str = "x-greptime-auth";
@@ -138,6 +140,9 @@ pub static PUBLIC_API_PREFIX: [&str; 4] = [
 #[derive(Default)]
 pub struct HttpServer {
     router: StdMutex<Router>,
+    /// Accumulated internal-only (non-`v1`) routes such as `/metrics` and `/config`.
+    /// They are mounted on the internal/full HTTP server but not on the API-only server.
+    internal_router: StdMutex<Router>,
     shutdown_tx: Mutex<Option<Sender<()>>>,
     user_provider: Option<UserProviderRef>,
     memory_limiter: ServerMemoryLimiter,
@@ -145,6 +150,25 @@ pub struct HttpServer {
     // server configs
     options: HttpOptions,
     bind_addr: Option<SocketAddr>,
+    /// `true` when this server is the dedicated HTTP **API** server that serves
+    /// only the `v1` interfaces plus the dashboard. When `false` it is the
+    /// internal/full server that additionally serves health, status, metrics,
+    /// config and debug interfaces.
+    api_only: bool,
+}
+
+impl HttpServer {
+    /// Returns `true` when this server also serves the internal-only interfaces
+    /// (health, ready, status, metrics, config, debug). Only the internal/full
+    /// server does; the API-only server does not.
+    fn serves_internal_routes(&self) -> bool {
+        !self.api_only
+    }
+
+    /// A short human-readable label for this server instance, used in logs.
+    fn kind(&self) -> &'static str {
+        if self.api_only { "HTTP API" } else { "HTTP" }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -171,6 +195,16 @@ pub struct HttpOptions {
     pub enable_cors: bool,
 
     pub experimental_enable_explain_analyze_stream: bool,
+
+    /// Whether to start the dedicated public HTTP **API** server, which serves
+    /// only the `v1` interfaces plus the dashboard. It shares every other
+    /// `[http]` option with the main server and only differs by its bound
+    /// address (see `api_server_host` / `api_server_port`).
+    pub api_server_enable: bool,
+    /// Host of the dedicated HTTP API server. Defaults to `127.0.0.1`.
+    pub api_server_host: String,
+    /// Port of the dedicated HTTP API server. Defaults to `4006`.
+    pub api_server_port: u16,
 }
 
 impl Default for HttpOptions {
@@ -185,6 +219,9 @@ impl Default for HttpOptions {
             prom_validation_mode: PromValidationMode::Strict,
             experimental_enable_prometheus_native_histogram: false,
             experimental_enable_explain_analyze_stream: true,
+            api_server_enable: true,
+            api_server_host: "127.0.0.1".to_string(),
+            api_server_port: DEFAULT_HTTP_API_ADDR_PORT,
         }
     }
 }
@@ -526,6 +563,8 @@ pub struct HttpServerBuilder {
     options: HttpOptions,
     user_provider: Option<UserProviderRef>,
     router: Router,
+    /// Accumulated internal (non-`v1`) routes such as `/metrics` and `/config`.
+    internal_router: Router,
     memory_limiter: ServerMemoryLimiter,
 }
 
@@ -535,6 +574,7 @@ impl HttpServerBuilder {
             options,
             user_provider: None,
             router: Router::new(),
+            internal_router: Router::new(),
             memory_limiter: ServerMemoryLimiter::default(),
         }
     }
@@ -653,7 +693,9 @@ impl HttpServerBuilder {
 
     pub fn with_metrics_handler(self, handler: MetricsHandler) -> Self {
         Self {
-            router: self.router.merge(HttpServer::route_metrics(handler)),
+            internal_router: self
+                .internal_router
+                .merge(HttpServer::route_metrics(handler)),
             ..self
         }
     }
@@ -712,7 +754,7 @@ impl HttpServerBuilder {
         });
 
         Self {
-            router: self.router.merge(config_router),
+            internal_router: self.internal_router.merge(config_router),
             ..self
         }
     }
@@ -764,37 +806,99 @@ impl HttpServerBuilder {
             user_provider: self.user_provider,
             shutdown_tx: Mutex::new(None),
             router: StdMutex::new(self.router),
+            internal_router: StdMutex::new(self.internal_router),
             bind_addr: None,
             memory_limiter: self.memory_limiter,
+            api_only: false,
         }
+    }
+
+    /// Builds the internal/full HTTP server (serves the `v1` interfaces **and**
+    /// the internal interfaces such as health, status, metrics, config and debug).
+    /// When [`HttpOptions::api_server_enable`] is `true` (the default), it also
+    /// builds a dedicated HTTP **API** server that serves only the `v1`
+    /// interfaces plus the dashboard.
+    ///
+    /// The first returned server is bound to `self.options.addr` (e.g. port
+    /// `4000`) and keeps the historical single-server behavior, so nothing that
+    /// talks to it breaks. The optional second server is bound to
+    /// `api_server_host:api_server_port` (e.g. port `4006`) and is meant to be
+    /// the public-facing API surface. The API server inherits **every** option
+    /// from `[http]` except the bound address, so anything configured under
+    /// `[http]` is effective for both servers.
+    pub fn build_servers(self) -> (HttpServer, Option<HttpServer>) {
+        let api_enabled = self.options.api_server_enable;
+        let api_addr = format!(
+            "{}:{}",
+            self.options.api_server_host, self.options.api_server_port
+        );
+
+        let internal = HttpServer {
+            options: self.options,
+            user_provider: self.user_provider.clone(),
+            shutdown_tx: Mutex::new(None),
+            router: StdMutex::new(self.router.clone()),
+            internal_router: StdMutex::new(self.internal_router.clone()),
+            bind_addr: None,
+            memory_limiter: self.memory_limiter.clone(),
+            api_only: false,
+        };
+
+        let api = if api_enabled {
+            // The API server shares every option with the internal/full server
+            // except the bound address.
+            let api_options = HttpOptions {
+                addr: api_addr,
+                ..internal.options.clone()
+            };
+            Some(HttpServer {
+                options: api_options,
+                user_provider: self.user_provider.clone(),
+                shutdown_tx: Mutex::new(None),
+                router: StdMutex::new(self.router),
+                internal_router: StdMutex::new(self.internal_router),
+                bind_addr: None,
+                memory_limiter: self.memory_limiter,
+                api_only: true,
+            })
+        } else {
+            None
+        };
+
+        (internal, api)
     }
 }
 
 impl HttpServer {
     /// Gets the router and adds necessary root routes (health, status, dashboard).
     pub fn make_app(&self) -> Router {
-        let mut router = {
-            let router = self.router.lock().unwrap();
-            router.clone()
-        };
+        let mut router = self.router.lock().unwrap().clone();
 
-        router = router
-            .route("/", routing::get(handler::index))
-            .route(
-                "/health",
-                routing::get(handler::health).post(handler::health),
-            )
-            .route(
-                &format!("/{HTTP_API_VERSION}/health"),
-                routing::get(handler::health).post(handler::health),
-            )
-            .route(
-                "/ready",
-                routing::get(handler::health).post(handler::health),
-            );
+        // The `v1` health check is available on every HTTP server (including the
+        // API-only server) so clients can probe it.
+        router = router.route(
+            &format!("/{HTTP_API_VERSION}/health"),
+            routing::get(handler::health).post(handler::health),
+        );
 
-        router = router.route("/status", routing::get(handler::status));
+        if self.serves_internal_routes() {
+            // Internal-only interfaces live on the internal/full HTTP server.
+            router = router.merge(self.internal_router.lock().unwrap().clone());
+            router = router
+                .route("/", routing::get(handler::index))
+                .route(
+                    "/health",
+                    routing::get(handler::health).post(handler::health),
+                )
+                .route(
+                    "/ready",
+                    routing::get(handler::health).post(handler::health),
+                )
+                .route("/status", routing::get(handler::status));
+        }
 
+        // The dashboard runs on top of the `v1` APIs, so it is served on every
+        // HTTP server (including the API-only server).
         #[cfg(feature = "dashboard")]
         {
             if !self.options.disable_dashboard {
@@ -881,7 +985,7 @@ impl HttpServer {
             None
         };
 
-        Ok(router
+        let router = router
             // middlewares
             .layer(
                 ServiceBuilder::new()
@@ -906,9 +1010,11 @@ impl HttpServer {
                     .layer(middleware::from_fn(
                         read_preference::extract_read_preference,
                     )),
-            )
-            // Handlers for debug, we don't expect a timeout.
-            .nest(
+            );
+
+        // Debug handlers only live on the server that serves the internal interfaces.
+        if self.serves_internal_routes() {
+            Ok(router.nest(
                 "/debug",
                 Router::new()
                     // handler for changing log level dynamically
@@ -939,6 +1045,9 @@ impl HttpServer {
                             ),
                     ),
             ))
+        } else {
+            Ok(router)
+        }
     }
 
     fn route_metrics<S>(metrics_handler: MetricsHandler) -> Router<S> {
@@ -1270,6 +1379,7 @@ impl HttpServer {
 }
 
 pub const HTTP_SERVER: &str = "HTTP_SERVER";
+pub const HTTP_API_SERVER: &str = "HTTP_API_SERVER";
 
 #[async_trait]
 impl Server for HttpServer {
@@ -1280,7 +1390,7 @@ impl Server for HttpServer {
         {
             info!("Receiver dropped, the HTTP server has already exited");
         }
-        info!("Shutdown HTTP server");
+        info!("Shutdown {}", self.kind());
 
         Ok(())
     }
@@ -1291,7 +1401,9 @@ impl Server for HttpServer {
             let mut shutdown_tx = self.shutdown_tx.lock().await;
             ensure!(
                 shutdown_tx.is_none(),
-                AlreadyStartedSnafu { server: "HTTP" }
+                AlreadyStartedSnafu {
+                    server: self.kind()
+                }
             );
 
             let app = self.build(self.make_app())?;
@@ -1329,7 +1441,7 @@ impl Server for HttpServer {
             serve
         };
         let listening = serve.local_addr().context(InternalIoSnafu)?;
-        info!("HTTP server is bound to {}", listening);
+        info!("{} server is bound to {}", self.kind(), listening);
 
         common_runtime::spawn_global(async move {
             if let Err(e) = serve
@@ -1346,7 +1458,11 @@ impl Server for HttpServer {
     }
 
     fn name(&self) -> &str {
-        HTTP_SERVER
+        if self.api_only {
+            HTTP_API_SERVER
+        } else {
+            HTTP_SERVER
+        }
     }
 
     fn bind_addr(&self) -> Option<SocketAddr> {
@@ -1475,6 +1591,120 @@ mod test {
             .send()
             .await;
         assert_ne!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    fn make_split_builder() -> HttpServerBuilder {
+        let (tx, _rx) = mpsc::channel(100);
+        let instance = Arc::new(DummyInstance { _tx: tx });
+        HttpServerBuilder::new(HttpOptions::default())
+            .with_sql_handler(instance)
+            .with_metrics_handler(MetricsHandler)
+            .with_greptime_config_options("dummy = \"value\"".to_string())
+    }
+
+    #[tokio::test]
+    pub async fn test_http_api_options_defaults() {
+        let opts = HttpOptions::default();
+        assert!(opts.api_server_enable);
+        assert_eq!(opts.api_server_host, "127.0.0.1");
+        assert_eq!(opts.api_server_port, 4006);
+    }
+
+    #[tokio::test]
+    pub async fn test_build_serves_all_routes() {
+        // The single (internal/full) server built via `build()` keeps serving both
+        // the public v1 interfaces and the internal ones. This is the historical
+        // single-server behavior and must not change.
+        let server = make_split_builder().build();
+        assert_eq!(server.name(), HTTP_SERVER);
+
+        let app = server.build(server.make_app()).unwrap();
+        let client = TestClient::new(app).await;
+
+        for path in ["/v1/health", "/health", "/status", "/metrics", "/config"] {
+            let res = client.get(path).send().await;
+            assert_eq!(
+                res.status(),
+                StatusCode::OK,
+                "internal/full server should serve {path}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    pub async fn test_build_servers_separates_api_and_internal_routes() {
+        // `build_servers` produces the internal/full server (everything) plus a
+        // dedicated API server that only serves the v1 interfaces (and dashboard).
+        let (internal, api) = make_split_builder().build_servers();
+        let api = api.expect("API server is enabled by default");
+        assert_eq!(internal.name(), HTTP_SERVER);
+        assert_eq!(api.name(), HTTP_API_SERVER);
+
+        let internal_app = internal.build(internal.make_app()).unwrap();
+        let api_app = api.build(api.make_app()).unwrap();
+
+        let internal_client = TestClient::new(internal_app).await;
+        let api_client = TestClient::new(api_app).await;
+
+        // Both servers serve the v1 interfaces (e.g. the v1 health check).
+        assert_eq!(
+            internal_client.get("/v1/health").send().await.status(),
+            StatusCode::OK
+        );
+        assert_eq!(
+            api_client.get("/v1/health").send().await.status(),
+            StatusCode::OK
+        );
+
+        // The internal-only interfaces are served by the internal/full server...
+        for path in ["/health", "/status", "/metrics", "/config"] {
+            assert_eq!(
+                internal_client.get(path).send().await.status(),
+                StatusCode::OK,
+                "internal/full server should serve {path}"
+            );
+            // ...and NOT by the API-only server.
+            assert_eq!(
+                api_client.get(path).send().await.status(),
+                StatusCode::NOT_FOUND,
+                "API server should NOT serve {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_build_servers_api_inherits_http_options() {
+        // The API server must inherit every `[http]` option except the bound addr.
+        let http_opts = HttpOptions {
+            timeout: Duration::from_secs(42),
+            body_limit: ReadableSize::mb(128),
+            cors_allowed_origins: vec!["https://example.com".to_string()],
+            ..HttpOptions::default()
+        };
+        let (internal, api) = HttpServerBuilder::new(http_opts.clone()).build_servers();
+        let api = api.expect("API server is enabled by default");
+
+        // Only the bound address differs.
+        assert_eq!(internal.options.addr, http_opts.addr);
+        assert_eq!(api.options.addr, "127.0.0.1:4006");
+        // Everything else is inherited from `[http]`.
+        assert_eq!(api.options.timeout, http_opts.timeout);
+        assert_eq!(api.options.body_limit, http_opts.body_limit);
+        assert_eq!(
+            api.options.cors_allowed_origins,
+            http_opts.cors_allowed_origins
+        );
+    }
+
+    #[test]
+    fn test_build_servers_can_disable_api_server() {
+        // When `api_server_enable` is false, no API server is built.
+        let opts = HttpOptions {
+            api_server_enable: false,
+            ..HttpOptions::default()
+        };
+        let (_internal, api) = HttpServerBuilder::new(opts).build_servers();
+        assert!(api.is_none());
     }
 
     #[tokio::test]

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -219,7 +219,7 @@ impl Default for HttpOptions {
             prom_validation_mode: PromValidationMode::Strict,
             experimental_enable_prometheus_native_histogram: false,
             experimental_enable_explain_analyze_stream: true,
-            api_server_enable: true,
+            api_server_enable: false,
             api_server_host: "127.0.0.1".to_string(),
             api_server_port: DEFAULT_HTTP_API_ADDR_PORT,
         }
@@ -1596,7 +1596,12 @@ mod test {
     fn make_split_builder() -> HttpServerBuilder {
         let (tx, _rx) = mpsc::channel(100);
         let instance = Arc::new(DummyInstance { _tx: tx });
-        HttpServerBuilder::new(HttpOptions::default())
+        // Enable the dedicated API server so the split behavior can be exercised.
+        let options = HttpOptions {
+            api_server_enable: true,
+            ..HttpOptions::default()
+        };
+        HttpServerBuilder::new(options)
             .with_sql_handler(instance)
             .with_metrics_handler(MetricsHandler)
             .with_greptime_config_options("dummy = \"value\"".to_string())
@@ -1605,7 +1610,8 @@ mod test {
     #[tokio::test]
     pub async fn test_http_api_options_defaults() {
         let opts = HttpOptions::default();
-        assert!(opts.api_server_enable);
+        // The API server is disabled by default.
+        assert!(!opts.api_server_enable);
         assert_eq!(opts.api_server_host, "127.0.0.1");
         assert_eq!(opts.api_server_port, 4006);
     }
@@ -1636,7 +1642,7 @@ mod test {
         // `build_servers` produces the internal/full server (everything) plus a
         // dedicated API server that only serves the v1 interfaces (and dashboard).
         let (internal, api) = make_split_builder().build_servers();
-        let api = api.expect("API server is enabled by default");
+        let api = api.expect("API server is explicitly enabled in make_split_builder");
         assert_eq!(internal.name(), HTTP_SERVER);
         assert_eq!(api.name(), HTTP_API_SERVER);
 
@@ -1679,10 +1685,11 @@ mod test {
             timeout: Duration::from_secs(42),
             body_limit: ReadableSize::mb(128),
             cors_allowed_origins: vec!["https://example.com".to_string()],
+            api_server_enable: true,
             ..HttpOptions::default()
         };
         let (internal, api) = HttpServerBuilder::new(http_opts.clone()).build_servers();
-        let api = api.expect("API server is enabled by default");
+        let api = api.expect("API server is explicitly enabled");
 
         // Only the bound address differs.
         assert_eq!(internal.options.addr, http_opts.addr);
@@ -1697,13 +1704,10 @@ mod test {
     }
 
     #[test]
-    fn test_build_servers_can_disable_api_server() {
-        // When `api_server_enable` is false, no API server is built.
-        let opts = HttpOptions {
-            api_server_enable: false,
-            ..HttpOptions::default()
-        };
-        let (_internal, api) = HttpServerBuilder::new(opts).build_servers();
+    fn test_build_servers_api_disabled_by_default() {
+        // The API server is disabled by default, so `build_servers` returns no
+        // second server unless `api_server_enable` is set.
+        let (_internal, api) = HttpServerBuilder::new(HttpOptions::default()).build_servers();
         assert!(api.is_none());
     }
 

--- a/src/servers/src/http/client_ip.rs
+++ b/src/servers/src/http/client_ip.rs
@@ -61,8 +61,7 @@ pub async fn log_error_with_client_ip(req: Request<Body>, next: Next) -> Respons
 }
 
 fn is_public_http_api_path(path: &str) -> bool {
-    path == super::HTTP_API_PREFIX_WITHOUT_TRAILING_SLASH
-        || path.starts_with(super::HTTP_API_PREFIX)
+    super::is_namespace(path, super::HTTP_API_PREFIX_WITHOUT_TRAILING_SLASH)
 }
 
 #[cfg(test)]

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -2084,7 +2084,7 @@ experimental_enable_prometheus_native_histogram = false
 cors_allowed_origins = []
 enable_cors = true
 experimental_enable_explain_analyze_stream = true
-api_server_enable = true
+api_server_enable = false
 api_server_host = "127.0.0.1"
 api_server_port = 4006
 

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -2085,8 +2085,7 @@ cors_allowed_origins = []
 enable_cors = true
 experimental_enable_explain_analyze_stream = true
 api_server_enable = false
-api_server_host = "127.0.0.1"
-api_server_port = 4006
+api_server_addr = "127.0.0.1:4006"
 
 [grpc]
 bind_addr = "127.0.0.1:4001"

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -2084,6 +2084,9 @@ experimental_enable_prometheus_native_histogram = false
 cors_allowed_origins = []
 enable_cors = true
 experimental_enable_explain_analyze_stream = true
+api_server_enable = true
+api_server_host = "127.0.0.1"
+api_server_port = 4006
 
 [grpc]
 bind_addr = "127.0.0.1:4001"

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -2084,7 +2084,7 @@ experimental_enable_prometheus_native_histogram = false
 cors_allowed_origins = []
 enable_cors = true
 experimental_enable_explain_analyze_stream = true
-api_server_enable = false
+enable_api_server = false
 api_server_addr = "127.0.0.1:4006"
 
 [grpc]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This patch adds a dedicated http api server port for our `/v1` and `/dashboard`.
The new port is opt-in, and can be configured via something like `enable_api_server`. 

This patch will reuse same axum `Router` for both servers, but adding a new middleware to block paths for api server.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
