### PR TITLE
fix(mito2): suppress empty compaction skip logs

### DIFF
--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -79,13 +79,15 @@ impl TwcsPicker {
                     .into_iter()
                     .partition(|fg| fg.size() <= max_size as usize);
                 files_to_merge = kept_files;
-                info!(
-                    "Skipped {} large files in append mode for region {}, window {}, max_size: {}",
-                    ignored_files.len(),
-                    region_id,
-                    window,
-                    max_size
-                );
+                if !ignored_files.is_empty() {
+                    info!(
+                        "Skipped {} large files in append mode for region {}, window {}, max_size: {}",
+                        ignored_files.len(),
+                        region_id,
+                        window,
+                        max_size
+                    );
+                }
             }
 
             let sorted_runs = if files_to_merge.len() < 1024 {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The TWCS compaction picker currently emits an INFO log such as `Skipped 0 large files` for every processed time window in append mode, even when no file is filtered out.

This PR guards the existing log with a non-empty check so it is emitted only when at least one oversized file group is actually skipped. The picker behavior and the existing aggregated log format remain unchanged.

There are no API, schema, data format, or compatibility changes.

## Test Plan

- `cargo nextest run -p mito2 compaction::twcs` (16 passed)
- `cargo fmt --all -- --check`
- `cargo check -p mito2 --lib`
- `git diff --check`

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
