### PR TITLE
ci: limit fuzz test parallelism

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -167,6 +167,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
+      max-parallel: 4
       matrix:
         target: [ "fuzz_create_table", "fuzz_alter_table", "fuzz_create_database", "fuzz_create_logical_table", "fuzz_alter_logical_table", "fuzz_insert", "fuzz_insert_logical_table" ]
     steps:
@@ -224,6 +225,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         target: [ "unstable_fuzz_create_table_standalone" ]
     steps:
@@ -334,6 +336,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
+      max-parallel: 5
       matrix:
         target: [ "fuzz_create_table", "fuzz_alter_table", "fuzz_create_database", "fuzz_create_logical_table", "fuzz_alter_logical_table", "fuzz_insert", "fuzz_insert_logical_table" ]
         mode:
@@ -561,6 +564,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
+      max-parallel: 4
       matrix:
         target: ["fuzz_migrate_mito_regions", "fuzz_migrate_metric_regions", "fuzz_failover_mito_regions", "fuzz_failover_metric_regions"]
         mode:


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

None.

## What's changed and what's your intention?

Limit concurrent fuzz jobs so fuzz testing no longer monopolizes GitHub-hosted runners.

- Set `max-parallel: 4` for the standalone fuzz matrix.
- Set `max-parallel: 1` for the unstable fuzz matrix.
- Set `max-parallel: 5` for the distributed fuzz matrix.
- Set `max-parallel: 4` for the distributed chaos fuzz matrix.
- Each fuzz matrix can complete its targets in at most two waves, while retaining all targets, triggers, and the existing `fail-fast: false` behavior.

This change only adjusts GitHub Actions scheduling. It introduces no API, schema, data-format, or documentation changes.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
