### PR TITLE
fix(query): preserve dictionary regex filter semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2195,7 +2195,7 @@ checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.1",
 ]
 
 [[package]]
@@ -2206,7 +2206,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.1",
 ]
 
 [[package]]
@@ -2222,7 +2222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5084,7 +5084,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6532,7 +6532,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -6603,7 +6603,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -7047,7 +7047,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7750,7 +7750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.5",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -11178,7 +11178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -11198,8 +11198,8 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -11247,7 +11247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11260,7 +11260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11660,7 +11660,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12600,7 +12600,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12613,7 +12613,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12694,7 +12694,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13577,7 +13577,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1961e2ef424c1424204d3a5d6975f934f56b6d50ff5732382d84ebf460e147f7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -13992,7 +13992,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -14600,7 +14600,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -16351,7 +16351,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2195,7 +2195,7 @@ checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.2.1",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -2206,7 +2206,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.2.1",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -2222,7 +2222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3692,7 +3692,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 [[package]]
 name = "datafusion"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "arrow 58.3.0",
  "arrow-schema 58.3.0",
@@ -3746,7 +3746,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3770,7 +3770,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3792,7 +3792,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -3816,7 +3816,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "futures",
  "log",
@@ -3826,7 +3826,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "arrow 58.3.0",
  "async-compression",
@@ -3860,7 +3860,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "arrow 58.3.0",
  "arrow-ipc 58.3.0",
@@ -3883,7 +3883,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3905,7 +3905,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3928,7 +3928,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3957,12 +3957,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 
 [[package]]
 name = "datafusion-execution"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "arrow 58.3.0",
  "arrow-buffer 58.3.0",
@@ -3984,7 +3984,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4006,7 +4006,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4018,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "arrow 58.3.0",
  "arrow-buffer 58.3.0",
@@ -4049,7 +4049,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4070,7 +4070,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4082,7 +4082,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "arrow 58.3.0",
  "arrow-ord 58.3.0",
@@ -4106,7 +4106,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4121,7 +4121,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4138,7 +4138,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -4147,7 +4147,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -4157,7 +4157,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -4206,7 +4206,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4229,7 +4229,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4243,7 +4243,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4259,7 +4259,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4277,7 +4277,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4308,7 +4308,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -4335,7 +4335,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4345,7 +4345,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4361,7 +4361,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -4374,7 +4374,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "arrow 58.3.0",
  "bigdecimal 0.4.8",
@@ -4392,7 +4392,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -5084,7 +5084,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6532,7 +6532,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -6603,7 +6603,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -7047,7 +7047,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7750,7 +7750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -11178,7 +11178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -11198,8 +11198,8 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.11.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -11247,7 +11247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11260,7 +11260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11660,7 +11660,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12600,7 +12600,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12613,7 +12613,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12694,7 +12694,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13577,7 +13577,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1961e2ef424c1424204d3a5d6975f934f56b6d50ff5732382d84ebf460e147f7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -13992,7 +13992,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -14600,7 +14600,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -16351,7 +16351,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3692,7 +3692,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 [[package]]
 name = "datafusion"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "arrow 58.3.0",
  "arrow-schema 58.3.0",
@@ -3746,7 +3746,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3770,7 +3770,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3792,7 +3792,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -3816,7 +3816,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "futures",
  "log",
@@ -3826,7 +3826,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "arrow 58.3.0",
  "async-compression",
@@ -3860,7 +3860,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "arrow 58.3.0",
  "arrow-ipc 58.3.0",
@@ -3883,7 +3883,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3905,7 +3905,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3928,7 +3928,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3957,12 +3957,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 
 [[package]]
 name = "datafusion-execution"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "arrow 58.3.0",
  "arrow-buffer 58.3.0",
@@ -3984,7 +3984,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4006,7 +4006,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4018,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "arrow 58.3.0",
  "arrow-buffer 58.3.0",
@@ -4049,7 +4049,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4070,7 +4070,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4082,7 +4082,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "arrow 58.3.0",
  "arrow-ord 58.3.0",
@@ -4106,7 +4106,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4121,7 +4121,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4138,7 +4138,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -4147,7 +4147,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -4157,7 +4157,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -4206,7 +4206,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4229,7 +4229,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4243,7 +4243,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4259,7 +4259,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4277,7 +4277,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4308,7 +4308,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -4335,7 +4335,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4345,7 +4345,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4361,7 +4361,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -4374,7 +4374,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "arrow 58.3.0",
  "bigdecimal 0.4.8",
