### PR TITLE
feat(mito2): support cancelling flush jobs

### DIFF
--- a/src/mito2/src/compaction.rs
+++ b/src/mito2/src/compaction.rs
@@ -32,9 +32,7 @@ use common_telemetry::{debug, error};
 use common_time::TimeToLive;
 use common_time::range::TimestampRange;
 pub use scheduler::CompactionRequest;
-pub(crate) use scheduler::{
-    CompactionExecution, CompactionPickFinished, CompactionScheduler, LocalCompactionState,
-};
+pub(crate) use scheduler::{CompactionExecution, CompactionPickFinished, CompactionScheduler};
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use store_api::storage::RegionId;

--- a/src/mito2/src/compaction/compactor.rs
+++ b/src/mito2/src/compaction/compactor.rs
@@ -52,7 +52,7 @@ use crate::region::version::VersionRef;
 use crate::region::{ManifestContext, RegionLeaderState, RegionRoleState};
 use crate::schedule::scheduler::LocalScheduler;
 use crate::sst::FormatType;
-use crate::sst::file::FileMeta;
+use crate::sst::file::{FileMeta, UncommittedSsts};
 use crate::sst::file_purger::LocalFilePurger;
 use crate::sst::index::intermediate::IntermediateManager;
 use crate::sst::index::puffin_manager::PuffinManagerFactory;
@@ -547,6 +547,7 @@ impl SstMerger for DefaultSstMerger {
 pub struct DefaultCompactor<M = DefaultSstMerger> {
     merger: M,
     cancel_handle: Arc<CancellationHandle>,
+    uncommitted: Option<UncommittedSsts>,
 }
 
 #[cfg(test)]
@@ -555,15 +556,20 @@ impl<M: SstMerger> DefaultCompactor<M> {
         Self {
             merger,
             cancel_handle: Arc::new(CancellationHandle::default()),
+            uncommitted: None,
         }
     }
 }
 
 impl DefaultCompactor {
-    pub fn with_cancel_handle(cancel_handle: Arc<CancellationHandle>) -> Self {
+    pub(crate) fn with_cancel_handle(
+        cancel_handle: Arc<CancellationHandle>,
+        uncommitted: UncommittedSsts,
+    ) -> Self {
         Self {
             merger: DefaultSstMerger,
             cancel_handle,
+            uncommitted: Some(uncommitted),
         }
     }
 }
@@ -596,10 +602,15 @@ where
             };
             let merger = self.merger.clone();
             let compaction_region = compaction_region.clone();
+            let uncommitted = self.uncommitted.clone();
             let fut = async move {
-                merger
+                let result = merger
                     .merge_single_output(compaction_region, output, write_opts)
-                    .await
+                    .await;
+                if let (Some(uncommitted), Ok((_, infos))) = (&uncommitted, &result) {
+                    uncommitted.track(infos);
+                }
+                result
             };
             tasks.push((inputs_to_remove, fut));
         }
@@ -627,9 +638,9 @@ where
                 })
                 .collect();
 
