### PR TITLE
chore(deps): pin timestamp widening preimage fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3695,7 +3695,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 [[package]]
 name = "datafusion"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "arrow 58.3.0",
  "arrow-schema 58.3.0",
@@ -3749,7 +3749,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3773,7 +3773,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3795,7 +3795,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -3819,7 +3819,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "futures",
  "log",
@@ -3829,7 +3829,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "arrow 58.3.0",
  "async-compression",
@@ -3863,7 +3863,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "arrow 58.3.0",
  "arrow-ipc 58.3.0",
@@ -3886,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3908,7 +3908,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3931,7 +3931,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3960,12 +3960,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 
 [[package]]
 name = "datafusion-execution"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "arrow 58.3.0",
  "arrow-buffer 58.3.0",
@@ -3987,7 +3987,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4009,7 +4009,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4021,7 +4021,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "arrow 58.3.0",
  "arrow-buffer 58.3.0",
@@ -4052,7 +4052,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4073,7 +4073,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4085,7 +4085,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "arrow 58.3.0",
  "arrow-ord 58.3.0",
@@ -4109,7 +4109,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4124,7 +4124,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -4150,7 +4150,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -4160,7 +4160,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -4209,7 +4209,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4232,7 +4232,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4246,7 +4246,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4262,7 +4262,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4280,7 +4280,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4311,7 +4311,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -4338,7 +4338,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4348,7 +4348,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4364,7 +4364,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -4377,7 +4377,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "arrow 58.3.0",
  "bigdecimal 0.4.8",
@@ -4395,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=af8d0979ff2e0ad373980055355eea35dfed0457#af8d0979ff2e0ad373980055355eea35dfed0457"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=6d6ae9a8073900bdf89d098d491d4dc0269699b0#6d6ae9a8073900bdf89d098d491d4dc0269699b0"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -342,21 +342,21 @@ git = "https://github.com/GreptimeTeam/greptime-meter.git"
 rev = "5618e779cf2bb4755b499c630fba4c35e91898cb"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
-datafusion-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
-datafusion-datasource = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
-datafusion-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
-datafusion-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
-datafusion-functions = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
-datafusion-functions-aggregate-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
-datafusion-functions-window-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
-datafusion-optimizer = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
-datafusion-physical-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
-datafusion-physical-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
-datafusion-physical-plan = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
-datafusion-proto = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
-datafusion-sql = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
-datafusion-substrait = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "af8d0979ff2e0ad373980055355eea35dfed0457" }
+datafusion = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "6d6ae9a8073900bdf89d098d491d4dc0269699b0" }
+datafusion-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "6d6ae9a8073900bdf89d098d491d4dc0269699b0" }
+datafusion-datasource = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "6d6ae9a8073900bdf89d098d491d4dc0269699b0" }
+datafusion-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "6d6ae9a8073900bdf89d098d491d4dc0269699b0" }
+datafusion-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "6d6ae9a8073900bdf89d098d491d4dc0269699b0" }
+datafusion-functions = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "6d6ae9a8073900bdf89d098d491d4dc0269699b0" }
+datafusion-functions-aggregate-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "6d6ae9a8073900bdf89d098d491d4dc0269699b0" }
+datafusion-functions-window-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "6d6ae9a8073900bdf89d098d491d4dc0269699b0" }
+datafusion-optimizer = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "6d6ae9a8073900bdf89d098d491d4dc0269699b0" }
+datafusion-physical-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "6d6ae9a8073900bdf89d098d491d4dc0269699b0" }
+datafusion-physical-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "6d6ae9a8073900bdf89d098d491d4dc0269699b0" }
+datafusion-physical-plan = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "6d6ae9a8073900bdf89d098d491d4dc0269699b0" }
+datafusion-proto = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "6d6ae9a8073900bdf89d098d491d4dc0269699b0" }
+datafusion-sql = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "6d6ae9a8073900bdf89d098d491d4dc0269699b0" }
+datafusion-substrait = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "6d6ae9a8073900bdf89d098d491d4dc0269699b0" }
 sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "2aefa08a8d69c96eec2d6d6703598a009bba6e4c" }                           # on branch v0.61.x
 
 [profile.release]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

- GreptimeTeam/datafusion#23

## What's changed and what's your intention?

This PR updates GreptimeDB's pinned DataFusion fork revision from
`af8d0979ff2e0ad373980055355eea35dfed0457` to
`6d6ae9a8073900bdf89d098d491d4dc0269699b0`.

The new revision includes the ordered timestamp-widening predicate preimage
rewrite from GreptimeTeam/datafusion#23. It restores scan pruning when
DataFusion coerces a comparison such as a millisecond timestamp column against
a non-millisecond-aligned nanosecond literal into
`CAST(timestamp_ms AS timestamp_ns) OP literal_ns`.

This is a dependency-pin-only change. DataFusion crate versions remain at
53.1.0, and there are no GreptimeDB API, schema, persisted-data, or wire-format
changes.

## PR Checklist

- [x] I have written the necessary rustdoc comments. (No GreptimeDB Rust code changed.)
- [x] I have added the necessary unit tests and integration tests. (The rewrite is covered by upstream DataFusion tests.)
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.

## Verification

- `cargo metadata --locked --no-deps --format-version 1`
- `cargo check --locked -p query`
- `git diff --check`