@@ -4392,7 +4392,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=aa6f9fa05d94a1f694eabd05bbbb8a443ebace35#aa6f9fa05d94a1f694eabd05bbbb8a443ebace35"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a0af1f0685e3cb9be27e9fce069a6534475ec2af#a0af1f0685e3cb9be27e9fce069a6534475ec2af"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -342,21 +342,21 @@ git = "https://github.com/GreptimeTeam/greptime-meter.git"
 rev = "5618e779cf2bb4755b499c630fba4c35e91898cb"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
-datafusion-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
-datafusion-datasource = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
-datafusion-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
-datafusion-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
-datafusion-functions = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
-datafusion-functions-aggregate-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
-datafusion-functions-window-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
-datafusion-optimizer = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
-datafusion-physical-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
-datafusion-physical-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
-datafusion-physical-plan = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
-datafusion-proto = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
-datafusion-sql = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
-datafusion-substrait = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
+datafusion = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
+datafusion-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
+datafusion-datasource = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
+datafusion-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
+datafusion-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
+datafusion-functions = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
+datafusion-functions-aggregate-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
+datafusion-functions-window-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
+datafusion-optimizer = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
+datafusion-physical-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
+datafusion-physical-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
+datafusion-physical-plan = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
+datafusion-proto = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
+datafusion-sql = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
+datafusion-substrait = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
 sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "2aefa08a8d69c96eec2d6d6703598a009bba6e4c" }                           # on branch v0.61.x
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -342,21 +342,21 @@ git = "https://github.com/GreptimeTeam/greptime-meter.git"
 rev = "5618e779cf2bb4755b499c630fba4c35e91898cb"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
-datafusion-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
-datafusion-datasource = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
-datafusion-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
-datafusion-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
-datafusion-functions = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
-datafusion-functions-aggregate-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
-datafusion-functions-window-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
-datafusion-optimizer = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
-datafusion-physical-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
-datafusion-physical-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
-datafusion-physical-plan = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
-datafusion-proto = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
-datafusion-sql = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
-datafusion-substrait = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "aa6f9fa05d94a1f694eabd05bbbb8a443ebace35" }
+datafusion = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a0af1f0685e3cb9be27e9fce069a6534475ec2af" }
+datafusion-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a0af1f0685e3cb9be27e9fce069a6534475ec2af" }
+datafusion-datasource = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a0af1f0685e3cb9be27e9fce069a6534475ec2af" }
+datafusion-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a0af1f0685e3cb9be27e9fce069a6534475ec2af" }
+datafusion-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a0af1f0685e3cb9be27e9fce069a6534475ec2af" }
+datafusion-functions = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a0af1f0685e3cb9be27e9fce069a6534475ec2af" }
+datafusion-functions-aggregate-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a0af1f0685e3cb9be27e9fce069a6534475ec2af" }
+datafusion-functions-window-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a0af1f0685e3cb9be27e9fce069a6534475ec2af" }
+datafusion-optimizer = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a0af1f0685e3cb9be27e9fce069a6534475ec2af" }
+datafusion-physical-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a0af1f0685e3cb9be27e9fce069a6534475ec2af" }
+datafusion-physical-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a0af1f0685e3cb9be27e9fce069a6534475ec2af" }
+datafusion-physical-plan = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a0af1f0685e3cb9be27e9fce069a6534475ec2af" }
+datafusion-proto = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a0af1f0685e3cb9be27e9fce069a6534475ec2af" }
+datafusion-sql = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a0af1f0685e3cb9be27e9fce069a6534475ec2af" }
+datafusion-substrait = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a0af1f0685e3cb9be27e9fce069a6534475ec2af" }
 sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "2aefa08a8d69c96eec2d6d6703598a009bba6e4c" }                           # on branch v0.61.x
 
 [profile.release]

--- a/src/common/recordbatch/src/filter.rs
+++ b/src/common/recordbatch/src/filter.rs
@@ -269,7 +269,7 @@ impl SimpleFilterEvaluator {
         };
         result
             .context(ArrowComputeSnafu)
-            .map(|array| array.values().clone())
+            .map(|array| boolean_array_to_scan_mask(&array).values().clone())
     }
 
     /// Builds a regex pattern from a scalar value and operator.
@@ -364,8 +364,24 @@ pub fn batch_filter(
                     Ok::<BooleanArray, DataFusionError>(BooleanArray::new_null(null_array.len()))
                 }
             }?;
-            Ok(filter_record_batch(batch, &filter_array)?)
+            Ok(filter_record_batch(
+                batch,
+                &boolean_array_to_scan_mask(&filter_array),
+            )?)
         })
