### PR TITLE
fix(mito2): make async index publication conditional

### DIFF
--- a/src/cmd/src/bin/query_perf_fixture/direct_sst.rs
+++ b/src/cmd/src/bin/query_perf_fixture/direct_sst.rs
@@ -58,7 +58,7 @@ struct NoopIndexBuilder;
 impl IndexerBuilder for NoopIndexBuilder {
     async fn build(
         &self,
-        _file_id: FileId,
+        _file_id: RegionFileId,
         _index_version: u64,
         _row_group_size: Option<usize>,
     ) -> Indexer {

--- a/src/mito2/src/engine/index_build_test.rs
+++ b/src/mito2/src/engine/index_build_test.rs
@@ -239,11 +239,9 @@ async fn assert_stale_artifact_caches_removed(engine: &MitoEngine, source_files:
         .write_cache()
         .expect("race tests enable write cache");
     for source in source_files {
-        let index_version = if source.index_file_size > 0 {
-            source.index_version + 1
-        } else {
-            0
-        };
+        let index_version = source
+            .index_version()
+            .map_or(0, |index_version| index_version + 1);
         assert!(
             !write_cache.file_cache().contains_key(&IndexKey::new(
                 source.region_id,
@@ -262,11 +260,9 @@ async fn assert_index_artifacts_exist(
 ) {
     let region = engine.get_region(region_id).unwrap();
     for source in source_files {
-        let index_version = if source.index_file_size > 0 {
-            source.index_version + 1
-        } else {
-            0
-        };
+        let index_version = source
+            .index_version()
+            .map_or(0, |index_version| index_version + 1);
         let index_id = RegionIndexId::new(
             RegionFileId::new(source.region_id, source.file_id),
             index_version,

--- a/src/mito2/src/engine/index_build_test.rs
+++ b/src/mito2/src/engine/index_build_test.rs
@@ -422,17 +422,17 @@ async fn test_compaction_wins_before_index_worker_apply() {
 }
 
 #[tokio::test]
-async fn test_index_build_routes_cross_region_file_to_logical_region() {
+async fn test_index_build_uses_physical_file_region_and_logical_manifest_region() {
     let mut env = TestEnv::with_prefix("test_cross_region_index_build_").await;
     let listener = Arc::new(IndexBuildListener::default());
+    let config = async_build_mode_config(false).enable_write_cache(
+        env.data_home().join("write_cache").display().to_string(),
+        ReadableSize::mb(32),
+        None,
+    );
     let engine = Arc::new(
-        env.create_engine_with(
-            async_build_mode_config(false),
-            None,
-            Some(listener.clone()),
-            None,
-        )
-        .await,
+        env.create_engine_with(config, None, Some(listener.clone()), None)
+            .await,
     );
 
     let source_region_id = RegionId::new(1, 1);
@@ -498,6 +498,14 @@ async fn test_index_build_routes_cross_region_file_to_logical_region() {
     assert_eq!(target_files.len(), 1);
     assert_eq!(target_files[0].region_id, source_region_id);
     assert!(target_files[0].exists_index());
+    let scanner = engine
+        .scanner(target_region_id, ScanRequest::default())
+        .await
+        .unwrap();
+    assert_eq!(
+        num_of_index_files(&engine, &scanner, target_region_id).await,
+        1
+    );
     assert_eq!(
         engine
             .get_region(target_region_id)

--- a/src/mito2/src/engine/index_build_test.rs
+++ b/src/mito2/src/engine/index_build_test.rs
@@ -39,6 +39,7 @@ use crate::config::{IndexBuildMode, MitoConfig, Mode};
 use crate::engine::MitoEngine;
 use crate::engine::compaction_test::put_and_flush;
 use crate::engine::listener::{EventListener, GateIndexBuildListener, IndexBuildListener};
+use crate::manifest::action::RegionEdit;
 use crate::read::scan_region::Scanner;
 use crate::sst::file::{FileMeta, RegionFileId, RegionIndexId};
 use crate::sst::location;
@@ -232,12 +233,7 @@ async fn assert_compacted_state(
     );
 }
 
-async fn assert_stale_artifacts_removed(
-    engine: &MitoEngine,
-    region_id: RegionId,
-    source_files: &[FileMeta],
-) {
-    let region = engine.get_region(region_id).unwrap();
+async fn assert_stale_artifact_caches_removed(engine: &MitoEngine, source_files: &[FileMeta]) {
     let cache_manager = engine.cache_manager();
     let write_cache = cache_manager
         .write_cache()
@@ -248,29 +244,46 @@ async fn assert_stale_artifacts_removed(
         } else {
             0
         };
-        let index_id =
-            RegionIndexId::new(RegionFileId::new(region_id, source.file_id), index_version);
+        assert!(
+            !write_cache.file_cache().contains_key(&IndexKey::new(
+                source.region_id,
+                source.file_id,
+                FileType::Puffin(index_version),
+            )),
+            "stale index artifact remains in write cache"
+        );
+    }
+}
+
+async fn assert_index_artifacts_exist(
+    engine: &MitoEngine,
+    region_id: RegionId,
+    source_files: &[FileMeta],
+) {
+    let region = engine.get_region(region_id).unwrap();
+    for source in source_files {
+        let index_version = if source.index_file_size > 0 {
+            source.index_version + 1
+        } else {
+            0
+        };
+        let index_id = RegionIndexId::new(
+            RegionFileId::new(source.region_id, source.file_id),
+            index_version,
+        );
         let path = location::index_file_path(
             region.access_layer.table_dir(),
             index_id,
             region.access_layer.path_type(),
         );
         assert!(
-            !region
+            region
                 .access_layer
                 .object_store()
                 .exists(&path)
                 .await
                 .unwrap(),
-            "stale index artifact still exists: {path}"
-        );
-        assert!(
-            !write_cache.file_cache().contains_key(&IndexKey::new(
-                region_id,
-                source.file_id,
-                FileType::Puffin(index_version),
-            )),
-            "stale index artifact remains in write cache"
+            "stale index artifact was deleted outside FilePurger/GC: {path}"
         );
     }
 }
@@ -367,7 +380,11 @@ async fn run_index_publication_compaction_race(phase: IndexPublicationPhase, gc_
     assert_eq!(gate.abort_count.load(Ordering::Relaxed), old_files.len());
 
     assert_compacted_state(&engine, region_id, &old_files).await;
-    assert_stale_artifacts_removed(&engine, region_id, &old_files).await;
+    assert_stale_artifact_caches_removed(&engine, &old_files).await;
+    if gc_enabled {
+        // ObjectStoreFilePurger leaves remote deletion to reference-aware GC.
+        assert_index_artifacts_exist(&engine, region_id, &old_files).await;
+    }
     let before_reopen = scan_timestamps(&engine, region_id).await;
     assert_eq!(before_reopen.len(), 20);
     assert_eq!(
@@ -402,6 +419,97 @@ async fn test_compaction_wins_before_index_worker_apply() {
         )
         .await;
     }
+}
+
+#[tokio::test]
+async fn test_index_build_routes_cross_region_file_to_logical_region() {
+    let mut env = TestEnv::with_prefix("test_cross_region_index_build_").await;
+    let listener = Arc::new(IndexBuildListener::default());
+    let engine = Arc::new(
+        env.create_engine_with(
+            async_build_mode_config(false),
+            None,
+            Some(listener.clone()),
+            None,
+        )
+        .await,
+    );
+
+    let source_region_id = RegionId::new(1, 1);
+    let target_region_id = RegionId::new(1, 2);
+    env.get_schema_metadata_manager()
+        .register_region_table_info(
+            source_region_id.table_id(),
+            "test_table",
+            "test_catalog",
+            "test_schema",
+            None,
+            env.get_kv_backend(),
+        )
+        .await;
+
+    let builder = CreateRequestBuilder::new();
+    let source_request = builder.build_with_index();
+    let column_schemas = rows_schema(&source_request);
+    engine
+        .handle_request(source_region_id, RegionRequest::Create(source_request))
+        .await
+        .unwrap();
+    engine
+        .handle_request(
+            target_region_id,
+            RegionRequest::Create(builder.build_with_index()),
+        )
+        .await
+        .unwrap();
+
+    put_and_flush(&engine, source_region_id, &column_schemas, 0..10).await;
+    let source_files = current_file_metas(&engine, source_region_id).await;
+    assert_eq!(source_files.len(), 1);
+    assert_eq!(source_files[0].region_id, source_region_id);
+
+    engine
+        .edit_region(
+            target_region_id,
+            RegionEdit {
+                files_to_add: source_files.clone(),
+                files_to_remove: Vec::new(),
+                timestamp_ms: None,
+                compaction_time_window: None,
+                flushed_entry_id: None,
+                flushed_sequence: None,
+                committed_sequence: None,
+            },
+        )
+        .await
+        .unwrap();
+    engine
+        .handle_request(
+            target_region_id,
+            RegionRequest::BuildIndex(RegionBuildIndexRequest {}),
+        )
+        .await
+        .unwrap();
+    tokio::time::timeout(Duration::from_secs(10), listener.wait_finish(1))
+        .await
+        .expect("cross-region index build did not apply to the logical region");
+
+    let target_files = current_file_metas(&engine, target_region_id).await;
+    assert_eq!(target_files.len(), 1);
+    assert_eq!(target_files[0].region_id, source_region_id);
+    assert!(target_files[0].exists_index());
+    assert_eq!(
+        engine
+            .get_region(target_region_id)
+            .unwrap()
+            .manifest_ctx
+            .manifest()
+            .await
+            .files
+            .get(&target_files[0].file_id),
+        Some(&target_files[0])
+    );
+    assert!(!current_file_metas(&engine, source_region_id).await[0].exists_index());
 }
 
 #[tokio::test]

--- a/src/mito2/src/engine/index_build_test.rs
+++ b/src/mito2/src/engine/index_build_test.rs
@@ -28,8 +28,8 @@ use datatypes::arrow::array::AsArray;
 use datatypes::arrow::datatypes::TimestampMillisecondType;
 use store_api::region_engine::RegionEngine;
 use store_api::region_request::{
-    AlterKind, RegionAlterRequest, RegionBuildIndexRequest, RegionCompactRequest, RegionRequest,
-    SetIndexOption,
+    AlterKind, RegionAlterRequest, RegionBuildIndexRequest, RegionCloseRequest,
+    RegionCompactRequest, RegionRequest, SetIndexOption,
 };
 use store_api::storage::{RegionId, ScanRequest};
 use tokio::sync::{Notify, Semaphore};
@@ -624,8 +624,7 @@ async fn test_index_build_type_schema_change() {
 /// for all pre-existing SST files, not just one.  Covers the scenario
 /// where multiple SSTs were flushed before the index was defined:
 /// 1. Create region without index, flush 3 files.
-/// 2. Reset scheduler state via reopen_region (flush-triggered no-index
-///    builds pollute building_files).
+/// 2. Reopen while flush-triggered no-index builds may still be stopping.
 /// 3. Verify 3 SST files and 0 index files.
 /// 4. ALTER SetIndexes — triggers rebuild of all 3 inconsistent SSTs.
 /// 5. Wait for 3 finishes, then verify 3 SST files + 3 index files.
@@ -670,8 +669,8 @@ async fn test_index_build_type_schema_change_multiple_files() {
 
     // Async flush still schedules index builds for flushed SSTs. Since this
     // region has no index metadata yet, those builds are no-ops; if they already
-    // stopped, reopening is harmless, and if they are still running, reopening
-    // clears building_files so the subsequent ALTER rebuild schedules cleanly.
+    // stopped, reopening is harmless. Otherwise the subsequent ALTER rebuilds
+    // wait behind their active leases.
     reopen_region(&engine, region_id, table_dir, true, HashMap::new()).await;
 
     let scanner = engine
@@ -968,8 +967,8 @@ async fn test_index_build_type_manual_duplicate_in_flight() {
     // so on_index_build_finish is NOT called.
     gate.release_begin();
 
-    // Reset scheduler state via reopen_region. This ensures the flush-triggered
-    // build's entry is removed from building_files and the scheduler is clean.
+    // Reopen the region. If the flush-triggered no-op is still stopping, the
+    // manual build below waits behind its active lease.
     reopen_region(&engine, region_id, table_dir.clone(), true, HashMap::new()).await;
 
     // Verify no index file exists after flush (create_on_flush=false).
@@ -1034,6 +1033,140 @@ async fn test_index_build_type_manual_duplicate_in_flight() {
         .unwrap();
     assert_eq!(scanner.num_files(), 1);
     assert_eq!(num_of_index_files(&engine, &scanner, region_id).await, 1);
+}
+
+#[tokio::test]
+async fn test_reopen_waits_for_active_index_build_of_previous_incarnation() {
+    let mut env =
+        TestEnv::with_prefix("test_reopen_waits_for_active_index_build_of_previous_incarnation_")
+            .await;
+    let gate = Arc::new(GateIndexBuildListener::default());
+    let engine = Arc::new(
+        env.create_engine_with(
+            async_build_mode_config(false),
+            None,
+            Some(gate.clone()),
+            None,
+        )
+        .await,
+    );
+
+    let region_id = RegionId::new(1, 1);
+    env.get_schema_metadata_manager()
+        .register_region_table_info(
+            region_id.table_id(),
+            "test_table",
+            "test_catalog",
+            "test_schema",
+            None,
+            env.get_kv_backend(),
+        )
+        .await;
+
+    let request = CreateRequestBuilder::new().build_with_index();
+    let table_dir = request.table_dir.clone();
+    let column_schemas = rows_schema(&request);
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+    put_and_flush(&engine, region_id, &column_schemas, 0..20).await;
+
+    tokio::time::timeout(Duration::from_secs(10), gate.wait_begin(1))
+        .await
+        .expect("flush index build did not start");
+    gate.release_begin();
+    reopen_region(&engine, region_id, table_dir.clone(), true, HashMap::new()).await;
+
+    let engine_for_old_build = engine.clone();
+    let old_build = tokio::spawn(async move {
+        engine_for_old_build
+            .handle_request(
+                region_id,
+                RegionRequest::BuildIndex(RegionBuildIndexRequest {}),
+            )
+            .await
+    });
+    tokio::time::timeout(Duration::from_secs(10), gate.wait_begin(2))
+        .await
+        .expect("old index build did not reach the begin gate");
+
+    // Closing the region must not wait for the blocked index build.
+    tokio::time::timeout(
+        Duration::from_secs(10),
+        engine.handle_request(
+            region_id,
+            RegionRequest::Close(RegionCloseRequest::default()),
+        ),
+    )
+    .await
+    .expect("close waited for the active index build")
+    .unwrap();
+    reopen_region(&engine, region_id, table_dir.clone(), true, HashMap::new()).await;
+
+    let received_before_rebuild = gate.recv_count();
+    let aborts_before_rebuild = gate.abort_count();
+    let engine_for_new_build = engine.clone();
+    let new_build = tokio::spawn(async move {
+        engine_for_new_build
+            .handle_request(
+                region_id,
+                RegionRequest::BuildIndex(RegionBuildIndexRequest {}),
+            )
+            .await
+    });
+    tokio::time::timeout(
+        Duration::from_secs(10),
+        gate.wait_recv(received_before_rebuild + 1),
+    )
+    .await
+    .expect("worker did not receive the reopened index build request");
+
+    // The reopened task is queued: it is neither started nor rejected as a
+    // duplicate while the old incarnation still owns the SST build lease.
+    assert_eq!(gate.begin_count(), 2);
+    assert_eq!(gate.abort_count(), aborts_before_rebuild);
+
+    gate.release_begin();
+    tokio::time::timeout(Duration::from_secs(10), old_build)
+        .await
+        .expect("old index build request did not finish")
+        .expect("old index build task panicked")
+        .unwrap();
+    tokio::time::timeout(Duration::from_secs(10), gate.wait_begin(3))
+        .await
+        .expect("reopened index build did not start after the old build stopped");
+
+    gate.release_begin();
+    tokio::time::timeout(Duration::from_secs(10), gate.wait_finish(1))
+        .await
+        .expect("reopened index build did not finish");
+    tokio::time::timeout(Duration::from_secs(10), new_build)
+        .await
+        .expect("reopened index build request did not finish")
+        .expect("reopened index build task panicked")
+        .unwrap();
+
+    assert_eq!(gate.begin_count(), 3);
+    assert_eq!(gate.finish_count(), 1);
+    assert_eq!(gate.abort_count(), aborts_before_rebuild + 1);
+    let scanner = engine
+        .scanner(region_id, ScanRequest::default())
+        .await
+        .unwrap();
+    assert_eq!(scanner.num_files(), 1);
+    assert_eq!(num_of_index_files(&engine, &scanner, region_id).await, 1);
+
+    let before_reopen = scan_timestamps(&engine, region_id).await;
+    assert_eq!(before_reopen.len(), 20);
+    assert_eq!(
+        before_reopen.iter().copied().collect::<HashSet<_>>().len(),
+        20,
+        "scan contains duplicate rows before reopen"
+    );
+
+    reopen_region(&engine, region_id, table_dir, true, HashMap::new()).await;
+    assert_eq!(scan_timestamps(&engine, region_id).await, before_reopen);
 }
 
 /// Tests the race between an in-flight index build and a compaction that

--- a/src/mito2/src/engine/index_build_test.rs
+++ b/src/mito2/src/engine/index_build_test.rs
@@ -357,6 +357,7 @@ async fn run_index_publication_compaction_race(phase: IndexPublicationPhase, gc_
                     window_seconds: 60,
                 }),
                 parallelism: None,
+                time_range: None,
             }),
         )
         .await

--- a/src/mito2/src/engine/index_build_test.rs
+++ b/src/mito2/src/engine/index_build_test.rs
@@ -14,21 +14,33 @@
 
 //! Index build tests for mito engine.
 //!
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 
 use api::v1::Rows;
+use api::v1::region::{StrictWindow, compact_request};
+use async_trait::async_trait;
+use common_base::readable_size::ReadableSize;
+use common_recordbatch::RecordBatches;
+use datatypes::arrow::array::AsArray;
+use datatypes::arrow::datatypes::TimestampMillisecondType;
 use store_api::region_engine::RegionEngine;
 use store_api::region_request::{
-    AlterKind, RegionAlterRequest, RegionBuildIndexRequest, RegionRequest, SetIndexOption,
+    AlterKind, RegionAlterRequest, RegionBuildIndexRequest, RegionCompactRequest, RegionRequest,
+    SetIndexOption,
 };
 use store_api::storage::{RegionId, ScanRequest};
+use tokio::sync::{Notify, Semaphore};
 
+use crate::cache::file_cache::{FileType, IndexKey};
 use crate::config::{IndexBuildMode, MitoConfig, Mode};
 use crate::engine::MitoEngine;
 use crate::engine::compaction_test::put_and_flush;
-use crate::engine::listener::{GateIndexBuildListener, IndexBuildListener};
+use crate::engine::listener::{EventListener, GateIndexBuildListener, IndexBuildListener};
 use crate::read::scan_region::Scanner;
+use crate::sst::file::{FileMeta, RegionFileId, RegionIndexId};
 use crate::sst::location;
 use crate::test_util::{
     CreateRequestBuilder, TestEnv, build_rows, flush_region, put_rows, reopen_region, rows_schema,
@@ -80,6 +92,316 @@ fn assert_listener_counts(
 ) {
     assert_eq!(listener.begin_count(), expected_begin_count);
     assert_eq!(listener.finish_count(), expected_success_count);
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum IndexPublicationPhase {
+    BeforeManifestCommit,
+    AfterManifestCommit,
+}
+
+struct IndexPublicationGate {
+    phase: IndexPublicationPhase,
+    entered: AtomicUsize,
+    entered_notify: Notify,
+    permits: Semaphore,
+    finish_count: AtomicUsize,
+    abort_count: AtomicUsize,
+    stopped_notify: Notify,
+}
+
+impl IndexPublicationGate {
+    fn new(phase: IndexPublicationPhase) -> Self {
+        Self {
+            phase,
+            entered: AtomicUsize::new(0),
+            entered_notify: Notify::new(),
+            permits: Semaphore::new(0),
+            finish_count: AtomicUsize::new(0),
+            abort_count: AtomicUsize::new(0),
+            stopped_notify: Notify::new(),
+        }
+    }
+
+    async fn enter(&self) {
+        self.entered.fetch_add(1, Ordering::Relaxed);
+        self.entered_notify.notify_one();
+        self.permits
+            .acquire()
+            .await
+            .expect("index publication gate should remain open")
+            .forget();
+    }
+
+    async fn wait_entered(&self, count: usize) {
+        while self.entered.load(Ordering::Relaxed) < count {
+            self.entered_notify.notified().await;
+        }
+    }
+
+    fn release(&self, count: usize) {
+        self.permits.add_permits(count);
+    }
+
+    async fn wait_stopped(&self, count: usize) {
+        while self.finish_count.load(Ordering::Relaxed) + self.abort_count.load(Ordering::Relaxed)
+            < count
+        {
+            self.stopped_notify.notified().await;
+        }
+    }
+}
+
+#[async_trait]
+impl EventListener for IndexPublicationGate {
+    async fn on_index_build_before_manifest_commit(&self, _region_file_id: RegionFileId) {
+        if self.phase == IndexPublicationPhase::BeforeManifestCommit {
+            self.enter().await;
+        }
+    }
+
+    async fn on_index_build_manifest_committed(&self, _region_file_id: RegionFileId) {
+        if self.phase == IndexPublicationPhase::AfterManifestCommit {
+            self.enter().await;
+        }
+    }
+
+    async fn on_index_build_finish(&self, _region_file_id: RegionFileId) {
+        self.finish_count.fetch_add(1, Ordering::Relaxed);
+        self.stopped_notify.notify_one();
+    }
+
+    async fn on_index_build_abort(&self, _region_file_id: RegionFileId) {
+        self.abort_count.fetch_add(1, Ordering::Relaxed);
+        self.stopped_notify.notify_one();
+    }
+}
+
+async fn scan_timestamps(engine: &MitoEngine, region_id: RegionId) -> Vec<i64> {
+    let scanner = engine
+        .scanner(region_id, ScanRequest::default())
+        .await
+        .unwrap();
+    let batches = RecordBatches::try_collect(scanner.scan().await.unwrap())
+        .await
+        .unwrap();
+    let mut timestamps = Vec::new();
+    for batch in batches {
+        let column = batch
+            .column_by_name("ts")
+            .unwrap()
+            .as_primitive::<TimestampMillisecondType>();
+        timestamps.extend((0..column.len()).map(|index| column.value(index)));
+    }
+    timestamps
+}
+
+async fn current_file_metas(engine: &MitoEngine, region_id: RegionId) -> Vec<FileMeta> {
+    engine
+        .get_region(region_id)
+        .unwrap()
+        .version()
+        .ssts
+        .levels()
+        .iter()
+        .flat_map(|level| level.files.values())
+        .map(|file| file.meta_ref().clone())
+        .collect()
+}
+
+async fn assert_compacted_state(
+    engine: &MitoEngine,
+    region_id: RegionId,
+    source_files: &[FileMeta],
+) {
+    let region = engine.get_region(region_id).unwrap();
+    let manifest = region.manifest_ctx.manifest().await;
+    assert_eq!(manifest.files.len(), 1);
+    for source in source_files {
+        assert!(!manifest.files.contains_key(&source.file_id));
+    }
+
+    let current_files = current_file_metas(engine, region_id).await;
+    assert_eq!(current_files.len(), 1);
+    assert_eq!(
+        manifest.files.keys().copied().collect::<HashSet<_>>(),
+        current_files
+            .iter()
+            .map(|file| file.file_id)
+            .collect::<HashSet<_>>()
+    );
+}
+
+async fn assert_stale_artifacts_removed(
+    engine: &MitoEngine,
+    region_id: RegionId,
+    source_files: &[FileMeta],
+) {
+    let region = engine.get_region(region_id).unwrap();
+    let cache_manager = engine.cache_manager();
+    let write_cache = cache_manager
+        .write_cache()
+        .expect("race tests enable write cache");
+    for source in source_files {
+        let index_version = if source.index_file_size > 0 {
+            source.index_version + 1
+        } else {
+            0
+        };
+        let index_id =
+            RegionIndexId::new(RegionFileId::new(region_id, source.file_id), index_version);
+        let path = location::index_file_path(
+            region.access_layer.table_dir(),
+            index_id,
+            region.access_layer.path_type(),
+        );
+        assert!(
+            !region
+                .access_layer
+                .object_store()
+                .exists(&path)
+                .await
+                .unwrap(),
+            "stale index artifact still exists: {path}"
+        );
+        assert!(
+            !write_cache.file_cache().contains_key(&IndexKey::new(
+                region_id,
+                source.file_id,
+                FileType::Puffin(index_version),
+            )),
+            "stale index artifact remains in write cache"
+        );
+    }
+}
+
+async fn run_index_publication_compaction_race(phase: IndexPublicationPhase, gc_enabled: bool) {
+    let prefix = format!("test_index_publication_{phase:?}_{gc_enabled}_");
+    let mut env = TestEnv::with_prefix(&prefix).await;
+    let mut config = async_build_mode_config(false);
+    config.max_background_index_builds = 4;
+    config.gc.enable = gc_enabled;
+    config = config.enable_write_cache(
+        env.data_home().join("write_cache").display().to_string(),
+        ReadableSize::mb(32),
+        None,
+    );
+    let gate = Arc::new(IndexPublicationGate::new(phase));
+    let engine = Arc::new(
+        env.create_engine_with(config, None, Some(gate.clone()), None)
+            .await,
+    );
+
+    let region_id = RegionId::new(1, 1);
+    env.get_schema_metadata_manager()
+        .register_region_table_info(
+            region_id.table_id(),
+            "test_table",
+            "test_catalog",
+            "test_schema",
+            None,
+            env.get_kv_backend(),
+        )
+        .await;
+
+    let request = CreateRequestBuilder::new()
+        .insert_option("compaction.type", "twcs")
+        .insert_option("compaction.twcs.trigger_file_num", "100")
+        .build_with_index();
+    let table_dir = request.table_dir.clone();
+    let column_schemas = rows_schema(&request);
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+    let purger = format!("{:?}", engine.get_region(region_id).unwrap().file_purger);
+    if gc_enabled {
+        assert!(purger.contains("ObjectStoreFilePurger"), "{purger}");
+    } else {
+        assert!(purger.contains("LocalFilePurger"), "{purger}");
+    }
+
+    put_and_flush(&engine, region_id, &column_schemas, 0..10).await;
+    put_and_flush(&engine, region_id, &column_schemas, 10..20).await;
+    reopen_region(&engine, region_id, table_dir.clone(), true, HashMap::new()).await;
+    let old_files = current_file_metas(&engine, region_id).await;
+    assert_eq!(old_files.len(), 2);
+
+    let engine_for_build = engine.clone();
+    let build = tokio::spawn(async move {
+        engine_for_build
+            .handle_request(
+                region_id,
+                RegionRequest::BuildIndex(RegionBuildIndexRequest {}),
+            )
+            .await
+    });
+    tokio::time::timeout(Duration::from_secs(10), gate.wait_entered(old_files.len()))
+        .await
+        .expect("index builds did not reach the publication gate");
+
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Compact(RegionCompactRequest {
+                options: compact_request::Options::StrictWindow(StrictWindow {
+                    window_seconds: 60,
+                }),
+                parallelism: None,
+            }),
+        )
+        .await
+        .unwrap();
+    assert_compacted_state(&engine, region_id, &old_files).await;
+
+    gate.release(old_files.len());
+    tokio::time::timeout(Duration::from_secs(10), build)
+        .await
+        .expect("build index request did not finish")
+        .expect("build index task panicked")
+        .unwrap();
+    tokio::time::timeout(Duration::from_secs(10), gate.wait_stopped(old_files.len()))
+        .await
+        .expect("stale index builds were not consumed");
+    assert_eq!(gate.finish_count.load(Ordering::Relaxed), 0);
+    assert_eq!(gate.abort_count.load(Ordering::Relaxed), old_files.len());
+
+    assert_compacted_state(&engine, region_id, &old_files).await;
+    assert_stale_artifacts_removed(&engine, region_id, &old_files).await;
+    let before_reopen = scan_timestamps(&engine, region_id).await;
+    assert_eq!(before_reopen.len(), 20);
+    assert_eq!(
+        before_reopen.iter().copied().collect::<HashSet<_>>().len(),
+        20,
+        "scan contains duplicate rows before reopen"
+    );
+
+    reopen_region(&engine, region_id, table_dir, true, HashMap::new()).await;
+    assert_compacted_state(&engine, region_id, &old_files).await;
+    let after_reopen = scan_timestamps(&engine, region_id).await;
+    assert_eq!(after_reopen, before_reopen);
+}
+
+#[tokio::test]
+async fn test_compaction_wins_before_index_manifest_commit() {
+    for gc_enabled in [false, true] {
+        run_index_publication_compaction_race(
+            IndexPublicationPhase::BeforeManifestCommit,
+            gc_enabled,
+        )
+        .await;
+    }
+}
+
+#[tokio::test]
+async fn test_compaction_wins_before_index_worker_apply() {
+    for gc_enabled in [false, true] {
+        run_index_publication_compaction_race(
+            IndexPublicationPhase::AfterManifestCommit,
+            gc_enabled,
+        )
+        .await;
+    }
 }
 
 #[tokio::test]

--- a/src/mito2/src/engine/listener.rs
+++ b/src/mito2/src/engine/listener.rs
@@ -474,6 +474,8 @@ impl EventListener for IndexBuildListener {
 /// gate.release_begin();           // let begin proceed
 /// ```
 pub struct GateIndexBuildListener {
+    recv_count: AtomicUsize,
+    recv_notify: Notify,
     begin_count: AtomicUsize,
     begin_notify: Notify,
     /// Blocks `on_index_build_begin` until released by the test.
@@ -489,6 +491,8 @@ pub struct GateIndexBuildListener {
 impl Default for GateIndexBuildListener {
     fn default() -> Self {
         Self {
+            recv_count: AtomicUsize::new(0),
+            recv_notify: Notify::new(),
             begin_count: AtomicUsize::new(0),
             begin_notify: Notify::new(),
             begin_blocker: Semaphore::new(0),
@@ -502,6 +506,13 @@ impl Default for GateIndexBuildListener {
 }
 
 impl GateIndexBuildListener {
+    /// Wait until the worker has received at least `times` requests.
+    pub async fn wait_recv(&self, times: usize) {
+        while self.recv_count.load(Ordering::Relaxed) < times {
+            self.recv_notify.notified().await;
+        }
+    }
+
     /// Wait until index build begin is reached for `times` times.
     pub async fn wait_begin(&self, times: usize) {
         while self.begin_count.load(Ordering::Relaxed) < times {
@@ -554,10 +565,20 @@ impl GateIndexBuildListener {
     pub fn abort_count(&self) -> usize {
         self.abort_count.load(Ordering::Relaxed)
     }
+
+    /// Returns the number of requests received by the worker.
+    pub fn recv_count(&self) -> usize {
+        self.recv_count.load(Ordering::Relaxed)
+    }
 }
 
 #[async_trait]
 impl EventListener for GateIndexBuildListener {
+    fn on_recv_requests(&self, request_num: usize) {
+        self.recv_count.fetch_add(request_num, Ordering::Relaxed);
+        self.recv_notify.notify_one();
+    }
+
     async fn on_index_build_begin(&self, region_file_id: RegionFileId) {
         info!("Region {} index build begin (gated)", region_file_id);
         self.begin_count.fetch_add(1, Ordering::Relaxed);

--- a/src/mito2/src/engine/listener.rs
+++ b/src/mito2/src/engine/listener.rs
@@ -97,6 +97,12 @@ pub trait EventListener: Send + Sync {
 
     /// Notifies the listener that the index build task is aborted.
     async fn on_index_build_abort(&self, _region_file_id: RegionFileId) {}
+
+    /// Notifies the listener after the final source check and before manifest publication.
+    async fn on_index_build_before_manifest_commit(&self, _region_file_id: RegionFileId) {}
+
+    /// Notifies the listener after manifest publication and before notifying the worker.
+    async fn on_index_build_manifest_committed(&self, _region_file_id: RegionFileId) {}
 }
 
 pub type EventListenerRef = Arc<dyn EventListener>;

--- a/src/mito2/src/manifest/action.rs
+++ b/src/mito2/src/manifest/action.rs
@@ -263,11 +263,14 @@ impl RegionManifestBuilder {
                 removed_files.push(RemovedFile::Index(old_file.file_id, old_index));
             }
         }
-        removed_files.extend(
-            edit.files_to_remove
-                .iter()
-                .map(|f| RemovedFile::File(f.file_id, f.index_version())),
-        );
+        removed_files.extend(edit.files_to_remove.iter().map(|file| {
+            let index_version = self
+                .files
+                .get(&file.file_id)
+                .and_then(FileMeta::index_version)
+                .or_else(|| file.index_version());
+            RemovedFile::File(file.file_id, index_version)
+        }));
         let at = edit
             .timestamp_ms
             .unwrap_or_else(|| Utc::now().timestamp_millis());
@@ -914,6 +917,54 @@ mod tests {
         let new: RegionManifest = serde_json::from_str(&json).unwrap();
 
         assert_eq!(manifest, new);
+    }
+
+    #[test]
+    fn test_remove_tracks_current_manifest_index_version() {
+        let file_id = FileId::random();
+        let current = FileMeta {
+            region_id: RegionId::new(1, 1),
+            file_id,
+            available_indexes: smallvec::smallvec![crate::sst::file::IndexType::InvertedIndex],
+            index_file_size: 1024,
+            index_version: 2,
+            ..Default::default()
+        };
+        let mut stale = current.clone();
+        stale.available_indexes.clear();
+        stale.index_file_size = 0;
+        stale.index_version = 0;
+
+        let mut builder = RegionManifestBuilder::default();
+        builder.apply_edit(
+            1,
+            RegionEdit {
+                files_to_add: vec![current],
+                files_to_remove: Vec::new(),
+                timestamp_ms: None,
+                compaction_time_window: None,
+                flushed_entry_id: None,
+                flushed_sequence: None,
+                committed_sequence: None,
+            },
+        );
+        builder.apply_edit(
+            2,
+            RegionEdit {
+                files_to_add: Vec::new(),
+                files_to_remove: vec![stale],
+                timestamp_ms: Some(42),
+                compaction_time_window: None,
+                flushed_entry_id: None,
+                flushed_sequence: None,
+                committed_sequence: None,
+            },
+        );
+
+        assert_eq!(
+            builder.removed_files.removed_files[0].files,
+            HashSet::from([RemovedFile::File(file_id, Some(2))])
+        );
     }
 
     /// Test if old version can still be deserialized then serialized to the new version.

--- a/src/mito2/src/manifest/manager.rs
+++ b/src/mito2/src/manifest/manager.rs
@@ -381,6 +381,11 @@ impl RegionManifestManager {
         self.stopped = true;
     }
 
+    /// Returns whether the manager has stopped accepting updates.
+    pub(crate) fn is_stopped(&self) -> bool {
+        self.stopped
+    }
+
     /// Installs the manifest changes from the current version to the target version (inclusive).
     ///
     /// Returns installed version.

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -326,11 +326,11 @@ lazy_static! {
             "stale index publications rejected",
             &[STAGE_LABEL],
         ).unwrap();
-    /// Number of failures while cleaning stale index artifacts.
+    /// Number of failures while cleaning local state for stale index artifacts.
     pub static ref INDEX_ARTIFACT_CLEANUP_FAILURE_TOTAL: IntCounter =
         register_int_counter!(
             "greptime_mito_index_artifact_cleanup_failure_total",
-            "failures while cleaning stale index artifacts",
+            "failures while cleaning local state for stale index artifacts",
         ).unwrap();
     /// Timer of index application.
     pub static ref INDEX_APPLY_ELAPSED: HistogramVec = register_histogram_vec!(

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -91,19 +91,6 @@ lazy_static! {
             "greptime_mito_inflight_flush_count",
             "inflight flush count",
         ).unwrap();
-    /// Number of stale index publications rejected at each publication stage.
-    pub static ref INDEX_PUBLICATION_STALE_TOTAL: IntCounterVec =
-        register_int_counter_vec!(
-            "greptime_mito_index_publication_stale_total",
-            "stale index publications rejected",
-            &[STAGE_LABEL],
-        ).unwrap();
-    /// Number of failures while cleaning stale index artifacts.
-    pub static ref INDEX_ARTIFACT_CLEANUP_FAILURE_TOTAL: IntCounter =
-        register_int_counter!(
-            "greptime_mito_index_artifact_cleanup_failure_total",
-            "failures while cleaning stale index artifacts",
-        ).unwrap();
     // ------ End of flush related metrics
 
 
@@ -332,6 +319,19 @@ lazy_static! {
 // Index metrics.
 lazy_static! {
     // Index metrics.
+    /// Number of stale index publications rejected at each publication stage.
+    pub static ref INDEX_PUBLICATION_STALE_TOTAL: IntCounterVec =
+        register_int_counter_vec!(
+            "greptime_mito_index_publication_stale_total",
+            "stale index publications rejected",
+            &[STAGE_LABEL],
+        ).unwrap();
+    /// Number of failures while cleaning stale index artifacts.
+    pub static ref INDEX_ARTIFACT_CLEANUP_FAILURE_TOTAL: IntCounter =
+        register_int_counter!(
+            "greptime_mito_index_artifact_cleanup_failure_total",
+            "failures while cleaning stale index artifacts",
+        ).unwrap();
     /// Timer of index application.
     pub static ref INDEX_APPLY_ELAPSED: HistogramVec = register_histogram_vec!(
         "greptime_index_apply_elapsed",

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -91,6 +91,19 @@ lazy_static! {
             "greptime_mito_inflight_flush_count",
             "inflight flush count",
         ).unwrap();
+    /// Number of stale index publications rejected at each publication stage.
+    pub static ref INDEX_PUBLICATION_STALE_TOTAL: IntCounterVec =
+        register_int_counter_vec!(
+            "greptime_mito_index_publication_stale_total",
+            "stale index publications rejected",
+            &[STAGE_LABEL],
+        ).unwrap();
+    /// Number of failures while cleaning stale index artifacts.
+    pub static ref INDEX_ARTIFACT_CLEANUP_FAILURE_TOTAL: IntCounter =
+        register_int_counter!(
+            "greptime_mito_index_artifact_cleanup_failure_total",
+            "failures while cleaning stale index artifacts",
+        ).unwrap();
     // ------ End of flush related metrics
 
 

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -1229,7 +1229,7 @@ impl ManifestContext {
         source: &FileMeta,
         updated: FileMeta,
     ) -> Result<IndexPublication> {
-        let mut manager = self.manifest_manager.write().await;
+        let manager = self.manifest_manager.write().await;
         let manifest = manager.manifest();
         let region_id = manifest.metadata.region_id;
         let current_state = self.state.load();
@@ -1266,17 +1266,7 @@ impl ManifestContext {
             compaction_time_window: None,
         };
         let action_list = RegionMetaActionList::with_action(RegionMetaAction::Edit(edit));
-        let pending = self.update_locked(&mut manager, action_list, false).await?;
-        let manifest_version = pending.version();
-        drop(manager);
-
-        if self.state.load() == RegionRoleState::Follower {
-            warn!(
-                "Region {} becomes follower while publishing index metadata, manifest version: {}",
-                region_id, manifest_version
-            );
-        }
-        pending.fire().await;
+        let manifest_version = self.update_and_fire(manager, action_list, false).await?;
 
         Ok(IndexPublication::Committed {
             manifest_version,
@@ -1317,6 +1307,38 @@ impl ManifestContext {
         ))
     }
 
+    /// Updates the manifest using a caller-held write lock, releases the lock,
+    /// and then fires the manifest hook.
+    ///
+    /// Callers must perform state and applicability checks before calling this
+    /// method so the checks and update remain in the same lock critical section.
+    async fn update_and_fire(
+        &self,
+        mut manager: RwLockWriteGuard<'_, RegionManifestManager>,
+        action_list: RegionMetaActionList,
+        is_staging: bool,
+    ) -> Result<ManifestVersion> {
+        let region_id = manager.manifest().metadata.region_id;
+        let pending = self
+            .update_locked(&mut manager, action_list, is_staging)
+            .await?;
+        let version = pending.version();
+
+        // Hook implementations may read the manifest or send region requests
+        // that acquire this lock.
+        drop(manager);
+
+        if self.state.load() == RegionRoleState::Follower {
+            warn!(
+                "Region {} becomes follower while updating manifest which may cause inconsistency, manifest version: {version}",
+                region_id
+            );
+        }
+
+        pending.fire().await;
+        Ok(version)
+    }
+
     async fn update_manifest_with_state_check(
         &self,
         action_list: RegionMetaActionList,
@@ -1324,7 +1346,7 @@ impl ManifestContext {
         check_state: impl FnOnce(RegionRoleState, RegionId) -> Result<()>,
     ) -> Result<ManifestVersion> {
         // Acquires the write lock of the manifest manager.
-        let mut manager = self.manifest_manager.write().await;
+        let manager = self.manifest_manager.write().await;
         // Gets current manifest.
         let manifest = manager.manifest();
         // Checks state inside the lock. This is to ensure that we won't update the manifest
@@ -1382,28 +1404,7 @@ impl ManifestContext {
             }
         }
 
-        // `update_locked` returns a `PendingManifestHook` we fire after releasing the lock.
-        let region_id = manifest.metadata.region_id;
-        let pending = self
-            .update_locked(&mut manager, action_list, is_staging)
-            .await?;
-        let version = pending.version();
-
-        // Drop the write lock before invoking the hook. Hook implementations may
-        // read the manifest or send region requests that acquire this lock;
-        // holding it would deadlock. Slow hooks also must not block manifest updates.
-        drop(manager);
-
-        if self.state.load() == RegionRoleState::Follower {
-            warn!(
-                "Region {} becomes follower while updating manifest which may cause inconsistency, manifest version: {version}",
-                region_id
-            );
-        }
-
-        pending.fire().await;
-
-        Ok(version)
+        self.update_and_fire(manager, action_list, is_staging).await
     }
 
     /// Sets the [`RegionRole`].

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -1019,6 +1019,18 @@ impl Drop for MitoRegion {
     }
 }
 
+/// Result of publishing rebuilt index metadata to the manifest.
+#[derive(Debug)]
+pub(crate) enum IndexPublication {
+    /// The index metadata was committed.
+    Committed {
+        manifest_version: ManifestVersion,
+        file_meta: FileMeta,
+    },
+    /// The source SST no longer matches the generation captured by the task.
+    Stale,
+}
+
 /// Context to update the region manifest.
 #[derive(Debug)]
 pub(crate) struct ManifestContext {
@@ -1205,6 +1217,71 @@ impl ManifestContext {
             Ok(())
         })
         .await
+    }
+
+    /// Conditionally publishes rebuilt index metadata for `source`.
+    ///
+    /// The source-generation check and manifest update share the manifest write
+    /// lock, so a concurrent compaction or another index build cannot commit
+    /// between them.
+    pub(crate) async fn update_manifest_for_index(
+        &self,
+        source: &FileMeta,
+        updated: FileMeta,
+    ) -> Result<IndexPublication> {
+        let mut manager = self.manifest_manager.write().await;
+        let manifest = manager.manifest();
+        let region_id = manifest.metadata.region_id;
+        let current_state = self.state.load();
+        ensure!(
+            matches!(
+                current_state,
+                RegionRoleState::Leader(RegionLeaderState::Writable)
+                    | RegionRoleState::Leader(RegionLeaderState::Downgrading)
+            ),
+            UpdateManifestSnafu {
+                region_id,
+                state: current_state,
+            }
+        );
+
+        if manifest.files.get(&source.file_id) != Some(source) {
+            return Ok(IndexPublication::Stale);
+        }
+
+        // Only index metadata is allowed to change in this publication.
+        let mut committed = source.clone();
+        committed.available_indexes = updated.available_indexes;
+        committed.indexes = updated.indexes;
+        committed.index_file_size = updated.index_file_size;
+        committed.index_version = updated.index_version;
+
+        let edit = crate::manifest::action::RegionEdit {
+            files_to_add: vec![committed.clone()],
+            files_to_remove: Vec::new(),
+            timestamp_ms: Some(chrono::Utc::now().timestamp_millis()),
+            flushed_sequence: None,
+            flushed_entry_id: None,
+            committed_sequence: None,
+            compaction_time_window: None,
+        };
+        let action_list = RegionMetaActionList::with_action(RegionMetaAction::Edit(edit));
+        let pending = self.update_locked(&mut manager, action_list, false).await?;
+        let manifest_version = pending.version();
+        drop(manager);
+
+        if self.state.load() == RegionRoleState::Follower {
+            warn!(
+                "Region {} becomes follower while publishing index metadata, manifest version: {}",
+                region_id, manifest_version
+            );
+        }
+        pending.fire().await;
+
+        Ok(IndexPublication::Committed {
+            manifest_version,
+            file_meta: committed,
+        })
     }
 
     /// Performs a manifest write under a caller-held write lock and returns a
@@ -1802,7 +1879,8 @@ mod tests {
     };
     use crate::manifest::manager::{RegionManifestManager, RegionManifestOptions};
     use crate::region::{
-        ManifestContext, ManifestStats, MitoRegion, RegionLeaderState, RegionRoleState, RegionStats,
+        IndexPublication, ManifestContext, ManifestStats, MitoRegion, RegionLeaderState,
+        RegionRoleState, RegionStats,
     };
     use crate::sst::FormatType;
     use crate::sst::index::intermediate::IntermediateManager;
@@ -1924,6 +2002,88 @@ mod tests {
                 .await
                 .files
                 .contains_key(&file_id)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_index_publication_rejects_older_source_generation() {
+        let env = SchedulerEnv::new().await;
+        let region = build_test_region(&env).await;
+        let source = crate::sst::file::FileMeta {
+            region_id: region.region_id,
+            file_id: FileId::random(),
+            level: 1,
+            file_size: 1024,
+            ..Default::default()
+        };
+        region
+            .manifest_ctx
+            .update_manifest(
+                RegionLeaderState::Writable,
+                RegionMetaActionList::with_action(RegionMetaAction::Edit(RegionEdit {
+                    files_to_add: vec![source.clone()],
+                    ..empty_edit()
+                })),
+                false,
+            )
+            .await
+            .unwrap();
+
+        let mut first_update = source.clone();
+        first_update.index_version = 1;
+        first_update.index_file_size = 128;
+        let first_committed = match region
+            .manifest_ctx
+            .update_manifest_for_index(&source, first_update)
+            .await
+            .unwrap()
+        {
+            IndexPublication::Committed { file_meta, .. } => file_meta,
+            IndexPublication::Stale => panic!("first index publication should commit"),
+        };
+
+        let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let delayed_manifest_ctx = region.manifest_ctx.clone();
+        let delayed_source = first_committed.clone();
+        let delayed_publication = tokio::spawn(async move {
+            let mut delayed_update = delayed_source.clone();
+            delayed_update.index_version = 2;
+            delayed_update.index_file_size = 128;
+            ready_tx.send(()).unwrap();
+            release_rx.await.unwrap();
+            delayed_manifest_ctx
+                .update_manifest_for_index(&delayed_source, delayed_update)
+                .await
+        });
+        ready_rx.await.unwrap();
+
+        let mut newer_update = first_committed.clone();
+        newer_update.index_version = 3;
+        newer_update.index_file_size = 256;
+        let newer_committed = match region
+            .manifest_ctx
+            .update_manifest_for_index(&first_committed, newer_update)
+            .await
+            .unwrap()
+        {
+            IndexPublication::Committed { file_meta, .. } => file_meta,
+            IndexPublication::Stale => panic!("newer index publication should commit"),
+        };
+
+        release_tx.send(()).unwrap();
+        assert!(matches!(
+            delayed_publication.await.unwrap().unwrap(),
+            IndexPublication::Stale
+        ));
+        assert_eq!(
+            region
+                .manifest_ctx
+                .manifest()
+                .await
+                .files
+                .get(&source.file_id),
+            Some(&newer_committed)
         );
     }
 

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -1027,7 +1027,7 @@ pub(crate) enum IndexPublication {
         manifest_version: ManifestVersion,
         file_meta: FileMeta,
     },
-    /// The source SST no longer matches the generation captured by the task.
+    /// The source SST or region incarnation is no longer publishable.
     Stale,
 }
 
@@ -1231,19 +1231,15 @@ impl ManifestContext {
     ) -> Result<IndexPublication> {
         let manager = self.manifest_manager.write().await;
         let manifest = manager.manifest();
-        let region_id = manifest.metadata.region_id;
         let current_state = self.state.load();
-        ensure!(
-            matches!(
-                current_state,
-                RegionRoleState::Leader(RegionLeaderState::Writable)
-                    | RegionRoleState::Leader(RegionLeaderState::Downgrading)
-            ),
-            UpdateManifestSnafu {
-                region_id,
-                state: current_state,
-            }
-        );
+        if !matches!(
+            current_state,
+            RegionRoleState::Leader(RegionLeaderState::Writable)
+                | RegionRoleState::Leader(RegionLeaderState::Downgrading)
+        ) || manager.is_stopped()
+        {
+            return Ok(IndexPublication::Stale);
+        }
 
         if manifest.files.get(&source.file_id) != Some(source) {
             return Ok(IndexPublication::Stale);

--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -983,8 +983,6 @@ pub(crate) struct IndexBuildFinished {
 /// Notifies an index build job has been stopped.
 #[derive(Debug)]
 pub(crate) struct IndexBuildStopped {
-    #[allow(dead_code)]
-    pub(crate) region_id: RegionId,
     pub(crate) file_id: FileId,
 }
 

--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -976,8 +976,6 @@ pub(crate) struct FlushFailed {
 
 #[derive(Debug)]
 pub(crate) struct IndexBuildFinished {
-    #[allow(dead_code)]
-    pub(crate) region_id: RegionId,
     pub(crate) manifest_version: ManifestVersion,
     pub(crate) file_meta: FileMeta,
 }

--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -978,7 +978,8 @@ pub(crate) struct FlushFailed {
 pub(crate) struct IndexBuildFinished {
     #[allow(dead_code)]
     pub(crate) region_id: RegionId,
-    pub(crate) edit: RegionEdit,
+    pub(crate) manifest_version: ManifestVersion,
+    pub(crate) file_meta: FileMeta,
 }
 
 /// Notifies an index build job has been stopped.

--- a/src/mito2/src/sst/index.rs
+++ b/src/mito2/src/sst/index.rs
@@ -917,7 +917,6 @@ impl IndexBuildTask {
                         .on_index_build_manifest_committed(region_file_id)
                         .await;
                     let index_build_finished = IndexBuildFinished {
-                        region_id: self.file_meta.region_id,
                         manifest_version,
                         file_meta,
                     };
@@ -940,18 +939,11 @@ impl IndexBuildTask {
                     .await;
                     self.listener.on_index_build_abort(region_file_id).await;
                     return Ok(IndexBuildOutcome::Aborted(format!(
-                        "Source SST generation changed before index publication, region: {}, file_id: {}",
+                        "Source SST or region incarnation changed before index publication, region: {}, file_id: {}",
                         self.file_meta.region_id, self.file_meta.file_id
                     )));
                 }
                 Err(e) => {
-                    cleanup_stale_index_artifact(
-                        RegionIndexId::new(region_file_id, new_index_version),
-                        &self.access_layer,
-                        self.cache_manager.as_ref(),
-                        self.write_cache.as_ref(),
-                    )
-                    .await;
                     let err = Arc::new(e);
                     WorkerRequest::Background {
                         region_id: self.file_meta.region_id,
@@ -1065,25 +1057,54 @@ impl Ord for IndexBuildTask {
     }
 }
 
+#[derive(Clone)]
+struct PendingIndexBuild {
+    task: IndexBuildTask,
+    version_control: VersionControlRef,
+}
+
+impl PartialEq for PendingIndexBuild {
+    fn eq(&self, other: &Self) -> bool {
+        self.task == other.task
+    }
+}
+
+impl Eq for PendingIndexBuild {}
+
+impl PartialOrd for PendingIndexBuild {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for PendingIndexBuild {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.task.cmp(&other.task)
+    }
+}
+
 /// Tracks the index build status of a region scheduled by the [IndexBuildScheduler].
-pub struct IndexBuildStatus {
-    pub region_id: RegionId,
-    pub building_files: HashSet<FileId>,
-    pub pending_tasks: BinaryHeap<IndexBuildTask>,
+struct IndexBuildStatus {
+    building_files: HashSet<FileId>,
+    pending_tasks: BinaryHeap<PendingIndexBuild>,
+    /// Whether the active builds belong to a region incarnation that has
+    /// stopped accepting index publications.
+    retiring: bool,
 }
 
 impl IndexBuildStatus {
-    pub fn new(region_id: RegionId) -> Self {
+    fn new() -> Self {
         IndexBuildStatus {
-            region_id,
             building_files: HashSet::new(),
             pending_tasks: BinaryHeap::new(),
+            retiring: false,
         }
     }
 
-    async fn on_failure(self, err: Arc<Error>) {
-        for task in self.pending_tasks {
-            task.on_failure(err.clone()).await;
+    async fn retire(&mut self, err: Arc<Error>) {
+        self.retiring = !self.building_files.is_empty();
+        for pending in std::mem::take(&mut self.pending_tasks) {
+            pending.task.on_failure(err.clone()).await;
         }
     }
 }
@@ -1093,7 +1114,7 @@ pub struct IndexBuildScheduler {
     scheduler: SchedulerRef,
     /// Tracks regions need to build index.
     region_status: HashMap<RegionId, IndexBuildStatus>,
-    /// Limit of files allowed to build index concurrently for a region.
+    /// Limit of files allowed to build index concurrently on this worker.
     files_limit: usize,
 }
 
@@ -1115,9 +1136,17 @@ impl IndexBuildScheduler {
         let status = self
             .region_status
             .entry(task.file_meta.region_id)
-            .or_insert_with(|| IndexBuildStatus::new(task.file_meta.region_id));
+            .or_insert_with(IndexBuildStatus::new);
 
-        if status.building_files.contains(&task.file_meta.file_id) {
+        let duplicate = if status.retiring {
+            status
+                .pending_tasks
+                .iter()
+                .any(|pending| pending.task.file_meta.file_id == task.file_meta.file_id)
+        } else {
+            status.building_files.contains(&task.file_meta.file_id)
+        };
+        if duplicate {
             let region_file_id =
                 RegionFileId::new(task.file_meta.region_id, task.file_meta.file_id);
             debug!(
@@ -1133,31 +1162,37 @@ impl IndexBuildScheduler {
             return Ok(());
         }
 
-        status.pending_tasks.push(task);
+        status.pending_tasks.push(PendingIndexBuild {
+            task,
+            version_control: version_control.clone(),
+        });
 
-        self.schedule_next_build_batch(version_control);
+        if !status.retiring {
+            self.schedule_next_build_batch();
+        }
         Ok(())
     }
 
     /// Schedule tasks until reaching the files limit or no more tasks.
-    fn schedule_next_build_batch(&mut self, version_control: &VersionControlRef) {
+    fn schedule_next_build_batch(&mut self) {
         let mut building_count = 0;
         for status in self.region_status.values() {
             building_count += status.building_files.len();
         }
 
         while building_count < self.files_limit {
-            if let Some(task) = self.find_next_task() {
+            if let Some(pending) = self.find_next_task() {
+                let task = pending.task;
                 let region_id = task.file_meta.region_id;
                 let file_id = task.file_meta.file_id;
-                let job = task.into_index_build_job(version_control.clone());
+                let job = task.into_index_build_job(pending.version_control);
                 if self.scheduler.schedule(job).is_ok() {
                     if let Some(status) = self.region_status.get_mut(&region_id) {
                         status.building_files.insert(file_id);
                         building_count += 1;
                         status
                             .pending_tasks
-                            .retain(|t| t.file_meta.file_id != file_id);
+                            .retain(|pending| pending.task.file_meta.file_id != file_id);
                     } else {
                         error!(
                             "Region status not found when scheduling index build task, region: {}",
@@ -1169,6 +1204,7 @@ impl IndexBuildScheduler {
                         "Failed to schedule index build job, region: {}, file_id: {}",
                         region_id, file_id
                     );
+                    break;
                 }
             } else {
                 // No more tasks to schedule.
@@ -1178,45 +1214,54 @@ impl IndexBuildScheduler {
     }
 
     /// Find the next task which has the highest priority to run.
-    fn find_next_task(&self) -> Option<IndexBuildTask> {
+    fn find_next_task(&self) -> Option<PendingIndexBuild> {
         self.region_status
             .values()
+            .filter(|status| !status.retiring)
             .filter_map(|status| status.pending_tasks.peek())
             .max()
             .cloned()
     }
 
-    pub(crate) fn on_task_stopped(
-        &mut self,
-        region_id: RegionId,
-        file_id: FileId,
-        version_control: &VersionControlRef,
-    ) {
+    pub(crate) fn on_task_stopped(&mut self, region_id: RegionId, file_id: FileId) {
         if let Some(status) = self.region_status.get_mut(&region_id) {
-            status.building_files.remove(&file_id);
+            if !status.building_files.remove(&file_id) {
+                return;
+            }
             if status.building_files.is_empty() && status.pending_tasks.is_empty() {
                 // No more tasks for this region, remove it.
                 self.region_status.remove(&region_id);
+            } else if status.building_files.is_empty() {
+                // All builds from the previous region incarnation have stopped.
+                status.retiring = false;
             }
         }
 
-        self.schedule_next_build_batch(version_control);
+        self.schedule_next_build_batch();
     }
 
     pub(crate) async fn on_failure(&mut self, region_id: RegionId, err: Arc<Error>) {
-        error!(
-            err; "Index build scheduler encountered failure for region {}, removing all pending tasks.",
-            region_id
-        );
-        let Some(status) = self.region_status.remove(&region_id) else {
+        let Some(status) = self.region_status.get_mut(&region_id) else {
+            error!(err; "Index build failed after scheduler state was removed, region: {}", region_id);
             return;
         };
-        status.on_failure(err).await;
+        if status.retiring {
+            error!(err; "Index build from a retiring region incarnation failed, region: {}", region_id);
+            return;
+        }
+        error!(
+            err; "Index build scheduler encountered failure for region {}, retiring active builds and failing pending tasks.",
+            region_id
+        );
+        status.retire(err).await;
+        if status.building_files.is_empty() {
+            self.region_status.remove(&region_id);
+        }
     }
 
     /// Notifies the scheduler that the region is dropped.
     pub(crate) async fn on_region_dropped(&mut self, region_id: RegionId) {
-        self.remove_region_on_failure(
+        self.retire_region(
             region_id,
             Arc::new(RegionDroppedSnafu { region_id }.build()),
         )
@@ -1225,24 +1270,27 @@ impl IndexBuildScheduler {
 
     /// Notifies the scheduler that the region is closed.
     pub(crate) async fn on_region_closed(&mut self, region_id: RegionId) {
-        self.remove_region_on_failure(region_id, Arc::new(RegionClosedSnafu { region_id }.build()))
+        self.retire_region(region_id, Arc::new(RegionClosedSnafu { region_id }.build()))
             .await;
     }
 
     /// Notifies the scheduler that the region is truncated.
     pub(crate) async fn on_region_truncated(&mut self, region_id: RegionId) {
-        self.remove_region_on_failure(
+        self.retire_region(
             region_id,
             Arc::new(RegionTruncatedSnafu { region_id }.build()),
         )
         .await;
     }
 
-    async fn remove_region_on_failure(&mut self, region_id: RegionId, err: Arc<Error>) {
-        let Some(status) = self.region_status.remove(&region_id) else {
+    async fn retire_region(&mut self, region_id: RegionId, err: Arc<Error>) {
+        let Some(status) = self.region_status.get_mut(&region_id) else {
             return;
         };
-        status.on_failure(err).await;
+        status.retire(err).await;
+        if status.building_files.is_empty() {
+            self.region_status.remove(&region_id);
+        }
     }
 }
 
@@ -2409,7 +2457,7 @@ mod tests {
         assert_eq!(status.pending_tasks.len(), 3); // Three pending
 
         // Test 5: Task completion triggers scheduling next highest priority task (Manual)
-        scheduler.on_task_stopped(region_id, file_id1, &version_control);
+        scheduler.on_task_stopped(region_id, file_id1);
         let status = scheduler.region_status.get(&region_id).unwrap();
         assert!(!status.building_files.contains(&file_id1));
         assert_eq!(status.building_files.len(), 2); // Should schedule next task
@@ -2418,22 +2466,22 @@ mod tests {
         assert!(status.building_files.contains(&file_id5));
 
         // Test 6: Complete another task, should schedule SchemaChange (second highest priority)
-        scheduler.on_task_stopped(region_id, file_id2, &version_control);
+        scheduler.on_task_stopped(region_id, file_id2);
         let status = scheduler.region_status.get(&region_id).unwrap();
         assert_eq!(status.building_files.len(), 2);
         assert_eq!(status.pending_tasks.len(), 1); // One less pending
         assert!(status.building_files.contains(&file_id4)); // SchemaChange should be building
 
         // Test 7: Complete remaining tasks and cleanup
-        scheduler.on_task_stopped(region_id, file_id5, &version_control);
-        scheduler.on_task_stopped(region_id, file_id4, &version_control);
+        scheduler.on_task_stopped(region_id, file_id5);
+        scheduler.on_task_stopped(region_id, file_id4);
 
         let status = scheduler.region_status.get(&region_id).unwrap();
         assert_eq!(status.building_files.len(), 1); // Last task (Compact) should be building
         assert_eq!(status.pending_tasks.len(), 0);
         assert!(status.building_files.contains(&file_id3));
 
-        scheduler.on_task_stopped(region_id, file_id3, &version_control);
+        scheduler.on_task_stopped(region_id, file_id3);
 
         // Region should be removed when all tasks complete
         assert!(!scheduler.region_status.contains_key(&region_id));
@@ -2465,12 +2513,20 @@ mod tests {
         assert_eq!(status.pending_tasks.len(), 1);
 
         scheduler.on_region_dropped(region_id).await;
+        let status = scheduler.region_status.get(&region_id).unwrap();
+        assert!(status.retiring);
+        assert_eq!(status.building_files.len(), 2);
+        assert!(status.pending_tasks.is_empty());
+
+        scheduler.on_task_stopped(region_id, file_id1);
+        assert!(scheduler.region_status.contains_key(&region_id));
+        scheduler.on_task_stopped(region_id, file_id2);
         assert!(!scheduler.region_status.contains_key(&region_id));
     }
 
     /// Helper to set up a scheduler with files_limit=1 and 3 scheduled tasks,
     /// returning the scheduler, the two pending-task result receivers, and the
-    /// version_control (needed for no-op assertion after cleanup).
+    /// version control.
     async fn setup_scheduler_with_pending_tasks(
         env: &SchedulerEnv,
     ) -> (
@@ -2623,23 +2679,22 @@ mod tests {
 
         // --- on_region_dropped ---
         {
-            let (mut scheduler, mut rx2, mut rx3, version_control, region_id, building_file_id) =
+            let (mut scheduler, mut rx2, mut rx3, _version_control, region_id, building_file_id) =
                 setup_scheduler_with_pending_tasks(&env).await;
 
             scheduler.on_region_dropped(region_id).await;
 
-            // region_status is removed.
-            assert!(
-                !scheduler.region_status.contains_key(&region_id),
-                "region_status should be removed after on_region_dropped"
-            );
+            let status = scheduler.region_status.get(&region_id).unwrap();
+            assert!(status.retiring);
+            assert_eq!(status.building_files.len(), 1);
+            assert!(status.pending_tasks.is_empty());
 
             // Pending-task receivers get lifecycle errors (with timeout).
             recv_lifecycle_error(&mut rx2, "dropped", "on_region_dropped").await;
             recv_lifecycle_error(&mut rx3, "dropped", "on_region_dropped").await;
 
-            // on_task_stopped after cleanup is a safe no-op.
-            scheduler.on_task_stopped(region_id, building_file_id, &version_control);
+            // The active build keeps its lease until it stops.
+            scheduler.on_task_stopped(region_id, building_file_id);
             assert!(!scheduler.region_status.contains_key(&region_id));
         }
 
@@ -2650,34 +2705,65 @@ mod tests {
 
             scheduler.on_region_closed(region_id).await;
 
-            assert!(
-                !scheduler.region_status.contains_key(&region_id),
-                "region_status should be removed after on_region_closed"
-            );
+            let status = scheduler.region_status.get(&region_id).unwrap();
+            assert!(status.retiring);
+            assert_eq!(status.building_files.len(), 1);
+            assert!(status.pending_tasks.is_empty());
 
             recv_lifecycle_error(&mut rx2, "closed", "on_region_closed").await;
             recv_lifecycle_error(&mut rx3, "closed", "on_region_closed").await;
 
-            scheduler.on_task_stopped(region_id, building_file_id, &version_control);
+            // A build scheduled by the reopened region waits behind the old
+            // incarnation's active lease.
+            let (reopened_task, _reopened_rx) = create_mock_task_for_schedule_with_result(
+                &env,
+                building_file_id,
+                region_id,
+                IndexBuildType::Manual,
+            )
+            .await;
+            scheduler
+                .schedule_build(&version_control, reopened_task)
+                .await
+                .unwrap();
+            let status = scheduler.region_status.get(&region_id).unwrap();
+            assert!(status.retiring);
+            assert_eq!(status.building_files.len(), 1);
+            assert_eq!(status.pending_tasks.len(), 1);
+
+            // A manifest error from the old incarnation must not discard the
+            // reopened task before the old build reports stopped.
+            scheduler
+                .on_failure(region_id, Arc::new(RegionClosedSnafu { region_id }.build()))
+                .await;
+            assert_eq!(scheduler.region_status[&region_id].pending_tasks.len(), 1);
+
+            scheduler.on_task_stopped(region_id, building_file_id);
+            let status = scheduler.region_status.get(&region_id).unwrap();
+            assert!(!status.retiring);
+            assert_eq!(status.building_files.len(), 1);
+            assert!(status.pending_tasks.is_empty());
+
+            scheduler.on_task_stopped(region_id, building_file_id);
             assert!(!scheduler.region_status.contains_key(&region_id));
         }
 
         // --- on_region_truncated ---
         {
-            let (mut scheduler, mut rx2, mut rx3, version_control, region_id, building_file_id) =
+            let (mut scheduler, mut rx2, mut rx3, _version_control, region_id, building_file_id) =
                 setup_scheduler_with_pending_tasks(&env).await;
 
             scheduler.on_region_truncated(region_id).await;
 
-            assert!(
-                !scheduler.region_status.contains_key(&region_id),
-                "region_status should be removed after on_region_truncated"
-            );
+            let status = scheduler.region_status.get(&region_id).unwrap();
+            assert!(status.retiring);
+            assert_eq!(status.building_files.len(), 1);
+            assert!(status.pending_tasks.is_empty());
 
             recv_lifecycle_error(&mut rx2, "truncated", "on_region_truncated").await;
             recv_lifecycle_error(&mut rx3, "truncated", "on_region_truncated").await;
 
-            scheduler.on_task_stopped(region_id, building_file_id, &version_control);
+            scheduler.on_task_stopped(region_id, building_file_id);
             assert!(!scheduler.region_status.contains_key(&region_id));
         }
     }

--- a/src/mito2/src/sst/index.rs
+++ b/src/mito2/src/sst/index.rs
@@ -87,27 +87,18 @@ pub(crate) const TYPE_BLOOM_FILTER_INDEX: &str = "bloom_filter_index";
 #[cfg(feature = "vector_index")]
 pub(crate) const TYPE_VECTOR_INDEX: &str = "vector_index";
 
-/// Deletes one stale index artifact and evicts all caches for its exact version.
-pub(crate) async fn cleanup_stale_index_artifact(
+/// Evicts local state for a stale index artifact.
+///
+/// The remote artifact may already be referenced by another region manifest
+/// because repartitioned regions share physical SST and index paths. Remote
+/// deletion therefore stays in the normal FilePurger/GC lifecycle; object-store
+/// GC can account for cross-region references and the configured lingering time.
+pub(crate) async fn cleanup_stale_index_caches(
     index_id: RegionIndexId,
     access_layer: &AccessLayerRef,
     cache_manager: Option<&CacheManagerRef>,
     write_cache: Option<&WriteCacheRef>,
 ) {
-    // Same-file builds stay serialized until stale cleanup and
-    // IndexBuildStopped complete, so this exact version cannot become
-    // referenced concurrently.
-    if let Err(e) = access_layer.delete_index(index_id).await {
-        INDEX_ARTIFACT_CLEANUP_FAILURE_TOTAL.inc();
-        warn!(
-            e;
-            "Failed to delete stale index artifact, region: {}, file_id: {}, index_version: {}",
-            index_id.region_id(),
-            index_id.file_id(),
-            index_id.version
-        );
-    }
-
     if let Some(cache_manager) = cache_manager {
         CacheStrategy::EnableAll(cache_manager.clone())
             .evict_puffin_cache(index_id)
@@ -705,6 +696,8 @@ pub type ResultMpscSender = Sender<Result<IndexBuildOutcome>>;
 
 #[derive(Clone)]
 pub struct IndexBuildTask {
+    /// The logical region whose manifest and in-memory version this task updates.
+    pub region_id: RegionId,
     /// The SST file handle to build index for.
     pub file: FileHandle,
     /// The file meta to build index for.
@@ -728,7 +721,8 @@ pub struct IndexBuildTask {
 impl std::fmt::Debug for IndexBuildTask {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("IndexBuildTask")
-            .field("region_id", &self.file_meta.region_id)
+            .field("region_id", &self.region_id)
+            .field("origin_region_id", &self.file_meta.region_id)
             .field("file_id", &self.file_meta.file_id)
             .field("reason", &self.reason)
             .finish()
@@ -746,7 +740,7 @@ impl IndexBuildTask {
         let _ = self
             .result_sender
             .send(Err(err.clone()).context(BuildIndexAsyncSnafu {
-                region_id: self.file_meta.region_id,
+                region_id: self.region_id,
             }))
             .await;
     }
@@ -769,15 +763,14 @@ impl IndexBuildTask {
             Err(e) => {
                 warn!(
                     e; "Index build task failed, region: {}, file_id: {}",
-                    self.file_meta.region_id, self.file_meta.file_id,
+                    self.region_id, self.file_meta.file_id,
                 );
                 self.on_failure(e.into()).await
             }
         }
         let worker_request = WorkerRequest::Background {
-            region_id: self.file_meta.region_id,
+            region_id: self.region_id,
             notify: BackgroundNotify::IndexBuildStopped(IndexBuildStopped {
-                region_id: self.file_meta.region_id,
                 file_id: self.file_meta.file_id,
             }),
         };
@@ -797,7 +790,7 @@ impl IndexBuildTask {
         let Some(level_files) = version.ssts.levels().get(level as usize) else {
             warn!(
                 "File id {} not found in level {} for index build, region: {}",
-                file_id, level, self.file_meta.region_id
+                file_id, level, self.region_id
             );
             return false;
         };
@@ -812,7 +805,7 @@ impl IndexBuildTask {
             _ => {
                 warn!(
                     "File id {} not found in region version for index build, region: {}",
-                    file_id, self.file_meta.region_id
+                    file_id, self.region_id
                 );
                 false
             }
@@ -841,7 +834,7 @@ impl IndexBuildTask {
                 .await;
             return Ok(IndexBuildOutcome::Aborted(format!(
                 "SST file not found during index build, region: {}, file_id: {}",
-                self.file_meta.region_id, self.file_meta.file_id
+                self.region_id, self.file_meta.file_id
             )));
         }
 
@@ -897,7 +890,7 @@ impl IndexBuildTask {
                     .await;
                 return Ok(IndexBuildOutcome::Aborted(format!(
                     "SST file not found during index build, region: {}, file_id: {}",
-                    self.file_meta.region_id, self.file_meta.file_id
+                    self.region_id, self.file_meta.file_id
                 )));
             }
 
@@ -924,7 +917,7 @@ impl IndexBuildTask {
                         file_meta,
                     };
                     WorkerRequest::Background {
-                        region_id: self.file_meta.region_id,
+                        region_id: self.region_id,
                         notify: BackgroundNotify::IndexBuildFinished(index_build_finished),
                     }
                 }
@@ -933,7 +926,7 @@ impl IndexBuildTask {
                         .with_label_values(&["manifest_commit"])
                         .inc();
                     let index_id = RegionIndexId::new(region_file_id, new_index_version);
-                    cleanup_stale_index_artifact(
+                    cleanup_stale_index_caches(
                         index_id,
                         &self.access_layer,
                         self.cache_manager.as_ref(),
@@ -943,13 +936,13 @@ impl IndexBuildTask {
                     self.listener.on_index_build_abort(region_file_id).await;
                     return Ok(IndexBuildOutcome::Aborted(format!(
                         "Source SST or region incarnation changed before index publication, region: {}, file_id: {}",
-                        self.file_meta.region_id, self.file_meta.file_id
+                        self.region_id, self.file_meta.file_id
                     )));
                 }
                 Err(e) => {
                     let err = Arc::new(e);
                     WorkerRequest::Background {
-                        region_id: self.file_meta.region_id,
+                        region_id: self.region_id,
                         notify: BackgroundNotify::IndexBuildFailed(IndexBuildFailed { err }),
                     }
                 }
@@ -1032,7 +1025,7 @@ impl IndexBuildTask {
             info!(
                 "Successfully update manifest version to {}, region: {}, reason: {}",
                 manifest_version,
-                self.file_meta.region_id,
+                self.region_id,
                 self.reason.as_str()
             );
         }
@@ -1142,7 +1135,7 @@ impl IndexBuildScheduler {
     ) -> Result<()> {
         let status = self
             .region_status
-            .entry(task.file_meta.region_id)
+            .entry(task.region_id)
             .or_insert_with(IndexBuildStatus::new);
 
         let duplicate = if status.retiring {
@@ -1190,7 +1183,7 @@ impl IndexBuildScheduler {
         while building_count < self.files_limit {
             if let Some(pending) = self.find_next_task() {
                 let task = pending.task;
-                let region_id = task.file_meta.region_id;
+                let region_id = task.region_id;
                 let file_id = task.file_meta.file_id;
                 let job = task.into_index_build_job(pending.version_control);
                 if self.scheduler.schedule(job).is_ok() {
@@ -1947,6 +1940,7 @@ mod tests {
 
         // Create mock task.
         let task = IndexBuildTask {
+            region_id,
             file,
             file_meta,
             reason: IndexBuildType::Flush,
@@ -2007,6 +2001,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(4);
         let (result_tx, mut result_rx) = mpsc::channel::<Result<IndexBuildOutcome>>(4);
         let task = IndexBuildTask {
+            region_id,
             file,
             file_meta: file_meta.clone(),
             reason: IndexBuildType::Flush,
@@ -2083,6 +2078,7 @@ mod tests {
         let (tx, _rx) = mpsc::channel(4);
         let (result_tx, mut result_rx) = mpsc::channel::<Result<IndexBuildOutcome>>(4);
         let task = IndexBuildTask {
+            region_id,
             file,
             file_meta: file_meta.clone(),
             reason: IndexBuildType::Flush,
@@ -2189,6 +2185,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(4);
         let (result_tx, mut result_rx) = mpsc::channel::<Result<IndexBuildOutcome>>(4);
         let task = IndexBuildTask {
+            region_id,
             file,
             file_meta: file_meta.clone(),
             reason: IndexBuildType::Flush,
@@ -2283,6 +2280,7 @@ mod tests {
         let (tx, mut _rx) = mpsc::channel(4);
         let (result_tx, mut result_rx) = mpsc::channel::<Result<IndexBuildOutcome>>(4);
         let task = IndexBuildTask {
+            region_id,
             file,
             file_meta: file_meta.clone(),
             reason: IndexBuildType::Flush,
@@ -2355,6 +2353,7 @@ mod tests {
         let file = FileHandle::new(file_meta.clone(), file_purger.clone());
 
         let task = IndexBuildTask {
+            region_id,
             file,
             file_meta,
             reason,

--- a/src/mito2/src/sst/index.rs
+++ b/src/mito2/src/sst/index.rs
@@ -1227,6 +1227,10 @@ impl IndexBuildScheduler {
     pub(crate) fn on_task_stopped(&mut self, region_id: RegionId, file_id: FileId) {
         if let Some(status) = self.region_status.get_mut(&region_id) {
             if !status.building_files.remove(&file_id) {
+                debug!(
+                    "Index build task is not tracked as building, region: {}, file: {}",
+                    region_id, file_id
+                );
                 return;
             }
             if status.building_files.is_empty() && status.pending_tasks.is_empty() {

--- a/src/mito2/src/sst/index.rs
+++ b/src/mito2/src/sst/index.rs
@@ -257,7 +257,10 @@ pub type VectorIndexOutput = IndexBaseOutput;
 #[derive(Default)]
 pub struct Indexer {
     file_id: FileId,
+    /// The logical region used for metadata and intermediate index files.
     region_id: RegionId,
+    /// The region that owns the physical SST and Puffin files.
+    physical_region_id: RegionId,
     index_version: u64,
     puffin_manager: Option<SstPuffinManager>,
     write_cache_enabled: bool,
@@ -348,10 +351,10 @@ impl Indexer {
 
 #[async_trait::async_trait]
 pub trait IndexerBuilder {
-    /// Builds indexer of given file id to [index_file_path].
+    /// Builds an indexer for the physical SST file.
     async fn build(
         &self,
-        file_id: FileId,
+        region_file_id: RegionFileId,
         index_version: u64,
         row_group_size: Option<usize>,
     ) -> Indexer;
@@ -376,24 +379,26 @@ impl IndexerBuilder for IndexerBuilderImpl {
     /// Sanity check for arguments and create a new [Indexer] if arguments are valid.
     async fn build(
         &self,
-        file_id: FileId,
+        region_file_id: RegionFileId,
         index_version: u64,
         row_group_size: Option<usize>,
     ) -> Indexer {
         let mut indexer = Indexer {
-            file_id,
+            file_id: region_file_id.file_id(),
             region_id: self.metadata.region_id,
+            physical_region_id: region_file_id.region_id(),
             index_version,
             write_cache_enabled: self.write_cache_enabled,
             ..Default::default()
         };
 
-        indexer.inverted_indexer = self.build_inverted_indexer(file_id, row_group_size);
-        indexer.fulltext_indexer = self.build_fulltext_indexer(file_id).await;
-        indexer.bloom_filter_indexer = self.build_bloom_filter_indexer(file_id);
+        indexer.inverted_indexer =
+            self.build_inverted_indexer(region_file_id.file_id(), row_group_size);
+        indexer.fulltext_indexer = self.build_fulltext_indexer(region_file_id.file_id()).await;
+        indexer.bloom_filter_indexer = self.build_bloom_filter_indexer(region_file_id.file_id());
         #[cfg(feature = "vector_index")]
         {
-            indexer.vector_indexer = self.build_vector_indexer(file_id);
+            indexer.vector_indexer = self.build_vector_indexer(region_file_id.file_id());
         }
         indexer.intermediate_manager = Some(self.intermediate_manager.clone());
 
@@ -854,10 +859,11 @@ impl IndexBuildTask {
         });
 
         // Use the same file_id but with new version for index file.
-        let index_file_id = self.file_meta.file_id;
+        let region_file_id = RegionFileId::new(self.file_meta.region_id, self.file_meta.file_id);
+        let index_file_id = region_file_id.file_id();
         let mut indexer = self
             .indexer_builder
-            .build(index_file_id, new_index_version, row_group_size)
+            .build(region_file_id, new_index_version, row_group_size)
             .await;
 
         if let Some(mut parquet_reader) = parquet_reader.take() {
@@ -898,8 +904,6 @@ impl IndexBuildTask {
             self.maybe_upload_index_file(index_output.clone(), index_file_id, new_index_version)
                 .await?;
 
-            let region_file_id =
-                RegionFileId::new(self.file_meta.region_id, self.file_meta.file_id);
             self.listener
                 .on_index_build_before_manifest_commit(region_file_id)
                 .await;
@@ -1505,6 +1509,11 @@ mod tests {
     async fn mock_intm_mgr(path: impl AsRef<str>) -> IntermediateManager {
         IntermediateManager::init_fs(path).await.unwrap()
     }
+
+    fn random_region_file_id() -> RegionFileId {
+        RegionFileId::new(RegionId::new(1, 2), FileId::random())
+    }
+
     struct NoopPathProvider;
 
     impl FilePathProvider for NoopPathProvider {
@@ -1628,7 +1637,7 @@ mod tests {
             #[cfg(feature = "vector_index")]
             vector_index_config: Default::default(),
         }
-        .build(FileId::random(), 0, Some(1024))
+        .build(random_region_file_id(), 0, Some(1024))
         .await;
 
         assert!(indexer.inverted_indexer.is_some());
@@ -1665,7 +1674,7 @@ mod tests {
             #[cfg(feature = "vector_index")]
             vector_index_config: Default::default(),
         }
-        .build(FileId::random(), 0, Some(1024))
+        .build(random_region_file_id(), 0, Some(1024))
         .await;
 
         assert!(indexer.inverted_indexer.is_none());
@@ -1688,7 +1697,7 @@ mod tests {
             #[cfg(feature = "vector_index")]
             vector_index_config: Default::default(),
         }
-        .build(FileId::random(), 0, Some(1024))
+        .build(random_region_file_id(), 0, Some(1024))
         .await;
 
         assert!(indexer.inverted_indexer.is_some());
@@ -1711,7 +1720,7 @@ mod tests {
             #[cfg(feature = "vector_index")]
             vector_index_config: Default::default(),
         }
-        .build(FileId::random(), 0, Some(1024))
+        .build(random_region_file_id(), 0, Some(1024))
         .await;
 
         assert!(indexer.inverted_indexer.is_some());
@@ -1745,7 +1754,7 @@ mod tests {
             #[cfg(feature = "vector_index")]
             vector_index_config: Default::default(),
         }
-        .build(FileId::random(), 0, Some(1024))
+        .build(random_region_file_id(), 0, Some(1024))
         .await;
 
         assert!(indexer.inverted_indexer.is_none());
@@ -1772,7 +1781,7 @@ mod tests {
             #[cfg(feature = "vector_index")]
             vector_index_config: Default::default(),
         }
-        .build(FileId::random(), 0, Some(1024))
+        .build(random_region_file_id(), 0, Some(1024))
         .await;
 
         assert!(indexer.inverted_indexer.is_some());
@@ -1799,7 +1808,7 @@ mod tests {
             #[cfg(feature = "vector_index")]
             vector_index_config: Default::default(),
         }
-        .build(FileId::random(), 0, Some(1024))
+        .build(random_region_file_id(), 0, Some(1024))
         .await;
 
         assert!(indexer.inverted_indexer.is_some());
@@ -1833,7 +1842,7 @@ mod tests {
             #[cfg(feature = "vector_index")]
             vector_index_config: Default::default(),
         }
-        .build(FileId::random(), 0, Some(0))
+        .build(random_region_file_id(), 0, Some(0))
         .await;
 
         assert!(indexer.inverted_indexer.is_some());
@@ -1892,7 +1901,7 @@ mod tests {
             bloom_filter_index_config: BloomFilterConfig::default(),
             vector_index_config: Default::default(),
         }
-        .build(FileId::random(), 0, Some(1024))
+        .build(random_region_file_id(), 0, Some(1024))
         .await;
 
         assert!(indexer.vector_indexer.is_some());

--- a/src/mito2/src/sst/index.rs
+++ b/src/mito2/src/sst/index.rs
@@ -49,6 +49,7 @@ use vector_index::creator::VectorIndexer;
 use crate::access_layer::{AccessLayerRef, FilePathProvider, OperationType, RegionFilePathFactory};
 use crate::cache::file_cache::{FileCacheRef, FileType, IndexKey};
 use crate::cache::write_cache::{UploadTracker, WriteCacheRef};
+use crate::cache::{CacheManagerRef, CacheStrategy};
 #[cfg(feature = "vector_index")]
 use crate::config::VectorIndexConfig;
 use crate::config::{BloomFilterConfig, FulltextIndexConfig, InvertedIndexConfig};
@@ -56,12 +57,13 @@ use crate::error::{
     BuildIndexAsyncSnafu, DecodeSnafu, Error, InvalidRecordBatchSnafu, RegionClosedSnafu,
     RegionDroppedSnafu, RegionTruncatedSnafu, Result,
 };
-use crate::manifest::action::{RegionEdit, RegionMetaAction, RegionMetaActionList};
-use crate::metrics::INDEX_CREATE_MEMORY_USAGE;
+use crate::metrics::{
+    INDEX_ARTIFACT_CLEANUP_FAILURE_TOTAL, INDEX_CREATE_MEMORY_USAGE, INDEX_PUBLICATION_STALE_TOTAL,
+};
 use crate::read::Batch;
 use crate::region::options::IndexOptions;
 use crate::region::version::VersionControlRef;
-use crate::region::{ManifestContextRef, RegionLeaderState};
+use crate::region::{IndexPublication, ManifestContextRef};
 use crate::request::{
     BackgroundNotify, IndexBuildFailed, IndexBuildFinished, IndexBuildStopped, WorkerRequest,
     WorkerRequestWithTime,
@@ -84,6 +86,54 @@ pub(crate) const TYPE_FULLTEXT_INDEX: &str = "fulltext_index";
 pub(crate) const TYPE_BLOOM_FILTER_INDEX: &str = "bloom_filter_index";
 #[cfg(feature = "vector_index")]
 pub(crate) const TYPE_VECTOR_INDEX: &str = "vector_index";
+
+/// Deletes one stale index artifact and evicts all caches for its exact version.
+pub(crate) async fn cleanup_stale_index_artifact(
+    index_id: RegionIndexId,
+    access_layer: &AccessLayerRef,
+    cache_manager: Option<&CacheManagerRef>,
+    write_cache: Option<&WriteCacheRef>,
+) {
+    if let Err(e) = access_layer.delete_index(index_id).await {
+        INDEX_ARTIFACT_CLEANUP_FAILURE_TOTAL.inc();
+        warn!(
+            e;
+            "Failed to delete stale index artifact, region: {}, file_id: {}, index_version: {}",
+            index_id.region_id(),
+            index_id.file_id(),
+            index_id.version
+        );
+    }
+
+    if let Some(cache_manager) = cache_manager {
+        CacheStrategy::EnableAll(cache_manager.clone())
+            .evict_puffin_cache(index_id)
+            .await;
+    }
+    if let Some(write_cache) = write_cache {
+        write_cache
+            .remove(IndexKey::new(
+                index_id.region_id(),
+                index_id.file_id(),
+                FileType::Puffin(index_id.version),
+            ))
+            .await;
+    }
+    if let Err(e) = access_layer
+        .puffin_manager_factory()
+        .purge_stager(index_id)
+        .await
+    {
+        INDEX_ARTIFACT_CLEANUP_FAILURE_TOTAL.inc();
+        warn!(
+            e;
+            "Failed to purge stale index artifact from stager, region: {}, file_id: {}, index_version: {}",
+            index_id.region_id(),
+            index_id.file_id(),
+            index_id.version
+        );
+    }
+}
 
 /// Triggers background download of an index file to the local cache.
 pub(crate) fn trigger_index_background_download(
@@ -661,6 +711,7 @@ pub struct IndexBuildTask {
     pub(crate) listener: WorkerListener,
     pub(crate) manifest_ctx: ManifestContextRef,
     pub write_cache: Option<WriteCacheRef>,
+    pub cache_manager: Option<CacheManagerRef>,
     pub file_purger: FilePurgerRef,
     /// When write cache is enabled, the indexer builder should be built from the write cache.
     /// Otherwise, it should be built from the access layer.
@@ -851,18 +902,56 @@ impl IndexBuildTask {
             self.maybe_upload_index_file(index_output.clone(), index_file_id, new_index_version)
                 .await?;
 
+            let region_file_id =
+                RegionFileId::new(self.file_meta.region_id, self.file_meta.file_id);
+            self.listener
+                .on_index_build_before_manifest_commit(region_file_id)
+                .await;
+
             let worker_request = match self.update_manifest(index_output, new_index_version).await {
-                Ok(edit) => {
+                Ok(IndexPublication::Committed {
+                    manifest_version,
+                    file_meta,
+                }) => {
+                    self.listener
+                        .on_index_build_manifest_committed(region_file_id)
+                        .await;
                     let index_build_finished = IndexBuildFinished {
                         region_id: self.file_meta.region_id,
-                        edit,
+                        manifest_version,
+                        file_meta,
                     };
                     WorkerRequest::Background {
                         region_id: self.file_meta.region_id,
                         notify: BackgroundNotify::IndexBuildFinished(index_build_finished),
                     }
                 }
+                Ok(IndexPublication::Stale) => {
+                    INDEX_PUBLICATION_STALE_TOTAL
+                        .with_label_values(&["manifest_commit"])
+                        .inc();
+                    let index_id = RegionIndexId::new(region_file_id, new_index_version);
+                    cleanup_stale_index_artifact(
+                        index_id,
+                        &self.access_layer,
+                        self.cache_manager.as_ref(),
+                        self.write_cache.as_ref(),
+                    )
+                    .await;
+                    self.listener.on_index_build_abort(region_file_id).await;
+                    return Ok(IndexBuildOutcome::Aborted(format!(
+                        "Source SST generation changed before index publication, region: {}, file_id: {}",
+                        self.file_meta.region_id, self.file_meta.file_id
+                    )));
+                }
                 Err(e) => {
+                    cleanup_stale_index_artifact(
+                        RegionIndexId::new(region_file_id, new_index_version),
+                        &self.access_layer,
+                        self.cache_manager.as_ref(),
+                        self.write_cache.as_ref(),
+                    )
+                    .await;
                     let err = Arc::new(e);
                     WorkerRequest::Background {
                         region_id: self.file_meta.region_id,
@@ -928,37 +1017,31 @@ impl IndexBuildTask {
     }
 
     async fn update_manifest(
-        &mut self,
+        &self,
         output: IndexOutput,
         new_index_version: u64,
-    ) -> Result<RegionEdit> {
-        self.file_meta.available_indexes = output.build_available_indexes();
-        self.file_meta.indexes = output.build_indexes();
-        self.file_meta.index_file_size = output.file_size;
-        self.file_meta.index_version = new_index_version;
-        let edit = RegionEdit {
-            files_to_add: vec![self.file_meta.clone()],
-            files_to_remove: vec![],
-            timestamp_ms: Some(chrono::Utc::now().timestamp_millis()),
-            flushed_sequence: None,
-            flushed_entry_id: None,
-            committed_sequence: None,
-            compaction_time_window: None,
-        };
-        let version = self
+    ) -> Result<IndexPublication> {
+        let mut updated = self.file_meta.clone();
+        updated.available_indexes = output.build_available_indexes();
+        updated.indexes = output.build_indexes();
+        updated.index_file_size = output.file_size;
+        updated.index_version = new_index_version;
+        let publication = self
             .manifest_ctx
-            .update_manifest(
-                RegionLeaderState::Writable,
-                RegionMetaActionList::with_action(RegionMetaAction::Edit(edit.clone())),
-                false,
-            )
+            .update_manifest_for_index(&self.file_meta, updated)
             .await?;
-        info!(
-            "Successfully update manifest version to {version}, region: {}, reason: {}",
-            self.file_meta.region_id,
-            self.reason.as_str()
-        );
-        Ok(edit)
+        if let IndexPublication::Committed {
+            manifest_version, ..
+        } = &publication
+        {
+            info!(
+                "Successfully update manifest version to {}, region: {}, reason: {}",
+                manifest_version,
+                self.file_meta.region_id,
+                self.reason.as_str()
+            );
+        }
+        Ok(publication)
     }
 }
 
@@ -1233,7 +1316,9 @@ mod tests {
     use crate::access_layer::{FilePathProvider, Metrics, SstWriteRequest, WriteType};
     use crate::cache::write_cache::WriteCache;
     use crate::config::{FulltextIndexConfig, IndexBuildMode, MitoConfig, Mode};
+    use crate::manifest::action::{RegionEdit, RegionMetaAction, RegionMetaActionList};
     use crate::memtable::time_partition::TimePartitions;
+    use crate::region::RegionLeaderState;
     use crate::region::version::{VersionBuilder, VersionControl};
     use crate::sst::file::RegionFileId;
     use crate::sst::file_purger::NoopFilePurger;
@@ -1251,6 +1336,25 @@ mod tests {
         with_skipping_bloom: bool,
         #[cfg(feature = "vector_index")]
         with_vector: bool,
+    }
+
+    async fn seed_manifest_file(manifest_ctx: &ManifestContextRef, file_meta: &FileMeta) {
+        manifest_ctx
+            .update_manifest(
+                RegionLeaderState::Writable,
+                RegionMetaActionList::with_action(RegionMetaAction::Edit(RegionEdit {
+                    files_to_add: vec![file_meta.clone()],
+                    files_to_remove: Vec::new(),
+                    timestamp_ms: None,
+                    flushed_sequence: None,
+                    flushed_entry_id: None,
+                    committed_sequence: None,
+                    compaction_time_window: None,
+                })),
+                false,
+            )
+            .await
+            .unwrap();
     }
 
     fn mock_region_metadata(
@@ -1795,6 +1899,7 @@ mod tests {
             listener: WorkerListener::default(),
             manifest_ctx,
             write_cache: None,
+            cache_manager: None,
             file_purger,
             indexer_builder,
             request_sender: tx,
@@ -1835,6 +1940,7 @@ mod tests {
             num_row_groups: sst_info.num_row_groups,
             ..Default::default()
         };
+        seed_manifest_file(&manifest_ctx, &file_meta).await;
         let files = HashMap::from([(file_meta.file_id, file_meta.clone())]);
         let version_control =
             mock_version_control(metadata.clone(), file_purger.clone(), files).await;
@@ -1853,6 +1959,7 @@ mod tests {
             listener: WorkerListener::default(),
             manifest_ctx,
             write_cache: None,
+            cache_manager: None,
             file_purger,
             indexer_builder,
             request_sender: tx,
@@ -1880,8 +1987,7 @@ mod tests {
                 notify: BackgroundNotify::IndexBuildFinished(finished),
             } => {
                 assert_eq!(req_region_id, region_id);
-                assert_eq!(finished.edit.files_to_add.len(), 1);
-                let updated_meta = &finished.edit.files_to_add[0];
+                let updated_meta = &finished.file_meta;
 
                 // The mock indexer builder creates all index types.
                 assert!(!updated_meta.available_indexes.is_empty());
@@ -1910,6 +2016,7 @@ mod tests {
             num_row_groups: sst_info.num_row_groups,
             ..Default::default()
         };
+        seed_manifest_file(&manifest_ctx, &file_meta).await;
         let files = HashMap::from([(file_meta.file_id, file_meta.clone())]);
         let version_control =
             mock_version_control(metadata.clone(), file_purger.clone(), files).await;
@@ -1928,6 +2035,7 @@ mod tests {
             listener: WorkerListener::default(),
             manifest_ctx,
             write_cache: None,
+            cache_manager: None,
             file_purger,
             indexer_builder,
             request_sender: tx,
@@ -2014,6 +2122,7 @@ mod tests {
             num_row_groups: sst_info.num_row_groups,
             ..Default::default()
         };
+        seed_manifest_file(&manifest_ctx, &file_meta).await;
         let files = HashMap::from([(file_meta.file_id, file_meta.clone())]);
         let version_control =
             mock_version_control(metadata.clone(), file_purger.clone(), files).await;
@@ -2032,6 +2141,7 @@ mod tests {
             listener: WorkerListener::default(),
             manifest_ctx,
             write_cache: None,
+            cache_manager: None,
             file_purger,
             indexer_builder,
             request_sender: tx,
@@ -2107,6 +2217,7 @@ mod tests {
             num_row_groups: sst_info.num_row_groups,
             ..Default::default()
         };
+        seed_manifest_file(&manifest_ctx, &file_meta).await;
         let files = HashMap::from([(file_meta.file_id, file_meta.clone())]);
         let version_control =
             mock_version_control(metadata.clone(), file_purger.clone(), files).await;
@@ -2124,6 +2235,7 @@ mod tests {
             listener: WorkerListener::default(),
             manifest_ctx,
             write_cache: Some(write_cache.clone()),
+            cache_manager: None,
             file_purger,
             indexer_builder,
             request_sender: tx,
@@ -2195,6 +2307,7 @@ mod tests {
             listener: WorkerListener::default(),
             manifest_ctx,
             write_cache: None,
+            cache_manager: None,
             file_purger,
             indexer_builder,
             request_sender: tx,

--- a/src/mito2/src/sst/index.rs
+++ b/src/mito2/src/sst/index.rs
@@ -821,13 +821,10 @@ impl IndexBuildTask {
         &mut self,
         version_control: VersionControlRef,
     ) -> Result<IndexBuildOutcome> {
-        // Determine the new index version
-        let new_index_version = if self.file_meta.index_file_size > 0 {
-            // Increment version if index file exists to avoid overwrite.
-            self.file_meta.index_version + 1
-        } else {
-            0 // Default version for new index files
-        };
+        let new_index_version = self
+            .file_meta
+            .index_version()
+            .map_or(0, |version| version + 1);
 
         // Check SST file existence before building index to avoid failure of parquet reader.
         if !self.check_sst_file_exists(&version_control).await {
@@ -1980,7 +1977,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_index_build_task_sst_exist() {
+    async fn test_index_build_task_increments_legacy_index_version() {
         let env = SchedulerEnv::new().await;
         let mut scheduler = env.mock_index_build_scheduler(4);
         let metadata = Arc::new(sst_region_metadata());
@@ -1993,7 +1990,10 @@ mod tests {
             file_id: sst_info.file_id,
             file_size: sst_info.file_size,
             max_row_group_uncompressed_size: sst_info.max_row_group_uncompressed_size,
-            index_file_size: sst_info.index_metadata.file_size,
+            available_indexes: smallvec![IndexType::InvertedIndex],
+            // Old manifests may publish an index without recording its size.
+            index_file_size: 0,
+            index_version: 0,
             num_rows: sst_info.num_rows as u64,
             num_row_groups: sst_info.num_row_groups,
             ..Default::default()
@@ -2052,6 +2052,7 @@ mod tests {
                 assert!(!updated_meta.available_indexes.is_empty());
                 assert!(updated_meta.index_file_size > 0);
                 assert_eq!(updated_meta.file_id, file_meta.file_id);
+                assert_eq!(updated_meta.index_version, 1);
             }
             _ => panic!("Unexpected worker request: {:?}", worker_req),
         }

--- a/src/mito2/src/sst/index.rs
+++ b/src/mito2/src/sst/index.rs
@@ -94,6 +94,9 @@ pub(crate) async fn cleanup_stale_index_artifact(
     cache_manager: Option<&CacheManagerRef>,
     write_cache: Option<&WriteCacheRef>,
 ) {
+    // Same-file builds stay serialized until stale cleanup and
+    // IndexBuildStopped complete, so this exact version cannot become
+    // referenced concurrently.
     if let Err(e) = access_layer.delete_index(index_id).await {
         INDEX_ARTIFACT_CLEANUP_FAILURE_TOTAL.inc();
         warn!(
@@ -1101,11 +1104,15 @@ impl IndexBuildStatus {
         }
     }
 
-    async fn retire(&mut self, err: Arc<Error>) {
-        self.retiring = !self.building_files.is_empty();
+    async fn fail_pending(&mut self, err: Arc<Error>) {
         for pending in std::mem::take(&mut self.pending_tasks) {
             pending.task.on_failure(err.clone()).await;
         }
+    }
+
+    async fn retire(&mut self, err: Arc<Error>) {
+        self.retiring = !self.building_files.is_empty();
+        self.fail_pending(err).await;
     }
 }
 
@@ -1250,10 +1257,10 @@ impl IndexBuildScheduler {
             return;
         }
         error!(
-            err; "Index build scheduler encountered failure for region {}, retiring active builds and failing pending tasks.",
+            err; "Index build scheduler encountered failure for region {}, failing pending tasks.",
             region_id
         );
-        status.retire(err).await;
+        status.fail_pending(err).await;
         if status.building_files.is_empty() {
             self.region_status.remove(&region_id);
         }
@@ -2486,7 +2493,7 @@ mod tests {
         // Region should be removed when all tasks complete
         assert!(!scheduler.region_status.contains_key(&region_id));
 
-        // Test 8: Region dropped with pending tasks
+        // Test 8: A build failure keeps active leases without retiring the region
         let task6 =
             create_mock_task_for_schedule(&env, file_id1, region_id, IndexBuildType::Flush).await;
         let task7 =
@@ -2512,9 +2519,19 @@ mod tests {
         assert_eq!(status.building_files.len(), 2);
         assert_eq!(status.pending_tasks.len(), 1);
 
-        scheduler.on_region_dropped(region_id).await;
+        scheduler
+            .on_failure(
+                region_id,
+                Arc::new(
+                    crate::error::UnexpectedSnafu {
+                        reason: "index build failed".to_string(),
+                    }
+                    .build(),
+                ),
+            )
+            .await;
         let status = scheduler.region_status.get(&region_id).unwrap();
-        assert!(status.retiring);
+        assert!(!status.retiring);
         assert_eq!(status.building_files.len(), 2);
         assert!(status.pending_tasks.is_empty());
 

--- a/src/mito2/src/sst/index/indexer/abort.rs
+++ b/src/mito2/src/sst/index/indexer/abort.rs
@@ -102,7 +102,7 @@ impl Indexer {
         let fs_accessor = puffin_manager.file_accessor();
 
         let fs_handle = RegionIndexId::new(
-            RegionFileId::new(self.region_id, self.file_id),
+            RegionFileId::new(self.physical_region_id, self.file_id),
             self.index_version,
         )
         .to_string();

--- a/src/mito2/src/sst/index/indexer/finish.rs
+++ b/src/mito2/src/sst/index/indexer/finish.rs
@@ -76,7 +76,7 @@ impl Indexer {
 
         let err = match puffin_manager
             .writer(&RegionIndexId::new(
-                RegionFileId::new(self.region_id, self.file_id),
+                RegionFileId::new(self.physical_region_id, self.file_id),
                 self.index_version,
             ))
             .await

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -194,7 +194,7 @@ mod tests {
     impl IndexerBuilder for NoopIndexBuilder {
         async fn build(
             &self,
-            _file_id: FileId,
+            _file_id: RegionFileId,
             _index_version: u64,
             _row_group_size: Option<usize>,
         ) -> Indexer {

--- a/src/mito2/src/sst/parquet/writer.rs
+++ b/src/mito2/src/sst/parquet/writer.rs
@@ -177,7 +177,9 @@ where
         metrics: &'a mut Metrics,
     ) -> ParquetWriter<'a, F, I, P> {
         let init_file = FileId::random();
-        let indexer = indexer_builder.build(init_file, 0, None).await;
+        let indexer = indexer_builder
+            .build(RegionFileId::new(metadata.region_id, init_file), 0, None)
+            .await;
 
         ParquetWriter {
             path_provider,
@@ -464,7 +466,11 @@ where
 
             let indexer = self
                 .indexer_builder
-                .build(self.current_file, 0, Some(opts.row_group_size))
+                .build(
+                    RegionFileId::new(self.metadata.region_id, self.current_file),
+                    0,
+                    Some(opts.row_group_size),
+                )
                 .await;
             self.current_indexer = Some(indexer);
 

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -1482,6 +1482,27 @@ impl WorkerListener {
             listener.on_index_build_abort(_region_file_id).await;
         }
     }
+
+    pub(crate) async fn on_index_build_before_manifest_commit(
+        &self,
+        _region_file_id: RegionFileId,
+    ) {
+        #[cfg(any(test, feature = "test"))]
+        if let Some(listener) = &self.listener {
+            listener
+                .on_index_build_before_manifest_commit(_region_file_id)
+                .await;
+        }
+    }
+
+    pub(crate) async fn on_index_build_manifest_committed(&self, _region_file_id: RegionFileId) {
+        #[cfg(any(test, feature = "test"))]
+        if let Some(listener) = &self.listener {
+            listener
+                .on_index_build_manifest_committed(_region_file_id)
+                .await;
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/mito2/src/worker/handle_rebuild_index.rs
+++ b/src/mito2/src/worker/handle_rebuild_index.rs
@@ -24,6 +24,8 @@ use tokio::sync::mpsc;
 
 use crate::cache::CacheStrategy;
 use crate::error::Result;
+use crate::manifest::action::RegionEdit;
+use crate::metrics::INDEX_PUBLICATION_STALE_TOTAL;
 use crate::region::MitoRegionRef;
 use crate::request::{
     BuildIndexRequest, IndexBuildFailed, IndexBuildFinished, IndexBuildStopped, OptionOutputTx,
@@ -31,6 +33,7 @@ use crate::request::{
 use crate::sst::file::{FileHandle, RegionFileId, RegionIndexId};
 use crate::sst::index::{
     IndexBuildOutcome, IndexBuildTask, IndexBuildType, IndexerBuilderImpl, ResultMpscSender,
+    cleanup_stale_index_artifact,
 };
 use crate::worker::RegionWorkerLoop;
 
@@ -79,6 +82,7 @@ impl<S> RegionWorkerLoop<S> {
             listener: self.listener.clone(),
             manifest_ctx: region.manifest_ctx.clone(),
             write_cache: self.cache_manager.write_cache().cloned(),
+            cache_manager: Some(self.cache_manager.clone()),
             file_purger: file.file_purger(),
             request_sender: self.sender.clone(),
             indexer_builder: indexer_builder_ref.clone(),
@@ -214,25 +218,54 @@ impl<S> RegionWorkerLoop<S> {
             }
         };
 
-        // Clean old puffin-related cache for all rebuilt files.
+        let file_meta = request.file_meta;
+        let region_file_id = RegionFileId::new(region_id, file_meta.file_id);
+        let index_id = RegionIndexId::new(region_file_id, file_meta.index_version);
+
+        // Clean old puffin-related cache before making the new metadata visible.
         let cache_strategy = CacheStrategy::EnableAll(self.cache_manager.clone());
-        for file_meta in &request.edit.files_to_add {
-            let region_file_id = RegionFileId::new(region_id, file_meta.file_id);
-            let index_id = RegionIndexId::new(region_file_id, file_meta.index_version);
-            cache_strategy.evict_puffin_cache(index_id).await;
+        cache_strategy.evict_puffin_cache(index_id).await;
+
+        let manager = region.manifest_ctx.manifest_manager.read().await;
+        let manifest = manager.manifest();
+        let is_current = manifest.files.get(&file_meta.file_id) == Some(&file_meta);
+        if is_current {
+            region.version_control.apply_edit(
+                Some(RegionEdit {
+                    files_to_add: vec![file_meta.clone()],
+                    files_to_remove: Vec::new(),
+                    timestamp_ms: None,
+                    flushed_sequence: None,
+                    flushed_entry_id: None,
+                    committed_sequence: None,
+                    compaction_time_window: None,
+                }),
+                &[],
+                region.file_purger.clone(),
+            );
+        }
+        drop(manager);
+
+        if !is_current {
+            INDEX_PUBLICATION_STALE_TOTAL
+                .with_label_values(&["worker_apply"])
+                .inc();
+            warn!(
+                "Ignores stale index build result, region: {}, file_id: {}, index_version: {}, committed manifest version: {}",
+                region_id, file_meta.file_id, file_meta.index_version, request.manifest_version
+            );
+            cleanup_stale_index_artifact(
+                index_id,
+                &region.access_layer,
+                Some(&self.cache_manager),
+                self.cache_manager.write_cache(),
+            )
+            .await;
+            self.listener.on_index_build_abort(region_file_id).await;
+            return;
         }
 
-        region.version_control.apply_edit(
-            Some(request.edit.clone()),
-            &[],
-            region.file_purger.clone(),
-        );
-
-        for file_meta in &request.edit.files_to_add {
-            self.listener
-                .on_index_build_finish(RegionFileId::new(region_id, file_meta.file_id))
-                .await;
-        }
+        self.listener.on_index_build_finish(region_file_id).await;
     }
 
     pub(crate) async fn handle_index_build_failed(

--- a/src/mito2/src/worker/handle_rebuild_index.rs
+++ b/src/mito2/src/worker/handle_rebuild_index.rs
@@ -33,7 +33,7 @@ use crate::request::{
 use crate::sst::file::{FileHandle, RegionFileId, RegionIndexId};
 use crate::sst::index::{
     IndexBuildOutcome, IndexBuildTask, IndexBuildType, IndexerBuilderImpl, ResultMpscSender,
-    cleanup_stale_index_artifact,
+    cleanup_stale_index_caches,
 };
 use crate::worker::RegionWorkerLoop;
 
@@ -75,6 +75,7 @@ impl<S> RegionWorkerLoop<S> {
         });
 
         IndexBuildTask {
+            region_id: region.region_id,
             file: file.clone(),
             file_meta: file.meta_ref().clone(),
             reason: build_type,
@@ -219,7 +220,7 @@ impl<S> RegionWorkerLoop<S> {
         };
 
         let file_meta = request.file_meta;
-        let region_file_id = RegionFileId::new(region_id, file_meta.file_id);
+        let region_file_id = RegionFileId::new(file_meta.region_id, file_meta.file_id);
         let index_id = RegionIndexId::new(region_file_id, file_meta.index_version);
 
         // Clean old puffin-related cache before making the new metadata visible.
@@ -254,7 +255,7 @@ impl<S> RegionWorkerLoop<S> {
                 "Ignores stale index build result, region: {}, file_id: {}, index_version: {}, committed manifest version: {}",
                 region_id, file_meta.file_id, file_meta.index_version, request.manifest_version
             );
-            cleanup_stale_index_artifact(
+            cleanup_stale_index_caches(
                 index_id,
                 &region.access_layer,
                 Some(&self.cache_manager),

--- a/src/mito2/src/worker/handle_rebuild_index.rs
+++ b/src/mito2/src/worker/handle_rebuild_index.rs
@@ -284,17 +284,7 @@ impl<S> RegionWorkerLoop<S> {
         region_id: RegionId,
         request: IndexBuildStopped,
     ) {
-        let Some(region) = self.regions.get_region(region_id) else {
-            warn!(
-                "Region not found for index build stopped, region_id: {}",
-                region_id
-            );
-            return;
-        };
-        self.index_build_scheduler.on_task_stopped(
-            region_id,
-            request.file_id,
-            &region.version_control,
-        );
+        self.index_build_scheduler
+            .on_task_stopped(region_id, request.file_id);
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

N/A

## What's changed and what's your intention?

Async index publication had two races with compaction:

- Compaction could replace the source SST between the final source check and the manifest update.
- A delayed worker notification could apply metadata that a later manifest edit had already removed.

This PR fixes both publication stages:

- Commit index metadata only when the manifest still contains the full source `FileMeta` generation. The check and commit use the same manifest write lock.
- Before applying the result in memory, revalidate the committed `FileMeta` under the manifest read lock and keep that lock through `apply_edit`.
- Keep the logical region ID separate from `FileMeta.region_id`. The logical ID is used for scheduler state, worker routing, and manifest/version updates; the physical ID is used for SST/index paths.
- Choose the next artifact version from published index metadata, not the optional file-size hint. This prevents legacy manifests with a zero size from overwriting an already published version.
- Evict local caches and staging files for stale publications. Remote artifacts are left to reference-aware/full-listing GC.
- When a file is removed, record the index version currently stored in the manifest rather than the possibly stale version captured by compaction.

Close/reopen can otherwise schedule the same SST while a job from the previous region incarnation is still running. The scheduler keeps the active build lease after close, drop, or truncate. Reopened builds wait until the old active batch sends `IndexBuildStopped`; close does not cancel or wait for index work. Pending tasks carry their own `VersionControlRef`.

Deterministic tests cover both compaction orderings, cross-region files where the logical and physical region IDs differ, close/reopen overlap, repeated-row checks across reopen, legacy index metadata without a file-size hint, local cache cleanup, remote artifact retention for `ObjectStoreFilePurger`, and both purger implementations.

This does not change persisted formats, public APIs, or schemas.

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
