### PR TITLE
chore: bump release version to 1.2.0-beta.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,7 +213,7 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "api"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "arrow-schema 58.3.0",
  "common-base",
@@ -936,7 +936,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auth"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-trait",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "catalog",
  "common-error",
@@ -1622,7 +1622,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "arrow 58.3.0",
@@ -1957,7 +1957,7 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "cli"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "arc-swap",
@@ -2048,7 +2048,7 @@ dependencies = [
  "serde_json",
  "snafu 0.8.6",
  "store-api",
- "substrait 1.2.0",
+ "substrait 1.2.0-beta.1",
  "tokio",
  "tokio-stream",
  "tonic 0.14.2",
@@ -2097,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-trait",
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "common-base"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "ahash 0.8.12",
  "anymap2",
@@ -2268,14 +2268,14 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "const_format",
 ]
 
 [[package]]
 name = "common-config"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "common-base",
  "common-error",
@@ -2299,7 +2299,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "arrow 58.3.0",
  "arrow-schema 58.3.0",
@@ -2335,7 +2335,7 @@ dependencies = [
 
 [[package]]
 name = "common-decimal"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "bigdecimal 0.4.8",
  "common-error",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "common-macro",
  "http 1.3.1",
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "common-event-recorder"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-trait",
@@ -2384,7 +2384,7 @@ dependencies = [
 
 [[package]]
 name = "common-frontend"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-trait",
@@ -2405,7 +2405,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "common-greptimedb-telemetry"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-trait",
  "common-runtime",
@@ -2485,7 +2485,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "arrow-flight",
@@ -2520,7 +2520,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "common-base",
@@ -2540,7 +2540,7 @@ dependencies = [
 
 [[package]]
 name = "common-macro"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "greptime-proto",
  "once_cell",
@@ -2551,7 +2551,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "anyhow",
  "common-error",
@@ -2567,7 +2567,7 @@ dependencies = [
 
 [[package]]
 name = "common-memory-manager"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2579,7 +2579,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "anymap2",
  "api",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "common-options"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "common-grpc",
  "humantime-serde",
@@ -2661,11 +2661,11 @@ dependencies = [
 
 [[package]]
 name = "common-plugins"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 
 [[package]]
 name = "common-pprof"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2676,7 +2676,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-stream",
@@ -2705,7 +2705,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -2715,7 +2715,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-trait",
@@ -2745,7 +2745,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "arc-swap",
  "common-base",
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-trait",
  "clap",
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "common-session"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "serde",
  "strum 0.27.1",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "common-sql"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "arrow-schema 58.3.0",
  "common-base",
@@ -2827,7 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "common-stat"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "common-base",
  "common-runtime",
@@ -2842,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "backtrace",
  "common-base",
@@ -2871,7 +2871,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "client",
  "common-grpc",
@@ -2884,7 +2884,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -2902,7 +2902,7 @@ dependencies = [
 
 [[package]]
 name = "common-version"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "cargo-manifest",
  "const_format",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "common-wal"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "common-base",
  "common-error",
@@ -2935,7 +2935,7 @@ dependencies = [
 
 [[package]]
 name = "common-workload"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "common-telemetry",
  "serde",
@@ -4410,7 +4410,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "arrow-flight",
@@ -4484,7 +4484,7 @@ checksum = "c286de4e81ea2590afc24d754e0f83810c566f50a1388fa75ebd57928c0d9745"
 
 [[package]]
 name = "datatypes"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "arrow 58.3.0",
  "arrow-array 58.3.0",
@@ -5221,7 +5221,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "file-engine"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-trait",
@@ -5352,7 +5352,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "flow"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "arrow 58.3.0",
@@ -5421,7 +5421,7 @@ dependencies = [
  "sql",
  "store-api",
  "strum 0.27.1",
- "substrait 1.2.0",
+ "substrait 1.2.0-beta.1",
  "table",
  "tokio",
  "tokio-stream",
@@ -5504,7 +5504,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "frontend"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "arc-swap",
@@ -6794,7 +6794,7 @@ dependencies = [
 
 [[package]]
 name = "index"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -7893,7 +7893,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "log-query"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "chrono",
  "common-error",
@@ -7905,7 +7905,7 @@ dependencies = [
 
 [[package]]
 name = "log-store"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8224,7 +8224,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-trait",
@@ -8256,7 +8256,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-trait",
@@ -8356,7 +8356,7 @@ dependencies = [
 
 [[package]]
 name = "metric-engine"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "aquamarine",
@@ -8457,7 +8457,7 @@ dependencies = [
 
 [[package]]
 name = "mito-codec"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "bytes",
@@ -8482,7 +8482,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "aquamarine",
@@ -9272,7 +9272,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9841,7 +9841,7 @@ dependencies = [
 
 [[package]]
 name = "operator"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -9900,7 +9900,7 @@ dependencies = [
  "sql",
  "sqlparser",
  "store-api",
- "substrait 1.2.0",
+ "substrait 1.2.0-beta.1",
  "table",
  "tokio",
  "tokio-util",
@@ -10185,7 +10185,7 @@ checksum = "e3c406c9e2aa74554e662d2c2ee11cd3e73756988800be7e6f5eddb16fed4699"
 
 [[package]]
 name = "partition"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-trait",
@@ -10579,7 +10579,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeline"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -10736,7 +10736,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "auth",
  "catalog",
@@ -11076,7 +11076,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -11429,7 +11429,7 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-compression",
  "async-trait",
@@ -11491,7 +11491,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -11561,7 +11561,7 @@ dependencies = [
  "sql",
  "sqlparser",
  "store-api",
- "substrait 1.2.0",
+ "substrait 1.2.0-beta.1",
  "table",
  "tokio",
  "tokio-stream",
@@ -13161,7 +13161,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -13301,7 +13301,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -13654,7 +13654,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "arrow-buffer 58.3.0",
@@ -13715,7 +13715,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-trait",
  "clap",
@@ -13997,7 +13997,7 @@ dependencies = [
 
 [[package]]
 name = "standalone"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-trait",
  "catalog",
@@ -14043,7 +14043,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "store-api"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "aquamarine",
@@ -14236,7 +14236,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -14358,7 +14358,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "arc-swap",
@@ -14641,7 +14641,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tests-fuzz"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "arbitrary",
  "async-trait",
@@ -14689,7 +14689,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "arrow-flight",
@@ -14769,7 +14769,7 @@ dependencies = [
  "sqlx",
  "standalone",
  "store-api",
- "substrait 1.2.0",
+ "substrait 1.2.0-beta.1",
  "table",
  "tempfile",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.2.0"
+version = "1.2.0-beta.1"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Prerequisite release-safety change: #8653.

## What's changed and what's your intention?

Prepare the first GreptimeDB v1.2 beta release by updating only the `release/v1.2` workspace version from `1.2.0` to `1.2.0-beta.1`. The `main` branch remains at `1.2.0`.

This PR changes only:

- the root `[workspace.package].version` in `Cargo.toml`;
- Cargo-generated workspace package metadata and qualified internal references in `Cargo.lock`.

The PR is based on the initial `release/v1.2` commit `5ad4e7100763219e40ce90ff4eda9de13c7c775f`.

Lockfile audit:

- total package count remains 1364;
- the same 71 source-less workspace packages move from `1.2.0` to `1.2.0-beta.1`;
- all 1293 external package name/version/source/checksum identities remain unchanged;
- no package was added or removed.

Validation:

- `cargo metadata --locked --no-deps --format-version 1`
- `make check-toml`
- `git diff --check`
- `uv run --no-project python .github/scripts/check-version-test.py`
- formal tag validation accepts `v1.2.0-beta.1` and rejects mismatched `v1.2.0`

This PR changes no runtime behavior, API, schema, persisted format, or wire format.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments. (N/A: metadata-only change.)
- [x] I have added the necessary unit tests and integration tests. (Existing focused version tests pass.)
- [ ] This PR requires documentation updates. (No documentation update is required.)
- [x] API changes are backward compatible. (No API changes.)
- [x] Schema or data changes are backward compatible. (No schema or data changes.)