+}
+
+/// Converts nullable SQL predicate values to a scan mask, where `NULL` is `false`.
+fn boolean_array_to_scan_mask(array: &BooleanArray) -> BooleanArray {
+    if array.null_count() == 0 {
+        return array.clone();
+    }
+
+    let mut values = BooleanBufferBuilder::new(array.len());
+    for index in 0..array.len() {
+        values.append(array.is_valid(index) && array.value(index));
+    }
+    BooleanArray::new(values.into(), None)
 }
 
 /// The same as arrow [regexp_is_match_scalar()](datatypes::compute::kernels::regexp::regexp_is_match_scalar())
@@ -421,13 +437,15 @@ pub fn regexp_is_match_dictionary(
             ArrowError::CastError("Dictionary values must be StringArray".to_string())
         })?;
 
-    let null_bit_buffer = dict_array.nulls().map(|x| x.inner().sliced());
+    // Dictionary logical nulls include both null keys and keys whose dictionary value is null.
+    let logical_nulls = dict_array.logical_nulls();
+    let null_bit_buffer = logical_nulls.as_ref().map(|x| x.inner().sliced());
     let mut result = BooleanBufferBuilder::new(dict_array.len());
 
     if let Some(re) = regex {
         let keys = dict_array.keys().values();
         for i in 0..dict_array.len() {
-            if dict_array.is_null(i) {
+            if logical_nulls.as_ref().is_some_and(|nulls| nulls.is_null(i)) {
                 result.append(false);
             } else {
                 let key = keys[i] as usize;
@@ -769,5 +787,94 @@ mod test {
         assert!(result3.value(1));
         assert!(result3.value(2));
         assert!(result3.value(3));
+    }
+
+    #[test]
+    fn test_regex_scan_masks_preserve_sql_null_semantics() {
+        let plain = Arc::new(datatypes::arrow::array::StringArray::from(vec![
+            Some("api"),
+            Some("API"),
+            Some("db"),
+            None,
+        ])) as ArrayRef;
+        assert_regex_scan_masks(
+            &plain,
+            [
+                vec![true, false, false, false],
+                vec![true, true, false, false],
+                vec![false, true, true, false],
+                vec![false, false, true, false],
+            ],
+        );
+
+        let dictionary = DictionaryArray::new(
+            datatypes::arrow::array::UInt32Array::from(vec![
+                Some(0),
+                Some(1),
+                Some(2),
+                None,
+                Some(3),
+            ]),
+            Arc::new(datatypes::arrow::array::StringArray::from(vec![
+                Some("api"),
+                Some("API"),
+                Some("db"),
+                None,
+            ])),
+        );
+        let raw =
+            regexp_is_match_dictionary(&dictionary, Some(&Regex::new("^api$").unwrap())).unwrap();
+        assert!(raw.is_null(3)); // null dictionary key
+        assert!(raw.is_null(4)); // non-null key referencing a null dictionary value
+
+        let dictionary = Arc::new(dictionary) as ArrayRef;
+        assert_regex_scan_masks(
+            &dictionary,
+            [
+                vec![true, false, false, false, false],
+                vec![true, true, false, false, false],
+                vec![false, true, true, false, false],
+                vec![false, false, true, false, false],
+            ],
+        );
+
+        let negative = regex_evaluator(Operator::RegexNotMatch);
+        assert!(!negative.evaluate_scalar(&ScalarValue::Utf8(None)).unwrap());
+    }
+
+    #[test]
+    fn test_nullable_boolean_predicate_becomes_scan_mask() {
+        let predicate = BooleanArray::from(vec![Some(true), None, Some(false)]);
+        assert_eq!(
+            BooleanArray::from(vec![true, false, false]),
+            boolean_array_to_scan_mask(&predicate)
+        );
+    }
+
+    fn assert_regex_scan_masks(input: &ArrayRef, expected: [Vec<bool>; 4]) {
+        for (op, expected) in [
+            Operator::RegexMatch,
+            Operator::RegexIMatch,
+            Operator::RegexNotMatch,
+            Operator::RegexNotIMatch,
+        ]
+        .into_iter()
+        .zip(expected)
+        {
+            assert_eq!(
+                BooleanBuffer::from(expected),
+                regex_evaluator(op).evaluate_array(input).unwrap(),
+                "{op:?}"
+            );
+        }
+    }
+
+    fn regex_evaluator(op: Operator) -> SimpleFilterEvaluator {
+        let expr = Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(Expr::Column(Column::from_name("host"))),
+            op,
+            right: Box::new("^api$".lit()),
+        });
+        SimpleFilterEvaluator::try_new(&expr).unwrap()
     }
 }

--- a/src/query/src/optimizer/const_normalization.rs
+++ b/src/query/src/optimizer/const_normalization.rs
@@ -217,6 +217,10 @@ fn rewrite_like_expr(
 }
 
 fn rewrite_binary_expr(binary: BinaryExpr, schema: &DFSchemaRef) -> Result<Option<Expr>> {
+    if let Some(expr) = rewrite_dictionary_string_regex(binary.clone(), schema)? {
+        return Ok(Some(expr));
+    }
+
     if !binary.op.supports_propagation() {
         return Ok(None);
     }
@@ -233,6 +237,46 @@ fn rewrite_binary_expr(binary: BinaryExpr, schema: &DFSchemaRef) -> Result<Optio
     };
 
     rewrite_binary_side(right, swapped_op, left, schema)
+}
+
+/// Removes the string coercion/schema-reconciliation cast present before physical regex planning.
+///
+/// Keeping the dictionary input lets DataFusion's physical regex kernel evaluate scalar patterns
+/// against dictionary values instead of materializing the string column first.
+fn rewrite_dictionary_string_regex(
+    binary: BinaryExpr,
+    schema: &DFSchemaRef,
+) -> Result<Option<Expr>> {
+    let BinaryExpr { left, op, right } = binary;
+    if !matches!(
+        &op,
+        Operator::RegexMatch
+            | Operator::RegexIMatch
+            | Operator::RegexNotMatch
+            | Operator::RegexNotIMatch
+    ) || !matches!(right.as_literal(), Some(ScalarValue::Utf8(Some(_))))
+    {
+        return Ok(None);
+    }
+
+    let Some((CastInputKind::Cast, source, DataType::Utf8)) = extract_cast_input(&left) else {
+        return Ok(None);
+    };
+    if !matches!(source, Expr::Column(_))
+        || !matches!(
+            source.get_type(schema)?,
+            DataType::Dictionary(key_type, value_type)
+                if key_type.as_ref() == &DataType::UInt32 && value_type.as_ref() == &DataType::Utf8
+        )
+    {
+        return Ok(None);
+    }
+
+    Ok(Some(Expr::BinaryExpr(BinaryExpr {
+        left: Box::new(source.clone()),
+        op,
+        right,
+    })))
 }
 
 fn rewrite_binary_side(
@@ -595,6 +639,7 @@ fn timestamp_scalar(unit: ArrowTimeUnit, timezone: Option<Arc<str>>, value: i64)
 mod tests {
     use std::sync::Arc;
 
+    use arrow::array::{DictionaryArray, StringArray, UInt32Array};
     use arrow_schema::{DataType, TimeUnit as ArrowTimeUnit};
     use async_trait::async_trait;
     use common_time::Timestamp;
@@ -602,15 +647,19 @@ mod tests {
     use common_time::timestamp::TimeUnit;
     use datafusion::catalog::Session;
     use datafusion::config::ConfigOptions;
-    use datafusion::datasource::{TableProvider, provider_as_source};
-    use datafusion::physical_plan::ExecutionPlan;
+    use datafusion::datasource::{MemTable, TableProvider, provider_as_source};
+    use datafusion::execution::SessionStateBuilder;
+    use datafusion::execution::context::SessionContext;
+    use datafusion::physical_plan::filter::FilterExec;
+    use datafusion::physical_plan::{ExecutionPlan, collect};
+    use datafusion::physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner};
     use datafusion_common::arrow::datatypes::Field;
     use datafusion_common::{DFSchema, ScalarValue, ToDFSchema};
-    use datafusion_expr::expr::{Between, Like};
+    use datafusion_expr::expr::{Between, BinaryExpr, Like};
     use datafusion_expr::expr_fn::{cast, col, try_cast};
     use datafusion_expr::{
-        Expr, LogicalPlan, LogicalPlanBuilder, TableProviderFilterPushDown, TableScan, TableSource,
-        TableType, lit,
+        Expr, LogicalPlan, LogicalPlanBuilder, Operator, TableProviderFilterPushDown, TableScan,
+        TableSource, TableType, lit,
     };
     use datafusion_optimizer::analyzer::AnalyzerRule;
     use datafusion_optimizer::optimizer::{Optimizer, OptimizerContext};
@@ -619,7 +668,8 @@ mod tests {
     use table::predicate::build_time_range_predicate;
 
     use super::{
-        ConstNormalizationRule, PatternMatchKind, lower_bound_for_ge, try_cast_literal_to_type,
+        ConstNormalizationRule, PatternMatchKind, lower_bound_for_ge,
+        rewrite_dictionary_string_regex, try_cast_literal_to_type,
     };
 
     #[test]
@@ -807,6 +857,199 @@ mod tests {
             PatternMatchKind::SimilarTo,
             ScalarValue::LargeUtf8(Some("api.*".to_string())),
             "Filter: t.s SIMILAR TO Utf8(\"api.*\")\n  TableScan: t",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dictionary_regex_filter_keeps_dictionary_input() {
+        let dictionary_type =
+            DataType::Dictionary(Box::new(DataType::UInt32), Box::new(DataType::Utf8));
+        let schema = Arc::new(arrow_schema::Schema::new(vec![Field::new(
+            "host",
+            dictionary_type.clone(),
+            true,
+        )]));
+        let host = DictionaryArray::new(
+            UInt32Array::from(vec![Some(0), Some(1), Some(2), None, Some(3)]),
+            Arc::new(StringArray::from(vec![
+                Some("api"),
+                Some("API"),
+                Some("db"),
+                None,
+            ])),
+        );
+        let batch = datafusion::arrow::record_batch::RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(host)],
+        )
+        .unwrap();
+
+        for (op, expected_rows) in [
+            (Operator::RegexMatch, 1),
+            (Operator::RegexIMatch, 2),
+            (Operator::RegexNotMatch, 2),
+            (Operator::RegexNotIMatch, 1),
+        ] {
+            let table = MemTable::try_new(schema.clone(), vec![vec![batch.clone()]]).unwrap();
+            let predicate = Expr::BinaryExpr(BinaryExpr {
+                // This string coercion/schema-reconciliation cast is present before physical
+                // regex planning and would bypass DataFusion's dictionary-aware scalar regex
+                // kernel.
+                left: Box::new(cast(col("host"), DataType::Utf8)),
+                op,
+                right: Box::new(lit("^api$")),
+            });
+            let plan = LogicalPlanBuilder::scan("t", provider_as_source(Arc::new(table)), None)
+                .unwrap()
+                .filter(predicate)
+                .unwrap()
+                .build()
+                .unwrap();
+            let analyzed = analyze_plan(plan);
+
+            let LogicalPlan::Filter(filter) = &analyzed else {
+                panic!("expected filter plan");
+            };
+            let Expr::BinaryExpr(BinaryExpr { left, .. }) = &filter.predicate else {
+                panic!("expected regex binary predicate");
+            };
+            assert!(matches!(left.as_ref(), Expr::Column(_)));
+
+            let session_state = SessionStateBuilder::new().with_default_features().build();
+            let physical_plan = DefaultPhysicalPlanner::default()
+                .create_physical_plan(&analyzed, &session_state)
+                .await
+                .unwrap();
+            let filter = physical_plan
+                .as_any()
+                .downcast_ref::<FilterExec>()
+                .expect("regex residual must remain a FilterExec");
+            assert!(matches!(
+                filter.schema().field(0).data_type(),
+                DataType::Dictionary(_, value_type) if value_type.as_ref() == &DataType::Utf8
+            ));
+            assert!(!format!("{:?}", filter.predicate()).contains("Cast"));
+
+            let batches = collect(physical_plan, SessionContext::new().task_ctx())
+                .await
+                .unwrap();
+            assert_eq!(
+                expected_rows,
+                batches.iter().map(|batch| batch.num_rows()).sum::<usize>()
+            );
+        }
+    }
+
+    #[test]
+    fn test_dictionary_regex_rewrite_requires_scalar_utf8_pattern() {
+        assert_filter_left_is_cast(
+            vec![
+                Field::new(
+                    "host",
+                    DataType::Dictionary(Box::new(DataType::UInt32), Box::new(DataType::Utf8)),
+                    true,
+                ),
+                Field::new("pattern", DataType::Utf8, true),
+            ],
+            Expr::BinaryExpr(BinaryExpr {
+                left: Box::new(cast(col("host"), DataType::Utf8)),
+                op: Operator::RegexMatch,
+                right: Box::new(col("pattern")),
+            }),
+        );
+    }
+
+    #[test]
+    fn test_dictionary_regex_rewrite_excludes_non_regex_and_non_utf8_dictionary() {
+        assert_filter_left_is_cast(
+            vec![Field::new(
+                "host",
+                DataType::Dictionary(Box::new(DataType::UInt32), Box::new(DataType::Utf8)),
+                true,
+            )],
+            Expr::BinaryExpr(BinaryExpr {
+                left: Box::new(cast(col("host"), DataType::Utf8)),
+                op: Operator::Eq,
+                right: Box::new(lit("api")),
+            }),
+        );
+        assert_filter_left_is_cast(
+            vec![Field::new(
+                "host",
+                DataType::Dictionary(Box::new(DataType::UInt32), Box::new(DataType::LargeUtf8)),
+                true,
+            )],
+            Expr::BinaryExpr(BinaryExpr {
+                left: Box::new(cast(col("host"), DataType::Utf8)),
+                op: Operator::RegexMatch,
+                right: Box::new(lit("^api$")),
+            }),
+        );
+    }
+
+    #[test]
+    fn test_dictionary_regex_rewrite_requires_exact_contract() {
+        let dictionary_utf8 = || {
+            vec![Field::new(
+                "host",
+                DataType::Dictionary(Box::new(DataType::UInt32), Box::new(DataType::Utf8)),
+                true,
+            )]
+        };
+
+        for op in [
+            Operator::RegexMatch,
+            Operator::RegexIMatch,
+            Operator::RegexNotMatch,
+            Operator::RegexNotIMatch,
+        ] {
+            let rewritten = rewrite_dictionary_regex(
+                dictionary_utf8(),
+                cast(col("host"), DataType::Utf8),
+                lit("^api$"),
+                op,
+            );
+            assert!(matches!(
+                rewritten,
+                Some(Expr::BinaryExpr(BinaryExpr { left, .. })) if matches!(left.as_ref(), Expr::Column(_))
+            ));
+        }
+
+        for left in [
+            try_cast(col("host"), DataType::Utf8),
+            cast(cast(col("host"), DataType::Utf8), DataType::Utf8),
+        ] {
+            assert!(
+                rewrite_dictionary_regex(
+                    dictionary_utf8(),
+                    left,
+                    lit("^api$"),
+                    Operator::RegexMatch,
+                )
+                .is_none()
+            );
+        }
+        assert!(
+            rewrite_dictionary_regex(
+                dictionary_utf8(),
+                cast(col("host"), DataType::Utf8),
+                lit(ScalarValue::Utf8(None)),
+                Operator::RegexMatch,
+            )
+            .is_none()
+        );
+        assert!(
+            rewrite_dictionary_regex(
+                vec![Field::new(
+                    "host",
+                    DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+                    true,
+                )],
+                cast(col("host"), DataType::Utf8),
+                lit("^api$"),
+                Operator::RegexMatch,
+            )
+            .is_none()
         );
     }
 
@@ -1131,6 +1374,34 @@ mod tests {
 
     fn assert_filter_plan(fields: Vec<Field>, predicate: Expr, expected: &str) {
         assert_eq!(expected, analyze_filter(fields, predicate).to_string());
+    }
+
+    fn assert_filter_left_is_cast(fields: Vec<Field>, predicate: Expr) {
+        let analyzed = analyze_filter(fields, predicate);
+        let LogicalPlan::Filter(filter) = analyzed else {
+            panic!("expected filter plan");
+        };
+        let Expr::BinaryExpr(BinaryExpr { left, .. }) = filter.predicate else {
+            panic!("expected binary predicate");
+        };
+        assert!(matches!(left.as_ref(), Expr::Cast(_)));
+    }
+
+    fn rewrite_dictionary_regex(
+        fields: Vec<Field>,
+        left: Expr,
+        right: Expr,
+        op: Operator,
+    ) -> Option<Expr> {
+        rewrite_dictionary_string_regex(
+            BinaryExpr {
+                left: Box::new(left),
+                op,
+                right: Box::new(right),
+            },
+            &test_schema(fields),
+        )
+        .unwrap()
     }
 
     fn assert_timestamp_pushdown(

--- a/tests/cases/distributed/optimizer/metric_dictionary_regex_filter.result
+++ b/tests/cases/distributed/optimizer/metric_dictionary_regex_filter.result
@@ -1,0 +1,87 @@
+-- Exercise dictionary-encoded metric labels across physical-table partitions.
+CREATE TABLE metric_dictionary_regex_filter_physical (
+    ts TIMESTAMP(3) TIME INDEX,
+    host STRING,
+    val DOUBLE,
+    PRIMARY KEY(host)
+)
+PARTITION ON COLUMNS (host) (
+    host < 'api-02',
+    host >= 'api-02' AND host < 'db',
+    host >= 'db'
+)
+ENGINE = metric
+WITH (
+    physical_metric_table = "true"
+);
+
+Affected Rows: 0
+
+CREATE TABLE metric_dictionary_regex_filter (
+    ts TIMESTAMP(3) TIME INDEX,
+    host STRING PRIMARY KEY,
+    val DOUBLE
+)
+ENGINE = metric
+WITH (
+    on_physical_table = "metric_dictionary_regex_filter_physical"
+);
+
+Affected Rows: 0
+
+INSERT INTO metric_dictionary_regex_filter (ts, host, val) VALUES
+    (1000, 'api-01', 1.0),
+    (2000, 'api-02', 2.0),
+    (3000, 'db-01', 3.0);
+
+Affected Rows: 3
+
+ADMIN FLUSH_TABLE('metric_dictionary_regex_filter_physical');
+
++--------------------------------------------------------------+
+| ADMIN FLUSH_TABLE('metric_dictionary_regex_filter_physical') |
++--------------------------------------------------------------+
+| 0                                                            |
++--------------------------------------------------------------+
+
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (2, 2, '1s') metric_dictionary_regex_filter{host=~"api-.*"};
+
++-----+--------+---------------------+
+| val | host   | ts                  |
++-----+--------+---------------------+
+| 1.0 | api-01 | 1970-01-01T00:00:02 |
+| 2.0 | api-02 | 1970-01-01T00:00:02 |
++-----+--------+---------------------+
+
+SELECT host, ts, val
+FROM metric_dictionary_regex_filter
+WHERE host ~ '^api-.*$'
+ORDER BY host, ts;
+
++--------+---------------------+-----+
+| host   | ts                  | val |
++--------+---------------------+-----+
+| api-01 | 1970-01-01T00:00:01 | 1.0 |
+| api-02 | 1970-01-01T00:00:02 | 2.0 |
++--------+---------------------+-----+
+
+SELECT host, ts, val
+FROM metric_dictionary_regex_filter
+WHERE host !~ '^api-.*$'
+ORDER BY host, ts;
+
++-------+---------------------+-----+
+| host  | ts                  | val |
++-------+---------------------+-----+
+| db-01 | 1970-01-01T00:00:03 | 3.0 |
++-------+---------------------+-----+
+
+DROP TABLE metric_dictionary_regex_filter;
+
+Affected Rows: 0
+
+DROP TABLE metric_dictionary_regex_filter_physical;
+
+Affected Rows: 0
+

--- a/tests/cases/distributed/optimizer/metric_dictionary_regex_filter.sql
+++ b/tests/cases/distributed/optimizer/metric_dictionary_regex_filter.sql
@@ -1,0 +1,49 @@
+-- Exercise dictionary-encoded metric labels across physical-table partitions.
+CREATE TABLE metric_dictionary_regex_filter_physical (
+    ts TIMESTAMP(3) TIME INDEX,
+    host STRING,
+    val DOUBLE,
+    PRIMARY KEY(host)
+)
+PARTITION ON COLUMNS (host) (
+    host < 'api-02',
+    host >= 'api-02' AND host < 'db',
+    host >= 'db'
+)
+ENGINE = metric
+WITH (
+    physical_metric_table = "true"
+);
+
+CREATE TABLE metric_dictionary_regex_filter (
+    ts TIMESTAMP(3) TIME INDEX,
+    host STRING PRIMARY KEY,
+    val DOUBLE
+)
+ENGINE = metric
+WITH (
+    on_physical_table = "metric_dictionary_regex_filter_physical"
+);
+
+INSERT INTO metric_dictionary_regex_filter (ts, host, val) VALUES
+    (1000, 'api-01', 1.0),
+    (2000, 'api-02', 2.0),
+    (3000, 'db-01', 3.0);
+
+ADMIN FLUSH_TABLE('metric_dictionary_regex_filter_physical');
+
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (2, 2, '1s') metric_dictionary_regex_filter{host=~"api-.*"};
+
+SELECT host, ts, val
+FROM metric_dictionary_regex_filter
+WHERE host ~ '^api-.*$'
+ORDER BY host, ts;
+
+SELECT host, ts, val
+FROM metric_dictionary_regex_filter
+WHERE host !~ '^api-.*$'
+ORDER BY host, ts;
+
+DROP TABLE metric_dictionary_regex_filter;
+DROP TABLE metric_dictionary_regex_filter_physical;

--- a/tests/cases/standalone/common/select/tql_filter.result
+++ b/tests/cases/standalone/common/select/tql_filter.result
@@ -69,7 +69,6 @@ tql analyze (1, 3, '1s') t1{ a =~ "a.*" };
 |_|_|_|
 | 1_| 0_|_PromInstantManipulateExec: range=[1000..3000], lookback=[300000], interval=[1000], time index=[b] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["a"] REDACTED
-|_|_|_FilterExec: CAST(a@0 AS Utf8) ~ ^(?:a.*)$ REDACTED
 |_|_|_CooperativeExec REDACTED
 |_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
 |_|_|_|

--- a/tests/cases/standalone/common/tql/tql-cte.result
+++ b/tests/cases/standalone/common/tql/tql-cte.result
@@ -233,24 +233,24 @@ EXPLAIN WITH tql_agg(ts, summary) AS (
 )
 SELECT round(avg(summary)) as avg_sum FROM tql_agg;
 
-+---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| plan_type     | plan                                                                                                                                                                                                    |
-+---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| logical_plan  | MergeScan [is_placeholder=false, remote_input=[                                                                                                                                                         |
-|               | Projection: round(avg(tql_agg.summary)) AS avg_sum                                                                                                                                                      |
-|               |   Aggregate: groupBy=[[]], aggr=[[avg(tql_agg.summary)]]                                                                                                                                                |
-|               |     SubqueryAlias: tql_agg                                                                                                                                                                              |
-|               |       Projection: labels.ts AS ts, sum(labels.cpu) AS summary                                                                                                                                           |
-|               |         Aggregate: groupBy=[[labels.ts]], aggr=[[sum(labels.cpu)]]                                                                                                                                      |
-|               |           PromInstantManipulate: range=[0..40000], lookback=[300000], interval=[10000], time index=[ts]                                                                                                 |
-|               |             PromSeriesDivide: tags=["host"]                                                                                                                                                             |
-|               |               Filter: CAST(labels.host AS Utf8) ~ Utf8("^(?:host.*)$") AND labels.ts >= TimestampMillisecond(-299999, None) AND labels.ts <= TimestampMillisecond(40000, None)                          |
-|               |                 TableScan: labels, partial_filters=[CAST(labels.host AS Utf8) ~ Utf8("^(?:host.*)$"), labels.ts >= TimestampMillisecond(-299999, None), labels.ts <= TimestampMillisecond(40000, None)] |
-|               | ]]                                                                                                                                                                                                      |
-| physical_plan | CooperativeExec                                                                                                                                                                                         |
++---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_type     | plan                                                                                                                                                                                      |
++---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| logical_plan  | MergeScan [is_placeholder=false, remote_input=[                                                                                                                                           |
+|               | Projection: round(avg(tql_agg.summary)) AS avg_sum                                                                                                                                        |
+|               |   Aggregate: groupBy=[[]], aggr=[[avg(tql_agg.summary)]]                                                                                                                                  |
+|               |     SubqueryAlias: tql_agg                                                                                                                                                                |
+|               |       Projection: labels.ts AS ts, sum(labels.cpu) AS summary                                                                                                                             |
+|               |         Aggregate: groupBy=[[labels.ts]], aggr=[[sum(labels.cpu)]]                                                                                                                        |
+|               |           PromInstantManipulate: range=[0..40000], lookback=[300000], interval=[10000], time index=[ts]                                                                                   |
+|               |             PromSeriesDivide: tags=["host"]                                                                                                                                               |
+|               |               Filter: labels.host ~ Utf8("^(?:host.*)$") AND labels.ts >= TimestampMillisecond(-299999, None) AND labels.ts <= TimestampMillisecond(40000, None)                          |
+|               |                 TableScan: labels, partial_filters=[labels.host ~ Utf8("^(?:host.*)$"), labels.ts >= TimestampMillisecond(-299999, None), labels.ts <= TimestampMillisecond(40000, None)] |
+|               | ]]                                                                                                                                                                                        |
+| physical_plan | CooperativeExec                                                                                                                                                                           |
 |               |   MergeScanExec: REDACTED
-|               |                                                                                                                                                                                                         |
-+---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|               |                                                                                                                                                                                           |
++---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 -- TQL CTE with label selectors
 WITH host_metrics AS (


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

- Fixes #8541
- DataFusion dependency: https://github.com/GreptimeTeam/datafusion/pull/22 (merged)

## What's changed and what's your intention?

This PR restores native dictionary evaluation for regex filters on metric tag columns and preserves SQL NULL semantics throughout the filter path.

- Normalize only DataFusion-added `CAST(Dictionary(UInt32, Utf8) AS Utf8)` operands for regex operators when the expression matches the exact supported contract, allowing region-level exact filter pushdown.
- Preserve logical nulls when converting nullable boolean predicates into scan masks, so `UNKNOWN` rows are consistently excluded.
- Pin DataFusion to merged revision `a0af1f0685e3cb9be27e9fce069a6534475ec2af`, which preserves dictionary child validity during regex evaluation.
- Add focused unit tests and distributed SQLness coverage for positive/negative regex operators, nullable dictionary values, and physical-plan behavior.
- Update existing SQLness plan snapshots to reflect native Dictionary regex pushdown and removal of the redundant residual filter.

DataFusion PR #22 is merged. This PR remains a draft while the final release-equivalent query-regression gate runs. No public API, schema, persisted-format, or wire-format changes are introduced.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.