-            while let Some((inputs, handle)) = spawned.pop() {
+            while let Some((inputs, mut handle)) = spawned.pop() {
                 let abort_handle = handle.abort_handle();
-                match CancellableFuture::new(handle, self.cancel_handle.clone()).await {
+                match CancellableFuture::new(&mut handle, self.cancel_handle.clone()).await {
                     Ok(Ok(Ok((files, infos)))) => {
                         output_files.extend(files);
                         if hook.is_some() {
@@ -655,8 +666,11 @@ where
                         // cancel the remaining tasks before returns the error.
                         if self.cancel_handle.is_cancelled() {
                             abort_handle.abort();
-                            for (_, handle) in spawned {
+                            for (_, handle) in &spawned {
                                 handle.abort();
+                            }
+                            for (_, handle) in spawned {
+                                let _ = handle.await;
                             }
                         }
                         return Err(e).context(error::JoinSnafu);
@@ -668,8 +682,12 @@ where
                             spawned.len(),
                         );
                         abort_handle.abort();
-                        for (_, handle) in spawned {
+                        for (_, handle) in &spawned {
                             handle.abort();
+                        }
+                        let _ = handle.await;
+                        for (_, handle) in spawned {
+                            let _ = handle.await;
                         }
                         break;
                     }
@@ -1004,6 +1022,7 @@ mod tests {
                 call_idx: call_idx.clone(),
             },
             cancel_handle: cancel_handle.clone(),
+            uncommitted: None,
         };
 
         let picker_output = PickerOutput {

--- a/src/mito2/src/compaction/scheduler.rs
+++ b/src/mito2/src/compaction/scheduler.rs
@@ -26,8 +26,8 @@ use common_telemetry::{debug, error, info};
 use common_time::range::TimestampRange;
 pub(crate) use planning::CompactionPickFinished;
 pub use planning::CompactionRequest;
-use state::{ActiveCompaction, CompactionStatus, PendingCompaction, RequestCancelResult};
-pub(crate) use state::{CompactionExecution, LocalCompactionState};
+pub(crate) use state::CompactionExecution;
+use state::{ActiveCompaction, CompactionStatus, PendingCompaction};
 use store_api::storage::RegionId;
 use tokio::sync::mpsc::Sender;
 
@@ -43,6 +43,7 @@ use crate::error::{
 use crate::region::version::VersionControlRef;
 use crate::region::{ManifestContextRef, RegionLeaderState, RegionRoleState};
 use crate::request::{DdlRequest, OptionOutputTx, SenderDdlRequest, WorkerRequestWithTime};
+use crate::schedule::RequestCancelResult;
 use crate::schedule::scheduler::SchedulerRef;
 use crate::worker::WorkerListener;
 

--- a/src/mito2/src/compaction/scheduler/planning.rs
+++ b/src/mito2/src/compaction/scheduler/planning.rs
@@ -54,7 +54,7 @@ use crate::request::{
 use crate::schedule::remote_job_scheduler::{
     CompactionJob, DefaultNotifier, RemoteJob, RemoteJobSchedulerRef,
 };
-use crate::sst::file::FileHandle;
+use crate::sst::file::{FileHandle, UncommittedSsts};
 use crate::sst::version::SstVersion;
 use crate::worker::WorkerListener;
 
@@ -529,6 +529,11 @@ impl CompactionScheduler {
         let cancel_handle = Arc::new(CancellationHandle::default());
         let state = LocalCompactionState::new(cancel_handle.clone());
         let execution = CompactionExecution::new(plan_id, files);
+        let uncommitted = UncommittedSsts::new(
+            region_id,
+            compaction_region.access_layer.clone(),
+            Some(compaction_region.cache_manager.clone()),
+        );
         let local_compaction_task = Box::new(CompactionTaskImpl {
             state: state.clone(),
             execution: execution.clone(),
@@ -538,10 +543,14 @@ impl CompactionScheduler {
             listener: self.listener.clone(),
             picker_output,
             compaction_region,
-            compactor: Arc::new(DefaultCompactor::with_cancel_handle(cancel_handle.clone())),
+            compactor: Arc::new(DefaultCompactor::with_cancel_handle(
+                cancel_handle.clone(),
+                uncommitted.clone(),
+            )),
             memory_manager: self.memory_manager.clone(),
             memory_policy: self.memory_policy,
             estimated_memory_bytes: estimated_bytes,
+            uncommitted,
         });
 
         match self.submit_compaction_task(local_compaction_task, region_id) {

--- a/src/mito2/src/compaction/scheduler/planning.rs
+++ b/src/mito2/src/compaction/scheduler/planning.rs
@@ -19,7 +19,6 @@ use std::time::Instant;
 
 use api::v1::region::compact_request;
 use common_base::Plugins;
-use common_base::cancellation::CancellationHandle;
 use common_meta::key::SchemaMetadataManagerRef;
 use common_telemetry::{debug, error, info, warn};
 use common_time::TimeToLive;
@@ -35,7 +34,7 @@ use crate::compaction::compactor::{CompactionRegion, CompactionVersion, DefaultC
 use crate::compaction::picker::{CompactionTask, PickerOutput, new_picker};
 use crate::compaction::scheduler::CompactionScheduler;
 use crate::compaction::scheduler::state::{
-    CompactingFiles, CompactionExecution, CompactionPhase, CompactionStatus, LocalCompactionState,
+    CompactingFiles, CompactionExecution, CompactionPhase, CompactionStatus,
 };
 use crate::compaction::task::CompactionTaskImpl;
 use crate::compaction::{CompactionOutput, find_dynamic_options};
@@ -51,6 +50,7 @@ use crate::region::options::RegionOptions;
 use crate::request::{
     BackgroundNotify, OutputTx, SenderDdlRequest, WorkerRequest, WorkerRequestWithTime,
 };
+use crate::schedule::CancellableTaskState;
 use crate::schedule::remote_job_scheduler::{
     CompactionJob, DefaultNotifier, RemoteJob, RemoteJobSchedulerRef,
 };
@@ -526,8 +526,8 @@ impl CompactionScheduler {
             return Ok(None);
         }
 
-        let cancel_handle = Arc::new(CancellationHandle::default());
-        let state = LocalCompactionState::new(cancel_handle.clone());
+        let state = CancellableTaskState::new();
+        let cancel_handle = state.cancel_handle();
         let execution = CompactionExecution::new(plan_id, files);
         let uncommitted = UncommittedSsts::new(
             region_id,

--- a/src/mito2/src/compaction/scheduler/state.rs
+++ b/src/mito2/src/compaction/scheduler/state.rs
@@ -13,11 +13,10 @@
 // limitations under the License.
 
 use std::collections::HashSet;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Instant;
 
 use api::v1::region::compact_request;
-use common_base::cancellation::CancellationHandle;
 use common_meta::key::SchemaMetadataManagerRef;
 use common_telemetry::debug;
 use common_time::range::TimestampRange;
@@ -37,6 +36,7 @@ use crate::error::{
 use crate::region::ManifestContextRef;
 use crate::region::version::VersionControlRef;
 use crate::request::{OptionOutputTx, OutputTx, SenderDdlRequest, WorkerRequestWithTime};
+use crate::schedule::{CancellableTaskState, RequestCancelResult};
 use crate::sst::file::FileHandle;
 use crate::worker::WorkerListener;
 
@@ -66,12 +66,6 @@ impl CompactionExecution {
     }
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct LocalCompactionState {
-    cancel_handle: Arc<CancellationHandle>,
-    commit_started: Arc<Mutex<bool>>,
-}
-
 #[derive(Debug)]
 pub(super) enum CompactionPhase {
     Picking {
@@ -79,7 +73,7 @@ pub(super) enum CompactionPhase {
         cancelled: bool,
     },
     Local {
-        state: LocalCompactionState,
+        state: CancellableTaskState,
         execution: CompactionExecution,
     },
     Remote {
@@ -239,57 +233,6 @@ impl Drop for CompactingFilesInner {
     }
 }
 
-impl LocalCompactionState {
-    pub(super) fn new(cancel_handle: Arc<CancellationHandle>) -> Self {
-        Self {
-            cancel_handle,
-            commit_started: Arc::new(Mutex::new(false)),
-        }
-    }
-
-    #[cfg(test)]
-    fn cancel_handle(&self) -> Arc<CancellationHandle> {
-        self.cancel_handle.clone()
-    }
-
-    /// Marks the compaction task as started to commit,
-    /// which means the compaction task is in the final stage and is about to update region version and manifest.
-    /// It will reject cancellation request after this method is called.
-    ///
-    /// Returns true if this is the first time to mark commit started, false otherwise.
-    pub(crate) fn mark_commit_started(&self) -> bool {
-        let mut commit_started = self.commit_started.lock().unwrap();
-        if self.cancel_handle.is_cancelled() {
-            return false;
-        }
-        *commit_started = true;
-        true
-    }
-
-    /// Request cancellation for this compaction task.
-    pub(crate) fn request_cancel(&self) -> RequestCancelResult {
-        // The cancel handle must under the lock of `commit_started` to avoid racing between cancellation and commit.
-        let commit_started = self.commit_started.lock().unwrap();
-        if *commit_started {
-            return RequestCancelResult::TooLateToCancel;
-        }
-        if self.cancel_handle.is_cancelled() {
-            return RequestCancelResult::AlreadyCancelling;
-        }
-
-        self.cancel_handle.cancel();
-        RequestCancelResult::CancelIssued
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum RequestCancelResult {
-    CancelIssued,
-    AlreadyCancelling,
-    TooLateToCancel,
-    NotRunning,
-}
-
 /// Status of running and pending region compaction tasks.
 pub(super) struct CompactionStatus {
     /// Id of the region.
@@ -391,8 +334,8 @@ impl CompactionStatus {
     }
 
     #[cfg(test)]
-    pub(super) fn start_local_task(&mut self) -> LocalCompactionState {
-        let state = LocalCompactionState::new(Arc::new(CancellationHandle::default()));
+    pub(super) fn start_local_task(&mut self) -> CancellableTaskState {
+        let state = CancellableTaskState::new();
         let execution = CompactionExecution::new(0, CompactingFiles::empty());
         let phase = CompactionPhase::Local {
             state: state.clone(),

--- a/src/mito2/src/compaction/scheduler/state.rs
+++ b/src/mito2/src/compaction/scheduler/state.rs
@@ -247,8 +247,8 @@ impl LocalCompactionState {
         }
     }
 
-    /// Returns the cancellation handle for this compaction task.
-    pub(crate) fn cancel_handle(&self) -> Arc<CancellationHandle> {
+    #[cfg(test)]
+    fn cancel_handle(&self) -> Arc<CancellationHandle> {
         self.cancel_handle.clone()
     }
 

--- a/src/mito2/src/compaction/task.rs
+++ b/src/mito2/src/compaction/task.rs
@@ -16,6 +16,7 @@ use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 use std::time::Instant;
 
+use common_base::cancellation::CancellableFuture;
 use common_memory_manager::OnExhaustedPolicy;
 use common_telemetry::{error, info, warn};
 use itertools::Itertools;
@@ -101,6 +102,15 @@ impl CompactionTaskImpl {
                 region_id,
                 policy: format!("{policy:?}"),
             })
+    }
+
+    fn cancelled_notify(&mut self) -> BackgroundNotify {
+        let senders = std::mem::take(&mut self.waiters);
+        BackgroundNotify::CompactionCancelled(CompactionCancelled {
+            region_id: self.compaction_region.region_id,
+            execution: self.execution.clone(),
+            senders,
+        })
     }
 
     /// Remove expired ssts files, update manifest immediately
@@ -284,9 +294,15 @@ impl CompactionTaskImpl {
 impl CompactionTask for CompactionTaskImpl {
     async fn run(&mut self) {
         // Acquire memory budget before starting compaction
-        let _memory_guard = match self.acquire_memory_with_policy().await {
-            Ok(guard) => guard,
-            Err(e) => {
+        let cancel_handle = self.state.cancel_handle();
+        let _memory_guard = match CancellableFuture::new(
+            self.acquire_memory_with_policy(),
+            cancel_handle,
+        )
+        .await
+        {
+            Ok(Ok(guard)) => guard,
+            Ok(Err(e)) => {
                 error!(e; "Failed to acquire memory for compaction, region id: {}", self.compaction_region.region_id);
                 let err = Arc::new(e);
                 self.on_failure(err.clone());
@@ -302,7 +318,31 @@ impl CompactionTask for CompactionTaskImpl {
                 .await;
                 return;
             }
+            Err(_) => {
+                info!(
+                    "Compaction cancelled while waiting for memory, region id: {}",
+                    self.compaction_region.region_id
+                );
+                let notify = self.cancelled_notify();
+                self.send_to_worker(WorkerRequest::Background {
+                    region_id: self.compaction_region.region_id,
+                    notify,
+                })
+                .await;
+                return;
+            }
         };
+
+        // Cancellation may be requested immediately after memory acquisition completes.
+        if self.state.is_cancelled() {
+            let notify = self.cancelled_notify();
+            self.send_to_worker(WorkerRequest::Background {
+                region_id: self.compaction_region.region_id,
+                notify,
+            })
+            .await;
+            return;
+        }
 
         self.handle_expiration().await;
 
@@ -314,19 +354,14 @@ impl CompactionTask for CompactionTaskImpl {
                 // Stop accepting cancellation once we are about to publish the compaction edit.
                 if !self.state.mark_commit_started() {
                     self.uncommitted.cleanup().await;
-                    let senders = std::mem::take(&mut self.waiters);
-                    BackgroundNotify::CompactionCancelled(CompactionCancelled {
-                        region_id: self.compaction_region.region_id,
-                        execution: self.execution.clone(),
-                        senders,
-                    })
+                    self.cancelled_notify()
                 } else {
                     self.listener
                         .on_compaction_commit_begin(self.compaction_region.region_id)
                         .await;
                     match self.update_manifest(merge_output).await {
                         Ok((edit, _manifest_version)) => {
-                            self.uncommitted.commit();
+                            self.uncommitted.disarm_cleanup();
                             let senders = std::mem::take(&mut self.waiters);
                             BackgroundNotify::CompactionFinished(CompactionFinished {
                                 region_id: self.compaction_region.region_id,
@@ -337,8 +372,16 @@ impl CompactionTask for CompactionTaskImpl {
                             })
                         }
                         Err(e) => {
+                            if e.may_have_persisted_manifest_update() {
+                                self.uncommitted.disarm_cleanup();
+                            } else {
+                                info!(
+                                    "Cleaning uncommitted SSTs because the manifest update was not persisted, region: {}, job: compaction, error: {:?}",
+                                    self.compaction_region.region_id, e
+                                );
+                                self.uncommitted.cleanup().await;
+                            }
                             error!(e; "Failed to compact region, region id: {}", self.compaction_region.region_id);
-                            self.uncommitted.cleanup().await;
                             let err = Arc::new(e);
                             self.on_failure(err.clone());
                             BackgroundNotify::CompactionFailed(CompactionFailed {
@@ -374,10 +417,45 @@ impl CompactionTask for CompactionTaskImpl {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
+    use common_memory_manager::OnExhaustedPolicy;
     use store_api::storage::FileId;
 
+    use super::*;
+    use crate::compaction::memory_manager::new_compaction_memory_manager;
     use crate::compaction::picker::PickerOutput;
     use crate::compaction::test_util::new_file_handle;
+    use crate::schedule::RequestCancelResult;
+
+    #[tokio::test]
+    async fn test_memory_wait_observes_cancellation() {
+        let manager = Arc::new(new_compaction_memory_manager(1));
+        let _guard = manager.try_acquire(1).unwrap();
+        let state = CancellableTaskState::new();
+        let cancel_handle = state.cancel_handle();
+        let manager_for_waiter = manager.clone();
+        let waiter = tokio::spawn(async move {
+            CancellableFuture::new(
+                manager_for_waiter.acquire_with_policy(
+                    1,
+                    OnExhaustedPolicy::Wait {
+                        timeout: Duration::from_secs(30),
+                    },
+                ),
+                cancel_handle,
+            )
+            .await
+        });
+        tokio::task::yield_now().await;
+
+        assert_eq!(RequestCancelResult::CancelIssued, state.request_cancel());
+        let result = tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("memory wait did not observe cancellation")
+            .unwrap();
+        assert!(result.is_err());
+    }
 
     #[test]
     fn test_picker_output_with_expired_ssts() {

--- a/src/mito2/src/compaction/task.rs
+++ b/src/mito2/src/compaction/task.rs
@@ -333,17 +333,6 @@ impl CompactionTask for CompactionTaskImpl {
             }
         };
 
-        // Cancellation may be requested immediately after memory acquisition completes.
-        if self.state.is_cancelled() {
-            let notify = self.cancelled_notify();
-            self.send_to_worker(WorkerRequest::Background {
-                region_id: self.compaction_region.region_id,
-                notify,
-            })
-            .await;
-            return;
-        }
-
         self.handle_expiration().await;
 
         // The local compactor owns cancellation of its spawned merge tasks. Waiting for it to

--- a/src/mito2/src/compaction/task.rs
+++ b/src/mito2/src/compaction/task.rs
@@ -417,45 +417,10 @@ impl CompactionTask for CompactionTaskImpl {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
-    use common_memory_manager::OnExhaustedPolicy;
     use store_api::storage::FileId;
 
-    use super::*;
-    use crate::compaction::memory_manager::new_compaction_memory_manager;
     use crate::compaction::picker::PickerOutput;
     use crate::compaction::test_util::new_file_handle;
-    use crate::schedule::RequestCancelResult;
-
-    #[tokio::test]
-    async fn test_memory_wait_observes_cancellation() {
-        let manager = Arc::new(new_compaction_memory_manager(1));
-        let _guard = manager.try_acquire(1).unwrap();
-        let state = CancellableTaskState::new();
-        let cancel_handle = state.cancel_handle();
-        let manager_for_waiter = manager.clone();
-        let waiter = tokio::spawn(async move {
-            CancellableFuture::new(
-                manager_for_waiter.acquire_with_policy(
-                    1,
-                    OnExhaustedPolicy::Wait {
-                        timeout: Duration::from_secs(30),
-                    },
-                ),
-                cancel_handle,
-            )
-            .await
-        });
-        tokio::task::yield_now().await;
-
-        assert_eq!(RequestCancelResult::CancelIssued, state.request_cancel());
-        let result = tokio::time::timeout(Duration::from_secs(1), waiter)
-            .await
-            .expect("memory wait did not observe cancellation")
-            .unwrap();
-        assert!(result.is_err());
-    }
 
     #[test]
     fn test_picker_output_with_expired_ssts() {

--- a/src/mito2/src/compaction/task.rs
+++ b/src/mito2/src/compaction/task.rs
@@ -16,7 +16,6 @@ use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 use std::time::Instant;
 
-use common_base::cancellation::CancellableFuture;
 use common_memory_manager::OnExhaustedPolicy;
 use common_telemetry::{error, info, warn};
 use itertools::Itertools;
@@ -36,7 +35,7 @@ use crate::request::{
     BackgroundNotify, CompactionCancelled, CompactionFailed, CompactionFinished, OutputTx,
     RegionEditResult, Waiters, WorkerRequest, WorkerRequestWithTime,
 };
-use crate::sst::file::FileMeta;
+use crate::sst::file::{FileMeta, UncommittedSsts};
 use crate::worker::WorkerListener;
 use crate::{error, metrics};
 
@@ -67,6 +66,8 @@ pub(crate) struct CompactionTaskImpl {
     pub(crate) memory_policy: OnExhaustedPolicy,
     /// Estimated memory bytes needed for this compaction.
     pub(crate) estimated_memory_bytes: u64,
+    /// Finalized output SSTs not committed to the manifest yet.
+    pub(crate) uncommitted: UncommittedSsts,
 }
 
 impl Debug for CompactionTaskImpl {
@@ -304,18 +305,14 @@ impl CompactionTask for CompactionTaskImpl {
 
         self.handle_expiration().await;
 
-        let cancel_handle = self.state.cancel_handle();
-        // Run compaction with cooperative cancellation.
-        let notify = match CancellableFuture::new(
-            async { self.handle_compaction().await },
-            cancel_handle,
-        )
-        .await
-        {
-            Ok(Ok(merge_output)) => {
+        // The local compactor owns cancellation of its spawned merge tasks. Waiting for it to
+        // return ensures all finalized outputs are tracked before cleanup starts.
+        let notify = match self.handle_compaction().await {
+            Ok(merge_output) => {
                 self.invoke_sst_hook(&merge_output).await;
                 // Stop accepting cancellation once we are about to publish the compaction edit.
                 if !self.state.mark_commit_started() {
+                    self.uncommitted.cleanup().await;
                     let senders = std::mem::take(&mut self.waiters);
                     BackgroundNotify::CompactionCancelled(CompactionCancelled {
                         region_id: self.compaction_region.region_id,
@@ -328,6 +325,7 @@ impl CompactionTask for CompactionTaskImpl {
                         .await;
                     match self.update_manifest(merge_output).await {
                         Ok((edit, _manifest_version)) => {
+                            self.uncommitted.commit();
                             let senders = std::mem::take(&mut self.waiters);
                             BackgroundNotify::CompactionFinished(CompactionFinished {
                                 region_id: self.compaction_region.region_id,
@@ -339,6 +337,7 @@ impl CompactionTask for CompactionTaskImpl {
                         }
                         Err(e) => {
                             error!(e; "Failed to compact region, region id: {}", self.compaction_region.region_id);
+                            self.uncommitted.cleanup().await;
                             let err = Arc::new(e);
                             self.on_failure(err.clone());
                             BackgroundNotify::CompactionFailed(CompactionFailed {
@@ -350,20 +349,9 @@ impl CompactionTask for CompactionTaskImpl {
                     }
                 }
             }
-            Err(_) => {
-                info!(
-                    "Compaction cancelled, region id: {}",
-                    self.compaction_region.region_id
-                );
-                let senders = std::mem::take(&mut self.waiters);
-                BackgroundNotify::CompactionCancelled(CompactionCancelled {
-                    region_id: self.compaction_region.region_id,
-                    execution: self.execution.clone(),
-                    senders,
-                })
-            }
-            Ok(Err(e)) => {
+            Err(e) => {
                 error!(e; "Failed to compact region, region id: {}", self.compaction_region.region_id);
+                self.uncommitted.cleanup().await;
                 let err = Arc::new(e);
                 // notify compaction waiters
                 self.on_failure(err.clone());

--- a/src/mito2/src/compaction/task.rs
+++ b/src/mito2/src/compaction/task.rs
@@ -23,10 +23,10 @@ use snafu::ResultExt;
 use store_api::ManifestVersion;
 use tokio::sync::mpsc;
 
+use crate::compaction::CompactionExecution;
 use crate::compaction::compactor::{CompactionRegion, Compactor, MergeOutput};
 use crate::compaction::memory_manager::{CompactionMemoryGuard, CompactionMemoryManager};
 use crate::compaction::picker::{CompactionTask, PickerOutput};
-use crate::compaction::{CompactionExecution, LocalCompactionState};
 use crate::error::{CompactRegionSnafu, CompactionMemoryExhaustedSnafu};
 use crate::manifest::action::{RegionEdit, RegionMetaAction, RegionMetaActionList};
 use crate::metrics::{COMPACTION_FAILURE_COUNT, COMPACTION_MEMORY_WAIT, COMPACTION_STAGE_ELAPSED};
@@ -35,6 +35,7 @@ use crate::request::{
     BackgroundNotify, CompactionCancelled, CompactionFailed, CompactionFinished, OutputTx,
     RegionEditResult, Waiters, WorkerRequest, WorkerRequestWithTime,
 };
+use crate::schedule::CancellableTaskState;
 use crate::sst::file::{FileMeta, UncommittedSsts};
 use crate::worker::WorkerListener;
 use crate::{error, metrics};
@@ -44,7 +45,7 @@ pub const MAX_PARALLEL_COMPACTION: usize = 1;
 
 pub(crate) struct CompactionTaskImpl {
     /// Shared local-compaction state for cooperative cancellation.
-    pub(crate) state: LocalCompactionState,
+    pub(crate) state: CancellableTaskState,
     /// Identity and reservation lease of this accepted execution.
     pub(crate) execution: CompactionExecution,
     pub compaction_region: CompactionRegion,

--- a/src/mito2/src/engine/drop_test.rs
+++ b/src/mito2/src/engine/drop_test.rs
@@ -18,6 +18,8 @@ use std::time::Duration;
 
 use api::v1::Rows;
 use common_base::Plugins;
+use common_error::ext::ErrorExt;
+use common_error::status_code::StatusCode;
 use common_meta::key::SchemaMetadataManager;
 use common_meta::kv_backend::KvBackendRef;
 use object_store::util::join_path;
@@ -28,7 +30,7 @@ use store_api::storage::RegionId;
 use crate::config::MitoConfig;
 use crate::engine::MitoEngine;
 use crate::engine::flush_test::MockRegionHook;
-use crate::engine::listener::{DropListener, FlushTruncateListener};
+use crate::engine::listener::{DropListener, FlushCancellationListener};
 use crate::engine::region_hook::RegionHookRef;
 use crate::test_util::{
     CreateRequestBuilder, MockWriteBufferManager, TestEnv, build_rows_for_key, flush_region,
@@ -40,7 +42,7 @@ use crate::worker::DROPPING_MARKER_FILE;
 async fn test_drop_cancels_running_flush() {
     common_telemetry::init_default_ut_logging();
     let mut env = TestEnv::with_prefix("drop-during-flush").await;
-    let listener = Arc::new(FlushTruncateListener::default());
+    let listener = Arc::new(FlushCancellationListener::default());
     let engine = env
         .create_engine_with(
             MitoConfig::default(),
@@ -75,21 +77,31 @@ async fn test_drop_cancels_running_flush() {
             )
             .await
     });
-    listener.wait_truncate().await;
+    tokio::time::timeout(Duration::from_secs(5), listener.wait_flush_started())
+        .await
+        .expect("flush did not reach the cancellation gate");
 
-    engine
-        .handle_request(
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        engine.handle_request(
             region_id,
             RegionRequest::Drop(RegionDropRequest {
                 fast_path: false,
                 force: false,
                 partial_drop: false,
             }),
-        )
-        .await
-        .unwrap();
+        ),
+    )
+    .await
+    .expect("drop did not finish after cancelling flush")
+    .unwrap();
 
-    assert!(flush_task.await.unwrap().is_err());
+    let flush_err = tokio::time::timeout(Duration::from_secs(5), flush_task)
+        .await
+        .expect("cancelled flush did not finish")
+        .expect("flush task panicked")
+        .unwrap_err();
+    assert_eq!(flush_err.status_code(), StatusCode::Cancelled);
     assert!(engine.get_region(region_id).is_none());
 }
 

--- a/src/mito2/src/engine/drop_test.rs
+++ b/src/mito2/src/engine/drop_test.rs
@@ -22,18 +22,76 @@ use common_meta::key::SchemaMetadataManager;
 use common_meta::kv_backend::KvBackendRef;
 use object_store::util::join_path;
 use store_api::region_engine::RegionEngine;
-use store_api::region_request::{RegionDropRequest, RegionRequest};
+use store_api::region_request::{RegionDropRequest, RegionFlushRequest, RegionRequest};
 use store_api::storage::RegionId;
 
 use crate::config::MitoConfig;
 use crate::engine::MitoEngine;
 use crate::engine::flush_test::MockRegionHook;
-use crate::engine::listener::DropListener;
+use crate::engine::listener::{DropListener, FlushTruncateListener};
 use crate::engine::region_hook::RegionHookRef;
 use crate::test_util::{
-    CreateRequestBuilder, TestEnv, build_rows_for_key, flush_region, put_rows, rows_schema,
+    CreateRequestBuilder, MockWriteBufferManager, TestEnv, build_rows_for_key, flush_region,
+    put_rows, rows_schema,
 };
 use crate::worker::DROPPING_MARKER_FILE;
+
+#[tokio::test]
+async fn test_drop_cancels_running_flush() {
+    common_telemetry::init_default_ut_logging();
+    let mut env = TestEnv::with_prefix("drop-during-flush").await;
+    let listener = Arc::new(FlushTruncateListener::default());
+    let engine = env
+        .create_engine_with(
+            MitoConfig::default(),
+            Some(Arc::new(MockWriteBufferManager::default())),
+            Some(listener.clone()),
+            None,
+        )
+        .await;
+    let region_id = RegionId::new(100, 1);
+    let request = CreateRequestBuilder::new().build();
+    let rows = rows_schema(&request);
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+    put_rows(
+        &engine,
+        region_id,
+        Rows {
+            schema: rows,
+            rows: build_rows_for_key("a", 0, 2, 0),
+        },
+    )
+    .await;
+
+    let flush_engine = engine.clone();
+    let flush_task = tokio::spawn(async move {
+        flush_engine
+            .handle_request(
+                region_id,
+                RegionRequest::Flush(RegionFlushRequest::default()),
+            )
+            .await
+    });
+    listener.wait_truncate().await;
+
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Drop(RegionDropRequest {
+                fast_path: false,
+                force: false,
+                partial_drop: false,
+            }),
+        )
+        .await
+        .unwrap();
+
+    assert!(flush_task.await.unwrap().is_err());
+    assert!(engine.get_region(region_id).is_none());
+}
 
 #[tokio::test]
 async fn test_engine_drop_region() {

--- a/src/mito2/src/engine/drop_test.rs
+++ b/src/mito2/src/engine/drop_test.rs
@@ -23,8 +23,10 @@ use common_error::status_code::StatusCode;
 use common_meta::key::SchemaMetadataManager;
 use common_meta::kv_backend::KvBackendRef;
 use object_store::util::join_path;
-use store_api::region_engine::RegionEngine;
-use store_api::region_request::{RegionDropRequest, RegionFlushRequest, RegionRequest};
+use store_api::region_engine::{RegionEngine, RegionRole};
+use store_api::region_request::{
+    RegionDropRequest, RegionFlushReason, RegionFlushRequest, RegionRequest,
+};
 use store_api::storage::RegionId;
 
 use crate::config::MitoConfig;
@@ -103,6 +105,82 @@ async fn test_drop_cancels_running_flush() {
         .unwrap_err();
     assert_eq!(flush_err.status_code(), StatusCode::Cancelled);
     assert!(engine.get_region(region_id).is_none());
+}
+
+#[tokio::test]
+async fn test_drop_rejects_downgrading_region_without_cancelling_flush() {
+    common_telemetry::init_default_ut_logging();
+    let mut env = TestEnv::with_prefix("drop-during-downgrade-flush").await;
+    let listener = Arc::new(FlushCancellationListener::default());
+    let engine = env
+        .create_engine_with(
+            MitoConfig::default(),
+            Some(Arc::new(MockWriteBufferManager::default())),
+            Some(listener.clone()),
+            None,
+        )
+        .await;
+    let region_id = RegionId::new(101, 1);
+    let request = CreateRequestBuilder::new().build();
+    let rows = rows_schema(&request);
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+    put_rows(
+        &engine,
+        region_id,
+        Rows {
+            schema: rows,
+            rows: build_rows_for_key("a", 0, 2, 0),
+        },
+    )
+    .await;
+    engine
+        .set_region_role(region_id, RegionRole::DowngradingLeader)
+        .unwrap();
+
+    let flush_engine = engine.clone();
+    let flush_task = tokio::spawn(async move {
+        flush_engine
+            .handle_request(
+                region_id,
+                RegionRequest::Flush(RegionFlushRequest {
+                    reason: Some(RegionFlushReason::Downgrading),
+                    ..Default::default()
+                }),
+            )
+            .await
+    });
+    tokio::time::timeout(Duration::from_secs(5), listener.wait_flush_started())
+        .await
+        .expect("downgrade flush did not reach the cancellation gate");
+
+    let drop_err = tokio::time::timeout(
+        Duration::from_secs(5),
+        engine.handle_request(
+            region_id,
+            RegionRequest::Drop(RegionDropRequest {
+                fast_path: false,
+                force: false,
+                partial_drop: false,
+            }),
+        ),
+    )
+    .await
+    .expect("drop was not rejected while the downgrade flush was blocked")
+    .unwrap_err();
+    assert_eq!(drop_err.status_code(), StatusCode::RegionNotReady);
+    assert!(engine.get_region(region_id).is_some());
+    assert_eq!(engine.role(region_id), Some(RegionRole::DowngradingLeader));
+
+    listener.resume_flush();
+    let flush_result = tokio::time::timeout(Duration::from_secs(5), flush_task)
+        .await
+        .expect("downgrade flush did not finish")
+        .expect("downgrade flush task panicked")
+        .expect("downgrade flush was cancelled");
+    assert_eq!(flush_result.affected_rows, 0);
 }
 
 #[tokio::test]

--- a/src/mito2/src/engine/listener.rs
+++ b/src/mito2/src/engine/listener.rs
@@ -41,6 +41,12 @@ pub trait EventListener: Send + Sync {
         let _ = region_id;
     }
 
+    /// Notifies the listener after a flush becomes non-cancellable and before commit.
+    async fn on_flush_commit_begin(&self, _region_id: RegionId) {}
+
+    /// Notifies the listener after flush cancellation is requested and its DDL is queued.
+    fn on_flush_cancel_requested(&self, _region_id: RegionId) {}
+
     /// Notifies the listener that the later drop task starts running.
     /// Returns the gc interval if we want to override the default one.
     fn on_later_drop_begin(&self, region_id: RegionId) -> Option<Duration> {

--- a/src/mito2/src/engine/listener.rs
+++ b/src/mito2/src/engine/listener.rs
@@ -166,43 +166,32 @@ impl EventListener for StallListener {
     }
 }
 
-/// Listener to watch begin flush events.
+/// Blocks a flush at its begin event until the worker requests flush cancellation.
 ///
-/// Creates a background thread to execute flush region, and the main thread calls `wait_truncate()`
-/// to block and wait for `on_flush_region()`.
-/// When the background thread calls `on_flush_begin()`, the main thread is notified to truncate
-/// region, and background thread thread blocks and waits for `notify_flush()` to continue flushing.
+/// Tests use this gate to ensure a flush is active before submitting a lifecycle DDL.
 #[derive(Default)]
-pub struct FlushTruncateListener {
-    /// Notify flush operation.
-    notify_flush: Notify,
-    /// Notify truncate operation.
-    notify_truncate: Notify,
+pub struct FlushCancellationListener {
+    flush_started: Notify,
+    resume_flush: Notify,
 }
 
-impl FlushTruncateListener {
-    /// Notify flush region to proceed.
-    pub fn notify_flush(&self) {
-        self.notify_flush.notify_one();
-    }
-
-    /// Wait for a truncate event.
-    pub async fn wait_truncate(&self) {
-        self.notify_truncate.notified().await;
+impl FlushCancellationListener {
+    /// Waits until the flush reaches the cancellation gate.
+    pub async fn wait_flush_started(&self) {
+        self.flush_started.notified().await;
     }
 }
 
 #[async_trait]
-impl EventListener for FlushTruncateListener {
-    /// Calling this function will block the thread!
-    /// Notify the listener to perform a truncate region and block the flush region job.
+impl EventListener for FlushCancellationListener {
     async fn on_flush_begin(&self, region_id: RegionId) {
-        info!(
-            "Region {} begin do flush, notify region to truncate",
-            region_id
-        );
-        self.notify_truncate.notify_one();
-        self.notify_flush.notified().await;
+        info!("Region {} reached the flush cancellation gate", region_id);
+        self.flush_started.notify_one();
+        self.resume_flush.notified().await;
+    }
+
+    fn on_flush_cancel_requested(&self, _region_id: RegionId) {
+        self.resume_flush.notify_one();
     }
 }
 

--- a/src/mito2/src/engine/listener.rs
+++ b/src/mito2/src/engine/listener.rs
@@ -180,6 +180,11 @@ impl FlushCancellationListener {
     pub async fn wait_flush_started(&self) {
         self.flush_started.notified().await;
     }
+
+    /// Allows the blocked flush to continue.
+    pub fn resume_flush(&self) {
+        self.resume_flush.notify_one();
+    }
 }
 
 #[async_trait]
@@ -191,7 +196,7 @@ impl EventListener for FlushCancellationListener {
     }
 
     fn on_flush_cancel_requested(&self, _region_id: RegionId) {
-        self.resume_flush.notify_one();
+        self.resume_flush();
     }
 }
 

--- a/src/mito2/src/engine/truncate_test.rs
+++ b/src/mito2/src/engine/truncate_test.rs
@@ -14,8 +14,11 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use api::v1::Rows;
+use common_error::ext::ErrorExt;
+use common_error::status_code::StatusCode;
 use common_recordbatch::RecordBatches;
 use common_telemetry::{info, init_default_ut_logging};
 use store_api::region_engine::RegionEngine;
@@ -26,7 +29,7 @@ use store_api::storage::RegionId;
 
 use super::ScanRequest;
 use crate::config::MitoConfig;
-use crate::engine::listener::FlushTruncateListener;
+use crate::engine::listener::FlushCancellationListener;
 use crate::test_util::{
     CreateRequestBuilder, MockWriteBufferManager, TestEnv, build_rows, put_rows, rows_schema,
 };
@@ -350,7 +353,7 @@ async fn test_engine_truncate_during_flush_with_format(flat_format: bool) {
     init_default_ut_logging();
     let mut env = TestEnv::with_prefix("truncate-during-flush").await;
     let write_buffer_manager = Arc::new(MockWriteBufferManager::default());
-    let listener = Arc::new(FlushTruncateListener::default());
+    let listener = Arc::new(FlushCancellationListener::default());
     let engine = env
         .create_engine_with(
             MitoConfig {
@@ -399,23 +402,29 @@ async fn test_engine_truncate_during_flush_with_format(flat_format: bool) {
             .await
     });
 
-    // Wait truncate before flush memtable.
-    listener.wait_truncate().await;
+    // Ensure the flush is running before submitting truncate.
+    tokio::time::timeout(Duration::from_secs(5), listener.wait_flush_started())
+        .await
+        .expect("flush did not reach the cancellation gate");
 
-    // Truncate the region.
-    engine
-        .handle_request(
+    // Truncate cancels the flush, releases the listener gate, and runs after cancellation.
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        engine.handle_request(
             region_id,
             RegionRequest::Truncate(RegionTruncateRequest::All),
-        )
+        ),
+    )
+    .await
+    .expect("truncate did not finish after cancelling flush")
+    .unwrap();
+
+    let flush_err = tokio::time::timeout(Duration::from_secs(5), flush_task)
         .await
-        .unwrap();
-
-    // Notify region to continue flushing.
-    listener.notify_flush();
-
-    // Wait handle flushed finish.
-    let _err = flush_task.await.unwrap().unwrap_err();
+        .expect("cancelled flush did not finish")
+        .expect("flush task panicked")
+        .unwrap_err();
+    assert_eq!(flush_err.status_code(), StatusCode::Cancelled);
 
     // Check sequences and entry id.
     let version_data = region.version_control.current();

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -1663,7 +1663,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_manifest_update_persistence_for_opendal_errors() {
+    fn test_manifest_update_persistence() {
         let rejected_kinds = [
             ErrorKind::Unsupported,
             ErrorKind::ConfigInvalid,
@@ -1688,10 +1688,7 @@ mod tests {
         let error =
             OpenDalSnafu {}.into_error(object_store::Error::new(ErrorKind::Unexpected, "test"));
         assert!(error.may_have_persisted_manifest_update());
-    }
 
-    #[test]
-    fn test_manifest_update_persistence_for_mito_errors() {
         let region_id = RegionId::new(1, 1);
         let error = RegionTruncatedSnafu { region_id }.build();
         assert!(!error.may_have_persisted_manifest_update());

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -1160,6 +1160,9 @@ pub enum Error {
     #[snafu(display("Compaction is cancelled."))]
     CompactionCancelled {},
 
+    #[snafu(display("Flush is cancelled."))]
+    FlushCancelled {},
+
     #[snafu(display("Compaction memory exhausted for region {region_id} (policy: {policy})",))]
     CompactionMemoryExhausted {
         region_id: RegionId,
@@ -1514,7 +1517,9 @@ impl ErrorExt for Error {
             #[cfg(feature = "vector_index")]
             VectorIndexBuild { .. } | VectorIndexFinish { .. } => StatusCode::Internal,
 
-            ManualCompactionOverride {} | CompactionCancelled {} => StatusCode::Cancelled,
+            ManualCompactionOverride {} | CompactionCancelled {} | FlushCancelled {} => {
+                StatusCode::Cancelled
+            }
 
             CompactionMemoryExhausted { source, .. } => source.status_code(),
 

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -1359,6 +1359,36 @@ impl Error {
             _ => false,
         }
     }
+
+    /// Returns whether a failed manifest update may have been persisted.
+    ///
+    /// Unknown errors are treated conservatively because deleting output SSTs after an ambiguous
+    /// manifest write could leave the manifest referencing missing files.
+    pub(crate) fn may_have_persisted_manifest_update(&self) -> bool {
+        match self {
+            Error::UpdateManifest { .. }
+            | Error::RegionState { .. }
+            | Error::RegionTruncated { .. }
+            | Error::RegionStopped { .. }
+            | Error::SerdeJson { .. }
+            | Error::CompressObject { .. } => false,
+            Error::OpenDal { error, .. } => !matches!(
+                error.kind(),
+                ErrorKind::Unsupported
+                    | ErrorKind::ConfigInvalid
+                    | ErrorKind::NotFound
+                    | ErrorKind::PermissionDenied
+                    | ErrorKind::IsADirectory
+                    | ErrorKind::NotADirectory
+                    | ErrorKind::AlreadyExists
+                    | ErrorKind::RateLimited
+                    | ErrorKind::IsSameFile
+                    | ErrorKind::ConditionNotMatch
+                    | ErrorKind::RangeNotSatisfied
+            ),
+            _ => true,
+        }
+    }
 }
 
 impl ErrorExt for Error {
@@ -1623,5 +1653,51 @@ impl ErrorExt for Error {
 
             _ => RetryHint::NonRetryable,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use snafu::IntoError;
+
+    use super::*;
+
+    #[test]
+    fn test_manifest_update_persistence_for_opendal_errors() {
+        let rejected_kinds = [
+            ErrorKind::Unsupported,
+            ErrorKind::ConfigInvalid,
+            ErrorKind::NotFound,
+            ErrorKind::PermissionDenied,
+            ErrorKind::IsADirectory,
+            ErrorKind::NotADirectory,
+            ErrorKind::AlreadyExists,
+            ErrorKind::RateLimited,
+            ErrorKind::IsSameFile,
+            ErrorKind::ConditionNotMatch,
+            ErrorKind::RangeNotSatisfied,
+        ];
+        for kind in rejected_kinds {
+            let error = OpenDalSnafu {}.into_error(object_store::Error::new(kind, "test"));
+            assert!(
+                !error.may_have_persisted_manifest_update(),
+                "error kind {kind:?} should prove the manifest was not persisted"
+            );
+        }
+
+        let error =
+            OpenDalSnafu {}.into_error(object_store::Error::new(ErrorKind::Unexpected, "test"));
+        assert!(error.may_have_persisted_manifest_update());
+    }
+
+    #[test]
+    fn test_manifest_update_persistence_for_mito_errors() {
+        let region_id = RegionId::new(1, 1);
+        let error = RegionTruncatedSnafu { region_id }.build();
+        assert!(!error.may_have_persisted_manifest_update());
+
+        // This can be raised while applying an edit after its manifest file was saved.
+        let error = RegionMetadataNotFoundSnafu {}.build();
+        assert!(error.may_have_persisted_manifest_update());
     }
 }

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -2058,38 +2058,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_uncommitted_ssts_disarm_cleanup() {
-        let env = SchedulerEnv::new().await;
-        let region_id = RegionId::new(1, 1);
-        let file_id = store_api::storage::FileId::random();
-        let path = crate::sst::location::sst_file_path(
-            env.access_layer.table_dir(),
-            crate::sst::file::RegionFileId::new(region_id, file_id),
-            env.access_layer.path_type(),
-        );
-        env.access_layer
-            .object_store()
-            .write(&path, Bytes::from_static(b"sst"))
-            .await
-            .unwrap();
-
-        let uncommitted = UncommittedSsts::new(region_id, env.access_layer.clone(), None);
-        uncommitted.track(&[SstInfo {
-            file_id,
-            ..Default::default()
-        }]);
-        uncommitted.disarm_cleanup();
-        assert_eq!(0, uncommitted.num_tracked_files());
-        uncommitted.cleanup_for_test().await.unwrap();
-
-        env.access_layer
-            .object_store()
-            .read(&path)
-            .await
-            .expect("disarmed cleanup deleted the SST");
-    }
-
-    #[tokio::test]
     async fn test_region_closed_notifies_pending_bulk_writes() {
         let region_id = RegionId::new(1, 1);
         let version_control = Arc::new(VersionControlBuilder::new().build());

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -1379,16 +1379,15 @@ impl FlushScheduler {
         None
     }
 
-    /// Notifies the scheduler that the flush job is failed.
+    /// Notifies the scheduler that the flush job failed.
+    ///
+    /// Returns pending drop and truncate requests in their original order. All other pending
+    /// requests are failed with `err`.
     pub(crate) fn on_flush_failed(
         &mut self,
         region_id: RegionId,
         err: Arc<Error>,
-    ) -> Option<(
-        Vec<SenderDdlRequest>,
-        Vec<SenderWriteRequest>,
-        Vec<SenderBulkRequest>,
-    )> {
+    ) -> Vec<SenderDdlRequest> {
         if matches!(err.as_ref(), Error::FlushCancelled { .. }) {
             info!("Region {} flush was cancelled", region_id);
         } else {
@@ -1397,7 +1396,9 @@ impl FlushScheduler {
         }
 
         // Remove this region.
-        let flush_status = self.region_status.remove(&region_id)?;
+        let Some(flush_status) = self.region_status.remove(&region_id) else {
+            return Vec::new();
+        };
 
         flush_status.on_failure(err)
     }
@@ -1567,14 +1568,8 @@ impl FlushStatus {
             .any(|ddl| matches!(ddl.request, DdlRequest::Drop(_) | DdlRequest::Truncate(_)))
     }
 
-    fn on_failure(
-        self,
-        err: Arc<Error>,
-    ) -> Option<(
-        Vec<SenderDdlRequest>,
-        Vec<SenderWriteRequest>,
-        Vec<SenderBulkRequest>,
-    )> {
+    /// Fails pending requests except drop and truncate, which the worker must revalidate.
+    fn on_failure(self, err: Arc<Error>) -> Vec<SenderDdlRequest> {
         if let Some(mut task) = self.pending_task {
             task.on_failure(err.clone());
         }
@@ -1587,13 +1582,6 @@ impl FlushStatus {
                     region_id: self.region_id,
                 }));
             }
-        }
-        if !lifecycle_ddls.is_empty() {
-            return Some((
-                lifecycle_ddls,
-                self.pending_writes,
-                self.pending_bulk_writes,
-            ));
         }
         for write_req in self.pending_writes {
             write_req
@@ -1609,26 +1597,14 @@ impl FlushStatus {
                     region_id: self.region_id,
                 }));
         }
-        None
+        lifecycle_ddls
     }
 
     fn fail_all(self, err: Arc<Error>) {
         let region_id = self.region_id;
-        let Some((ddls, writes, bulk_writes)) = self.on_failure(err.clone()) else {
-            return;
-        };
+        let ddls = self.on_failure(err.clone());
         for ddl in ddls {
             ddl.sender
-                .send(Err(err.clone()).context(FlushRegionSnafu { region_id }));
-        }
-        for write in writes {
-            write
-                .sender
-                .send(Err(err.clone()).context(FlushRegionSnafu { region_id }));
-        }
-        for bulk_write in bulk_writes {
-            bulk_write
-                .sender
                 .send(Err(err.clone()).context(FlushRegionSnafu { region_id }));
         }
     }
@@ -1667,6 +1643,7 @@ impl FlushStatus {
 
 #[cfg(test)]
 mod tests {
+    use api::v1::{OpType, Rows};
     use common_error::ext::ErrorExt;
     use common_error::status_code::StatusCode;
     use mito_codec::row_converter::build_primary_key_codec;
@@ -1678,6 +1655,7 @@ mod tests {
     use crate::memtable::bulk::part::BulkPartConverter;
     use crate::memtable::time_series::TimeSeriesMemtableBuilder;
     use crate::memtable::{Memtable, RangesOptions};
+    use crate::request::WriteRequest;
     use crate::schedule::scheduler::Scheduler;
     use crate::sst::{FlatSchemaOptions, to_flat_sst_arrow_schema};
     use crate::test_util::memtable_util::{build_key_values_with_ts_seq_values, metadata_for_test};
@@ -1753,6 +1731,23 @@ mod tests {
                 request: converter.convert().unwrap(),
                 region_metadata: Some(metadata),
                 partition_expr_version: None,
+            },
+            receiver,
+        )
+    }
+
+    fn new_test_write_request(
+        region_id: RegionId,
+    ) -> (
+        SenderWriteRequest,
+        oneshot::Receiver<Result<store_api::region_request::AffectedRows>>,
+    ) {
+        let (sender, receiver) = oneshot::channel();
+        let request = WriteRequest::new(region_id, OpType::Put, Rows::default(), None).unwrap();
+        (
+            SenderWriteRequest {
+                sender: OptionOutputTx::from(sender),
+                request,
             },
             receiver,
         )
@@ -1975,7 +1970,8 @@ mod tests {
             pending_bulk_writes: vec![bulk_req],
         };
 
-        status.on_failure(Arc::new(RegionClosedSnafu { region_id }.build()));
+        let pending_ddls = status.on_failure(Arc::new(RegionClosedSnafu { region_id }.build()));
+        assert!(pending_ddls.is_empty());
 
         let err = output_rx
             .await
@@ -1985,39 +1981,64 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_flush_failure_retains_truncate_ddl_and_pending_writes() {
+    async fn test_flush_failure_retains_lifecycle_ddls_and_fails_pending_writes() {
         let region_id = RegionId::new(1, 1);
         let version_control = Arc::new(VersionControlBuilder::new().build());
-        let (bulk_req, mut bulk_rx) = new_test_bulk_request(region_id);
-        let (ddl_tx, ddl_rx) = oneshot::channel();
+        let (write_req, write_rx) = new_test_write_request(region_id);
+        let (bulk_req, bulk_rx) = new_test_bulk_request(region_id);
+        let (truncate_tx, mut truncate_rx) = oneshot::channel();
+        let (drop_tx, mut drop_rx) = oneshot::channel();
         let status = FlushStatus {
             region_id,
             version_control,
             state: CancellableTaskState::new(),
             pending_task: None,
             closing: false,
-            pending_ddls: vec![SenderDdlRequest {
-                region_id,
-                sender: OptionOutputTx::from(ddl_tx),
-                request: DdlRequest::Truncate(
-                    store_api::region_request::RegionTruncateRequest::All,
-                ),
-            }],
-            pending_writes: Vec::new(),
+            pending_ddls: vec![
+                SenderDdlRequest {
+                    region_id,
+                    sender: OptionOutputTx::from(truncate_tx),
+                    request: DdlRequest::Truncate(
+                        store_api::region_request::RegionTruncateRequest::All,
+                    ),
+                },
+                SenderDdlRequest {
+                    region_id,
+                    sender: OptionOutputTx::from(drop_tx),
+                    request: DdlRequest::Drop(store_api::region_request::RegionDropRequest {
+                        fast_path: false,
+                        force: false,
+                        partial_drop: false,
+                    }),
+                },
+            ],
+            pending_writes: vec![write_req],
             pending_bulk_writes: vec![bulk_req],
         };
 
-        let (mut ddls, writes, bulk_writes) = status
-            .on_failure(Arc::new(RegionBusySnafu { region_id }.build()))
-            .expect("truncate should survive flush failure");
-        assert_eq!(1, ddls.len());
-        assert!(writes.is_empty());
-        assert_eq!(1, bulk_writes.len());
+        let ddls = status.on_failure(Arc::new(RegionBusySnafu { region_id }.build()));
+        assert_eq!(2, ddls.len());
         assert!(matches!(ddls[0].request, DdlRequest::Truncate(_)));
+        assert!(matches!(ddls[1].request, DdlRequest::Drop(_)));
 
-        ddls.pop().unwrap().sender.send(Ok(0));
-        assert_eq!(0, ddl_rx.await.unwrap().unwrap());
-        assert!(bulk_rx.try_recv().is_err());
+        let write_err = write_rx
+            .await
+            .expect("pending write must receive explicit error")
+            .unwrap_err();
+        assert_eq!(write_err.status_code(), StatusCode::RegionBusy);
+        let bulk_err = bulk_rx
+            .await
+            .expect("pending bulk write must receive explicit error")
+            .unwrap_err();
+        assert_eq!(bulk_err.status_code(), StatusCode::RegionBusy);
+
+        assert!(truncate_rx.try_recv().is_err());
+        assert!(drop_rx.try_recv().is_err());
+        for ddl in ddls {
+            ddl.sender.send(Ok(0));
+        }
+        assert_eq!(0, truncate_rx.await.unwrap().unwrap());
+        assert_eq!(0, drop_rx.await.unwrap().unwrap());
     }
 
     #[tokio::test]

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -21,7 +21,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use bytes::Bytes;
-use common_base::cancellation::{CancellableFuture, CancellationHandle};
+use common_base::cancellation::CancellableFuture;
 use common_telemetry::{debug, error, info};
 use datatypes::arrow::datatypes::SchemaRef;
 use datatypes::extension::json::is_structured_json_field;
@@ -61,6 +61,7 @@ use crate::request::{
     BackgroundNotify, DdlRequest, FlushFailed, FlushFinished, OnFailure, OptionOutputTx, OutputTx,
     SenderBulkRequest, SenderDdlRequest, SenderWriteRequest, WorkerRequest, WorkerRequestWithTime,
 };
+use crate::schedule::CancellableTaskState;
 use crate::schedule::scheduler::{Job, SchedulerRef};
 use crate::sst::file::{FileMeta, UncommittedSsts};
 use crate::sst::parquet::metadata::extract_primary_key_range;
@@ -350,7 +351,7 @@ impl RegionFlushTask {
     fn into_flush_job(
         mut self,
         version_control: &VersionControlRef,
-        state: FlushState,
+        state: CancellableTaskState,
     ) -> (Job, Arc<FlushTaskWaiters>) {
         // Get a version of this region before creating a job to get current
         // wal entry id, sequence and immutable memtables.
@@ -371,38 +372,22 @@ impl RegionFlushTask {
     }
 
     /// Runs the flush task.
-    async fn do_flush(&mut self, version_data: VersionControlData, state: FlushState) {
+    async fn do_flush(&mut self, version_data: VersionControlData, state: CancellableTaskState) {
         let timer = FLUSH_ELAPSED.with_label_values(&["total"]).start_timer();
         let uncommitted = UncommittedSsts::new(
             self.region_id,
             self.access_layer.clone(),
             Some(self.cache_manager.clone()),
         );
-        let flush_result = match CancellableFuture::new(
-            self.listener.on_flush_begin(self.region_id),
-            state.cancel_handle(),
-        )
-        .await
-        {
-            Err(_) => FlushCancelledSnafu.fail(),
-            Ok(()) => {
-                self.flush_memtables(&version_data, &state, &uncommitted)
-                    .await
-            }
+        self.listener.on_flush_begin(self.region_id).await;
+        let flush_result = if state.is_cancelled() {
+            FlushCancelledSnafu.fail()
+        } else {
+            self.flush_memtables(&version_data, &state, &uncommitted)
+                .await
         };
 
         let worker_request = match flush_result {
-            Err(Error::FlushCancelled { .. }) => {
-                info!("Flush cancelled for region {}", self.region_id);
-                timer.stop_and_discard();
-                uncommitted.cleanup().await;
-                let err = Arc::new(FlushCancelledSnafu.build());
-                self.on_failure(err.clone());
-                WorkerRequest::Background {
-                    region_id: self.region_id,
-                    notify: BackgroundNotify::FlushFailed(FlushFailed { err }),
-                }
-            }
             Ok(edit) => {
                 let memtables_to_remove = version_data
                     .version
@@ -428,16 +413,21 @@ impl RegionFlushTask {
                 }
             }
             Err(e) => {
-                error!(e; "Failed to flush region {}", self.region_id);
+                let err = Arc::new(e);
+                let failed = FlushFailed { err: err.clone() };
+                if failed.is_cancelled() {
+                    info!("Flush cancelled for region {}", self.region_id);
+                } else {
+                    error!(err; "Failed to flush region {}", self.region_id);
+                }
                 // Discard the timer.
                 timer.stop_and_discard();
                 uncommitted.cleanup().await;
 
-                let err = Arc::new(e);
                 self.on_failure(err.clone());
                 WorkerRequest::Background {
                     region_id: self.region_id,
-                    notify: BackgroundNotify::FlushFailed(FlushFailed { err }),
+                    notify: BackgroundNotify::FlushFailed(failed),
                 }
             }
         };
@@ -449,7 +439,7 @@ impl RegionFlushTask {
     async fn flush_memtables(
         &self,
         version_data: &VersionControlData,
-        state: &FlushState,
+        state: &CancellableTaskState,
         uncommitted: &UncommittedSsts,
     ) -> Result<RegionEdit> {
         // We must use the immutable memtables list and entry ids from the `version_data`
@@ -571,7 +561,7 @@ impl RegionFlushTask {
         &self,
         version: &VersionRef,
         write_opts: WriteOptions,
-        state: &FlushState,
+        state: &CancellableTaskState,
         uncommitted: &UncommittedSsts,
     ) -> Result<DoFlushMemtablesResult> {
         let memtables = version.memtables.immutables();
@@ -689,7 +679,7 @@ impl RegionFlushTask {
         version: &VersionRef,
         write_opts: &WriteOptions,
         mem_ranges: MemtableRanges,
-        state: &FlushState,
+        state: &CancellableTaskState,
         uncommitted: &UncommittedSsts,
     ) -> Result<FlushFlatMemResult> {
         let batch_schema = to_flat_sst_arrow_schema(
@@ -746,10 +736,13 @@ impl RegionFlushTask {
             .iter()
             .map(|task| task.abort_handle())
             .collect::<Vec<_>>();
-        let join_all = futures::future::try_join_all(tasks);
+        let join_all = futures::future::join_all(tasks);
         tokio::pin!(join_all);
         let results = match CancellableFuture::new(join_all.as_mut(), state.cancel_handle()).await {
-            Ok(results) => results.context(JoinSnafu)?,
+            Ok(results) => results
+                .into_iter()
+                .map(|result| result.context(JoinSnafu))
+                .collect::<Result<Vec<_>>>()?,
             Err(_) => {
                 for handle in abort_handles {
                     handle.abort();
@@ -1203,55 +1196,6 @@ pub fn maybe_dedup_one(
     }
 }
 
-/// Shared state for cooperative cancellation of a running flush.
-#[derive(Debug, Clone)]
-struct FlushState {
-    cancel_handle: Arc<CancellationHandle>,
-    commit_started: Arc<Mutex<bool>>,
-}
-
-impl FlushState {
-    fn new() -> Self {
-        Self {
-            cancel_handle: Arc::new(CancellationHandle::default()),
-            commit_started: Arc::new(Mutex::new(false)),
-        }
-    }
-
-    fn cancel_handle(&self) -> Arc<CancellationHandle> {
-        self.cancel_handle.clone()
-    }
-
-    fn mark_commit_started(&self) -> bool {
-        let mut commit_started = self.commit_started.lock().unwrap();
-        if self.cancel_handle.is_cancelled() {
-            return false;
-        }
-        *commit_started = true;
-        true
-    }
-
-    fn request_cancel(&self) -> FlushCancelResult {
-        let commit_started = self.commit_started.lock().unwrap();
-        if *commit_started {
-            return FlushCancelResult::TooLateToCancel;
-        }
-        if self.cancel_handle.is_cancelled() {
-            return FlushCancelResult::AlreadyCancelling;
-        }
-
-        self.cancel_handle.cancel();
-        FlushCancelResult::CancelIssued
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum FlushCancelResult {
-    CancelIssued,
-    AlreadyCancelling,
-    TooLateToCancel,
-}
-
 /// Manages background flushes of a worker.
 pub(crate) struct FlushScheduler {
     /// Tracks regions need to flush.
@@ -1278,7 +1222,7 @@ impl FlushScheduler {
         &mut self,
         version_control: &VersionControlRef,
         mut task: RegionFlushTask,
-    ) -> Result<FlushState> {
+    ) -> Result<CancellableTaskState> {
         let region_id = task.region_id;
 
         // If current region doesn't have flush status, we can flush the region directly.
@@ -1289,7 +1233,7 @@ impl FlushScheduler {
             return Err(e);
         }
         // Submit a flush job.
-        let state = FlushState::new();
+        let state = CancellableTaskState::new();
         let (job, waiters) = task.into_flush_job(version_control, state.clone());
         if let Err(e) = self.scheduler.schedule(job) {
             error!(e; "Failed to schedule flush job for region {}", region_id);
@@ -1428,9 +1372,10 @@ impl FlushScheduler {
         Vec<SenderWriteRequest>,
         Vec<SenderBulkRequest>,
     )> {
-        error!(err; "Region {} failed to flush, cancel all pending tasks", region_id);
-
-        if !matches!(err.as_ref(), Error::FlushCancelled { .. }) {
+        if matches!(err.as_ref(), Error::FlushCancelled { .. }) {
+            info!("Region {} flush was cancelled", region_id);
+        } else {
+            error!(err; "Region {} failed to flush, cancel all pending tasks", region_id);
             FLUSH_FAILURE_TOTAL.inc();
         }
 
@@ -1557,7 +1502,7 @@ struct FlushStatus {
     /// Version control of the region.
     version_control: VersionControlRef,
     /// Cancellation state of the running flush.
-    state: FlushState,
+    state: CancellableTaskState,
     /// Task waiting for next flush.
     pending_task: Option<RegionFlushTask>,
     /// Whether a close-time flush is in progress or pending.
@@ -1574,7 +1519,7 @@ impl FlushStatus {
     fn new(
         region_id: RegionId,
         version_control: VersionControlRef,
-        state: FlushState,
+        state: CancellableTaskState,
         closing: bool,
     ) -> FlushStatus {
         FlushStatus {
@@ -2005,7 +1950,7 @@ mod tests {
         let status = FlushStatus {
             region_id,
             version_control,
-            state: FlushState::new(),
+            state: CancellableTaskState::new(),
             pending_task: None,
             closing: false,
             pending_ddls: Vec::new(),
@@ -2031,7 +1976,7 @@ mod tests {
         let status = FlushStatus {
             region_id,
             version_control,
-            state: FlushState::new(),
+            state: CancellableTaskState::new(),
             pending_task: None,
             closing: false,
             pending_ddls: vec![SenderDdlRequest {
@@ -2056,17 +2001,6 @@ mod tests {
         ddls.pop().unwrap().sender.send(Ok(0));
         assert_eq!(0, ddl_rx.await.unwrap().unwrap());
         assert!(bulk_rx.try_recv().is_err());
-    }
-
-    #[test]
-    fn test_flush_cancellation_commit_gate() {
-        let state = FlushState::new();
-        assert_eq!(FlushCancelResult::CancelIssued, state.request_cancel());
-        assert!(!state.mark_commit_started());
-
-        let state = FlushState::new();
-        assert!(state.mark_commit_started());
-        assert_eq!(FlushCancelResult::TooLateToCancel, state.request_cancel());
     }
 
     #[tokio::test]
@@ -2114,7 +2048,7 @@ mod tests {
         let status = FlushStatus {
             region_id,
             version_control,
-            state: FlushState::new(),
+            state: CancellableTaskState::new(),
             pending_task: None,
             closing: false,
             pending_ddls: Vec::new(),

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -542,11 +542,28 @@ impl RegionFlushTask {
                 RegionLeaderState::Writable
             }
         };
-        let manifest_version = self
+        let manifest_version = match self
             .manifest_ctx
             .update_manifest(expected_state, action_list, self.is_staging)
-            .await?;
-        uncommitted.commit();
+            .await
+        {
+            Ok(manifest_version) => {
+                uncommitted.disarm_cleanup();
+                manifest_version
+            }
+            Err(e) => {
+                if e.may_have_persisted_manifest_update() {
+                    uncommitted.disarm_cleanup();
+                } else {
+                    info!(
+                        "Cleaning uncommitted SSTs because the manifest update was not persisted, region: {}, job: flush, error: {:?}",
+                        self.region_id, e
+                    );
+                    uncommitted.cleanup().await;
+                }
+                return Err(e);
+            }
+        };
         info!(
             "Successfully update manifest version to {manifest_version}, region: {}, is_staging: {}, reason: {}",
             self.region_id,
@@ -2038,6 +2055,38 @@ mod tests {
             .await
             .unwrap();
         assert!(entries.iter().all(|entry| entry.path() != path));
+    }
+
+    #[tokio::test]
+    async fn test_uncommitted_ssts_disarm_cleanup() {
+        let env = SchedulerEnv::new().await;
+        let region_id = RegionId::new(1, 1);
+        let file_id = store_api::storage::FileId::random();
+        let path = crate::sst::location::sst_file_path(
+            env.access_layer.table_dir(),
+            crate::sst::file::RegionFileId::new(region_id, file_id),
+            env.access_layer.path_type(),
+        );
+        env.access_layer
+            .object_store()
+            .write(&path, Bytes::from_static(b"sst"))
+            .await
+            .unwrap();
+
+        let uncommitted = UncommittedSsts::new(region_id, env.access_layer.clone(), None);
+        uncommitted.track(&[SstInfo {
+            file_id,
+            ..Default::default()
+        }]);
+        uncommitted.disarm_cleanup();
+        assert_eq!(0, uncommitted.num_tracked_files());
+        uncommitted.cleanup_for_test().await.unwrap();
+
+        env.access_layer
+            .object_store()
+            .read(&path)
+            .await
+            .expect("disarmed cleanup deleted the SST");
     }
 
     #[tokio::test]

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -21,6 +21,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use bytes::Bytes;
+use common_base::cancellation::{CancellableFuture, CancellationHandle};
 use common_telemetry::{debug, error, info};
 use datatypes::arrow::datatypes::SchemaRef;
 use datatypes::extension::json::is_structured_json_field;
@@ -39,8 +40,8 @@ use crate::cache::CacheManagerRef;
 use crate::config::MitoConfig;
 use crate::engine::region_hook::SstFileInfo;
 use crate::error::{
-    Error, FlushRegionSnafu, JoinSnafu, RegionBusySnafu, RegionClosedSnafu, RegionDroppedSnafu,
-    RegionTruncatedSnafu, Result,
+    Error, FlushCancelledSnafu, FlushRegionSnafu, JoinSnafu, RegionBusySnafu, RegionClosedSnafu,
+    RegionDroppedSnafu, RegionTruncatedSnafu, Result,
 };
 use crate::manifest::action::{RegionEdit, RegionMetaAction, RegionMetaActionList};
 use crate::memtable::bulk::ENCODE_ROW_THRESHOLD;
@@ -61,7 +62,7 @@ use crate::request::{
     SenderBulkRequest, SenderDdlRequest, SenderWriteRequest, WorkerRequest, WorkerRequestWithTime,
 };
 use crate::schedule::scheduler::{Job, SchedulerRef};
-use crate::sst::file::FileMeta;
+use crate::sst::file::{FileMeta, UncommittedSsts};
 use crate::sst::parquet::metadata::extract_primary_key_range;
 use crate::sst::parquet::{
     DEFAULT_READ_BATCH_SIZE, DEFAULT_ROW_GROUP_SIZE, SstInfo, WriteOptions, flat_format,
@@ -349,6 +350,7 @@ impl RegionFlushTask {
     fn into_flush_job(
         mut self,
         version_control: &VersionControlRef,
+        state: FlushState,
     ) -> (Job, Arc<FlushTaskWaiters>) {
         // Get a version of this region before creating a job to get current
         // wal entry id, sequence and immutable memtables.
@@ -362,18 +364,45 @@ impl RegionFlushTask {
         let job = Box::pin(async move {
             self.senders = job_waiters.take();
             INFLIGHT_FLUSH_COUNT.inc();
-            self.do_flush(version_data).await;
+            self.do_flush(version_data, state).await;
             INFLIGHT_FLUSH_COUNT.dec();
         });
         (job, waiters)
     }
 
     /// Runs the flush task.
-    async fn do_flush(&mut self, version_data: VersionControlData) {
+    async fn do_flush(&mut self, version_data: VersionControlData, state: FlushState) {
         let timer = FLUSH_ELAPSED.with_label_values(&["total"]).start_timer();
-        self.listener.on_flush_begin(self.region_id).await;
+        let uncommitted = UncommittedSsts::new(
+            self.region_id,
+            self.access_layer.clone(),
+            Some(self.cache_manager.clone()),
+        );
+        let flush_result = match CancellableFuture::new(
+            self.listener.on_flush_begin(self.region_id),
+            state.cancel_handle(),
+        )
+        .await
+        {
+            Err(_) => FlushCancelledSnafu.fail(),
+            Ok(()) => {
+                self.flush_memtables(&version_data, &state, &uncommitted)
+                    .await
+            }
+        };
 
-        let worker_request = match self.flush_memtables(&version_data).await {
+        let worker_request = match flush_result {
+            Err(Error::FlushCancelled { .. }) => {
+                info!("Flush cancelled for region {}", self.region_id);
+                timer.stop_and_discard();
+                uncommitted.cleanup().await;
+                let err = Arc::new(FlushCancelledSnafu.build());
+                self.on_failure(err.clone());
+                WorkerRequest::Background {
+                    region_id: self.region_id,
+                    notify: BackgroundNotify::FlushFailed(FlushFailed { err }),
+                }
+            }
             Ok(edit) => {
                 let memtables_to_remove = version_data
                     .version
@@ -402,6 +431,7 @@ impl RegionFlushTask {
                 error!(e; "Failed to flush region {}", self.region_id);
                 // Discard the timer.
                 timer.stop_and_discard();
+                uncommitted.cleanup().await;
 
                 let err = Arc::new(e);
                 self.on_failure(err.clone());
@@ -416,7 +446,12 @@ impl RegionFlushTask {
 
     /// Flushes memtables to level 0 SSTs and updates the manifest.
     /// Returns the [RegionEdit] to apply.
-    async fn flush_memtables(&self, version_data: &VersionControlData) -> Result<RegionEdit> {
+    async fn flush_memtables(
+        &self,
+        version_data: &VersionControlData,
+        state: &FlushState,
+        uncommitted: &UncommittedSsts,
+    ) -> Result<RegionEdit> {
         // We must use the immutable memtables list and entry ids from the `version_data`
         // for consistency as others might already modify the version in the `version_control`.
         let version = &version_data.version;
@@ -439,7 +474,9 @@ impl RegionFlushTask {
             encoded_part_count,
             flush_metrics,
             sst_infos,
-        } = self.do_flush_memtables(version, write_opts).await?;
+        } = self
+            .do_flush_memtables(version, write_opts, state, uncommitted)
+            .await?;
 
         if !file_metas.is_empty() {
             FLUSH_BYTES_TOTAL.inc_by(flushed_bytes);
@@ -498,6 +535,12 @@ impl RegionFlushTask {
 
         let action_list = RegionMetaActionList::with_action(RegionMetaAction::Edit(edit.clone()));
 
+        // Stop accepting cancellation once the flush is about to publish its manifest edit.
+        if !state.mark_commit_started() {
+            return FlushCancelledSnafu.fail();
+        }
+        self.listener.on_flush_commit_begin(self.region_id).await;
+
         let expected_state = if matches!(self.reason, FlushReason::Downgrading) {
             RegionLeaderState::Downgrading
         } else {
@@ -509,12 +552,11 @@ impl RegionFlushTask {
                 RegionLeaderState::Writable
             }
         };
-        // We will leak files if the manifest update fails, but we ignore them for simplicity. We can
-        // add a cleanup job to remove them later.
         let manifest_version = self
             .manifest_ctx
             .update_manifest(expected_state, action_list, self.is_staging)
             .await?;
+        uncommitted.commit();
         info!(
             "Successfully update manifest version to {manifest_version}, region: {}, is_staging: {}, reason: {}",
             self.region_id,
@@ -529,6 +571,8 @@ impl RegionFlushTask {
         &self,
         version: &VersionRef,
         write_opts: WriteOptions,
+        state: &FlushState,
+        uncommitted: &UncommittedSsts,
     ) -> Result<DoFlushMemtablesResult> {
         let memtables = version.memtables.immutables();
         let mut file_metas = Vec::with_capacity(memtables.len());
@@ -577,7 +621,7 @@ impl RegionFlushTask {
                 num_sources,
                 results,
             } = self
-                .flush_flat_mem_ranges(version, &write_opts, mem_ranges)
+                .flush_flat_mem_ranges(version, &write_opts, mem_ranges, state, uncommitted)
                 .await?;
             encoded_part_count += num_encoded;
             for (source_idx, result) in results.into_iter().enumerate() {
@@ -645,6 +689,8 @@ impl RegionFlushTask {
         version: &VersionRef,
         write_opts: &WriteOptions,
         mem_ranges: MemtableRanges,
+        state: &FlushState,
+        uncommitted: &UncommittedSsts,
     ) -> Result<FlushFlatMemResult> {
         let batch_schema = to_flat_sst_arrow_schema(
             &version.metadata,
@@ -665,12 +711,14 @@ impl RegionFlushTask {
             let access_layer = self.access_layer.clone();
             let write_opts = write_opts.clone();
             let semaphore = self.flush_semaphore.clone();
+            let uncommitted = uncommitted.clone();
             let task = common_runtime::spawn_global(async move {
                 let _permit = semaphore.acquire().await.unwrap();
                 let mut metrics = Metrics::new(WriteType::Flush);
                 let ssts = access_layer
                     .write_sst(write_request, &write_opts, &mut metrics)
                     .await?;
+                uncommitted.track(&ssts);
                 FLUSH_FILE_TOTAL.inc_by(ssts.len() as u64);
                 Ok((max_sequence, ssts, metrics))
             });
@@ -681,20 +729,37 @@ impl RegionFlushTask {
             let cache_manager = self.cache_manager.clone();
             let region_id = version.metadata.region_id;
             let semaphore = self.flush_semaphore.clone();
+            let uncommitted = uncommitted.clone();
             let task = common_runtime::spawn_global(async move {
                 let _permit = semaphore.acquire().await.unwrap();
                 let metrics = access_layer
                     .put_sst(&encoded.data, region_id, &encoded.sst_info, &cache_manager)
                     .await?;
+                uncommitted.track(std::slice::from_ref(&encoded.sst_info));
                 FLUSH_FILE_TOTAL.inc();
                 Ok((max_sequence, smallvec![encoded.sst_info], metrics))
             });
             tasks.push(task);
         }
         let num_sources = tasks.len();
-        let results = futures::future::try_join_all(tasks)
-            .await
-            .context(JoinSnafu)?;
+        let abort_handles = tasks
+            .iter()
+            .map(|task| task.abort_handle())
+            .collect::<Vec<_>>();
+        let join_all = futures::future::try_join_all(tasks);
+        tokio::pin!(join_all);
+        let results = match CancellableFuture::new(join_all.as_mut(), state.cancel_handle()).await {
+            Ok(results) => results.context(JoinSnafu)?,
+            Err(_) => {
+                for handle in abort_handles {
+                    handle.abort();
+                }
+                // Wait until every writer observes the abort so cleanup cannot race with a late
+                // finalized output.
+                let _ = join_all.await;
+                return FlushCancelledSnafu.fail();
+            }
+        };
         Ok(FlushFlatMemResult {
             num_encoded,
             num_sources,
@@ -1138,6 +1203,55 @@ pub fn maybe_dedup_one(
     }
 }
 
+/// Shared state for cooperative cancellation of a running flush.
+#[derive(Debug, Clone)]
+struct FlushState {
+    cancel_handle: Arc<CancellationHandle>,
+    commit_started: Arc<Mutex<bool>>,
+}
+
+impl FlushState {
+    fn new() -> Self {
+        Self {
+            cancel_handle: Arc::new(CancellationHandle::default()),
+            commit_started: Arc::new(Mutex::new(false)),
+        }
+    }
+
+    fn cancel_handle(&self) -> Arc<CancellationHandle> {
+        self.cancel_handle.clone()
+    }
+
+    fn mark_commit_started(&self) -> bool {
+        let mut commit_started = self.commit_started.lock().unwrap();
+        if self.cancel_handle.is_cancelled() {
+            return false;
+        }
+        *commit_started = true;
+        true
+    }
+
+    fn request_cancel(&self) -> FlushCancelResult {
+        let commit_started = self.commit_started.lock().unwrap();
+        if *commit_started {
+            return FlushCancelResult::TooLateToCancel;
+        }
+        if self.cancel_handle.is_cancelled() {
+            return FlushCancelResult::AlreadyCancelling;
+        }
+
+        self.cancel_handle.cancel();
+        FlushCancelResult::CancelIssued
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FlushCancelResult {
+    CancelIssued,
+    AlreadyCancelling,
+    TooLateToCancel,
+}
+
 /// Manages background flushes of a worker.
 pub(crate) struct FlushScheduler {
     /// Tracks regions need to flush.
@@ -1164,7 +1278,7 @@ impl FlushScheduler {
         &mut self,
         version_control: &VersionControlRef,
         mut task: RegionFlushTask,
-    ) -> Result<()> {
+    ) -> Result<FlushState> {
         let region_id = task.region_id;
 
         // If current region doesn't have flush status, we can flush the region directly.
@@ -1175,14 +1289,15 @@ impl FlushScheduler {
             return Err(e);
         }
         // Submit a flush job.
-        let (job, waiters) = task.into_flush_job(version_control);
+        let state = FlushState::new();
+        let (job, waiters) = task.into_flush_job(version_control, state.clone());
         if let Err(e) = self.scheduler.schedule(job) {
             error!(e; "Failed to schedule flush job for region {}", region_id);
             waiters.on_failure(Arc::new(RegionBusySnafu { region_id }.build()));
 
             return Err(e);
         }
-        Ok(())
+        Ok(state)
     }
 
     /// Schedules a flush `task` for specific `region`.
@@ -1190,7 +1305,7 @@ impl FlushScheduler {
         &mut self,
         region_id: RegionId,
         version_control: &VersionControlRef,
-        task: RegionFlushTask,
+        mut task: RegionFlushTask,
     ) -> Result<()> {
         debug_assert_eq!(region_id, task.region_id);
 
@@ -1209,6 +1324,10 @@ impl FlushScheduler {
 
         // If current region has flush status, merge the task.
         if let Some(flush_status) = self.region_status.get_mut(&region_id) {
+            if flush_status.has_pending_lifecycle_ddl() {
+                task.on_failure(Arc::new(FlushCancelledSnafu.build()));
+                return Ok(());
+            }
             // Checks whether we can flush the region now.
             debug!("Merging flush task for region {}", region_id);
             flush_status.merge_task(task);
@@ -1216,12 +1335,12 @@ impl FlushScheduler {
         }
 
         let closing = task.reason == FlushReason::Closing;
-        self.schedule_flush_task(version_control, task)?;
+        let state = self.schedule_flush_task(version_control, task)?;
 
         // Add this region to status map.
         let _ = self.region_status.insert(
             region_id,
-            FlushStatus::new(region_id, version_control.clone(), closing),
+            FlushStatus::new(region_id, version_control.clone(), state, closing),
         );
 
         Ok(())
@@ -1281,32 +1400,69 @@ impl FlushScheduler {
         // Safety: The flush status must exist.
         let task = flush_status.pending_task.take().unwrap();
         let version_control = flush_status.version_control.clone();
-        if let Err(err) = self.schedule_flush_task(&version_control, task) {
-            error!(
-                err;
-                "Flush succeeded for region {region_id}, but failed to schedule next flush for it."
-            );
-            let flush_status = self.region_status.remove(&region_id).unwrap();
-            flush_status.on_failure(Arc::new(RegionBusySnafu { region_id }.build()));
-            return None;
+        match self.schedule_flush_task(&version_control, task) {
+            Ok(state) => {
+                self.region_status.get_mut(&region_id).unwrap().state = state;
+            }
+            Err(err) => {
+                error!(
+                    err;
+                    "Flush succeeded for region {region_id}, but failed to schedule next flush for it."
+                );
+                let flush_status = self.region_status.remove(&region_id).unwrap();
+                flush_status.fail_all(Arc::new(RegionBusySnafu { region_id }.build()));
+                return None;
+            }
         }
         // We can flush the region again, keep it in the region status.
         None
     }
 
     /// Notifies the scheduler that the flush job is failed.
-    pub(crate) fn on_flush_failed(&mut self, region_id: RegionId, err: Arc<Error>) {
+    pub(crate) fn on_flush_failed(
+        &mut self,
+        region_id: RegionId,
+        err: Arc<Error>,
+    ) -> Option<(
+        Vec<SenderDdlRequest>,
+        Vec<SenderWriteRequest>,
+        Vec<SenderBulkRequest>,
+    )> {
         error!(err; "Region {} failed to flush, cancel all pending tasks", region_id);
 
-        FLUSH_FAILURE_TOTAL.inc();
+        if !matches!(err.as_ref(), Error::FlushCancelled { .. }) {
+            FLUSH_FAILURE_TOTAL.inc();
+        }
 
         // Remove this region.
-        let Some(flush_status) = self.region_status.remove(&region_id) else {
-            return;
+        let flush_status = self.region_status.remove(&region_id)?;
+
+        flush_status.on_failure(err)
+    }
+
+    /// Cancels the running flush and queues its dependent lifecycle DDL atomically.
+    pub(crate) fn try_cancel_and_add_ddl<T>(
+        &mut self,
+        region_id: RegionId,
+        sender: OptionOutputTx,
+        request: T,
+        into_ddl_request: impl FnOnce(T) -> DdlRequest,
+    ) -> std::result::Result<(), (OptionOutputTx, T)> {
+        let Some(status) = self.region_status.get_mut(&region_id) else {
+            return Err((sender, request));
         };
 
-        // Fast fail: cancels all pending tasks and sends error to their waiters.
-        flush_status.on_failure(err);
+        let cancel_result = status.state.request_cancel();
+        debug!(
+            "Requested flush cancellation for region {}, result: {:?}",
+            region_id, cancel_result
+        );
+        status.pending_ddls.push(SenderDdlRequest {
+            region_id,
+            sender,
+            request: into_ddl_request(request),
+        });
+        Ok(())
     }
 
     /// Notifies the scheduler that the region is dropped.
@@ -1341,7 +1497,7 @@ impl FlushScheduler {
         };
 
         // Notifies all pending tasks.
-        flush_status.on_failure(err);
+        flush_status.fail_all(err);
     }
 
     /// Add ddl request to pending queue.
@@ -1387,7 +1543,7 @@ impl Drop for FlushScheduler {
     fn drop(&mut self) {
         for (region_id, flush_status) in self.region_status.drain() {
             // We are shutting down so notify all pending tasks.
-            flush_status.on_failure(Arc::new(RegionClosedSnafu { region_id }.build()));
+            flush_status.fail_all(Arc::new(RegionClosedSnafu { region_id }.build()));
         }
     }
 }
@@ -1400,6 +1556,8 @@ struct FlushStatus {
     region_id: RegionId,
     /// Version control of the region.
     version_control: VersionControlRef,
+    /// Cancellation state of the running flush.
+    state: FlushState,
     /// Task waiting for next flush.
     pending_task: Option<RegionFlushTask>,
     /// Whether a close-time flush is in progress or pending.
@@ -1413,10 +1571,16 @@ struct FlushStatus {
 }
 
 impl FlushStatus {
-    fn new(region_id: RegionId, version_control: VersionControlRef, closing: bool) -> FlushStatus {
+    fn new(
+        region_id: RegionId,
+        version_control: VersionControlRef,
+        state: FlushState,
+        closing: bool,
+    ) -> FlushStatus {
         FlushStatus {
             region_id,
             version_control,
+            state,
             pending_task: None,
             closing,
             pending_ddls: Vec::new(),
@@ -1435,14 +1599,39 @@ impl FlushStatus {
         }
     }
 
-    fn on_failure(self, err: Arc<Error>) {
+    fn has_pending_lifecycle_ddl(&self) -> bool {
+        self.pending_ddls
+            .iter()
+            .any(|ddl| matches!(ddl.request, DdlRequest::Drop(_) | DdlRequest::Truncate(_)))
+    }
+
+    fn on_failure(
+        self,
+        err: Arc<Error>,
+    ) -> Option<(
+        Vec<SenderDdlRequest>,
+        Vec<SenderWriteRequest>,
+        Vec<SenderBulkRequest>,
+    )> {
         if let Some(mut task) = self.pending_task {
             task.on_failure(err.clone());
         }
+        let mut lifecycle_ddls = Vec::new();
         for ddl in self.pending_ddls {
-            ddl.sender.send(Err(err.clone()).context(FlushRegionSnafu {
-                region_id: self.region_id,
-            }));
+            if matches!(ddl.request, DdlRequest::Drop(_) | DdlRequest::Truncate(_)) {
+                lifecycle_ddls.push(ddl);
+            } else {
+                ddl.sender.send(Err(err.clone()).context(FlushRegionSnafu {
+                    region_id: self.region_id,
+                }));
+            }
+        }
+        if !lifecycle_ddls.is_empty() {
+            return Some((
+                lifecycle_ddls,
+                self.pending_writes,
+                self.pending_bulk_writes,
+            ));
         }
         for write_req in self.pending_writes {
             write_req
@@ -1457,6 +1646,28 @@ impl FlushStatus {
                 .send(Err(err.clone()).context(FlushRegionSnafu {
                     region_id: self.region_id,
                 }));
+        }
+        None
+    }
+
+    fn fail_all(self, err: Arc<Error>) {
+        let region_id = self.region_id;
+        let Some((ddls, writes, bulk_writes)) = self.on_failure(err.clone()) else {
+            return;
+        };
+        for ddl in ddls {
+            ddl.sender
+                .send(Err(err.clone()).context(FlushRegionSnafu { region_id }));
+        }
+        for write in writes {
+            write
+                .sender
+                .send(Err(err.clone()).context(FlushRegionSnafu { region_id }));
+        }
+        for bulk_write in bulk_writes {
+            bulk_write
+                .sender
+                .send(Err(err.clone()).context(FlushRegionSnafu { region_id }));
         }
     }
 
@@ -1794,6 +2005,7 @@ mod tests {
         let status = FlushStatus {
             region_id,
             version_control,
+            state: FlushState::new(),
             pending_task: None,
             closing: false,
             pending_ddls: Vec::new(),
@@ -1811,6 +2023,90 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_flush_failure_retains_truncate_ddl_and_pending_writes() {
+        let region_id = RegionId::new(1, 1);
+        let version_control = Arc::new(VersionControlBuilder::new().build());
+        let (bulk_req, mut bulk_rx) = new_test_bulk_request(region_id);
+        let (ddl_tx, ddl_rx) = oneshot::channel();
+        let status = FlushStatus {
+            region_id,
+            version_control,
+            state: FlushState::new(),
+            pending_task: None,
+            closing: false,
+            pending_ddls: vec![SenderDdlRequest {
+                region_id,
+                sender: OptionOutputTx::from(ddl_tx),
+                request: DdlRequest::Truncate(
+                    store_api::region_request::RegionTruncateRequest::All,
+                ),
+            }],
+            pending_writes: Vec::new(),
+            pending_bulk_writes: vec![bulk_req],
+        };
+
+        let (mut ddls, writes, bulk_writes) = status
+            .on_failure(Arc::new(RegionBusySnafu { region_id }.build()))
+            .expect("truncate should survive flush failure");
+        assert_eq!(1, ddls.len());
+        assert!(writes.is_empty());
+        assert_eq!(1, bulk_writes.len());
+        assert!(matches!(ddls[0].request, DdlRequest::Truncate(_)));
+
+        ddls.pop().unwrap().sender.send(Ok(0));
+        assert_eq!(0, ddl_rx.await.unwrap().unwrap());
+        assert!(bulk_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn test_flush_cancellation_commit_gate() {
+        let state = FlushState::new();
+        assert_eq!(FlushCancelResult::CancelIssued, state.request_cancel());
+        assert!(!state.mark_commit_started());
+
+        let state = FlushState::new();
+        assert!(state.mark_commit_started());
+        assert_eq!(FlushCancelResult::TooLateToCancel, state.request_cancel());
+    }
+
+    #[tokio::test]
+    async fn test_uncommitted_ssts_cleanup_finalized_file() {
+        let env = SchedulerEnv::new().await;
+        let region_id = RegionId::new(1, 1);
+        let file_id = store_api::storage::FileId::random();
+        let path = crate::sst::location::sst_file_path(
+            env.access_layer.table_dir(),
+            crate::sst::file::RegionFileId::new(region_id, file_id),
+            env.access_layer.path_type(),
+        );
+        env.access_layer
+            .object_store()
+            .write(&path, Bytes::from_static(b"sst"))
+            .await
+            .unwrap();
+        assert!(env.access_layer.object_store().exists(&path).await.unwrap());
+
+        let uncommitted = UncommittedSsts::new(region_id, env.access_layer.clone(), None);
+        uncommitted.track(&[SstInfo {
+            file_id,
+            ..Default::default()
+        }]);
+        assert_eq!(1, uncommitted.num_tracked_files());
+        uncommitted.cleanup_for_test().await.unwrap();
+        assert_eq!(0, uncommitted.num_tracked_files());
+
+        // The object-store wrapper caches successful stat results, so list the directory instead
+        // of using `exists()` again to verify the deletion.
+        let entries = env
+            .access_layer
+            .object_store()
+            .list(&env.access_layer.build_region_dir(region_id))
+            .await
+            .unwrap();
+        assert!(entries.iter().all(|entry| entry.path() != path));
+    }
+
+    #[tokio::test]
     async fn test_region_closed_notifies_pending_bulk_writes() {
         let region_id = RegionId::new(1, 1);
         let version_control = Arc::new(VersionControlBuilder::new().build());
@@ -1818,6 +2114,7 @@ mod tests {
         let status = FlushStatus {
             region_id,
             version_control,
+            state: FlushState::new(),
             pending_task: None,
             closing: false,
             pending_ddls: Vec::new(),

--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -974,6 +974,13 @@ pub(crate) struct FlushFailed {
     pub(crate) err: Arc<Error>,
 }
 
+impl FlushFailed {
+    /// Returns whether the flush was cancelled cooperatively.
+    pub(crate) fn is_cancelled(&self) -> bool {
+        matches!(self.err.as_ref(), Error::FlushCancelled { .. })
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct IndexBuildFinished {
     pub(crate) manifest_version: ManifestVersion,
@@ -1359,6 +1366,24 @@ mod tests {
         let err = rx.blocking_recv().unwrap().unwrap_err();
         assert!(matches!(err, Error::CompactionCancelled { .. }));
         assert_eq!(err.status_code(), StatusCode::Cancelled);
+    }
+
+    #[test]
+    fn test_flush_failed_detects_cancellation() {
+        let cancelled = FlushFailed {
+            err: Arc::new(crate::error::FlushCancelledSnafu.build()),
+        };
+        assert!(cancelled.is_cancelled());
+
+        let failed = FlushFailed {
+            err: Arc::new(
+                crate::error::RegionBusySnafu {
+                    region_id: RegionId::new(1, 1),
+                }
+                .build(),
+            ),
+        };
+        assert!(!failed.is_cancelled());
     }
 
     #[test]

--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -1369,24 +1369,6 @@ mod tests {
     }
 
     #[test]
-    fn test_flush_failed_detects_cancellation() {
-        let cancelled = FlushFailed {
-            err: Arc::new(crate::error::FlushCancelledSnafu.build()),
-        };
-        assert!(cancelled.is_cancelled());
-
-        let failed = FlushFailed {
-            err: Arc::new(
-                crate::error::RegionBusySnafu {
-                    region_id: RegionId::new(1, 1),
-                }
-                .build(),
-            ),
-        };
-        assert!(!failed.is_cancelled());
-    }
-
-    #[test]
     fn test_write_request_column_num() {
         let rows = Rows {
             schema: vec![

--- a/src/mito2/src/schedule.rs
+++ b/src/mito2/src/schedule.rs
@@ -12,5 +12,88 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::{Arc, Mutex};
+
+use common_base::cancellation::CancellationHandle;
+
 pub mod remote_job_scheduler;
 pub mod scheduler;
+
+/// Shared state for cooperatively cancelling a task until it starts committing.
+#[derive(Debug, Clone)]
+pub(crate) struct CancellableTaskState {
+    cancel_handle: Arc<CancellationHandle>,
+    commit_started: Arc<Mutex<bool>>,
+}
+
+impl CancellableTaskState {
+    pub(crate) fn new() -> Self {
+        Self {
+            cancel_handle: Arc::new(CancellationHandle::default()),
+            commit_started: Arc::new(Mutex::new(false)),
+        }
+    }
+
+    pub(crate) fn cancel_handle(&self) -> Arc<CancellationHandle> {
+        self.cancel_handle.clone()
+    }
+
+    pub(crate) fn is_cancelled(&self) -> bool {
+        self.cancel_handle.is_cancelled()
+    }
+
+    /// Starts the non-cancellable commit phase.
+    ///
+    /// Returns false if cancellation was requested first.
+    pub(crate) fn mark_commit_started(&self) -> bool {
+        let mut commit_started = self.commit_started.lock().unwrap();
+        if self.cancel_handle.is_cancelled() {
+            return false;
+        }
+        *commit_started = true;
+        true
+    }
+
+    pub(crate) fn request_cancel(&self) -> RequestCancelResult {
+        // Hold the commit lock while cancelling to serialize cancellation with commit startup.
+        let commit_started = self.commit_started.lock().unwrap();
+        if *commit_started {
+            return RequestCancelResult::TooLateToCancel;
+        }
+        if self.cancel_handle.is_cancelled() {
+            return RequestCancelResult::AlreadyCancelling;
+        }
+
+        self.cancel_handle.cancel();
+        RequestCancelResult::CancelIssued
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RequestCancelResult {
+    CancelIssued,
+    AlreadyCancelling,
+    TooLateToCancel,
+    NotRunning,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cancellable_task_state_transitions() {
+        let state = CancellableTaskState::new();
+        assert_eq!(RequestCancelResult::CancelIssued, state.request_cancel());
+        assert!(state.is_cancelled());
+        assert_eq!(
+            RequestCancelResult::AlreadyCancelling,
+            state.request_cancel()
+        );
+        assert!(!state.mark_commit_started());
+
+        let state = CancellableTaskState::new();
+        assert!(state.mark_commit_started());
+        assert_eq!(RequestCancelResult::TooLateToCancel, state.request_cancel());
+    }
+}

--- a/src/mito2/src/sst/file.rs
+++ b/src/mito2/src/sst/file.rs
@@ -730,8 +730,11 @@ impl UncommittedSsts {
         }
     }
 
-    /// Disarms cleanup after the manifest edit has committed.
-    pub(crate) fn commit(&self) {
+    /// Disarms cleanup after the manifest edit has committed or may have committed.
+    ///
+    /// A manifest update error does not guarantee that the edit was not persisted. Once an edit
+    /// may become visible, its SSTs must be retained to avoid deleting referenced files.
+    pub(crate) fn disarm_cleanup(&self) {
         self.files.lock().unwrap().clear();
     }
 

--- a/src/mito2/src/sst/file.rs
+++ b/src/mito2/src/sst/file.rs
@@ -14,11 +14,12 @@
 
 //! Structures to describe metadata of files.
 
+use std::collections::HashMap;
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::num::NonZeroU64;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 
 use base64::prelude::{BASE64_STANDARD, Engine};
 use bytes::Bytes;
@@ -37,6 +38,7 @@ use crate::cache::CacheManagerRef;
 use crate::cache::file_cache::{FileType, IndexKey};
 use crate::sst::file_purger::FilePurgerRef;
 use crate::sst::location;
+use crate::sst::parquet::SstInfo;
 
 /// Custom serde functions for Bytes fields serialized as base64 strings.
 fn serialize_bytes_option<S>(bytes: &Option<Bytes>, serializer: S) -> Result<S::Ok, S::Error>
@@ -689,6 +691,87 @@ pub async fn delete_files(
         .await;
     }
     Ok(())
+}
+
+/// Tracks finalized SSTs until their manifest edit is committed.
+///
+/// Flush and local compaction jobs use this to remove files that were written successfully but
+/// abandoned by cancellation or a later failure.
+#[derive(Clone)]
+pub(crate) struct UncommittedSsts {
+    region_id: RegionId,
+    files: Arc<Mutex<HashMap<FileId, (u64, bool)>>>,
+    access_layer: AccessLayerRef,
+    cache_manager: Option<CacheManagerRef>,
+}
+
+impl UncommittedSsts {
+    pub(crate) fn new(
+        region_id: RegionId,
+        access_layer: AccessLayerRef,
+        cache_manager: Option<CacheManagerRef>,
+    ) -> Self {
+        Self {
+            region_id,
+            files: Arc::new(Mutex::new(HashMap::new())),
+            access_layer,
+            cache_manager,
+        }
+    }
+
+    /// Tracks newly finalized SSTs before they become visible in the manifest.
+    pub(crate) fn track(&self, ssts: &[SstInfo]) {
+        let mut files = self.files.lock().unwrap();
+        for sst in ssts {
+            files.insert(
+                sst.file_id,
+                (sst.index_metadata.version, sst.index_metadata.file_size > 0),
+            );
+        }
+    }
+
+    /// Disarms cleanup after the manifest edit has committed.
+    pub(crate) fn commit(&self) {
+        self.files.lock().unwrap().clear();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn num_tracked_files(&self) -> usize {
+        self.files.lock().unwrap().len()
+    }
+
+    /// Removes all finalized SSTs still owned by this job.
+    pub(crate) async fn cleanup(&self) {
+        if let Err(err) = self.try_cleanup().await {
+            error!(err; "Failed to clean uncommitted SSTs for region {}", self.region_id);
+        }
+    }
+
+    async fn try_cleanup(&self) -> crate::error::Result<()> {
+        let files = std::mem::take(&mut *self.files.lock().unwrap());
+        if files.is_empty() {
+            return Ok(());
+        }
+
+        let delete_index = files.values().any(|(_, exists_index)| *exists_index);
+        let file_ids = files
+            .into_iter()
+            .map(|(file_id, (index_version, _))| (file_id, index_version))
+            .collect::<Vec<_>>();
+        delete_files(
+            self.region_id,
+            &file_ids,
+            delete_index,
+            &self.access_layer,
+            &self.cache_manager,
+        )
+        .await
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn cleanup_for_test(&self) -> crate::error::Result<()> {
+        self.try_cleanup().await
+    }
 }
 
 pub async fn delete_index(

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -1148,22 +1148,8 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             let res = match ddl.request {
                 DdlRequest::Create(req) => self.handle_create_request(ddl.region_id, req).await,
                 DdlRequest::Drop(req) => {
-                    let (sender, req) = match self.flush_scheduler.try_cancel_and_add_ddl(
-                        ddl.region_id,
-                        ddl.sender,
-                        req,
-                        DdlRequest::Drop,
-                    ) {
-                        Ok(()) => {
-                            self.listener.on_flush_cancel_requested(ddl.region_id);
-                            continue;
-                        }
-                        Err(request) => request,
-                    };
-                    let res = self
-                        .handle_drop_request(ddl.region_id, req.partial_drop)
+                    self.handle_drop_request(ddl.region_id, req, ddl.sender)
                         .await;
-                    sender.send(res);
                     continue;
                 }
                 DdlRequest::Open((req, wal_entry_receiver)) => {

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -1148,8 +1148,23 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             let res = match ddl.request {
                 DdlRequest::Create(req) => self.handle_create_request(ddl.region_id, req).await,
                 DdlRequest::Drop(req) => {
-                    self.handle_drop_request(ddl.region_id, req.partial_drop)
-                        .await
+                    let (sender, req) = match self.flush_scheduler.try_cancel_and_add_ddl(
+                        ddl.region_id,
+                        ddl.sender,
+                        req,
+                        DdlRequest::Drop,
+                    ) {
+                        Ok(()) => {
+                            self.listener.on_flush_cancel_requested(ddl.region_id);
+                            continue;
+                        }
+                        Err(request) => request,
+                    };
+                    let res = self
+                        .handle_drop_request(ddl.region_id, req.partial_drop)
+                        .await;
+                    sender.send(res);
+                    continue;
                 }
                 DdlRequest::Open((req, wal_entry_receiver)) => {
                     self.handle_open_request(ddl.region_id, req, wal_entry_receiver, ddl.sender)
@@ -1363,6 +1378,20 @@ impl WorkerListener {
         }
         // Avoid compiler warning.
         let _ = region_id;
+    }
+
+    pub(crate) async fn on_flush_commit_begin(&self, _region_id: RegionId) {
+        #[cfg(any(test, feature = "test"))]
+        if let Some(listener) = &self.listener {
+            listener.on_flush_commit_begin(_region_id).await;
+        }
+    }
+
+    pub(crate) fn on_flush_cancel_requested(&self, _region_id: RegionId) {
+        #[cfg(any(test, feature = "test"))]
+        if let Some(listener) = &self.listener {
+            listener.on_flush_cancel_requested(_region_id);
+        }
     }
 
     pub(crate) fn on_later_drop_begin(&self, region_id: RegionId) -> Option<Duration> {

--- a/src/mito2/src/worker/handle_drop.rs
+++ b/src/mito2/src/worker/handle_drop.rs
@@ -24,7 +24,7 @@ use object_store::{EntryMode, ObjectStore};
 use snafu::ResultExt;
 use store_api::logstore::LogStore;
 use store_api::metadata::RegionMetadataRef;
-use store_api::region_request::{AffectedRows, PathType};
+use store_api::region_request::{AffectedRows, PathType, RegionDropRequest};
 use store_api::storage::RegionId;
 use tokio::time::sleep;
 
@@ -32,6 +32,7 @@ use crate::cache::CacheManagerRef;
 use crate::engine::region_hook::RegionHookRef;
 use crate::error::{OpenDalSnafu, Result};
 use crate::region::{RegionLeaderState, RegionMapRef};
+use crate::request::{DdlRequest, OptionOutputTx};
 use crate::sst::index::intermediate::IntermediateManager;
 use crate::worker::{DROPPING_MARKER_FILE, RegionWorkerLoop};
 
@@ -43,6 +44,29 @@ where
     S: LogStore,
 {
     pub(crate) async fn handle_drop_request(
+        &mut self,
+        region_id: RegionId,
+        req: RegionDropRequest,
+        sender: OptionOutputTx,
+    ) {
+        let (sender, req) = match self.flush_scheduler.try_cancel_and_add_ddl(
+            region_id,
+            sender,
+            req,
+            DdlRequest::Drop,
+        ) {
+            Ok(()) => {
+                self.listener.on_flush_cancel_requested(region_id);
+                return;
+            }
+            Err(request) => request,
+        };
+
+        let result = self.drop_region(region_id, req.partial_drop).await;
+        sender.send(result);
+    }
+
+    async fn drop_region(
         &mut self,
         region_id: RegionId,
         partial_drop: bool,

--- a/src/mito2/src/worker/handle_drop.rs
+++ b/src/mito2/src/worker/handle_drop.rs
@@ -31,7 +31,7 @@ use tokio::time::sleep;
 use crate::cache::CacheManagerRef;
 use crate::engine::region_hook::RegionHookRef;
 use crate::error::{OpenDalSnafu, Result};
-use crate::region::{RegionLeaderState, RegionMapRef};
+use crate::region::{MitoRegionRef, RegionLeaderState, RegionMapRef};
 use crate::request::{DdlRequest, OptionOutputTx};
 use crate::sst::index::intermediate::IntermediateManager;
 use crate::worker::{DROPPING_MARKER_FILE, RegionWorkerLoop};
@@ -49,6 +49,14 @@ where
         req: RegionDropRequest,
         sender: OptionOutputTx,
     ) {
+        let region = match self.regions.writable_region(region_id) {
+            Ok(region) => region,
+            Err(e) => {
+                sender.send(Err(e));
+                return;
+            }
+        };
+
         let (sender, req) = match self.flush_scheduler.try_cancel_and_add_ddl(
             region_id,
             sender,
@@ -62,16 +70,16 @@ where
             Err(request) => request,
         };
 
-        let result = self.drop_region(region_id, req.partial_drop).await;
+        let result = self.drop_region(region, req.partial_drop).await;
         sender.send(result);
     }
 
     async fn drop_region(
         &mut self,
-        region_id: RegionId,
+        region: MitoRegionRef,
         partial_drop: bool,
     ) -> Result<AffectedRows> {
-        let region = self.regions.writable_region(region_id)?;
+        let region_id = region.region_id;
 
         info!("Try to drop region: {}, worker: {}", region_id, self.id);
 

--- a/src/mito2/src/worker/handle_flush.rs
+++ b/src/mito2/src/worker/handle_flush.rs
@@ -60,16 +60,14 @@ fn resolve_flush_reason(
 impl<S: LogStore> RegionWorkerLoop<S> {
     /// On region flush job failed.
     pub(crate) async fn handle_flush_failed(&mut self, region_id: RegionId, request: FlushFailed) {
-        let cancelled = request.is_cancelled();
-        let pending = self.flush_scheduler.on_flush_failed(region_id, request.err);
-        debug!(
-            "Flush terminated for region {}, cancelled: {}, handling pending requests",
-            region_id, cancelled
-        );
-        if let Some((mut ddl_requests, mut write_requests, mut bulk_writes)) = pending {
-            self.handle_ddl_requests(&mut ddl_requests).await;
-            self.handle_write_requests(&mut write_requests, &mut bulk_writes, false)
-                .await;
+        let mut pending_ddls = self.flush_scheduler.on_flush_failed(region_id, request.err);
+        if !pending_ddls.is_empty() {
+            info!(
+                "Flush terminated for region {}, handling {} pending lifecycle DDL requests",
+                region_id,
+                pending_ddls.len()
+            );
+            self.handle_ddl_requests(&mut pending_ddls).await;
         }
         // Maybe flush worker again.
         self.maybe_flush_worker();

--- a/src/mito2/src/worker/handle_flush.rs
+++ b/src/mito2/src/worker/handle_flush.rs
@@ -60,11 +60,17 @@ fn resolve_flush_reason(
 impl<S: LogStore> RegionWorkerLoop<S> {
     /// On region flush job failed.
     pub(crate) async fn handle_flush_failed(&mut self, region_id: RegionId, request: FlushFailed) {
-        self.flush_scheduler.on_flush_failed(region_id, request.err);
+        let cancelled = request.is_cancelled();
+        let pending = self.flush_scheduler.on_flush_failed(region_id, request.err);
         debug!(
-            "Flush failed for region {}, handling stalled requests",
-            region_id
+            "Flush terminated for region {}, cancelled: {}, handling pending requests",
+            region_id, cancelled
         );
+        if let Some((mut ddl_requests, mut write_requests, mut bulk_writes)) = pending {
+            self.handle_ddl_requests(&mut ddl_requests).await;
+            self.handle_write_requests(&mut write_requests, &mut bulk_writes, false)
+                .await;
+        }
         // Maybe flush worker again.
         self.maybe_flush_worker();
 

--- a/src/mito2/src/worker/handle_truncate.rs
+++ b/src/mito2/src/worker/handle_truncate.rs
@@ -40,6 +40,19 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             }
         };
 
+        let (sender, req) = match self.flush_scheduler.try_cancel_and_add_ddl(
+            region_id,
+            sender,
+            req,
+            DdlRequest::Truncate,
+        ) {
+            Ok(()) => {
+                self.listener.on_flush_cancel_requested(region_id);
+                return;
+            }
+            Err(request) => request,
+        };
+
         let (sender, req) = match self.compaction_scheduler.try_cancel_and_add_ddl(
             region_id,
             sender,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/8464

## What's changed and what's your intention?

This PR adds cooperative cancellation support to mito's flush scheduler so table drop and truncate requests do not need to wait for an unnecessary flush to finish.

- Add a cancellation handle and commit gate to each running flush. Once manifest commit begins, cancellation becomes a queued post-flush operation.
- Queue drop and truncate requests behind the running flush, then dispatch them through the existing `FlushFailed` notification path when the flush is cancelled or fails.
- Detect cancellation through `FlushFailed::is_cancelled()` by matching the error, avoiding an additional event field.
- Preserve pending lifecycle DDL and writes across flush cancellation or failure while failing unrelated pending DDL as before.
- Track finalized, uncommitted SSTs and delete them when flush or local compaction is cancelled or fails, including manifest update failures.
- Abort and await spawned writers before cleanup to prevent late finalized files from leaking.

This does not change public APIs or persisted data formats.

Validation:

- `cargo nextest run --retries 0 -p mito2` with focused cancellation and cleanup filters (8 tests)
- `cargo check -p mito2 --tests`
- `cargo clippy -p mito2 --tests -- -D warnings`
- `cargo fmt --all`
- `git diff --check`

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
