### PR TITLE
fix(repartition): enforce GC across lifecycle

### DIFF
--- a/src/common/meta/src/ddl_manager.rs
+++ b/src/common/meta/src/ddl_manager.rs
@@ -48,10 +48,11 @@ use crate::ddl::truncate_table::TruncateTableProcedure;
 use crate::ddl::undrop_table::UndropTableProcedure;
 use crate::ddl::{DdlContext, utils};
 use crate::error::{
-    self, CreateRepartitionProcedureSnafu, EmptyDdlTasksSnafu, ProcedureOutputSnafu,
-    RegisterProcedureLoaderSnafu, RegisterRepartitionProcedureLoaderSnafu, Result,
-    SubmitProcedureSnafu, TableInfoNotFoundSnafu, TableNotFoundSnafu, TableRouteNotFoundSnafu,
-    UnexpectedLogicalRouteTableSnafu, WaitProcedureSnafu,
+    self, CreateRepartitionProcedureSnafu, EmptyDdlTasksSnafu,
+    PersistRepartitionGcRequirementSnafu, ProcedureOutputSnafu, RegisterProcedureLoaderSnafu,
+    RegisterRepartitionProcedureLoaderSnafu, Result, SubmitProcedureSnafu, TableInfoNotFoundSnafu,
+    TableNotFoundSnafu, TableRouteNotFoundSnafu, UnexpectedLogicalRouteTableSnafu,
+    WaitProcedureSnafu,
 };
 use crate::key::table_info::TableInfoValue;
 use crate::key::table_name::TableNameKey;
@@ -170,6 +171,7 @@ pub enum RepartitionSource {
     },
 }
 
