### PR TITLE
fix(region-migration): fence promotion by manifest version

### DIFF
--- a/src/common/meta/src/instruction.rs
+++ b/src/common/meta/src/instruction.rs
@@ -19,6 +19,7 @@ use std::time::Duration;
 use common_error::ext::{ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use store_api::ManifestVersion;
 use store_api::region_engine::SyncRegionFromRequest;
 use store_api::region_request::{RegionFlushReason, RegionRequirements};
 use store_api::storage::{FileRefsManifest, GcReport, RegionId, RegionNumber};
@@ -156,6 +157,12 @@ pub struct DowngradeRegionReply {
     pub last_entry_id: Option<u64>,
     /// Returns the `metadata_last_entry_id` if available (Only available for metric engine).
     pub metadata_last_entry_id: Option<u64>,
+    /// Returns the final manifest version if available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub manifest_version: Option<ManifestVersion>,
+    /// Returns the final metadata manifest version if available (Only available for metric engine).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata_manifest_version: Option<ManifestVersion>,
     /// Indicates whether the region exists.
     pub exists: bool,
     /// Return error if any during the operation.
@@ -166,8 +173,8 @@ impl Display for DowngradeRegionReply {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "(last_entry_id={:?}, exists={}, error={:?})",
-            self.last_entry_id, self.exists, self.error
+            "(last_entry_id={:?}, manifest_version={:?}, exists={}, error={:?})",
+            self.last_entry_id, self.manifest_version, self.exists, self.error
         )
     }
 }
@@ -360,6 +367,12 @@ pub struct UpgradeRegion {
     pub last_entry_id: Option<u64>,
     /// The `last_entry_id` of old leader metadata region (Only used for metric engine).
     pub metadata_last_entry_id: Option<u64>,
+    /// The final manifest version of the old leader region.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub manifest_version: Option<ManifestVersion>,
+    /// The final manifest version of the old leader metadata region.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata_manifest_version: Option<ManifestVersion>,
     /// The timeout of waiting for a wal replay.
     ///
     /// `None` stands for no wait,
@@ -1332,6 +1345,8 @@ mod tests {
             region_id: RegionId::new(1024, 1),
             last_entry_id: None,
             metadata_last_entry_id: None,
+            manifest_version: Some(10),
+            metadata_manifest_version: Some(11),
             replay_timeout: Duration::from_millis(1000),
             location_id: None,
             replay_entry_id: None,
@@ -1340,8 +1355,12 @@ mod tests {
 
         let serialized = serde_json::to_string(&upgrade_region).unwrap();
         assert_eq!(
-            r#"{"UpgradeRegions":[{"region_id":4398046511105,"last_entry_id":null,"metadata_last_entry_id":null,"replay_timeout":"1s","location_id":null}]}"#,
+            r#"{"UpgradeRegions":[{"region_id":4398046511105,"last_entry_id":null,"metadata_last_entry_id":null,"manifest_version":10,"metadata_manifest_version":11,"replay_timeout":"1s","location_id":null}]}"#,
             serialized
+        );
+        assert_eq!(
+            upgrade_region,
+            serde_json::from_str::<Instruction>(&serialized).unwrap()
         );
     }
 
@@ -1352,6 +1371,8 @@ mod tests {
                 region_id: RegionId::new(1024, 1),
                 last_entry_id: None,
                 metadata_last_entry_id: None,
+                manifest_version: Some(10),
+                metadata_manifest_version: Some(11),
                 exists: true,
                 error: None,
             }),
@@ -1359,8 +1380,12 @@ mod tests {
 
         let serialized = serde_json::to_string(&downgrade_region_reply).unwrap();
         assert_eq!(
-            r#"{"type":"downgrade_regions","replies":[{"region_id":4398046511105,"last_entry_id":null,"metadata_last_entry_id":null,"exists":true,"error":null}]}"#,
+            r#"{"type":"downgrade_regions","replies":[{"region_id":4398046511105,"last_entry_id":null,"metadata_last_entry_id":null,"manifest_version":10,"metadata_manifest_version":11,"exists":true,"error":null}]}"#,
             serialized
+        );
+        assert_eq!(
+            downgrade_region_reply,
+            serde_json::from_str::<InstructionReply>(&serialized).unwrap()
         );
 
         let upgrade_region_reply =
@@ -1429,6 +1454,8 @@ mod tests {
             region_id: RegionId::new(1024, 1),
             last_entry_id: None,
             metadata_last_entry_id: None,
+            manifest_version: None,
+            metadata_manifest_version: None,
             replay_timeout: Duration::from_millis(1000),
             location_id: None,
             replay_entry_id: None,
@@ -1469,6 +1496,8 @@ mod tests {
                 region_id: RegionId::new(1024, 1),
                 last_entry_id: None,
                 metadata_last_entry_id: None,
+                manifest_version: None,
+                metadata_manifest_version: None,
                 exists: true,
                 error: None,
             }),

--- a/src/datanode/src/heartbeat/handler/downgrade_region.rs
+++ b/src/datanode/src/heartbeat/handler/downgrade_region.rs
@@ -43,6 +43,8 @@ impl DowngradeRegionsHandler {
                 region_id,
                 last_entry_id: None,
                 metadata_last_entry_id: None,
+                manifest_version: None,
+                metadata_manifest_version: None,
                 exists: false,
                 error: None,
             };
@@ -79,6 +81,8 @@ impl DowngradeRegionsHandler {
                     region_id,
                     last_entry_id: None,
                     metadata_last_entry_id: None,
+                    manifest_version: None,
+                    metadata_manifest_version: None,
                     exists: false,
                     error: None,
                 };
@@ -89,6 +93,8 @@ impl DowngradeRegionsHandler {
                     region_id,
                     last_entry_id: None,
                     metadata_last_entry_id: None,
+                    manifest_version: None,
+                    metadata_manifest_version: None,
                     exists: true,
                     error: Some(InstructionError::from_error(&err)),
                 };
@@ -99,6 +105,8 @@ impl DowngradeRegionsHandler {
                     region_id,
                     last_entry_id: None,
                     metadata_last_entry_id: None,
+                    manifest_version: None,
+                    metadata_manifest_version: None,
                     exists: true,
                     error: Some(InstructionError::from_error(&err)),
                 };
@@ -135,6 +143,8 @@ impl DowngradeRegionsHandler {
                 region_id,
                 last_entry_id: None,
                 metadata_last_entry_id: None,
+                manifest_version: None,
+                metadata_manifest_version: None,
                 exists: true,
                 error: Some(InstructionError::legacy_internal_retryable(format!(
                     "Flush region timeout, region: {region_id}, timeout: {:?}",
@@ -146,6 +156,8 @@ impl DowngradeRegionsHandler {
                 region_id,
                 last_entry_id: None,
                 metadata_last_entry_id: None,
+                manifest_version: None,
+                metadata_manifest_version: None,
                 exists: true,
                 error: Some(InstructionError::from_error(&err)),
             },
@@ -185,6 +197,8 @@ impl HandlerContext {
                 region_id,
                 last_entry_id: success.last_entry_id(),
                 metadata_last_entry_id: success.metadata_last_entry_id(),
+                manifest_version: success.manifest_version(),
+                metadata_manifest_version: success.metadata_manifest_version(),
                 exists: true,
                 error: None,
             },
@@ -194,6 +208,8 @@ impl HandlerContext {
                     region_id,
                     last_entry_id: None,
                     metadata_last_entry_id: None,
+                    manifest_version: None,
+                    metadata_manifest_version: None,
                     exists: false,
                     error: None,
                 }
@@ -204,6 +220,8 @@ impl HandlerContext {
                     region_id,
                     last_entry_id: None,
                     metadata_last_entry_id: None,
+                    manifest_version: None,
+                    metadata_manifest_version: None,
                     exists: true,
                     error: Some(InstructionError::from_error(&err)),
                 }
@@ -214,6 +232,8 @@ impl HandlerContext {
                     region_id,
                     last_entry_id: None,
                     metadata_last_entry_id: None,
+                    manifest_version: None,
+                    metadata_manifest_version: None,
                     exists: true,
                     error: Some(InstructionError::from_error(&err)),
                 }
@@ -295,7 +315,7 @@ mod tests {
                 }));
                 region_engine.handle_set_readonly_gracefully_mock_fn = Some(Box::new(|_| {
                     Ok(SetRegionRoleStateResponse::success(
-                        SetRegionRoleStateSuccess::mito(1024),
+                        SetRegionRoleStateSuccess::mito(1024, 2048),
                     ))
                 }))
             });
@@ -319,6 +339,7 @@ mod tests {
             assert!(reply.exists);
             assert!(reply.error.is_none());
             assert_eq!(reply.last_entry_id.unwrap(), 1024);
+            assert_eq!(reply.manifest_version, Some(2048));
         }
     }
 
@@ -332,7 +353,7 @@ mod tests {
                 region_engine.handle_request_delay = Some(Duration::from_secs(100));
                 region_engine.handle_set_readonly_gracefully_mock_fn = Some(Box::new(|_| {
                     Ok(SetRegionRoleStateResponse::success(
-                        SetRegionRoleStateSuccess::mito(1024),
+                        SetRegionRoleStateSuccess::mito(1024, 2048),
                     ))
                 }))
             });
