### PR TITLE
chore: bump main branch version to 1.2.0-beta.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,7 +213,7 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "api"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "arrow-schema 58.3.0",
  "common-base",
@@ -936,7 +936,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auth"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-trait",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "catalog",
  "common-error",
@@ -1622,7 +1622,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "arrow 58.3.0",
@@ -1957,7 +1957,7 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "cli"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "arc-swap",
@@ -2048,7 +2048,7 @@ dependencies = [
  "serde_json",
  "snafu 0.8.6",
  "store-api",
- "substrait 1.2.0",
+ "substrait 1.2.0-beta.1",
  "tokio",
  "tokio-stream",
  "tonic 0.14.2",
@@ -2097,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-trait",
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "common-base"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "ahash 0.8.12",
  "anymap2",
@@ -2268,14 +2268,14 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "const_format",
 ]
 
 [[package]]
 name = "common-config"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "common-base",
  "common-error",
@@ -2299,7 +2299,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "arrow 58.3.0",
  "arrow-schema 58.3.0",
@@ -2335,7 +2335,7 @@ dependencies = [
 
 [[package]]
 name = "common-decimal"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "bigdecimal 0.4.8",
  "common-error",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "common-macro",
  "http 1.3.1",
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "common-event-recorder"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-trait",
@@ -2383,7 +2383,7 @@ dependencies = [
 
 [[package]]
 name = "common-frontend"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-trait",
@@ -2404,7 +2404,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -2467,7 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "common-greptimedb-telemetry"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-trait",
  "common-runtime",
@@ -2484,7 +2484,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "arrow-flight",
@@ -2519,7 +2519,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "common-base",
@@ -2539,7 +2539,7 @@ dependencies = [
 
 [[package]]
 name = "common-macro"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "greptime-proto",
  "once_cell",
@@ -2550,7 +2550,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "anyhow",
  "common-error",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "common-memory-manager"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2578,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "anymap2",
  "api",
@@ -2650,7 +2650,7 @@ dependencies = [
 
 [[package]]
 name = "common-options"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "common-grpc",
  "humantime-serde",
@@ -2660,11 +2660,11 @@ dependencies = [
 
 [[package]]
 name = "common-plugins"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 
 [[package]]
 name = "common-pprof"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2675,7 +2675,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-stream",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -2714,7 +2714,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-trait",
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "arc-swap",
  "common-base",
@@ -2769,7 +2769,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-trait",
  "clap",
@@ -2798,7 +2798,7 @@ dependencies = [
 
 [[package]]
 name = "common-session"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "serde",
  "strum 0.27.1",
@@ -2806,7 +2806,7 @@ dependencies = [
 
 [[package]]
 name = "common-sql"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "arrow-schema 58.3.0",
  "common-base",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "common-stat"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "common-base",
  "common-runtime",
@@ -2841,7 +2841,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "backtrace",
  "common-base",
@@ -2870,7 +2870,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "client",
  "common-grpc",
@@ -2883,7 +2883,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -2901,7 +2901,7 @@ dependencies = [
 
 [[package]]
 name = "common-version"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "cargo-manifest",
  "const_format",
@@ -2911,7 +2911,7 @@ dependencies = [
 
 [[package]]
 name = "common-wal"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "common-base",
  "common-error",
@@ -2934,7 +2934,7 @@ dependencies = [
 
 [[package]]
 name = "common-workload"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "common-telemetry",
  "serde",
@@ -4409,7 +4409,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "arrow-flight",
@@ -4483,7 +4483,7 @@ checksum = "c286de4e81ea2590afc24d754e0f83810c566f50a1388fa75ebd57928c0d9745"
 
 [[package]]
 name = "datatypes"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "arrow 58.3.0",
  "arrow-array 58.3.0",
@@ -5220,7 +5220,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "file-engine"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-trait",
@@ -5351,7 +5351,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "flow"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "arrow 58.3.0",
@@ -5420,7 +5420,7 @@ dependencies = [
  "sql",
  "store-api",
  "strum 0.27.1",
- "substrait 1.2.0",
+ "substrait 1.2.0-beta.1",
  "table",
  "tokio",
  "tokio-stream",
@@ -5503,7 +5503,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "frontend"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "arc-swap",
@@ -6793,7 +6793,7 @@ dependencies = [
 
 [[package]]
 name = "index"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -7892,7 +7892,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "log-query"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "chrono",
  "common-error",
@@ -7904,7 +7904,7 @@ dependencies = [
 
 [[package]]
 name = "log-store"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8223,7 +8223,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-trait",
@@ -8255,7 +8255,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-trait",
@@ -8355,7 +8355,7 @@ dependencies = [
 
 [[package]]
 name = "metric-engine"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "aquamarine",
@@ -8456,7 +8456,7 @@ dependencies = [
 
 [[package]]
 name = "mito-codec"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "bytes",
@@ -8481,7 +8481,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "aquamarine",
@@ -9271,7 +9271,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9840,7 +9840,7 @@ dependencies = [
 
 [[package]]
 name = "operator"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -9899,7 +9899,7 @@ dependencies = [
  "sql",
  "sqlparser",
  "store-api",
- "substrait 1.2.0",
+ "substrait 1.2.0-beta.1",
  "table",
  "tokio",
  "tokio-util",
@@ -10184,7 +10184,7 @@ checksum = "e3c406c9e2aa74554e662d2c2ee11cd3e73756988800be7e6f5eddb16fed4699"
 
 [[package]]
 name = "partition"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-trait",
@@ -10578,7 +10578,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeline"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -10735,7 +10735,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "auth",
  "catalog",
@@ -11075,7 +11075,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -11428,7 +11428,7 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-compression",
  "async-trait",
@@ -11490,7 +11490,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -11560,7 +11560,7 @@ dependencies = [
  "sql",
  "sqlparser",
  "store-api",
- "substrait 1.2.0",
+ "substrait 1.2.0-beta.1",
  "table",
  "tokio",
  "tokio-stream",
@@ -13160,7 +13160,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -13300,7 +13300,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -13653,7 +13653,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "arrow-buffer 58.3.0",
@@ -13714,7 +13714,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-trait",
  "clap",
@@ -13996,7 +13996,7 @@ dependencies = [
 
 [[package]]
 name = "standalone"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-trait",
  "catalog",
@@ -14040,7 +14040,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "store-api"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "aquamarine",
@@ -14233,7 +14233,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -14355,7 +14355,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "arc-swap",
@@ -14638,7 +14638,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tests-fuzz"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "arbitrary",
  "async-trait",
@@ -14686,7 +14686,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "arrow-flight",
@@ -14766,7 +14766,7 @@ dependencies = [
  "sqlx",
  "standalone",
  "store-api",
- "substrait 1.2.0",
+ "substrait 1.2.0-beta.1",
  "table",
  "tempfile",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.2.0"
+version = "1.2.0-beta.1"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Prerequisite release-safety change: #8653.

## What's changed and what's your intention?

Prepare the first GreptimeDB v1.2 beta release by updating the main-branch workspace version from `1.2.0` to `1.2.0-beta.1`.

This PR changes only:

- the root `[workspace.package].version` in `Cargo.toml`;
- Cargo-generated workspace package metadata and qualified internal references in `Cargo.lock`.

The PR is based on main commit `3e67c67607c857b24df3d168398cc78e06e5d16b`. After this PR merges, the release owner will create `release/v1.2` at the exact merged commit and use `v1.2.0-beta.1` for the formal prerelease tag.

Lockfile audit:

- total package count remains 1364;
- the same 71 source-less workspace packages move from `1.2.0` to `1.2.0-beta.1`;
- all 1293 external package name/version/source/checksum identities remain unchanged;
- no package was added or removed.

Validation:

- `cargo metadata --locked --no-deps --format-version 1`
- `make check-toml`
- `git diff --check`
- `uv run --no-project python .github/scripts/check-version-test.py`
- formal tag validation accepts `v1.2.0-beta.1` and rejects mismatched `v1.2.0`
- `cargo build --bin greptime`; the binary reports `version: 1.2.0-beta.1`
- `cargo sqlness bare -t 'standalone:common/function/system' --preserve-state`
- `cargo sqlness bare -t 'standalone:information_schema/cluster_info' --preserve-state`
- `cargo sqlness bare -t 'distributed:information_schema/cluster_info' --preserve-state`

All focused SQLness cases passed without source or result changes. This PR changes no runtime behavior, API, schema, persisted format, or wire format.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments. (N/A: metadata-only change.)
- [x] I have added the necessary unit tests and integration tests. (Existing focused version tests pass.)
- [ ] This PR requires documentation updates. (No documentation update is required.)
- [x] API changes are backward compatible. (No API changes.)
- [x] Schema or data changes are backward compatible. (No schema or data changes.)
