### PR TITLE
refactor(mito2): add prerequisites for range-based series reads

### DIFF
--- a/src/mito2/src/read.rs
+++ b/src/mito2/src/read.rs
@@ -34,6 +34,7 @@ pub mod scan_region;
 pub mod scan_util;
 pub(crate) mod seq_scan;
 pub(crate) mod series_candidate;
+pub(crate) mod series_reader;
 pub mod series_scan;
 pub mod stream;
 pub(crate) mod unordered_scan;

--- a/src/mito2/src/read/pruner.rs
+++ b/src/mito2/src/read/pruner.rs
@@ -198,6 +198,19 @@ struct PrunerInner {
     /// negative decisions are not cached. Reset by `add_partition_ranges()` for
     /// each fresh batch of partition ranges.
     manifest_pruned_files: Vec<AtomicBool>,
+    /// Keeps file range builders until the query-scoped pruner is dropped.
+    retain_builders: bool,
+}
+
+impl Drop for PrunerInner {
+    fn drop(&mut self) {
+        let active_builders = self
+            .file_entries
+            .iter_mut()
+            .map(|entry| usize::from(entry.get_mut().is_ok_and(|entry| entry.builder.is_some())))
+            .sum::<usize>();
+        PRUNER_ACTIVE_BUILDERS.sub(active_builders as i64);
+    }
 }
 
 impl PrunerInner {
@@ -230,10 +243,15 @@ impl PrunerInner {
 
 /// Per-file state tracking.
 struct FileBuilderEntry {
-    /// Cached builder after pruning. None if not yet built or already cleared.
+    /// Cached builder for this file.
+    ///
+    /// A newly completed builder is cached only while `remaining_ranges > 0`.
+    /// In retaining mode, the builder may remain cached after
+    /// `remaining_ranges` reaches zero.
     builder: Option<Arc<FileRangeBuilder>>,
-    /// Number of remaining ranges to scan for this file.
-    /// When this reaches 0, the builder is dropped for memory cleanup.
+    /// Number of ranges remaining in the current initialized batch.
+    ///
+    /// This may be zero while `builder` is still present in retaining mode.
     remaining_ranges: usize,
     /// Waiters when pruning is in-progress.
     waiters: Vec<oneshot::Sender<Result<Arc<FileRangeBuilder>>>>,
@@ -257,6 +275,15 @@ impl Pruner {
     /// Initially all file_entries have `remaining_ranges = 0`.
     /// Call `add_partition_ranges()` to initialize ref counts.
     pub fn new(stream_ctx: Arc<StreamContext>, num_workers: usize) -> Self {
+        Self::new_with_retained_builders(stream_ctx, num_workers, false)
+    }
+
+    /// Creates a new pruner and optionally retains file range builders until drop.
+    pub fn new_with_retained_builders(
+        stream_ctx: Arc<StreamContext>,
+        num_workers: usize,
+        retain_builders: bool,
+    ) -> Self {
         let num_files = stream_ctx.input.num_files();
         let file_entries: Vec<_> = (0..num_files)
             .map(|_| {
@@ -283,6 +310,7 @@ impl Pruner {
             file_entries,
             stream_ctx,
             manifest_pruned_files,
+            retain_builders,
         });
 
         // Spawn worker tasks with their receivers
@@ -299,10 +327,14 @@ impl Pruner {
         }
     }
 
-    /// Adds reference counts for all partitions' ranges and resets the full
-    /// manifest-prune cache so that dynamic-filter updates are visible to the
-    /// fresh scan.
+    /// Adds reference counts for partition ranges that the caller will scan.
+    ///
+    /// The caller must keep these ranges consistent with the ranges passed to
+    /// `PartitionPruner`. If called multiple times, all calls must describe
+    /// ranges from the same logical scan because their reference counts
+    /// accumulate in this pruner.
     pub fn add_partition_ranges(&self, partition_ranges: &[PartitionRange]) {
+        // Reset manifest-prune results so the latest dynamic filters are visible.
         for pruned in &self.inner.manifest_pruned_files {
             pruned.store(false, Ordering::Relaxed);
         }
@@ -324,7 +356,7 @@ impl Pruner {
     }
 
     /// Gets or creates the FileRangeBuilder for a file, builds ranges,
-    /// and decrements ref count (cleans up if zero).
+    /// and decrements its ref count. Non-retained builders are cleaned up at zero.
     ///
     /// Callers should invoke [add_partition_ranges()](Pruner::add_partition_ranges()) to initialize the
     /// file entries and ref counts.
@@ -351,7 +383,7 @@ impl Pruner {
         let mut ranges = SmallVec::new();
         builder.build_ranges(index.row_group_index, &mut ranges);
 
-        // Decrement ref count and cleanup if needed
+        // Decrement ref count and clean up non-retained builders if needed.
         self.decrement_and_maybe_clear(file_index, reader_metrics);
 
         Ok(ranges)
@@ -489,8 +521,8 @@ impl Pruner {
 
         let arc_builder = Arc::new(builder);
 
-        // Caches the builder only if the file still has remaining ranges.
-        // `skip_file_range` may have already consumed all ranges for this file.
+        // Cache only while the file still has remaining ranges. Retaining mode
+        // affects cleanup after the builder has been cached, not cache eligibility.
         {
             let mut entry = self.inner.file_entries[file_index].lock().unwrap();
             cache_builder_if_needed(&mut entry, &arc_builder, reader_metrics);
@@ -504,7 +536,8 @@ impl Pruner {
         let mut entry = self.inner.file_entries[file_index].lock().unwrap();
         entry.remaining_ranges = entry.remaining_ranges.saturating_sub(1);
 
-        if entry.remaining_ranges == 0
+        if !self.inner.retain_builders
+            && entry.remaining_ranges == 0
             && let Some(builder) = entry.builder.take()
         {
             PRUNER_ACTIVE_BUILDERS.dec();
@@ -577,10 +610,10 @@ impl Pruner {
                     let arc_builder = Arc::new(builder);
                     let is_background = response_tx.is_none();
 
-                    // Only cache the builder if the file still has remaining ranges.
-                    // If remaining_ranges == 0, a concurrent `skip_file_range` (e.g. from a
-                    // dynamic filter tightening via manifest-prune fast-skip) already consumed
-                    // all ranges and may have cleared a previously cached builder.
+                    // Cache only if the file still has remaining ranges. If
+                    // remaining_ranges == 0, a concurrent `skip_file_range` already consumed
+                    // all ranges and may have cleared a previously cached builder. Retaining
+                    // mode only preserves builders that were cached before the count reached 0.
                     // Skip caching manifest-pruned empty builders; the cache flag is enough.
                     let did_cache =
                         if inner.manifest_pruned_files[file_index].load(Ordering::Relaxed) {
@@ -691,8 +724,8 @@ fn should_cache_builder(entry: &FileBuilderEntry) -> bool {
     entry.builder.is_none() && entry.remaining_ranges > 0
 }
 
-/// Caches a freshly pruned builder if the file still has remaining ranges, and
-/// records the corresponding builder memory/count deltas for verbose metrics.
+/// Caches a freshly pruned builder if it is still referenced, and records the
+/// corresponding builder memory/count deltas for verbose metrics.
 fn cache_builder_if_needed(
     entry: &mut FileBuilderEntry,
     builder: &Arc<FileRangeBuilder>,
@@ -730,6 +763,13 @@ mod tests {
     use crate::test_util::scheduler_util::SchedulerEnv;
 
     async fn make_test_pruner(num_files: usize) -> (SchedulerEnv, Arc<Pruner>) {
+        make_test_pruner_with_retained_builders(num_files, false).await
+    }
+
+    async fn make_test_pruner_with_retained_builders(
+        num_files: usize,
+        retain_builders: bool,
+    ) -> (SchedulerEnv, Arc<Pruner>) {
         let env = SchedulerEnv::new().await;
         let metadata = Arc::new(metadata_with_primary_key(vec![0, 1], false));
         let mapper = FlatProjectionMapper::new(&metadata, [0, 2, 3]).unwrap();
@@ -756,7 +796,11 @@ mod tests {
             .with_files(files)
             .with_append_mode(true);
         let stream_ctx = Arc::new(StreamContext::unordered_scan_ctx(input));
-        let pruner = Arc::new(Pruner::new(stream_ctx, 1));
+        let pruner = Arc::new(Pruner::new_with_retained_builders(
+            stream_ctx,
+            1,
+            retain_builders,
+        ));
         (env, pruner)
     }
 
@@ -866,7 +910,7 @@ mod tests {
         assert!(cache_builder_if_needed(
             &mut entry,
             &builder,
-            &mut reader_metrics
+            &mut reader_metrics,
         ));
         assert!(entry.builder.is_some());
         assert_eq!(
@@ -912,8 +956,69 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn worker_does_not_cache_after_skip_file_range_consumed_all() {
-        let (_env, pruner) = make_test_pruner(1).await;
+    async fn retained_builder_survives_after_last_range() {
+        let (_env, pruner) = make_test_pruner_with_retained_builders(1, true).await;
+        pruner.add_partition_ranges(&[file_partition_range(0)]);
+        {
+            let mut entry = pruner.inner.file_entries[0].lock().unwrap();
+            entry.builder = Some(Arc::new(FileRangeBuilder::default()));
+            PRUNER_ACTIVE_BUILDERS.inc();
+        }
+
+        let mut reader_metrics = ReaderMetrics::default();
+        pruner.skip_file_range(
+            RowGroupIndex {
+                index: 0,
+                row_group_index: 0,
+            },
+            &mut reader_metrics,
+        );
+
+        assert_eq!(pruner.test_remaining_ranges(0), 0);
+        assert!(pruner.test_has_builder(0));
+
+        let partition_metrics = make_partition_metrics();
+        let mut reader_metrics = ReaderMetrics::default();
+        let _builder = pruner
+            .get_file_builder(
+                0,
+                PreFilterMode::SkipFields,
+                &partition_metrics,
+                &mut reader_metrics,
+            )
+            .await
+            .unwrap();
+        assert_eq!(reader_metrics.filter_metrics.pruner_cache_hit, 1);
+    }
+
+    #[tokio::test]
+    async fn add_partition_ranges_keeps_retained_builder() {
+        let (_env, pruner) = make_test_pruner_with_retained_builders(1, true).await;
+        pruner.add_partition_ranges(&[file_partition_range(0)]);
+        {
+            let mut entry = pruner.inner.file_entries[0].lock().unwrap();
+            entry.builder = Some(Arc::new(FileRangeBuilder::default()));
+            PRUNER_ACTIVE_BUILDERS.inc();
+        }
+
+        let mut reader_metrics = ReaderMetrics::default();
+        pruner.skip_file_range(
+            RowGroupIndex {
+                index: 0,
+                row_group_index: 0,
+            },
+            &mut reader_metrics,
+        );
+        assert!(pruner.test_has_builder(0));
+
+        pruner.add_partition_ranges(&[file_partition_range(0)]);
+        assert!(pruner.test_has_builder(0));
+        assert_eq!(pruner.test_remaining_ranges(0), 1);
+    }
+
+    #[tokio::test]
+    async fn retaining_mode_does_not_cache_after_skip_file_range_consumed_all() {
+        let (_env, pruner) = make_test_pruner_with_retained_builders(1, true).await;
 
         // Simulate one range for file 0.
         let ranges = vec![file_partition_range(0)];

--- a/src/mito2/src/read/range_cache.rs
+++ b/src/mito2/src/read/range_cache.rs
@@ -41,6 +41,7 @@ use crate::read::BoxedRecordBatchStream;
 use crate::read::read_columns::ReadColumns;
 use crate::read::scan_region::StreamContext;
 use crate::read::scan_util::PartitionMetrics;
+use crate::read::series_reader::SeriesRange;
 use crate::region::options::MergeMode;
 use crate::sst::parquet::DEFAULT_READ_BATCH_SIZE;
 
@@ -72,6 +73,7 @@ pub(crate) struct ScanRequestFingerprint {
 enum RangeScanStage {
     Data,
     CandidateSeries,
+    SeriesData(SeriesRange),
 }
 
 #[derive(Debug)]
@@ -176,6 +178,19 @@ impl ScanRequestFingerprint {
             filter_deleted: self.filter_deleted,
             merge_mode: self.merge_mode,
             stage: RangeScanStage::CandidateSeries,
+            partition_expr_version: self.partition_expr_version,
+        }
+    }
+
+    fn for_series_data(&self, range: SeriesRange) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            time_filters: self.time_filters.clone(),
+            series_row_selector: self.series_row_selector,
+            append_mode: self.append_mode,
+            filter_deleted: self.filter_deleted,
+            merge_mode: self.merge_mode,
+            stage: RangeScanStage::SeriesData(range),
             partition_expr_version: self.partition_expr_version,
         }
     }
@@ -470,7 +485,7 @@ pub(crate) fn build_range_cache_key(
     stream_ctx: &StreamContext,
     part_range: &PartitionRange,
 ) -> Option<RangeScanCacheKey> {
-    build_range_cache_key_inner(stream_ctx, part_range, false)
+    build_range_cache_key_inner(stream_ctx, part_range, None)
 }
 
 /// Builds a cache key for a candidate-series partition-range result.
@@ -478,13 +493,31 @@ pub(crate) fn build_candidate_range_cache_key(
     stream_ctx: &StreamContext,
     part_range: &PartitionRange,
 ) -> Option<RangeScanCacheKey> {
-    build_range_cache_key_inner(stream_ctx, part_range, true)
+    build_range_cache_key_inner(
+        stream_ctx,
+        part_range,
+        Some(RangeScanStage::CandidateSeries),
+    )
+}
+
+/// Builds a cache key for a two-phase series-data partition-range result.
+#[allow(dead_code)]
+pub(crate) fn build_series_range_cache_key(
+    stream_ctx: &StreamContext,
+    part_range: &PartitionRange,
+    range: SeriesRange,
+) -> Option<RangeScanCacheKey> {
+    build_range_cache_key_inner(
+        stream_ctx,
+        part_range,
+        Some(RangeScanStage::SeriesData(range)),
+    )
 }
 
 fn build_range_cache_key_inner(
     stream_ctx: &StreamContext,
     part_range: &PartitionRange,
-    candidate_series: bool,
+    stage: Option<RangeScanStage>,
 ) -> Option<RangeScanCacheKey> {
     if !stream_ctx.input.cache_strategy.has_range_result_cache() {
         return None;
@@ -537,10 +570,10 @@ fn build_range_cache_key_inner(
     } else {
         fingerprint.clone()
     };
-    let scan = if candidate_series {
-        scan.for_candidate_series()
-    } else {
-        scan
+    let scan = match stage {
+        Some(RangeScanStage::CandidateSeries) => scan.for_candidate_series(),
+        Some(RangeScanStage::SeriesData(assignment)) => scan.for_series_data(assignment),
+        Some(RangeScanStage::Data) | None => scan,
     };
 
     Some(RangeScanCacheKey {
@@ -1134,7 +1167,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn candidate_series_cache_key_is_separate_from_data() {
+    async fn scan_stages_have_separate_cache_keys() {
         let partition_range = (
             Timestamp::new_millisecond(1000),
             Timestamp::new_millisecond(2000),
@@ -1144,9 +1177,17 @@ mod tests {
 
         let data_key = build_range_cache_key(&ctx, &part_range).unwrap();
         let candidate_key = build_candidate_range_cache_key(&ctx, &part_range).unwrap();
+        let range_0 = SeriesRange::new(0, 2).unwrap();
+        let range_1 = SeriesRange::new(1, 2).unwrap();
+        let series_key_0 = build_series_range_cache_key(&ctx, &part_range, range_0).unwrap();
+        let series_key_1 = build_series_range_cache_key(&ctx, &part_range, range_1).unwrap();
 
         assert_ne!(data_key.scan, candidate_key.scan);
+        assert_ne!(data_key.scan, series_key_0.scan);
+        assert_ne!(candidate_key.scan, series_key_0.scan);
+        assert_ne!(series_key_0.scan, series_key_1.scan);
         assert_eq!(data_key.row_groups, candidate_key.row_groups);
+        assert_eq!(data_key.row_groups, series_key_0.row_groups);
     }
 
     #[tokio::test]

--- a/src/mito2/src/read/series_candidate.rs
+++ b/src/mito2/src/read/series_candidate.rs
@@ -62,7 +62,7 @@ use crate::sst::parquet::row_group::ParquetFetchMetrics;
 const CANDIDATE_SERIES_BATCH_SIZE: usize = 500;
 
 /// Identifies one series in a physical metric region.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct MetricSeriesId {
     pub(crate) table_id: u32,
     pub(crate) tsid: u64,
@@ -75,7 +75,7 @@ pub(crate) type MetricSeriesIdStream = BoxStream<'static, Result<Vec<MetricSerie
 pub(crate) struct SeriesCandidateScanner {
     stream_ctx: Arc<StreamContext>,
     partitions: Vec<Vec<PartitionRange>>,
-    pruner: Arc<Pruner>,
+    partition_pruner: Arc<PartitionPruner>,
     range_semaphore: Arc<Semaphore>,
     memory_pool: Arc<dyn MemoryPool>,
     metrics_set: ExecutionPlanMetricsSet,
@@ -106,10 +106,13 @@ impl SeriesCandidateScanner {
                 reason: "candidate-series scan does not support extension ranges; use the legacy series-scan path",
             }
         );
+        let all_ranges = partitions.iter().flatten().copied().collect::<Vec<_>>();
+        pruner.add_partition_ranges(&all_ranges);
+        let partition_pruner = Arc::new(PartitionPruner::new(pruner, &all_ranges));
         Ok(Self {
             stream_ctx,
             partitions,
-            pruner,
+            partition_pruner,
             range_semaphore,
             memory_pool,
             metrics_set,
@@ -125,11 +128,9 @@ impl SeriesCandidateScanner {
             .flatten()
             .copied()
             .collect::<Vec<_>>();
-        self.pruner.add_partition_ranges(&all_ranges);
-        let partition_pruner = Arc::new(PartitionPruner::new(self.pruner.clone(), &all_ranges));
-
         let range_builder = SeriesCandidateRangeBuilder {
             stream_ctx: self.stream_ctx.clone(),
+            partition_pruner: self.partition_pruner.clone(),
             range_semaphore: self.range_semaphore.clone(),
             memory_pool: self.memory_pool.clone(),
             metrics_set: self.metrics_set.clone(),
@@ -138,7 +139,6 @@ impl SeriesCandidateScanner {
         let mut tasks = Vec::with_capacity(all_ranges.len());
         for (range_idx, part_range) in all_ranges.into_iter().enumerate() {
             let range_builder = range_builder.clone();
-            let partition_pruner = partition_pruner.clone();
             tasks.push(common_runtime::spawn_query(async move {
                 let _permit = range_builder
                     .range_semaphore
@@ -152,7 +152,7 @@ impl SeriesCandidateScanner {
                         .build()
                     })?;
                 range_builder
-                    .build_range_stream(part_range, partition_pruner, range_idx)
+                    .build_range_stream(part_range, range_idx)
                     .await
             }));
         }
@@ -173,11 +173,17 @@ impl SeriesCandidateScanner {
         )?;
         decode_metric_series(merged, self.stream_ctx.input.region_metadata().clone())
     }
+
+    /// Returns the partition pruner shared with the data phase.
+    pub(crate) fn partition_pruner(&self) -> Arc<PartitionPruner> {
+        self.partition_pruner.clone()
+    }
 }
 
 #[derive(Clone)]
 struct SeriesCandidateRangeBuilder {
     stream_ctx: Arc<StreamContext>,
+    partition_pruner: Arc<PartitionPruner>,
     range_semaphore: Arc<Semaphore>,
     memory_pool: Arc<dyn MemoryPool>,
     metrics_set: ExecutionPlanMetricsSet,
@@ -188,7 +194,6 @@ impl SeriesCandidateRangeBuilder {
     async fn build_range_stream(
         &self,
         part_range: PartitionRange,
-        partition_pruner: Arc<PartitionPruner>,
         merge_partition: usize,
     ) -> Result<BoxedRecordBatchStream> {
         let cache_key = build_candidate_range_cache_key(&self.stream_ctx, &part_range);
@@ -203,9 +208,7 @@ impl SeriesCandidateRangeBuilder {
         let range_meta = &self.stream_ctx.ranges[part_range.identifier];
         let mut sources = Vec::with_capacity(range_meta.row_group_indices.len());
         for index in &range_meta.row_group_indices {
-            let source = self
-                .build_source(*index, range_meta.time_range, partition_pruner.clone())
-                .await?;
+            let source = self.build_source(*index, range_meta.time_range).await?;
             if let Some(source) = source {
                 sources.push(source);
             }
@@ -239,7 +242,6 @@ impl SeriesCandidateRangeBuilder {
         &self,
         index: RowGroupIndex,
         time_range: crate::sst::file::FileTimeRange,
-        partition_pruner: Arc<PartitionPruner>,
     ) -> Result<Option<BoxedRecordBatchStream>> {
         let metadata = self.stream_ctx.input.region_metadata().clone();
         if self.stream_ctx.is_mem_range_index(index) {
@@ -257,15 +259,18 @@ impl SeriesCandidateRangeBuilder {
         }
 
         if self.stream_ctx.is_file_range_index(index) {
-            if partition_pruner.try_skip_manifest_pruned_file_range(index, &self.part_metrics) {
+            if self
+                .partition_pruner
+                .try_skip_manifest_pruned_file_range(index, &self.part_metrics)
+            {
                 return Ok(None);
             }
-
             let mut reader_metrics = ReaderMetrics {
                 filter_metrics: new_filter_metrics(self.part_metrics.explain_verbose()),
                 ..Default::default()
             };
-            let ranges = partition_pruner
+            let ranges = self
+                .partition_pruner
                 .build_file_ranges(index, &self.part_metrics, &mut reader_metrics)
                 .await?;
             self.part_metrics.inc_num_file_ranges(ranges.len());
@@ -319,7 +324,7 @@ impl SeriesCandidateRangeBuilder {
     }
 }
 
-fn validate_metric_metadata(stream_ctx: &StreamContext) -> Result<()> {
+pub(crate) fn validate_metric_metadata(stream_ctx: &StreamContext) -> Result<()> {
     let metadata = stream_ctx.input.region_metadata();
     let valid_prefix = metadata
         .primary_key

--- a/src/mito2/src/read/series_reader.rs
+++ b/src/mito2/src/read/series_reader.rs
@@ -1,0 +1,62 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared types for range-based metric series reads.
+
+#[allow(dead_code)]
+const TSID_DOMAIN_END: u128 = 1u128 << u64::BITS;
+
+/// A stable partition of the TSID integer domain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct SeriesRange {
+    start: u128,
+    end: u128,
+}
+
+#[allow(dead_code)]
+impl SeriesRange {
+    pub(crate) fn new(partition: usize, partitions: usize) -> Option<Self> {
+        if partitions == 0 || partition >= partitions {
+            return None;
+        }
+
+        let partitions = partitions as u128;
+        let partition = partition as u128;
+        let boundary = |partition: u128| {
+            let numerator = partition * TSID_DOMAIN_END;
+            numerator / partitions + u128::from(!numerator.is_multiple_of(partitions))
+        };
+        Some(Self {
+            start: boundary(partition),
+            end: boundary(partition + 1),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn series_ranges_cover_the_tsid_domain() {
+        let ranges = (0..3)
+            .map(|partition| SeriesRange::new(partition, 3).unwrap())
+            .collect::<Vec<_>>();
+
+        assert_eq!(0, ranges[0].start);
+        assert_eq!(TSID_DOMAIN_END, ranges[2].end);
+        assert_eq!(ranges[0].end, ranges[1].start);
+        assert_eq!(ranges[1].end, ranges[2].start);
+    }
+}

--- a/src/mito2/src/sst/parquet/file_range.rs
+++ b/src/mito2/src/sst/parquet/file_range.rs
@@ -31,6 +31,7 @@ use futures::StreamExt;
 use mito_codec::row_converter::PrimaryKeyCodec;
 use parquet::arrow::arrow_reader::RowSelection;
 use parquet::file::metadata::ParquetMetaData;
+use parquet::file::statistics::Statistics;
 use snafu::{OptionExt, ResultExt};
 use store_api::codec::PrimaryKeyEncoding;
 use store_api::metadata::RegionMetadataRef;
@@ -48,10 +49,11 @@ use crate::read::last_row::FlatRowGroupLastRowCachedReader;
 use crate::read::prune::FlatPruneReader;
 use crate::sst::file::FileHandle;
 use crate::sst::parquet::flat_format::{
-    DecodedPrimaryKeys, FlatReadFormat, decode_primary_keys, time_index_column_index,
+    DecodedPrimaryKeys, FlatReadFormat, decode_primary_keys, primary_key_column_index,
+    time_index_column_index,
 };
 use crate::sst::parquet::json_align::ProjectedRecordBatchStream;
-use crate::sst::parquet::prefilter::CachedPrimaryKeyFilter;
+use crate::sst::parquet::prefilter::{CachedPrimaryKeyFilter, primary_key_filter_mask};
 use crate::sst::parquet::reader::{
     FlatRowGroupReader, MaybeFilter, RowGroupBuildContext, RowGroupReaderBuilder,
     SimpleFilterContext,
@@ -101,6 +103,24 @@ impl FileRange {
     /// Builds the encoded-primary-key filter selected for this file.
     pub(crate) fn primary_key_filter(&self) -> Option<CachedPrimaryKeyFilter> {
         self.context.reader_builder.primary_key_filter()
+    }
+
+    /// Returns encoded primary-key min/max statistics for this row group.
+    #[allow(dead_code)]
+    pub(crate) fn primary_key_range(&self) -> Option<(&[u8], &[u8])> {
+        let metadata = self.context.reader_builder.parquet_metadata();
+        let num_columns = metadata.file_metadata().schema_descr().num_columns();
+        let primary_key_index = primary_key_column_index(num_columns);
+        match metadata
+            .row_group(self.row_group_idx)
+            .column(primary_key_index)
+            .statistics()?
+        {
+            Statistics::ByteArray(statistics) => {
+                Some((statistics.min_bytes_opt()?, statistics.max_bytes_opt()?))
+            }
+            _ => None,
+        }
     }
 
     /// Creates a new [FileRange].
@@ -239,10 +259,17 @@ impl FileRange {
         &self,
         fetch_metrics: Option<&ParquetFetchMetrics>,
     ) -> Result<Option<ProjectedRecordBatchStream>> {
-        if !self.in_dynamic_filter_range() {
+        self.primary_key_reader_inner(fetch_metrics, true).await
+    }
+
+    async fn primary_key_reader_inner(
+        &self,
+        fetch_metrics: Option<&ParquetFetchMetrics>,
+        check_dynamic_filter: bool,
+    ) -> Result<Option<ProjectedRecordBatchStream>> {
+        if check_dynamic_filter && !self.in_dynamic_filter_range() {
             return Ok(None);
         }
-
         let stream = self
             .context
             .reader_builder
@@ -270,6 +297,47 @@ impl FileRange {
         Ok(Some(stream))
     }
 
+    /// Builds a full-projection reader selected only by the provided encoded-PK
+    /// filter and this range's existing row selection.
+    ///
+    /// This deliberately bypasses generic predicate prefiltering. The series
+    /// pruner selected the row group independently, and non-tag simple predicates
+    /// are applied after merge and dedup by the series reader.
+    #[allow(dead_code)]
+    pub(crate) async fn reader_by_primary_key(
+        &self,
+        primary_key_filter: &mut dyn mito_codec::row_converter::PrimaryKeyFilter,
+        fetch_metrics: Option<&ParquetFetchMetrics>,
+    ) -> Result<Option<FlatRowGroupReader>> {
+        let Some(mut primary_keys) = self.primary_key_reader_inner(fetch_metrics, false).await?
+        else {
+            return Ok(None);
+        };
+
+        let mut masks = Vec::new();
+        while let Some(batch) = primary_keys.next().await {
+            let batch = batch?;
+            masks.push(BooleanArray::from(primary_key_filter_mask(
+                &batch,
+                primary_key_filter,
+            )?));
+        }
+        let Some(selected) = refine_primary_key_selection(&masks, &self.row_selection) else {
+            return Ok(None);
+        };
+
+        let stream = self
+            .context
+            .reader_builder
+            .build_without_prefilter(self.context.build_context(
+                self.row_group_idx,
+                Some(selected),
+                fetch_metrics,
+            ))
+            .await?;
+        Ok(Some(FlatRowGroupReader::new(self.context.clone(), stream)))
+    }
+
     /// Returns the helper to compat batches.
     pub(crate) fn compat_batch(&self) -> Option<&FlatCompatBatch> {
         self.context.compat_batch()
@@ -284,6 +352,22 @@ impl FileRange {
     pub(crate) fn file_handle(&self) -> &FileHandle {
         self.context.reader_builder.file_handle()
     }
+}
+
+#[allow(dead_code)]
+fn refine_primary_key_selection(
+    masks: &[BooleanArray],
+    original: &Option<RowSelection>,
+) -> Option<RowSelection> {
+    if masks.is_empty() {
+        return None;
+    }
+    let selected = RowSelection::from_filters(masks);
+    let selected = match original {
+        Some(original) => original.and_then(&selected),
+        None => selected,
+    };
+    (selected.row_count() > 0).then_some(selected)
 }
 
 /// Context shared by ranges of the same parquet SST.
@@ -699,6 +783,7 @@ mod tests {
     use std::sync::Arc;
 
     use datafusion_expr::{col, lit};
+    use parquet::arrow::arrow_reader::RowSelector;
 
     use super::*;
     use crate::read::read_columns::ReadColumns;
@@ -778,5 +863,26 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(mask.count_set_bits(), 4);
+    }
+
+    #[test]
+    fn test_refine_primary_key_selection_intersects_original_selection() {
+        let original = Some(RowSelection::from(vec![
+            RowSelector::skip(2),
+            RowSelector::select(3),
+            RowSelector::skip(1),
+            RowSelector::select(2),
+        ]));
+        let mask = BooleanArray::from(vec![true, false, true, false, true]);
+        let actual = refine_primary_key_selection(&[mask], &original).unwrap();
+        let expected = RowSelection::from(vec![
+            RowSelector::skip(2),
+            RowSelector::select(1),
+            RowSelector::skip(1),
+            RowSelector::select(1),
+            RowSelector::skip(2),
+            RowSelector::select(1),
+        ]);
+        assert_eq!(actual, expected);
     }
 }

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -1051,12 +1051,13 @@ fn eval_entry_mask(
             let pk_filter = prefilter_ctx.pk_filter.as_mut().context(UnexpectedSnafu {
                 reason: "Missing primary key filter for prefilter cache entry",
             })?;
-            eval_pk_group_mask(batch, pk_filter.as_mut())
+            primary_key_filter_mask(batch, pk_filter.as_mut())
         }
     }
 }
 
-fn eval_pk_group_mask(
+/// Evaluates an encoded-primary-key filter against a primary-key batch.
+pub(crate) fn primary_key_filter_mask(
     batch: &RecordBatch,
     pk_filter: &mut dyn PrimaryKeyFilter,
 ) -> Result<BooleanBuffer> {
@@ -1727,7 +1728,7 @@ mod tests {
             &[10, 11, 12, 13],
         );
 
-        let mask = eval_pk_group_mask(&batch, pk_filter.as_mut().unwrap().as_mut()).unwrap();
+        let mask = primary_key_filter_mask(&batch, pk_filter.as_mut().unwrap().as_mut()).unwrap();
 
         assert_eq!(mask.count_set_bits(), 2);
     }
@@ -1751,7 +1752,7 @@ mod tests {
             &[10, 11, 12, 13],
         );
 
-        let mask = eval_pk_group_mask(&batch, pk_filter.as_mut().unwrap().as_mut()).unwrap();
+        let mask = primary_key_filter_mask(&batch, pk_filter.as_mut().unwrap().as_mut()).unwrap();
 
         assert_eq!(mask.count_set_bits(), 2);
     }

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -1903,6 +1903,26 @@ impl RowGroupReaderBuilder {
         self.make_projected_stream(stream)
     }
 
+    /// Builds the normal projection without running the generic predicate prefilter.
+    ///
+    /// The series reader uses this after computing its own primary-key-only row
+    /// selection.
+    #[allow(dead_code)]
+    pub(crate) async fn build_without_prefilter(
+        &self,
+        build_ctx: RowGroupBuildContext<'_>,
+    ) -> Result<ProjectedRecordBatchStream> {
+        let stream = self
+            .build_with_projection(
+                build_ctx.row_group_idx,
+                build_ctx.row_selection,
+                self.projection.mask.clone(),
+                build_ctx.fetch_metrics,
+            )
+            .await?;
+        self.make_projected_stream(stream)
+    }
+
     /// Builds a stream that reads only the encoded primary-key column.
     ///
     /// It preserves the normal reader's binary-or-dictionary decision. This path deliberately


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up to #8586.

## What's changed and what's your intention?

This PR prepares the internal Mito2 read path for a range-based metric-series reader while deliberately leaving the reader implementation and runtime wiring for a follow-up PR.

- Allow an opt-in pruner to retain already-cached file-range builders after the current range batch is consumed, so candidate and data phases can share them without changing existing scan behavior.
- Preserve the original cache-eligibility rule: late pruning results are never cached after all range references are consumed, while retained builders remain query-scoped until the pruner is dropped.
- Document that repeated `add_partition_ranges()` calls must register consistent ranges from the same logical scan; their reference counts accumulate in the pruner.
- Add distinct cache-key stages for candidate-series and assigned series-data reads.
- Add primary-key range/filter and row-selection primitives needed to read selected series from Parquet.
- Keep only the shared `SeriesRange` type in `series_reader.rs`; the actual reader, batch collection, filtering, and stream assembly are deferred.
- Keep existing `SeqScan`, `SeriesScan`, and `UnorderedScan` behavior unchanged; they continue to use the non-retaining `Pruner::new` path.
- Do not add series-v2 scanbench code or two-stage runtime wiring.

There are no public API, wire-format, schema, persisted-format, or runtime behavior changes. The internal APIs intended for the follow-up are narrowly marked `allow(dead_code)` until that reader consumes them.

Validation:

- `make fmt`
- `make check`
- `make clippy`
- `cargo nextest run -p mito2` (1,052 passed)
- `make check-udeps` completed compilation but reported the pre-existing `common-stat -> nix` unused-dependency warning; this PR changes no Cargo manifests or `common-stat` code.

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