@@ -367,7 +388,7 @@ mod tests {
                 region_engine.handle_request_delay = Some(Duration::from_millis(300));
                 region_engine.handle_set_readonly_gracefully_mock_fn = Some(Box::new(|_| {
                     Ok(SetRegionRoleStateResponse::success(
-                        SetRegionRoleStateSuccess::mito(1024),
+                        SetRegionRoleStateSuccess::mito(1024, 2048),
                     ))
                 }))
             });
@@ -413,6 +434,7 @@ mod tests {
         assert!(reply.exists);
         assert!(reply.error.is_none());
         assert_eq!(reply.last_entry_id.unwrap(), 1024);
+        assert_eq!(reply.manifest_version, Some(2048));
     }
 
     #[tokio::test]
@@ -431,7 +453,7 @@ mod tests {
                 }));
                 region_engine.handle_set_readonly_gracefully_mock_fn = Some(Box::new(|_| {
                     Ok(SetRegionRoleStateResponse::success(
-                        SetRegionRoleStateSuccess::mito(1024),
+                        SetRegionRoleStateSuccess::mito(1024, 2048),
                     ))
                 }))
             });
@@ -597,10 +619,12 @@ mod tests {
         assert!(reply[0].exists);
         assert!(reply[0].error.is_none());
         assert_eq!(reply[0].last_entry_id, Some(0));
+        assert!(reply[0].manifest_version.is_some());
         assert_eq!(reply[1].region_id, region_id1);
         assert!(reply[1].exists);
         assert!(reply[1].error.is_none());
         assert_eq!(reply[1].last_entry_id, Some(0));
+        assert!(reply[1].manifest_version.is_some());
 
         assert_eq!(engine.role(region_id).unwrap(), RegionRole::Follower);
         assert_eq!(engine.role(region_id1).unwrap(), RegionRole::Follower);

--- a/src/datanode/src/heartbeat/handler/upgrade_region.rs
+++ b/src/datanode/src/heartbeat/handler/upgrade_region.rs
@@ -130,6 +130,8 @@ impl UpgradeRegionsHandler {
                 let UpgradeRegion {
                     last_entry_id,
                     metadata_last_entry_id,
+                    manifest_version,
+                    metadata_manifest_version,
                     location_id,
                     replay_entry_id,
                     metadata_replay_entry_id,
@@ -159,6 +161,8 @@ impl UpgradeRegionsHandler {
                     upgrade_region.region_id,
                     RegionCatchupRequest {
                         set_writable: true,
+                        manifest_version,
+                        metadata_manifest_version,
                         entry_id: last_entry_id,
                         metadata_entry_id: metadata_last_entry_id,
                         location_id,
@@ -228,6 +232,7 @@ mod tests {
     use common_meta::kv_backend::memory::MemoryKvBackend;
     use mito2::engine::MITO_ENGINE_NAME;
     use store_api::region_engine::RegionRole;
+    use store_api::region_request::RegionRequest;
     use store_api::storage::RegionId;
 
     use crate::error;
@@ -329,7 +334,16 @@ mod tests {
             MockRegionEngine::with_custom_apply_fn(MITO_ENGINE_NAME, |region_engine| {
                 // Region is not ready.
                 region_engine.mock_role = Some(Some(RegionRole::Follower));
-                region_engine.handle_request_mock_fn = Some(Box::new(|_, _| Ok(0)));
+                region_engine.handle_request_mock_fn = Some(Box::new(|_, request| {
+                    let RegionRequest::Catchup(request) = request else {
+                        panic!("expected catchup request");
+                    };
+                    assert_eq!(request.manifest_version, Some(10));
+                    assert_eq!(request.metadata_manifest_version, Some(11));
+                    assert_eq!(request.entry_id, Some(12));
+                    assert_eq!(request.metadata_entry_id, Some(13));
+                    Ok(0)
+                }));
                 // Note: Don't change.
                 region_engine.handle_request_delay = Some(Duration::from_secs(100));
             });
@@ -342,6 +356,10 @@ mod tests {
                 &handler_context,
                 vec![UpgradeRegion {
                     region_id,
+                    manifest_version: Some(10),
+                    metadata_manifest_version: Some(11),
+                    last_entry_id: Some(12),
+                    metadata_last_entry_id: Some(13),
                     replay_timeout,
                     ..Default::default()
                 }],

--- a/src/meta-srv/src/procedure/region_migration.rs
+++ b/src/meta-srv/src/procedure/region_migration.rs
@@ -59,6 +59,7 @@ pub use manager::{
 };
 use serde::{Deserialize, Deserializer, Serialize};
 use snafu::{OptionExt, ResultExt};
+use store_api::ManifestVersion;
 use store_api::storage::{RegionId, TableId};
 use tokio::time::Instant;
 
@@ -321,6 +322,10 @@ pub struct VolatileContext {
     leader_region_last_entry_ids: HashMap<RegionId, u64>,
     /// The last_entry_ids of leader metadata regions (Only used for metric engine).
     leader_region_metadata_last_entry_ids: HashMap<RegionId, u64>,
+    /// The final manifest versions of leader regions.
+    leader_region_manifest_versions: HashMap<RegionId, ManifestVersion>,
+    /// The final manifest versions of leader metadata regions (Only used for metric engine).
+    leader_region_metadata_manifest_versions: HashMap<RegionId, ManifestVersion>,
     /// Metrics of region migration.
     metrics: Metrics,
 }
@@ -348,6 +353,22 @@ impl VolatileContext {
     pub fn set_metadata_last_entry_id(&mut self, region_id: RegionId, last_entry_id: u64) {
         self.leader_region_metadata_last_entry_ids
             .insert(region_id, last_entry_id);
+    }
+
+    /// Sets the final manifest version of a leader region.
+    pub fn set_manifest_version(&mut self, region_id: RegionId, manifest_version: ManifestVersion) {
+        self.leader_region_manifest_versions
+            .insert(region_id, manifest_version);
+    }
+
+    /// Sets the final manifest version of a leader metadata region.
+    pub fn set_metadata_manifest_version(
+        &mut self,
+        region_id: RegionId,
+        manifest_version: ManifestVersion,
+    ) {
+        self.leader_region_metadata_manifest_versions
+            .insert(region_id, manifest_version);
     }
 }
 

--- a/src/meta-srv/src/procedure/region_migration/downgrade_leader_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/downgrade_leader_region.rs
@@ -143,6 +143,8 @@ impl DowngradeLeaderRegion {
             region_id,
             last_entry_id,
             metadata_last_entry_id,
+            manifest_version,
+            metadata_manifest_version,
             exists,
             error,
         } = reply;
@@ -169,11 +171,13 @@ impl DowngradeLeaderRegion {
             );
         } else {
             info!(
-                "Region {} leader is downgraded on datanode {:?}, last_entry_id: {:?}, metadata_last_entry_id: {:?}, elapsed: {:?}",
+                "Region {} leader is downgraded on datanode {:?}, last_entry_id: {:?}, metadata_last_entry_id: {:?}, manifest_version: {:?}, metadata_manifest_version: {:?}, elapsed: {:?}",
                 region_id,
                 leader,
                 last_entry_id,
                 metadata_last_entry_id,
+                manifest_version,
+                metadata_manifest_version,
                 now.elapsed()
             );
         }
@@ -190,6 +194,16 @@ impl DowngradeLeaderRegion {
         if let Some(metadata_last_entry_id) = metadata_last_entry_id {
             ctx.volatile_ctx
                 .set_metadata_last_entry_id(*region_id, *metadata_last_entry_id);
+        }
+
+        if let Some(manifest_version) = manifest_version {
+            ctx.volatile_ctx
+                .set_manifest_version(*region_id, *manifest_version);
+        }
+
+        if let Some(metadata_manifest_version) = metadata_manifest_version {
+            ctx.volatile_ctx
+                .set_metadata_manifest_version(*region_id, *metadata_manifest_version);
         }
 
         Ok(())
@@ -393,7 +407,8 @@ mod tests {
     use crate::procedure::region_migration::test_util::{TestingEnv, new_procedure_context};
     use crate::procedure::region_migration::{ContextFactory, PersistentContext};
     use crate::procedure::test_util::{
-        new_close_region_reply, new_downgrade_region_reply, send_mock_reply,
+        new_close_region_reply, new_downgrade_region_reply, new_downgrade_region_reply_with_fences,
+        send_mock_reply,
     };
 
     fn new_persistent_context() -> PersistentContext {
@@ -612,7 +627,15 @@ mod tests {
             mailbox
                 .on_recv(
                     reply_id,
-                    Ok(new_downgrade_region_reply(reply_id, Some(1), true, None)),
+                    Ok(new_downgrade_region_reply_with_fences(
+                        reply_id,
+                        Some(1),
+                        Some(2),
+                        Some(3),
+                        Some(4),
+                        true,
+                        None,
+                    )),
                 )
                 .await
                 .unwrap();
@@ -625,6 +648,24 @@ mod tests {
                 .get(&RegionId::new(0, 0))
                 .cloned(),
             Some(1)
+        );
+        assert_eq!(
+            ctx.volatile_ctx
+                .leader_region_metadata_last_entry_ids
+                .get(&RegionId::new(0, 0)),
+            Some(&2)
+        );
+        assert_eq!(
+            ctx.volatile_ctx
+                .leader_region_manifest_versions
+                .get(&RegionId::new(0, 0)),
+            Some(&3)
+        );
+        assert_eq!(
+            ctx.volatile_ctx
+                .leader_region_metadata_manifest_versions
+                .get(&RegionId::new(0, 0)),
+            Some(&4)
         );
         assert!(ctx.volatile_ctx.leader_region_lease_deadline.is_none());
     }

--- a/src/meta-srv/src/procedure/region_migration/upgrade_candidate_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/upgrade_candidate_region.rs
@@ -153,11 +153,23 @@ impl UpgradeCandidateRegion {
                 .leader_region_metadata_last_entry_ids
                 .get(&region_id)
                 .copied();
+            let manifest_version = ctx
+                .volatile_ctx
+                .leader_region_manifest_versions
+                .get(&region_id)
+                .copied();
+            let metadata_manifest_version = ctx
+                .volatile_ctx
+                .leader_region_metadata_manifest_versions
+                .get(&region_id)
+                .copied();
             let checkpoint = replay_checkpoints.get(&region_id).copied();
             upgrade_regions.push(UpgradeRegion {
                 region_id,
                 last_entry_id,
                 metadata_last_entry_id,
+                manifest_version,
+                metadata_manifest_version,
                 replay_timeout,
                 location_id: Some(ctx.persistent_ctx.from_peer.id),
                 replay_entry_id: checkpoint.map(|c| c.entry_id),
@@ -424,6 +436,7 @@ mod tests {
         let mut ctx = env.context_factory().new_context(persistent_context);
         let region_id = ctx.persistent_ctx.region_ids[0];
         let topic = "test_topic";
+        ctx.volatile_ctx.set_manifest_version(region_id, 30);
         prepare_table_metadata(&ctx, kafka_wal_options(topic)).await;
         ctx.table_metadata_manager
             .topic_region_manager()
@@ -459,6 +472,8 @@ mod tests {
         };
 
         assert_eq!(upgrade_regions.len(), 1);
+        assert_eq!(upgrade_regions[0].manifest_version, Some(30));
+        assert_eq!(upgrade_regions[0].metadata_manifest_version, None);
         assert_eq!(upgrade_regions[0].replay_entry_id, Some(20));
         assert_eq!(upgrade_regions[0].metadata_replay_entry_id, None);
     }
@@ -471,6 +486,9 @@ mod tests {
         let mut ctx = env.context_factory().new_context(persistent_context);
         let region_id = ctx.persistent_ctx.region_ids[0];
         let topic = "test_topic";
+        ctx.volatile_ctx.set_manifest_version(region_id, 30);
+        ctx.volatile_ctx
+            .set_metadata_manifest_version(region_id, 31);
         prepare_table_metadata_with_engine(&ctx, kafka_wal_options(topic), METRIC_ENGINE_NAME)
             .await;
         ctx.table_metadata_manager
@@ -510,6 +528,8 @@ mod tests {
         };
 
         assert_eq!(upgrade_regions.len(), 1);
+        assert_eq!(upgrade_regions[0].manifest_version, Some(30));
+        assert_eq!(upgrade_regions[0].metadata_manifest_version, Some(31));
         assert_eq!(upgrade_regions[0].replay_entry_id, Some(20));
         assert_eq!(upgrade_regions[0].metadata_replay_entry_id, Some(20));
     }

--- a/src/meta-srv/src/procedure/test_util.rs
+++ b/src/meta-srv/src/procedure/test_util.rs
@@ -202,6 +202,19 @@ pub fn new_downgrade_region_reply(
     exist: bool,
     error: Option<String>,
 ) -> MailboxMessage {
+    new_downgrade_region_reply_with_fences(id, last_entry_id, None, None, None, exist, error)
+}
+
+/// Generates a downgrade reply with WAL and manifest fences.
+pub fn new_downgrade_region_reply_with_fences(
+    id: u64,
+    last_entry_id: Option<u64>,
+    metadata_last_entry_id: Option<u64>,
+    manifest_version: Option<u64>,
+    metadata_manifest_version: Option<u64>,
+    exist: bool,
+    error: Option<String>,
+) -> MailboxMessage {
     MailboxMessage {
         id,
         subject: "mock".to_string(),
@@ -213,7 +226,9 @@ pub fn new_downgrade_region_reply(
                 DowngradeRegionsReply::new(vec![DowngradeRegionReply {
                     region_id: RegionId::new(0, 0),
                     last_entry_id,
-                    metadata_last_entry_id: None,
+                    metadata_last_entry_id,
+                    manifest_version,
+                    metadata_manifest_version,
                     exists: exist,
                     error: legacy_instruction_error(error),
                 }]),

--- a/src/metric-engine/src/engine.rs
+++ b/src/metric-engine/src/engine.rs
@@ -446,7 +446,9 @@ impl RegionEngine for MetricEngine {
         Ok(SetRegionRoleStateResponse::success(
             SetRegionRoleStateSuccess::metric(
                 data_result.last_entry_id().unwrap_or_default(),
+                data_result.manifest_version().unwrap_or_default(),
                 metadata_result.last_entry_id().unwrap_or_default(),
+                metadata_result.manifest_version().unwrap_or_default(),
             ),
         ))
     }
@@ -945,6 +947,115 @@ mod test {
                 assert!(state.logical_regions().contains_key(logical_region));
             }
         }
+    }
+
+    #[tokio::test]
+    async fn test_catchup_requires_both_physical_region_fences() {
+        let env = TestEnv::new().await;
+        env.init_metric_region().await;
+        let metric_engine = env.metric();
+        let mito_engine = env.mito();
+        let physical_region_id = env.default_physical_region_id();
+        metric_engine
+            .handle_request(
+                physical_region_id,
+                RegionRequest::Flush(RegionFlushRequest::default()),
+            )
+            .await
+            .unwrap();
+
+        let response = metric_engine
+            .set_region_role_state_gracefully(physical_region_id, SettableRegionRoleState::Follower)
+            .await
+            .unwrap();
+        let SetRegionRoleStateResponse::Success(success) = response else {
+            panic!("expected successful downgrade");
+        };
+        let data_entry_id = success.last_entry_id().unwrap();
+        let metadata_entry_id = success.metadata_last_entry_id().unwrap();
+        let data_manifest_version = success.manifest_version().unwrap();
+        let metadata_manifest_version = success.metadata_manifest_version().unwrap();
+
+        let responses = metric_engine
+            .handle_batch_catchup_requests(
+                2,
+                vec![(
+                    physical_region_id,
+                    RegionCatchupRequest {
+                        set_writable: true,
+                        manifest_version: Some(data_manifest_version + 1),
+                        metadata_manifest_version: Some(metadata_manifest_version),
+                        entry_id: Some(data_entry_id),
+                        metadata_entry_id: Some(metadata_entry_id),
+                        ..Default::default()
+                    },
+                )],
+            )
+            .await
+            .unwrap();
+        assert!(responses[0].1.is_err());
+        assert_eq!(
+            mito_engine.role(utils::to_data_region_id(physical_region_id)),
+            Some(RegionRole::Follower)
+        );
+        assert_eq!(
+            mito_engine.role(utils::to_metadata_region_id(physical_region_id)),
+            Some(RegionRole::Follower)
+        );
+
+        let responses = metric_engine
+            .handle_batch_catchup_requests(
+                2,
+                vec![(
+                    physical_region_id,
+                    RegionCatchupRequest {
+                        set_writable: true,
+                        manifest_version: Some(data_manifest_version),
+                        metadata_manifest_version: Some(metadata_manifest_version + 1),
+                        entry_id: Some(data_entry_id),
+                        metadata_entry_id: Some(metadata_entry_id),
+                        ..Default::default()
+                    },
+                )],
+            )
+            .await
+            .unwrap();
+        assert!(responses[0].1.is_err());
+        assert_eq!(
+            mito_engine.role(utils::to_data_region_id(physical_region_id)),
+            Some(RegionRole::Follower)
+        );
+        assert_eq!(
+            mito_engine.role(utils::to_metadata_region_id(physical_region_id)),
+            Some(RegionRole::Follower)
+        );
+
+        let responses = metric_engine
+            .handle_batch_catchup_requests(
+                2,
+                vec![(
+                    physical_region_id,
+                    RegionCatchupRequest {
+                        set_writable: true,
+                        manifest_version: Some(data_manifest_version),
+                        metadata_manifest_version: Some(metadata_manifest_version),
+                        entry_id: Some(data_entry_id),
+                        metadata_entry_id: Some(metadata_entry_id),
+                        ..Default::default()
+                    },
+                )],
+            )
+            .await
+            .unwrap();
+        assert!(responses[0].1.is_ok());
+        assert_eq!(
+            mito_engine.role(utils::to_data_region_id(physical_region_id)),
+            Some(RegionRole::Leader)
+        );
+        assert_eq!(
+            mito_engine.role(utils::to_metadata_region_id(physical_region_id)),
+            Some(RegionRole::Leader)
+        );
     }
 
     #[tokio::test]

--- a/src/metric-engine/src/engine/catchup.rs
+++ b/src/metric-engine/src/engine/catchup.rs
@@ -25,6 +25,48 @@ use crate::error::{BatchCatchupMitoRegionSnafu, PhysicalRegionNotFoundSnafu, Res
 use crate::utils;
 
 impl MetricEngineInner {
+    fn physical_catchup_requests(
+        region_id: RegionId,
+        req: RegionCatchupRequest,
+        set_writable: bool,
+    ) -> Vec<(RegionId, RegionCatchupRequest)> {
+        let metadata_region_id = utils::to_metadata_region_id(region_id);
+        let data_region_id = utils::to_data_region_id(region_id);
+
+        vec![
+            (
+                metadata_region_id,
+                RegionCatchupRequest {
+                    set_writable,
+                    manifest_version: req.metadata_manifest_version,
+                    metadata_manifest_version: None,
+                    entry_id: req.metadata_entry_id,
+                    metadata_entry_id: None,
+                    location_id: req.location_id,
+                    checkpoint: req.checkpoint.map(|c| ReplayCheckpoint {
+                        entry_id: c.metadata_entry_id.unwrap_or_default(),
+                        metadata_entry_id: None,
+                    }),
+                },
+            ),
+            (
+                data_region_id,
+                RegionCatchupRequest {
+                    set_writable,
+                    manifest_version: req.manifest_version,
+                    metadata_manifest_version: None,
+                    entry_id: req.entry_id,
+                    metadata_entry_id: None,
+                    location_id: req.location_id,
+                    checkpoint: req.checkpoint.map(|c| ReplayCheckpoint {
+                        entry_id: c.entry_id,
+                        metadata_entry_id: None,
+                    }),
+                },
+            ),
+        ]
+    }
+
     pub async fn handle_batch_catchup_requests(
         &self,
         parallelism: usize,
@@ -34,7 +76,6 @@ impl MetricEngineInner {
         let mut physical_region_options_list = Vec::with_capacity(requests.len());
 
         for (region_id, req) in requests {
-            let metadata_region_id = utils::to_metadata_region_id(region_id);
             let data_region_id = utils::to_data_region_id(region_id);
 
             let physical_region_options = *self
@@ -47,33 +88,8 @@ impl MetricEngineInner {
                     region_id: data_region_id,
                 })?
                 .options();
-            physical_region_options_list.push((data_region_id, physical_region_options));
-            all_requests.push((
-                metadata_region_id,
-                RegionCatchupRequest {
-                    set_writable: req.set_writable,
-                    entry_id: req.metadata_entry_id,
-                    metadata_entry_id: None,
-                    location_id: req.location_id,
-                    checkpoint: req.checkpoint.map(|c| ReplayCheckpoint {
-                        entry_id: c.metadata_entry_id.unwrap_or_default(),
-                        metadata_entry_id: None,
-                    }),
-                },
-            ));
-            all_requests.push((
-                data_region_id,
-                RegionCatchupRequest {
-                    set_writable: req.set_writable,
-                    entry_id: req.entry_id,
-                    metadata_entry_id: None,
-                    location_id: req.location_id,
-                    checkpoint: req.checkpoint.map(|c| ReplayCheckpoint {
-                        entry_id: c.entry_id,
-                        metadata_entry_id: None,
-                    }),
-                },
-            ));
+            physical_region_options_list.push((data_region_id, physical_region_options, req));
+            all_requests.extend(Self::physical_catchup_requests(region_id, req, false));
         }
 
         let mut results = self
@@ -85,11 +101,32 @@ impl MetricEngineInner {
             .collect::<HashMap<_, _>>();
 
         let mut responses = Vec::with_capacity(physical_region_options_list.len());
-        for (physical_region_id, physical_region_options) in physical_region_options_list {
+        for (physical_region_id, physical_region_options, req) in physical_region_options_list {
             let metadata_region_id = utils::to_metadata_region_id(physical_region_id);
             let data_region_id = utils::to_data_region_id(physical_region_id);
-            let metadata_region_result = results.remove(&metadata_region_id);
-            let data_region_result = results.remove(&data_region_id);
+            let mut metadata_region_result = results.remove(&metadata_region_id);
+            let mut data_region_result = results.remove(&data_region_id);
+
+            let fences_satisfied = metadata_region_result
+                .as_ref()
+                .is_some_and(|result| result.is_ok())
+                && data_region_result
+                    .as_ref()
+                    .is_some_and(|result| result.is_ok());
+            if req.set_writable && fences_satisfied {
+                let mut promotion_results = self
+                    .mito
+                    .handle_batch_catchup_requests(
+                        2,
+                        Self::physical_catchup_requests(physical_region_id, req, true),
+                    )
+                    .await
+                    .context(BatchCatchupMitoRegionSnafu {})?
+                    .into_iter()
+                    .collect::<HashMap<_, _>>();
+                metadata_region_result = promotion_results.remove(&metadata_region_id);
+                data_region_result = promotion_results.remove(&data_region_id);
+            }
 
             // Pass the optional `metadata_region_result` and `data_region_result` to
             // `recover_physical_region_with_results`. This function handles errors for each

--- a/src/mito2/src/engine/batch_catchup_test.rs
+++ b/src/mito2/src/engine/batch_catchup_test.rs
@@ -182,6 +182,8 @@ async fn test_batch_catchup_with_format(factory: Option<LogStoreFactory>, flat_f
                 region_id,
                 RegionCatchupRequest {
                     set_writable: true,
+                    manifest_version: None,
+                    metadata_manifest_version: None,
                     entry_id: None,
                     metadata_entry_id: None,
                     location_id: None,
@@ -229,6 +231,8 @@ async fn test_batch_catchup_err_with_format(factory: Option<LogStoreFactory>, fl
                 region_id,
                 RegionCatchupRequest {
                     set_writable: true,
+                    manifest_version: None,
+                    metadata_manifest_version: None,
                     entry_id: None,
                     metadata_entry_id: None,
                     location_id: None,

--- a/src/mito2/src/engine/catchup_test.rs
+++ b/src/mito2/src/engine/catchup_test.rs
@@ -25,7 +25,8 @@ use rstest_reuse::{self, apply};
 use store_api::logstore::provider::RaftEngineProvider;
 use store_api::region_engine::{RegionEngine, RegionRole, SetRegionRoleStateResponse};
 use store_api::region_request::{
-    PathType, RegionCatchupRequest, RegionCloseRequest, RegionOpenRequest, RegionRequest,
+    PathType, RegionCatchupRequest, RegionCloseRequest, RegionCompactRequest, RegionOpenRequest,
+    RegionRequest,
 };
 use store_api::storage::{RegionId, ScanRequest};
 
@@ -43,6 +44,17 @@ use crate::wal::EntryId;
 fn get_last_entry_id(resp: SetRegionRoleStateResponse) -> Option<EntryId> {
     if let SetRegionRoleStateResponse::Success(success) = resp {
         success.last_entry_id()
+    } else {
+        unreachable!();
+    }
+}
+
+fn get_fences(resp: SetRegionRoleStateResponse) -> (EntryId, u64) {
+    if let SetRegionRoleStateResponse::Success(success) = resp {
+        (
+            success.last_entry_id().unwrap(),
+            success.manifest_version().unwrap(),
+        )
     } else {
         unreachable!();
     }
@@ -439,6 +451,16 @@ async fn test_catchup_with_manifest_update(factory: Option<LogStoreFactory>) {
     // Triggers to create a new manifest file.
     flush_region(&leader_engine, region_id, None).await;
 
+    let (expected_last_entry_id, expected_manifest_version) = get_fences(
+        leader_engine
+            .set_region_role_state_gracefully(
+                region_id,
+                store_api::region_engine::SettableRegionRoleState::Follower,
+            )
+            .await
+            .unwrap(),
+    );
+
     let region = follower_engine.get_region(region_id).unwrap();
     // Ensures the mutable is empty.
     assert!(region.version().memtables.mutable.is_empty());
@@ -446,11 +468,46 @@ async fn test_catchup_with_manifest_update(factory: Option<LogStoreFactory>) {
     let manifest = region.manifest_ctx.manifest().await;
     assert_eq!(manifest.manifest_version, 0);
 
+    let err = follower_engine
+        .handle_request(
+            region_id,
+            RegionRequest::Catchup(RegionCatchupRequest {
+                set_writable: true,
+                manifest_version: Some(expected_manifest_version + 1),
+                entry_id: Some(expected_last_entry_id),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap_err();
+    assert!(!follower_engine.get_region(region_id).unwrap().is_writable());
+    assert!(err.retry_hint().is_retryable());
+
+    let err = follower_engine
+        .handle_request(
+            region_id,
+            RegionRequest::Catchup(RegionCatchupRequest {
+                set_writable: true,
+                manifest_version: Some(expected_manifest_version),
+                entry_id: Some(expected_last_entry_id + 1),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap_err();
+    assert!(!follower_engine.get_region(region_id).unwrap().is_writable());
+    assert_matches!(
+        err.as_any().downcast_ref::<Error>(),
+        Some(Error::Unexpected { .. })
+    );
+
     let resp = follower_engine
         .handle_request(
             region_id,
             RegionRequest::Catchup(RegionCatchupRequest {
                 set_writable: false,
+                manifest_version: Some(expected_manifest_version),
+                entry_id: Some(expected_last_entry_id),
                 ..Default::default()
             }),
         )
@@ -460,7 +517,7 @@ async fn test_catchup_with_manifest_update(factory: Option<LogStoreFactory>) {
     // The inner region was replaced. We must get it again.
     let region = follower_engine.get_region(region_id).unwrap();
     let manifest = region.manifest_ctx.manifest().await;
-    assert_eq!(manifest.manifest_version, 2);
+    assert_eq!(manifest.manifest_version, expected_manifest_version);
     assert!(!region.is_writable());
 
     let request = ScanRequest::default();
@@ -487,6 +544,8 @@ async fn test_catchup_with_manifest_update(factory: Option<LogStoreFactory>) {
             region_id,
             RegionRequest::Catchup(RegionCatchupRequest {
                 set_writable: true,
+                manifest_version: Some(expected_manifest_version),
+                entry_id: Some(expected_last_entry_id),
                 ..Default::default()
             }),
         )
@@ -633,12 +692,34 @@ async fn test_local_catchup(factory: Option<LogStoreFactory>) {
     assert_eq!(start.unwrap(), 2);
     assert_eq!(end.unwrap(), 3);
 
+    let manifest_version = region.manifest_ctx.manifest_version().await;
+    let err = leader_engine
+        .handle_request(
+            region_id,
+            RegionRequest::Catchup(RegionCatchupRequest {
+                set_writable: true,
+                manifest_version: Some(manifest_version),
+                entry_id: Some(3),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap_err();
+    assert_matches!(
+        err.as_any().downcast_ref::<Error>(),
+        Some(Error::Unexpected { .. })
+    );
+    let region = leader_engine.get_region(region_id).unwrap();
+    assert!(!region.is_writable());
+    assert_eq!(region.version_control.current().last_entry_id, 1);
+
     // Try to catchup the region.
     let resp = leader_engine
         .handle_request(
             region_id,
             RegionRequest::Catchup(RegionCatchupRequest {
                 set_writable: true,
+                entry_id: Some(3),
                 ..Default::default()
             }),
         )
@@ -686,6 +767,85 @@ async fn test_local_catchup(factory: Option<LogStoreFactory>) {
 | 6     | 6.0     | 1970-01-01T00:00:06 |
 +-------+---------+---------------------+";
     assert_eq!(expected, batches.pretty_print().unwrap());
+}
+
+#[apply(single_raft_engine_log_store_factory)]
+async fn test_catchup_installs_compaction_manifest(factory: Option<LogStoreFactory>) {
+    use store_api::region_engine::SettableRegionRoleState;
+
+    let Some(factory) = factory else {
+        return;
+    };
+
+    let mut env = TestEnv::with_prefix("catchup_compaction_manifest")
+        .await
+        .with_log_store_factory(factory);
+    let leader_engine = env.create_engine(MitoConfig::default()).await;
+    let follower_engine = env.create_follower_engine(MitoConfig::default()).await;
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new()
+        .insert_option("compaction.type", "twcs")
+        .insert_option("compaction.twcs.trigger_file_num", "2")
+        .build();
+    let table_dir = request.table_dir.clone();
+    let column_schemas = rows_schema(&request);
+    leader_engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    for range in [0..3, 3..6, 6..9] {
+        put_rows(
+            &leader_engine,
+            region_id,
+            Rows {
+                schema: column_schemas.clone(),
+                rows: build_rows(range.start, range.end),
+            },
+        )
+        .await;
+        flush_region(&leader_engine, region_id, None).await;
+    }
+
+    open_region(&follower_engine, region_id, table_dir, true).await;
+    let follower_region = follower_engine.get_region(region_id).unwrap();
+    let manifest_version_before_compaction = follower_region.manifest_ctx.manifest_version().await;
+    let last_entry_id_before_compaction = follower_region.version_control.current().last_entry_id;
+
+    leader_engine
+        .handle_request(
+            region_id,
+            RegionRequest::Compact(RegionCompactRequest::default()),
+        )
+        .await
+        .unwrap();
+
+    let (expected_last_entry_id, expected_manifest_version) = get_fences(
+        leader_engine
+            .set_region_role_state_gracefully(region_id, SettableRegionRoleState::Follower)
+            .await
+            .unwrap(),
+    );
+    assert_eq!(expected_last_entry_id, last_entry_id_before_compaction);
+    assert!(expected_manifest_version > manifest_version_before_compaction);
+
+    follower_engine
+        .handle_request(
+            region_id,
+            RegionRequest::Catchup(RegionCatchupRequest {
+                set_writable: true,
+                manifest_version: Some(expected_manifest_version),
+                entry_id: Some(expected_last_entry_id),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+    let follower_region = follower_engine.get_region(region_id).unwrap();
+    assert!(follower_region.is_writable());
+    assert!(follower_region.manifest_ctx.manifest_version().await >= expected_manifest_version);
+    assert!(follower_region.version_control.current().last_entry_id >= expected_last_entry_id);
 }
 
 #[tokio::test]

--- a/src/mito2/src/engine/set_role_state_test.rs
+++ b/src/mito2/src/engine/set_role_state_test.rs
@@ -30,7 +30,10 @@ use crate::test_util::{CreateRequestBuilder, TestEnv, build_rows, put_rows, rows
 /// Helper function to assert a successful response with expected entry id
 fn assert_success_response(response: &SetRegionRoleStateResponse, expected_entry_id: u64) {
     match response {
-        SetRegionRoleStateResponse::Success(SetRegionRoleStateSuccess::Mito { last_entry_id }) => {
+        SetRegionRoleStateResponse::Success(SetRegionRoleStateSuccess::Mito {
+            last_entry_id,
+            ..
+        }) => {
             assert_eq!(*last_entry_id, expected_entry_id);
         }
         _ => panic!("Expected success response, got: {:?}", response),

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -1557,7 +1557,9 @@ impl ErrorExt for Error {
             | UpdateManifest { .. }
             | RegionStopped { .. }
             | RegionBusy { .. }
-            | FlushableRegionState { .. } => RetryHint::Retryable,
+            | FlushableRegionState { .. }
+            | NoManifests { .. }
+            | InstallManifestTo { .. } => RetryHint::Retryable,
 
             OpenDal { error, .. }
             | DeleteSsts { error, .. }

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -474,7 +474,7 @@ impl MitoRegion {
     pub(crate) async fn set_role_state_gracefully(
         &self,
         state: SettableRegionRoleState,
-    ) -> Result<()> {
+    ) -> Result<ManifestVersion> {
         let mut manager: RwLockWriteGuard<'_, RegionManifestManager> =
             self.manifest_ctx.manifest_manager.write().await;
         let current_state = self.state();
@@ -617,6 +617,7 @@ impl MitoRegion {
             }
         }
 
+        let manifest_version = manager.manifest().manifest_version;
         drop(manager);
 
         // Merge both payloads so consumers see the complete set of actions in
@@ -632,7 +633,7 @@ impl MitoRegion {
             pending.fire().await;
         }
 
-        Ok(())
+        Ok(manifest_version)
     }
 
     /// Switches the region state to `RegionRoleState::Leader(RegionLeaderState::Writable)` if the current state is `expect`.

--- a/src/mito2/src/region/catchup.rs
+++ b/src/mito2/src/region/catchup.rs
@@ -17,6 +17,7 @@ use std::time::Instant;
 
 use common_telemetry::{info, warn};
 use snafu::ensure;
+use store_api::ManifestVersion;
 use store_api::logstore::LogStore;
 
 use crate::error::{self, Result};
@@ -29,6 +30,7 @@ pub struct RegionCatchupTask<S> {
     entry_receiver: Option<WalEntryReceiver>,
     region: Arc<MitoRegion>,
     replay_checkpoint_entry_id: Option<u64>,
+    expected_manifest_version: Option<ManifestVersion>,
     expected_last_entry_id: Option<u64>,
     allow_stale_entries: bool,
     location_id: Option<u64>,
@@ -41,11 +43,21 @@ impl<S: LogStore> RegionCatchupTask<S> {
             entry_receiver: None,
             region,
             replay_checkpoint_entry_id: None,
+            expected_manifest_version: None,
             expected_last_entry_id: None,
             allow_stale_entries,
             location_id: None,
             wal,
         }
+    }
+
+    /// Sets the expected manifest version.
+    pub(crate) fn with_expected_manifest_version(
+        mut self,
+        expected_manifest_version: Option<ManifestVersion>,
+    ) -> Self {
+        self.expected_manifest_version = expected_manifest_version;
+        self
     }
 
     /// Sets the location id.
@@ -79,6 +91,21 @@ impl<S: LogStore> RegionCatchupTask<S> {
     }
 
     pub async fn run(&mut self) -> Result<()> {
+        if let Some(expected_manifest_version) = self.expected_manifest_version {
+            let installed_manifest_version = self.region.manifest_ctx.manifest_version().await;
+            ensure!(
+                installed_manifest_version >= expected_manifest_version,
+                error::UnexpectedSnafu {
+                    reason: format!(
+                        "Failed to catchup region {}, expected manifest version {}, installed {}",
+                        self.region.region_id,
+                        expected_manifest_version,
+                        installed_manifest_version,
+                    ),
+                }
+            );
+        }
+
         if self.region.provider.is_remote_wal() {
             self.remote_wal_catchup().await
         } else {
@@ -142,6 +169,20 @@ impl<S: LogStore> RegionCatchupTask<S> {
         let version = self.region.version_control.current();
         let mut flushed_entry_id = version.last_entry_id;
         let region_id = self.region.region_id;
+        // Without a manifest target, preserve the legacy rolling-upgrade behavior.
+        if self.expected_manifest_version.is_some()
+            && let Some(expected_last_entry_id) = self.expected_last_entry_id
+        {
+            ensure!(
+                flushed_entry_id >= expected_last_entry_id,
+                error::UnexpectedSnafu {
+                    reason: format!(
+                        "Failed to catchup region {}, expected manifest entry id {}, installed {}",
+                        region_id, expected_last_entry_id, flushed_entry_id,
+                    ),
+                }
+            );
+        }
         let latest_entry_id = self
             .wal
             .store()

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -1281,10 +1281,10 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             // We need to do this in background as we need the manifest lock.
             common_runtime::spawn_global(async move {
                 match region.set_role_state_gracefully(region_role_state).await {
-                    Ok(()) => {
+                    Ok(manifest_version) => {
                         let last_entry_id = region.version_control.current().last_entry_id;
                         let _ = sender.send(SetRegionRoleStateResponse::success(
-                            SetRegionRoleStateSuccess::mito(last_entry_id),
+                            SetRegionRoleStateSuccess::mito(last_entry_id, manifest_version),
                         ));
                     }
                     Err(e) => {

--- a/src/mito2/src/worker/handle_catchup.rs
+++ b/src/mito2/src/worker/handle_catchup.rs
@@ -56,8 +56,10 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             return;
         }
 
-        // If the memtable is not empty or the manifest has been updated, we need to reopen the region.
-        let region = match self.reopen_region_if_needed(region).await {
+        let region = match self
+            .prepare_region_for_catchup(region, request.manifest_version)
+            .await
+        {
             Ok(region) => region,
             Err(e) => {
                 sender.send(Err(e));
@@ -72,6 +74,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         common_runtime::spawn_global(async move {
             let mut task = RegionCatchupTask::new(region.clone(), wal, allow_stale_entries)
                 .with_entry_receiver(entry_receiver)
+                .with_expected_manifest_version(request.manifest_version)
                 .with_expected_last_entry_id(request.entry_id)
                 .with_location_id(request.location_id)
                 .with_replay_checkpoint_entry_id(request.checkpoint.map(|c| c.entry_id));
@@ -98,6 +101,21 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                 }
             }
         });
+    }
+
+    async fn prepare_region_for_catchup(
+        &mut self,
+        region: Arc<MitoRegion>,
+        manifest_version: Option<store_api::ManifestVersion>,
+    ) -> Result<Arc<MitoRegion>> {
+        if let Some(manifest_version) = manifest_version {
+            self.install_region_manifest(&region, manifest_version)
+                .await?;
+            Ok(region)
+        } else {
+            // A missing target version indicates a rolling-upgrade migration.
+            self.reopen_region_if_needed(region).await
+        }
     }
 
     /// Reopens a region.

--- a/src/mito2/src/worker/handle_manifest.rs
+++ b/src/mito2/src/worker/handle_manifest.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 use common_telemetry::{debug, info, warn};
 use parquet::file::metadata::PageIndexPolicy;
 use snafu::ResultExt;
+use store_api::ManifestVersion;
 use store_api::logstore::LogStore;
 use store_api::metadata::RegionMetadataRef;
 use store_api::storage::RegionId;
@@ -39,7 +40,7 @@ use crate::metrics::WRITE_CACHE_INFLIGHT_DOWNLOAD;
 use crate::region::opener::{sanitize_region_options, version_builder_from_manifest};
 use crate::region::options::RegionOptions;
 use crate::region::version::VersionControlRef;
-use crate::region::{MitoRegionRef, RegionLeaderState, RegionRoleState};
+use crate::region::{MitoRegion, MitoRegionRef, RegionLeaderState, RegionRoleState};
 use crate::request::{
     BackgroundNotify, BuildIndexRequest, OptionOutputTx, RegionChangeResult, RegionEditRequest,
     RegionEditResult, RegionSyncRequest, TruncateResult, WorkerRequest, WorkerRequestWithTime,
@@ -205,6 +206,60 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             .await;
     }
 
+    /// Installs a manifest version and rebuilds the in-memory region version.
+    ///
+    /// The installed version may be greater than `manifest_version`.
+    pub(crate) async fn install_region_manifest(
+        &mut self,
+        region: &Arc<MitoRegion>,
+        manifest_version: ManifestVersion,
+    ) -> Result<ManifestVersion> {
+        let manifest = region
+            .manifest_ctx
+            .install_manifest_to(manifest_version)
+            .await?;
+        let version = region.version();
+        let mut region_options = version.options.clone();
+        let old_format = region_options.sst_format.unwrap_or_default();
+        sanitize_region_options(&manifest, &mut region_options);
+        if !version.memtables.is_empty() {
+            let current = region.version_control.current();
+            warn!(
+                "Region {} memtables is not empty, which should not happen, manifest version: {}, last entry id: {}",
+                region.region_id, manifest.manifest_version, current.last_entry_id
+            );
+        }
+
+        let memtable_builder = if old_format != region_options.sst_format.unwrap_or_default() {
+            Some(
+                self.memtable_builder_provider
+                    .builder_for_options(&region_options),
+            )
+        } else {
+            None
+        };
+        let new_mutable = Arc::new(
+            region
+                .version()
+                .memtables
+                .mutable
+                .new_with_part_duration(version.compaction_time_window, memtable_builder),
+        );
+        let metadata = manifest.metadata.clone();
+        let version_builder = version_builder_from_manifest(
+            &manifest,
+            metadata,
+            region.file_purger.clone(),
+            new_mutable,
+            region_options,
+        );
+        region
+            .version_control
+            .overwrite_current(Arc::new(version_builder.build()));
+
+        Ok(manifest.manifest_version)
+    }
+
     /// Handles region sync request.
     ///
     /// Updates the manifest to at least the given version.
@@ -221,62 +276,18 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         };
 
         let original_manifest_version = region.manifest_ctx.manifest_version().await;
-        let manifest = match region
-            .manifest_ctx
-            .install_manifest_to(request.manifest_version)
+        let installed_manifest_version = match self
+            .install_region_manifest(&region, request.manifest_version)
             .await
         {
-            Ok(manifest) => manifest,
+            Ok(manifest_version) => manifest_version,
             Err(e) => {
                 let _ = sender.send(Err(e));
                 return;
             }
         };
-        let version = region.version();
-        let mut region_options = version.options.clone();
-        let old_format = region_options.sst_format.unwrap_or_default();
-        // Updates the region options with the manifest.
-        sanitize_region_options(&manifest, &mut region_options);
-        if !version.memtables.is_empty() {
-            let current = region.version_control.current();
-            warn!(
-                "Region {} memtables is not empty, which should not happen, manifest version: {}, last entry id: {}",
-                region.region_id, manifest.manifest_version, current.last_entry_id
-            );
-        }
-
-        // We should sanitize the region options before creating a new memtable.
-        let memtable_builder = if old_format != region_options.sst_format.unwrap_or_default() {
-            // Format changed, also needs to replace the memtable builder.
-            Some(
-                self.memtable_builder_provider
-                    .builder_for_options(&region_options),
-            )
-        } else {
-            None
-        };
-        let new_mutable = Arc::new(
-            region
-                .version()
-                .memtables
-                .mutable
-                .new_with_part_duration(version.compaction_time_window, memtable_builder),
-        );
-        // Here it assumes the leader has backfilled the partition_expr of the metadata.
-        let metadata = manifest.metadata.clone();
-
-        let version_builder = version_builder_from_manifest(
-            &manifest,
-            metadata,
-            region.file_purger.clone(),
-            new_mutable,
-            region_options,
-        );
-        let version = version_builder.build();
-        region.version_control.overwrite_current(Arc::new(version));
-
-        let updated = manifest.manifest_version > original_manifest_version;
-        let _ = sender.send(Ok((manifest.manifest_version, updated)));
+        let updated = installed_manifest_version > original_manifest_version;
+        let _ = sender.send(Ok((installed_manifest_version, updated)));
     }
 }
 

--- a/src/store-api/src/region_engine.rs
+++ b/src/store-api/src/region_engine.rs
@@ -33,6 +33,7 @@ use futures::future::join_all;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Semaphore;
 
+use crate::ManifestVersion;
 use crate::logstore::entry;
 use crate::metadata::RegionMetadataRef;
 use crate::region_request::{
@@ -86,10 +87,13 @@ pub enum SetRegionRoleStateSuccess {
     File,
     Mito {
         last_entry_id: entry::Id,
+        manifest_version: ManifestVersion,
     },
     Metric {
         last_entry_id: entry::Id,
+        manifest_version: ManifestVersion,
         metadata_last_entry_id: entry::Id,
+        metadata_manifest_version: ManifestVersion,
     },
 }
 
@@ -99,16 +103,26 @@ impl SetRegionRoleStateSuccess {
         Self::File
     }
 
-    /// Returns a [SetRegionRoleStateSuccess::Mito] with the `last_entry_id`.
-    pub fn mito(last_entry_id: entry::Id) -> Self {
-        SetRegionRoleStateSuccess::Mito { last_entry_id }
+    /// Returns a [SetRegionRoleStateSuccess::Mito].
+    pub fn mito(last_entry_id: entry::Id, manifest_version: ManifestVersion) -> Self {
+        SetRegionRoleStateSuccess::Mito {
+            last_entry_id,
+            manifest_version,
+        }
     }
 
-    /// Returns a [SetRegionRoleStateSuccess::Metric] with the `last_entry_id` and `metadata_last_entry_id`.
-    pub fn metric(last_entry_id: entry::Id, metadata_last_entry_id: entry::Id) -> Self {
+    /// Returns a [SetRegionRoleStateSuccess::Metric].
+    pub fn metric(
+        last_entry_id: entry::Id,
+        manifest_version: ManifestVersion,
+        metadata_last_entry_id: entry::Id,
+        metadata_manifest_version: ManifestVersion,
+    ) -> Self {
         SetRegionRoleStateSuccess::Metric {
             last_entry_id,
+            manifest_version,
             metadata_last_entry_id,
+            metadata_manifest_version,
         }
     }
 }
@@ -118,8 +132,21 @@ impl SetRegionRoleStateSuccess {
     pub fn last_entry_id(&self) -> Option<entry::Id> {
         match self {
             SetRegionRoleStateSuccess::File => None,
-            SetRegionRoleStateSuccess::Mito { last_entry_id } => Some(*last_entry_id),
+            SetRegionRoleStateSuccess::Mito { last_entry_id, .. } => Some(*last_entry_id),
             SetRegionRoleStateSuccess::Metric { last_entry_id, .. } => Some(*last_entry_id),
+        }
+    }
+
+    /// Returns the manifest version of the region.
+    pub fn manifest_version(&self) -> Option<ManifestVersion> {
+        match self {
+            SetRegionRoleStateSuccess::File => None,
+            SetRegionRoleStateSuccess::Mito {
+                manifest_version, ..
+            }
+            | SetRegionRoleStateSuccess::Metric {
+                manifest_version, ..
+            } => Some(*manifest_version),
         }
     }
 
@@ -132,6 +159,17 @@ impl SetRegionRoleStateSuccess {
                 metadata_last_entry_id,
                 ..
             } => Some(*metadata_last_entry_id),
+        }
+    }
+
+    /// Returns the manifest version of the metadata region.
+    pub fn metadata_manifest_version(&self) -> Option<ManifestVersion> {
+        match self {
+            SetRegionRoleStateSuccess::File | SetRegionRoleStateSuccess::Mito { .. } => None,
+            SetRegionRoleStateSuccess::Metric {
+                metadata_manifest_version,
+                ..
+            } => Some(*metadata_manifest_version),
         }
     }
 }

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -52,7 +52,6 @@ use crate::metadata::{
     RegionMetadata, Result, UnexpectedSnafu,
 };
 use crate::metric_engine_consts::PHYSICAL_TABLE_METADATA_KEY;
-use crate::metrics;
 use crate::mito_engine_options::{
     APPEND_MODE_KEY, AUTO_FLUSH_INTERVAL_KEY, MAX_ROW_GROUP_ROW_COUNT,
     MAX_ROW_GROUP_ROW_COUNT_LIMIT, SST_FORMAT_KEY, TTL_KEY, TWCS_MAX_OUTPUT_FILE_SIZE,
@@ -60,6 +59,7 @@ use crate::mito_engine_options::{
 };
 use crate::path_utils::table_dir;
 use crate::storage::{ColumnId, RegionId, ScanRequest};
+use crate::{ManifestVersion, metrics};
 
 /// The type of path to generate.
 #[derive(Debug, Clone, Copy, PartialEq, TryFromPrimitive)]
@@ -1605,6 +1605,10 @@ pub enum RegionTruncateRequest {
 pub struct RegionCatchupRequest {
     /// Sets it to writable if it's available after it has caught up with all changes.
     pub set_writable: bool,
+    /// The minimum manifest version that must be installed before promotion.
+    pub manifest_version: Option<ManifestVersion>,
+    /// The minimum manifest version for the metric metadata region.
+    pub metadata_manifest_version: Option<ManifestVersion>,
     /// The `entry_id` that was expected to reply to.
     /// `None` stands replaying to latest.
     pub entry_id: Option<entry::Id>,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

N/A

## What's changed and what's your intention?

Region migration previously fenced candidate promotion only by WAL entry ID. That is insufficient because compaction and index metadata publication advance the manifest without advancing WAL. A candidate could therefore become writable with stale persisted region state.

This PR adds an explicit manifest-version fence:

- Graceful leader downgrade returns the final manifest version captured while holding the Mito manifest write lock. Metric regions return independent data and metadata fences.
- Migration instructions carry the target versions to the candidate. Catchup directly installs the requested manifest and requires both the manifest and WAL entry fences before promotion. Local WAL progress cannot satisfy a fence using the candidate's own latest entry ID.
- Metric catchup first validates both physical regions while they remain followers, then promotes them only after both fences pass.
- Missing manifest fields preserve the legacy path for rolling upgrades. The new JSON fields are optional and have compatibility tests.

The internal `SetRegionRoleStateSuccess` and `RegionCatchupRequest` Rust APIs now carry manifest versions. There is no schema or persisted-data format change.

Validation:

- `cargo nextest run -p common-meta instruction` (17 passed)
- `cargo nextest run -p mito2 catchup` (10 passed)
- `cargo nextest run -p meta-srv region_migration` (92 passed)
- `cargo nextest run -p datanode downgrade_region` (9 passed)
- `cargo nextest run -p datanode upgrade_region` (5 passed)
- `cargo nextest run -p metric-engine` (95 passed)
- `make fmt`
- `cargo fmt --all -- --check`
- `make clippy`

The Kafka-parameterized catchup cases require `GT_KAFKA_ENDPOINTS`; no external Kafka broker was configured for this local run.

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