+#[async_trait::async_trait]
 pub trait RepartitionProcedureFactory: Send + Sync {
     fn create(
         &self,
@@ -186,6 +188,9 @@ pub trait RepartitionProcedureFactory: Send + Sync {
         ddl_ctx: &DdlContext,
         procedure_manager: &ProcedureManagerRef,
     ) -> std::result::Result<(), BoxedError>;
+
+    /// Persists the cluster-level GC requirement before submitting a repartition.
+    async fn ensure_gc_requirement(&self) -> std::result::Result<(), BoxedError>;
 }
 
 /// The options for DDL tasks.
@@ -356,6 +361,10 @@ impl DdlManager {
                 Some(timeout),
             )
             .context(CreateRepartitionProcedureSnafu)?;
+        self.repartition_procedure_factory
+            .ensure_gc_requirement()
+            .await
+            .context(PersistRepartitionGcRequirementSnafu)?;
         let procedure_with_id = ProcedureWithId::with_random_id(Box::new(procedure));
         if wait {
             self.execute_procedure_and_wait(procedure_with_id).await
@@ -1326,6 +1335,10 @@ mod tests {
             _ddl_ctx: &DdlContext,
             _procedure_manager: &ProcedureManagerRef,
         ) -> std::result::Result<(), BoxedError> {
+            Ok(())
+        }
+
+        async fn ensure_gc_requirement(&self) -> std::result::Result<(), BoxedError> {
             Ok(())
         }
     }

--- a/src/common/meta/src/error.rs
+++ b/src/common/meta/src/error.rs
@@ -127,6 +127,13 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display("Failed to persist the repartition GC requirement"))]
+    PersistRepartitionGcRequirement {
+        source: BoxedError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Failed to submit procedure"))]
     SubmitProcedure {
         #[snafu(implicit)]
@@ -1264,6 +1271,7 @@ impl ErrorExt for Error {
             ProcedureStateReceiver { source, .. } => source.status_code(),
             RegisterRepartitionProcedureLoader { source, .. } => source.status_code(),
             CreateRepartitionProcedure { source, .. } => source.status_code(),
+            PersistRepartitionGcRequirement { source, .. } => source.status_code(),
 
             ParseProcedureId { .. }
             | InvalidNumTopics { .. }
@@ -1336,7 +1344,8 @@ impl ErrorExt for Error {
             | OperateDatanode { source, .. }
             | AbortProcedure { source, .. }
             | RegisterRepartitionProcedureLoader { source, .. }
-            | CreateRepartitionProcedure { source, .. } => source.retry_hint(),
+            | CreateRepartitionProcedure { source, .. }
+            | PersistRepartitionGcRequirement { source, .. } => source.retry_hint(),
             Table { source, .. } => source.retry_hint(),
             ConvertAlterTableRequest { source, .. } => source.retry_hint(),
             ConvertColumnDef { source, .. } => source.retry_hint(),

--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -174,6 +174,7 @@ use crate::wal_provider::RegionWalOptions;
 pub const TOPIC_NAME_PATTERN: &str = r"[a-zA-Z0-9_:-][a-zA-Z0-9_:\-\.@#]*";
 pub const LEGACY_MAINTENANCE_KEY: &str = "__maintenance";
 pub const MAINTENANCE_KEY: &str = "__switches/maintenance";
+pub const REPARTITION_GC_REQUIRED_KEY: &str = "__requirements/gc/repartition";
 pub const PAUSE_PROCEDURE_KEY: &str = "__switches/pause_procedure";
 pub const RECOVERY_MODE_KEY: &str = "__switches/recovery";
 

--- a/src/common/procedure/src/error.rs
+++ b/src/common/procedure/src/error.rs
@@ -58,22 +58,6 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display(
-        "Failed to load procedure data, procedure_id: {}, type_name: {}",
-        procedure_id,
-        type_name
-    ))]
-    LoadProcedure {
-        procedure_id: ProcedureId,
-        type_name: String,
-        source: Box<Error>,
-        #[snafu(implicit)]
-        location: Location,
-    },
-
-    #[snafu(display("Procedure recovery is blocked"))]
-    RecoveryBlocked { source: BoxedError },
-
     #[snafu(display("Procedure Manager is stopped"))]
     ManagerNotStart {
         #[snafu(implicit)]
@@ -302,8 +286,6 @@ impl ErrorExt for Error {
             | &Error::ProcedureNotFound { .. }
             | Error::PoisonKeyNotDefined { .. } => StatusCode::Unexpected,
             Error::ProcedureExec { source, .. } => source.status_code(),
-            Error::LoadProcedure { source, .. } => source.status_code(),
-            Error::RecoveryBlocked { source } => source.status_code(),
             Error::StartRemoveOutdatedMetaTask { source, .. }
             | Error::StopRemoveOutdatedMetaTask { source, .. } => source.status_code(),
         }
@@ -325,8 +307,6 @@ impl ErrorExt for Error {
             | Error::GetPoison { source, .. }
             | Error::CheckStatus { source, .. } => source.retry_hint(),
             Error::ProcedureExec { source, .. } => source.retry_hint(),
-            Error::LoadProcedure { source, .. } => source.retry_hint(),
-            Error::RecoveryBlocked { source } => source.retry_hint(),
             Error::StartRemoveOutdatedMetaTask { source, .. }
             | Error::StopRemoveOutdatedMetaTask { source, .. } => source.retry_hint(),
             Error::DeleteState { error, .. } => retry_hint_from_opendal_error(error),
@@ -339,18 +319,6 @@ impl ErrorExt for Error {
 }
 
 impl Error {
-    /// Creates an error that explicitly prevents procedure recovery from continuing.
-    pub fn recovery_blocked<E: ErrorExt + Send + Sync + 'static>(err: E) -> Error {
-        Error::RecoveryBlocked {
-            source: BoxedError::new(err),
-        }
-    }
-
-    /// Returns whether this error must block procedure recovery.
-    pub fn is_recovery_blocked(&self) -> bool {
-        matches!(self, Error::RecoveryBlocked { .. })
-    }
-
     /// Creates a new [Error::External] error from source `err`.
     pub fn external<E: ErrorExt + Send + Sync + 'static>(err: E) -> Error {
         Error::External {

--- a/src/common/procedure/src/error.rs
+++ b/src/common/procedure/src/error.rs
@@ -58,6 +58,22 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display(
+        "Failed to load procedure data, procedure_id: {}, type_name: {}",
+        procedure_id,
+        type_name
+    ))]
+    LoadProcedure {
+        procedure_id: ProcedureId,
+        type_name: String,
+        source: Box<Error>,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Procedure recovery is blocked"))]
+    RecoveryBlocked { source: BoxedError },
+
     #[snafu(display("Procedure Manager is stopped"))]
     ManagerNotStart {
         #[snafu(implicit)]
@@ -286,6 +302,8 @@ impl ErrorExt for Error {
             | &Error::ProcedureNotFound { .. }
             | Error::PoisonKeyNotDefined { .. } => StatusCode::Unexpected,
             Error::ProcedureExec { source, .. } => source.status_code(),
+            Error::LoadProcedure { source, .. } => source.status_code(),
+            Error::RecoveryBlocked { source } => source.status_code(),
             Error::StartRemoveOutdatedMetaTask { source, .. }
             | Error::StopRemoveOutdatedMetaTask { source, .. } => source.status_code(),
         }
@@ -307,6 +325,8 @@ impl ErrorExt for Error {
             | Error::GetPoison { source, .. }
             | Error::CheckStatus { source, .. } => source.retry_hint(),
             Error::ProcedureExec { source, .. } => source.retry_hint(),
+            Error::LoadProcedure { source, .. } => source.retry_hint(),
+            Error::RecoveryBlocked { source } => source.retry_hint(),
             Error::StartRemoveOutdatedMetaTask { source, .. }
             | Error::StopRemoveOutdatedMetaTask { source, .. } => source.retry_hint(),
             Error::DeleteState { error, .. } => retry_hint_from_opendal_error(error),
@@ -319,6 +339,18 @@ impl ErrorExt for Error {
 }
 
 impl Error {
+    /// Creates an error that explicitly prevents procedure recovery from continuing.
+    pub fn recovery_blocked<E: ErrorExt + Send + Sync + 'static>(err: E) -> Error {
+        Error::RecoveryBlocked {
+            source: BoxedError::new(err),
+        }
+    }
+
+    /// Returns whether this error must block procedure recovery.
+    pub fn is_recovery_blocked(&self) -> bool {
+        matches!(self, Error::RecoveryBlocked { .. })
+    }
+
     /// Creates a new [Error::External] error from source `err`.
     pub fn external<E: ErrorExt + Send + Sync + 'static>(err: E) -> Error {
         Error::External {

--- a/src/common/procedure/src/local.rs
+++ b/src/common/procedure/src/local.rs
@@ -487,30 +487,37 @@ impl ManagerContext {
         &self,
         procedure_id: ProcedureId,
         message: &ProcedureMessage,
-    ) -> Option<LoadedProcedure> {
+    ) -> Result<Option<LoadedProcedure>> {
         let loaders = self.loaders.lock().unwrap();
-        let loader = loaders.get(&message.type_name).or_else(|| {
+        let Some(loader) = loaders.get(&message.type_name) else {
             error!(
                 "Loader not found, procedure_id: {}, type_name: {}",
                 procedure_id, message.type_name
             );
-            None
-        })?;
+            return Ok(None);
+        };
 
-        let procedure = loader(&message.data)
-            .map_err(|e| {
+        let procedure = match loader(&message.data) {
+            Ok(procedure) => procedure,
+            Err(err) if err.is_recovery_blocked() => {
+                return Err(Box::new(err)).context(error::LoadProcedureSnafu {
+                    procedure_id,
+                    type_name: &message.type_name,
+                });
+            }
+            Err(err) => {
                 error!(
                     "Failed to load procedure data, key: {}, source: {:?}",
-                    procedure_id, e
+                    procedure_id, err
                 );
-                e
-            })
-            .ok()?;
+                return Ok(None);
+            }
+        };
 
-        Some(LoadedProcedure {
+        Ok(Some(LoadedProcedure {
             procedure,
             step: message.step,
-        })
+        }))
     }
 
     /// Returns all procedures in the tree (including given `root` procedure).
@@ -786,20 +793,18 @@ impl LocalManager {
         Ok(watcher)
     }
 
-    fn submit_recovered_messages(
+    fn load_recovered_messages(
         &self,
         messages: HashMap<ProcedureId, ProcedureMessage>,
         init_state: InitProcedureState,
-    ) {
+    ) -> Result<Vec<(ProcedureId, ProcedureState, LoadedProcedure)>> {
+        let mut recovered = Vec::new();
         for (procedure_id, message) in &messages {
             if message.parent_id.is_none() {
-                // This is the root procedure. We only submit the root procedure as it will
-                // submit sub-procedures to the manager.
-                let Some(mut loaded_procedure) = self
+                let Some(loaded_procedure) = self
                     .manager_ctx
-                    .load_one_procedure_from_message(*procedure_id, message)
+                    .load_one_procedure_from_message(*procedure_id, message)?
                 else {
-                    // Try to load other procedures.
                     continue;
                 };
 
@@ -822,19 +827,34 @@ impl LocalManager {
                     InitProcedureState::Running => ProcedureState::Running,
                 };
 
-                if let Err(e) = loaded_procedure.procedure.recover() {
-                    error!(e; "Failed to recover procedure {}", procedure_id);
-                }
+                recovered.push((*procedure_id, procedure_state, loaded_procedure));
+            }
+        }
 
-                if let Err(e) = self.submit_root(
-                    *procedure_id,
-                    procedure_state,
-                    loaded_procedure.step,
-                    loaded_procedure.procedure,
-                    RootSubmissionOrigin::Recovery,
-                ) {
-                    error!(e; "Failed to recover procedure {}", procedure_id);
-                }
+        Ok(recovered)
+    }
+
+    fn run_recovery_hooks(&self, recovered: &mut [(ProcedureId, ProcedureState, LoadedProcedure)]) {
+        for (procedure_id, _, loaded_procedure) in recovered {
+            if let Err(e) = loaded_procedure.procedure.recover() {
+                error!(e; "Failed to recover procedure {}", procedure_id);
+            }
+        }
+    }
+
+    fn submit_recovered_procedures(
+        &self,
+        recovered: Vec<(ProcedureId, ProcedureState, LoadedProcedure)>,
+    ) {
+        for (procedure_id, procedure_state, loaded_procedure) in recovered {
+            if let Err(e) = self.submit_root(
+                procedure_id,
+                procedure_state,
+                loaded_procedure.step,
+                loaded_procedure.procedure,
+                RootSubmissionOrigin::Recovery,
+            ) {
+                error!(e; "Failed to recover procedure {}", procedure_id);
             }
         }
     }
@@ -849,9 +869,15 @@ impl LocalManager {
             rollback_messages,
             finished_ids,
         } = self.procedure_store.load_messages().await?;
-        // Submits recovered messages first.
-        self.submit_recovered_messages(rollback_messages, InitProcedureState::RollingBack);
-        self.submit_recovered_messages(messages, InitProcedureState::Running);
+        // Load every root before running recovery hooks or submitting any of them.
+        // Only an explicit recovery-blocking loader error fails the whole recovery.
+        let mut recovered_rollbacks =
+            self.load_recovered_messages(rollback_messages, InitProcedureState::RollingBack)?;
+        let mut recovered = self.load_recovered_messages(messages, InitProcedureState::Running)?;
+        self.run_recovery_hooks(&mut recovered_rollbacks);
+        self.run_recovery_hooks(&mut recovered);
+        self.submit_recovered_procedures(recovered_rollbacks);
+        self.submit_recovered_procedures(recovered);
 
         if !finished_ids.is_empty() {
             info!(
@@ -911,20 +937,29 @@ impl ProcedureManager for LocalManager {
             return Ok(());
         }
 
-        let task_inner = self.build_remove_outdated_meta_task();
-
-        task_inner
-            .start(common_runtime::global_runtime())
-            .context(StartRemoveOutdatedMetaTaskSnafu)?;
-
-        *task = Some(task_inner);
-
         self.manager_ctx.reset_runtime_state();
         self.manager_ctx.start();
 
         info!("LocalManager is start.");
 
-        self.recover().await
+        if let Err(err) = self.recover().await {
+            self.manager_ctx.stop();
+            self.manager_ctx.reset_runtime_state();
+            return Err(err);
+        }
+
+        let task_inner = self.build_remove_outdated_meta_task();
+        if let Err(err) = task_inner
+            .start(common_runtime::global_runtime())
+            .context(StartRemoveOutdatedMetaTaskSnafu)
+        {
+            self.manager_ctx.stop();
+            self.manager_ctx.reset_runtime_state();
+            return Err(err);
+        }
+        *task = Some(task_inner);
+
+        Ok(())
     }
 
     async fn stop(&self) -> Result<()> {
@@ -972,6 +1007,15 @@ impl ProcedureManager for LocalManager {
 
     async fn list_procedures(&self) -> Result<Vec<ProcedureInfo>> {
         Ok(self.manager_ctx.list_procedure())
+    }
+
+    async fn has_unfinished_procedure(&self, type_names: &[&str]) -> Result<bool> {
+        let messages = self.procedure_store.load_messages().await?;
+        Ok(messages
+            .messages
+            .values()
+            .chain(messages.rollback_messages.values())
+            .any(|message| type_names.contains(&message.type_name.as_str())))
     }
 }
 
@@ -1623,6 +1667,137 @@ mod tests {
         // Since the mocked root procedure actually doesn't submit subprocedures, so there is no
         // related state.
         assert!(manager.procedure_state(child_id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_recovery_blocked_error_fails_recovery_without_losing_state() {
+        let dir = create_temp_dir("loader_error_recovery");
+        let object_store = test_util::new_object_store(&dir);
+        let state_store = Arc::new(ObjectStateStore::new(object_store.clone()));
+        let poison_manager = Arc::new(InMemoryPoisonStore::new());
+        let manager = LocalManager::new(
+            ManagerConfig {
+                parent_path: "data/".to_string(),
+                ..Default::default()
+            },
+            state_store,
+            poison_manager,
+            None,
+            None,
+        );
+
+        let loader_enabled = Arc::new(AtomicBool::new(false));
+        let moved_loader_enabled = loader_enabled.clone();
+        manager
+            .register_loader(
+                "ProcedureToLoad",
+                Box::new(move |json| {
+                    if !moved_loader_enabled.load(AtomicOrdering::Relaxed) {
+                        return Err(Error::recovery_blocked(MockError::new(
+                            StatusCode::IllegalState,
+                        )));
+                    }
+                    Ok(Box::new(ProcedureToLoad::new(json)))
+                }),
+            )
+            .unwrap();
+
+        let procedure_id = ProcedureId::random();
+        let procedure = ProcedureToLoad::new("recover after loader is enabled");
+        ProcedureStore::from_object_store(object_store)
+            .store_procedure(
+                procedure_id,
+                0,
+                procedure.type_name().to_string(),
+                procedure.dump().unwrap(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let err = manager.start().await.unwrap_err();
+        assert!(matches!(err, Error::LoadProcedure { .. }), "{err:?}");
+        assert!(
+            manager
+                .has_unfinished_procedure(&["ProcedureToLoad"])
+                .await
+                .unwrap()
+        );
+        assert!(
+            manager
+                .procedure_state(procedure_id)
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        loader_enabled.store(true, AtomicOrdering::Relaxed);
+        manager.start().await.unwrap();
+        assert!(
+            manager
+                .procedure_state(procedure_id)
+                .await
+                .unwrap()
+                .is_some()
+        );
+        manager.stop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_regular_loader_error_does_not_fail_recovery() {
+        let dir = create_temp_dir("regular_loader_error_recovery");
+        let object_store = test_util::new_object_store(&dir);
+        let state_store = Arc::new(ObjectStateStore::new(object_store.clone()));
+        let poison_manager = Arc::new(InMemoryPoisonStore::new());
+        let manager = LocalManager::new(
+            ManagerConfig {
+                parent_path: "data/".to_string(),
+                ..Default::default()
+            },
+            state_store,
+            poison_manager,
+            None,
+            None,
+        );
+        manager
+            .register_loader(
+                "ProcedureToLoad",
+                Box::new(|_| {
+                    Err(Error::external(MockError::new(
+                        StatusCode::InvalidArguments,
+                    )))
+                }),
+            )
+            .unwrap();
+
+        let procedure_id = ProcedureId::random();
+        let procedure = ProcedureToLoad::new("skip regular loader error");
+        ProcedureStore::from_object_store(object_store)
+            .store_procedure(
+                procedure_id,
+                0,
+                procedure.type_name().to_string(),
+                procedure.dump().unwrap(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        manager.start().await.unwrap();
+        assert!(
+            manager
+                .has_unfinished_procedure(&["ProcedureToLoad"])
+                .await
+                .unwrap()
+        );
+        assert!(
+            manager
+                .procedure_state(procedure_id)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        manager.stop().await.unwrap();
     }
 
     #[tokio::test]

--- a/src/common/procedure/src/local.rs
+++ b/src/common/procedure/src/local.rs
@@ -487,37 +487,30 @@ impl ManagerContext {
         &self,
         procedure_id: ProcedureId,
         message: &ProcedureMessage,
-    ) -> Result<Option<LoadedProcedure>> {
+    ) -> Option<LoadedProcedure> {
         let loaders = self.loaders.lock().unwrap();
-        let Some(loader) = loaders.get(&message.type_name) else {
+        let loader = loaders.get(&message.type_name).or_else(|| {
             error!(
                 "Loader not found, procedure_id: {}, type_name: {}",
                 procedure_id, message.type_name
             );
-            return Ok(None);
-        };
+            None
+        })?;
 
-        let procedure = match loader(&message.data) {
-            Ok(procedure) => procedure,
-            Err(err) if err.is_recovery_blocked() => {
-                return Err(Box::new(err)).context(error::LoadProcedureSnafu {
-                    procedure_id,
-                    type_name: &message.type_name,
-                });
-            }
-            Err(err) => {
+        let procedure = loader(&message.data)
+            .map_err(|e| {
                 error!(
                     "Failed to load procedure data, key: {}, source: {:?}",
-                    procedure_id, err
+                    procedure_id, e
                 );
-                return Ok(None);
-            }
-        };
+                e
+            })
+            .ok()?;
 
-        Ok(Some(LoadedProcedure {
+        Some(LoadedProcedure {
             procedure,
             step: message.step,
-        }))
+        })
     }
 
     /// Returns all procedures in the tree (including given `root` procedure).
@@ -793,18 +786,20 @@ impl LocalManager {
         Ok(watcher)
     }
 
-    fn load_recovered_messages(
+    fn submit_recovered_messages(
         &self,
         messages: HashMap<ProcedureId, ProcedureMessage>,
         init_state: InitProcedureState,
-    ) -> Result<Vec<(ProcedureId, ProcedureState, LoadedProcedure)>> {
-        let mut recovered = Vec::new();
+    ) {
         for (procedure_id, message) in &messages {
             if message.parent_id.is_none() {
-                let Some(loaded_procedure) = self
+                // This is the root procedure. We only submit the root procedure as it will
+                // submit sub-procedures to the manager.
+                let Some(mut loaded_procedure) = self
                     .manager_ctx
-                    .load_one_procedure_from_message(*procedure_id, message)?
+                    .load_one_procedure_from_message(*procedure_id, message)
                 else {
+                    // Try to load other procedures.
                     continue;
                 };
 
@@ -827,34 +822,19 @@ impl LocalManager {
                     InitProcedureState::Running => ProcedureState::Running,
                 };
 
-                recovered.push((*procedure_id, procedure_state, loaded_procedure));
-            }
-        }
+                if let Err(e) = loaded_procedure.procedure.recover() {
+                    error!(e; "Failed to recover procedure {}", procedure_id);
+                }
 
-        Ok(recovered)
-    }
-
-    fn run_recovery_hooks(&self, recovered: &mut [(ProcedureId, ProcedureState, LoadedProcedure)]) {
-        for (procedure_id, _, loaded_procedure) in recovered {
-            if let Err(e) = loaded_procedure.procedure.recover() {
-                error!(e; "Failed to recover procedure {}", procedure_id);
-            }
-        }
-    }
-
-    fn submit_recovered_procedures(
-        &self,
-        recovered: Vec<(ProcedureId, ProcedureState, LoadedProcedure)>,
-    ) {
-        for (procedure_id, procedure_state, loaded_procedure) in recovered {
-            if let Err(e) = self.submit_root(
-                procedure_id,
-                procedure_state,
-                loaded_procedure.step,
-                loaded_procedure.procedure,
-                RootSubmissionOrigin::Recovery,
-            ) {
-                error!(e; "Failed to recover procedure {}", procedure_id);
+                if let Err(e) = self.submit_root(
+                    *procedure_id,
+                    procedure_state,
+                    loaded_procedure.step,
+                    loaded_procedure.procedure,
+                    RootSubmissionOrigin::Recovery,
+                ) {
+                    error!(e; "Failed to recover procedure {}", procedure_id);
+                }
             }
         }
     }
@@ -869,15 +849,9 @@ impl LocalManager {
             rollback_messages,
             finished_ids,
         } = self.procedure_store.load_messages().await?;
-        // Load every root before running recovery hooks or submitting any of them.
-        // Only an explicit recovery-blocking loader error fails the whole recovery.
-        let mut recovered_rollbacks =
-            self.load_recovered_messages(rollback_messages, InitProcedureState::RollingBack)?;
-        let mut recovered = self.load_recovered_messages(messages, InitProcedureState::Running)?;
-        self.run_recovery_hooks(&mut recovered_rollbacks);
-        self.run_recovery_hooks(&mut recovered);
-        self.submit_recovered_procedures(recovered_rollbacks);
-        self.submit_recovered_procedures(recovered);
+        // Submits recovered messages first.
+        self.submit_recovered_messages(rollback_messages, InitProcedureState::RollingBack);
+        self.submit_recovered_messages(messages, InitProcedureState::Running);
 
         if !finished_ids.is_empty() {
             info!(
@@ -937,29 +911,20 @@ impl ProcedureManager for LocalManager {
             return Ok(());
         }
 
+        let task_inner = self.build_remove_outdated_meta_task();
+
+        task_inner
+            .start(common_runtime::global_runtime())
+            .context(StartRemoveOutdatedMetaTaskSnafu)?;
+
+        *task = Some(task_inner);
+
         self.manager_ctx.reset_runtime_state();
         self.manager_ctx.start();
 
         info!("LocalManager is start.");
 
-        if let Err(err) = self.recover().await {
-            self.manager_ctx.stop();
-            self.manager_ctx.reset_runtime_state();
-            return Err(err);
-        }
-
-        let task_inner = self.build_remove_outdated_meta_task();
-        if let Err(err) = task_inner
-            .start(common_runtime::global_runtime())
-            .context(StartRemoveOutdatedMetaTaskSnafu)
-        {
-            self.manager_ctx.stop();
-            self.manager_ctx.reset_runtime_state();
-            return Err(err);
-        }
-        *task = Some(task_inner);
-
-        Ok(())
+        self.recover().await
     }
 
     async fn stop(&self) -> Result<()> {
@@ -1667,137 +1632,6 @@ mod tests {
         // Since the mocked root procedure actually doesn't submit subprocedures, so there is no
         // related state.
         assert!(manager.procedure_state(child_id).await.unwrap().is_none());
-    }
-
-    #[tokio::test]
-    async fn test_recovery_blocked_error_fails_recovery_without_losing_state() {
-        let dir = create_temp_dir("loader_error_recovery");
-        let object_store = test_util::new_object_store(&dir);
-        let state_store = Arc::new(ObjectStateStore::new(object_store.clone()));
-        let poison_manager = Arc::new(InMemoryPoisonStore::new());
-        let manager = LocalManager::new(
-            ManagerConfig {
-                parent_path: "data/".to_string(),
-                ..Default::default()
-            },
-            state_store,
-            poison_manager,
-            None,
-            None,
-        );
-
-        let loader_enabled = Arc::new(AtomicBool::new(false));
-        let moved_loader_enabled = loader_enabled.clone();
-        manager
-            .register_loader(
-                "ProcedureToLoad",
-                Box::new(move |json| {
-                    if !moved_loader_enabled.load(AtomicOrdering::Relaxed) {
-                        return Err(Error::recovery_blocked(MockError::new(
-                            StatusCode::IllegalState,
-                        )));
-                    }
-                    Ok(Box::new(ProcedureToLoad::new(json)))
-                }),
-            )
-            .unwrap();
-
-        let procedure_id = ProcedureId::random();
-        let procedure = ProcedureToLoad::new("recover after loader is enabled");
-        ProcedureStore::from_object_store(object_store)
-            .store_procedure(
-                procedure_id,
-                0,
-                procedure.type_name().to_string(),
-                procedure.dump().unwrap(),
-                None,
-            )
-            .await
-            .unwrap();
-
-        let err = manager.start().await.unwrap_err();
-        assert!(matches!(err, Error::LoadProcedure { .. }), "{err:?}");
-        assert!(
-            manager
-                .has_unfinished_procedure(&["ProcedureToLoad"])
-                .await
-                .unwrap()
-        );
-        assert!(
-            manager
-                .procedure_state(procedure_id)
-                .await
-                .unwrap()
-                .is_none()
-        );
-
-        loader_enabled.store(true, AtomicOrdering::Relaxed);
-        manager.start().await.unwrap();
-        assert!(
-            manager
-                .procedure_state(procedure_id)
-                .await
-                .unwrap()
-                .is_some()
-        );
-        manager.stop().await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_regular_loader_error_does_not_fail_recovery() {
-        let dir = create_temp_dir("regular_loader_error_recovery");
-        let object_store = test_util::new_object_store(&dir);
-        let state_store = Arc::new(ObjectStateStore::new(object_store.clone()));
-        let poison_manager = Arc::new(InMemoryPoisonStore::new());
-        let manager = LocalManager::new(
-            ManagerConfig {
-                parent_path: "data/".to_string(),
-                ..Default::default()
-            },
-            state_store,
-            poison_manager,
-            None,
-            None,
-        );
-        manager
-            .register_loader(
-                "ProcedureToLoad",
-                Box::new(|_| {
-                    Err(Error::external(MockError::new(
-                        StatusCode::InvalidArguments,
-                    )))
-                }),
-            )
-            .unwrap();
-
-        let procedure_id = ProcedureId::random();
-        let procedure = ProcedureToLoad::new("skip regular loader error");
-        ProcedureStore::from_object_store(object_store)
-            .store_procedure(
-                procedure_id,
-                0,
-                procedure.type_name().to_string(),
-                procedure.dump().unwrap(),
-                None,
-            )
-            .await
-            .unwrap();
-
-        manager.start().await.unwrap();
-        assert!(
-            manager
-                .has_unfinished_procedure(&["ProcedureToLoad"])
-                .await
-                .unwrap()
-        );
-        assert!(
-            manager
-                .procedure_state(procedure_id)
-                .await
-                .unwrap()
-                .is_none()
-        );
-        manager.stop().await.unwrap();
     }
 
     #[tokio::test]

--- a/src/common/procedure/src/procedure.rs
+++ b/src/common/procedure/src/procedure.rs
@@ -701,6 +701,11 @@ pub trait ProcedureManager: Send + Sync + 'static {
 
     /// Returns the details of the procedure.
     async fn list_procedures(&self) -> Result<Vec<ProcedureInfo>>;
+
+    /// Returns whether persisted unfinished procedures contain any requested type.
+    ///
+    /// This inspects durable state without submitting procedures for execution.
+    async fn has_unfinished_procedure(&self, type_names: &[&str]) -> Result<bool>;
 }
 
 /// Ref-counted pointer to the [ProcedureManager].

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -105,6 +105,8 @@ impl MetasrvInstance {
     }
 
     pub async fn start(&mut self) -> Result<()> {
+        self.metasrv.ensure_repartition_gc_enabled().await?;
+
         if let Some(builder) = self.http_server.as_mut().left()
             && let Some(mut builder) = builder.take()
         {
@@ -472,6 +474,7 @@ mod tests {
 
     use super::*;
     use crate::metasrv::{SelectorFactory, SelectorFactoryContext};
+    use crate::procedure::repartition::gc_requirement::RepartitionGcRequirementManager;
 
     struct RecordingSelectorFactory {
         called: Arc<AtomicBool>,
@@ -505,6 +508,32 @@ mod tests {
         .unwrap();
 
         assert!(called.load(Ordering::Relaxed));
+    }
+
+    #[tokio::test]
+    async fn gc_requirement_is_checked_before_http_server_start() {
+        let kv_backend: KvBackendRef = Arc::new(MemoryKvBackend::new());
+        RepartitionGcRequirementManager::new(kv_backend.clone())
+            .require_gc()
+            .await
+            .unwrap();
+
+        let opts = MetasrvOptions {
+            enable_telemetry: false,
+            ..Default::default()
+        };
+        let metasrv = MetasrvBuilder::new()
+            .options(opts)
+            .kv_backend(kv_backend)
+            .build()
+            .await
+            .unwrap();
+        let mut instance = MetasrvInstance::new(metasrv).await.unwrap();
+
+        let err = instance.start().await.unwrap_err();
+        assert!(matches!(err, error::Error::RepartitionGcRequired { .. }));
+        assert!(instance.http_server().is_none());
+        assert!(matches!(instance.mut_http_server(), Either::Left(Some(_))));
     }
 
     struct TestExtraHttpRouterProvider;

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -131,7 +131,7 @@ impl MetasrvInstance {
             return Ok(());
         };
 
-        self.metasrv.try_start().await?;
+        self.metasrv.try_start_after_gc_check().await?;
 
         let (tx, rx) = mpsc::channel::<()>(1);
 

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -813,12 +813,6 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Repartition procedure recovery requires metasrv GC to be enabled"))]
-    RepartitionGcRequiredForRecovery {
-        #[snafu(implicit)]
-        location: Location,
-    },
-
     #[snafu(display(
         "Source partition expression '{}' does not match any existing region",
         expr
@@ -1289,9 +1283,9 @@ impl ErrorExt for Error {
             Error::ListActiveFrontends { source, .. }
             | Error::ListActiveDatanodes { source, .. }
             | Error::ListActiveFlownodes { source, .. } => source.status_code(),
-            Error::NoAvailableFrontend { .. }
-            | Error::RepartitionGcRequired { .. }
-            | Error::RepartitionGcRequiredForRecovery { .. } => StatusCode::IllegalState,
+            Error::NoAvailableFrontend { .. } | Error::RepartitionGcRequired { .. } => {
+                StatusCode::IllegalState
+            }
 
             Error::InitMetadata { source, .. }
             | Error::InitDdlManager { source, .. }

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -791,6 +791,34 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display("Failed to manage the repartition GC requirement"))]
+    RepartitionGcRequirement {
+        source: common_meta::error::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Failed to inspect persisted repartition procedures"))]
+    InspectRepartitionProcedures {
+        source: common_procedure::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display(
+        "Metasrv GC must be enabled because the cluster has durable repartition state"
+    ))]
+    RepartitionGcRequired {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Repartition procedure recovery requires metasrv GC to be enabled"))]
+    RepartitionGcRequiredForRecovery {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display(
         "Source partition expression '{}' does not match any existing region",
         expr
@@ -1261,7 +1289,9 @@ impl ErrorExt for Error {
             Error::ListActiveFrontends { source, .. }
             | Error::ListActiveDatanodes { source, .. }
             | Error::ListActiveFlownodes { source, .. } => source.status_code(),
-            Error::NoAvailableFrontend { .. } => StatusCode::IllegalState,
+            Error::NoAvailableFrontend { .. }
+            | Error::RepartitionGcRequired { .. }
+            | Error::RepartitionGcRequiredForRecovery { .. } => StatusCode::IllegalState,
 
             Error::InitMetadata { source, .. }
             | Error::InitDdlManager { source, .. }
@@ -1270,6 +1300,8 @@ impl ErrorExt for Error {
             Error::BuildTlsOptions { source, .. } => source.status_code(),
             Error::Other { source, .. } => source.status_code(),
             Error::RepartitionCreateSubtasks { source, .. } => source.status_code(),
+            Error::RepartitionGcRequirement { source, .. } => source.status_code(),
+            Error::InspectRepartitionProcedures { source, .. } => source.status_code(),
             Error::RepartitionSubprocedureStateReceiver { source, .. } => source.status_code(),
             Error::AllocateRegions { source, .. } => source.status_code(),
             Error::DeallocateRegions { source, .. } => source.status_code(),
@@ -1360,7 +1392,8 @@ impl ErrorExt for Error {
             | Error::DeallocateRegions { source, .. }
             | Error::BuildCreateRequest { source, .. }
             | Error::AllocateRegionRoutes { source, .. }
-            | Error::AllocateWalOptions { source, .. } => source.retry_hint(),
+            | Error::AllocateWalOptions { source, .. }
+            | Error::RepartitionGcRequirement { source, .. } => source.retry_hint(),
 
             Error::Other { source, .. }
             | Error::ListCatalogs { source, .. }
@@ -1374,6 +1407,7 @@ impl ErrorExt for Error {
             | Error::StartProcedureManager { source, .. }
             | Error::StopProcedureManager { source, .. }
             | Error::RegisterProcedureLoader { source, .. }
+            | Error::InspectRepartitionProcedures { source, .. }
             | Error::RepartitionSubprocedureStateReceiver { source, .. } => source.retry_hint(),
 
             Error::ShutdownServer { source, .. } | Error::StartHttp { source, .. } => {

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -75,6 +75,7 @@ use crate::gc::{GcSchedulerOptions, GcTickerRef};
 use crate::handler::{HeartbeatHandlerGroupBuilder, HeartbeatHandlerGroupRef};
 use crate::procedure::ProcedureManagerListenerAdapter;
 use crate::procedure::region_migration::manager::RegionMigrationManagerRef;
+use crate::procedure::repartition::gc_requirement::RepartitionGcRequirementManagerRef;
 use crate::procedure::wal_prune::manager::WalPruneTickerRef;
 use crate::pubsub::{PublisherRef, SubscriptionManagerRef};
 use crate::region::flush_trigger::RegionFlushTickerRef;
@@ -582,6 +583,7 @@ pub struct Metasrv {
     wal_provider: WalProviderRef,
     table_metadata_manager: TableMetadataManagerRef,
     runtime_switch_manager: RuntimeSwitchManagerRef,
+    repartition_gc_requirement_manager: RepartitionGcRequirementManagerRef,
     memory_region_keeper: MemoryRegionKeeperRef,
     greptimedb_telemetry_task: Arc<GreptimeDBTelemetryTask>,
     region_migration_manager: RegionMigrationManagerRef,
@@ -602,6 +604,10 @@ pub struct Metasrv {
 
 impl Metasrv {
     pub async fn try_start(&self) -> Result<()> {
+        self.repartition_gc_requirement_manager
+            .ensure_gc_enabled(self.options.gc.enable, &self.procedure_manager)
+            .await?;
+
         if self
             .started
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -603,10 +603,14 @@ pub struct Metasrv {
 }
 
 impl Metasrv {
-    pub async fn try_start(&self) -> Result<()> {
+    pub(crate) async fn ensure_repartition_gc_enabled(&self) -> Result<()> {
         self.repartition_gc_requirement_manager
             .ensure_gc_enabled(self.options.gc.enable, &self.procedure_manager)
-            .await?;
+            .await
+    }
+
+    pub async fn try_start(&self) -> Result<()> {
+        self.ensure_repartition_gc_enabled().await?;
 
         if self
             .started

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -611,7 +611,10 @@ impl Metasrv {
 
     pub async fn try_start(&self) -> Result<()> {
         self.ensure_repartition_gc_enabled().await?;
+        self.try_start_after_gc_check().await
+    }
 
+    pub(crate) async fn try_start_after_gc_check(&self) -> Result<()> {
         if self
             .started
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -71,6 +71,7 @@ use crate::metasrv::{
 use crate::peer::MetasrvPeerAllocator;
 use crate::procedure::region_migration::DefaultContextFactory;
 use crate::procedure::region_migration::manager::RegionMigrationManager;
+use crate::procedure::repartition::gc_requirement::RepartitionGcRequirementManager;
 use crate::procedure::repartition::{
     DefaultRepartitionProcedureFactory, GcDisabledRepartitionProcedureFactory,
 };
@@ -255,6 +256,8 @@ impl MetasrvBuilder {
         let pushers = Pushers::default();
         let mailbox = build_mailbox(&kv_backend, &pushers);
         let runtime_switch_manager = Arc::new(RuntimeSwitchManager::new(kv_backend.clone()));
+        let repartition_gc_requirement_manager =
+            Arc::new(RepartitionGcRequirementManager::new(kv_backend.clone()));
         let procedure_manager = build_procedure_manager(
             &options,
             &kv_backend,
@@ -436,6 +439,7 @@ impl MetasrvBuilder {
             Arc::new(DefaultRepartitionProcedureFactory::new(
                 mailbox.clone(),
                 options.grpc.server_addr.clone(),
+                repartition_gc_requirement_manager.clone(),
             ))
         } else {
             Arc::new(GcDisabledRepartitionProcedureFactory::new(
@@ -628,6 +632,7 @@ impl MetasrvBuilder {
             wal_provider,
             table_metadata_manager,
             runtime_switch_manager,
+            repartition_gc_requirement_manager,
             greptimedb_telemetry_task: get_greptimedb_telemetry_task(
                 Some(metasrv_home),
                 meta_peer_client,

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -445,6 +445,7 @@ impl MetasrvBuilder {
             Arc::new(GcDisabledRepartitionProcedureFactory::new(
                 mailbox.clone(),
                 options.grpc.server_addr.clone(),
+                repartition_gc_requirement_manager.clone(),
             ))
         };
         let ddl_manager = DdlManager::new(

--- a/src/meta-srv/src/procedure/repartition.rs
+++ b/src/meta-srv/src/procedure/repartition.rs
@@ -48,8 +48,8 @@ use common_meta::rpc::router::{RegionRoute, operating_leader_region_roles};
 use common_meta::wal_provider::RegionWalOptions;
 use common_procedure::error::{FromJsonSnafu, ToJsonSnafu};
 use common_procedure::{
-    BoxedProcedure, BoxedProcedureLoader, Context as ProcedureContext, Error as ProcedureError,
-    LockKey, Procedure, ProcedureManagerRef, Result as ProcedureResult, Status, StringKey,
+    BoxedProcedure, Context as ProcedureContext, Error as ProcedureError, LockKey, Procedure,
+    ProcedureManagerRef, Result as ProcedureResult, Status, StringKey,
 };
 use common_telemetry::{error, info, warn};
 use partition::expr::PartitionExpr;
@@ -813,22 +813,26 @@ impl DefaultRepartitionProcedureFactory {
 
 /// Rejects new repartition requests when metasrv GC is disabled.
 ///
-/// Procedure type names remain registered, but their loaders fail recovery
-/// closed without discarding durable procedure state.
-pub struct GcDisabledRepartitionProcedureFactory;
-
-impl GcDisabledRepartitionProcedureFactory {
-    pub fn new(_mailbox: MailboxRef, _server_addr: String) -> Self {
-        Self
-    }
+/// Procedure loaders are still delegated to the enabled factory so procedures
+/// persisted before a metasrv restart remain recoverable after GC is re-enabled.
+pub struct GcDisabledRepartitionProcedureFactory {
+    enabled_factory: DefaultRepartitionProcedureFactory,
 }
 
-fn gc_required_recovery_loader() -> BoxedProcedureLoader {
-    Box::new(|_| {
-        Err(ProcedureError::recovery_blocked(
-            error::RepartitionGcRequiredForRecoverySnafu.build(),
-        ))
-    })
+impl GcDisabledRepartitionProcedureFactory {
+    pub fn new(
+        mailbox: MailboxRef,
+        server_addr: String,
+        gc_requirement_manager: RepartitionGcRequirementManagerRef,
+    ) -> Self {
+        Self {
+            enabled_factory: DefaultRepartitionProcedureFactory::new(
+                mailbox,
+                server_addr,
+                gc_requirement_manager,
+            ),
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -852,21 +856,11 @@ impl RepartitionProcedureFactory for GcDisabledRepartitionProcedureFactory {
 
     fn register_loaders(
         &self,
-        _ddl_ctx: &DdlContext,
+        ddl_ctx: &DdlContext,
         procedure_manager: &ProcedureManagerRef,
     ) -> std::result::Result<(), BoxedError> {
-        procedure_manager
-            .register_loader(
-                RepartitionProcedure::TYPE_NAME,
-                gc_required_recovery_loader(),
-            )
-            .map_err(BoxedError::new)?;
-        procedure_manager
-            .register_loader(
-                RepartitionGroupProcedure::TYPE_NAME,
-                gc_required_recovery_loader(),
-            )
-            .map_err(BoxedError::new)
+        self.enabled_factory
+            .register_loaders(ddl_ctx, procedure_manager)
     }
 
     async fn ensure_gc_requirement(&self) -> std::result::Result<(), BoxedError> {
@@ -1023,6 +1017,7 @@ mod tests {
     use crate::procedure::repartition::collect::Collect;
     use crate::procedure::repartition::deallocate_region::DeallocateRegion;
     use crate::procedure::repartition::dispatch::Dispatch;
+    use crate::procedure::repartition::gc_requirement::RepartitionGcRequirementManager;
     use crate::procedure::repartition::group::update_metadata::UpdateMetadata;
     use crate::procedure::repartition::plan::{SourceRegionDescriptor, TargetRegionDescriptor};
     use crate::procedure::repartition::repartition_end::RepartitionEnd;
@@ -1132,13 +1127,14 @@ mod tests {
     }
 
     #[test]
-    fn test_gc_disabled_factory_rejects_repartition_and_registers_blocked_loaders() {
+    fn test_gc_disabled_factory_rejects_repartition_and_registers_loaders() {
         let env = TestingEnv::new();
         let node_manager = Arc::new(MockDatanodeManager::new(UnexpectedErrorDatanodeHandler));
         let ddl_ctx = env.ddl_context(node_manager);
         let factory = GcDisabledRepartitionProcedureFactory::new(
             env.mailbox_ctx.mailbox().clone(),
             env.server_addr.clone(),
+            Arc::new(RepartitionGcRequirementManager::new(env.kv_backend.clone())),
         );
 
         let err = factory

--- a/src/meta-srv/src/procedure/repartition.rs
+++ b/src/meta-srv/src/procedure/repartition.rs
@@ -16,6 +16,7 @@ pub mod allocate_region;
 pub mod collect;
 pub mod deallocate_region;
 pub mod dispatch;
+pub mod gc_requirement;
 pub mod group;
 pub mod plan;
 pub mod repartition_end;
@@ -47,8 +48,8 @@ use common_meta::rpc::router::{RegionRoute, operating_leader_region_roles};
 use common_meta::wal_provider::RegionWalOptions;
 use common_procedure::error::{FromJsonSnafu, ToJsonSnafu};
 use common_procedure::{
-    BoxedProcedure, Context as ProcedureContext, Error as ProcedureError, LockKey, Procedure,
-    ProcedureManagerRef, Result as ProcedureResult, Status, StringKey,
+    BoxedProcedure, BoxedProcedureLoader, Context as ProcedureContext, Error as ProcedureError,
+    LockKey, Procedure, ProcedureManagerRef, Result as ProcedureResult, Status, StringKey,
 };
 use common_telemetry::{error, info, warn};
 use partition::expr::PartitionExpr;
@@ -60,6 +61,7 @@ use table::table_name::TableName;
 use crate::error::{self, Result};
 use crate::procedure::repartition::collect::ProcedureMeta;
 use crate::procedure::repartition::deallocate_region::DeallocateRegion;
+use crate::procedure::repartition::gc_requirement::RepartitionGcRequirementManagerRef;
 use crate::procedure::repartition::group::{
     Context as RepartitionGroupContext, RepartitionGroupProcedure, region_routes,
 };
@@ -792,33 +794,44 @@ impl Procedure for RepartitionProcedure {
 pub struct DefaultRepartitionProcedureFactory {
     mailbox: MailboxRef,
     server_addr: String,
+    gc_requirement_manager: RepartitionGcRequirementManagerRef,
 }
 
 impl DefaultRepartitionProcedureFactory {
-    pub fn new(mailbox: MailboxRef, server_addr: String) -> Self {
+    pub fn new(
+        mailbox: MailboxRef,
+        server_addr: String,
+        gc_requirement_manager: RepartitionGcRequirementManagerRef,
+    ) -> Self {
         Self {
             mailbox,
             server_addr,
+            gc_requirement_manager,
         }
     }
 }
 
 /// Rejects new repartition requests when metasrv GC is disabled.
 ///
-/// Procedure loaders are still delegated to the enabled factory so procedures
-/// persisted before a metasrv restart can be recovered.
-pub struct GcDisabledRepartitionProcedureFactory {
-    enabled_factory: DefaultRepartitionProcedureFactory,
-}
+/// Procedure type names remain registered, but their loaders fail recovery
+/// closed without discarding durable procedure state.
+pub struct GcDisabledRepartitionProcedureFactory;
 
 impl GcDisabledRepartitionProcedureFactory {
-    pub fn new(mailbox: MailboxRef, server_addr: String) -> Self {
-        Self {
-            enabled_factory: DefaultRepartitionProcedureFactory::new(mailbox, server_addr),
-        }
+    pub fn new(_mailbox: MailboxRef, _server_addr: String) -> Self {
+        Self
     }
 }
 
+fn gc_required_recovery_loader() -> BoxedProcedureLoader {
+    Box::new(|_| {
+        Err(ProcedureError::recovery_blocked(
+            error::RepartitionGcRequiredForRecoverySnafu.build(),
+        ))
+    })
+}
+
+#[async_trait::async_trait]
 impl RepartitionProcedureFactory for GcDisabledRepartitionProcedureFactory {
     fn create(
         &self,
@@ -839,14 +852,34 @@ impl RepartitionProcedureFactory for GcDisabledRepartitionProcedureFactory {
 
     fn register_loaders(
         &self,
-        ddl_ctx: &DdlContext,
+        _ddl_ctx: &DdlContext,
         procedure_manager: &ProcedureManagerRef,
     ) -> std::result::Result<(), BoxedError> {
-        self.enabled_factory
-            .register_loaders(ddl_ctx, procedure_manager)
+        procedure_manager
+            .register_loader(
+                RepartitionProcedure::TYPE_NAME,
+                gc_required_recovery_loader(),
+            )
+            .map_err(BoxedError::new)?;
+        procedure_manager
+            .register_loader(
+                RepartitionGroupProcedure::TYPE_NAME,
+                gc_required_recovery_loader(),
+            )
+            .map_err(BoxedError::new)
+    }
+
+    async fn ensure_gc_requirement(&self) -> std::result::Result<(), BoxedError> {
+        Err(BoxedError::new(
+            error::InvalidArgumentsSnafu {
+                err_msg: "Repartition requires metasrv GC to be enabled".to_string(),
+            }
+            .build(),
+        ))
     }
 }
 
+#[async_trait::async_trait]
 impl RepartitionProcedureFactory for DefaultRepartitionProcedureFactory {
     fn create(
         &self,
@@ -950,6 +983,13 @@ impl RepartitionProcedureFactory for DefaultRepartitionProcedureFactory {
 
         Ok(())
     }
+
+    async fn ensure_gc_requirement(&self) -> std::result::Result<(), BoxedError> {
+        self.gc_requirement_manager
+            .require_gc()
+            .await
+            .map_err(BoxedError::new)
+    }
 }
 
 #[cfg(test)]
@@ -968,7 +1008,9 @@ mod tests {
     use common_meta::peer::Peer;
     use common_meta::region_keeper::MemoryRegionKeeper;
     use common_meta::rpc::router::{LeaderState, Region, RegionRoute};
+    use common_meta::state_store::KvStateStore;
     use common_meta::test_util::MockDatanodeManager;
+    use common_procedure::local::{LocalManager, ManagerConfig};
     use common_procedure::{Error as ProcedureError, Procedure, ProcedureId, ProcedureState};
     use store_api::region_engine::RegionRole;
     use store_api::storage::RegionId;
@@ -1090,7 +1132,7 @@ mod tests {
     }
 
     #[test]
-    fn test_gc_disabled_factory_rejects_repartition() {
+    fn test_gc_disabled_factory_rejects_repartition_and_registers_blocked_loaders() {
         let env = TestingEnv::new();
         let node_manager = Arc::new(MockDatanodeManager::new(UnexpectedErrorDatanodeHandler));
         let ddl_ctx = env.ddl_context(node_manager);
@@ -1118,6 +1160,21 @@ mod tests {
             "Invalid arguments: Repartition requires metasrv GC to be enabled",
             err.to_string()
         );
+
+        let state_store = Arc::new(KvStateStore::new(env.kv_backend));
+        let procedure_manager = Arc::new(LocalManager::new(
+            ManagerConfig::default(),
+            state_store.clone(),
+            state_store,
+            None,
+            None,
+        ));
+        let procedure_manager_ref: ProcedureManagerRef = procedure_manager.clone();
+        factory
+            .register_loaders(&ddl_ctx, &procedure_manager_ref)
+            .unwrap();
+        assert!(procedure_manager.contains_loader(RepartitionProcedure::TYPE_NAME));
+        assert!(procedure_manager.contains_loader(RepartitionGroupProcedure::TYPE_NAME));
     }
 
     #[test]

--- a/src/meta-srv/src/procedure/repartition/gc_requirement.rs
+++ b/src/meta-srv/src/procedure/repartition/gc_requirement.rs
@@ -1,0 +1,319 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use common_meta::key::REPARTITION_GC_REQUIRED_KEY;
+use common_meta::key::table_repart::TableRepartManager;
+use common_meta::kv_backend::KvBackendRef;
+use common_meta::rpc::store::PutRequest;
+use common_procedure::ProcedureManagerRef;
+use snafu::{ResultExt, ensure};
+
+use crate::error::{self, Result};
+use crate::procedure::repartition::RepartitionProcedure;
+use crate::procedure::repartition::group::RepartitionGroupProcedure;
+
+const REPARTITION_GC_REQUIREMENT_VALUE: &[u8] = b"repartition";
+
+pub type RepartitionGcRequirementManagerRef = Arc<RepartitionGcRequirementManager>;
+
+/// Persists and enforces the cluster-level GC requirement introduced by repartition.
+pub struct RepartitionGcRequirementManager {
+    kv_backend: KvBackendRef,
+}
+
+impl RepartitionGcRequirementManager {
+    pub fn new(kv_backend: KvBackendRef) -> Self {
+        Self { kv_backend }
+    }
+
+    /// Persists the requirement before a repartition procedure can be submitted.
+    pub async fn require_gc(&self) -> Result<()> {
+        self.kv_backend
+            .put(
+                PutRequest::new()
+                    .with_key(REPARTITION_GC_REQUIRED_KEY.as_bytes().to_vec())
+                    .with_value(REPARTITION_GC_REQUIREMENT_VALUE.to_vec()),
+            )
+            .await
+            .context(error::RepartitionGcRequirementSnafu)?;
+        Ok(())
+    }
+
+    pub async fn is_gc_required(&self) -> Result<bool> {
+        self.kv_backend
+            .get(REPARTITION_GC_REQUIRED_KEY.as_bytes())
+            .await
+            .map(|value| value.is_some())
+            .context(error::RepartitionGcRequirementSnafu)
+    }
+
+    /// Backfills the requirement from durable state written by older versions.
+    ///
+    /// An unfinished procedure covers the crash window before repartition mappings
+    /// are written. A non-empty mapping covers completed repartitions whose
+    /// manifests can still contain cross-region file references.
+    pub async fn reconcile_legacy_state(
+        &self,
+        procedure_manager: &ProcedureManagerRef,
+    ) -> Result<bool> {
+        if self.is_gc_required().await? {
+            return Ok(true);
+        }
+
+        let table_reparts = TableRepartManager::new(self.kv_backend.clone())
+            .table_reparts()
+            .await
+            .context(error::RepartitionGcRequirementSnafu)?;
+        let has_cross_region_references = table_reparts
+            .iter()
+            .any(|(_, value)| !value.src_to_dst.is_empty());
+        let has_unfinished_repartition = procedure_manager
+            .has_unfinished_procedure(&[
+                RepartitionProcedure::TYPE_NAME,
+                RepartitionGroupProcedure::TYPE_NAME,
+            ])
+            .await
+            .context(error::InspectRepartitionProceduresSnafu)?;
+
+        if has_cross_region_references || has_unfinished_repartition {
+            self.require_gc().await?;
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
+
+    pub async fn ensure_gc_enabled(
+        &self,
+        gc_enabled: bool,
+        procedure_manager: &ProcedureManagerRef,
+    ) -> Result<()> {
+        let required = self.reconcile_legacy_state(procedure_manager).await?;
+        ensure!(!required || gc_enabled, error::RepartitionGcRequiredSnafu);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+    use common_meta::kv_backend::memory::MemoryKvBackend;
+    use common_meta::state_store::KvStateStore;
+    use common_procedure::local::{LocalManager, ManagerConfig};
+    use common_procedure::{
+        Context, LockKey, Procedure, ProcedureId, ProcedureManager, ProcedureWithId, Status,
+    };
+    use store_api::storage::RegionId;
+    use tokio::sync::oneshot;
+    use tokio::time::timeout;
+
+    use super::*;
+
+    fn local_procedure_manager(kv_backend: KvBackendRef) -> Arc<LocalManager> {
+        let state_store = Arc::new(KvStateStore::new(kv_backend));
+        Arc::new(LocalManager::new(
+            ManagerConfig::default(),
+            state_store.clone(),
+            state_store,
+            None,
+            None,
+        ))
+    }
+
+    fn procedure_manager(kv_backend: KvBackendRef) -> ProcedureManagerRef {
+        local_procedure_manager(kv_backend)
+    }
+
+    #[derive(Debug)]
+    struct LegacyRepartitionProcedure {
+        persisted: bool,
+        block_after_persist: bool,
+        persisted_tx: Option<oneshot::Sender<()>>,
+    }
+
+    #[async_trait]
+    impl Procedure for LegacyRepartitionProcedure {
+        fn type_name(&self) -> &str {
+            RepartitionProcedure::TYPE_NAME
+        }
+
+        async fn execute(&mut self, _ctx: &Context) -> common_procedure::error::Result<Status> {
+            if !self.persisted {
+                self.persisted = true;
+                return Ok(Status::executing(true));
+            }
+
+            if self.block_after_persist {
+                if let Some(tx) = self.persisted_tx.take() {
+                    let _ = tx.send(());
+                }
+                return std::future::pending().await;
+            }
+
+            Ok(Status::done())
+        }
+
+        fn dump(&self) -> common_procedure::error::Result<String> {
+            Ok("{}".to_string())
+        }
+
+        fn lock_key(&self) -> LockKey {
+            LockKey::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_completed_repartition_requirement_rejects_gc_disabled_restart() {
+        let kv_backend: KvBackendRef = Arc::new(MemoryKvBackend::new());
+        let manager = RepartitionGcRequirementManager::new(kv_backend.clone());
+        let procedure_manager = procedure_manager(kv_backend.clone());
+
+        manager.require_gc().await.unwrap();
+        let marker = kv_backend
+            .get(REPARTITION_GC_REQUIRED_KEY.as_bytes())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(REPARTITION_GC_REQUIREMENT_VALUE, marker.value.as_slice());
+
+        let err = manager
+            .ensure_gc_enabled(false, &procedure_manager)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, error::Error::RepartitionGcRequired { .. }));
+        assert!(manager.is_gc_required().await.unwrap());
+        manager
+            .ensure_gc_enabled(true, &procedure_manager)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_legacy_repartition_mapping() {
+        let kv_backend: KvBackendRef = Arc::new(MemoryKvBackend::new());
+        let manager = RepartitionGcRequirementManager::new(kv_backend.clone());
+        let procedure_manager = procedure_manager(kv_backend.clone());
+        let table_id = 1024;
+        let source = RegionId::new(table_id, 1);
+        let destination = RegionId::new(table_id, 2);
+        TableRepartManager::new(kv_backend)
+            .update_mappings(table_id, &HashMap::from([(source, vec![destination])]))
+            .await
+            .unwrap();
+
+        assert!(
+            manager
+                .reconcile_legacy_state(&procedure_manager)
+                .await
+                .unwrap()
+        );
+        assert!(manager.is_gc_required().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_legacy_unfinished_repartition_fails_closed_and_recovers() {
+        let kv_backend: KvBackendRef = Arc::new(MemoryKvBackend::new());
+        let first_manager = local_procedure_manager(kv_backend.clone());
+        first_manager.start().await.unwrap();
+
+        let procedure_id = ProcedureId::random();
+        let (persisted_tx, persisted_rx) = oneshot::channel();
+        first_manager
+            .submit(ProcedureWithId {
+                id: procedure_id,
+                procedure: Box::new(LegacyRepartitionProcedure {
+                    persisted: false,
+                    block_after_persist: true,
+                    persisted_tx: Some(persisted_tx),
+                }),
+            })
+            .await
+            .unwrap();
+        timeout(Duration::from_secs(10), persisted_rx)
+            .await
+            .unwrap()
+            .unwrap();
+        first_manager.stop().await.unwrap();
+
+        let requirement_manager = RepartitionGcRequirementManager::new(kv_backend.clone());
+        let disabled_manager = local_procedure_manager(kv_backend.clone());
+        let disabled_manager_ref: ProcedureManagerRef = disabled_manager.clone();
+        let err = requirement_manager
+            .ensure_gc_enabled(false, &disabled_manager_ref)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, error::Error::RepartitionGcRequired { .. }));
+        assert!(requirement_manager.is_gc_required().await.unwrap());
+
+        disabled_manager
+            .register_loader(
+                RepartitionProcedure::TYPE_NAME,
+                crate::procedure::repartition::gc_required_recovery_loader(),
+            )
+            .unwrap();
+        let err = disabled_manager.start().await.unwrap_err();
+        assert!(matches!(
+            err,
+            common_procedure::error::Error::LoadProcedure { .. }
+        ));
+        assert!(
+            disabled_manager
+                .has_unfinished_procedure(&[RepartitionProcedure::TYPE_NAME])
+                .await
+                .unwrap()
+        );
+        assert!(
+            disabled_manager
+                .procedure_state(procedure_id)
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        let enabled_manager = local_procedure_manager(kv_backend);
+        enabled_manager
+            .register_loader(
+                RepartitionProcedure::TYPE_NAME,
+                Box::new(|_| {
+                    Ok(Box::new(LegacyRepartitionProcedure {
+                        persisted: true,
+                        block_after_persist: false,
+                        persisted_tx: None,
+                    }) as _)
+                }),
+            )
+            .unwrap();
+        enabled_manager.start().await.unwrap();
+        let mut watcher = enabled_manager.procedure_watcher(procedure_id).unwrap();
+        timeout(Duration::from_secs(10), async {
+            while !watcher.borrow().is_done() {
+                watcher.changed().await.unwrap();
+            }
+        })
+        .await
+        .unwrap();
+        assert!(
+            !enabled_manager
+                .has_unfinished_procedure(&[RepartitionProcedure::TYPE_NAME])
+                .await
+                .unwrap()
+        );
+        enabled_manager.stop().await.unwrap();
+    }
+}

--- a/src/meta-srv/src/procedure/repartition/gc_requirement.rs
+++ b/src/meta-srv/src/procedure/repartition/gc_requirement.rs
@@ -261,17 +261,6 @@ mod tests {
         assert!(matches!(err, error::Error::RepartitionGcRequired { .. }));
         assert!(requirement_manager.is_gc_required().await.unwrap());
 
-        disabled_manager
-            .register_loader(
-                RepartitionProcedure::TYPE_NAME,
-                crate::procedure::repartition::gc_required_recovery_loader(),
-            )
-            .unwrap();
-        let err = disabled_manager.start().await.unwrap_err();
-        assert!(matches!(
-            err,
-            common_procedure::error::Error::LoadProcedure { .. }
-        ));
         assert!(
             disabled_manager
                 .has_unfinished_procedure(&[RepartitionProcedure::TYPE_NAME])

--- a/src/meta-srv/src/procedure/repartition/gc_requirement.rs
+++ b/src/meta-srv/src/procedure/repartition/gc_requirement.rs
@@ -101,6 +101,8 @@ impl RepartitionGcRequirementManager {
         gc_enabled: bool,
         procedure_manager: &ProcedureManagerRef,
     ) -> Result<()> {
+        // Reconciliation is also a legacy migration and must run before GC can
+        // remove the repartition mappings used to backfill the durable marker.
         let required = self.reconcile_legacy_state(procedure_manager).await?;
         ensure!(!required || gc_enabled, error::RepartitionGcRequiredSnafu);
         Ok(())

--- a/src/standalone/src/procedure.rs
+++ b/src/standalone/src/procedure.rs
@@ -63,6 +63,7 @@ pub fn build_procedure_manager(
 /// work in [`RepartitionProcedureFactory::register_loaders`].
 pub struct StandaloneRepartitionProcedureFactory;
 
+#[async_trait::async_trait]
 impl RepartitionProcedureFactory for StandaloneRepartitionProcedureFactory {
     fn create(
         &self,
@@ -82,5 +83,9 @@ impl RepartitionProcedureFactory for StandaloneRepartitionProcedureFactory {
         _procedure_manager: &ProcedureManagerRef,
     ) -> std::result::Result<(), BoxedError> {
         Ok(())
+    }
+
+    async fn ensure_gc_requirement(&self) -> std::result::Result<(), BoxedError> {
+        Err(BoxedError::new(NoSupportRepartitionProcedureSnafu.build()))
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

N/A

## What is changed and what is your intention?

Repartition depends on global GC beyond request creation. An unfinished procedure may be recovered after a restart, and a completed repartition may still have destination manifests referencing SSTs owned by source regions. The existing request-time check does not cover either case.

This PR enforces one durable invariant: while the cluster has repartition state whose cross-region references cannot be proven to be gone, GC must remain enabled.

- Persist `__requirements/gc/repartition` before submitting a new repartition procedure. The marker is not cleared because the current system has no global proof that every manifest and in-memory handle has released cross-region references.
- Reconcile older clusters from unfinished repartition procedure records and non-empty `__table_repart` mappings.
- Run the GC preflight before procedure recovery. With GC disabled, metasrv startup fails before any repartition procedure is loaded or executed; durable procedure records are left untouched and recover normally after GC is re-enabled.
- Keep the existing recovery loader behavior unchanged. The GC-disabled factory still registers the normal loaders for backward compatibility.
- Run the preflight before consuming or starting the HTTP server so a rejected startup does not leave a partially started, non-retryable instance.

The metadata change is additive and backward compatible. There are no wire-format or user-facing API changes.

Validation:

- `cargo nextest run -p common-procedure` — 75 passed
- `cargo nextest run -p common-meta ddl_manager` — 3 passed
- `cargo nextest run -p meta-srv repartition` — 105 passed
- `cargo nextest run -p meta-srv gc_requirement_is_checked_before_http_server_start` — 1 passed
- `make fmt-check`
- `make clippy`

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.